### PR TITLE
fix(projection-worker): normalize projected values before object upsert

### DIFF
--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -1,0 +1,196 @@
+import {
+  type DatasetColumnDefinition,
+  type DatasetDefinition,
+  type DatasetRow,
+  getDatasetRowValidationError,
+  type ObjectProjectionDefinition,
+  type OntologyRegistry,
+  type Schema,
+} from "@pario/core"
+import { ProjectionWorkerError } from "./errors"
+import { resolveProjectionSchema } from "./projection-schema"
+import { normalizeProjectedValue } from "./projection-value-coercion"
+
+export interface ObjectProjectionPlan {
+  readonly projection: ObjectProjectionDefinition
+  readonly dataset: DatasetDefinition
+  readonly primaryPropertyId: string
+  readonly propertyPlans: ReadonlyMap<string, ProjectedPropertyPlan>
+}
+
+export interface ProjectedObjectRow {
+  readonly properties: Record<string, unknown>
+  readonly primaryValue: unknown
+}
+
+export type ProjectObjectRowResult =
+  | {
+      readonly ok: true
+      readonly row: ProjectedObjectRow
+    }
+  | {
+      readonly ok: false
+      readonly errorMessage: string
+    }
+
+interface ProjectedPropertyPlan {
+  readonly propertyId: string
+  readonly columnName: string
+  readonly columnType: DatasetColumnDefinition["type"]
+  readonly schema: Schema
+}
+
+type CollectPropertiesResult =
+  | {
+      readonly ok: true
+      readonly properties: Record<string, unknown>
+      readonly rowForValidation: DatasetRow
+    }
+  | {
+      readonly ok: false
+      readonly errorMessage: string
+    }
+
+export function buildObjectProjectionPlan(input: {
+  readonly ontology: OntologyRegistry
+  readonly projection: ObjectProjectionDefinition
+  readonly dataset: DatasetDefinition
+  readonly primaryPropertyId: string
+}): ObjectProjectionPlan {
+  const { ontology, projection, dataset, primaryPropertyId } = input
+
+  return {
+    projection,
+    dataset,
+    primaryPropertyId,
+    propertyPlans: buildProjectedPropertyPlans({ ontology, projection, dataset }),
+  }
+}
+
+export function projectObjectRow(plan: ObjectProjectionPlan, row: unknown): ProjectObjectRowResult {
+  const { projection, dataset, primaryPropertyId, propertyPlans } = plan
+
+  if (!isPlainObject(row)) {
+    const validationError = getDatasetRowValidationError(row, dataset)
+    return {
+      ok: false,
+      errorMessage: validationError ?? `Dataset '${dataset.id}' rows must be plain objects.`,
+    }
+  }
+
+  const collected = collectProperties(projection, row, propertyPlans)
+  if (!collected.ok) {
+    return collected
+  }
+
+  const rowValidationError = getDatasetRowValidationError(collected.rowForValidation, dataset)
+  if (rowValidationError) {
+    return { ok: false, errorMessage: rowValidationError }
+  }
+
+  return {
+    ok: true,
+    row: {
+      properties: collected.properties,
+      primaryValue: collected.properties[primaryPropertyId],
+    },
+  }
+}
+
+function buildProjectedPropertyPlans(input: {
+  readonly ontology: OntologyRegistry
+  readonly projection: ObjectProjectionDefinition
+  readonly dataset: DatasetDefinition
+}): ReadonlyMap<string, ProjectedPropertyPlan> {
+  const { ontology, projection, dataset } = input
+  const objectType = ontology.getObjectTypeById(projection.objectTypeId)
+  if (!objectType) {
+    throw new ProjectionWorkerError(
+      `[ParioProjectionWorker] Projection '${projection.id}' references unknown object type '${projection.objectTypeId}'.`
+    )
+  }
+
+  const propertiesById = new Map(objectType.properties.map((property) => [property.id, property]))
+  const columnsByName = new Map(dataset.schema.columns.map((column) => [column.name, column]))
+  const valueTypesById = ontology.getValueTypesById()
+  const propertyPlans = new Map<string, ProjectedPropertyPlan>()
+
+  for (const [propertyId, columnName] of Object.entries(projection.properties)) {
+    const property = propertiesById.get(propertyId)
+    if (!property) {
+      throw new ProjectionWorkerError(
+        `[ParioProjectionWorker] Projection '${projection.id}' references unknown property '${propertyId}' on object type '${objectType.id}'.`
+      )
+    }
+
+    const column = columnsByName.get(columnName)
+    if (!column) {
+      throw new ProjectionWorkerError(
+        `[ParioProjectionWorker] Projection '${projection.id}' references unknown dataset column '${columnName}' on dataset '${dataset.id}'.`
+      )
+    }
+
+    propertyPlans.set(propertyId, {
+      propertyId,
+      columnName,
+      columnType: column.type,
+      schema: resolveProjectionSchema(property.schema, valueTypesById),
+    })
+  }
+
+  return propertyPlans
+}
+
+function collectProperties(
+  projection: ObjectProjectionDefinition,
+  row: DatasetRow,
+  propertyPlans: ReadonlyMap<string, ProjectedPropertyPlan>
+): CollectPropertiesResult {
+  const properties: Record<string, unknown> = {}
+  let rowForValidation: Record<string, unknown> | undefined
+
+  for (const [propertyId, columnName] of Object.entries(projection.properties)) {
+    const value = row[columnName]
+    if (value === null || value === undefined) {
+      continue
+    }
+
+    const propertyPlan = propertyPlans.get(propertyId)
+    if (!propertyPlan) {
+      return {
+        ok: false,
+        errorMessage: `[ParioProjectionWorker] Projection '${projection.id}' has no property plan for '${propertyId}'.`,
+      }
+    }
+
+    const normalized = normalizeProjectedValue({
+      columnType: propertyPlan.columnType,
+      schema: propertyPlan.schema,
+      value,
+    })
+    if (!normalized.ok) {
+      return {
+        ok: false,
+        errorMessage: `[ParioProjectionWorker] Projection '${projection.id}' property '${propertyId}' from dataset column '${columnName}' (${propertyPlan.columnType}) ${normalized.errorMessage}.`,
+      }
+    }
+
+    if (normalized.value !== value) {
+      rowForValidation ??= { ...row }
+      rowForValidation[columnName] = normalized.value
+    }
+
+    properties[propertyId] = normalized.value
+  }
+
+  return { ok: true, properties, rowForValidation: rowForValidation ?? row }
+}
+
+function isPlainObject(value: unknown): value is DatasetRow {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -44,7 +44,6 @@ type CollectPropertiesResult =
   | {
       readonly ok: true
       readonly properties: Record<string, unknown>
-      readonly rowForValidation: DatasetRow
     }
   | {
       readonly ok: false
@@ -78,14 +77,14 @@ export function projectObjectRow(plan: ObjectProjectionPlan, row: unknown): Proj
     }
   }
 
+  const rowValidationError = getDatasetRowValidationError(row, dataset)
+  if (rowValidationError) {
+    return { ok: false, errorMessage: rowValidationError }
+  }
+
   const collected = collectProperties(projection, row, propertyPlans)
   if (!collected.ok) {
     return collected
-  }
-
-  const rowValidationError = getDatasetRowValidationError(collected.rowForValidation, dataset)
-  if (rowValidationError) {
-    return { ok: false, errorMessage: rowValidationError }
   }
 
   return {
@@ -147,7 +146,6 @@ function collectProperties(
   propertyPlans: ReadonlyMap<string, ProjectedPropertyPlan>
 ): CollectPropertiesResult {
   const properties: Record<string, unknown> = {}
-  let rowForValidation: Record<string, unknown> | undefined
 
   for (const [propertyId, columnName] of Object.entries(projection.properties)) {
     const value = row[columnName]
@@ -175,15 +173,10 @@ function collectProperties(
       }
     }
 
-    if (normalized.value !== value) {
-      rowForValidation ??= { ...row }
-      rowForValidation[columnName] = normalized.value
-    }
-
     properties[propertyId] = normalized.value
   }
 
-  return { ok: true, properties, rowForValidation: rowForValidation ?? row }
+  return { ok: true, properties }
 }
 
 function isPlainObject(value: unknown): value is DatasetRow {

--- a/packages/projection-worker/src/projection-schema.ts
+++ b/packages/projection-worker/src/projection-schema.ts
@@ -1,0 +1,42 @@
+import type { Schema, ValueType } from "@pario/core"
+import { ProjectionWorkerError } from "./errors"
+
+export function resolveProjectionSchema(
+  schema: Schema,
+  valueTypesById: ReadonlyMap<string, ValueType>,
+  seen = new Set<string>()
+): Schema {
+  if (typeof schema === "string") {
+    return schema
+  }
+
+  if (schema.type !== "valueTypeRef") {
+    return schema
+  }
+
+  if (seen.has(schema.valueTypeId)) {
+    throw new ProjectionWorkerError(
+      `[ParioProjectionWorker] Circular valueTypeRef '${schema.valueTypeId}' in projection schema.`
+    )
+  }
+
+  const nextSeen = new Set(seen)
+  nextSeen.add(schema.valueTypeId)
+
+  if (schema._resolved) {
+    return resolveProjectionSchema(schema._resolved, valueTypesById, nextSeen)
+  }
+
+  const valueType = valueTypesById.get(schema.valueTypeId)
+  if (!valueType) {
+    throw new ProjectionWorkerError(
+      `[ParioProjectionWorker] Unknown valueTypeRef '${schema.valueTypeId}' in projection schema.`
+    )
+  }
+
+  return resolveProjectionSchema(valueType.schema, valueTypesById, nextSeen)
+}
+
+export function isIntegerEnumSchema(schema: Schema): boolean {
+  return typeof schema !== "string" && schema.type === "enum" && schema.valueType === "integer"
+}

--- a/packages/projection-worker/src/projection-value-coercion.ts
+++ b/packages/projection-worker/src/projection-value-coercion.ts
@@ -1,0 +1,150 @@
+import type { DatasetColumnDefinition, Schema } from "@pario/core"
+import { isIntegerEnumSchema } from "./projection-schema"
+
+export type ProjectedValueCoercionResult =
+  | {
+      readonly ok: true
+      readonly value: unknown
+    }
+  | {
+      readonly ok: false
+      readonly errorMessage: string
+    }
+
+const finiteNumberStringPattern = /^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/
+
+export function normalizeProjectedValue(input: {
+  readonly columnType: DatasetColumnDefinition["type"]
+  readonly schema: Schema
+  readonly value: unknown
+}): ProjectedValueCoercionResult {
+  const { columnType, schema, value } = input
+
+  if (columnType === "int64") {
+    if (isIntegerLikeSchema(schema)) {
+      return coerceSafeInteger(value)
+    }
+
+    if (isNumberSchema(schema)) {
+      return coerceFiniteNumber(value)
+    }
+  }
+
+  if ((columnType === "decimal" || columnType === "float64") && isNumberSchema(schema)) {
+    return coerceFiniteNumber(value)
+  }
+
+  return { ok: true, value }
+}
+
+function coerceSafeInteger(value: unknown): ProjectedValueCoercionResult {
+  if (typeof value === "number") {
+    if (Number.isSafeInteger(value)) {
+      return { ok: true, value }
+    }
+
+    return {
+      ok: false,
+      errorMessage: `cannot safely coerce value ${formatProjectionValue(value)} to a safe integer`,
+    }
+  }
+
+  if (typeof value === "bigint") {
+    if (value >= BigInt(Number.MIN_SAFE_INTEGER) && value <= BigInt(Number.MAX_SAFE_INTEGER)) {
+      return { ok: true, value: Number(value) }
+    }
+
+    return {
+      ok: false,
+      errorMessage: `cannot safely coerce value ${formatProjectionValue(value)} to a safe integer`,
+    }
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (!/^-?\d+$/.test(trimmed)) {
+      return {
+        ok: false,
+        errorMessage: `cannot coerce value ${formatProjectionValue(value)} to an integer`,
+      }
+    }
+
+    const bigint = BigInt(trimmed)
+    if (bigint < BigInt(Number.MIN_SAFE_INTEGER) || bigint > BigInt(Number.MAX_SAFE_INTEGER)) {
+      return {
+        ok: false,
+        errorMessage: `cannot safely coerce value ${formatProjectionValue(value)} to a safe integer`,
+      }
+    }
+
+    return { ok: true, value: Number(bigint) }
+  }
+
+  return {
+    ok: false,
+    errorMessage: `cannot coerce value ${formatProjectionValue(value)} to an integer`,
+  }
+}
+
+function coerceFiniteNumber(value: unknown): ProjectedValueCoercionResult {
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) {
+      return { ok: true, value }
+    }
+
+    return {
+      ok: false,
+      errorMessage: `cannot coerce value ${formatProjectionValue(value)} to a finite number`,
+    }
+  }
+
+  if (typeof value === "bigint") {
+    const number = Number(value)
+    if (Number.isFinite(number)) {
+      return { ok: true, value: number }
+    }
+
+    return {
+      ok: false,
+      errorMessage: `cannot coerce value ${formatProjectionValue(value)} to a finite number`,
+    }
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    const number = finiteNumberStringPattern.test(trimmed) ? Number(trimmed) : Number.NaN
+    if (Number.isFinite(number)) {
+      return { ok: true, value: number }
+    }
+
+    return {
+      ok: false,
+      errorMessage: `cannot coerce value ${formatProjectionValue(value)} to a finite number`,
+    }
+  }
+
+  return {
+    ok: false,
+    errorMessage: `cannot coerce value ${formatProjectionValue(value)} to a finite number`,
+  }
+}
+
+function isIntegerLikeSchema(schema: Schema): boolean {
+  return schema === "integer" || isIntegerEnumSchema(schema)
+}
+
+function isNumberSchema(schema: Schema): boolean {
+  return schema === "double" || schema === "decimal"
+}
+
+function formatProjectionValue(value: unknown): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value)
+  }
+
+  if (typeof value === "bigint") {
+    return `${value.toString()}n`
+  }
+
+  return String(value)
+}

--- a/packages/projection-worker/src/run-object-projection.ts
+++ b/packages/projection-worker/src/run-object-projection.ts
@@ -1,11 +1,14 @@
 import {
   type DatasetDefinition,
-  type DatasetRow,
-  getDatasetRowValidationError,
   ObjectNotFoundError,
   type ObjectProjectionDefinition,
   objectService,
 } from "@pario/core"
+import {
+  buildObjectProjectionPlan,
+  type ProjectedObjectRow,
+  projectObjectRow,
+} from "./object-projection-plan"
 import type {
   ProjectionExecutionResult,
   ProjectionProgressReporter,
@@ -29,11 +32,6 @@ interface RunObjectProjectionInput {
   readonly onProgress?: ProjectionProgressReporter
 }
 
-interface CollectedObjectRow {
-  readonly properties: Record<string, unknown>
-  readonly primaryValue: unknown
-}
-
 interface ForeignKeyLinkItem {
   readonly objectTypeId: string
   readonly sourceId: string
@@ -50,7 +48,13 @@ export async function runObjectProjection(
   const { runtime, projection, dataset, versionId, signal, batchSize, onProgress } = input
   const counters = createZeroCounters()
   const primaryPropertyId = runtime.ontology.getPrimaryPropertyId(projection.objectTypeId)
-  const batch: CollectedObjectRow[] = []
+  const projectionPlan = buildObjectProjectionPlan({
+    ontology: runtime.ontology,
+    projection,
+    dataset,
+    primaryPropertyId,
+  })
+  const batch: ProjectedObjectRow[] = []
   let firstErrorMessage: string | undefined
 
   const rememberError = (message: string): void => {
@@ -69,7 +73,7 @@ export async function runObjectProjection(
       rows.map((row) => ({ properties: row.properties }))
     )
 
-    const succeededRows: CollectedObjectRow[] = []
+    const succeededRows: ProjectedObjectRow[] = []
     for (let index = 0; index < rows.length; index += 1) {
       const result = batchResults[index]
       const row = rows[index]!
@@ -103,21 +107,19 @@ export async function runObjectProjection(
     throwIfAborted(signal)
     counters.rowsProcessed += 1
 
-    const validationError = getDatasetRowValidationError(row, dataset)
-    if (validationError) {
+    const projected = projectObjectRow(projectionPlan, row)
+    if (!projected.ok) {
       counters.rowsSkipped += 1
-      rememberError(validationError)
+      rememberError(projected.errorMessage)
       continue
     }
 
-    const properties = collectProperties(projection, row)
-    const primaryValue = properties[primaryPropertyId]
-    if (isBlank(primaryValue)) {
+    if (isBlank(projected.row.primaryValue)) {
       counters.rowsSkipped += 1
       continue
     }
 
-    batch.push({ properties, primaryValue })
+    batch.push(projected.row)
     if (batch.length >= batchSize) {
       await flushBatch()
     }
@@ -134,24 +136,10 @@ export async function runObjectProjection(
   }
 }
 
-function collectProperties(
-  projection: ObjectProjectionDefinition,
-  row: DatasetRow
-): Record<string, unknown> {
-  const properties: Record<string, unknown> = {}
-  for (const [propertyId, columnName] of Object.entries(projection.properties)) {
-    const value = row[columnName]
-    if (value !== null && value !== undefined) {
-      properties[propertyId] = value
-    }
-  }
-  return properties
-}
-
 async function upsertForeignKeyLinks(input: {
   readonly runtime: ProjectionWorkerContext
   readonly projection: ObjectProjectionDefinition
-  readonly rows: readonly CollectedObjectRow[]
+  readonly rows: readonly ProjectedObjectRow[]
   readonly counters: {
     linksUpserted: number
   }

--- a/packages/projection-worker/src/schema-validation.ts
+++ b/packages/projection-worker/src/schema-validation.ts
@@ -11,6 +11,7 @@ import type {
   ValueType,
 } from "@pario/core"
 import { ProjectionWorkerError } from "./errors"
+import { isIntegerEnumSchema, resolveProjectionSchema } from "./projection-schema"
 
 type DatasetColumnsByName = Map<string, DatasetColumnDefinition>
 
@@ -275,52 +276,12 @@ function isDatasetColumnCompatibleWithSchema(
     case "json":
       return isJsonCompatibleSchema(resolved)
     case "fileRef":
-      return false
+      return resolved === "fileRef"
   }
-}
-
-function resolveProjectionSchema(
-  schema: Schema,
-  valueTypesById: ReadonlyMap<string, ValueType>,
-  seen = new Set<string>()
-): Schema {
-  if (typeof schema === "string") {
-    return schema
-  }
-
-  if (schema.type !== "valueTypeRef") {
-    return schema
-  }
-
-  if (seen.has(schema.valueTypeId)) {
-    throw new ProjectionWorkerError(
-      `[ParioProjectionWorker] Circular valueTypeRef '${schema.valueTypeId}' in projection schema.`
-    )
-  }
-
-  const nextSeen = new Set(seen)
-  nextSeen.add(schema.valueTypeId)
-
-  if (schema._resolved) {
-    return resolveProjectionSchema(schema._resolved, valueTypesById, nextSeen)
-  }
-
-  const valueType = valueTypesById.get(schema.valueTypeId)
-  if (!valueType) {
-    throw new ProjectionWorkerError(
-      `[ParioProjectionWorker] Unknown valueTypeRef '${schema.valueTypeId}' in projection schema.`
-    )
-  }
-
-  return resolveProjectionSchema(valueType.schema, valueTypesById, nextSeen)
 }
 
 function isStringEnumSchema(schema: Schema): boolean {
   return typeof schema !== "string" && schema.type === "enum" && schema.valueType === "string"
-}
-
-function isIntegerEnumSchema(schema: Schema): boolean {
-  return typeof schema !== "string" && schema.type === "enum" && schema.valueType === "integer"
 }
 
 function isJsonCompatibleSchema(schema: Schema): boolean {

--- a/packages/projection-worker/tests/object-projection-plan.test.ts
+++ b/packages/projection-worker/tests/object-projection-plan.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import {
+  col,
+  defineDataset,
+  defineObjectType,
+  defineProjection,
+  OntologyRegistry,
+  prop,
+} from "@pario/core"
+import { buildObjectProjectionPlan, projectObjectRow } from "../src/object-projection-plan"
+
+describe("object projection plan", () => {
+  test("validates original dataset row before numeric projection coercion", () => {
+    const Meter = defineObjectType({
+      id: "Meter",
+      name: "Meter",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("reading", "double"),
+      ],
+    })
+    const readingsDataset = defineDataset("canonical.meter-readings", {
+      schema: [col("meter_id", "string"), col("reading", "float64")],
+    })
+    const readingProjection = defineProjection("meter-reading-proj", Meter)
+      .fromDataset(readingsDataset)
+      .properties({ id: "meter_id", reading: "reading" })
+    const ontology = new OntologyRegistry({ sources: [Meter] })
+    const plan = buildObjectProjectionPlan({
+      ontology,
+      projection: readingProjection,
+      dataset: readingsDataset,
+      primaryPropertyId: ontology.getPrimaryPropertyId("Meter"),
+    })
+
+    expect(projectObjectRow(plan, { meter_id: "m1", reading: "1.5" })).toEqual({
+      ok: false,
+      errorMessage:
+        "Dataset 'canonical.meter-readings' column 'reading' must match type 'float64'.",
+    })
+  })
+})

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -7,12 +7,14 @@ import {
   defineLinkProjection,
   defineObjectType,
   defineProjection,
+  defineValueType,
   fromForeignKey,
   InMemoryBlobStorage,
   InMemoryBroker,
   InMemoryLakeStorage,
   InMemoryQueues,
   InMemoryStorage,
+  integerEnum,
   type LakeStorage,
   link,
   Pario,
@@ -20,6 +22,7 @@ import {
   type ProjectionRunStorage,
   prop,
   stringEnum,
+  valueTypeRef,
 } from "@pario/core"
 import { type ProjectionWorkerContext, ProjectionWorkerError, runProjectionJob } from "../src"
 
@@ -456,6 +459,182 @@ describe("runProjectionJob", () => {
     expect(run?.rowsSkipped).toBe(1)
     expect(run?.objectsUpserted).toBe(0)
     expect(run?.errorMessage).toContain("must be one of")
+  })
+
+  test("normalizes int64 strings mapped to integer-like object properties", async () => {
+    const ReadingCount = defineValueType({
+      id: "ReadingCount",
+      name: "Reading Count",
+      schema: "integer",
+    })
+    const Device = defineObjectType({
+      id: "Device",
+      name: "Device",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("count", "integer"),
+        prop("level", integerEnum([1, 2, 3])),
+        prop("readingCount", valueTypeRef(ReadingCount)),
+      ],
+    })
+    const devicesDataset = defineDataset("canonical.integer-devices", {
+      schema: [
+        col("device_id", "string"),
+        col("device_count", "int64"),
+        col("device_level", "int64"),
+        col("reading_count", "int64"),
+      ],
+    })
+    const deviceProjection = defineProjection("integer-device-proj", Device)
+      .fromDataset(devicesDataset)
+      .properties({
+        id: "device_id",
+        count: "device_count",
+        level: "device_level",
+        readingCount: "reading_count",
+      })
+    const deps = createDeps()
+    const pario = new Pario({
+      id: "projection-worker-tests",
+      ontology: [Device],
+      ...deps,
+      datasets: [devicesDataset],
+      projections: [deviceProjection],
+    })
+    const version = await commitDatasetVersion(deps.lakeStorage, devicesDataset, [
+      {
+        device_id: "d1",
+        device_count: "100",
+        device_level: "2",
+        reading_count: "7",
+      },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(pario),
+      job: {
+        id: "projrun-int64-string",
+        projectionId: "integer-device-proj",
+        projectionKind: "object",
+        datasetId: devicesDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.objectsUpserted).toBe(1)
+    const device = await deps.storage.objects.getByPrimaryId({
+      projectId: pario.id,
+      objectTypeId: "Device",
+      primaryId: "d1",
+    })
+    expect(device?.properties.count).toBe(100)
+    expect(device?.properties.level).toBe(2)
+    expect(device?.properties.readingCount).toBe(7)
+  })
+
+  test("fails unsafe int64 strings mapped to integer object properties", async () => {
+    const Device = defineObjectType({
+      id: "Device",
+      name: "Device",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("count", "integer"),
+      ],
+    })
+    const devicesDataset = defineDataset("canonical.unsafe-integer-devices", {
+      schema: [col("device_id", "string"), col("device_count", "int64")],
+    })
+    const deviceProjection = defineProjection("unsafe-integer-device-proj", Device)
+      .fromDataset(devicesDataset)
+      .properties({ id: "device_id", count: "device_count" })
+    const deps = createDeps()
+    const pario = new Pario({
+      id: "projection-worker-tests",
+      ontology: [Device],
+      ...deps,
+      datasets: [devicesDataset],
+      projections: [deviceProjection],
+    })
+    const version = await commitDatasetVersion(deps.lakeStorage, devicesDataset, [
+      { device_id: "d1", device_count: "9007199254740992" },
+    ])
+
+    await expect(
+      runProjectionJob({
+        runtime: createRuntime(pario),
+        job: {
+          id: "projrun-unsafe-int64-string",
+          projectionId: "unsafe-integer-device-proj",
+          projectionKind: "object",
+          datasetId: devicesDataset.id,
+          versionId: version.versionId,
+        },
+      })
+    ).rejects.toThrow("cannot safely coerce")
+
+    const run = await deps.storage.projectionRuns.getById({
+      projectId: pario.id,
+      id: "projrun-unsafe-int64-string",
+    })
+    expect(run?.status).toBe("failed")
+    expect(run?.rowsProcessed).toBe(1)
+    expect(run?.rowsSkipped).toBe(1)
+    expect(run?.objectsUpserted).toBe(0)
+    expect(run?.errorMessage).toContain("cannot safely coerce")
+  })
+
+  test("materializes fileRef object properties from fileRef dataset columns", async () => {
+    const Document = defineObjectType({
+      id: "Document",
+      name: "Document",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("attachment", "fileRef"),
+      ],
+    })
+    const documentsDataset = defineDataset("canonical.documents", {
+      schema: [col("document_id", "string"), col("attachment", "fileRef")],
+    })
+    const documentProjection = defineProjection("document-proj", Document)
+      .fromDataset(documentsDataset)
+      .properties({ id: "document_id", attachment: "attachment" })
+    const deps = createDeps()
+    const pario = new Pario({
+      id: "projection-worker-tests",
+      ontology: [Document],
+      ...deps,
+      datasets: [documentsDataset],
+      projections: [documentProjection],
+    })
+    const attachment = {
+      blobId: "blob_document",
+      digest: "sha256:document",
+      sizeBytes: 8,
+      fileName: "document.pdf",
+      mediaType: "application/pdf",
+    } as const
+    const version = await commitDatasetVersion(deps.lakeStorage, documentsDataset, [
+      { document_id: "doc1", attachment },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(pario),
+      job: {
+        id: "projrun-fileref",
+        projectionId: "document-proj",
+        projectionKind: "object",
+        datasetId: documentsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.objectsUpserted).toBe(1)
+    const document = await deps.storage.objects.getByPrimaryId({
+      projectId: pario.id,
+      objectTypeId: "Document",
+      primaryId: "doc1",
+    })
+    expect(document?.properties.attachment).toEqual(attachment)
   })
 
   test("marks the run failed before reading rows when the committed schema mismatches", async () => {


### PR DESCRIPTION
# Projection Worker: Normalize Projected Values

## Summary

This PR fixes two projection-worker edge cases where schema validation allowed a mapping, but runtime materialization could still fail.

| Case | Before | After |
| --- | --- | --- |
| `int64` column read as `"100"` into `integer` | Object upsert failed with `must be an integer` | Value is safely coerced to `100` |
| unsafe `int64` string | Failed later through ontology validation | Row fails clearly with a projection coercion error |
| `fileRef` column into `fileRef` property | Compatibility validation rejected it | Projection validates and materializes |

## What Changed

- Added schema-aware normalization before object upserts.
- Resolved target property schemas, including `valueTypeRef`.
- Added safe numeric coercion for compatible `int64`, `decimal`, and `float64` mappings.
- Allowed `fileRef -> fileRef` projection compatibility.
- Split object projection mapping into a clearer plan/coercion flow.

## Tests

- Added regression coverage for:
  - `int64` string to `integer`
  - unsafe `int64` string rejection
  - `fileRef` projection materialization

Verified with:

```bash
bun test packages/projection-worker/tests/run-projection-job.test.ts
bun --filter @pario/projection-worker typecheck
bun --filter @pario/projection-worker build
bun run check
```