### PR TITLE
datasets: stabilize DuckLake-backed browsing

### DIFF
--- a/packages/atlas/src/index.ts
+++ b/packages/atlas/src/index.ts
@@ -114,10 +114,6 @@ async function atlasResponse(
     })
   }
 
-  if (isAssetRequest(url.pathname)) {
-    return notFoundResponse()
-  }
-
   return htmlResponse(request, options.shell)
 }
 
@@ -163,11 +159,6 @@ function isReservedParioRoute(pathname: string): boolean {
     pathname === "/docs" ||
     pathname.startsWith("/docs/")
   )
-}
-
-function isAssetRequest(pathname: string): boolean {
-  const lastSegment = pathname.split("/").pop() ?? ""
-  return /\.[^/]+$/.test(lastSegment)
 }
 
 function normalizeOrigin(value: string, label: string): string {

--- a/packages/atlas/tests/atlas-app.test.ts
+++ b/packages/atlas/tests/atlas-app.test.ts
@@ -41,19 +41,23 @@ describe("createAtlasApp", () => {
       const baseUrl = `http://127.0.0.1:${port}`
       const rootResponse = await fetch(`${baseUrl}/`)
       const routeResponse = await fetch(`${baseUrl}/devices`)
+      const dottedRouteResponse = await fetch(`${baseUrl}/datasets/raw.ace.sites`)
 
       expect(rootResponse.status).toBe(200)
       expect(routeResponse.status).toBe(200)
+      expect(dottedRouteResponse.status).toBe(200)
 
       const html = await rootResponse.text()
       const scriptPath = extractAssetPath(html, "script")
       const stylesheetPath = extractAssetPath(html, "stylesheet")
+      const dottedRouteHtml = await dottedRouteResponse.text()
 
       expect(html).toContain('"api":{"baseUrl":"http://api.localhost"}')
       expect(html).toContain('"auth":{"audience":"atlas","enabled":true}')
       expect(scriptPath).toMatch(/^\/__pario\/main-[^.]+\.js$/)
       expect(stylesheetPath).toMatch(/^\/__pario\/main-[^.]+\.css$/)
       expect(html).toContain('<div id="root"></div>')
+      expect(dottedRouteHtml).toContain('<div id="root"></div>')
 
       for (const assetPath of [scriptPath, stylesheetPath]) {
         const assetResponse = await fetch(`${baseUrl}${assetPath}`)

--- a/packages/sentinel/src/index.ts
+++ b/packages/sentinel/src/index.ts
@@ -112,10 +112,6 @@ async function sentinelResponse(
     })
   }
 
-  if (isAssetRequest(url.pathname)) {
-    return notFoundResponse()
-  }
-
   return htmlResponse(request, options.shell)
 }
 
@@ -161,11 +157,6 @@ function isReservedParioRoute(pathname: string): boolean {
     pathname === "/docs" ||
     pathname.startsWith("/docs/")
   )
-}
-
-function isAssetRequest(pathname: string): boolean {
-  const lastSegment = pathname.split("/").pop() ?? ""
-  return /\.[^/]+$/.test(lastSegment)
 }
 
 function normalizeOrigin(value: string, label: string): string {

--- a/packages/sentinel/tests/sentinel-app.test.ts
+++ b/packages/sentinel/tests/sentinel-app.test.ts
@@ -40,15 +40,20 @@ describe("createSentinelApp", () => {
       const baseUrl = `http://127.0.0.1:${port}`
       const rootResponse = await fetch(`${baseUrl}/`)
       const workflowResponse = await fetch(`${baseUrl}/workflows/invoice-reminder-workflow`)
+      const dottedWorkflowResponse = await fetch(
+        `${baseUrl}/workflows/invoice-reminder.workflow.v1`
+      )
       const runResponse = await fetch(`${baseUrl}/runs/run-123`)
 
       expect(rootResponse.status).toBe(200)
       expect(workflowResponse.status).toBe(200)
+      expect(dottedWorkflowResponse.status).toBe(200)
       expect(runResponse.status).toBe(200)
 
       const html = await rootResponse.text()
       const scriptPath = extractAssetPath(html, "script")
       const stylesheetPath = extractAssetPath(html, "stylesheet")
+      const dottedWorkflowHtml = await dottedWorkflowResponse.text()
 
       expect(html).toContain("<title>Pario Sentinel</title>")
       expect(html).toContain('"api":{"baseUrl":"http://api.localhost"}')
@@ -56,6 +61,7 @@ describe("createSentinelApp", () => {
       expect(scriptPath).toMatch(/^\/__pario\/main-[^.]+\.js$/)
       expect(stylesheetPath).toMatch(/^\/__pario\/main-[^.]+\.css$/)
       expect(html).toContain('<div id="root"></div>')
+      expect(dottedWorkflowHtml).toContain('<div id="root"></div>')
 
       for (const assetPath of [scriptPath, stylesheetPath]) {
         const assetResponse = await fetch(`${baseUrl}${assetPath}`)

--- a/packages/server/src/routes/datasets.ts
+++ b/packages/server/src/routes/datasets.ts
@@ -91,10 +91,44 @@ async function serializeDatasetCatalogItem(
     pario.lakeStorage.getLatestVersion(dataset.id),
   ])
 
+  return serializeDatasetCatalogItemFromState(pario, dataset, {
+    materialized: storedDataset !== null,
+    latestVersion,
+  })
+}
+
+async function serializeDatasetCatalogItems(pario: Pario<readonly OntologySource[]>) {
+  const storedDatasets = new Set(
+    (await pario.lakeStorage.listDatasets()).map((dataset) => dataset.id)
+  )
+
+  return Promise.all(
+    pario.getDatasetDefinitions().map(async (dataset) => {
+      const materialized = storedDatasets.has(dataset.id)
+      const latestVersion = materialized
+        ? await pario.lakeStorage.getLatestVersion(dataset.id)
+        : null
+
+      return serializeDatasetCatalogItemFromState(pario, dataset, {
+        materialized,
+        latestVersion,
+      })
+    })
+  )
+}
+
+function serializeDatasetCatalogItemFromState(
+  pario: Pario<readonly OntologySource[]>,
+  dataset: DatasetDefinition,
+  state: {
+    readonly materialized: boolean
+    readonly latestVersion: DatasetVersion | null
+  }
+) {
   return DatasetCatalogItemSchema.parse({
     ...dataset,
-    materialized: storedDataset !== null,
-    latestVersion: latestVersion ? serializeDatasetVersion(latestVersion) : null,
+    materialized: state.materialized,
+    latestVersion: state.latestVersion ? serializeDatasetVersion(state.latestVersion) : null,
     ...getDatasetReferences(pario, dataset.id),
   })
 }
@@ -147,11 +181,7 @@ export function registerDatasetRoutes(app: Elysia, pario: Pario<readonly Ontolog
       "/api/datasets",
       async ({ set }) => {
         try {
-          return await Promise.all(
-            pario
-              .getDatasetDefinitions()
-              .map((dataset) => serializeDatasetCatalogItem(pario, dataset))
-          )
+          return await serializeDatasetCatalogItems(pario)
         } catch (error) {
           set.status = 400
           return { error: error instanceof Error ? error.message : String(error) }

--- a/storage/ducklake/src/internal/duckdb-runtime.ts
+++ b/storage/ducklake/src/internal/duckdb-runtime.ts
@@ -1,7 +1,13 @@
 import { type DuckDBConnection, DuckDBInstance, type DuckDBValue } from "@duckdb/node-api"
 import { LakeStorageError } from "@pario/core"
 import type { DuckDbRuntimeOptions, DuckLakeStorageOptions } from "../types"
-import { buildAttachSql, buildCreateSecretSql, quoteIdentifier, requiredExtensions } from "./sql"
+import {
+  buildAttachSql,
+  buildConfigurePostgresMetadataPoolSql,
+  buildCreateSecretSql,
+  quoteIdentifier,
+  requiredExtensions,
+} from "./sql"
 
 /**
  * Narrow adapter around `@duckdb/node-api`.
@@ -16,7 +22,11 @@ export interface DuckDbRuntime {
 }
 
 class NodeDuckDbRuntime implements DuckDbRuntime {
+  private closing = false
   private closed = false
+  // One DuckDBConnection is shared by the runtime. Serialize calls so request
+  // handlers cannot interleave statements or close/reset an active query.
+  private operations: Promise<void> = Promise.resolve()
 
   constructor(
     private readonly instance: DuckDBInstance,
@@ -24,20 +34,22 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
   ) {}
 
   async run(sql: string, values?: readonly DuckDBValue[]): Promise<void> {
-    this.assertOpen()
-    await this.connection.run(sql, values === undefined ? undefined : [...values])
+    await this.enqueue(async () => {
+      await this.connection.run(sql, values === undefined ? undefined : [...values])
+    })
   }
 
   async query(
     sql: string,
     values?: readonly DuckDBValue[]
   ): Promise<readonly Record<string, unknown>[]> {
-    this.assertOpen()
-    const reader = await this.connection.runAndReadAll(
-      sql,
-      values === undefined ? undefined : [...values]
-    )
-    return reader.getRowObjectsJS()
+    return this.enqueue(async () => {
+      const reader = await this.connection.runAndReadAll(
+        sql,
+        values === undefined ? undefined : [...values]
+      )
+      return reader.getRowObjectsJS()
+    })
   }
 
   async close(): Promise<void> {
@@ -45,12 +57,38 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
       return
     }
 
+    this.closing = true
+    // resetRuntime()/close() can run while an API read is still using this
+    // runtime. Wait for accepted work before closing the native connection.
+    await this.operations.catch(() => {})
     this.closed = true
     this.connection.closeSync()
     this.instance.closeSync()
   }
 
-  private assertOpen(): void {
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    this.assertAcceptingOperations()
+
+    // Keep the chain alive after failures so one rejected query does not block
+    // all later work on this runtime.
+    const result = this.operations.then(async () => {
+      this.assertNotClosed()
+      return operation()
+    })
+    this.operations = result.then(
+      () => {},
+      () => {}
+    )
+    return result
+  }
+
+  private assertAcceptingOperations(): void {
+    if (this.closing || this.closed) {
+      throw new LakeStorageError("[ParioDuckLake] DuckDB runtime is closed.")
+    }
+  }
+
+  private assertNotClosed(): void {
     if (this.closed) {
       throw new LakeStorageError("[ParioDuckLake] DuckDB runtime is closed.")
     }
@@ -92,4 +130,8 @@ export async function setupDuckLake(
   }
 
   await runtime.run(buildAttachSql(options))
+
+  if (options.catalog.type === "postgres") {
+    await runtime.run(buildConfigurePostgresMetadataPoolSql(options))
+  }
 }

--- a/storage/ducklake/src/internal/sql.ts
+++ b/storage/ducklake/src/internal/sql.ts
@@ -28,6 +28,20 @@ function duckLakeMetadataCatalog(options: Pick<DuckLakeStorageOptions, "alias">)
 }
 
 /**
+ * Configure the PostgreSQL extension pool used by DuckLake's attached metadata
+ * catalog. DuckDB worker threads can otherwise pin pooled Postgres connections
+ * in the thread-local cache until the pool is exhausted during repeated
+ * DuckLake metadata reads.
+ */
+export function buildConfigurePostgresMetadataPoolSql(
+  options: Pick<DuckLakeStorageOptions, "alias">
+): string {
+  return `FROM postgres_configure_pool(catalog_name=${quoteSqlString(
+    duckLakeMetadataCatalog(options)
+  )}, enable_thread_local_cache=false)`
+}
+
+/**
  * Render a fully-qualified DuckLake metadata table path.
  *
  * PostgreSQL catalogs expose DuckLake metadata tables under the configured

--- a/storage/ducklake/tests/ducklake-concurrency.e2e.ts
+++ b/storage/ducklake/tests/ducklake-concurrency.e2e.ts
@@ -29,6 +29,27 @@ describe("DuckLakeStorage optimistic concurrency", () => {
     await rm(rootDir, { recursive: true, force: true })
   })
 
+  test("serializes concurrent metadata reads on one provider instance", async () => {
+    const version = await seedInitialVersion(storage)
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, async () => {
+        const [dataset, latestVersion, versions] = await Promise.all([
+          storage.getDataset(ordersDataset.id),
+          storage.getLatestVersion(ordersDataset.id),
+          storage.listVersions(ordersDataset.id),
+        ])
+        return { dataset, latestVersion, versions }
+      })
+    )
+
+    for (const result of results) {
+      expect(result.dataset?.id).toBe(ordersDataset.id)
+      expect(result.latestVersion?.versionId).toBe(version.versionId)
+      expect(result.versions.map((item) => item.versionId)).toEqual([version.versionId])
+    }
+  })
+
   test("rejects a stale guarded commit from an older write session", async () => {
     const initialVersion = await seedInitialVersion(storage)
 

--- a/storage/ducklake/tests/ducklake-remote.e2e.ts
+++ b/storage/ducklake/tests/ducklake-remote.e2e.ts
@@ -57,6 +57,33 @@ describe("DuckLakeStorage remote catalogs", () => {
     }
   })
 
+  test("does not exhaust the PostgreSQL catalog pool across repeated metadata reads", async () => {
+    const dataset = defineDataset(`raw.pg.metadata.${randomId()}`, {
+      schema: [col("orderId", "string")],
+    })
+    const storage = new DuckLakeStorage({
+      catalog: postgresCatalog(),
+      dataPath: `s3://${s3Bucket()}/lake/${randomId()}`,
+      secrets: [minioSecret()],
+    })
+
+    try {
+      await storage.createDataset(dataset)
+      const write = await storage.beginWrite({ dataset, mode: "snapshot" })
+      await write.writeRows([{ orderId: "ord_1" }])
+      const version = await write.commit()
+
+      for (let index = 0; index < 20; index += 1) {
+        await expect(storage.getDataset(dataset.id)).resolves.toMatchObject({ id: dataset.id })
+        await expect(storage.getLatestVersion(dataset.id)).resolves.toMatchObject({
+          versionId: version.versionId,
+        })
+      }
+    } finally {
+      await storage.close()
+    }
+  }, 60_000)
+
   test("allows two provider instances to commit to one PostgreSQL catalog", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "pario-ducklake-pg-shared-"))
     const dataset = defineDataset(`raw.pg.shared.${randomId()}`, {

--- a/storage/ducklake/tests/ducklake-storage.test.ts
+++ b/storage/ducklake/tests/ducklake-storage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { type DatasetDefinition, LakeStorageError } from "@pario/core"
 import { DuckLakeStorage } from "../src"
+import { createDuckDbRuntime } from "../src/internal/duckdb-runtime"
 
 describe("DuckLakeStorage", () => {
   test("rejects schemaless dataset definitions", async () => {
@@ -49,5 +50,18 @@ describe("DuckLakeStorage", () => {
     const rejected = storage.getVersion("missing.dataset", "not-a-ducklake-version")
     await expect(rejected).rejects.toBeInstanceOf(LakeStorageError)
     await expect(rejected).rejects.toThrow("Invalid DuckLake version id")
+  })
+
+  test("runtime close waits for accepted operations and rejects new operations", async () => {
+    const runtime = await createDuckDbRuntime()
+    const running = runtime.query("SELECT sum(sin(i)) AS total FROM range(50000000) AS t(i)")
+    const close = runtime.close()
+
+    await expect(runtime.query("SELECT 1")).rejects.toThrow("closed")
+    await expect(
+      Promise.race([running.then(() => "operation"), close.then(() => "close")])
+    ).resolves.toBe("operation")
+    await close
+    await expect(runtime.query("SELECT 1")).rejects.toThrow("closed")
   })
 })

--- a/storage/ducklake/tests/sql.test.ts
+++ b/storage/ducklake/tests/sql.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   buildAttachSql,
+  buildConfigurePostgresMetadataPoolSql,
   buildCreateSecretSql,
   catalogUri,
   duckLakeMetadataTableName,
@@ -110,6 +111,12 @@ describe("DuckLake SQL rendering", () => {
         "ducklake_snapshot"
       )
     ).toBe('"__ducklake_metadata_lake"."pario_meta"."ducklake_snapshot"')
+  })
+
+  test("builds PostgreSQL metadata pool configuration SQL", () => {
+    expect(buildConfigurePostgresMetadataPoolSql({ alias: "lake" })).toBe(
+      "FROM postgres_configure_pool(catalog_name='__ducklake_metadata_lake', enable_thread_local_cache=false)"
+    )
   })
 
   test("loads extensions required by catalogs, data paths, and secrets", () => {


### PR DESCRIPTION
## Summary

Stabilizes DuckLake-backed dataset browsing and the built-in UI reload path.

This PR keeps the implementation small and targeted:

- configures DuckDB's PostgreSQL metadata catalog pool so repeated DuckLake metadata reads do not exhaust the default Postgres connection pool
- serializes operations on the shared `DuckDBConnection`, including close/reset, so accepted reads finish before the native connection is closed
- reduces `/api/datasets` metadata work by listing materialized datasets once and only reading latest versions for datasets that exist in storage
- fixes built-in Atlas and Sentinel SPA fallback for dotted route segments such as `/datasets/raw.ace.sites`

## Why

The BACnet example exposed a few related problems while loading Atlas datasets:

- repeated DuckLake metadata calls could pin PostgreSQL catalog connections in DuckDB's thread-local cache until the pool timed out
- API reads and runtime reset/close could race on the same `DuckDBConnection`
- `/api/datasets` performed unnecessary per-definition storage reads
- Atlas reloads for dataset ids containing dots returned `404 Not Found` because the server treated the route segment as an asset filename

## Before / After

### DuckLake PostgreSQL metadata pool

Before, DuckLake attached the catalog and used DuckDB's default PostgreSQL extension pool behavior:

```ts
await runtime.run(buildAttachSql(options))
```

After, PostgreSQL-backed DuckLake metadata catalogs disable thread-local pool caching:

```ts
await runtime.run(buildAttachSql(options))

if (options.catalog.type === "postgres") {
  await runtime.run(buildConfigurePostgresMetadataPoolSql(options))
}
```

That renders:

```sql
FROM postgres_configure_pool(
  catalog_name='__ducklake_metadata_lake',
  enable_thread_local_cache=false
)
```

### Shared DuckDB runtime operations

Before, queries and close/reset could touch the same native connection independently.

After, `run`, `query`, and `close` use one small promise chain:

```ts
const result = this.operations.then(async () => {
  this.assertNotClosed()
  return operation()
})
this.operations = result.then(
  () => {},
  () => {}
)
```

This keeps one shared connection simple while preventing a reset from closing work that was already accepted.

### Dataset catalog list route

Before, `/api/datasets` hydrated each definition independently:

```ts
return await Promise.all(
  pario.getDatasetDefinitions().map((dataset) => serializeDatasetCatalogItem(pario, dataset))
)
```

After, it does one `listDatasets()` call and only asks for latest versions for materialized datasets:

```ts
const storedDatasets = new Set(
  (await pario.lakeStorage.listDatasets()).map((dataset) => dataset.id)
)
```

In local BACnet testing this moved the route from roughly `190-330ms` to roughly `90-175ms`.

### Atlas/Sentinel dotted route reloads

Before, the built-in UI server rejected any non-static route whose last segment contained a dot:

```ts
if (isAssetRequest(url.pathname)) {
  return notFoundResponse()
}
```

After, built assets are constrained to `/__pario/*` and favicon routes; every other non-reserved `GET`/`HEAD` path falls through to the SPA shell:

```ts
if (url.pathname.startsWith("/__pario/")) {
  return await fileResponse(request, join(options.bundleOutdir, relativePath), cacheHeaders)
}

return htmlResponse(request, options.shell)
```

That makes a direct reload of `/datasets/raw.ace.sites` return the Atlas shell instead of `404 Not Found`.

## Validation

- `bun test ./storage/ducklake/tests/sql.test.ts ./storage/ducklake/tests/ducklake-storage.test.ts ./storage/ducklake/tests/ducklake-concurrency.e2e.ts`
- `bun test --preload ./storage/ducklake/tests/setup.ts ./storage/ducklake/tests/ducklake-remote.e2e.ts`
- `bun test ./packages/server/tests/httpContract.test.ts ./packages/atlas/tests/atlas-app.test.ts ./packages/sentinel/tests/sentinel-app.test.ts`
- `bun --filter @pario/ducklake typecheck`
- `bun --filter @pario/server typecheck`
- `bun --filter @pario/atlas typecheck`
- `bun --filter @pario/sentinel typecheck`
- `bun run generate:client`
- `bun run check`
- direct Atlas server fetch for `/datasets/raw.ace.sites` now returns `200 text/html; charset=utf-8` with the app shell
