### PR TITLE
storage: optimize DuckLake write connections

### DIFF
--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -23,6 +23,68 @@ const lakeStorage = new DuckLakeStorage({
 await lakeStorage.close()
 ```
 
+## Runtime and Connections
+
+`DuckLakeStorage` creates one embedded DuckDB runtime for each provider
+instance. DuckLake attaches lazily on the first lake operation, so constructing
+the provider does not immediately open catalog connections.
+
+Within one provider instance, DuckDB work is queued on that runtime. This keeps
+writes, SQL transforms, and metadata reads predictable and keeps PostgreSQL
+connection use bounded.
+
+```txt
+one DuckLakeStorage instance
+  -> one DuckDB runtime
+  -> one DuckLake attachment
+  -> one bounded PostgreSQL extension pool, when catalog.type is "postgres"
+```
+
+For PostgreSQL catalogs, `postgresPool.maxConnections` is a per-instance budget.
+If four production processes each create a `DuckLakeStorage` with
+`maxConnections: 4`, the deployment can use about sixteen PostgreSQL catalog
+connections for DuckLake metadata.
+
+```ts
+const lakeStorage = new DuckLakeStorage({
+  catalog: { type: "postgres", host, database, user, password },
+  dataPath: "s3://pario-lake/data",
+  duckdb: {
+    config: {
+      threads: "1",
+    },
+  },
+  postgresPool: {
+    maxConnections: 4,
+    idleTimeoutMillis: 1_000,
+    enableThreadLocalCache: false,
+  },
+})
+```
+
+Use `close()` during service shutdown so DuckDB can close its runtime and release
+catalog connections cleanly.
+
+### Read and Write Concurrency
+
+Reads, writes, SQL previews, and SQL transforms use the same DuckDB runtime and
+the same DuckLake PostgreSQL metadata pool. Work is serialized inside one
+`DuckLakeStorage` instance, so a large write can make later reads wait. A large
+streaming read can also make a later write wait until the stream is consumed or
+closed.
+
+```txt
+same provider instance:
+  read -> write -> read
+
+the operations run in order on one DuckDB runtime
+```
+
+This is the simplest and most predictable default, especially for small
+PostgreSQL plans. A future provider option could add a bounded read-runtime pool
+for deployments that have enough PostgreSQL capacity and need more concurrent
+read throughput.
+
 Datasets must declare a schema before they can be stored in DuckLake:
 
 ```ts
@@ -200,6 +262,143 @@ const lakeStorage = new DuckLakeStorage({
   ],
 })
 ```
+
+## PostgreSQL Configuration
+
+Use a PostgreSQL catalog for production or any deployment where multiple Pario
+processes need to see the same DuckLake snapshots. Local DuckDB or SQLite
+catalogs are better suited to development and tests.
+
+PostgreSQL stores only DuckLake metadata. Dataset table data still lives under
+`dataPath`, usually in object storage such as S3, R2, GCS, or Azure Blob.
+
+```txt
+PostgreSQL catalog  -> snapshots, schemas, transactions, metadata
+dataPath            -> physical DuckLake table data and files
+BlobStorage         -> Pario fileRef payload bytes
+```
+
+Recommended production shape:
+
+```ts
+const lakeStorage = new DuckLakeStorage({
+  catalog: {
+    type: "postgres",
+    host: process.env.PGHOST!,
+    port: Number(process.env.PGPORT ?? 5432),
+    database: process.env.PGDATABASE!,
+    user: process.env.PGUSER!,
+    password: process.env.PGPASSWORD!,
+    sslMode: "require",
+    applicationName: "pario-api",
+    connectTimeoutSeconds: 10,
+    metadataSchema: "pario_lake",
+  },
+  dataPath: "s3://pario-lake/data",
+  duckdb: {
+    config: {
+      threads: "2",
+    },
+  },
+  postgresPool: {
+    maxConnections: 8,
+    waitTimeoutMillis: 30_000,
+    idleTimeoutMillis: 1_000,
+    maxLifetimeMillis: 300_000,
+    enableThreadLocalCache: false,
+  },
+  secrets: [
+    {
+      type: "s3",
+      keyId: process.env.AWS_ACCESS_KEY_ID,
+      secret: process.env.AWS_SECRET_ACCESS_KEY,
+      region: "us-east-1",
+      scope: "s3://pario-lake",
+    },
+  ],
+})
+```
+
+### What Each Setting Controls
+
+| Setting | Controls |
+| --- | --- |
+| `catalog` | The PostgreSQL database DuckLake uses for metadata. |
+| `catalog.metadataSchema` | The schema that holds DuckLake metadata tables. |
+| `dataPath` | Where DuckLake stores physical table data. |
+| `duckdb.config.threads` | Local DuckDB worker threads inside this process. |
+| `postgresPool` | DuckDB PostgreSQL extension connections for DuckLake metadata. |
+
+This pool is separate from any normal Pario `PostgresStorage` pool. Count both
+when sizing a small database.
+
+### Connection Sizing
+
+Start with the smallest budget that supports your workload, then raise it after
+observing real latency and PostgreSQL connection use.
+
+| Deployment | `duckdb.config.threads` | `postgresPool.maxConnections` | Notes |
+| --- | ---: | ---: | --- |
+| Small managed PostgreSQL, about 20 connections | `"1"` | `4` | Run only the services that need the lake provider. |
+| Normal production service | `"2"` to `"4"` | `8` to `16` | Good default range for API and worker processes. |
+| Larger read-heavy deployment | `"4"` or more | `16` or more | Scale only with PostgreSQL headroom and monitoring. |
+
+The budget multiplies by process count:
+
+```txt
+estimated DuckLake catalog connections =
+  number of processes with DuckLakeStorage * postgresPool.maxConnections
+```
+
+If the PostgreSQL role has a `CONNECTION LIMIT`, size it for the whole
+deployment:
+
+```txt
+role connection limit >=
+  DuckLake catalog connections
+  + normal application PostgreSQL pool connections
+  + migration, admin, and monitoring headroom
+```
+
+Leave headroom for the normal Pario PostgreSQL storage provider, migrations,
+admin sessions, monitoring, and PostgreSQL reserved connections.
+
+### Pool Options
+
+`postgresPool` maps to DuckDB's PostgreSQL extension pool settings for the
+DuckLake metadata catalog.
+
+| Option | Use it for |
+| --- | --- |
+| `maxConnections` | Hard cap for DuckDB PostgreSQL extension connections. |
+| `waitTimeoutMillis` | How long a request can wait for a pool connection. |
+| `idleTimeoutMillis` | How quickly unused pool connections are released. |
+| `maxLifetimeMillis` | Recycling long-lived PostgreSQL connections. |
+| `enableThreadLocalCache` | Keep `false` for constrained databases. |
+| `healthCheckQuery` | Custom pool connection health checks, rarely needed. |
+
+Prefer `postgresPool` over raw `setupSql` for PostgreSQL pool tuning. The
+provider applies the settings before and after DuckLake attachment so the
+metadata catalog uses the intended pool.
+
+### Service Layout
+
+Each service process that constructs `DuckLakeStorage` owns its own DuckDB
+runtime and PostgreSQL pool. Avoid creating the lake provider in services that
+do not need it.
+
+```txt
+needs DuckLakeStorage:
+  api reads, sync worker, pipeline worker, projection worker
+
+does not need DuckLakeStorage:
+  static app server, health-only process, services that only use BlobStorage
+```
+
+On very small PostgreSQL plans, run fewer lake-owning processes or group workers
+into one process before lowering `maxConnections` too far. A pool budget below
+`4` can become fragile because one runtime may need several metadata operations
+during attach, commit, and snapshot hydration.
 
 Use `custom` when you need to pass a DuckLake catalog URI that Pario does not
 model directly:

--- a/storage/ducklake/src/index.ts
+++ b/storage/ducklake/src/index.ts
@@ -4,6 +4,7 @@ export type {
   DuckDbRuntimeOptions,
   DuckDbSecretOptions,
   DuckLakeCatalogOptions,
+  DuckLakePostgresPoolOptions,
   DuckLakeStorageOptions,
   GcsSecretOptions,
   R2SecretOptions,

--- a/storage/ducklake/src/internal/catalog-key.ts
+++ b/storage/ducklake/src/internal/catalog-key.ts
@@ -1,0 +1,28 @@
+import { resolve } from "node:path"
+import type { DuckLakeStorageOptions } from "../types"
+
+/**
+ * Stable key for coordinating local catalog users inside this process.
+ *
+ * PostgreSQL coordinates through the database. In-memory local catalogs have no
+ * shared file identity. File-backed local catalogs need equivalent path
+ * spellings, such as `lake.ducklake` and `dir/../lake.ducklake`, to map to the
+ * same coordination key.
+ */
+export function localCatalogCoordinationKey(
+  options: Pick<DuckLakeStorageOptions, "catalog">
+): string | undefined {
+  switch (options.catalog.type) {
+    case "duckdb":
+    case "sqlite":
+      if (options.catalog.path === ":memory:") {
+        return undefined
+      }
+
+      return `${options.catalog.type}:${resolve(options.catalog.path)}`
+    case "custom":
+      return `custom:${options.catalog.uri}`
+    case "postgres":
+      return undefined
+  }
+}

--- a/storage/ducklake/src/internal/dataset-row-commit.ts
+++ b/storage/ducklake/src/internal/dataset-row-commit.ts
@@ -6,6 +6,16 @@ import { encodeDatasetTableName } from "./names"
 import { datasetSchemaColumnNamesSql } from "./schema"
 import { qualifiedTableName } from "./sql"
 
+export type CommitRowCount =
+  | { readonly kind: "exact"; readonly value: number }
+  | { readonly kind: "unknown" }
+
+export interface ApplyDatasetRowsResult {
+  readonly dataChangeExpected: boolean
+  readonly sourceRowCount: number
+  readonly resultingRowCount: CommitRowCount
+}
+
 export function assertDatasetWriteMode(
   mode: unknown,
   operation: string
@@ -24,12 +34,16 @@ export async function applyDatasetRowsFromRelation(input: {
   readonly mode: DatasetWriteMode
   /** Provider-rendered relation SQL, such as a quoted staging or temp table. */
   readonly sourceRelationSql: string
-}): Promise<boolean> {
+  readonly previousRowCount?: number
+}): Promise<ApplyDatasetRowsResult> {
   const tableName = encodeDatasetTableName(input.dataset.id)
   const table = qualifiedTableName(input.options, tableName)
   const columnsSql = datasetSchemaColumnNamesSql(input.dataset.schema)
   const sourceRowCount = await countRows(input.runtime, input.sourceRelationSql)
-  const existingRowCount = input.mode === "snapshot" ? await countRows(input.runtime, table) : 0
+  const existingRowCount =
+    input.mode === "snapshot" && sourceRowCount === 0
+      ? (input.previousRowCount ?? (await countRows(input.runtime, table)))
+      : 0
 
   if (input.mode === "snapshot") {
     await input.runtime.run(`DELETE FROM ${table}`)
@@ -39,7 +53,22 @@ export async function applyDatasetRowsFromRelation(input: {
     `INSERT INTO ${table} (${columnsSql}) SELECT ${columnsSql} FROM ${input.sourceRelationSql}`
   )
 
-  return input.mode === "append" ? sourceRowCount > 0 : sourceRowCount > 0 || existingRowCount > 0
+  if (input.mode === "append") {
+    return {
+      dataChangeExpected: sourceRowCount > 0,
+      sourceRowCount,
+      resultingRowCount:
+        input.previousRowCount === undefined
+          ? { kind: "unknown" }
+          : { kind: "exact", value: input.previousRowCount + sourceRowCount },
+    }
+  }
+
+  return {
+    dataChangeExpected: sourceRowCount > 0 || existingRowCount > 0,
+    sourceRowCount,
+    resultingRowCount: { kind: "exact", value: sourceRowCount },
+  }
 }
 
 async function countRows(runtime: DuckDbRuntime, relationSql: string): Promise<number> {

--- a/storage/ducklake/src/internal/dataset-row-commit.ts
+++ b/storage/ducklake/src/internal/dataset-row-commit.ts
@@ -1,7 +1,7 @@
 import { type DatasetDefinition, type DatasetWriteMode, LakeStorageError } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
 import { getBigIntLike } from "./duckdb-row"
-import type { DuckDbRuntime } from "./duckdb-runtime"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import { encodeDatasetTableName } from "./names"
 import { datasetSchemaColumnNamesSql } from "./schema"
 import { qualifiedTableName } from "./sql"
@@ -29,7 +29,7 @@ export function assertDatasetWriteMode(
 
 export async function applyDatasetRowsFromRelation(input: {
   readonly options: DuckLakeStorageOptions
-  readonly runtime: DuckDbRuntime
+  readonly runtime: DuckDbQueryRuntime
   readonly dataset: DatasetDefinition
   readonly mode: DatasetWriteMode
   /** Provider-rendered relation SQL, such as a quoted staging or temp table. */
@@ -71,7 +71,7 @@ export async function applyDatasetRowsFromRelation(input: {
   }
 }
 
-async function countRows(runtime: DuckDbRuntime, relationSql: string): Promise<number> {
+async function countRows(runtime: DuckDbQueryRuntime, relationSql: string): Promise<number> {
   const [row] = await runtime.query(`SELECT count(*) AS row_count FROM ${relationSql}`)
   if (row === undefined) {
     return 0

--- a/storage/ducklake/src/internal/duckdb-runtime.ts
+++ b/storage/ducklake/src/internal/duckdb-runtime.ts
@@ -22,6 +22,7 @@ import {
  */
 export interface DuckDbRuntime {
   run(sql: string, values?: readonly DuckDBValue[]): Promise<void>
+  runStatements(statements: readonly string[]): Promise<void>
   query(sql: string, values?: readonly DuckDBValue[]): Promise<readonly Record<string, unknown>[]>
   streamRows(sql: string, values?: readonly DuckDBValue[]): AsyncIterable<Record<string, unknown>>
   withAppender<T>(
@@ -41,6 +42,10 @@ export interface DuckDbAppender {
   endRow(): void
 }
 
+interface SetupDuckLakeOptions {
+  readonly installExtensions?: boolean
+}
+
 class NodeDuckDbRuntime implements DuckDbRuntime {
   private closing = false
   private closed = false
@@ -56,6 +61,14 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
   async run(sql: string, values?: readonly DuckDBValue[]): Promise<void> {
     await this.enqueue(async () => {
       await this.connection.run(sql, values === undefined ? undefined : [...values])
+    })
+  }
+
+  async runStatements(statements: readonly string[]): Promise<void> {
+    await this.enqueue(async () => {
+      for (const sql of statements) {
+        await this.connection.run(sql)
+      }
     })
   }
 
@@ -208,18 +221,37 @@ export async function createDuckDbRuntime(
 }
 
 /**
- * Install/load DuckLake, install/load catalog extensions, run caller setup SQL,
- * and attach the configured DuckLake catalog.
+ * Install DuckLake and any catalog/data-path extensions into DuckDB's local
+ * extension directory. Installation is idempotent and can be shared by many
+ * short-lived runtimes created by one provider instance.
  */
-export async function setupDuckLake(
+export async function installDuckLakeExtensions(
   runtime: DuckDbRuntime,
   options: DuckLakeStorageOptions
 ): Promise<void> {
   await runtime.run("INSTALL ducklake")
-  await runtime.run("LOAD ducklake")
 
   for (const extension of requiredExtensions(options)) {
     await runtime.run(`INSTALL ${quoteIdentifier(extension)}`)
+  }
+}
+
+/**
+ * Load DuckLake, load catalog extensions, run caller setup SQL, and attach the
+ * configured DuckLake catalog.
+ */
+export async function setupDuckLake(
+  runtime: DuckDbRuntime,
+  options: DuckLakeStorageOptions,
+  setupOptions: SetupDuckLakeOptions = {}
+): Promise<void> {
+  if (setupOptions.installExtensions ?? true) {
+    await installDuckLakeExtensions(runtime, options)
+  }
+
+  await runtime.run("LOAD ducklake")
+
+  for (const extension of requiredExtensions(options)) {
     await runtime.run(`LOAD ${quoteIdentifier(extension)}`)
   }
 

--- a/storage/ducklake/src/internal/duckdb-runtime.ts
+++ b/storage/ducklake/src/internal/duckdb-runtime.ts
@@ -10,6 +10,7 @@ import {
   buildAttachSql,
   buildConfigurePostgresMetadataPoolSql,
   buildCreateSecretSql,
+  buildSetPostgresPoolSql,
   quoteIdentifier,
   requiredExtensions,
 } from "./sql"
@@ -19,18 +20,38 @@ import {
  *
  * Keeping the public provider behind this interface lets later slices add
  * appender/query helpers without leaking driver types into `DuckLakeStorage`.
+ * Calls on a runtime are serialized through one queue because a runtime owns
+ * one DuckDB connection.
  */
-export interface DuckDbRuntime {
+export interface DuckDbQueryRuntime {
   run(sql: string, values?: readonly DuckDBValue[]): Promise<void>
   runStatements(statements: readonly string[]): Promise<void>
   query(sql: string, values?: readonly DuckDBValue[]): Promise<readonly Record<string, unknown>[]>
-  streamRows(sql: string, values?: readonly DuckDBValue[]): AsyncIterable<Record<string, unknown>>
   withAppender<T>(
     tableName: string,
     useAppender: (appender: DuckDbAppender) => T | Promise<T>
   ): Promise<T>
+}
+
+export interface DuckDbRuntime extends DuckDbQueryRuntime {
+  streamRows(sql: string, values?: readonly DuckDBValue[]): AsyncIterable<Record<string, unknown>>
+  /**
+   * Reserve the runtime queue for a multi-statement critical section.
+   *
+   * Use this for sequences such as BEGIN/read metadata/write/COMMIT where an
+   * interleaved read or write would observe the wrong connection state.
+   */
+  withExclusive<T>(useRuntime: (runtime: DuckDbExclusiveRuntime) => Promise<T>): Promise<T>
   close(): Promise<void>
 }
+
+/**
+ * Runtime surface available while the caller already owns the queue slot.
+ *
+ * This is the query/appender subset only: no streaming, no close, and no nested
+ * exclusive block.
+ */
+export type DuckDbExclusiveRuntime = DuckDbQueryRuntime
 
 export interface DuckDbAppender {
   appendNull(): void
@@ -44,6 +65,7 @@ export interface DuckDbAppender {
 
 interface SetupDuckLakeOptions {
   readonly installExtensions?: boolean
+  readonly attach?: boolean
 }
 
 class NodeDuckDbRuntime implements DuckDbRuntime {
@@ -91,6 +113,9 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
   ): AsyncIterable<Record<string, unknown>> {
     this.assertAcceptingOperations()
 
+    // A stream holds its queue slot until the consumer finishes or abandons the
+    // iterator. This keeps later writes from running while rows are still being
+    // read from the same DuckDB connection.
     let releaseOperation: (() => void) | undefined
     const operationFinished = new Promise<void>((resolve) => {
       releaseOperation = resolve
@@ -135,6 +160,14 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
     })
   }
 
+  async withExclusive<T>(useRuntime: (runtime: DuckDbExclusiveRuntime) => Promise<T>): Promise<T> {
+    return this.enqueue(async () => {
+      // The exclusive adapter talks directly to the underlying connection while
+      // this queued operation is active. Do not pass `this` into the callback.
+      return useRuntime(new NodeDuckDbExclusiveRuntime(this.connection))
+    })
+  }
+
   async close(): Promise<void> {
     if (this.closed) {
       return
@@ -174,6 +207,43 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
   private assertNotClosed(): void {
     if (this.closed) {
       throw new LakeStorageError("[ParioDuckLake] DuckDB runtime is closed.")
+    }
+  }
+}
+
+class NodeDuckDbExclusiveRuntime implements DuckDbExclusiveRuntime {
+  constructor(private readonly connection: DuckDBConnection) {}
+
+  async run(sql: string, values?: readonly DuckDBValue[]): Promise<void> {
+    await this.connection.run(sql, values === undefined ? undefined : [...values])
+  }
+
+  async runStatements(statements: readonly string[]): Promise<void> {
+    for (const sql of statements) {
+      await this.connection.run(sql)
+    }
+  }
+
+  async query(
+    sql: string,
+    values?: readonly DuckDBValue[]
+  ): Promise<readonly Record<string, unknown>[]> {
+    const reader = await this.connection.runAndReadAll(
+      sql,
+      values === undefined ? undefined : [...values]
+    )
+    return reader.getRowObjectsJS()
+  }
+
+  async withAppender<T>(
+    tableName: string,
+    useAppender: (appender: DuckDbAppender) => T | Promise<T>
+  ): Promise<T> {
+    const appender = await this.connection.createAppender(tableName)
+    try {
+      return await useAppender(new NodeDuckDbAppenderAdapter(appender))
+    } finally {
+      appender.closeSync()
     }
   }
 }
@@ -237,8 +307,8 @@ export async function installDuckLakeExtensions(
 }
 
 /**
- * Load DuckLake, load catalog extensions, run caller setup SQL, and attach the
- * configured DuckLake catalog.
+ * Load DuckLake, load catalog extensions, run caller setup SQL, and optionally
+ * attach the configured DuckLake catalog.
  */
 export async function setupDuckLake(
   runtime: DuckDbRuntime,
@@ -259,13 +329,19 @@ export async function setupDuckLake(
     await runtime.run(sql)
   }
 
+  if (options.catalog.type === "postgres") {
+    await runtime.runStatements(buildSetPostgresPoolSql(options))
+  }
+
   for (const secret of options.secrets ?? []) {
     await runtime.run(buildCreateSecretSql(secret))
   }
 
-  await runtime.run(buildAttachSql(options))
+  if (setupOptions.attach ?? true) {
+    await runtime.run(buildAttachSql(options))
 
-  if (options.catalog.type === "postgres") {
-    await runtime.run(buildConfigurePostgresMetadataPoolSql(options))
+    if (options.catalog.type === "postgres") {
+      await runtime.run(buildConfigurePostgresMetadataPoolSql(options))
+    }
   }
 }

--- a/storage/ducklake/src/internal/ducklake-connection-manager.ts
+++ b/storage/ducklake/src/internal/ducklake-connection-manager.ts
@@ -1,16 +1,58 @@
 import { LakeStorageError } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
-import { createDuckDbRuntime, type DuckDbRuntime, setupDuckLake } from "./duckdb-runtime"
+import {
+  createDuckDbRuntime,
+  type DuckDbRuntime,
+  installDuckLakeExtensions,
+  setupDuckLake,
+} from "./duckdb-runtime"
+import {
+  buildAttachSql,
+  buildConfigurePostgresMetadataPoolSql,
+  duckLakeAlias,
+  quoteIdentifier,
+} from "./sql"
+
+interface ReleaseWriteRuntimeOptions {
+  readonly reuse: boolean
+}
+
+export interface DuckLakeCommittedWriteRuntimeRelease {
+  readonly kind: "committed"
+  readonly guarded: boolean
+  readonly reusable: boolean
+}
+
+export type DuckLakeWriteRuntimeRelease =
+  | DuckLakeCommittedWriteRuntimeRelease
+  | { readonly kind: "aborted"; readonly reusable?: boolean }
+  | { readonly kind: "failed" }
+
+export interface DuckLakeWriteRuntimeLease {
+  readonly runtime: DuckDbRuntime
+  committedReadRuntime(release: DuckLakeCommittedWriteRuntimeRelease): Promise<DuckDbRuntime>
+  release(result: DuckLakeWriteRuntimeRelease): Promise<void>
+}
+
+export interface DuckLakeWriteRuntimeLeaseResult<T> {
+  readonly value: T
+  readonly release: DuckLakeWriteRuntimeRelease
+}
+
+const MAX_IDLE_WRITE_RUNTIMES = 1
 
 /**
  * Owns DuckDB/DuckLake runtime lifecycle for DuckLakeStorage.
  *
- * The shared runtime serves reads and metadata calls. Dedicated write runtimes
- * are created per write session because DuckDB temp staging tables are
- * connection-scoped.
+ * The shared runtime serves reads and metadata calls. Active writes receive
+ * isolated runtime leases because DuckDB temp staging tables are
+ * connection-scoped. Clean leases can be reused for catalog types that have
+ * reliable cross-connection snapshot visibility.
  */
 export class DuckLakeConnectionManager {
   private runtimePromise: Promise<DuckDbRuntime> | undefined
+  private installExtensionsPromise: Promise<void> | undefined
+  private readonly idleWriteRuntimes: DuckDbRuntime[] = []
   private closed = false
 
   constructor(private readonly options: DuckLakeStorageOptions) {}
@@ -38,15 +80,17 @@ export class DuckLakeConnectionManager {
   }
 
   /**
-   * Create a fresh attached runtime. Write sessions use this directly so they
-   * can keep connection-scoped staging tables isolated from shared reads.
+   * Create a fresh initialized runtime. Setup work here is runtime-scoped:
+   * extensions are loaded, secrets/setup SQL run, and the DuckLake catalog is
+   * attached exactly once for this runtime.
    */
   async createRuntime(): Promise<DuckDbRuntime> {
     this.assertOpen()
 
     const runtime = await createDuckDbRuntime(this.options.duckdb)
     try {
-      await setupDuckLake(runtime, this.options)
+      await this.ensureExtensionsInstalled(runtime)
+      await setupDuckLake(runtime, this.options, { installExtensions: false })
       return runtime
     } catch (error) {
       await runtime.close()
@@ -54,18 +98,98 @@ export class DuckLakeConnectionManager {
     }
   }
 
+  async acquireWriteRuntime(): Promise<DuckDbRuntime> {
+    this.assertOpen()
+
+    const runtime = this.idleWriteRuntimes.pop()
+    return runtime ?? this.createRuntime()
+  }
+
+  async acquireWriteLease(): Promise<DuckLakeWriteRuntimeLease> {
+    return new ManagedDuckLakeWriteRuntimeLease(this, await this.acquireWriteRuntime())
+  }
+
+  async withWriteRuntime<T>(
+    useLease: (
+      lease: DuckLakeWriteRuntimeLease
+    ) => DuckLakeWriteRuntimeLeaseResult<T> | Promise<DuckLakeWriteRuntimeLeaseResult<T>>
+  ): Promise<T> {
+    const lease = await this.acquireWriteLease()
+
+    try {
+      const result = await useLease(lease)
+      await lease.release(result.release)
+      return result.value
+    } catch (error) {
+      await lease.release({ kind: "failed" })
+      throw error
+    }
+  }
+
+  async releaseWriteRuntime(
+    runtime: DuckDbRuntime,
+    options: ReleaseWriteRuntimeOptions
+  ): Promise<void> {
+    if (
+      this.closed ||
+      !options.reuse ||
+      !this.canReuseWriteRuntime() ||
+      this.idleWriteRuntimes.length >= MAX_IDLE_WRITE_RUNTIMES
+    ) {
+      await runtime.close()
+      return
+    }
+
+    this.idleWriteRuntimes.push(runtime)
+  }
+
+  canReuseWriteRuntime(): boolean {
+    return canReuseWriteRuntimeForOptions(this.options)
+  }
+
+  private canRefreshReadRuntime(): boolean {
+    return this.options.catalog.type === "postgres"
+  }
+
   /**
-   * Reconnect the shared read/runtime connection after a write commits.
+   * Refresh the shared read/runtime connection after a write commits.
    *
    * DuckLake snapshot visibility is attached to the connection that loaded the
-   * catalog. A fresh runtime prevents latest-version and read queries from
-   * observing stale metadata after a dedicated write connection commits.
+   * catalog. PostgreSQL catalogs can re-attach in place; local metadata files
+   * need a fresh runtime to avoid stale or invalid file-backed catalog state.
    */
   async resetRuntime(): Promise<void> {
     const runtimePromise = this.runtimePromise
-    this.runtimePromise = undefined
+    if (runtimePromise === undefined) {
+      return
+    }
 
-    await this.closeRuntimePromise(runtimePromise)
+    if (!this.canRefreshReadRuntime()) {
+      this.runtimePromise = undefined
+      await this.closeRuntimePromise(runtimePromise)
+      return
+    }
+
+    let refreshedPromise: Promise<DuckDbRuntime>
+    refreshedPromise = runtimePromise
+      .then(async (runtime) => {
+        try {
+          await this.refreshAttachedRuntime(runtime)
+          return runtime
+        } catch (error) {
+          await runtime.close()
+          throw error
+        }
+      })
+      .catch((error) => {
+        if (this.runtimePromise === refreshedPromise) {
+          this.runtimePromise = undefined
+        }
+        throw error
+      })
+
+    this.runtimePromise = refreshedPromise
+    await refreshedPromise
   }
 
   async close(): Promise<void> {
@@ -75,8 +199,36 @@ export class DuckLakeConnectionManager {
 
     this.closed = true
 
+    const idleWriteRuntimes = this.idleWriteRuntimes.splice(0)
     await this.closeRuntimePromise(this.runtimePromise)
+    await Promise.all(idleWriteRuntimes.map((runtime) => runtime.close()))
     this.runtimePromise = undefined
+  }
+
+  private async ensureExtensionsInstalled(runtime: DuckDbRuntime): Promise<void> {
+    if (this.installExtensionsPromise === undefined) {
+      const installExtensionsPromise = installDuckLakeExtensions(runtime, this.options).catch(
+        (error) => {
+          if (this.installExtensionsPromise === installExtensionsPromise) {
+            this.installExtensionsPromise = undefined
+          }
+          throw error
+        }
+      )
+      this.installExtensionsPromise = installExtensionsPromise
+    }
+
+    await this.installExtensionsPromise
+  }
+
+  private async refreshAttachedRuntime(runtime: DuckDbRuntime): Promise<void> {
+    await runtime.runStatements([
+      `DETACH ${quoteIdentifier(duckLakeAlias(this.options))}`,
+      buildAttachSql(this.options),
+      ...(this.options.catalog.type === "postgres"
+        ? [buildConfigurePostgresMetadataPoolSql(this.options)]
+        : []),
+    ])
   }
 
   private async closeRuntimePromise(
@@ -98,4 +250,56 @@ export class DuckLakeConnectionManager {
 
     await runtime.close()
   }
+}
+
+function canReuseWriteRuntimeForOptions(options: DuckLakeStorageOptions): boolean {
+  // Local DuckDB/SQLite metadata catalogs need the committing connection to
+  // close before freshly attached read runtimes reliably observe the commit.
+  // PostgreSQL catalogs provide cross-connection visibility without relying on
+  // the writer connection closing, so they can safely keep one idle write lease.
+  return options.catalog.type === "postgres"
+}
+
+class ManagedDuckLakeWriteRuntimeLease implements DuckLakeWriteRuntimeLease {
+  private released = false
+
+  constructor(
+    private readonly connections: DuckLakeConnectionManager,
+    readonly runtime: DuckDbRuntime
+  ) {}
+
+  async committedReadRuntime(
+    release: DuckLakeCommittedWriteRuntimeRelease
+  ): Promise<DuckDbRuntime> {
+    await this.connections.resetRuntime()
+
+    if (!this.connections.canReuseWriteRuntime()) {
+      await this.release({ ...release, reusable: false })
+    }
+
+    return this.connections.runtime()
+  }
+
+  async release(result: DuckLakeWriteRuntimeRelease): Promise<void> {
+    if (this.released) {
+      return
+    }
+
+    this.released = true
+    await this.connections.releaseWriteRuntime(this.runtime, {
+      reuse: shouldReuseWriteRuntimeAfterRelease(result),
+    })
+  }
+}
+
+function shouldReuseWriteRuntimeAfterRelease(result: DuckLakeWriteRuntimeRelease): boolean {
+  if (result.kind === "failed") {
+    return false
+  }
+
+  if (result.kind === "aborted") {
+    return result.reusable ?? true
+  }
+
+  return result.reusable && !result.guarded
 }

--- a/storage/ducklake/src/internal/ducklake-connection-manager.ts
+++ b/storage/ducklake/src/internal/ducklake-connection-manager.ts
@@ -1,7 +1,10 @@
 import { LakeStorageError } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
+import { localCatalogCoordinationKey } from "./catalog-key"
 import {
   createDuckDbRuntime,
+  type DuckDbExclusiveRuntime,
+  type DuckDbQueryRuntime,
   type DuckDbRuntime,
   installDuckLakeExtensions,
   setupDuckLake,
@@ -13,49 +16,36 @@ import {
   quoteIdentifier,
 } from "./sql"
 
-interface ReleaseWriteRuntimeOptions {
-  readonly reuse: boolean
-}
-
-export interface DuckLakeCommittedWriteRuntimeRelease {
-  readonly kind: "committed"
-  readonly guarded: boolean
-  readonly reusable: boolean
-}
-
-export type DuckLakeWriteRuntimeRelease =
-  | DuckLakeCommittedWriteRuntimeRelease
-  | { readonly kind: "aborted"; readonly reusable?: boolean }
-  | { readonly kind: "failed" }
-
-export interface DuckLakeWriteRuntimeLease {
+export interface DuckLakeAttachedRuntimeLease {
   readonly runtime: DuckDbRuntime
-  committedReadRuntime(release: DuckLakeCommittedWriteRuntimeRelease): Promise<DuckDbRuntime>
-  release(result: DuckLakeWriteRuntimeRelease): Promise<void>
+  release(): Promise<void>
 }
-
-export interface DuckLakeWriteRuntimeLeaseResult<T> {
-  readonly value: T
-  readonly release: DuckLakeWriteRuntimeRelease
-}
-
-const MAX_IDLE_WRITE_RUNTIMES = 1
 
 /**
  * Owns DuckDB/DuckLake runtime lifecycle for DuckLakeStorage.
  *
- * The shared runtime serves reads and metadata calls. Active writes receive
- * isolated runtime leases because DuckDB temp staging tables are
- * connection-scoped. Clean leases can be reused for catalog types that have
- * reliable cross-connection snapshot visibility.
+ * A storage instance owns one DuckDB runtime and at most one DuckLake
+ * attachment. The runtime starts unattached so construction and non-lake setup
+ * do not immediately open DuckLake metadata connections; reads and commits
+ * attach lazily through `attachedRuntime()`.
  */
 export class DuckLakeConnectionManager {
   private runtimePromise: Promise<DuckDbRuntime> | undefined
   private installExtensionsPromise: Promise<void> | undefined
-  private readonly idleWriteRuntimes: DuckDbRuntime[] = []
+  private attachPromise: Promise<void> | undefined
+  private refreshPromise: Promise<void> | undefined
+  // Local catalogs need DETACH/ATTACH to refresh metadata visibility. Keep
+  // those attachment changes outside whole read operations so a read cannot
+  // observe the DuckLake alias disappearing between its metadata queries.
+  private localAttachmentLock: Promise<void> = Promise.resolve()
+  private observedLocalCatalogGeneration: number
+  private attached = false
   private closed = false
+  private runtimePoisoned = false
 
-  constructor(private readonly options: DuckLakeStorageOptions) {}
+  constructor(private readonly options: DuckLakeStorageOptions) {
+    this.observedLocalCatalogGeneration = currentLocalCatalogGeneration(options)
+  }
 
   assertOpen(): void {
     if (this.closed) {
@@ -79,10 +69,83 @@ export class DuckLakeConnectionManager {
     return this.runtimePromise
   }
 
+  async attachedRuntime(): Promise<DuckDbRuntime> {
+    const runtime = await this.runtime()
+    await this.ensureAttached(runtime)
+    return runtime
+  }
+
+  async withAttachedRuntime<T>(run: (runtime: DuckDbRuntime) => Promise<T>): Promise<T> {
+    const lease = await this.acquireAttachedRuntime()
+    try {
+      return await run(lease.runtime)
+    } finally {
+      await lease.release()
+    }
+  }
+
+  async acquireAttachedRuntime(): Promise<DuckLakeAttachedRuntimeLease> {
+    this.assertOpen()
+
+    // The lease is intentionally wider than one DuckDB queue operation. It
+    // covers the full Pario read/commit boundary for local catalogs while
+    // remaining a no-op for PostgreSQL catalogs.
+    const releaseLock = await this.acquireLocalAttachmentLock()
+    let released = false
+    const release = async () => {
+      if (released) {
+        return
+      }
+
+      released = true
+      try {
+        if (this.runtimePoisoned) {
+          this.runtimePoisoned = false
+          await this.discardRuntimeUnlocked()
+        } else {
+          await this.detachDuckDbCatalogAfterLease()
+        }
+      } finally {
+        releaseLock()
+      }
+    }
+
+    try {
+      await this.refreshForExternalChangesUnlocked()
+      const runtime = await this.attachedRuntime()
+      return { runtime, release }
+    } catch (error) {
+      await release()
+      throw error
+    }
+  }
+
+  async withExclusiveAttached<T>(run: (runtime: DuckDbExclusiveRuntime) => Promise<T>): Promise<T> {
+    const lease = await this.acquireAttachedRuntime()
+    try {
+      return await lease.runtime.withExclusive(run)
+    } finally {
+      await lease.release()
+    }
+  }
+
+  async stagingRuntime(): Promise<DuckDbRuntime> {
+    const runtime = await this.runtime()
+
+    if (this.options.catalog.type !== "postgres") {
+      // Local catalogs can keep stale attached metadata when another provider
+      // commits while this write session is open. Stage rows unattached so the
+      // later exclusive commit attaches fresh without losing temp tables.
+      await this.detachRuntime()
+    }
+
+    return runtime
+  }
+
   /**
-   * Create a fresh initialized runtime. Setup work here is runtime-scoped:
-   * extensions are loaded, secrets/setup SQL run, and the DuckLake catalog is
-   * attached exactly once for this runtime.
+   * Create the one runtime owned by this manager. Setup loads extensions,
+   * secrets, setup SQL, and pre-attach Postgres pool settings, but deliberately
+   * leaves DuckLake unattached until `attachedRuntime()` is needed.
    */
   async createRuntime(): Promise<DuckDbRuntime> {
     this.assertOpen()
@@ -90,83 +153,37 @@ export class DuckLakeConnectionManager {
     const runtime = await createDuckDbRuntime(this.options.duckdb)
     try {
       await this.ensureExtensionsInstalled(runtime)
-      await setupDuckLake(runtime, this.options, { installExtensions: false })
+      await setupDuckLake(runtime, this.options, {
+        attach: false,
+        installExtensions: false,
+      })
       return runtime
     } catch (error) {
-      await runtime.close()
+      await this.closeRuntime(runtime, { detach: false })
       throw error
     }
   }
 
-  async acquireWriteRuntime(): Promise<DuckDbRuntime> {
-    this.assertOpen()
-
-    const runtime = this.idleWriteRuntimes.pop()
-    return runtime ?? this.createRuntime()
-  }
-
-  async acquireWriteLease(): Promise<DuckLakeWriteRuntimeLease> {
-    return new ManagedDuckLakeWriteRuntimeLease(this, await this.acquireWriteRuntime())
-  }
-
-  async withWriteRuntime<T>(
-    useLease: (
-      lease: DuckLakeWriteRuntimeLease
-    ) => DuckLakeWriteRuntimeLeaseResult<T> | Promise<DuckLakeWriteRuntimeLeaseResult<T>>
-  ): Promise<T> {
-    const lease = await this.acquireWriteLease()
-
-    try {
-      const result = await useLease(lease)
-      await lease.release(result.release)
-      return result.value
-    } catch (error) {
-      await lease.release({ kind: "failed" })
-      throw error
-    }
-  }
-
-  async releaseWriteRuntime(
-    runtime: DuckDbRuntime,
-    options: ReleaseWriteRuntimeOptions
-  ): Promise<void> {
-    if (
-      this.closed ||
-      !options.reuse ||
-      !this.canReuseWriteRuntime() ||
-      this.idleWriteRuntimes.length >= MAX_IDLE_WRITE_RUNTIMES
-    ) {
-      await runtime.close()
-      return
-    }
-
-    this.idleWriteRuntimes.push(runtime)
-  }
-
-  canReuseWriteRuntime(): boolean {
-    return canReuseWriteRuntimeForOptions(this.options)
-  }
-
-  private canRefreshReadRuntime(): boolean {
-    return this.options.catalog.type === "postgres"
-  }
-
-  /**
-   * Refresh the shared read/runtime connection after a write commits.
-   *
-   * DuckLake snapshot visibility is attached to the connection that loaded the
-   * catalog. PostgreSQL catalogs can re-attach in place; local metadata files
-   * need a fresh runtime to avoid stale or invalid file-backed catalog state.
-   */
   async resetRuntime(): Promise<void> {
+    const releaseLock = await this.acquireLocalAttachmentLock()
+    try {
+      await this.resetRuntimeUnlocked()
+    } finally {
+      releaseLock()
+    }
+  }
+
+  private async resetRuntimeUnlocked(): Promise<void> {
     const runtimePromise = this.runtimePromise
     if (runtimePromise === undefined) {
       return
     }
 
-    if (!this.canRefreshReadRuntime()) {
-      this.runtimePromise = undefined
-      await this.closeRuntimePromise(runtimePromise)
+    if (this.attachPromise !== undefined) {
+      await this.attachPromise
+    }
+
+    if (!this.attached) {
       return
     }
 
@@ -175,9 +192,11 @@ export class DuckLakeConnectionManager {
       .then(async (runtime) => {
         try {
           await this.refreshAttachedRuntime(runtime)
+          this.attached = true
           return runtime
         } catch (error) {
-          await runtime.close()
+          this.attached = false
+          await this.closeRuntime(runtime, { detach: false })
           throw error
         }
       })
@@ -188,8 +207,72 @@ export class DuckLakeConnectionManager {
         throw error
       })
 
+    this.attached = false
     this.runtimePromise = refreshedPromise
     await refreshedPromise
+  }
+
+  async refreshForExternalChanges(): Promise<void> {
+    if (this.options.catalog.type === "postgres") {
+      return
+    }
+
+    if (!this.needsLocalCatalogRefresh()) {
+      return
+    }
+
+    if (this.refreshPromise === undefined) {
+      let refreshPromise: Promise<void>
+      refreshPromise = this.withLocalAttachmentLock(() =>
+        this.refreshForExternalChangesUnlocked()
+      ).finally(() => {
+        if (this.refreshPromise === refreshPromise) {
+          this.refreshPromise = undefined
+        }
+      })
+      this.refreshPromise = refreshPromise
+    }
+
+    await this.refreshPromise
+  }
+
+  markLocalCatalogChanged(): void {
+    if (this.options.catalog.type === "postgres") {
+      return
+    }
+
+    this.observedLocalCatalogGeneration = incrementLocalCatalogGeneration(this.options)
+  }
+
+  async detachLocalCatalogAfterCommit(runtime: DuckDbQueryRuntime): Promise<void> {
+    if (this.options.catalog.type === "postgres") {
+      return
+    }
+
+    try {
+      await runtime.run(`DETACH ${quoteIdentifier(duckLakeAlias(this.options))}`)
+      this.attached = false
+    } catch {
+      // The commit already succeeded. Keep the original write result and let a
+      // later refresh/close retry detaching this local catalog if needed.
+    } finally {
+      this.markLocalCatalogChanged()
+    }
+  }
+
+  private async refreshForExternalChangesUnlocked(): Promise<void> {
+    const generation = currentLocalCatalogGeneration(this.options)
+    if (this.observedLocalCatalogGeneration === generation) {
+      return
+    }
+
+    await this.resetRuntimeUnlocked()
+
+    this.observedLocalCatalogGeneration = generation
+  }
+
+  private needsLocalCatalogRefresh(): boolean {
+    return this.observedLocalCatalogGeneration !== currentLocalCatalogGeneration(this.options)
   }
 
   async close(): Promise<void> {
@@ -199,10 +282,47 @@ export class DuckLakeConnectionManager {
 
     this.closed = true
 
-    const idleWriteRuntimes = this.idleWriteRuntimes.splice(0)
-    await this.closeRuntimePromise(this.runtimePromise)
-    await Promise.all(idleWriteRuntimes.map((runtime) => runtime.close()))
+    const runtimePromise = this.runtimePromise
     this.runtimePromise = undefined
+    await this.closeRuntimePromise(runtimePromise, {
+      // For Postgres catalogs, the DuckDB Postgres extension owns the attached
+      // pool. Explicit DETACH can briefly create or retain another backend;
+      // closing the DuckDB runtime is the tighter shutdown path.
+      detach: this.attached && this.options.catalog.type !== "postgres",
+    })
+    this.attached = false
+  }
+
+  private async ensureAttached(runtime: DuckDbRuntime): Promise<void> {
+    this.assertOpen()
+
+    if (this.attached) {
+      return
+    }
+
+    if (this.attachPromise === undefined) {
+      let attachPromise: Promise<void>
+      attachPromise = this.attachRuntime(runtime)
+        .then(() => {
+          this.attached = true
+        })
+        .catch(async (error) => {
+          if (this.attachPromise === attachPromise) {
+            this.runtimePromise = undefined
+            this.attached = false
+          }
+          await this.closeRuntime(runtime, { detach: false })
+          throw error
+        })
+        .finally(() => {
+          if (this.attachPromise === attachPromise) {
+            this.attachPromise = undefined
+          }
+        })
+      this.attachPromise = attachPromise
+    }
+
+    await this.attachPromise
   }
 
   private async ensureExtensionsInstalled(runtime: DuckDbRuntime): Promise<void> {
@@ -221,6 +341,15 @@ export class DuckLakeConnectionManager {
     await this.installExtensionsPromise
   }
 
+  private async attachRuntime(runtime: DuckDbRuntime): Promise<void> {
+    await runtime.runStatements([
+      buildAttachSql(this.options),
+      ...(this.options.catalog.type === "postgres"
+        ? [buildConfigurePostgresMetadataPoolSql(this.options)]
+        : []),
+    ])
+  }
+
   private async refreshAttachedRuntime(runtime: DuckDbRuntime): Promise<void> {
     await runtime.runStatements([
       `DETACH ${quoteIdentifier(duckLakeAlias(this.options))}`,
@@ -231,8 +360,96 @@ export class DuckLakeConnectionManager {
     ])
   }
 
+  private async detachRuntime(): Promise<void> {
+    await this.withLocalAttachmentLock(() => this.detachRuntimeUnlocked())
+  }
+
+  /**
+   * Mark the active runtime as unusable for reuse. The next lease release
+   * discards the connection so session state that could not be cleaned up
+   * (such as a SET pragma whose RESET failed) cannot reach a later operation.
+   */
+  poisonRuntime(): void {
+    this.runtimePoisoned = true
+  }
+
+  private async detachDuckDbCatalogAfterLease(): Promise<void> {
+    if (this.options.catalog.type !== "duckdb" || !this.attached) {
+      return
+    }
+
+    try {
+      await this.detachRuntimeUnlocked()
+    } catch {
+      // DuckDB-backed DuckLake catalogs are single-client local catalogs. If
+      // cleanup cannot detach, discard this runtime so the next operation
+      // starts from an unattached connection instead of keeping stale metadata.
+      await this.discardRuntimeUnlocked()
+    }
+  }
+
+  // Close and forget the current runtime so the next `runtime()` builds a fresh
+  // connection with default session state. Unlike `resetRuntimeUnlocked()`,
+  // which DETACH/ATTACHes the same connection, this drops the connection
+  // entirely -- the only way to clear a leaked session pragma.
+  private async discardRuntimeUnlocked(): Promise<void> {
+    const runtimePromise = this.runtimePromise
+    this.runtimePromise = undefined
+    this.attached = false
+    await this.closeRuntimePromise(runtimePromise, { detach: false }).catch(() => {})
+  }
+
+  private async detachRuntimeUnlocked(): Promise<void> {
+    if (this.attachPromise !== undefined) {
+      await this.attachPromise
+    }
+
+    if (!this.attached) {
+      return
+    }
+
+    const runtime = await this.runtime()
+    await runtime.run(`DETACH ${quoteIdentifier(duckLakeAlias(this.options))}`)
+    this.attached = false
+  }
+
+  private async withLocalAttachmentLock<T>(run: () => Promise<T>): Promise<T> {
+    const releaseLock = await this.acquireLocalAttachmentLock()
+    try {
+      return await run()
+    } finally {
+      releaseLock()
+    }
+  }
+
+  private async acquireLocalAttachmentLock(): Promise<() => void> {
+    if (this.options.catalog.type === "postgres") {
+      return () => {}
+    }
+
+    const previous = this.localAttachmentLock.catch(() => {})
+    let release!: () => void
+    const current = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    this.localAttachmentLock = previous.then(() => current)
+
+    await previous
+
+    let released = false
+    return () => {
+      if (released) {
+        return
+      }
+
+      released = true
+      release()
+    }
+  }
+
   private async closeRuntimePromise(
-    runtimePromise: Promise<DuckDbRuntime> | undefined
+    runtimePromise: Promise<DuckDbRuntime> | undefined,
+    options: { readonly detach: boolean }
   ): Promise<void> {
     if (runtimePromise === undefined) {
       return
@@ -242,64 +459,49 @@ export class DuckLakeConnectionManager {
     try {
       runtime = await runtimePromise
     } catch {
-      // createRuntime already closes partially-initialized runtimes before
-      // rejecting. Swallowing here keeps close/reset idempotent after attach
-      // failures while preserving the original operation error.
+      // createRuntime/attachRuntime already close partially-initialized
+      // runtimes before rejecting. Swallowing here keeps close/reset
+      // idempotent while preserving the original operation error.
       return
+    }
+
+    await this.closeRuntime(runtime, options)
+  }
+
+  private async closeRuntime(
+    runtime: DuckDbRuntime,
+    options: { readonly detach: boolean }
+  ): Promise<void> {
+    if (options.detach) {
+      try {
+        await runtime.run(`DETACH ${quoteIdentifier(duckLakeAlias(this.options))}`)
+      } catch {
+        // The runtime may already be detached, partially initialized, or in an
+        // error state. Closing the native connection is still required.
+      }
     }
 
     await runtime.close()
   }
 }
 
-function canReuseWriteRuntimeForOptions(options: DuckLakeStorageOptions): boolean {
-  // Local DuckDB/SQLite metadata catalogs need the committing connection to
-  // close before freshly attached read runtimes reliably observe the commit.
-  // PostgreSQL catalogs provide cross-connection visibility without relying on
-  // the writer connection closing, so they can safely keep one idle write lease.
-  return options.catalog.type === "postgres"
+// Local catalog tests commonly create multiple DuckLakeStorage instances in one
+// process. DuckLake/Postgres handles cross-connection visibility itself; local
+// file catalogs need this in-process signal so peers refresh after Pario writes.
+const localCatalogGenerations = new Map<string, number>()
+
+function currentLocalCatalogGeneration(options: DuckLakeStorageOptions): number {
+  const key = localCatalogCoordinationKey(options)
+  return key === undefined ? 0 : (localCatalogGenerations.get(key) ?? 0)
 }
 
-class ManagedDuckLakeWriteRuntimeLease implements DuckLakeWriteRuntimeLease {
-  private released = false
-
-  constructor(
-    private readonly connections: DuckLakeConnectionManager,
-    readonly runtime: DuckDbRuntime
-  ) {}
-
-  async committedReadRuntime(
-    release: DuckLakeCommittedWriteRuntimeRelease
-  ): Promise<DuckDbRuntime> {
-    await this.connections.resetRuntime()
-
-    if (!this.connections.canReuseWriteRuntime()) {
-      await this.release({ ...release, reusable: false })
-    }
-
-    return this.connections.runtime()
+function incrementLocalCatalogGeneration(options: DuckLakeStorageOptions): number {
+  const key = localCatalogCoordinationKey(options)
+  if (key === undefined) {
+    return 0
   }
 
-  async release(result: DuckLakeWriteRuntimeRelease): Promise<void> {
-    if (this.released) {
-      return
-    }
-
-    this.released = true
-    await this.connections.releaseWriteRuntime(this.runtime, {
-      reuse: shouldReuseWriteRuntimeAfterRelease(result),
-    })
-  }
-}
-
-function shouldReuseWriteRuntimeAfterRelease(result: DuckLakeWriteRuntimeRelease): boolean {
-  if (result.kind === "failed") {
-    return false
-  }
-
-  if (result.kind === "aborted") {
-    return result.reusable ?? true
-  }
-
-  return result.reusable && !result.guarded
+  const nextGeneration = (localCatalogGenerations.get(key) ?? 0) + 1
+  localCatalogGenerations.set(key, nextGeneration)
+  return nextGeneration
 }

--- a/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
+++ b/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
@@ -8,7 +8,7 @@ import type {
 import { LakeStorageError, planDatasetDefinitionUpdate } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
 import { getOptionalString, getString } from "./duckdb-row"
-import type { DuckDbRuntime } from "./duckdb-runtime"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import { decodeDatasetTableName, encodeDatasetTableName } from "./names"
 import {
@@ -59,6 +59,7 @@ export class DuckLakeDatasetCatalog {
       const plan = planDatasetDefinitionUpdate(existing, definition)
       if (plan.changed) {
         await this.applyExistingDatasetUpdate(plan)
+        this.connections.markLocalCatalogChanged()
         await this.connections.resetRuntime()
       }
 
@@ -69,19 +70,23 @@ export class DuckLakeDatasetCatalog {
     // table name is reversible, so no sidecar mapping is needed.
     const tableName = encodeDatasetTableName(definition.id)
     const qualifiedName = qualifiedTableName(this.options, tableName)
-    const runtime = await this.runtime()
 
-    await runtime.run(
-      `CREATE TABLE ${qualifiedName} (${datasetSchemaToDuckDbColumnsSql(definition.schema)})`
-    )
-
-    if (definition.description !== undefined) {
+    // Creating a dataset can be several catalog DDL statements. Keep them in
+    // one runtime slot so writes cannot observe a half-created table.
+    await this.connections.withExclusiveAttached(async (runtime) => {
       await runtime.run(
-        `COMMENT ON TABLE ${qualifiedName} IS ${quoteSqlString(definition.description)}`
+        `CREATE TABLE ${qualifiedName} (${datasetSchemaToDuckDbColumnsSql(definition.schema)})`
       )
-    }
 
-    await this.applyPartitionBy(runtime, qualifiedName, definition)
+      if (definition.description !== undefined) {
+        await runtime.run(
+          `COMMENT ON TABLE ${qualifiedName} IS ${quoteSqlString(definition.description)}`
+        )
+      }
+
+      await this.applyPartitionBy(runtime, qualifiedName, definition)
+    })
+    this.connections.markLocalCatalogChanged()
 
     return structuredClone(definition)
   }
@@ -100,16 +105,25 @@ export class DuckLakeDatasetCatalog {
   async getDataset(datasetId: string): Promise<DatasetDefinition | null> {
     this.connections.assertOpen()
 
+    return this.connections.withAttachedRuntime((runtime) =>
+      this.getDatasetOnRuntime(runtime, datasetId)
+    )
+  }
+
+  async getDatasetOnRuntime(
+    runtime: DuckDbQueryRuntime,
+    datasetId: string
+  ): Promise<DatasetDefinition | null> {
     // Reconstruct definitions from DuckLake instead of trusting caller input.
     // This keeps repeated createDataset calls honest across provider instances.
     const tableName = encodeDatasetTableName(datasetId)
-    const table = await this.getDatasetTable(tableName)
+    const table = await this.getDatasetTable(runtime, tableName)
     if (!table) {
       return null
     }
 
-    const schema = await this.describeDatasetSchema(await this.runtime(), tableName)
-    const partitionBy = await this.getDatasetPartitionBy(tableName)
+    const schema = await this.describeDatasetSchema(runtime, tableName)
+    const partitionBy = await this.getDatasetPartitionBy(runtime, tableName)
 
     return {
       kind: "dataset",
@@ -123,34 +137,35 @@ export class DuckLakeDatasetCatalog {
   async listDatasets(): Promise<readonly DatasetDefinition[]> {
     this.connections.assertOpen()
 
-    // Only Pario-encoded dataset tables are surfaced. Any DuckLake metadata,
-    // internal tables, or unrelated user tables remain invisible to LakeStorage.
-    const runtime = await this.runtime()
-    const rows = await runtime.query(
-      `SELECT table_name FROM duckdb_tables() WHERE database_name = ${quoteSqlString(
-        duckLakeAlias(this.options)
-      )} AND schema_name = 'main' AND NOT internal ORDER BY table_name`
-    )
+    return this.connections.withAttachedRuntime(async (runtime) => {
+      // Only Pario-encoded dataset tables are surfaced. Any DuckLake metadata,
+      // internal tables, or unrelated user tables remain invisible to LakeStorage.
+      const rows = await runtime.query(
+        `SELECT table_name FROM duckdb_tables() WHERE database_name = ${quoteSqlString(
+          duckLakeAlias(this.options)
+        )} AND schema_name = 'main' AND NOT internal ORDER BY table_name`
+      )
 
-    const datasets: DatasetDefinition[] = []
-    for (const row of rows) {
-      const tableName = getString(row, "table_name")
-      const datasetId = decodeDatasetTableName(tableName)
-      if (datasetId === null) {
-        continue
+      const datasets: DatasetDefinition[] = []
+      for (const row of rows) {
+        const tableName = getString(row, "table_name")
+        const datasetId = decodeDatasetTableName(tableName)
+        if (datasetId === null) {
+          continue
+        }
+
+        const definition = await this.getDatasetOnRuntime(runtime, datasetId)
+        if (definition) {
+          datasets.push(definition)
+        }
       }
 
-      const definition = await this.getDataset(datasetId)
-      if (definition) {
-        datasets.push(definition)
-      }
-    }
-
-    return datasets.sort((left, right) => left.id.localeCompare(right.id))
+      return datasets.sort((left, right) => left.id.localeCompare(right.id))
+    })
   }
 
   async getDatasetSchemaAtSnapshot(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     datasetId: string,
     snapshotId: string
   ): Promise<DatasetSchema> {
@@ -168,42 +183,39 @@ export class DuckLakeDatasetCatalog {
     }
   }
 
-  private async runtime() {
-    return this.connections.runtime()
-  }
-
   private async applyExistingDatasetUpdate(plan: DatasetDefinitionUpdatePlan): Promise<void> {
     const tableName = encodeDatasetTableName(plan.definition.id)
     const qualifiedName = qualifiedTableName(this.options, tableName)
-    const runtime = await this.runtime()
 
-    if (plan.schema.kind === "none") {
-      await this.applyMetadataDelta(runtime, qualifiedName, plan)
-      return
-    }
-
-    // Schema-only DuckLake snapshots still matter to Pario. Apply schema and
-    // compatible metadata DDL atomically, then tag the commit so versions can
-    // treat it as this dataset's schema-change version.
-    await runtime.run("BEGIN TRANSACTION")
-    let committed = false
-    try {
-      await this.applySchemaEvolutionDdl(runtime, qualifiedName, plan.schema)
-      await this.applyMetadataDelta(runtime, qualifiedName, plan)
-      await this.setSchemaEvolutionCommitMetadata(runtime, plan.definition.id, plan.schema)
-
-      await runtime.run("COMMIT")
-      committed = true
-    } catch (error) {
-      if (!committed) {
-        await this.rollbackTransaction(runtime)
+    await this.connections.withExclusiveAttached(async (runtime) => {
+      if (plan.schema.kind === "none") {
+        await this.applyMetadataDelta(runtime, qualifiedName, plan)
+        return
       }
-      throw error
-    }
+
+      // Schema-only DuckLake snapshots still matter to Pario. Apply schema and
+      // compatible metadata DDL atomically, then tag the commit so versions can
+      // treat it as this dataset's schema-change version.
+      await runtime.run("BEGIN TRANSACTION")
+      let committed = false
+      try {
+        await this.applySchemaEvolutionDdl(runtime, qualifiedName, plan.schema)
+        await this.applyMetadataDelta(runtime, qualifiedName, plan)
+        await this.setSchemaEvolutionCommitMetadata(runtime, plan.definition.id, plan.schema)
+
+        await runtime.run("COMMIT")
+        committed = true
+      } catch (error) {
+        if (!committed) {
+          await this.rollbackTransaction(runtime)
+        }
+        throw error
+      }
+    })
   }
 
   private async applySchemaEvolutionDdl(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     qualifiedName: string,
     plan: Extract<DatasetSchemaUpdatePlan, { readonly kind: "addNullableColumns" }>
   ): Promise<void> {
@@ -215,7 +227,7 @@ export class DuckLakeDatasetCatalog {
   }
 
   private async applyMetadataDelta(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     qualifiedName: string,
     plan: DatasetDefinitionUpdatePlan
   ): Promise<void> {
@@ -234,7 +246,7 @@ export class DuckLakeDatasetCatalog {
   }
 
   private async applyPartitionBy(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     qualifiedName: string,
     definition: DatasetDefinition
   ): Promise<void> {
@@ -260,7 +272,7 @@ export class DuckLakeDatasetCatalog {
   }
 
   private async setSchemaEvolutionCommitMetadata(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     datasetId: string,
     plan: Extract<DatasetSchemaUpdatePlan, { readonly kind: "addNullableColumns" }>
   ): Promise<void> {
@@ -283,7 +295,7 @@ export class DuckLakeDatasetCatalog {
     )
   }
 
-  private async rollbackTransaction(runtime: DuckDbRuntime): Promise<void> {
+  private async rollbackTransaction(runtime: DuckDbQueryRuntime): Promise<void> {
     try {
       await runtime.run("ROLLBACK")
     } catch {
@@ -292,10 +304,12 @@ export class DuckLakeDatasetCatalog {
     }
   }
 
-  private async getDatasetTable(tableName: string): Promise<DatasetTableRow | null> {
+  private async getDatasetTable(
+    runtime: DuckDbQueryRuntime,
+    tableName: string
+  ): Promise<DatasetTableRow | null> {
     // duckdb_tables() gives us the user-facing table comment without reaching
     // into DuckLake's private metadata tables.
-    const runtime = await this.runtime()
     const rows = await runtime.query(
       `SELECT table_name, comment FROM duckdb_tables() WHERE database_name = ${quoteSqlString(
         duckLakeAlias(this.options)
@@ -313,7 +327,7 @@ export class DuckLakeDatasetCatalog {
   }
 
   private async describeDatasetSchema(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     tableName: string,
     snapshotId?: string
   ): Promise<DatasetSchema> {
@@ -331,8 +345,10 @@ export class DuckLakeDatasetCatalog {
     return duckDbColumnsToDatasetSchema(columns)
   }
 
-  private async getDatasetPartitionBy(tableName: string): Promise<readonly string[]> {
-    const runtime = await this.runtime()
+  private async getDatasetPartitionBy(
+    runtime: DuckDbQueryRuntime,
+    tableName: string
+  ): Promise<readonly string[]> {
     const ducklakeTable = duckLakeMetadataTableName(this.options, "ducklake_table")
     const ducklakePartitionInfo = duckLakeMetadataTableName(this.options, "ducklake_partition_info")
     const ducklakePartitionColumn = duckLakeMetadataTableName(

--- a/storage/ducklake/src/internal/ducklake-row-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-row-reader.ts
@@ -34,39 +34,45 @@ export class DuckLakeRowReader {
   async *readRows(input: ReadDatasetRowsInput): AsyncIterable<DatasetRow> {
     this.connections.assertOpen()
 
-    // Step 1: use the catalog definition, not caller-provided shape. That
-    // keeps projection validation and value normalization aligned with the
-    // physical DuckLake table.
-    const definition = await this.datasets.getDataset(input.datasetId)
-    if (!definition) {
-      throw new LakeStorageError(`[ParioDuckLake] Unknown dataset '${input.datasetId}'.`)
-    }
+    const lease = await this.connections.acquireAttachedRuntime()
+    try {
+      const runtime = lease.runtime
 
-    const runtime = await this.connections.runtime()
-    const version = await this.resolveVersion(runtime, definition, input.versionId)
-    const snapshotId = parseVersionId(version.versionId)
-    const selectedColumns = this.resolveReadColumns(definition.id, version.schema, input.columns)
-
-    // Step 2: query DuckLake at the exact snapshot id. Version ids are just
-    // `ducklake:<snapshot_id>`, so reads can use native DuckLake time travel
-    // directly after validation.
-    const tableName = encodeDatasetTableName(input.datasetId)
-    const columnsSql = selectedColumns.map((column) => quoteIdentifier(column.name)).join(", ")
-    const tableSql = qualifiedTableName(this.options, tableName)
-    const limitSql = input.limit === undefined ? "" : ` LIMIT ${Math.max(0, input.limit)}`
-    const offsetSql = input.offset === undefined ? "" : ` OFFSET ${Math.max(0, input.offset)}`
-    const rows = runtime.streamRows(
-      `SELECT ${columnsSql} FROM ${tableSql} AT (VERSION => ${snapshotId})${limitSql}${offsetSql}`
-    )
-
-    // Step 3: DuckDB returns driver-native values. Normalize each projected
-    // column through the schema that was active at the resolved version.
-    for await (const row of rows) {
-      const output: Record<string, unknown> = {}
-      for (const column of selectedColumns) {
-        output[column.name] = normalizeReadValue(row[column.name], column)
+      // Step 1: use the catalog definition, not caller-provided shape. That
+      // keeps projection validation and value normalization aligned with the
+      // physical DuckLake table.
+      const definition = await this.datasets.getDatasetOnRuntime(runtime, input.datasetId)
+      if (!definition) {
+        throw new LakeStorageError(`[ParioDuckLake] Unknown dataset '${input.datasetId}'.`)
       }
-      yield output
+
+      const version = await this.resolveVersion(runtime, definition, input.versionId)
+      const snapshotId = parseVersionId(version.versionId)
+      const selectedColumns = this.resolveReadColumns(definition.id, version.schema, input.columns)
+
+      // Step 2: query DuckLake at the exact snapshot id. Version ids are just
+      // `ducklake:<snapshot_id>`, so reads can use native DuckLake time travel
+      // directly after validation.
+      const tableName = encodeDatasetTableName(input.datasetId)
+      const columnsSql = selectedColumns.map((column) => quoteIdentifier(column.name)).join(", ")
+      const tableSql = qualifiedTableName(this.options, tableName)
+      const limitSql = input.limit === undefined ? "" : ` LIMIT ${Math.max(0, input.limit)}`
+      const offsetSql = input.offset === undefined ? "" : ` OFFSET ${Math.max(0, input.offset)}`
+      const rows = runtime.streamRows(
+        `SELECT ${columnsSql} FROM ${tableSql} AT (VERSION => ${snapshotId})${limitSql}${offsetSql}`
+      )
+
+      // Step 3: DuckDB returns driver-native values. Normalize each projected
+      // column through the schema that was active at the resolved version.
+      for await (const row of rows) {
+        const output: Record<string, unknown> = {}
+        for (const column of selectedColumns) {
+          output[column.name] = normalizeReadValue(row[column.name], column)
+        }
+        yield output
+      }
+    } finally {
+      await lease.release()
     }
   }
 

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -7,7 +7,7 @@ import type {
 import { LakeStorageError } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
 import { getBigIntLike, getBoolean, getDate, getString } from "./duckdb-row"
-import type { DuckDbRuntime } from "./duckdb-runtime"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
 import { encodeDatasetTableName } from "./names"
@@ -82,39 +82,45 @@ export class DuckLakeSnapshotReader {
   async listVersions(datasetId: string, limit?: number): Promise<readonly DatasetVersion[]> {
     this.connections.assertOpen()
 
-    const definition = await this.datasets.getDataset(datasetId)
-    if (!definition) {
-      return []
-    }
+    return this.connections.withAttachedRuntime(async (runtime) => {
+      const definition = await this.datasets.getDatasetOnRuntime(runtime, datasetId)
+      if (!definition) {
+        return []
+      }
 
-    return this.listVersionsForDefinition(await this.connections.runtime(), definition, limit)
+      return this.listVersionsForDefinition(runtime, definition, limit)
+    })
   }
 
   async getLatestVersion(datasetId: string): Promise<DatasetVersion | null> {
     this.connections.assertOpen()
 
-    const definition = await this.datasets.getDataset(datasetId)
-    if (!definition) {
-      return null
-    }
+    return this.connections.withAttachedRuntime(async (runtime) => {
+      const definition = await this.datasets.getDatasetOnRuntime(runtime, datasetId)
+      if (!definition) {
+        return null
+      }
 
-    return this.getLatestVersionForDefinition(await this.connections.runtime(), definition)
+      return this.getLatestVersionForDefinition(runtime, definition)
+    })
   }
 
   async getVersion(datasetId: string, versionId: string): Promise<DatasetVersion | null> {
     const snapshotId = parseVersionId(versionId)
     this.connections.assertOpen()
 
-    const definition = await this.datasets.getDataset(datasetId)
-    if (!definition) {
-      return null
-    }
+    return this.connections.withAttachedRuntime(async (runtime) => {
+      const definition = await this.datasets.getDatasetOnRuntime(runtime, datasetId)
+      if (!definition) {
+        return null
+      }
 
-    return this.getVersionForSnapshot(await this.connections.runtime(), definition, snapshotId)
+      return this.getVersionForSnapshot(runtime, definition, snapshotId)
+    })
   }
 
   async getLatestVersionForDefinition(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition
   ): Promise<DatasetVersion | null> {
     const [latest] = await this.listVersionsForDefinition(runtime, dataset, 1)
@@ -122,7 +128,7 @@ export class DuckLakeSnapshotReader {
   }
 
   async getLatestVersionRefForDefinition(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition
   ): Promise<DatasetVersionRef | null> {
     const summary = await this.getLatestVersionSummaryForDefinition(runtime, dataset)
@@ -130,7 +136,7 @@ export class DuckLakeSnapshotReader {
   }
 
   async getLatestVersionSummaryForDefinition(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition
   ): Promise<DuckLakeVersionSummary | null> {
     const row = await this.getLatestSnapshotRowForDefinition(runtime, dataset)
@@ -146,7 +152,7 @@ export class DuckLakeSnapshotReader {
   }
 
   async getVersionForSnapshot(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition,
     snapshotId: string
   ): Promise<DatasetVersion | null> {
@@ -157,7 +163,7 @@ export class DuckLakeSnapshotReader {
   }
 
   async getVersionRefForSnapshot(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition,
     snapshotId: string
   ): Promise<DatasetVersionRef | null> {
@@ -168,7 +174,7 @@ export class DuckLakeSnapshotReader {
   }
 
   async listVersionsForDefinition(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition,
     limit?: number
   ): Promise<readonly DatasetVersion[]> {
@@ -183,7 +189,7 @@ export class DuckLakeSnapshotReader {
   }
 
   private async getLatestSnapshotRowForDefinition(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition
   ): Promise<DatasetSnapshotRow | null> {
     const tableName = encodeDatasetTableName(dataset.id)
@@ -201,7 +207,7 @@ export class DuckLakeSnapshotReader {
   }
 
   private async getSnapshotRowForDefinition(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition,
     snapshotId: string,
     options: { readonly includeParent: boolean }
@@ -239,7 +245,7 @@ export class DuckLakeSnapshotReader {
   }
 
   private async getSnapshotRowsForDefinition(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition,
     limit?: number
   ): Promise<readonly DatasetSnapshotRow[]> {
@@ -264,7 +270,7 @@ export class DuckLakeSnapshotReader {
   }
 
   private async collectVisibleSnapshotRows(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     input: VisibleSnapshotRowsInput
   ): Promise<readonly DatasetSnapshotRow[]> {
     if (input.visibleRowLimit !== undefined && input.visibleRowLimit <= 0) {
@@ -307,7 +313,7 @@ export class DuckLakeSnapshotReader {
   }
 
   private async querySnapshotCandidates(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     input: SnapshotCandidateQueryInput
   ): Promise<readonly DatasetSnapshotCandidateRow[]> {
     if (input.limit !== undefined && input.limit <= 0) {
@@ -408,7 +414,7 @@ export class DuckLakeSnapshotReader {
     })
   }
 
-  private async getTableId(runtime: DuckDbRuntime, tableName: string): Promise<bigint | null> {
+  private async getTableId(runtime: DuckDbQueryRuntime, tableName: string): Promise<bigint | null> {
     const ducklakeTable = duckLakeMetadataTableName(this.options, "ducklake_table")
     const [row] = await runtime.query(`
       SELECT table_id
@@ -465,7 +471,7 @@ export class DuckLakeSnapshotReader {
   }
 
   private async snapshotToVersion(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition,
     row: DatasetSnapshotRow
   ): Promise<DatasetVersion> {
@@ -498,7 +504,7 @@ export class DuckLakeSnapshotReader {
   }
 
   private async countRowsAtSnapshot(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition,
     snapshotId: string
   ): Promise<number> {

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -52,6 +52,12 @@ interface VisibleSnapshotRowsInput {
   readonly visibleRowLimit?: number
 }
 
+export interface DuckLakeVersionSummary {
+  readonly datasetId: string
+  readonly versionId: string
+  readonly rowCount?: number
+}
+
 const SNAPSHOT_ROW_BATCH_SIZE = 128
 
 /**
@@ -119,8 +125,24 @@ export class DuckLakeSnapshotReader {
     runtime: DuckDbRuntime,
     dataset: DatasetDefinition
   ): Promise<DatasetVersionRef | null> {
+    const summary = await this.getLatestVersionSummaryForDefinition(runtime, dataset)
+    return summary ? { datasetId: summary.datasetId, versionId: summary.versionId } : null
+  }
+
+  async getLatestVersionSummaryForDefinition(
+    runtime: DuckDbRuntime,
+    dataset: DatasetDefinition
+  ): Promise<DuckLakeVersionSummary | null> {
     const row = await this.getLatestSnapshotRowForDefinition(runtime, dataset)
-    return row ? { datasetId: dataset.id, versionId: toVersionId(row.snapshotId) } : null
+    if (!row) {
+      return null
+    }
+
+    return {
+      datasetId: dataset.id,
+      versionId: toVersionId(row.snapshotId),
+      ...(row.metadata?.rowCount !== undefined ? { rowCount: row.metadata.rowCount } : {}),
+    }
   }
 
   async getVersionForSnapshot(
@@ -455,8 +477,12 @@ export class DuckLakeSnapshotReader {
 
     // DuckLake gives us version id, timestamp, and time travel. Pario metadata
     // fills in caller intent such as append vs snapshot and producer lineage.
-    // Parent ids and row counts are derived from DuckLake snapshot order and
-    // time travel instead of duplicated in commit metadata.
+    // New Pario commits include exact row counts to avoid full table counts on
+    // the write hot path; legacy or external snapshots still fall back to
+    // DuckLake time travel.
+    const rowCount =
+      row.metadata?.rowCount ?? (await this.countRowsAtSnapshot(runtime, dataset, row.snapshotId))
+
     return {
       datasetId: dataset.id,
       versionId: toVersionId(row.snapshotId),
@@ -467,7 +493,7 @@ export class DuckLakeSnapshotReader {
       schema: schemaAtSnapshot,
       producer: row.metadata?.producer,
       inputs: row.metadata?.inputs,
-      rowCount: await this.countRowsAtSnapshot(runtime, dataset, row.snapshotId),
+      rowCount,
     }
   }
 

--- a/storage/ducklake/src/internal/ducklake-sql-executor.ts
+++ b/storage/ducklake/src/internal/ducklake-sql-executor.ts
@@ -18,7 +18,7 @@ import {
   assertDatasetWriteMode,
 } from "./dataset-row-commit"
 import { getString } from "./duckdb-row"
-import type { DuckDbRuntime } from "./duckdb-runtime"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
 import type { DuckLakeSnapshotReader } from "./ducklake-snapshot-reader"
@@ -40,7 +40,7 @@ interface ResolvedDuckLakeSqlTransformSources {
 }
 
 interface ApplySqlTransformInput {
-  readonly runtime: DuckDbRuntime
+  readonly runtime: DuckDbQueryRuntime
   readonly target: DatasetDefinition
   readonly mode: DatasetWriteMode
   readonly sql: string
@@ -69,14 +69,15 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
   async *preview(input: PreviewSqlTransformInput<"duckdb">): AsyncIterable<DatasetRow> {
     this.connections.assertOpen()
 
-    const runtime = await this.connections.runtime()
-    const sources = await this.resolveSources(runtime, input.sources)
-    const sql = renderDuckLakeSqlTransformSql({
-      options: this.options,
-      sources: sources.relations,
-      sql: input.sql,
+    const rows = await this.connections.withAttachedRuntime(async (runtime) => {
+      const sources = await this.resolveSources(runtime, input.sources)
+      const sql = renderDuckLakeSqlTransformSql({
+        options: this.options,
+        sources: sources.relations,
+        sql: input.sql,
+      })
+      return runtime.query(buildPreviewSql(sql, previewLimit(input.limit)))
     })
-    const rows = await runtime.query(buildPreviewSql(sql, previewLimit(input.limit)))
 
     for (const row of rows) {
       yield normalizePreviewRow(row)
@@ -87,9 +88,8 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
     this.connections.assertOpen()
     assertDatasetWriteMode(input.mode, "SQL transform")
 
-    const target = await this.resolveTargetDataset(input.target)
-    return this.connections.withWriteRuntime(async (lease) => {
-      const runtime = lease.runtime
+    return this.writes.withCommitRuntime(async (runtime) => {
+      const target = await this.resolveTargetDataset(runtime, input.target)
       const sources = await this.resolveSources(runtime, input.sources)
       const sql = renderDuckLakeSqlTransformSql({
         options: this.options,
@@ -99,15 +99,13 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
 
       await this.assertResultSchemaMatchesTarget(runtime, target, sql)
 
-      const version = await this.writes.commitDatasetVersion({
-        runtime,
+      return this.writes.commitDatasetVersionOnExclusiveRuntime(runtime, {
         dataset: target,
         mode: input.mode,
         expectedLatestVersionId: input.expectedLatestVersionId,
         commitMessage: input.commitMessage ?? `execute SQL transform for dataset ${target.id}`,
         producer: input.producer,
         inputs: sources.inputs,
-        committedReadRuntime: (release) => lease.committedReadRuntime(release),
         applyChanges: (runtime, context) =>
           this.applySqlTransform({
             runtime,
@@ -117,27 +115,18 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
             previousRowCount: context.previousRowCount,
           }),
       })
-
-      return {
-        value: version,
-        release: {
-          kind: "committed",
-          guarded: input.expectedLatestVersionId !== undefined,
-          reusable: true,
-        },
-      }
     })
   }
 
   private async resolveSources(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     sources: PreviewSqlTransformInput<"duckdb">["sources"]
   ): Promise<ResolvedDuckLakeSqlTransformSources> {
     const relations: Record<string, DuckLakeSqlTransformSourceRelation> = Object.create(null)
     const inputs: DatasetVersionRef[] = []
 
     for (const [sourceName, source] of Object.entries(sources)) {
-      const definition = await this.resolveSourceDataset(source.dataset)
+      const definition = await this.resolveSourceDataset(runtime, source.dataset)
       const versionRef = await this.resolveSourceVersion(runtime, definition, source.versionId)
 
       relations[sourceName] = {
@@ -156,8 +145,11 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
     }
   }
 
-  private async resolveSourceDataset(dataset: DatasetDefinition): Promise<DatasetDefinition> {
-    const definition = await this.datasets.getDataset(dataset.id)
+  private async resolveSourceDataset(
+    runtime: DuckDbQueryRuntime,
+    dataset: DatasetDefinition
+  ): Promise<DatasetDefinition> {
+    const definition = await this.datasets.getDatasetOnRuntime(runtime, dataset.id)
     if (!definition) {
       throw new LakeStorageError(
         `[ParioDuckLake] Unknown SQL transform source dataset '${dataset.id}'.`
@@ -167,8 +159,11 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
     return definition
   }
 
-  private async resolveTargetDataset(dataset: DatasetDefinition): Promise<DatasetDefinition> {
-    const definition = await this.datasets.getDataset(dataset.id)
+  private async resolveTargetDataset(
+    runtime: DuckDbQueryRuntime,
+    dataset: DatasetDefinition
+  ): Promise<DatasetDefinition> {
+    const definition = await this.datasets.getDatasetOnRuntime(runtime, dataset.id)
     if (!definition) {
       throw new LakeStorageError(
         `[ParioDuckLake] Unknown SQL transform target dataset '${dataset.id}'.`
@@ -180,7 +175,7 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
   }
 
   private async resolveSourceVersion(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition,
     versionId?: string
   ): Promise<DatasetVersionRef> {
@@ -203,7 +198,7 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
   }
 
   private async assertResultSchemaMatchesTarget(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     target: DatasetDefinition,
     sql: string
   ): Promise<void> {

--- a/storage/ducklake/src/internal/ducklake-sql-executor.ts
+++ b/storage/ducklake/src/internal/ducklake-sql-executor.ts
@@ -12,7 +12,11 @@ import {
   type PreviewSqlTransformInput,
 } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
-import { applyDatasetRowsFromRelation, assertDatasetWriteMode } from "./dataset-row-commit"
+import {
+  type ApplyDatasetRowsResult,
+  applyDatasetRowsFromRelation,
+  assertDatasetWriteMode,
+} from "./dataset-row-commit"
 import { getString } from "./duckdb-row"
 import type { DuckDbRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
@@ -40,6 +44,7 @@ interface ApplySqlTransformInput {
   readonly target: DatasetDefinition
   readonly mode: DatasetWriteMode
   readonly sql: string
+  readonly previousRowCount?: number
 }
 
 /**
@@ -83,9 +88,8 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
     assertDatasetWriteMode(input.mode, "SQL transform")
 
     const target = await this.resolveTargetDataset(input.target)
-    const runtime = await this.connections.createRuntime()
-
-    try {
+    return this.connections.withWriteRuntime(async (lease) => {
+      const runtime = lease.runtime
       const sources = await this.resolveSources(runtime, input.sources)
       const sql = renderDuckLakeSqlTransformSql({
         options: this.options,
@@ -95,7 +99,7 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
 
       await this.assertResultSchemaMatchesTarget(runtime, target, sql)
 
-      return await this.writes.commitDatasetVersion({
+      const version = await this.writes.commitDatasetVersion({
         runtime,
         dataset: target,
         mode: input.mode,
@@ -103,18 +107,26 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
         commitMessage: input.commitMessage ?? `execute SQL transform for dataset ${target.id}`,
         producer: input.producer,
         inputs: sources.inputs,
-        applyChanges: (runtime) =>
+        committedReadRuntime: (release) => lease.committedReadRuntime(release),
+        applyChanges: (runtime, context) =>
           this.applySqlTransform({
             runtime,
             target,
             mode: input.mode,
             sql,
+            previousRowCount: context.previousRowCount,
           }),
       })
-    } catch (error) {
-      await runtime.close()
-      throw error
-    }
+
+      return {
+        value: version,
+        release: {
+          kind: "committed",
+          guarded: input.expectedLatestVersionId !== undefined,
+          reusable: true,
+        },
+      }
+    })
   }
 
   private async resolveSources(
@@ -228,7 +240,7 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
     }
   }
 
-  private async applySqlTransform(input: ApplySqlTransformInput): Promise<boolean> {
+  private async applySqlTransform(input: ApplySqlTransformInput): Promise<ApplyDatasetRowsResult> {
     const tempTableName = `pario_sql_transform_${randomUUID().replaceAll("-", "")}`
     const tempTable = quoteIdentifier(tempTableName)
 
@@ -236,13 +248,18 @@ export class DuckLakeSqlExecutor implements LakeSqlExecutor<"duckdb"> {
       `CREATE TEMP TABLE ${tempTable} AS SELECT * FROM (${input.sql}) AS pario_sql_transform_result`
     )
 
-    return applyDatasetRowsFromRelation({
-      options: this.options,
-      runtime: input.runtime,
-      dataset: input.target,
-      mode: input.mode,
-      sourceRelationSql: tempTable,
-    })
+    try {
+      return await applyDatasetRowsFromRelation({
+        options: this.options,
+        runtime: input.runtime,
+        dataset: input.target,
+        mode: input.mode,
+        sourceRelationSql: tempTable,
+        previousRowCount: input.previousRowCount,
+      })
+    } finally {
+      await input.runtime.run(`DROP TABLE IF EXISTS ${tempTable}`)
+    }
   }
 }
 

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -8,6 +8,7 @@ import type {
 } from "@pario/core"
 import { LakeStorageError } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
+import { localCatalogCoordinationKey } from "./catalog-key"
 import {
   type ApplyDatasetRowsResult,
   applyDatasetRowsFromRelation,
@@ -15,37 +16,29 @@ import {
   type CommitRowCount,
 } from "./dataset-row-commit"
 import { getBigIntLike } from "./duckdb-row"
-import type { DuckDbRuntime } from "./duckdb-runtime"
-import type {
-  DuckLakeCommittedWriteRuntimeRelease,
-  DuckLakeConnectionManager,
-  DuckLakeWriteRuntimeLease,
-} from "./ducklake-connection-manager"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
+import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
 import type { DuckLakeSnapshotReader, DuckLakeVersionSummary } from "./ducklake-snapshot-reader"
 import { createDuckLakeWriteSession, type DuckLakeCommitWriteInput } from "./ducklake-write-session"
-import {
-  buildAttachSql,
-  duckLakeAlias,
-  duckLakeMetadataTableName,
-  quoteIdentifier,
-  quoteSqlString,
-} from "./sql"
+import { duckLakeAlias, duckLakeMetadataTableName, quoteIdentifier, quoteSqlString } from "./sql"
 import { type ParioCommitMetadata, parseCommitMetadata } from "./versions"
 
 export interface DuckLakeCommitDatasetVersionInput {
-  readonly runtime: DuckDbRuntime
   readonly dataset: DatasetDefinition
   readonly mode: DatasetWriteMode
   readonly expectedLatestVersionId?: string
   readonly commitMessage: string
   readonly producer?: BeginDatasetWriteInput["producer"]
   readonly inputs?: BeginDatasetWriteInput["inputs"]
-  committedReadRuntime(release: DuckLakeCommittedWriteRuntimeRelease): Promise<DuckDbRuntime>
   applyChanges(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     context: DuckLakeApplyChangesContext
   ): Promise<ApplyDatasetRowsResult>
+}
+
+interface DuckLakeCommitDatasetVersionRuntimeInput extends DuckLakeCommitDatasetVersionInput {
+  readonly runtime: DuckDbQueryRuntime
 }
 
 export interface DuckLakeApplyChangesContext {
@@ -80,12 +73,14 @@ export class DuckLakeWriteCoordinator {
     const mode = input.mode ?? "snapshot"
     assertDatasetWriteMode(mode, "write")
 
-    // Staging tables are connection-scoped in DuckDB, so every active write
-    // session owns a dedicated runtime lease until commit or abort releases it.
-    const lease = await this.connections.acquireWriteLease()
+    // Staging tables are connection-scoped in DuckDB. In the single-runtime
+    // model every active write session creates a uniquely named temp table on
+    // the shared runtime; the durable commit later runs on that same
+    // connection under an exclusive queue slot.
+    const runtime = await this.connections.stagingRuntime()
     return createDuckLakeWriteSession({
-      commitWrite: (options) => this.commitWrite(options, lease),
-      lease,
+      commitWrite: (options) => this.commitWrite(options),
+      runtime,
       write: {
         ...input,
         dataset: definition,
@@ -94,10 +89,7 @@ export class DuckLakeWriteCoordinator {
     })
   }
 
-  private async commitWrite(
-    input: DuckLakeCommitWriteInput,
-    lease: DuckLakeWriteRuntimeLease
-  ): Promise<DatasetVersion> {
+  private async commitWrite(input: DuckLakeCommitWriteInput): Promise<DatasetVersion> {
     const definition = await this.datasets.getDataset(input.write.dataset.id)
     if (!definition) {
       throw new LakeStorageError(`[ParioDuckLake] Unknown dataset '${input.write.dataset.id}'.`)
@@ -107,14 +99,12 @@ export class DuckLakeWriteCoordinator {
     assertDatasetWriteMode(mode, "write")
 
     return this.commitDatasetVersion({
-      runtime: input.runtime,
       dataset: definition,
       mode,
       expectedLatestVersionId: input.commit?.expectedLatestVersionId,
       commitMessage: input.commit?.commitMessage ?? `write dataset ${input.write.dataset.id}`,
       producer: input.write.producer,
       inputs: input.write.inputs,
-      committedReadRuntime: (release) => lease.committedReadRuntime(release),
       applyChanges: (runtime, context) =>
         this.applyStagedRows({
           ...input,
@@ -125,12 +115,78 @@ export class DuckLakeWriteCoordinator {
   }
 
   async commitDatasetVersion(input: DuckLakeCommitDatasetVersionInput): Promise<DatasetVersion> {
-    await this.prepareRuntimeForCommit(input.runtime, input.expectedLatestVersionId !== undefined)
+    return this.withCommitRuntime((runtime) =>
+      this.commitDatasetVersionOnExclusiveRuntime(runtime, input)
+    )
+  }
 
+  async withCommitRuntime<T>(run: (runtime: DuckDbQueryRuntime) => Promise<T>): Promise<T> {
+    return withCatalogCommitLock(this.options, async () => {
+      // `withExclusiveAttached` refreshes local catalogs before the exclusive
+      // slot, then holds the local attachment boundary through the commit.
+      return this.connections.withExclusiveAttached(run)
+    })
+  }
+
+  async commitDatasetVersionOnExclusiveRuntime(
+    runtime: DuckDbQueryRuntime,
+    input: DuckLakeCommitDatasetVersionInput
+  ): Promise<DatasetVersion> {
+    const runtimeInput = { ...input, runtime }
+    return this.withGuardedRetrySetting(runtimeInput, () =>
+      this.commitDatasetVersionUnlocked(runtimeInput)
+    )
+  }
+
+  private async withGuardedRetrySetting<T>(
+    input: DuckLakeCommitDatasetVersionRuntimeInput,
+    run: () => Promise<T>
+  ): Promise<T> {
+    if (input.expectedLatestVersionId === undefined) {
+      return run()
+    }
+
+    // DuckLake can retry transactions internally. Guarded Pario commits need a
+    // strict compare-and-swap check, so disable retries only for this exclusive
+    // commit and always restore the runtime setting before releasing the queue.
+    await input.runtime.run("SET ducklake_max_retry_count = 0")
+    let outcome:
+      | { readonly kind: "success"; readonly value: T }
+      | {
+          readonly kind: "error"
+          readonly error: unknown
+        }
+
+    try {
+      outcome = { kind: "success", value: await run() }
+    } catch (error) {
+      outcome = { kind: "error", error }
+    }
+
+    try {
+      await input.runtime.run("RESET ducklake_max_retry_count")
+    } catch {
+      // The retry count is session state on a shared, long-lived connection.
+      // If it cannot be restored, recycle the connection so a leftover value of
+      // 0 cannot silently disable DuckLake auto-retry for a later unguarded
+      // commit. The commit already succeeded or failed durably, so this cleanup
+      // must never change the outcome reported to the caller.
+      this.connections.poisonRuntime()
+    }
+
+    if (outcome.kind === "error") {
+      throw outcome.error
+    }
+
+    return outcome.value
+  }
+
+  private async commitDatasetVersionUnlocked(
+    input: DuckLakeCommitDatasetVersionRuntimeInput
+  ): Promise<DatasetVersion> {
     // Capture the write connection's last committed DuckLake snapshot before
-    // and after COMMIT. Fresh write runtimes usually start at null; this is a
-    // helpful no-op signal, but non-empty writes still prove ownership through
-    // the commitId in DuckLake commit_extra_info.
+    // and after COMMIT. The commitId in DuckLake commit_extra_info proves
+    // which snapshot belongs to this transaction.
     const previousWriteSnapshotId = await this.lastCommittedSnapshotId(input.runtime)
 
     await input.runtime.run("BEGIN TRANSACTION")
@@ -162,45 +218,38 @@ export class DuckLakeWriteCoordinator {
       committed = true
 
       const committedWriteSnapshotId = await this.lastCommittedSnapshotId(input.runtime)
-      const readRuntime = await input.committedReadRuntime({
-        kind: "committed",
-        guarded: input.expectedLatestVersionId !== undefined,
-        reusable: true,
-      })
-      const version = await this.versionForCommittedWrite({
-        ...input,
-        readRuntime,
-        commitId,
-        previousWriteSnapshotId,
-        committedWriteSnapshotId,
-        changeResult,
-      })
-      return version
+      try {
+        return await this.versionForCommittedWrite({
+          ...input,
+          commitId,
+          previousWriteSnapshotId,
+          committedWriteSnapshotId,
+          changeResult,
+        })
+      } finally {
+        await this.connections.detachLocalCatalogAfterCommit(input.runtime)
+      }
     } catch (error) {
       if (!committed) {
         await this.rollbackTransaction(input.runtime)
       }
-      await this.connections.resetRuntime()
       throw error
     }
   }
 
   private async versionForCommittedWrite(
-    input: DuckLakeCommitDatasetVersionInput & {
-      readonly readRuntime: DuckDbRuntime
+    input: DuckLakeCommitDatasetVersionRuntimeInput & {
       readonly commitId: string
       readonly previousWriteSnapshotId: string | null
       readonly committedWriteSnapshotId: string | null
       readonly changeResult: ApplyDatasetRowsResult
     }
   ): Promise<DatasetVersion> {
-    // The lease chooses the correct post-commit read runtime. Local catalogs
-    // close the writer before returning a fresh reader; PostgreSQL catalogs
-    // refresh the shared reader while keeping the writer lease available for
-    // cleanup and possible reuse.
-    const readRuntime = input.readRuntime
+    // Hydrate the committed version on the same exclusive runtime. That keeps
+    // snapshot matching and row-count fallback inside the same serialized
+    // connection state that just committed.
     const ownSnapshotId = await this.findOwnSnapshotId(
-      readRuntime,
+      input.runtime,
       input.dataset.id,
       input.commitId,
       input.previousWriteSnapshotId,
@@ -209,7 +258,7 @@ export class DuckLakeWriteCoordinator {
 
     if (ownSnapshotId !== null) {
       const version = await this.snapshots.getVersionForSnapshot(
-        readRuntime,
+        input.runtime,
         input.dataset,
         ownSnapshotId
       )
@@ -223,7 +272,7 @@ export class DuckLakeWriteCoordinator {
     }
 
     if (!input.changeResult.dataChangeExpected) {
-      return this.versionForNoOpCommit(readRuntime, input.dataset)
+      return this.versionForNoOpCommit(input.runtime, input.dataset)
     }
 
     if (input.committedWriteSnapshotId === input.previousWriteSnapshotId) {
@@ -238,10 +287,13 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async applyStagedRows(
-    input: DuckLakeCommitWriteInput & { readonly previousRowCount?: number }
+    input: DuckLakeCommitWriteInput & {
+      readonly runtime: DuckDbQueryRuntime
+      readonly previousRowCount?: number
+    }
   ): Promise<ApplyDatasetRowsResult> {
     const mode = input.write.mode ?? "snapshot"
-    return applyDatasetRowsFromRelation({
+    const result = await applyDatasetRowsFromRelation({
       options: this.options,
       runtime: input.runtime,
       dataset: input.write.dataset,
@@ -249,10 +301,18 @@ export class DuckLakeWriteCoordinator {
       sourceRelationSql: quoteIdentifier(input.stagingTableName),
       previousRowCount: input.previousRowCount,
     })
+
+    if (input.rowsWritten > 0 && !result.dataChangeExpected) {
+      throw new LakeStorageError(
+        `[ParioDuckLake] Staged write for dataset '${input.write.dataset.id}' accepted ${input.rowsWritten} row(s), but DuckLake did not apply any row changes.`
+      )
+    }
+
+    return result
   }
 
   private async setCommitMetadata(
-    input: DuckLakeCommitDatasetVersionInput,
+    input: DuckLakeCommitDatasetVersionRuntimeInput,
     commitId: string,
     rowCount: CommitRowCount
   ): Promise<void> {
@@ -280,7 +340,7 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async versionForNoOpCommit(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     definition: DatasetDefinition
   ): Promise<DatasetVersion> {
     const latestVersion = await this.snapshots.getLatestVersionForDefinition(runtime, definition)
@@ -293,7 +353,7 @@ export class DuckLakeWriteCoordinator {
     )
   }
 
-  private async rollbackTransaction(runtime: DuckDbRuntime): Promise<void> {
+  private async rollbackTransaction(runtime: DuckDbQueryRuntime): Promise<void> {
     try {
       await runtime.run("ROLLBACK")
     } catch {
@@ -302,22 +362,8 @@ export class DuckLakeWriteCoordinator {
     }
   }
 
-  private async prepareRuntimeForCommit(runtime: DuckDbRuntime, guarded: boolean): Promise<void> {
-    if (guarded) {
-      await runtime.run("SET ducklake_max_retry_count = 0")
-    }
-
-    // Write sessions can live long enough for other connections to commit.
-    // Re-attaching refreshes DuckLake metadata while preserving temp staging
-    // tables on the same DuckDB connection.
-    await runtime.runStatements([
-      `DETACH ${quoteIdentifier(duckLakeAlias(this.options))}`,
-      buildAttachSql(this.options),
-    ])
-  }
-
   private async latestVersionForCommit(
-    input: DuckLakeCommitDatasetVersionInput
+    input: DuckLakeCommitDatasetVersionRuntimeInput
   ): Promise<DuckLakeVersionSummary | null> {
     if (input.expectedLatestVersionId === undefined && input.mode !== "append") {
       return null
@@ -326,9 +372,8 @@ export class DuckLakeWriteCoordinator {
     return this.snapshots.getLatestVersionSummaryForDefinition(input.runtime, input.dataset)
   }
 
-  private async lastCommittedSnapshotId(runtime: DuckDbRuntime): Promise<string | null> {
-    // DuckLake reports the last snapshot committed by this connection. Fresh
-    // write runtimes may return null even when the lake already has history.
+  private async lastCommittedSnapshotId(runtime: DuckDbQueryRuntime): Promise<string | null> {
+    // DuckLake reports the last snapshot committed by this connection.
     const [row] = await runtime.query(
       `SELECT id FROM ${quoteIdentifier(duckLakeAlias(this.options))}.last_committed_snapshot()`
     )
@@ -340,7 +385,7 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async findSnapshotIdByCommitId(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     datasetId: string,
     commitId: string,
     snapshotId?: string
@@ -373,7 +418,7 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async findOwnSnapshotId(
-    runtime: DuckDbRuntime,
+    runtime: DuckDbQueryRuntime,
     datasetId: string,
     commitId: string,
     previousWriteSnapshotId: string | null,
@@ -442,5 +487,40 @@ function commitRowCount(
 function assertDuckLakeSnapshotId(snapshotId: string): void {
   if (!/^\d+$/.test(snapshotId)) {
     throw new LakeStorageError(`[ParioDuckLake] Invalid DuckLake snapshot id '${snapshotId}'.`)
+  }
+}
+
+// Local metadata catalogs are useful for dev/test, but they do not have the
+// same multi-connection conflict behavior as PostgreSQL. Serialize local
+// commits within this process so a losing writer cannot hydrate another
+// connection's snapshot during DuckLake conflict handling.
+const localCatalogCommitLocks = new Map<string, Promise<void>>()
+
+async function withCatalogCommitLock<T>(
+  options: DuckLakeStorageOptions,
+  run: () => Promise<T>
+): Promise<T> {
+  const key = localCatalogCoordinationKey(options)
+  if (key === undefined) {
+    return run()
+  }
+
+  const previous = localCatalogCommitLocks.get(key) ?? Promise.resolve()
+  const ready = previous.catch(() => {})
+  let release!: () => void
+  const next = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const current = ready.then(() => next)
+  localCatalogCommitLocks.set(key, current)
+
+  await ready
+  try {
+    return await run()
+  } finally {
+    release()
+    if (localCatalogCommitLocks.get(key) === current) {
+      localCatalogCommitLocks.delete(key)
+    }
   }
 }

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -8,12 +8,21 @@ import type {
 } from "@pario/core"
 import { LakeStorageError } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
-import { applyDatasetRowsFromRelation, assertDatasetWriteMode } from "./dataset-row-commit"
+import {
+  type ApplyDatasetRowsResult,
+  applyDatasetRowsFromRelation,
+  assertDatasetWriteMode,
+  type CommitRowCount,
+} from "./dataset-row-commit"
 import { getBigIntLike } from "./duckdb-row"
 import type { DuckDbRuntime } from "./duckdb-runtime"
-import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
+import type {
+  DuckLakeCommittedWriteRuntimeRelease,
+  DuckLakeConnectionManager,
+  DuckLakeWriteRuntimeLease,
+} from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
-import type { DuckLakeSnapshotReader } from "./ducklake-snapshot-reader"
+import type { DuckLakeSnapshotReader, DuckLakeVersionSummary } from "./ducklake-snapshot-reader"
 import { createDuckLakeWriteSession, type DuckLakeCommitWriteInput } from "./ducklake-write-session"
 import {
   buildAttachSql,
@@ -32,7 +41,15 @@ export interface DuckLakeCommitDatasetVersionInput {
   readonly commitMessage: string
   readonly producer?: BeginDatasetWriteInput["producer"]
   readonly inputs?: BeginDatasetWriteInput["inputs"]
-  applyChanges(runtime: DuckDbRuntime): Promise<boolean>
+  committedReadRuntime(release: DuckLakeCommittedWriteRuntimeRelease): Promise<DuckDbRuntime>
+  applyChanges(
+    runtime: DuckDbRuntime,
+    context: DuckLakeApplyChangesContext
+  ): Promise<ApplyDatasetRowsResult>
+}
+
+export interface DuckLakeApplyChangesContext {
+  readonly previousRowCount?: number
 }
 
 /**
@@ -63,12 +80,12 @@ export class DuckLakeWriteCoordinator {
     const mode = input.mode ?? "snapshot"
     assertDatasetWriteMode(mode, "write")
 
-    // Staging tables are connection-scoped in DuckDB, so every write session
-    // owns a dedicated runtime until commit or abort closes it.
-    const runtime = await this.connections.createRuntime()
+    // Staging tables are connection-scoped in DuckDB, so every active write
+    // session owns a dedicated runtime lease until commit or abort releases it.
+    const lease = await this.connections.acquireWriteLease()
     return createDuckLakeWriteSession({
-      commitWrite: (options) => this.commitWrite(options),
-      runtime,
+      commitWrite: (options) => this.commitWrite(options, lease),
+      lease,
       write: {
         ...input,
         dataset: definition,
@@ -77,7 +94,10 @@ export class DuckLakeWriteCoordinator {
     })
   }
 
-  private async commitWrite(input: DuckLakeCommitWriteInput): Promise<DatasetVersion> {
+  private async commitWrite(
+    input: DuckLakeCommitWriteInput,
+    lease: DuckLakeWriteRuntimeLease
+  ): Promise<DatasetVersion> {
     const definition = await this.datasets.getDataset(input.write.dataset.id)
     if (!definition) {
       throw new LakeStorageError(`[ParioDuckLake] Unknown dataset '${input.write.dataset.id}'.`)
@@ -94,7 +114,13 @@ export class DuckLakeWriteCoordinator {
       commitMessage: input.commit?.commitMessage ?? `write dataset ${input.write.dataset.id}`,
       producer: input.write.producer,
       inputs: input.write.inputs,
-      applyChanges: (runtime) => this.applyStagedRows({ ...input, runtime }),
+      committedReadRuntime: (release) => lease.committedReadRuntime(release),
+      applyChanges: (runtime, context) =>
+        this.applyStagedRows({
+          ...input,
+          runtime,
+          previousRowCount: context.previousRowCount,
+        }),
     })
   }
 
@@ -113,61 +139,43 @@ export class DuckLakeWriteCoordinator {
       // Guarded Pario commits need compare-and-swap semantics. DuckLake can
       // automatically retry non-conflicting commits, so guarded transactions
       // disable retries and re-check the dataset head after BEGIN.
-      const latestVersionRef = await this.snapshots.getLatestVersionRefForDefinition(
-        input.runtime,
-        input.dataset
-      )
-      this.assertExpectedLatestVersion({
-        datasetId: input.dataset.id,
-        expectedLatestVersionId: input.expectedLatestVersionId,
-        actualLatestVersionId: latestVersionRef?.versionId ?? null,
-      })
+      const latestVersion = await this.latestVersionForCommit(input)
+      if (input.expectedLatestVersionId !== undefined) {
+        this.assertExpectedLatestVersion({
+          datasetId: input.dataset.id,
+          expectedLatestVersionId: input.expectedLatestVersionId,
+          actualLatestVersionId: latestVersion?.versionId ?? null,
+        })
+      }
 
-      const dataChangeExpected = await input.applyChanges(input.runtime)
+      const changeResult = await input.applyChanges(input.runtime, {
+        previousRowCount: latestVersion?.rowCount,
+      })
       const commitId = randomUUID()
-      await this.setCommitMetadata(input, commitId)
+      await this.setCommitMetadata(
+        input,
+        commitId,
+        commitRowCount(input, changeResult, latestVersion)
+      )
 
       await input.runtime.run("COMMIT")
       committed = true
 
       const committedWriteSnapshotId = await this.lastCommittedSnapshotId(input.runtime)
-      await this.connections.resetRuntime()
-      await input.runtime.close()
-      const readRuntime = await this.connections.runtime()
-      const ownSnapshotId = await this.findSnapshotIdByCommitId(
+      const readRuntime = await input.committedReadRuntime({
+        kind: "committed",
+        guarded: input.expectedLatestVersionId !== undefined,
+        reusable: true,
+      })
+      const version = await this.versionForCommittedWrite({
+        ...input,
         readRuntime,
-        input.dataset.id,
-        commitId
-      )
-
-      if (ownSnapshotId !== null) {
-        const version = await this.snapshots.getVersionForSnapshot(
-          readRuntime,
-          input.dataset,
-          ownSnapshotId
-        )
-        if (version) {
-          return version
-        }
-
-        throw new LakeStorageError(
-          `[ParioDuckLake] DuckLake committed snapshot '${ownSnapshotId}' for dataset '${input.dataset.id}', but Pario could not hydrate it as a dataset version.`
-        )
-      }
-
-      if (!dataChangeExpected) {
-        return this.versionForNoOpCommit(readRuntime, input.dataset)
-      }
-
-      if (committedWriteSnapshotId === previousWriteSnapshotId) {
-        throw new LakeStorageError(
-          `[ParioDuckLake] DuckLake commit for dataset '${input.dataset.id}' completed without producing a snapshot for this non-empty write.`
-        )
-      }
-
-      throw new LakeStorageError(
-        `[ParioDuckLake] DuckLake commit for dataset '${input.dataset.id}' completed, but Pario could not find a matching snapshot for this write.`
-      )
+        commitId,
+        previousWriteSnapshotId,
+        committedWriteSnapshotId,
+        changeResult,
+      })
+      return version
     } catch (error) {
       if (!committed) {
         await this.rollbackTransaction(input.runtime)
@@ -177,7 +185,61 @@ export class DuckLakeWriteCoordinator {
     }
   }
 
-  private async applyStagedRows(input: DuckLakeCommitWriteInput): Promise<boolean> {
+  private async versionForCommittedWrite(
+    input: DuckLakeCommitDatasetVersionInput & {
+      readonly readRuntime: DuckDbRuntime
+      readonly commitId: string
+      readonly previousWriteSnapshotId: string | null
+      readonly committedWriteSnapshotId: string | null
+      readonly changeResult: ApplyDatasetRowsResult
+    }
+  ): Promise<DatasetVersion> {
+    // The lease chooses the correct post-commit read runtime. Local catalogs
+    // close the writer before returning a fresh reader; PostgreSQL catalogs
+    // refresh the shared reader while keeping the writer lease available for
+    // cleanup and possible reuse.
+    const readRuntime = input.readRuntime
+    const ownSnapshotId = await this.findOwnSnapshotId(
+      readRuntime,
+      input.dataset.id,
+      input.commitId,
+      input.previousWriteSnapshotId,
+      input.committedWriteSnapshotId
+    )
+
+    if (ownSnapshotId !== null) {
+      const version = await this.snapshots.getVersionForSnapshot(
+        readRuntime,
+        input.dataset,
+        ownSnapshotId
+      )
+      if (version) {
+        return version
+      }
+
+      throw new LakeStorageError(
+        `[ParioDuckLake] DuckLake committed snapshot '${ownSnapshotId}' for dataset '${input.dataset.id}', but Pario could not hydrate it as a dataset version.`
+      )
+    }
+
+    if (!input.changeResult.dataChangeExpected) {
+      return this.versionForNoOpCommit(readRuntime, input.dataset)
+    }
+
+    if (input.committedWriteSnapshotId === input.previousWriteSnapshotId) {
+      throw new LakeStorageError(
+        `[ParioDuckLake] DuckLake commit for dataset '${input.dataset.id}' completed without producing a snapshot for this non-empty write.`
+      )
+    }
+
+    throw new LakeStorageError(
+      `[ParioDuckLake] DuckLake commit for dataset '${input.dataset.id}' completed, but Pario could not find a matching snapshot for this write.`
+    )
+  }
+
+  private async applyStagedRows(
+    input: DuckLakeCommitWriteInput & { readonly previousRowCount?: number }
+  ): Promise<ApplyDatasetRowsResult> {
     const mode = input.write.mode ?? "snapshot"
     return applyDatasetRowsFromRelation({
       options: this.options,
@@ -185,18 +247,19 @@ export class DuckLakeWriteCoordinator {
       dataset: input.write.dataset,
       mode,
       sourceRelationSql: quoteIdentifier(input.stagingTableName),
+      previousRowCount: input.previousRowCount,
     })
   }
 
   private async setCommitMetadata(
     input: DuckLakeCommitDatasetVersionInput,
-    commitId: string
+    commitId: string,
+    rowCount: CommitRowCount
   ): Promise<void> {
     // DuckLake stores this JSON on the snapshot it creates for the current
-    // transaction. Keep it Pario-semantic only: version id, timestamp, row
-    // count, and data-change detection all come from DuckLake itself. commitId
-    // is only a transaction correlation token so concurrent writers do not
-    // accidentally hydrate each other's snapshots.
+    // transaction. Version id, timestamp, and data-change detection still come
+    // from DuckLake itself. commitId is only a transaction correlation token so
+    // concurrent writers do not accidentally hydrate each other's snapshots.
     const metadata: ParioCommitMetadata = {
       kind: "datasetVersion",
       datasetId: input.dataset.id,
@@ -204,6 +267,7 @@ export class DuckLakeWriteCoordinator {
       mode: input.mode,
       producer: input.producer ? structuredClone(input.producer) : undefined,
       inputs: input.inputs ? structuredClone(input.inputs) : undefined,
+      ...(rowCount.kind === "exact" ? { rowCount: rowCount.value } : {}),
     }
 
     await input.runtime.run(
@@ -246,8 +310,20 @@ export class DuckLakeWriteCoordinator {
     // Write sessions can live long enough for other connections to commit.
     // Re-attaching refreshes DuckLake metadata while preserving temp staging
     // tables on the same DuckDB connection.
-    await runtime.run(`DETACH ${quoteIdentifier(duckLakeAlias(this.options))}`)
-    await runtime.run(buildAttachSql(this.options))
+    await runtime.runStatements([
+      `DETACH ${quoteIdentifier(duckLakeAlias(this.options))}`,
+      buildAttachSql(this.options),
+    ])
+  }
+
+  private async latestVersionForCommit(
+    input: DuckLakeCommitDatasetVersionInput
+  ): Promise<DuckLakeVersionSummary | null> {
+    if (input.expectedLatestVersionId === undefined && input.mode !== "append") {
+      return null
+    }
+
+    return this.snapshots.getLatestVersionSummaryForDefinition(input.runtime, input.dataset)
   }
 
   private async lastCommittedSnapshotId(runtime: DuckDbRuntime): Promise<string | null> {
@@ -266,16 +342,24 @@ export class DuckLakeWriteCoordinator {
   private async findSnapshotIdByCommitId(
     runtime: DuckDbRuntime,
     datasetId: string,
-    commitId: string
+    commitId: string,
+    snapshotId?: string
   ): Promise<string | null> {
+    if (snapshotId !== undefined) {
+      assertDuckLakeSnapshotId(snapshotId)
+    }
+
     const ducklakeSnapshotChanges = duckLakeMetadataTableName(
       this.options,
       "ducklake_snapshot_changes"
     )
+    const whereSql = snapshotId === undefined ? "" : `WHERE snapshot_id = ${snapshotId}`
+    const orderSql = snapshotId === undefined ? "ORDER BY snapshot_id DESC" : ""
     const rows = await runtime.query(`
       SELECT snapshot_id, commit_extra_info
       FROM ${ducklakeSnapshotChanges}
-      ORDER BY snapshot_id DESC
+      ${whereSql}
+      ${orderSql}
     `)
 
     for (const row of rows) {
@@ -286,6 +370,32 @@ export class DuckLakeWriteCoordinator {
     }
 
     return null
+  }
+
+  private async findOwnSnapshotId(
+    runtime: DuckDbRuntime,
+    datasetId: string,
+    commitId: string,
+    previousWriteSnapshotId: string | null,
+    committedWriteSnapshotId: string | null
+  ): Promise<string | null> {
+    if (committedWriteSnapshotId === null || committedWriteSnapshotId === previousWriteSnapshotId) {
+      return null
+    }
+
+    const exactMatch = await this.findSnapshotIdByCommitId(
+      runtime,
+      datasetId,
+      commitId,
+      committedWriteSnapshotId
+    )
+    if (exactMatch !== null) {
+      return exactMatch
+    }
+
+    // Defensive fallback for driver/version edge cases. The expected hot path
+    // above reads a single metadata row keyed by last_committed_snapshot().
+    return this.findSnapshotIdByCommitId(runtime, datasetId, commitId)
   }
 
   private assertExpectedLatestVersion(input: {
@@ -302,5 +412,35 @@ export class DuckLakeWriteCoordinator {
         `[ParioDuckLake] Optimistic commit failed for dataset '${input.datasetId}': expected latest version '${input.expectedLatestVersionId}', found '${input.actualLatestVersionId ?? "none"}'.`
       )
     }
+  }
+}
+
+function commitRowCount(
+  input: Pick<DuckLakeCommitDatasetVersionInput, "expectedLatestVersionId" | "mode">,
+  changeResult: ApplyDatasetRowsResult,
+  latestVersion: DuckLakeVersionSummary | null
+): CommitRowCount {
+  // Unguarded append commits can be retried by DuckLake after this transaction
+  // read the previous latest version. In that case previousRowCount +
+  // sourceRowCount can underreport the committed snapshot, so omit metadata
+  // and let hydration count the exact committed snapshot instead.
+  if (input.mode === "append" && input.expectedLatestVersionId === undefined) {
+    return { kind: "unknown" }
+  }
+
+  if (changeResult.resultingRowCount.kind === "exact") {
+    return changeResult.resultingRowCount
+  }
+
+  if (input.mode === "append" && latestVersion === null) {
+    return { kind: "exact", value: changeResult.sourceRowCount }
+  }
+
+  return { kind: "unknown" }
+}
+
+function assertDuckLakeSnapshotId(snapshotId: string): void {
+  if (!/^\d+$/.test(snapshotId)) {
+    throw new LakeStorageError(`[ParioDuckLake] Invalid DuckLake snapshot id '${snapshotId}'.`)
   }
 }

--- a/storage/ducklake/src/internal/ducklake-write-session.ts
+++ b/storage/ducklake/src/internal/ducklake-write-session.ts
@@ -8,6 +8,10 @@ import type {
 } from "@pario/core"
 import { getDatasetRowValidationError, LakeStorageError } from "@pario/core"
 import type { DuckDbRuntime } from "./duckdb-runtime"
+import type {
+  DuckLakeWriteRuntimeLease,
+  DuckLakeWriteRuntimeRelease,
+} from "./ducklake-connection-manager"
 import { appendDatasetRow } from "./row-appender"
 import { datasetSchemaToDuckDbColumnsSql } from "./schema"
 import { quoteIdentifier } from "./sql"
@@ -23,7 +27,7 @@ type DuckLakeCommitWrite = (options: DuckLakeCommitWriteInput) => Promise<Datase
 
 interface CreateDuckLakeWriteSessionInput {
   readonly commitWrite: DuckLakeCommitWrite
-  readonly runtime: DuckDbRuntime
+  readonly lease: DuckLakeWriteRuntimeLease
   readonly write: BeginDatasetWriteInput
 }
 
@@ -36,17 +40,17 @@ export async function createDuckLakeWriteSession(
     // The temp table lives only on this write connection. That keeps partially
     // written rows invisible until DuckLakeStorage commits them into the
     // durable dataset table.
-    await input.runtime.run(
+    await input.lease.runtime.run(
       `CREATE TEMP TABLE ${quoteIdentifier(stagingTableName)} (${datasetSchemaToDuckDbColumnsSql(
         input.write.dataset.schema
       )})`
     )
   } catch (error) {
-    await input.runtime.close()
+    await input.lease.release({ kind: "failed" })
     throw error
   }
 
-  return new DuckLakeWriteSession(input.commitWrite, input.runtime, input.write, stagingTableName)
+  return new DuckLakeWriteSession(input.commitWrite, input.lease, input.write, stagingTableName)
 }
 
 /**
@@ -62,7 +66,7 @@ class DuckLakeWriteSession implements LakeWriteSession {
 
   constructor(
     private readonly commitWrite: DuckLakeCommitWrite,
-    private readonly runtime: DuckDbRuntime,
+    private readonly lease: DuckLakeWriteRuntimeLease,
     private readonly input: BeginDatasetWriteInput,
     private readonly stagingTableName: string
   ) {}
@@ -70,7 +74,7 @@ class DuckLakeWriteSession implements LakeWriteSession {
   async writeRows(rows: Iterable<DatasetRow> | AsyncIterable<DatasetRow>): Promise<void> {
     this.assertOpen()
 
-    await this.runtime.withAppender(this.stagingTableName, async (appender) => {
+    await this.lease.runtime.withAppender(this.stagingTableName, async (appender) => {
       for await (const row of rows) {
         const validationError = getDatasetRowValidationError(row, this.input.dataset)
         if (validationError) {
@@ -86,17 +90,28 @@ class DuckLakeWriteSession implements LakeWriteSession {
     this.assertOpen()
     this.closed = true
 
+    let committed = false
     try {
-      return await this.commitWrite({
+      const version = await this.commitWrite({
         write: this.input,
         commit: input,
-        runtime: this.runtime,
+        runtime: this.lease.runtime,
         stagingTableName: this.stagingTableName,
       })
-    } finally {
+      committed = true
       // Even successful commits no longer need the staging table or dedicated
-      // connection once rows have been inserted into the DuckLake table.
-      await this.cleanup()
+      // lease once rows have been inserted into the DuckLake table.
+      await this.cleanup({
+        kind: "committed",
+        guarded: input?.expectedLatestVersionId !== undefined,
+        reusable: true,
+      })
+      return version
+    } catch (error) {
+      if (!committed) {
+        await this.cleanup({ kind: "failed" })
+      }
+      throw error
     }
   }
 
@@ -106,7 +121,7 @@ class DuckLakeWriteSession implements LakeWriteSession {
     }
 
     this.closed = true
-    await this.cleanup()
+    await this.cleanup({ kind: "aborted" })
   }
 
   private assertOpen(): void {
@@ -115,12 +130,33 @@ class DuckLakeWriteSession implements LakeWriteSession {
     }
   }
 
-  private async cleanup(): Promise<void> {
+  private async cleanup(release: DuckLakeWriteRuntimeRelease): Promise<void> {
     if (this.cleanedUp) {
       return
     }
 
     this.cleanedUp = true
-    await this.runtime.close()
+
+    if (release.kind === "failed") {
+      await this.lease.release(release)
+      return
+    }
+
+    const reusable = await this.dropStagingTable()
+    const releaseResult =
+      release.kind === "committed"
+        ? { ...release, reusable: release.reusable && reusable }
+        : { ...release, reusable }
+
+    await this.lease.release(releaseResult)
+  }
+
+  private async dropStagingTable(): Promise<boolean> {
+    try {
+      await this.lease.runtime.run(`DROP TABLE IF EXISTS ${quoteIdentifier(this.stagingTableName)}`)
+      return true
+    } catch {
+      return false
+    }
   }
 }

--- a/storage/ducklake/src/internal/ducklake-write-session.ts
+++ b/storage/ducklake/src/internal/ducklake-write-session.ts
@@ -8,10 +8,6 @@ import type {
 } from "@pario/core"
 import { getDatasetRowValidationError, LakeStorageError } from "@pario/core"
 import type { DuckDbRuntime } from "./duckdb-runtime"
-import type {
-  DuckLakeWriteRuntimeLease,
-  DuckLakeWriteRuntimeRelease,
-} from "./ducklake-connection-manager"
 import { appendDatasetRow } from "./row-appender"
 import { datasetSchemaToDuckDbColumnsSql } from "./schema"
 import { quoteIdentifier } from "./sql"
@@ -19,15 +15,15 @@ import { quoteIdentifier } from "./sql"
 export interface DuckLakeCommitWriteInput {
   readonly write: BeginDatasetWriteInput
   readonly commit?: CommitDatasetWriteInput
-  readonly runtime: DuckDbRuntime
   readonly stagingTableName: string
+  readonly rowsWritten: number
 }
 
 type DuckLakeCommitWrite = (options: DuckLakeCommitWriteInput) => Promise<DatasetVersion>
 
 interface CreateDuckLakeWriteSessionInput {
   readonly commitWrite: DuckLakeCommitWrite
-  readonly lease: DuckLakeWriteRuntimeLease
+  readonly runtime: DuckDbRuntime
   readonly write: BeginDatasetWriteInput
 }
 
@@ -36,21 +32,16 @@ export async function createDuckLakeWriteSession(
 ): Promise<LakeWriteSession> {
   const stagingTableName = `pario_write_${randomUUID().replaceAll("-", "")}`
 
-  try {
-    // The temp table lives only on this write connection. That keeps partially
-    // written rows invisible until DuckLakeStorage commits them into the
-    // durable dataset table.
-    await input.lease.runtime.run(
-      `CREATE TEMP TABLE ${quoteIdentifier(stagingTableName)} (${datasetSchemaToDuckDbColumnsSql(
-        input.write.dataset.schema
-      )})`
-    )
-  } catch (error) {
-    await input.lease.release({ kind: "failed" })
-    throw error
-  }
+  // The temp table lives only on this runtime connection. That keeps
+  // partially written rows invisible until DuckLakeStorage commits them into
+  // the durable dataset table.
+  await input.runtime.run(
+    `CREATE TEMP TABLE ${quoteIdentifier(stagingTableName)} (${datasetSchemaToDuckDbColumnsSql(
+      input.write.dataset.schema
+    )})`
+  )
 
-  return new DuckLakeWriteSession(input.commitWrite, input.lease, input.write, stagingTableName)
+  return new DuckLakeWriteSession(input.commitWrite, input.runtime, input.write, stagingTableName)
 }
 
 /**
@@ -63,10 +54,11 @@ export async function createDuckLakeWriteSession(
 class DuckLakeWriteSession implements LakeWriteSession {
   private closed = false
   private cleanedUp = false
+  private rowsWritten = 0
 
   constructor(
     private readonly commitWrite: DuckLakeCommitWrite,
-    private readonly lease: DuckLakeWriteRuntimeLease,
+    private readonly runtime: DuckDbRuntime,
     private readonly input: BeginDatasetWriteInput,
     private readonly stagingTableName: string
   ) {}
@@ -74,7 +66,7 @@ class DuckLakeWriteSession implements LakeWriteSession {
   async writeRows(rows: Iterable<DatasetRow> | AsyncIterable<DatasetRow>): Promise<void> {
     this.assertOpen()
 
-    await this.lease.runtime.withAppender(this.stagingTableName, async (appender) => {
+    await this.runtime.withAppender(this.stagingTableName, async (appender) => {
       for await (const row of rows) {
         const validationError = getDatasetRowValidationError(row, this.input.dataset)
         if (validationError) {
@@ -82,6 +74,7 @@ class DuckLakeWriteSession implements LakeWriteSession {
         }
 
         appendDatasetRow(appender, this.input.dataset.schema, row)
+        this.rowsWritten += 1
       }
     })
   }
@@ -95,21 +88,17 @@ class DuckLakeWriteSession implements LakeWriteSession {
       const version = await this.commitWrite({
         write: this.input,
         commit: input,
-        runtime: this.lease.runtime,
+        rowsWritten: this.rowsWritten,
         stagingTableName: this.stagingTableName,
       })
       committed = true
-      // Even successful commits no longer need the staging table or dedicated
-      // lease once rows have been inserted into the DuckLake table.
-      await this.cleanup({
-        kind: "committed",
-        guarded: input?.expectedLatestVersionId !== undefined,
-        reusable: true,
-      })
+      // Even successful commits no longer need the staging table once rows
+      // have been inserted into the durable DuckLake table.
+      await this.cleanup()
       return version
     } catch (error) {
       if (!committed) {
-        await this.cleanup({ kind: "failed" })
+        await this.cleanup()
       }
       throw error
     }
@@ -121,7 +110,7 @@ class DuckLakeWriteSession implements LakeWriteSession {
     }
 
     this.closed = true
-    await this.cleanup({ kind: "aborted" })
+    await this.cleanup()
   }
 
   private assertOpen(): void {
@@ -130,33 +119,21 @@ class DuckLakeWriteSession implements LakeWriteSession {
     }
   }
 
-  private async cleanup(release: DuckLakeWriteRuntimeRelease): Promise<void> {
+  private async cleanup(): Promise<void> {
     if (this.cleanedUp) {
       return
     }
 
     this.cleanedUp = true
-
-    if (release.kind === "failed") {
-      await this.lease.release(release)
-      return
-    }
-
-    const reusable = await this.dropStagingTable()
-    const releaseResult =
-      release.kind === "committed"
-        ? { ...release, reusable: release.reusable && reusable }
-        : { ...release, reusable }
-
-    await this.lease.release(releaseResult)
+    await this.dropStagingTable()
   }
 
-  private async dropStagingTable(): Promise<boolean> {
+  private async dropStagingTable(): Promise<void> {
     try {
-      await this.lease.runtime.run(`DROP TABLE IF EXISTS ${quoteIdentifier(this.stagingTableName)}`)
-      return true
+      await this.runtime.run(`DROP TABLE IF EXISTS ${quoteIdentifier(this.stagingTableName)}`)
     } catch {
-      return false
+      // Preserve the commit/abort failure. Temp tables are connection-scoped
+      // and will disappear when the storage runtime closes.
     }
   }
 }

--- a/storage/ducklake/src/internal/sql.ts
+++ b/storage/ducklake/src/internal/sql.ts
@@ -34,11 +34,26 @@ function duckLakeMetadataCatalog(options: Pick<DuckLakeStorageOptions, "alias">)
  * DuckLake metadata reads.
  */
 export function buildConfigurePostgresMetadataPoolSql(
-  options: Pick<DuckLakeStorageOptions, "alias">
+  options: Pick<DuckLakeStorageOptions, "alias" | "postgresPool">
 ): string {
-  return `FROM postgres_configure_pool(catalog_name=${quoteSqlString(
-    duckLakeMetadataCatalog(options)
-  )}, enable_thread_local_cache=false)`
+  const parameters = [
+    `catalog_name=${quoteSqlString(duckLakeMetadataCatalog(options))}`,
+    ...postgresPoolParameters(options.postgresPool).map(({ name, value }) => `${name}=${value}`),
+  ]
+
+  return `FROM postgres_configure_pool(${parameters.join(", ")})`
+}
+
+/**
+ * Configure DuckDB's PostgreSQL extension before ATTACH. These settings only
+ * affect databases attached after they are set.
+ */
+export function buildSetPostgresPoolSql(
+  options: Pick<DuckLakeStorageOptions, "postgresPool">
+): readonly string[] {
+  return postgresPoolParameters(options.postgresPool).map(
+    ({ name, value }) => `SET pg_pool_${name} = ${value}`
+  )
 }
 
 /**
@@ -233,6 +248,48 @@ function storageExtensions(path: string | undefined): readonly string[] {
     default:
       return []
   }
+}
+
+/**
+ * The single source of truth for PostgreSQL pool options. Both the pre-attach
+ * `SET pg_pool_*` form and the post-attach `postgres_configure_pool(...)` form
+ * render from this list so the two stay in sync. `name` is the unprefixed
+ * option key; `value` is already rendered (numbers/booleans bare, strings
+ * quoted as SQL literals).
+ */
+function postgresPoolParameters(
+  pool: DuckLakeStorageOptions["postgresPool"]
+): readonly { readonly name: string; readonly value: string }[] {
+  const parameters: { name: string; value: string }[] = [
+    { name: "enable_thread_local_cache", value: String(pool?.enableThreadLocalCache ?? false) },
+  ]
+
+  appendPoolNumber(parameters, "max_connections", pool?.maxConnections)
+  appendPoolNumber(parameters, "wait_timeout_millis", pool?.waitTimeoutMillis)
+  appendPoolNumber(parameters, "max_lifetime_millis", pool?.maxLifetimeMillis)
+  appendPoolNumber(parameters, "idle_timeout_millis", pool?.idleTimeoutMillis)
+
+  if (pool?.enableReaperThread !== undefined) {
+    parameters.push({ name: "enable_reaper_thread", value: String(pool.enableReaperThread) })
+  }
+
+  if (pool?.healthCheckQuery !== undefined) {
+    parameters.push({ name: "health_check_query", value: quoteSqlString(pool.healthCheckQuery) })
+  }
+
+  return parameters
+}
+
+function appendPoolNumber(
+  parameters: { name: string; value: string }[],
+  name: string,
+  value: number | undefined
+): void {
+  if (value === undefined) {
+    return
+  }
+
+  parameters.push({ name, value: String(value) })
 }
 
 function secretExtensions(secret: DuckDbSecretOptions): readonly string[] {

--- a/storage/ducklake/src/internal/versions.ts
+++ b/storage/ducklake/src/internal/versions.ts
@@ -12,6 +12,7 @@ export interface ParioCommitMetadata {
   readonly mode?: DatasetVersion["mode"]
   readonly producer?: DatasetVersion["producer"]
   readonly inputs?: DatasetVersion["inputs"]
+  readonly rowCount?: number
   readonly schemaChange?: ParioSchemaChangeMetadata
 }
 
@@ -55,6 +56,7 @@ export function parseCommitMetadata(value: unknown): ParioCommitMetadata | undef
 
   const mode = parsed.pario.mode
   const commitId = parsed.pario.commitId
+  const rowCount = parsed.pario.rowCount
 
   return {
     kind: "datasetVersion",
@@ -63,6 +65,7 @@ export function parseCommitMetadata(value: unknown): ParioCommitMetadata | undef
     ...(mode === "snapshot" || mode === "append" || mode === "schema" ? { mode } : {}),
     ...(isDatasetProducer(parsed.pario.producer) ? { producer: parsed.pario.producer } : {}),
     ...(isDatasetVersionRefs(parsed.pario.inputs) ? { inputs: parsed.pario.inputs } : {}),
+    ...(typeof commitId === "string" && isRowCount(rowCount) ? { rowCount } : {}),
     ...(isSchemaChangeMetadata(parsed.pario.schemaChange)
       ? { schemaChange: parsed.pario.schemaChange }
       : {}),
@@ -130,4 +133,8 @@ function isSchemaChangeMetadata(value: unknown): value is ParioSchemaChangeMetad
 
 function optionalString(value: unknown): boolean {
   return value === undefined || typeof value === "string"
+}
+
+function isRowCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
 }

--- a/storage/ducklake/src/types.ts
+++ b/storage/ducklake/src/types.ts
@@ -45,6 +45,20 @@ export interface DuckDbRuntimeOptions {
 }
 
 /**
+ * DuckDB PostgreSQL extension pool settings for a Postgres-backed DuckLake
+ * metadata catalog.
+ */
+export interface DuckLakePostgresPoolOptions {
+  readonly maxConnections?: number
+  readonly waitTimeoutMillis?: number
+  readonly maxLifetimeMillis?: number
+  readonly idleTimeoutMillis?: number
+  readonly enableThreadLocalCache?: boolean
+  readonly enableReaperThread?: boolean
+  readonly healthCheckQuery?: string
+}
+
+/**
  * Common CREATE SECRET options shared by DuckDB object-store integrations.
  */
 interface BaseSecretOptions {
@@ -118,6 +132,7 @@ export interface DuckLakeStorageOptions {
   readonly dataPath?: string
   readonly alias?: string
   readonly duckdb?: DuckDbRuntimeOptions
+  readonly postgresPool?: DuckLakePostgresPoolOptions
   readonly secrets?: readonly DuckDbSecretOptions[]
   /** Runs after DuckLake/catalog extensions load and before ATTACH. */
   readonly setupSql?: readonly string[]

--- a/storage/ducklake/tests/ducklake-catalogs.e2e.ts
+++ b/storage/ducklake/tests/ducklake-catalogs.e2e.ts
@@ -5,8 +5,6 @@ import { join } from "node:path"
 import { col, defineDataset } from "@pario/core"
 import { DuckLakeStorage } from "../src"
 import { createDuckDbRuntime, setupDuckLake } from "../src/internal/duckdb-runtime"
-import { DuckLakeConnectionManager } from "../src/internal/ducklake-connection-manager"
-import { localDuckLakeOptions } from "./test-utils"
 
 const ordersDataset = defineDataset("raw.erp.orders", {
   schema: [col("orderId", "string")],
@@ -172,31 +170,6 @@ describe("DuckLakeStorage catalog options", () => {
     await expect(storage.listDatasets()).rejects.toThrow()
     await storage.close()
     await storage.close()
-  })
-
-  test("closes local committed write leases before returning a read runtime", async () => {
-    const connections = new DuckLakeConnectionManager(localDuckLakeOptions(rootDir))
-
-    try {
-      const lease = await connections.acquireWriteLease()
-      const writeRuntime = lease.runtime
-      const readRuntime = await lease.committedReadRuntime({
-        kind: "committed",
-        guarded: false,
-        reusable: true,
-      })
-
-      expect(readRuntime).not.toBe(writeRuntime)
-      await expect(writeRuntime.query("SELECT 1 AS value")).rejects.toThrow(
-        "DuckDB runtime is closed"
-      )
-
-      const nextLease = await connections.acquireWriteLease()
-      expect(nextLease.runtime).not.toBe(writeRuntime)
-      await nextLease.release({ kind: "aborted" })
-    } finally {
-      await connections.close()
-    }
   })
 
   function track(storage: DuckLakeStorage): DuckLakeStorage {

--- a/storage/ducklake/tests/ducklake-catalogs.e2e.ts
+++ b/storage/ducklake/tests/ducklake-catalogs.e2e.ts
@@ -5,6 +5,8 @@ import { join } from "node:path"
 import { col, defineDataset } from "@pario/core"
 import { DuckLakeStorage } from "../src"
 import { createDuckDbRuntime, setupDuckLake } from "../src/internal/duckdb-runtime"
+import { DuckLakeConnectionManager } from "../src/internal/ducklake-connection-manager"
+import { localDuckLakeOptions } from "./test-utils"
 
 const ordersDataset = defineDataset("raw.erp.orders", {
   schema: [col("orderId", "string")],
@@ -170,6 +172,31 @@ describe("DuckLakeStorage catalog options", () => {
     await expect(storage.listDatasets()).rejects.toThrow()
     await storage.close()
     await storage.close()
+  })
+
+  test("closes local committed write leases before returning a read runtime", async () => {
+    const connections = new DuckLakeConnectionManager(localDuckLakeOptions(rootDir))
+
+    try {
+      const lease = await connections.acquireWriteLease()
+      const writeRuntime = lease.runtime
+      const readRuntime = await lease.committedReadRuntime({
+        kind: "committed",
+        guarded: false,
+        reusable: true,
+      })
+
+      expect(readRuntime).not.toBe(writeRuntime)
+      await expect(writeRuntime.query("SELECT 1 AS value")).rejects.toThrow(
+        "DuckDB runtime is closed"
+      )
+
+      const nextLease = await connections.acquireWriteLease()
+      expect(nextLease.runtime).not.toBe(writeRuntime)
+      await nextLease.release({ kind: "aborted" })
+    } finally {
+      await connections.close()
+    }
   })
 
   function track(storage: DuckLakeStorage): DuckLakeStorage {

--- a/storage/ducklake/tests/ducklake-concurrency.e2e.ts
+++ b/storage/ducklake/tests/ducklake-concurrency.e2e.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { col, defineDataset } from "@pario/core"
-import type { DuckLakeStorage } from "../src"
+import { type DuckLakeStorage, DuckLakeStorage as DuckLakeStorageProvider } from "../src"
 import { collectRows, createLocalDuckLakeStorage } from "./test-utils"
 
 const ordersDataset = defineDataset("raw.erp.orders", {
@@ -114,6 +114,44 @@ describe("DuckLakeStorage optimistic concurrency", () => {
       { orderId: "ord_1", customerName: "Ada" },
       { orderId: "ord_3", customerName: "Katherine" },
     ])
+  })
+
+  test("lets an attached local DuckDB peer observe another provider's commit", async () => {
+    const secondStorage = createLocalDuckLakeStorage(rootDir)
+    extraStorages.push(secondStorage)
+
+    expect(await secondStorage.listDatasets()).toEqual([ordersDataset])
+
+    const committedVersion = await seedInitialVersion(storage)
+
+    await expect(secondStorage.getLatestVersion(ordersDataset.id)).resolves.toMatchObject({
+      versionId: committedVersion.versionId,
+    })
+    await expect(
+      collectRows(secondStorage.readRows({ datasetId: ordersDataset.id }))
+    ).resolves.toEqual([{ orderId: "ord_1", customerName: "Ada" }])
+  })
+
+  test("coordinates local catalog peers with equivalent path spellings", async () => {
+    await mkdir(join(rootDir, "alias"))
+    const firstStorage = new DuckLakeStorageProvider({
+      catalog: { type: "sqlite", path: join(rootDir, "metadata.sqlite") },
+      dataPath: join(rootDir, "sqlite-data"),
+    })
+    const secondStorage = new DuckLakeStorageProvider({
+      catalog: { type: "sqlite", path: `${rootDir}/alias/../metadata.sqlite` },
+      dataPath: join(rootDir, "sqlite-data"),
+    })
+    extraStorages.push(firstStorage, secondStorage)
+
+    await firstStorage.createDataset(ordersDataset)
+    expect(await secondStorage.listDatasets()).toEqual([ordersDataset])
+
+    const committedVersion = await seedInitialVersion(firstStorage)
+
+    await expect(secondStorage.getLatestVersion(ordersDataset.id)).resolves.toMatchObject({
+      versionId: committedVersion.versionId,
+    })
   })
 
   test("does not report another session's concurrent commit as successful", async () => {

--- a/storage/ducklake/tests/ducklake-connection-manager.test.ts
+++ b/storage/ducklake/tests/ducklake-connection-manager.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test"
+import type { DuckDBValue } from "@duckdb/node-api"
+import type { DuckLakeStorageOptions } from "../src"
+import type { DuckDbAppender, DuckDbRuntime } from "../src/internal/duckdb-runtime"
+import { DuckLakeConnectionManager } from "../src/internal/ducklake-connection-manager"
+
+describe("DuckLakeConnectionManager", () => {
+  test("does not run shared-runtime readers between PostgreSQL DETACH and ATTACH", async () => {
+    const runtime = new PausedRefreshRuntime()
+    const connections = new TestConnectionManager(runtime)
+
+    try {
+      const sharedRuntime = await connections.runtime()
+      const refresh = connections.resetRuntime()
+
+      await withTimeout(runtime.detached(), "refresh did not reach DETACH")
+      const read = sharedRuntime.query("SELECT 1 AS value")
+      const readResult = read.then(
+        (rows) => ({ kind: "resolved" as const, rows }),
+        (error: unknown) => ({
+          error: error instanceof Error ? error.message : String(error),
+          kind: "rejected" as const,
+        })
+      )
+
+      runtime.resumeDetach()
+
+      await withTimeout(refresh, "refresh did not finish")
+      expect(await readResult).toEqual({
+        kind: "resolved",
+        rows: [{ value: 1 }],
+      })
+    } finally {
+      runtime.resumeDetach()
+      await connections.close()
+    }
+  })
+})
+
+const postgresOptions: DuckLakeStorageOptions = {
+  catalog: {
+    type: "postgres",
+    host: "127.0.0.1",
+    database: "postgres",
+  },
+  dataPath: "/tmp/pario-ducklake-test-data",
+}
+
+async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timeout: Timer | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), 1_000)
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+class TestConnectionManager extends DuckLakeConnectionManager {
+  private created = false
+
+  constructor(private readonly testRuntime: DuckDbRuntime) {
+    super(postgresOptions)
+  }
+
+  override async createRuntime(): Promise<DuckDbRuntime> {
+    if (this.created) {
+      throw new Error("test expected a single shared runtime")
+    }
+
+    this.created = true
+    return this.testRuntime
+  }
+}
+
+class PausedRefreshRuntime implements DuckDbRuntime {
+  private readonly detachedDeferred = createDeferred<void>()
+  private readonly resumeDetachDeferred = createDeferred<void>()
+  private operations: Promise<void> = Promise.resolve()
+  private closed = false
+  private aliasAttached = true
+  private detachResumed = false
+
+  detached(): Promise<void> {
+    return this.detachedDeferred.promise
+  }
+
+  resumeDetach(): void {
+    if (this.detachResumed) {
+      return
+    }
+
+    this.detachResumed = true
+    this.resumeDetachDeferred.resolve()
+  }
+
+  run(sql: string, values?: readonly DuckDBValue[]): Promise<void> {
+    void values
+    return this.enqueue(() => this.runStatement(sql))
+  }
+
+  runStatements(statements: readonly string[]): Promise<void> {
+    return this.enqueue(async () => {
+      for (const sql of statements) {
+        await this.runStatement(sql)
+      }
+    })
+  }
+
+  private async runStatement(sql: string): Promise<void> {
+    if (sql.startsWith("DETACH ")) {
+      this.aliasAttached = false
+      this.detachedDeferred.resolve()
+      await this.resumeDetachDeferred.promise
+      return
+    }
+
+    if (sql.startsWith("ATTACH ")) {
+      this.aliasAttached = true
+    }
+  }
+
+  query(sql: string, values?: readonly DuckDBValue[]): Promise<readonly Record<string, unknown>[]> {
+    void sql
+    void values
+    return this.enqueue(async () => {
+      this.assertAliasAttached()
+      return [{ value: 1 }]
+    })
+  }
+
+  async *streamRows(
+    sql: string,
+    values?: readonly DuckDBValue[]
+  ): AsyncIterable<Record<string, unknown>> {
+    void sql
+    void values
+    for (const row of await this.query("SELECT 1 AS value")) {
+      yield row
+    }
+  }
+
+  withAppender<T>(
+    tableName: string,
+    useAppender: (appender: DuckDbAppender) => T | Promise<T>
+  ): Promise<T> {
+    void tableName
+    void useAppender
+    throw new Error("withAppender is not needed in this test")
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return
+    }
+
+    this.resumeDetach()
+    await this.operations.catch(() => {})
+    this.closed = true
+  }
+
+  private enqueue<T>(operation: () => T | Promise<T>): Promise<T> {
+    if (this.closed) {
+      throw new Error("runtime is closed")
+    }
+
+    const result = this.operations.then(async () => {
+      if (this.closed) {
+        throw new Error("runtime is closed")
+      }
+
+      return operation()
+    })
+    this.operations = result.then(
+      () => {},
+      () => {}
+    )
+    return result
+  }
+
+  private assertAliasAttached(): void {
+    if (!this.aliasAttached) {
+      throw new Error("DuckLake alias is detached")
+    }
+  }
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T | PromiseLike<T>) => void
+} {
+  let resolve: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return {
+    promise,
+    resolve: resolve!,
+  }
+}

--- a/storage/ducklake/tests/ducklake-connection-manager.test.ts
+++ b/storage/ducklake/tests/ducklake-connection-manager.test.ts
@@ -1,16 +1,107 @@
 import { describe, expect, test } from "bun:test"
 import type { DuckDBValue } from "@duckdb/node-api"
 import type { DuckLakeStorageOptions } from "../src"
-import type { DuckDbAppender, DuckDbRuntime } from "../src/internal/duckdb-runtime"
+import type {
+  DuckDbAppender,
+  DuckDbExclusiveRuntime,
+  DuckDbRuntime,
+} from "../src/internal/duckdb-runtime"
 import { DuckLakeConnectionManager } from "../src/internal/ducklake-connection-manager"
 
 describe("DuckLakeConnectionManager", () => {
-  test("does not run shared-runtime readers between PostgreSQL DETACH and ATTACH", async () => {
-    const runtime = new PausedRefreshRuntime()
-    const connections = new TestConnectionManager(runtime)
+  test("starts the shared runtime unattached and attaches only once", async () => {
+    const runtime = new RecordingRuntime()
+    const connections = new TestConnectionManager(() => runtime)
 
     try {
-      const sharedRuntime = await connections.runtime()
+      expect(await connections.runtime()).toBe(runtime)
+      expect(runtime.attachCount()).toBe(0)
+
+      expect(await connections.attachedRuntime()).toBe(runtime)
+      expect(await connections.attachedRuntime()).toBe(runtime)
+      expect(runtime.attachCount()).toBe(1)
+    } finally {
+      await connections.close()
+    }
+
+    expect(runtime.detachCount()).toBe(1)
+    expect(runtime.closed).toBe(true)
+  })
+
+  test("does not detach an unattached runtime on close", async () => {
+    const runtime = new RecordingRuntime()
+    const connections = new TestConnectionManager(() => runtime)
+
+    await connections.runtime()
+    await connections.close()
+
+    expect(runtime.attachCount()).toBe(0)
+    expect(runtime.detachCount()).toBe(0)
+    expect(runtime.closed).toBe(true)
+  })
+
+  test("clears failed attachments so the next request can retry with a fresh runtime", async () => {
+    const first = new RecordingRuntime({ failOnAttach: true })
+    const second = new RecordingRuntime()
+    const runtimes = [first, second]
+    const connections = new TestConnectionManager(() => {
+      const runtime = runtimes.shift()
+      if (!runtime) {
+        throw new Error("test did not expect another runtime")
+      }
+      return runtime
+    })
+
+    try {
+      await expect(connections.attachedRuntime()).rejects.toThrow("attach failed")
+      expect(first.attachCount()).toBe(1)
+      expect(first.closed).toBe(true)
+
+      await expect(connections.attachedRuntime()).resolves.toBe(second)
+      expect(second.attachCount()).toBe(1)
+    } finally {
+      await connections.close()
+    }
+  })
+
+  test("recycles a poisoned runtime on release so leaked session state cannot reach a later lease", async () => {
+    const first = new RecordingRuntime()
+    const second = new RecordingRuntime()
+    const runtimes = [first, second]
+    const connections = new TestConnectionManager(() => {
+      const runtime = runtimes.shift()
+      if (!runtime) {
+        throw new Error("test did not expect another runtime")
+      }
+      return runtime
+    })
+
+    try {
+      const lease = await connections.acquireAttachedRuntime()
+      expect(lease.runtime).toBe(first)
+
+      // A guarded commit that could not RESET a session pragma poisons the
+      // runtime. Release must then drop the connection instead of detaching and
+      // reusing it, so the leftover setting cannot affect a later commit.
+      connections.poisonRuntime()
+      await lease.release()
+      expect(first.closed).toBe(true)
+
+      const next = await connections.acquireAttachedRuntime()
+      expect(next.runtime).toBe(second)
+      expect(second.closed).toBe(false)
+      await next.release()
+    } finally {
+      await connections.close()
+    }
+  })
+
+  test("does not run readers between DuckLake DETACH and ATTACH during reset", async () => {
+    const runtime = new PausedRefreshRuntime()
+    const connections = new TestConnectionManager(() => runtime)
+
+    try {
+      const sharedRuntime = await connections.attachedRuntime()
       const refresh = connections.resetRuntime()
 
       await withTimeout(runtime.detached(), "refresh did not reach DETACH")
@@ -23,6 +114,7 @@ describe("DuckLakeConnectionManager", () => {
         })
       )
 
+      expect(await resolvesWithin(readResult, 25)).toBe(false)
       runtime.resumeDetach()
 
       await withTimeout(refresh, "refresh did not finish")
@@ -37,13 +129,11 @@ describe("DuckLakeConnectionManager", () => {
   })
 })
 
-const postgresOptions: DuckLakeStorageOptions = {
+const localOptions: DuckLakeStorageOptions = {
   catalog: {
-    type: "postgres",
-    host: "127.0.0.1",
-    database: "postgres",
+    type: "duckdb",
+    path: ":memory:",
   },
-  dataPath: "/tmp/pario-ducklake-test-data",
 }
 
 async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
@@ -62,20 +152,127 @@ async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> 
   }
 }
 
-class TestConnectionManager extends DuckLakeConnectionManager {
-  private created = false
+async function resolvesWithin(promise: Promise<unknown>, milliseconds: number): Promise<boolean> {
+  let timeout: Timer | undefined
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), milliseconds)
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+  }
+}
 
-  constructor(private readonly testRuntime: DuckDbRuntime) {
-    super(postgresOptions)
+class TestConnectionManager extends DuckLakeConnectionManager {
+  constructor(private readonly createTestRuntime: () => DuckDbRuntime) {
+    super(localOptions)
   }
 
   override async createRuntime(): Promise<DuckDbRuntime> {
-    if (this.created) {
-      throw new Error("test expected a single shared runtime")
-    }
+    return this.createTestRuntime()
+  }
+}
 
-    this.created = true
-    return this.testRuntime
+class RecordingRuntime implements DuckDbRuntime {
+  readonly statements: string[] = []
+  closed = false
+
+  constructor(private readonly options: { readonly failOnAttach?: boolean } = {}) {}
+
+  attachCount(): number {
+    return this.statements.filter((sql) => sql.startsWith("ATTACH ")).length
+  }
+
+  detachCount(): number {
+    return this.statements.filter((sql) => sql.startsWith("DETACH ")).length
+  }
+
+  run(sql: string, values?: readonly DuckDBValue[]): Promise<void> {
+    void values
+    this.assertOpen()
+    this.statements.push(sql)
+    if (this.options.failOnAttach && sql.startsWith("ATTACH ")) {
+      throw new Error("attach failed")
+    }
+    return Promise.resolve()
+  }
+
+  async runStatements(statements: readonly string[]): Promise<void> {
+    for (const sql of statements) {
+      await this.run(sql)
+    }
+  }
+
+  query(sql: string, values?: readonly DuckDBValue[]): Promise<readonly Record<string, unknown>[]> {
+    void sql
+    void values
+    this.assertOpen()
+    return Promise.resolve([{ value: 1 }])
+  }
+
+  async *streamRows(
+    sql: string,
+    values?: readonly DuckDBValue[]
+  ): AsyncIterable<Record<string, unknown>> {
+    void sql
+    void values
+    this.assertOpen()
+    yield* []
+  }
+
+  withAppender<T>(
+    tableName: string,
+    useAppender: (appender: DuckDbAppender) => T | Promise<T>
+  ): Promise<T> {
+    void tableName
+    void useAppender
+    throw new Error("withAppender is not needed in this test")
+  }
+
+  async withExclusive<T>(useRuntime: (runtime: DuckDbExclusiveRuntime) => Promise<T>): Promise<T> {
+    return useRuntime(new RecordingExclusiveRuntime(this))
+  }
+
+  close(): Promise<void> {
+    this.closed = true
+    return Promise.resolve()
+  }
+
+  assertOpen(): void {
+    if (this.closed) {
+      throw new Error("runtime is closed")
+    }
+  }
+}
+
+class RecordingExclusiveRuntime implements DuckDbExclusiveRuntime {
+  constructor(private readonly runtime: RecordingRuntime) {}
+
+  run(sql: string, values?: readonly DuckDBValue[]): Promise<void> {
+    return this.runtime.run(sql, values)
+  }
+
+  runStatements(statements: readonly string[]): Promise<void> {
+    return this.runtime.runStatements(statements)
+  }
+
+  query(sql: string, values?: readonly DuckDBValue[]): Promise<readonly Record<string, unknown>[]> {
+    return this.runtime.query(sql, values)
+  }
+
+  withAppender<T>(
+    tableName: string,
+    useAppender: (appender: DuckDbAppender) => T | Promise<T>
+  ): Promise<T> {
+    return this.runtime.withAppender(tableName, useAppender)
   }
 }
 
@@ -84,7 +281,7 @@ class PausedRefreshRuntime implements DuckDbRuntime {
   private readonly resumeDetachDeferred = createDeferred<void>()
   private operations: Promise<void> = Promise.resolve()
   private closed = false
-  private aliasAttached = true
+  private aliasAttached = false
   private detachResumed = false
 
   detached(): Promise<void> {
@@ -113,7 +310,7 @@ class PausedRefreshRuntime implements DuckDbRuntime {
     })
   }
 
-  private async runStatement(sql: string): Promise<void> {
+  async runStatement(sql: string): Promise<void> {
     if (sql.startsWith("DETACH ")) {
       this.aliasAttached = false
       this.detachedDeferred.resolve()
@@ -155,6 +352,10 @@ class PausedRefreshRuntime implements DuckDbRuntime {
     throw new Error("withAppender is not needed in this test")
   }
 
+  withExclusive<T>(useRuntime: (runtime: DuckDbExclusiveRuntime) => Promise<T>): Promise<T> {
+    return this.enqueue(() => useRuntime(new PausedRefreshExclusiveRuntime(this)))
+  }
+
   async close(): Promise<void> {
     if (this.closed) {
       return
@@ -184,10 +385,41 @@ class PausedRefreshRuntime implements DuckDbRuntime {
     return result
   }
 
-  private assertAliasAttached(): void {
+  assertAliasAttached(): void {
     if (!this.aliasAttached) {
       throw new Error("DuckLake alias is detached")
     }
+  }
+}
+
+class PausedRefreshExclusiveRuntime implements DuckDbExclusiveRuntime {
+  constructor(private readonly runtime: PausedRefreshRuntime) {}
+
+  run(sql: string, values?: readonly DuckDBValue[]): Promise<void> {
+    void values
+    return this.runtime.runStatement(sql)
+  }
+
+  async runStatements(statements: readonly string[]): Promise<void> {
+    for (const sql of statements) {
+      await this.runtime.runStatement(sql)
+    }
+  }
+
+  query(sql: string, values?: readonly DuckDBValue[]): Promise<readonly Record<string, unknown>[]> {
+    void sql
+    void values
+    this.runtime.assertAliasAttached()
+    return Promise.resolve([{ value: 1 }])
+  }
+
+  withAppender<T>(
+    tableName: string,
+    useAppender: (appender: DuckDbAppender) => T | Promise<T>
+  ): Promise<T> {
+    void tableName
+    void useAppender
+    throw new Error("withAppender is not needed in this test")
   }
 }
 

--- a/storage/ducklake/tests/ducklake-datasets.e2e.ts
+++ b/storage/ducklake/tests/ducklake-datasets.e2e.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { col, defineDataset, LakeStorageError } from "@pario/core"
 import type { DuckLakeStorage } from "../src"
-import { createDuckDbRuntime, setupDuckLake } from "../src/internal/duckdb-runtime"
+import {
+  createDuckDbRuntime,
+  type DuckDbExclusiveRuntime,
+  type DuckDbRuntime,
+  setupDuckLake,
+} from "../src/internal/duckdb-runtime"
 import { encodeDatasetTableName } from "../src/internal/names"
 import { createLocalDuckLakeStorage, localDuckLakeOptions } from "./test-utils"
 
@@ -198,6 +203,56 @@ describe("DuckLakeStorage dataset metadata", () => {
     })
   })
 
+  test("keeps schema evolution transaction exclusive from concurrent commit blocks", async () => {
+    const initialSchemaDataset = defineDataset("raw.erp.concurrent_schema", {
+      schema: [col("invoiceId", "string")],
+    })
+    const evolvedSchemaDataset = defineDataset("raw.erp.concurrent_schema", {
+      schema: [col("invoiceId", "string"), col("currency", "string", { nullable: true })],
+    })
+
+    await storage.createDataset(initialSchemaDataset)
+
+    const runtime = await runtimeForStorage(storage)
+    const pause = pauseAfterNextBeginTransaction(runtime)
+
+    const schemaEvolution = storage.createDataset(evolvedSchemaDataset)
+    await withTimeout(pause.paused, "schema evolution did not begin a transaction")
+
+    const concurrentCommitBlock = runtime.withExclusive(async (runtime) => {
+      await runtime.run("BEGIN TRANSACTION")
+      await runtime.run("COMMIT")
+    })
+    expect(await settlesWithin(concurrentCommitBlock, 25)).toBe(false)
+
+    pause.resume()
+
+    await expect(schemaEvolution).resolves.toEqual(evolvedSchemaDataset)
+    await expect(concurrentCommitBlock).resolves.toBeUndefined()
+  })
+
+  test("does not detach the local catalog during a whole dataset list read", async () => {
+    await storage.createDataset(ordersDataset)
+
+    const runtime = await runtimeForStorage(storage)
+    const pause = pauseAfterNextQuery(runtime, (sql) => sql.includes("duckdb_tables()"))
+
+    const listing = storage.listDatasets()
+    await withTimeout(pause.paused, "listDatasets did not reach its first metadata query")
+
+    const beginWrite = storage.beginWrite({
+      dataset: ordersDataset,
+      mode: "append",
+    })
+    expect(await settlesWithin(beginWrite, 25)).toBe(false)
+
+    pause.resume()
+
+    await expect(listing).resolves.toEqual([ordersDataset])
+    const write = await beginWrite
+    await write.abort()
+  })
+
   test("listDatasets filters non-dataset provider tables", async () => {
     const runtime = await createDuckDbRuntime()
 
@@ -258,3 +313,139 @@ describe("DuckLakeStorage dataset metadata", () => {
     )
   })
 })
+
+async function runtimeForStorage(storage: DuckLakeStorage): Promise<DuckDbRuntime> {
+  return (
+    storage as unknown as { readonly connections: { attachedRuntime(): Promise<DuckDbRuntime> } }
+  ).connections.attachedRuntime()
+}
+
+function pauseAfterNextBeginTransaction(runtime: DuckDbRuntime): {
+  readonly paused: Promise<void>
+  resume(): void
+} {
+  const paused = createDeferred<void>()
+  const resumed = createDeferred<void>()
+  const originalRun = runtime.run.bind(runtime)
+  const originalWithExclusive = runtime.withExclusive.bind(runtime)
+  let didPause = false
+
+  async function pauseIfNeeded(sql: string): Promise<void> {
+    if (didPause || sql !== "BEGIN TRANSACTION") {
+      return
+    }
+
+    didPause = true
+    paused.resolve()
+    await resumed.promise
+  }
+
+  runtime.run = async (sql, values) => {
+    await originalRun(sql, values)
+    await pauseIfNeeded(sql)
+  }
+
+  runtime.withExclusive = (useRuntime) =>
+    originalWithExclusive((exclusiveRuntime) =>
+      useRuntime(wrapExclusiveRuntime(exclusiveRuntime, pauseIfNeeded))
+    )
+
+  return {
+    paused: paused.promise,
+    resume: () => resumed.resolve(),
+  }
+}
+
+function pauseAfterNextQuery(
+  runtime: DuckDbRuntime,
+  matches: (sql: string) => boolean
+): {
+  readonly paused: Promise<void>
+  resume(): void
+} {
+  const paused = createDeferred<void>()
+  const resumed = createDeferred<void>()
+  const originalQuery = runtime.query.bind(runtime)
+  let didPause = false
+
+  runtime.query = async (sql, values) => {
+    const rows = await originalQuery(sql, values)
+    if (!didPause && matches(sql)) {
+      didPause = true
+      paused.resolve()
+      await resumed.promise
+    }
+
+    return rows
+  }
+
+  return {
+    paused: paused.promise,
+    resume: () => resumed.resolve(),
+  }
+}
+
+function wrapExclusiveRuntime(
+  runtime: DuckDbExclusiveRuntime,
+  afterRun: (sql: string) => Promise<void>
+): DuckDbExclusiveRuntime {
+  return {
+    run: async (sql, values) => {
+      await runtime.run(sql, values)
+      await afterRun(sql)
+    },
+    runStatements: (statements) => runtime.runStatements(statements),
+    query: (sql, values) => runtime.query(sql, values),
+    withAppender: (tableName, useAppender) => runtime.withAppender(tableName, useAppender),
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timeout: Timer | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), 1_000)
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+async function settlesWithin(promise: Promise<unknown>, milliseconds: number): Promise<boolean> {
+  let timeout: Timer | undefined
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), milliseconds)
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+function createDeferred<T = void>(): {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T | PromiseLike<T>) => void
+} {
+  let resolve: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return {
+    promise,
+    resolve: resolve!,
+  }
+}

--- a/storage/ducklake/tests/ducklake-remote.e2e.ts
+++ b/storage/ducklake/tests/ducklake-remote.e2e.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { col, defineDataset } from "@pario/core"
 import { type DuckDbSecretOptions, DuckLakeStorage, type DuckLakeStorageOptions } from "../src"
+import { DuckLakeConnectionManager } from "../src/internal/ducklake-connection-manager"
 import { collectRows } from "./test-utils"
 
 describe("DuckLakeStorage remote catalogs", () => {
@@ -24,8 +25,13 @@ describe("DuckLakeStorage remote catalogs", () => {
       await write.writeRows([{ orderId: "ord_1" }])
       await write.commit()
 
+      const append = await storage.beginWrite({ dataset, mode: "append" })
+      await append.writeRows([{ orderId: "ord_2" }])
+      await append.commit()
+
       expect(await collectRows(storage.readRows({ datasetId: dataset.id }))).toEqual([
         { orderId: "ord_1" },
+        { orderId: "ord_2" },
       ])
     } finally {
       await storage.close()
@@ -114,6 +120,35 @@ describe("DuckLakeStorage remote catalogs", () => {
     } finally {
       await first.close()
       await second.close()
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  test("reuses clean PostgreSQL write leases after committed reads", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "pario-ducklake-pg-lease-"))
+    const connections = new DuckLakeConnectionManager({
+      catalog: postgresCatalog(),
+      dataPath: join(rootDir, "data"),
+    })
+
+    try {
+      const lease = await connections.acquireWriteLease()
+      const writeRuntime = lease.runtime
+      const readRuntime = await lease.committedReadRuntime({
+        kind: "committed",
+        guarded: false,
+        reusable: true,
+      })
+
+      expect(readRuntime).not.toBe(writeRuntime)
+      await lease.release({ kind: "committed", guarded: false, reusable: true })
+
+      const nextLease = await connections.acquireWriteLease()
+      expect(nextLease.runtime).toBe(writeRuntime)
+      await expect(nextLease.runtime.query("SELECT 1 AS value")).resolves.toEqual([{ value: 1 }])
+      await nextLease.release({ kind: "aborted" })
+    } finally {
+      await connections.close()
       await rm(rootDir, { recursive: true, force: true })
     }
   })

--- a/storage/ducklake/tests/ducklake-remote.e2e.ts
+++ b/storage/ducklake/tests/ducklake-remote.e2e.ts
@@ -4,8 +4,8 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { col, defineDataset } from "@pario/core"
+import { SQL } from "bun"
 import { type DuckDbSecretOptions, DuckLakeStorage, type DuckLakeStorageOptions } from "../src"
-import { DuckLakeConnectionManager } from "../src/internal/ducklake-connection-manager"
 import { collectRows } from "./test-utils"
 
 describe("DuckLakeStorage remote catalogs", () => {
@@ -124,34 +124,206 @@ describe("DuckLakeStorage remote catalogs", () => {
     }
   })
 
-  test("reuses clean PostgreSQL write leases after committed reads", async () => {
-    const rootDir = await mkdtemp(join(tmpdir(), "pario-ducklake-pg-lease-"))
-    const connections = new DuckLakeConnectionManager({
-      catalog: postgresCatalog(),
-      dataPath: join(rootDir, "data"),
+  test("operates within a constrained PostgreSQL catalog connection budget", async () => {
+    const catalogConnectionBudget = 4
+    const rootDir = await mkdtemp(join(tmpdir(), "pario-ducklake-pg-budget-"))
+    const roleName = `pario_limited_${randomId()}`
+    const password = `pw_${randomId()}`
+    const metadataSchema = `pario_${randomId()}`
+    const applicationName = `pario_budget_${randomId()}`
+    const adminSql = createAdminSql()
+    const dataset = defineDataset(`raw.pg.budget.${randomId()}`, {
+      schema: [col("orderId", "string")],
     })
+    const projectionDataset = defineDataset(`analytics.pg.budget.${randomId()}`, {
+      schema: [col("orderId", "string")],
+    })
+    const catalog = postgresCatalog()
+    if (catalog.type !== "postgres") {
+      throw new Error("[ParioDuckLake] Expected PostgreSQL catalog test configuration.")
+    }
+
+    const storage = new DuckLakeStorage({
+      catalog: {
+        ...catalog,
+        user: roleName,
+        password,
+        metadataSchema,
+        applicationName,
+      },
+      dataPath: join(rootDir, "data"),
+      duckdb: {
+        config: {
+          threads: "1",
+        },
+      },
+      postgresPool: {
+        maxConnections: catalogConnectionBudget,
+        idleTimeoutMillis: 100,
+        enableThreadLocalCache: false,
+      },
+    })
+    let closeError: unknown
 
     try {
-      const lease = await connections.acquireWriteLease()
-      const writeRuntime = lease.runtime
-      const readRuntime = await lease.committedReadRuntime({
-        kind: "committed",
-        guarded: false,
-        reusable: true,
-      })
+      await adminSql.unsafe(
+        `CREATE ROLE ${quotePgIdent(roleName)} WITH LOGIN PASSWORD ${quotePgLiteral(
+          password
+        )} NOSUPERUSER NOCREATEDB NOCREATEROLE CONNECTION LIMIT ${catalogConnectionBudget}`
+      )
+      await adminSql.unsafe(
+        `CREATE SCHEMA ${quotePgIdent(metadataSchema)} AUTHORIZATION ${quotePgIdent(roleName)}`
+      )
 
-      expect(readRuntime).not.toBe(writeRuntime)
-      await lease.release({ kind: "committed", guarded: false, reusable: true })
+      await expectCatalogConnectionsAtMost(adminSql, roleName, 0, "before first lake operation")
+      await runBudgetStep("create dataset", () => storage.createDataset(dataset))
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after source dataset create"
+      )
+      await runBudgetStep("create projection dataset", () =>
+        storage.createDataset(projectionDataset)
+      )
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after projection dataset create"
+      )
 
-      const nextLease = await connections.acquireWriteLease()
-      expect(nextLease.runtime).toBe(writeRuntime)
-      await expect(nextLease.runtime.query("SELECT 1 AS value")).resolves.toEqual([{ value: 1 }])
-      await nextLease.release({ kind: "aborted" })
+      const write = await runBudgetStep("begin snapshot write", () =>
+        storage.beginWrite({ dataset, mode: "snapshot" })
+      )
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after begin snapshot write"
+      )
+      await runBudgetStep("stage snapshot rows", () => write.writeRows([{ orderId: "ord_1" }]))
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after stage snapshot rows"
+      )
+      await runBudgetStep("commit snapshot write", () => write.commit())
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after commit snapshot write"
+      )
+
+      const append = await runBudgetStep("begin append write", () =>
+        storage.beginWrite({ dataset, mode: "append" })
+      )
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after begin append write"
+      )
+      await runBudgetStep("stage append rows", () => append.writeRows([{ orderId: "ord_2" }]))
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after stage append rows"
+      )
+      await runBudgetStep("commit append write", () => append.commit())
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after commit append write"
+      )
+
+      for (let index = 0; index < 10; index += 1) {
+        await expect(
+          runBudgetStep(`get dataset ${index}`, () => storage.getDataset(dataset.id))
+        ).resolves.toMatchObject({ id: dataset.id })
+        await expect(
+          runBudgetStep(`get latest version ${index}`, () => storage.getLatestVersion(dataset.id))
+        ).resolves.toMatchObject({
+          datasetId: dataset.id,
+        })
+        await expectCatalogConnectionsAtMost(
+          adminSql,
+          roleName,
+          catalogConnectionBudget,
+          `after repeated metadata read ${index}`
+        )
+      }
+
+      expect(
+        await runBudgetStep("read rows", () =>
+          collectRows(storage.readRows({ datasetId: dataset.id }))
+        )
+      ).toEqual([{ orderId: "ord_1" }, { orderId: "ord_2" }])
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after read rows"
+      )
+
+      await runBudgetStep("execute SQL transform", () =>
+        storage.sql.execute({
+          sources: {
+            orders: { dataset },
+          },
+          target: projectionDataset,
+          mode: "snapshot",
+          sql: ({ orders }) => `SELECT orderId FROM ${orders} ORDER BY orderId`,
+        })
+      )
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after SQL transform commit"
+      )
+      expect(
+        await runBudgetStep("read projected rows", () =>
+          collectRows(storage.readRows({ datasetId: projectionDataset.id }))
+        )
+      ).toEqual([{ orderId: "ord_1" }, { orderId: "ord_2" }])
+      await expectCatalogConnectionsAtMost(
+        adminSql,
+        roleName,
+        catalogConnectionBudget,
+        "after read projected rows"
+      )
     } finally {
-      await connections.close()
+      try {
+        await storage.close()
+        // The DuckDB PostgreSQL extension can retain one pool's worth of idle
+        // backends after runtime close; the provider must not leave more than
+        // the configured pool budget behind.
+        await expectCatalogConnectionsAtMost(
+          adminSql,
+          roleName,
+          catalogConnectionBudget,
+          "after storage close"
+        )
+      } catch (error) {
+        closeError = error
+      }
+
+      await terminateCatalogConnections(adminSql, roleName)
+      await adminSql.unsafe(`DROP SCHEMA IF EXISTS ${quotePgIdent(metadataSchema)} CASCADE`)
+      await adminSql.unsafe(`DROP ROLE IF EXISTS ${quotePgIdent(roleName)}`)
+      await adminSql.close()
       await rm(rootDir, { recursive: true, force: true })
     }
-  })
+
+    if (closeError !== undefined) {
+      throw closeError
+    }
+  }, 60_000)
 })
 
 function postgresCatalog(): DuckLakeStorageOptions["catalog"] {
@@ -185,4 +357,91 @@ function s3Bucket(): string {
 
 function randomId(): string {
   return randomUUID().replaceAll("-", "_")
+}
+
+function createAdminSql(): SQL {
+  const url = new URL(
+    `postgres://${process.env.PARIO_DUCKLAKE_POSTGRES_HOST ?? "127.0.0.1"}:${
+      process.env.PARIO_DUCKLAKE_POSTGRES_PORT ?? "54331"
+    }/${process.env.PARIO_DUCKLAKE_POSTGRES_DATABASE ?? "postgres"}`
+  )
+  url.username = process.env.PARIO_DUCKLAKE_POSTGRES_USER ?? "postgres"
+  url.password = process.env.PARIO_DUCKLAKE_POSTGRES_PASSWORD ?? "test"
+
+  return new SQL({ url: url.toString(), max: 1 })
+}
+
+async function expectCatalogConnectionsAtMost(
+  sql: SQL,
+  roleName: string,
+  maxConnections: number,
+  step: string
+): Promise<void> {
+  const deadline = Date.now() + 5_000
+  let connections: CatalogConnectionRow[] = []
+
+  while (Date.now() < deadline) {
+    connections = await catalogConnections(sql, roleName)
+    if (connections.length <= maxConnections) {
+      expect(connections.length).toBeLessThanOrEqual(maxConnections)
+      return
+    }
+
+    await sleep(50)
+  }
+
+  throw new Error(
+    `[ParioDuckLake] Expected at most ${maxConnections} PostgreSQL catalog connection(s) for role '${roleName}' ${step}, found ${connections.length}: ${JSON.stringify(
+      connections
+    )}`
+  )
+}
+
+interface CatalogConnectionRow {
+  readonly application_name: string
+  readonly state: string | null
+  readonly wait_event_type: string | null
+  readonly wait_event: string | null
+  readonly query: string
+}
+
+async function catalogConnections(sql: SQL, roleName: string): Promise<CatalogConnectionRow[]> {
+  return (await sql.unsafe(
+    `
+      SELECT application_name, state, wait_event_type, wait_event, query
+      FROM pg_stat_activity
+      WHERE usename = $1
+      ORDER BY application_name, state, wait_event_type, wait_event, query
+    `,
+    [roleName]
+  )) as CatalogConnectionRow[]
+}
+
+async function terminateCatalogConnections(sql: SQL, roleName: string): Promise<void> {
+  await sql.unsafe("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE usename = $1", [
+    roleName,
+  ])
+}
+
+async function runBudgetStep<T>(step: string, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `[ParioDuckLake] Constrained connection budget test failed during ${step}: ${message}`
+    )
+  }
+}
+
+function quotePgIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+function quotePgLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+async function sleep(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds))
 }

--- a/storage/ducklake/tests/ducklake-storage.test.ts
+++ b/storage/ducklake/tests/ducklake-storage.test.ts
@@ -83,4 +83,139 @@ describe("DuckLakeStorage", () => {
       await runtime.close()
     }
   })
+
+  test("runtime withExclusive blocks normal operations until the callback finishes", async () => {
+    const runtime = await createDuckDbRuntime()
+    const enteredExclusive = createDeferred<void>()
+    const releaseExclusive = createDeferred<void>()
+
+    try {
+      await runtime.run("CREATE TEMP TABLE exclusive_rows (id INTEGER)")
+
+      const exclusive = runtime.withExclusive(async (exclusiveRuntime) => {
+        await exclusiveRuntime.run("INSERT INTO exclusive_rows VALUES (1)")
+        enteredExclusive.resolve()
+        await releaseExclusive.promise
+        await exclusiveRuntime.run("INSERT INTO exclusive_rows VALUES (2)")
+      })
+
+      await withTimeout(enteredExclusive.promise, "exclusive block did not start")
+
+      const blockedQuery = runtime.query("SELECT count(*) AS row_count FROM exclusive_rows")
+      expect(await resolvesWithin(blockedQuery, 25)).toBe(false)
+
+      releaseExclusive.resolve()
+
+      await exclusive
+      await expect(blockedQuery).resolves.toEqual([{ row_count: 2n }])
+    } finally {
+      releaseExclusive.resolve()
+      await runtime.close()
+    }
+  })
+
+  test("runtime withExclusive releases the queue after a failed callback", async () => {
+    const runtime = await createDuckDbRuntime()
+
+    try {
+      await runtime.run("CREATE TEMP TABLE exclusive_failures (id INTEGER)")
+
+      await expect(
+        runtime.withExclusive(async (exclusiveRuntime) => {
+          await exclusiveRuntime.run("INSERT INTO exclusive_failures VALUES (1)")
+          throw new Error("exclusive failure")
+        })
+      ).rejects.toThrow("exclusive failure")
+
+      await expect(
+        runtime.query("SELECT count(*) AS row_count FROM exclusive_failures")
+      ).resolves.toEqual([{ row_count: 1n }])
+    } finally {
+      await runtime.close()
+    }
+  })
+
+  test("runtime withExclusive waits for active streams", async () => {
+    const runtime = await createDuckDbRuntime()
+    const enteredExclusive = createDeferred<void>()
+
+    try {
+      await runtime.run(
+        "CREATE TEMP TABLE stream_rows AS SELECT i::INTEGER AS id FROM range(3) AS t(i)"
+      )
+
+      const iterator = runtime
+        .streamRows("SELECT id FROM stream_rows ORDER BY id")
+        [Symbol.asyncIterator]()
+      expect(await iterator.next()).toEqual({ done: false, value: { id: 0 } })
+
+      const exclusive = runtime.withExclusive(async (exclusiveRuntime) => {
+        enteredExclusive.resolve()
+        await exclusiveRuntime.run("INSERT INTO stream_rows VALUES (99)")
+      })
+
+      expect(await resolvesWithin(enteredExclusive.promise, 25)).toBe(false)
+      expect(await iterator.next()).toEqual({ done: false, value: { id: 1 } })
+      expect(await iterator.next()).toEqual({ done: false, value: { id: 2 } })
+      expect(await iterator.next()).toEqual({ done: true, value: undefined })
+
+      await withTimeout(enteredExclusive.promise, "exclusive block did not start after stream")
+      await exclusive
+      await expect(runtime.query("SELECT count(*) AS row_count FROM stream_rows")).resolves.toEqual(
+        [{ row_count: 4n }]
+      )
+    } finally {
+      await runtime.close()
+    }
+  })
 })
+
+async function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timeout: Timer | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), 1_000)
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+async function resolvesWithin(promise: Promise<unknown>, milliseconds: number): Promise<boolean> {
+  let timeout: Timer | undefined
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), milliseconds)
+      }),
+    ])
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T | PromiseLike<T>) => void
+} {
+  let resolve: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return {
+    promise,
+    resolve: resolve!,
+  }
+}

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -11,7 +11,7 @@ import { collectRows, createLocalDuckLakeStorage, localDuckLakeOptions } from ".
 
 interface DuckLakeStorageInternals {
   readonly connections: {
-    runtime(): Promise<{
+    attachedRuntime(): Promise<{
       query(sql: string): Promise<readonly Record<string, unknown>[]>
     }>
   }
@@ -573,7 +573,9 @@ async function commitExtraInfoForVersion(
   rootDir: string,
   versionId: string
 ) {
-  const runtime = await (storage as unknown as DuckLakeStorageInternals).connections.runtime()
+  const runtime = await (
+    storage as unknown as DuckLakeStorageInternals
+  ).connections.attachedRuntime()
   const snapshotId = parseVersionId(versionId)
   const [row] = await runtime.query(`
     SELECT commit_extra_info

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -5,9 +5,16 @@ import { join } from "node:path"
 import { col, type DatasetRow, defineDataset } from "@pario/core"
 import type { DuckLakeStorage } from "../src"
 import type { DuckLakeSnapshotReader } from "../src/internal/ducklake-snapshot-reader"
-import { collectRows, createLocalDuckLakeStorage } from "./test-utils"
+import { duckLakeMetadataTableName } from "../src/internal/sql"
+import { parseCommitMetadata, parseVersionId } from "../src/internal/versions"
+import { collectRows, createLocalDuckLakeStorage, localDuckLakeOptions } from "./test-utils"
 
 interface DuckLakeStorageInternals {
+  readonly connections: {
+    runtime(): Promise<{
+      query(sql: string): Promise<readonly Record<string, unknown>[]>
+    }>
+  }
   readonly snapshotReader: {
     getLatestVersionForDefinition: DuckLakeSnapshotReader["getLatestVersionForDefinition"]
   }
@@ -93,6 +100,49 @@ describe("DuckLakeStorage writes and latest reads", () => {
       { orderId: "ord_2", customerName: "Grace", orderCount: "2", metadata: { source: "erp" } },
       { orderId: "ord_3", customerName: "Katherine", orderCount: "3", metadata: null },
     ])
+  })
+
+  test("does not persist derived row counts for unguarded appends", async () => {
+    const snapshotWrite = await storage.beginWrite({
+      dataset: ordersDataset,
+      mode: "snapshot",
+    })
+    await snapshotWrite.writeRows([{ orderId: "ord_1", customerName: "Ada", orderCount: 1 }])
+    const snapshotVersion = await snapshotWrite.commit()
+    const snapshotExtraInfo = await commitExtraInfoForVersion(
+      storage,
+      rootDir,
+      snapshotVersion.versionId
+    )
+    const snapshotMetadata = parseCommitMetadata(snapshotExtraInfo)
+    expect(snapshotMetadata?.rowCount).toBe(1)
+    expect(JSON.parse(String(snapshotExtraInfo)).pario.rowCount).toBe(1)
+
+    const appendWrite = await storage.beginWrite({
+      dataset: ordersDataset,
+      mode: "append",
+    })
+    await appendWrite.writeRows([{ orderId: "ord_2", customerName: "Grace", orderCount: 2 }])
+    const appendVersion = await appendWrite.commit()
+
+    expect(appendVersion.rowCount).toBe(2)
+    expect(await storage.getLatestVersion(ordersDataset.id)).toMatchObject({
+      versionId: appendVersion.versionId,
+      rowCount: 2,
+    })
+
+    const metadata = await commitMetadataForVersion(storage, rootDir, appendVersion.versionId)
+    expect(metadata).toMatchObject({
+      datasetId: ordersDataset.id,
+      mode: "append",
+    })
+    expect(metadata?.rowCount).toBeUndefined()
+    const appendExtraInfo = await commitExtraInfoForVersion(
+      storage,
+      rootDir,
+      appendVersion.versionId
+    )
+    expect(JSON.parse(String(appendExtraInfo)).pario).not.toHaveProperty("rowCount")
   })
 
   test("supports projected latest reads with limits", async () => {
@@ -509,3 +559,27 @@ describe("DuckLakeStorage writes and latest reads", () => {
     expect(await storage.listVersions(ordersDataset.id)).toEqual([])
   })
 })
+
+async function commitMetadataForVersion(
+  storage: DuckLakeStorage,
+  rootDir: string,
+  versionId: string
+) {
+  return parseCommitMetadata(await commitExtraInfoForVersion(storage, rootDir, versionId))
+}
+
+async function commitExtraInfoForVersion(
+  storage: DuckLakeStorage,
+  rootDir: string,
+  versionId: string
+) {
+  const runtime = await (storage as unknown as DuckLakeStorageInternals).connections.runtime()
+  const snapshotId = parseVersionId(versionId)
+  const [row] = await runtime.query(`
+    SELECT commit_extra_info
+    FROM ${duckLakeMetadataTableName(localDuckLakeOptions(rootDir), "ducklake_snapshot_changes")}
+    WHERE snapshot_id = ${snapshotId}
+  `)
+
+  return row?.commit_extra_info
+}

--- a/storage/ducklake/tests/sql.test.ts
+++ b/storage/ducklake/tests/sql.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { localCatalogCoordinationKey } from "../src/internal/catalog-key"
 import {
   buildAttachSql,
   buildConfigurePostgresMetadataPoolSql,
   buildCreateSecretSql,
+  buildSetPostgresPoolSql,
   catalogUri,
   duckLakeMetadataTableName,
   postgresConnectionString,
@@ -117,6 +122,42 @@ describe("DuckLake SQL rendering", () => {
     expect(buildConfigurePostgresMetadataPoolSql({ alias: "lake" })).toBe(
       "FROM postgres_configure_pool(catalog_name='__ducklake_metadata_lake', enable_thread_local_cache=false)"
     )
+
+    expect(
+      buildSetPostgresPoolSql({
+        postgresPool: {
+          maxConnections: 4,
+          waitTimeoutMillis: 10_000,
+          idleTimeoutMillis: 1_000,
+          enableThreadLocalCache: false,
+          enableReaperThread: true,
+          healthCheckQuery: "SELECT 1",
+        },
+      })
+    ).toEqual([
+      "SET pg_pool_enable_thread_local_cache = false",
+      "SET pg_pool_max_connections = 4",
+      "SET pg_pool_wait_timeout_millis = 10000",
+      "SET pg_pool_idle_timeout_millis = 1000",
+      "SET pg_pool_enable_reaper_thread = true",
+      "SET pg_pool_health_check_query = 'SELECT 1'",
+    ])
+
+    expect(
+      buildConfigurePostgresMetadataPoolSql({
+        alias: "lake",
+        postgresPool: {
+          maxConnections: 4,
+          waitTimeoutMillis: 10_000,
+          idleTimeoutMillis: 1_000,
+          enableThreadLocalCache: false,
+          enableReaperThread: true,
+          healthCheckQuery: "SELECT 1",
+        },
+      })
+    ).toBe(
+      "FROM postgres_configure_pool(catalog_name='__ducklake_metadata_lake', enable_thread_local_cache=false, max_connections=4, wait_timeout_millis=10000, idle_timeout_millis=1000, enable_reaper_thread=true, health_check_query='SELECT 1')"
+    )
   })
 
   test("loads extensions required by catalogs, data paths, and secrets", () => {
@@ -201,5 +242,36 @@ describe("DuckLake SQL rendering", () => {
     ).toBe(
       "CREATE OR REPLACE TEMPORARY SECRET (TYPE azure, CONNECTION_STRING 'DefaultEndpointsProtocol=https;AccountName=storage;AccountKey=account-key;EndpointSuffix=core.windows.net')"
     )
+  })
+
+  test("normalizes local catalog coordination keys", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "pario-ducklake-catalog-key-"))
+
+    try {
+      await mkdir(join(rootDir, "alias"))
+      const directPath = join(rootDir, "metadata.ducklake")
+      const equivalentPath = `${rootDir}/alias/../metadata.ducklake`
+
+      expect(
+        localCatalogCoordinationKey({
+          catalog: { type: "duckdb", path: directPath },
+        })
+      ).toBe(
+        localCatalogCoordinationKey({
+          catalog: { type: "duckdb", path: equivalentPath },
+        })
+      )
+      expect(
+        localCatalogCoordinationKey({
+          catalog: { type: "sqlite", path: directPath },
+        })
+      ).toBe(
+        localCatalogCoordinationKey({
+          catalog: { type: "sqlite", path: equivalentPath },
+        })
+      )
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
   })
 })

--- a/storage/ducklake/tests/versions.test.ts
+++ b/storage/ducklake/tests/versions.test.ts
@@ -26,6 +26,7 @@ describe("DuckLake version metadata", () => {
             mode: "schema",
             producer: { kind: "sync", id: "sync-orders", runId: "run_123" },
             inputs: [{ datasetId: "raw.erp.customers", versionId: "ducklake:7" }],
+            rowCount: 1250,
             schemaChange: { addColumns: ["currency"] },
           },
         })
@@ -37,6 +38,7 @@ describe("DuckLake version metadata", () => {
       mode: "schema",
       producer: { kind: "sync", id: "sync-orders", runId: "run_123" },
       inputs: [{ datasetId: "raw.erp.customers", versionId: "ducklake:7" }],
+      rowCount: 1250,
       schemaChange: { addColumns: ["currency"] },
     })
   })


### PR DESCRIPTION
## Summary

Reworks the DuckLake storage provider so each `DuckLakeStorage` instance owns one lazily attached DuckDB runtime instead of maintaining separate read/write runtime lifecycles. The goal is lower and more predictable PostgreSQL connection pressure while keeping DuckLake operations serialized where DuckDB connection state requires it.

This PR:

- starts DuckDB runtimes unattached and attaches DuckLake only when an operation actually touches the lake
- removes the branch-only write-runtime pool/tuning surface
- stages row writes on the shared runtime, then commits on that same runtime under an exclusive queue slot
- runs SQL transform commits through the same exclusive commit path
- reserves the runtime queue for schema/catalog DDL transactions so commits cannot interleave with DDL `BEGIN`/`COMMIT`
- adds `postgresPool` configuration for DuckLake PostgreSQL metadata pool settings
- configures PostgreSQL DuckLake metadata pools before/after attach and disables thread-local metadata pool caching by default
- avoids explicit PostgreSQL `DETACH` during normal shutdown because closing DuckDB is the tighter path for releasing metadata connections
- coordinates local DuckDB/SQLite catalogs with normalized catalog keys, in-process commit locks, and generation refreshes
- detaches DuckDB-backed local catalogs after each whole read/commit lease so peer local providers do not keep stale attachments
- updates DuckLake README docs for provider usage and PostgreSQL-specific connection guidance

## Why

Small managed PostgreSQL instances can have very low connection ceilings. In the reported production setup, PostgreSQL allowed about 22 connections, while multiple Pario services could each instantiate DuckLake and each DuckLake attach could create metadata pool connections.

The previous direction tried to optimize by reusing write runtimes, but that kept more moving parts than necessary. The final design is simpler: one runtime per provider instance, one queue, lazy attach, explicit PostgreSQL pool controls, and exclusive boundaries around the operations that must not interleave.

This does not remove deployment-level budgeting. If API, sync worker, pipeline worker, projection worker, and other processes all instantiate DuckLake, each process still owns its own DuckLake metadata pool. The provider now makes that pool controllable and avoids extra internal runtimes, but production deployments still need sensible per-process pool sizing.

## Current Model

| Catalog type | Behavior |
| --- | --- |
| PostgreSQL | One DuckDB runtime per `DuckLakeStorage`; DuckLake attaches lazily; metadata pool is controlled with `postgresPool`; reads/writes share the runtime queue inside one provider instance. |
| DuckDB local | Treated conservatively as a single-client local catalog; attached for a whole operation, then detached on lease release so another local provider can observe commits safely. |
| SQLite local | Local peers coordinate through normalized file keys and generation refreshes; commits are serialized inside the process. |
| Custom | Uses the provided custom URI as the coordination key when local-style coordination is needed. |

Example PostgreSQL config:

```ts
storage: new DuckLakeStorage({
  catalog: {
    type: "postgres",
    host: process.env.PGHOST,
    port: 25060,
    database: "defaultdb",
    user: "doadmin",
    password: process.env.PGPASSWORD,
    sslMode: "require",
  },
  dataPath: "s3://example-bucket/lake",
  duckdb: {
    config: {
      threads: 1,
    },
  },
  postgresPool: {
    maxConnections: 4,
    waitTimeoutMillis: 10_000,
    idleTimeoutMillis: 1_000,
  },
})
```

## Review Notes Addressed

- Whole read operations now hold an attached-runtime lease, so local `DETACH`/`ATTACH` cannot be queued in the middle of multi-query reads.
- Schema evolution and dataset catalog DDL now run inside the exclusive runtime path, so commits cannot interleave inside DDL transactions.
- Local DuckDB peers no longer recreate stale attached runtimes after another provider commits; DuckDB local attachments are released after the operation boundary.
- Local catalog coordination now normalizes file-backed catalog paths before using them for generation tracking or commit locks.

## Validation

- `bun --filter @pario/ducklake typecheck`
- `bunx biome check storage/ducklake/src/internal/catalog-key.ts storage/ducklake/src/internal/ducklake-connection-manager.ts storage/ducklake/src/internal/ducklake-row-reader.ts storage/ducklake/src/internal/ducklake-write-coordinator.ts storage/ducklake/tests/ducklake-concurrency.e2e.ts storage/ducklake/tests/sql.test.ts`
- `bun test ./tests/ducklake-concurrency.e2e.ts ./tests/ducklake-connection-manager.test.ts ./tests/sql.test.ts`
- `bun run test:e2e:local` → 75 pass
- `bun run test:e2e:remote` → 5 pass
- `bun --filter @pario/ducklake build`
- `git diff --check`
