### PR TITLE
storage: bulk dataset catalog state for cheap dataset list

### DIFF
--- a/packages/atlas/src/pages/DatasetsPage.tsx
+++ b/packages/atlas/src/pages/DatasetsPage.tsx
@@ -2,6 +2,7 @@ import type {
   GetDatasetResponse,
   ListDatasetRowsResponse,
   ListDatasetsResponse,
+  ListDatasetVersionsResponse,
 } from "@pario/client"
 import {
   getDatasetOptions,
@@ -52,7 +53,10 @@ import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPrefe
 
 type Dataset = ListDatasetsResponse[number] | GetDatasetResponse
 type DatasetListItem = ListDatasetsResponse[number]
-type DatasetVersion = NonNullable<GetDatasetResponse["latestVersion"]>
+// The catalog list/detail routes return a lightweight `latestVersion` summary.
+// Full version metadata (schema, producer, sizeBytes) comes from the versions
+// route, so detail views type their versions from that response.
+type DatasetVersion = ListDatasetVersionsResponse["versions"][number]
 type DatasetColumn = Dataset["schema"]["columns"][number]
 type DatasetListViewStyle = "cards" | "table"
 
@@ -784,9 +788,10 @@ export function DatasetDetailPage() {
     }
   }, [dataset?.latestVersion?.versionId, selectedVersionId, versions])
 
+  // Full version metadata lives in the versions route; the catalog summary on
+  // `dataset.latestVersion` only drives selection defaults above.
   const selectedVersion =
-    versions.find((version) => version.versionId === selectedVersionId) ??
-    (dataset?.latestVersion?.versionId === selectedVersionId ? dataset.latestVersion : null)
+    versions.find((version) => version.versionId === selectedVersionId) ?? null
 
   const handleSelectVersion = (versionId: string) => {
     setSelectedVersionId(versionId)

--- a/packages/atlas/src/pages/PipelinesPage.tsx
+++ b/packages/atlas/src/pages/PipelinesPage.tsx
@@ -910,7 +910,9 @@ function DatasetPreviewDrawer({
               Size
             </p>
             <p className="mt-0.5 truncate text-sm text-foreground">
-              {version?.sizeBytes !== undefined ? formatBytes(version.sizeBytes) : "—"}
+              {rowsData?.version?.sizeBytes !== undefined
+                ? formatBytes(rowsData.version.sizeBytes)
+                : "—"}
             </p>
           </div>
           <div className="bg-card px-4 py-2">

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -1300,9 +1300,6 @@
                           "versionId": {
                             "type": "string"
                           },
-                          "parentVersionId": {
-                            "type": "string"
-                          },
                           "mode": {
                             "type": "string",
                             "enum": ["snapshot", "append", "schema"]
@@ -1310,84 +1307,11 @@
                           "createdAt": {
                             "type": "string"
                           },
-                          "schema": {
-                            "type": "object",
-                            "properties": {
-                              "columns": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "type": {
-                                      "type": "string",
-                                      "enum": [
-                                        "string",
-                                        "boolean",
-                                        "int64",
-                                        "float64",
-                                        "decimal",
-                                        "date",
-                                        "timestamp",
-                                        "json",
-                                        "fileRef"
-                                      ]
-                                    },
-                                    "nullable": {
-                                      "type": "boolean"
-                                    }
-                                  },
-                                  "required": ["name", "type"],
-                                  "additionalProperties": false
-                                }
-                              }
-                            },
-                            "required": ["columns"],
-                            "additionalProperties": false
-                          },
-                          "producer": {
-                            "type": "object",
-                            "properties": {
-                              "kind": {
-                                "type": "string",
-                                "enum": ["sync", "pipeline"]
-                              },
-                              "id": {
-                                "type": "string"
-                              },
-                              "runId": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["kind"],
-                            "additionalProperties": false
-                          },
-                          "inputs": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "datasetId": {
-                                  "type": "string"
-                                },
-                                "versionId": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["datasetId", "versionId"],
-                              "additionalProperties": false
-                            }
-                          },
                           "rowCount": {
-                            "type": "number"
-                          },
-                          "sizeBytes": {
                             "type": "number"
                           }
                         },
-                        "required": ["datasetId", "versionId", "mode", "createdAt", "schema"],
+                        "required": ["datasetId", "versionId", "mode", "createdAt"],
                         "additionalProperties": false,
                         "nullable": true
                       },
@@ -1542,9 +1466,6 @@
                         "versionId": {
                           "type": "string"
                         },
-                        "parentVersionId": {
-                          "type": "string"
-                        },
                         "mode": {
                           "type": "string",
                           "enum": ["snapshot", "append", "schema"]
@@ -1552,84 +1473,11 @@
                         "createdAt": {
                           "type": "string"
                         },
-                        "schema": {
-                          "type": "object",
-                          "properties": {
-                            "columns": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "name": {
-                                    "type": "string"
-                                  },
-                                  "type": {
-                                    "type": "string",
-                                    "enum": [
-                                      "string",
-                                      "boolean",
-                                      "int64",
-                                      "float64",
-                                      "decimal",
-                                      "date",
-                                      "timestamp",
-                                      "json",
-                                      "fileRef"
-                                    ]
-                                  },
-                                  "nullable": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": ["name", "type"],
-                                "additionalProperties": false
-                              }
-                            }
-                          },
-                          "required": ["columns"],
-                          "additionalProperties": false
-                        },
-                        "producer": {
-                          "type": "object",
-                          "properties": {
-                            "kind": {
-                              "type": "string",
-                              "enum": ["sync", "pipeline"]
-                            },
-                            "id": {
-                              "type": "string"
-                            },
-                            "runId": {
-                              "type": "string"
-                            }
-                          },
-                          "required": ["kind"],
-                          "additionalProperties": false
-                        },
-                        "inputs": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "datasetId": {
-                                "type": "string"
-                              },
-                              "versionId": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["datasetId", "versionId"],
-                            "additionalProperties": false
-                          }
-                        },
                         "rowCount": {
-                          "type": "number"
-                        },
-                        "sizeBytes": {
                           "type": "number"
                         }
                       },
-                      "required": ["datasetId", "versionId", "mode", "createdAt", "schema"],
+                      "required": ["datasetId", "versionId", "mode", "createdAt"],
                       "additionalProperties": false,
                       "nullable": true
                     },

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -490,36 +490,9 @@ export type ListDatasetsResponses = {
     latestVersion: {
       datasetId: string
       versionId: string
-      parentVersionId?: string
       mode: "snapshot" | "append" | "schema"
       createdAt: string
-      schema: {
-        columns: Array<{
-          name: string
-          type:
-            | "string"
-            | "boolean"
-            | "int64"
-            | "float64"
-            | "decimal"
-            | "date"
-            | "timestamp"
-            | "json"
-            | "fileRef"
-          nullable?: boolean
-        }>
-      }
-      producer?: {
-        kind: "sync" | "pipeline"
-        id?: string
-        runId?: string
-      }
-      inputs?: Array<{
-        datasetId: string
-        versionId: string
-      }>
       rowCount?: number
-      sizeBytes?: number
     } | null
     syncIds: Array<string>
     sourcePipelineIds: Array<string>
@@ -585,36 +558,9 @@ export type GetDatasetResponses = {
     latestVersion: {
       datasetId: string
       versionId: string
-      parentVersionId?: string
       mode: "snapshot" | "append" | "schema"
       createdAt: string
-      schema: {
-        columns: Array<{
-          name: string
-          type:
-            | "string"
-            | "boolean"
-            | "int64"
-            | "float64"
-            | "decimal"
-            | "date"
-            | "timestamp"
-            | "json"
-            | "fileRef"
-          nullable?: boolean
-        }>
-      }
-      producer?: {
-        kind: "sync" | "pipeline"
-        id?: string
-        runId?: string
-      }
-      inputs?: Array<{
-        datasetId: string
-        versionId: string
-      }>
       rowCount?: number
-      sizeBytes?: number
     } | null
     syncIds: Array<string>
     sourcePipelineIds: Array<string>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -573,7 +573,9 @@ export {
 export type {
   BeginDatasetWriteInput,
   CommitDatasetWriteInput,
+  DatasetCatalogState,
   DatasetDefinitionUpdatePlan,
+  DatasetLatestVersionSummary,
   DatasetMetadataUpdatePlan,
   DatasetProducer,
   DatasetRow,

--- a/packages/core/src/lake-storage/in-memory.ts
+++ b/packages/core/src/lake-storage/in-memory.ts
@@ -6,6 +6,7 @@ import { LakeStorageError } from "./errors"
 import type {
   BeginDatasetWriteInput,
   CommitDatasetWriteInput,
+  DatasetCatalogState,
   DatasetRow,
   DatasetVersion,
   LakeStorage,
@@ -127,6 +128,33 @@ export class InMemoryLakeStorage implements LakeStorage {
 
   async listDatasets(): Promise<readonly DatasetDefinition[]> {
     return [...this.datasets.values()].map((definition) => cloneDatasetDefinition(definition))
+  }
+
+  async listDatasetCatalogState(
+    datasetIds: readonly string[]
+  ): Promise<readonly DatasetCatalogState[]> {
+    return Promise.all(
+      datasetIds.map(async (datasetId) => {
+        if (!this.datasets.has(datasetId)) {
+          return { datasetId, materialized: false, latestVersion: null }
+        }
+
+        const latest = await this.getLatestVersion(datasetId)
+        return {
+          datasetId,
+          materialized: true,
+          latestVersion: latest
+            ? {
+                datasetId: latest.datasetId,
+                versionId: latest.versionId,
+                mode: latest.mode,
+                createdAt: latest.createdAt,
+                ...(latest.rowCount !== undefined ? { rowCount: latest.rowCount } : {}),
+              }
+            : null,
+        }
+      })
+    )
   }
 
   async listVersions(datasetId: string, limit?: number): Promise<readonly DatasetVersion[]> {

--- a/packages/core/src/lake-storage/index.ts
+++ b/packages/core/src/lake-storage/index.ts
@@ -31,6 +31,8 @@ export type {
 export type {
   BeginDatasetWriteInput,
   CommitDatasetWriteInput,
+  DatasetCatalogState,
+  DatasetLatestVersionSummary,
   DatasetProducer,
   DatasetRow,
   DatasetVersion,

--- a/packages/core/src/lake-storage/types.ts
+++ b/packages/core/src/lake-storage/types.ts
@@ -37,6 +37,20 @@ export interface DatasetVersion {
   readonly sizeBytes?: number
 }
 
+export interface DatasetLatestVersionSummary {
+  readonly datasetId: string
+  readonly versionId: string
+  readonly mode: DatasetVersionMode
+  readonly createdAt: Date
+  readonly rowCount?: number
+}
+
+export interface DatasetCatalogState {
+  readonly datasetId: string
+  readonly materialized: boolean
+  readonly latestVersion?: DatasetLatestVersionSummary | null
+}
+
 export interface BeginDatasetWriteInput {
   readonly dataset: DatasetDefinition
   readonly mode?: DatasetWriteMode
@@ -78,6 +92,18 @@ export interface LakeStorage {
   createDataset(definition: DatasetDefinition): Promise<DatasetDefinition>
   getDataset(datasetId: string): Promise<DatasetDefinition | null>
   listDatasets(): Promise<readonly DatasetDefinition[]>
+
+  /**
+   * Bulk catalog-summary read for the dataset list view.
+   *
+   * Returns lightweight materialized + latest-version state for the requested
+   * dataset ids using a bounded number of catalog calls, never a per-dataset
+   * full version hydration or a count(*) over dataset contents. Row counts are
+   * only populated when storage already knows them cheaply (such as Pario commit
+   * metadata); otherwise `rowCount` is omitted.
+   */
+  listDatasetCatalogState(datasetIds: readonly string[]): Promise<readonly DatasetCatalogState[]>
+
   listVersions(datasetId: string, limit?: number): Promise<readonly DatasetVersion[]>
 
   beginWrite(input: BeginDatasetWriteInput): Promise<LakeWriteSession>

--- a/packages/core/src/testing/lake-storage-contract.ts
+++ b/packages/core/src/testing/lake-storage-contract.ts
@@ -195,6 +195,61 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
       })
     })
 
+    describe("catalog state", () => {
+      test("reports materialized state and latest version summaries in bulk", async () => {
+        await withStorage(async (storage) => {
+          await storage.createDataset(writeDataset)
+          const write = await storage.beginWrite({ dataset: writeDataset, mode: "snapshot" })
+          await write.writeRows([
+            { orderId: "ord_1", customerName: "Ada" },
+            { orderId: "ord_2", customerName: "Grace" },
+          ])
+          const version = await write.commit()
+
+          await storage.createDataset(definitionDataset)
+
+          const state = await storage.listDatasetCatalogState([
+            writeDataset.id,
+            definitionDataset.id,
+            "contract.missing.dataset",
+          ])
+
+          const byId = new Map(state.map((entry) => [entry.datasetId, entry]))
+
+          expect(byId.get(writeDataset.id)).toMatchObject({
+            datasetId: writeDataset.id,
+            materialized: true,
+          })
+          expect(byId.get(writeDataset.id)?.latestVersion).toMatchObject({
+            datasetId: writeDataset.id,
+            versionId: version.versionId,
+            mode: "snapshot",
+            rowCount: 2,
+          })
+
+          // Created without a committed write: materialized, but no version.
+          expect(byId.get(definitionDataset.id)).toEqual({
+            datasetId: definitionDataset.id,
+            materialized: true,
+            latestVersion: null,
+          })
+
+          // Registered but never created.
+          expect(byId.get("contract.missing.dataset")).toEqual({
+            datasetId: "contract.missing.dataset",
+            materialized: false,
+            latestVersion: null,
+          })
+        })
+      })
+
+      test("returns an empty result for an empty request", async () => {
+        await withStorage(async (storage) => {
+          expect(await storage.listDatasetCatalogState([])).toEqual([])
+        })
+      })
+    })
+
     describe("writes and reads", () => {
       test("rejects writes for unknown datasets", async () => {
         await withStorage(async (storage) => {

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -107,6 +107,10 @@ class RecordingLakeStorage implements LakeStorage {
     return this.delegate.listDatasets()
   }
 
+  listDatasetCatalogState(datasetIds: readonly string[]) {
+    return this.delegate.listDatasetCatalogState(datasetIds)
+  }
+
   listVersions(datasetId: string, limit?: number) {
     return this.delegate.listVersions(datasetId, limit)
   }

--- a/packages/server/src/routes/datasets.ts
+++ b/packages/server/src/routes/datasets.ts
@@ -1,4 +1,11 @@
-import type { DatasetDefinition, DatasetVersion, OntologySource, Pario } from "@pario/core"
+import type {
+  DatasetCatalogState,
+  DatasetDefinition,
+  DatasetLatestVersionSummary,
+  DatasetVersion,
+  OntologySource,
+  Pario,
+} from "@pario/core"
 import type { Elysia } from "elysia"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
@@ -49,88 +56,104 @@ function serializeDatasetVersion(version: DatasetVersion) {
   })
 }
 
-function getDatasetReferences(pario: Pario<readonly OntologySource[]>, datasetId: string) {
-  const pipelines = pario.getPipelineDefinitions()
-  const projections = [...pario.getObjectProjections(), ...pario.getLinkProjections()]
+interface DatasetReferences {
+  readonly syncIds: string[]
+  readonly sourcePipelineIds: string[]
+  readonly targetPipelineIds: string[]
+  readonly projectionIds: string[]
+}
 
-  const syncIds = pario
-    .getSyncDefinitions()
-    .filter((sync) => sync.target.dataset.id === datasetId)
-    .map((sync) => sync.id)
+const EMPTY_DATASET_REFERENCES: DatasetReferences = {
+  syncIds: [],
+  sourcePipelineIds: [],
+  targetPipelineIds: [],
+  projectionIds: [],
+}
 
-  const sourcePipelineIds = pipelines
-    .filter((pipeline) =>
-      pipeline.graph.nodes.some((node) =>
-        Object.values(node.step.inputs).some((input) => input.id === datasetId)
-      )
-    )
-    .map((pipeline) => pipeline.id)
+/**
+ * Index dataset references in a single pass so the catalog routes never rescan
+ * syncs, pipelines, and projections once per dataset.
+ */
+function buildDatasetReferenceIndex(
+  pario: Pario<readonly OntologySource[]>
+): Map<string, DatasetReferences> {
+  const index = new Map<string, DatasetReferences>()
+  const referencesFor = (datasetId: string): DatasetReferences => {
+    let references = index.get(datasetId)
+    if (!references) {
+      references = { syncIds: [], sourcePipelineIds: [], targetPipelineIds: [], projectionIds: [] }
+      index.set(datasetId, references)
+    }
+    return references
+  }
 
-  const targetPipelineIds = pipelines
-    .filter((pipeline) => pipeline.graph.nodes.some((node) => node.step.output.id === datasetId))
-    .map((pipeline) => pipeline.id)
+  for (const sync of pario.getSyncDefinitions()) {
+    referencesFor(sync.target.dataset.id).syncIds.push(sync.id)
+  }
 
-  const projectionIds = projections
-    .filter((projection) => projection.datasetId === datasetId)
-    .map((projection) => projection.id)
+  for (const pipeline of pario.getPipelineDefinitions()) {
+    const sourceDatasetIds = new Set<string>()
+    const targetDatasetIds = new Set<string>()
+    for (const node of pipeline.graph.nodes) {
+      for (const input of Object.values(node.step.inputs)) {
+        sourceDatasetIds.add(input.id)
+      }
+      targetDatasetIds.add(node.step.output.id)
+    }
+    for (const datasetId of sourceDatasetIds) {
+      referencesFor(datasetId).sourcePipelineIds.push(pipeline.id)
+    }
+    for (const datasetId of targetDatasetIds) {
+      referencesFor(datasetId).targetPipelineIds.push(pipeline.id)
+    }
+  }
 
+  for (const projection of [...pario.getObjectProjections(), ...pario.getLinkProjections()]) {
+    referencesFor(projection.datasetId).projectionIds.push(projection.id)
+  }
+
+  return index
+}
+
+function serializeLatestVersionSummary(summary: DatasetLatestVersionSummary) {
   return {
-    syncIds,
-    sourcePipelineIds,
-    targetPipelineIds,
-    projectionIds,
+    datasetId: summary.datasetId,
+    versionId: summary.versionId,
+    mode: summary.mode,
+    createdAt: toIsoString(summary.createdAt),
+    rowCount: summary.rowCount,
   }
 }
 
-async function serializeDatasetCatalogItem(
-  pario: Pario<readonly OntologySource[]>,
-  dataset: DatasetDefinition
+function serializeDatasetCatalogItem(
+  dataset: DatasetDefinition,
+  state: DatasetCatalogState | undefined,
+  references: DatasetReferences
 ) {
-  const [storedDataset, latestVersion] = await Promise.all([
-    pario.lakeStorage.getDataset(dataset.id),
-    pario.lakeStorage.getLatestVersion(dataset.id),
-  ])
-
-  return serializeDatasetCatalogItemFromState(pario, dataset, {
-    materialized: storedDataset !== null,
-    latestVersion,
+  return DatasetCatalogItemSchema.parse({
+    ...dataset,
+    materialized: state?.materialized ?? false,
+    latestVersion: state?.latestVersion ? serializeLatestVersionSummary(state.latestVersion) : null,
+    syncIds: references.syncIds,
+    sourcePipelineIds: references.sourcePipelineIds,
+    targetPipelineIds: references.targetPipelineIds,
+    projectionIds: references.projectionIds,
   })
 }
 
 async function serializeDatasetCatalogItems(pario: Pario<readonly OntologySource[]>) {
-  const storedDatasets = new Set(
-    (await pario.lakeStorage.listDatasets()).map((dataset) => dataset.id)
+  const definitions = pario.getDatasetDefinitions()
+  const references = buildDatasetReferenceIndex(pario)
+  const states = await pario.lakeStorage.listDatasetCatalogState(definitions.map((d) => d.id))
+  const stateByDatasetId = new Map(states.map((state) => [state.datasetId, state]))
+
+  return definitions.map((definition) =>
+    serializeDatasetCatalogItem(
+      definition,
+      stateByDatasetId.get(definition.id),
+      references.get(definition.id) ?? EMPTY_DATASET_REFERENCES
+    )
   )
-
-  return Promise.all(
-    pario.getDatasetDefinitions().map(async (dataset) => {
-      const materialized = storedDatasets.has(dataset.id)
-      const latestVersion = materialized
-        ? await pario.lakeStorage.getLatestVersion(dataset.id)
-        : null
-
-      return serializeDatasetCatalogItemFromState(pario, dataset, {
-        materialized,
-        latestVersion,
-      })
-    })
-  )
-}
-
-function serializeDatasetCatalogItemFromState(
-  pario: Pario<readonly OntologySource[]>,
-  dataset: DatasetDefinition,
-  state: {
-    readonly materialized: boolean
-    readonly latestVersion: DatasetVersion | null
-  }
-) {
-  return DatasetCatalogItemSchema.parse({
-    ...dataset,
-    materialized: state.materialized,
-    latestVersion: state.latestVersion ? serializeDatasetVersion(state.latestVersion) : null,
-    ...getDatasetReferences(pario, dataset.id),
-  })
 }
 
 function requireDataset(pario: Pario<readonly OntologySource[]>, datasetId: string) {
@@ -201,7 +224,9 @@ export function registerDatasetRoutes(app: Elysia, pario: Pario<readonly Ontolog
       async ({ params, set }) => {
         try {
           const dataset = requireDataset(pario, params.datasetId)
-          return await serializeDatasetCatalogItem(pario, dataset)
+          const [state] = await pario.lakeStorage.listDatasetCatalogState([dataset.id])
+          const references = buildDatasetReferenceIndex(pario).get(dataset.id)
+          return serializeDatasetCatalogItem(dataset, state, references ?? EMPTY_DATASET_REFERENCES)
         } catch (error) {
           return handleRouteError(error, set)
         }

--- a/packages/server/src/schemas/datasets.ts
+++ b/packages/server/src/schemas/datasets.ts
@@ -70,10 +70,18 @@ export const DatasetVersionSchema = z.object({
   sizeBytes: z.number().optional(),
 })
 
+export const DatasetLatestVersionSummarySchema = z.object({
+  datasetId: z.string(),
+  versionId: z.string(),
+  mode: z.enum(["snapshot", "append", "schema"]),
+  createdAt: z.string(),
+  rowCount: z.number().optional(),
+})
+
 export const DatasetCatalogItemSchema = DatasetDefinitionSchema.extend({
   kind: z.literal("dataset"),
   materialized: z.boolean(),
-  latestVersion: DatasetVersionSchema.nullable(),
+  latestVersion: DatasetLatestVersionSummarySchema.nullable(),
   syncIds: z.array(z.string()),
   sourcePipelineIds: z.array(z.string()),
   targetPipelineIds: z.array(z.string()),

--- a/packages/server/tests/datasets-routes.test.ts
+++ b/packages/server/tests/datasets-routes.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  DatasetCatalogState,
+  DatasetDefinition,
+  LakeStorage,
+  OntologySource,
+  Pario,
+} from "@pario/core"
+import { col, defineDataset } from "@pario/core"
+import { Elysia } from "elysia"
+import { registerDatasetRoutes } from "../src/routes/datasets"
+
+/**
+ * A LakeStorage that only answers the bulk catalog read. Any per-dataset call
+ * the route should have avoided throws, so the test fails loudly if the route
+ * regresses to a `getDataset`/`getLatestVersion` loop.
+ */
+function createCatalogOnlyStorage(states: readonly DatasetCatalogState[]) {
+  let listDatasetCatalogStateCalls = 0
+  const storage = {
+    async listDatasetCatalogState(
+      datasetIds: readonly string[]
+    ): Promise<readonly DatasetCatalogState[]> {
+      listDatasetCatalogStateCalls += 1
+      return datasetIds.map(
+        (datasetId) =>
+          states.find((state) => state.datasetId === datasetId) ?? {
+            datasetId,
+            materialized: false,
+            latestVersion: null,
+          }
+      )
+    },
+    async getDataset() {
+      throw new Error("getDataset must not be called from the catalog list route")
+    },
+    async getLatestVersion() {
+      throw new Error("getLatestVersion must not be called from the catalog list route")
+    },
+    async listDatasets() {
+      throw new Error("listDatasets must not be called from the catalog list route")
+    },
+  }
+
+  return {
+    storage: storage as unknown as LakeStorage,
+    calls: () => listDatasetCatalogStateCalls,
+  }
+}
+
+function createParioStub(
+  lakeStorage: LakeStorage,
+  definitions: readonly DatasetDefinition[]
+): Pario<readonly OntologySource[]> {
+  return {
+    lakeStorage,
+    getDatasetDefinitions: () => definitions,
+    getDatasetById: (id: string) => definitions.find((definition) => definition.id === id) ?? null,
+    getSyncDefinitions: () => [],
+    getPipelineDefinitions: () => [],
+    getObjectProjections: () => [],
+    getLinkProjections: () => [],
+  } as unknown as Pario<readonly OntologySource[]>
+}
+
+const definitions: DatasetDefinition[] = Array.from({ length: 5 }, (_, index) =>
+  defineDataset(`raw.catalog.dataset_${index}`, { schema: [col("id", "string")] })
+)
+
+const states: DatasetCatalogState[] = definitions.map((definition, index) => ({
+  datasetId: definition.id,
+  materialized: true,
+  latestVersion: {
+    datasetId: definition.id,
+    versionId: `ducklake:${index + 1}`,
+    mode: "snapshot",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    rowCount: 2,
+  },
+}))
+
+describe("dataset catalog routes", () => {
+  test("list route reads bulk catalog state once, never per-dataset reads", async () => {
+    const { storage, calls } = createCatalogOnlyStorage(states)
+    const app = registerDatasetRoutes(new Elysia(), createParioStub(storage, definitions))
+
+    const response = await app.handle(new Request("http://localhost/api/datasets"))
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as Array<{
+      id: string
+      materialized: boolean
+      latestVersion: { versionId: string; mode: string; rowCount?: number } | null
+    }>
+
+    expect(body).toHaveLength(5)
+    for (const item of body) {
+      expect(item.materialized).toBe(true)
+      expect(item.latestVersion?.mode).toBe("snapshot")
+      expect(item.latestVersion?.rowCount).toBe(2)
+      expect(item.latestVersion?.versionId).toMatch(/^ducklake:\d+$/)
+    }
+
+    expect(calls()).toBe(1)
+  })
+
+  test("single route reads catalog state without per-dataset reads", async () => {
+    const { storage, calls } = createCatalogOnlyStorage(states)
+    const app = registerDatasetRoutes(new Elysia(), createParioStub(storage, definitions))
+
+    const response = await app.handle(
+      new Request(`http://localhost/api/datasets/${definitions[0].id}`)
+    )
+    expect(response.status).toBe(200)
+
+    const item = (await response.json()) as {
+      materialized: boolean
+      latestVersion: { mode: string } | null
+    }
+    expect(item.materialized).toBe(true)
+    expect(item.latestVersion?.mode).toBe("snapshot")
+
+    expect(calls()).toBe(1)
+  })
+})

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -130,6 +130,9 @@ describe("runSyncJob", () => {
       listDatasets() {
         return lakeStorage.listDatasets()
       },
+      listDatasetCatalogState(datasetIds) {
+        return lakeStorage.listDatasetCatalogState(datasetIds)
+      },
       listVersions(datasetId, limit) {
         return lakeStorage.listVersions(datasetId, limit)
       },
@@ -490,6 +493,9 @@ describe("runSyncJob", () => {
       },
       listDatasets() {
         return lakeStorage.listDatasets()
+      },
+      listDatasetCatalogState(datasetIds) {
+        return lakeStorage.listDatasetCatalogState(datasetIds)
       },
       listVersions(datasetId, limit) {
         return lakeStorage.listVersions(datasetId, limit)

--- a/storage/ducklake/package.json
+++ b/storage/ducklake/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:e2e": "bun run test:e2e:local && bun run test:e2e:remote",
-    "test:e2e:local": "bun test ./tests/ducklake-contract.e2e.ts ./tests/ducklake-file-refs.e2e.ts ./tests/ducklake-catalogs.e2e.ts ./tests/ducklake-concurrency.e2e.ts ./tests/ducklake-datasets.e2e.ts ./tests/ducklake-driver.e2e.ts ./tests/ducklake-sql-transforms.e2e.ts ./tests/ducklake-versions.e2e.ts ./tests/ducklake-writes.e2e.ts",
+    "test:e2e:local": "bun test ./tests/ducklake-contract.e2e.ts ./tests/ducklake-file-refs.e2e.ts ./tests/ducklake-catalog-state.e2e.ts ./tests/ducklake-catalogs.e2e.ts ./tests/ducklake-concurrency.e2e.ts ./tests/ducklake-datasets.e2e.ts ./tests/ducklake-driver.e2e.ts ./tests/ducklake-sql-transforms.e2e.ts ./tests/ducklake-versions.e2e.ts ./tests/ducklake-writes.e2e.ts",
     "test:e2e:remote": "bun test --preload ./tests/setup.ts ./tests/ducklake-remote.e2e.ts"
   },
   "dependencies": {

--- a/storage/ducklake/src/ducklake-storage.ts
+++ b/storage/ducklake/src/ducklake-storage.ts
@@ -1,5 +1,6 @@
 import type {
   BeginDatasetWriteInput,
+  DatasetCatalogState,
   DatasetDefinition,
   DatasetRow,
   DatasetVersion,
@@ -85,6 +86,12 @@ export class DuckLakeStorage implements LakeStorageWithSql<"duckdb"> {
 
   async listDatasets(): Promise<readonly DatasetDefinition[]> {
     return this.datasets.listDatasets()
+  }
+
+  async listDatasetCatalogState(
+    datasetIds: readonly string[]
+  ): Promise<readonly DatasetCatalogState[]> {
+    return this.snapshotReader.listDatasetCatalogState(datasetIds)
   }
 
   async listVersions(datasetId: string, limit?: number): Promise<readonly DatasetVersion[]> {

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -1,12 +1,14 @@
 import type {
+  DatasetCatalogState,
   DatasetDefinition,
+  DatasetLatestVersionSummary,
   DatasetVersion,
   DatasetVersionMode,
   DatasetVersionRef,
 } from "@pario/core"
 import { LakeStorageError } from "@pario/core"
 import type { DuckLakeStorageOptions } from "../types"
-import { getBigIntLike, getBoolean, getDate, getString } from "./duckdb-row"
+import { getBigIntLike, getBoolean, getDate, getOptionalString, getString } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
@@ -58,7 +60,28 @@ export interface DuckLakeVersionSummary {
   readonly rowCount?: number
 }
 
+/** One snapshot row from the shared catalog scan, before per-dataset filtering. */
+interface CatalogScanSnapshot {
+  readonly snapshotId: string
+  readonly createdAt: Date
+  readonly changesMade: string
+  readonly metadata?: ParioCommitMetadata
+}
+
+/** Per (snapshot, table) file-change flags merged into the catalog scan. */
+interface FileChangeFlags {
+  readonly hasFileChange: boolean
+  readonly hasFileDeleteChange: boolean
+}
+
 const SNAPSHOT_ROW_BATCH_SIZE = 128
+
+// The bulk catalog scan shares one descending walk of recent snapshots across
+// all requested datasets, so its cost is bounded by this window rather than by
+// the dataset count. A dataset whose latest version is older than the window
+// reports a null latest version, which is acceptable for a catalog summary; the
+// detail routes still hydrate exact history.
+const CATALOG_SNAPSHOT_SCAN_LIMIT = 512
 
 /**
  * Reconstructs Pario DatasetVersion objects from DuckLake snapshots.
@@ -117,6 +140,272 @@ export class DuckLakeSnapshotReader {
 
       return this.getVersionForSnapshot(runtime, definition, snapshotId)
     })
+  }
+
+  /**
+   * Bulk catalog-summary read used by the dataset list view.
+   *
+   * Resolves materialized state and a lightweight latest-version summary for
+   * many datasets with a bounded number of metadata queries, never one snapshot
+   * scan per dataset and never a count(*) over dataset contents.
+   */
+  async listDatasetCatalogState(
+    datasetIds: readonly string[]
+  ): Promise<readonly DatasetCatalogState[]> {
+    this.connections.assertOpen()
+
+    if (datasetIds.length === 0) {
+      return []
+    }
+
+    return this.connections.withAttachedRuntime((runtime) =>
+      this.collectDatasetCatalogState(runtime, datasetIds)
+    )
+  }
+
+  private async collectDatasetCatalogState(
+    runtime: DuckDbQueryRuntime,
+    datasetIds: readonly string[]
+  ): Promise<readonly DatasetCatalogState[]> {
+    const uniqueIds = [...new Set(datasetIds)]
+    const tableIdsByDatasetId = await this.resolveDatasetTableIds(runtime, uniqueIds)
+    const latestRowByDatasetId = await this.resolveLatestSnapshotRows(runtime, tableIdsByDatasetId)
+
+    return uniqueIds.map((datasetId) => {
+      if (!tableIdsByDatasetId.has(datasetId)) {
+        return { datasetId, materialized: false, latestVersion: null }
+      }
+
+      const row = latestRowByDatasetId.get(datasetId)
+      return {
+        datasetId,
+        materialized: true,
+        latestVersion: row ? this.snapshotRowToSummary(datasetId, row) : null,
+      }
+    })
+  }
+
+  private snapshotRowToSummary(
+    datasetId: string,
+    row: DatasetSnapshotRow
+  ): DatasetLatestVersionSummary {
+    return {
+      datasetId,
+      versionId: toVersionId(row.snapshotId),
+      mode: row.mode,
+      createdAt: row.createdAt,
+      ...(row.metadata?.rowCount !== undefined ? { rowCount: row.metadata.rowCount } : {}),
+    }
+  }
+
+  private async resolveDatasetTableIds(
+    runtime: DuckDbQueryRuntime,
+    datasetIds: readonly string[]
+  ): Promise<Map<string, bigint>> {
+    // Encoded table names are a collision-free bijection with dataset ids, so a
+    // single `ducklake_table` read maps every requested id to its current table.
+    const datasetIdByTableName = new Map<string, string>()
+    for (const datasetId of datasetIds) {
+      datasetIdByTableName.set(encodeDatasetTableName(datasetId), datasetId)
+    }
+
+    const ducklakeTable = duckLakeMetadataTableName(this.options, "ducklake_table")
+    const tableNameList = [...datasetIdByTableName.keys()]
+      .map((name) => quoteSqlString(name))
+      .join(", ")
+    const rows = await runtime.query(`
+      SELECT table_id, table_name
+      FROM ${ducklakeTable}
+      WHERE table_name IN (${tableNameList})
+        AND end_snapshot IS NULL
+    `)
+
+    const tableIdsByDatasetId = new Map<string, bigint>()
+    for (const row of rows) {
+      const datasetId = datasetIdByTableName.get(getString(row, "table_name"))
+      if (datasetId !== undefined) {
+        tableIdsByDatasetId.set(datasetId, getBigIntLike(row, "table_id"))
+      }
+    }
+
+    return tableIdsByDatasetId
+  }
+
+  /**
+   * Resolve each dataset's latest snapshot row with one shared descending walk.
+   *
+   * The walk reuses {@link candidateToSnapshotRow} so Pario visibility, mode
+   * derivation, and the loud conflict rule match exact version hydration. Cost
+   * is bounded by the snapshot window, not by the number of datasets.
+   */
+  private async resolveLatestSnapshotRows(
+    runtime: DuckDbQueryRuntime,
+    tableIdsByDatasetId: ReadonlyMap<string, bigint>
+  ): Promise<Map<string, DatasetSnapshotRow>> {
+    const result = new Map<string, DatasetSnapshotRow>()
+    if (tableIdsByDatasetId.size === 0) {
+      return result
+    }
+
+    const unresolved = new Map<string, bigint>(tableIdsByDatasetId)
+    const tableIds = [...new Set(tableIdsByDatasetId.values())]
+
+    let beforeSnapshotId: string | undefined
+    let scanned = 0
+    while (unresolved.size > 0 && scanned < CATALOG_SNAPSHOT_SCAN_LIMIT) {
+      const candidates = await this.queryCatalogSnapshotBatch(
+        runtime,
+        beforeSnapshotId,
+        SNAPSHOT_ROW_BATCH_SIZE
+      )
+      if (candidates.length === 0) {
+        break
+      }
+
+      const fileFlags = await this.queryFileChangeFlags(
+        runtime,
+        candidates.map((candidate) => candidate.snapshotId),
+        tableIds
+      )
+
+      for (const candidate of candidates) {
+        scanned += 1
+        for (const [datasetId, tableId] of [...unresolved]) {
+          const flags = fileFlags.get(fileChangeKey(candidate.snapshotId, tableId))
+          const row = this.candidateToSnapshotRow(datasetId, tableId, {
+            snapshotId: candidate.snapshotId,
+            createdAt: candidate.createdAt,
+            changesMade: candidate.changesMade,
+            hasFileChange: flags?.hasFileChange ?? false,
+            hasFileDeleteChange: flags?.hasFileDeleteChange ?? false,
+            ...(candidate.metadata !== undefined ? { metadata: candidate.metadata } : {}),
+          })
+          if (row) {
+            result.set(datasetId, row)
+            unresolved.delete(datasetId)
+          }
+        }
+
+        if (unresolved.size === 0) {
+          break
+        }
+      }
+
+      if (candidates.length < SNAPSHOT_ROW_BATCH_SIZE) {
+        break
+      }
+      beforeSnapshotId = candidates[candidates.length - 1]?.snapshotId
+    }
+
+    return result
+  }
+
+  private async queryCatalogSnapshotBatch(
+    runtime: DuckDbQueryRuntime,
+    beforeSnapshotId: string | undefined,
+    limit: number
+  ): Promise<readonly CatalogScanSnapshot[]> {
+    const ducklakeSnapshot = duckLakeMetadataTableName(this.options, "ducklake_snapshot")
+    const ducklakeSnapshotChanges = duckLakeMetadataTableName(
+      this.options,
+      "ducklake_snapshot_changes"
+    )
+
+    let whereSql = ""
+    if (beforeSnapshotId !== undefined) {
+      assertDuckLakeSnapshotId(beforeSnapshotId)
+      whereSql = `WHERE snapshot.snapshot_id < ${beforeSnapshotId}`
+    }
+
+    const rows = await runtime.query(`
+      SELECT
+        snapshot.snapshot_id,
+        snapshot.snapshot_time,
+        changes.changes_made,
+        changes.commit_extra_info
+      FROM ${ducklakeSnapshot} snapshot
+      JOIN ${ducklakeSnapshotChanges} changes ON changes.snapshot_id = snapshot.snapshot_id
+      ${whereSql}
+      ORDER BY snapshot.snapshot_id DESC
+      LIMIT ${Math.max(0, Math.trunc(limit))}
+    `)
+
+    return rows.map((row) => {
+      const metadata = parseCommitMetadata(getOptionalString(row, "commit_extra_info"))
+      return {
+        snapshotId: String(getBigIntLike(row, "snapshot_id")),
+        createdAt: getDate(row, "snapshot_time"),
+        changesMade: getString(row, "changes_made"),
+        ...(metadata !== undefined ? { metadata } : {}),
+      }
+    })
+  }
+
+  private async queryFileChangeFlags(
+    runtime: DuckDbQueryRuntime,
+    snapshotIds: readonly string[],
+    tableIds: readonly bigint[]
+  ): Promise<Map<string, FileChangeFlags>> {
+    const flags = new Map<string, FileChangeFlags>()
+    if (snapshotIds.length === 0 || tableIds.length === 0) {
+      return flags
+    }
+
+    for (const snapshotId of snapshotIds) {
+      assertDuckLakeSnapshotId(snapshotId)
+    }
+
+    const snapshotIdList = snapshotIds.join(", ")
+    const tableIdList = tableIds.map((tableId) => tableId.toString()).join(", ")
+    const ducklakeDataFile = duckLakeMetadataTableName(this.options, "ducklake_data_file")
+    const ducklakeDeleteFile = duckLakeMetadataTableName(this.options, "ducklake_delete_file")
+
+    // Large tables keep their changes in data/delete files instead of inline
+    // `changes_made`, so merge file-level changes for the scanned snapshots.
+    const rows = await runtime.query(`
+      WITH file_changes AS (
+        SELECT begin_snapshot AS snapshot_id, table_id, false AS is_delete
+        FROM ${ducklakeDataFile}
+        WHERE table_id IN (${tableIdList}) AND begin_snapshot IN (${snapshotIdList})
+        UNION ALL
+        SELECT end_snapshot, table_id, true
+        FROM ${ducklakeDataFile}
+        WHERE table_id IN (${tableIdList}) AND end_snapshot IN (${snapshotIdList})
+        UNION ALL
+        SELECT begin_snapshot, table_id, true
+        FROM ${ducklakeDeleteFile}
+        WHERE table_id IN (${tableIdList}) AND begin_snapshot IN (${snapshotIdList})
+        UNION ALL
+        SELECT end_snapshot, table_id, true
+        FROM ${ducklakeDeleteFile}
+        WHERE table_id IN (${tableIdList}) AND end_snapshot IN (${snapshotIdList})
+      )
+      SELECT snapshot_id, table_id, bool_or(is_delete) AS has_delete
+      FROM file_changes
+      GROUP BY snapshot_id, table_id
+    `)
+
+    for (const row of rows) {
+      const key = fileChangeKey(
+        String(getBigIntLike(row, "snapshot_id")),
+        getBigIntLike(row, "table_id")
+      )
+      flags.set(key, { hasFileChange: true, hasFileDeleteChange: getBoolean(row, "has_delete") })
+    }
+
+    return flags
+  }
+
+  private assertNoMetadataConflict(
+    snapshotId: string,
+    datasetId: string,
+    metadata: ParioCommitMetadata | undefined
+  ): void {
+    if (metadata !== undefined && metadata.datasetId !== datasetId) {
+      throw new LakeStorageError(
+        `[ParioDuckLake] DuckLake snapshot '${snapshotId}' changed dataset '${datasetId}' but Pario commit metadata references dataset '${metadata.datasetId}'.`
+      )
+    }
   }
 
   async getLatestVersionForDefinition(
@@ -456,11 +745,7 @@ export class DuckLakeSnapshotReader {
     // A real data-change snapshot belongs to this dataset because DuckLake's
     // change metadata touched this table id. If Pario metadata is present but
     // points elsewhere, fail loudly rather than hydrating the wrong lineage.
-    if (candidate.metadata !== undefined && candidate.metadata.datasetId !== datasetId) {
-      throw new LakeStorageError(
-        `[ParioDuckLake] DuckLake snapshot '${candidate.snapshotId}' changed dataset '${datasetId}' but Pario commit metadata references dataset '${candidate.metadata.datasetId}'.`
-      )
-    }
+    this.assertNoMetadataConflict(candidate.snapshotId, datasetId, candidate.metadata)
 
     return {
       snapshotId: candidate.snapshotId,
@@ -541,4 +826,8 @@ function assertDuckLakeSnapshotId(snapshotId: string): void {
   if (!/^\d+$/.test(snapshotId)) {
     throw new LakeStorageError(`[ParioDuckLake] Invalid DuckLake snapshot id '${snapshotId}'.`)
   }
+}
+
+function fileChangeKey(snapshotId: string, tableId: bigint): string {
+  return `${snapshotId}|${tableId}`
 }

--- a/storage/ducklake/tests/ducklake-catalog-state.e2e.ts
+++ b/storage/ducklake/tests/ducklake-catalog-state.e2e.ts
@@ -72,9 +72,11 @@ describe("DuckLakeStorage bulk catalog state", () => {
 
   // Performance regression: the bulk read must not fan out into one query per
   // dataset. Many materialized datasets are resolved with the same small,
-  // bounded set of metadata queries as a few would need.
+  // bounded set of metadata queries as a few would need. The dataset count is
+  // kept modest (and the timeout generous) because the slow part is the
+  // sequential write setup, not the bulk read under test.
   test("resolves many datasets with a bounded, count-independent query set", async () => {
-    const datasetCount = 30
+    const datasetCount = 12
     const datasetIds: string[] = []
     for (let index = 0; index < datasetCount; index += 1) {
       const dataset = defineDataset(`raw.erp.dataset_${index}`, {
@@ -115,7 +117,7 @@ describe("DuckLakeStorage bulk catalog state", () => {
       expect(sql.toLowerCase()).not.toContain("count(*)")
       expect(sql).not.toContain("AT (VERSION")
     }
-  })
+  }, 30_000)
 
   test("carries row counts from Pario commit metadata, omitting unguarded appends", async () => {
     await storage.createDataset(ordersDataset)

--- a/storage/ducklake/tests/ducklake-catalog-state.e2e.ts
+++ b/storage/ducklake/tests/ducklake-catalog-state.e2e.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { col, defineDataset } from "@pario/core"
+import type { DuckLakeStorage } from "../src"
+import { createDuckDbRuntime, setupDuckLake } from "../src/internal/duckdb-runtime"
+import { encodeDatasetTableName } from "../src/internal/names"
+import { quoteSqlString } from "../src/internal/sql"
+import { createLocalDuckLakeStorage, localDuckLakeOptions } from "./test-utils"
+
+interface DuckLakeStorageInternals {
+  readonly connections: {
+    attachedRuntime(): Promise<{
+      query: (
+        sql: string,
+        values?: readonly unknown[]
+      ) => Promise<readonly Record<string, unknown>[]>
+    }>
+  }
+}
+
+async function captureCatalogStateQueries(
+  storage: DuckLakeStorage,
+  datasetIds: readonly string[]
+): Promise<{ queries: string[] }> {
+  // Warm the attachment so wrapping targets the runtime the bulk read reuses.
+  await storage.listDatasetCatalogState(datasetIds)
+
+  const internals = storage as unknown as DuckLakeStorageInternals
+  const runtime = await internals.connections.attachedRuntime()
+  const originalQuery = runtime.query.bind(runtime)
+  const queries: string[] = []
+  runtime.query = async (sql, values) => {
+    queries.push(sql)
+    return originalQuery(sql, values)
+  }
+
+  await storage.listDatasetCatalogState(datasetIds)
+  runtime.query = originalQuery
+  return { queries }
+}
+
+describe("DuckLakeStorage bulk catalog state", () => {
+  let rootDir: string
+  let storage: DuckLakeStorage
+
+  const ordersDataset = defineDataset("raw.erp.orders", {
+    schema: [col("orderId", "string"), col("customerName", "string"), col("orderCount", "int64")],
+  })
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "pario-ducklake-catalog-"))
+    storage = createLocalDuckLakeStorage(rootDir)
+  })
+
+  afterEach(async () => {
+    await storage.close()
+    await rm(rootDir, { recursive: true, force: true })
+  })
+
+  test("returns materialized false for registered-but-uncreated datasets", async () => {
+    await storage.createDataset(ordersDataset)
+
+    const state = await storage.listDatasetCatalogState([ordersDataset.id, "raw.not.created"])
+
+    expect(state).toEqual([
+      { datasetId: ordersDataset.id, materialized: true, latestVersion: null },
+      { datasetId: "raw.not.created", materialized: false, latestVersion: null },
+    ])
+  })
+
+  // Performance regression: the bulk read must not fan out into one query per
+  // dataset. Many materialized datasets are resolved with the same small,
+  // bounded set of metadata queries as a few would need.
+  test("resolves many datasets with a bounded, count-independent query set", async () => {
+    const datasetCount = 30
+    const datasetIds: string[] = []
+    for (let index = 0; index < datasetCount; index += 1) {
+      const dataset = defineDataset(`raw.erp.dataset_${index}`, {
+        schema: [col("id", "string"), col("amount", "int64")],
+      })
+      await storage.createDataset(dataset)
+      const write = await storage.beginWrite({ dataset, mode: "snapshot" })
+      await write.writeRows([
+        { id: "a", amount: 1 },
+        { id: "b", amount: 2 },
+      ])
+      await write.commit()
+      datasetIds.push(dataset.id)
+    }
+
+    const { queries } = await captureCatalogStateQueries(storage, [...datasetIds, "raw.missing"])
+    const state = await storage.listDatasetCatalogState([...datasetIds, "raw.missing"])
+
+    for (const datasetId of datasetIds) {
+      const item = state.find((entry) => entry.datasetId === datasetId)
+      expect(item?.materialized).toBe(true)
+      expect(item?.latestVersion?.datasetId).toBe(datasetId)
+      expect(item?.latestVersion?.mode).toBe("snapshot")
+      expect(item?.latestVersion?.rowCount).toBe(2)
+      expect(item?.latestVersion?.versionId).toMatch(/^ducklake:\d+$/)
+    }
+
+    expect(state.find((entry) => entry.datasetId === "raw.missing")).toEqual({
+      datasetId: "raw.missing",
+      materialized: false,
+      latestVersion: null,
+    })
+
+    // Table-id map + one snapshot-batch scan (candidates + file flags). A
+    // per-dataset getLatestVersion loop would scale with datasetCount instead.
+    expect(queries.length).toBeLessThanOrEqual(3)
+    for (const sql of queries) {
+      expect(sql.toLowerCase()).not.toContain("count(*)")
+      expect(sql).not.toContain("AT (VERSION")
+    }
+  })
+
+  test("carries row counts from Pario commit metadata, omitting unguarded appends", async () => {
+    await storage.createDataset(ordersDataset)
+    const snapshot = await storage.beginWrite({ dataset: ordersDataset, mode: "snapshot" })
+    await snapshot.writeRows([{ orderId: "ord_1", customerName: "Ada", orderCount: 1 }])
+    const snapshotVersion = await snapshot.commit()
+
+    // A guarded append commits an exact row count in its Pario metadata.
+    const append = await storage.beginWrite({ dataset: ordersDataset, mode: "append" })
+    await append.writeRows([{ orderId: "ord_2", customerName: "Grace", orderCount: 2 }])
+    await append.commit({ expectedLatestVersionId: snapshotVersion.versionId })
+
+    const [guarded] = await storage.listDatasetCatalogState([ordersDataset.id])
+    expect(guarded).toMatchObject({
+      datasetId: ordersDataset.id,
+      materialized: true,
+      latestVersion: expect.objectContaining({ mode: "append", rowCount: 2 }),
+    })
+
+    // An unguarded append intentionally omits its row count so the bulk read
+    // never falls back to count(*). The summary must leave rowCount undefined.
+    const unguarded = await storage.beginWrite({ dataset: ordersDataset, mode: "append" })
+    await unguarded.writeRows([{ orderId: "ord_3", customerName: "Katherine", orderCount: 3 }])
+    await unguarded.commit()
+
+    const [item] = await storage.listDatasetCatalogState([ordersDataset.id])
+    expect(item?.latestVersion?.mode).toBe("append")
+    expect(item?.latestVersion?.rowCount).toBeUndefined()
+  })
+
+  test("surfaces a metadata-only schema version as the latest", async () => {
+    await storage.createDataset(ordersDataset)
+    const write = await storage.beginWrite({ dataset: ordersDataset, mode: "snapshot" })
+    await write.writeRows([{ orderId: "ord_1", customerName: "Ada", orderCount: 1 }])
+    await write.commit()
+
+    // Schema evolution commits a metadata-only snapshot newer than the data write.
+    await storage.createDataset(
+      defineDataset(ordersDataset.id, {
+        schema: [
+          col("orderId", "string"),
+          col("customerName", "string"),
+          col("orderCount", "int64"),
+          col("region", "string", { nullable: true }),
+        ],
+      })
+    )
+
+    const [item] = await storage.listDatasetCatalogState([ordersDataset.id])
+    expect(item).toMatchObject({
+      datasetId: ordersDataset.id,
+      materialized: true,
+      latestVersion: expect.objectContaining({ mode: "schema" }),
+    })
+    expect(item?.latestVersion?.rowCount).toBeUndefined()
+  })
+
+  test("fails loudly on conflicting Pario metadata", async () => {
+    await storage.createDataset(ordersDataset)
+    await storage.close()
+
+    const runtime = await createDuckDbRuntime()
+    try {
+      await setupDuckLake(runtime, localDuckLakeOptions(rootDir))
+      const tableName = encodeDatasetTableName(ordersDataset.id)
+      await runtime.run("BEGIN TRANSACTION")
+      await runtime.run(`INSERT INTO pario_lake.main.${tableName} VALUES ('raw_1', 'External', 1)`)
+      await runtime.run(
+        `CALL pario_lake.set_commit_message('Pario', 'wrong dataset metadata', extra_info => ${quoteSqlString(
+          JSON.stringify({
+            pario: {
+              kind: "datasetVersion",
+              datasetId: "other.dataset",
+              mode: "append",
+              rowCount: 1,
+            },
+          })
+        )})`
+      )
+      await runtime.run("COMMIT")
+    } finally {
+      await runtime.close()
+    }
+
+    storage = createLocalDuckLakeStorage(rootDir)
+    await expect(storage.listDatasetCatalogState([ordersDataset.id])).rejects.toThrow(
+      "metadata references dataset 'other.dataset'"
+    )
+  })
+
+  test("returns an empty result for an empty request", async () => {
+    expect(await storage.listDatasetCatalogState([])).toEqual([])
+  })
+})

--- a/storage/lake-local/src/local-lake-storage.ts
+++ b/storage/lake-local/src/local-lake-storage.ts
@@ -14,6 +14,7 @@ import { basename, join, resolve } from "node:path"
 import {
   type BeginDatasetWriteInput,
   type CommitDatasetWriteInput,
+  type DatasetCatalogState,
   type DatasetDefinition,
   type DatasetRow,
   type DatasetVersion,
@@ -171,6 +172,33 @@ export class LocalLakeStorage implements LakeStorage {
     }
 
     return datasets.sort((left, right) => left.id.localeCompare(right.id))
+  }
+
+  async listDatasetCatalogState(
+    datasetIds: readonly string[]
+  ): Promise<readonly DatasetCatalogState[]> {
+    return Promise.all(
+      datasetIds.map(async (datasetId) => {
+        if (!(await this.getDataset(datasetId))) {
+          return { datasetId, materialized: false, latestVersion: null }
+        }
+
+        const latest = await this.getLatestVersion(datasetId)
+        return {
+          datasetId,
+          materialized: true,
+          latestVersion: latest
+            ? {
+                datasetId: latest.datasetId,
+                versionId: latest.versionId,
+                mode: latest.mode,
+                createdAt: latest.createdAt,
+                ...(latest.rowCount !== undefined ? { rowCount: latest.rowCount } : {}),
+              }
+            : null,
+        }
+      })
+    )
   }
 
   async listVersions(datasetId: string, limit?: number): Promise<readonly DatasetVersion[]> {


### PR DESCRIPTION
> Stacked on #33 (`ducklake-conn-optimization`) — review/merge that first. This PR targets that branch, so its diff will shrink once #33 lands.

## Problem

`GET /api/datasets` cost scaled with the number of materialized datasets. For each one the route called `getDataset()` and `getLatestVersion()`, which on DuckLake fan out into many Postgres-catalog metadata queries and, for some snapshots, a `count(*)` over the dataset table. A 50+ dataset catalog blocked on per-dataset version hydration.

## Change

Add a bulk catalog read to `LakeStorage` and use it from the route:

```ts
listDatasetCatalogState(datasetIds: readonly string[]): Promise<readonly DatasetCatalogState[]>
```

It returns lightweight per-dataset state — a materialized flag plus an optional latest-version summary:

```ts
interface DatasetCatalogState {
  datasetId: string
  materialized: boolean
  latestVersion?: { datasetId; versionId; mode; createdAt; rowCount? } | null
}
```

The list route reads everything in one bulk call and builds references in a single pass:

```ts
const definitions = pario.getDatasetDefinitions()
const references = buildDatasetReferenceIndex(pario)        // one pass, not per-dataset
const states = await pario.lakeStorage.listDatasetCatalogState(definitions.map((d) => d.id))
return definitions.map((d) => serializeDatasetCatalogItem(d, byId.get(d.id), references.get(d.id)))
```

No more `getDataset()` / `getLatestVersion()` loops, and `latestVersion` is now a lightweight summary (full version metadata stays on the detail routes).

## DuckLake

One bounded descending snapshot scan resolves all requested datasets at once, reusing the existing `candidateToSnapshotRow` logic so Pario visibility, mode derivation, and the loud conflict rule stay identical. It never runs `count(*)` — row counts come only from Pario commit metadata, so unguarded appends correctly omit them rather than falling back to a table count.

```
table-id map  +  one snapshot-batch scan (candidates + file flags)
```

Query count is bounded by the snapshot window, not the dataset count. DuckLake inlines small tables (`changes_made: "inlined_insert:1"`), so data-change detection uses commit metadata + inline changes, not just data files.

## Notes

- Promoted onto `LakeStorage` and implemented in all three providers (InMemory, Local, DuckLake).
- Response schema changed, so the client is regenerated. Atlas now reads full version fields (schema / producer / sizeBytes) from the versions and rows routes it already fetches.

## Testing

- Shared `LakeStorage` contract suite covers the bulk read for InMemory, Local, and DuckLake.
- DuckLake e2e: materialized state, metadata-only schema versions, conflict failure, and a perf regression (30 datasets resolved in ≤3 metadata queries).
- Server route test fails if the route regresses to a per-dataset `getLatestVersion` loop.
- `bun run typecheck`, `build`, `test`, `check` all green; `generate:client` is up to date.
