### PR TITLE
app: sidebar and workflow run detail polish

### DIFF
--- a/packages/atlas/src/components/layout/AppLayout.tsx
+++ b/packages/atlas/src/components/layout/AppLayout.tsx
@@ -17,12 +17,7 @@ export function AppLayout() {
     retry: false,
   })
 
-  const selectedProject = projectInfo
-    ? {
-        name: projectInfo.id,
-        type: projectInfo.type,
-      }
-    : null
+  const selectedProject = projectInfo ? { name: projectInfo.id } : null
   const viewMode = getViewModeFromPath(location.pathname)
 
   const handleViewChange = (mode: ViewMode) => {
@@ -40,7 +35,6 @@ export function AppLayout() {
   const sidebar = (
     <Sidebar
       selectedProject={selectedProject}
-      connected={sidebarData?.connected ?? false}
       viewMode={viewMode}
       onViewChange={handleViewChange}
       objectCount={sidebarData?.objectCount}

--- a/packages/atlas/src/components/layout/Sidebar.tsx
+++ b/packages/atlas/src/components/layout/Sidebar.tsx
@@ -1,6 +1,8 @@
 import { client, type ProjectInfo } from "@pario/client"
+import { getAuthSessionOptions, signOutMutation } from "@pario/client/hooks"
 import {
   Sidebar as ShadcnSidebar,
+  SidebarCollapseToggle,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
@@ -11,17 +13,14 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
-  ThemeSwitcher,
-  useSidebar,
+  SidebarUserMenu,
 } from "@pario/ui/components"
-import { cn } from "@pario/ui/lib/utils"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import {
   Box,
   Cable,
-  ChevronsLeft,
-  ChevronsRight,
   Database,
-  ExternalLink,
+  Globe,
   LayoutGrid,
   ListChecks,
   RefreshCw,
@@ -62,7 +61,6 @@ function apiDocsUrl(): string {
 
 interface SidebarProps {
   selectedProject: ProjectInfo | null
-  connected: boolean
   viewMode: ViewMode
   onViewChange: (mode: ViewMode) => void
   datasetCount?: number
@@ -76,7 +74,6 @@ interface SidebarProps {
 
 export function Sidebar({
   selectedProject,
-  connected,
   viewMode,
   onViewChange,
   datasetCount,
@@ -98,47 +95,35 @@ export function Sidebar({
     return undefined
   }
 
+  const session = useQuery(getAuthSessionOptions()).data
+  const signOut = useMutation(signOutMutation())
+  const user =
+    session?.authenticated === true
+      ? {
+          name: session.user.displayName ?? session.user.email,
+          email: session.user.displayName ? session.user.email : undefined,
+          avatarUrl: session.user.avatarUrl,
+        }
+      : null
+  const handleSignOut = () => {
+    signOut.mutate({}, { onSettled: () => window.location.reload() })
+  }
+
   return (
     <ShadcnSidebar collapsible="icon">
       <SidebarHeader className="border-b border-sidebar-border">
         <div className="flex items-center gap-3 px-2 py-2 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center">
-          {/* Avatar */}
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-accent text-sm font-semibold text-sidebar-accent-foreground">
-            {selectedProject ? selectedProject.name[0]?.toUpperCase() : "P"}
+          {/* App icon */}
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-accent text-sidebar-accent-foreground">
+            <Globe className="h-4 w-4" />
           </div>
-          {/* Name + status */}
+          {/* App name + project slug */}
           <div className="min-w-0 flex-1 group-data-[collapsible=icon]:hidden">
-            {selectedProject ? (
-              <>
-                <p className="truncate text-sm font-semibold text-sidebar-foreground">
-                  {selectedProject.name}
-                </p>
-                <p className="truncate text-xs text-sidebar-foreground">{selectedProject.type}</p>
-              </>
-            ) : (
-              <p className="text-sm font-medium text-sidebar-foreground">Loading…</p>
-            )}
+            <p className="truncate text-sm font-semibold text-sidebar-foreground">Atlas</p>
+            <p className="truncate text-xs text-sidebar-foreground">
+              {selectedProject ? selectedProject.name : "Loading project"}
+            </p>
           </div>
-          {/* Connection dot */}
-          {selectedProject ? (
-            <div
-              className="relative flex h-2 w-2 shrink-0 group-data-[collapsible=icon]:hidden"
-              title={connected ? "Live" : "Disconnected"}
-            >
-              <span
-                className={cn(
-                  "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
-                  connected ? "bg-emerald-500" : "bg-red-500"
-                )}
-              />
-              <span
-                className={cn(
-                  "relative inline-flex h-2 w-2 rounded-full",
-                  connected ? "bg-emerald-500" : "bg-red-500"
-                )}
-              />
-            </div>
-          ) : null}
         </div>
       </SidebarHeader>
 
@@ -181,40 +166,10 @@ export function Sidebar({
       </SidebarContent>
 
       <SidebarFooter className="border-t border-sidebar-border">
-        <div className="flex items-center justify-between gap-2 px-2 group-data-[collapsible=icon]:hidden">
-          <ThemeSwitcher />
-          <a
-            href={apiDocsUrl()}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs text-sidebar-foreground transition-colors hover:text-sidebar-accent-foreground"
-          >
-            <ExternalLink className="h-3.5 w-3.5" />
-            API
-          </a>
-        </div>
+        <SidebarUserMenu user={user} apiHref={apiDocsUrl()} onSignOut={handleSignOut} />
       </SidebarFooter>
 
       <SidebarRail />
     </ShadcnSidebar>
-  )
-}
-
-function SidebarCollapseToggle() {
-  const { state, toggleSidebar } = useSidebar()
-  const collapsed = state === "collapsed"
-  const label = collapsed ? "Expand sidebar" : "Collapse sidebar"
-  const Icon = collapsed ? ChevronsRight : ChevronsLeft
-
-  return (
-    <SidebarMenuButton
-      onClick={toggleSidebar}
-      tooltip={`${label} (⌘B)`}
-      aria-label={label}
-      className="text-sidebar-foreground"
-    >
-      <Icon />
-      <span>{label}</span>
-    </SidebarMenuButton>
   )
 }

--- a/packages/atlas/src/components/layout/sidebarData.ts
+++ b/packages/atlas/src/components/layout/sidebarData.ts
@@ -8,7 +8,6 @@ export interface ProjectSidebarData {
   pipelineCount: number
   ruleCount: number
   ontologyCount: number
-  connected: boolean
 }
 
 export const SidebarDataContext = createContext<{

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -282,7 +282,7 @@ export function ProjectWorkspace() {
     [resolvedProjectName]
   )
 
-  const { connected } = useParioEvents({
+  useParioEvents({
     topic: "telemetry",
     types: ["telemetry.appended"],
     enabled: Boolean(resolvedProjectName),
@@ -303,7 +303,6 @@ export function ProjectWorkspace() {
       pipelineCount: pipelines.length,
       ruleCount: rules.length,
       ontologyCount: objectTypes.length,
-      connected,
     })
   }, [
     globalObjectCountQuery.data,
@@ -314,7 +313,6 @@ export function ProjectWorkspace() {
     pipelines.length,
     rules.length,
     objectTypes.length,
-    connected,
     setSidebarData,
   ])
 

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -997,13 +997,9 @@
                   "properties": {
                     "id": {
                       "type": "string"
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": ["local"]
                     }
                   },
-                  "required": ["id", "type"],
+                  "required": ["id"],
                   "additionalProperties": false
                 }
               }

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -348,7 +348,6 @@ export type GetProjectInfoResponses = {
    */
   200: {
     id: string
-    type: "local"
   }
 }
 

--- a/packages/client/src/models.ts
+++ b/packages/client/src/models.ts
@@ -50,7 +50,6 @@ export interface TelemetryProperty {
 
 export interface ProjectInfo {
   name: string
-  type: string
 }
 
 export type ObjectSummary = {
@@ -281,7 +280,6 @@ function mapTelemetryProperties(
 export function toProjectInfo(project: GetProjectInfoResponse): ProjectInfo {
   return {
     name: project.id,
-    type: project.type,
   }
 }
 

--- a/packages/sentinel/src/components/layout/AppLayout.tsx
+++ b/packages/sentinel/src/components/layout/AppLayout.tsx
@@ -25,14 +25,11 @@ export function AppLayout() {
     enabled: projectQuery.isSuccess,
   })
 
-  const selectedProject = projectQuery.data
-    ? { name: projectQuery.data.id, type: projectQuery.data.type }
-    : null
+  const selectedProject = projectQuery.data ? { name: projectQuery.data.id } : null
   const viewMode = getViewModeFromPath(location.pathname)
   const sidebar = (
     <Sidebar
       selectedProject={selectedProject}
-      connected={projectQuery.isSuccess}
       viewMode={viewMode}
       onViewChange={(mode) => navigate(mode === "workflows" ? "/" : "/runs")}
       workflowCount={workflowsQuery.data?.length}

--- a/packages/sentinel/src/components/layout/Sidebar.tsx
+++ b/packages/sentinel/src/components/layout/Sidebar.tsx
@@ -1,6 +1,8 @@
 import { client } from "@pario/client"
+import { getAuthSessionOptions, signOutMutation } from "@pario/client/hooks"
 import {
   Sidebar as ShadcnSidebar,
+  SidebarCollapseToggle,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
@@ -11,25 +13,16 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
-  ThemeSwitcher,
-  useSidebar,
+  SidebarUserMenu,
 } from "@pario/ui/components"
-import { cn } from "@pario/ui/lib/utils"
-import {
-  Activity,
-  ChevronsLeft,
-  ChevronsRight,
-  ExternalLink,
-  GitBranch,
-  History,
-} from "lucide-react"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { Activity, GitBranch, History } from "lucide-react"
 import type { ComponentType } from "react"
 
 export type ViewMode = "workflows" | "runs"
 
 interface ProjectSummary {
   readonly name: string
-  readonly type: string
 }
 
 interface NavItem {
@@ -49,7 +42,6 @@ function apiDocsUrl(): string {
 
 interface SidebarProps {
   selectedProject: ProjectSummary | null
-  connected: boolean
   viewMode: ViewMode
   onViewChange: (mode: ViewMode) => void
   workflowCount?: number
@@ -58,7 +50,6 @@ interface SidebarProps {
 
 export function Sidebar({
   selectedProject,
-  connected,
   viewMode,
   onViewChange,
   workflowCount,
@@ -68,6 +59,20 @@ export function Sidebar({
     if (id === "workflows") return workflowCount
     if (id === "runs") return runCount
     return undefined
+  }
+
+  const session = useQuery(getAuthSessionOptions()).data
+  const signOut = useMutation(signOutMutation())
+  const user =
+    session?.authenticated === true
+      ? {
+          name: session.user.displayName ?? session.user.email,
+          email: session.user.displayName ? session.user.email : undefined,
+          avatarUrl: session.user.avatarUrl,
+        }
+      : null
+  const handleSignOut = () => {
+    signOut.mutate({}, { onSettled: () => window.location.reload() })
   }
 
   return (
@@ -80,30 +85,9 @@ export function Sidebar({
           <div className="min-w-0 flex-1 group-data-[collapsible=icon]:hidden">
             <p className="truncate text-sm font-semibold text-sidebar-foreground">Sentinel</p>
             <p className="truncate text-xs text-sidebar-foreground">
-              {selectedProject
-                ? `${selectedProject.name} · ${selectedProject.type}`
-                : "Loading project"}
+              {selectedProject ? selectedProject.name : "Loading project"}
             </p>
           </div>
-          {selectedProject ? (
-            <div
-              className="relative flex h-2 w-2 shrink-0 group-data-[collapsible=icon]:hidden"
-              title={connected ? "API ready" : "Disconnected"}
-            >
-              <span
-                className={cn(
-                  "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
-                  connected ? "bg-emerald-500" : "bg-red-500"
-                )}
-              />
-              <span
-                className={cn(
-                  "relative inline-flex h-2 w-2 rounded-full",
-                  connected ? "bg-emerald-500" : "bg-red-500"
-                )}
-              />
-            </div>
-          ) : null}
         </div>
       </SidebarHeader>
 
@@ -145,40 +129,10 @@ export function Sidebar({
       </SidebarContent>
 
       <SidebarFooter className="border-t border-sidebar-border">
-        <div className="flex items-center justify-between gap-2 px-2 group-data-[collapsible=icon]:hidden">
-          <ThemeSwitcher />
-          <a
-            href={apiDocsUrl()}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs text-sidebar-foreground transition-colors hover:text-sidebar-accent-foreground"
-          >
-            <ExternalLink className="h-3.5 w-3.5" />
-            API
-          </a>
-        </div>
+        <SidebarUserMenu user={user} apiHref={apiDocsUrl()} onSignOut={handleSignOut} />
       </SidebarFooter>
 
       <SidebarRail />
     </ShadcnSidebar>
-  )
-}
-
-function SidebarCollapseToggle() {
-  const { state, toggleSidebar } = useSidebar()
-  const collapsed = state === "collapsed"
-  const label = collapsed ? "Expand sidebar" : "Collapse sidebar"
-  const Icon = collapsed ? ChevronsRight : ChevronsLeft
-
-  return (
-    <SidebarMenuButton
-      onClick={toggleSidebar}
-      tooltip={`${label} (⌘B)`}
-      aria-label={label}
-      className="text-sidebar-foreground"
-    >
-      <Icon />
-      <span>{label}</span>
-    </SidebarMenuButton>
   )
 }

--- a/packages/sentinel/src/features/workflows/components/nodes/RunNodeRow.tsx
+++ b/packages/sentinel/src/features/workflows/components/nodes/RunNodeRow.tsx
@@ -1,15 +1,30 @@
 import { Badge, Card, CardContent } from "@pario/ui/components"
-import { Workflow, Zap } from "lucide-react"
+import { cn } from "@pario/ui/lib/utils"
+import { ChevronRight, Workflow, Zap } from "lucide-react"
+import { useState } from "react"
 import { formatNodeDuration, formatRelativeTime, type WorkflowRunNode } from "../../utils/workflows"
 import { RunIOShape } from "../runs/RunIOShape"
 import { NodeStatusBadge } from "../runs/StatusBadge"
 
-export function RunNodeRow({ node }: { node: WorkflowRunNode }) {
+export function RunNodeRow({
+  node,
+  defaultOpen = true,
+}: {
+  node: WorkflowRunNode
+  defaultOpen?: boolean
+}) {
   const isStep = node.nodeType === "step"
+  const [open, setOpen] = useState(defaultOpen)
+
   return (
     <Card className="gap-0 overflow-hidden py-0">
       <CardContent className="p-0">
-        <div className="flex items-start gap-3 p-4">
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          aria-expanded={open}
+          className="flex w-full items-start gap-3 p-4 text-left transition-colors hover:bg-muted/40"
+        >
           <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted font-mono text-sm font-medium tabular-nums text-muted-foreground">
             {node.nodeIndex + 1}
           </span>
@@ -31,15 +46,23 @@ export function RunNodeRow({ node }: { node: WorkflowRunNode }) {
             </div>
           </div>
           <NodeStatusBadge status={node.status} />
-        </div>
-
-        <div className="grid gap-px border-t border-border/60 bg-border/40 lg:grid-cols-2">
-          <JsonPanel label="Input" value={node.input} />
-          <JsonPanel
-            label={node.error ? "Error" : "Output"}
-            value={node.output ?? node.error ?? null}
+          <ChevronRight
+            className={cn(
+              "mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-90"
+            )}
           />
-        </div>
+        </button>
+
+        {open ? (
+          <div className="grid gap-px border-t border-border/60 bg-border/40 lg:grid-cols-2">
+            <JsonPanel label="Input" value={node.input} />
+            <JsonPanel
+              label={node.error ? "Error" : "Output"}
+              value={node.output ?? node.error ?? null}
+            />
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   )

--- a/packages/sentinel/src/features/workflows/components/runs/RunIOShape.tsx
+++ b/packages/sentinel/src/features/workflows/components/runs/RunIOShape.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@pario/ui/lib/utils"
-import { Box, Braces, Brackets, Check, Hash, Minus, Type } from "lucide-react"
+import { Box, Braces, Brackets, Check, Copy, Hash, Minus, Type } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
 
 export function RunIOShape({
   value,
@@ -64,7 +65,7 @@ function RunValue({ label, value }: { label?: string; value: unknown }) {
           <TypeChip icon="array" label="array" detail={`${value.length} items`} />
         </div>
         {value.length > 0 ? (
-          <div className="rounded-md border border-border bg-background/60 px-3">
+          <div className="border-l border-border pl-3">
             <RunIOShape value={value} />
           </div>
         ) : null}
@@ -81,10 +82,19 @@ function RunValue({ label, value }: { label?: string; value: unknown }) {
           <TypeChip icon="object" label="object" detail={`${entries.length} fields`} />
         </div>
         {entries.length > 0 ? (
-          <div className="rounded-md border border-border bg-background/60 px-3">
+          <div className="border-l border-border pl-3">
             <RunIOShape value={value} />
           </div>
         ) : null}
+      </div>
+    )
+  }
+
+  if (isLongString(value)) {
+    return (
+      <div className="space-y-1.5">
+        {label ? <FieldLabel>{label}</FieldLabel> : null}
+        <ExpandableText text={value} />
       </div>
     )
   }
@@ -153,6 +163,87 @@ function TypeChip({
       <span className="truncate">{label}</span>
       {detail ? <span className="text-muted-foreground">{detail}</span> : null}
     </span>
+  )
+}
+
+const LONG_STRING_THRESHOLD = 80
+
+function isLongString(value: unknown): value is string {
+  return typeof value === "string" && (value.length > LONG_STRING_THRESHOLD || value.includes("\n"))
+}
+
+function ExpandableText({ text }: { text: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const [overflowing, setOverflowing] = useState(false)
+  const textRef = useRef<HTMLParagraphElement>(null)
+
+  // Measure overflow only while clamped — once expanded the element grows to fit.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure when the text content changes (e.g. live output)
+  useEffect(() => {
+    const element = textRef.current
+    if (!element || expanded) return
+    setOverflowing(element.scrollHeight > element.clientHeight + 1)
+  }, [expanded, text])
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-start gap-2">
+        <p
+          ref={textRef}
+          className={cn(
+            "min-w-0 flex-1 whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground",
+            expanded ? "max-h-80 overflow-y-auto" : "line-clamp-3"
+          )}
+        >
+          {text}
+        </p>
+        <CopyButton text={text} />
+      </div>
+      {overflowing ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!copied) return
+    const timeout = window.setTimeout(() => setCopied(false), 1600)
+    return () => window.clearTimeout(timeout)
+  }, [copied])
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+    } catch {
+      // Clipboard access can be blocked; failing silently is acceptable here.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onCopy}
+      aria-label="Copy value"
+      className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-emerald-600" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
   )
 }
 

--- a/packages/sentinel/src/features/workflows/components/runs/RunProgress.tsx
+++ b/packages/sentinel/src/features/workflows/components/runs/RunProgress.tsx
@@ -1,0 +1,82 @@
+import { cn } from "@pario/ui/lib/utils"
+import type { WorkflowRunNode, WorkflowRunStatus } from "../../utils/workflows"
+
+const barColorByStatus: Record<WorkflowRunStatus, string> = {
+  queued: "bg-sky-500",
+  running: "bg-amber-500",
+  succeeded: "bg-emerald-500",
+  failed: "bg-red-500",
+  cancelled: "bg-zinc-400",
+}
+
+interface RunProgressProps {
+  status: WorkflowRunStatus
+  nodes: readonly WorkflowRunNode[]
+  /** Total nodes defined by the workflow — the "of Y". */
+  totalSteps: number
+  className?: string
+}
+
+/**
+ * Compact "Step X of Y" indicator with a progress bar. Reflects how far a run has
+ * advanced through its defined steps — most useful while a run is streaming live.
+ */
+export function RunProgress({ status, nodes, totalSteps, className }: RunProgressProps) {
+  if (totalSteps <= 0) return null
+
+  const succeeded = nodes.filter((node) => node.status === "succeeded").length
+  // The node that pins "where we are": the one running, else the one that ended the run.
+  const marker =
+    nodes.find((node) => node.status === "running") ??
+    nodes.find((node) => node.status === "failed") ??
+    nodes.find((node) => node.status === "cancelled")
+  const current = clamp(marker ? marker.nodeIndex + 1 : succeeded, 0, totalSteps)
+  const percent = Math.round((current / totalSteps) * 100)
+
+  return (
+    <div className={cn("min-w-0 sm:w-56", className)}>
+      <span className="block truncate text-xs font-medium tabular-nums text-foreground">
+        {progressLabel(status, current, succeeded, totalSteps)}
+      </span>
+      <div
+        className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-muted"
+        role="progressbar"
+        aria-valuenow={current}
+        aria-valuemin={0}
+        aria-valuemax={totalSteps}
+      >
+        <div
+          className={cn(
+            "h-full rounded-full transition-[width] duration-500 ease-out",
+            barColorByStatus[status]
+          )}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function progressLabel(
+  status: WorkflowRunStatus,
+  current: number,
+  succeeded: number,
+  total: number
+): string {
+  switch (status) {
+    case "queued":
+      return `0 of ${total} steps`
+    case "running":
+      return `Step ${current} of ${total}`
+    case "failed":
+      return `Failed at step ${current} of ${total}`
+    case "cancelled":
+      return `Cancelled at step ${current} of ${total}`
+    default:
+      return `${succeeded} of ${total} steps`
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}

--- a/packages/sentinel/src/pages/RunDetailPage.tsx
+++ b/packages/sentinel/src/pages/RunDetailPage.tsx
@@ -1,4 +1,4 @@
-import { getWorkflowRunOptions } from "@pario/client/hooks"
+import { getWorkflowOptions, getWorkflowRunOptions } from "@pario/client/hooks"
 import { Badge, Button, Card, CardContent, CardTitle, EmptyState } from "@pario/ui/components"
 import { useQuery } from "@tanstack/react-query"
 import { Check, Copy, GitBranch, Play } from "lucide-react"
@@ -8,6 +8,7 @@ import { Link, Navigate, useParams } from "react-router-dom"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
 import { RunNodeRow } from "../features/workflows/components/nodes/RunNodeRow"
 import { RunIOShape } from "../features/workflows/components/runs/RunIOShape"
+import { RunProgress } from "../features/workflows/components/runs/RunProgress"
 import { StatusBadge } from "../features/workflows/components/runs/StatusBadge"
 import {
   formatDate,
@@ -28,6 +29,11 @@ export function RunDetailPage() {
       return status && isActiveRunStatus(status) ? 5000 : false
     },
   })
+  const workflowId = runQuery.data?.run.workflowId
+  const workflowQuery = useQuery({
+    ...getWorkflowOptions({ path: { workflowId: workflowId ?? "" } }),
+    enabled: Boolean(workflowId),
+  })
 
   if (!runId) {
     return <Navigate to="/runs" replace />
@@ -42,6 +48,7 @@ export function RunDetailPage() {
   }
 
   const { run, nodes } = runQuery.data
+  const totalSteps = workflowQuery.data?.nodes.length ?? 0
 
   return (
     <PageFrame
@@ -55,12 +62,15 @@ export function RunDetailPage() {
         <RunHeaderStats run={run} />
 
         <section className="space-y-3">
-          <div>
-            <h2 className="text-sm font-medium text-foreground">Timeline</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Run input followed by {nodes.length} recorded node
-              {nodes.length === 1 ? "" : "s"}.
-            </p>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="text-sm font-medium text-foreground">Timeline</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Run input followed by {nodes.length} recorded node
+                {nodes.length === 1 ? "" : "s"}.
+              </p>
+            </div>
+            <RunProgress status={run.status} nodes={nodes} totalSteps={totalSteps} />
           </div>
 
           <RunInputCard value={run.input} />
@@ -75,8 +85,14 @@ export function RunDetailPage() {
             </Card>
           ) : (
             <div className="space-y-3">
-              {nodes.map((node) => (
-                <RunNodeRow key={`${node.workflowRunId}:${node.nodeIndex}`} node={node} />
+              {nodes.map((node, index) => (
+                <RunNodeRow
+                  key={`${node.workflowRunId}:${node.nodeIndex}`}
+                  node={node}
+                  // Collapse finished steps so the run reads as a scannable flow;
+                  // keep the last step (final output) and any non-succeeded step open.
+                  defaultOpen={node.status !== "succeeded" || index === nodes.length - 1}
+                />
               ))}
             </div>
           )}

--- a/packages/sentinel/src/pages/WorkflowsPage.tsx
+++ b/packages/sentinel/src/pages/WorkflowsPage.tsx
@@ -1,8 +1,7 @@
 import { listWorkflowsOptions } from "@pario/client/hooks"
-import { Card } from "@pario/ui/components"
+import { Card, EmptyState } from "@pario/ui/components"
 import { useQuery } from "@tanstack/react-query"
 import { Workflow } from "lucide-react"
-import type { ReactNode } from "react"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
 import { WorkflowCard } from "../features/workflows/components/workflows/WorkflowCard"
 
@@ -29,8 +28,8 @@ export function WorkflowsPage() {
       <section className="space-y-3">
         {workflows.length === 0 ? (
           <Card>
-            <QuietEmptyState
-              icon={<Workflow className="h-5 w-5" />}
+            <EmptyState
+              icon={<Workflow className="size-12 stroke-1" />}
               title="No workflows registered"
               description="Create a workflow definition to see it appear here."
             />
@@ -44,23 +43,5 @@ export function WorkflowsPage() {
         )}
       </section>
     </PageFrame>
-  )
-}
-
-function QuietEmptyState({
-  icon,
-  title,
-  description,
-}: {
-  icon: ReactNode
-  title: string
-  description: string
-}) {
-  return (
-    <div className="px-5 py-14 text-center">
-      <div className="mx-auto text-muted-foreground">{icon}</div>
-      <p className="mt-4 font-medium text-foreground">{title}</p>
-      <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">{description}</p>
-    </div>
   )
 }

--- a/packages/server/src/routes/project.ts
+++ b/packages/server/src/routes/project.ts
@@ -3,7 +3,7 @@ import type { Elysia } from "elysia"
 import { ProjectInfoResponseSchema } from "../schemas/project"
 
 export function registerProjectRoutes(app: Elysia, pario: Pario<readonly OntologySource[]>) {
-  return app.get("/api/project", async () => ({ id: pario.id, type: "local" as const }), {
+  return app.get("/api/project", async () => ({ id: pario.id }), {
     response: { 200: ProjectInfoResponseSchema },
     detail: {
       summary: "Get current project metadata",

--- a/packages/server/src/schemas/project.ts
+++ b/packages/server/src/schemas/project.ts
@@ -2,5 +2,4 @@ import { z } from "zod"
 
 export const ProjectInfoResponseSchema = z.object({
   id: z.string(),
-  type: z.literal("local"),
 })

--- a/packages/server/tests/auth-guard.test.ts
+++ b/packages/server/tests/auth-guard.test.ts
@@ -135,7 +135,7 @@ describe("server auth guard", () => {
     const response = await app.fetch(new Request("http://localhost/api/project"))
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ id: "test-project", type: "local" })
+    expect(await response.json()).toEqual({ id: "test-project" })
   })
 
   test("fails closed in production when auth is missing", () => {

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -402,7 +402,7 @@ describe("ParioServer HTTP contract", () => {
     await withHttpContractServer(async ({ baseUrl }) => {
       const projectResponse = await fetch(`${baseUrl}/api/project`)
       expect(projectResponse.status).toBe(200)
-      expect(await projectResponse.json()).toEqual({ id: "contract-project", type: "local" })
+      expect(await projectResponse.json()).toEqual({ id: "contract-project" })
 
       const statusResponse = await fetch(`${baseUrl}/api/status`)
       expect(statusResponse.status).toBe(200)

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -10,6 +10,11 @@ export {
   CollectionViewToggle,
 } from "./collection-view"
 export { EmptyState } from "./empty-state"
+export {
+  SidebarCollapseToggle,
+  type SidebarUser,
+  SidebarUserMenu,
+} from "./sidebar-user-menu"
 export { ThemeSwitcher } from "./theme-switcher"
 export { Alert, AlertDescription, AlertTitle } from "./ui/alert"
 export { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"

--- a/packages/ui/src/components/sidebar-user-menu.tsx
+++ b/packages/ui/src/components/sidebar-user-menu.tsx
@@ -1,0 +1,186 @@
+import {
+  Check,
+  ChevronsLeft,
+  ChevronsRight,
+  ChevronsUpDown,
+  ExternalLink,
+  LaptopMinimal,
+  LogOut,
+  MoonStar,
+  Settings2,
+  SunMedium,
+} from "lucide-react"
+import { useTheme } from "../hooks/useTheme"
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu"
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "./ui/sidebar"
+
+const themes = [
+  { value: "light", label: "Light", Icon: SunMedium },
+  { value: "dark", label: "Dark", Icon: MoonStar },
+  { value: "system", label: "System", Icon: LaptopMinimal },
+] as const
+
+export interface SidebarUser {
+  readonly name: string
+  readonly email?: string
+  readonly avatarUrl?: string
+}
+
+interface SidebarUserMenuProps {
+  /** The signed-in user, or null when auth is disabled or unauthenticated. */
+  user: SidebarUser | null
+  /** Optional link to the API reference, surfaced inside the menu. */
+  apiHref?: string
+  /** Sign-out handler. Only shown when a user and handler are both present. */
+  onSignOut?: () => void
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return "?"
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+}
+
+/**
+ * Standardized sidebar footer menu: signed-in identity, theme switching, an API
+ * reference link, and sign-out, all folded into a single dropdown off the avatar
+ * row. When no user is present it degrades to a preferences menu (theme + API).
+ */
+export function SidebarUserMenu({ user, apiHref, onSignOut }: SidebarUserMenuProps) {
+  const { theme, setTheme } = useTheme()
+  const { isMobile } = useSidebar()
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            {user ? (
+              <SidebarMenuButton
+                size="lg"
+                tooltip={user.name}
+                className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+              >
+                <Avatar className="h-8 w-8 rounded-md">
+                  {user.avatarUrl ? <AvatarImage src={user.avatarUrl} alt={user.name} /> : null}
+                  <AvatarFallback className="rounded-md text-xs">
+                    {initials(user.name)}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-semibold">{user.name}</span>
+                  {user.email ? (
+                    <span className="truncate text-xs text-sidebar-foreground/70">
+                      {user.email}
+                    </span>
+                  ) : null}
+                </div>
+                <ChevronsUpDown className="ml-auto size-4" />
+              </SidebarMenuButton>
+            ) : (
+              <SidebarMenuButton
+                tooltip="Preferences"
+                className="text-sidebar-foreground data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+              >
+                <Settings2 />
+                <span>Preferences</span>
+              </SidebarMenuButton>
+            )}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            side={isMobile ? "bottom" : "top"}
+            align="end"
+            sideOffset={4}
+            className="min-w-56 rounded-lg"
+            onCloseAutoFocus={(event) => event.preventDefault()}
+          >
+            {user ? (
+              <>
+                <DropdownMenuLabel className="p-0 font-normal">
+                  <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                    <Avatar className="h-8 w-8 rounded-md">
+                      {user.avatarUrl ? <AvatarImage src={user.avatarUrl} alt={user.name} /> : null}
+                      <AvatarFallback className="rounded-md text-xs">
+                        {initials(user.name)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="grid flex-1 text-left text-sm leading-tight">
+                      <span className="truncate font-semibold">{user.name}</span>
+                      {user.email ? (
+                        <span className="truncate text-xs text-muted-foreground">{user.email}</span>
+                      ) : null}
+                    </div>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+              </>
+            ) : null}
+
+            {themes.map((option) => {
+              const Icon = option.Icon
+              const selected = option.value === theme
+              return (
+                <DropdownMenuItem key={option.value} onClick={() => setTheme(option.value)}>
+                  <Icon />
+                  <span className="flex-1">{option.label}</span>
+                  {selected ? <Check className="text-muted-foreground" /> : null}
+                </DropdownMenuItem>
+              )
+            })}
+
+            {apiHref ? (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                  <a href={apiHref} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink />
+                    <span>API reference</span>
+                  </a>
+                </DropdownMenuItem>
+              </>
+            ) : null}
+
+            {user && onSignOut ? (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={onSignOut}>
+                  <LogOut />
+                  <span>Log out</span>
+                </DropdownMenuItem>
+              </>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+
+/** Shared collapse/expand toggle for the sidebar rail. */
+export function SidebarCollapseToggle() {
+  const { state, toggleSidebar } = useSidebar()
+  const collapsed = state === "collapsed"
+  const label = collapsed ? "Expand sidebar" : "Collapse sidebar"
+  const Icon = collapsed ? ChevronsRight : ChevronsLeft
+
+  return (
+    <SidebarMenuButton
+      onClick={toggleSidebar}
+      tooltip={`${label} (⌘B)`}
+      aria-label={label}
+      className="text-sidebar-foreground"
+    >
+      <Icon />
+      <span>{label}</span>
+    </SidebarMenuButton>
+  )
+}


### PR DESCRIPTION
Small UI polish across Atlas and Sentinel.

### Sidebar
- Header shows **app name + icon + project slug** (dropped the always-"local" label and the misleading connection dot).
- Footer standardized into one shared **user menu**: identity, theme, API link, and log out.

### Workflow run detail (Sentinel)
- Added a **"Step X of Y"** progress bar.
- **Collapsible step cards** — finished steps collapse to their header; the final step and any running/failed step stay open.
- **Readable long values** — long/multiline text wraps with expand + copy instead of truncating (fixes unreadable reports). Fixed the "No workflows" empty state.

### Server / client
- Removed the unused `type: "local"` field from `/api/project` and regenerated the client.

**Checks:** typecheck, build, biome, tests (1071 pass), and `generate:client` all green.

---

### Before

Was showing "local" in prod setting

<img width="274" height="120" alt="Screenshot 2026-05-29 at 7 04 23 PM" src="https://github.com/user-attachments/assets/106dfcff-5dda-4810-aea4-81fb3c56e86e" />

### After

<img width="272" height="98" alt="Screenshot 2026-05-29 at 7 00 06 PM" src="https://github.com/user-attachments/assets/0040f5aa-6ae8-407b-a5e1-a8423be59693" />
<img width="292" height="124" alt="Screenshot 2026-05-29 at 6 59 57 PM" src="https://github.com/user-attachments/assets/8d56483a-04dc-444b-b3ab-686bf38f6514" />

<img width="301" height="338" alt="Screenshot 2026-05-29 at 6 59 59 PM" src="https://github.com/user-attachments/assets/a91a34cb-b458-42e1-bdd9-c8d2f4156163" />
<img width="1098" height="814" alt="Screenshot 2026-05-29 at 7 00 24 PM" src="https://github.com/user-attachments/assets/6412dcde-cd40-4fe8-b5f0-cd13e2bed0d3" />
