### PR TITLE
storage: stream DuckLake projection reads

### DIFF
--- a/packages/projection-worker/src/run-link-projection.ts
+++ b/packages/projection-worker/src/run-link-projection.ts
@@ -93,6 +93,7 @@ export async function runLinkProjection(
   for await (const row of runtime.lakeStorage.readRows({
     datasetId: projection.datasetId,
     versionId,
+    columns: linkProjectionReadColumns(projection),
   })) {
     throwIfAborted(signal)
     counters.rowsProcessed += 1
@@ -132,6 +133,10 @@ export async function runLinkProjection(
     ...snapshotCounters(counters),
     firstErrorMessage,
   }
+}
+
+function linkProjectionReadColumns(projection: LinkProjectionDefinition): readonly string[] {
+  return [...new Set([projection.sourceField, projection.targetField])]
 }
 
 function collectLinkRow(

--- a/packages/projection-worker/src/run-object-projection.ts
+++ b/packages/projection-worker/src/run-object-projection.ts
@@ -103,6 +103,7 @@ export async function runObjectProjection(
   for await (const row of runtime.lakeStorage.readRows({
     datasetId: projection.datasetId,
     versionId,
+    columns: objectProjectionReadColumns(projection),
   })) {
     throwIfAborted(signal)
     counters.rowsProcessed += 1
@@ -134,6 +135,10 @@ export async function runObjectProjection(
     ...snapshotCounters(counters),
     firstErrorMessage,
   }
+}
+
+function objectProjectionReadColumns(projection: ObjectProjectionDefinition): readonly string[] {
+  return [...new Set(Object.values(projection.properties))]
 }
 
 async function upsertForeignKeyLinks(input: {

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  type BeginDatasetWriteInput,
   col,
   type DatasetDefinition,
   type DatasetRow,
@@ -21,6 +22,7 @@ import {
   type ProjectionDefinition,
   type ProjectionRunStorage,
   prop,
+  type ReadDatasetRowsInput,
   stringEnum,
   valueTypeRef,
 } from "@pario/core"
@@ -80,6 +82,55 @@ const roomSensorProjection = defineLinkProjection("room-sensor-proj", Room.l.has
   .fromDataset(roomSensorsDataset)
   .sourceField("room_id")
   .targetField("sensor_id")
+
+class RecordingLakeStorage implements LakeStorage {
+  readonly standard: LakeStorage["standard"]
+  readonly readInputs: ReadDatasetRowsInput[] = []
+
+  constructor(private readonly delegate: LakeStorage) {
+    this.standard = delegate.standard
+  }
+
+  assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void> {
+    return this.delegate.assertDatasetDefinitionCompatible(definition)
+  }
+
+  createDataset(definition: DatasetDefinition): Promise<DatasetDefinition> {
+    return this.delegate.createDataset(definition)
+  }
+
+  getDataset(datasetId: string): Promise<DatasetDefinition | null> {
+    return this.delegate.getDataset(datasetId)
+  }
+
+  listDatasets(): Promise<readonly DatasetDefinition[]> {
+    return this.delegate.listDatasets()
+  }
+
+  listVersions(datasetId: string, limit?: number) {
+    return this.delegate.listVersions(datasetId, limit)
+  }
+
+  beginWrite(input: BeginDatasetWriteInput) {
+    return this.delegate.beginWrite(input)
+  }
+
+  getLatestVersion(datasetId: string) {
+    return this.delegate.getLatestVersion(datasetId)
+  }
+
+  getVersion(datasetId: string, versionId: string) {
+    return this.delegate.getVersion(datasetId, versionId)
+  }
+
+  readRows(input: ReadDatasetRowsInput): AsyncIterable<DatasetRow> {
+    this.readInputs.push({
+      ...input,
+      columns: input.columns === undefined ? undefined : [...input.columns],
+    })
+    return this.delegate.readRows(input)
+  }
+}
 
 interface TestRuntimeDeps {
   readonly broker: InMemoryBroker
@@ -170,7 +221,7 @@ function createPario(
     datasets: readonly DatasetDefinition[]
     projections: readonly ProjectionDefinition[]
   },
-  deps = createDeps()
+  deps: Omit<TestRuntimeDeps, "lakeStorage"> & { readonly lakeStorage: LakeStorage } = createDeps()
 ) {
   return new Pario({
     id: "projection-worker-tests",
@@ -235,6 +286,46 @@ describe("runProjectionJob", () => {
       primaryId: "r1",
     })
     expect(room?.properties.name).toBe("Kitchen")
+  })
+
+  test("object projections read only mapped dataset columns", async () => {
+    const deps = createDeps()
+    const lakeStorage = new RecordingLakeStorage(deps.lakeStorage)
+    const wideRoomsDataset = defineDataset("canonical.wide-rooms", {
+      schema: [
+        col("room_id", "string"),
+        col("room_name", "string"),
+        col("unused_a", "string", { nullable: true }),
+        col("unused_b", "json", { nullable: true }),
+      ],
+    })
+    const wideRoomProjection = defineProjection("wide-room-proj", Room)
+      .fromDataset(wideRoomsDataset)
+      .properties({ id: "room_id", name: "room_name" })
+    const pario = createPario(
+      {
+        datasets: [wideRoomsDataset],
+        projections: [wideRoomProjection],
+      },
+      { ...deps, lakeStorage }
+    )
+    const version = await commitDatasetVersion(lakeStorage, wideRoomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", unused_a: "ignored", unused_b: { ignored: true } },
+    ])
+
+    await runProjectionJob({
+      runtime: createRuntime(pario),
+      job: {
+        id: "projrun-column-pruning-object",
+        projectionId: "wide-room-proj",
+        projectionKind: "object",
+        datasetId: wideRoomsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(lakeStorage.readInputs).toHaveLength(1)
+    expect(lakeStorage.readInputs[0]?.columns).toEqual(["room_id", "room_name"])
   })
 
   test("materializes FK links after object upserts", async () => {
@@ -348,6 +439,51 @@ describe("runProjectionJob", () => {
     })
     expect(links).toHaveLength(1)
     expect(links[0]?.targetId).toBe("s1")
+  })
+
+  test("link projections read only source and target columns", async () => {
+    const deps = createDeps()
+    const lakeStorage = new RecordingLakeStorage(deps.lakeStorage)
+    const wideRoomSensorsDataset = defineDataset("canonical.wide-room-sensors", {
+      schema: [
+        col("room_id", "string"),
+        col("sensor_id", "string"),
+        col("unused_weight", "float64", { nullable: true }),
+      ],
+    })
+    const wideRoomSensorProjection = defineLinkProjection(
+      "wide-room-sensor-proj",
+      Room.l.hasSensors
+    )
+      .fromDataset(wideRoomSensorsDataset)
+      .sourceField("room_id")
+      .targetField("sensor_id")
+    const pario = createPario(
+      {
+        datasets: [wideRoomSensorsDataset],
+        projections: [wideRoomSensorProjection],
+      },
+      { ...deps, lakeStorage }
+    )
+    await pario.upsertObject("Room", { id: "r1", name: "Kitchen" })
+    await pario.upsertObject("Sensor", { id: "s1", name: "Motion" })
+    const version = await commitDatasetVersion(lakeStorage, wideRoomSensorsDataset, [
+      { room_id: "r1", sensor_id: "s1", unused_weight: 0.75 },
+    ])
+
+    await runProjectionJob({
+      runtime: createRuntime(pario),
+      job: {
+        id: "projrun-column-pruning-link",
+        projectionId: "wide-room-sensor-proj",
+        projectionKind: "link",
+        datasetId: wideRoomSensorsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(lakeStorage.readInputs).toHaveLength(1)
+    expect(lakeStorage.readInputs[0]?.columns).toEqual(["room_id", "sensor_id"])
   })
 
   test("skips blank object primary values and blank link fields", async () => {

--- a/storage/ducklake/src/internal/duckdb-runtime.ts
+++ b/storage/ducklake/src/internal/duckdb-runtime.ts
@@ -23,6 +23,7 @@ import {
 export interface DuckDbRuntime {
   run(sql: string, values?: readonly DuckDBValue[]): Promise<void>
   query(sql: string, values?: readonly DuckDBValue[]): Promise<readonly Record<string, unknown>[]>
+  streamRows(sql: string, values?: readonly DuckDBValue[]): AsyncIterable<Record<string, unknown>>
   withAppender<T>(
     tableName: string,
     useAppender: (appender: DuckDbAppender) => T | Promise<T>
@@ -69,6 +70,42 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
       )
       return reader.getRowObjectsJS()
     })
+  }
+
+  async *streamRows(
+    sql: string,
+    values?: readonly DuckDBValue[]
+  ): AsyncIterable<Record<string, unknown>> {
+    this.assertAcceptingOperations()
+
+    let releaseOperation: (() => void) | undefined
+    const operationFinished = new Promise<void>((resolve) => {
+      releaseOperation = resolve
+    })
+    const waitForTurn = this.operations.then(() => {
+      this.assertNotClosed()
+    })
+    this.operations = waitForTurn
+      .then(() => operationFinished)
+      .then(
+        () => {},
+        () => {}
+      )
+
+    try {
+      await waitForTurn
+      const result = await this.connection.stream(
+        sql,
+        values === undefined ? undefined : [...values]
+      )
+      for await (const batch of result.yieldRowObjectJs()) {
+        for (const row of batch) {
+          yield row as Record<string, unknown>
+        }
+      }
+    } finally {
+      releaseOperation?.()
+    }
   }
 
   async withAppender<T>(

--- a/storage/ducklake/src/internal/ducklake-row-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-row-reader.ts
@@ -55,13 +55,13 @@ export class DuckLakeRowReader {
     const tableSql = qualifiedTableName(this.options, tableName)
     const limitSql = input.limit === undefined ? "" : ` LIMIT ${Math.max(0, input.limit)}`
     const offsetSql = input.offset === undefined ? "" : ` OFFSET ${Math.max(0, input.offset)}`
-    const rows = await runtime.query(
+    const rows = runtime.streamRows(
       `SELECT ${columnsSql} FROM ${tableSql} AT (VERSION => ${snapshotId})${limitSql}${offsetSql}`
     )
 
     // Step 3: DuckDB returns driver-native values. Normalize each projected
     // column through the schema that was active at the resolved version.
-    for (const row of rows) {
+    for await (const row of rows) {
       const output: Record<string, unknown> = {}
       for (const column of selectedColumns) {
         output[column.name] = normalizeReadValue(row[column.name], column)

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -130,6 +130,28 @@ describe("DuckLakeStorage writes and latest reads", () => {
     ])
   })
 
+  test("supports breaking out of streamed reads without blocking later reads", async () => {
+    const write = await storage.beginWrite({
+      dataset: ordersDataset,
+      mode: "snapshot",
+    })
+
+    await write.writeRows([
+      { orderId: "ord_1", customerName: "Ada", orderCount: 1 },
+      { orderId: "ord_2", customerName: "Grace", orderCount: 2 },
+    ])
+    await write.commit()
+
+    for await (const row of storage.readRows({ datasetId: ordersDataset.id })) {
+      expect(row.orderId).toBe("ord_1")
+      break
+    }
+
+    await expect(
+      collectRows(storage.readRows({ datasetId: ordersDataset.id }))
+    ).resolves.toHaveLength(2)
+  })
+
   test("writes large row streams through the appender staging path", async () => {
     const ROW_COUNT = 1001
 


### PR DESCRIPTION
DuckLake projection reads were doing more work than necessary before projection processing could start.

The root cause was two-fold: DuckLake `readRows()` selected through the row reader, but the runtime implementation used `runAndReadAll()`, which materialized the selected result into JS memory before yielding the first row. Projection jobs also did not pass a column list, so wide datasets read every column even when a projection only needed two or three fields.

This PR makes the read path streaming and narrows projection reads to the mapped fields.

What changed:

- Added an internal DuckDB streaming row API backed by `connection.stream(...).yieldRowObjectJs()`.
- Switched DuckLake `readRows()` from materialized `query()` reads to streamed row iteration.
- Updated object projections to read only mapped property columns.
- Updated link projections to read only source and target columns.
- Added tests for projection column pruning and early stream break behavior.

Key implementation shape:

```ts
for await (const row of runtime.lakeStorage.readRows({
  datasetId: projection.datasetId,
  versionId,
  columns: objectProjectionReadColumns(projection),
})) {
  // project row
}
```

```ts
for await (const batch of result.yieldRowObjectJs()) {
  for (const row of batch) {
    yield row as Record<string, unknown>
  }
}
```

Local benchmark, using 10k rows, 13 columns, 256 byte string cells:

| Metric | Before | After |
| --- | ---: | ---: |
| First row latency | 68ms | 29ms |
| Heap before read | 3.9 MiB | 3.9 MiB |
| Heap after first row | 33.6 MiB | 3.9 MiB |
| First-row heap delta | +29.7 MiB | ~0 MiB |
| Total read time | 77ms | 80ms |

The important behavior change is that DuckLake no longer loads the whole 10k-row selected result into JS memory before the projection can process row one. A projection that reads all rows still processes all rows over time; it just starts processing immediately and avoids the upfront materialization spike. Column pruning also reduces per-row decode/allocation work for wide datasets.

Validation:

```bash
bun run check
bun --filter @pario/ducklake typecheck
bun --filter @pario/projection-worker typecheck
bun test packages/projection-worker/tests/run-projection-job.test.ts
bun test ./storage/ducklake/tests/ducklake-writes.e2e.ts
```
