### PR TITLE
objects: add directional link listing

### DIFF
--- a/packages/atlas/src/pages/ObjectDetailPage.tsx
+++ b/packages/atlas/src/pages/ObjectDetailPage.tsx
@@ -5,6 +5,7 @@ import type {
   TelemetryHistory,
   TelemetryProperty,
 } from "@pario/client"
+import { decodeObjectId, encodeObjectId } from "@pario/client"
 import {
   getObjectOptions,
   getTelemetryHistoryOptions,
@@ -122,6 +123,12 @@ export function ObjectDetailPage({
     setSelectedPropertyId(null)
   }, [objectId])
 
+  const canonicalObjectId = useMemo(() => {
+    if (!objectId) return null
+    const parsed = decodeObjectId(objectId)
+    return parsed ? encodeObjectId(parsed.objectTypeId, parsed.primaryId) : objectId
+  }, [objectId])
+
   const { data: object, isLoading: objectLoading } = useQuery({
     ...getObjectOptions({
       path: { projectName, objectId: objectId! },
@@ -132,7 +139,7 @@ export function ObjectDetailPage({
   const { data: relationships = [] } = useQuery({
     ...listRelationshipsOptions({
       path: { projectName },
-      query: { objectId: objectId ?? undefined },
+      query: { objectId: canonicalObjectId ?? undefined },
     }),
     enabled: !!objectId,
   })
@@ -323,12 +330,12 @@ export function ObjectDetailPage({
   }, [object?.actions])
 
   const outgoing = useMemo(
-    () => relationships.filter((r) => r.source === objectId),
-    [relationships, objectId]
+    () => relationships.filter((r) => r.source === canonicalObjectId),
+    [relationships, canonicalObjectId]
   )
   const incoming = useMemo(
-    () => relationships.filter((r) => r.target === objectId),
-    [relationships, objectId]
+    () => relationships.filter((r) => r.target === canonicalObjectId),
+    [relationships, canonicalObjectId]
   )
 
   const usagePercent = object ? getUsagePercent(telemetryWithLive, object.class) : null
@@ -543,20 +550,20 @@ export function ObjectDetailPage({
         </Section>
       ) : null}
 
-      {Object.keys(properties).length > 0 || outgoing.length > 0 ? (
+      {Object.keys(properties).length > 0 ? (
         <Section title="Details">
-          <DetailsList
-            properties={properties}
-            outgoing={outgoing}
-            objectLookup={objectLookup}
-            onSelectObject={(id) => navigate(`/${id}`)}
-          />
+          <DetailsList properties={properties} />
         </Section>
       ) : null}
 
-      {incoming.length > 0 ? (
-        <Section title="Links" count={incoming.length}>
-          <LinksList edges={incoming} objectLookup={objectLookup} />
+      {outgoing.length > 0 || incoming.length > 0 ? (
+        <Section title="Links" count={outgoing.length + incoming.length}>
+          <LinksList
+            outgoing={outgoing}
+            incoming={incoming}
+            objectLookup={objectLookup}
+            onSelectObject={(id) => navigate(`/${id}`)}
+          />
         </Section>
       ) : null}
 
@@ -599,31 +606,13 @@ export function ObjectDetailPage({
   )
 }
 
-function DetailsList({
-  properties,
-  outgoing,
-  objectLookup,
-  onSelectObject,
-}: {
-  properties: Record<string, unknown>
-  outgoing: RelationshipEdge[]
-  objectLookup: Record<string, ObjectSummary>
-  onSelectObject: (id: string) => void
-}) {
+function DetailsList({ properties }: { properties: Record<string, unknown> }) {
   const rows = useMemo(() => {
-    const outgoingByTarget = new Map<string, RelationshipEdge>()
-    for (const edge of outgoing) {
-      outgoingByTarget.set(edge.target, edge)
-      outgoingByTarget.set(unqualifyId(edge.target), edge)
-    }
-
-    const seen = new Set<RelationshipEdge>()
     const list: Array<{
       key: string
       label: string
-      kind: "value" | "edge" | "primary"
+      kind: "value" | "primary"
       value?: unknown
-      edge?: RelationshipEdge
     }> = []
 
     if (typeof properties.id !== "undefined") {
@@ -632,27 +621,11 @@ function DetailsList({
 
     for (const [key, value] of Object.entries(properties)) {
       if (key === "id") continue
-      const matched = matchEdge(value, outgoingByTarget)
-      if (matched) {
-        seen.add(matched)
-        list.push({ key, label: humanizeIdentifier(matched.type), kind: "edge", edge: matched })
-      } else {
-        list.push({ key, label: humanizeIdentifier(key), kind: "value", value })
-      }
-    }
-
-    for (const edge of outgoing) {
-      if (seen.has(edge)) continue
-      list.push({
-        key: `__edge_${edge.type}_${edge.target}`,
-        label: humanizeIdentifier(edge.type),
-        kind: "edge",
-        edge,
-      })
+      list.push({ key, label: humanizeIdentifier(key), kind: "value", value })
     }
 
     return list
-  }, [properties, outgoing])
+  }, [properties])
 
   if (rows.length === 0) return null
 
@@ -673,15 +646,7 @@ function DetailsList({
               ) : null}
             </dt>
             <dd className="min-w-0 text-foreground">
-              {row.kind === "edge" && row.edge ? (
-                <RelationshipLink
-                  edge={row.edge}
-                  related={objectLookup[row.edge.target]}
-                  onSelect={onSelectObject}
-                />
-              ) : (
-                <FormattedValue value={row.value} />
-              )}
+              <FormattedValue value={row.value} />
             </dd>
           </Fragment>
         ))}
@@ -690,59 +655,65 @@ function DetailsList({
   )
 }
 
-function unqualifyId(value: string): string {
-  const idx = value.indexOf("~")
-  return idx >= 0 ? value.slice(idx + 1) : value
-}
-
-function matchEdge(
-  value: unknown,
-  outgoingByTarget: Map<string, RelationshipEdge>
-): RelationshipEdge | null {
-  if (typeof value !== "string") return null
-  const direct = outgoingByTarget.get(value)
-  if (direct) return direct
-  return outgoingByTarget.get(unqualifyId(value)) ?? null
-}
-
 function LinksList({
-  edges,
+  outgoing,
+  incoming,
   objectLookup,
+  onSelectObject,
 }: {
-  edges: RelationshipEdge[]
+  outgoing: RelationshipEdge[]
+  incoming: RelationshipEdge[]
   objectLookup: Record<string, ObjectSummary>
+  onSelectObject: (id: string) => void
 }) {
-  const sorted = useMemo(() => {
-    return [...edges].sort((a, b) => {
-      const typeCompare = a.type.localeCompare(b.type)
+  const rows = useMemo(() => {
+    const linkRows = [
+      ...outgoing.map((edge) => ({
+        key: `out:${edge.type}:${edge.target}`,
+        direction: "to" as const,
+        edge,
+        relatedId: edge.target,
+      })),
+      ...incoming.map((edge) => ({
+        key: `in:${edge.type}:${edge.source}`,
+        direction: "from" as const,
+        edge,
+        relatedId: edge.source,
+      })),
+    ]
+
+    return linkRows.sort((a, b) => {
+      if (a.direction !== b.direction) return a.direction === "to" ? -1 : 1
+      const typeCompare = a.edge.type.localeCompare(b.edge.type)
       if (typeCompare !== 0) return typeCompare
-      const aName = objectLookup[a.source]?.name ?? a.source
-      const bName = objectLookup[b.source]?.name ?? b.source
+      const aName = objectLookup[a.relatedId]?.name ?? a.relatedId
+      const bName = objectLookup[b.relatedId]?.name ?? b.relatedId
       return aName.localeCompare(bName)
     })
-  }, [edges, objectLookup])
+  }, [incoming, objectLookup, outgoing])
 
   return (
     <Card className="p-4 sm:p-5">
-      <dl className="grid grid-cols-[max-content_max-content_max-content_max-content] items-baseline gap-x-3 gap-y-2 text-sm">
-        {sorted.map((edge) => {
-          const related = objectLookup[edge.source]
+      <dl className="grid grid-cols-[max-content_minmax(0,1fr)] items-baseline gap-x-6 gap-y-2.5 text-sm">
+        {rows.map((row) => {
+          const related = objectLookup[row.relatedId]
           return (
-            <Fragment key={`${edge.type}__${edge.source}`}>
-              <dt className="text-xs text-muted-foreground">{humanizeIdentifier(edge.type)}</dt>
-              <span aria-hidden="true" className="text-muted-foreground/40">
-                ←
-              </span>
-              <dd>
-                <Link
-                  to={`/${edge.source}`}
-                  className="text-foreground underline-offset-2 hover:underline"
+            <Fragment key={row.key}>
+              <dt className="flex items-baseline gap-1.5 text-xs text-muted-foreground">
+                <span>{humanizeIdentifier(row.edge.type)}</span>
+                <Badge
+                  variant="secondary"
+                  className="h-4 border-0 bg-muted px-1.5 text-[9px] font-medium text-muted-foreground"
                 >
-                  {related?.name ?? edge.source}
-                </Link>
-              </dd>
-              <dd className="text-xs text-muted-foreground">
-                {related?.class ? humanizeIdentifier(related.class) : ""}
+                  {row.direction}
+                </Badge>
+              </dt>
+              <dd className="min-w-0 text-foreground">
+                <RelatedObjectLink
+                  objectId={row.relatedId}
+                  related={related}
+                  onSelect={onSelectObject}
+                />
               </dd>
             </Fragment>
           )
@@ -752,26 +723,26 @@ function LinksList({
   )
 }
 
-function RelationshipLink({
-  edge,
+function RelatedObjectLink({
+  objectId,
   related,
   onSelect,
 }: {
-  edge: RelationshipEdge
+  objectId: string
   related: ObjectSummary | undefined
   onSelect: (id: string) => void
 }) {
   return (
     <Link
-      to={`/${edge.target}`}
+      to={`/${objectId}`}
       onClick={(event) => {
         event.preventDefault()
-        onSelect(edge.target)
+        onSelect(objectId)
       }}
       className="inline-flex items-baseline gap-1.5 underline-offset-2 hover:underline"
-      title={edge.target}
+      title={objectId}
     >
-      <span>{related?.name ?? edge.target}</span>
+      <span>{related?.name ?? objectId}</span>
       {related?.class ? (
         <span className="text-xs text-muted-foreground">{humanizeIdentifier(related.class)}</span>
       ) : null}

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -7613,6 +7613,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["outgoing", "incoming", "both"],
+              "default": "outgoing"
+            }
           }
         ],
         "responses": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2623,6 +2623,7 @@ export type ListObjectLinksData = {
   }
   query?: {
     linkId?: string
+    direction?: "outgoing" | "incoming" | "both"
   }
   url: "/api/objects/{objectTypeId}/{objectId}/links"
 }

--- a/packages/client/src/hooks.ts
+++ b/packages/client/src/hooks.ts
@@ -126,60 +126,27 @@ export const listRelationshipsOptions = (options?: ListRelationshipsOptions) => 
   return queryOptions({
     queryKey: listRelationshipsQueryKey(options),
     queryFn: async (): Promise<RelationshipEdge[]> => {
-      const { data: objectsResponse } = await listObjects({
+      const objectId = options?.query?.objectId
+      const requestedObject = objectId ? decodeObjectId(objectId) : null
+      if (!requestedObject) return []
+
+      const { data = [] } = await listObjectLinks({
+        path: {
+          objectTypeId: requestedObject.objectTypeId,
+          objectId: requestedObject.primaryId,
+        },
         query: {
-          limit: "500",
-          orderBy: "updatedAt",
-          order: "desc",
+          direction: "both",
         },
         throwOnError: true,
       })
 
-      const objects = objectsResponse?.objects ?? []
-      if (objects.length === 0) {
-        return []
-      }
-
-      const linksByKey = new Map<string, RelationshipEdge>()
-      const linkResponses = await Promise.all(
-        objects.map(async (object) => {
-          try {
-            const { data } = await listObjectLinks({
-              path: {
-                objectTypeId: object.objectTypeId,
-                objectId: object.primaryId,
-              },
-              throwOnError: true,
-            })
-            return data ?? []
-          } catch {
-            return []
-          }
-        })
-      )
-
-      for (const links of linkResponses) {
-        for (const link of links) {
-          const source = encodeObjectId(link.sourceTypeId, link.sourceId)
-          const target = encodeObjectId(link.targetTypeId, link.targetId)
-          const key = `${source}|${target}|${link.linkId}`
-
-          linksByKey.set(key, {
-            source,
-            target,
-            type: link.linkId,
-            properties: link.properties,
-          })
-        }
-      }
-
-      const all = Array.from(linksByKey.values())
-      const objectId = options?.query?.objectId
-      if (!objectId) {
-        return all
-      }
-
-      return all.filter((edge) => edge.source === objectId || edge.target === objectId)
+      return data.map((link) => ({
+        source: encodeObjectId(link.sourceTypeId, link.sourceId),
+        target: encodeObjectId(link.targetTypeId, link.targetId),
+        type: link.linkId,
+        properties: link.properties,
+      }))
     },
   })
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -424,6 +424,7 @@ export type {
   GroupMembershipSource,
   InvitationRecord,
   InvitationStatus,
+  LinkDirection,
   ListActionRunsInput,
   ListActionRunsResult,
   ListActiveRuleStatesInput,

--- a/packages/core/src/objects/link/upsert-batch.ts
+++ b/packages/core/src/objects/link/upsert-batch.ts
@@ -133,8 +133,8 @@ function collectLinkLookups(
   items: {
     item: { objectType: ObjectTypeWithPropertyTokens; sourceId: string; linkId: string }
   }[]
-): { sourceTypeId: string; sourceId: string; linkId: string }[] {
-  const lookups: { sourceTypeId: string; sourceId: string; linkId: string }[] = []
+): { objectTypeId: string; objectId: string; linkId: string }[] {
+  const lookups: { objectTypeId: string; objectId: string; linkId: string }[] = []
   const keys = new Set<string>()
 
   for (const { item } of items) {
@@ -142,8 +142,8 @@ function collectLinkLookups(
     if (!keys.has(key)) {
       keys.add(key)
       lookups.push({
-        sourceTypeId: item.objectType.id,
-        sourceId: item.sourceId,
+        objectTypeId: item.objectType.id,
+        objectId: item.sourceId,
         linkId: item.linkId,
       })
     }

--- a/packages/core/src/objects/link/upsert.ts
+++ b/packages/core/src/objects/link/upsert.ts
@@ -29,8 +29,8 @@ export async function upsertLink(
 
   const existingLinks = await storage.objects.listLinks({
     projectId,
-    sourceTypeId: objectType.id,
-    sourceId,
+    objectTypeId: objectType.id,
+    objectId: sourceId,
     linkId,
   })
 

--- a/packages/core/src/objects/sdk/object-handle.ts
+++ b/packages/core/src/objects/sdk/object-handle.ts
@@ -39,8 +39,8 @@ export function createObjectByIdHandle<
       }
       return ctx.storage.objects.listLinks({
         projectId: ctx.projectId,
-        sourceTypeId: ctx.objectType.id,
-        sourceId: primaryId,
+        objectTypeId: ctx.objectType.id,
+        objectId: primaryId,
         linkId: linkToken?.id,
       })
     },

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -72,7 +72,7 @@ export {
   runMigrationSet,
   step,
 } from "./migrations"
-export type { ObjectLinkRow, ObjectRow, ObjectStorage } from "./objects"
+export type { LinkDirection, ObjectLinkRow, ObjectRow, ObjectStorage } from "./objects"
 export { InMemoryObjectStorage } from "./objects"
 export type {
   FinishPipelineRunInput,

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -4,7 +4,7 @@ import type {
   StoredObjectUpsertedEvent,
   StoredTelemetryAppendedEvent,
 } from "../../events"
-import type { ObjectLinkRow, ObjectRow, ObjectStorage } from "./types"
+import type { LinkDirection, ObjectLinkRow, ObjectRow, ObjectStorage } from "./types"
 
 function objectRowKey(projectId: string, objectTypeId: string): string {
   return `${projectId}:${objectTypeId}`
@@ -16,6 +16,10 @@ function sourceLinkBucketKey(projectId: string, sourceTypeId: string, sourceId: 
 
 function linkRowKey(linkId: string, targetTypeId: string, targetId: string): string {
   return `${linkId}:${targetTypeId}:${targetId}`
+}
+
+function fullLinkRowKey(row: ObjectLinkRow): string {
+  return `${row.sourceTypeId}:${row.sourceId}:${row.linkId}:${row.targetTypeId}:${row.targetId}`
 }
 
 export class InMemoryObjectStorage implements ObjectStorage {
@@ -199,22 +203,39 @@ export class InMemoryObjectStorage implements ObjectStorage {
 
   async listLinks(params: {
     projectId: string
-    sourceTypeId: string
-    sourceId: string
+    objectTypeId: string
+    objectId: string
     linkId?: string
+    direction?: LinkDirection
   }): Promise<readonly ObjectLinkRow[]> {
-    const bucketKey = sourceLinkBucketKey(params.projectId, params.sourceTypeId, params.sourceId)
-    const bucket = this.links.get(bucketKey)
-    if (!bucket) {
-      return []
+    const direction = params.direction ?? "outgoing"
+    const matches = (row: ObjectLinkRow) => !params.linkId || row.linkId === params.linkId
+    const rows: ObjectLinkRow[] = []
+
+    if (direction === "outgoing" || direction === "both") {
+      const bucket = this.links.get(
+        sourceLinkBucketKey(params.projectId, params.objectTypeId, params.objectId)
+      )
+      if (bucket) rows.push(...[...bucket.values()].filter(matches))
     }
 
-    const rows = [...bucket.values()]
-    if (!params.linkId) {
-      return rows
+    if (direction === "incoming" || direction === "both") {
+      for (const bucket of this.links.values()) {
+        for (const row of bucket.values()) {
+          if (
+            row.projectId === params.projectId &&
+            row.targetTypeId === params.objectTypeId &&
+            row.targetId === params.objectId &&
+            matches(row)
+          ) {
+            rows.push(row)
+          }
+        }
+      }
     }
 
-    return rows.filter((row) => row.linkId === params.linkId)
+    if (direction !== "both") return rows
+    return [...new Map(rows.map((row) => [fullLinkRowKey(row), row])).values()]
   }
 
   async getByPrimaryIdBatch(params: {
@@ -237,18 +258,18 @@ export class InMemoryObjectStorage implements ObjectStorage {
 
   async listLinksBatch(params: {
     projectId: string
-    items: readonly { sourceTypeId: string; sourceId: string; linkId: string }[]
+    items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<string, ObjectLinkRow[]>> {
     const result = new Map<string, ObjectLinkRow[]>()
     for (const item of params.items) {
       const rows = await this.listLinks({
         projectId: params.projectId,
-        sourceTypeId: item.sourceTypeId,
-        sourceId: item.sourceId,
+        objectTypeId: item.objectTypeId,
+        objectId: item.objectId,
         linkId: item.linkId,
       })
       if (rows.length > 0) {
-        result.set(`${item.sourceTypeId}:${item.sourceId}:${item.linkId}`, [...rows])
+        result.set(`${item.objectTypeId}:${item.objectId}:${item.linkId}`, [...rows])
       }
     }
     return result

--- a/packages/core/src/storage/objects/index.ts
+++ b/packages/core/src/storage/objects/index.ts
@@ -1,2 +1,2 @@
 export { InMemoryObjectStorage } from "./in-memory"
-export type { ObjectLinkRow, ObjectRow, ObjectStorage } from "./types"
+export type { LinkDirection, ObjectLinkRow, ObjectRow, ObjectStorage } from "./types"

--- a/packages/core/src/storage/objects/types.ts
+++ b/packages/core/src/storage/objects/types.ts
@@ -33,6 +33,8 @@ export interface ObjectLinkRow {
   sourceEventId?: string
 }
 
+export type LinkDirection = "outgoing" | "incoming" | "both"
+
 export interface ObjectStorage {
   applyObjectUpserted(event: StoredObjectUpsertedEvent): Promise<ObjectRow>
   applyObjectUpsertedBatch(
@@ -62,9 +64,10 @@ export interface ObjectStorage {
 
   listLinks(params: {
     projectId: string
-    sourceTypeId: string
-    sourceId: string
+    objectTypeId: string
+    objectId: string
     linkId?: string
+    direction?: LinkDirection
   }): Promise<readonly ObjectLinkRow[]>
 
   /**
@@ -77,12 +80,12 @@ export interface ObjectStorage {
   }): Promise<Map<string, ObjectRow>>
 
   /**
-   * Batch fetch links by (sourceTypeId, sourceId, linkId) tuples.
-   * Returns a Map keyed by "sourceTypeId:sourceId:linkId". Missing entries are absent.
+   * Batch fetch outgoing links by (objectTypeId, objectId, linkId) tuples.
+   * Returns a Map keyed by "objectTypeId:objectId:linkId". Missing entries are absent.
    */
   listLinksBatch(params: {
     projectId: string
-    items: readonly { sourceTypeId: string; sourceId: string; linkId: string }[]
+    items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<string, ObjectLinkRow[]>>
 
   list(params: {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -61,7 +61,7 @@ export type {
   UserStatus,
 } from "./auth"
 export { AuthStorageError } from "./auth"
-export type { ObjectLinkRow, ObjectRow, ObjectStorage } from "./objects/types"
+export type { LinkDirection, ObjectLinkRow, ObjectRow, ObjectStorage } from "./objects/types"
 export type {
   FinishPipelineRunInput,
   FinishPipelineStepRunInput,

--- a/packages/core/tests/batch-upsert.test.ts
+++ b/packages/core/tests/batch-upsert.test.ts
@@ -190,8 +190,8 @@ describe("upsertLinkBatch", () => {
 
     const links = await deps.storage.objects.listLinks({
       projectId: pario.id,
-      sourceTypeId: "room",
-      sourceId: "r1",
+      objectTypeId: "room",
+      objectId: "r1",
       linkId: "hasSensors",
     })
     expect(links).toHaveLength(2)

--- a/packages/core/tests/in-memory-providers.test.ts
+++ b/packages/core/tests/in-memory-providers.test.ts
@@ -247,8 +247,8 @@ describe("InMemoryObjectStorage", () => {
 
     const links = await storage.listLinks({
       projectId: "p1",
-      sourceTypeId: "Room",
-      sourceId: "r1",
+      objectTypeId: "Room",
+      objectId: "r1",
     })
     expect(links).toHaveLength(1)
     expect(links[0].targetId).toBe("d1")
@@ -266,8 +266,8 @@ describe("InMemoryObjectStorage", () => {
 
     const links = await storage.listLinks({
       projectId: "p1",
-      sourceTypeId: "Room",
-      sourceId: "r1",
+      objectTypeId: "Room",
+      objectId: "r1",
     })
     expect(links).toHaveLength(0)
   })
@@ -283,12 +283,38 @@ describe("InMemoryObjectStorage", () => {
 
     const deviceLinks = await storage.listLinks({
       projectId: "p1",
-      sourceTypeId: "Room",
-      sourceId: "r1",
+      objectTypeId: "Room",
+      objectId: "r1",
       linkId: "hasDevice",
     })
     expect(deviceLinks).toHaveLength(1)
     expect(deviceLinks[0].linkId).toBe("hasDevice")
+  })
+
+  test("listLinks supports incoming and both directions", async () => {
+    const storage = new InMemoryObjectStorage()
+    await storage.applyLinkUpserted(
+      makeLinkUpsertedEvent("p1", "Room", "r1", "hasDevice", "Device", "d1", "1")
+    )
+    await storage.applyLinkUpserted(
+      makeLinkUpsertedEvent("p1", "Device", "d1", "installedIn", "Room", "r1", "2")
+    )
+
+    const incoming = await storage.listLinks({
+      projectId: "p1",
+      objectTypeId: "Room",
+      objectId: "r1",
+      direction: "incoming",
+    })
+    const both = await storage.listLinks({
+      projectId: "p1",
+      objectTypeId: "Room",
+      objectId: "r1",
+      direction: "both",
+    })
+
+    expect(incoming.map((link) => link.linkId)).toEqual(["installedIn"])
+    expect(both.map((link) => link.linkId).sort()).toEqual(["hasDevice", "installedIn"])
   })
 })
 

--- a/packages/core/tests/pario-runtime.test.ts
+++ b/packages/core/tests/pario-runtime.test.ts
@@ -311,8 +311,8 @@ describe("Pario runtime", () => {
 
     const links = await runtimeDeps.storage.objects.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
       linkId: "hasThermostat",
     })
 
@@ -568,8 +568,8 @@ describe("Pario runtime", () => {
 
     const linksBefore = await runtimeDeps.storage.objects.listLinks({
       projectId: "remove-link-test",
-      sourceTypeId: "Room",
-      sourceId: "room:201",
+      objectTypeId: "Room",
+      objectId: "room:201",
     })
     expect(linksBefore).toHaveLength(1)
 
@@ -582,8 +582,8 @@ describe("Pario runtime", () => {
 
     const linksAfter = await runtimeDeps.storage.objects.listLinks({
       projectId: "remove-link-test",
-      sourceTypeId: "Room",
-      sourceId: "room:201",
+      objectTypeId: "Room",
+      objectId: "room:201",
     })
     expect(linksAfter).toHaveLength(0)
   })

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -399,8 +399,8 @@ describe("runProjectionJob", () => {
 
     const links = await deps.storage.objects.listLinks({
       projectId: pario.id,
-      sourceTypeId: "Room",
-      sourceId: "r1",
+      objectTypeId: "Room",
+      objectId: "r1",
       linkId: "inBuilding",
     })
     expect(links).toHaveLength(1)
@@ -474,8 +474,8 @@ describe("runProjectionJob", () => {
 
     const links = await deps.storage.objects.listLinks({
       projectId: pario.id,
-      sourceTypeId: "Room",
-      sourceId: "r1",
+      objectTypeId: "Room",
+      objectId: "r1",
       linkId: "hasSensors",
     })
     expect(links).toHaveLength(1)

--- a/packages/rules-worker/src/evaluate-rule-event.ts
+++ b/packages/rules-worker/src/evaluate-rule-event.ts
@@ -311,8 +311,8 @@ async function loadLinksWithOverlay(
     linkIds.map(async (linkId) => {
       const rows = await input.runtime.storage.objects.listLinks({
         projectId: input.runtime.projectId,
-        sourceTypeId: input.subject.objectTypeId,
-        sourceId: input.subject.primaryId,
+        objectTypeId: input.subject.objectTypeId,
+        objectId: input.subject.primaryId,
         linkId,
       })
       links.set(linkId, [...rows])

--- a/packages/server/src/routes/links.ts
+++ b/packages/server/src/routes/links.ts
@@ -21,9 +21,10 @@ export function registerLinkRoutes(app: Elysia, pario: Pario<readonly OntologySo
           const parsedQuery = LinkQuerySchema.parse(query)
           const links = await pario.storage.objects.listLinks({
             projectId: pario.id,
-            sourceTypeId: params.objectTypeId,
-            sourceId: params.objectId,
+            objectTypeId: params.objectTypeId,
+            objectId: params.objectId,
             linkId: parsedQuery.linkId,
+            direction: parsedQuery.direction,
           })
 
           return links.map((link) => ({

--- a/packages/server/src/schemas/links.ts
+++ b/packages/server/src/schemas/links.ts
@@ -11,6 +11,7 @@ export const LinkParamsSchema = LinkSourceParamsSchema.extend({
 
 export const LinkQuerySchema = z.object({
   linkId: z.string().optional(),
+  direction: z.enum(["outgoing", "incoming", "both"]).default("outgoing"),
 })
 
 export const RemoveLinkQuerySchema = z.object({

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -1028,6 +1028,18 @@ describe("ParioServer HTTP contract", () => {
         }),
       ])
 
+      const incomingLinksResponse = await fetch(
+        `${baseUrl}/api/objects/device/fan-1/links?direction=incoming`
+      )
+      expect(incomingLinksResponse.status).toBe(200)
+      const incomingLinks = (await incomingLinksResponse.json()) as Array<{ sourceId: string }>
+      expect(incomingLinks.map((link) => link.sourceId)).toEqual(["system"])
+
+      const invalidDirectionResponse = await fetch(
+        `${baseUrl}/api/objects/device/fan-1/links?direction=sideways`
+      )
+      expect(invalidDirectionResponse.status).toBe(422)
+
       const historyResponse = await fetch(
         `${baseUrl}/api/objects/device/fan-1/telemetry/rpm/history?limit=2&order=desc`
       )

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -1,4 +1,5 @@
 import type {
+  LinkDirection,
   ObjectLinkRow,
   ObjectRow,
   ObjectStorage,
@@ -474,28 +475,25 @@ export class PgObjectStorage implements ObjectStorage {
 
   async listLinks(params: {
     projectId: string
-    sourceTypeId: string
-    sourceId: string
+    objectTypeId: string
+    objectId: string
     linkId?: string
+    direction?: LinkDirection
   }): Promise<readonly ObjectLinkRow[]> {
-    let rows: LinkDatabaseRow[]
-
-    if (params.linkId) {
-      rows = (await this.sql`
-        SELECT * FROM links
-        WHERE project_id = ${params.projectId}
-          AND source_type_id = ${params.sourceTypeId}
-          AND source_id = ${params.sourceId}
-          AND link_id = ${params.linkId}
-      `) as LinkDatabaseRow[]
-    } else {
-      rows = (await this.sql`
-        SELECT * FROM links
-        WHERE project_id = ${params.projectId}
-          AND source_type_id = ${params.sourceTypeId}
-          AND source_id = ${params.sourceId}
-      `) as LinkDatabaseRow[]
-    }
+    const direction = params.direction ?? "outgoing"
+    const directionWhere =
+      direction === "incoming"
+        ? "target_type_id = $2 AND target_id = $3"
+        : direction === "both"
+          ? "((source_type_id = $2 AND source_id = $3) OR (target_type_id = $2 AND target_id = $3))"
+          : "source_type_id = $2 AND source_id = $3"
+    const query = `SELECT * FROM links WHERE project_id = $1 AND ${directionWhere}${
+      params.linkId ? " AND link_id = $4" : ""
+    }`
+    const args = params.linkId
+      ? [params.projectId, params.objectTypeId, params.objectId, params.linkId]
+      : [params.projectId, params.objectTypeId, params.objectId]
+    const rows = (await this.sql.unsafe(query, args)) as LinkDatabaseRow[]
 
     return rows.map((row) => rowToLink(row))
   }
@@ -523,7 +521,7 @@ export class PgObjectStorage implements ObjectStorage {
 
   async listLinksBatch(params: {
     projectId: string
-    items: readonly { sourceTypeId: string; sourceId: string; linkId: string }[]
+    items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<string, ObjectLinkRow[]>> {
     const result = new Map<string, ObjectLinkRow[]>()
     if (params.items.length === 0) return result
@@ -531,7 +529,7 @@ export class PgObjectStorage implements ObjectStorage {
       this.sql,
       "SELECT l.* FROM links l",
       ["source_type_id", "source_id", "link_id"],
-      params.items.map((i) => [i.sourceTypeId, i.sourceId, i.linkId]),
+      params.items.map((i) => [i.objectTypeId, i.objectId, i.linkId]),
       `WHERE l.project_id = $1`,
       [params.projectId]
     )) as LinkDatabaseRow[]

--- a/storage/pg/tests/pg-object-storage.e2e.ts
+++ b/storage/pg/tests/pg-object-storage.e2e.ts
@@ -271,8 +271,8 @@ describe("PgObjectStorage", () => {
 
     const links = await storage.objects.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
     })
 
     expect(links).toHaveLength(1)
@@ -306,8 +306,8 @@ describe("PgObjectStorage", () => {
 
     const links = await storage.objects.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
     })
 
     expect(links).toHaveLength(1)
@@ -341,8 +341,8 @@ describe("PgObjectStorage", () => {
 
     const links = await storage.objects.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
     })
 
     expect(links).toHaveLength(0)
@@ -374,13 +374,38 @@ describe("PgObjectStorage", () => {
 
     const links = await storage.objects.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
       linkId: "hasThermostat",
     })
 
     expect(links).toHaveLength(1)
     expect(links[0]?.linkId).toBe("hasThermostat")
+  })
+
+  test("listLinks supports incoming and both directions", async () => {
+    await storage.objects.applyLinkUpserted(
+      createLinkUpsertedEvent("project-a", "Room", "room:101", "hasSensor", "Sensor", "s1", "1")
+    )
+    await storage.objects.applyLinkUpserted(
+      createLinkUpsertedEvent("project-a", "Sensor", "s1", "installedIn", "Room", "room:101", "2")
+    )
+
+    const incoming = await storage.objects.listLinks({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      direction: "incoming",
+    })
+    const both = await storage.objects.listLinks({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      direction: "both",
+    })
+
+    expect(incoming.map((link) => link.linkId)).toEqual(["installedIn"])
+    expect(both.map((link) => link.linkId).sort()).toEqual(["hasSensor", "installedIn"])
   })
 
   test("list returns objects with pagination", async () => {
@@ -604,8 +629,8 @@ describe("PgObjectStorage", () => {
 
     const links = await storage.objects.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
       linkId: "hasThermostat",
     })
 
@@ -710,8 +735,8 @@ describe("PgObjectStorage", () => {
 
     const links = await storage.objects.listLinks({
       projectId: "p1",
-      sourceTypeId: "Room",
-      sourceId: "r1",
+      objectTypeId: "Room",
+      objectId: "r1",
       linkId: "hasSensors",
     })
     expect(links).toHaveLength(2)
@@ -750,8 +775,8 @@ describe("PgObjectStorage", () => {
     const result = await storage.objects.listLinksBatch({
       projectId: "p1",
       items: [
-        { sourceTypeId: "Room", sourceId: "r1", linkId: "hasSensors" },
-        { sourceTypeId: "Room", sourceId: "r1", linkId: "noLinks" },
+        { objectTypeId: "Room", objectId: "r1", linkId: "hasSensors" },
+        { objectTypeId: "Room", objectId: "r1", linkId: "noLinks" },
       ],
     })
 

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite"
 import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import type {
+  LinkDirection,
   ObjectLinkRow,
   ObjectRow,
   ObjectStorage,
@@ -459,12 +460,29 @@ export class SqliteObjectStorage implements ObjectStorage {
 
   async listLinks(params: {
     projectId: string
-    sourceTypeId: string
-    sourceId: string
+    objectTypeId: string
+    objectId: string
     linkId?: string
+    direction?: LinkDirection
   }): Promise<readonly ObjectLinkRow[]> {
-    let query = "SELECT * FROM links WHERE project_id = ? AND source_type_id = ? AND source_id = ?"
-    const args: (string | number)[] = [params.projectId, params.sourceTypeId, params.sourceId]
+    const direction = params.direction ?? "outgoing"
+    const directionWhere =
+      direction === "incoming"
+        ? "target_type_id = ? AND target_id = ?"
+        : direction === "both"
+          ? "((source_type_id = ? AND source_id = ?) OR (target_type_id = ? AND target_id = ?))"
+          : "source_type_id = ? AND source_id = ?"
+    let query = `SELECT * FROM links WHERE project_id = ? AND ${directionWhere}`
+    const args: (string | number)[] =
+      direction === "both"
+        ? [
+            params.projectId,
+            params.objectTypeId,
+            params.objectId,
+            params.objectTypeId,
+            params.objectId,
+          ]
+        : [params.projectId, params.objectTypeId, params.objectId]
 
     if (params.linkId) {
       query += " AND link_id = ?"
@@ -501,7 +519,7 @@ export class SqliteObjectStorage implements ObjectStorage {
 
   async listLinksBatch(params: {
     projectId: string
-    items: readonly { sourceTypeId: string; sourceId: string; linkId: string }[]
+    items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<string, ObjectLinkRow[]>> {
     const result = new Map<string, ObjectLinkRow[]>()
     if (params.items.length === 0) return result
@@ -512,13 +530,13 @@ export class SqliteObjectStorage implements ObjectStorage {
     for (const item of params.items) {
       const rows = stmt.all(
         params.projectId,
-        item.sourceTypeId,
-        item.sourceId,
+        item.objectTypeId,
+        item.objectId,
         item.linkId
       ) as LinkDatabaseRow[]
       if (rows.length > 0) {
         result.set(
-          `${item.sourceTypeId}:${item.sourceId}:${item.linkId}`,
+          `${item.objectTypeId}:${item.objectId}:${item.linkId}`,
           rows.map((r) => this.rowToLink(r))
         )
       }

--- a/storage/sqlite/tests/sqlite-object-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-object-storage.test.ts
@@ -269,8 +269,8 @@ describe("SqliteObjectStorage", () => {
 
     const links = await storage.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
     })
 
     expect(links).toHaveLength(1)
@@ -304,8 +304,8 @@ describe("SqliteObjectStorage", () => {
 
     const links = await storage.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
     })
 
     expect(links).toHaveLength(1)
@@ -339,8 +339,8 @@ describe("SqliteObjectStorage", () => {
 
     const links = await storage.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
     })
 
     expect(links).toHaveLength(0)
@@ -372,13 +372,38 @@ describe("SqliteObjectStorage", () => {
 
     const links = await storage.listLinks({
       projectId: "project-a",
-      sourceTypeId: "Room",
-      sourceId: "room:101",
+      objectTypeId: "Room",
+      objectId: "room:101",
       linkId: "hasThermostat",
     })
 
     expect(links).toHaveLength(1)
     expect(links[0]?.linkId).toBe("hasThermostat")
+  })
+
+  test("listLinks supports incoming and both directions", async () => {
+    await storage.applyLinkUpserted(
+      createLinkUpsertedEvent("project-a", "Room", "room:101", "hasSensor", "Sensor", "s1", "1")
+    )
+    await storage.applyLinkUpserted(
+      createLinkUpsertedEvent("project-a", "Sensor", "s1", "installedIn", "Room", "room:101", "2")
+    )
+
+    const incoming = await storage.listLinks({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      direction: "incoming",
+    })
+    const both = await storage.listLinks({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      direction: "both",
+    })
+
+    expect(incoming.map((link) => link.linkId)).toEqual(["installedIn"])
+    expect(both.map((link) => link.linkId).sort()).toEqual(["hasSensor", "installedIn"])
   })
 
   test("list returns objects with pagination", async () => {
@@ -544,8 +569,8 @@ describe("SqliteObjectStorage", () => {
 
     const links = await storage.listLinks({
       projectId: "p1",
-      sourceTypeId: "Room",
-      sourceId: "r1",
+      objectTypeId: "Room",
+      objectId: "r1",
       linkId: "hasSensors",
     })
     expect(links).toHaveLength(2)
@@ -580,8 +605,8 @@ describe("SqliteObjectStorage", () => {
     const result = await storage.listLinksBatch({
       projectId: "p1",
       items: [
-        { sourceTypeId: "Room", sourceId: "r1", linkId: "hasSensors" },
-        { sourceTypeId: "Room", sourceId: "r1", linkId: "noLinks" },
+        { objectTypeId: "Room", objectId: "r1", linkId: "hasSensors" },
+        { objectTypeId: "Room", objectId: "r1", linkId: "noLinks" },
       ],
     })
 


### PR DESCRIPTION
Problem

Object detail pages need to show what an object is related to. The existing object links endpoint only listed outgoing links, so incoming relationships were invisible unless the client scanned other objects and rebuilt the graph itself.

What changed

- Add a `direction` query option to object link listing.
- Support `outgoing`, `incoming`, and `both` in in-memory, SQLite, and Postgres storage.
- Regenerate the client contract and simplify Atlas to load relationships with one request.
- Render object links in a separate Atlas `Links` card below `Details`.

API

```http
GET /api/objects/{objectTypeId}/{objectId}/links?direction=both
```

Client usage

```ts
listObjectLinks({
  path: { objectTypeId, objectId },
  query: { direction: "both" },
})
```

Verification

- `bun run generate:client`
- `bun run typecheck`
- `bun run check`
- `bun run test`
- `bun run build`