### PR TITLE
redis: batch broker appends

### DIFF
--- a/broker/redis/src/redis-broker.ts
+++ b/broker/redis/src/redis-broker.ts
@@ -8,7 +8,11 @@ import {
 import { assertCursor, compareStreamIds } from "./cursor"
 import { RedisBrokerError } from "./errors"
 import { assertPrefix, assertStreamId, validateProjectId } from "./keys"
-import { APPEND_RECORD_SCRIPT, ENFORCE_AGE_RETENTION_SCRIPT } from "./scripts"
+import {
+  APPEND_RECORDS_SCRIPT,
+  ENFORCE_AGE_RETENTION_SCRIPT,
+  TRIM_STREAM_RETENTION_SCRIPT,
+} from "./scripts"
 import { assertEncodableRecord, decodeRecord, encodeRecord } from "./serialization"
 import { type EnsuredStream, StreamManager } from "./stream-manager"
 import {
@@ -25,6 +29,18 @@ const DEFAULT_DEDUPE_TTL_MS = 120_000
 const DEFAULT_READ_BATCH_SIZE = 1_000
 const DEFAULT_SUBSCRIBE_BATCH_SIZE = 100
 const DEFAULT_SUBSCRIBE_BLOCK_MS = 1_000
+
+interface EncodedAppendRecord {
+  readonly input: BrokerRecordInput
+  readonly body: string
+  readonly publishedAt: string
+}
+
+interface AppendBatchResult {
+  readonly cursor: string
+  readonly duplicate: boolean
+  readonly duplicateBody?: string
+}
 
 export interface RedisBrokerOptions {
   /** Bun Redis client options, commonly `{ url: "redis://localhost:6379" }`. */
@@ -99,33 +115,53 @@ export class RedisBroker implements Broker {
 
     const ensured = await this.streamManager.requireStream(params.projectId, params.streamId)
     const client = await this.connectionManager.connect()
-    const records: BrokerRecord[] = []
-
-    for (const input of params.records) {
-      // Multi-record append is sequential like NatsBroker. Each individual
-      // record is atomic, but callers should use idempotency keys when retrying
-      // a batch that may have partially committed.
+    const encodedRecords: EncodedAppendRecord[] = params.records.map((input) => {
       const publishedAt = new Date().toISOString()
-      const body = encodeRecord(input, publishedAt)
-      const result = await this.appendOne({
-        client,
-        ensured,
+      return {
         input,
-        body,
-      })
+        publishedAt,
+        body: encodeRecord(input, publishedAt),
+      }
+    })
+
+    const appendResults = await this.appendBatch({
+      client,
+      ensured,
+      records: encodedRecords,
+    })
+
+    if (appendResults.length !== encodedRecords.length) {
+      throw new RedisBrokerError(
+        `Redis append script returned ${appendResults.length} result(s) for ${encodedRecords.length} record(s).`
+      )
+    }
+
+    const records: BrokerRecord[] = []
+    for (let index = 0; index < encodedRecords.length; index += 1) {
+      const encoded = encodedRecords[index]!
+      const result = appendResults[index]!
 
       if (result.duplicate) {
-        records.push(await this.fetchRecordByCursor(client, ensured, result.cursor))
+        records.push(
+          result.duplicateBody
+            ? decodeRecord({
+                streamId: ensured.streamId,
+                body: result.duplicateBody,
+                cursor: result.cursor,
+                fallbackPublishedAt: new Date().toISOString(),
+              })
+            : await this.fetchRecordByCursor(client, ensured, result.cursor)
+        )
         continue
       }
 
       records.push({
         streamId: params.streamId,
         cursor: result.cursor,
-        name: input.name,
-        key: input.key,
-        payload: cloneJsonValue(input.payload),
-        publishedAt,
+        name: encoded.input.name,
+        key: encoded.input.key,
+        payload: cloneJsonValue(encoded.input.payload),
+        publishedAt: encoded.publishedAt,
       })
     }
 
@@ -155,12 +191,18 @@ export class RedisBroker implements Broker {
 
     const client = await this.connectionManager.connect()
     await this.enforceAgeRetention(client, ensured)
-    await this.assertCursorInRetainedRange(client, ensured, params.afterCursor)
+    const lastTrimmedId = await this.readLastTrimmedId(client, ensured)
+    this.assertCursorInRetainedRange(ensured.streamId, params.afterCursor, lastTrimmedId)
 
     const names = params.names && params.names.length > 0 ? new Set(params.names) : undefined
     const records: BrokerRecord[] = []
     // Redis makes range starts exclusive by prefixing the id with "(".
-    let start = params.afterCursor === undefined ? "-" : `(${params.afterCursor}`
+    let start =
+      params.afterCursor === undefined
+        ? lastTrimmedId === undefined
+          ? "-"
+          : `(${lastTrimmedId}`
+        : `(${params.afterCursor}`
 
     while (params.limit === undefined || records.length < params.limit) {
       const entries = await this.readRange(client, ensured, start, this.readBatchSize)
@@ -217,8 +259,9 @@ export class RedisBroker implements Broker {
     const ensured = await this.streamManager.requireStream(params.projectId, params.streamId)
     const commandClient = await this.connectionManager.connect()
     await this.enforceAgeRetention(commandClient, ensured)
+    const lastTrimmedId = await this.readLastTrimmedId(commandClient, ensured)
     if (params.afterCursor !== undefined) {
-      await this.assertCursorInRetainedRange(commandClient, ensured, params.afterCursor)
+      this.assertCursorInRetainedRange(ensured.streamId, params.afterCursor, lastTrimmedId)
     }
 
     const client = await this.connectionManager.createSubscriptionClient()
@@ -227,7 +270,9 @@ export class RedisBroker implements Broker {
     // timeout can skip records written between two XREAD calls.
     let lastSeenId =
       params.afterCursor ??
-      (params.from === "earliest" ? "0-0" : await this.latestCursor(client, ensured))
+      (params.from === "earliest"
+        ? (lastTrimmedId ?? "0-0")
+        : await this.latestCursor(client, ensured))
     let stopped = false
 
     const pump = (async () => {
@@ -307,50 +352,62 @@ export class RedisBroker implements Broker {
     }
   }
 
-  private async appendOne(params: {
+  private async appendBatch(params: {
     client: RedisBrokerClient
     ensured: EnsuredStream
-    input: BrokerRecordInput
-    body: string
-  }): Promise<{ readonly cursor: string; readonly duplicate: boolean }> {
-    const hasIdempotencyKey = params.input.idempotencyKey !== undefined
-
+    records: readonly EncodedAppendRecord[]
+  }): Promise<readonly AppendBatchResult[]> {
     let reply: unknown
     try {
-      // One Lua call keeps XADD, dedupe-key writes, trimming, and retained-range
-      // metadata updates in the same Redis atomic operation.
+      const dedupeKeys = params.records.map((record) =>
+        params.ensured.keys.dedupeKey(record.input.idempotencyKey)
+      )
+      const args = params.records.flatMap((record) => [
+        record.body,
+        record.input.idempotencyKey === undefined ? "0" : "1",
+      ])
+
+      // One Lua call keeps XADDs and dedupe-key writes atomic for the whole
+      // append batch. Retention trimming follows as a separate command so
+      // blocked XREAD subscribers can observe the complete live batch first.
       reply = await params.client.send("EVAL", [
-        APPEND_RECORD_SCRIPT,
-        "3",
+        APPEND_RECORDS_SCRIPT,
+        String(2 + dedupeKeys.length),
         params.ensured.keys.streamKey,
         params.ensured.keys.metaKey,
-        params.ensured.keys.dedupeKey(params.input.idempotencyKey),
-        params.body,
-        hasIdempotencyKey ? "1" : "0",
+        ...dedupeKeys,
         String(this.dedupeTtlMs),
+        String(params.records.length),
+        ...args,
       ])
     } catch (error) {
-      throw new RedisBrokerError(`Failed to append record to stream "${params.ensured.streamId}"`, {
-        cause: error,
-      })
+      throw new RedisBrokerError(
+        `Failed to append records to stream "${params.ensured.streamId}"`,
+        {
+          cause: error,
+        }
+      )
     }
 
-    if (!Array.isArray(reply) || reply.length !== 2) {
-      throw new RedisBrokerError("Redis append script returned a malformed reply")
+    const results = parseAppendBatchReply(reply)
+    if (results.some((result) => !result.duplicate)) {
+      await this.trimRetention(params.client, params.ensured)
     }
 
-    const status = toText(reply[0])
-    const cursor = toText(reply[1])
-    assertCursor(cursor)
+    return results
+  }
 
-    if (status === "stored") {
-      return { cursor, duplicate: false }
+  private async trimRetention(client: RedisBrokerClient, ensured: EnsuredStream): Promise<void> {
+    try {
+      await client.send("EVAL", [
+        TRIM_STREAM_RETENTION_SCRIPT,
+        "2",
+        ensured.keys.streamKey,
+        ensured.keys.metaKey,
+      ])
+    } catch (error) {
+      throw new RedisBrokerError(`Failed to trim stream "${ensured.streamId}"`, { cause: error })
     }
-    if (status === "duplicate") {
-      return { cursor, duplicate: true }
-    }
-
-    throw new RedisBrokerError(`Redis append script returned unknown status "${status}"`)
   }
 
   private async fetchRecordByCursor(
@@ -473,26 +530,31 @@ export class RedisBroker implements Broker {
     return parseStreamEntries(reply)
   }
 
-  private async assertCursorInRetainedRange(
+  private async readLastTrimmedId(
     client: RedisBrokerClient,
-    ensured: EnsuredStream,
-    afterCursor: string | undefined
-  ): Promise<void> {
+    ensured: EnsuredStream
+  ): Promise<string | undefined> {
+    const metadata = await this.streamManager.readMetadata(client, ensured, ["lastTrimmedId"])
+    return metadata.get("lastTrimmedId")
+  }
+
+  private assertCursorInRetainedRange(
+    streamId: string,
+    afterCursor: string | undefined,
+    lastTrimmedId: string | undefined
+  ): void {
     if (afterCursor === undefined) {
       return
     }
 
-    const metadata = await this.streamManager.readMetadata(client, ensured, ["lastTrimmedId"])
-    const lastTrimmedId = metadata.get("lastTrimmedId")
-
     // Do not compare against the first retained entry: Redis ids are not dense,
     // so the cursor immediately before the first retained entry is still valid.
-    // The append script records the latest id actually trimmed; only cursors
-    // older than that represent unavailable history.
+    // The append/trim scripts record the latest id removed from the logical
+    // retained range; only cursors older than that represent unavailable history.
     if (lastTrimmedId !== undefined && compareStreamIds(afterCursor, lastTrimmedId) < 0) {
       throw new RedisBrokerError(
         `afterCursor '${afterCursor}' is outside the retained range for stream ` +
-          `'${ensured.streamId}'. The latest trimmed cursor is '${lastTrimmedId}'.`
+          `'${streamId}'. The latest trimmed cursor is '${lastTrimmedId}'.`
       )
     }
   }
@@ -509,4 +571,41 @@ function positiveInteger(value: number): number {
     throw new RedisBrokerError("broker numeric options must be positive finite integers")
   }
   return value
+}
+
+function parseAppendBatchReply(reply: unknown): readonly AppendBatchResult[] {
+  if (!Array.isArray(reply)) {
+    throw new RedisBrokerError("Redis append script returned a malformed reply")
+  }
+
+  return reply.map(parseAppendBatchResult)
+}
+
+function parseAppendBatchResult(item: unknown): AppendBatchResult {
+  if (!Array.isArray(item) || item.length < 2) {
+    throw new RedisBrokerError("Redis append script returned a malformed item")
+  }
+
+  const status = toText(item[0])
+  const cursor = toText(item[1])
+  assertCursor(cursor)
+  const duplicateBody = item.length >= 3 ? optionalText(item[2]) : undefined
+
+  if (status === "stored") {
+    return { cursor, duplicate: false }
+  }
+  if (status === "duplicate") {
+    return { cursor, duplicate: true, duplicateBody }
+  }
+
+  throw new RedisBrokerError(`Redis append script returned unknown status "${status}"`)
+}
+
+function optionalText(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined
+  }
+
+  const text = toText(value)
+  return text.length === 0 ? undefined : text
 }

--- a/broker/redis/src/scripts.ts
+++ b/broker/redis/src/scripts.ts
@@ -75,30 +75,16 @@ end
 return last_trimmed_id
 `
 
-// Appends exactly one broker record. Keep this operation in Lua so the returned
-// cursor, dedupe key, retention trim, and retained-range metadata cannot drift
-// apart if another process writes to the same Redis stream concurrently.
-export const APPEND_RECORD_SCRIPT = `
+// Trims retained append history after appends have committed. This is separate
+// from APPEND_RECORDS_SCRIPT so blocked XREAD subscribers can be woken with the
+// full live batch before retained history is reduced to its configured window.
+export const TRIM_STREAM_RETENTION_SCRIPT = `
 local stream_key = KEYS[1]
 local meta_key = KEYS[2]
-local dedupe_key = KEYS[3]
-local body = ARGV[1]
-local has_idempotency_key = ARGV[2]
-local dedupe_ttl_ms = ARGV[3]
 
 if redis.call("EXISTS", meta_key) == 0 then
   return redis.error_reply("broker stream has not been ensured")
 end
-
-if has_idempotency_key == "1" then
-  local existing_id = redis.call("GET", dedupe_key)
-  if existing_id then
-    return { "duplicate", existing_id }
-  end
-end
-
-local id = redis.call("XADD", stream_key, "*", "body", body)
-redis.call("HSET", meta_key, "lastId", id)
 
 local last_trimmed_id = nil
 local max_records = redis.call("HGET", meta_key, "maxRecords")
@@ -153,9 +139,101 @@ if last_trimmed_id then
   redis.call("HSET", meta_key, "lastTrimmedId", last_trimmed_id)
 end
 
-if has_idempotency_key == "1" then
-  redis.call("SET", dedupe_key, id, "PX", dedupe_ttl_ms)
+return last_trimmed_id
+`
+
+// Appends a batch of broker records with one Redis round trip. Each record still
+// gets its own stream id and idempotency decision.
+//
+// KEYS:
+//   1: stream key
+//   2: metadata key
+//   3..N: per-record dedupe keys, using a placeholder key when the record has no idempotency key
+// ARGV:
+//   1: dedupe ttl ms
+//   2: record count
+//   3..N: repeated pairs of { body, has idempotency key: "1" | "0" }
+export const APPEND_RECORDS_SCRIPT = `
+local stream_key = KEYS[1]
+local meta_key = KEYS[2]
+local dedupe_ttl_ms = ARGV[1]
+local record_count = tonumber(ARGV[2])
+
+if redis.call("EXISTS", meta_key) == 0 then
+  return redis.error_reply("broker stream has not been ensured")
 end
 
-return { "stored", id }
+if not record_count then
+  return redis.error_reply("invalid broker record count")
+end
+
+if (#KEYS - 2) ~= record_count then
+  return redis.error_reply("dedupe key count does not match broker record count")
+end
+
+local replies = {}
+local stored_count = 0
+local last_stored_id = nil
+
+for i = 1, record_count do
+  local dedupe_key = KEYS[i + 2]
+  local arg_index = 3 + ((i - 1) * 2)
+  local body = ARGV[arg_index]
+  local has_idempotency_key = ARGV[arg_index + 1]
+
+  if has_idempotency_key == "1" then
+    local existing_id = redis.call("GET", dedupe_key)
+    if existing_id then
+      local existing_body = ""
+      local existing_entries = redis.call("XRANGE", stream_key, existing_id, existing_id, "COUNT", 1)
+      if #existing_entries > 0 then
+        local fields = existing_entries[1][2]
+        for field_index = 1, #fields, 2 do
+          if fields[field_index] == "body" then
+            existing_body = fields[field_index + 1]
+            break
+          end
+        end
+      end
+      replies[#replies + 1] = { "duplicate", existing_id, existing_body }
+    else
+      local id = redis.call("XADD", stream_key, "*", "body", body)
+      redis.call("SET", dedupe_key, id, "PX", dedupe_ttl_ms)
+      replies[#replies + 1] = { "stored", id, "" }
+      stored_count = stored_count + 1
+      last_stored_id = id
+    end
+  else
+    local id = redis.call("XADD", stream_key, "*", "body", body)
+    replies[#replies + 1] = { "stored", id, "" }
+    stored_count = stored_count + 1
+    last_stored_id = id
+  end
+end
+
+if stored_count == 0 then
+  return replies
+end
+
+redis.call("HSET", meta_key, "lastId", last_stored_id)
+
+local max_records = redis.call("HGET", meta_key, "maxRecords")
+
+if max_records then
+  -- Mark the retained boundary atomically with append so retained reads do not
+  -- observe entries beyond maxRecords while physical XTRIM is deferred for live
+  -- XREAD delivery.
+  local max_records_number = tonumber(max_records)
+  local length = redis.call("XLEN", stream_key)
+  local remove_count = length - max_records_number
+
+  if remove_count > 0 then
+    local removed = redis.call("XRANGE", stream_key, "-", "+", "COUNT", remove_count)
+    if #removed > 0 then
+      redis.call("HSET", meta_key, "lastTrimmedId", removed[#removed][1])
+    end
+  end
+end
+
+return replies
 `

--- a/broker/redis/tests/redis-broker.e2e.ts
+++ b/broker/redis/tests/redis-broker.e2e.ts
@@ -95,6 +95,99 @@ describe("RedisBroker", () => {
     }
   })
 
+  test("deduplicates records inside a bulk append before retention trims them", async () => {
+    const { broker, projectId, cleanup } = createTestBroker()
+    const stream = { id: "__bulk_dedupe_retained", retention: { maxRecords: 1 } }
+    try {
+      await broker.ensureStream({ projectId, stream })
+      const [first, duplicate, newest] = await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [
+          { payload: { id: "old" }, idempotencyKey: "same" },
+          { payload: { id: "ignored" }, idempotencyKey: "same" },
+          { payload: { id: "new" }, idempotencyKey: "new" },
+        ],
+      })
+
+      expect(duplicate?.cursor).toBe(first?.cursor)
+      expect(duplicate?.payload).toEqual({ id: "old" })
+      expect(newest?.payload).toEqual({ id: "new" })
+      expect(
+        (await broker.read({ projectId, streamId: stream.id })).map((record) => record.payload)
+      ).toEqual([{ id: "new" }])
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test("delivers live bulk append records before maxRecords retention trims them", async () => {
+    const { broker, projectId, cleanup } = createTestBroker()
+    const stream = { id: "__live_bulk_retained", retention: { maxRecords: 1 } }
+    const received: string[] = []
+    let unsubscribe: (() => void) | undefined
+
+    try {
+      await broker.ensureStream({ projectId, stream })
+      unsubscribe = await broker.subscribe({ projectId, streamId: stream.id }, (records) => {
+        received.push(...records.map((record) => String(record.payload)))
+      })
+      await Bun.sleep(150)
+
+      await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [{ payload: "one" }, { payload: "two" }, { payload: "three" }],
+      })
+
+      await waitUntil(() => received.length === 3, 5_000)
+      expect(received).toEqual(["one", "two", "three"])
+      expect(
+        (await broker.read({ projectId, streamId: stream.id })).map((record) => record.payload)
+      ).toEqual(["three"])
+    } finally {
+      unsubscribe?.()
+      await cleanup()
+    }
+  })
+
+  test("enforces maxRecords retained reads before physical trim completes", async () => {
+    const { broker, projectId, cleanup } = createTestBroker()
+    const brokerWithTrimDisabled = broker as unknown as { trimRetention: () => Promise<void> }
+    brokerWithTrimDisabled.trimRetention = async () => {}
+    const stream = { id: "__logical_bulk_retained", retention: { maxRecords: 1 } }
+    const received: string[] = []
+    let unsubscribe: (() => void) | undefined
+
+    try {
+      await broker.ensureStream({ projectId, stream })
+      const [first] = await broker.append({
+        projectId,
+        streamId: stream.id,
+        records: [{ payload: "one" }, { payload: "two" }, { payload: "three" }],
+      })
+
+      expect(
+        (await broker.read({ projectId, streamId: stream.id })).map((record) => record.payload)
+      ).toEqual(["three"])
+      await expect(
+        broker.read({ projectId, streamId: stream.id, afterCursor: first?.cursor })
+      ).rejects.toThrow("outside the retained range")
+
+      unsubscribe = await broker.subscribe(
+        { projectId, streamId: stream.id, from: "earliest" },
+        (records) => {
+          received.push(...records.map((record) => String(record.payload)))
+        }
+      )
+      await waitUntil(() => received.length === 1, 5_000)
+      expect(received).toEqual(["three"])
+    } finally {
+      unsubscribe?.()
+      await cleanup()
+    }
+  })
+
   test("close drains active subscriptions and rejects later operations", async () => {
     const { broker, projectId } = createTestBroker()
     const stream = { id: "__events" }


### PR DESCRIPTION
## Summary

Batch Redis broker appends so projection and sync workloads stop paying one Redis Lua round trip per emitted event.

The previous path called the single-record append script for every record in a framework batch. Projection materialization already groups object/link events before calling `events.append(...)`, but the Redis broker still expanded that back into per-record `EVAL` calls and per-record retention work.

```ts
// Before: one Redis script call per record in params.records
for (const input of params.records) {
  await this.appendOne({ client, ensured, input, body })
}
```

This PR keeps the broker contract the same while sending the whole append batch through one append script, then running retention once.

```ts
const appendResults = await this.appendBatch({
  client,
  ensured,
  records: encodedRecords,
})
```

## What Changed

- Added `APPEND_RECORDS_SCRIPT` for bulk Redis Stream writes.
- Preserved per-record stream cursors, idempotency decisions, and returned record order.
- Kept same-batch idempotency safe even when retention removes the original stream entry.
- Split physical retention trimming into `TRIM_STREAM_RETENTION_SCRIPT` so blocked live `XREAD` subscribers can receive the full batch before old retained history is removed.
- Added a logical retained boundary during append so retained `read()` and `subscribe({ from: "earliest" })` do not expose records beyond `maxRecords` during the small physical-trim gap.

## Why

CPU stress testing showed Redis broker append overhead as a high-impact hot path. A single projection batch can emit hundreds of object or link events. With per-record Redis Lua calls, that means hundreds of Redis round trips, repeated script execution, and repeated retention checks for one logical framework batch.

This change reduces that to:

```text
1 append script call per batch
1 retention trim script call per batch with stored records
```

instead of:

```text
N append script calls per batch
N retention passes per batch
```

## Edge Cases Covered

- Duplicate idempotency keys inside one bulk append.
- Duplicate return payload when maxRecords retention trims the original retained entry.
- Live subscribers on retained streams receive all records from a bulk append before physical trim.
- Retained reads and earliest subscriptions honor `maxRecords` even before physical trim completes.

## Benchmarks

Local Redis direct broker append benchmark, same machine and same record payload shape:

```text
Before batching:
1,000 records: 186 ms
5,000 records: 822.44 ms

After batching:
1,000 records median: 7.38 ms
5,000 records median: 32.00 ms
```

The 5,000-record benchmark improved from about 6,079 records/sec to about 156,230 records/sec.

## Validation

```bash
bunx tsc --noEmit --pretty false --project broker/redis/tsconfig.json
PARIO_REDIS_BROKER_URL=redis://localhost:6379 bun test --preload ./broker/redis/tests/setup.ts ./broker/redis/tests/redis-broker.e2e.ts
```

Result:

```text
29 pass
0 fail
54 expect() calls
```
