### PR TITLE
add sandbox contract and local sandbox provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -435,6 +435,17 @@
         "typescript": "^5.7.0",
       },
     },
+    "sandboxes/local": {
+      "name": "@sixb/sandboxes-local",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sixb/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "storage/blob-local": {
       "name": "@sixb/blob-local",
       "version": "0.1.0",
@@ -872,6 +883,8 @@
     "@sixb/queues-bullmq": ["@sixb/queues-bullmq@workspace:queues/bullmq"],
 
     "@sixb/rules-worker": ["@sixb/rules-worker@workspace:packages/rules-worker"],
+
+    "@sixb/sandboxes-local": ["@sixb/sandboxes-local@workspace:sandboxes/local"],
 
     "@sixb/server": ["@sixb/server@workspace:packages/server"],
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "connectors/*",
     "broker/*",
     "queues/*",
+    "sandboxes/*",
     "storage/*",
     "examples/*"
   ],
@@ -20,7 +21,7 @@
     "test": "bun test",
     "test:e2e": "bun run --workspaces --if-present test:e2e",
     "test:all": "bun run test && bun run test:e2e",
-    "lint": "biome check auth/*/src packages/*/src connectors/*/src",
+    "lint": "biome check auth/*/src packages/*/src connectors/*/src sandboxes/*/src",
     "typecheck": "bun --filter '@sixb/*' typecheck",
     "link-cli": "ln -sf \"$(pwd)/packages/cli/src/index.tsx\" ~/.bun/bin/sixb && echo 'Linked sixb CLI to ~/.bun/bin/sixb'",
     "sixb": "bun packages/cli/src/index.tsx",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -832,6 +832,23 @@ export { InMemoryQueues, QueueError } from "./queues"
 export type { QueueWorkerConfig, QueueWorkerFailureDecision } from "./workers"
 export { QueueWorker, Worker, WorkerAbortError } from "./workers"
 
+// ── Sandboxes ──────────────────────────────────────────────
+
+export type {
+  CommandResult,
+  CreateSandboxOptions,
+  RunCommandOptions,
+  Sandbox,
+  SandboxFactory,
+  SandboxStatus,
+} from "./sandboxes"
+export {
+  SandboxError,
+  SandboxIsolationUnavailableError,
+  SandboxNotRunningError,
+  SandboxTimeoutError,
+} from "./sandboxes"
+
 // ── Object Operations ───────────────────────────────────────
 
 export { objectService } from "./objects"

--- a/packages/core/src/runtime/create.ts
+++ b/packages/core/src/runtime/create.ts
@@ -27,6 +27,7 @@ import type { PipelineDefinition } from "../pipelines/types"
 import type { ProjectionDefinition } from "../projections/types"
 import type { Queues } from "../queues"
 import type { RuleDefinition } from "../rules"
+import type { SandboxFactory } from "../sandboxes"
 import type { ScheduleDefinition } from "../schedules"
 import type { GroupDefinition, InvitePolicyDefinition, RoleDefinition } from "../security"
 import type { Storage } from "../storage"
@@ -43,6 +44,7 @@ export interface CreateSixbOptions {
   lakeStorage: LakeStorage
   blobStorage: BlobStorage
   queues: Queues
+  sandboxes?: SandboxFactory
   ontologies?: readonly OntologySource[]
   actions?: readonly ActionDefinition[]
   datasets?: readonly DatasetDefinition[]
@@ -122,6 +124,7 @@ export async function createSixb(
     lakeStorage: options.lakeStorage,
     blobStorage: options.blobStorage,
     queues: options.queues,
+    sandboxes: options.sandboxes,
     actions,
     datasets: [...(options.datasets ?? []), ...datasets],
     connectors: [...(options.connectors ?? []), ...connectors],

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -45,6 +45,7 @@ import { validateProjectionsAtStartup } from "../projections/validation"
 import type { Queues } from "../queues"
 import type { RuleDefinition } from "../rules"
 import { validateRulesAtStartup } from "../rules"
+import type { SandboxFactory } from "../sandboxes"
 import { SchedulerRuntime } from "../scheduler"
 import type { ScheduleDefinition } from "../schedules"
 import type {
@@ -81,6 +82,7 @@ export interface SixbOptions<TOntologySources extends readonly OntologySource[]>
   lakeStorage: LakeStorage
   blobStorage: BlobStorage
   queues: Queues
+  sandboxes?: SandboxFactory
   actions?: readonly ActionDefinition[]
   datasets?: readonly DatasetDefinition[]
   /** Connector definitions registered with this runtime. */
@@ -126,6 +128,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
   readonly lakeStorage: LakeStorage
   readonly blobStorage: BlobStorage
   readonly queues: Queues
+  readonly sandboxes?: SandboxFactory
   readonly rules: readonly RuleDefinition[]
   readonly security: SecurityRegistry
   readonly auth: AuthRuntime
@@ -142,6 +145,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     this.lakeStorage = options.lakeStorage
     this.blobStorage = options.blobStorage
     this.queues = options.queues
+    this.sandboxes = options.sandboxes
     this.rules = options.rules ?? []
     // Ontology and actions resolve first so every later registry (security,
     // rules, workflows, projections) can validate its references against them.
@@ -273,6 +277,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       lakeStorage: this.lakeStorage,
       blobStorage: this.blobStorage,
       queues: this.queues,
+      sandboxes: this.sandboxes,
     }
     this.actions = new ActionsRuntime(this.runtimeContext)
     this.workflows = new WorkflowsRuntime(this.runtimeContext, workflows)

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -52,6 +52,7 @@ import type {
 } from "../projections/types"
 import type { Queues } from "../queues"
 import type { RuleDefinition } from "../rules"
+import type { SandboxFactory } from "../sandboxes"
 import type { ScheduleDefinition } from "../schedules"
 import type { SecurityRegistry } from "../security"
 import type { ActionRunRecord, ObjectLinkRow, ObjectRow, Storage } from "../storage"
@@ -80,6 +81,7 @@ export interface SixbRuntimeContext {
   readonly lakeStorage: LakeStorage
   readonly blobStorage: BlobStorage
   readonly queues: Queues
+  readonly sandboxes?: SandboxFactory
   readonly rules?: readonly RuleDefinition[]
   /**
    * Principal scope for this context. Absent on privileged runtimes (raw
@@ -629,6 +631,7 @@ export interface SixbInstance<_ extends readonly OntologySource[]> {
   readonly lakeStorage: LakeStorage
   readonly blobStorage: BlobStorage
   readonly queues: Queues
+  readonly sandboxes?: SandboxFactory
   readonly rules?: readonly RuleDefinition[]
   readonly security: SecurityRegistry
   readonly auth: AuthRuntime

--- a/packages/core/src/sandboxes/errors.ts
+++ b/packages/core/src/sandboxes/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Errors thrown by sandbox providers. Hosts can catch SandboxError at the
+ * audit boundary while still distinguishing recoverable provider states.
+ */
+export class SandboxError extends Error {
+  readonly name: string = "SandboxError"
+}
+
+/** runCommand / stop / destroy called after the sandbox is stopped or destroyed. */
+export class SandboxNotRunningError extends SandboxError {
+  override readonly name = "SandboxNotRunningError"
+}
+
+/** Command exceeded its timeout and was killed. */
+export class SandboxTimeoutError extends SandboxError {
+  override readonly name = "SandboxTimeoutError"
+}
+
+/** Requested isolation backend is not available on the host. */
+export class SandboxIsolationUnavailableError extends SandboxError {
+  override readonly name = "SandboxIsolationUnavailableError"
+}

--- a/packages/core/src/sandboxes/index.ts
+++ b/packages/core/src/sandboxes/index.ts
@@ -1,0 +1,14 @@
+export {
+  SandboxError,
+  SandboxIsolationUnavailableError,
+  SandboxNotRunningError,
+  SandboxTimeoutError,
+} from "./errors"
+export type {
+  CommandResult,
+  CreateSandboxOptions,
+  RunCommandOptions,
+  Sandbox,
+  SandboxFactory,
+  SandboxStatus,
+} from "./sandbox"

--- a/packages/core/src/sandboxes/sandbox.ts
+++ b/packages/core/src/sandboxes/sandbox.ts
@@ -1,0 +1,71 @@
+/**
+ * Provider-agnostic sandbox surface.
+ *
+ * A Sandbox is the agent's command execution target. Concrete providers
+ * implement this interface while consumers only depend on Sandbox and
+ * SandboxFactory.
+ */
+
+export type SandboxStatus = "running" | "stopped" | "failed"
+
+/**
+ * Per-command overrides. Each field overrides the matching sandbox-level
+ * default set at factory.create(...).
+ */
+export interface RunCommandOptions {
+  /** Overrides the sandbox-level workingDirectory for this call. */
+  readonly cwd?: string
+  /** Merged on top of sandbox-level env. Per-call wins on collision. */
+  readonly env?: Readonly<Record<string, string>>
+  /** Overrides the sandbox-level timeout, in milliseconds. */
+  readonly timeout?: number
+  /** Per-call only; there is no sandbox-level equivalent. */
+  readonly signal?: AbortSignal
+}
+
+export interface CommandResult {
+  readonly exitCode: number
+  readonly stdout: string
+  readonly stderr: string
+  readonly durationMs: number
+  /** True when the command was killed because it exceeded timeout. */
+  readonly timedOut?: boolean
+}
+
+/**
+ * Options accepted by every SandboxFactory.create. Provider-specific factories
+ * may extend this type with their own options.
+ */
+export interface CreateSandboxOptions {
+  readonly workingDirectory?: string
+  readonly env?: Readonly<Record<string, string>>
+  readonly timeout?: number
+  readonly allowNetwork?: boolean
+}
+
+export interface Sandbox {
+  readonly id: string
+  /** Provider id matching the package suffix, for example "local". */
+  readonly provider: string
+  readonly status: SandboxStatus
+  readonly workingDirectory: string
+
+  runCommand(
+    command: string,
+    args?: readonly string[],
+    options?: RunCommandOptions
+  ): Promise<CommandResult>
+
+  /** Mark the sandbox stopped; subsequent runCommand calls reject. Idempotent. */
+  stop(): Promise<void>
+  /** Stop and reclaim any provider-side resources. Idempotent. */
+  destroy(): Promise<void>
+}
+
+/**
+ * What createSixb({ sandboxes }) accepts. Provider-specific factories hold
+ * their defaults set once and expose create(options) for each run.
+ */
+export interface SandboxFactory {
+  create(options?: CreateSandboxOptions): Promise<Sandbox>
+}

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -21,3 +21,8 @@ export {
   type QueueContractSuiteOptions,
   runQueueContractSuite,
 } from "./queues-contract"
+export {
+  runSandboxesContractSuite,
+  type SandboxesContractCapabilities,
+  type SandboxesContractSuiteOptions,
+} from "./sandboxes-contract"

--- a/packages/core/src/testing/sandboxes-contract.ts
+++ b/packages/core/src/testing/sandboxes-contract.ts
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { realpath } from "node:fs/promises"
+import { type SandboxFactory, SandboxNotRunningError } from "../sandboxes"
+
+/**
+ * Capability flags letting a provider declare which contract slices are
+ * meaningful for it. Tests gated by an unsupported capability are skipped.
+ */
+export interface SandboxesContractCapabilities {
+  /** allowNetwork: false actually blocks outbound network access. */
+  readonly networkBlocking?: boolean
+  /** readOnlyPaths/readWritePaths actually restrict filesystem writes. */
+  readonly readOnlyEnforcement?: boolean
+  /** Strong isolation, such as process namespaces, is in effect. */
+  readonly isolation?: boolean
+}
+
+export interface SandboxesContractSuiteOptions {
+  /** Factory under test. Called once per describe block. */
+  readonly createFactory: () => SandboxFactory | Promise<SandboxFactory>
+  /** Optional cleanup invoked once per test after factory-created sandboxes are destroyed. */
+  readonly teardown?: (factory: SandboxFactory) => void | Promise<void>
+  readonly capabilities?: SandboxesContractCapabilities
+  /**
+   * Timeout in milliseconds used by the timeout/abort tests. Bump on slow CI.
+   * Default 200ms.
+   */
+  readonly shortTimeoutMs?: number
+}
+
+const SLEEP_BUDGET_SECONDS = 5
+
+/**
+ * Provider-independent contract for Sandbox and SandboxFactory. Concrete
+ * providers wire this into their tests via runSandboxesContractSuite(...).
+ */
+export function runSandboxesContractSuite(
+  label: string,
+  options: SandboxesContractSuiteOptions
+): void {
+  const shortTimeoutMs = options.shortTimeoutMs ?? 200
+  const capabilities = options.capabilities ?? {}
+
+  describe(label, () => {
+    let factory: SandboxFactory
+
+    beforeEach(async () => {
+      factory = await options.createFactory()
+    })
+
+    afterEach(async () => {
+      await options.teardown?.(factory)
+    })
+
+    describe("lifecycle", () => {
+      test("create returns a running sandbox with a non-empty id", async () => {
+        const sandbox = await factory.create()
+        try {
+          expect(sandbox.status).toBe("running")
+          expect(sandbox.id.length).toBeGreaterThan(0)
+          expect(sandbox.workingDirectory.length).toBeGreaterThan(0)
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("runCommand returns exit code 0 and captured stdout for echo", async () => {
+        const sandbox = await factory.create()
+        try {
+          const result = await sandbox.runCommand("echo", ["hello"])
+          expect(result.exitCode).toBe(0)
+          expect(result.stdout.trim()).toBe("hello")
+          expect(result.stderr).toBe("")
+          expect(result.durationMs).toBeGreaterThanOrEqual(0)
+          expect(result.timedOut).not.toBe(true)
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("nonexistent binary resolves with non-zero exit code", async () => {
+        const sandbox = await factory.create()
+        try {
+          const result = await sandbox.runCommand("does-not-exist-xyz-sixb-test", [])
+          expect(result.exitCode).not.toBe(0)
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("captures stdout and stderr as separate streams", async () => {
+        const sandbox = await factory.create()
+        try {
+          const result = await sandbox.runCommand("/bin/sh", [
+            "-c",
+            "echo out-line; echo err-line >&2; exit 0",
+          ])
+          expect(result.exitCode).toBe(0)
+          expect(result.stdout).toContain("out-line")
+          expect(result.stderr).toContain("err-line")
+          expect(result.stdout).not.toContain("err-line")
+          expect(result.stderr).not.toContain("out-line")
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("stop transitions status and rejects subsequent runCommand", async () => {
+        const sandbox = await factory.create()
+        try {
+          await sandbox.stop()
+          expect(sandbox.status).toBe("stopped")
+          await expect(sandbox.runCommand("echo", ["nope"])).rejects.toBeInstanceOf(
+            SandboxNotRunningError
+          )
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("destroy is idempotent", async () => {
+        const sandbox = await factory.create()
+        await sandbox.destroy()
+        await sandbox.destroy()
+        await expect(sandbox.runCommand("echo", ["x"])).rejects.toBeInstanceOf(
+          SandboxNotRunningError
+        )
+      })
+    })
+
+    describe("working directory", () => {
+      test("pwd reflects the configured workingDirectory", async () => {
+        const sandbox = await factory.create()
+        try {
+          const result = await sandbox.runCommand("pwd")
+          const expected = await realpath(sandbox.workingDirectory)
+          expect(result.exitCode).toBe(0)
+          expect(result.stdout.trim()).toBe(expected)
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("per-call cwd overrides the sandbox-level workingDirectory", async () => {
+        const sandbox = await factory.create()
+        try {
+          const expected = await realpath("/tmp")
+          const result = await sandbox.runCommand("pwd", [], { cwd: "/tmp" })
+          expect(result.exitCode).toBe(0)
+          expect(result.stdout.trim()).toBe(expected)
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+    })
+
+    describe("env merging", () => {
+      test("sandbox-level env is visible to commands", async () => {
+        const sandbox = await factory.create({ env: { SIXB_TEST_A: "alpha" } })
+        try {
+          const result = await sandbox.runCommand("printenv", ["SIXB_TEST_A"])
+          expect(result.exitCode).toBe(0)
+          expect(result.stdout.trim()).toBe("alpha")
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("per-call env wins on collision and adds new keys", async () => {
+        const sandbox = await factory.create({
+          env: { SIXB_TEST_A: "alpha", SIXB_TEST_B: "beta" },
+        })
+        try {
+          const a = await sandbox.runCommand("printenv", ["SIXB_TEST_A"], {
+            env: { SIXB_TEST_A: "alpha2", SIXB_TEST_C: "gamma" },
+          })
+          const b = await sandbox.runCommand("printenv", ["SIXB_TEST_B"], {
+            env: { SIXB_TEST_A: "alpha2", SIXB_TEST_C: "gamma" },
+          })
+          const c = await sandbox.runCommand("printenv", ["SIXB_TEST_C"], {
+            env: { SIXB_TEST_A: "alpha2", SIXB_TEST_C: "gamma" },
+          })
+          expect(a.stdout.trim()).toBe("alpha2")
+          expect(b.stdout.trim()).toBe("beta")
+          expect(c.stdout.trim()).toBe("gamma")
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("host secrets are not leaked into the sandbox", async () => {
+        const secretKey = "SIXB_HOST_SECRET_DO_NOT_LEAK"
+        const previous = process.env[secretKey]
+        process.env[secretKey] = "host-only-value"
+        try {
+          const sandbox = await factory.create()
+          try {
+            const result = await sandbox.runCommand("printenv", [secretKey])
+            expect(result.exitCode).not.toBe(0)
+            expect(result.stdout).not.toContain("host-only-value")
+          } finally {
+            await sandbox.destroy()
+          }
+        } finally {
+          if (previous === undefined) {
+            delete process.env[secretKey]
+          } else {
+            process.env[secretKey] = previous
+          }
+        }
+      })
+    })
+
+    describe("timeout and abort", () => {
+      test("sleep beyond timeout marks the result timedOut and exits non-zero", async () => {
+        const sandbox = await factory.create()
+        try {
+          const start = Date.now()
+          const result = await sandbox.runCommand("sleep", [String(SLEEP_BUDGET_SECONDS)], {
+            timeout: shortTimeoutMs,
+          })
+          const elapsed = Date.now() - start
+          expect(result.timedOut).toBe(true)
+          expect(result.exitCode).not.toBe(0)
+          expect(elapsed).toBeLessThan(SLEEP_BUDGET_SECONDS * 1000)
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("abort signal aborts an in-flight command", async () => {
+        const sandbox = await factory.create()
+        try {
+          const ac = new AbortController()
+          setTimeout(() => ac.abort(), shortTimeoutMs)
+          const start = Date.now()
+          const result = await sandbox.runCommand("sleep", [String(SLEEP_BUDGET_SECONDS)], {
+            signal: ac.signal,
+          })
+          const elapsed = Date.now() - start
+          expect(result.exitCode).not.toBe(0)
+          expect(elapsed).toBeLessThan(SLEEP_BUDGET_SECONDS * 1000)
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+
+      test("per-call timeout overrides sandbox-level timeout", async () => {
+        const sandbox = await factory.create({ timeout: SLEEP_BUDGET_SECONDS * 1000 })
+        try {
+          const result = await sandbox.runCommand("sleep", [String(SLEEP_BUDGET_SECONDS)], {
+            timeout: shortTimeoutMs,
+          })
+          expect(result.timedOut).toBe(true)
+        } finally {
+          await sandbox.destroy()
+        }
+      })
+    })
+
+    if (capabilities.networkBlocking) {
+      describe("network isolation", () => {
+        test("allowNetwork: false blocks outbound DNS / TCP", async () => {
+          const sandbox = await factory.create({ allowNetwork: false })
+          try {
+            const result = await sandbox.runCommand("curl", [
+              "-sS",
+              "--max-time",
+              "2",
+              "https://example.com",
+            ])
+            expect(result.exitCode).not.toBe(0)
+          } finally {
+            await sandbox.destroy()
+          }
+        })
+
+        test("allowNetwork: true permits outbound traffic", async () => {
+          const sandbox = await factory.create({ allowNetwork: true })
+          try {
+            const result = await sandbox.runCommand("curl", [
+              "-sS",
+              "--max-time",
+              "5",
+              "https://example.com",
+            ])
+            expect(result.exitCode).not.toBe(6)
+          } finally {
+            await sandbox.destroy()
+          }
+        })
+      })
+    }
+
+    if (capabilities.readOnlyEnforcement) {
+      describe("filesystem isolation", () => {
+        test("writing inside readWritePaths succeeds", async () => {
+          const sandbox = await factory.create()
+          try {
+            const result = await sandbox.runCommand("/bin/sh", [
+              "-c",
+              `echo content > ${sandbox.workingDirectory}/probe.txt && cat ${sandbox.workingDirectory}/probe.txt`,
+            ])
+            expect(result.exitCode).toBe(0)
+            expect(result.stdout.trim()).toBe("content")
+          } finally {
+            await sandbox.destroy()
+          }
+        })
+
+        test("writing outside readWritePaths fails", async () => {
+          const sandbox = await factory.create()
+          try {
+            const result = await sandbox.runCommand("/bin/sh", [
+              "-c",
+              "echo nope > /etc/sixb-sandbox-must-not-write",
+            ])
+            expect(result.exitCode).not.toBe(0)
+          } finally {
+            await sandbox.destroy()
+          }
+        })
+      })
+    }
+  })
+}

--- a/packages/core/tests/sandboxes/types.test.ts
+++ b/packages/core/tests/sandboxes/types.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import {
+  SandboxError,
+  SandboxIsolationUnavailableError,
+  SandboxNotRunningError,
+  SandboxTimeoutError,
+} from "../../src/sandboxes"
+
+describe("sandbox error hierarchy", () => {
+  test("each subclass extends SandboxError with a distinct name", () => {
+    const notRunning = new SandboxNotRunningError("stopped")
+    const timedOut = new SandboxTimeoutError("too slow")
+    const unavailable = new SandboxIsolationUnavailableError("bwrap missing")
+
+    expect(notRunning).toBeInstanceOf(SandboxError)
+    expect(timedOut).toBeInstanceOf(SandboxError)
+    expect(unavailable).toBeInstanceOf(SandboxError)
+
+    expect(notRunning.name).toBe("SandboxNotRunningError")
+    expect(timedOut.name).toBe("SandboxTimeoutError")
+    expect(unavailable.name).toBe("SandboxIsolationUnavailableError")
+
+    expect(notRunning.message).toBe("stopped")
+  })
+
+  test("base SandboxError extends Error", () => {
+    const err = new SandboxError("boom")
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe("SandboxError")
+  })
+})

--- a/packages/core/tests/sandboxes/wiring.test.ts
+++ b/packages/core/tests/sandboxes/wiring.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import { defineObjectType, prop } from "../../src/ontology"
+import { Sixb } from "../../src/runtime"
+import type { Sandbox, SandboxFactory } from "../../src/sandboxes"
+import { createTestRuntimeDeps } from "../test-runtime-deps"
+
+const Room = defineObjectType({
+  id: "Room",
+  name: "Room",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+function makeFactory(): SandboxFactory {
+  return {
+    create: async () =>
+      ({
+        id: "stub",
+        provider: "stub",
+        status: "running",
+        workingDirectory: "/tmp/stub",
+        runCommand: async () => ({ exitCode: 0, stdout: "", stderr: "", durationMs: 0 }),
+        stop: async () => {},
+        destroy: async () => {},
+      }) satisfies Sandbox,
+  }
+}
+
+describe("Sixb sandboxes wiring", () => {
+  test("sandboxes is undefined when not configured", () => {
+    const sixb = new Sixb({ ontology: [Room], ...createTestRuntimeDeps() })
+    expect(sixb.sandboxes).toBeUndefined()
+  })
+
+  test("sandboxes is the exact factory passed in", () => {
+    const factory = makeFactory()
+    const sixb = new Sixb({
+      ontology: [Room],
+      ...createTestRuntimeDeps(),
+      sandboxes: factory,
+    })
+    expect(sixb.sandboxes).toBe(factory)
+  })
+
+  test("the runtime exposes the same factory", async () => {
+    const factory = makeFactory()
+    const sixb = new Sixb({
+      ontology: [Room],
+      ...createTestRuntimeDeps(),
+      sandboxes: factory,
+    })
+
+    const sandbox = await sixb.sandboxes?.create()
+    expect(sandbox?.provider).toBe("stub")
+  })
+})

--- a/sandboxes/local/package.json
+++ b/sandboxes/local/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sixb/sandboxes-local",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@sixb/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  }
+}

--- a/sandboxes/local/src/exec.ts
+++ b/sandboxes/local/src/exec.ts
@@ -1,0 +1,99 @@
+import type { CommandResult } from "@sixb/core"
+
+export interface ExecOptions {
+  readonly argv: readonly string[]
+  readonly cwd: string
+  readonly env: Readonly<Record<string, string>>
+  readonly timeoutMs?: number
+  readonly signal?: AbortSignal
+}
+
+const DEFAULT_KILL_EXIT_CODE = 137
+
+/**
+ * Spawn a child process and gather its result. This wraps Bun.spawn with
+ * timeout and AbortSignal handling, and never throws.
+ */
+export async function exec(options: ExecOptions): Promise<CommandResult> {
+  const start = Date.now()
+
+  const [head, ...rest] = options.argv
+  if (!head) {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: "[Sandbox] empty argv",
+      durationMs: 0,
+    }
+  }
+
+  let proc: ReturnType<typeof Bun.spawn>
+  try {
+    proc = Bun.spawn([head, ...rest], {
+      cwd: options.cwd,
+      env: options.env,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+  } catch (error) {
+    return {
+      exitCode: 127,
+      stdout: "",
+      stderr: error instanceof Error ? error.message : String(error),
+      durationMs: Date.now() - start,
+    }
+  }
+
+  let timedOut = false
+  let killed = false
+
+  const timer =
+    options.timeoutMs !== undefined && options.timeoutMs > 0
+      ? setTimeout(() => {
+          timedOut = true
+          killed = true
+          proc.kill("SIGKILL")
+        }, options.timeoutMs)
+      : undefined
+
+  const onAbort = (): void => {
+    if (!killed) {
+      killed = true
+      proc.kill("SIGKILL")
+    }
+  }
+  options.signal?.addEventListener("abort", onAbort)
+  if (options.signal?.aborted) {
+    onAbort()
+  }
+
+  let stdout = ""
+  let stderr = ""
+  let exitCode = 0
+  try {
+    const [stdoutText, stderrText, code] = await Promise.all([
+      new Response(proc.stdout as ReadableStream<Uint8Array>).text(),
+      new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+      proc.exited,
+    ])
+    stdout = stdoutText
+    stderr = stderrText
+    exitCode = typeof code === "number" ? code : DEFAULT_KILL_EXIT_CODE
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+    options.signal?.removeEventListener("abort", onAbort)
+  }
+
+  if (killed && exitCode === 0) {
+    exitCode = DEFAULT_KILL_EXIT_CODE
+  }
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    durationMs: Date.now() - start,
+    ...(timedOut ? { timedOut: true } : {}),
+  }
+}

--- a/sandboxes/local/src/index.ts
+++ b/sandboxes/local/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  type DetectInput,
+  detectIsolation,
+  type IsolationProbe,
+  type LocalIsolation,
+  type ResolvedIsolation,
+} from "./isolation/detect"
+export { LocalSandbox, type LocalSandboxOptions } from "./local-sandbox"
+export { LocalSandboxFactory, type LocalSandboxFactoryOptions } from "./local-sandbox-factory"

--- a/sandboxes/local/src/isolation/bwrap.ts
+++ b/sandboxes/local/src/isolation/bwrap.ts
@@ -1,0 +1,37 @@
+export interface BwrapArgvInput {
+  readonly command: string
+  readonly args: readonly string[]
+  readonly workingDirectory: string
+  readonly readOnlyPaths: readonly string[]
+  readonly readWritePaths: readonly string[]
+  readonly allowNetwork: boolean
+}
+
+/**
+ * Build the argv invoked by Bun.spawn to run a command under bwrap.
+ * Arguments are passed verbatim after --, so shell metacharacters are not
+ * interpreted unless the caller explicitly runs a shell.
+ */
+export function buildBwrapArgv(input: BwrapArgvInput): readonly string[] {
+  const argv: string[] = ["bwrap"]
+
+  argv.push("--ro-bind", "/", "/")
+  for (const path of input.readOnlyPaths) {
+    argv.push("--ro-bind", path, path)
+  }
+  argv.push("--bind", input.workingDirectory, input.workingDirectory)
+  for (const path of input.readWritePaths) {
+    argv.push("--bind", path, path)
+  }
+  argv.push("--proc", "/proc", "--dev", "/dev")
+
+  argv.push("--unshare-pid")
+  if (!input.allowNetwork) {
+    argv.push("--unshare-net")
+  }
+
+  argv.push("--die-with-parent")
+  argv.push("--", input.command, ...input.args)
+
+  return argv
+}

--- a/sandboxes/local/src/isolation/detect.ts
+++ b/sandboxes/local/src/isolation/detect.ts
@@ -1,0 +1,82 @@
+export type LocalIsolation = "auto" | "seatbelt" | "bwrap" | "none"
+
+export type ResolvedIsolation = "seatbelt" | "bwrap" | "none"
+
+export interface IsolationProbe {
+  readonly backend: ResolvedIsolation
+  readonly available: boolean
+  readonly message: string
+}
+
+/**
+ * Inputs to detectIsolation. Tests can pass synthetic values for platform and
+ * binary availability without monkey-patching globals.
+ */
+export interface DetectInput {
+  readonly platform: NodeJS.Platform
+  hasBinary(name: string): boolean
+  canRunSeatbelt?(): boolean
+}
+
+export function detectIsolation(input: DetectInput = defaultDetectInput()): IsolationProbe {
+  if (input.platform === "darwin") {
+    if (input.hasBinary("sandbox-exec")) {
+      if (input.canRunSeatbelt?.() === false) {
+        return {
+          backend: "none",
+          available: true,
+          message: "darwin: sandbox-exec cannot apply a sandbox; falling back to no isolation",
+        }
+      }
+      return {
+        backend: "seatbelt",
+        available: true,
+        message: "darwin: sandbox-exec available",
+      }
+    }
+    return {
+      backend: "none",
+      available: true,
+      message: "darwin: sandbox-exec not on PATH; falling back to no isolation",
+    }
+  }
+
+  if (input.platform === "linux") {
+    if (input.hasBinary("bwrap")) {
+      return { backend: "bwrap", available: true, message: "linux: bwrap available" }
+    }
+    return {
+      backend: "none",
+      available: true,
+      message: "linux: bwrap not on PATH; falling back to no isolation",
+    }
+  }
+
+  return {
+    backend: "none",
+    available: true,
+    message: `unsupported platform ${input.platform}; using no isolation`,
+  }
+}
+
+function defaultDetectInput(): DetectInput {
+  return {
+    platform: process.platform as NodeJS.Platform,
+    hasBinary: (name) => Boolean(Bun.which(name)),
+    canRunSeatbelt,
+  }
+}
+
+function canRunSeatbelt(): boolean {
+  try {
+    const result = Bun.spawnSync([
+      "sandbox-exec",
+      "-p",
+      "(version 1)\n(allow default)\n",
+      "/usr/bin/true",
+    ])
+    return result.exitCode === 0
+  } catch {
+    return false
+  }
+}

--- a/sandboxes/local/src/isolation/none.ts
+++ b/sandboxes/local/src/isolation/none.ts
@@ -1,0 +1,9 @@
+/**
+ * Build the argv for the none isolation backend: passthrough, no wrapper.
+ */
+export function buildNoneArgv(input: {
+  readonly command: string
+  readonly args: readonly string[]
+}): readonly string[] {
+  return [input.command, ...input.args]
+}

--- a/sandboxes/local/src/isolation/seatbelt.ts
+++ b/sandboxes/local/src/isolation/seatbelt.ts
@@ -1,0 +1,46 @@
+export interface SeatbeltProfileInput {
+  readonly workingDirectory: string
+  readonly readOnlyPaths: readonly string[]
+  readonly readWritePaths: readonly string[]
+  readonly allowNetwork: boolean
+}
+
+export interface SeatbeltArgvInput {
+  readonly profile: string
+  readonly command: string
+  readonly args: readonly string[]
+}
+
+/**
+ * Build a Seatbelt profile string for sandbox-exec.
+ */
+export function buildSeatbeltProfile(input: SeatbeltProfileInput): string {
+  const lines: string[] = []
+  lines.push("(version 1)")
+  lines.push("(allow default)")
+
+  if (!input.allowNetwork) {
+    lines.push("(deny network-outbound)")
+  }
+
+  lines.push("(deny file-write*)")
+  lines.push(`(allow file-write* (subpath ${sbplString(input.workingDirectory)}))`)
+  lines.push('(allow file-write* (subpath "/private/tmp"))')
+  lines.push('(allow file-write* (subpath "/private/var/folders"))')
+  for (const path of input.readWritePaths) {
+    lines.push(`(allow file-write* (subpath ${sbplString(path)}))`)
+  }
+
+  return `${lines.join("\n")}\n`
+}
+
+/**
+ * Build the argv invoked by Bun.spawn to run a command under sandbox-exec.
+ */
+export function buildSeatbeltArgv(input: SeatbeltArgvInput): readonly string[] {
+  return ["sandbox-exec", "-p", input.profile, input.command, ...input.args]
+}
+
+function sbplString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+}

--- a/sandboxes/local/src/local-sandbox-factory.ts
+++ b/sandboxes/local/src/local-sandbox-factory.ts
@@ -1,0 +1,35 @@
+import type { CreateSandboxOptions, Sandbox, SandboxFactory } from "@sixb/core"
+import type { LocalIsolation } from "./isolation/detect"
+import { LocalSandbox } from "./local-sandbox"
+
+export interface LocalSandboxFactoryOptions {
+  readonly isolation?: LocalIsolation
+  readonly readOnlyPaths?: readonly string[]
+  readonly readWritePaths?: readonly string[]
+  /** Default env merged into every sandbox the factory creates. */
+  readonly env?: Readonly<Record<string, string>>
+  /** Default timeout, in milliseconds, applied when none is specified. */
+  readonly timeout?: number
+  /** Default network policy. Overridable per-create. */
+  readonly allowNetwork?: boolean
+}
+
+/**
+ * Pluggable factory for LocalSandbox. Wire once into createSixb({ sandboxes })
+ * and call create(options) for each run.
+ */
+export class LocalSandboxFactory implements SandboxFactory {
+  constructor(private readonly defaults: LocalSandboxFactoryOptions = {}) {}
+
+  async create(options: CreateSandboxOptions = {}): Promise<Sandbox> {
+    return await LocalSandbox.create({
+      isolation: this.defaults.isolation,
+      readOnlyPaths: this.defaults.readOnlyPaths,
+      readWritePaths: this.defaults.readWritePaths,
+      timeout: options.timeout ?? this.defaults.timeout,
+      allowNetwork: options.allowNetwork ?? this.defaults.allowNetwork,
+      env: { ...(this.defaults.env ?? {}), ...(options.env ?? {}) },
+      workingDirectory: options.workingDirectory,
+    })
+  }
+}

--- a/sandboxes/local/src/local-sandbox.ts
+++ b/sandboxes/local/src/local-sandbox.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from "node:crypto"
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  type CommandResult,
+  type CreateSandboxOptions,
+  type RunCommandOptions,
+  type Sandbox,
+  SandboxIsolationUnavailableError,
+  SandboxNotRunningError,
+  type SandboxStatus,
+} from "@sixb/core"
+import { exec } from "./exec"
+import { buildBwrapArgv } from "./isolation/bwrap"
+import {
+  detectIsolation,
+  type IsolationProbe,
+  type LocalIsolation,
+  type ResolvedIsolation,
+} from "./isolation/detect"
+import { buildNoneArgv } from "./isolation/none"
+import { buildSeatbeltArgv, buildSeatbeltProfile } from "./isolation/seatbelt"
+
+export interface LocalSandboxOptions extends CreateSandboxOptions {
+  readonly id?: string
+  readonly isolation?: LocalIsolation
+  readonly readOnlyPaths?: readonly string[]
+  readonly readWritePaths?: readonly string[]
+}
+
+const HOST_ENV_ALLOWLIST = ["PATH", "HOME", "LANG", "TMPDIR"] as const
+
+export class LocalSandbox implements Sandbox {
+  readonly id: string
+  readonly provider = "local"
+  readonly workingDirectory: string
+
+  private currentStatus: SandboxStatus
+  private readonly backend: ResolvedIsolation
+  private readonly sandboxEnv: Readonly<Record<string, string>>
+  private readonly defaultTimeoutMs: number | undefined
+  private readonly allowNetwork: boolean
+  private readonly readOnlyPaths: readonly string[]
+  private readonly readWritePaths: readonly string[]
+  private readonly inFlight = new Set<AbortController>()
+  private readonly cleanupWorkingDirectory: boolean
+
+  private constructor(input: {
+    readonly id: string
+    readonly workingDirectory: string
+    readonly backend: ResolvedIsolation
+    readonly env: Readonly<Record<string, string>>
+    readonly timeout: number | undefined
+    readonly allowNetwork: boolean
+    readonly readOnlyPaths: readonly string[]
+    readonly readWritePaths: readonly string[]
+    readonly cleanupWorkingDirectory: boolean
+  }) {
+    this.id = input.id
+    this.workingDirectory = input.workingDirectory
+    this.backend = input.backend
+    this.sandboxEnv = input.env
+    this.defaultTimeoutMs = input.timeout
+    this.allowNetwork = input.allowNetwork
+    this.readOnlyPaths = input.readOnlyPaths
+    this.readWritePaths = input.readWritePaths
+    this.cleanupWorkingDirectory = input.cleanupWorkingDirectory
+    this.currentStatus = "running"
+  }
+
+  get status(): SandboxStatus {
+    return this.currentStatus
+  }
+
+  static detectIsolation(): IsolationProbe {
+    return detectIsolation()
+  }
+
+  static async create(options: LocalSandboxOptions = {}): Promise<LocalSandbox> {
+    const requested = options.isolation ?? "auto"
+    const backend = await resolveBackend(requested)
+
+    const id = options.id ?? randomUUID()
+    const { workingDirectory, generated } = await resolveWorkingDirectory(
+      options.workingDirectory,
+      id
+    )
+
+    return new LocalSandbox({
+      id,
+      workingDirectory,
+      backend,
+      env: options.env ?? {},
+      timeout: options.timeout,
+      allowNetwork: options.allowNetwork ?? false,
+      readOnlyPaths: options.readOnlyPaths ?? [],
+      readWritePaths: options.readWritePaths ?? [],
+      cleanupWorkingDirectory: generated,
+    })
+  }
+
+  async runCommand(
+    command: string,
+    args: readonly string[] = [],
+    options: RunCommandOptions = {}
+  ): Promise<CommandResult> {
+    if (this.currentStatus !== "running") {
+      throw new SandboxNotRunningError(
+        `[Sandbox] sandbox ${this.id} is ${this.currentStatus}; cannot run commands`
+      )
+    }
+
+    const argv = this.buildArgv(command, args)
+    const env = this.mergeEnv(options.env)
+    const cwd = options.cwd ?? this.workingDirectory
+    const timeoutMs = options.timeout ?? this.defaultTimeoutMs
+
+    const controller = new AbortController()
+    const onUserAbort = (): void => controller.abort()
+    options.signal?.addEventListener("abort", onUserAbort)
+    if (options.signal?.aborted) {
+      onUserAbort()
+    }
+    this.inFlight.add(controller)
+
+    try {
+      return await exec({
+        argv,
+        cwd,
+        env,
+        timeoutMs,
+        signal: controller.signal,
+      })
+    } finally {
+      this.inFlight.delete(controller)
+      options.signal?.removeEventListener("abort", onUserAbort)
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.currentStatus !== "running") {
+      return
+    }
+    this.currentStatus = "stopped"
+    for (const controller of this.inFlight) {
+      controller.abort()
+    }
+    this.inFlight.clear()
+  }
+
+  async destroy(): Promise<void> {
+    if (this.currentStatus === "running") {
+      await this.stop()
+    }
+    if (this.cleanupWorkingDirectory) {
+      await rm(this.workingDirectory, { recursive: true, force: true })
+    }
+  }
+
+  private buildArgv(command: string, args: readonly string[]): readonly string[] {
+    if (this.backend === "none") {
+      return buildNoneArgv({ command, args })
+    }
+    if (this.backend === "bwrap") {
+      return buildBwrapArgv({
+        command,
+        args,
+        workingDirectory: this.workingDirectory,
+        readOnlyPaths: this.readOnlyPaths,
+        readWritePaths: this.readWritePaths,
+        allowNetwork: this.allowNetwork,
+      })
+    }
+    if (this.backend === "seatbelt") {
+      const profile = buildSeatbeltProfile({
+        workingDirectory: this.workingDirectory,
+        readOnlyPaths: this.readOnlyPaths,
+        readWritePaths: this.readWritePaths,
+        allowNetwork: this.allowNetwork,
+      })
+      return buildSeatbeltArgv({ profile, command, args })
+    }
+    throw new SandboxIsolationUnavailableError(
+      `[Sandbox] isolation backend '${this.backend}' is not implemented`
+    )
+  }
+
+  private mergeEnv(perCall: RunCommandOptions["env"]): Record<string, string> {
+    const out: Record<string, string> = {}
+    for (const key of HOST_ENV_ALLOWLIST) {
+      const value = process.env[key]
+      if (value !== undefined) out[key] = value
+    }
+    Object.assign(out, this.sandboxEnv)
+    if (perCall) {
+      Object.assign(out, perCall)
+    }
+    return out
+  }
+}
+
+async function resolveBackend(requested: LocalIsolation): Promise<ResolvedIsolation> {
+  const probe = detectIsolation()
+
+  if (requested === "auto") {
+    return probe.backend
+  }
+
+  if (requested === "none") {
+    return "none"
+  }
+
+  if (requested === probe.backend) {
+    return requested
+  }
+
+  throw new SandboxIsolationUnavailableError(
+    `[Sandbox] isolation '${requested}' is not available on this host (${probe.message})`
+  )
+}
+
+async function resolveWorkingDirectory(
+  configured: string | undefined,
+  id: string
+): Promise<{ readonly workingDirectory: string; readonly generated: boolean }> {
+  if (configured) {
+    await mkdir(configured, { recursive: true })
+    return { workingDirectory: await realpath(configured), generated: false }
+  }
+  const dir = await mkdtemp(join(tmpdir(), `sixb-sandbox-${id}-`))
+  return { workingDirectory: await realpath(dir), generated: true }
+}

--- a/sandboxes/local/tests/bwrap-argv.test.ts
+++ b/sandboxes/local/tests/bwrap-argv.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+import { buildBwrapArgv } from "../src/isolation/bwrap"
+
+describe("buildBwrapArgv", () => {
+  test("canonical argv with network blocked and no extra paths", () => {
+    const argv = buildBwrapArgv({
+      command: "echo",
+      args: ["hi"],
+      workingDirectory: "/tmp/wd",
+      readOnlyPaths: [],
+      readWritePaths: [],
+      allowNetwork: false,
+    })
+
+    expect(argv).toEqual([
+      "bwrap",
+      "--ro-bind",
+      "/",
+      "/",
+      "--bind",
+      "/tmp/wd",
+      "/tmp/wd",
+      "--proc",
+      "/proc",
+      "--dev",
+      "/dev",
+      "--unshare-pid",
+      "--unshare-net",
+      "--die-with-parent",
+      "--",
+      "echo",
+      "hi",
+    ])
+  })
+
+  test("allowNetwork true drops --unshare-net", () => {
+    const argv = buildBwrapArgv({
+      command: "curl",
+      args: ["https://example.com"],
+      workingDirectory: "/tmp/wd",
+      readOnlyPaths: [],
+      readWritePaths: [],
+      allowNetwork: true,
+    })
+
+    expect(argv).not.toContain("--unshare-net")
+    expect(argv).toContain("--unshare-pid")
+  })
+
+  test("readOnlyPaths produce --ro-bind pairs in input order", () => {
+    const argv = buildBwrapArgv({
+      command: "echo",
+      args: [],
+      workingDirectory: "/tmp/wd",
+      readOnlyPaths: ["/usr", "/opt/data"],
+      readWritePaths: [],
+      allowNetwork: false,
+    })
+
+    const usrIdx = argv.findIndex(
+      (value, index) => value === "--ro-bind" && argv[index + 1] === "/usr"
+    )
+    const optIdx = argv.findIndex(
+      (value, index) => value === "--ro-bind" && argv[index + 1] === "/opt/data"
+    )
+    expect(usrIdx).toBeGreaterThan(0)
+    expect(optIdx).toBeGreaterThan(usrIdx)
+  })
+
+  test("readWritePaths produce --bind pairs after the workingDirectory bind", () => {
+    const argv = buildBwrapArgv({
+      command: "echo",
+      args: [],
+      workingDirectory: "/tmp/wd",
+      readOnlyPaths: [],
+      readWritePaths: ["/var/cache/agent"],
+      allowNetwork: false,
+    })
+
+    const wdIdx = argv.findIndex(
+      (value, index) => value === "--bind" && argv[index + 1] === "/tmp/wd"
+    )
+    const cacheIdx = argv.findIndex(
+      (value, index) => value === "--bind" && argv[index + 1] === "/var/cache/agent"
+    )
+    expect(wdIdx).toBeGreaterThan(0)
+    expect(cacheIdx).toBeGreaterThan(wdIdx)
+  })
+
+  test("command and args are passed verbatim after --", () => {
+    const argv = buildBwrapArgv({
+      command: "echo",
+      args: ["a; rm -rf /", "$(whoami)"],
+      workingDirectory: "/tmp/wd",
+      readOnlyPaths: [],
+      readWritePaths: [],
+      allowNetwork: false,
+    })
+
+    const dashDash = argv.indexOf("--")
+    expect(dashDash).toBeGreaterThan(0)
+    expect(argv.slice(dashDash + 1)).toEqual(["echo", "a; rm -rf /", "$(whoami)"])
+  })
+})

--- a/sandboxes/local/tests/bwrap-integration.test.ts
+++ b/sandboxes/local/tests/bwrap-integration.test.ts
@@ -1,0 +1,13 @@
+import { runSandboxesContractSuite } from "@sixb/core/testing"
+import { LocalSandboxFactory } from "../src/local-sandbox-factory"
+
+if (process.platform === "linux" && Bun.which("bwrap")) {
+  runSandboxesContractSuite("LocalSandbox (bwrap)", {
+    createFactory: () => new LocalSandboxFactory({ isolation: "bwrap" }),
+    capabilities: {
+      networkBlocking: true,
+      readOnlyEnforcement: true,
+      isolation: true,
+    },
+  })
+}

--- a/sandboxes/local/tests/isolation-detect.test.ts
+++ b/sandboxes/local/tests/isolation-detect.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { detectIsolation } from "../src/isolation/detect"
+
+describe("detectIsolation", () => {
+  test("darwin with sandbox-exec available picks seatbelt", () => {
+    const probe = detectIsolation({
+      platform: "darwin",
+      hasBinary: (name) => name === "sandbox-exec",
+    })
+    expect(probe.backend).toBe("seatbelt")
+    expect(probe.available).toBe(true)
+  })
+
+  test("darwin with unusable sandbox-exec falls back to none", () => {
+    const probe = detectIsolation({
+      platform: "darwin",
+      hasBinary: (name) => name === "sandbox-exec",
+      canRunSeatbelt: () => false,
+    })
+    expect(probe.backend).toBe("none")
+    expect(probe.available).toBe(true)
+    expect(probe.message).toContain("cannot apply")
+  })
+
+  test("darwin without sandbox-exec falls back to none", () => {
+    const probe = detectIsolation({ platform: "darwin", hasBinary: () => false })
+    expect(probe.backend).toBe("none")
+    expect(probe.available).toBe(true)
+    expect(probe.message).toContain("sandbox-exec")
+  })
+
+  test("linux with bwrap available picks bwrap", () => {
+    const probe = detectIsolation({
+      platform: "linux",
+      hasBinary: (name) => name === "bwrap",
+    })
+    expect(probe.backend).toBe("bwrap")
+    expect(probe.available).toBe(true)
+  })
+
+  test("linux without bwrap falls back to none", () => {
+    const probe = detectIsolation({ platform: "linux", hasBinary: () => false })
+    expect(probe.backend).toBe("none")
+    expect(probe.message).toContain("bwrap")
+  })
+
+  test("unsupported platform falls back to none", () => {
+    const probe = detectIsolation({ platform: "win32", hasBinary: () => true })
+    expect(probe.backend).toBe("none")
+    expect(probe.message).toContain("win32")
+  })
+})

--- a/sandboxes/local/tests/local-sandbox.test.ts
+++ b/sandboxes/local/tests/local-sandbox.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { runSandboxesContractSuite } from "@sixb/core/testing"
+import { LocalSandbox } from "../src/local-sandbox"
+import { LocalSandboxFactory } from "../src/local-sandbox-factory"
+
+runSandboxesContractSuite("LocalSandbox (none)", {
+  createFactory: () => new LocalSandboxFactory({ isolation: "none" }),
+  capabilities: {
+    networkBlocking: false,
+    readOnlyEnforcement: false,
+    isolation: false,
+  },
+})
+
+describe("LocalSandbox shell-injection regression", () => {
+  test("args containing shell metacharacters are passed verbatim", async () => {
+    const factory = new LocalSandboxFactory({ isolation: "none" })
+    const sandbox = await factory.create()
+    try {
+      const result = await sandbox.runCommand("echo", ["a; rm -rf /"])
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout.trim()).toBe("a; rm -rf /")
+    } finally {
+      await sandbox.destroy()
+    }
+  })
+
+  test("LocalSandbox.detectIsolation reports the host backend", () => {
+    const probe = LocalSandbox.detectIsolation()
+    expect(["seatbelt", "bwrap", "none"]).toContain(probe.backend)
+  })
+})

--- a/sandboxes/local/tests/seatbelt-integration.test.ts
+++ b/sandboxes/local/tests/seatbelt-integration.test.ts
@@ -1,0 +1,14 @@
+import { runSandboxesContractSuite } from "@sixb/core/testing"
+import { detectIsolation } from "../src/isolation/detect"
+import { LocalSandboxFactory } from "../src/local-sandbox-factory"
+
+if (process.platform === "darwin" && detectIsolation().backend === "seatbelt") {
+  runSandboxesContractSuite("LocalSandbox (seatbelt)", {
+    createFactory: () => new LocalSandboxFactory({ isolation: "seatbelt" }),
+    capabilities: {
+      networkBlocking: true,
+      readOnlyEnforcement: true,
+      isolation: true,
+    },
+  })
+}

--- a/sandboxes/local/tests/seatbelt-profile.test.ts
+++ b/sandboxes/local/tests/seatbelt-profile.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test"
+import { buildSeatbeltArgv, buildSeatbeltProfile } from "../src/isolation/seatbelt"
+
+describe("buildSeatbeltProfile", () => {
+  test("canonical profile with network blocked and no extra paths", () => {
+    const profile = buildSeatbeltProfile({
+      workingDirectory: "/private/tmp/wd",
+      readOnlyPaths: [],
+      readWritePaths: [],
+      allowNetwork: false,
+    })
+
+    expect(profile).toBe(
+      [
+        "(version 1)",
+        "(allow default)",
+        "(deny network-outbound)",
+        "(deny file-write*)",
+        '(allow file-write* (subpath "/private/tmp/wd"))',
+        '(allow file-write* (subpath "/private/tmp"))',
+        '(allow file-write* (subpath "/private/var/folders"))',
+        "",
+      ].join("\n")
+    )
+  })
+
+  test("allowNetwork true drops the network-outbound deny", () => {
+    const profile = buildSeatbeltProfile({
+      workingDirectory: "/private/tmp/wd",
+      readOnlyPaths: [],
+      readWritePaths: [],
+      allowNetwork: true,
+    })
+
+    expect(profile).not.toContain("network-outbound")
+    expect(profile).toContain("(allow default)")
+  })
+
+  test("readWritePaths produce additional file-write allow rules", () => {
+    const profile = buildSeatbeltProfile({
+      workingDirectory: "/private/tmp/wd",
+      readOnlyPaths: [],
+      readWritePaths: ["/private/var/cache/agent"],
+      allowNetwork: false,
+    })
+
+    expect(profile).toContain('(allow file-write* (subpath "/private/var/cache/agent"))')
+  })
+
+  test("escapes quotes and backslashes in subpath strings", () => {
+    const profile = buildSeatbeltProfile({
+      workingDirectory: '/tmp/with "quotes"\\and\\backslashes',
+      readOnlyPaths: [],
+      readWritePaths: [],
+      allowNetwork: false,
+    })
+
+    expect(profile).toContain(
+      '(allow file-write* (subpath "/tmp/with \\"quotes\\"\\\\and\\\\backslashes"))'
+    )
+  })
+
+  test("readOnlyPaths is informational on Seatbelt", () => {
+    const profile = buildSeatbeltProfile({
+      workingDirectory: "/private/tmp/wd",
+      readOnlyPaths: ["/etc/secrets"],
+      readWritePaths: [],
+      allowNetwork: false,
+    })
+
+    expect(profile).not.toContain("/etc/secrets")
+  })
+})
+
+describe("buildSeatbeltArgv", () => {
+  test("argv passes profile inline and command verbatim", () => {
+    const argv = buildSeatbeltArgv({
+      profile: "(version 1)\n(allow default)\n",
+      command: "echo",
+      args: ["a; rm -rf /"],
+    })
+
+    expect(argv).toEqual([
+      "sandbox-exec",
+      "-p",
+      "(version 1)\n(allow default)\n",
+      "echo",
+      "a; rm -rf /",
+    ])
+  })
+})

--- a/sandboxes/local/tsconfig.json
+++ b/sandboxes/local/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary

Ports the sandbox-only slice from the old Pario sandboxes PR into sixb:

- adds the provider-agnostic `Sandbox` / `SandboxFactory` contract and sandbox error exports in `@pario/core`
- wires an optional `sandboxes` factory through `createPario`, `Pario`, `ParioInstance`, and `ParioRuntimeContext`
- adds the `@pario/sandboxes-local` workspace package with local command execution, timeout/abort handling, host env allowlisting, and `none` / Seatbelt / bwrap isolation backends
- adds provider-independent sandbox contract tests plus local sandbox unit/integration coverage

This intentionally excludes S4 provider changes, S4 workspace/dependency updates, and S4 config rendering from the original PR.

## Validation

- `bun test packages/core/tests/sandboxes sandboxes/local/tests`
- `bun --filter @pario/core typecheck`
- `bun --filter @pario/sandboxes-local typecheck`
- `bun --filter @pario/core build`
- `bun --filter @pario/sandboxes-local build`
- `bun run check`
- `bun run typecheck`
- `bun run test`
