### PR TITLE
workflow-worker: pause and resume interventions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -635,7 +635,9 @@ export type {
   QueueJobError,
   Queues,
   SyncRunRequestedQueueJob,
+  WorkflowQueueJob,
   WorkflowRunRequestedQueueJob,
+  WorkflowRunResumeRequestedQueueJob,
 } from "./queues"
 export { InMemoryQueues, QueueError } from "./queues"
 

--- a/packages/core/src/queues/in-memory.ts
+++ b/packages/core/src/queues/in-memory.ts
@@ -10,7 +10,7 @@ import type {
   QueueJobError,
   Queues,
   SyncRunRequestedQueueJob,
-  WorkflowRunRequestedQueueJob,
+  WorkflowQueueJob,
 } from "./types"
 
 type QueueRecordState = "queued" | "completed" | "failed"
@@ -345,5 +345,5 @@ export class InMemoryQueues implements Queues {
     this.store,
     "projection.runs"
   )
-  readonly workflows = new InMemoryQueue<WorkflowRunRequestedQueueJob>(this.store, "workflow.runs")
+  readonly workflows = new InMemoryQueue<WorkflowQueueJob>(this.store, "workflow.runs")
 }

--- a/packages/core/src/queues/index.ts
+++ b/packages/core/src/queues/index.ts
@@ -11,5 +11,7 @@ export type {
   QueueJobError,
   Queues,
   SyncRunRequestedQueueJob,
+  WorkflowQueueJob,
   WorkflowRunRequestedQueueJob,
+  WorkflowRunResumeRequestedQueueJob,
 } from "./types"

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -138,9 +138,21 @@ export interface WorkflowRunRequestedQueueJob
     }
   > {}
 
+export interface WorkflowRunResumeRequestedQueueJob
+  extends QueueJob<
+    "workflow.run.resume.requested",
+    {
+      readonly workflowId: string
+      readonly runId: string
+      readonly pendingInterventionId: string
+    }
+  > {}
+
+export type WorkflowQueueJob = WorkflowRunRequestedQueueJob | WorkflowRunResumeRequestedQueueJob
+
 export interface Queues {
   readonly syncRuns: Queue<SyncRunRequestedQueueJob>
   readonly pipelines: Queue<PipelineRunRequestedQueueJob>
   readonly projections: Queue<ProjectionRunRequestedQueueJob>
-  readonly workflows: Queue<WorkflowRunRequestedQueueJob>
+  readonly workflows: Queue<WorkflowQueueJob>
 }

--- a/packages/workflow-worker/src/execution/node-executor.ts
+++ b/packages/workflow-worker/src/execution/node-executor.ts
@@ -35,11 +35,16 @@ export interface WorkflowNodeStatePatch {
   readonly steps?: WorkflowStepOutputs
 }
 
-export interface WorkflowNodeOutcome {
-  readonly outputSnapshot?: WorkflowIOSnapshot
-  readonly statePatch?: WorkflowNodeStatePatch
-  readonly waitForIntervention?: WorkflowInterventionRecord
-}
+export type WorkflowNodeOutcome =
+  | {
+      readonly status?: "succeeded"
+      readonly outputSnapshot?: WorkflowIOSnapshot
+      readonly statePatch?: WorkflowNodeStatePatch
+    }
+  | {
+      readonly status: "waiting"
+      readonly intervention: WorkflowInterventionRecord
+    }
 
 export interface WorkflowNodePrepareInput<TNode extends WorkflowNodeDefinition> {
   readonly node: TNode

--- a/packages/workflow-worker/src/execution/workflow-node-runner.ts
+++ b/packages/workflow-worker/src/execution/workflow-node-runner.ts
@@ -1,4 +1,4 @@
-import type { WorkflowNodeDefinition } from "@pario/core"
+import type { WorkflowNodeDefinition, WorkflowRunRecord } from "@pario/core"
 import { WorkflowWorkerError } from "../errors"
 import { throwIfAborted } from "../normalize"
 import type { WorkflowRunRecorder } from "../recorder"
@@ -45,22 +45,25 @@ export class WorkflowNodeRunner {
       context: input.context,
     })
 
-    if (outcome.waitForIntervention) {
-      if (outcome.waitForIntervention.nodeRunId !== nodeRun.id) {
+    if (outcome.status === "waiting") {
+      if (outcome.intervention.nodeRunId !== nodeRun.id) {
         throw new WorkflowWorkerError(
           `[ParioWorkflowWorker] Workflow '${input.context.workflow.id}' intervention node '${input.node.id}' returned an intervention for a different node run.`
         )
       }
 
-      await this.dependencies.recorder.recordInterventionRequested(outcome.waitForIntervention)
+      await this.dependencies.recorder.recordInterventionRequested(outcome.intervention)
       await this.dependencies.recorder.waitActiveNode({
         nodeRunId: nodeRun.id,
-        waitingAt: outcome.waitForIntervention.requestedAt,
+        waitingAt: outcome.intervention.requestedAt,
+      })
+      const run = await this.dependencies.recorder.waitRun({
+        waitingAt: outcome.intervention.requestedAt,
       })
 
       return {
         status: "waiting",
-        waitingAt: outcome.waitForIntervention.requestedAt,
+        run,
       }
     }
 
@@ -70,7 +73,10 @@ export class WorkflowNodeRunner {
     })
 
     applyStatePatch(input.context.state, outcome.statePatch)
-    return { status: "completed" }
+
+    return {
+      status: "succeeded",
+    }
   }
 
   private executorFor<TNode extends WorkflowNodeDefinition>(
@@ -80,9 +86,9 @@ export class WorkflowNodeRunner {
   }
 }
 
-type WorkflowNodeRunResult =
-  | { readonly status: "completed" }
-  | { readonly status: "waiting"; readonly waitingAt: Date }
+export type WorkflowNodeRunResult =
+  | { readonly status: "succeeded" }
+  | { readonly status: "waiting"; readonly run: WorkflowRunRecord }
 
 function applyStatePatch(
   state: WorkflowNodeExecutionContext["state"],

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -124,11 +124,6 @@ export class WorkflowRunSession {
       projectId: runtime.projectId,
       id: job.id,
     })
-    const nodeRuns = await runtime.workflowRuns.nodes.list({
-      projectId: runtime.projectId,
-      workflowRunId: job.id,
-      order: "asc",
-    })
     const waitingNode = await requireWorkflowNodeRun({
       workflowRuns: runtime.workflowRuns,
       projectId: runtime.projectId,
@@ -136,6 +131,12 @@ export class WorkflowRunSession {
     })
 
     assertResumeMatchesRun({ workflow, job, run, intervention, waitingNode })
+
+    const nodeRuns = await runtime.workflowRuns.nodes.list({
+      projectId: runtime.projectId,
+      workflowRunId: job.id,
+      order: "asc",
+    })
 
     if (run.status === "succeeded" && waitingNode.status === "succeeded") {
       return {
@@ -173,6 +174,19 @@ export class WorkflowRunSession {
     }
 
     const interventionNode = requireInterventionNode(workflow, intervention)
+    const response = validateWorkflowInterventionResponse({
+      workflowId: workflow.id,
+      intervention: interventionNode.intervention,
+      value: intervention.response,
+      valueTypesById,
+    })
+    const responseSnapshot = snapshotWorkflowInterventionResponse({
+      workflowId: workflow.id,
+      intervention: interventionNode.intervention,
+      value: response,
+      valueTypesById,
+    })
+    const responseOutput: Record<string, unknown> = { ...response }
     const state = reconstructWorkflowState({
       workflow,
       run,
@@ -212,24 +226,17 @@ export class WorkflowRunSession {
     })
 
     session.markSideEffectBoundaryPassed()
-    const response = validateWorkflowInterventionResponse({
-      workflowId: workflow.id,
-      intervention: interventionNode.intervention,
-      value: intervention.response,
-      valueTypesById,
-    })
-    const responseSnapshot = snapshotWorkflowInterventionResponse({
-      workflowId: workflow.id,
-      intervention: interventionNode.intervention,
-      value: response,
-      valueTypesById,
-    })
-    const responseOutput: Record<string, unknown> = { ...response }
 
-    await recorder.finishNodeSucceeded({
-      nodeRunId: waitingNode.id,
-      output: responseSnapshot,
-    })
+    try {
+      await recorder.finishNodeSucceeded({
+        nodeRunId: waitingNode.id,
+        output: responseSnapshot,
+      })
+    } catch (error) {
+      await session.finishAfterError(error)
+      throw error
+    }
+
     state.current = responseOutput
     state.steps[interventionNode.key] = responseOutput
     session.resumeFromIndex = intervention.nodeIndex + 1

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -1,14 +1,31 @@
 import type {
   ValueType,
   WorkflowDefinition,
+  WorkflowInterventionNodeDefinition,
+  WorkflowInterventionRecord,
+  WorkflowInterventionStorage,
   WorkflowIOSnapshot,
+  WorkflowNodeDefinition,
+  WorkflowNodeRunRecord,
   WorkflowRunRecord,
+  WorkflowRunStorage,
 } from "@pario/core"
-import { snapshotWorkflowInput, validateWorkflowInput } from "@pario/core"
+import {
+  snapshotWorkflowInput,
+  snapshotWorkflowInterventionResponse,
+  validateWorkflowInput,
+  validateWorkflowInterventionResponse,
+  validateWorkflowStepOutput,
+} from "@pario/core"
 import { WorkflowWorkerError } from "../errors"
 import { statusForFailure, throwIfAborted, toWorkflowRunError } from "../normalize"
 import { noopWorkflowRunObserver, WorkflowRunRecorder } from "../recorder"
-import type { RunWorkflowJobInput, WorkflowJob, WorkflowRunResult } from "../types"
+import type {
+  RunWorkflowJobInput,
+  RunWorkflowResumeJobInput,
+  WorkflowJob,
+  WorkflowRunResult,
+} from "../types"
 import type { WorkflowExecutionState, WorkflowNodeExecutorRegistry } from "./node-executor"
 import { WorkflowNodeRunner } from "./workflow-node-runner"
 
@@ -79,6 +96,149 @@ export class WorkflowRunSession {
     })
   }
 
+  static async createForResume(
+    input: RunWorkflowResumeJobInput,
+    options: { readonly executors: WorkflowNodeExecutorRegistry }
+  ): Promise<WorkflowRunSession | WorkflowRunResult> {
+    const { runtime, job } = input
+    const signal = input.signal ?? new AbortController().signal
+    const workflow = requireWorkflow(runtime.getWorkflowById(job.workflowId), job)
+    const valueTypesById = runtime.ontology.getValueTypesById()
+    const workflowInterventions = runtime.storage.workflowInterventions
+
+    if (!workflowInterventions) {
+      throw new WorkflowWorkerError(
+        `[ParioWorkflowWorker] Workflow '${job.workflowId}' resume requires storage.workflowInterventions.`
+      )
+    }
+
+    throwIfAborted(signal)
+
+    const intervention = await requireInterventionRecord({
+      storage: workflowInterventions,
+      projectId: runtime.projectId,
+      id: job.pendingInterventionId,
+    })
+    const run = await requireWorkflowRun({
+      workflowRuns: runtime.workflowRuns,
+      projectId: runtime.projectId,
+      id: job.id,
+    })
+    const nodeRuns = await runtime.workflowRuns.nodes.list({
+      projectId: runtime.projectId,
+      workflowRunId: job.id,
+      order: "asc",
+    })
+    const waitingNode = await requireWorkflowNodeRun({
+      workflowRuns: runtime.workflowRuns,
+      projectId: runtime.projectId,
+      id: intervention.nodeRunId,
+    })
+
+    assertResumeMatchesRun({ workflow, job, run, intervention, waitingNode })
+
+    if (run.status === "succeeded" && waitingNode.status === "succeeded") {
+      return {
+        id: job.id,
+        workflowId: workflow.id,
+        status: "succeeded",
+        run,
+        nodes: nodeRuns.nodes,
+        steps: reconstructWorkflowState({
+          workflow,
+          run,
+          nodeRuns: nodeRuns.nodes,
+          upToNodeIndex: workflow.nodes.length,
+          valueTypesById,
+        }).steps,
+      }
+    }
+
+    if (run.status !== "waiting") {
+      throw new WorkflowWorkerError(
+        `[ParioWorkflowWorker] Workflow run '${job.id}' must be waiting to resume.`
+      )
+    }
+
+    if (waitingNode.status !== "waiting") {
+      throw new WorkflowWorkerError(
+        `[ParioWorkflowWorker] Workflow node run '${waitingNode.id}' must be waiting to resume.`
+      )
+    }
+
+    if (intervention.status !== "submitted" || !intervention.response) {
+      throw new WorkflowWorkerError(
+        `[ParioWorkflowWorker] Workflow intervention '${intervention.id}' must be submitted to resume.`
+      )
+    }
+
+    const interventionNode = requireInterventionNode(workflow, intervention)
+    const state = reconstructWorkflowState({
+      workflow,
+      run,
+      nodeRuns: nodeRuns.nodes,
+      upToNodeIndex: intervention.nodeIndex,
+      valueTypesById,
+    })
+    const recorder = new WorkflowRunRecorder({
+      projectId: runtime.projectId,
+      workflow,
+      runId: job.id,
+      workflowRuns: runtime.workflowRuns,
+      observer: input.observer ?? noopWorkflowRunObserver,
+      initialCompletedNodes: nodeRuns.nodes.filter(
+        (nodeRun) => nodeRun.nodeIndex < intervention.nodeIndex && nodeRun.status === "succeeded"
+      ),
+      alreadyStarted: true,
+    })
+    const session = new WorkflowRunSession({
+      runtime,
+      job,
+      workflow,
+      signal,
+      valueTypesById,
+      workflowInputSnapshot: run.input,
+      state,
+      recorder,
+      runner: new WorkflowNodeRunner({
+        recorder,
+        executors: options.executors,
+      }),
+    })
+
+    await runtime.workflowRuns.resume({
+      projectId: runtime.projectId,
+      id: job.id,
+    })
+
+    session.markSideEffectBoundaryPassed()
+    const response = validateWorkflowInterventionResponse({
+      workflowId: workflow.id,
+      intervention: interventionNode.intervention,
+      value: intervention.response,
+      valueTypesById,
+    })
+    const responseSnapshot = snapshotWorkflowInterventionResponse({
+      workflowId: workflow.id,
+      intervention: interventionNode.intervention,
+      value: response,
+      valueTypesById,
+    })
+    const responseOutput: Record<string, unknown> = { ...response }
+
+    await recorder.finishNodeSucceeded({
+      nodeRunId: waitingNode.id,
+      output: responseSnapshot,
+    })
+    state.current = responseOutput
+    state.steps[interventionNode.key] = responseOutput
+    session.resumeFromIndex = intervention.nodeIndex + 1
+
+    return session
+  }
+
+  private resumeFromIndex = 0
+
   async start(): Promise<void> {
     await this.dependencies.recorder.startRun({
       input: this.dependencies.workflowInputSnapshot,
@@ -86,7 +246,20 @@ export class WorkflowRunSession {
   }
 
   async runAllNodes(): Promise<WorkflowRunRecord | null> {
-    for (const [nodeIndex, node] of this.dependencies.workflow.nodes.entries()) {
+    return this.runNodesFrom(this.resumeFromIndex)
+  }
+
+  async runNodesFrom(startIndex: number): Promise<WorkflowRunRecord | null> {
+    for (
+      let nodeIndex = startIndex;
+      nodeIndex < this.dependencies.workflow.nodes.length;
+      nodeIndex++
+    ) {
+      const node = this.dependencies.workflow.nodes[nodeIndex]
+      if (!node) {
+        continue
+      }
+
       throwIfAborted(this.dependencies.signal)
 
       const result = await this.dependencies.runner.runNode({
@@ -104,7 +277,7 @@ export class WorkflowRunSession {
       })
 
       if (result.status === "waiting") {
-        return await this.dependencies.recorder.waitRun({ waitingAt: result.waitingAt })
+        return result.run
       }
     }
 
@@ -124,7 +297,7 @@ export class WorkflowRunSession {
     }
   }
 
-  waitingResult(run: WorkflowRunRecord): WorkflowRunResult {
+  finishWaiting(run: WorkflowRunRecord): WorkflowRunResult {
     return {
       id: this.dependencies.job.id,
       workflowId: this.dependencies.workflow.id,
@@ -192,13 +365,199 @@ export class WorkflowRunSession {
 
 function requireWorkflow(
   workflow: WorkflowDefinition | null,
-  job: WorkflowJob
+  job: { readonly workflowId: string }
 ): WorkflowDefinition {
   if (!workflow) {
     throw new WorkflowWorkerError(`[ParioWorkflowWorker] Unknown workflow '${job.workflowId}'.`)
   }
 
   return workflow
+}
+
+async function requireInterventionRecord(input: {
+  readonly storage: WorkflowInterventionStorage
+  readonly projectId: string
+  readonly id: string
+}): Promise<WorkflowInterventionRecord> {
+  const intervention = await input.storage.getById({
+    projectId: input.projectId,
+    id: input.id,
+  })
+
+  if (!intervention) {
+    throw new WorkflowWorkerError(
+      `[ParioWorkflowWorker] Workflow intervention '${input.id}' not found.`
+    )
+  }
+
+  return intervention
+}
+
+async function requireWorkflowRun(input: {
+  readonly workflowRuns: WorkflowRunStorage
+  readonly projectId: string
+  readonly id: string
+}): Promise<WorkflowRunRecord> {
+  const run = await input.workflowRuns.getById({
+    projectId: input.projectId,
+    id: input.id,
+  })
+
+  if (!run) {
+    throw new WorkflowWorkerError(`[ParioWorkflowWorker] Workflow run '${input.id}' not found.`)
+  }
+
+  return run
+}
+
+async function requireWorkflowNodeRun(input: {
+  readonly workflowRuns: WorkflowRunStorage
+  readonly projectId: string
+  readonly id: string
+}): Promise<WorkflowNodeRunRecord> {
+  const node = await input.workflowRuns.nodes.getById({
+    projectId: input.projectId,
+    id: input.id,
+  })
+
+  if (!node) {
+    throw new WorkflowWorkerError(
+      `[ParioWorkflowWorker] Workflow node run '${input.id}' not found.`
+    )
+  }
+
+  return node
+}
+
+function assertResumeMatchesRun(input: {
+  readonly workflow: WorkflowDefinition
+  readonly job: { readonly id: string; readonly workflowId: string }
+  readonly run: WorkflowRunRecord
+  readonly intervention: WorkflowInterventionRecord
+  readonly waitingNode: WorkflowNodeRunRecord
+}): void {
+  if (input.run.workflowId !== input.workflow.id || input.job.workflowId !== input.workflow.id) {
+    throw new WorkflowWorkerError(
+      `[ParioWorkflowWorker] Workflow resume job for '${input.job.workflowId}' does not match run '${input.run.workflowId}'.`
+    )
+  }
+
+  if (
+    input.intervention.workflowId !== input.workflow.id ||
+    input.intervention.workflowRunId !== input.job.id
+  ) {
+    throw new WorkflowWorkerError(
+      `[ParioWorkflowWorker] Workflow intervention '${input.intervention.id}' does not match run '${input.job.id}'.`
+    )
+  }
+
+  if (
+    input.waitingNode.workflowId !== input.workflow.id ||
+    input.waitingNode.workflowRunId !== input.job.id ||
+    input.waitingNode.id !== input.intervention.nodeRunId
+  ) {
+    throw new WorkflowWorkerError(
+      `[ParioWorkflowWorker] Workflow node run '${input.waitingNode.id}' does not match intervention '${input.intervention.id}'.`
+    )
+  }
+}
+
+function requireInterventionNode(
+  workflow: WorkflowDefinition,
+  intervention: WorkflowInterventionRecord
+): WorkflowInterventionNodeDefinition {
+  const node = workflow.nodes[intervention.nodeIndex]
+
+  if (
+    !node ||
+    node.type !== "intervention" ||
+    node.id !== intervention.nodeId ||
+    node.key !== intervention.nodeKey
+  ) {
+    throw new WorkflowWorkerError(
+      `[ParioWorkflowWorker] Workflow '${workflow.id}' does not contain intervention node '${intervention.nodeId}' at index ${intervention.nodeIndex}.`
+    )
+  }
+
+  return node
+}
+
+function reconstructWorkflowState(input: {
+  readonly workflow: WorkflowDefinition
+  readonly run: WorkflowRunRecord
+  readonly nodeRuns: readonly WorkflowNodeRunRecord[]
+  readonly upToNodeIndex: number
+  readonly valueTypesById: ReadonlyMap<string, ValueType>
+}): WorkflowExecutionState {
+  const workflowInput = validateWorkflowInput({
+    workflow: input.workflow,
+    value: input.run.input,
+    valueTypesById: input.valueTypesById,
+  })
+  const state: WorkflowExecutionState = {
+    workflowInput,
+    current: workflowInput,
+    steps: {},
+  }
+  const nodeRunsByIndex = new Map(input.nodeRuns.map((nodeRun) => [nodeRun.nodeIndex, nodeRun]))
+
+  for (let nodeIndex = 0; nodeIndex < input.upToNodeIndex; nodeIndex++) {
+    const node = input.workflow.nodes[nodeIndex]
+    const nodeRun = nodeRunsByIndex.get(nodeIndex)
+    if (!node || !nodeRun) {
+      throw new WorkflowWorkerError(
+        `[ParioWorkflowWorker] Workflow run '${input.run.id}' is missing node run at index ${nodeIndex}.`
+      )
+    }
+
+    applyCompletedNodeToState({
+      workflowId: input.workflow.id,
+      node,
+      nodeRun,
+      state,
+      valueTypesById: input.valueTypesById,
+    })
+  }
+
+  return state
+}
+
+function applyCompletedNodeToState(input: {
+  readonly workflowId: string
+  readonly node: WorkflowNodeDefinition
+  readonly nodeRun: WorkflowNodeRunRecord
+  readonly state: WorkflowExecutionState
+  readonly valueTypesById: ReadonlyMap<string, ValueType>
+}): void {
+  if (input.nodeRun.status !== "succeeded") {
+    throw new WorkflowWorkerError(
+      `[ParioWorkflowWorker] Workflow node run '${input.nodeRun.id}' must be succeeded to reconstruct workflow state.`
+    )
+  }
+
+  if (input.node.type === "action") {
+    return
+  }
+
+  const output = input.nodeRun.output ?? {}
+  const validatedOutput =
+    input.node.type === "step"
+      ? validateWorkflowStepOutput({
+          workflowId: input.workflowId,
+          step: input.node.step,
+          value: output,
+          valueTypesById: input.valueTypesById,
+        })
+      : validateWorkflowInterventionResponse({
+          workflowId: input.workflowId,
+          intervention: input.node.intervention,
+          value: output,
+          valueTypesById: input.valueTypesById,
+        })
+  const stateOutput: Record<string, unknown> = { ...validatedOutput }
+
+  input.state.current = stateOutput
+  input.state.steps[input.node.key] = stateOutput
 }
 
 function createWorkflowBookkeepingError(input: {

--- a/packages/workflow-worker/src/index.ts
+++ b/packages/workflow-worker/src/index.ts
@@ -1,11 +1,13 @@
 export { WorkflowWorkerError } from "./errors"
 export { EventsRuntimeWorkflowRunObserver, emitWorkflowRunFinished } from "./events"
 export { noopWorkflowRunObserver, WorkflowRunRecorder } from "./recorder"
-export { runWorkflowJob } from "./run-workflow-job"
+export { runWorkflowJob, runWorkflowResumeJob } from "./run-workflow-job"
 export type {
   RunWorkflowJobInput,
+  RunWorkflowResumeJobInput,
   WorkflowJob,
   WorkflowNodeLifecycleContext,
+  WorkflowResumeJob,
   WorkflowRunObserver,
   WorkflowRunResult,
   WorkflowWorkerContext,

--- a/packages/workflow-worker/src/nodes/intervention-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/intervention-node-executor.ts
@@ -2,11 +2,11 @@ import type { WorkflowInterventionNodeDefinition } from "@pario/core"
 import {
   snapshotWorkflowInterventionDefaultResponse,
   snapshotWorkflowInterventionInput,
-  validateWorkflowInterventionDefaultResponse,
   validateWorkflowInterventionInput,
 } from "@pario/core"
 import { WorkflowWorkerError } from "../errors"
 import type { WorkflowNodeExecutor } from "../execution/node-executor"
+import { throwIfAborted } from "../normalize"
 import { callWorkflowMapper, requireRecordInput } from "./mapper"
 
 export const interventionNodeExecutor: WorkflowNodeExecutor<WorkflowInterventionNodeDefinition> = {
@@ -48,30 +48,20 @@ export const interventionNodeExecutor: WorkflowNodeExecutor<WorkflowIntervention
   },
 
   async execute({ node, nodeIndex, nodeRun, prepared, context }) {
-    const interventionStorage = context.runtime.storage.workflowInterventions
-    if (!interventionStorage) {
-      throw new WorkflowWorkerError(
-        "[ParioWorkflowWorker] Workflow intervention nodes require storage.workflowInterventions."
-      )
-    }
-
     const interventionInput = requireRecordInput({
       value: prepared.input,
       workflowId: context.workflow.id,
       nodeId: node.id,
     })
-    const rawDefaultResponse =
-      (await node.intervention.defaults?.({
-        input: interventionInput,
-        workflowInput: context.state.workflowInput,
-        steps: context.state.steps,
-      })) ?? {}
-    const defaultResponse = validateWorkflowInterventionDefaultResponse({
-      workflowId: context.workflow.id,
-      intervention: node.intervention,
-      value: rawDefaultResponse,
-      valueTypesById: context.valueTypesById,
-    })
+    const defaultResponse = node.intervention.defaults
+      ? await node.intervention.defaults({
+          input: interventionInput,
+          workflowInput: context.state.workflowInput,
+          steps: context.state.steps,
+        })
+      : {}
+    throwIfAborted(context.signal)
+
     const defaultResponseSnapshot = snapshotWorkflowInterventionDefaultResponse({
       workflowId: context.workflow.id,
       intervention: node.intervention,
@@ -79,9 +69,15 @@ export const interventionNodeExecutor: WorkflowNodeExecutor<WorkflowIntervention
       valueTypesById: context.valueTypesById,
     })
     const requestedAt = new Date()
+    const workflowInterventions = context.runtime.storage.workflowInterventions
+    if (!workflowInterventions) {
+      throw new WorkflowWorkerError(
+        `[ParioWorkflowWorker] Workflow '${context.workflow.id}' intervention node '${node.id}' requires storage.workflowInterventions.`
+      )
+    }
 
     context.markSideEffectBoundaryPassed()
-    const pendingIntervention = await interventionStorage.create({
+    const intervention = await workflowInterventions.create({
       id: `${context.job.id}:intervention:${nodeIndex}`,
       projectId: context.runtime.projectId,
       workflowId: context.workflow.id,
@@ -97,7 +93,8 @@ export const interventionNodeExecutor: WorkflowNodeExecutor<WorkflowIntervention
     })
 
     return {
-      waitForIntervention: pendingIntervention,
+      status: "waiting",
+      intervention,
     }
   },
 }

--- a/packages/workflow-worker/src/recorder.ts
+++ b/packages/workflow-worker/src/recorder.ts
@@ -19,9 +19,9 @@ export const noopWorkflowRunObserver: WorkflowRunObserver = {
 }
 
 export class WorkflowRunRecorder {
-  private readonly nodeRuns: WorkflowNodeRunRecord[] = []
+  private readonly nodeRuns: WorkflowNodeRunRecord[]
   private activeNodeRunId: string | null = null
-  private started = false
+  private started: boolean
   private finished = false
 
   constructor(
@@ -31,8 +31,13 @@ export class WorkflowRunRecorder {
       readonly runId: string
       readonly workflowRuns: WorkflowRunStorage
       readonly observer: WorkflowRunObserver
+      readonly initialCompletedNodes?: readonly WorkflowNodeRunRecord[]
+      readonly alreadyStarted?: boolean
     }
-  ) {}
+  ) {
+    this.nodeRuns = [...(dependencies.initialCompletedNodes ?? [])]
+    this.started = dependencies.alreadyStarted ?? false
+  }
 
   get hasStarted(): boolean {
     return this.started

--- a/packages/workflow-worker/src/run-workflow-job.ts
+++ b/packages/workflow-worker/src/run-workflow-job.ts
@@ -1,7 +1,7 @@
 import { workflowNodeExecutors } from "./execution/node-executors"
 import { WorkflowRunSession } from "./execution/workflow-run-session"
 import { statusForFailure, toWorkflowRunError } from "./normalize"
-import type { RunWorkflowJobInput, WorkflowRunResult } from "./types"
+import type { RunWorkflowJobInput, RunWorkflowResumeJobInput, WorkflowRunResult } from "./types"
 
 export async function runWorkflowJob(input: RunWorkflowJobInput): Promise<WorkflowRunResult> {
   let session: WorkflowRunSession
@@ -18,13 +18,35 @@ export async function runWorkflowJob(input: RunWorkflowJobInput): Promise<Workfl
     await session.start()
     const waitingRun = await session.runAllNodes()
     if (waitingRun) {
-      return session.waitingResult(waitingRun)
+      return session.finishWaiting(waitingRun)
     }
-
     return await session.finishSucceeded()
   } catch (error) {
     await session.finishAfterError(error)
     await failQueuedRun(input, error)
+    throw error
+  }
+}
+
+export async function runWorkflowResumeJob(
+  input: RunWorkflowResumeJobInput
+): Promise<WorkflowRunResult> {
+  const sessionOrResult = await WorkflowRunSession.createForResume(input, {
+    executors: workflowNodeExecutors,
+  })
+  if (!(sessionOrResult instanceof WorkflowRunSession)) {
+    return sessionOrResult
+  }
+
+  const session = sessionOrResult
+  try {
+    const waitingRun = await session.runAllNodes()
+    if (waitingRun) {
+      return session.finishWaiting(waitingRun)
+    }
+    return await session.finishSucceeded()
+  } catch (error) {
+    await session.finishAfterError(error)
     throw error
   }
 }

--- a/packages/workflow-worker/src/types.ts
+++ b/packages/workflow-worker/src/types.ts
@@ -28,9 +28,22 @@ export interface WorkflowJob {
   readonly input?: Readonly<Record<string, unknown>>
 }
 
+export interface WorkflowResumeJob {
+  readonly id: string
+  readonly workflowId: string
+  readonly pendingInterventionId: string
+}
+
 export interface RunWorkflowJobInput {
   readonly runtime: WorkflowWorkerContext
   readonly job: WorkflowJob
+  readonly signal?: AbortSignal
+  readonly observer?: WorkflowRunObserver
+}
+
+export interface RunWorkflowResumeJobInput {
+  readonly runtime: WorkflowWorkerContext
+  readonly job: WorkflowResumeJob
   readonly signal?: AbortSignal
   readonly observer?: WorkflowRunObserver
 }

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -1,20 +1,21 @@
 import type {
   ClaimedQueueJob,
   QueueWorkerFailureDecision,
-  WorkflowRunRequestedQueueJob,
+  WorkflowQueueJob,
   WorkflowRunStorage,
 } from "@pario/core"
 import { QueueWorker } from "@pario/core"
 import { EventsRuntimeWorkflowRunObserver } from "./events"
-import { runWorkflowJob } from "./run-workflow-job"
+import { runWorkflowJob, runWorkflowResumeJob } from "./run-workflow-job"
 import type {
   WorkflowJob,
+  WorkflowResumeJob,
   WorkflowRunObserver,
   WorkflowWorkerContext,
   WorkflowWorkerPario,
 } from "./types"
 
-export class WorkflowWorker extends QueueWorker<WorkflowRunRequestedQueueJob> {
+export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
   private readonly context: WorkflowWorkerContext
   private readonly observer: WorkflowRunObserver
 
@@ -28,6 +29,12 @@ export class WorkflowWorker extends QueueWorker<WorkflowRunRequestedQueueJob> {
       throw new Error("[ParioWorkflowWorker] Workflow workers require storage.workflowRuns.")
     }
 
+    if (requiresWorkflowInterventionStorage(pario) && !pario.storage.workflowInterventions) {
+      throw new Error(
+        "[ParioWorkflowWorker] Workflow workers with intervention nodes require storage.workflowInterventions."
+      )
+    }
+
     super({
       projectId: pario.projectId,
       queue: pario.queues.workflows,
@@ -39,9 +46,19 @@ export class WorkflowWorker extends QueueWorker<WorkflowRunRequestedQueueJob> {
   }
 
   protected async execute(
-    claimed: ClaimedQueueJob<WorkflowRunRequestedQueueJob>,
+    claimed: ClaimedQueueJob<WorkflowQueueJob>,
     signal: AbortSignal
   ): Promise<void> {
+    if (claimed.job.type === "workflow.run.resume.requested") {
+      await runWorkflowResumeJob({
+        runtime: this.context,
+        job: workflowResumeJobFromClaimed(claimed),
+        signal,
+        observer: this.observer,
+      })
+      return
+    }
+
     const workflowJob = workflowJobFromClaimed(claimed)
 
     await runWorkflowJob({
@@ -53,28 +70,51 @@ export class WorkflowWorker extends QueueWorker<WorkflowRunRequestedQueueJob> {
   }
 
   protected override async onExecutionError(
-    _claimed: ClaimedQueueJob<WorkflowRunRequestedQueueJob>,
+    _claimed: ClaimedQueueJob<WorkflowQueueJob>,
     _error: unknown
   ): Promise<QueueWorkerFailureDecision> {
     return { kind: "fail" }
   }
 
   protected override async onAbortError(
-    _claimed: ClaimedQueueJob<WorkflowRunRequestedQueueJob>,
+    _claimed: ClaimedQueueJob<WorkflowQueueJob>,
     _error: unknown
   ): Promise<QueueWorkerFailureDecision> {
     return { kind: "fail" }
   }
 }
 
-function workflowJobFromClaimed(
-  claimed: ClaimedQueueJob<WorkflowRunRequestedQueueJob>
-): WorkflowJob {
+function requiresWorkflowInterventionStorage(pario: WorkflowWorkerPario): boolean {
+  return pario.workflows
+    .list()
+    .some((workflow) => workflow.nodes.some((node) => node.type === "intervention"))
+}
+
+function workflowJobFromClaimed(claimed: ClaimedQueueJob<WorkflowQueueJob>): WorkflowJob {
   const { job } = claimed
+  if (job.type !== "workflow.run.requested") {
+    throw new Error(`[ParioWorkflowWorker] Unsupported workflow job type '${job.type}'.`)
+  }
+
   return {
     id: job.payload.runId ?? `${job.id}:attempt:${job.attempt}`,
     workflowId: job.payload.workflowId,
     input: job.payload.input,
+  }
+}
+
+function workflowResumeJobFromClaimed(
+  claimed: ClaimedQueueJob<WorkflowQueueJob>
+): WorkflowResumeJob {
+  const { job } = claimed
+  if (job.type !== "workflow.run.resume.requested") {
+    throw new Error(`[ParioWorkflowWorker] Unsupported workflow job type '${job.type}'.`)
+  }
+
+  return {
+    id: job.payload.runId,
+    workflowId: job.payload.workflowId,
+    pendingInterventionId: job.payload.pendingInterventionId,
   }
 }
 

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -578,6 +578,65 @@ describe("runWorkflowJob", () => {
     expect(afterDuplicate.nodes.map((node) => node.id)).toEqual(nodes.nodes.map((node) => node.id))
   })
 
+  test("keeps runs waiting when submitted intervention responses are invalid", async () => {
+    const workflow = defineWorkflow("intervention-invalid-response")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(reviewBeforeAttach)
+      .then(attachReviewedInvoice, ({ steps }) => ({
+        invoice: steps.reviewBeforeAttach.invoice,
+      }))
+    const pario = createPario({ workflows: [workflow] })
+    const runtime = createRuntime(pario)
+
+    await runWorkflowJob({
+      runtime,
+      job: {
+        id: "wfrun_invalid_resume_response",
+        workflowId: workflow.id,
+        input: {
+          transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+        },
+      },
+    })
+    await pario.storage.workflowInterventions!.submit({
+      projectId: pario.id,
+      id: "wfrun_invalid_resume_response:intervention:1",
+      response: {
+        invoice: { objectTypeId: "Transaction", primaryId: "txn_1" },
+      },
+    })
+
+    await expect(
+      runWorkflowResumeJob({
+        runtime,
+        job: {
+          id: "wfrun_invalid_resume_response",
+          workflowId: workflow.id,
+          pendingInterventionId: "wfrun_invalid_resume_response:intervention:1",
+        },
+      })
+    ).rejects.toBeInstanceOf(WorkflowValidationError)
+
+    const run = await pario.storage.workflowRuns!.getById({
+      projectId: pario.id,
+      id: "wfrun_invalid_resume_response",
+    })
+    const nodes = await pario.storage.workflowRuns!.nodes.list({
+      projectId: pario.id,
+      workflowRunId: "wfrun_invalid_resume_response",
+      order: "asc",
+    })
+
+    expect(run?.status).toBe("waiting")
+    expect(nodes.nodes.map((node) => `${node.nodeId}:${node.status}`)).toEqual([
+      "find-best-invoice:succeeded",
+      "review-before-attach:waiting",
+    ])
+  })
+
   test("validates workflow input before starting the run", async () => {
     const workflow = defineWorkflow("requires-transaction")
       .input({

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   EventsRuntimeWorkflowRunObserver,
   runWorkflowJob,
+  runWorkflowResumeJob,
   type WorkflowRunObserver,
   type WorkflowWorkerContext,
   WorkflowWorkerError,
@@ -79,6 +80,30 @@ const reviewInvoiceDecision = defineIntervention("review-invoice-decision")
   })
   .defaults(({ input }) => ({
     approved: input.confidence >= 0.95,
+  }))
+
+const reviewBeforeAttach = defineIntervention("review-before-attach")
+  .input({
+    transaction: ref(Transaction),
+    invoice: ref(Invoice),
+    confidence: "double",
+  })
+  .response({
+    invoice: ref(Invoice),
+  })
+  .defaults(({ input }) => ({
+    invoice: input.invoice,
+  }))
+
+const attachReviewedInvoice = defineWorkflowStep("attach-reviewed-invoice")
+  .input({
+    invoice: ref(Invoice),
+  })
+  .output({
+    invoice: ref(Invoice),
+  })
+  .run(({ input }) => ({
+    invoice: input.invoice,
   }))
 
 const failingStep = defineWorkflowStep("explode")
@@ -356,6 +381,201 @@ describe("runWorkflowJob", () => {
       objectTypeId: "Invoice",
       primaryId: "inv_1",
     })
+  })
+
+  test("suspends workflow runs at intervention nodes", async () => {
+    const workflow = defineWorkflow("intervention-suspends")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(reviewBeforeAttach)
+    const pario = createPario({ workflows: [workflow] })
+
+    const result = await runWorkflowJob({
+      runtime: createRuntime(pario),
+      job: {
+        id: "wfrun_intervention_waiting",
+        workflowId: workflow.id,
+        input: {
+          transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+        },
+      },
+      observer: new EventsRuntimeWorkflowRunObserver(pario.events),
+    })
+
+    const run = await pario.storage.workflowRuns!.getById({
+      projectId: pario.id,
+      id: "wfrun_intervention_waiting",
+    })
+    const nodes = await pario.storage.workflowRuns!.nodes.list({
+      projectId: pario.id,
+      workflowRunId: "wfrun_intervention_waiting",
+      order: "asc",
+    })
+    const interventions = await pario.storage.workflowInterventions!.list({
+      projectId: pario.id,
+    })
+    const events = await pario.events.read({
+      types: [
+        "workflow.run.started",
+        "workflow.run.node.started",
+        "workflow.run.node.finished",
+        "workflow.intervention.requested",
+        "workflow.run.node.waiting",
+        "workflow.run.waiting",
+        "workflow.run.finished",
+      ],
+    })
+
+    expect(result.status).toBe("waiting")
+    expect(run?.status).toBe("waiting")
+    expect(nodes.nodes.map((node) => `${node.nodeId}:${node.status}`)).toEqual([
+      "find-best-invoice:succeeded",
+      "review-before-attach:waiting",
+    ])
+    expect(interventions.total).toBe(1)
+    expect(interventions.interventions[0]).toMatchObject({
+      id: "wfrun_intervention_waiting:intervention:1",
+      workflowId: workflow.id,
+      workflowRunId: "wfrun_intervention_waiting",
+      nodeRunId: "wfrun_intervention_waiting:node:1",
+      nodeIndex: 1,
+      nodeId: "review-before-attach",
+      nodeKey: "reviewBeforeAttach",
+      interventionId: "review-before-attach",
+      status: "pending",
+      input: {
+        transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+        invoice: { objectTypeId: "Invoice", primaryId: "inv_1" },
+        confidence: 0.98,
+      },
+      defaultResponse: {
+        invoice: { objectTypeId: "Invoice", primaryId: "inv_1" },
+      },
+    })
+    expect(events.map((event) => event.type)).toEqual([
+      "workflow.run.started",
+      "workflow.run.node.started",
+      "workflow.run.node.finished",
+      "workflow.run.node.started",
+      "workflow.intervention.requested",
+      "workflow.run.node.waiting",
+      "workflow.run.waiting",
+    ])
+    expect(events[4]?.payload).toMatchObject({
+      workflowId: workflow.id,
+      runId: "wfrun_intervention_waiting",
+      nodeRunId: "wfrun_intervention_waiting:node:1",
+      interventionId: "review-before-attach",
+      pendingInterventionId: "wfrun_intervention_waiting:intervention:1",
+    })
+  })
+
+  test("resumes submitted interventions and continues workflow dataflow", async () => {
+    const workflow = defineWorkflow("intervention-resumes")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(reviewBeforeAttach)
+      .then(attachReviewedInvoice, ({ steps }) => ({
+        invoice: steps.reviewBeforeAttach.invoice,
+      }))
+    const pario = createPario({ workflows: [workflow] })
+    const runtime = createRuntime(pario)
+    const observer = new EventsRuntimeWorkflowRunObserver(pario.events)
+
+    const waiting = await runWorkflowJob({
+      runtime,
+      job: {
+        id: "wfrun_resume",
+        workflowId: workflow.id,
+        input: {
+          transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+        },
+      },
+      observer,
+    })
+
+    expect(waiting.status).toBe("waiting")
+    await pario.storage.workflowInterventions!.submit({
+      projectId: pario.id,
+      id: "wfrun_resume:intervention:1",
+      response: {
+        invoice: { objectTypeId: "Invoice", primaryId: "inv_reviewed" },
+      },
+      submittedAt: new Date("2026-05-08T12:00:00.000Z"),
+    })
+
+    const resumed = await runWorkflowResumeJob({
+      runtime,
+      job: {
+        id: "wfrun_resume",
+        workflowId: workflow.id,
+        pendingInterventionId: "wfrun_resume:intervention:1",
+      },
+      observer,
+    })
+
+    const run = await pario.storage.workflowRuns!.getById({
+      projectId: pario.id,
+      id: "wfrun_resume",
+    })
+    const nodes = await pario.storage.workflowRuns!.nodes.list({
+      projectId: pario.id,
+      workflowRunId: "wfrun_resume",
+      order: "asc",
+    })
+    const events = await pario.events.read({
+      types: ["workflow.run.node.finished", "workflow.run.node.started", "workflow.run.finished"],
+    })
+
+    expect(resumed.status).toBe("succeeded")
+    expect(run?.status).toBe("succeeded")
+    expect(nodes.nodes.map((node) => `${node.nodeId}:${node.status}`)).toEqual([
+      "find-best-invoice:succeeded",
+      "review-before-attach:succeeded",
+      "attach-reviewed-invoice:succeeded",
+    ])
+    expect(nodes.nodes[1]?.output).toEqual({
+      invoice: { objectTypeId: "Invoice", primaryId: "inv_reviewed" },
+    })
+    expect(resumed.steps.reviewBeforeAttach.invoice).toEqual({
+      objectTypeId: "Invoice",
+      primaryId: "inv_reviewed",
+    })
+    expect(resumed.steps.attachReviewedInvoice.invoice).toEqual({
+      objectTypeId: "Invoice",
+      primaryId: "inv_reviewed",
+    })
+    expect(events.map((event) => event.type)).toEqual([
+      "workflow.run.node.started",
+      "workflow.run.node.finished",
+      "workflow.run.node.started",
+      "workflow.run.node.finished",
+      "workflow.run.node.started",
+      "workflow.run.node.finished",
+      "workflow.run.finished",
+    ])
+
+    const duplicate = await runWorkflowResumeJob({
+      runtime,
+      job: {
+        id: "wfrun_resume",
+        workflowId: workflow.id,
+        pendingInterventionId: "wfrun_resume:intervention:1",
+      },
+      observer,
+    })
+    const afterDuplicate = await pario.storage.workflowRuns!.nodes.list({
+      projectId: pario.id,
+      workflowRunId: "wfrun_resume",
+      order: "asc",
+    })
+
+    expect(duplicate.status).toBe("succeeded")
+    expect(afterDuplicate.nodes.map((node) => node.id)).toEqual(nodes.nodes.map((node) => node.id))
   })
 
   test("validates workflow input before starting the run", async () => {

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import {
   actionParam,
   defineAction,
+  defineIntervention,
   defineObjectType,
   defineWorkflow,
   defineWorkflowStep,
@@ -66,6 +67,25 @@ const attachInvoice = defineAction("attach-invoice")
   })
   .run(() => {})
 
+const reviewInvoice = defineIntervention("review-invoice")
+  .input({
+    invoice: ref(Invoice),
+  })
+  .response({
+    approvedInvoice: ref(Invoice),
+  })
+
+const finalizeInvoice = defineWorkflowStep("finalize-invoice")
+  .input({
+    approvedInvoice: ref(Invoice),
+  })
+  .output({
+    invoice: ref(Invoice),
+  })
+  .run(({ input }) => ({
+    invoice: input.approvedInvoice,
+  }))
+
 const workers: WorkflowWorker[] = []
 
 afterEach(async () => {
@@ -112,7 +132,7 @@ async function waitFor<T>(
 }
 
 describe("WorkflowWorker", () => {
-  test("requires registered workflows and workflow run storage", () => {
+  test("requires registered workflows and workflow storage", () => {
     expect(() => new WorkflowWorker(createPario({}))).toThrow("No workflow definitions")
 
     const workflow = defineWorkflow("reconcile-transaction")
@@ -138,6 +158,33 @@ describe("WorkflowWorker", () => {
     }
 
     expect(() => new WorkflowWorker(withoutWorkflowRuns)).toThrow("storage.workflowRuns")
+
+    const interventionWorkflow = defineWorkflow("review-transaction")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(reviewInvoice)
+    const parioWithIntervention = createPario({ workflows: [interventionWorkflow] })
+    const withoutWorkflowInterventions = {
+      id: parioWithIntervention.id,
+      projectId: parioWithIntervention.projectId,
+      ontology: parioWithIntervention.ontology,
+      actionRegistry: parioWithIntervention.actionRegistry,
+      events: parioWithIntervention.events,
+      storage: {
+        ...parioWithIntervention.storage,
+        workflowInterventions: undefined,
+      },
+      lakeStorage: parioWithIntervention.lakeStorage,
+      blobStorage: parioWithIntervention.blobStorage,
+      queues: parioWithIntervention.queues,
+      workflows: parioWithIntervention.workflows,
+    }
+
+    expect(() => new WorkflowWorker(withoutWorkflowInterventions)).toThrow(
+      "storage.workflowInterventions"
+    )
   })
 
   test("processes queued workflow jobs and emits workflow lifecycle events", async () => {
@@ -294,6 +341,200 @@ describe("WorkflowWorker", () => {
       finishedAt: expect.any(String),
       error: "workflow exploded",
     })
+
+    const claimed = await pario.queues.workflows.claim({
+      projectId: pario.id,
+      workerId: "observer",
+    })
+    expect(claimed).toHaveLength(0)
+  })
+
+  test("completes queue jobs when workflow runs suspend at intervention nodes", async () => {
+    const workflow = defineWorkflow("review-transaction")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(reviewInvoice, ({ steps }) => ({
+        invoice: steps.findBestInvoice.invoice,
+      }))
+    const pario = createPario({ workflows: [workflow] })
+    await pario.queues.workflows.enqueue({
+      projectId: pario.id,
+      jobs: [
+        {
+          type: "workflow.run.requested",
+          payload: {
+            workflowId: workflow.id,
+            runId: "wfrun_worker_waiting",
+            input: {
+              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+            },
+          },
+        },
+      ],
+    })
+
+    const worker = new WorkflowWorker(pario)
+    workers.push(worker)
+    await worker.start()
+
+    const run = await waitFor(
+      () =>
+        pario.storage.workflowRuns!.getById({
+          projectId: pario.id,
+          id: "wfrun_worker_waiting",
+        }),
+      (value) => value?.status === "waiting"
+    )
+    const interventions = await waitFor(
+      () =>
+        pario.storage.workflowInterventions!.list({
+          projectId: pario.id,
+          workflowRunId: "wfrun_worker_waiting",
+        }),
+      (value) => value.total === 1
+    )
+    const events = await waitFor(
+      () =>
+        pario.events.read({
+          types: [
+            "workflow.run.started",
+            "workflow.run.node.started",
+            "workflow.run.node.finished",
+            "workflow.intervention.requested",
+            "workflow.run.node.waiting",
+            "workflow.run.waiting",
+          ],
+        }),
+      (value) => value.length === 7
+    )
+
+    expect(run?.workflowId).toBe(workflow.id)
+    expect(interventions.interventions[0]).toMatchObject({
+      id: "wfrun_worker_waiting:intervention:1",
+      workflowRunId: "wfrun_worker_waiting",
+      status: "pending",
+      input: {
+        invoice: { objectTypeId: "Invoice", primaryId: "inv_1" },
+      },
+    })
+    expect(events.map((event) => event.type)).toEqual([
+      "workflow.run.started",
+      "workflow.run.node.started",
+      "workflow.run.node.finished",
+      "workflow.run.node.started",
+      "workflow.intervention.requested",
+      "workflow.run.node.waiting",
+      "workflow.run.waiting",
+    ])
+
+    const claimed = await pario.queues.workflows.claim({
+      projectId: pario.id,
+      workerId: "observer",
+    })
+    expect(claimed).toHaveLength(0)
+  })
+
+  test("processes resume jobs for submitted workflow interventions", async () => {
+    const workflow = defineWorkflow("resume-reviewed-transaction")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(reviewInvoice, ({ steps }) => ({
+        invoice: steps.findBestInvoice.invoice,
+      }))
+      .then(finalizeInvoice, ({ steps }) => ({
+        approvedInvoice: steps.reviewInvoice.approvedInvoice,
+      }))
+    const pario = createPario({ workflows: [workflow] })
+
+    await pario.queues.workflows.enqueue({
+      projectId: pario.id,
+      jobs: [
+        {
+          type: "workflow.run.requested",
+          payload: {
+            workflowId: workflow.id,
+            runId: "wfrun_worker_resume",
+            input: {
+              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+            },
+          },
+        },
+      ],
+    })
+
+    const worker = new WorkflowWorker(pario)
+    workers.push(worker)
+    await worker.start()
+
+    await waitFor(
+      () =>
+        pario.storage.workflowRuns!.getById({
+          projectId: pario.id,
+          id: "wfrun_worker_resume",
+        }),
+      (value) => value?.status === "waiting"
+    )
+
+    await pario.storage.workflowInterventions!.submit({
+      projectId: pario.id,
+      id: "wfrun_worker_resume:intervention:1",
+      response: {
+        approvedInvoice: { objectTypeId: "Invoice", primaryId: "inv_reviewed" },
+      },
+    })
+    await pario.queues.workflows.enqueue({
+      projectId: pario.id,
+      jobs: [
+        {
+          type: "workflow.run.resume.requested",
+          payload: {
+            workflowId: workflow.id,
+            runId: "wfrun_worker_resume",
+            pendingInterventionId: "wfrun_worker_resume:intervention:1",
+          },
+        },
+      ],
+    })
+
+    const run = await waitFor(
+      () =>
+        pario.storage.workflowRuns!.getById({
+          projectId: pario.id,
+          id: "wfrun_worker_resume",
+        }),
+      (value) => value?.status === "succeeded"
+    )
+    const nodes = await pario.storage.workflowRuns!.nodes.list({
+      projectId: pario.id,
+      workflowRunId: "wfrun_worker_resume",
+      order: "asc",
+    })
+    const events = await waitFor(
+      () =>
+        pario.events.read({
+          types: [
+            "workflow.run.node.finished",
+            "workflow.run.node.started",
+            "workflow.run.finished",
+          ],
+        }),
+      (value) => value.length === 7
+    )
+
+    expect(run?.workflowId).toBe(workflow.id)
+    expect(nodes.nodes.map((node) => `${node.nodeId}:${node.status}`)).toEqual([
+      "find-best-invoice:succeeded",
+      "review-invoice:succeeded",
+      "finalize-invoice:succeeded",
+    ])
+    expect(nodes.nodes[2]?.output).toEqual({
+      invoice: { objectTypeId: "Invoice", primaryId: "inv_reviewed" },
+    })
+    expect(events.at(-1)?.type).toBe("workflow.run.finished")
 
     const claimed = await pario.queues.workflows.claim({
       projectId: pario.id,


### PR DESCRIPTION
This is the second slice of the workflow intervention stack. It teaches the workflow worker to suspend at intervention nodes, create pending intervention records, and resume a waiting run after a submitted response is queued.

The worker now treats intervention nodes as a first-class execution boundary, records waiting run/node state, and reconstructs prior workflow state when processing resume jobs.

**Code Snippets**

```ts
if (result.status === "waiting") {
  return session.finishWaiting(result.run)
}
```

```ts
const response = validateWorkflowInterventionResponse({
  workflowId: workflow.id,
  intervention: interventionNode.intervention,
  value: intervention.response,
  valueTypesById,
})
```

**Checks**

Validated on the top of the stacked branch:

```bash
bun run typecheck
bun run check
bun test packages/core/tests/workflows.test.ts packages/core/tests/workflow-runtime-validation.test.ts packages/core/tests/workflow-interventions.test.ts packages/core/tests/workflow-runs.test.ts packages/core/tests/workflow-events.test.ts packages/workflow-worker/tests/run-workflow-job.test.ts packages/workflow-worker/tests/worker.test.ts packages/server/tests/httpContract.test.ts packages/server/tests/openapi-docs.test.ts examples/acme-corp/tests/review-app.test.ts
git diff --check origin/main..HEAD
```