### PR TITLE
atlas: fix object counts and pagination

### DIFF
--- a/packages/atlas/src/ui/src/App.tsx
+++ b/packages/atlas/src/ui/src/App.tsx
@@ -3,23 +3,32 @@ import {
   getProjectInfoOptions,
   listConnectorsOptions,
   listDatasetsOptions,
-  listObjectsOptions,
+  listObjectsPageOptions,
   listObjectTypesOptions,
   listPipelinesOptions,
   listRulesOptions,
   listSyncsOptions,
+  objectCountOptions,
 } from "@pario/client/hooks"
 import { Button, Card, EmptyState } from "@pario/ui/components"
 import { cn } from "@pario/ui/lib/utils"
-import { useQuery } from "@tanstack/react-query"
+import { useQueries, useQuery } from "@tanstack/react-query"
 import { Box, Loader2 } from "lucide-react"
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
-import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from "react-router-dom"
+import {
+  Navigate,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom"
 import { ConnectorDetailPage, ConnectorsPage } from "./components/ConnectorsPage"
 import { DatasetDetailPage, DatasetsPage } from "./components/DatasetsPage"
 import { AppShell, Sidebar, type ViewMode } from "./components/layout"
 import { ObjectDetailPage } from "./components/ObjectDetailPage"
-import { ObjectsWorkbench } from "./components/ObjectsWorkbench"
+import { ObjectsWorkbench, type ObjectTypePreviewSection } from "./components/ObjectsWorkbench"
 import { ObjectTypeDetail } from "./components/ObjectTypeDetail"
 import { OntologyExplorer } from "./components/OntologyExplorer"
 import { PipelineDetailPage, PipelinesPage } from "./components/PipelinesPage"
@@ -34,7 +43,7 @@ import {
 } from "./lib/userPreferences"
 
 interface ProjectSidebarData {
-  objectCount: number
+  objectCount?: number
   datasetCount: number
   connectorCount: number
   syncCount: number
@@ -60,6 +69,16 @@ const KNOWN_VIEWS = new Set([
   "settings",
 ])
 const emptyObjectList: ObjectSummary[] = []
+const OBJECT_PAGE_SIZE = 300
+const OBJECT_TYPE_PREVIEW_LIMIT = 12
+
+function parseObjectOffset(value: string | null): number {
+  if (!value) return 0
+
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return 0
+  return parsed
+}
 
 function getViewModeFromPath(pathname: string): ViewMode {
   if (pathname === "/" || pathname === "") return "home"
@@ -137,6 +156,52 @@ function ProjectWorkspace() {
 
   const [latestUpdates, setLatestUpdates] = useState<Record<string, TelemetryUpdate>>({})
   const [objectSortBy, setObjectSortBy] = useState<ObjectSortPreference>(getObjectSortPreference)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const classFilter = searchParams.get("class") || null
+  const objectOffset = parseObjectOffset(searchParams.get("offset"))
+
+  const setObjectOffset = useCallback(
+    (nextOffset: number, options?: { replace?: boolean }) => {
+      const offset = Math.max(0, Math.trunc(nextOffset))
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev)
+          if (offset > 0) {
+            params.set("offset", String(offset))
+          } else {
+            params.delete("offset")
+          }
+          return params
+        },
+        { replace: options?.replace ?? false }
+      )
+    },
+    [setSearchParams]
+  )
+
+  const setClassFilter = useCallback(
+    (next: string | null, options?: { offset?: number; replace?: boolean }) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev)
+          if (next) {
+            params.set("class", next)
+          } else {
+            params.delete("class")
+          }
+          const offset = Math.max(0, Math.trunc(options?.offset ?? 0))
+          if (offset > 0) {
+            params.set("offset", String(offset))
+          } else {
+            params.delete("offset")
+          }
+          return params
+        },
+        { replace: options?.replace ?? true }
+      )
+    },
+    [setSearchParams]
+  )
 
   const {
     data: projectInfo,
@@ -154,21 +219,122 @@ function ProjectWorkspace() {
   }, [resolvedProjectName])
 
   const objectsQuery = useQuery({
-    ...listObjectsOptions({
+    ...listObjectsPageOptions({
       query: {
+        objectTypeId: classFilter ?? undefined,
+        limit: String(OBJECT_PAGE_SIZE),
+        offset: objectOffset > 0 ? String(objectOffset) : undefined,
         orderBy: objectSortBy,
         order: objectSortBy === "primaryId" ? "asc" : "desc",
       },
     }),
-    enabled: !!projectInfo,
+    enabled: !!projectInfo && !!classFilter,
   })
-  const objects = objectsQuery.data ?? emptyObjectList
+  const objectsPage = objectsQuery.data
+  const objects = objectsPage?.objects ?? emptyObjectList
   const { isLoading: objectsLoading } = objectsQuery
 
-  const { data: objectTypes = [] } = useQuery({
+  const { data: objectTypes = [], isLoading: objectTypesLoading } = useQuery({
     ...listObjectTypesOptions(),
     enabled: !!projectInfo,
   })
+
+  useEffect(() => {
+    if (objectTypes.length === 0 || !classFilter) return
+    if (!objectTypes.some((objectType) => objectType.id === classFilter)) {
+      setClassFilter(null, { replace: true })
+    }
+  }, [classFilter, objectTypes, setClassFilter])
+
+  useEffect(() => {
+    const total = objectsPage?.total
+    if (typeof total !== "number" || objectOffset === 0) return
+    if (total === 0) {
+      setObjectOffset(0, { replace: true })
+      return
+    }
+    if (objectOffset < total) return
+
+    const lastOffset = Math.floor((total - 1) / OBJECT_PAGE_SIZE) * OBJECT_PAGE_SIZE
+    setObjectOffset(lastOffset, { replace: true })
+  }, [objectOffset, objectsPage?.total, setObjectOffset])
+
+  const globalObjectCountQuery = useQuery({
+    ...objectCountOptions(),
+    enabled: !!projectInfo,
+  })
+
+  const objectTypePreviewQueries = useQueries({
+    queries: objectTypes.map((objectType) => ({
+      ...listObjectsPageOptions({
+        query: {
+          objectTypeId: objectType.id,
+          limit: String(OBJECT_TYPE_PREVIEW_LIMIT),
+          orderBy: objectSortBy,
+          order: objectSortBy === "primaryId" ? "asc" : "desc",
+        },
+      }),
+      enabled: !!projectInfo && !classFilter,
+    })),
+  })
+
+  const objectTypeCountQueries = useQueries({
+    queries: objectTypes.map((objectType, index) => ({
+      ...objectCountOptions({
+        query: {
+          objectTypeId: objectType.id,
+        },
+      }),
+      enabled:
+        !!projectInfo &&
+        !!classFilter &&
+        typeof objectTypePreviewQueries[index]?.data?.total !== "number",
+    })),
+  })
+
+  const objectTypePreviewSections = useMemo<ObjectTypePreviewSection[]>(() => {
+    return objectTypes
+      .map((objectType, index) => {
+        const previewQuery = objectTypePreviewQueries[index]
+        const page = previewQuery?.data
+        const total = page?.total ?? 0
+
+        return {
+          objectTypeId: objectType.id,
+          objects: page?.objects ?? emptyObjectList,
+          total,
+        }
+      })
+      .filter((section) => section.total > 0 || section.objects.length > 0)
+  }, [objectTypes, objectTypePreviewQueries])
+
+  const objectTypeCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (let i = 0; i < objectTypes.length; i += 1) {
+      const count = objectTypeCountQueries[i]?.data ?? objectTypePreviewQueries[i]?.data?.total
+      if (typeof count === "number") counts.set(objectTypes[i].id, count)
+    }
+    return counts
+  }, [objectTypes, objectTypeCountQueries, objectTypePreviewQueries])
+
+  const objectTypeTotal = useMemo(() => {
+    if (objectTypes.length === 0 || objectTypeCounts.size !== objectTypes.length) return undefined
+
+    let total = 0
+    for (const objectType of objectTypes) {
+      const count = objectTypeCounts.get(objectType.id)
+      if (typeof count !== "number") return undefined
+      total += count
+    }
+    return total
+  }, [objectTypes, objectTypeCounts])
+
+  const allObjectsTotal = globalObjectCountQuery.data ?? objectTypeTotal ?? 0
+
+  const overviewLoading =
+    !classFilter &&
+    (objectTypesLoading ||
+      (objectTypes.length > 0 && objectTypePreviewQueries.some((query) => query.isLoading)))
 
   const { data: connectors = [] } = useQuery({
     ...listConnectorsOptions(),
@@ -214,7 +380,7 @@ function ProjectWorkspace() {
 
   useEffect(() => {
     setSidebarData({
-      objectCount: objects.length,
+      objectCount: globalObjectCountQuery.data ?? objectTypeTotal,
       datasetCount: datasets.length,
       connectorCount: connectors.length,
       syncCount: syncs.length,
@@ -224,7 +390,8 @@ function ProjectWorkspace() {
       connected,
     })
   }, [
-    objects.length,
+    globalObjectCountQuery.data,
+    objectTypeTotal,
     datasets.length,
     connectors.length,
     syncs.length,
@@ -246,8 +413,13 @@ function ProjectWorkspace() {
   )
 
   const objectLookup = useMemo(
-    () => Object.fromEntries(objects.map((object) => [object.id, object])),
-    [objects]
+    () =>
+      Object.fromEntries(
+        [...objects, ...objectTypePreviewSections.flatMap((section) => section.objects)].map(
+          (object) => [object.id, object]
+        )
+      ),
+    [objects, objectTypePreviewSections]
   )
 
   const toProjectPath = (suffix: string) => `/${suffix}`
@@ -255,6 +427,7 @@ function ProjectWorkspace() {
   const handleObjectSortByChange = (sortBy: ObjectSortPreference) => {
     setObjectSortBy(sortBy)
     setObjectSortPreference(sortBy)
+    setObjectOffset(0, { replace: true })
   }
 
   if (projectLoading) {
@@ -307,11 +480,24 @@ function ProjectWorkspace() {
                 <ObjectsWorkbench
                   projectName={resolvedProjectName}
                   objects={objects}
+                  objectsTotal={objectsPage?.total ?? objects.length}
+                  objectsHasMore={objectsPage?.hasMore ?? false}
+                  objectOffset={objectOffset}
+                  objectPageSize={OBJECT_PAGE_SIZE}
+                  allObjectsTotal={allObjectsTotal}
+                  objectTypeCounts={objectTypeCounts}
+                  overviewSections={objectTypePreviewSections}
+                  overviewLoading={overviewLoading}
                   loading={objectsLoading}
                   sortBy={objectSortBy}
+                  classFilter={classFilter}
                   selectedObjectId={selectedObjectIdForSidebar}
                   latestProjectUpdates={latestProjectUpdates}
                   onSortByChange={handleObjectSortByChange}
+                  onClassFilterChange={(objectTypeId, offset) =>
+                    setClassFilter(objectTypeId, { offset })
+                  }
+                  onObjectOffsetChange={setObjectOffset}
                   onSelectObject={(objectId) => navigate(toProjectPath(objectId))}
                 />
               }

--- a/packages/atlas/src/ui/src/components/ObjectsWorkbench.tsx
+++ b/packages/atlas/src/ui/src/components/ObjectsWorkbench.tsx
@@ -1,6 +1,7 @@
 import type { ObjectDetail, ObjectSummary } from "@pario/client"
 import { getObjectOptions } from "@pario/client/hooks"
 import {
+  Button,
   Card,
   CollectionCardButton,
   CollectionCardGrid,
@@ -22,9 +23,8 @@ import {
 } from "@pario/ui/components"
 import { cn } from "@pario/ui/lib/utils"
 import { useQueries } from "@tanstack/react-query"
-import { Box, Search } from "lucide-react"
-import { useCallback, useEffect, useMemo, useState } from "react"
-import { useSearchParams } from "react-router-dom"
+import { Box, ChevronLeft, ChevronRight, Search } from "lucide-react"
+import { type ReactNode, useMemo, useState } from "react"
 import type { TelemetryUpdate } from "../hooks/useWebSocket"
 import { formatLocation, humanizeIdentifier } from "../lib/labels"
 import { formatRelativeTime } from "../lib/time"
@@ -37,14 +37,31 @@ import {
 import { LetterAvatar, LoadingState } from "./common"
 import { ObjectIcon } from "./ObjectIcon"
 
+export interface ObjectTypePreviewSection {
+  objectTypeId: string
+  objects: ObjectSummary[]
+  total: number
+}
+
 interface ObjectsWorkbenchProps {
   projectName: string
   objects: ObjectSummary[]
+  objectsTotal: number
+  objectsHasMore: boolean
+  objectOffset: number
+  objectPageSize: number
+  allObjectsTotal: number
+  objectTypeCounts: ReadonlyMap<string, number>
+  overviewSections: ObjectTypePreviewSection[]
+  overviewLoading: boolean
   loading: boolean
   sortBy: ObjectSortPreference
+  classFilter?: string | null
   selectedObjectId?: string | null
   latestProjectUpdates: TelemetryUpdate[]
   onSortByChange: (sortBy: ObjectSortPreference) => void
+  onClassFilterChange: (objectTypeId: string | null, offset?: number) => void
+  onObjectOffsetChange: (offset: number) => void
   onSelectObject: (id: string) => void
 }
 
@@ -63,41 +80,67 @@ function formatCompactValue(value: number | string | boolean): string {
   return value
 }
 
+function formatCount(value: number): string {
+  return value.toLocaleString()
+}
+
+function formatLoadedCount(loaded: number, total: number | undefined): string {
+  if (typeof total === "number" && total !== loaded) {
+    return `${formatCount(loaded)} of ${formatCount(total)}`
+  }
+  return formatCount(total ?? loaded)
+}
+
+function objectMatchesQuery(
+  candidate: ObjectSummary,
+  query: string,
+  details: ReadonlyMap<string, ObjectDetail>
+): boolean {
+  const detail = details.get(candidate.id)
+  const location = formatLocation(detail?.location).toLowerCase()
+  const name = (candidate.name || "").toLowerCase()
+  const className = humanizeIdentifier(candidate.class).toLowerCase()
+  return (
+    candidate.id.toLowerCase().includes(query) ||
+    candidate.class.toLowerCase().includes(query) ||
+    className.includes(query) ||
+    name.includes(query) ||
+    location.includes(query)
+  )
+}
+
 export function ObjectsWorkbench({
   projectName,
   objects,
+  objectsTotal,
+  objectsHasMore,
+  objectOffset,
+  objectPageSize,
+  allObjectsTotal,
+  objectTypeCounts,
+  overviewSections,
+  overviewLoading,
   loading,
   sortBy,
+  classFilter,
   selectedObjectId,
   latestProjectUpdates,
   onSortByChange,
+  onClassFilterChange,
+  onObjectOffsetChange,
   onSelectObject,
 }: ObjectsWorkbenchProps) {
   const [searchQuery, setSearchQuery] = useState("")
   const [viewStyle, setViewStyle] = useState<ViewStyle>(getObjectViewStyle)
-  const [searchParams, setSearchParams] = useSearchParams()
-  const classFilter = searchParams.get("class")
+  const selectedTypeMode = classFilter != null
 
-  const setClassFilter = useCallback(
-    (next: string | null) => {
-      setSearchParams(
-        (prev) => {
-          const params = new URLSearchParams(prev)
-          if (next) {
-            params.set("class", next)
-          } else {
-            params.delete("class")
-          }
-          return params
-        },
-        { replace: true }
-      )
-    },
-    [setSearchParams]
+  const displayObjects = useMemo(
+    () => (selectedTypeMode ? objects : overviewSections.flatMap((section) => section.objects)),
+    [objects, overviewSections, selectedTypeMode]
   )
 
   const detailQueries = useQueries({
-    queries: objects.map((object) => ({
+    queries: displayObjects.map((object) => ({
       ...getObjectOptions({
         path: { projectName, objectId: object.id },
       }),
@@ -108,12 +151,12 @@ export function ObjectsWorkbench({
 
   const detailById = useMemo(() => {
     const detailMap = new Map<string, ObjectDetail>()
-    for (let i = 0; i < objects.length; i += 1) {
+    for (let i = 0; i < displayObjects.length; i += 1) {
       const detail = detailQueries[i]?.data as ObjectDetail | undefined
-      if (detail) detailMap.set(objects[i].id, detail)
+      if (detail) detailMap.set(displayObjects[i].id, detail)
     }
     return detailMap
-  }, [objects, detailQueries])
+  }, [displayObjects, detailQueries])
 
   const updatesByObject = useMemo(() => {
     const grouped = new Map<string, TelemetryUpdate[]>()
@@ -128,45 +171,39 @@ export function ObjectsWorkbench({
     return grouped
   }, [latestProjectUpdates])
 
-  const classCounts = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const obj of objects) {
-      counts.set(obj.class, (counts.get(obj.class) ?? 0) + 1)
-    }
-    return counts
-  }, [objects])
-
   const availableClasses = useMemo(
     () =>
-      Array.from(classCounts.keys()).sort((a, b) =>
-        humanizeIdentifier(a).localeCompare(humanizeIdentifier(b))
-      ),
-    [classCounts]
+      Array.from(objectTypeCounts.entries())
+        .filter(([className, count]) => count > 0 || className === classFilter)
+        .map(([className]) => className)
+        .sort((a, b) => humanizeIdentifier(a).localeCompare(humanizeIdentifier(b))),
+    [objectTypeCounts, classFilter]
   )
-
-  // Reset filter if the active class disappears from the dataset.
-  useEffect(() => {
-    if (!loading && classFilter && !classCounts.has(classFilter)) {
-      setClassFilter(null)
-    }
-  }, [classFilter, classCounts, loading, setClassFilter])
 
   const filteredObjects = useMemo(() => {
     const query = searchQuery.trim().toLowerCase()
-    const result = classFilter ? objects.filter((obj) => obj.class === classFilter) : objects
-    if (!query) return result
-    return result.filter((candidate) => {
-      const detail = detailById.get(candidate.id)
-      const location = formatLocation(detail?.location).toLowerCase()
-      const name = (candidate.name || "").toLowerCase()
-      return (
-        candidate.id.toLowerCase().includes(query) ||
-        candidate.class.toLowerCase().includes(query) ||
-        name.includes(query) ||
-        location.includes(query)
+    if (!query) return objects
+    return objects.filter((candidate) => objectMatchesQuery(candidate, query, detailById))
+  }, [objects, searchQuery, detailById])
+
+  const filteredOverviewSections = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+    if (!query) return overviewSections
+
+    return overviewSections
+      .map((section) => ({
+        ...section,
+        objects: section.objects.filter((candidate) =>
+          objectMatchesQuery(candidate, query, detailById)
+        ),
+      }))
+      .filter(
+        (section) =>
+          section.objects.length > 0 ||
+          humanizeIdentifier(section.objectTypeId).toLowerCase().includes(query) ||
+          section.objectTypeId.toLowerCase().includes(query)
       )
-    })
-  }, [objects, classFilter, searchQuery, detailById])
+  }, [overviewSections, searchQuery, detailById])
 
   const groups = useMemo(() => {
     const grouped = new Map<string, ObjectSummary[]>()
@@ -185,11 +222,27 @@ export function ObjectsWorkbench({
     onSelectObject(objectId)
   }
 
+  const searching = searchQuery.trim().length > 0
+  const visibleObjectCount = selectedTypeMode
+    ? filteredObjects.length
+    : filteredOverviewSections.reduce((total, section) => total + section.objects.length, 0)
+  const headerCount = searching
+    ? visibleObjectCount
+    : selectedTypeMode
+      ? objectsTotal
+      : allObjectsTotal
+  const pageLoading = selectedTypeMode ? loading : overviewLoading
+  const showPagination =
+    selectedTypeMode && !loading && (objectsTotal > objectPageSize || objectOffset > 0)
+  const hasResults = selectedTypeMode
+    ? filteredObjects.length > 0
+    : filteredOverviewSections.some((section) => section.objects.length > 0)
+
   return (
     <div className="mx-auto w-full max-w-5xl">
       <CollectionHeader
         title="Objects"
-        count={filteredObjects.length}
+        count={headerCount}
         actions={
           <div className="flex items-center gap-2">
             <Select
@@ -208,14 +261,16 @@ export function ObjectsWorkbench({
                 <SelectItem value="updatedAt">Updated at</SelectItem>
               </SelectContent>
             </Select>
-            <CollectionViewToggle
-              value={viewStyle}
-              options={objectViewOptions}
-              onChange={(style) => {
-                setViewStyle(style)
-                setObjectViewStyle(style)
-              }}
-            />
+            {selectedTypeMode ? (
+              <CollectionViewToggle
+                value={viewStyle}
+                options={objectViewOptions}
+                onChange={(style) => {
+                  setViewStyle(style)
+                  setObjectViewStyle(style)
+                }}
+              />
+            ) : null}
           </div>
         }
       />
@@ -224,17 +279,17 @@ export function ObjectsWorkbench({
         <div className="mt-3 flex flex-wrap items-center gap-1.5">
           <ClassChip
             label="All"
-            count={objects.length}
-            active={classFilter === null}
-            onClick={() => setClassFilter(null)}
+            count={allObjectsTotal}
+            active={classFilter == null}
+            onClick={() => onClassFilterChange(null)}
           />
           {availableClasses.map((cls) => (
             <ClassChip
               key={cls}
               label={humanizeIdentifier(cls)}
-              count={classCounts.get(cls) ?? 0}
+              count={objectTypeCounts.get(cls) ?? 0}
               active={classFilter === cls}
-              onClick={() => setClassFilter(cls)}
+              onClick={() => onClassFilterChange(cls)}
             />
           ))}
         </div>
@@ -251,17 +306,46 @@ export function ObjectsWorkbench({
         />
       </div>
 
-      <div className="mt-4">
-        {loading ? (
+      <div className="mt-4 space-y-4">
+        {pageLoading ? (
           <div className="flex min-h-72 items-center justify-center">
             <LoadingState label="Loading objects..." />
           </div>
-        ) : filteredObjects.length === 0 ? (
+        ) : !hasResults ? (
           <EmptyState
             icon={<Box className="size-12 stroke-1" />}
             title="No matching objects"
             description="Try a broader search query."
           />
+        ) : !selectedTypeMode ? (
+          <div className="space-y-6">
+            {filteredOverviewSections.map((section) => (
+              <ObjectCardSection
+                key={section.objectTypeId}
+                objectTypeId={section.objectTypeId}
+                objects={section.objects}
+                count={formatLoadedCount(
+                  section.objects.length,
+                  searching ? undefined : section.total
+                )}
+                selectedObjectId={selectedObjectId}
+                onSelectObject={handleSelectObject}
+                action={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="ml-auto h-7 px-2 text-xs"
+                    title={`View ${humanizeIdentifier(section.objectTypeId)} objects`}
+                    onClick={() => onClassFilterChange(section.objectTypeId)}
+                  >
+                    View all
+                    <ChevronRight />
+                  </Button>
+                }
+              />
+            ))}
+          </div>
         ) : viewStyle === "table" ? (
           <TableView
             objects={filteredObjects}
@@ -273,30 +357,133 @@ export function ObjectsWorkbench({
         ) : (
           <div className="space-y-6">
             {groups.map(([className, items]) => (
-              <section key={className} className="space-y-2">
-                <div className="sticky top-0 z-10 -mx-1 flex items-baseline gap-2 bg-background/95 px-1 py-1.5 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-                  <LetterAvatar label={humanizeIdentifier(className)} />
-                  <h3 className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
-                    {humanizeIdentifier(className)}
-                  </h3>
-                  <span className="text-[11px] text-muted-foreground tabular-nums">
-                    · {items.length}
-                  </span>
-                </div>
-                <CollectionCardGrid>
-                  {items.map((candidate) => (
-                    <ObjectCardItem
-                      key={candidate.id}
-                      object={candidate}
-                      isActive={selectedObjectId === candidate.id}
-                      onSelect={() => handleSelectObject(candidate.id)}
-                    />
-                  ))}
-                </CollectionCardGrid>
-              </section>
+              <ObjectCardSection
+                key={className}
+                objectTypeId={className}
+                objects={items}
+                count={formatLoadedCount(
+                  items.length,
+                  searching
+                    ? undefined
+                    : className === classFilter
+                      ? objectsTotal
+                      : objectTypeCounts.get(className)
+                )}
+                selectedObjectId={selectedObjectId}
+                onSelectObject={handleSelectObject}
+              />
             ))}
           </div>
         )}
+        {showPagination ? (
+          <ObjectsPagination
+            offset={objectOffset}
+            pageSize={objectPageSize}
+            total={objectsTotal}
+            loadedCount={objects.length}
+            visibleCount={filteredObjects.length}
+            hasMore={objectsHasMore}
+            searching={searching}
+            onOffsetChange={onObjectOffsetChange}
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function ObjectCardSection({
+  objectTypeId,
+  objects,
+  count,
+  selectedObjectId,
+  action,
+  onSelectObject,
+}: {
+  objectTypeId: string
+  objects: ObjectSummary[]
+  count: string
+  selectedObjectId?: string | null
+  action?: ReactNode
+  onSelectObject: (id: string) => void
+}) {
+  const label = humanizeIdentifier(objectTypeId)
+
+  return (
+    <section className="space-y-2">
+      <div className="sticky top-0 z-10 -mx-1 flex items-baseline gap-2 bg-background/95 px-1 py-1.5 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <LetterAvatar label={label} />
+        <h3 className="text-[11px] font-semibold uppercase tracking-wider text-foreground">
+          {label}
+        </h3>
+        <span className="text-[11px] text-muted-foreground tabular-nums">· {count}</span>
+        {action}
+      </div>
+      <CollectionCardGrid>
+        {objects.map((candidate) => (
+          <ObjectCardItem
+            key={candidate.id}
+            object={candidate}
+            isActive={selectedObjectId === candidate.id}
+            onSelect={() => onSelectObject(candidate.id)}
+          />
+        ))}
+      </CollectionCardGrid>
+    </section>
+  )
+}
+
+function ObjectsPagination({
+  offset,
+  pageSize,
+  total,
+  loadedCount,
+  visibleCount,
+  hasMore,
+  searching,
+  onOffsetChange,
+}: {
+  offset: number
+  pageSize: number
+  total: number
+  loadedCount: number
+  visibleCount: number
+  hasMore: boolean
+  searching: boolean
+  onOffsetChange: (offset: number) => void
+}) {
+  const rangeStart = loadedCount > 0 ? offset + 1 : 0
+  const rangeEnd = loadedCount > 0 ? offset + loadedCount : 0
+  const canGoBack = offset > 0
+  const canGoForward = hasMore
+
+  return (
+    <div className="flex flex-col gap-3 border-t border-border pt-3 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-xs tabular-nums text-muted-foreground">
+        Showing {formatCount(rangeStart)}-{formatCount(rangeEnd)} of {formatCount(total)}
+        {searching ? ` · ${formatCount(visibleCount)} matching this page` : ""}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!canGoBack}
+          onClick={() => onOffsetChange(Math.max(0, offset - pageSize))}
+        >
+          <ChevronLeft />
+          Previous
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!canGoForward}
+          onClick={() => onOffsetChange(offset + pageSize)}
+        >
+          Next
+          <ChevronRight />
+        </Button>
       </div>
     </div>
   )
@@ -326,7 +513,7 @@ function ClassChip({
     >
       <span>{label}</span>
       <span className={cn("tabular-nums", active ? "text-background/70" : "text-muted-foreground")}>
-        {count}
+        {formatCount(count)}
       </span>
     </button>
   )

--- a/packages/client/src/hooks.ts
+++ b/packages/client/src/hooks.ts
@@ -11,6 +11,7 @@ import type { GetObjectData, GetTelemetryHistoryData, ListObjectsData } from "./
 import {
   decodeObjectId,
   encodeObjectId,
+  type ObjectSummary,
   type RelationshipEdge,
   toObjectDetail,
   toObjectSummary,
@@ -73,9 +74,21 @@ function parseLimit(value: string | number | undefined): string | undefined {
   return undefined
 }
 
-async function fetchObjectTypeMap() {
+async function loadObjectTypeMap() {
   const { data } = await listObjectTypes({ throwOnError: true })
   return new Map((data ?? []).map((objectType) => [objectType.id, objectType]))
+}
+
+let objectTypeMapPromise: ReturnType<typeof loadObjectTypeMap> | null = null
+
+async function fetchObjectTypeMap() {
+  objectTypeMapPromise ??= loadObjectTypeMap()
+  try {
+    return await objectTypeMapPromise
+  } catch (error) {
+    objectTypeMapPromise = null
+    throw error
+  }
 }
 
 export interface ListRelationshipsOptions {
@@ -162,6 +175,28 @@ export interface ListObjectsOptions extends Omit<Options<ListObjectsData>, "path
   }
 }
 
+export interface ObjectListPage {
+  objects: ObjectSummary[]
+  hasMore: boolean
+  total: number
+}
+
+function buildListObjectsQuery(query: ListObjectsOptions["query"] | undefined) {
+  return {
+    limit: query?.limit ?? "300",
+    orderBy: query?.orderBy ?? "updatedAt",
+    order: query?.order ?? "desc",
+    objectTypeId: query?.objectTypeId,
+    idPrefix: query?.idPrefix,
+    idSuffix: query?.idSuffix,
+    updatedAfter: query?.updatedAfter,
+    updatedBefore: query?.updatedBefore,
+    createdAfter: query?.createdAfter,
+    createdBefore: query?.createdBefore,
+    offset: query?.offset,
+  }
+}
+
 export const listObjectsQueryKey = (options?: ListObjectsOptions): QueryKey => {
   return createQueryKey("listObjects", {
     path: options?.path,
@@ -169,36 +204,70 @@ export const listObjectsQueryKey = (options?: ListObjectsOptions): QueryKey => {
   })
 }
 
+export const listObjectsPageQueryKey = (options?: ListObjectsOptions): QueryKey => {
+  return createQueryKey("listObjectsPage", {
+    path: options?.path,
+    query: options?.query as Record<string, unknown> | undefined,
+  })
+}
+
+async function fetchObjectListPage(options?: ListObjectsOptions): Promise<ObjectListPage> {
+  const { path: _path, query, ...rest } = options ?? {}
+  const [objectTypeMap, objectsResponse] = await Promise.all([
+    fetchObjectTypeMap(),
+    listObjects({
+      ...rest,
+      query: buildListObjectsQuery(query),
+      throwOnError: true,
+    }),
+  ])
+
+  const response = objectsResponse.data
+  const rows = response?.objects ?? []
+  return {
+    objects: rows.map((object) => toObjectSummary(object, objectTypeMap.get(object.objectTypeId))),
+    hasMore: response?.hasMore ?? false,
+    total: response?.total ?? rows.length,
+  }
+}
+
+export const listObjectsPageOptions = (options?: ListObjectsOptions) => {
+  return queryOptions({
+    queryKey: listObjectsPageQueryKey(options),
+    queryFn: async () => fetchObjectListPage(options),
+  })
+}
+
 export const listObjectsOptions = (options?: ListObjectsOptions) => {
   return queryOptions({
     queryKey: listObjectsQueryKey(options),
+    queryFn: async () => (await fetchObjectListPage(options)).objects,
+  })
+}
+
+export const objectCountQueryKey = (options?: ListObjectsOptions): QueryKey => {
+  return createQueryKey("objectCount", {
+    path: options?.path,
+    query: options?.query as Record<string, unknown> | undefined,
+  })
+}
+
+export const objectCountOptions = (options?: ListObjectsOptions) => {
+  return queryOptions({
+    queryKey: objectCountQueryKey(options),
     queryFn: async () => {
       const { path: _path, query, ...rest } = options ?? {}
-      const [objectTypeMap, objectsResponse] = await Promise.all([
-        fetchObjectTypeMap(),
-        listObjects({
-          ...rest,
-          query: {
-            limit: query?.limit ?? "300",
-            orderBy: query?.orderBy ?? "updatedAt",
-            order: query?.order ?? "desc",
-            objectTypeId: query?.objectTypeId,
-            idPrefix: query?.idPrefix,
-            idSuffix: query?.idSuffix,
-            updatedAfter: query?.updatedAfter,
-            updatedBefore: query?.updatedBefore,
-            createdAfter: query?.createdAfter,
-            createdBefore: query?.createdBefore,
-            offset: query?.offset,
-          },
-          throwOnError: true,
-        }),
-      ])
+      const { data } = await listObjects({
+        ...rest,
+        query: {
+          ...buildListObjectsQuery(query),
+          limit: "0",
+          offset: undefined,
+        },
+        throwOnError: true,
+      })
 
-      const objects = objectsResponse.data?.objects ?? []
-      return objects.map((object) =>
-        toObjectSummary(object, objectTypeMap.get(object.objectTypeId))
-      )
+      return data?.total ?? 0
     },
   })
 }

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -317,6 +317,10 @@ export class InMemoryObjectStorage implements ObjectStorage {
 
     const total = allRows.length
 
+    const offset = params.offset ?? 0
+    const limit = params.limit ?? 50
+    if (limit === 0) return { objects: [], hasMore: offset < total, total }
+
     const orderBy = params.orderBy ?? "updatedAt"
     const order = params.order ?? "desc"
 
@@ -336,8 +340,6 @@ export class InMemoryObjectStorage implements ObjectStorage {
       return order === "desc" ? -comparison : comparison
     })
 
-    const offset = params.offset ?? 0
-    const limit = params.limit ?? 50
     const objects = allRows.slice(offset, offset + limit)
     const hasMore = offset + limit < total
 

--- a/packages/core/tests/in-memory-providers.test.ts
+++ b/packages/core/tests/in-memory-providers.test.ts
@@ -144,6 +144,11 @@ describe("InMemoryObjectStorage", () => {
     expect(page1.total).toBe(5)
     expect(page1.hasMore).toBe(true)
 
+    const countOnly = await storage.list({ projectId: "p1", objectTypeId: "Room", limit: 0 })
+    expect(countOnly.objects).toHaveLength(0)
+    expect(countOnly.total).toBe(5)
+    expect(countOnly.hasMore).toBe(true)
+
     const page2 = await storage.list({ projectId: "p1", objectTypeId: "Room", limit: 2, offset: 4 })
     expect(page2.objects).toHaveLength(1)
     expect(page2.hasMore).toBe(false)

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -616,6 +616,8 @@ export class PgObjectStorage implements ObjectStorage {
     `) as { total: number }[]
     const total = countResult.total
 
+    if (limit === 0) return { objects: [], hasMore: queryOffset < total, total }
+
     // Get paginated results (+1 for hasMore check)
     // Column and direction derived from a fixed mapping — safe to use as identifiers
     const fetchLimit = limit + 1

--- a/storage/pg/tests/pg-object-storage.e2e.ts
+++ b/storage/pg/tests/pg-object-storage.e2e.ts
@@ -400,6 +400,15 @@ describe("PgObjectStorage", () => {
     expect(result.objects).toHaveLength(2)
     expect(result.total).toBe(5)
     expect(result.hasMore).toBe(true)
+
+    const countOnly = await storage.objects.list({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      limit: 0,
+    })
+    expect(countOnly.objects).toHaveLength(0)
+    expect(countOnly.total).toBe(5)
+    expect(countOnly.hasMore).toBe(true)
   })
 
   test("list with primaryIdPrefix filter", async () => {

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -589,6 +589,10 @@ export class SqliteObjectStorage implements ObjectStorage {
     }
     const total = countResult.total
 
+    const offset = params.offset ?? 0
+    const limit = params.limit ?? 50
+    if (limit === 0) return { objects: [], hasMore: offset < total, total }
+
     // Add ordering
     const orderBy = params.orderBy ?? "updatedAt"
     const order = params.order ?? "desc"
@@ -597,8 +601,6 @@ export class SqliteObjectStorage implements ObjectStorage {
     query += ` ORDER BY ${orderColumn} ${order.toUpperCase()}`
 
     // Add pagination
-    const offset = params.offset ?? 0
-    const limit = params.limit ?? 50
     query += " LIMIT ? OFFSET ?"
     args.push(limit + 1, offset) // +1 to check for hasMore
 

--- a/storage/sqlite/tests/sqlite-object-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-object-storage.test.ts
@@ -398,6 +398,15 @@ describe("SqliteObjectStorage", () => {
     expect(result.objects).toHaveLength(2)
     expect(result.total).toBe(5)
     expect(result.hasMore).toBe(true)
+
+    const countOnly = await storage.list({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      limit: 0,
+    })
+    expect(countOnly.objects).toHaveLength(0)
+    expect(countOnly.total).toBe(5)
+    expect(countOnly.hasMore).toBe(true)
   })
 
   test("list with primaryIdPrefix filter", async () => {


### PR DESCRIPTION
## Summary

Stacked on #24 (`ducklake-conn-fixes`).

- use API-backed object totals instead of counting only the currently loaded page
- make the default Objects view an object-type overview so small types like Ace Site are visible without filtering
- paginate the selected object type through URL-backed offsets
- add count-only behavior for `limit=0` object list calls in in-memory, SQLite, and Postgres storage

## Root cause

Atlas was deriving counts from loaded object arrays while `/api/objects` defaults to a limited page. That made the sidebar, object-type sections, and filter chips show page counts instead of total counts.

## Validation

- `bunx biome check --write packages/client/src/hooks.ts packages/atlas/src/ui/src/App.tsx packages/atlas/src/ui/src/components/ObjectsWorkbench.tsx packages/core/src/storage/objects/in-memory.ts packages/core/tests/in-memory-providers.test.ts storage/pg/src/pg-object-storage.ts storage/pg/tests/pg-object-storage.e2e.ts storage/sqlite/src/object-storage.ts storage/sqlite/tests/sqlite-object-storage.test.ts`
- `bun --filter @pario/client typecheck`
- `bun --filter @pario/atlas typecheck`
- `bun --filter @pario/atlas build`
- `bun --filter @pario/core typecheck`
- `bun --filter @pario/pg typecheck`
- `bun --filter @pario/sqlite typecheck`
- `bun test packages/core/tests/in-memory-providers.test.ts`
- `bun test storage/sqlite/tests/sqlite-object-storage.test.ts`

Not run: Postgres e2e suite; the matching assertion was added, but that suite requires the Docker/Postgres e2e harness.


## Screenshots

Before this was incorrectly showing total as "300". Now shows proper counts 

<img width="266" height="111" alt="Screenshot 2026-05-26 at 7 42 41 PM" src="https://github.com/user-attachments/assets/ebf7e1ff-2123-4ee9-ad0d-5e27521eeead" />

