### PR TITLE
broker: add Redis Streams broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
             package: "@pario/ducklake"
           - name: broker-nats
             package: "@pario/broker-nats"
+          - name: broker-redis
+            package: "@pario/broker-redis"
           - name: pg
             package: "@pario/pg"
           - name: queues-bullmq

--- a/broker/redis/README.md
+++ b/broker/redis/README.md
@@ -11,6 +11,8 @@ bun add @pario/broker-redis
 
 Requires Redis 7.2 or newer.
 
+This package uses Bun's native Redis client.
+
 ## Usage
 
 ```typescript
@@ -30,18 +32,28 @@ export const pario = createPario({
 ```
 
 The constructor is synchronous. Redis connections are opened lazily on the
-first `append()`, `read()`, or `subscribe()` call.
+first `append()`, `read()`, or `subscribe()` call. If `connection` is omitted,
+the broker reads `REDIS_URL`, then `VALKEY_URL`, before falling back to Bun's
+default Redis URL.
 
 ## Options
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `connection` | `RedisClientOptions` | required | node-redis connection options. |
+| `connection` | `RedisBrokerConnectionOptions` | `undefined` | Bun Redis URL/options. Supports `url`, `connectionTimeout`, `idleTimeout`, `autoReconnect`, `maxRetries`, `enableOfflineQueue`, `enableAutoPipelining`, and `tls`. |
 | `prefix` | `string` | `"pario:broker"` | Redis key prefix. |
 | `dedupeTtlMs` | `number` | `120000` | Retry dedupe window for `idempotencyKey`. |
 | `readBatchSize` | `number` | `1000` | `XRANGE COUNT` page size for retained reads. |
 | `subscribeBatchSize` | `number` | `100` | `XREAD COUNT` page size for subscriptions. |
 | `subscribeBlockMs` | `number` | `1000` | `XREAD BLOCK` duration. |
+
+Connection examples:
+
+```typescript
+new RedisBroker()
+new RedisBroker({ connection: { url: "redis://localhost:6379" } })
+new RedisBroker({ connection: { url: "rediss://redis.example.com:6379", tls: true } })
+```
 
 ## Redis Key Scheme
 
@@ -54,9 +66,10 @@ and broker stream id:
 | Metadata key | `{prefix}:brk:{base64url(projectId):base64url(streamId)}:meta` |
 | Dedupe key | `{prefix}:brk:{base64url(projectId):base64url(streamId)}:dedupe:{base64url(idempotencyKey)}` |
 
-The `{...}` segment is a Redis Cluster hash tag. It keeps the stream, metadata,
-and dedupe keys for one logical broker stream in the same cluster slot so the
-append Lua script can update them atomically.
+The `{...}` segment is hash-tag-compatible and keeps the stream, metadata, and
+dedupe keys for one logical broker stream grouped together. Bun's native Redis
+client does not currently support Redis Cluster, so this provider targets
+standalone Redis-compatible servers.
 
 ## Behavior Notes
 

--- a/broker/redis/README.md
+++ b/broker/redis/README.md
@@ -1,0 +1,117 @@
+# @pario/broker-redis
+
+Redis Streams-backed implementation of the Pario `Broker` interface. Use it
+for deployments that want a durable multi-process broker backed by Redis.
+
+## Installation
+
+```bash
+bun add @pario/broker-redis
+```
+
+Requires Redis 7.2 or newer.
+
+## Usage
+
+```typescript
+import { createPario, InMemoryQueues } from "@pario/core"
+import { RedisBroker } from "@pario/broker-redis"
+
+export const pario = createPario({
+  id: "my-project",
+  broker: new RedisBroker({
+    connection: { url: "redis://localhost:6379" },
+  }),
+  storage: myStorage,
+  lakeStorage: myLakeStorage,
+  blobStorage: myBlobStorage,
+  queues: new InMemoryQueues(),
+})
+```
+
+The constructor is synchronous. Redis connections are opened lazily on the
+first `append()`, `read()`, or `subscribe()` call.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `connection` | `RedisClientOptions` | required | node-redis connection options. |
+| `prefix` | `string` | `"pario:broker"` | Redis key prefix. |
+| `dedupeTtlMs` | `number` | `120000` | Retry dedupe window for `idempotencyKey`. |
+| `readBatchSize` | `number` | `1000` | `XRANGE COUNT` page size for retained reads. |
+| `subscribeBatchSize` | `number` | `100` | `XREAD COUNT` page size for subscriptions. |
+| `subscribeBlockMs` | `number` | `1000` | `XREAD BLOCK` duration. |
+
+## Redis Key Scheme
+
+The provider stores one Redis Stream plus one metadata hash per Pario project
+and broker stream id:
+
+| Concept | Shape |
+| --- | --- |
+| Stream key | `{prefix}:brk:{base64url(projectId):base64url(streamId)}:stream` |
+| Metadata key | `{prefix}:brk:{base64url(projectId):base64url(streamId)}:meta` |
+| Dedupe key | `{prefix}:brk:{base64url(projectId):base64url(streamId)}:dedupe:{base64url(idempotencyKey)}` |
+
+The `{...}` segment is a Redis Cluster hash tag. It keeps the stream, metadata,
+and dedupe keys for one logical broker stream in the same cluster slot so the
+append Lua script can update them atomically.
+
+## Behavior Notes
+
+### Cursors
+
+Broker cursors are opaque strings. This provider uses Redis stream IDs such as
+`1716400000000-0`. Callers should only pass cursors back to `read()` or
+`subscribe()`.
+
+When retention removes old entries, the provider records the latest trimmed
+cursor in metadata. Reads after older cursors reject instead of silently
+skipping unavailable history.
+
+### Append
+
+A single `append()` call with multiple records writes them sequentially. Each
+individual record append is atomic through a Lua script that handles `XADD`,
+retry dedupe, retention trimming, and retained-range metadata updates.
+
+For retryable writes, pass a stable `idempotencyKey`. The provider maps it to a
+short-lived Redis key and returns the original retained record when the same key
+is retried within `dedupeTtlMs`.
+
+### Subscribe
+
+`subscribe()` uses plain `XREAD`, not consumer groups. That preserves the Pario
+broker contract: every subscriber receives every matching record independently.
+
+By default subscriptions start at the latest retained cursor and receive only
+new records. Use `from: "earliest"` or `afterCursor` for retained replay.
+
+### Retention
+
+`maxRecords` maps to exact `XTRIM MAXLEN`, and `maxAgeMs` maps to exact
+`XTRIM MINID`. Trimming happens during append. Existing metadata is not rewritten
+by later `ensureStream()` calls with different retention options.
+
+## Local Development
+
+Start the test Redis server:
+
+```bash
+docker compose up -d --wait
+```
+
+This exposes Redis on `127.0.0.1:46380`.
+
+Stop and clean up with:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+## Running Tests
+
+```bash
+bun run test:e2e
+```

--- a/broker/redis/docker-compose.yml
+++ b/broker/redis/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  redis:
+    image: redis:7.2-alpine
+    # Custom port (46380) so local dev Redis instances and the BullMQ test
+    # Redis on 46379 do not collide with this broker test server.
+    command: ["redis-server", "--port", "46380"]
+    ports:
+      - "46380:46380"
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "46380", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15

--- a/broker/redis/package.json
+++ b/broker/redis/package.json
@@ -13,8 +13,7 @@
     "test:e2e": "bun test --preload ./tests/setup.ts ./tests/*.e2e.ts"
   },
   "dependencies": {
-    "@pario/core": "workspace:*",
-    "redis": "^5.12.1"
+    "@pario/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/broker/redis/package.json
+++ b/broker/redis/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@pario/broker-redis",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "bun test --preload ./tests/setup.ts ./tests/*.e2e.ts"
+  },
+  "dependencies": {
+    "@pario/core": "workspace:*",
+    "redis": "^5.12.1"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  }
+}

--- a/broker/redis/src/connection.ts
+++ b/broker/redis/src/connection.ts
@@ -1,7 +1,11 @@
-import { createClient, type RedisClientOptions } from "redis"
+import { RedisClient, type RedisOptions } from "bun"
 import { RedisBrokerError } from "./errors"
 
-export type RedisBrokerClient = ReturnType<typeof createClient>
+export interface RedisBrokerConnectionOptions extends RedisOptions {
+  readonly url?: string
+}
+
+export type RedisBrokerClient = RedisClient
 
 /**
  * Lazily manages Redis clients for the broker.
@@ -10,31 +14,38 @@ export type RedisBrokerClient = ReturnType<typeof createClient>
  * dedicated clients so a blocked subscription cannot starve append/read calls.
  */
 export class RedisConnectionManager {
-  private readonly options: RedisClientOptions
+  private readonly url: string | undefined
+  private readonly options: RedisOptions | undefined
   private connectPromise: Promise<RedisBrokerClient> | undefined
   private client: RedisBrokerClient | undefined
 
-  constructor(options: RedisClientOptions) {
-    this.options = options
+  constructor(options: RedisBrokerConnectionOptions = {}) {
+    const { url, ...redisOptions } = options
+    this.url = url
+    this.options = Object.keys(redisOptions).length === 0 ? undefined : redisOptions
   }
 
   async connect(): Promise<RedisBrokerClient> {
-    if (this.client?.isOpen) {
+    if (this.client?.connected) {
       return this.client
     }
     if (this.connectPromise !== undefined) {
       return this.connectPromise
     }
 
-    this.connectPromise = this.openClient("Failed to connect to Redis").then((client) => {
+    const connectPromise = this.openClient("Failed to connect to Redis").then((client) => {
       this.client = client
+      this.connectPromise = undefined
       return client
     })
+    this.connectPromise = connectPromise
 
     try {
-      return await this.connectPromise
+      return await connectPromise
     } catch (error) {
-      this.connectPromise = undefined
+      if (this.connectPromise === connectPromise) {
+        this.connectPromise = undefined
+      }
       throw error
     }
   }
@@ -47,30 +58,32 @@ export class RedisConnectionManager {
     const client = this.client
     this.client = undefined
     this.connectPromise = undefined
-    if (client === undefined || !client.isOpen) {
+    if (client === undefined) {
       return
     }
-    await client.close().catch(() => undefined)
+    this.closeClient(client)
   }
 
-  destroyClient(client: RedisBrokerClient): void {
-    if (!client.isOpen) {
-      return
+  closeClient(client: RedisBrokerClient): void {
+    try {
+      client.close()
+    } catch {
+      // Closing is best-effort during unsubscribe and broker shutdown.
     }
-    client.destroy()
   }
 
   private async openClient(errorMessage: string): Promise<RedisBrokerClient> {
-    const client = createClient(this.options)
-    client.on("error", noop)
+    const client = new RedisClient(this.url ?? redisUrlFromEnvironment(), this.options)
     try {
       await client.connect()
       return client
     } catch (error) {
-      client.destroy()
+      this.closeClient(client)
       throw new RedisBrokerError(errorMessage, { cause: error })
     }
   }
 }
 
-function noop(): void {}
+function redisUrlFromEnvironment(): string | undefined {
+  return process.env["REDIS_URL"] || process.env["VALKEY_URL"]
+}

--- a/broker/redis/src/connection.ts
+++ b/broker/redis/src/connection.ts
@@ -26,7 +26,9 @@ export class RedisConnectionManager {
   }
 
   async connect(): Promise<RedisBrokerClient> {
-    if (this.client?.connected) {
+    if (this.client !== undefined) {
+      // Bun owns reconnects and offline queueing for the client. Keep returning
+      // the same main client while it reconnects instead of opening duplicates.
       return this.client
     }
     if (this.connectPromise !== undefined) {

--- a/broker/redis/src/connection.ts
+++ b/broker/redis/src/connection.ts
@@ -1,0 +1,76 @@
+import { createClient, type RedisClientOptions } from "redis"
+import { RedisBrokerError } from "./errors"
+
+export type RedisBrokerClient = ReturnType<typeof createClient>
+
+/**
+ * Lazily manages Redis clients for the broker.
+ *
+ * The main client handles ordinary commands. Blocking `XREAD` subscriptions get
+ * dedicated clients so a blocked subscription cannot starve append/read calls.
+ */
+export class RedisConnectionManager {
+  private readonly options: RedisClientOptions
+  private connectPromise: Promise<RedisBrokerClient> | undefined
+  private client: RedisBrokerClient | undefined
+
+  constructor(options: RedisClientOptions) {
+    this.options = options
+  }
+
+  async connect(): Promise<RedisBrokerClient> {
+    if (this.client?.isOpen) {
+      return this.client
+    }
+    if (this.connectPromise !== undefined) {
+      return this.connectPromise
+    }
+
+    this.connectPromise = this.openClient("Failed to connect to Redis").then((client) => {
+      this.client = client
+      return client
+    })
+
+    try {
+      return await this.connectPromise
+    } catch (error) {
+      this.connectPromise = undefined
+      throw error
+    }
+  }
+
+  async createSubscriptionClient(): Promise<RedisBrokerClient> {
+    return this.openClient("Failed to connect Redis subscription client")
+  }
+
+  async close(): Promise<void> {
+    const client = this.client
+    this.client = undefined
+    this.connectPromise = undefined
+    if (client === undefined || !client.isOpen) {
+      return
+    }
+    await client.close().catch(() => undefined)
+  }
+
+  destroyClient(client: RedisBrokerClient): void {
+    if (!client.isOpen) {
+      return
+    }
+    client.destroy()
+  }
+
+  private async openClient(errorMessage: string): Promise<RedisBrokerClient> {
+    const client = createClient(this.options)
+    client.on("error", noop)
+    try {
+      await client.connect()
+      return client
+    } catch (error) {
+      client.destroy()
+      throw new RedisBrokerError(errorMessage, { cause: error })
+    }
+  }
+}
+
+function noop(): void {}

--- a/broker/redis/src/cursor.ts
+++ b/broker/redis/src/cursor.ts
@@ -1,0 +1,49 @@
+import { RedisBrokerError } from "./errors"
+
+export interface ParsedStreamId {
+  readonly milliseconds: bigint
+  readonly sequence: bigint
+}
+
+const STREAM_ID_PATTERN = /^(\d+)-(\d+)$/
+
+export function assertCursor(cursor: string | undefined): void {
+  if (cursor === undefined) {
+    return
+  }
+  parseStreamId(cursor)
+}
+
+export function compareStreamIds(left: string, right: string): number {
+  // Redis stream ids are timestamp-sequence pairs, not dense integers. Compare
+  // both components directly instead of trying to increment or parse as a
+  // single number.
+  const parsedLeft = parseStreamId(left)
+  const parsedRight = parseStreamId(right)
+
+  if (parsedLeft.milliseconds < parsedRight.milliseconds) {
+    return -1
+  }
+  if (parsedLeft.milliseconds > parsedRight.milliseconds) {
+    return 1
+  }
+  if (parsedLeft.sequence < parsedRight.sequence) {
+    return -1
+  }
+  if (parsedLeft.sequence > parsedRight.sequence) {
+    return 1
+  }
+  return 0
+}
+
+function parseStreamId(cursor: string): ParsedStreamId {
+  const match = STREAM_ID_PATTERN.exec(cursor)
+  if (!match) {
+    throw new RedisBrokerError("cursor must be a Redis stream id cursor")
+  }
+
+  return {
+    milliseconds: BigInt(match[1]!),
+    sequence: BigInt(match[2]!),
+  }
+}

--- a/broker/redis/src/errors.ts
+++ b/broker/redis/src/errors.ts
@@ -1,0 +1,11 @@
+import { BrokerError } from "@pario/core"
+
+/** Error class for Redis Streams-backed broker failures. */
+export class RedisBrokerError extends BrokerError {
+  override readonly name = "RedisBrokerError"
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.message = `[RedisBroker] ${message}`
+  }
+}

--- a/broker/redis/src/index.ts
+++ b/broker/redis/src/index.ts
@@ -1,0 +1,3 @@
+export { RedisBrokerError } from "./errors"
+export type { RedisBrokerOptions } from "./redis-broker"
+export { RedisBroker } from "./redis-broker"

--- a/broker/redis/src/index.ts
+++ b/broker/redis/src/index.ts
@@ -1,3 +1,4 @@
+export type { RedisBrokerConnectionOptions } from "./connection"
 export { RedisBrokerError } from "./errors"
 export type { RedisBrokerOptions } from "./redis-broker"
 export { RedisBroker } from "./redis-broker"

--- a/broker/redis/src/keys.ts
+++ b/broker/redis/src/keys.ts
@@ -13,7 +13,7 @@ export function assertPrefix(prefix: string): void {
     throw new RedisBrokerError("prefix must be a non-empty string")
   }
   if (/[{}]/.test(prefix)) {
-    throw new RedisBrokerError("prefix must not contain Redis Cluster hash-tag braces")
+    throw new RedisBrokerError("prefix must not contain Redis hash-tag braces")
   }
 }
 
@@ -34,9 +34,8 @@ export function streamKeysFor(
   projectId: string,
   streamId: string
 ): RedisStreamKeys {
-  // Keep every key for one logical broker stream in the same Redis Cluster
-  // hash slot. The append Lua script touches stream/meta/dedupe keys together,
-  // so cross-slot keys would break Redis Cluster deployments.
+  // Keep every key for one logical broker stream in a hash-tag-compatible group.
+  // The append Lua script touches stream/meta/dedupe keys together.
   const hashTag = `${encodeKeyPart(projectId)}:${encodeKeyPart(streamId)}`
   const base = `${prefix}:brk:{${hashTag}}`
 

--- a/broker/redis/src/keys.ts
+++ b/broker/redis/src/keys.ts
@@ -1,0 +1,56 @@
+import { RedisBrokerError } from "./errors"
+
+export interface RedisStreamKeys {
+  readonly streamKey: string
+  readonly metaKey: string
+  dedupeKey(idempotencyKey: string | undefined): string
+}
+
+const DEFAULT_DEDUPE_TOKEN = "_"
+
+export function assertPrefix(prefix: string): void {
+  if (prefix.trim().length === 0) {
+    throw new RedisBrokerError("prefix must be a non-empty string")
+  }
+  if (/[{}]/.test(prefix)) {
+    throw new RedisBrokerError("prefix must not contain Redis Cluster hash-tag braces")
+  }
+}
+
+export function validateProjectId(projectId: string): void {
+  if (typeof projectId !== "string" || projectId.trim().length === 0) {
+    throw new RedisBrokerError("projectId must be a non-empty string")
+  }
+}
+
+export function assertStreamId(streamId: string): void {
+  if (streamId.trim().length === 0) {
+    throw new RedisBrokerError("streamId must be a non-empty string")
+  }
+}
+
+export function streamKeysFor(
+  prefix: string,
+  projectId: string,
+  streamId: string
+): RedisStreamKeys {
+  // Keep every key for one logical broker stream in the same Redis Cluster
+  // hash slot. The append Lua script touches stream/meta/dedupe keys together,
+  // so cross-slot keys would break Redis Cluster deployments.
+  const hashTag = `${encodeKeyPart(projectId)}:${encodeKeyPart(streamId)}`
+  const base = `${prefix}:brk:{${hashTag}}`
+
+  return {
+    streamKey: `${base}:stream`,
+    metaKey: `${base}:meta`,
+    dedupeKey(idempotencyKey) {
+      return `${base}:dedupe:${encodeKeyPart(idempotencyKey ?? DEFAULT_DEDUPE_TOKEN)}`
+    },
+  }
+}
+
+export function encodeKeyPart(value: string): string {
+  // Project ids, stream ids, and idempotency keys are user-controlled. Encoding
+  // keeps Redis keys readable enough while avoiding accidental separators.
+  return Buffer.from(value, "utf8").toString("base64url")
+}

--- a/broker/redis/src/redis-broker.ts
+++ b/broker/redis/src/redis-broker.ts
@@ -1,7 +1,10 @@
 import type { Broker, BrokerRecord, BrokerRecordInput, BrokerStreamDefinition } from "@pario/core"
 import { cloneJsonValue } from "@pario/core"
-import type { RedisClientOptions } from "redis"
-import { type RedisBrokerClient, RedisConnectionManager } from "./connection"
+import {
+  type RedisBrokerClient,
+  type RedisBrokerConnectionOptions,
+  RedisConnectionManager,
+} from "./connection"
 import { assertCursor, compareStreamIds } from "./cursor"
 import { RedisBrokerError } from "./errors"
 import { assertPrefix, assertStreamId, validateProjectId } from "./keys"
@@ -24,8 +27,8 @@ const DEFAULT_SUBSCRIBE_BATCH_SIZE = 100
 const DEFAULT_SUBSCRIBE_BLOCK_MS = 1_000
 
 export interface RedisBrokerOptions {
-  /** node-redis client options, commonly `{ url: "redis://localhost:6379" }`. */
-  readonly connection: RedisClientOptions
+  /** Bun Redis client options, commonly `{ url: "redis://localhost:6379" }`. */
+  readonly connection?: RedisBrokerConnectionOptions
   /** Redis key prefix. Defaults to `"pario:broker"`. */
   readonly prefix?: string
   /** Retry-deduplication window for `idempotencyKey`. Defaults to two minutes. */
@@ -58,7 +61,7 @@ export class RedisBroker implements Broker {
   private readonly subscribeBlockMs: number
   private closed = false
 
-  constructor(options: RedisBrokerOptions) {
+  constructor(options: RedisBrokerOptions = {}) {
     const prefix = options.prefix ?? DEFAULT_PREFIX
     assertPrefix(prefix)
 
@@ -272,7 +275,7 @@ export class RedisBroker implements Broker {
           console.error("[RedisBroker] Subscription pump failed:", error)
         }
       } finally {
-        this.connectionManager.destroyClient(client)
+        this.connectionManager.closeClient(client)
       }
     })()
 
@@ -282,7 +285,7 @@ export class RedisBroker implements Broker {
           return
         }
         stopped = true
-        this.connectionManager.destroyClient(client)
+        this.connectionManager.closeClient(client)
       },
       drain: async () => {
         await pump
@@ -316,8 +319,7 @@ export class RedisBroker implements Broker {
     try {
       // One Lua call keeps XADD, dedupe-key writes, trimming, and retained-range
       // metadata updates in the same Redis atomic operation.
-      reply = await params.client.sendCommand([
-        "EVAL",
+      reply = await params.client.send("EVAL", [
         APPEND_RECORD_SCRIPT,
         "3",
         params.ensured.keys.streamKey,
@@ -381,8 +383,7 @@ export class RedisBroker implements Broker {
   ): Promise<readonly RedisStreamEntry[]> {
     let reply: unknown
     try {
-      reply = await client.sendCommand([
-        "XRANGE",
+      reply = await client.send("XRANGE", [
         ensured.keys.streamKey,
         start,
         end,
@@ -402,8 +403,7 @@ export class RedisBroker implements Broker {
   ): Promise<readonly RedisStreamEntry[]> {
     let reply: unknown
     try {
-      reply = await client.sendCommand([
-        "XREAD",
+      reply = await client.send("XREAD", [
         "COUNT",
         String(this.subscribeBatchSize),
         "BLOCK",
@@ -427,8 +427,7 @@ export class RedisBroker implements Broker {
     try {
       // Age retention is a Pario-level policy. Redis Streams only trim when a
       // command asks them to, so reads/replays must also trim idle streams.
-      await client.sendCommand([
-        "EVAL",
+      await client.send("EVAL", [
         ENFORCE_AGE_RETENTION_SCRIPT,
         "2",
         ensured.keys.streamKey,
@@ -461,8 +460,7 @@ export class RedisBroker implements Broker {
   ): Promise<readonly RedisStreamEntry[]> {
     let reply: unknown
     try {
-      reply = await client.sendCommand([
-        "XREVRANGE",
+      reply = await client.send("XREVRANGE", [
         ensured.keys.streamKey,
         start,
         end,

--- a/broker/redis/src/redis-broker.ts
+++ b/broker/redis/src/redis-broker.ts
@@ -505,8 +505,8 @@ export class RedisBroker implements Broker {
 }
 
 function positiveInteger(value: number): number {
-  if (!Number.isFinite(value) || value <= 0) {
-    throw new RedisBrokerError("broker numeric options must be positive finite numbers")
+  if (!Number.isFinite(value) || value <= 0 || !Number.isInteger(value)) {
+    throw new RedisBrokerError("broker numeric options must be positive finite integers")
   }
-  return Math.floor(value)
+  return value
 }

--- a/broker/redis/src/redis-broker.ts
+++ b/broker/redis/src/redis-broker.ts
@@ -1,0 +1,514 @@
+import type { Broker, BrokerRecord, BrokerRecordInput, BrokerStreamDefinition } from "@pario/core"
+import { cloneJsonValue } from "@pario/core"
+import type { RedisClientOptions } from "redis"
+import { type RedisBrokerClient, RedisConnectionManager } from "./connection"
+import { assertCursor, compareStreamIds } from "./cursor"
+import { RedisBrokerError } from "./errors"
+import { assertPrefix, assertStreamId, validateProjectId } from "./keys"
+import { APPEND_RECORD_SCRIPT, ENFORCE_AGE_RETENTION_SCRIPT } from "./scripts"
+import { assertEncodableRecord, decodeRecord, encodeRecord } from "./serialization"
+import { type EnsuredStream, StreamManager } from "./stream-manager"
+import {
+  bodyFromEntry,
+  parseStreamEntries,
+  parseXReadEntries,
+  type RedisStreamEntry,
+  toText,
+} from "./stream-replies"
+import { type ActiveSubscription, SubscriptionRegistry } from "./subscription-registry"
+
+const DEFAULT_PREFIX = "pario:broker"
+const DEFAULT_DEDUPE_TTL_MS = 120_000
+const DEFAULT_READ_BATCH_SIZE = 1_000
+const DEFAULT_SUBSCRIBE_BATCH_SIZE = 100
+const DEFAULT_SUBSCRIBE_BLOCK_MS = 1_000
+
+export interface RedisBrokerOptions {
+  /** node-redis client options, commonly `{ url: "redis://localhost:6379" }`. */
+  readonly connection: RedisClientOptions
+  /** Redis key prefix. Defaults to `"pario:broker"`. */
+  readonly prefix?: string
+  /** Retry-deduplication window for `idempotencyKey`. Defaults to two minutes. */
+  readonly dedupeTtlMs?: number
+  /** Redis `XRANGE COUNT` page size for bounded reads. */
+  readonly readBatchSize?: number
+  /** Redis `XREAD COUNT` page size for subscriptions. */
+  readonly subscribeBatchSize?: number
+  /** Redis `XREAD BLOCK` duration in milliseconds. */
+  readonly subscribeBlockMs?: number
+}
+
+/**
+ * Redis Streams-backed Broker provider.
+ *
+ * Each Pario project and broker stream id maps to a Redis Stream key, with a
+ * metadata hash marking the stream as ensured. Subscriptions use plain XREAD
+ * so every subscriber receives every matching record independently.
+ *
+ * This intentionally does not use consumer groups. Consumer groups are durable
+ * work-sharing primitives; the core Broker contract is retained fan-out.
+ */
+export class RedisBroker implements Broker {
+  private readonly connectionManager: RedisConnectionManager
+  private readonly streamManager: StreamManager
+  private readonly subscriptionRegistry = new SubscriptionRegistry()
+  private readonly dedupeTtlMs: number
+  private readonly readBatchSize: number
+  private readonly subscribeBatchSize: number
+  private readonly subscribeBlockMs: number
+  private closed = false
+
+  constructor(options: RedisBrokerOptions) {
+    const prefix = options.prefix ?? DEFAULT_PREFIX
+    assertPrefix(prefix)
+
+    this.connectionManager = new RedisConnectionManager(options.connection)
+    this.streamManager = new StreamManager({ connectionManager: this.connectionManager, prefix })
+    this.dedupeTtlMs = positiveInteger(options.dedupeTtlMs ?? DEFAULT_DEDUPE_TTL_MS)
+    this.readBatchSize = positiveInteger(options.readBatchSize ?? DEFAULT_READ_BATCH_SIZE)
+    this.subscribeBatchSize = positiveInteger(
+      options.subscribeBatchSize ?? DEFAULT_SUBSCRIBE_BATCH_SIZE
+    )
+    this.subscribeBlockMs = positiveInteger(options.subscribeBlockMs ?? DEFAULT_SUBSCRIBE_BLOCK_MS)
+  }
+
+  async ensureStream(params: { projectId: string; stream: BrokerStreamDefinition }): Promise<void> {
+    this.assertOpen()
+    await this.streamManager.ensureStream(params.projectId, params.stream)
+  }
+
+  async append(params: {
+    projectId: string
+    streamId: string
+    records: readonly BrokerRecordInput[]
+  }): Promise<readonly BrokerRecord[]> {
+    this.assertOpen()
+    validateProjectId(params.projectId)
+    assertStreamId(params.streamId)
+
+    if (params.records.length === 0) {
+      return []
+    }
+
+    for (const input of params.records) {
+      assertEncodableRecord(input)
+    }
+
+    const ensured = await this.streamManager.requireStream(params.projectId, params.streamId)
+    const client = await this.connectionManager.connect()
+    const records: BrokerRecord[] = []
+
+    for (const input of params.records) {
+      // Multi-record append is sequential like NatsBroker. Each individual
+      // record is atomic, but callers should use idempotency keys when retrying
+      // a batch that may have partially committed.
+      const publishedAt = new Date().toISOString()
+      const body = encodeRecord(input, publishedAt)
+      const result = await this.appendOne({
+        client,
+        ensured,
+        input,
+        body,
+      })
+
+      if (result.duplicate) {
+        records.push(await this.fetchRecordByCursor(client, ensured, result.cursor))
+        continue
+      }
+
+      records.push({
+        streamId: params.streamId,
+        cursor: result.cursor,
+        name: input.name,
+        key: input.key,
+        payload: cloneJsonValue(input.payload),
+        publishedAt,
+      })
+    }
+
+    return records
+  }
+
+  async read(params: {
+    projectId: string
+    streamId: string
+    afterCursor?: string
+    limit?: number
+    names?: readonly string[]
+  }): Promise<readonly BrokerRecord[]> {
+    this.assertOpen()
+    validateProjectId(params.projectId)
+    assertStreamId(params.streamId)
+    assertCursor(params.afterCursor)
+
+    if (params.limit !== undefined && params.limit <= 0) {
+      return []
+    }
+
+    const ensured = await this.streamManager.getExistingStream(params.projectId, params.streamId)
+    if (ensured === null) {
+      return []
+    }
+
+    const client = await this.connectionManager.connect()
+    await this.enforceAgeRetention(client, ensured)
+    await this.assertCursorInRetainedRange(client, ensured, params.afterCursor)
+
+    const names = params.names && params.names.length > 0 ? new Set(params.names) : undefined
+    const records: BrokerRecord[] = []
+    // Redis makes range starts exclusive by prefixing the id with "(".
+    let start = params.afterCursor === undefined ? "-" : `(${params.afterCursor}`
+
+    while (params.limit === undefined || records.length < params.limit) {
+      const entries = await this.readRange(client, ensured, start, this.readBatchSize)
+      if (entries.length === 0) {
+        break
+      }
+
+      let lastScannedId: string | undefined
+      for (const entry of entries) {
+        lastScannedId = entry.id
+        const record = decodeRecord({
+          streamId: ensured.streamId,
+          body: bodyFromEntry(entry),
+          cursor: entry.id,
+          fallbackPublishedAt: new Date().toISOString(),
+        })
+
+        // Redis Streams cannot filter by arbitrary entry fields. Keep scanning
+        // until the caller's limit is met after application-level name filtering.
+        if (names && (!record.name || !names.has(record.name))) {
+          continue
+        }
+
+        records.push(record)
+        if (params.limit !== undefined && records.length >= params.limit) {
+          break
+        }
+      }
+
+      if (lastScannedId === undefined || entries.length < this.readBatchSize) {
+        break
+      }
+      start = `(${lastScannedId}`
+    }
+
+    return records
+  }
+
+  async subscribe(
+    params: {
+      projectId: string
+      streamId: string
+      from?: "latest" | "earliest"
+      afterCursor?: string
+      names?: readonly string[]
+    },
+    handler: (records: readonly BrokerRecord[]) => void
+  ): Promise<() => void> {
+    this.assertOpen()
+    validateProjectId(params.projectId)
+    assertStreamId(params.streamId)
+    assertCursor(params.afterCursor)
+
+    const ensured = await this.streamManager.requireStream(params.projectId, params.streamId)
+    const commandClient = await this.connectionManager.connect()
+    await this.enforceAgeRetention(commandClient, ensured)
+    if (params.afterCursor !== undefined) {
+      await this.assertCursorInRetainedRange(commandClient, ensured, params.afterCursor)
+    }
+
+    const client = await this.connectionManager.createSubscriptionClient()
+    const names = params.names && params.names.length > 0 ? new Set(params.names) : undefined
+    // Resolve "latest" to a concrete id once. Reusing "$" after each BLOCK
+    // timeout can skip records written between two XREAD calls.
+    let lastSeenId =
+      params.afterCursor ??
+      (params.from === "earliest" ? "0-0" : await this.latestCursor(client, ensured))
+    let stopped = false
+
+    const pump = (async () => {
+      try {
+        while (!stopped) {
+          const entries = await this.xread(client, ensured, lastSeenId)
+          const records: BrokerRecord[] = []
+
+          for (const entry of entries) {
+            // Advance even for records filtered out by name so the loop never
+            // replays unmatched entries forever.
+            lastSeenId = entry.id
+
+            let record: BrokerRecord
+            try {
+              record = decodeRecord({
+                streamId: ensured.streamId,
+                body: bodyFromEntry(entry),
+                cursor: entry.id,
+                fallbackPublishedAt: new Date().toISOString(),
+              })
+            } catch (error) {
+              console.error("[RedisBroker] Failed to decode subscribed record:", error)
+              continue
+            }
+
+            if (names && (!record.name || !names.has(record.name))) {
+              continue
+            }
+            records.push(record)
+          }
+
+          if (records.length === 0) {
+            continue
+          }
+
+          try {
+            handler(records)
+          } catch {
+            // Handler failures are swallowed per the Broker subscribe contract.
+          }
+        }
+      } catch (error) {
+        if (!stopped) {
+          console.error("[RedisBroker] Subscription pump failed:", error)
+        }
+      } finally {
+        this.connectionManager.destroyClient(client)
+      }
+    })()
+
+    const subscription: ActiveSubscription = {
+      stop: () => {
+        if (stopped) {
+          return
+        }
+        stopped = true
+        this.connectionManager.destroyClient(client)
+      },
+      drain: async () => {
+        await pump
+      },
+    }
+
+    return this.subscriptionRegistry.register(subscription)
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    try {
+      await this.subscriptionRegistry.drain()
+    } finally {
+      await this.connectionManager.close()
+    }
+  }
+
+  private async appendOne(params: {
+    client: RedisBrokerClient
+    ensured: EnsuredStream
+    input: BrokerRecordInput
+    body: string
+  }): Promise<{ readonly cursor: string; readonly duplicate: boolean }> {
+    const hasIdempotencyKey = params.input.idempotencyKey !== undefined
+
+    let reply: unknown
+    try {
+      // One Lua call keeps XADD, dedupe-key writes, trimming, and retained-range
+      // metadata updates in the same Redis atomic operation.
+      reply = await params.client.sendCommand([
+        "EVAL",
+        APPEND_RECORD_SCRIPT,
+        "3",
+        params.ensured.keys.streamKey,
+        params.ensured.keys.metaKey,
+        params.ensured.keys.dedupeKey(params.input.idempotencyKey),
+        params.body,
+        hasIdempotencyKey ? "1" : "0",
+        String(this.dedupeTtlMs),
+      ])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to append record to stream "${params.ensured.streamId}"`, {
+        cause: error,
+      })
+    }
+
+    if (!Array.isArray(reply) || reply.length !== 2) {
+      throw new RedisBrokerError("Redis append script returned a malformed reply")
+    }
+
+    const status = toText(reply[0])
+    const cursor = toText(reply[1])
+    assertCursor(cursor)
+
+    if (status === "stored") {
+      return { cursor, duplicate: false }
+    }
+    if (status === "duplicate") {
+      return { cursor, duplicate: true }
+    }
+
+    throw new RedisBrokerError(`Redis append script returned unknown status "${status}"`)
+  }
+
+  private async fetchRecordByCursor(
+    client: RedisBrokerClient,
+    ensured: EnsuredStream,
+    cursor: string
+  ): Promise<BrokerRecord> {
+    const entries = await this.readRange(client, ensured, cursor, 1, cursor)
+    const entry = entries[0]
+    if (entry === undefined || entry.id !== cursor) {
+      throw new RedisBrokerError(
+        `Redis deduplicated publish at cursor ${cursor}, but the retained record was not found.`
+      )
+    }
+
+    return decodeRecord({
+      streamId: ensured.streamId,
+      body: bodyFromEntry(entry),
+      cursor: entry.id,
+      fallbackPublishedAt: new Date().toISOString(),
+    })
+  }
+
+  private async readRange(
+    client: RedisBrokerClient,
+    ensured: EnsuredStream,
+    start: string,
+    count: number,
+    end = "+"
+  ): Promise<readonly RedisStreamEntry[]> {
+    let reply: unknown
+    try {
+      reply = await client.sendCommand([
+        "XRANGE",
+        ensured.keys.streamKey,
+        start,
+        end,
+        "COUNT",
+        String(count),
+      ])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to read stream "${ensured.streamId}"`, { cause: error })
+    }
+    return parseStreamEntries(reply)
+  }
+
+  private async xread(
+    client: RedisBrokerClient,
+    ensured: EnsuredStream,
+    lastSeenId: string
+  ): Promise<readonly RedisStreamEntry[]> {
+    let reply: unknown
+    try {
+      reply = await client.sendCommand([
+        "XREAD",
+        "COUNT",
+        String(this.subscribeBatchSize),
+        "BLOCK",
+        String(this.subscribeBlockMs),
+        "STREAMS",
+        ensured.keys.streamKey,
+        lastSeenId,
+      ])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to subscribe to stream "${ensured.streamId}"`, {
+        cause: error,
+      })
+    }
+    return parseXReadEntries(reply)
+  }
+
+  private async enforceAgeRetention(
+    client: RedisBrokerClient,
+    ensured: EnsuredStream
+  ): Promise<void> {
+    try {
+      // Age retention is a Pario-level policy. Redis Streams only trim when a
+      // command asks them to, so reads/replays must also trim idle streams.
+      await client.sendCommand([
+        "EVAL",
+        ENFORCE_AGE_RETENTION_SCRIPT,
+        "2",
+        ensured.keys.streamKey,
+        ensured.keys.metaKey,
+      ])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to enforce retention for stream "${ensured.streamId}"`, {
+        cause: error,
+      })
+    }
+  }
+
+  private async latestCursor(client: RedisBrokerClient, ensured: EnsuredStream): Promise<string> {
+    const entries = await this.readReverseRange(client, ensured, "+", "-", 1)
+    const latest = entries[0]
+    if (latest !== undefined) {
+      return latest.id
+    }
+
+    const metadata = await this.streamManager.readMetadata(client, ensured, ["lastId"])
+    return metadata.get("lastId") ?? "0-0"
+  }
+
+  private async readReverseRange(
+    client: RedisBrokerClient,
+    ensured: EnsuredStream,
+    start: string,
+    end: string,
+    count: number
+  ): Promise<readonly RedisStreamEntry[]> {
+    let reply: unknown
+    try {
+      reply = await client.sendCommand([
+        "XREVRANGE",
+        ensured.keys.streamKey,
+        start,
+        end,
+        "COUNT",
+        String(count),
+      ])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to read stream "${ensured.streamId}"`, { cause: error })
+    }
+    return parseStreamEntries(reply)
+  }
+
+  private async assertCursorInRetainedRange(
+    client: RedisBrokerClient,
+    ensured: EnsuredStream,
+    afterCursor: string | undefined
+  ): Promise<void> {
+    if (afterCursor === undefined) {
+      return
+    }
+
+    const metadata = await this.streamManager.readMetadata(client, ensured, ["lastTrimmedId"])
+    const lastTrimmedId = metadata.get("lastTrimmedId")
+
+    // Do not compare against the first retained entry: Redis ids are not dense,
+    // so the cursor immediately before the first retained entry is still valid.
+    // The append script records the latest id actually trimmed; only cursors
+    // older than that represent unavailable history.
+    if (lastTrimmedId !== undefined && compareStreamIds(afterCursor, lastTrimmedId) < 0) {
+      throw new RedisBrokerError(
+        `afterCursor '${afterCursor}' is outside the retained range for stream ` +
+          `'${ensured.streamId}'. The latest trimmed cursor is '${lastTrimmedId}'.`
+      )
+    }
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new RedisBrokerError("broker has been closed")
+    }
+  }
+}
+
+function positiveInteger(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RedisBrokerError("broker numeric options must be positive finite numbers")
+  }
+  return Math.floor(value)
+}

--- a/broker/redis/src/retention.ts
+++ b/broker/redis/src/retention.ts
@@ -1,0 +1,20 @@
+import type { BrokerRetention, BrokerStreamDefinition } from "@pario/core"
+import { RedisBrokerError } from "./errors"
+
+export interface NormalizedRetention {
+  readonly maxAgeMs?: number
+  readonly maxRecords?: number
+}
+
+export function assertStream(stream: BrokerStreamDefinition): void {
+  if (stream.id.trim().length === 0) {
+    throw new RedisBrokerError("stream.id must be a non-empty string")
+  }
+}
+
+export function normalizeRetention(retention: BrokerRetention | undefined): NormalizedRetention {
+  return {
+    maxAgeMs: retention?.maxAgeMs === undefined ? undefined : Math.max(0, retention.maxAgeMs),
+    maxRecords: retention?.maxRecords === undefined ? undefined : Math.max(0, retention.maxRecords),
+  }
+}

--- a/broker/redis/src/scripts.ts
+++ b/broker/redis/src/scripts.ts
@@ -1,0 +1,161 @@
+// Creates the metadata hash that represents an ensured broker stream.
+// Redis Stream keys are born on first XADD, so metadata lets us distinguish an
+// empty ensured stream from one that has never been provisioned.
+export const ENSURE_STREAM_SCRIPT = `
+local meta_key = KEYS[1]
+
+if redis.call("EXISTS", meta_key) == 1 then
+  return 0
+end
+
+redis.call(
+  "HSET",
+  meta_key,
+  "projectId", ARGV[1],
+  "streamId", ARGV[2],
+  "createdAt", ARGV[3]
+)
+
+if ARGV[4] ~= "" then
+  redis.call("HSET", meta_key, "maxAgeMs", ARGV[4])
+end
+
+if ARGV[5] ~= "" then
+  redis.call("HSET", meta_key, "maxRecords", ARGV[5])
+end
+
+return 1
+`
+
+// Enforces age-based retention without appending. Redis Streams do not have a
+// background TTL policy for entries, so idle streams need this before retained
+// reads/replays to avoid returning expired records.
+export const ENFORCE_AGE_RETENTION_SCRIPT = `
+local stream_key = KEYS[1]
+local meta_key = KEYS[2]
+
+if redis.call("EXISTS", meta_key) == 0 then
+  return redis.error_reply("broker stream has not been ensured")
+end
+
+local max_age_ms = redis.call("HGET", meta_key, "maxAgeMs")
+
+if not max_age_ms then
+  return nil
+end
+
+local max_age_number = tonumber(max_age_ms)
+local last_trimmed_id = nil
+
+if max_age_number <= 0 then
+  local removed = redis.call("XREVRANGE", stream_key, "+", "-", "COUNT", 1)
+  if #removed > 0 then
+    last_trimmed_id = removed[1][1]
+  end
+  redis.call("XTRIM", stream_key, "MAXLEN", "=", "0")
+else
+  local now = redis.call("TIME")
+  local now_ms = (tonumber(now[1]) * 1000) + math.floor(tonumber(now[2]) / 1000)
+  local min_ms = now_ms - max_age_number
+  if min_ms < 0 then
+    min_ms = 0
+  end
+  local min_id = tostring(min_ms) .. "-0"
+  local removed = redis.call("XREVRANGE", stream_key, "(" .. min_id, "-", "COUNT", 1)
+  if #removed > 0 then
+    last_trimmed_id = removed[1][1]
+  end
+  redis.call("XTRIM", stream_key, "MINID", "=", min_id)
+end
+
+if last_trimmed_id then
+  redis.call("HSET", meta_key, "lastTrimmedId", last_trimmed_id)
+end
+
+return last_trimmed_id
+`
+
+// Appends exactly one broker record. Keep this operation in Lua so the returned
+// cursor, dedupe key, retention trim, and retained-range metadata cannot drift
+// apart if another process writes to the same Redis stream concurrently.
+export const APPEND_RECORD_SCRIPT = `
+local stream_key = KEYS[1]
+local meta_key = KEYS[2]
+local dedupe_key = KEYS[3]
+local body = ARGV[1]
+local has_idempotency_key = ARGV[2]
+local dedupe_ttl_ms = ARGV[3]
+
+if redis.call("EXISTS", meta_key) == 0 then
+  return redis.error_reply("broker stream has not been ensured")
+end
+
+if has_idempotency_key == "1" then
+  local existing_id = redis.call("GET", dedupe_key)
+  if existing_id then
+    return { "duplicate", existing_id }
+  end
+end
+
+local id = redis.call("XADD", stream_key, "*", "body", body)
+redis.call("HSET", meta_key, "lastId", id)
+
+local last_trimmed_id = nil
+local max_records = redis.call("HGET", meta_key, "maxRecords")
+
+if max_records then
+  -- Exact trimming is deliberate: the broker contract needs deterministic
+  -- retained-range behavior so callers know when recovery is required.
+  local max_records_number = tonumber(max_records)
+  local length = redis.call("XLEN", stream_key)
+  local remove_count = length - max_records_number
+
+  if remove_count > 0 then
+    local removed = redis.call("XRANGE", stream_key, "-", "+", "COUNT", remove_count)
+    if #removed > 0 then
+      last_trimmed_id = removed[#removed][1]
+    end
+    redis.call("XTRIM", stream_key, "MAXLEN", "=", max_records)
+  end
+end
+
+local max_age_ms = redis.call("HGET", meta_key, "maxAgeMs")
+
+if max_age_ms then
+  local max_age_number = tonumber(max_age_ms)
+
+  if max_age_number <= 0 then
+    local removed = redis.call("XREVRANGE", stream_key, "+", "-", "COUNT", 1)
+    if #removed > 0 then
+      last_trimmed_id = removed[1][1]
+    end
+    redis.call("XTRIM", stream_key, "MAXLEN", "=", "0")
+  else
+    local now = redis.call("TIME")
+    local now_ms = (tonumber(now[1]) * 1000) + math.floor(tonumber(now[2]) / 1000)
+    local min_ms = now_ms - max_age_number
+    if min_ms < 0 then
+      min_ms = 0
+    end
+    local min_id = tostring(min_ms) .. "-0"
+    -- Capture the newest entry that will be removed by MINID before trimming.
+    -- Later reads compare cursors to this boundary instead of guessing from the
+    -- first retained id, which is unsafe because Redis ids are not dense.
+    local removed = redis.call("XREVRANGE", stream_key, "(" .. min_id, "-", "COUNT", 1)
+    if #removed > 0 then
+      last_trimmed_id = removed[1][1]
+    end
+    redis.call("XTRIM", stream_key, "MINID", "=", min_id)
+  end
+end
+
+if last_trimmed_id then
+  redis.call("HSET", meta_key, "lastTrimmedId", last_trimmed_id)
+end
+
+if has_idempotency_key == "1" then
+  redis.call("SET", dedupe_key, id, "PX", dedupe_ttl_ms)
+end
+
+return { "stored", id }
+`

--- a/broker/redis/src/serialization.ts
+++ b/broker/redis/src/serialization.ts
@@ -1,0 +1,66 @@
+import type { BrokerRecord, BrokerRecordInput } from "@pario/core"
+import { getInvalidJsonValueReason, type JsonValue } from "@pario/core"
+import { RedisBrokerError } from "./errors"
+
+interface WireBrokerRecord {
+  readonly name?: string
+  readonly key?: string
+  readonly payload?: unknown
+  readonly publishedAt: string
+}
+
+export function encodeRecord(input: BrokerRecordInput, publishedAt: string): string {
+  assertBrokerPayload(input.payload)
+
+  return JSON.stringify({
+    name: input.name,
+    key: input.key,
+    payload: input.payload,
+    publishedAt,
+  } satisfies WireBrokerRecord)
+}
+
+export function assertEncodableRecord(input: BrokerRecordInput): void {
+  assertBrokerPayload(input.payload)
+}
+
+export function decodeRecord(params: {
+  readonly streamId: string
+  readonly body: string
+  readonly cursor: string
+  readonly fallbackPublishedAt: string
+}): BrokerRecord {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(params.body)
+  } catch (error) {
+    throw new RedisBrokerError("Failed to decode broker record body as JSON", { cause: error })
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new RedisBrokerError("Decoded broker record body is not an object")
+  }
+
+  const record = parsed as Partial<WireBrokerRecord>
+  if (!("payload" in record)) {
+    throw new RedisBrokerError("Decoded broker record body is missing payload")
+  }
+  assertBrokerPayload(record.payload)
+
+  return {
+    streamId: params.streamId,
+    cursor: params.cursor,
+    name: typeof record.name === "string" ? record.name : undefined,
+    key: typeof record.key === "string" ? record.key : undefined,
+    payload: record.payload,
+    publishedAt:
+      typeof record.publishedAt === "string" ? record.publishedAt : params.fallbackPublishedAt,
+  }
+}
+
+function assertBrokerPayload(payload: unknown): asserts payload is JsonValue {
+  const reason = getInvalidJsonValueReason(payload, "record.payload")
+  if (reason) {
+    throw new RedisBrokerError(`record.payload must be a JSON value; ${reason}`)
+  }
+}

--- a/broker/redis/src/stream-manager.ts
+++ b/broker/redis/src/stream-manager.ts
@@ -1,0 +1,133 @@
+import type { BrokerStreamDefinition } from "@pario/core"
+import type { RedisBrokerClient, RedisConnectionManager } from "./connection"
+import { RedisBrokerError } from "./errors"
+import { assertStreamId, type RedisStreamKeys, streamKeysFor, validateProjectId } from "./keys"
+import { assertStream, normalizeRetention } from "./retention"
+import { ENSURE_STREAM_SCRIPT } from "./scripts"
+import { toText } from "./stream-replies"
+
+export interface EnsuredStream {
+  readonly projectId: string
+  readonly streamId: string
+  readonly keys: RedisStreamKeys
+}
+
+/**
+ * Owns Redis stream metadata provisioning and local stream-existence cache.
+ *
+ * Redis creates Stream keys on first XADD, so `ensureStream()` cannot create an
+ * empty stream without adding a fake record. The metadata hash is therefore the
+ * source of truth for "this broker stream has been ensured".
+ */
+export class StreamManager {
+  private readonly connectionManager: RedisConnectionManager
+  private readonly prefix: string
+  private readonly knownStreams = new Map<string, EnsuredStream>()
+
+  constructor(options: { connectionManager: RedisConnectionManager; prefix: string }) {
+    this.connectionManager = options.connectionManager
+    this.prefix = options.prefix
+  }
+
+  async ensureStream(projectId: string, stream: BrokerStreamDefinition): Promise<EnsuredStream> {
+    validateProjectId(projectId)
+    assertStream(stream)
+
+    const keys = streamKeysFor(this.prefix, projectId, stream.id)
+    const cached = this.knownStreams.get(keys.metaKey)
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const retention = normalizeRetention(stream.retention)
+    const client = await this.connectionManager.connect()
+
+    try {
+      // The script creates metadata only when absent. That mirrors NATS'
+      // "bind to existing stream config" behavior and avoids changing
+      // production retention if a later runtime starts with different options.
+      await client.sendCommand([
+        "EVAL",
+        ENSURE_STREAM_SCRIPT,
+        "1",
+        keys.metaKey,
+        projectId,
+        stream.id,
+        new Date().toISOString(),
+        retention.maxAgeMs === undefined ? "" : String(retention.maxAgeMs),
+        retention.maxRecords === undefined ? "" : String(retention.maxRecords),
+      ])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to ensure stream "${stream.id}"`, { cause: error })
+    }
+
+    const ensured = { projectId, streamId: stream.id, keys }
+    this.knownStreams.set(keys.metaKey, ensured)
+    return ensured
+  }
+
+  async getExistingStream(projectId: string, streamId: string): Promise<EnsuredStream | null> {
+    validateProjectId(projectId)
+    assertStreamId(streamId)
+
+    const keys = streamKeysFor(this.prefix, projectId, streamId)
+    const cached = this.knownStreams.get(keys.metaKey)
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const client = await this.connectionManager.connect()
+    let exists: unknown
+    try {
+      exists = await client.sendCommand(["EXISTS", keys.metaKey])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to inspect stream "${streamId}"`, { cause: error })
+    }
+
+    if (Number(exists) !== 1) {
+      return null
+    }
+
+    const ensured = { projectId, streamId, keys }
+    this.knownStreams.set(keys.metaKey, ensured)
+    return ensured
+  }
+
+  async requireStream(projectId: string, streamId: string): Promise<EnsuredStream> {
+    const ensured = await this.getExistingStream(projectId, streamId)
+    if (ensured === null) {
+      throw new RedisBrokerError(
+        `stream '${streamId}' has not been ensured for project '${projectId}'. Call ensureStream() before append or subscribe.`
+      )
+    }
+    return ensured
+  }
+
+  async readMetadata(
+    client: RedisBrokerClient,
+    ensured: EnsuredStream,
+    fields: readonly string[]
+  ): Promise<ReadonlyMap<string, string>> {
+    let reply: unknown
+    try {
+      reply = await client.sendCommand(["HMGET", ensured.keys.metaKey, ...fields])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to read stream "${ensured.streamId}" metadata`, {
+        cause: error,
+      })
+    }
+
+    if (!Array.isArray(reply)) {
+      throw new RedisBrokerError("Redis HMGET reply was not an array")
+    }
+
+    const values = new Map<string, string>()
+    for (let index = 0; index < fields.length; index += 1) {
+      const value = reply[index]
+      if (value !== null && value !== undefined) {
+        values.set(fields[index]!, toText(value))
+      }
+    }
+    return values
+  }
+}

--- a/broker/redis/src/stream-manager.ts
+++ b/broker/redis/src/stream-manager.ts
@@ -4,7 +4,6 @@ import { RedisBrokerError } from "./errors"
 import { assertStreamId, type RedisStreamKeys, streamKeysFor, validateProjectId } from "./keys"
 import { assertStream, normalizeRetention } from "./retention"
 import { ENSURE_STREAM_SCRIPT } from "./scripts"
-import { toText } from "./stream-replies"
 
 export interface EnsuredStream {
   readonly projectId: string
@@ -46,8 +45,7 @@ export class StreamManager {
       // The script creates metadata only when absent. That mirrors NATS'
       // "bind to existing stream config" behavior and avoids changing
       // production retention if a later runtime starts with different options.
-      await client.sendCommand([
-        "EVAL",
+      await client.send("EVAL", [
         ENSURE_STREAM_SCRIPT,
         "1",
         keys.metaKey,
@@ -77,14 +75,14 @@ export class StreamManager {
     }
 
     const client = await this.connectionManager.connect()
-    let exists: unknown
+    let exists: boolean
     try {
-      exists = await client.sendCommand(["EXISTS", keys.metaKey])
+      exists = await client.exists(keys.metaKey)
     } catch (error) {
       throw new RedisBrokerError(`Failed to inspect stream "${streamId}"`, { cause: error })
     }
 
-    if (Number(exists) !== 1) {
+    if (!exists) {
       return null
     }
 
@@ -108,24 +106,20 @@ export class StreamManager {
     ensured: EnsuredStream,
     fields: readonly string[]
   ): Promise<ReadonlyMap<string, string>> {
-    let reply: unknown
+    let reply: Array<string | null>
     try {
-      reply = await client.sendCommand(["HMGET", ensured.keys.metaKey, ...fields])
+      reply = await client.hmget(ensured.keys.metaKey, [...fields])
     } catch (error) {
       throw new RedisBrokerError(`Failed to read stream "${ensured.streamId}" metadata`, {
         cause: error,
       })
     }
 
-    if (!Array.isArray(reply)) {
-      throw new RedisBrokerError("Redis HMGET reply was not an array")
-    }
-
     const values = new Map<string, string>()
     for (let index = 0; index < fields.length; index += 1) {
       const value = reply[index]
-      if (value !== null && value !== undefined) {
-        values.set(fields[index]!, toText(value))
+      if (value !== null) {
+        values.set(fields[index]!, value)
       }
     }
     return values

--- a/broker/redis/src/stream-replies.ts
+++ b/broker/redis/src/stream-replies.ts
@@ -1,0 +1,71 @@
+import { RedisBrokerError } from "./errors"
+
+export interface RedisStreamEntry {
+  readonly id: string
+  readonly fields: ReadonlyMap<string, string>
+}
+
+export function parseStreamEntries(reply: unknown): readonly RedisStreamEntry[] {
+  if (!Array.isArray(reply)) {
+    throw new RedisBrokerError("Redis stream range reply was not an array")
+  }
+
+  return reply.map(parseStreamEntry)
+}
+
+export function parseXReadEntries(reply: unknown): readonly RedisStreamEntry[] {
+  if (reply === null) {
+    return []
+  }
+  if (!Array.isArray(reply)) {
+    throw new RedisBrokerError("Redis XREAD reply was not an array")
+  }
+
+  const entries: RedisStreamEntry[] = []
+  for (const stream of reply) {
+    if (!Array.isArray(stream) || stream.length !== 2 || !Array.isArray(stream[1])) {
+      throw new RedisBrokerError("Redis XREAD stream reply was malformed")
+    }
+    for (const entry of stream[1]) {
+      entries.push(parseStreamEntry(entry))
+    }
+  }
+  return entries
+}
+
+export function bodyFromEntry(entry: RedisStreamEntry): string {
+  const body = entry.fields.get("body")
+  if (body === undefined) {
+    throw new RedisBrokerError("Redis stream entry is missing body field")
+  }
+  return body
+}
+
+function parseStreamEntry(entry: unknown): RedisStreamEntry {
+  if (!Array.isArray(entry) || entry.length !== 2 || !Array.isArray(entry[1])) {
+    throw new RedisBrokerError("Redis stream entry reply was malformed")
+  }
+
+  const id = toText(entry[0])
+  const rawFields = entry[1]
+  if (rawFields.length % 2 !== 0) {
+    throw new RedisBrokerError("Redis stream entry field list had odd length")
+  }
+
+  const fields = new Map<string, string>()
+  for (let index = 0; index < rawFields.length; index += 2) {
+    fields.set(toText(rawFields[index]), toText(rawFields[index + 1]))
+  }
+
+  return { id, fields }
+}
+
+export function toText(value: unknown): string {
+  if (typeof value === "string") {
+    return value
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value).toString("utf8")
+  }
+  throw new RedisBrokerError("Redis reply value was not a string")
+}

--- a/broker/redis/src/stream-replies.ts
+++ b/broker/redis/src/stream-replies.ts
@@ -17,20 +17,33 @@ export function parseXReadEntries(reply: unknown): readonly RedisStreamEntry[] {
   if (reply === null) {
     return []
   }
-  if (!Array.isArray(reply)) {
-    throw new RedisBrokerError("Redis XREAD reply was not an array")
-  }
 
   const entries: RedisStreamEntry[] = []
-  for (const stream of reply) {
-    if (!Array.isArray(stream) || stream.length !== 2 || !Array.isArray(stream[1])) {
-      throw new RedisBrokerError("Redis XREAD stream reply was malformed")
+  if (Array.isArray(reply)) {
+    for (const stream of reply) {
+      if (!Array.isArray(stream) || stream.length !== 2 || !Array.isArray(stream[1])) {
+        throw new RedisBrokerError("Redis XREAD stream reply was malformed")
+      }
+      for (const entry of stream[1]) {
+        entries.push(parseStreamEntry(entry))
+      }
     }
-    for (const entry of stream[1]) {
-      entries.push(parseStreamEntry(entry))
-    }
+    return entries
   }
-  return entries
+
+  if (typeof reply === "object") {
+    for (const streamEntries of Object.values(reply)) {
+      if (!Array.isArray(streamEntries)) {
+        throw new RedisBrokerError("Redis XREAD stream reply was malformed")
+      }
+      for (const entry of streamEntries) {
+        entries.push(parseStreamEntry(entry))
+      }
+    }
+    return entries
+  }
+
+  throw new RedisBrokerError("Redis XREAD reply was not an array or object")
 }
 
 export function bodyFromEntry(entry: RedisStreamEntry): string {

--- a/broker/redis/src/subscription-registry.ts
+++ b/broker/redis/src/subscription-registry.ts
@@ -1,0 +1,47 @@
+/**
+ * A registered subscription with handles the registry can use to stop and
+ * finalize it. Redis-specific client lifecycle lives in the caller.
+ */
+export interface ActiveSubscription {
+  /** Stop delivery quickly. Must be safe to call more than once. */
+  stop(): void
+  /** Await cleanup. May throw; callers decide how to surface the error. */
+  drain(): Promise<void>
+}
+
+/** Tracks active subscriptions so `RedisBroker.close()` can drain them. */
+export class SubscriptionRegistry {
+  private readonly active = new Set<ActiveSubscription>()
+
+  register(subscription: ActiveSubscription): () => void {
+    this.active.add(subscription)
+    return () => {
+      if (!this.active.delete(subscription)) {
+        return
+      }
+      subscription.stop()
+      subscription.drain().catch((error: unknown) => {
+        console.error("[RedisBroker] Failed to drain subscription during unsubscribe:", error)
+      })
+    }
+  }
+
+  async drain(): Promise<void> {
+    const subscriptions = [...this.active]
+    this.active.clear()
+    for (const subscription of subscriptions) {
+      subscription.stop()
+    }
+    const results = await Promise.allSettled(
+      subscriptions.map((subscription) => subscription.drain())
+    )
+    const firstRejection = results.find((r): r is PromiseRejectedResult => r.status === "rejected")
+    if (firstRejection !== undefined) {
+      throw firstRejection.reason
+    }
+  }
+
+  size(): number {
+    return this.active.size
+  }
+}

--- a/broker/redis/tests/helpers.ts
+++ b/broker/redis/tests/helpers.ts
@@ -1,0 +1,36 @@
+import { randomUUID } from "node:crypto"
+import { RedisBroker } from "../src"
+
+export function requireRedisUrl(): string {
+  const url = process.env["PARIO_REDIS_BROKER_URL"]
+  if (!url) {
+    throw new Error(
+      "[RedisBroker test] PARIO_REDIS_BROKER_URL is required. Run `bun run test:e2e` from the @pario/broker-redis package."
+    )
+  }
+  return url
+}
+
+/**
+ * Build a RedisBroker wired against the test Redis server. Each broker gets a
+ * unique prefix and project id so shared contract tests can use stable stream
+ * names without colliding with parallel runs.
+ */
+export function createTestBroker(): {
+  broker: RedisBroker
+  projectId: string
+  cleanup: () => Promise<void>
+} {
+  const suffix = randomUUID().slice(0, 8)
+  const broker = new RedisBroker({
+    connection: { url: requireRedisUrl() },
+    prefix: `pario:test:broker:${suffix}`,
+    subscribeBlockMs: 100,
+  })
+
+  const cleanup = async (): Promise<void> => {
+    await broker.close()
+  }
+
+  return { broker, projectId: `project-${suffix}`, cleanup }
+}

--- a/broker/redis/tests/redis-broker.e2e.ts
+++ b/broker/redis/tests/redis-broker.e2e.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test"
+import { runBrokerContractSuite } from "@pario/core/testing"
+import { createTestBroker } from "./helpers"
+
+runBrokerContractSuite("RedisBroker", {
+  createBroker: async () => createTestBroker().broker,
+  teardown: async (broker) => {
+    await broker.close()
+  },
+  maxAgeMs: 1_000,
+  maxAgeWaitMs: 1_500,
+  subscriptionSetupMs: 150,
+  subscriptionDeliveryTimeoutMs: 5_000,
+  subscriptionPollIntervalMs: 25,
+})
+
+describe("RedisBroker", () => {
+  test("deduplicates records by idempotencyKey within the configured retry window", async () => {
+    const { broker, projectId, cleanup } = createTestBroker()
+    const stream = { id: "__events" }
+    try {
+      await broker.ensureStream({ projectId, stream })
+      const [first] = await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [
+          {
+            name: "object.upserted",
+            payload: { id: "room-1" },
+            idempotencyKey: "dedupe-room-1",
+          },
+        ],
+      })
+      const [second] = await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [
+          {
+            name: "object.upserted",
+            payload: { id: "room-2" },
+            idempotencyKey: "dedupe-room-1",
+          },
+        ],
+      })
+
+      expect(first).toBeDefined()
+      expect(second?.cursor).toBe(first?.cursor)
+      expect(second?.payload).toEqual({ id: "room-1" })
+      expect(await broker.read({ projectId, streamId: stream.id })).toEqual([first])
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test("close drains active subscriptions and rejects later operations", async () => {
+    const { broker, projectId } = createTestBroker()
+    const stream = { id: "__events" }
+    const received: unknown[] = []
+
+    await broker.ensureStream({ projectId, stream })
+    await broker.subscribe({ projectId, streamId: stream.id }, (records) => {
+      received.push(...records.map((record) => record.payload))
+    })
+    await Bun.sleep(150)
+
+    await broker.append({
+      projectId,
+      streamId: stream.id,
+      records: [{ name: "object.upserted", payload: { id: "room-before-close" } }],
+    })
+    await waitUntil(() => received.length === 1, 5_000)
+
+    await broker.close()
+    await expect(broker.close()).resolves.toBeUndefined()
+    await expect(
+      broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [{ name: "object.upserted", payload: { id: "room-after-close" } }],
+      })
+    ).rejects.toThrow("broker has been closed")
+
+    expect(received).toEqual([{ id: "room-before-close" }])
+  })
+
+  test("allows reads after the latest trimmed cursor boundary", async () => {
+    const { broker, projectId, cleanup } = createTestBroker()
+    const stream = { id: "__retained", retention: { maxRecords: 2 } }
+    try {
+      await broker.ensureStream({ projectId, stream })
+      const [first] = await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [{ payload: "one" }],
+      })
+      await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [{ payload: "two" }, { payload: "three" }],
+      })
+
+      const records = await broker.read({
+        projectId,
+        streamId: stream.id,
+        afterCursor: first?.cursor,
+      })
+
+      expect(records.map((record) => record.payload)).toEqual(["two", "three"])
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test("enforces maxAgeMs retention on idle retained reads", async () => {
+    const { broker, projectId, cleanup } = createTestBroker()
+    const stream = { id: "__age_retained_idle", retention: { maxAgeMs: 100 } }
+    try {
+      await broker.ensureStream({ projectId, stream })
+      const [old] = await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [{ payload: "old" }],
+      })
+
+      await Bun.sleep(250)
+
+      await expect(
+        broker.read({
+          projectId,
+          streamId: stream.id,
+          afterCursor: "0-0",
+        })
+      ).rejects.toThrow("outside the retained range")
+      expect(
+        await broker.read({
+          projectId,
+          streamId: stream.id,
+          afterCursor: old?.cursor,
+        })
+      ).toEqual([])
+      expect(await broker.read({ projectId, streamId: stream.id })).toEqual([])
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test("enforces maxAgeMs retention before retained subscription replay", async () => {
+    const { broker, projectId, cleanup } = createTestBroker()
+    const stream = { id: "__age_retained_replay", retention: { maxAgeMs: 100 } }
+    const received: unknown[] = []
+
+    try {
+      await broker.ensureStream({ projectId, stream })
+      await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [{ payload: "old" }],
+      })
+
+      await Bun.sleep(250)
+
+      await expect(
+        broker.subscribe({ projectId, streamId: stream.id, afterCursor: "0-0" }, () => undefined)
+      ).rejects.toThrow("outside the retained range")
+
+      const unsubscribe = await broker.subscribe(
+        { projectId, streamId: stream.id, from: "earliest" },
+        (records) => {
+          received.push(...records.map((record) => record.payload))
+        }
+      )
+      await Bun.sleep(250)
+      unsubscribe()
+
+      expect(received).toEqual([])
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return
+    }
+    await Bun.sleep(25)
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms`)
+}

--- a/broker/redis/tests/redis-broker.e2e.ts
+++ b/broker/redis/tests/redis-broker.e2e.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
 import { runBrokerContractSuite } from "@pario/core/testing"
-import { createTestBroker } from "./helpers"
+import { RedisBroker } from "../src"
+import { createTestBroker, requireRedisUrl } from "./helpers"
 
 runBrokerContractSuite("RedisBroker", {
   createBroker: async () => createTestBroker().broker,
@@ -15,6 +17,37 @@ runBrokerContractSuite("RedisBroker", {
 })
 
 describe("RedisBroker", () => {
+  test("uses Redis environment defaults when connection is omitted", async () => {
+    const previousRedisUrl = process.env["REDIS_URL"]
+    process.env["REDIS_URL"] = requireRedisUrl()
+
+    const suffix = randomUUID().slice(0, 8)
+    const broker = new RedisBroker({
+      prefix: `pario:test:broker:${suffix}`,
+      subscribeBlockMs: 100,
+    })
+    const projectId = `project-${suffix}`
+    const stream = { id: "__events" }
+
+    try {
+      await broker.ensureStream({ projectId, stream })
+      const [record] = await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [{ name: "object.upserted", payload: { id: "room-1" } }],
+      })
+
+      expect(await broker.read({ projectId, streamId: stream.id })).toEqual([record])
+    } finally {
+      await broker.close()
+      if (previousRedisUrl === undefined) {
+        delete process.env["REDIS_URL"]
+      } else {
+        process.env["REDIS_URL"] = previousRedisUrl
+      }
+    }
+  })
+
   test("deduplicates records by idempotencyKey within the configured retry window", async () => {
     const { broker, projectId, cleanup } = createTestBroker()
     const stream = { id: "__events" }

--- a/broker/redis/tests/redis-broker.e2e.ts
+++ b/broker/redis/tests/redis-broker.e2e.ts
@@ -17,6 +17,16 @@ runBrokerContractSuite("RedisBroker", {
 })
 
 describe("RedisBroker", () => {
+  test("rejects fractional numeric options", () => {
+    expect(
+      () =>
+        new RedisBroker({
+          connection: { url: requireRedisUrl() },
+          subscribeBlockMs: 0.5,
+        })
+    ).toThrow("positive finite integers")
+  })
+
   test("uses Redis environment defaults when connection is omitted", async () => {
     const previousRedisUrl = process.env["REDIS_URL"]
     process.env["REDIS_URL"] = requireRedisUrl()

--- a/broker/redis/tests/setup.ts
+++ b/broker/redis/tests/setup.ts
@@ -1,0 +1,15 @@
+import { afterAll, beforeAll } from "bun:test"
+
+const composeFile = `${import.meta.dir}/../docker-compose.yml`
+
+// 60s budget for docker compose up + healthcheck. `bun run --workspaces test:e2e`
+// runs workspaces in parallel, so on 2-vCPU CI runners several Docker images are
+// pulled/started concurrently — keep the margin generous to avoid flakes.
+beforeAll(async () => {
+  await Bun.$`docker compose -f ${composeFile} up -d --wait`.quiet()
+  process.env.PARIO_REDIS_BROKER_URL = "redis://127.0.0.1:46380"
+}, 60_000)
+
+afterAll(async () => {
+  await Bun.$`docker compose -f ${composeFile} down -v --remove-orphans`.quiet()
+}, 15_000)

--- a/broker/redis/tsconfig.json
+++ b/broker/redis/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,18 @@
         "typescript": "^5.7.0",
       },
     },
+    "broker/redis": {
+      "name": "@pario/broker-redis",
+      "version": "0.1.0",
+      "dependencies": {
+        "@pario/core": "workspace:*",
+        "redis": "^5.12.1",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "connectors/rest": {
       "name": "@pario/connector-rest",
       "version": "0.1.0",
@@ -613,6 +625,8 @@
 
     "@pario/broker-nats": ["@pario/broker-nats@workspace:broker/nats"],
 
+    "@pario/broker-redis": ["@pario/broker-redis@workspace:broker/redis"],
+
     "@pario/cli": ["@pario/cli@workspace:packages/cli"],
 
     "@pario/client": ["@pario/client@workspace:packages/client"],
@@ -776,6 +790,16 @@
     "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
+
+    "@redis/bloom": ["@redis/bloom@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA=="],
+
+    "@redis/client": ["@redis/client@5.12.1", "", { "dependencies": { "cluster-key-slot": "1.1.2" }, "peerDependencies": { "@node-rs/xxhash": "^1.1.0", "@opentelemetry/api": ">=1 <2" }, "optionalPeers": ["@node-rs/xxhash", "@opentelemetry/api"] }, "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA=="],
+
+    "@redis/json": ["@redis/json@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg=="],
+
+    "@redis/search": ["@redis/search@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w=="],
+
+    "@redis/time-series": ["@redis/time-series@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
@@ -1180,6 +1204,8 @@
     "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
 
     "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
+
+    "redis": ["redis@5.12.1", "", { "dependencies": { "@redis/bloom": "5.12.1", "@redis/client": "5.12.1", "@redis/json": "5.12.1", "@redis/search": "5.12.1", "@redis/time-series": "5.12.1" } }, "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g=="],
 
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@pario/core": "workspace:*",
-        "redis": "^5.12.1",
       },
       "devDependencies": {
         "@types/bun": "latest",


### PR DESCRIPTION
closes #7 

## Summary

Adds `@pario/broker-redis`, a Redis Streams-backed implementation of the core `Broker` contract.

This gives Pario a durable broker option for Redis deployments, parallel to the existing NATS JetStream broker, while preserving the current broker semantics:

- retained stream reads
- opaque cursors
- live fan-out subscriptions
- name filtering
- idempotent append retries
- max-record and max-age retention
- deterministic `close()` for workers and tests

## Why

The in-memory broker is useful for development, and NATS JetStream is a durable option for NATS deployments. Redis is already a common infrastructure dependency for queues, so this adds a Redis-native durable stream provider without changing the core `Broker` API.

Redis Streams do not have JetStream-style server-owned retention policies. Retention is enforced by explicit trim commands, so this provider owns that behavior inside the broker implementation.

## Design

Each Pario broker stream maps to one Redis Stream plus one metadata hash:

```text
{prefix}:brk:{base64url(projectId):base64url(streamId)}:stream
{prefix}:brk:{base64url(projectId):base64url(streamId)}:meta
{prefix}:brk:{base64url(projectId):base64url(streamId)}:dedupe:{base64url(idempotencyKey)}
```

The `{...}` segment is a Redis Cluster hash tag. It keeps stream, metadata, and dedupe keys in the same cluster slot so Lua scripts can update them atomically.

Append is atomic per record:

```text
append one record
  check metadata exists
  check idempotency key
  XADD body
  apply exact XTRIM retention
  update lastId / lastTrimmedId metadata
  write dedupe key
```

Subscriptions use plain `XREAD`, not consumer groups:

```text
subscribe()
  resolve start cursor
  XREAD BLOCK from last seen id
  decode records
  filter names in-process
  deliver matching records to handler
```

That is intentional: consumer groups are work-sharing/ack primitives, while Pario broker subscriptions are live fan-out where every subscriber should see every matching record.

## Retention Details

`maxRecords` maps to exact `XTRIM MAXLEN`.

`maxAgeMs` maps to exact `XTRIM MINID`. Because Redis does not clean idle streams automatically, the provider enforces age retention on both append and retained read/replay paths:

```text
read()
  enforce age retention now
  check afterCursor against lastTrimmedId
  XRANGE retained records
```

`lastTrimmedId` is tracked because Redis stream ids are not dense integers. Comparing `afterCursor` to the first retained entry would reject valid cursors at the retention boundary.

## Testing

Adds a Redis Docker e2e setup and runs the shared broker contract suite against `RedisBroker`, plus Redis-specific tests for:

- idempotency by `idempotencyKey`
- close/drain behavior
- max-record retention boundary behavior
- idle max-age retention on reads
- idle max-age retention before retained subscription replay

## Validation

```bash
bun run check
bun --filter @pario/broker-redis typecheck
bun --filter @pario/broker-redis build
bun --filter @pario/broker-redis test:e2e
bun run typecheck
bun run build
```

Latest Redis e2e result:

```text
24 pass
0 fail
```
