### PR TITLE
core: add pario.workflows.request to start workflow runs

### DIFF
--- a/packages/cli/src/lib/loadPario.ts
+++ b/packages/cli/src/lib/loadPario.ts
@@ -16,7 +16,7 @@ import type {
   RuleDefinition,
   ScheduleDefinition,
   SyncDefinition,
-  WorkflowDefinition,
+  WorkflowsRuntime,
 } from "@pario/core"
 
 export interface LoadedPario extends ParioRuntimeContext {
@@ -30,8 +30,7 @@ export interface LoadedPario extends ParioRuntimeContext {
   getPipelineDefinitions(): readonly PipelineDefinition[]
   getPipelineById(pipelineId: string): PipelineDefinition | null
   getScheduleDefinitions(): readonly ScheduleDefinition[]
-  getWorkflowDefinitions(): readonly WorkflowDefinition[]
-  getWorkflowById(workflowId: string): WorkflowDefinition | null
+  readonly workflows: WorkflowsRuntime
   getObjectProjections(): readonly ObjectProjectionDefinition[]
   getLinkProjections(): readonly LinkProjectionDefinition[]
   getDatasetDefinitions(): readonly DatasetDefinition[]
@@ -84,8 +83,8 @@ function isParioInstance(value: unknown): value is LoadedPario {
     typeof (value as { getPipelineDefinitions?: unknown }).getPipelineDefinitions === "function" &&
     typeof (value as { getPipelineById?: unknown }).getPipelineById === "function" &&
     typeof (value as { getScheduleDefinitions?: unknown }).getScheduleDefinitions === "function" &&
-    typeof (value as { getWorkflowDefinitions?: unknown }).getWorkflowDefinitions === "function" &&
-    typeof (value as { getWorkflowById?: unknown }).getWorkflowById === "function" &&
+    typeof (value as { workflows?: { list?: unknown } }).workflows?.list === "function" &&
+    typeof (value as { workflows?: { getById?: unknown } }).workflows?.getById === "function" &&
     typeof (value as { getObjectProjections?: unknown }).getObjectProjections === "function" &&
     typeof (value as { getLinkProjections?: unknown }).getLinkProjections === "function" &&
     typeof (value as { getDatasetDefinitions?: unknown }).getDatasetDefinitions === "function" &&

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -122,7 +122,7 @@ export async function startOrchestratorRuntime(
     syncs: pario.getSyncDefinitions(),
     pipelines: pario.getPipelineDefinitions(),
     projections: [...pario.getObjectProjections(), ...pario.getLinkProjections()],
-    workflows: pario.getWorkflowDefinitions(),
+    workflows: pario.workflows.list(),
   })
   const warnings = diagnostics.map(formatRouteDiagnosticWarning)
   let orchestratorWorker: OrchestratorWorker | null = null
@@ -229,7 +229,7 @@ export async function startParioRuntime(
         await pipelineWorker.start()
       }
 
-      if (pario.getWorkflowDefinitions().length > 0) {
+      if (pario.workflows.list().length > 0) {
         workflowWorker = new WorkflowWorker(pario)
         await workflowWorker.start()
       }

--- a/packages/cli/src/lib/worker-registry.ts
+++ b/packages/cli/src/lib/worker-registry.ts
@@ -70,7 +70,7 @@ export function resolveRegisteredWorkerTypes(pario: LoadedPario): readonly strin
     workerTypes.push("action")
   }
 
-  if (pario.getWorkflowDefinitions().length > 0) {
+  if (pario.workflows.list().length > 0) {
     workerTypes.push("workflow")
   }
 

--- a/packages/core/src/events/types/workflows.ts
+++ b/packages/core/src/events/types/workflows.ts
@@ -1,3 +1,4 @@
+import type { WorkflowRunSource } from "../../workflows/types"
 import type { EventEnvelope } from "../envelope"
 
 export interface WorkflowRunQueuedEvent extends EventEnvelope {
@@ -9,10 +10,7 @@ export interface WorkflowRunQueuedEvent extends EventEnvelope {
     runId: string
     queuedAt: string
     jobId?: string
-    source?: {
-      type: "manual" | "schedule" | "event"
-      id?: string
-    }
+    source?: WorkflowRunSource
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -734,6 +734,7 @@ export type {
   InferStepInput,
   InferStepOutput,
   InferWorkflowInput,
+  RequestWorkflowRunInput,
   StepBuilder,
   StepDefinition,
   StepHandler,
@@ -751,6 +752,9 @@ export type {
   WorkflowIOSnapshot,
   WorkflowMapperContext,
   WorkflowNodeDefinition,
+  WorkflowRunRequestOptions,
+  WorkflowRunRequestResult,
+  WorkflowRunSource,
   WorkflowStepMapper,
   WorkflowStepNodeDefinition,
   WorkflowStepOutputs,
@@ -761,6 +765,7 @@ export {
   defineWorkflowStep,
   isStepDefinition,
   isWorkflowDefinition,
+  requestWorkflowRun,
   snapshotWorkflowActionInput,
   snapshotWorkflowInput,
   snapshotWorkflowStepInput,
@@ -770,6 +775,7 @@ export {
   validateWorkflowStepInput,
   validateWorkflowStepOutput,
   WorkflowDefinitionError,
+  WorkflowsRuntime,
   WorkflowValidationError,
 } from "./workflows"
 

--- a/packages/core/src/runtime/pario.ts
+++ b/packages/core/src/runtime/pario.ts
@@ -48,7 +48,7 @@ import type { SyncDefinition } from "../syncs"
 import type { RegisteredWebhook } from "../webhooks"
 import { registerWebhooks, WebhookValidationError, webhookRoute } from "../webhooks"
 import type { WorkflowDefinition } from "../workflows"
-import { validateWorkflowsAtStartup } from "../workflows"
+import { validateWorkflowsAtStartup, WorkflowsRuntime } from "../workflows"
 import { RuntimeError } from "./errors"
 import type {
   BatchItemResult,
@@ -96,7 +96,6 @@ export class Pario<TOntologySources extends readonly OntologySource[]>
   private readonly syncsById = new Map<string, SyncDefinition>()
   private readonly pipelinesById = new Map<string, PipelineDefinition>()
   private readonly rulesById = new Map<string, RuleDefinition>()
-  private readonly workflowsById = new Map<string, WorkflowDefinition>()
   private readonly connectorRuntime: ConnectorRuntime
   private readonly webhooksByRoute = new Map<string, RegisteredWebhook>()
   private readonly webhooks: readonly RegisteredWebhook[]
@@ -107,6 +106,7 @@ export class Pario<TOntologySources extends readonly OntologySource[]>
   readonly ontology: OntologyRegistry
   readonly actionRegistry: ActionRegistry
   readonly actions: ActionsRuntime
+  readonly workflows: WorkflowsRuntime
   readonly broker: Broker
   readonly events: EventsRuntime
   readonly storage: Storage
@@ -237,11 +237,12 @@ export class Pario<TOntologySources extends readonly OntologySource[]>
       registeredActionIds: new Set(this.actionRegistry.list().map((action) => action.id)),
     })
 
+    const workflowIds = new Set<string>()
     for (const workflow of workflows) {
-      if (this.workflowsById.has(workflow.id)) {
+      if (workflowIds.has(workflow.id)) {
         throw new RuntimeError(`Duplicate workflow id: ${workflow.id}`)
       }
-      this.workflowsById.set(workflow.id, workflow)
+      workflowIds.add(workflow.id)
     }
     this.runtimeContext = {
       projectId: this.projectId,
@@ -254,6 +255,7 @@ export class Pario<TOntologySources extends readonly OntologySource[]>
       queues: this.queues,
     }
     this.actions = new ActionsRuntime(this.runtimeContext)
+    this.workflows = new WorkflowsRuntime(this.runtimeContext, workflows)
 
     const { objectProjections, linkProjections } = categorizeProjections(options.projections ?? [])
     this.objectProjections = objectProjections
@@ -342,14 +344,6 @@ export class Pario<TOntologySources extends readonly OntologySource[]>
 
   getRuleById(ruleId: string): RuleDefinition | null {
     return this.rulesById.get(ruleId) ?? null
-  }
-
-  getWorkflowDefinitions(): readonly WorkflowDefinition[] {
-    return [...this.workflowsById.values()]
-  }
-
-  getWorkflowById(workflowId: string): WorkflowDefinition | null {
-    return this.workflowsById.get(workflowId) ?? null
   }
 
   /** All connector definitions registered with this runtime. */

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -43,7 +43,7 @@ import type { SecurityRegistry } from "../security"
 import type { ObjectLinkRow, ObjectRow, Storage } from "../storage"
 import type { SyncDefinition } from "../syncs"
 import type { RegisteredWebhook } from "../webhooks"
-import type { WorkflowDefinition } from "../workflows"
+import type { WorkflowsRuntime } from "../workflows"
 
 // ── Shared runtime context ──────────────────────────────────
 
@@ -325,6 +325,7 @@ export interface ParioInstance<_ extends readonly OntologySource[]> {
   readonly security: SecurityRegistry
   readonly auth: AuthRuntime
   readonly actions: ActionsRuntime
+  readonly workflows: WorkflowsRuntime
 
   /** All registered object types. */
   listObjectTypes(): readonly ObjectTypeWithPropertyTokens[]
@@ -376,12 +377,6 @@ export interface ParioInstance<_ extends readonly OntologySource[]> {
 
   /** Lookup a rule definition by id. */
   getRuleById(ruleId: string): RuleDefinition | null
-
-  /** All registered workflow definitions. */
-  getWorkflowDefinitions(): readonly WorkflowDefinition[]
-
-  /** Lookup a workflow definition by id. */
-  getWorkflowById(workflowId: string): WorkflowDefinition | null
 
   /** All registered connector definitions. */
   listConnectors(): readonly ConnectorDefinition[]

--- a/packages/core/src/storage/workflow-runs/in-memory.ts
+++ b/packages/core/src/storage/workflow-runs/in-memory.ts
@@ -58,6 +58,7 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
       input: cloneRecord(input.input),
       queuedAt,
       startedAt: queuedAt,
+      ...(input.source ? { source: cloneRecord(input.source) } : {}),
     }
 
     this.runs.set(key, cloneRecord(record))

--- a/packages/core/src/storage/workflow-runs/types.ts
+++ b/packages/core/src/storage/workflow-runs/types.ts
@@ -1,6 +1,6 @@
-import type { WorkflowIOSnapshot } from "../../workflows/types"
+import type { WorkflowIOSnapshot, WorkflowRunSource } from "../../workflows/types"
 
-export type { WorkflowIOSnapshot } from "../../workflows/types"
+export type { WorkflowIOSnapshot, WorkflowRunSource } from "../../workflows/types"
 
 export type WorkflowRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled"
 export type WorkflowNodeRunStatus = Exclude<WorkflowRunStatus, "queued">
@@ -16,6 +16,7 @@ export interface WorkflowRunRecord {
   readonly startedAt: Date
   readonly finishedAt?: Date
   readonly error?: string
+  readonly source?: WorkflowRunSource
 }
 
 export interface WorkflowNodeRunRecord {
@@ -49,6 +50,7 @@ export interface QueueWorkflowRunInput {
   readonly workflowId: string
   readonly input: WorkflowIOSnapshot
   readonly queuedAt?: Date
+  readonly source?: WorkflowRunSource
 }
 
 export type FinishWorkflowRunInput =

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -1,5 +1,12 @@
 export { defineWorkflow, defineWorkflowStep } from "./builders"
 export { WorkflowDefinitionError, WorkflowValidationError } from "./errors"
+export type {
+  RequestWorkflowRunInput,
+  WorkflowRunRequestOptions,
+  WorkflowRunRequestResult,
+} from "./request"
+export { requestWorkflowRun } from "./request"
+export { WorkflowsRuntime } from "./runtime"
 export {
   snapshotWorkflowActionInput,
   snapshotWorkflowInput,
@@ -28,6 +35,7 @@ export type {
   WorkflowIOSnapshot,
   WorkflowMapperContext,
   WorkflowNodeDefinition,
+  WorkflowRunSource,
   WorkflowStepMapper,
   WorkflowStepNodeDefinition,
   WorkflowStepOutputs,

--- a/packages/core/src/workflows/request.ts
+++ b/packages/core/src/workflows/request.ts
@@ -1,0 +1,129 @@
+import { randomUUID } from "node:crypto"
+import type { ParioRuntimeContext } from "../runtime/types"
+import { WorkflowValidationError } from "./errors"
+import { snapshotWorkflowInput } from "./snapshot"
+import type { WorkflowDefinition, WorkflowRunSource } from "./types"
+
+export interface WorkflowRunRequestOptions {
+  readonly input?: Readonly<Record<string, unknown>>
+  readonly runId?: string
+  readonly source?: WorkflowRunSource
+}
+
+export interface RequestWorkflowRunInput extends WorkflowRunRequestOptions {
+  readonly workflowId: string
+}
+
+export interface WorkflowRunRequestResult {
+  readonly workflowId: string
+  readonly runId: string
+  readonly queuedAt: string
+  readonly jobId?: string
+  /**
+   * `false` when a deterministic `runId` already existed for the same workflow,
+   * so no second queue job was enqueued.
+   */
+  readonly created: boolean
+}
+
+/**
+ * Validate, snapshot, persist, queue, and announce a workflow run request.
+ *
+ * Operates on an already-resolved workflow definition and the shared runtime
+ * context, so it stays decoupled from how workflows are registered or looked up.
+ */
+export async function requestWorkflowRun(
+  runtime: ParioRuntimeContext,
+  workflow: WorkflowDefinition,
+  options: WorkflowRunRequestOptions = {}
+): Promise<WorkflowRunRequestResult> {
+  const storage = runtime.storage.workflowRuns
+  if (!storage) {
+    throw new WorkflowValidationError("[Pario] Workflow run storage is not configured.")
+  }
+
+  const queue = runtime.queues.workflows
+  if (!queue) {
+    throw new WorkflowValidationError("[Pario] Workflow run queue is not configured.")
+  }
+
+  const runId = createWorkflowRunId(options.runId)
+  const value = options.input ?? {}
+  // Validates the input against the workflow contract and rejects before any
+  // storage or queue write.
+  const snapshot = snapshotWorkflowInput({
+    workflow,
+    value,
+    valueTypesById: runtime.ontology.getValueTypesById(),
+  })
+
+  const existing = await storage.getById({ projectId: runtime.projectId, id: runId })
+  if (existing) {
+    if (existing.workflowId !== workflow.id) {
+      throw new WorkflowValidationError(
+        `[Pario] Workflow run '${runId}' already exists for a different workflow '${existing.workflowId}'.`
+      )
+    }
+
+    return {
+      workflowId: workflow.id,
+      runId,
+      queuedAt: (existing.queuedAt ?? existing.startedAt).toISOString(),
+      created: false,
+    }
+  }
+
+  const queuedAt = new Date()
+  await storage.queue({
+    projectId: runtime.projectId,
+    id: runId,
+    workflowId: workflow.id,
+    input: snapshot,
+    queuedAt,
+    source: options.source,
+  })
+
+  const [job] = await queue.enqueue({
+    projectId: runtime.projectId,
+    jobs: [
+      {
+        type: "workflow.run.requested",
+        payload: { workflowId: workflow.id, runId, input: value },
+      },
+    ],
+  })
+
+  await runtime.events.append({
+    events: [
+      {
+        type: "workflow.run.queued",
+        payload: {
+          workflowId: workflow.id,
+          runId,
+          queuedAt: queuedAt.toISOString(),
+          ...(job?.id ? { jobId: job.id } : {}),
+          ...(options.source ? { source: options.source } : {}),
+        },
+      },
+    ],
+  })
+
+  return {
+    workflowId: workflow.id,
+    runId,
+    queuedAt: queuedAt.toISOString(),
+    jobId: job?.id,
+    created: true,
+  }
+}
+
+function createWorkflowRunId(runId: string | undefined): string {
+  if (runId !== undefined) {
+    if (!runId.trim()) {
+      throw new WorkflowValidationError("[Pario] Workflow run id must not be empty")
+    }
+    return runId
+  }
+
+  return `run_${randomUUID()}`
+}

--- a/packages/core/src/workflows/runtime.ts
+++ b/packages/core/src/workflows/runtime.ts
@@ -1,0 +1,57 @@
+import type { ParioRuntimeContext } from "../runtime/types"
+import { WorkflowValidationError } from "./errors"
+import {
+  type RequestWorkflowRunInput,
+  requestWorkflowRun,
+  type WorkflowRunRequestResult,
+} from "./request"
+import type { InferWorkflowInput, WorkflowDefinition, WorkflowRunSource } from "./types"
+
+/**
+ * Typed entry point for workflow definitions and runs, exposed as
+ * `pario.workflows`.
+ *
+ * Owns the registered workflow definitions and implements lookup directly,
+ * then delegates run requests to {@link requestWorkflowRun}.
+ */
+export class WorkflowsRuntime {
+  private readonly runtime: ParioRuntimeContext
+  private readonly workflowsById: ReadonlyMap<string, WorkflowDefinition>
+
+  constructor(runtime: ParioRuntimeContext, workflows: readonly WorkflowDefinition[]) {
+    this.runtime = runtime
+    this.workflowsById = new Map(workflows.map((workflow) => [workflow.id, workflow]))
+  }
+
+  /** All registered workflow definitions. */
+  list(): readonly WorkflowDefinition[] {
+    return [...this.workflowsById.values()]
+  }
+
+  /** Look up a registered workflow definition by id. */
+  getById(workflowId: string): WorkflowDefinition | null {
+    return this.workflowsById.get(workflowId) ?? null
+  }
+
+  /** Start a run for a known workflow definition with typed input. */
+  request<TWorkflow extends WorkflowDefinition>(
+    workflow: TWorkflow,
+    options: {
+      readonly input?: InferWorkflowInput<TWorkflow>
+      readonly runId?: string
+      readonly source?: WorkflowRunSource
+    } = {}
+  ): Promise<WorkflowRunRequestResult> {
+    return this.requestById({ workflowId: workflow.id, ...options })
+  }
+
+  /** Start a run by workflow id (server routes and dynamic use cases). */
+  async requestById(input: RequestWorkflowRunInput): Promise<WorkflowRunRequestResult> {
+    const workflow = this.getById(input.workflowId)
+    if (!workflow) {
+      throw new WorkflowValidationError(`[Pario] Unknown workflow '${input.workflowId}'`)
+    }
+
+    return requestWorkflowRun(this.runtime, workflow, input)
+  }
+}

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -84,6 +84,23 @@ export type WorkflowTriggerDefinition = {
   readonly scheduleId: string
 }
 
+/**
+ * Origin of a workflow run request.
+ *
+ * Captured on the queued run record and emitted with `workflow.run.queued`
+ * so downstream consumers can trace why a run started. Intentionally minimal
+ * for now — additional sources (schedule, sync, pipeline, ...) can be added
+ * when the triggers that produce them land.
+ */
+export type WorkflowRunSource =
+  | { readonly type: "manual" }
+  | {
+      readonly type: "webhook"
+      readonly connectorId: string
+      readonly webhookId: string
+      readonly deliveryId?: string
+    }
+
 export type InferStepInput<TStep extends StepDefinition> = TStep extends {
   readonly [stepInputValueType]?: infer TInputValue
 }

--- a/packages/core/tests/create-pario.test.ts
+++ b/packages/core/tests/create-pario.test.ts
@@ -173,9 +173,9 @@ export const syncOrders = defineSync("sync-orders")
       ...createTestRuntimeDeps(),
     })
 
-    expect(pario.getWorkflowDefinitions()).toEqual([workflow])
-    expect(pario.getWorkflowById("explicit-transaction-workflow")).toBe(workflow)
-    expect(pario.getWorkflowById("missing-workflow")).toBeNull()
+    expect(pario.workflows.list()).toEqual([workflow])
+    expect(pario.workflows.getById("explicit-transaction-workflow")).toBe(workflow)
+    expect(pario.workflows.getById("missing-workflow")).toBeNull()
   })
 
   test("discovers workflows from workflows directory", async () => {
@@ -267,13 +267,11 @@ export const reconcileTransaction = defineWorkflow("reconcile-transaction")
       ...createTestRuntimeDeps(),
     })
 
-    expect(pario.getWorkflowDefinitions().map((workflow) => workflow.id)).toEqual([
-      "reconcile-transaction",
-    ])
-    expect(pario.getWorkflowById("reconcile-transaction")?.triggers).toEqual([
+    expect(pario.workflows.list().map((workflow) => workflow.id)).toEqual(["reconcile-transaction"])
+    expect(pario.workflows.getById("reconcile-transaction")?.triggers).toEqual([
       { type: "schedule", scheduleId: "daily-reconciliation" },
     ])
-    expect(pario.getWorkflowById("reconcile-transaction")?.nodes.map((node) => node.id)).toEqual([
+    expect(pario.workflows.getById("reconcile-transaction")?.nodes.map((node) => node.id)).toEqual([
       "find-best-invoice",
       "attach-invoice",
     ])

--- a/packages/core/tests/workflow-request.test.ts
+++ b/packages/core/tests/workflow-request.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test"
+import {
+  defineObjectType,
+  defineWorkflow,
+  defineWorkflowStep,
+  Pario,
+  type ParioRuntimeContext,
+  prop,
+  type Queues,
+  ref,
+  requestWorkflowRun,
+  type Storage,
+  type WorkflowDefinition,
+  WorkflowValidationError,
+} from "../src"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const Transaction = defineObjectType({
+  id: "Transaction",
+  name: "Transaction",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const Invoice = defineObjectType({
+  id: "Invoice",
+  name: "Invoice",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const findBestInvoice = defineWorkflowStep("find-best-invoice")
+  .input({ transaction: ref(Transaction) })
+  .output({ invoice: ref(Invoice) })
+  .run(async () => ({ invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" } }))
+
+const draftInvoice = defineWorkflow("draft-invoice")
+  .input({ transaction: ref(Transaction) })
+  .then(findBestInvoice)
+
+// Widened to the base type: only used for registration and id lookup, so it
+// keeps the registered workflow array from instantiating two deep chain types.
+const reviewTransaction: WorkflowDefinition = defineWorkflow("review-transaction")
+  .input({ transaction: ref(Transaction) })
+  .then(findBestInvoice)
+
+function createPario() {
+  const workflows: readonly WorkflowDefinition[] = [draftInvoice, reviewTransaction]
+  return new Pario({
+    ontology: [Transaction, Invoice],
+    workflows,
+    ...createTestRuntimeDeps(),
+  })
+}
+
+function validInput() {
+  return { transaction: { objectTypeId: "Transaction" as const, primaryId: "txn_1" } }
+}
+
+async function claimAll(pario: { queues: Queues; id: string }) {
+  return pario.queues.workflows.claim({ projectId: pario.id, workerId: "test", limit: 50 })
+}
+
+describe("pario.workflows.request", () => {
+  test("queues a run, enqueues a job, and emits workflow.run.queued", async () => {
+    const pario = createPario()
+
+    const result = await pario.workflows.request(draftInvoice, { input: validInput() })
+
+    expect(result.created).toBe(true)
+    expect(result.workflowId).toBe("draft-invoice")
+    expect(result.runId).toMatch(/^run_/)
+    expect(result.jobId).toBeDefined()
+
+    const run = await pario.storage.workflowRuns?.getById({ projectId: pario.id, id: result.runId })
+    expect(run?.status).toBe("queued")
+    expect(run?.workflowId).toBe("draft-invoice")
+    expect(run?.input).toEqual({
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+    })
+
+    const jobs = await claimAll(pario)
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0]?.job.payload).toMatchObject({
+      workflowId: "draft-invoice",
+      runId: result.runId,
+      input: { transaction: { objectTypeId: "Transaction", primaryId: "txn_1" } },
+    })
+
+    const events = await pario.events.read({ types: ["workflow.run.queued"] })
+    expect(events).toHaveLength(1)
+    expect(events[0]?.payload).toMatchObject({
+      workflowId: "draft-invoice",
+      runId: result.runId,
+      queuedAt: result.queuedAt,
+      jobId: result.jobId,
+    })
+  })
+
+  test("requestById rejects unknown input fields at runtime", async () => {
+    const pario = createPario()
+
+    await expect(
+      pario.workflows.requestById({ workflowId: "draft-invoice", input: { bogus: true } })
+    ).rejects.toBeInstanceOf(WorkflowValidationError)
+  })
+
+  test("rejects invalid input before any storage or queue write", async () => {
+    const pario = createPario()
+
+    await expect(
+      pario.workflows.requestById({ workflowId: "draft-invoice", runId: "run_fixed", input: {} })
+    ).rejects.toBeInstanceOf(WorkflowValidationError)
+
+    const run = await pario.storage.workflowRuns?.getById({ projectId: pario.id, id: "run_fixed" })
+    expect(run).toBeNull()
+    expect(await claimAll(pario)).toHaveLength(0)
+    expect(await pario.events.read({ types: ["workflow.run.queued"] })).toHaveLength(0)
+  })
+
+  test("throws for an unknown workflow", async () => {
+    const pario = createPario()
+
+    await expect(pario.workflows.requestById({ workflowId: "missing", input: {} })).rejects.toThrow(
+      "[Pario] Unknown workflow 'missing'"
+    )
+  })
+
+  test("deterministic runId returns the existing run without enqueuing twice", async () => {
+    const pario = createPario()
+
+    const first = await pario.workflows.request(draftInvoice, {
+      runId: "run_dedupe",
+      input: validInput(),
+    })
+    const second = await pario.workflows.request(draftInvoice, {
+      runId: "run_dedupe",
+      input: validInput(),
+    })
+
+    expect(first.created).toBe(true)
+    expect(second.created).toBe(false)
+    expect(second.runId).toBe("run_dedupe")
+    expect(second.queuedAt).toBe(first.queuedAt)
+    expect(second.jobId).toBeUndefined()
+
+    expect(await claimAll(pario)).toHaveLength(1)
+    expect(await pario.events.read({ types: ["workflow.run.queued"] })).toHaveLength(1)
+  })
+
+  test("deterministic runId throws when reused for a different workflow", async () => {
+    const pario = createPario()
+
+    await pario.workflows.request(draftInvoice, { runId: "run_shared", input: validInput() })
+
+    await expect(
+      pario.workflows.requestById({
+        workflowId: "review-transaction",
+        runId: "run_shared",
+        input: validInput(),
+      })
+    ).rejects.toThrow("already exists for a different workflow")
+  })
+
+  test("persists and emits the run source", async () => {
+    const pario = createPario()
+    const source = {
+      type: "webhook" as const,
+      connectorId: "companycam",
+      webhookId: "photo-created",
+      deliveryId: "delivery-1",
+    }
+
+    const result = await pario.workflows.request(draftInvoice, { input: validInput(), source })
+
+    const run = await pario.storage.workflowRuns?.getById({ projectId: pario.id, id: result.runId })
+    expect(run?.source).toEqual(source)
+
+    const events = await pario.events.read({ types: ["workflow.run.queued"] })
+    expect(events[0]?.payload).toMatchObject({ source })
+  })
+
+  test("retried webhook delivery with a deterministic runId enqueues a single run", async () => {
+    const pario = createPario()
+    const source = {
+      type: "webhook" as const,
+      connectorId: "companycam",
+      webhookId: "photo-created",
+      deliveryId: "delivery-1",
+    }
+    const options = { runId: "run_companycam_photo-1", input: validInput(), source }
+
+    const first = await pario.workflows.request(draftInvoice, options)
+    const second = await pario.workflows.request(draftInvoice, options)
+
+    expect(first.created).toBe(true)
+    expect(second.created).toBe(false)
+    expect(await claimAll(pario)).toHaveLength(1)
+  })
+
+  test("throws a clear error when workflow run storage is not configured", async () => {
+    const pario = createPario()
+    const runtime: ParioRuntimeContext = {
+      projectId: pario.id,
+      ontology: pario.ontology,
+      actionRegistry: pario.actionRegistry,
+      events: pario.events,
+      storage: { ...pario.storage, workflowRuns: undefined } as Storage,
+      lakeStorage: pario.lakeStorage,
+      blobStorage: pario.blobStorage,
+      queues: pario.queues,
+    }
+
+    await expect(
+      requestWorkflowRun(runtime, draftInvoice, { input: validInput() })
+    ).rejects.toThrow("[Pario] Workflow run storage is not configured.")
+  })
+
+  test("throws a clear error when the workflow queue is not configured", async () => {
+    const pario = createPario()
+    const runtime: ParioRuntimeContext = {
+      projectId: pario.id,
+      ontology: pario.ontology,
+      actionRegistry: pario.actionRegistry,
+      events: pario.events,
+      storage: pario.storage,
+      lakeStorage: pario.lakeStorage,
+      blobStorage: pario.blobStorage,
+      queues: { ...pario.queues, workflows: undefined } as unknown as Queues,
+    }
+
+    await expect(
+      requestWorkflowRun(runtime, draftInvoice, { input: validInput() })
+    ).rejects.toThrow("[Pario] Workflow run queue is not configured.")
+  })
+})

--- a/packages/core/tests/workflows.test.ts
+++ b/packages/core/tests/workflows.test.ts
@@ -297,9 +297,9 @@ describe("Pario workflow registration", () => {
       ...createTestRuntimeDeps(),
     })
 
-    expect(pario.getWorkflowDefinitions()).toEqual([workflow])
-    expect(pario.getWorkflowById("reconcile-transaction")).toBe(workflow)
-    expect(pario.getWorkflowById("missing-workflow")).toBeNull()
+    expect(pario.workflows.list()).toEqual([workflow])
+    expect(pario.workflows.getById("reconcile-transaction")).toBe(workflow)
+    expect(pario.workflows.getById("missing-workflow")).toBeNull()
   })
 
   test("rejects duplicate workflow ids", () => {

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto"
 import type {
   OntologySource,
   Pario,
@@ -6,7 +5,6 @@ import type {
   WorkflowNodeRunRecord,
   WorkflowRunRecord,
 } from "@pario/core"
-import { snapshotWorkflowInput } from "@pario/core"
 import type { Elysia } from "elysia"
 import { PARIO_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import { ErrorResponseSchema } from "../schemas/common"
@@ -111,7 +109,7 @@ export function registerWorkflowRoutes(app: Elysia, pario: Pario<readonly Ontolo
       "/api/workflows",
       async () => {
         return await Promise.all(
-          pario.getWorkflowDefinitions().map((workflow) => serializeWorkflow(pario, workflow))
+          pario.workflows.list().map((workflow) => serializeWorkflow(pario, workflow))
         )
       },
       {
@@ -126,7 +124,7 @@ export function registerWorkflowRoutes(app: Elysia, pario: Pario<readonly Ontolo
     .get(
       "/api/workflows/:workflowId",
       async ({ params, set }) => {
-        const workflow = pario.getWorkflowById(params.workflowId)
+        const workflow = pario.workflows.getById(params.workflowId)
         if (!workflow) {
           set.status = 404
           return { error: "Workflow not found" }
@@ -232,83 +230,30 @@ export function registerWorkflowRoutes(app: Elysia, pario: Pario<readonly Ontolo
       "/api/workflows/:workflowId/runs",
       async ({ params, body, set }) => {
         try {
-          const workflow = pario.getWorkflowById(params.workflowId)
+          const workflow = pario.workflows.getById(params.workflowId)
           if (!workflow) {
             set.status = 404
             return { error: "Workflow not found" }
           }
 
-          const storage = pario.storage.workflowRuns
-          if (!storage) {
+          if (!pario.storage.workflowRuns) {
             set.status = 400
             return { error: "Workflow run storage is not configured" }
           }
 
           const parsedBody = RequestWorkflowRunBodySchema.parse(body)
-          const input = parsedBody.input ?? {}
-          const snapshot = snapshotWorkflowInput({
-            workflow,
-            value: input,
-            valueTypesById: pario.ontology.getValueTypesById(),
-          })
-          const runId = `run_${randomUUID()}`
-          const queuedAt = new Date()
-
-          await storage.queue({
-            projectId: pario.id,
-            id: runId,
+          const result = await pario.workflows.requestById({
             workflowId: workflow.id,
-            input: snapshot,
-            queuedAt,
+            input: parsedBody.input ?? {},
+            source: { type: "manual" },
           })
-
-          let jobId = ""
-          try {
-            const [job] = await pario.queues.workflows.enqueue({
-              projectId: pario.id,
-              jobs: [
-                {
-                  type: "workflow.run.requested",
-                  payload: { workflowId: workflow.id, runId, input },
-                },
-              ],
-            })
-            jobId = job?.id ?? ""
-          } catch (error) {
-            await storage.finish({
-              projectId: pario.id,
-              id: runId,
-              status: "failed",
-              error: error instanceof Error ? error.message : String(error),
-            })
-            throw error
-          }
-
-          await pario.events
-            .append({
-              events: [
-                {
-                  type: "workflow.run.queued",
-                  payload: {
-                    workflowId: workflow.id,
-                    runId,
-                    queuedAt: queuedAt.toISOString(),
-                    ...(jobId ? { jobId } : {}),
-                    source: { type: "manual" },
-                  },
-                },
-              ],
-            })
-            .catch((error: unknown) => {
-              console.error("[ParioServer] Failed to emit workflow.run.queued:", error)
-            })
 
           set.status = 202
           return RequestWorkflowRunResponseSchema.parse({
-            runId,
-            jobId,
-            workflowId: workflow.id,
-            queuedAt: queuedAt.toISOString(),
+            runId: result.runId,
+            jobId: result.jobId ?? "",
+            workflowId: result.workflowId,
+            queuedAt: result.queuedAt,
           })
         } catch (error) {
           return handleRouteError(error, set)

--- a/packages/workflow-worker/src/types.ts
+++ b/packages/workflow-worker/src/types.ts
@@ -7,6 +7,7 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
   WorkflowStepOutputs,
+  WorkflowsRuntime,
 } from "@pario/core"
 
 export interface WorkflowWorkerContext extends ParioRuntimeContext {
@@ -17,8 +18,7 @@ export interface WorkflowWorkerContext extends ParioRuntimeContext {
 
 export interface WorkflowWorkerPario extends ParioRuntimeContext {
   readonly id: string
-  getWorkflowDefinitions(): readonly WorkflowDefinition[]
-  getWorkflowById(workflowId: string): WorkflowDefinition | null
+  readonly workflows: WorkflowsRuntime
 }
 
 export interface WorkflowJob {

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -19,7 +19,7 @@ export class WorkflowWorker extends QueueWorker<WorkflowRunRequestedQueueJob> {
   private readonly observer: WorkflowRunObserver
 
   constructor(pario: WorkflowWorkerPario) {
-    if (pario.getWorkflowDefinitions().length === 0) {
+    if (pario.workflows.list().length === 0) {
       throw new Error("[ParioWorkflowWorker] No workflow definitions are registered.")
     }
 
@@ -95,7 +95,7 @@ function buildWorkflowContext(
     workflowRuns,
     pario: pario as unknown as WorkflowWorkerContext["pario"],
     getWorkflowById(workflowId) {
-      return pario.getWorkflowById(workflowId)
+      return pario.workflows.getById(workflowId)
     },
   }
 }

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -138,7 +138,7 @@ function createRuntime(pario: {
   readonly blobStorage: WorkflowWorkerContext["blobStorage"]
   readonly queues: WorkflowWorkerContext["queues"]
   readonly rules?: WorkflowWorkerContext["rules"]
-  getWorkflowById: WorkflowWorkerContext["getWorkflowById"]
+  readonly workflows: { getById(workflowId: string): WorkflowDefinition | null }
 }) {
   return {
     projectId: pario.projectId,
@@ -153,7 +153,7 @@ function createRuntime(pario: {
     workflowRuns: requireWorkflowRunsStorage(pario),
     pario: pario as unknown as Pario<readonly OntologySource[]>,
     getWorkflowById(workflowId: string) {
-      return pario.getWorkflowById(workflowId)
+      return pario.workflows.getById(workflowId)
     },
   } satisfies WorkflowWorkerContext
 }

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -134,8 +134,7 @@ describe("WorkflowWorker", () => {
       lakeStorage: pario.lakeStorage,
       blobStorage: pario.blobStorage,
       queues: pario.queues,
-      getWorkflowDefinitions: () => pario.getWorkflowDefinitions(),
-      getWorkflowById: (workflowId: string) => pario.getWorkflowById(workflowId),
+      workflows: pario.workflows,
     }
 
     expect(() => new WorkflowWorker(withoutWorkflowRuns)).toThrow("storage.workflowRuns")

--- a/storage/pg/src/migrations/001-initial-schema.sql
+++ b/storage/pg/src/migrations/001-initial-schema.sql
@@ -175,6 +175,7 @@ CREATE TABLE IF NOT EXISTS workflow_runs (
   started_at TIMESTAMPTZ NOT NULL,
   finished_at TIMESTAMPTZ,
   error TEXT,
+  source JSONB,
   PRIMARY KEY (project_id, id)
 );
 

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -12,6 +12,7 @@ import type {
   WorkflowNodeRunRecord,
   WorkflowNodeRunStorage,
   WorkflowRunRecord,
+  WorkflowRunSource,
   WorkflowRunStorage,
 } from "@pario/core"
 import { WorkflowRunError } from "@pario/core"
@@ -38,7 +39,8 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           status,
           input,
           queued_at,
-          started_at
+          started_at,
+          source
         ) VALUES (
           ${input.projectId},
           ${input.id},
@@ -46,7 +48,8 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           ${"queued"},
           ${serializeRecord(input.input)}::text::jsonb,
           ${queuedAt},
-          ${queuedAt}
+          ${queuedAt},
+          ${input.source ? JSON.stringify(input.source) : null}::text::jsonb
         )
         RETURNING *
       `) as WorkflowRunDatabaseRow[]
@@ -436,7 +439,16 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     error: row.error ?? undefined,
+    source: parseSource(row.source),
   }
+}
+
+function parseSource(value: WorkflowRunSource | string | null): WorkflowRunSource | undefined {
+  if (value === null || value === undefined) {
+    return undefined
+  }
+
+  return typeof value === "string" ? (JSON.parse(value) as WorkflowRunSource) : value
 }
 
 function rowToWorkflowNodeRunRecord(row: WorkflowNodeRunDatabaseRow): WorkflowNodeRunRecord {
@@ -483,6 +495,7 @@ interface WorkflowRunDatabaseRow {
   started_at: Date | string
   finished_at: Date | string | null
   error: string | null
+  source: WorkflowRunSource | string | null
 }
 
 interface WorkflowNodeRunDatabaseRow {

--- a/storage/sqlite/src/migrations/001-initial-schema.sql
+++ b/storage/sqlite/src/migrations/001-initial-schema.sql
@@ -173,6 +173,7 @@ CREATE TABLE IF NOT EXISTS workflow_runs (
   started_at TEXT NOT NULL,
   finished_at TEXT,
   error TEXT,
+  source TEXT,
   PRIMARY KEY (project_id, id)
 );
 

--- a/storage/sqlite/src/workflow-run-storage.ts
+++ b/storage/sqlite/src/workflow-run-storage.ts
@@ -15,6 +15,7 @@ import type {
   WorkflowNodeRunRecord,
   WorkflowNodeRunStorage,
   WorkflowRunRecord,
+  WorkflowRunSource,
   WorkflowRunStorage,
 } from "@pario/core"
 import { WorkflowRunError } from "@pario/core"
@@ -63,8 +64,9 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
             status,
             input,
             queued_at,
-            started_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            started_at,
+            source
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         `
         )
         .run(
@@ -74,7 +76,8 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
           "queued",
           serializeRecord(input.input),
           queuedAt.toISOString(),
-          queuedAt.toISOString()
+          queuedAt.toISOString(),
+          input.source ? JSON.stringify(input.source) : null
         )
     } catch (error) {
       if (isUniqueConstraintError(error)) {
@@ -496,6 +499,7 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     error: row.error ?? undefined,
+    source: row.source ? (JSON.parse(row.source) as WorkflowRunSource) : undefined,
   }
 }
 
@@ -543,6 +547,7 @@ interface WorkflowRunDatabaseRow {
   started_at: string
   finished_at: string | null
   error: string | null
+  source: string | null
 }
 
 interface WorkflowNodeRunDatabaseRow {


### PR DESCRIPTION
## What

Adds a first-class `pario.workflows` runtime for starting workflow runs from application code — webhook handlers, syncs, functions, and server routes — without copying server-route internals.

```ts
await pario.workflows.request(draftInvoiceProposal, {
  input: { evidence: { objectTypeId: "WorkEvidence", primaryId } },
  source: { type: "webhook", connectorId: "companycam", webhookId: "photo-created", deliveryId },
})
```

It centralizes input validation, snapshotting, queued-run creation, deterministic `runId` dedupe, and `workflow.run.queued` emission in one place.

## Why

The `POST /api/workflows/:id/runs` route already knew how to validate input, create a queued run, enqueue the job, and emit the event — but that logic lived only in the route. A webhook handler that wanted to start a workflow had to duplicate it and keep storage, queue, and events consistent by hand. This exposes the same behavior as a runtime API, so the route becomes a thin wrapper and other callers reuse it.

The motivating case: CompanyCam/PandaDoc webhooks need to kick off a workflow when a delivery arrives.

## Public API

`pario.workflows` owns both lookups and run requests:

```ts
pario.workflows.list()                      // registered workflow definitions
pario.workflows.getById(id)                 // lookup by id
pario.workflows.request(workflow, options)  // typed input via InferWorkflowInput
pario.workflows.requestById({ workflowId, input, runId?, source? })
```

Result:

```ts
interface WorkflowRunRequestResult {
  workflowId: string
  runId: string
  queuedAt: string
  jobId?: string
  created: boolean   // false when a deterministic runId already existed
}
```

## Triggering from a webhook

A webhook handler can start a workflow directly off `ctx.pario`, and a deterministic `runId` makes retried deliveries idempotent — the second call returns the existing run with `created: false` and enqueues nothing:

```ts
.handle(async (ctx) => {
  const evidence = await upsertCompanyCamEvidence(ctx.pario, { photo, fileRef })

  await ctx.pario.workflows.request(draftInvoiceProposal, {
    runId: `run_companycam_${ctx.body.photoId}`,
    input: { evidence: { objectTypeId: "WorkEvidence", primaryId: evidence.primaryId } },
    source: {
      type: "webhook",
      connectorId: ctx.connector.id,
      webhookId: ctx.webhook.id,
      deliveryId: ctx.request.headers.get("x-companycam-delivery-id") ?? undefined,
    },
  })
})
```

## Notable details

- **Server route is now a thin wrapper** over `pario.workflows.requestById({ ..., source: { type: "manual" } })`; response shape and error statuses are unchanged.
- **Run `source` is persisted** on the queued run (in-memory, SQLite, PG) and emitted with `workflow.run.queued`. Kept intentionally minimal — `manual | webhook` — more variants can be added when the triggers that produce them land.
- **Namespaced lookups:** removed the flat `pario.getWorkflowById` / `pario.getWorkflowDefinitions` in favor of `pario.workflows.list()` / `getById()`, matching `pario.security` / `pario.auth`. `WorkflowsRuntime` owns the registered definitions directly.
- Deterministic `runId` reused for a *different* workflow throws a clear `[Pario]` error.

## Out of scope

Human-in-the-loop suspension, intervention APIs, declarative webhook→workflow triggers, external-event wait nodes, and built-in CompanyCam/PandaDoc connector packages.

## Checks

`bun run typecheck`, `bun run check`, `bun run build`, `bun run generate:client` (no drift), and `bun run test` all pass. New core tests cover request parity, runtime input validation, pre-write rejection, missing storage/queue, deterministic-runId dedupe (same + different workflow), source persistence/emission, and retried-webhook idempotency.