### PR TITLE
server: add browser API origin foundation

### DIFF
--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -11,7 +11,7 @@
         "type": "apiKey",
         "in": "header",
         "name": "x-pario-csrf",
-        "description": "Required for authenticated mutating requests. Copy the value from the pario_csrf cookie."
+        "description": "Required for authenticated mutating requests. Use the csrfToken returned by GET /api/auth/session."
       }
     },
     "schemas": {}
@@ -109,6 +109,9 @@
                           "type": "boolean",
                           "enum": [true]
                         },
+                        "csrfToken": {
+                          "type": "string"
+                        },
                         "user": {
                           "type": "object",
                           "properties": {
@@ -148,7 +151,7 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["authenticated", "user", "session"],
+                      "required": ["authenticated", "csrfToken", "user", "session"],
                       "additionalProperties": false
                     }
                   ]

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -21,6 +21,7 @@ export type GetAuthSessionResponses = {
       }
     | {
         authenticated: true
+        csrfToken: string
         user: {
           id: string
           email: string

--- a/packages/core/src/auth/cookies.ts
+++ b/packages/core/src/auth/cookies.ts
@@ -10,6 +10,8 @@ export interface ResolvedAuthCookieOptions {
   readonly csrfCookieName: string
   readonly domain?: string
   readonly secure: boolean | "auto"
+  readonly sameSite: "strict"
+  readonly csrfHttpOnly: boolean
 }
 
 interface CookieSerializationOptions {
@@ -20,17 +22,23 @@ interface CookieSerializationOptions {
   readonly expires?: Date
   readonly domain?: string
   readonly secure?: boolean
+  readonly sameSite: "strict"
 }
 
 export function resolveAuthCookieOptions(
   options: AuthCookieOptions | undefined
 ): ResolvedAuthCookieOptions {
-  return {
+  const resolved = {
     sessionCookieName: options?.sessionCookieName ?? DEFAULT_SESSION_COOKIE_NAME,
     csrfCookieName: options?.csrfCookieName ?? DEFAULT_CSRF_COOKIE_NAME,
     domain: options?.cookieDomain,
     secure: options?.secure ?? "auto",
+    sameSite: options?.sameSite ?? "strict",
+    csrfHttpOnly: options?.csrfHttpOnly ?? false,
   }
+
+  assertValidCookieOptions(resolved)
+  return resolved
 }
 
 export function resolveAuthCookieOptionsForAudience(
@@ -81,7 +89,7 @@ export function serializeCookie(options: CookieSerializationOptions): string {
   const parts = [`${options.name}=${options.value}`]
 
   parts.push("Path=/")
-  parts.push("SameSite=Lax")
+  parts.push("SameSite=Strict")
 
   if (options.domain) {
     parts.push(`Domain=${options.domain}`)
@@ -110,6 +118,13 @@ export function shouldUseSecureCookies(
   request: Request,
   options: ResolvedAuthCookieOptions
 ): boolean {
+  if (
+    requiresSecureCookieName(options.sessionCookieName) ||
+    requiresSecureCookieName(options.csrfCookieName)
+  ) {
+    return true
+  }
+
   if (typeof options.secure === "boolean") {
     return options.secure
   }
@@ -135,6 +150,7 @@ export function createSessionCookieHeader(params: {
     maxAge: params.maxAgeSeconds,
     domain: params.options.domain,
     secure: shouldUseSecureCookies(params.request, params.options),
+    sameSite: params.options.sameSite,
   })
 }
 
@@ -147,9 +163,11 @@ export function createCsrfCookieHeader(params: {
   return serializeCookie({
     name: params.options.csrfCookieName,
     value: params.value,
+    httpOnly: params.options.csrfHttpOnly,
     maxAge: params.maxAgeSeconds,
     domain: params.options.domain,
     secure: shouldUseSecureCookies(params.request, params.options),
+    sameSite: params.options.sameSite,
   })
 }
 
@@ -165,6 +183,7 @@ export function clearSessionCookieHeader(params: {
     expires: new Date(0),
     domain: params.options.domain,
     secure: shouldUseSecureCookies(params.request, params.options),
+    sameSite: params.options.sameSite,
   })
 }
 
@@ -179,9 +198,49 @@ export function clearCsrfCookieHeader(params: {
     expires: new Date(0),
     domain: params.options.domain,
     secure: shouldUseSecureCookies(params.request, params.options),
+    sameSite: params.options.sameSite,
   })
 }
 
 function isLocalhost(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+}
+
+function assertValidCookieOptions(options: ResolvedAuthCookieOptions): void {
+  assertValidCookieName(options.sessionCookieName, "sessionCookieName")
+  assertValidCookieName(options.csrfCookieName, "csrfCookieName")
+
+  if (options.sameSite !== "strict") {
+    throw new Error("[Pario] Auth cookie sameSite must be 'strict'.")
+  }
+
+  if (
+    options.domain &&
+    (isHostPrefixedCookieName(options.sessionCookieName) ||
+      isHostPrefixedCookieName(options.csrfCookieName))
+  ) {
+    throw new Error("[Pario] __Host- auth cookies cannot be configured with cookieDomain.")
+  }
+
+  if (
+    options.secure === false &&
+    (requiresSecureCookieName(options.sessionCookieName) ||
+      requiresSecureCookieName(options.csrfCookieName))
+  ) {
+    throw new Error("[Pario] __Host- auth cookies require secure cookies.")
+  }
+}
+
+function assertValidCookieName(name: string, label: string): void {
+  if (!/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(name)) {
+    throw new Error(`[Pario] Auth cookie ${label} '${name}' is not a valid cookie name.`)
+  }
+}
+
+function isHostPrefixedCookieName(name: string): boolean {
+  return name.startsWith("__Host-")
+}
+
+function requiresSecureCookieName(name: string): boolean {
+  return isHostPrefixedCookieName(name) || name.startsWith("__Secure-")
 }

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -189,6 +189,8 @@ export interface AuthCookieOptions {
   readonly csrfCookieName?: string
   readonly cookieDomain?: string
   readonly secure?: boolean | "auto"
+  readonly sameSite?: "strict"
+  readonly csrfHttpOnly?: boolean
 }
 
 export type ParioAuthConfig =

--- a/packages/core/tests/auth-runtime.test.ts
+++ b/packages/core/tests/auth-runtime.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import {
   type AuthStrategy,
+  createCsrfCookieHeader,
+  createSessionCookieHeader,
   createSessionCredential,
   defineGroup,
   defineInvitePolicy,
@@ -9,6 +11,7 @@ import {
   type MagicLinkAuthStrategy,
   Pario,
   parseSessionCookieValue,
+  resolveAuthCookieOptions,
   verifyDoubleSubmitCsrf,
 } from "../src"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
@@ -568,5 +571,67 @@ describe("Pario auth runtime", () => {
         cookieName: "pario_csrf",
       })
     ).toBe(true)
+  })
+
+  test("serializes auth cookies with strict same-site defaults", () => {
+    const options = resolveAuthCookieOptions(undefined)
+    const request = new Request("http://localhost/api/auth/session")
+
+    expect(
+      createSessionCookieHeader({
+        request,
+        value: "ses_1.secret",
+        maxAgeSeconds: 60,
+        options,
+      })
+    ).toContain("SameSite=Strict")
+    expect(
+      createCsrfCookieHeader({
+        request,
+        value: "csrf_1",
+        maxAgeSeconds: 60,
+        options,
+      })
+    ).toContain("SameSite=Strict")
+  })
+
+  test("supports HttpOnly CSRF cookies and validates host-prefixed cookie config", () => {
+    const request = new Request("https://api.example.com/api/auth/session")
+    const options = resolveAuthCookieOptions({
+      sessionCookieName: "__Host-pario_session",
+      csrfCookieName: "__Host-pario_csrf",
+      csrfHttpOnly: true,
+    })
+
+    expect(
+      createCsrfCookieHeader({
+        request,
+        value: "csrf_1",
+        maxAgeSeconds: 60,
+        options,
+      })
+    ).toContain("HttpOnly")
+    expect(
+      createSessionCookieHeader({
+        request,
+        value: "ses_1.secret",
+        maxAgeSeconds: 60,
+        options,
+      })
+    ).toContain("Secure")
+    expect(() =>
+      resolveAuthCookieOptions({
+        sessionCookieName: "__Host-pario_session",
+        csrfCookieName: "__Host-pario_csrf",
+        cookieDomain: ".example.com",
+      })
+    ).toThrow("__Host- auth cookies cannot be configured with cookieDomain")
+    expect(() =>
+      resolveAuthCookieOptions({
+        sessionCookieName: "__Host-pario_session",
+        csrfCookieName: "__Host-pario_csrf",
+        secure: false,
+      })
+    ).toThrow("__Host- auth cookies require secure cookies")
   })
 })

--- a/packages/server/src/auth/browser-origin.ts
+++ b/packages/server/src/auth/browser-origin.ts
@@ -1,0 +1,178 @@
+import {
+  type AuthSessionAudience,
+  DEFAULT_AUTH_SESSION_AUDIENCE,
+  resolveAuthSessionAudience,
+} from "@pario/core"
+
+export interface ParioBrowserOrigin {
+  readonly origin: string
+  readonly audience: AuthSessionAudience
+  readonly kind?: "admin" | "app"
+}
+
+export interface ParioApiBrowserPolicy {
+  readonly publicOrigin?: string
+  readonly allowedOrigins: readonly ParioBrowserOrigin[]
+  readonly sameOriginAudience?: AuthSessionAudience
+}
+
+export interface ResolvedParioBrowserOrigin {
+  readonly origin: string
+  readonly audience: AuthSessionAudience
+  readonly kind?: "admin" | "app"
+}
+
+export interface ResolvedParioApiBrowserPolicy {
+  readonly publicOrigin?: string
+  readonly sameOriginAudience: AuthSessionAudience
+  readonly allowedOrigins: readonly ResolvedParioBrowserOrigin[]
+}
+
+export interface RequestAuthContext {
+  readonly audience: AuthSessionAudience
+  readonly browserOrigin?: string
+}
+
+export type ResolveRequestAuthContext = (request: Request) => RequestAuthContext
+
+export class BrowserOriginError extends Error {
+  readonly name = "BrowserOriginError"
+}
+
+export function resolveBrowserApiPolicy(
+  policy: ParioApiBrowserPolicy
+): ResolvedParioApiBrowserPolicy {
+  const sameOriginAudience = resolveAuthSessionAudience(
+    policy.sameOriginAudience ?? DEFAULT_AUTH_SESSION_AUDIENCE
+  )
+  const origins = new Map<string, ResolvedParioBrowserOrigin>()
+
+  for (const entry of policy.allowedOrigins) {
+    const origin = normalizeHttpOrigin(entry.origin, "browser origin")
+    const audience = resolveAuthSessionAudience(entry.audience)
+    const existing = origins.get(origin)
+    if (existing) {
+      if (existing.audience !== audience) {
+        throw new Error(
+          `[ParioServer] Browser origin '${origin}' is mapped to multiple auth audiences.`
+        )
+      }
+      continue
+    }
+
+    origins.set(origin, {
+      origin,
+      audience,
+      kind: entry.kind,
+    })
+  }
+
+  if (origins.size === 0) {
+    throw new Error("[ParioServer] browserApi requires at least one allowed browser origin.")
+  }
+
+  return {
+    publicOrigin: policy.publicOrigin
+      ? normalizeHttpOrigin(policy.publicOrigin, "browser API public origin")
+      : undefined,
+    sameOriginAudience,
+    allowedOrigins: [...origins.values()],
+  }
+}
+
+export function createFixedAuthContextResolver(
+  audience: AuthSessionAudience
+): ResolveRequestAuthContext {
+  const resolvedAudience = resolveAuthSessionAudience(audience)
+  return () => ({ audience: resolvedAudience })
+}
+
+export function createBrowserApiAuthContextResolver(
+  policy: ResolvedParioApiBrowserPolicy
+): ResolveRequestAuthContext {
+  return (request) => resolveBrowserApiAuthContext(policy, request)
+}
+
+export function resolveBrowserApiAuthContext(
+  policy: ResolvedParioApiBrowserPolicy,
+  request: Request
+): RequestAuthContext {
+  const origin = normalizeRequestOrigin(request)
+  if (!origin) {
+    return { audience: policy.sameOriginAudience }
+  }
+
+  const allowed = findAllowedBrowserOrigin(policy, origin)
+  if (allowed) {
+    return { audience: allowed.audience, browserOrigin: allowed.origin }
+  }
+
+  if (isSameOriginApiRequest(policy, origin, request)) {
+    return { audience: policy.sameOriginAudience, browserOrigin: origin }
+  }
+
+  throw new BrowserOriginError(`[ParioServer] Browser origin '${origin}' is not allowed.`)
+}
+
+export function isAllowedBrowserApiOrigin(
+  policy: ResolvedParioApiBrowserPolicy,
+  request: Request
+): boolean {
+  const origin = normalizeRequestOrigin(request)
+  if (!origin) {
+    return false
+  }
+
+  return (
+    findAllowedBrowserOrigin(policy, origin) !== null ||
+    isSameOriginApiRequest(policy, origin, request)
+  )
+}
+
+function findAllowedBrowserOrigin(
+  policy: ResolvedParioApiBrowserPolicy,
+  origin: string
+): ResolvedParioBrowserOrigin | null {
+  return policy.allowedOrigins.find((entry) => entry.origin === origin) ?? null
+}
+
+function isSameOriginApiRequest(
+  policy: ResolvedParioApiBrowserPolicy,
+  origin: string,
+  request: Request
+): boolean {
+  const apiOrigin = policy.publicOrigin ?? new URL(request.url).origin
+  return origin === apiOrigin
+}
+
+function normalizeRequestOrigin(request: Request): string | null {
+  const origin = request.headers.get("origin")
+  if (!origin) {
+    return null
+  }
+
+  try {
+    return normalizeHttpOrigin(origin, "Origin header")
+  } catch {
+    throw new BrowserOriginError("[ParioServer] Origin header is not allowed.")
+  }
+}
+
+function normalizeHttpOrigin(value: string, label: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`[ParioServer] Invalid ${label}: '${value}'.`)
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`[ParioServer] ${label} must use http or https.`)
+  }
+
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(`[ParioServer] ${label} must be an origin, not a full URL.`)
+  }
+
+  return url.origin
+}

--- a/packages/server/src/auth/guard.ts
+++ b/packages/server/src/auth/guard.ts
@@ -7,28 +7,40 @@ import {
   resolveAuthSessionAudience,
   verifyDoubleSubmitCsrf,
 } from "@pario/core"
+import {
+  BrowserOriginError,
+  createFixedAuthContextResolver,
+  type ResolveRequestAuthContext,
+} from "./browser-origin"
 import { classifyRoute } from "./public-routes"
 import {
   htmlAuthRedirectResponse,
   jsonAuthRequiredResponse,
   jsonCsrfFailedResponse,
+  jsonForbiddenResponse,
   websocketAuthFailedResponse,
 } from "./responses"
 
 export interface ServerAuthGuardOptions {
   readonly pario: Pario<readonly OntologySource[]>
   readonly audience?: AuthSessionAudience
+  readonly resolveAuthContext?: ResolveRequestAuthContext
 }
 
 export type HtmlRouteHandler = (request: Request) => Response | Promise<Response>
 
 export class ServerAuthGuard {
   private readonly pario: Pario<readonly OntologySource[]>
-  private readonly audience: AuthSessionAudience
+  private readonly resolveAuthContext: ResolveRequestAuthContext
+  private readonly staticAudience: AuthSessionAudience
 
   constructor(options: ServerAuthGuardOptions) {
     this.pario = options.pario
-    this.audience = resolveAuthSessionAudience(options.audience ?? DEFAULT_AUTH_SESSION_AUDIENCE)
+    this.staticAudience = resolveAuthSessionAudience(
+      options.audience ?? DEFAULT_AUTH_SESSION_AUDIENCE
+    )
+    this.resolveAuthContext =
+      options.resolveAuthContext ?? createFixedAuthContextResolver(this.staticAudience)
   }
 
   isAuthEnabled(): boolean {
@@ -49,7 +61,14 @@ export class ServerAuthGuard {
       return undefined
     }
 
-    const session = await this.pario.auth.getSession(request, { audience: this.audience })
+    const authContext = this.tryResolveAuthContext(request)
+    if (authContext instanceof Response) {
+      return authContext
+    }
+
+    const session = await this.pario.auth.getSession(request, {
+      audience: authContext.audience,
+    })
     if (!session.authenticated) {
       if (route.kind === "html") {
         return htmlAuthRedirectResponse(request)
@@ -74,7 +93,14 @@ export class ServerAuthGuard {
       return undefined
     }
 
-    const session = await this.pario.auth.getSession(request, { audience: this.audience })
+    const authContext = this.tryResolveAuthContext(request)
+    if (authContext instanceof Response) {
+      return authContext
+    }
+
+    const session = await this.pario.auth.getSession(request, {
+      audience: authContext.audience,
+    })
     if (!session.authenticated) {
       return htmlAuthRedirectResponse(request)
     }
@@ -94,11 +120,13 @@ export class ServerAuthGuard {
   }
 
   async getSession(request: Request): Promise<AuthSessionResult> {
-    return this.pario.auth.getSession(request, { audience: this.audience })
+    const authContext = this.resolveAuthContext(request)
+    return this.pario.auth.getSession(request, { audience: authContext.audience })
   }
 
-  getCsrfCookieName(): string {
-    return this.pario.auth.getCookieOptions({ audience: this.audience }).csrfCookieName
+  getCsrfCookieName(request?: Request): string {
+    const audience = request ? this.resolveAuthContext(request).audience : this.staticAudience
+    return this.pario.auth.getCookieOptions({ audience }).csrfCookieName
   }
 
   verifyCsrf(
@@ -106,7 +134,21 @@ export class ServerAuthGuard {
     _session: Extract<AuthSessionResult, { authenticated: true }>
   ): boolean {
     return verifyDoubleSubmitCsrf(request, {
-      cookieName: this.getCsrfCookieName(),
+      cookieName: this.getCsrfCookieName(request),
     })
+  }
+
+  private tryResolveAuthContext(
+    request: Request
+  ): ReturnType<ResolveRequestAuthContext> | Response {
+    try {
+      return this.resolveAuthContext(request)
+    } catch (error) {
+      if (error instanceof BrowserOriginError) {
+        return jsonForbiddenResponse("Browser origin is not allowed")
+      }
+
+      throw error
+    }
   }
 }

--- a/packages/server/src/auth/public-routes.ts
+++ b/packages/server/src/auth/public-routes.ts
@@ -29,6 +29,10 @@ export function classifyRoute(request: Request): RouteAccess {
 export function isPublicRoute(pathname: string, method: string): boolean {
   const normalizedMethod = method.toUpperCase()
 
+  if (normalizedMethod === "OPTIONS") {
+    return true
+  }
+
   if ((pathname === "/favicon.svg" || pathname === "/favicon.ico") && normalizedMethod === "GET") {
     return true
   }

--- a/packages/server/src/auth/responses.ts
+++ b/packages/server/src/auth/responses.ts
@@ -8,6 +8,10 @@ export function jsonCsrfFailedResponse(): Response {
   return jsonResponse({ error: "CSRF verification failed" }, 403)
 }
 
+export function jsonForbiddenResponse(message = "Forbidden"): Response {
+  return jsonResponse({ error: message }, 403)
+}
+
 export function htmlAuthRedirectResponse(request: Request): Response {
   const returnTo = encodeURIComponent(returnToForRequest(request))
   return new Response(null, {

--- a/packages/server/src/openapi/security.ts
+++ b/packages/server/src/openapi/security.ts
@@ -1,4 +1,4 @@
-import { CSRF_HEADER_NAME, DEFAULT_CSRF_COOKIE_NAME } from "@pario/core"
+import { CSRF_HEADER_NAME } from "@pario/core"
 
 export const PARIO_CSRF_SECURITY_SCHEME_ID = "parioCsrf"
 
@@ -12,5 +12,6 @@ export const PARIO_CSRF_SECURITY_SCHEME = {
   type: "apiKey",
   in: "header",
   name: CSRF_HEADER_NAME,
-  description: `Required for authenticated mutating requests. Copy the value from the ${DEFAULT_CSRF_COOKIE_NAME} cookie.`,
+  description:
+    "Required for authenticated mutating requests. Use the csrfToken returned by GET /api/auth/session.",
 } as const

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -9,6 +9,7 @@ import {
   createSessionCookieHeader,
   createSessionCredential,
   generateCsrfToken,
+  getCookie,
   type InvitationRecord,
   isMagicLinkAuthStrategy,
   isOidcAuthStrategy,
@@ -17,6 +18,7 @@ import {
   verifyDoubleSubmitCsrf,
 } from "@pario/core"
 import { type Elysia, t } from "elysia"
+import type { ResolveRequestAuthContext } from "../auth/browser-origin"
 import { sanitizeReturnTo } from "../auth/return-to"
 import { PARIO_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import {
@@ -32,8 +34,25 @@ import {
 import { ErrorResponseSchema } from "../schemas/common"
 import { parseDate, parseOptionalInt, toIsoString } from "../utils/http"
 
+type ResolvedCookieOptions = Parameters<typeof createCsrfCookieHeader>[0]["options"]
+type AuthenticatedAuthSessionResponse = {
+  readonly authenticated: true
+  readonly csrfToken: string
+  readonly user: {
+    readonly id: string
+    readonly email: string
+    readonly displayName?: string
+    readonly avatarUrl?: string
+    readonly groupIds: readonly string[]
+  }
+  readonly session: {
+    readonly id: string
+    readonly expiresAt: string
+  }
+}
+
 export interface AuthRoutesOptions {
-  readonly audience: AuthSessionAudience
+  readonly resolveAuthContext: ResolveRequestAuthContext
 }
 
 export function registerAuthRoutes(
@@ -41,30 +60,36 @@ export function registerAuthRoutes(
   pario: Pario<readonly OntologySource[]>,
   options: AuthRoutesOptions
 ) {
-  const authOptions = { audience: options.audience }
   return app
     .get(
       "/api/auth/session",
       async ({ request }) => {
+        const authOptions = resolveAuthOptions(options, request)
         const session = await pario.auth.getSession(request, authOptions)
         if (!session.authenticated) {
-          return { authenticated: false as const }
+          return jsonResponse({ authenticated: false as const }, 200)
         }
 
-        return {
-          authenticated: true as const,
-          user: {
-            id: session.user.id,
-            email: session.user.email,
-            displayName: session.user.displayName,
-            avatarUrl: session.user.avatarUrl,
-            groupIds: [...session.groupIds],
+        const cookieOptions = pario.auth.getCookieOptions(authOptions)
+        const csrf = resolveSessionCsrfToken({ pario, request, cookieOptions })
+        return authSessionJsonResponse(
+          {
+            authenticated: true as const,
+            csrfToken: csrf.token,
+            user: {
+              id: session.user.id,
+              email: session.user.email,
+              displayName: session.user.displayName,
+              avatarUrl: session.user.avatarUrl,
+              groupIds: [...session.groupIds],
+            },
+            session: {
+              id: session.session.id,
+              expiresAt: toIsoString(session.session.expiresAt),
+            },
           },
-          session: {
-            id: session.session.id,
-            expiresAt: toIsoString(session.session.expiresAt),
-          },
-        }
+          csrf.setCookie
+        )
       },
       {
         response: { 200: AuthSessionResponseSchema },
@@ -78,6 +103,7 @@ export function registerAuthRoutes(
     .post(
       "/api/auth/sign-out",
       async ({ request }) => {
+        const authOptions = resolveAuthOptions(options, request)
         const session = await pario.auth.getSession(request, authOptions)
         const cookieOptions = pario.auth.getCookieOptions(authOptions)
         if (
@@ -123,6 +149,7 @@ export function registerAuthRoutes(
       "/api/auth/invitations",
       async ({ request, body }) => {
         try {
+          const authOptions = resolveAuthOptions(options, request)
           const parsed = CreateAuthInvitationBodySchema.parse(body)
           const result = await pario.auth.invite(
             request,
@@ -169,6 +196,7 @@ export function registerAuthRoutes(
       "/api/auth/invitations",
       async ({ request, query }) => {
         try {
+          const authOptions = resolveAuthOptions(options, request)
           const parsed = ListAuthInvitationsQuerySchema.parse(query)
           const result = await pario.auth.listInvitations(
             request,
@@ -215,6 +243,7 @@ export function registerAuthRoutes(
       "/api/auth/invitations/:invitationId/revoke",
       async ({ request, params }) => {
         try {
+          const authOptions = resolveAuthOptions(options, request)
           const parsed = RevokeAuthInvitationParamsSchema.parse(params)
           const result = await pario.auth.revokeInvitation(
             request,
@@ -325,6 +354,7 @@ export function registerAuthRoutes(
         const sessionCredential = createSessionCredential()
 
         if (isMagicLinkAuthStrategy(strategy)) {
+          const authOptions = resolveAuthOptions(options, request)
           const url = new URL(request.url)
           const magicLinkId = url.searchParams.get("magicLinkId")?.trim()
           const token = url.searchParams.get("token")?.trim()
@@ -342,7 +372,7 @@ export function registerAuthRoutes(
               token,
               session: {
                 id: sessionCredential.sessionId,
-                audience: options.audience,
+                audience: authOptions.audience,
                 tokenHash: sessionCredential.tokenHash,
                 createdAt: now,
                 expiresAt: new Date(now.getTime() + pario.auth.getSessionTtlMs()),
@@ -352,17 +382,18 @@ export function registerAuthRoutes(
             return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
           }
 
-          return sessionRedirectResponse({
+          return sessionCallbackCompletionResponse({
             pario,
             request,
             sessionCredential,
-            audience: options.audience,
+            audience: authOptions.audience,
             returnTo,
           })
         }
 
         if (isOidcAuthStrategy(strategy)) {
           try {
+            const authOptions = resolveAuthOptions(options, request)
             const result = await strategy.completeOidcSignIn({
               projectId: pario.id,
               authStorage: requireAuthStorage(pario),
@@ -370,18 +401,18 @@ export function registerAuthRoutes(
               requestOrigin: new URL(request.url).origin,
               session: {
                 id: sessionCredential.sessionId,
-                audience: options.audience,
+                audience: authOptions.audience,
                 tokenHash: sessionCredential.tokenHash,
                 createdAt: now,
                 expiresAt: new Date(now.getTime() + pario.auth.getSessionTtlMs()),
               },
             })
 
-            return sessionRedirectResponse({
+            return sessionCallbackCompletionResponse({
               pario,
               request,
               sessionCredential,
-              audience: options.audience,
+              audience: authOptions.audience,
               returnTo: result.returnTo,
             })
           } catch (error) {
@@ -396,7 +427,7 @@ export function registerAuthRoutes(
     )
 }
 
-function sessionRedirectResponse(input: {
+function sessionCallbackCompletionResponse(input: {
   readonly pario: Pario<readonly OntologySource[]>
   readonly request: Request
   readonly sessionCredential: ReturnType<typeof createSessionCredential>
@@ -405,7 +436,6 @@ function sessionRedirectResponse(input: {
 }): Response {
   const cookieOptions = input.pario.auth.getCookieOptions({ audience: input.audience })
   const headers = new Headers({
-    location: input.returnTo,
     "cache-control": "no-store",
   })
   headers.append(
@@ -427,7 +457,89 @@ function sessionRedirectResponse(input: {
     })
   )
 
-  return new Response(null, { status: 303, headers })
+  return authCallbackCompletionResponse(input.returnTo, headers)
+}
+
+// OAuth and magic-link callbacks arrive from a cross-site navigation. A direct 3xx after
+// setting SameSite=Strict cookies can keep the next request in that cross-site redirect
+// chain. Finish on a Pario document first, then navigate to the sanitized return path.
+function authCallbackCompletionResponse(returnTo: string, headers: Headers): Response {
+  headers.set("content-type", "text/html; charset=utf-8")
+  headers.set(
+    "content-security-policy",
+    "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to 'self'"
+  )
+  headers.set("referrer-policy", "no-referrer")
+  headers.set("x-content-type-options", "nosniff")
+
+  return new Response(
+    [
+      "<!doctype html>",
+      '<html lang="en">',
+      "<head>",
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+      '<meta name="referrer" content="no-referrer">',
+      `<meta http-equiv="refresh" content="0;url=${escapeHtml(returnTo)}">`,
+      "<title>Signing in</title>",
+      "</head>",
+      "<body>",
+      "<main>",
+      "<p>Signing you in...</p>",
+      `<p><a href="${escapeHtml(returnTo)}">Continue</a></p>`,
+      "</main>",
+      "</body>",
+      "</html>",
+    ].join(""),
+    {
+      status: 200,
+      headers,
+    }
+  )
+}
+
+function resolveAuthOptions(
+  options: AuthRoutesOptions,
+  request: Request
+): {
+  readonly audience: AuthSessionAudience
+} {
+  return { audience: options.resolveAuthContext(request).audience }
+}
+
+function resolveSessionCsrfToken(input: {
+  readonly pario: Pario<readonly OntologySource[]>
+  readonly request: Request
+  readonly cookieOptions: ResolvedCookieOptions
+}): { readonly token: string; readonly setCookie?: string } {
+  const existing = getCookie(input.request, input.cookieOptions.csrfCookieName)
+  if (existing) {
+    return { token: existing }
+  }
+
+  const token = generateCsrfToken()
+  return {
+    token,
+    setCookie: createCsrfCookieHeader({
+      request: input.request,
+      value: token,
+      maxAgeSeconds: Math.trunc(input.pario.auth.getSessionTtlMs() / 1000),
+      options: input.cookieOptions,
+    }),
+  }
+}
+
+function authSessionJsonResponse(
+  body: AuthenticatedAuthSessionResponse,
+  csrfSetCookie: string | undefined
+): Response {
+  if (!csrfSetCookie) {
+    return jsonResponse(body, 200)
+  }
+
+  const headers = new Headers({ "content-type": "application/json; charset=utf-8" })
+  headers.append("set-cookie", csrfSetCookie)
+  return jsonResponse(body, 200, headers)
 }
 
 function redirectResponse(location: string): Response {
@@ -595,12 +707,13 @@ function logAuthCallbackError(kind: string, error: unknown): void {
   console.error(`[ParioServer] ${kind} auth callback failed: ${detail}`)
 }
 
-function jsonResponse(body: unknown, status: number): Response {
+function jsonResponse(body: unknown, status: number, headersInit?: HeadersInit): Response {
+  const headers = new Headers(headersInit)
+  headers.set("content-type", headers.get("content-type") ?? "application/json; charset=utf-8")
+  headers.set("cache-control", headers.get("cache-control") ?? "no-store")
+
   return new Response(JSON.stringify(body), {
     status,
-    headers: {
-      "content-type": "application/json; charset=utf-8",
-      "cache-control": "no-store",
-    },
+    headers,
   })
 }

--- a/packages/server/src/schemas/auth.ts
+++ b/packages/server/src/schemas/auth.ts
@@ -58,6 +58,7 @@ export const AuthSessionResponseSchema = z.union([
   }),
   z.object({
     authenticated: z.literal(true),
+    csrfToken: z.string(),
     user: z.object({
       id: z.string(),
       email: z.string(),

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -3,6 +3,7 @@ import { cors } from "@elysiajs/cors"
 import { openapi } from "@elysiajs/openapi"
 import {
   type AuthSessionAudience,
+  CSRF_HEADER_NAME,
   type OntologySource,
   type Pario,
   resolveAuthSessionAudience,
@@ -10,6 +11,17 @@ import {
 import { Elysia } from "elysia"
 import { websocket as elysiaWebSocket } from "elysia/ws"
 import { zodToJsonSchema } from "zod-to-json-schema"
+import {
+  BrowserOriginError,
+  createBrowserApiAuthContextResolver,
+  createFixedAuthContextResolver,
+  isAllowedBrowserApiOrigin,
+  type ParioApiBrowserPolicy,
+  type RequestAuthContext,
+  type ResolvedParioApiBrowserPolicy,
+  type ResolveRequestAuthContext,
+  resolveBrowserApiPolicy,
+} from "./auth/browser-origin"
 import { ServerAuthGuard } from "./auth/guard"
 import { PARIO_CSRF_SECURITY_SCHEME, PARIO_CSRF_SECURITY_SCHEME_ID } from "./openapi/security"
 import { registerHttpRoutes } from "./registerRoutes"
@@ -19,6 +31,13 @@ import { registerWsRoutes } from "./routes/ws"
 import { ensureBuiltInUiBundle, renderBuiltInUiShell } from "./ui/assets"
 import { type BuiltInUiCssHandle, ensureBuiltInUiCss } from "./ui/css"
 
+// Browser deployments are split by visible surface: UI surfaces serve public shells,
+// while browserApi owns API/auth/ws/docs and resolves the session audience from Origin.
+export type ParioServerSurface =
+  | { readonly kind: "builtInUi" }
+  | { readonly kind: "apiOnly"; readonly audience?: AuthSessionAudience }
+  | { readonly kind: "browserApi"; readonly browser: ParioApiBrowserPolicy }
+
 export interface ParioServerOptions {
   pario: Pario<readonly OntologySource[]>
   port?: number
@@ -26,6 +45,7 @@ export interface ParioServerOptions {
   quiet?: boolean
   ui?: boolean
   sessionAudience?: AuthSessionAudience
+  surface?: ParioServerSurface
 }
 
 export function createParioServer(options: ParioServerOptions): ParioServer {
@@ -37,8 +57,10 @@ export class ParioServer {
   private readonly port: number
   private readonly host: string
   private readonly quiet: boolean
-  private readonly ui: boolean
+  private readonly surface: ParioServerSurface
   private readonly sessionAudience: AuthSessionAudience
+  private readonly browserApiPolicy: ResolvedParioApiBrowserPolicy | null
+  private readonly authContextResolver: ResolveRequestAuthContext
   private app: ParioApp | null = null
   private bunServer: ReturnType<typeof Bun.serve> | null = null
   private uiCss: BuiltInUiCssHandle | null = null
@@ -48,8 +70,17 @@ export class ParioServer {
     this.port = options.port ?? 3000
     this.host = options.host ?? "0.0.0.0"
     this.quiet = options.quiet ?? false
-    this.ui = options.ui ?? true
-    this.sessionAudience = resolveAuthSessionAudience(options.sessionAudience)
+    this.surface = resolveServerSurface(options)
+    this.sessionAudience = resolveAuthSessionAudience(
+      this.surface.kind === "apiOnly"
+        ? (this.surface.audience ?? options.sessionAudience)
+        : options.sessionAudience
+    )
+    this.browserApiPolicy =
+      this.surface.kind === "browserApi" ? resolveBrowserApiPolicy(this.surface.browser) : null
+    this.authContextResolver = this.browserApiPolicy
+      ? createBrowserApiAuthContextResolver(this.browserApiPolicy)
+      : createFixedAuthContextResolver(this.sessionAudience)
   }
 
   getPario(): Pario<readonly OntologySource[]> {
@@ -64,6 +95,14 @@ export class ParioServer {
     return this.sessionAudience
   }
 
+  resolveAuthContext(request: Request): RequestAuthContext {
+    return this.authContextResolver(request)
+  }
+
+  getBrowserApiPolicy(): ResolvedParioApiBrowserPolicy | null {
+    return this.browserApiPolicy
+  }
+
   private isDevelopmentMode(): boolean {
     return process.env.NODE_ENV === "development"
   }
@@ -72,7 +111,7 @@ export class ParioServer {
     this.app = createParioApi(this)
 
     try {
-      if (this.ui) {
+      if (this.surface.kind === "builtInUi") {
         this.uiCss = await ensureBuiltInUiCss({
           watch: this.isDevelopmentMode(),
         })
@@ -95,7 +134,7 @@ export class ParioServer {
       const base = `http://${this.host}:${this.port}`
       console.log(`Pario server running at ${base}`)
       console.log(`OpenAPI docs at ${base}/docs`)
-      if (this.ui) {
+      if (this.surface.kind === "builtInUi") {
         console.log(`Built-in UI at ${base}/`)
       }
     }
@@ -150,10 +189,35 @@ export class ParioServer {
 
 export function createParioApi(server: ParioServer) {
   const pario = server.getPario()
-  const guard = new ServerAuthGuard({ pario, audience: server.getSessionAudience() })
+  const guard = new ServerAuthGuard({
+    pario,
+    resolveAuthContext: (request) => server.resolveAuthContext(request),
+  })
   guard.assertCanServeHttp({ production: process.env.NODE_ENV === "production" })
+  const browserApiPolicy = server.getBrowserApiPolicy()
 
-  const app = new Elysia().use(cors()).use(
+  const app = new Elysia()
+
+  if (browserApiPolicy) {
+    app.onRequest(({ request }) => {
+      const response = rejectDisallowedBrowserOrigin(request, browserApiPolicy)
+      if (response) {
+        return response
+      }
+    })
+    app.use(
+      cors({
+        origin: (request) => isAllowedBrowserApiOrigin(browserApiPolicy, request),
+        credentials: true,
+        methods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allowedHeaders: ["content-type", CSRF_HEADER_NAME],
+        exposeHeaders: [],
+        maxAge: 600,
+      })
+    )
+  }
+
+  app.use(
     openapi({
       path: "/docs",
       provider: "swagger-ui",
@@ -197,12 +261,53 @@ export function createParioApi(server: ParioServer) {
   )
 
   app.onBeforeHandle(({ request }) => guard.handle(request))
-  registerAuthRoutes(app, pario, { audience: server.getSessionAudience() })
+  registerAuthRoutes(app, pario, {
+    resolveAuthContext: (request) => server.resolveAuthContext(request),
+  })
   registerHttpRoutes(app, pario)
   registerWebhookRoutes(app, pario)
   registerWsRoutes(app, server)
 
   return app
+}
+
+function resolveServerSurface(options: ParioServerOptions): ParioServerSurface {
+  if (options.surface) {
+    return options.surface
+  }
+
+  if (options.ui === false) {
+    return { kind: "apiOnly", audience: options.sessionAudience }
+  }
+
+  return { kind: "builtInUi" }
+}
+
+function rejectDisallowedBrowserOrigin(
+  request: Request,
+  policy: ResolvedParioApiBrowserPolicy
+): Response | undefined {
+  if (!request.headers.has("origin")) {
+    return undefined
+  }
+
+  try {
+    if (isAllowedBrowserApiOrigin(policy, request)) {
+      return undefined
+    }
+  } catch (error) {
+    if (!(error instanceof BrowserOriginError)) {
+      throw error
+    }
+  }
+
+  return new Response(JSON.stringify({ error: "Browser origin is not allowed" }), {
+    status: 403,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  })
 }
 
 export const createApp = createParioApi

--- a/packages/server/tests/auth-guard.test.ts
+++ b/packages/server/tests/auth-guard.test.ts
@@ -177,6 +177,7 @@ describe("server auth guard", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       authenticated: true,
+      csrfToken: expect.any(String),
       user: {
         id: "usr_1",
         email: "ava@acme.com",
@@ -188,6 +189,7 @@ describe("server auth guard", () => {
         expiresAt: "2099-05-16T10:00:00.000Z",
       },
     })
+    expect(response.headers.get("set-cookie")).toContain("pario_csrf=")
   })
 
   test("resolves sessions with the server audience cookie names", async () => {
@@ -214,6 +216,159 @@ describe("server auth guard", () => {
       session: { id: "ses_1" },
     })
     expect(adminCookie.status).toBe(401)
+  })
+
+  test("resolves browser API sessions from the allowed origin audience", async () => {
+    const { pario, storage } = createRuntime({ auth: true })
+    const seeded = await seedSession(storage, { audience: "app" })
+    const app = createParioApi(
+      new ParioServer({
+        pario,
+        quiet: true,
+        surface: {
+          kind: "browserApi",
+          browser: {
+            publicOrigin: "http://api.localhost",
+            allowedOrigins: [
+              { origin: "http://admin.localhost", audience: "admin", kind: "admin" },
+              { origin: "http://app.localhost", audience: "app", kind: "app" },
+            ],
+          },
+        },
+      })
+    )
+
+    const accepted = await app.fetch(
+      new Request("http://api.localhost/api/auth/session", {
+        headers: {
+          origin: "http://app.localhost",
+          cookie: seeded.cookie,
+        },
+      })
+    )
+    const wrongCookieName = await app.fetch(
+      new Request("http://api.localhost/api/auth/session", {
+        headers: {
+          origin: "http://app.localhost",
+          cookie: `pario_session=${seeded.credential.cookieValue}`,
+        },
+      })
+    )
+
+    expect(accepted.status).toBe(200)
+    expect(accepted.headers.get("access-control-allow-origin")).toBe("http://app.localhost")
+    expect(accepted.headers.get("access-control-allow-credentials")).toBe("true")
+    expect(accepted.headers.get("vary")).toBe("Origin")
+    expect(await accepted.json()).toMatchObject({
+      authenticated: true,
+      csrfToken: expect.any(String),
+      session: { id: "ses_1" },
+    })
+    expect(await wrongCookieName.json()).toEqual({ authenticated: false })
+  })
+
+  test("rejects browser API requests from unknown origins", async () => {
+    const { pario } = createRuntime({ auth: true })
+    const app = createParioApi(
+      new ParioServer({
+        pario,
+        quiet: true,
+        surface: {
+          kind: "browserApi",
+          browser: {
+            publicOrigin: "http://api.localhost",
+            allowedOrigins: [{ origin: "http://admin.localhost", audience: "admin" }],
+          },
+        },
+      })
+    )
+
+    const response = await app.fetch(
+      new Request("http://api.localhost/api/auth/session", {
+        headers: { origin: "http://evil.localhost" },
+      })
+    )
+
+    expect(response.status).toBe(403)
+    expect(response.headers.get("access-control-allow-origin")).toBeNull()
+    expect(await response.json()).toEqual({ error: "Browser origin is not allowed" })
+  })
+
+  test("handles browser API preflights with an exact origin allowlist", async () => {
+    const { pario } = createRuntime({ auth: true })
+    const app = createParioApi(
+      new ParioServer({
+        pario,
+        quiet: true,
+        surface: {
+          kind: "browserApi",
+          browser: {
+            publicOrigin: "http://api.localhost",
+            allowedOrigins: [{ origin: "http://admin.localhost", audience: "admin" }],
+          },
+        },
+      })
+    )
+
+    const allowed = await app.fetch(
+      new Request("http://api.localhost/api/objects/device/fan-1", {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://admin.localhost",
+          "access-control-request-method": "PUT",
+          "access-control-request-headers": "content-type,x-pario-csrf",
+        },
+      })
+    )
+    const rejected = await app.fetch(
+      new Request("http://api.localhost/api/objects/device/fan-1", {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://evil.localhost",
+          "access-control-request-method": "PUT",
+        },
+      })
+    )
+
+    expect(allowed.status).toBe(204)
+    expect(allowed.headers.get("access-control-allow-origin")).toBe("http://admin.localhost")
+    expect(allowed.headers.get("access-control-allow-credentials")).toBe("true")
+    expect(allowed.headers.get("access-control-allow-headers")).toBe("content-type, x-pario-csrf")
+    expect(rejected.status).toBe(403)
+  })
+
+  test("uses the browser origin audience for CSRF-protected API mutations", async () => {
+    const { pario, storage } = createRuntime({ auth: true })
+    const seeded = await seedSession(storage, { audience: "app" })
+    const app = createParioApi(
+      new ParioServer({
+        pario,
+        quiet: true,
+        surface: {
+          kind: "browserApi",
+          browser: {
+            publicOrigin: "http://api.localhost",
+            allowedOrigins: [{ origin: "http://app.localhost", audience: "app" }],
+          },
+        },
+      })
+    )
+
+    const response = await app.fetch(
+      new Request("http://api.localhost/api/objects/device/fan-1", {
+        method: "PUT",
+        headers: {
+          origin: "http://app.localhost",
+          "content-type": "application/json",
+          cookie: `${seeded.cookie}; ${seeded.csrfCookie}`,
+          ...seeded.csrfHeader,
+        },
+        body: JSON.stringify({ properties: { name: "Fan" } }),
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("access-control-allow-origin")).toBe("http://app.localhost")
   })
 
   test("requires CSRF only after authentication for mutations", async () => {

--- a/packages/server/tests/invitations-auth-routes.test.ts
+++ b/packages/server/tests/invitations-auth-routes.test.ts
@@ -275,8 +275,11 @@ describe("auth invitation routes", () => {
       })
     )
 
-    expect(callback.status).toBe(303)
-    expect(callback.headers.get("location")).toBe("/dashboard")
+    expect(callback.status).toBe(200)
+    expect(callback.headers.get("location")).toBeNull()
+    expect(await callback.text()).toContain(
+      '<meta http-equiv="refresh" content="0;url=/dashboard">'
+    )
     await expect(
       storage.auth.groupMemberships.listForGroup({
         projectId,

--- a/packages/server/tests/magic-link-auth-routes.test.ts
+++ b/packages/server/tests/magic-link-auth-routes.test.ts
@@ -151,8 +151,14 @@ describe("magic-link auth routes", () => {
       })
     )
 
-    expect(callback.status).toBe(303)
-    expect(callback.headers.get("location")).toBe("/dashboard")
+    expect(callback.status).toBe(200)
+    expect(callback.headers.get("location")).toBeNull()
+    expect(callback.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to 'self'"
+    )
+    expect(await callback.clone().text()).toContain(
+      '<meta http-equiv="refresh" content="0;url=/dashboard">'
+    )
     const setCookie = callback.headers.get("set-cookie")
     const sessionCookie = cookieValue(setCookie, "pario_session")
     const csrfCookie = cookieValue(setCookie, "pario_csrf")
@@ -209,8 +215,9 @@ describe("magic-link auth routes", () => {
       })
     )
 
-    expect(callback.status).toBe(303)
-    expect(callback.headers.get("location")).toBe("/")
+    expect(callback.status).toBe(200)
+    expect(callback.headers.get("location")).toBeNull()
+    expect(await callback.text()).toContain('<meta http-equiv="refresh" content="0;url=/">')
   })
 
   test("sign-out revokes the magic-link-created session and clears cookies", async () => {

--- a/packages/server/tests/oidc-auth-routes.test.ts
+++ b/packages/server/tests/oidc-auth-routes.test.ts
@@ -198,8 +198,14 @@ describe("oidc auth routes", () => {
       })
     )
 
-    expect(callback.status).toBe(303)
-    expect(callback.headers.get("location")).toBe("/dashboard")
+    expect(callback.status).toBe(200)
+    expect(callback.headers.get("location")).toBeNull()
+    expect(callback.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to 'self'"
+    )
+    expect(await callback.clone().text()).toContain(
+      '<meta http-equiv="refresh" content="0;url=/dashboard">'
+    )
     const setCookie = callback.headers.get("set-cookie")
     const sessionCookie = cookieValue(setCookie, "pario_session")
     const csrfCookie = cookieValue(setCookie, "pario_csrf")
@@ -310,8 +316,11 @@ describe("oidc auth routes", () => {
       )
     )
 
-    expect(callback.status).toBe(303)
-    expect(callback.headers.get("location")).toBe("/dashboard")
+    expect(callback.status).toBe(200)
+    expect(callback.headers.get("location")).toBeNull()
+    expect(await callback.text()).toContain(
+      '<meta http-equiv="refresh" content="0;url=/dashboard">'
+    )
     await expect(
       storage.auth.groupMemberships.listForGroup({
         projectId,

--- a/packages/server/tests/openapi-docs.test.ts
+++ b/packages/server/tests/openapi-docs.test.ts
@@ -59,7 +59,7 @@ describe("OpenAPI docs", () => {
       in: "header",
       name: "x-pario-csrf",
       description:
-        "Required for authenticated mutating requests. Copy the value from the pario_csrf cookie.",
+        "Required for authenticated mutating requests. Use the csrfToken returned by GET /api/auth/session.",
     })
 
     const csrfRoutes = [


### PR DESCRIPTION
# PR Summary - Browser API Origin Foundation

## Why

Pario is moving to a clearer browser deployment model:

```txt
admin.example.com -> built-in admin UI
app.example.com   -> custom app UI
api.example.com   -> API, auth, WebSocket, docs
```

This PR lays the API-side foundation for that split. The API can now safely accept credentialed
browser requests from multiple allowed UI origins while keeping session cookies host-only on the API
origin and resolving the expected session audience from the request origin.

## What Changed

| Area | Change |
| --- | --- |
| Server surface | Added a `browserApi` surface for API/auth/ws/docs servers. |
| Origin policy | Added exact browser-origin allowlisting with origin-to-audience mapping. |
| Auth guard | Moved from a fixed server audience to a per-request auth context resolver. |
| CORS | Added credentialed CORS with exact origin echoing, preflight handling, and unknown-origin rejection. |
| Session API | `GET /api/auth/session` now returns a `csrfToken` for authenticated sessions. |
| CSRF | Mutating routes verify CSRF against the audience-specific API cookie. |
| Cookies | Auth cookies now use `SameSite=Strict`; `__Host-` names are validated; CSRF cookies can be `HttpOnly`. |
| Client contract | Regenerated OpenAPI and typed client output for the new session shape. |

## Key Behavior

- `admin` and `app` sessions are resolved from the browser `Origin`.
- Unknown browser origins get `403` and no credentialed CORS headers.
- CORS never falls back to wildcard origins with credentials.
- Session bootstrap returns the CSRF token in JSON, so future cross-origin UIs do not need to read
  API cookies through `document.cookie`.
- `SameSite=Strict` is the V1 auth-cookie default.

## Validation

```bash
bun test packages/core/tests/auth-runtime.test.ts packages/server/tests/auth-guard.test.ts packages/server/tests/openapi-docs.test.ts
bun test packages/server/tests
bun run generate:client
bun run typecheck
bun run check
bun run test
```
