### PR TITLE
docs: add standalone docs website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+      - docs-website-beginnings
+    paths:
+      - ".github/workflows/docs.yml"
+      - "apps/docs/**"
+      - "docs/**"
+      - "packages/ui/**"
+      - "package.json"
+      - "bun.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build docs
+        run: bun run docs:build
+
+      - name: Disable Jekyll
+        run: touch apps/docs/dist/.nojekyll
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: apps/docs/dist
+
+  deploy:
+    name: Deploy docs
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docs-website-beginnings
     paths:
       - ".github/workflows/docs.yml"
       - "apps/docs/**"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 build/
 .next/
 out/
+.docs/
 
 # OS
 .DS_Store
@@ -29,3 +30,4 @@ npm-debug.log*
 
 .local/
 .sixb/
+apps/docs/src/generated/

--- a/apps/docs/index.html
+++ b/apps/docs/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
+    <title>Sixb Docs</title>
+    <link rel="stylesheet" href="./.docs/styles.css" />
+    <script type="module" src="./src/main.tsx"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@sixb/docs",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "generate:docs": "bun ./src/docs/buildDocs.ts",
+    "clean:dist": "bun ./src/docs/cleanDist.ts",
+    "copy:docs": "bun ./src/docs/writeStaticDocs.ts",
+    "build:css": "bun ./src/buildCss.ts",
+    "dev": "NODE_ENV=development bun run generate:docs && bun run build:css && bun ./src/dev.ts",
+    "build": "NODE_ENV=production bun run generate:docs && bun run clean:dist && bun run build:css && bun build ./index.html --outdir ./dist --target browser --public-path / --minify && bun run copy:docs",
+    "typecheck": "bun run generate:docs && tsc --noEmit"
+  },
+  "dependencies": {
+    "@sixb/ui": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/cli": "^4.2.2",
+    "@types/bun": "latest",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "shiki": "^4.1.0",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@sixb/ui": "workspace:*",
+    "lucide-react": "^0.562.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/apps/docs/src/App.tsx
+++ b/apps/docs/src/App.tsx
@@ -1,0 +1,57 @@
+import { docs } from "./generated/docs"
+
+export function App() {
+  const pathname = window.location.pathname.replace(/\/$/, "") || "/"
+  const currentDoc = docs.find((doc) => doc.routePath === pathname)
+
+  if (currentDoc) {
+    return (
+      <main className="doc-layout">
+        <header className="doc-topbar">
+          <a className="doc-home-link" href="/">
+            Sixb Docs
+          </a>
+          <a className="doc-markdown-link" href={currentDoc.markdownPath}>
+            Markdown
+          </a>
+        </header>
+        <div className="doc-body">
+          <aside className="doc-sidebar" aria-label="Documentation">
+            <nav className="doc-sidebar-nav">
+              {docs.map((doc) => (
+                <a
+                  key={doc.routePath}
+                  className={
+                    doc.routePath === currentDoc.routePath
+                      ? "doc-sidebar-link active"
+                      : "doc-sidebar-link"
+                  }
+                  href={doc.routePath}
+                >
+                  {doc.title}
+                </a>
+              ))}
+            </nav>
+          </aside>
+          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Docs HTML is generated from trusted repository markdown. */}
+          <article className="doc-content" dangerouslySetInnerHTML={{ __html: currentDoc.html }} />
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <main className="docs-shell" aria-labelledby="docs-title">
+      <h1 id="docs-title" className="docs-title">
+        Sixb Docs
+      </h1>
+      <nav className="docs-toc" aria-label="Documentation">
+        {docs.map((doc) => (
+          <a key={doc.routePath} className="docs-link" href={doc.routePath}>
+            {doc.title}
+          </a>
+        ))}
+      </nav>
+    </main>
+  )
+}

--- a/apps/docs/src/App.tsx
+++ b/apps/docs/src/App.tsx
@@ -1,57 +1,469 @@
+import {
+  Button,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  ThemeSwitcher,
+} from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import { ChevronRight, FileText, Menu, Search } from "lucide-react"
+import { type MouseEvent, useCallback, useEffect, useMemo, useState } from "react"
 import { docs } from "./generated/docs"
 
-export function App() {
-  const pathname = window.location.pathname.replace(/\/$/, "") || "/"
-  const currentDoc = docs.find((doc) => doc.routePath === pathname)
+type Doc = (typeof docs)[number]
+type Navigate = (href: string) => void
 
-  if (currentDoc) {
-    return (
-      <main className="doc-layout">
-        <header className="doc-topbar">
-          <a className="doc-home-link" href="/">
-            Sixb Docs
-          </a>
-          <a className="doc-markdown-link" href={currentDoc.markdownPath}>
-            Markdown
-          </a>
-        </header>
-        <div className="doc-body">
-          <aside className="doc-sidebar" aria-label="Documentation">
-            <nav className="doc-sidebar-nav">
-              {docs.map((doc) => (
-                <a
-                  key={doc.routePath}
-                  className={
-                    doc.routePath === currentDoc.routePath
-                      ? "doc-sidebar-link active"
-                      : "doc-sidebar-link"
-                  }
-                  href={doc.routePath}
-                >
-                  {doc.title}
-                </a>
-              ))}
-            </nav>
-          </aside>
-          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Docs HTML is generated from trusted repository markdown. */}
-          <article className="doc-content" dangerouslySetInnerHTML={{ __html: currentDoc.html }} />
-        </div>
-      </main>
-    )
+interface NavGroup {
+  readonly title: string
+  readonly items: Doc[]
+}
+
+function normalize(path: string): string {
+  return path.replace(/\/+$/, "") || "/"
+}
+
+function groupDocs(): NavGroup[] {
+  const groups: NavGroup[] = []
+  for (const doc of docs) {
+    const existing = groups.find((group) => group.title === doc.section)
+    if (existing) {
+      existing.items.push(doc)
+    } else {
+      groups.push({ title: doc.section, items: [doc] })
+    }
   }
+  return groups
+}
+
+function intercept(navigate: Navigate, href: string) {
+  return (event: MouseEvent) => {
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) return
+    event.preventDefault()
+    navigate(href)
+  }
+}
+
+export function App() {
+  const groups = useMemo(groupDocs, [])
+  const [path, setPath] = useState(() => normalize(window.location.pathname))
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  useEffect(() => {
+    const onPop = () => setPath(normalize(window.location.pathname))
+    window.addEventListener("popstate", onPop)
+    return () => window.removeEventListener("popstate", onPop)
+  }, [])
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault()
+        setSearchOpen((open) => !open)
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [])
+
+  const navigate = useCallback<Navigate>((href) => {
+    const [rawPath, hash] = href.split("#")
+    const next = normalize(rawPath ?? "/")
+    if (next !== normalize(window.location.pathname)) {
+      window.history.pushState(null, "", hash ? `${next}#${hash}` : next)
+    }
+    setPath(next)
+    setSearchOpen(false)
+    setMenuOpen(false)
+    requestAnimationFrame(() => {
+      if (hash) document.getElementById(hash)?.scrollIntoView()
+      else window.scrollTo({ top: 0 })
+    })
+  }, [])
+
+  const current = docs.find((doc) => doc.routePath === path)
 
   return (
-    <main className="docs-shell" aria-labelledby="docs-title">
-      <h1 id="docs-title" className="docs-title">
-        Sixb Docs
-      </h1>
-      <nav className="docs-toc" aria-label="Documentation">
-        {docs.map((doc) => (
-          <a key={doc.routePath} className="docs-link" href={doc.routePath}>
-            {doc.title}
+    <div className="min-h-screen bg-background text-foreground">
+      <TopBar
+        onMenu={() => setMenuOpen(true)}
+        onSearch={() => setSearchOpen(true)}
+        navigate={navigate}
+      />
+      <div className="mx-auto flex w-full max-w-[1440px] px-4 lg:px-8">
+        <DesktopSidebar groups={groups} path={path} navigate={navigate} />
+        <main className="min-w-0 flex-1 py-10 lg:py-12 lg:pl-4 xl:pl-10">
+          {current ? (
+            <DocPage key={current.routePath} doc={current} navigate={navigate} />
+          ) : (
+            <Landing groups={groups} navigate={navigate} />
+          )}
+        </main>
+        {current && current.headings.length > 0 ? (
+          <Toc key={current.routePath} path={current.routePath} headings={current.headings} />
+        ) : null}
+      </div>
+      <MobileSidebar
+        open={menuOpen}
+        setOpen={setMenuOpen}
+        groups={groups}
+        path={path}
+        navigate={navigate}
+      />
+      <SearchPalette
+        open={searchOpen}
+        setOpen={setSearchOpen}
+        groups={groups}
+        navigate={navigate}
+      />
+    </div>
+  )
+}
+
+function TopBar({
+  onMenu,
+  onSearch,
+  navigate,
+}: {
+  onMenu: () => void
+  onSearch: () => void
+  navigate: Navigate
+}) {
+  return (
+    <header className="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+      <div className="mx-auto flex h-14 w-full max-w-[1440px] items-center gap-3 px-4 lg:px-8">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="lg:hidden"
+          aria-label="Open menu"
+          onClick={onMenu}
+        >
+          <Menu />
+        </Button>
+        <a
+          href="/"
+          onClick={intercept(navigate, "/")}
+          className="mr-auto flex items-center gap-2 font-semibold tracking-tight"
+        >
+          <span className="inline-flex size-6 items-center justify-center rounded-md bg-primary text-[13px] font-bold text-primary-foreground">
+            S
+          </span>
+          Sixb Docs
+        </a>
+        <button
+          type="button"
+          onClick={onSearch}
+          className="hidden h-9 items-center gap-2 rounded-lg border border-border bg-muted/40 pr-2 pl-3 text-sm text-muted-foreground transition-colors hover:bg-muted sm:flex"
+        >
+          <Search className="size-4" />
+          <span className="pr-10">Search docs</span>
+          <kbd className="rounded border border-border bg-background px-1.5 py-0.5 font-mono text-[11px] leading-none">
+            ⌘K
+          </kbd>
+        </button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="sm:hidden"
+          aria-label="Search"
+          onClick={onSearch}
+        >
+          <Search />
+        </Button>
+        <ThemeSwitcher />
+      </div>
+    </header>
+  )
+}
+
+function DesktopSidebar({
+  groups,
+  path,
+  navigate,
+}: {
+  groups: NavGroup[]
+  path: string
+  navigate: Navigate
+}) {
+  return (
+    <aside className="hidden w-64 shrink-0 lg:block">
+      <div className="sticky top-14 max-h-[calc(100vh-3.5rem)] overflow-y-auto py-10 pr-6">
+        <SidebarNav groups={groups} path={path} navigate={navigate} />
+      </div>
+    </aside>
+  )
+}
+
+function MobileSidebar({
+  open,
+  setOpen,
+  groups,
+  path,
+  navigate,
+}: {
+  open: boolean
+  setOpen: (open: boolean) => void
+  groups: NavGroup[]
+  path: string
+  navigate: Navigate
+}) {
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetContent side="left" className="w-72 overflow-y-auto p-6">
+        <SheetTitle className="mb-6 text-base font-semibold">Sixb Docs</SheetTitle>
+        <SidebarNav groups={groups} path={path} navigate={navigate} />
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function SidebarNav({
+  groups,
+  path,
+  navigate,
+}: {
+  groups: NavGroup[]
+  path: string
+  navigate: Navigate
+}) {
+  return (
+    <nav className="flex flex-col gap-7">
+      {groups.map((group) => (
+        <div key={group.title} className="flex flex-col gap-0.5">
+          <p className="mb-1.5 px-3 text-xs font-semibold tracking-wide text-foreground">
+            {group.title}
+          </p>
+          {group.items.map((doc) => {
+            const active = doc.routePath === path
+            return (
+              <a
+                key={doc.routePath}
+                href={doc.routePath}
+                onClick={intercept(navigate, doc.routePath)}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "rounded-lg px-3 py-1.5 text-sm transition-colors",
+                  active
+                    ? "bg-accent font-medium text-foreground"
+                    : "text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+                )}
+              >
+                {doc.title}
+              </a>
+            )
+          })}
+        </div>
+      ))}
+    </nav>
+  )
+}
+
+function DocPage({ doc, navigate }: { doc: Doc; navigate: Navigate }) {
+  const index = docs.findIndex((entry) => entry.routePath === doc.routePath)
+  const prev = index > 0 ? docs[index - 1] : undefined
+  const next = index < docs.length - 1 ? docs[index + 1] : undefined
+
+  const onClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      const target = event.target as HTMLElement
+      const copy = target.closest<HTMLButtonElement>("[data-copy]")
+      if (copy) {
+        const code = copy.closest(".code-block")?.querySelector("pre")?.textContent ?? ""
+        navigator.clipboard.writeText(code)
+        copy.textContent = "Copied"
+        window.setTimeout(() => {
+          copy.textContent = "Copy"
+        }, 1500)
+        return
+      }
+      const link = target.closest("a")
+      if (!link) return
+      const href = link.getAttribute("href") ?? ""
+      const base = normalize(href.split("#")[0] ?? "")
+      if (
+        href.startsWith("/") &&
+        !href.endsWith(".md") &&
+        docs.some((entry) => entry.routePath === base)
+      ) {
+        event.preventDefault()
+        navigate(href)
+      }
+    },
+    [navigate]
+  )
+
+  return (
+    <article className="relative mx-auto w-full max-w-[760px] lg:mx-0">
+      <Button
+        asChild
+        variant="ghost"
+        size="sm"
+        className="absolute top-1.5 right-0 font-normal text-muted-foreground"
+      >
+        <a href={doc.markdownPath} target="_blank" rel="noreferrer">
+          Markdown
+        </a>
+      </Button>
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Docs HTML is generated from trusted repository markdown. */}
+      <div className="prose" onClick={onClick} dangerouslySetInnerHTML={{ __html: doc.html }} />
+      {prev || next ? (
+        <nav className="mt-16 grid gap-3 border-t border-border pt-8 sm:grid-cols-2">
+          {prev ? <Pager doc={prev} dir="Previous" navigate={navigate} /> : <span />}
+          {next ? <Pager doc={next} dir="Next" navigate={navigate} /> : <span />}
+        </nav>
+      ) : null}
+    </article>
+  )
+}
+
+function Pager({ doc, dir, navigate }: { doc: Doc; dir: "Previous" | "Next"; navigate: Navigate }) {
+  return (
+    <a
+      href={doc.routePath}
+      onClick={intercept(navigate, doc.routePath)}
+      className={cn(
+        "flex flex-col gap-1 rounded-xl border border-border p-4 transition-colors hover:bg-accent/50",
+        dir === "Next" && "sm:items-end sm:text-right"
+      )}
+    >
+      <span className="text-xs text-muted-foreground">{dir}</span>
+      <span className="font-medium text-foreground">{doc.title}</span>
+    </a>
+  )
+}
+
+function Toc({ path, headings }: { path: string; headings: Doc["headings"] }) {
+  const [active, setActive] = useState(headings[0]?.id ?? "")
+
+  useEffect(() => {
+    const elements = headings
+      .map((heading) => document.getElementById(heading.id))
+      .filter((element): element is HTMLElement => element !== null)
+    if (elements.length === 0) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.filter((entry) => entry.isIntersecting)
+        if (visible[0]) setActive(visible[0].target.id)
+      },
+      { rootMargin: "-72px 0px -70% 0px", threshold: 0 }
+    )
+    for (const element of elements) observer.observe(element)
+    return () => observer.disconnect()
+  }, [headings])
+
+  return (
+    <aside className="hidden w-60 shrink-0 xl:block">
+      <div className="sticky top-14 max-h-[calc(100vh-3.5rem)] overflow-y-auto py-12 pl-8">
+        <p className="mb-3 text-xs font-semibold tracking-wide text-foreground">On this page</p>
+        <nav className="flex flex-col border-l border-border text-sm">
+          {headings.map((heading) => (
+            <a
+              key={heading.id}
+              href={`${path}#${heading.id}`}
+              onClick={() => setActive(heading.id)}
+              className={cn(
+                "-ml-px border-l-2 py-1 transition-colors",
+                heading.level === 3 ? "pl-7" : "pl-4",
+                active === heading.id
+                  ? "border-foreground font-medium text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {heading.text}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </aside>
+  )
+}
+
+function Landing({ groups, navigate }: { groups: NavGroup[]; navigate: Navigate }) {
+  const start = docs.find((doc) => doc.routePath === "/get-started")
+  return (
+    <div className="mx-auto w-full max-w-3xl lg:mx-0">
+      <p className="text-sm font-medium text-muted-foreground">Sixb</p>
+      <h1 className="mt-2 text-4xl font-bold tracking-tight sm:text-5xl">Sixb Documentation</h1>
+      <p className="mt-5 text-lg leading-relaxed text-muted-foreground">{start?.summary}</p>
+      <div className="mt-8 flex flex-wrap gap-3">
+        <Button asChild>
+          <a href="/get-started" onClick={intercept(navigate, "/get-started")}>
+            Get started
           </a>
+        </Button>
+      </div>
+      {groups.map((group) => (
+        <section key={group.title} className="mt-14">
+          <h2 className="text-lg font-semibold">{group.title}</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            {group.items.map((doc) => (
+              <a
+                key={doc.routePath}
+                href={doc.routePath}
+                onClick={intercept(navigate, doc.routePath)}
+                className="group flex flex-col gap-1.5 rounded-xl border border-border p-5 transition-colors hover:bg-accent/40"
+              >
+                <span className="flex items-center justify-between font-medium text-foreground">
+                  {doc.title}
+                  <ChevronRight className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                </span>
+                <span className="line-clamp-2 text-sm text-muted-foreground">{doc.summary}</span>
+              </a>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+function SearchPalette({
+  open,
+  setOpen,
+  groups,
+  navigate,
+}: {
+  open: boolean
+  setOpen: (open: boolean) => void
+  groups: NavGroup[]
+  navigate: Navigate
+}) {
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      title="Search docs"
+      description="Search the documentation"
+    >
+      <CommandInput placeholder="Search documentation..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        {groups.map((group) => (
+          <CommandGroup key={group.title} heading={group.title}>
+            {group.items.map((doc) => (
+              <CommandItem
+                key={doc.routePath}
+                value={`${doc.title} ${doc.summary} ${doc.headings.map((heading) => heading.text).join(" ")}`}
+                onSelect={() => navigate(doc.routePath)}
+              >
+                <FileText />
+                <span className="flex min-w-0 flex-col">
+                  <span>{doc.title}</span>
+                  <span className="line-clamp-1 text-xs text-muted-foreground">{doc.summary}</span>
+                </span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
         ))}
-      </nav>
-    </main>
+      </CommandList>
+    </CommandDialog>
   )
 }

--- a/apps/docs/src/buildCss.ts
+++ b/apps/docs/src/buildCss.ts
@@ -1,0 +1,35 @@
+import { mkdir } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const inputPath = join(import.meta.dir, "styles.css")
+const outputPath = join(import.meta.dir, "..", ".docs", "styles.css")
+
+await mkdir(dirname(outputPath), { recursive: true })
+
+const args = [process.execPath, await resolveTailwindCliEntry(), "-i", inputPath, "-o", outputPath]
+
+if (process.env.NODE_ENV === "production") {
+  args.push("--minify")
+}
+
+const proc = Bun.spawn(args, {
+  cwd: join(import.meta.dir, ".."),
+  stdout: "ignore",
+  stderr: "pipe",
+})
+
+const exitCode = await proc.exited
+
+if (exitCode !== 0) {
+  const stderr = await new Response(proc.stderr).text()
+  throw new Error(`[SixbDocs] Failed to build CSS: ${stderr.trim()}`)
+}
+
+async function resolveTailwindCliEntry(): Promise<string> {
+  return join(
+    dirname(fileURLToPath(import.meta.resolve("@tailwindcss/cli/package.json"))),
+    "dist",
+    "index.mjs"
+  )
+}

--- a/apps/docs/src/dev.ts
+++ b/apps/docs/src/dev.ts
@@ -1,0 +1,44 @@
+import app from "../index.html"
+import { docsConfig } from "./docs/config"
+
+type BunServeRoutes = NonNullable<Parameters<typeof Bun.serve>[0]["routes"]>
+
+const routes: BunServeRoutes = {
+  "/": app,
+  "/*": app,
+}
+
+for (const doc of docsConfig) {
+  routes[doc.routePath] = app
+  routes[doc.markdownPath] = {
+    GET: () => markdownResponse(doc.sourcePath),
+    HEAD: () => markdownHeadResponse(),
+  }
+}
+
+const server = Bun.serve({
+  port: 3004,
+  development: true,
+  routes,
+} as Parameters<typeof Bun.serve>[0])
+
+console.log(`url: http://${server.hostname}:${server.port}/`)
+
+function markdownResponse(sourcePath: string): Response {
+  return new Response(Bun.file(sourcePath), {
+    headers: markdownHeaders(),
+  })
+}
+
+function markdownHeadResponse(): Response {
+  return new Response(null, {
+    headers: markdownHeaders(),
+  })
+}
+
+function markdownHeaders(): HeadersInit {
+  return {
+    "content-type": "text/markdown; charset=utf-8",
+    "cache-control": "no-store",
+  }
+}

--- a/apps/docs/src/docs/buildDocs.ts
+++ b/apps/docs/src/docs/buildDocs.ts
@@ -8,15 +8,16 @@ const outputPath = join(import.meta.dir, "..", "generated", "docs.ts")
 const docs = await Promise.all(
   docsConfig.map(async (doc) => {
     const markdown = await Bun.file(doc.sourcePath).text()
+    const rendered = await renderHighlightedMarkdown(markdown, { doc, docs: docsConfig })
 
     return {
       title: doc.title,
+      section: doc.section,
       routePath: doc.routePath,
       markdownPath: doc.markdownPath,
-      html: await renderHighlightedMarkdown(markdown, {
-        doc,
-        docs: docsConfig,
-      }),
+      summary: rendered.summary,
+      headings: rendered.headings,
+      html: rendered.html,
     }
   })
 )
@@ -24,6 +25,6 @@ const docs = await Promise.all(
 await mkdir(dirname(outputPath), { recursive: true })
 await writeFile(
   outputPath,
-  `export const docs = ${JSON.stringify(docs, null, 2)} as const\n`,
+  `import type { DocEntry } from "../docs/types"\n\nexport const docs: readonly DocEntry[] = ${JSON.stringify(docs, null, 2)}\n`,
   "utf-8"
 )

--- a/apps/docs/src/docs/buildDocs.ts
+++ b/apps/docs/src/docs/buildDocs.ts
@@ -1,0 +1,29 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { docsConfig } from "./config"
+import { renderHighlightedMarkdown } from "./renderMarkdown"
+
+const outputPath = join(import.meta.dir, "..", "generated", "docs.ts")
+
+const docs = await Promise.all(
+  docsConfig.map(async (doc) => {
+    const markdown = await Bun.file(doc.sourcePath).text()
+
+    return {
+      title: doc.title,
+      routePath: doc.routePath,
+      markdownPath: doc.markdownPath,
+      html: await renderHighlightedMarkdown(markdown, {
+        doc,
+        docs: docsConfig,
+      }),
+    }
+  })
+)
+
+await mkdir(dirname(outputPath), { recursive: true })
+await writeFile(
+  outputPath,
+  `export const docs = ${JSON.stringify(docs, null, 2)} as const\n`,
+  "utf-8"
+)

--- a/apps/docs/src/docs/cleanDist.ts
+++ b/apps/docs/src/docs/cleanDist.ts
@@ -1,0 +1,7 @@
+import { rm } from "node:fs/promises"
+import { join } from "node:path"
+
+await rm(join(import.meta.dir, "..", "..", "dist"), {
+  recursive: true,
+  force: true,
+})

--- a/apps/docs/src/docs/config.ts
+++ b/apps/docs/src/docs/config.ts
@@ -5,6 +5,7 @@ const docsRoot = join(repoRoot, "docs")
 
 export interface DocConfig {
   readonly title: string
+  readonly section: string
   readonly routePath: string
   readonly markdownPath: string
   readonly sourcePath: string
@@ -13,54 +14,63 @@ export interface DocConfig {
 export const docsConfig: readonly DocConfig[] = [
   {
     title: "Get Started",
+    section: "Get started",
     routePath: "/get-started",
     markdownPath: "/get-started.md",
     sourcePath: join(docsRoot, "README.md"),
   },
   {
     title: "Ontology",
+    section: "Core concepts",
     routePath: "/concepts/ontology",
     markdownPath: "/concepts/ontology.md",
     sourcePath: join(docsRoot, "concepts", "ontology.md"),
   },
   {
     title: "Dataset",
+    section: "Core concepts",
     routePath: "/concepts/datasets",
     markdownPath: "/concepts/datasets.md",
     sourcePath: join(docsRoot, "concepts", "datasets.md"),
   },
   {
     title: "Connector",
+    section: "Core concepts",
     routePath: "/concepts/connector",
     markdownPath: "/concepts/connector.md",
     sourcePath: join(docsRoot, "concepts", "connector.md"),
   },
   {
     title: "Sync",
+    section: "Core concepts",
     routePath: "/concepts/sync",
     markdownPath: "/concepts/sync.md",
     sourcePath: join(docsRoot, "concepts", "sync.md"),
   },
   {
     title: "Pipeline",
+    section: "Core concepts",
     routePath: "/concepts/pipeline",
     markdownPath: "/concepts/pipeline.md",
     sourcePath: join(docsRoot, "concepts", "pipeline.md"),
   },
   {
     title: "Projection",
+    section: "Core concepts",
     routePath: "/concepts/projection",
     markdownPath: "/concepts/projection.md",
     sourcePath: join(docsRoot, "concepts", "projection.md"),
   },
   {
     title: "Rules",
+    section: "Core concepts",
     routePath: "/concepts/rules",
     markdownPath: "/concepts/rules.md",
     sourcePath: join(docsRoot, "concepts", "rules.md"),
   },
   {
     title: "Workflow",
+    section: "Core concepts",
     routePath: "/concepts/workflows",
     markdownPath: "/concepts/workflows.md",
     sourcePath: join(docsRoot, "concepts", "workflows.md"),

--- a/apps/docs/src/docs/config.ts
+++ b/apps/docs/src/docs/config.ts
@@ -1,0 +1,68 @@
+import { join } from "node:path"
+
+const repoRoot = join(import.meta.dir, "..", "..", "..", "..")
+const docsRoot = join(repoRoot, "docs")
+
+export interface DocConfig {
+  readonly title: string
+  readonly routePath: string
+  readonly markdownPath: string
+  readonly sourcePath: string
+}
+
+export const docsConfig: readonly DocConfig[] = [
+  {
+    title: "Get Started",
+    routePath: "/get-started",
+    markdownPath: "/get-started.md",
+    sourcePath: join(docsRoot, "README.md"),
+  },
+  {
+    title: "Ontology",
+    routePath: "/concepts/ontology",
+    markdownPath: "/concepts/ontology.md",
+    sourcePath: join(docsRoot, "concepts", "ontology.md"),
+  },
+  {
+    title: "Dataset",
+    routePath: "/concepts/datasets",
+    markdownPath: "/concepts/datasets.md",
+    sourcePath: join(docsRoot, "concepts", "datasets.md"),
+  },
+  {
+    title: "Connector",
+    routePath: "/concepts/connector",
+    markdownPath: "/concepts/connector.md",
+    sourcePath: join(docsRoot, "concepts", "connector.md"),
+  },
+  {
+    title: "Sync",
+    routePath: "/concepts/sync",
+    markdownPath: "/concepts/sync.md",
+    sourcePath: join(docsRoot, "concepts", "sync.md"),
+  },
+  {
+    title: "Pipeline",
+    routePath: "/concepts/pipeline",
+    markdownPath: "/concepts/pipeline.md",
+    sourcePath: join(docsRoot, "concepts", "pipeline.md"),
+  },
+  {
+    title: "Projection",
+    routePath: "/concepts/projection",
+    markdownPath: "/concepts/projection.md",
+    sourcePath: join(docsRoot, "concepts", "projection.md"),
+  },
+  {
+    title: "Rules",
+    routePath: "/concepts/rules",
+    markdownPath: "/concepts/rules.md",
+    sourcePath: join(docsRoot, "concepts", "rules.md"),
+  },
+  {
+    title: "Workflow",
+    routePath: "/concepts/workflows",
+    markdownPath: "/concepts/workflows.md",
+    sourcePath: join(docsRoot, "concepts", "workflows.md"),
+  },
+]

--- a/apps/docs/src/docs/renderMarkdown.ts
+++ b/apps/docs/src/docs/renderMarkdown.ts
@@ -1,0 +1,105 @@
+import { codeToHtml } from "shiki"
+import type { DocConfig } from "./config"
+
+const codeBlockPattern = /<pre><code(?: class="language-([^"]+)")?>([\s\S]*?)<\/code><\/pre>/g
+const localMarkdownLinkPattern = /href="([^"]+\.md)"/g
+
+export function renderMarkdown(markdown: string): string {
+  return Bun.markdown.html(markdown, {
+    tables: true,
+    strikethrough: true,
+    tasklists: true,
+    autolinks: true,
+    headings: { ids: true },
+    tagFilter: true,
+  })
+}
+
+export async function renderHighlightedMarkdown(
+  markdown: string,
+  options: {
+    readonly doc: DocConfig
+    readonly docs: readonly DocConfig[]
+  }
+): Promise<string> {
+  const html = rewriteLocalMarkdownLinks(renderMarkdown(markdown), options)
+  const parts: string[] = []
+  let lastIndex = 0
+
+  for (const match of html.matchAll(codeBlockPattern)) {
+    const index = match.index ?? 0
+    parts.push(html.slice(lastIndex, index))
+    parts.push(
+      await codeToHtml(decodeHtmlEntities(match[2] ?? ""), {
+        lang: match[1] ?? "text",
+        themes: {
+          light: "github-light",
+          dark: "github-dark",
+        },
+      })
+    )
+    lastIndex = index + match[0].length
+  }
+
+  parts.push(html.slice(lastIndex))
+  return parts.join("")
+}
+
+function rewriteLocalMarkdownLinks(
+  html: string,
+  options: {
+    readonly doc: DocConfig
+    readonly docs: readonly DocConfig[]
+  }
+): string {
+  return html.replace(localMarkdownLinkPattern, (match, rawHref: string) => {
+    const routePath = resolveRenderedRoutePath(rawHref, options)
+    return routePath ? `href="${routePath}"` : match
+  })
+}
+
+function resolveRenderedRoutePath(
+  rawHref: string,
+  options: {
+    readonly doc: DocConfig
+    readonly docs: readonly DocConfig[]
+  }
+): string | null {
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(rawHref) || rawHref.startsWith("#")) {
+    return null
+  }
+
+  let url: URL
+  try {
+    url = new URL(rawHref, `https://sixb.local${options.doc.markdownPath}`)
+  } catch {
+    return null
+  }
+
+  const pathname = url.pathname
+  const target = options.docs.find((doc) => doc.markdownPath === pathname)
+  if (!target) {
+    return null
+  }
+
+  return `${target.routePath}${url.hash}`
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(?:#(\d+)|#x([\da-fA-F]+)|([a-zA-Z]+));/g, (match, dec, hex, name) => {
+    if (dec) {
+      return String.fromCodePoint(Number.parseInt(dec, 10))
+    }
+
+    if (hex) {
+      return String.fromCodePoint(Number.parseInt(hex, 16))
+    }
+
+    if (name === "amp") return "&"
+    if (name === "lt") return "<"
+    if (name === "gt") return ">"
+    if (name === "quot") return '"'
+    if (name === "apos") return "'"
+    return match
+  })
+}

--- a/apps/docs/src/docs/renderMarkdown.ts
+++ b/apps/docs/src/docs/renderMarkdown.ts
@@ -1,8 +1,17 @@
 import { codeToHtml } from "shiki"
 import type { DocConfig } from "./config"
+import type { DocHeading } from "./types"
 
 const codeBlockPattern = /<pre><code(?: class="language-([^"]+)")?>([\s\S]*?)<\/code><\/pre>/g
 const localMarkdownLinkPattern = /href="([^"]+\.md)"/g
+const headingPattern = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h\1>/g
+const firstParagraphPattern = /<p>([\s\S]*?)<\/p>/
+
+export interface RenderedDoc {
+  readonly html: string
+  readonly summary: string
+  readonly headings: readonly DocHeading[]
+}
 
 export function renderMarkdown(markdown: string): string {
   return Bun.markdown.html(markdown, {
@@ -21,28 +30,56 @@ export async function renderHighlightedMarkdown(
     readonly doc: DocConfig
     readonly docs: readonly DocConfig[]
   }
-): Promise<string> {
-  const html = rewriteLocalMarkdownLinks(renderMarkdown(markdown), options)
+): Promise<RenderedDoc> {
+  const linked = rewriteLocalMarkdownLinks(renderMarkdown(markdown), options)
+  return {
+    html: await highlightCodeBlocks(linked),
+    summary: extractSummary(linked),
+    headings: extractHeadings(linked),
+  }
+}
+
+async function highlightCodeBlocks(html: string): Promise<string> {
   const parts: string[] = []
   let lastIndex = 0
 
   for (const match of html.matchAll(codeBlockPattern)) {
     const index = match.index ?? 0
     parts.push(html.slice(lastIndex, index))
+    const lang = match[1] ?? "text"
+    const code = await codeToHtml(decodeHtmlEntities(match[2] ?? ""), {
+      lang,
+      themes: { light: "github-light", dark: "github-dark" },
+    })
     parts.push(
-      await codeToHtml(decodeHtmlEntities(match[2] ?? ""), {
-        lang: match[1] ?? "text",
-        themes: {
-          light: "github-light",
-          dark: "github-dark",
-        },
-      })
+      `<figure class="code-block"><figcaption class="code-bar"><span class="code-lang">${lang}</span><button class="code-copy" type="button" data-copy aria-label="Copy code">Copy</button></figcaption>${code}</figure>`
     )
     lastIndex = index + match[0].length
   }
 
   parts.push(html.slice(lastIndex))
   return parts.join("")
+}
+
+function extractHeadings(html: string): DocHeading[] {
+  const headings: DocHeading[] = []
+  for (const match of html.matchAll(headingPattern)) {
+    headings.push({
+      level: Number(match[1]) as 2 | 3,
+      id: match[2] ?? "",
+      text: stripTags(match[3] ?? ""),
+    })
+  }
+  return headings
+}
+
+function extractSummary(html: string): string {
+  const match = html.match(firstParagraphPattern)
+  return match ? stripTags(match[1] ?? "") : ""
+}
+
+function stripTags(value: string): string {
+  return decodeHtmlEntities(value.replace(/<[^>]+>/g, "")).trim()
 }
 
 function rewriteLocalMarkdownLinks(

--- a/apps/docs/src/docs/types.ts
+++ b/apps/docs/src/docs/types.ts
@@ -1,0 +1,15 @@
+export interface DocHeading {
+  readonly id: string
+  readonly text: string
+  readonly level: 2 | 3
+}
+
+export interface DocEntry {
+  readonly title: string
+  readonly section: string
+  readonly routePath: string
+  readonly markdownPath: string
+  readonly summary: string
+  readonly headings: readonly DocHeading[]
+  readonly html: string
+}

--- a/apps/docs/src/docs/writeStaticDocs.ts
+++ b/apps/docs/src/docs/writeStaticDocs.ts
@@ -1,0 +1,16 @@
+import { copyFile, mkdir } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { docsConfig } from "./config"
+
+const distDir = join(import.meta.dir, "..", "..", "dist")
+const appIndexPath = join(distDir, "index.html")
+
+for (const doc of docsConfig) {
+  const markdownOutputPath = join(distDir, doc.markdownPath)
+  await mkdir(dirname(markdownOutputPath), { recursive: true })
+  await copyFile(doc.sourcePath, markdownOutputPath)
+
+  const routeOutputPath = join(distDir, doc.routePath, "index.html")
+  await mkdir(dirname(routeOutputPath), { recursive: true })
+  await copyFile(appIndexPath, routeOutputPath)
+}

--- a/apps/docs/src/main.tsx
+++ b/apps/docs/src/main.tsx
@@ -1,0 +1,18 @@
+import { ThemeProvider } from "@sixb/ui/hooks"
+import React from "react"
+import ReactDOM from "react-dom/client"
+import { App } from "./App"
+
+const root = document.getElementById("root")
+
+if (!root) {
+  throw new Error("[SixbDocs] Missing root element.")
+}
+
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
+)

--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -1,0 +1,307 @@
+@import "@sixb/ui/globals.css";
+
+@source "./**/*.{ts,tsx}";
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.docs-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 112px 24px 24px;
+  text-align: center;
+}
+
+.docs-title {
+  margin: 0;
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 52px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.1;
+}
+
+.docs-toc {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  margin-top: 40px;
+}
+
+.docs-link {
+  color: color-mix(in oklch, var(--foreground) 72%, var(--background));
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.5;
+  text-decoration: none;
+  text-underline-offset: 4px;
+}
+
+.docs-link:hover {
+  color: var(--foreground);
+  text-decoration: underline;
+}
+
+.doc-layout {
+  min-height: 100vh;
+}
+
+.doc-topbar {
+  width: min(100% - 48px, 880px);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-top: 32px;
+}
+
+.doc-body {
+  width: min(100% - 48px, 880px);
+  margin: 0 auto;
+  padding: 52px 0 80px;
+}
+
+.doc-sidebar {
+  display: none;
+}
+
+.doc-home-link,
+.doc-markdown-link {
+  color: var(--muted-foreground);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  text-decoration: none;
+}
+
+.doc-home-link:hover,
+.doc-markdown-link:hover {
+  color: var(--foreground);
+}
+
+.doc-content {
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.68;
+}
+
+.doc-content h1,
+.doc-content h2,
+.doc-content h3 {
+  color: var(--foreground);
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+.doc-content h1 {
+  margin: 0 0 24px;
+  font-size: 40px;
+  font-weight: 680;
+}
+
+.doc-content h2 {
+  margin: 36px 0 12px;
+  padding-top: 4px;
+  font-size: 24px;
+  font-weight: 650;
+}
+
+.doc-content h3 {
+  margin: 26px 0 8px;
+  font-size: 18px;
+  font-weight: 650;
+}
+
+.doc-content p,
+.doc-content ul,
+.doc-content ol,
+.doc-content table,
+.doc-content pre {
+  margin: 0 0 16px;
+}
+
+.doc-content ul,
+.doc-content ol {
+  padding-left: 24px;
+}
+
+.doc-content ul {
+  list-style: disc;
+}
+
+.doc-content ol {
+  list-style: decimal;
+}
+
+.doc-content li {
+  margin: 4px 0;
+}
+
+.doc-content a {
+  color: var(--foreground);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--foreground) 34%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.doc-content a:hover {
+  text-decoration-color: var(--foreground);
+}
+
+.doc-content code {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--muted);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  padding: 2px 5px;
+}
+
+.doc-content pre {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--muted);
+  padding: 16px;
+}
+
+.doc-content pre code {
+  display: block;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  white-space: pre;
+}
+
+.dark .doc-content pre.shiki {
+  background-color: var(--shiki-dark-bg) !important;
+  color: var(--shiki-dark) !important;
+}
+
+.dark .doc-content pre.shiki span {
+  color: var(--shiki-dark) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .doc-content pre.shiki {
+    background-color: var(--shiki-dark-bg) !important;
+    color: var(--shiki-dark) !important;
+  }
+
+  .doc-content pre.shiki span {
+    color: var(--shiki-dark) !important;
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
+  }
+}
+
+.doc-content table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.doc-content th,
+.doc-content td {
+  border: 1px solid var(--border);
+  padding: 9px 11px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.doc-content th {
+  background: var(--muted);
+  font-weight: 650;
+}
+
+@media (min-width: 1180px) {
+  .doc-topbar {
+    width: auto;
+    display: grid;
+    grid-template-columns: 220px minmax(0, 880px) 220px;
+    column-gap: 36px;
+    justify-content: center;
+    padding: 32px 32px 0;
+  }
+
+  .doc-home-link {
+    grid-column: 1;
+  }
+
+  .doc-markdown-link {
+    grid-column: 3;
+    justify-self: end;
+  }
+
+  .doc-body {
+    width: auto;
+    display: grid;
+    grid-template-columns: 220px minmax(0, 880px) 220px;
+    column-gap: 36px;
+    justify-content: center;
+    padding: 0 32px;
+    margin-top: 52px;
+  }
+
+  .doc-sidebar {
+    position: sticky;
+    top: 32px;
+    display: block;
+    align-self: start;
+    padding-top: 4px;
+  }
+
+  .doc-sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+    margin-top: 0;
+  }
+
+  .doc-sidebar-link {
+    color: var(--muted-foreground);
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.4;
+    text-decoration: none;
+    text-underline-offset: 4px;
+  }
+
+  .doc-sidebar-link:hover {
+    color: var(--foreground);
+    text-decoration: underline;
+  }
+
+  .doc-sidebar-link.active {
+    color: var(--foreground);
+    font-weight: 650;
+  }
+
+  .doc-content {
+    grid-column: 2;
+  }
+}

--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -2,6 +2,10 @@
 
 @source "./**/*.{ts,tsx}";
 
+html {
+  scroll-behavior: smooth;
+}
+
 html,
 body,
 #root {
@@ -14,294 +18,205 @@ body {
   color: var(--foreground);
 }
 
-.docs-shell {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  padding: 112px 24px 24px;
-  text-align: center;
-}
-
-.docs-title {
-  margin: 0;
+/* Article prose — rendered from trusted repository markdown. */
+.prose {
   color: var(--foreground);
-  font-family: var(--font-sans);
-  font-size: 52px;
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1.1;
-}
-
-.docs-toc {
-  display: flex;
-  flex-direction: column;
-  gap: 11px;
-  margin-top: 40px;
-}
-
-.docs-link {
-  color: color-mix(in oklch, var(--foreground) 72%, var(--background));
-  font-size: 18px;
-  font-weight: 500;
-  line-height: 1.5;
-  text-decoration: none;
-  text-underline-offset: 4px;
-}
-
-.docs-link:hover {
-  color: var(--foreground);
-  text-decoration: underline;
-}
-
-.doc-layout {
-  min-height: 100vh;
-}
-
-.doc-topbar {
-  width: min(100% - 48px, 880px);
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding-top: 32px;
-}
-
-.doc-body {
-  width: min(100% - 48px, 880px);
-  margin: 0 auto;
-  padding: 52px 0 80px;
-}
-
-.doc-sidebar {
-  display: none;
-}
-
-.doc-home-link,
-.doc-markdown-link {
-  color: var(--muted-foreground);
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1.4;
-  text-decoration: none;
-}
-
-.doc-home-link:hover,
-.doc-markdown-link:hover {
-  color: var(--foreground);
-}
-
-.doc-content {
-  color: var(--foreground);
-  font-family: var(--font-sans);
   font-size: 16px;
-  line-height: 1.68;
+  line-height: 1.7;
 }
 
-.doc-content h1,
-.doc-content h2,
-.doc-content h3 {
+.prose :is(h1, h2, h3, h4)[id] {
+  scroll-margin-top: 80px;
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
   color: var(--foreground);
-  letter-spacing: 0;
-  line-height: 1.2;
+  letter-spacing: -0.011em;
+  line-height: 1.25;
 }
 
-.doc-content h1 {
-  margin: 0 0 24px;
-  font-size: 40px;
-  font-weight: 680;
+.prose h1 {
+  margin: 0 0 20px;
+  font-size: 36px;
+  font-weight: 700;
 }
 
-.doc-content h2 {
-  margin: 36px 0 12px;
-  padding-top: 4px;
+.prose h2 {
+  margin: 48px 0 16px;
   font-size: 24px;
   font-weight: 650;
 }
 
-.doc-content h3 {
-  margin: 26px 0 8px;
+.prose h3 {
+  margin: 32px 0 10px;
   font-size: 18px;
   font-weight: 650;
 }
 
-.doc-content p,
-.doc-content ul,
-.doc-content ol,
-.doc-content table,
-.doc-content pre {
-  margin: 0 0 16px;
+.prose h4 {
+  margin: 24px 0 8px;
+  font-size: 15px;
+  font-weight: 650;
 }
 
-.doc-content ul,
-.doc-content ol {
+.prose p,
+.prose ul,
+.prose ol,
+.prose table,
+.prose blockquote {
+  margin: 0 0 18px;
+}
+
+.prose ul,
+.prose ol {
   padding-left: 24px;
 }
 
-.doc-content ul {
+.prose ul {
   list-style: disc;
 }
 
-.doc-content ol {
+.prose ol {
   list-style: decimal;
 }
 
-.doc-content li {
-  margin: 4px 0;
+.prose li {
+  margin: 6px 0;
 }
 
-.doc-content a {
+.prose li::marker {
+  color: var(--muted-foreground);
+}
+
+.prose a {
   color: var(--foreground);
   font-weight: 500;
   text-decoration: underline;
-  text-decoration-color: color-mix(in oklch, var(--foreground) 34%, transparent);
+  text-decoration-color: color-mix(in oklch, var(--foreground) 28%, transparent);
   text-decoration-thickness: 1px;
-  text-underline-offset: 4px;
+  text-underline-offset: 3px;
 }
 
-.doc-content a:hover {
+.prose a:hover {
   text-decoration-color: var(--foreground);
 }
 
-.doc-content code {
-  border: 1px solid var(--border);
-  border-radius: 6px;
+.prose strong {
+  font-weight: 650;
+}
+
+.prose hr {
+  margin: 40px 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+
+.prose blockquote {
+  border-left: 3px solid var(--border);
+  padding-left: 16px;
+  color: var(--muted-foreground);
+}
+
+/* Inline code */
+.prose :not(pre) > code {
+  border-radius: 5px;
   background: var(--muted);
   color: var(--foreground);
   font-family: var(--font-mono);
-  font-size: 0.9em;
-  padding: 2px 5px;
+  font-size: 0.86em;
+  padding: 0.15em 0.4em;
 }
 
-.doc-content pre {
-  overflow-x: auto;
+/* Code block */
+.prose .code-block {
+  margin: 0 0 20px;
+  overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 12px;
   background: var(--muted);
-  padding: 16px;
 }
 
-.doc-content pre code {
-  display: block;
+.prose .code-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 10px 7px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.prose .code-lang {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+
+.prose .code-copy {
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  padding: 3px 8px;
+  transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.prose .code-copy:hover {
+  background: var(--accent);
+  color: var(--foreground);
+}
+
+.prose .code-block pre.shiki {
+  margin: 0;
+  overflow-x: auto;
   border: 0;
   border-radius: 0;
+  background: transparent !important;
+  padding: 16px;
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+
+.prose .code-block pre.shiki code {
+  display: block;
+  border: 0;
   background: transparent;
-  color: inherit;
+  font-family: var(--font-mono);
   padding: 0;
   white-space: pre;
 }
 
-.dark .doc-content pre.shiki {
-  background-color: var(--shiki-dark-bg) !important;
-  color: var(--shiki-dark) !important;
-}
-
-.dark .doc-content pre.shiki span {
+.dark .prose .code-block pre.shiki span {
   color: var(--shiki-dark) !important;
   font-style: var(--shiki-dark-font-style) !important;
   font-weight: var(--shiki-dark-font-weight) !important;
   text-decoration: var(--shiki-dark-text-decoration) !important;
 }
 
-@media (prefers-color-scheme: dark) {
-  .doc-content pre.shiki {
-    background-color: var(--shiki-dark-bg) !important;
-    color: var(--shiki-dark) !important;
-  }
-
-  .doc-content pre.shiki span {
-    color: var(--shiki-dark) !important;
-    font-style: var(--shiki-dark-font-style) !important;
-    font-weight: var(--shiki-dark-font-weight) !important;
-    text-decoration: var(--shiki-dark-text-decoration) !important;
-  }
-}
-
-.doc-content table {
+/* Tables */
+.prose table {
   width: 100%;
   border-collapse: collapse;
   font-size: 14px;
 }
 
-.doc-content th,
-.doc-content td {
+.prose th,
+.prose td {
   border: 1px solid var(--border);
-  padding: 9px 11px;
+  padding: 9px 12px;
   text-align: left;
   vertical-align: top;
 }
 
-.doc-content th {
+.prose th {
   background: var(--muted);
   font-weight: 650;
 }
 
-@media (min-width: 1180px) {
-  .doc-topbar {
-    width: auto;
-    display: grid;
-    grid-template-columns: 220px minmax(0, 880px) 220px;
-    column-gap: 36px;
-    justify-content: center;
-    padding: 32px 32px 0;
-  }
-
-  .doc-home-link {
-    grid-column: 1;
-  }
-
-  .doc-markdown-link {
-    grid-column: 3;
-    justify-self: end;
-  }
-
-  .doc-body {
-    width: auto;
-    display: grid;
-    grid-template-columns: 220px minmax(0, 880px) 220px;
-    column-gap: 36px;
-    justify-content: center;
-    padding: 0 32px;
-    margin-top: 52px;
-  }
-
-  .doc-sidebar {
-    position: sticky;
-    top: 32px;
-    display: block;
-    align-self: start;
-    padding-top: 4px;
-  }
-
-  .doc-sidebar-nav {
-    display: flex;
-    flex-direction: column;
-    gap: 9px;
-    margin-top: 0;
-  }
-
-  .doc-sidebar-link {
-    color: var(--muted-foreground);
-    font-size: 14px;
-    font-weight: 500;
-    line-height: 1.4;
-    text-decoration: none;
-    text-underline-offset: 4px;
-  }
-
-  .doc-sidebar-link:hover {
-    color: var(--foreground);
-    text-decoration: underline;
-  }
-
-  .doc-sidebar-link.active {
-    color: var(--foreground);
-    font-weight: 650;
-  }
-
-  .doc-content {
-    grid-column: 2;
-  }
+.prose img {
+  max-width: 100%;
+  border-radius: 12px;
 }

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,25 @@
         "typescript": "^5.7.0",
       },
     },
+    "apps/docs": {
+      "name": "@sixb/docs",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sixb/ui": "workspace:*",
+        "lucide-react": "^0.562.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/cli": "^4.2.2",
+        "@types/bun": "latest",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "shiki": "^4.1.0",
+        "tailwindcss": "^4.1.18",
+        "typescript": "^5.7.0",
+      },
+    },
     "auth/magic-link": {
       "name": "@sixb/auth-magic-link",
       "version": "0.1.0",
@@ -784,6 +803,22 @@
 
     "@redis/time-series": ["@redis/time-series@5.12.1", "", { "peerDependencies": { "@redis/client": "^5.12.1" } }, "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ=="],
 
+    "@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w=="],
+
+    "@shikijs/types": ["@shikijs/types@4.2.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "@sixb/action-worker": ["@sixb/action-worker@workspace:packages/action-worker"],
@@ -815,6 +850,8 @@
     "@sixb/connector-sql": ["@sixb/connector-sql@workspace:connectors/sql"],
 
     "@sixb/core": ["@sixb/core@workspace:packages/core"],
+
+    "@sixb/docs": ["@sixb/docs@workspace:apps/docs"],
 
     "@sixb/ducklake": ["@sixb/ducklake@workspace:storage/ducklake"],
 
@@ -918,7 +955,11 @@
 
     "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
@@ -927,6 +968,10 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/ssh2": ["@types/ssh2@1.15.5", "", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
     "@xyflow/react": ["@xyflow/react@12.10.2", "", { "dependencies": { "@xyflow/system": "0.0.76", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="],
 
@@ -964,7 +1009,13 @@
 
     "c12": ["c12@3.3.3", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^17.2.3", "exsolve": "^1.0.8", "giget": "^2.0.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -989,6 +1040,8 @@
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
     "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
@@ -1052,11 +1105,15 @@
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
@@ -1093,6 +1150,12 @@
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -1166,7 +1229,19 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
     "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -1198,6 +1273,10 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
@@ -1219,6 +1298,8 @@
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
 
@@ -1260,6 +1341,12 @@
 
     "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -1274,11 +1361,15 @@
 
     "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
+    "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
+
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "ssh2": ["ssh2@1.17.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
 
@@ -1287,6 +1378,8 @@
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -1308,6 +1401,8 @@
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
@@ -1322,11 +1417,25 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
 
@@ -1345,6 +1454,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,21 +1,70 @@
 # Get Started
 
-Build operational software around real-world systems. Sixb is a TypeScript framework for
-modeling your domain, syncing live data, and shipping workflows, APIs, and apps from one
+Sixb is a TypeScript framework for building operational software around real-world systems.
+
+Use it to model your domain, sync live data, and ship workflows, APIs, and apps from one
 shared runtime.
 
-## Concepts
+## Quickstart
 
-- [Ontology](./concepts/ontology.md)
-- [Dataset](./concepts/datasets.md)
-- [Pipeline](./concepts/pipeline.md)
-- [Projection](./concepts/projection.md)
-- [Connector](./concepts/connector.md)
-- [Sync](./concepts/sync.md)
-- [Rules](./concepts/rules.md)
-- [Workflow](./concepts/workflows.md)
+The fastest way to start is with `create-sixb`.
 
-## Coming next
+```bash
+bun create-sixb my-sixb-app
+cd my-sixb-app
+bun install
+bun run dev
+```
 
-- Server and client
-- Apps
+Then open the local development UI:
+
+```txt
+http://localhost:3000
+```
+
+The starter project runs locally and gives you a small working app to edit.
+
+## What gets created
+
+```txt
+my-sixb-app/
+  ontology/
+    counter.ts
+  actions/
+    reset.ts
+  functions/
+    tick.ts
+  app/
+    page.tsx
+  sixb.config.ts
+```
+
+The default project is small on purpose.
+
+| File or folder | What it is for |
+| --- | --- |
+| `sixb.config.ts` | Creates the Sixb runtime |
+| `ontology/` | Defines the objects in your domain |
+| `actions/` | Defines commands users or systems can request |
+| `functions/` | Runs scheduled or reactive logic |
+| `app/` | Contains the custom app UI |
+
+## How Sixb projects work
+
+A Sixb project is built from a few simple pieces:
+
+- define your domain with an [ontology](./concepts/ontology.md)
+- connect to external systems with [connectors](./concepts/connector.md)
+- write external data into [datasets](./concepts/datasets.md)
+- move data with [syncs](./concepts/sync.md)
+- clean or reshape data with [pipelines](./concepts/pipeline.md)
+- turn rows into app objects with [projections](./concepts/projection.md)
+- run business logic with [rules](./concepts/rules.md) and [workflows](./concepts/workflows.md)
+
+You do not need all of these on day one. Start with the pieces your app needs.
+
+## Next steps
+
+- Read [Ontology](./concepts/ontology.md) to understand how domain objects are modeled.
+- Read [Connector](./concepts/connector.md) when you are ready to connect an external system.
+- Read [Sync](./concepts/sync.md) when you want to move data into Sixb.

--- a/docs/concepts/connector.md
+++ b/docs/concepts/connector.md
@@ -1,151 +1,171 @@
 # Connector
 
-A connector gives Sixb access to an external system.
+A connector is Sixb's reusable connection to an external system.
 
-## What it does
+Most connectors should feel boring. Pick a connector package, give it config, and use the
+connected client from syncs, functions, or app code.
 
-- handles how Sixb connects: auth, config, transport, retries, lifecycle
-- returns a connected client from `connect()`
-- connects only when resolved with `sixb.connector(...)`
-- can clean up with `disconnect()`
+## When to use a connector
 
-## Parts
+Create a connector when your project needs to:
 
-| Piece | Role |
-| --- | --- |
-| adapter | Knows how to open and optionally close the connection |
-| definition | `defineConnector("erpDb", adapter)` |
-| runtime | Registers definitions, connects lazily, caches clients, runs cleanup |
-| client | The connected value returned by `connect()` |
+- read data from an external system
+- call a third-party API
+- reuse the same database or API client in multiple places
+- keep credentials and connection setup out of syncs, functions, and app code
 
-## Adapter shape
+Do not use a connector to describe data shape. Use a [dataset](./datasets.md) for tables and
+an [ontology](./ontology.md) for objects.
 
-```ts
-const adapter = {
-  type: "sql",
-  connect(context) {
-    return createClient(context)
-  },
-  disconnect(client) {
-    return client.close()
-  },
-}
-```
+## Start with a connector package
 
-`context` includes:
+For common systems, define the connector with a package.
 
-- `projectId`
-- `connectorId`
-- `signal`
-
-`disconnect(client)` is optional.
-
-## Define a connector
-
-File: `connectors/erpDb.ts`
+File: `connectors/erp-db.ts`
 
 ```ts
 import { defineConnector } from "@sixb/core"
+import { sql } from "@sixb/connector-sql"
 
-const adapter = {
-  type: "sql",
-  connect(context) {
-    return {
-      async query(sql: string) {
-        console.log(`[${context.projectId}:${context.connectorId}] ${sql}`)
-        return []
-      },
-    }
-  },
-}
-
-export const erpDb = defineConnector("erpDb", adapter)
+export const erpDb = defineConnector("erp-db", sql(process.env.DATABASE_URL!))
 ```
 
-`defineConnector()` names the adapter so the runtime can register and resolve it.
+That is the whole connector. Sixb now has one named place to get an ERP database client.
 
-## Common definition styles
+## Use it from a sync
 
-### Use an adapter package
+Syncs receive the connected client from `.from(...)`.
+
+```ts
+import { defineSync } from "@sixb/core"
+import { erpDb } from "../connectors/erp-db"
+import { rawOrdersDataset } from "../datasets/orders"
+
+export const syncOrders = defineSync("sync-orders")
+  .from(erpDb)
+  .read((db) => db`select * from orders`)
+  .intoDataset(rawOrdersDataset)
+```
+
+This keeps the sync focused on one job: read rows and write them into a dataset.
+
+## Another package example
+
+REST APIs work the same way.
+
+File: `connectors/billing-api.ts`
 
 ```ts
 import { defineConnector } from "@sixb/core"
 import { rest } from "@sixb/connector-rest"
-import { sql } from "@sixb/connector-sql"
 
 export const billingApi = defineConnector(
-  "billingApi",
-  rest({ baseUrl: "https://api.example.com" })
-)
-
-export const erpDb = defineConnector(
-  "erpDb",
-  sql(process.env.DATABASE_URL!)
+  "billing-api",
+  rest({
+    baseUrl: "https://api.example.com",
+    headers: {
+      authorization: `Bearer ${process.env.BILLING_API_TOKEN}`,
+    },
+  })
 )
 ```
 
-### Define a custom adapter in the project
+Use package connectors when they already match what you need.
 
-Use this when the connection needs project-specific auth, headers, client setup, or
-protocol behavior.
+## Custom connectors
+
+When there is no package for your system, define the connection yourself.
 
 ```ts
 import { defineConnector } from "@sixb/core"
+import { createScannerClient } from "../lib/scanner"
 
-export const billingApi = defineConnector("billingApi", {
-  type: "rest",
-  connect({ signal }) {
-    return createBillingClient({ signal })
+export const warehouseScanner = defineConnector("warehouse-scanner", {
+  type: "scanner",
+  connect() {
+    return createScannerClient()
   },
 })
 ```
 
-## Convention
+A custom connector can return any client shape. Keep that client small and tailored to the
+calls your project actually makes.
 
-Export connector definitions from `connectors/`:
-
-```txt
-your-project/
-  connectors/
-    billingApi.ts
-    erpDb.ts
-  sixb.config.ts
-```
-
-`createSixb()` scans `connectors/` and registers exported connector definitions
-automatically.
-
-You can also register connectors explicitly with `createSixb({ connectors: [erpDb] })`.
-
-## Resolve a connector
-
-File: `lib/loadOrders.ts`
+Add `disconnect(...)` only when the client needs cleanup.
 
 ```ts
-import { erpDb } from "../connectors/erpDb"
+export const warehouseScanner = defineConnector("warehouse-scanner", {
+  type: "scanner",
+  connect() {
+    return createScannerClient()
+  },
+  disconnect(client) {
+    return client.close()
+  },
+})
+```
+
+## Use a connector directly
+
+You can also resolve a connector from the Sixb runtime.
+
+```ts
+import { erpDb } from "../connectors/erp-db"
 import { sixb } from "../sixb.config"
 
 export async function loadOrders() {
   const runtime = await sixb
   const db = await runtime.connector(erpDb)
-  return db.query("select * from orders")
+
+  return db`select * from orders`
 }
 ```
 
-The first call runs `connect(context)`. Later calls reuse the same client for that
-runtime.
+The first call opens the connection. Later calls reuse the same client for that runtime.
 
-## Lifecycle
+## Convention
 
-1. Define an adapter.
-2. Wrap it with `defineConnector(id, adapter)`.
-3. Register it explicitly or export it from `connectors/`.
-4. Resolve it with `sixb.connector(definition)`.
-5. Sixb caches the connected client.
-6. `sixb.disconnectConnectors()` calls `disconnect(client)` if present.
+Put connector definitions in `connectors/` and export them.
 
-## Guidelines
+```txt
+your-project/
+  connectors/
+    erp-db.ts
+    billing-api.ts
+  datasets/
+    orders.ts
+  syncs/
+    orders.ts
+  sixb.config.ts
+```
 
-- Keep the connector focused on connection setup.
-- Return a small client by default.
-- Add a separate service layer only if it makes project code clearer.
+`createSixb()` discovers exported connector definitions from `connectors/` automatically.
+
+You can also register connectors explicitly:
+
+```ts
+import { createSixb } from "@sixb/core"
+import { erpDb } from "./connectors/erp-db"
+
+export const sixb = createSixb({
+  connectors: [erpDb],
+})
+```
+
+## Core principles
+
+- Start with a connector package.
+- Keep one connector focused on one external system.
+- Keep credentials and connection setup inside the connector.
+- Keep data mapping in syncs, pipelines, or projections.
+- Move to a custom connector when the external system needs special behavior.
+
+## Where connectors fit
+
+| Need | Use |
+| --- | --- |
+| Talk to an external system | Connector |
+| Store rows from that system | Dataset |
+| Move external data into Sixb | Sync |
+| Transform rows into cleaner rows | Pipeline |
+| Turn rows into objects for apps | Projection |

--- a/docs/concepts/datasets.md
+++ b/docs/concepts/datasets.md
@@ -1,50 +1,34 @@
 # Dataset
 
-A dataset is Sixb's definition for a table of rows.
+A dataset is a typed table of rows.
 
-It gives a table a stable id, a required schema, and optional metadata such as partitioning
-and description.
+Datasets are where Sixb stores table-shaped data: raw rows from external systems, cleaned
+rows from pipelines, and rows that projections can turn into app objects.
 
-Syncs write datasets. Pipelines read datasets and produce new datasets. Storage versions a
-dataset's contents over time.
+## Why it is useful
 
-If ontology types are Sixb's model for objects, datasets are Sixb's model for tables and rows.
+A dataset gives table data a stable contract.
 
-## What It Is
+That contract says:
 
-A dataset is the contract for one table.
+- what the dataset is called
+- which columns exist
+- what type each column has
+- which columns can be missing or `null`
 
-That contract includes:
+Once a dataset is defined, syncs, pipelines, projections, and storage can all point at the
+same shape.
 
-- a stable id
-- a required schema
-- optional partitioning
-- an optional description
+## Core terms
 
-The important idea is that you define this contract once, then reuse it everywhere that table
-appears.
-
-In Sixb, datasets are always schema-first. A dataset is not just "some rows with a name". It
-is a named table with an explicit shape, and there is no schemaless dataset write path.
-
-## What It Gives You
-
-- one place to define a table's shape
-- one shared definition that syncs, pipelines, and storage can all reference
-- row validation before data is committed
-- versioned dataset contents over time
-
-## Parts
-
-| Piece | Role |
+| Concept | Meaning |
 | --- | --- |
-| `defineDataset` | Creates a runtime dataset definition |
-| `col` | Declares one dataset column |
-| `schema` | Lists allowed columns, types, and nullability |
-| `partitionBy` | Declares logical partition columns |
-| `description` | Adds human-readable context |
-| runtime registry | Registers datasets and resolves them by id |
-| lake storage | Materializes dataset definitions and versions writes |
+| Dataset | A named table contract |
+| Column | One typed field in each row |
+| Row | One record written to the dataset |
+| Version | One committed set of rows |
+
+If an [ontology](./ontology.md) is your app's object model, a dataset is your table model.
 
 ## Define a dataset
 
@@ -55,53 +39,87 @@ import { col, defineDataset } from "@sixb/core"
 
 export const rawOrdersDataset = defineDataset("raw.erp.orders", {
   schema: [
-    col("orderId", "string"),
-    col("customerId", "string", { nullable: true }),
-    col("total", "float64", { nullable: true }),
-    col("createdAt", "timestamp", { nullable: true }),
-    col("raw", "json", { nullable: true }),
+    col("order_id", "string"),
+    col("customer_id", "string"),
+    col("total", "decimal", { nullable: true }),
+    col("created_at", "timestamp"),
   ],
-  partitionBy: ["createdAt"],
-  description: "Raw ERP order rows",
+  description: "Raw order rows from the ERP.",
 })
 ```
 
-This defines one reusable dataset contract. Anything that writes to `raw.erp.orders` should use
-this same definition.
+This defines one reusable table shape.
 
-Every dataset must declare a schema. There is no schemaless dataset write path.
+The dataset id, `raw.erp.orders`, is the stable name other parts of the project use.
 
-## Derive a dataset schema
+## Use a dataset from a sync
 
-When a pipeline output keeps the same shape as an input dataset, or only narrows it to a known
-set of columns, derive the output schema from the parent dataset instead of restating every
-column:
+Syncs read from a connector and write into one dataset.
 
 ```ts
-import { col, defineDataset } from "@sixb/core"
-import { rawProjectsDataset } from "./projects"
+import { defineSync } from "@sixb/core"
+import { erpDb } from "../connectors/erp-db"
+import { rawOrdersDataset } from "../datasets/orders"
 
-export const activeProjectsDataset = defineDataset("erp.active_projects").derive(
-  rawProjectsDataset
-)
-
-export const projectSummariesDataset = defineDataset("erp.project_summaries").derive(
-  rawProjectsDataset,
-  {
-    pick: ["project_id", "project_name", "status", "budget_amount"],
-    add: [col("priority", "int64")],
-  }
-)
+export const syncOrders = defineSync("sync-orders")
+  .from(erpDb)
+  .read((db) => db`select * from orders`)
+  .intoDataset(rawOrdersDataset)
 ```
 
-`pick` columns must exist on the parent dataset. TypeScript catches typos for literal parent
-datasets, and runtime validation catches invalid dynamic values. `derive(...)` only derives the
-schema; set `partitionBy` and `description` explicitly when the child dataset needs its own
-metadata.
+The sync does not need to repeat the table shape. It references the dataset definition.
+
+## Use a dataset from a pipeline
+
+Pipelines read datasets and write new datasets.
+
+```ts
+import { col, datasetUpdated, defineDataset, definePipeline, definePipelineStep } from "@sixb/core"
+import { rawOrdersDataset } from "../datasets/orders"
+
+export const ordersDataset = defineDataset("orders", {
+  schema: [
+    col("id", "string"),
+    col("customer_id", "string"),
+    col("total", "decimal", { nullable: true }),
+  ],
+})
+
+export const cleanOrdersStep = definePipelineStep("clean-orders")
+  .inputs({ rawOrders: rawOrdersDataset })
+  .output(ordersDataset)
+  .sql(({ rawOrders }) => `
+    select
+      order_id as id,
+      customer_id,
+      total
+    from ${rawOrders}
+  `)
+
+export const ordersPipeline = definePipeline("orders")
+  .when(datasetUpdated(rawOrdersDataset.id))
+  .then(cleanOrdersStep)
+```
+
+This keeps raw source data separate from cleaner app-ready table data.
+
+## Dataset vs ontology
+
+Datasets and ontology types solve different problems.
+
+| Use | Choose |
+| --- | --- |
+| Raw source rows | Dataset |
+| Cleaned table rows | Dataset |
+| App objects users interact with | Ontology |
+| Relationships between objects | Ontology links |
+
+Usually, source data lands in a raw dataset, pipelines shape it into a clean dataset, and
+projections turn it into ontology objects.
 
 ## Column types
 
-Supported dataset column types:
+Common column types:
 
 - `string`
 - `boolean`
@@ -113,150 +131,68 @@ Supported dataset column types:
 - `json`
 - `fileRef`
 
-Use `nullable: true` when a column may be `null` or omitted.
+Use `nullable: true` when a column may be missing or `null`.
 
-## Use datasets from syncs
-
-```ts
-import { defineSync } from "@sixb/core"
-import { erpDb } from "../connectors/erpDb"
-import { rawOrdersDataset } from "../datasets/orders"
-
-export const syncOrders = defineSync("sync-orders")
-  .from(erpDb)
-  .read(({ query }) => query("select * from orders"))
-  .intoDataset(rawOrdersDataset)
-```
-
-Syncs reference the dataset definition directly, so the worker can materialize and validate
-against the same schema.
-
-## Use datasets from pipelines
-
-```ts
-import { col, datasetUpdated, defineDataset, definePipeline, definePipelineStep } from "@sixb/core"
-import { rawOrdersDataset } from "../datasets/orders"
-
-export const canonicalOrdersDataset = defineDataset("canonical.orders", {
-  schema: [
-    col("id", "string"),
-    col("customerId", "string"),
-    col("total", "float64", { nullable: true }),
-  ],
-})
-
-export const normalizeOrdersStep = definePipelineStep("normalize-orders")
-  .inputs({ rawOrders: rawOrdersDataset })
-  .output(canonicalOrdersDataset)
-  .run(async ({ inputs, output }) => {
-    async function* rows() {
-      for await (const order of inputs.rawOrders.readRows()) {
-        yield {
-          id: order.orderId,
-          customerId: order.customerId,
-          total: order.total,
-        }
-      }
-    }
-
-    await output.writeRows(rows())
-  })
-
-export const normalizeOrders = definePipeline("normalize-orders")
-  .when(datasetUpdated(rawOrdersDataset.id))
-  .then(normalizeOrdersStep)
-```
-
-## Convention
-
-Export dataset definitions from `datasets/`:
-
-```txt
-your-project/
-  datasets/
-    orders.ts
-    orderEvents.ts
-  syncs/
-    syncOrders.ts
-  pipelines/
-    normalizeOrders.ts
-  sixb.config.ts
-```
-
-`createSixb()` scans `datasets/` and registers exported dataset definitions automatically.
-
-You can also register them explicitly with:
-
-```ts
-createSixb({
-  datasets: [rawOrdersDataset],
-  // ...
-})
-```
-
-## Runtime lookups
-
-Sixb exposes dataset definitions through the runtime:
-
-```ts
-sixb.getDatasetDefinitions()
-sixb.getDatasetById("raw.erp.orders")
-```
-
-Startup rejects:
-
-- duplicate dataset ids
-- datasets without schemas
-- syncs that target unknown datasets
-- pipelines that reference unknown datasets
-
-## Validation rules
-
-Rows are validated against the dataset schema before commit.
-
-Rules:
-
-- every non-nullable column must be present
-- `null` is allowed only for nullable columns
-- every value must match the declared column type
-- unknown columns are rejected
-
-If you want to keep raw source payloads, declare them explicitly:
+Use `json` when the source payload is intentionally unstructured:
 
 ```ts
 col("raw", "json", { nullable: true })
 ```
 
-## Lake behavior
+## Convention
 
-When a worker writes to a dataset:
+Put dataset definitions in `datasets/` and export them.
 
-1. it resolves the registered dataset definition
-2. it calls `lakeStorage.createDataset(dataset)`
-3. it opens a write with `beginWrite({ dataset, ... })`
-4. it validates rows against `dataset.schema`
-5. it commits a new dataset version
+```txt
+your-project/
+  datasets/
+    orders.ts
+    customers.ts
+  syncs/
+    orders.ts
+  pipelines/
+    orders.ts
+  sixb.config.ts
+```
 
-`createDataset(...)` is idempotent. It does not only create a brand-new dataset. It also lets
-lake storage check whether the dataset definition declared by the current runtime still matches
-the definition already known by that storage provider.
+`createSixb()` discovers exported dataset definitions from `datasets/` automatically.
 
-That comparison is between two dataset definitions:
+You can also register datasets explicitly:
 
-- the persisted definition: the definition storage already knows about
-- the runtime definition: the definition currently declared in code
+```ts
+import { createSixb } from "@sixb/core"
+import { rawOrdersDataset } from "./datasets/orders"
 
-Most providers reject incompatible definition changes. Some durable providers may apply a small
-safe subset of schema or metadata changes, such as adding nullable columns, and then expose that
-definition-only change as a dataset version.
+export const sixb = createSixb({
+  datasets: [rawOrdersDataset],
+})
+```
 
-This is separate from dataset content versioning. A `DatasetVersion` represents committed rows
-at a point in time.
+## How to model datasets
 
-## Guidelines
+Start with the source shape.
 
-- Define datasets once and reuse them everywhere.
-- Keep raw and canonical datasets separate.
-- Be explicit about nullable fields from external systems.
-- Use `json` only when the payload is intentionally unstructured.
-- Treat `partitionBy` as part of the dataset contract, not per-sync behavior.
+1. Define a raw dataset for data coming from an external system.
+2. Keep source column names if that makes debugging easier.
+3. Mark uncertain fields as nullable.
+4. Add a `json` column only when you intentionally want to keep the raw payload.
+5. Create cleaner datasets later with pipelines.
+
+Good dataset names usually describe the layer and source:
+
+- `raw.erp.orders`
+- `raw.stripe.invoices`
+- `orders`
+- `customer_activity`
+
+## Extra details
+
+- `partitionBy` declares logical partition columns.
+- `defineDataset("next").derive(parent)` copies a parent schema.
+- `derive(parent, { pick, add })` narrows or extends a parent schema.
+- rows are validated against the schema before commit.
+- each successful write commits a new dataset version.
+- durable lake storage providers may reject incompatible schema changes.
+
+The important first step is to define the table shape once and reuse that definition wherever
+the table appears.

--- a/docs/concepts/ontology.md
+++ b/docs/concepts/ontology.md
@@ -1,420 +1,222 @@
 # Ontology
 
-An ontology describes the types of objects in your domain, their properties, relationships,
-and actions.
+An ontology is your app's object model.
 
+It defines the real things your software cares about, such as customers, orders, invoices,
+devices, buildings, rooms, projects, or tasks. Each object type declares the properties it has
+and the relationships it can make to other object types.
 
-## What it is
+## Why it is useful
 
-- a schema for the twin graph: what kinds of objects exist, what they hold, and how they
-  connect
-- built from object types, properties, links, and actions
-- each object type has one primary property that uniquely identifies instances
-- types can inherit from other types
-- types can reference reusable value types for shared schemas
-- registered at startup, validated, and used by the runtime for CRUD, telemetry, and
-  projection
+An ontology gives your project a shared language.
 
+Instead of passing around loose JSON, you define the important objects once and use those
+definitions everywhere:
 
-## Building blocks
+- app screens know what properties exist
+- workflows can request actions against real objects
+- projections can turn rows into objects
+- TypeScript can catch property and relationship mistakes
+- Sixb can validate writes before they become app state
 
-| Piece | Role |
+Use an ontology for the objects people interact with. Use [datasets](./datasets.md) for raw
+rows and table-shaped data.
+
+## Core terms
+
+| Concept | Meaning |
 | --- | --- |
-| ObjectType | A real-world entity, asset, or concept |
-| Property | An attribute on an object type (name, schema, mode) |
-| ObjectLink | A directional relationship from one object type to another |
-| Action | A command that can be dispatched against an object instance |
-| ValueType | A reusable named schema shared across properties |
-| Interface | A reusable contract of properties, links, and actions |
+| Object type | A kind of thing, like `Customer` or `Order` |
+| Object | One instance of that type, like customer `cust-001` |
+| Property | A value on the object, like `name`, `email`, or `status` |
+| Link | A relationship to another object, like a customer belonging to an organization |
+| Telemetry | A property value that changes over time, like temperature or monthly spend |
 
+Most ontologies start as nouns and relationships from your domain.
 
 ## Define an object type
 
 File: `ontology/customer.ts`
 
 ```ts
-import { defineObjectType, prop, link, stringEnum } from "@sixb/core"
+import { defineObjectType, prop, stringEnum } from "@sixb/core"
+
+export const Customer = defineObjectType({
+  id: "Customer",
+  name: "Customer",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+    prop("email", "string"),
+    prop("tier", stringEnum(["free", "team", "enterprise"])),
+    prop("monthlySpend", "double", {
+      mode: "telemetry",
+      semanticType: "Currency",
+    }),
+  ],
+})
+```
+
+This creates one object type: `Customer`.
+
+The `id` property is the primary property. It uniquely identifies each customer.
+
+## Properties
+
+Properties describe what an object knows.
+
+```ts
+prop("name", "string", { required: true })
+prop("tier", stringEnum(["free", "team", "enterprise"]))
+prop("monthlySpend", "double", { mode: "telemetry", semanticType: "Currency" })
+```
+
+There are two common property styles:
+
+| Style | Use it for |
+| --- | --- |
+| Static property | Facts that are stored on the object, like `name` or `email` |
+| Telemetry property | Values that change over time, like `temperature` or `monthlySpend` |
+
+Start with static properties. Add telemetry only when you care about the history of a value.
+
+## Links
+
+Links describe how objects relate to each other.
+
+File: `ontology/organization.ts`
+
+```ts
+import { defineObjectType, prop } from "@sixb/core"
+
+export const Organization = defineObjectType({
+  id: "Organization",
+  name: "Organization",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+  ],
+})
+```
+
+Then link customers to organizations:
+
+```ts
+import { defineObjectType, link, prop } from "@sixb/core"
 import { Organization } from "./organization"
 
 export const Customer = defineObjectType({
   id: "Customer",
   name: "Customer",
-  description: "A customer account in the system.",
   properties: [
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
-    prop("email", "string"),
-    prop("tier", stringEnum(["free", "starter", "business", "enterprise"])),
-    prop("monthlySpend", "double", { mode: "telemetry", semanticType: "Currency" }),
   ],
-  links: [
-    link("belongsTo", Organization, { cardinality: "one" }),
-    link("hasOrders", "Order"),
-  ],
+  links: [link("belongsTo", Organization, { cardinality: "one" })],
 })
 ```
 
-`defineObjectType()` returns the type definition plus typed tokens for properties and links:
-`Customer.p.name`, `Customer.p.monthlySpend`, `Customer.l.belongsTo`, etc.
+Use links for relationships your app needs to navigate or query.
 
+## Use objects from code
 
-## Properties
-
-A property is an attribute on an object type.
+Once an object type is registered, use `sixb.objects(Type)`.
 
 ```ts
-prop("name", "string", { required: true })
-prop("monthlySpend", "double", { mode: "telemetry", semanticType: "Currency" })
-prop("id", "string", { required: true, primary: true })
-```
+import { Customer } from "./ontology/customer"
 
-### Schemas
+const customers = sixb.objects(Customer)
 
-Sixb supports several schema types for property values:
-
-| Schema | Example |
-| --- | --- |
-| Primitive | `"string"`, `"integer"`, `"double"`, `"boolean"`, `"date"`, `"timestamp"`, `"uuid"`, `"fileRef"` |
-| Enum | `stringEnum(["draft", "confirmed", "shipped"])`, `integerEnum([1, 2, 3])` |
-| Object | `{ type: "object", properties: { amount: { schema: "double", required: true } } }` |
-| Array | `{ type: "array", items: "string" }` |
-| Map | `{ type: "map", keySchema: "string", valueSchema: "double" }` |
-| ValueType ref | `valueTypeRef(Money)` |
-
-Use `"fileRef"` for blob-backed documents, images, and attachments:
-
-```ts
-prop("pdf", "fileRef", { nullable: true })
-```
-
-Object upserts store only the `FileRef` metadata. Upload and download bytes through
-`sixb.blobStorage`; `fileRef` properties cannot use `mode: "telemetry"`.
-
-### Property mode
-
-Properties have a mode that determines their runtime behavior:
-
-| Mode | Behavior |
-| --- | --- |
-| `"static"` (default) | Stored as part of the object record. Rarely changes. |
-| `"telemetry"` | Appended to a time-series store. The object record holds only the latest value. |
-
-### Semantic type
-
-Numeric properties can declare a `semanticType` such as `"Currency"` or `"Weight"`. This
-constrains which units are valid when appending telemetry values, for example `USD`
-for a Currency property.
-
-
-## Primary property
-
-Every object type must declare exactly one property as `primary: true`. This property
-uniquely identifies object instances within that type and serves as the runtime key.
-
-```ts
-prop("id", "string", { required: true, primary: true })
-```
-
-Rules enforced at startup:
-
-- exactly one primary property per type (after inheritance)
-- the primary property must be `required: true`
-- the primary property must have a `"string"` schema
-
-When you upsert an object, the primary property value is extracted automatically from the
-properties you provide. There is no separate `key` parameter:
-
-```ts
-await sixb.objects(Customer).upsert({
-  properties: { id: "cust-001", name: "Acme Corp" },
-})
-// customer.id === "cust-001" (the primary value)
-```
-
-Retrieval uses the primary value directly:
-
-```ts
-const customer = await sixb.objects(Customer).get("cust-001")
-```
-
-
-## Links
-
-A link is a directional relationship from one object type to another.
-
-```ts
-// Single target type (ObjectType reference)
-link("belongsTo", Organization, { cardinality: "one" })
-
-// Multiple target types
-link("payments", [CreditCard, BankAccount])
-
-// String target (for circular references or external types)
-link("hasOrders", "Order")
-
-// Wildcard (any target type)
-link("assignedTo")
-```
-
-| Option | Values | Default |
-| --- | --- | --- |
-| `cardinality` | `"one"`, `"many"` | `"many"` |
-| `properties` | `Property[]` | none |
-
-Links can carry metadata via `properties`:
-
-```ts
-link("placedBy", Customer, {
-  cardinality: "one",
-  properties: [
-    prop("placedAt", "timestamp", { required: true }),
-    prop("channel", "string"),
-  ],
-})
-```
-
-Passing an ObjectType object directly (instead of a string id) gives compile-time type safety.
-String targets are still supported for cases like circular module dependencies.
-
-Wildcard links (`link("rel")`) accept any target object type at runtime. Polymorphic links
-(array of targets) accept any of the listed types plus their subtypes.
-
-
-## Actions
-
-An action models a command that can be dispatched against an object instance, such as issuing
-a credit or cancelling an order.
-
-```ts
-import { actionParam, defineAction } from "@sixb/core"
-import { Customer } from "../ontology/customer"
-
-export const issueCredit = defineAction("issueCredit")
-  .target(Customer)
-  .params({
-    amount: actionParam("double", { required: true, semanticType: "Currency" }),
-  })
-  .run(async ({ params, target, sixb }) => {
-    const billing = await sixb.connector(billingConnector)
-    await billing.issueCredit(target.primaryId, params.amount)
-  })
-```
-
-Actions define the contract, validation, and handler together. `requestAction(...)`
-validates the action id, parameter shape, and target object, then emits `action.requested`.
-The V1 definition layer captures handlers but does not execute them.
-
-
-## Value types
-
-A value type is a reusable named schema shared across properties. Use it when multiple
-properties need the same structure.
-
-```ts
-import { defineValueType } from "@sixb/core"
-
-export const Money = defineValueType({
-  id: "money",
-  name: "Money",
-  schema: "double",
-  semanticType: "Currency",
-})
-```
-
-Reference it from properties:
-
-```ts
-prop("monthlySpend", valueTypeRef(Money), { mode: "telemetry" })
-```
-
-
-## Inheritance
-
-Object types can extend a parent type. The child inherits all properties, links, and actions
-from the parent.
-
-```ts
-const Product = defineObjectType({
-  id: "Product",
-  name: "Product",
-  properties: [
-    prop("id", "string", { required: true, primary: true }),
-    prop("name", "string"),
-  ],
+await customers.upsert({
+  properties: {
+    id: "cust-001",
+    name: "Acme Corp",
+    email: "team@acme.example",
+    tier: "enterprise",
+  },
 })
 
-const DigitalProduct = defineObjectType({
-  extends: Product,
-  id: "DigitalProduct",
-  name: "Digital Product",
-  properties: [prop("fileSize", "double")],
-})
-
-const Subscription = defineObjectType({
-  extends: DigitalProduct,
-  id: "Subscription",
-  name: "Subscription",
-  properties: [prop("billingCycle", "string")],
-})
-
-// Subscription has: id (from Product), name (from Product), fileSize (from DigitalProduct), billingCycle
-// Subscription.p.name, Subscription.p.fileSize, Subscription.p.billingCycle all work
+const customer = await customers.get("cust-001")
 ```
 
-Rules:
+TypeScript understands the properties from your ontology. If you mistype `tier` or pass a value
+outside the enum, you get feedback while writing code.
 
-- only root types (no `extends`) define the primary property; children inherit it
-- a child can override a parent property by declaring one with the same id
-- circular extends chains are detected and rejected at startup
-- link targets accept subtypes: a link targeting `Product` accepts `Subscription` at runtime
+## Use telemetry
 
-### Multi-parent classification
-
-For ontologies where a type belongs to multiple parent categories (e.g., Brick `rdfs:subClassOf`
-with multiple parents), use `parents`:
+Telemetry stores a value over time.
 
 ```ts
-const GiftCard = defineObjectType({
-  extends: DigitalProduct,
-  id: "GiftCard",
-  name: "Gift Card",
-  parents: ["PaymentMethod"],
-  properties: [],
-})
-// GiftCard.parents === ["DigitalProduct", "PaymentMethod"]
-```
-
-`extends` determines structural inheritance (property merge). `parents` records additional
-classification for subtype queries.
-
-
-## Type tokens
-
-`defineObjectType()` returns an object with typed token maps:
-
-- `Customer.p` — property tokens keyed by property id
-- `Customer.l` — link tokens keyed by link id
-
-Tokens carry type information about the object type, property, or link they refer to. They are
-used throughout the Sixb API for type-safe operations:
-
-```ts
-// Telemetry with compile-time unit checking
 await sixb.objects(Customer).byId("cust-001").telemetry(Customer.p.monthlySpend).append({
-  value: 1250.00,
+  value: 1250,
   unit: "USD",
+  at: new Date(),
 })
+```
 
-// Linking with type-safe tokens
+Use telemetry for changing measurements, readings, counters, or values where history matters.
+
+## Use links
+
+Create relationships with typed link tokens.
+
+```ts
 await sixb.objects(Customer).byId("cust-001").link(Customer.l.belongsTo, {
   objectTypeId: "Organization",
-  primaryId: "org-1",
-})
-
-// Used in projections
-fromForeignKey({
-  link: Customer.l.belongsTo,
-  sourceProperty: Customer.p.organizationRef,
-  target: Organization,
+  primaryId: "org-001",
 })
 ```
 
+The link token comes from the object type: `Customer.l.belongsTo`.
 
 ## Convention
 
-Export object type definitions from `ontology/`:
+Put object types in `ontology/` and export them.
 
 ```txt
 your-project/
   ontology/
-    organization.ts
     customer.ts
+    organization.ts
     order.ts
   sixb.config.ts
 ```
 
-`createSixb()` scans `ontology/` and registers exported object types and value types
-automatically.
+`createSixb()` discovers exported object types from `ontology/` automatically.
 
-You can also register types explicitly with `createSixb({ ontology: [Customer, Organization] })`.
-
-
-## Typed API
-
-Once registered, access objects through the typed API:
+You can also register object types explicitly:
 
 ```ts
-const customers = sixb.objects(Customer)
+import { createSixb } from "@sixb/core"
+import { Customer } from "./ontology/customer"
+import { Organization } from "./ontology/organization"
 
-// Create or update
-const customer = await customers.upsert({
-  properties: { id: "cust-001", name: "Acme Corp", tier: "business" },
-})
-
-// Read
-const found = await customers.get("cust-001")
-
-// List with filters
-const results = await customers.list({
-  where: (c) => c.p.tier.eq("enterprise"),
-  limit: 10,
-})
-
-// Telemetry
-await customers.byId("cust-001").telemetry(Customer.p.monthlySpend).append({
-  value: 1250.00,
-  unit: "USD",
-  at: new Date(),
-})
-
-// Batch telemetry
-await customers.appendTelemetryBatch([
-  { id: "cust-001", properties: { monthlySpend: { value: 1250.00, unit: "USD" } } },
-  { id: "cust-002", properties: { monthlySpend: { value: 890.50, unit: "USD" } } },
-])
-
-// Links
-await customers.byId("cust-001").link(Customer.l.belongsTo, {
-  objectTypeId: "Organization",
-  primaryId: "org-1",
-})
-
-// Actions
-await customers.byId("cust-001").requestAction({
-  actionId: "issueCredit",
-  params: { amount: { value: 500.00, unit: "USD" } },
+export const sixb = createSixb({
+  ontology: [Customer, Organization],
 })
 ```
 
+## How to model your domain
 
-## Events
+Start small.
 
-All write operations emit typed events through the events runtime:
+1. Pick one object your app cares about.
+2. Give it an `id` primary property.
+3. Add the properties users need to see or workflows need to use.
+4. Add links only for relationships that matter in the app.
+5. Add telemetry only for values where history matters.
 
-| Event | Trigger |
-| --- | --- |
-| `object.upserted` | Object created or updated |
-| `telemetry.appended` | Telemetry value appended |
-| `link.upserted` | Link created or updated |
-| `link.removed` | Link removed |
-| `action.requested` | Action dispatched |
+Good object types are business-readable. `Customer`, `Invoice`, `Device`, `Room`, and `Task`
+are usually better starting points than implementation names.
 
+## Extra details
 
-## Lifecycle
+- `stringEnum(...)` and `integerEnum(...)` constrain allowed values.
+- `semanticType` adds unit-aware numeric values like currency or temperature.
+- `valueTypeRef(...)` reuses the same value shape across properties.
+- `extends` lets one object type inherit properties and links from another.
+- `fileRef` stores references to documents, images, and other blobs.
+- actions live in `actions/` and target ontology objects when users can request commands.
 
-1. Define object types with `defineObjectType()`, using `prop()` and `link()`.
-2. Optionally define value types with `defineValueType()`.
-3. Define actions with `defineAction()` in `actions/` or pass them to `createSixb()`.
-4. Export definitions from `ontology/` or pass them to `createSixb()`.
-5. Sixb validates types at startup: primaries, extends chains, link targets, action targets.
-6. Use `sixb.objects(Type)` for typed CRUD, telemetry, links, and action requests.
-
-
-## Guidelines
-
-- Define one primary property per type using `prop("id", "string", { required: true, primary: true })`.
-- Use `link()` with ObjectType references instead of string ids when possible.
-- Use `mode: "telemetry"` for time-varying measurements, `"static"` for facts.
-- Keep type definitions declarative. Avoid indirection around ontology setup.
-- Use `semanticType` on numeric properties to constrain valid units.
-- Place common properties in a parent type and use `extends` for sharing.
+The important first step is to define the objects your app is about. Everything else can grow
+from there.

--- a/docs/concepts/ontology.md
+++ b/docs/concepts/ontology.md
@@ -71,6 +71,54 @@ prop("tier", stringEnum(["free", "team", "enterprise"]))
 prop("monthlySpend", "double", { mode: "telemetry", semanticType: "Currency" })
 ```
 
+`prop(...)` takes these parameters:
+
+| Parameter | Required | Expected |
+| --- | --- | --- |
+| `id` | Yes | A stable property key, unique within the object type |
+| `schema` | Yes | A `Schema` value that describes which values the property accepts |
+| `options` | No | An object for metadata and behavior |
+
+`options` accepts these fields:
+
+| Option | Expected | Meaning |
+| --- | --- | --- |
+| `name` | `string` | Display name. Defaults to the property `id`. |
+| `description` | `string` | Human-readable context for the property. |
+| `required` | `boolean` | The property must be present when writing an object. |
+| `nullable` | `boolean` | The property may be set to `null`. |
+| `primary` | `true` | Marks the property as the object identifier. |
+| `mode` | `"static"` or `"telemetry"` | Controls how the value is stored over time. |
+| `semanticType` | Quantitative type id | Declares the unit family for numeric values. |
+
+When omitted, `mode` is `"static"`: the value is stored as a fact on the object record.
+Use `mode: "telemetry"` for time-varying measurements, readings, or counters. Telemetry
+values are appended over time, and the object record keeps the latest value.
+
+Each object type must have exactly one primary property. The primary property must use
+`{ required: true, primary: true }` with a `"string"` schema. `semanticType` is only useful
+with numeric schemas like `"double"`, `"integer"`, or `"decimal"`.
+
+The schema is usually one of these forms:
+
+| Form | Examples | Use it for |
+| --- | --- | --- |
+| Primitive | `"string"`, `"boolean"`, `"integer"`, `"double"`, `"decimal"` | Scalar values |
+| Date/time | `"date"`, `"timestamp"` | Dates or timestamps, as `Date` values or ISO strings |
+| Identifier | `"uuid"` | String identifiers that should be treated as UUIDs |
+| File reference | `"fileRef"` | Blob-backed documents, images, and attachments |
+| Enum | `stringEnum([...])`, `integerEnum([...])` | A fixed set of string or integer values |
+| Value type ref | `valueTypeRef("temperatureReading")` | Reusing a named value shape |
+
+The primitive schemas are `string`, `integer`, `double`, `decimal`, `boolean`, `date`,
+`timestamp`, `uuid`, and `fileRef`.
+
+Keep ontology properties shallow. Avoid complex nested shapes such as object fields that contain
+arrays, arrays of objects, or deeply nested records. When a value starts to behave like another
+thing in your domain, model it as a separate object type and connect it with a link.
+
+Telemetry properties cannot use `fileRef`.
+
 There are two common property styles:
 
 | Style | Use it for |

--- a/docs/concepts/ontology.md
+++ b/docs/concepts/ontology.md
@@ -164,6 +164,42 @@ export const Customer = defineObjectType({
 })
 ```
 
+`link(...)` takes these parameters:
+
+| Parameter | Required | Expected |
+| --- | --- | --- |
+| `id` | Yes | A stable relationship key, unique within the source object type |
+| `target` | No | The object type this link can point to |
+| `options` | No | An object for metadata and relationship behavior |
+
+The `target` can be an object type, an object type id, or an array of allowed object types or ids:
+
+```ts
+link("belongsTo", Organization)
+link("belongsTo", "Organization")
+link("relatedTo", [Organization, Customer])
+```
+
+When the target is omitted or set to `"*"`, the link is a wildcard link and can point to any
+object type. Prefer a specific target for relationships your app understands.
+
+`options` accepts these fields:
+
+| Option | Expected | Meaning |
+| --- | --- | --- |
+| `name` | `string` | Display name. Defaults to the link `id`. |
+| `description` | `string` | Human-readable context for the relationship. |
+| `cardinality` | `"one"` or `"many"` | Whether each source links to one or many targets. |
+| `properties` | `Property[]` | Metadata stored on each relationship instance. |
+
+Use `cardinality: "one"` when each source object should have at most one target for this link,
+like one customer belonging to one organization. Use `cardinality: "many"` when the source can
+point to multiple targets.
+
+Link `properties` use `prop(...)` too, but they describe the relationship itself, not either
+object. Good examples are `installedAt`, `commissionedBy`, or `confidence`. If a link does not
+declare properties, writes with link properties are rejected.
+
 Use links for relationships your app needs to navigate or query.
 
 ## Use objects from code

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -1,70 +1,112 @@
 # Pipeline
 
-A pipeline is a small ordered graph of dataset transform steps.
+A pipeline transforms datasets.
 
-Each step reads one or more committed dataset versions and commits one normal dataset version.
-Pipeline outputs can trigger projections, downstream pipelines, or any other route that listens for
-`dataset.version.committed`.
+Use pipelines after syncs when raw source rows need to become cleaner, smaller, joined, or more
+useful table data.
 
-## Define SQL Steps
+## Why it is useful
 
-Use SQL steps for dataset-to-dataset transforms that can be expressed by the lake storage SQL
-engine.
+Syncs should stay focused on getting data into Sixb. Pipelines are where you shape that data.
+
+Use a pipeline to:
+
+- clean source rows
+- rename columns
+- filter records
+- join datasets
+- create app-ready tables
+- prepare rows for projections
+
+A pipeline is made of steps. Each step reads one or more input datasets and writes one output
+dataset.
+
+## Define a pipeline
+
+File: `pipelines/orders.ts`
 
 ```ts
 import { datasetUpdated, definePipeline, definePipelineStep } from "@sixb/core"
-import { customersDataset, rawCustomersDataset } from "../datasets/customers"
+import { ordersDataset, rawOrdersDataset } from "../datasets/orders"
 
-export const cleanCustomersStep = definePipelineStep("clean-customers")
-  .inputs({ rawCustomers: rawCustomersDataset })
-  .output(customersDataset)
-  .sql(({ rawCustomers }) => `
+export const cleanOrdersStep = definePipelineStep("clean-orders")
+  .inputs({ rawOrders: rawOrdersDataset })
+  .output(ordersDataset)
+  .sql(({ rawOrders }) => `
     select
-      id,
-      trim(name) as name,
-      email
-    from ${rawCustomers}
+      order_id as id,
+      customer_id,
+      total
+    from ${rawOrders}
+    where order_id is not null
   `)
 
-export const customersPipeline = definePipeline("customers")
-  .when(datasetUpdated(rawCustomersDataset.id))
-  .then(cleanCustomersStep)
+export const ordersPipeline = definePipeline("orders")
+  .when(datasetUpdated(rawOrdersDataset.id))
+  .then(cleanOrdersStep)
 ```
 
-SQL steps require a lake storage provider with SQL transform support. Sixb does not fall back to
-JavaScript execution when SQL support is missing.
+This runs when `rawOrdersDataset` gets a new committed version. It reads raw order rows and
+writes cleaner order rows.
 
-`definePipelineStep(...)` is inert by itself. Exporting a standalone step does not register work
-unless a `definePipeline(...)` references it with `.then(step)`.
+## What each part does
 
-## Compose Steps
+| Part | Meaning |
+| --- | --- |
+| `definePipelineStep("clean-orders")` | Defines one transform step |
+| `.inputs({ rawOrders })` | Names the datasets the step reads |
+| `.output(ordersDataset)` | Chooses the dataset the step writes |
+| `.sql(...)` | Defines the transform |
+| `definePipeline("orders")` | Names the pipeline |
+| `.when(datasetUpdated(...))` | Runs after a dataset changes |
+| `.then(cleanOrdersStep)` | Adds the step to the pipeline |
+
+Steps are reusable definitions. A step only runs when a pipeline references it with `.then(...)`.
+
+## SQL steps
+
+Use SQL when the transform can be written as a query.
+
+SQL is usually the best first choice for:
+
+- selecting columns
+- renaming columns
+- filtering rows
+- simple joins
+- aggregations
 
 ```ts
-export const customerInsightsPipeline = definePipeline("customer-insights")
-  .when(datasetUpdated(rawCustomersDataset.id))
-  .then(cleanCustomersStep)
-  .then(customerInsightsStep)
+export const activeCustomersStep = definePipelineStep("active-customers")
+  .inputs({ customers: rawCustomersDataset })
+  .output(activeCustomersDataset)
+  .sql(({ customers }) => `
+    select
+      customer_id as id,
+      contact_name as name,
+      service_tier
+    from ${customers}
+    where status = 'active'
+  `)
 ```
 
-V1 runs steps sequentially. If an earlier step commits successfully and a later step fails, the
-earlier dataset version remains durable and the pipeline run is marked failed.
+SQL steps require a lake storage provider with SQL transform support.
 
-## Define Run Steps
+## TypeScript steps
 
-Use run steps when the transform needs TypeScript logic, library calls, or row-by-row behavior that
-does not fit naturally in SQL.
+Use a TypeScript step when the transform needs application logic, library calls, or row-by-row
+behavior that does not fit naturally in SQL.
 
 ```ts
-export const cleanCustomersRunStep = definePipelineStep("clean-customers")
+export const cleanCustomersStep = definePipelineStep("clean-customers")
   .inputs({ rawCustomers: rawCustomersDataset })
   .output(customersDataset)
   .run(async ({ inputs, output }) => {
     async function* rows() {
-      for await (const row of inputs.rawCustomers.readRows()) {
+      for await (const customer of inputs.rawCustomers.readRows()) {
         yield {
-          id: row.id,
-          name: String(row.name).trim(),
-          email: row.email,
+          id: customer.customer_id,
+          name: String(customer.contact_name).trim(),
+          tier: customer.service_tier,
         }
       }
     }
@@ -73,17 +115,101 @@ export const cleanCustomersRunStep = definePipelineStep("clean-customers")
   })
 ```
 
-The worker pins each input to a committed dataset version before calling the handler, and the
-handler writes through a worker-owned output writer.
+Start with SQL when you can. Use TypeScript when the transform needs code.
 
-## Running Pipelines
+## Compose steps
 
-`sixb dev` co-hosts `PipelineWorker` automatically when pipelines are registered.
+Pipelines can run multiple steps in order.
+
+```ts
+export const customerPipeline = definePipeline("customers")
+  .when(datasetUpdated(rawCustomersDataset.id))
+  .then(cleanCustomersStep)
+  .then(customerInsightsStep)
+```
+
+Each step writes its output before the next step runs.
+
+## Pipeline vs sync
+
+Syncs and pipelines solve different problems.
+
+| Need | Use |
+| --- | --- |
+| Read from an external system | Sync |
+| Write raw source rows | Sync |
+| Clean or reshape rows | Pipeline |
+| Join datasets | Pipeline |
+| Create projection-ready rows | Pipeline |
+
+A good rule: sync first, shape later.
+
+## Convention
+
+Put pipeline definitions in `pipelines/` and export them.
+
+```txt
+your-project/
+  datasets/
+    orders.ts
+  syncs/
+    orders.ts
+  pipelines/
+    orders.ts
+  projections/
+    orders.ts
+  sixb.config.ts
+```
+
+`createSixb()` discovers exported pipeline definitions from `pipelines/` automatically.
+
+You can also register pipelines explicitly:
+
+```ts
+import { createSixb } from "@sixb/core"
+import { ordersDataset, rawOrdersDataset } from "./datasets/orders"
+import { ordersPipeline } from "./pipelines/orders"
+
+export const sixb = createSixb({
+  datasets: [rawOrdersDataset, ordersDataset],
+  pipelines: [ordersPipeline],
+})
+```
+
+## How to model pipelines
+
+Start with one small transform.
+
+1. Pick the raw dataset you want to clean.
+2. Define the output dataset.
+3. Create one step that writes that output.
+4. Trigger the pipeline with `datasetUpdated(inputDataset.id)`.
+5. Add more steps only when each step has a clear job.
+
+Good pipeline names describe the data they produce:
+
+- `orders`
+- `customers`
+- `project-reporting`
+- `device-inventory`
+
+## Running pipelines
+
+In local development, `sixb dev` can co-host pipeline workers when pipelines are registered.
 
 For a separate worker process:
 
 ```bash
-sixb worker pipeline
+sixb worker --worker pipeline
 ```
 
-To co-host every registered queue worker type in one process, use `sixb worker-group`.
+## Extra details
+
+- pipeline steps write `snapshot` output by default.
+- step outputs can use `{ mode: "append" }` when needed.
+- V1 runs pipeline steps sequentially.
+- if a later step fails, earlier committed dataset versions remain durable.
+- a pipeline can also be triggered by a schedule with `.when(schedule)`.
+
+The important first step is to keep each pipeline focused on turning one table shape into a
+better table shape.

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -197,10 +197,17 @@ Good pipeline names describe the data they produce:
 
 In local development, `sixb dev` can co-host pipeline workers when pipelines are registered.
 
-For a separate worker process:
+In production, start a dedicated pipeline worker process:
 
 ```bash
-sixb worker --worker pipeline
+sixb worker pipeline
+```
+
+For constrained deployments, `sixb worker-group` can co-host several queue workers in one
+process, for example:
+
+```bash
+sixb worker-group sync pipeline projection
 ```
 
 ## Extra details

--- a/docs/concepts/projection.md
+++ b/docs/concepts/projection.md
@@ -173,7 +173,7 @@ registered.
 For a separate worker process:
 
 ```bash
-sixb worker --worker projection
+sixb worker projection
 ```
 
 ## Extra details

--- a/docs/concepts/projection.md
+++ b/docs/concepts/projection.md
@@ -1,72 +1,74 @@
 # Projection
 
-A projection maps committed dataset versions into typed objects and links in the twin graph.
+A projection turns dataset rows into ontology objects and links.
 
-Projection authoring lives in `@sixb/core`. Projection execution lives in
-`@sixb/projection-worker`.
+Use projections after syncs and pipelines have produced clean table data. Projections are the
+step that makes that data show up as typed app objects.
 
-## What It Does
+## Why it is useful
 
-- maps dataset columns to object type properties;
-- derives object primary ids from the mapped primary property;
-- resolves foreign key columns into ontology links;
-- materializes many-to-many join datasets into links;
-- records run status and aggregate counters in `ProjectionRunStorage`.
+Datasets are tables. Ontology types are app objects.
 
-## Parts
+A projection connects those two worlds:
 
-| Piece | Role |
-| --- | --- |
-| `defineDataset` / `col` | Typed dataset contract used by syncs, pipelines, and projections |
-| `defineProjection` | Fluent builder for object projections |
-| `defineLinkProjection` | Fluent builder for many-to-many link projections |
-| `fromForeignKey` | Type-safe FK descriptor tying a link, a source property, and a target type |
-| `OrchestratorWorker` | Routes `dataset.version.committed` events to `queues.projections` |
-| `ProjectionWorker` | Reads committed dataset versions and writes objects/links through `objectService` |
-| `ProjectionRunStorage` | Stores run status and counters |
+- map dataset columns to object properties
+- create or update objects from rows
+- create links from foreign key columns
+- keep app state in sync with committed dataset versions
 
-## Define a Dataset
+In a typical app, syncs and pipelines prepare clean datasets before projections create objects and
+links.
 
-File: `datasets/erp.ts`
+## Define an object projection
+
+File: `projections/customer.ts`
 
 ```ts
-import { col, defineDataset } from "@sixb/core"
-
-export const erpCustomersDataset = defineDataset("erp.customers", {
-  schema: [
-    col("customer_id", "string"),
-    col("contact_name", "string"),
-    col("contact_email", "string"),
-    col("company_name", "string"),
-    col("industry_sector", "string"),
-    col("service_tier", "string"),
-    col("account_mgr_id", "string"),
-  ],
-})
-```
-
-Projection builders receive the dataset definition directly, not a string id. The lowered projection definition remains serializable and stores `datasetId`.
-
-## Define an Object Projection
-
-File: `projections/customer-projection.ts`
-
-```ts
-import { defineProjection, fromForeignKey } from "@sixb/core"
-import { erpCustomersDataset } from "../datasets/erp"
+import { defineProjection } from "@sixb/core"
+import { customersDataset } from "../datasets/customers"
 import { Customer } from "../ontology/customer"
-import { Employee } from "../ontology/employee"
 
-export const customerProjection = defineProjection("customer-proj", Customer)
-  .fromDataset(erpCustomersDataset)
+export const customerProjection = defineProjection("customers", Customer)
+  .fromDataset(customersDataset)
   .properties({
     id: "customer_id",
     name: "contact_name",
     email: "contact_email",
-    company: "company_name",
-    industry: "industry_sector",
     tier: "service_tier",
-    accountManagerRef: "account_mgr_id",
+  })
+```
+
+Each row in `customersDataset` becomes a `Customer` object.
+
+The object property `id` is read from the dataset column `customer_id`. The object property
+`name` is read from `contact_name`, and so on.
+
+## What each part does
+
+| Part | Meaning |
+| --- | --- |
+| `defineProjection("customers", Customer)` | Names the projection and target object type |
+| `.fromDataset(customersDataset)` | Chooses the source dataset |
+| `.properties({ ... })` | Maps object properties to dataset columns |
+
+The primary property must be mapped. For `Customer`, that is usually `id`.
+
+## Project links from foreign keys
+
+If a dataset row contains a foreign key, a projection can turn it into an ontology link.
+
+```ts
+import { defineProjection, fromForeignKey } from "@sixb/core"
+import { customersDataset } from "../datasets/customers"
+import { Customer } from "../ontology/customer"
+import { Employee } from "../ontology/employee"
+
+export const customerProjection = defineProjection("customers", Customer)
+  .fromDataset(customersDataset)
+  .properties({
+    id: "customer_id",
+    name: "contact_name",
+    accountManagerRef: "account_manager_id",
   })
   .withLinks({
     accountManager: fromForeignKey({
@@ -77,170 +79,110 @@ export const customerProjection = defineProjection("customer-proj", Customer)
   })
 ```
 
-`.properties(...)` is type-safe:
+Here, `account_manager_id` stores the primary id of an `Employee`. The projection uses that
+value to create the `Customer -> Employee` link.
 
-- keys must be property ids on the object type;
-- values must be column names on the dataset;
-- mapped dataset column types must be compatible with the property schema;
-- the primary property must be mapped.
+## Project many-to-many links
 
-`fromForeignKey(...)` is also type-safe:
-
-- the link and source property must belong to the same object type;
-- the target object type must match the link target, or be a compatible subtype.
-
-At runtime, the FK column value is used as the target object's primary id.
-
-## Define a Link Projection
-
-For many-to-many relationships stored in a join dataset:
+Use a link projection when a join dataset stores relationships.
 
 ```ts
 import { defineLinkProjection } from "@sixb/core"
-import { erpProjectMembersDataset } from "../datasets/erp"
+import { projectMembersDataset } from "../datasets/projects"
 import { Project } from "../ontology/project"
 
 export const projectMembersProjection = defineLinkProjection("project-members", Project.l.members)
-  .fromDataset(erpProjectMembersDataset)
+  .fromDataset(projectMembersDataset)
   .sourceField("project_id")
   .targetField("employee_id")
 ```
 
-Link projection source and target fields must be string dataset columns. Polymorphic and wildcard link targets are rejected for V1.
+Each row creates one link from a `Project` to an `Employee`.
 
-## Runtime Flow
+## Projection vs pipeline
 
-Projection execution is driven by committed dataset versions:
+Pipelines and projections solve different problems.
 
-```text
-sync or pipeline writes rows
-  -> LakeStorage commits a dataset version
-  -> events emits dataset.version.committed
-  -> OrchestratorWorker enqueues projection.run.requested
-  -> ProjectionWorker reads the exact dataset version
-  -> objectService upserts objects and links
-  -> ProjectionRunStorage records counters and status
-```
+| Need | Use |
+| --- | --- |
+| Clean, filter, join, or reshape rows | Pipeline |
+| Create app objects from rows | Projection |
+| Create object relationships from foreign keys | Projection |
+| Keep data as tables | Dataset or pipeline |
 
-The Orchestrator matches projections by `projection.datasetId`. The Projection Worker executes the projection named by the queued job; it does not resolve projection dependencies itself.
-
-## Hosting Workers
-
-`sixb dev` starts the projection worker automatically when projection definitions are registered.
-No manual worker setup is needed for normal local development.
-
-Custom hosts can still start both workers explicitly:
-
-```ts
-import { compileRoutes, OrchestratorWorker } from "@sixb/orchestrator"
-import { ProjectionWorker } from "@sixb/projection-worker"
-
-const routes = compileRoutes({
-  syncs: sixb.getSyncDefinitions(),
-  pipelines: sixb.getPipelineDefinitions(),
-  projections: [...sixb.getObjectProjections(), ...sixb.getLinkProjections()],
-})
-
-const orchestrator = new OrchestratorWorker({
-  projectId: sixb.id,
-  events: sixb.events,
-  queues: sixb.queues,
-  routes,
-})
-
-const projectionWorker = new ProjectionWorker(sixb)
-
-await orchestrator.start()
-await projectionWorker.start()
-```
-
-Start the orchestrator before emitting dataset commit events. The V1 orchestrator is live-only and does not catch up on events emitted before startup.
-
-## Inspect Runs
-
-Projection runs are stored by `ProjectionRunStorage`:
-
-```ts
-const result = await sixb.storage.projectionRuns?.list({
-  projectId: sixb.id,
-  projectionId: "customer-proj",
-  statuses: ["succeeded", "failed"],
-  limit: 20,
-})
-```
-
-Each `ProjectionRunRecord` includes:
-
-```ts
-{
-  id: string
-  projectionId: string
-  projectionKind: "object" | "link"
-  datasetId: string
-  datasetVersionId: string
-  status: "running" | "succeeded" | "failed" | "cancelled"
-  rowsProcessed: number
-  rowsSkipped: number
-  objectsUpserted: number
-  linksUpserted: number
-  errorMessage?: string
-}
-```
-
-V1 stores aggregate counters and one terminal error message. Detailed per-row diagnostics can be added later if needed.
+A good rule: pipelines make better rows; projections make objects.
 
 ## Convention
 
-Export projection definitions from `projections/`:
+Put projection definitions in `projections/` and export them.
 
 ```txt
 your-project/
   datasets/
-    erp.ts
+    customers.ts
+    projects.ts
   ontology/
     customer.ts
     employee.ts
     project.ts
   projections/
-    customer-projection.ts
-    project-projection.ts
-    project-members-projection.ts
+    customers.ts
+    project-members.ts
   sixb.config.ts
 ```
 
-`createSixb()` scans `datasets/` and `projections/` and registers exported definitions automatically.
+`createSixb()` discovers exported projection definitions from `projections/` automatically.
 
 You can also register projections explicitly:
 
 ```ts
-createSixb({
-  datasets: [erpCustomersDataset],
+import { createSixb } from "@sixb/core"
+import { customersDataset } from "./datasets/customers"
+import { Customer } from "./ontology/customer"
+import { customerProjection } from "./projections/customers"
+
+export const sixb = createSixb({
+  datasets: [customersDataset],
+  ontology: [Customer],
   projections: [customerProjection],
 })
 ```
 
-Startup validation checks projections against registered datasets and ontology:
+## How to model projections
 
-- referenced dataset exists;
-- projected object type exists;
-- mapped properties and dataset columns exist;
-- mapped column types are compatible with property schemas;
-- primary property is mapped;
-- FK links reference valid links, mapped source properties, and compatible target types;
-- link projection source and target object types exist and have primary properties.
+Start with one object type.
 
-## Guidelines
+1. Choose the clean dataset you want to project.
+2. Choose the ontology object type the rows should become.
+3. Map the primary property first.
+4. Map the simple properties next.
+5. Add links only when the dataset has reliable foreign keys.
 
-- Keep one projection focused on one object type and one dataset.
-- Use `fromForeignKey()` for one-to-one and many-to-one relationships stored as columns.
-- Use `defineLinkProjection()` for many-to-many relationships stored in join datasets.
-- Pass dataset definitions to `.fromDataset(...)`, not string ids.
-- Commit datasets to `LakeStorage`; do not build ad hoc row sources.
-- Keep projection run storage enabled when hosting `ProjectionWorker`.
+Good projection names usually describe the object or relationship they materialize:
 
-## V1 Limits
+- `customers`
+- `invoices`
+- `projects`
+- `project-members`
 
-- Set-only: missing dataset rows do not delete existing objects or links.
-- Latest write wins: user edits and projection writes both go through object service.
-- Batch materialization is not globally transactional across object storage writes.
-- No manual CLI/API projection run trigger yet.
+## Running projections
+
+In local development, `sixb dev` can co-host projection workers when projections are
+registered.
+
+For a separate worker process:
+
+```bash
+sixb worker --worker projection
+```
+
+## Extra details
+
+- `.properties(...)` checks that mapped object properties and dataset columns exist.
+- mapped dataset column types must be compatible with object property schemas.
+- the primary property must be mapped.
+- projection execution is triggered by committed dataset versions.
+- projections are set-only in V1: missing rows do not delete existing objects or links.
+- link projections require string source and target fields.
+
+The important first step is to decide which clean table should become which object type.

--- a/docs/concepts/rules.md
+++ b/docs/concepts/rules.md
@@ -1,19 +1,26 @@
 # Rules
 
-Rules describe business conditions over ontology objects.
+A rule watches an ontology object for a business condition.
 
+Use rules for statements like "a posted transaction must have a document" or "a critical task
+should have an owner."
 
-## What they are
+A rule does not fetch data, transform rows, or run a process by itself. It names the condition,
+watches object and link changes, and emits a transition when the condition starts or clears.
 
-- inert, serializable definitions
-- scoped to a single ontology object type
-- written as "where the rule is active"
-- reactive to object and link changes
-- validated at runtime startup against the registered ontology
+## Why it is useful
 
-Rules are useful for business logic that should be evaluated when object state changes. For
-example, a finance application may require every transaction to be linked to a source document.
+Business software usually has conditions people care about:
 
+- invoices that are overdue
+- tasks that are critical and unassigned
+- customers that need an account manager
+- transactions that are missing a source document
+
+Rules give those conditions one typed place to live. Apps, alerts, and workflows can then react
+to the same definition.
+
+Write the rule as the state where the object needs attention.
 
 ## Define a rule
 
@@ -28,197 +35,164 @@ export const transactionRequiresDocument = defineRule("transaction.requires-docu
   .where((tx) => tx.l.document.isMissing())
 ```
 
-The `.where(...)` predicate describes when the rule is active. In this example, the rule is
-active for transactions that do not have a `document` link.
+This rule is triggered when a `Transaction` does not have a `document` link.
 
-The resulting definition is serializable data:
+## What each part does
+
+| Part | Meaning |
+| --- | --- |
+| `defineRule("transaction.requires-document")` | Names the rule |
+| `.on(Transaction)` | Chooses the object type the rule watches |
+| `.where(...)` | Describes when the rule should be triggered |
+| `tx.l.document.isMissing()` | Checks that the `document` link does not exist |
+
+## Property conditions
+
+Use `p` for object properties.
 
 ```ts
-{
-  kind: "rule",
-  id: "transaction.requires-document",
-  subject: { kind: "object", objectTypeId: "transaction" },
-  predicate: { kind: "link", linkId: "document", op: "isMissing" },
-}
+import { defineRule } from "@sixb/core"
+import { Invoice } from "../ontology/invoice"
+
+export const invoiceCollectionRisk = defineRule("invoice.collection-risk")
+  .on(Invoice)
+  .where((invoice) =>
+    invoice.any(
+      invoice.p.status.eq("overdue"),
+      invoice.all(invoice.p.status.eq("sent"), invoice.p.amount.gte(40000))
+    )
+  )
 ```
 
-The callback is not retained. It is only used by the builder to produce the predicate AST.
+This rule is triggered when an invoice is overdue, or when a sent invoice has a large amount.
 
+## Link conditions
+
+Use `l` for ontology links.
+
+```ts
+import { defineRule } from "@sixb/core"
+import { Customer } from "../ontology/customer"
+
+export const customerNeedsOwner = defineRule("customer.needs-owner")
+  .on(Customer)
+  .where((customer) => customer.l.accountManager.isMissing())
+```
+
+This rule is triggered when a `Customer` does not have an `accountManager` link.
+
+## Compose conditions
+
+Use `all`, `any`, and `not` to combine smaller conditions.
+
+```ts
+import { defineRule } from "@sixb/core"
+import { Task } from "../ontology/task"
+
+export const taskCriticalUnassigned = defineRule("task.critical-unassigned")
+  .on(Task)
+  .where((task) =>
+    task.all(
+      task.p.priority.eq("critical"),
+      task.not(task.p.status.eq("done")),
+      task.l.assignee.isMissing()
+    )
+  )
+```
+
+This rule is triggered when a task is critical, not done, and missing an assignee.
 
 ## Predicates
 
-The rule subject exposes typed property and link predicate builders for the selected object type:
-
-```ts
-defineRule("transaction.review-required")
-  .on(Transaction)
-  .where((tx) =>
-    tx.all(
-      tx.p.status.eq("posted"),
-      tx.p.amount.gt(1000),
-      tx.l.document.isMissing()
-    )
-  )
-```
-
-### Property predicates
-
-| Predicate | Meaning |
+| Need | Use |
 | --- | --- |
-| `eq(value)` | Property equals a scalar value |
-| `notEq(value)` | Property does not equal a scalar value |
-| `gt(value)` | Property is greater than a number |
-| `gte(value)` | Property is greater than or equal to a number |
-| `lt(value)` | Property is less than a number |
-| `lte(value)` | Property is less than or equal to a number |
-| `isPresent()` | Property value is not `null` or `undefined` |
-| `isMissing()` | Property value is `null` or `undefined` |
+| Equal or not equal | `eq(value)`, `notEq(value)` |
+| Compare numbers | `gt(value)`, `gte(value)`, `lt(value)`, `lte(value)` |
+| Check a property value | `isPresent()`, `isMissing()` |
+| Check a link | `exists()`, `isMissing()` |
+| Combine conditions | `all(...)`, `any(...)`, `not(...)` |
 
-### Link predicates
+Predicate values can be strings, numbers, booleans, or `null`.
 
-| Predicate | Meaning |
+## Rule vs workflow
+
+Rules and workflows solve different problems.
+
+| Need | Use |
 | --- | --- |
-| `exists()` | At least one link exists for that link id from the subject object |
-| `isMissing()` | No link exists for that link id from the subject object |
+| Know whether an object needs attention | Rule |
+| Emit a triggered or resolved signal | Rule |
+| Run a multi-step process | Workflow |
+| Fetch source data | Sync |
+| Clean or join table data | Pipeline |
 
-### Logical predicates
+A good rule: rules decide if something is true; workflows decide what to do next.
 
-Use `all`, `any`, and `not` to compose predicates:
+## Convention
 
-```ts
-defineRule("transaction.missing-document-for-posted")
-  .on(Transaction)
-  .where((tx) =>
-    tx.all(
-      tx.p.status.eq("posted"),
-      tx.not(tx.p.status.eq("void")),
-      tx.any(tx.p.amount.gt(0), tx.l.document.isMissing())
-    )
-  )
-```
-
-Empty `all()` and `any()` groups are rejected during runtime startup validation.
-
-
-## Discovery
-
-`createSixb()` discovers rule definitions exported from `rules/`:
+Put rule definitions in `rules/` and export them.
 
 ```txt
-my-project/
+your-project/
   ontology/
     transaction.ts
   rules/
     transaction-requires-document.ts
+  sixb.config.ts
 ```
 
-You can also pass rules explicitly:
+`createSixb()` discovers exported rule definitions from `rules/` automatically.
+
+You can also register rules explicitly:
 
 ```ts
 import { createSixb } from "@sixb/core"
+import { Transaction } from "./ontology/transaction"
 import { transactionRequiresDocument } from "./rules/transaction-requires-document"
 
-const sixb = await createSixb({
-  ontologies: [Transaction],
+export const sixb = createSixb({
+  ontology: [Transaction],
   rules: [transactionRequiresDocument],
-  broker,
-  storage,
-  lakeStorage,
-  blobStorage,
-  queues,
 })
 ```
 
-Registered rules can be inspected from the runtime:
+## How to model rules
 
-```ts
-sixb.getRuleDefinitions()
-sixb.getRuleById("transaction.requires-document")
-```
+Start with one plain sentence.
 
+1. Pick the ontology object type the rule watches.
+2. Write the condition in normal language.
+3. Convert that condition into property and link predicates.
+4. Keep the first version small.
+5. Add `all`, `any`, or `not` only when the condition needs them.
 
-## Event dependencies
+Good rule names describe the condition:
 
-Rules are reactive to ontology object events. A rule does not declare schedules.
+- `transaction.requires-document`
+- `invoice.collection-risk`
+- `customer.needs-owner`
+- `task.critical-unassigned`
 
-Use `deriveRuleEventDependencies()` to derive the domain events that can affect a rule:
+## What happens when a rule matches
 
-```ts
-import { deriveRuleEventDependencies } from "@sixb/core"
+Once registered, Sixb evaluates rules as ontology objects and links change.
 
-const dependencies = deriveRuleEventDependencies(transactionRequiresDocument)
-```
+When a rule starts matching an object, it is triggered. When the object no longer matches, it is
+resolved.
 
-For the transaction document rule, the dependencies are:
+That gives the rest of your app a stable signal to show attention states, send notifications, or
+start follow-up work.
 
-```ts
-[
-  { type: "object.upserted", objectTypeId: "transaction" },
-  { type: "link.upserted", sourceTypeId: "transaction", linkId: "document" },
-  { type: "link.removed", sourceTypeId: "transaction", linkId: "document" },
-]
-```
+## Extra details
 
-Property predicates are covered by `object.upserted`. Link predicates add `link.upserted` and
-`link.removed` dependencies for each referenced link id.
+- rule ids must be unique.
+- rules are scoped to one ontology object type.
+- predicates are validated against the registered ontology at startup.
+- empty `all()` and `any()` groups are rejected.
+- the `.where(...)` callback creates serializable rule data; the callback is not stored.
+- rule evaluation reacts to object and link changes after the worker starts.
+- active rule state is stored in `storage.rules`, which prevents duplicate triggers.
+- registered rules can be inspected with `sixb.getRuleDefinitions()` and `sixb.getRuleById(...)`.
 
-
-## Runtime validation
-
-At startup, Sixb rejects:
-
-- duplicate rule ids
-- rules whose subject object type is not registered
-- property predicates for properties not on the subject object type
-- link predicates for links not on the subject object type
-- empty `all()` or `any()` predicate groups
-
-
-## Rule transition events
-
-The core event model includes rule transition events:
-
-```ts
-{
-  type: "rule.triggered",
-  topic: "rules",
-  payload: {
-    ruleId: "transaction.requires-document",
-    subject: {
-      kind: "object",
-      objectTypeId: "transaction",
-      primaryId: "tx-001",
-    },
-    triggeredAt: "2026-05-06T00:00:00.000Z",
-  },
-}
-```
-
-```ts
-{
-  type: "rule.resolved",
-  topic: "rules",
-  payload: {
-    ruleId: "transaction.requires-document",
-    subject: {
-      kind: "object",
-      objectTypeId: "transaction",
-      primaryId: "tx-001",
-    },
-    resolvedAt: "2026-05-06T00:05:00.000Z",
-  },
-}
-```
-
-Rule transition events use a stable partition key:
-
-```ts
-`${ruleId}:${objectTypeId}:${primaryId}`
-```
-
-
-## Current scope
-
-The current core rules surface defines and registers rules, validates rule definitions, derives
-event dependencies, and adds rule transition event types. A full rule evaluator/runtime loop is
-not included yet.
+The important first step is to describe the business condition clearly before writing the
+predicate.

--- a/docs/concepts/sync.md
+++ b/docs/concepts/sync.md
@@ -1,222 +1,197 @@
 # Sync
 
-A sync reads data from an external system through a connector and writes it into one Sixb dataset.
+A sync moves data from an external system into a dataset.
 
-Use syncs for source data that should land in the lake first, then be cleaned up by pipelines or
-projected into objects later.
+It uses a [connector](./connector.md) to read from the outside world and writes the result into
+one [dataset](./datasets.md). Syncs are usually the first step in bringing real data into
+Sixb.
 
-## Basic shape
+## Why it is useful
+
+A sync gives data movement a clear shape:
+
+- one source connector
+- one read function
+- one target dataset
+- one write mode
+
+That keeps external access, table shape, and data movement separate.
+
+The connector knows how to talk to the external system. The dataset defines the table shape.
+The sync connects the two.
+
+## Define a sync
+
+File: `syncs/orders.ts`
 
 ```ts
 import { defineSync } from "@sixb/core"
-import { erpDb } from "../connectors/erpDb"
+import { erpDb } from "../connectors/erp-db"
 import { rawOrdersDataset } from "../datasets/orders"
 
 export const syncOrders = defineSync("sync-orders")
   .from(erpDb)
-  .read(({ query }) => query("select * from orders"))
+  .read((db) => db`select * from orders`)
   .intoDataset(rawOrdersDataset)
 ```
 
-| Step | Purpose |
+This reads rows from `erpDb` and writes them into `rawOrdersDataset`.
+
+## What each part does
+
+| Part | Meaning |
 | --- | --- |
-| `defineSync("sync-orders", options?)` | Names the sync and sets options such as `mode` |
-| `.checkpoint<T>()` | Optional: types source cursor state for later runs |
-| `.from(connector)` | Chooses the source connector |
-| `.read((client, context) => rows)` | Reads source rows |
-| `.intoDataset(dataset)` | Chooses the target dataset |
+| `defineSync("sync-orders")` | Names the sync |
+| `.from(erpDb)` | Chooses the source connector |
+| `.read((db) => ...)` | Reads records from the source |
+| `.intoDataset(rawOrdersDataset)` | Chooses the target dataset |
 
-The rows returned by `read(...)` should match the target dataset schema.
+The read handler receives the connected client returned by the connector.
 
-## Modes
+## Snapshot syncs
 
-Syncs support two write modes.
+Snapshot is the default mode.
 
-### `snapshot`
-
-Use `snapshot` when each run returns the full current source state.
+Use a snapshot sync when each run should replace the target dataset with the current full view
+of the source.
 
 ```ts
-export const syncOrders = defineSync("sync-orders", { mode: "snapshot" })
+export const syncOrders = defineSync("sync-orders")
   .from(erpDb)
-  .read(({ query }) => query("select * from orders"))
+  .read((db) => db`select * from orders`)
   .intoDataset(rawOrdersDataset)
 ```
 
-Good for:
+Good snapshot sources:
 
 - current orders
-- active devices
-- files where each run lists the whole folder
+- active customers
+- inventory levels
+- devices currently known by an API
 
-`snapshot` is the default mode, so `{ mode: "snapshot" }` is optional.
+## Append syncs
 
-### `append`
-
-Use `append` when each run returns new rows to add to the dataset.
+Use append mode when each run should add new rows instead of replacing the dataset.
 
 ```ts
 export const syncOrderEvents = defineSync("sync-order-events", { mode: "append" })
   .from(erpDb)
-  .read(({ query }) => query("select * from order_events"))
+  .read((db) => db`select * from order_events`)
   .intoDataset(rawOrderEventsDataset)
 ```
 
-Good for:
+Good append sources:
 
-- event logs
-- audit trails
-- changes feeds
-- incrementally discovered files
+- audit logs
+- webhook deliveries
+- order events
+- new files arriving over time
 
-Most append syncs should use a checkpoint so they know where to resume.
+## Schedule a sync
 
-## Read context
-
-The read handler receives the connector client and a context:
-
-```ts
-.read(async (client, context) => {
-  context.projectId
-  context.syncId
-  context.signal
-
-  return []
-})
-```
-
-Use `context.signal` with APIs that support cancellation.
-
-If the sync uses `.checkpoint<T>()`, the context also includes:
-
-```ts
-context.checkpoint // T | undefined
-context.setCheckpoint(next) // next must be T
-```
-
-## Checkpoints
-
-A checkpoint is the source cursor for the next successful run. It can be a page token, timestamp,
-incrementing id, high-water mark, or any other small JSON-compatible value.
-
-```ts
-type OrderEventsCheckpoint = {
-  cursor: string
-}
-
-export const syncOrderEvents = defineSync("sync-order-events", { mode: "append" })
-  .checkpoint<OrderEventsCheckpoint>()
-  .from(erpDb)
-  .read(async ({ query }, context) => {
-    const cursor = context.checkpoint?.cursor ?? "0"
-
-    const rows = await query(`select * from order_events where cursor > ${cursor}`)
-
-    const nextCursor = rows.at(-1)?.cursor
-    if (nextCursor) {
-      context.setCheckpoint({ cursor: String(nextCursor) })
-    }
-
-    return rows
-  })
-  .intoDataset(rawOrderEventsDataset)
-```
-
-Checkpoint rules to know:
-
-- First run: `context.checkpoint` is `undefined`.
-- Later runs: `context.checkpoint` is the last saved checkpoint for that sync.
-- Call `context.setCheckpoint(next)` when you know where the next run should resume.
-- If the run fails or is cancelled, the checkpoint is not advanced.
-- Checkpoints must be JSON-compatible. Store strings for dates, not `Date` objects.
-- Avoid overlapping runs for checkpointed syncs unless replaying rows is safe.
-
-### Changes-feed pattern
-
-For APIs with a changes feed, bookmark the source before the first full scan. This prevents missing
-changes that happen while the baseline scan is running.
-
-```ts
-type FilesCheckpoint = { startPageToken: string }
-
-export const syncFiles = defineSync("sync-files", { mode: "append" })
-  .checkpoint<FilesCheckpoint>()
-  .from(filesApi)
-  .read(async (files, context) => {
-    if (!context.checkpoint) {
-      const startPageToken = await files.getStartPageToken()
-      context.setCheckpoint({ startPageToken })
-      return files.listAllFiles()
-    }
-
-    const rows = []
-    let pageToken: string | undefined = context.checkpoint.startPageToken
-
-    while (pageToken) {
-      const page = await files.listChanges({ pageToken })
-      rows.push(...page.changes)
-      pageToken = page.nextPageToken
-
-      if (page.newStartPageToken) {
-        context.setCheckpoint({ startPageToken: page.newStartPageToken })
-      }
-    }
-
-    return rows
-  })
-  .intoDataset(rawFilesDataset)
-```
-
-## Triggers
-
-Attach triggers with `.when(...)`.
+Define a reusable schedule, then attach it with `.when(...)`.
 
 ```ts
 import { defineSchedule, defineSync } from "@sixb/core"
 
-export const hourly = defineSchedule("hourly-order-events").cron("0 * * * *")
+export const hourly = defineSchedule("hourly").cron("0 * * * *")
 
-export const syncOrderEvents = defineSync("sync-order-events", { mode: "append" })
+export const syncOrders = defineSync("sync-orders")
   .when(hourly)
   .from(erpDb)
-  .read(({ query }) => query("select * from order_events"))
-  .intoDataset(rawOrderEventsDataset)
+  .read((db) => db`select * from orders`)
+  .intoDataset(rawOrdersDataset)
 ```
 
-## Project layout
+You can also trigger one sync after another:
 
-Export sync definitions from `syncs/` and keep connectors and datasets separate:
+```ts
+import { defineSync, syncFinished } from "@sixb/core"
+
+export const syncCustomers = defineSync("sync-customers")
+  .when(syncFinished(syncDepartments.id))
+  .from(erp)
+  .read((client) => client.listCustomers())
+  .intoDataset(customersDataset)
+```
+
+## Keep syncs small
+
+A sync can do light cleanup when it reads data, but it should not become your whole data
+pipeline.
+
+Good work for a sync:
+
+- call the external system
+- return rows
+- flatten a response
+- drop obviously invalid records
+
+Better left to a [pipeline](./pipeline.md):
+
+- joins
+- heavy reshaping
+- business calculations
+- turning raw rows into canonical rows
+
+## Convention
+
+Put sync definitions in `syncs/` and export them.
 
 ```txt
 your-project/
   connectors/
-    erpDb.ts
+    erp-db.ts
   datasets/
     orders.ts
-    orderEvents.ts
+    order-events.ts
   syncs/
     orders.ts
-    orderEvents.ts
+    order-events.ts
+  schedules/
+    hourly.ts
+  sixb.config.ts
 ```
 
-`createSixb()` discovers exported syncs automatically. You can also register syncs explicitly:
+`createSixb()` discovers exported sync definitions from `syncs/` automatically.
+
+You can also register syncs explicitly:
 
 ```ts
-createSixb({
+import { createSixb } from "@sixb/core"
+import { rawOrdersDataset } from "./datasets/orders"
+import { syncOrders } from "./syncs/orders"
+
+export const sixb = createSixb({
   datasets: [rawOrdersDataset],
-  connectors: [erpDb],
   syncs: [syncOrders],
 })
 ```
 
-## Best practices
+## How to model syncs
 
-- Put auth, connection setup, and provider-specific clients in connectors.
-- Keep sync read handlers focused on fetching and lightly shaping source rows.
-- Use `snapshot` for full current-state reads.
-- Use `append` plus `.checkpoint<T>()` for event streams, cursors, and changes feeds.
-- Keep checkpoint values small, plain JSON, and source-focused.
-- Make append rows replay-safe when possible; failed runs can be retried from the previous
-  checkpoint.
-- Land raw source data in datasets first, then use pipelines/projections for cleanup and modeling.
-- Name syncs by source and entity, such as `sync-orders` or `sync-order-events`.
+Start with one sync per source shape.
+
+1. Define the connector first.
+2. Define the raw dataset shape.
+3. Create a sync that reads from the connector and writes that dataset.
+4. Use snapshot unless the source is event-like.
+5. Move cleanup and reshaping into pipelines as the project grows.
+
+Good sync names usually start with the action and source entity:
+
+- `sync-orders`
+- `sync-order-events`
+- `sync-customers`
+- `sync-device-inventory`
+
+## Extra details
+
+- `read(...)` receives `(client, context)`.
+- `context` includes `projectId`, `syncId`, and `signal`.
+- `read(...)` may return one row, an iterable, or an async iterable.
+- sync definitions are inert until a worker runs them.
+- `sixb dev` can co-host sync workers during local development.
+
+The important first step is to keep each sync focused on moving one source shape into one
+dataset.

--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -206,7 +206,7 @@ In local development, `sixb dev` can run workflow workers when workflows are reg
 For a separate worker process:
 
 ```bash
-sixb worker --worker workflow
+sixb worker workflow
 ```
 
 ## Extra details

--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -1,300 +1,223 @@
 # Workflow
 
-A workflow describes an ordered business process over typed inputs, step outputs, and action
-requests.
+A workflow runs a business process in a known order.
 
-## What It Is
+Use workflows when work needs multiple named steps, typed data between those steps, and a run
+history you can inspect.
 
-- an inert definition built with `defineWorkflow(...)`
-- a typed input contract using the same schema language as ontology values and action params
-- a linear sequence of step and action nodes
-- optionally triggered by a schedule
-- registered explicitly or discovered from `workflows/`
-- routable by the orchestrator when a scheduled workflow has empty input
+## Why it is useful
 
-Workflows are useful when business logic needs to move through several named stages and keep the
-data passed between those stages typed.
+Workflows are useful when a process should be more than one function call.
 
-## Parts
+Use a workflow to:
 
-| Piece | Role |
-| --- | --- |
-| `defineWorkflowStep` | Defines one reusable step handler with input and output schemas |
-| `defineWorkflow` | Defines the workflow input and ordered node list |
-| `.then(step)` | Adds a step when previous output already matches the step input |
-| `.then(step, mapper)` | Adds a step with an explicit input mapper |
-| `.then(action, mapper)` | Adds an action request node with target and params mapping |
-| `.when(schedule)` | Adds a schedule trigger to the definition |
-| `compileRoutes(...)` | Routes eligible scheduled workflows to `queues.workflows` |
-| `WorkflowWorker` | Consumes queued workflow runs and executes nodes sequentially |
+- prepare data before an action
+- break a process into clear steps
+- pass typed outputs from one step to the next
+- request object actions at the right time
+- track whether a process is running, succeeded, or failed
 
-## Define a Step
+A workflow is made of steps and optional actions. Steps create data. Actions do something to an
+object.
 
-File: `workflows/reconcileTransaction.ts`
+## Define a step
+
+File: `workflows/invoice-reminder.ts`
 
 ```ts
 import { defineWorkflowStep, ref } from "@sixb/core"
-import { Invoice, Transaction } from "../ontology/transaction"
+import { Invoice } from "../ontology/invoice"
 
-export const findBestInvoice = defineWorkflowStep("find-best-invoice")
+export const prepareInvoiceReminder = defineWorkflowStep("prepare-invoice-reminder")
   .input({
-    transaction: ref(Transaction),
+    invoice: ref(Invoice),
   })
   .output({
-    transaction: ref(Transaction),
     invoice: ref(Invoice),
-    confidence: "double",
+    message: "string",
   })
-  .run(async ({ input, sixb }) => {
-    return {
-      transaction: input.transaction,
-      invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" },
-      confidence: 0.98,
-    }
-  })
+  .run(({ input }) => ({
+    invoice: input.invoice,
+    message: "Please review this invoice and submit payment when convenient.",
+  }))
 ```
 
-Step ids are also used to derive keys for `steps` data. For example, `find-best-invoice` becomes
-`steps.findBestInvoice`.
+A step is a typed function. It declares the input it needs, the output it returns, and the code
+that runs.
 
-## Compose a Workflow
+## Compose a workflow
 
 ```ts
-import { actionParam, defineAction, defineWorkflow, ref } from "@sixb/core"
-import { Invoice, Transaction } from "../ontology/transaction"
-import { findBestInvoice } from "./reconcileTransaction"
+import { defineWorkflow, ref } from "@sixb/core"
+import { sendReminder } from "../actions/send-reminder"
+import { Invoice } from "../ontology/invoice"
+import { prepareInvoiceReminder } from "./invoice-reminder"
 
-export const attachInvoice = defineAction("attach-invoice")
-  .target(Transaction)
-  .params({
-    invoice: actionParam(ref(Invoice), { required: true }),
-  })
-  .run(async () => {})
-
-export const reconcileTransaction = defineWorkflow("reconcile-transaction")
+export const invoiceReminderWorkflow = defineWorkflow("invoice-reminder")
   .input({
-    transaction: ref(Transaction),
+    invoice: ref(Invoice),
   })
-  .then(findBestInvoice)
-  .then(attachInvoice, ({ input, steps }) => ({
-    target: input.transaction,
+  .then(prepareInvoiceReminder)
+  .then(sendReminder, ({ steps }) => ({
+    target: steps.prepareInvoiceReminder.invoice,
     params: {
-      invoice: steps.findBestInvoice.invoice,
+      message: steps.prepareInvoiceReminder.message,
     },
   }))
 ```
 
-The action mapper must return:
+This workflow prepares a reminder message, then requests the `sendReminder` action for the
+invoice.
+
+`sendReminder` is an object action defined elsewhere. The workflow decides when to call it and
+what params to pass.
+
+## What each part does
+
+| Part | Meaning |
+| --- | --- |
+| `defineWorkflow("invoice-reminder")` | Names the workflow |
+| `.input({ invoice })` | Declares the input needed to start the workflow |
+| `.then(prepareInvoiceReminder)` | Runs a step |
+| `.then(sendReminder, mapper)` | Requests an action |
+| `steps.prepareInvoiceReminder` | Reads output from the earlier step |
+
+Step ids become camelCase keys in `steps`. For example, `prepare-invoice-reminder` becomes
+`steps.prepareInvoiceReminder`.
+
+## Pass data between steps
+
+Use direct `.then(step)` when the previous output already matches the next step input.
 
 ```ts
-{
-  target: { objectTypeId: "Transaction", primaryId: "txn_123" },
-  params: { invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" } },
-}
+export const reviewInvoiceWorkflow = defineWorkflow("review-invoice")
+  .input({
+    invoice: ref(Invoice),
+  })
+  .then(prepareInvoiceReminder)
+  .then(reviewReminderMessage)
 ```
 
-Action nodes do not add business output to `steps`.
-
-## Step Dataflow
-
-When the previous workflow state already matches the next step input, use direct dataflow:
+Use a mapper when the next step or action needs a specific shape.
 
 ```ts
-defineWorkflow("direct-reconciliation")
-  .input({ transaction: ref(Transaction) })
-  .then(findBestInvoice)
-  .then(reviewInvoiceMatch)
-```
-
-Use a mapper when the next step needs a different shape:
-
-```ts
-defineWorkflow("mapped-reconciliation")
-  .input({ transaction: ref(Transaction) })
-  .then(findBestInvoice)
-  .then(reviewInvoiceMatch, ({ input, steps }) => ({
-    transaction: input.transaction,
-    invoice: steps.findBestInvoice.invoice,
-    confidence: steps.findBestInvoice.confidence,
+export const reviewInvoiceWorkflow = defineWorkflow("review-invoice")
+  .input({
+    invoice: ref(Invoice),
+  })
+  .then(prepareInvoiceReminder)
+  .then(reviewReminderMessage, ({ input, steps }) => ({
+    invoice: input.invoice,
+    message: steps.prepareInvoiceReminder.message,
   }))
 ```
 
-Mappers receive:
+Mappers can read the original workflow `input` and outputs from earlier `steps`.
 
-- `input`: the original workflow input
-- `steps`: outputs from earlier step nodes, keyed by derived step key
+## Add a schedule
 
-Later step outputs are not available yet, and action nodes do not expose step output.
-
-## Schedule Triggers
-
-Workflows can attach schedule triggers:
+Workflows can start from a schedule.
 
 ```ts
 import { defineSchedule, defineWorkflow } from "@sixb/core"
 
-export const daily = defineSchedule("daily-reconciliation").cron("0 6 * * *")
+export const daily = defineSchedule("daily-invoice-reminders").cron("0 9 * * *")
 
-export const nightlyReconciliation = defineWorkflow("nightly-reconciliation")
+export const dailyInvoiceReminders = defineWorkflow("daily-invoice-reminders")
   .input({})
   .when(daily)
-  .then(findTransactionsToReview)
+  .then(findInvoicesToRemind)
 ```
 
-A schedule event has no business payload. Because of that, the orchestrator only auto-routes
-scheduled workflows whose input shape is empty.
+Scheduled workflows should use empty input. A schedule says "run now"; it does not provide an
+invoice, customer, or other business object.
 
-This is routable:
+If a workflow needs input, start it from your app or API with that input.
 
-```ts
-defineWorkflow("nightly-reconciliation").input({}).when(daily).then(findTransactionsToReview)
-```
+## Workflow vs other concepts
 
-This is registered and valid, but not auto-routed from the schedule:
+| Need | Use |
+| --- | --- |
+| Move data from an external system | Sync |
+| Clean or join table data | Pipeline |
+| Turn rows into objects | Projection |
+| Watch whether an object needs attention | Rule |
+| Run a multi-step business process | Workflow |
+| Perform one command on one object | Action |
 
-```ts
-defineWorkflow("reconcile-transaction")
-  .input({ transaction: ref(Transaction) })
-  .when(daily)
-  .then(findBestInvoice)
-```
+A good rule: workflows coordinate work; steps and actions do the work.
 
-Use `compileRoutesWithDiagnostics(...)` to see skipped scheduled workflows:
+## Convention
 
-```ts
-import { compileRoutesWithDiagnostics } from "@sixb/orchestrator"
-
-const { routes, diagnostics } = compileRoutesWithDiagnostics({
-  syncs: sixb.getSyncDefinitions(),
-  pipelines: sixb.getPipelineDefinitions(),
-  projections: [...sixb.getObjectProjections(), ...sixb.getLinkProjections()],
-  workflows: sixb.getWorkflowDefinitions(),
-})
-```
-
-The diagnostic type is:
-
-```ts
-{
-  type: "workflow.schedule.input-required",
-  workflowId: "reconcile-transaction",
-  scheduleId: "daily-reconciliation",
-  inputFields: ["transaction"],
-}
-```
-
-## Discovery
-
-Export workflow definitions from `workflows/`:
+Put workflow definitions in `workflows/` and export them.
 
 ```txt
 your-project/
   actions/
-    attachInvoice.ts
+    send-reminder.ts
   ontology/
-    transaction.ts
-  schedules/
-    daily.ts
+    invoice.ts
   workflows/
-    reconcileTransaction.ts
+    invoice-reminder.ts
   sixb.config.ts
 ```
 
-`createSixb()` scans `workflows/` and registers exported workflow definitions automatically.
+`createSixb()` discovers exported workflow definitions from `workflows/` automatically.
 
 You can also register workflows explicitly:
 
 ```ts
-createSixb({
-  ontologies: [Transaction, Invoice],
-  actions: [attachInvoice],
-  schedules: [daily],
-  workflows: [reconcileTransaction],
-  // ...
+import { createSixb } from "@sixb/core"
+import { sendReminder } from "./actions/send-reminder"
+import { Invoice } from "./ontology/invoice"
+import { invoiceReminderWorkflow } from "./workflows/invoice-reminder"
+
+export const sixb = createSixb({
+  ontology: [Invoice],
+  actions: [sendReminder],
+  workflows: [invoiceReminderWorkflow],
 })
 ```
 
-Registered workflows can be inspected from the runtime:
+## How to model workflows
 
-```ts
-sixb.getWorkflowDefinitions()
-sixb.getWorkflowById("reconcile-transaction")
-```
+Start with the business process, not the code.
 
-## Runtime Validation
+1. Name the outcome the workflow should produce.
+2. Decide what input is needed to start.
+3. Define the smallest first step.
+4. Add another step only when it has a clear job.
+5. Use actions for side effects on objects.
+6. Add a schedule only when the workflow can start without business input.
 
-At startup, Sixb rejects:
+Good workflow names describe the process:
 
-- duplicate workflow ids
-- workflows with no nodes
-- workflow triggers that are not schedules
-- workflows referencing unknown schedules
-- workflows referencing unknown actions
-- duplicate node ids
-- duplicate derived node keys
-- action nodes without a mapper
+- `invoice-reminder`
+- `review-invoice`
+- `close-stale-projects`
+- `daily-health-check`
 
-## How Scheduled Routing Fits
+## Starting workflows
 
-The orchestrator compiles routes at startup:
+A workflow can be started by your app, by the API, or by a schedule.
 
-```text
-workflow definitions
-  -> compileRoutes(...)
-  -> route table
-```
+In local development, `sixb dev` can run workflow workers when workflows are registered.
 
-When a matching schedule event is observed, the orchestrator enqueues a workflow run request:
-
-```text
-schedule.triggered
-  -> OrchestratorWorker
-  -> queues.workflows.enqueue(workflow.run.requested)
-```
-
-The queued payload for an empty-input scheduled workflow looks like:
-
-```ts
-{
-  type: "workflow.run.requested",
-  payload: {
-    workflowId: "nightly-reconciliation",
-    input: {},
-  },
-}
-```
-
-Source event metadata is attached to the queue job envelope.
-
-In local development, `sixb dev` co-hosts `WorkflowWorker` when workflows are registered:
-
-```text
-sixb dev
-  -> compile workflow routes
-  -> start WorkflowWorker
-  -> start OrchestratorWorker
-  -> start scheduler
-```
-
-For a dedicated process, use:
+For a separate worker process:
 
 ```bash
-sixb worker workflow
+sixb worker --worker workflow
 ```
 
-## Current Scope
+## Extra details
 
-The current workflow surface defines, registers, validates, discovers, routes, and executes
-sequential workflow definitions. It does not add branching, parallel execution, nested workflows, trigger admission mappers, or aliases for workflow node keys.
+- workflows run nodes sequentially in V1.
+- a workflow must contain at least one node.
+- step input and output are validated at runtime.
+- action nodes must use a mapper.
+- action nodes request object actions and wait for them to finish.
+- scheduled auto-start works for workflows with empty input.
+- registered workflows can be inspected with `sixb.getWorkflowDefinitions()` and
+  `sixb.getWorkflowById(...)`.
 
-Scheduled auto-routing only supports empty workflow input. Workflows with required input need an
-explicit caller or a future trigger-admission mapper that can build input from the triggering event.
-
-## Guidelines
-
-- Keep workflow ids stable and business-readable.
-- Use step ids that produce readable derived keys, such as `find-best-invoice`.
-- Prefer direct `.then(step)` when the previous output already matches the next input.
-- Use mappers when passing a small, explicit shape is clearer.
-- Keep action nodes for side-effect requests and step nodes for workflow dataflow.
-- Use empty workflow input for scheduled workflows in V1.
+The important first step is to make each workflow read like the business process it represents.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sixb",
   "private": true,
   "workspaces": [
+    "apps/*",
     "auth/*",
     "packages/*",
     "connectors/*",
@@ -24,6 +25,9 @@
     "check": "biome check .",
     "check:fix": "biome check --write .",
     "generate:client": "bun --filter @sixb/server generate:openapi && bun --filter @sixb/client generate && bun check:fix",
+    "docs:dev": "bun --filter @sixb/docs dev",
+    "docs:build": "bun --filter @sixb/docs build",
+    "docs:typecheck": "bun --filter @sixb/docs typecheck",
     "ui:dev": "bun --filter @sixb/ui dev",
     "ui:add": "bun --cwd packages/ui x shadcn@latest add"
   },


### PR DESCRIPTION
@quentinnippert Played around a bit with what we can do for wrapping our /docs markdown files into a website. Made a simple version to start and see whats possible. Take a look and see what you like

https://docs.sixb.ai/

all pages having markdown rendered versions as well: https://docs.sixb.ai/concepts/sync.md

let me know if you like this custom approach or we should make use of pre built framework like docusaurous or nextra

I also updated the docs content and tried to improve it a bit 

feel free to push some updates

----

## Summary

- Add a standalone `apps/docs` React/Bun docs site that renders the markdown docs as clean static pages.
- Publish matching `.md` files for each rendered docs route for LLM-friendly access.
- Rewrite the core docs pages with a simpler developer-focused style.
- Add a GitHub Pages workflow for `main`, this branch, and manual dispatch so we can test hosting before merging.

## Testing

- `bun run docs:typecheck`
- `bun run docs:build`
- `bun run check .github/workflows/docs.yml`
- `bun run check docs/concepts/ontology.md docs/concepts/datasets.md docs/concepts/sync.md docs/concepts/pipeline.md docs/concepts/projection.md docs/concepts/rules.md docs/concepts/workflows.md`

## Notes

- This branch is intentionally included in the Pages workflow so we can test deployment before merging.
- Before merging or after testing, we should remove `docs-website-beginnings` from the Pages workflow trigger if we only want `main` deployments.