### PR TITLE
projection-worker: validate pruned projection rows

### DIFF
--- a/packages/core/src/datasets/validation.ts
+++ b/packages/core/src/datasets/validation.ts
@@ -175,7 +175,8 @@ export function isDatasetDefinition(value: unknown): value is DatasetDefinition 
 
 export function getDatasetRowValidationError(
   row: unknown,
-  dataset: DatasetDefinition
+  dataset: DatasetDefinition,
+  options?: { readonly columns?: Iterable<string> }
 ): string | null {
   if (!isPlainObject(row)) {
     return `Dataset '${dataset.id}' rows must be plain objects.`
@@ -185,6 +186,25 @@ export function getDatasetRowValidationError(
     dataset.schema.columns.map((column) => [column.name, column] as const)
   )
 
+  // When `columns` is provided, validate only that subset (e.g. the columns a
+  // projection actually maps). Projection reads are column-pruned, so the row
+  // never carries unmapped columns and must not be checked against them.
+  if (options?.columns !== undefined) {
+    const columnsToValidate = new Set(options.columns)
+    for (const column of dataset.schema.columns) {
+      if (!columnsToValidate.has(column.name)) {
+        continue
+      }
+
+      const error = getColumnValidationError(row, column, dataset)
+      if (error) {
+        return error
+      }
+    }
+
+    return null
+  }
+
   for (const columnName of Object.keys(row)) {
     if (!columnsByName.has(columnName)) {
       return `Dataset '${dataset.id}' row contains unknown column '${columnName}'.`
@@ -192,28 +212,41 @@ export function getDatasetRowValidationError(
   }
 
   for (const column of dataset.schema.columns) {
-    const hasValue = Object.hasOwn(row, column.name)
-    const value = row[column.name]
-
-    // Treat `undefined` the same as an omitted field so callers either send a real
-    // value or use `null` explicitly on nullable columns.
-    if (!hasValue || value === undefined) {
-      if (!column.nullable) {
-        return `Dataset '${dataset.id}' row is missing required column '${column.name}'.`
-      }
-      continue
+    const error = getColumnValidationError(row, column, dataset)
+    if (error) {
+      return error
     }
+  }
 
-    if (value === null) {
-      if (!column.nullable) {
-        return `Dataset '${dataset.id}' column '${column.name}' does not allow null values.`
-      }
-      continue
-    }
+  return null
+}
 
-    if (!matchesColumnType(value, column.type)) {
-      return `Dataset '${dataset.id}' column '${column.name}' must match type '${column.type}'.`
+function getColumnValidationError(
+  row: Record<string, unknown>,
+  column: DatasetColumnDefinition,
+  dataset: DatasetDefinition
+): string | null {
+  const hasValue = Object.hasOwn(row, column.name)
+  const value = row[column.name]
+
+  // Treat `undefined` the same as an omitted field so callers either send a real
+  // value or use `null` explicitly on nullable columns.
+  if (!hasValue || value === undefined) {
+    if (!column.nullable) {
+      return `Dataset '${dataset.id}' row is missing required column '${column.name}'.`
     }
+    return null
+  }
+
+  if (value === null) {
+    if (!column.nullable) {
+      return `Dataset '${dataset.id}' column '${column.name}' does not allow null values.`
+    }
+    return null
+  }
+
+  if (!matchesColumnType(value, column.type)) {
+    return `Dataset '${dataset.id}' column '${column.name}' must match type '${column.type}'.`
   }
 
   return null

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -1,10 +1,11 @@
-import type {
-  DatasetColumnDefinition,
-  DatasetDefinition,
-  DatasetRow,
-  ObjectProjectionDefinition,
-  OntologyRegistry,
-  Schema,
+import {
+  type DatasetColumnDefinition,
+  type DatasetDefinition,
+  type DatasetRow,
+  getDatasetRowValidationError,
+  type ObjectProjectionDefinition,
+  type OntologyRegistry,
+  type Schema,
 } from "@pario/core"
 import { ProjectionWorkerError } from "./errors"
 import { resolveProjectionSchema } from "./projection-schema"
@@ -67,6 +68,13 @@ export function buildObjectProjectionPlan(input: {
 
 export function projectObjectRow(plan: ObjectProjectionPlan, row: unknown): ProjectObjectRowResult {
   const { projection, dataset, primaryPropertyId, propertyPlans } = plan
+
+  const rowValidationError = getDatasetRowValidationError(row, dataset, {
+    columns: Object.values(projection.properties),
+  })
+  if (rowValidationError) {
+    return { ok: false, errorMessage: rowValidationError }
+  }
 
   if (!isPlainObject(row)) {
     return {

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -1,10 +1,10 @@
-import {
-  type DatasetColumnDefinition,
-  type DatasetDefinition,
-  type DatasetRow,
-  type ObjectProjectionDefinition,
-  type OntologyRegistry,
-  type Schema,
+import type {
+  DatasetColumnDefinition,
+  DatasetDefinition,
+  DatasetRow,
+  ObjectProjectionDefinition,
+  OntologyRegistry,
+  Schema,
 } from "@pario/core"
 import { ProjectionWorkerError } from "./errors"
 import { resolveProjectionSchema } from "./projection-schema"

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -2,7 +2,6 @@ import {
   type DatasetColumnDefinition,
   type DatasetDefinition,
   type DatasetRow,
-  getDatasetRowValidationError,
   type ObjectProjectionDefinition,
   type OntologyRegistry,
   type Schema,
@@ -70,16 +69,10 @@ export function projectObjectRow(plan: ObjectProjectionPlan, row: unknown): Proj
   const { projection, dataset, primaryPropertyId, propertyPlans } = plan
 
   if (!isPlainObject(row)) {
-    const validationError = getDatasetRowValidationError(row, dataset)
     return {
       ok: false,
-      errorMessage: validationError ?? `Dataset '${dataset.id}' rows must be plain objects.`,
+      errorMessage: `Dataset '${dataset.id}' rows must be plain objects.`,
     }
-  }
-
-  const rowValidationError = getDatasetRowValidationError(row, dataset)
-  if (rowValidationError) {
-    return { ok: false, errorMessage: rowValidationError }
   }
 
   const collected = collectProperties(projection, row, propertyPlans)

--- a/packages/projection-worker/src/run-link-projection.ts
+++ b/packages/projection-worker/src/run-link-projection.ts
@@ -1,7 +1,6 @@
 import {
   type DatasetDefinition,
   type DatasetRow,
-  getDatasetRowValidationError,
   type LinkProjectionDefinition,
   ObjectNotFoundError,
   objectService,
@@ -47,7 +46,7 @@ interface LinkItem {
 export async function runLinkProjection(
   input: RunLinkProjectionInput
 ): Promise<ProjectionExecutionResult> {
-  const { runtime, projection, dataset, versionId, signal, batchSize, onProgress } = input
+  const { runtime, projection, versionId, signal, batchSize, onProgress } = input
   const counters = createZeroCounters()
   const seenPairs = new Set<string>()
   const batch: CollectedLinkRow[] = []
@@ -97,13 +96,6 @@ export async function runLinkProjection(
   })) {
     throwIfAborted(signal)
     counters.rowsProcessed += 1
-
-    const validationError = getDatasetRowValidationError(row, dataset)
-    if (validationError) {
-      counters.rowsSkipped += 1
-      rememberError(validationError)
-      continue
-    }
 
     const linkRow = collectLinkRow(projection, row)
     if (!linkRow) {

--- a/packages/projection-worker/src/run-link-projection.ts
+++ b/packages/projection-worker/src/run-link-projection.ts
@@ -1,6 +1,7 @@
 import {
   type DatasetDefinition,
   type DatasetRow,
+  getDatasetRowValidationError,
   type LinkProjectionDefinition,
   ObjectNotFoundError,
   objectService,
@@ -46,7 +47,7 @@ interface LinkItem {
 export async function runLinkProjection(
   input: RunLinkProjectionInput
 ): Promise<ProjectionExecutionResult> {
-  const { runtime, projection, versionId, signal, batchSize, onProgress } = input
+  const { runtime, projection, dataset, versionId, signal, batchSize, onProgress } = input
   const counters = createZeroCounters()
   const seenPairs = new Set<string>()
   const batch: CollectedLinkRow[] = []
@@ -96,6 +97,15 @@ export async function runLinkProjection(
   })) {
     throwIfAborted(signal)
     counters.rowsProcessed += 1
+
+    const validationError = getDatasetRowValidationError(row, dataset, {
+      columns: linkProjectionReadColumns(projection),
+    })
+    if (validationError) {
+      counters.rowsSkipped += 1
+      rememberError(validationError)
+      continue
+    }
 
     const linkRow = collectLinkRow(projection, row)
     if (!linkRow) {

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -328,6 +328,47 @@ describe("runProjectionJob", () => {
     expect(lakeStorage.readInputs[0]?.columns).toEqual(["room_id", "room_name"])
   })
 
+  test("object projections tolerate required unmapped dataset columns", async () => {
+    const deps = createDeps()
+    const lakeStorage = new RecordingLakeStorage(deps.lakeStorage)
+    const requiredExtraRoomsDataset = defineDataset("canonical.required-extra-rooms", {
+      schema: [
+        col("room_id", "string"),
+        col("room_name", "string"),
+        col("relationship_ref", "string"),
+      ],
+    })
+    const requiredExtraRoomProjection = defineProjection("required-extra-room-proj", Room)
+      .fromDataset(requiredExtraRoomsDataset)
+      .properties({ id: "room_id", name: "room_name" })
+    const pario = createPario(
+      {
+        datasets: [requiredExtraRoomsDataset],
+        projections: [requiredExtraRoomProjection],
+      },
+      { ...deps, lakeStorage }
+    )
+    const version = await commitDatasetVersion(lakeStorage, requiredExtraRoomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", relationship_ref: "b1" },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(pario),
+      job: {
+        id: "projrun-required-unmapped-object",
+        projectionId: "required-extra-room-proj",
+        projectionKind: "object",
+        datasetId: requiredExtraRoomsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.objectsUpserted).toBe(1)
+    expect(result.rowsSkipped).toBe(0)
+    expect(lakeStorage.readInputs).toHaveLength(1)
+    expect(lakeStorage.readInputs[0]?.columns).toEqual(["room_id", "room_name"])
+  })
+
   test("materializes FK links after object upserts", async () => {
     const deps = createDeps()
     const pario = createPario(
@@ -482,6 +523,53 @@ describe("runProjectionJob", () => {
       },
     })
 
+    expect(lakeStorage.readInputs).toHaveLength(1)
+    expect(lakeStorage.readInputs[0]?.columns).toEqual(["room_id", "sensor_id"])
+  })
+
+  test("link projections tolerate required unmapped dataset columns", async () => {
+    const deps = createDeps()
+    const lakeStorage = new RecordingLakeStorage(deps.lakeStorage)
+    const requiredExtraRoomSensorsDataset = defineDataset("canonical.required-extra-room-sensors", {
+      schema: [
+        col("room_id", "string"),
+        col("sensor_id", "string"),
+        col("relationship_weight", "float64"),
+      ],
+    })
+    const requiredExtraRoomSensorProjection = defineLinkProjection(
+      "required-extra-room-sensor-proj",
+      Room.l.hasSensors
+    )
+      .fromDataset(requiredExtraRoomSensorsDataset)
+      .sourceField("room_id")
+      .targetField("sensor_id")
+    const pario = createPario(
+      {
+        datasets: [requiredExtraRoomSensorsDataset],
+        projections: [requiredExtraRoomSensorProjection],
+      },
+      { ...deps, lakeStorage }
+    )
+    await pario.upsertObject("Room", { id: "r1", name: "Kitchen" })
+    await pario.upsertObject("Sensor", { id: "s1", name: "Motion" })
+    const version = await commitDatasetVersion(lakeStorage, requiredExtraRoomSensorsDataset, [
+      { room_id: "r1", sensor_id: "s1", relationship_weight: 0.75 },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(pario),
+      job: {
+        id: "projrun-required-unmapped-link",
+        projectionId: "required-extra-room-sensor-proj",
+        projectionKind: "link",
+        datasetId: requiredExtraRoomSensorsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.linksUpserted).toBe(1)
+    expect(result.rowsSkipped).toBe(0)
     expect(lakeStorage.readInputs).toHaveLength(1)
     expect(lakeStorage.readInputs[0]?.columns).toEqual(["room_id", "sensor_id"])
   })


### PR DESCRIPTION
## Summary

Projection object and link runners prune dataset reads to only the columns they consume, but then validated those partial rows against the **full** dataset schema. That made projections fail when a dataset had a required column used by a different concern — for example a relationship column that should not be stored as an object property — because the pruned row legitimately omits it.

The fix scopes row validation to the columns a projection actually maps, rather than removing it. `getDatasetRowValidationError` gains an optional `columns` restriction; the object and link runners pass their mapped columns. This keeps `main`'s strict per-column type checks (a value whose type does not match its declared column type is still rejected before coercion) while tolerating required-but-unmapped columns. Dataset writes still validate full rows, and projection definitions still validate column existence and type compatibility.

```ts
defineDataset("canonical.required-extra-rooms", {
  schema: [
    col("room_id", "string"),
    col("room_name", "string"),
    col("relationship_ref", "string"),
  ],
})

defineProjection("required-extra-room-proj", Room)
  .fromDataset(requiredExtraRoomsDataset)
  .properties({ id: "room_id", name: "room_name" })
```

The projection above reads `room_id` and `room_name`; the required `relationship_ref` column remains valid dataset data but no longer makes the pruned projection row fail. A row carrying a type-mismatched mapped value (e.g. a string in a `float64` column) is still rejected.

## Linked issue

No linked issue. This is a small framework bug fix found while removing redundant relationship ref properties from an app ontology.

## Scope

- Add an optional `columns` restriction to `getDatasetRowValidationError`; default behavior (full-schema validation) is unchanged for dataset writes and the sync worker.
- Scope object projection row validation to the mapped property columns.
- Scope link projection row validation to the source/target field columns.
- Preserve strict per-column type validation before projected-value coercion.
- Add regression coverage for required unmapped columns in object and link projections.

## Validation

- `bun test packages/projection-worker/tests/`
- `bun test packages/core/tests/datasets packages/sync-worker/tests`
- `bun --filter @pario/core typecheck` / `bun --filter @pario/projection-worker typecheck`
- `bun run check`
