### PR TITLE
sentinel: add generic intervention review ui

### DIFF
--- a/examples/acme-corp/actions/sendReminder.ts
+++ b/examples/acme-corp/actions/sendReminder.ts
@@ -5,10 +5,31 @@ export const sendReminder = defineAction("sendReminder", {
   description: "Send a payment reminder to the customer.",
 })
   .target(Invoice)
-  .params({ message: actionParam("string") })
+  .params({
+    approved: actionParam("boolean", { required: true }),
+    message: actionParam("string", { required: true }),
+    reviewerNote: actionParam("string"),
+  })
   .run(async ({ params, target, pario }) => {
+    const reviewedAt = new Date().toISOString()
+
+    if (!params.approved) {
+      console.log(`[AcmeCorp] Reminder changes requested for invoice ${target.properties.number}.`)
+
+      await pario.objects(Invoice).upsert({
+        properties: {
+          ...target.properties,
+          id: target.primaryId,
+          reminderReviewStatus: "revision_requested",
+          reminderReviewedAt: reviewedAt,
+          reminderReviewerNote: params.reviewerNote,
+        },
+      })
+      return
+    }
+
     console.log(
-      `[AcmeCorp] Reminder requested for invoice ${target.properties.number}: ${params.message ?? ""}`
+      `[AcmeCorp] Reminder approved for invoice ${target.properties.number}: ${params.message}`
     )
 
     await pario.objects(Invoice).upsert({
@@ -16,6 +37,9 @@ export const sendReminder = defineAction("sendReminder", {
         ...target.properties,
         id: target.primaryId,
         status: "sent",
+        reminderReviewStatus: "approved",
+        reminderReviewedAt: reviewedAt,
+        reminderReviewerNote: params.reviewerNote,
       },
     })
   })

--- a/examples/acme-corp/app/globals.css
+++ b/examples/acme-corp/app/globals.css
@@ -1,0 +1,406 @@
+:root {
+  --bg: #f5f6f2;
+  --surface: #ffffff;
+  --surface-subtle: #eef2e8;
+  --border: #d9dfd0;
+  --text: #172018;
+  --muted: #66705f;
+  --accent: #1f7a5a;
+  --accent-strong: #145c43;
+  --accent-soft: #dceee6;
+  --warn: #9b5f13;
+  --warn-soft: #f3e5ca;
+  --danger: #a23b32;
+  --danger-soft: #f4d8d5;
+  --shadow: 0 10px 30px rgba(23, 32, 24, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100vh;
+  min-height: 100dvh;
+  margin: 0;
+  background: var(--bg);
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+.app-shell {
+  width: min(1120px, 100%);
+  min-height: 100vh;
+  min-height: 100dvh;
+  margin: 0 auto;
+  padding: 28px 20px 44px;
+}
+
+.topbar,
+.detail-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.topbar h1,
+.context-panel h1,
+.panel-heading h2 {
+  margin: 4px 0 0;
+  letter-spacing: 0;
+}
+
+.topbar h1 {
+  font-size: clamp(1.55rem, 3vw, 2.2rem);
+  line-height: 1.1;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--accent-strong);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.count-badge,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.count-badge {
+  flex-direction: column;
+  min-width: 76px;
+  min-height: 58px;
+}
+
+.count-badge span {
+  font-size: 1.35rem;
+}
+
+.count-badge small {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.status-pill {
+  min-height: 28px;
+  padding: 0 12px;
+  font-size: 0.78rem;
+  text-transform: capitalize;
+}
+
+.status-pill.is-muted {
+  background: var(--surface-subtle);
+  color: var(--muted);
+}
+
+.review-list {
+  display: grid;
+  gap: 12px;
+}
+
+.review-card,
+.empty-state,
+.context-panel,
+.review-panel {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.review-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  padding: 18px;
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+.review-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.review-card h2 {
+  margin: 10px 0 0;
+  font-size: 1.08rem;
+}
+
+.review-card p {
+  max-width: 760px;
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.review-card-meta {
+  display: grid;
+  align-content: center;
+  gap: 6px;
+  min-width: 176px;
+  color: var(--muted);
+  font-size: 0.84rem;
+  text-align: right;
+}
+
+.empty-state {
+  padding: 46px 20px;
+  text-align: center;
+}
+
+.empty-state h2,
+.empty-state p {
+  margin: 0;
+}
+
+.empty-state p {
+  color: var(--muted);
+}
+
+.empty-state h2 + p {
+  margin-top: 8px;
+}
+
+.error-state {
+  background: var(--danger-soft);
+  border-color: rgba(162, 59, 50, 0.28);
+  color: var(--danger);
+}
+
+.back-link {
+  color: var(--accent-strong);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 340px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.context-panel,
+.review-panel {
+  padding: 20px;
+}
+
+.context-panel h1 {
+  font-size: 1.45rem;
+}
+
+.context-panel dl {
+  display: grid;
+  gap: 14px;
+  margin: 24px 0 0;
+}
+
+.context-panel dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.context-panel dd {
+  margin: 4px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.panel-heading {
+  margin-bottom: 18px;
+}
+
+.decision-control {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  min-width: 0;
+  margin: 0 0 16px;
+  padding: 0;
+  border: 0;
+}
+
+.decision-control legend {
+  grid-column: 1 / -1;
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.decision-control button,
+.primary-action,
+.secondary-action {
+  min-height: 42px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 700;
+}
+
+.decision-control button.is-selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.field span {
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.field textarea {
+  width: 100%;
+  min-width: 0;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  color: var(--text);
+  background: var(--surface);
+  line-height: 1.5;
+}
+
+.field textarea:focus {
+  outline: 2px solid var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.primary-action {
+  min-width: 150px;
+  padding: 0 16px;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+
+.primary-action:hover:not(:disabled) {
+  background: var(--accent-strong);
+}
+
+.secondary-action {
+  min-width: 150px;
+  padding: 0 16px;
+  color: var(--danger);
+}
+
+.primary-action:disabled,
+.secondary-action:disabled,
+.decision-control:disabled button,
+.field textarea:disabled {
+  opacity: 0.58;
+}
+
+.result-message,
+.error-text {
+  margin: 14px 0 0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 0.9rem;
+}
+
+.result-message {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.error-text {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+@media (max-width: 760px) {
+  .app-shell {
+    padding: 18px 12px 32px;
+  }
+
+  .topbar,
+  .detail-topbar,
+  .review-card {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .topbar,
+  .detail-topbar {
+    flex-direction: column;
+  }
+
+  .count-badge {
+    align-self: flex-start;
+  }
+
+  .review-card-meta {
+    min-width: 0;
+    text-align: left;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .decision-control {
+    grid-template-columns: 1fr;
+  }
+
+  .primary-action,
+  .secondary-action {
+    flex: 1 1 100%;
+  }
+}

--- a/examples/acme-corp/app/layout.tsx
+++ b/examples/acme-corp/app/layout.tsx
@@ -1,0 +1,10 @@
+import type { PropsWithChildren } from "react"
+
+export const metadata = {
+  title: "Acme Review Desk",
+  description: "Review pending workflow interventions for Acme operations.",
+}
+
+export default function RootLayout({ children }: PropsWithChildren) {
+  return <>{children}</>
+}

--- a/examples/acme-corp/app/page.tsx
+++ b/examples/acme-corp/app/page.tsx
@@ -1,0 +1,96 @@
+import type { ListWorkflowInterventionsResponse } from "@pario/client"
+import { listWorkflowInterventionsOptions } from "@pario/client/hooks"
+import { useQuery } from "@tanstack/react-query"
+
+type WorkflowIntervention = ListWorkflowInterventionsResponse["interventions"][number]
+
+function asObjectRef(value: unknown): { objectTypeId: string; primaryId: string } | null {
+  if (!value || typeof value !== "object") {
+    return null
+  }
+
+  const ref = value as { objectTypeId?: unknown; primaryId?: unknown }
+  if (typeof ref.objectTypeId !== "string" || typeof ref.primaryId !== "string") {
+    return null
+  }
+
+  return { objectTypeId: ref.objectTypeId, primaryId: ref.primaryId }
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+function reviewTitle(intervention: WorkflowIntervention): string {
+  const invoice = asObjectRef(intervention.input.invoice)
+  return invoice ? `Invoice ${invoice.primaryId}` : intervention.id
+}
+
+function PendingReviewCard({ intervention }: { intervention: WorkflowIntervention }) {
+  return (
+    <a className="review-card" href={`/review/${encodeURIComponent(intervention.id)}`}>
+      <div className="review-card-main">
+        <span className="status-pill">Pending</span>
+        <h2>{reviewTitle(intervention)}</h2>
+        <p>{String(intervention.input.message ?? "Open review details.")}</p>
+      </div>
+      <div className="review-card-meta">
+        <span>{intervention.nodeKey}</span>
+        <span>{formatDate(intervention.requestedAt)}</span>
+      </div>
+    </a>
+  )
+}
+
+export default function ReviewQueuePage() {
+  const reviewsQuery = useQuery(
+    listWorkflowInterventionsOptions({
+      query: {
+        interventionId: "review-invoice-reminder",
+        status: "pending",
+        limit: "100",
+        order: "desc",
+      },
+    })
+  )
+  const interventions = reviewsQuery.data?.interventions ?? []
+
+  return (
+    <main className="app-shell">
+      <header className="topbar">
+        <div>
+          <p className="eyebrow">Acme Review Desk</p>
+          <h1>Pending reminder reviews</h1>
+        </div>
+        <div className="count-badge">
+          <span>{interventions.length}</span>
+          <small>open</small>
+        </div>
+      </header>
+
+      {reviewsQuery.isLoading ? (
+        <section className="empty-state">
+          <p>Loading review queue...</p>
+        </section>
+      ) : reviewsQuery.isError ? (
+        <section className="empty-state error-state">
+          <p>Review queue failed to load.</p>
+        </section>
+      ) : interventions.length === 0 ? (
+        <section className="empty-state">
+          <h2>No pending reviews</h2>
+          <p>Workflow interventions that need a reviewer will appear here.</p>
+        </section>
+      ) : (
+        <section className="review-list" aria-label="Pending workflow interventions">
+          {interventions.map((intervention) => (
+            <PendingReviewCard key={intervention.id} intervention={intervention} />
+          ))}
+        </section>
+      )}
+    </main>
+  )
+}

--- a/examples/acme-corp/app/review/[interventionId]/page.tsx
+++ b/examples/acme-corp/app/review/[interventionId]/page.tsx
@@ -1,0 +1,269 @@
+import type { GetWorkflowInterventionResponse } from "@pario/client"
+import {
+  cancelWorkflowInterventionMutation,
+  getWorkflowInterventionOptions,
+  getWorkflowInterventionQueryKey,
+  listWorkflowInterventionsQueryKey,
+  submitWorkflowInterventionMutation,
+} from "@pario/client/hooks"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
+import { useParams } from "react-router-dom"
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : ""
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback
+}
+
+function asObjectRef(value: unknown): { objectTypeId: string; primaryId: string } | null {
+  if (!value || typeof value !== "object") {
+    return null
+  }
+
+  const ref = value as { objectTypeId?: unknown; primaryId?: unknown }
+  if (typeof ref.objectTypeId !== "string" || typeof ref.primaryId !== "string") {
+    return null
+  }
+
+  return { objectTypeId: ref.objectTypeId, primaryId: ref.primaryId }
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+function invoiceLabel(intervention: GetWorkflowInterventionResponse): string {
+  const invoice = asObjectRef(intervention.input.invoice)
+  return invoice ? `${invoice.objectTypeId} ${invoice.primaryId}` : intervention.id
+}
+
+export default function ReviewDetailPage() {
+  const { interventionId } = useParams<{ interventionId: string }>()
+  const queryClient = useQueryClient()
+  const path = { interventionId: interventionId ?? "" }
+  const interventionQuery = useQuery({
+    ...getWorkflowInterventionOptions({ path }),
+    enabled: Boolean(interventionId),
+  })
+  const intervention = interventionQuery.data
+  const [approved, setApproved] = useState(true)
+  const [message, setMessage] = useState("")
+  const [reviewerNote, setReviewerNote] = useState("")
+  const [resultMessage, setResultMessage] = useState("")
+
+  useEffect(() => {
+    if (!intervention) {
+      return
+    }
+
+    setApproved(asBoolean(intervention.defaultResponse.approved, true))
+    setMessage(
+      asString(intervention.defaultResponse.message) || asString(intervention.input.message)
+    )
+    setReviewerNote(asString(intervention.defaultResponse.reviewerNote))
+    setResultMessage("")
+  }, [intervention])
+
+  const invalidateReviewQueries = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: getWorkflowInterventionQueryKey({ path }),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: listWorkflowInterventionsQueryKey({
+          query: {
+            interventionId: "review-invoice-reminder",
+            status: "pending",
+            limit: "100",
+            order: "desc",
+          },
+        }),
+      }),
+    ])
+  }
+
+  const submitReview = useMutation({
+    ...submitWorkflowInterventionMutation(),
+    async onSuccess(data) {
+      await invalidateReviewQueries()
+      setResultMessage(`Review submitted. Resume job ${data.jobId} was queued.`)
+    },
+  })
+  const cancelReview = useMutation({
+    ...cancelWorkflowInterventionMutation(),
+    async onSuccess() {
+      await invalidateReviewQueries()
+      setResultMessage("Review cancelled and the waiting workflow run was cancelled.")
+    },
+  })
+
+  if (!interventionId) {
+    return (
+      <main className="app-shell">
+        <section className="empty-state error-state">
+          <p>Missing review id.</p>
+        </section>
+      </main>
+    )
+  }
+
+  if (interventionQuery.isLoading) {
+    return (
+      <main className="app-shell">
+        <section className="empty-state">
+          <p>Loading review...</p>
+        </section>
+      </main>
+    )
+  }
+
+  if (!intervention) {
+    return (
+      <main className="app-shell">
+        <section className="empty-state error-state">
+          <p>Review not found.</p>
+          <a href="/">Back to queue</a>
+        </section>
+      </main>
+    )
+  }
+
+  const isPending = intervention.status === "pending"
+  const canSubmit =
+    isPending && message.trim().length > 0 && !submitReview.isPending && !cancelReview.isPending
+
+  return (
+    <main className="app-shell">
+      <header className="detail-topbar">
+        <a href="/" className="back-link">
+          Back to queue
+        </a>
+        <span className={`status-pill ${isPending ? "" : "is-muted"}`}>{intervention.status}</span>
+      </header>
+
+      <section className="detail-grid">
+        <aside className="context-panel">
+          <p className="eyebrow">Workflow Intervention</p>
+          <h1>{invoiceLabel(intervention)}</h1>
+          <dl>
+            <div>
+              <dt>Workflow</dt>
+              <dd>{intervention.workflowId}</dd>
+            </div>
+            <div>
+              <dt>Requested</dt>
+              <dd>{formatDate(intervention.requestedAt)}</dd>
+            </div>
+            <div>
+              <dt>Channel</dt>
+              <dd>{asString(intervention.input.channel) || "standard"}</dd>
+            </div>
+            <div>
+              <dt>Batch</dt>
+              <dd>{asString(intervention.input.deliveryBatchId) || "none"}</dd>
+            </div>
+          </dl>
+        </aside>
+
+        <section className="review-panel">
+          <div className="panel-heading">
+            <p className="eyebrow">Reviewer Response</p>
+            <h2>Finalize reminder copy</h2>
+          </div>
+
+          <fieldset className="decision-control" disabled={!isPending}>
+            <legend>Decision</legend>
+            <button
+              type="button"
+              className={approved ? "is-selected" : ""}
+              onClick={() => setApproved(true)}
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              className={!approved ? "is-selected" : ""}
+              onClick={() => setApproved(false)}
+            >
+              Request changes
+            </button>
+          </fieldset>
+
+          <label className="field">
+            <span>Reminder message</span>
+            <textarea
+              value={message}
+              onChange={(event) => setMessage(event.currentTarget.value)}
+              rows={7}
+              disabled={!isPending}
+            />
+          </label>
+
+          <label className="field">
+            <span>Reviewer note</span>
+            <textarea
+              value={reviewerNote}
+              onChange={(event) => setReviewerNote(event.currentTarget.value)}
+              rows={4}
+              disabled={!isPending}
+            />
+          </label>
+
+          {resultMessage && <p className="result-message">{resultMessage}</p>}
+          {submitReview.isError && <p className="error-text">Review submission failed.</p>}
+          {cancelReview.isError && <p className="error-text">Review cancellation failed.</p>}
+
+          <div className="actions-row">
+            <button
+              type="button"
+              className="primary-action"
+              disabled={!canSubmit}
+              onClick={() => {
+                submitReview.mutate({
+                  path,
+                  body: {
+                    response: {
+                      approved,
+                      message: message.trim(),
+                      ...(reviewerNote.trim() ? { reviewerNote: reviewerNote.trim() } : {}),
+                    },
+                    submittedBy: {
+                      principalType: "user",
+                      principalId: "acme-reviewer",
+                    },
+                  },
+                })
+              }}
+            >
+              Submit review
+            </button>
+            <button
+              type="button"
+              className="secondary-action"
+              disabled={!isPending || submitReview.isPending || cancelReview.isPending}
+              onClick={() => {
+                cancelReview.mutate({
+                  path,
+                  body: {
+                    cancelledBy: {
+                      principalType: "user",
+                      principalId: "acme-reviewer",
+                    },
+                  },
+                })
+              }}
+            >
+              Cancel workflow
+            </button>
+          </div>
+        </section>
+      </section>
+    </main>
+  )
+}

--- a/examples/acme-corp/ontology/invoice.ts
+++ b/examples/acme-corp/ontology/invoice.ts
@@ -16,6 +16,13 @@ export const Invoice = defineObjectType({
     prop("dueDate", "date"),
     prop("customerRef", "string"),
     prop("projectRef", "string"),
+    prop(
+      "reminderReviewStatus",
+      stringEnum(["not_requested", "needs_review", "approved", "revision_requested", "cancelled"])
+    ),
+    prop("reminderReviewRequestedAt", "timestamp"),
+    prop("reminderReviewedAt", "timestamp"),
+    prop("reminderReviewerNote", "string"),
   ],
   links: [
     link("customer", Customer, { cardinality: "one" }),

--- a/examples/acme-corp/tests/review-app.test.ts
+++ b/examples/acme-corp/tests/review-app.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { rm } from "node:fs/promises"
+import { createServer } from "node:net"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { createCustomApp } from "@pario/app"
+
+const acmeRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+
+async function getFreePort(): Promise<number> {
+  return await new Promise<number>((resolvePromise, reject) => {
+    const server = createServer()
+    server.on("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        reject(new Error("Could not resolve an open port"))
+        return
+      }
+
+      server.close((error) => {
+        if (error) reject(error)
+        else resolvePromise(address.port)
+      })
+    })
+  })
+}
+
+describe("Acme review app", () => {
+  let tempRoot = ""
+
+  afterEach(async () => {
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true })
+      tempRoot = ""
+    }
+  })
+
+  test("serves the workflow intervention review path in the custom app", async () => {
+    tempRoot = join(acmeRoot, ".pario", "review-app-test")
+    const generatedDir = join(tempRoot, "generated")
+    const app = await createCustomApp({
+      rootDir: acmeRoot,
+      generatedDir,
+      apiBaseUrl: "http://127.0.0.1:3000",
+      authEnabled: false,
+    })
+
+    const routes = await app.scanRoutes()
+    expect(routes.map((route) => route.path).sort()).toEqual(["/", "/review/:interventionId"])
+
+    const port = await getFreePort()
+    const server = await app.dev({
+      host: "127.0.0.1",
+      port,
+    })
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/review/workflow-intervention-1`)
+      expect(response.status).toBe(200)
+      const html = await response.text()
+      expect(html).toContain('<div id="root"></div>')
+      expect(html).toContain('"auth":{"audience":"app","enabled":false}')
+    } finally {
+      await server.stop()
+    }
+  })
+})

--- a/examples/acme-corp/tests/review-app.test.ts
+++ b/examples/acme-corp/tests/review-app.test.ts
@@ -1,68 +1,19 @@
-import { afterEach, describe, expect, test } from "bun:test"
-import { rm } from "node:fs/promises"
-import { createServer } from "node:net"
-import { dirname, join } from "node:path"
+import { describe, expect, test } from "bun:test"
+import { dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import { createCustomApp } from "@pario/app"
 
 const acmeRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 
-async function getFreePort(): Promise<number> {
-  return await new Promise<number>((resolvePromise, reject) => {
-    const server = createServer()
-    server.on("error", reject)
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address()
-      if (!address || typeof address === "string") {
-        reject(new Error("Could not resolve an open port"))
-        return
-      }
-
-      server.close((error) => {
-        if (error) reject(error)
-        else resolvePromise(address.port)
-      })
-    })
-  })
-}
-
 describe("Acme review app", () => {
-  let tempRoot = ""
-
-  afterEach(async () => {
-    if (tempRoot) {
-      await rm(tempRoot, { recursive: true, force: true })
-      tempRoot = ""
-    }
-  })
-
-  test("serves the workflow intervention review path in the custom app", async () => {
-    tempRoot = join(acmeRoot, ".pario", "review-app-test")
-    const generatedDir = join(tempRoot, "generated")
+  test("declares the workflow intervention review routes", async () => {
     const app = await createCustomApp({
       rootDir: acmeRoot,
-      generatedDir,
       apiBaseUrl: "http://127.0.0.1:3000",
       authEnabled: false,
     })
 
     const routes = await app.scanRoutes()
     expect(routes.map((route) => route.path).sort()).toEqual(["/", "/review/:interventionId"])
-
-    const port = await getFreePort()
-    const server = await app.dev({
-      host: "127.0.0.1",
-      port,
-    })
-
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/review/workflow-intervention-1`)
-      expect(response.status).toBe(200)
-      const html = await response.text()
-      expect(html).toContain('<div id="root"></div>')
-      expect(html).toContain('"auth":{"audience":"app","enabled":false}')
-    } finally {
-      await server.stop()
-    }
   })
 })

--- a/examples/acme-corp/tsconfig.json
+++ b/examples/acme-corp/tsconfig.json
@@ -6,6 +6,8 @@
   },
   "include": [
     "actions/**/*.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
     "connectors/**/*.ts",
     "datasets/**/*.ts",
     "functions/**/*.ts",
@@ -17,6 +19,7 @@
     "schedules/**/*.ts",
     "scripts/**/*.ts",
     "syncs/**/*.ts",
+    "tests/**/*.ts",
     "workflows/**/*.ts",
     "pario.config.ts"
   ]

--- a/examples/acme-corp/workflows/invoice-reminder.ts
+++ b/examples/acme-corp/workflows/invoice-reminder.ts
@@ -1,4 +1,10 @@
-import { defineWorkflow, defineWorkflowStep, ref } from "@pario/core"
+import {
+  defineIntervention,
+  defineWorkflow,
+  defineWorkflowStep,
+  interventionField,
+  ref,
+} from "@pario/core"
 import { sendReminder } from "../actions/sendReminder"
 import { Invoice } from "../ontology/invoice"
 
@@ -76,19 +82,55 @@ const composeInvoiceReminder = defineWorkflowStep("compose-invoice-reminder")
     channel: "string",
     deliveryBatchId: "string",
   })
-  .run(async ({ input }) => {
+  .run(async ({ input, pario }) => {
     await wait(750)
+
+    const message =
+      input.urgency === "high"
+        ? `Invoice ${input.invoiceNumber} for ${input.amountLabel} is overdue. Please review and submit payment.`
+        : `Please review invoice ${input.invoiceNumber} for ${input.amountLabel} and submit payment when convenient.`
+    const invoice = await pario.objects(Invoice).get(input.invoice.primaryId)
+    if (!invoice) {
+      throw new Error(`[AcmeCorp] Invoice '${input.invoice.primaryId}' was not found.`)
+    }
+
+    // Business review state stays on the invoice; workflow interventions only track the runtime
+    // pause and submitted response.
+    await pario.objects(Invoice).upsert({
+      properties: {
+        ...invoice.properties,
+        id: invoice.primaryId,
+        reminderReviewStatus: "needs_review",
+        reminderReviewRequestedAt: new Date().toISOString(),
+      },
+    })
 
     return {
       invoice: input.invoice,
-      message:
-        input.urgency === "high"
-          ? `Invoice ${input.invoiceNumber} for ${input.amountLabel} is overdue. Please review and submit payment.`
-          : `Please review invoice ${input.invoiceNumber} for ${input.amountLabel} and submit payment when convenient.`,
+      message,
       channel: input.channel,
       deliveryBatchId: `reminder-${new Date().toISOString()}`,
     }
   })
+
+export const reviewInvoiceReminder = defineIntervention("review-invoice-reminder", {
+  description: "Approve or request changes before sending the invoice reminder.",
+})
+  .input({
+    invoice: ref(Invoice),
+    message: "string",
+    channel: "string",
+    deliveryBatchId: "string",
+  })
+  .response({
+    approved: interventionField("boolean", { required: true }),
+    message: interventionField("string", { required: true }),
+    reviewerNote: interventionField("string", { required: false }),
+  })
+  .defaults(({ input }) => ({
+    approved: true,
+    message: input.message,
+  }))
 
 export const invoiceReminderWorkflow = defineWorkflow("invoice-reminder-workflow")
   .input({
@@ -97,10 +139,13 @@ export const invoiceReminderWorkflow = defineWorkflow("invoice-reminder-workflow
   .then(loadInvoiceContext)
   .then(evaluateReminderPolicy)
   .then(composeInvoiceReminder)
+  .then(reviewInvoiceReminder)
   .then(sendReminder, ({ steps }) => ({
     target: steps.composeInvoiceReminder.invoice,
     params: {
-      message: steps.composeInvoiceReminder.message,
+      approved: steps.reviewInvoiceReminder.approved,
+      message: steps.reviewInvoiceReminder.message,
+      reviewerNote: steps.reviewInvoiceReminder.reviewerNote,
     },
   }))
 

--- a/packages/sentinel/src/features/workflows/components/WorkflowRunInputForm.tsx
+++ b/packages/sentinel/src/features/workflows/components/WorkflowRunInputForm.tsx
@@ -30,17 +30,19 @@ export function WorkflowRunInputFields({
   values,
   errors,
   onChange,
+  emptyLabel = "This workflow does not require any input.",
 }: {
   fields: Readonly<Record<string, unknown>>
   values: WorkflowInputFormValues
   errors: WorkflowInputFormErrors
   onChange: (path: readonly string[], value: string) => void
+  emptyLabel?: string
 }) {
   const entries = Object.entries(fields)
   if (entries.length === 0) {
     return (
       <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm text-muted-foreground">
-        This workflow does not require any input.
+        {emptyLabel}
       </div>
     )
   }
@@ -64,11 +66,17 @@ export function WorkflowRunInputFields({
 }
 
 export function createInitialWorkflowInputFormValues(
-  fields: Readonly<Record<string, unknown>>
+  fields: Readonly<Record<string, unknown>>,
+  initialValue: Readonly<Record<string, unknown>> = {}
 ): WorkflowInputFormValues {
   const values: WorkflowInputFormValues = {}
   for (const [name, descriptor] of Object.entries(fields)) {
-    collectInitialFormValues(unwrapFieldDescriptor(descriptor, true), [name], values)
+    collectInitialFormValues(
+      unwrapFieldDescriptor(descriptor, true),
+      [name],
+      values,
+      initialValue[name]
+    )
   }
   return values
 }
@@ -438,20 +446,28 @@ function FieldError({ id, message }: { id: string; message: string }) {
 function collectInitialFormValues(
   spec: FieldSpec,
   path: readonly string[],
-  values: WorkflowInputFormValues
+  values: WorkflowInputFormValues,
+  initialValue: unknown
 ): void {
   const schema = resolveRenderableSchema(spec.schema)
+  const initialFormValue = initialFormValueForSchema(schema, initialValue)
+  if (initialFormValue !== null) {
+    values[pathKey(path)] = initialFormValue
+  }
+
   const defaultJson = defaultJsonForSchema(schema)
-  if (spec.required && defaultJson) {
+  if (initialFormValue === null && spec.required && defaultJson) {
     values[pathKey(path)] = defaultJson
   }
 
   if (isObjectSchema(schema)) {
+    const initialObject = isRecord(initialValue) ? initialValue : {}
     for (const [fieldName, fieldDescriptor] of Object.entries(schema.properties)) {
       collectInitialFormValues(
         unwrapFieldDescriptor(fieldDescriptor, false),
         [...path, fieldName],
-        values
+        values,
+        initialObject[fieldName]
       )
     }
   }
@@ -627,6 +643,55 @@ function defaultJsonForSchema(schema: unknown): string {
   if (isArraySchema(schema)) return "[]"
   if (isMapSchema(schema)) return "{}"
   return ""
+}
+
+function initialFormValueForSchema(schema: unknown, value: unknown): string | null {
+  if (value === undefined || value === null || isObjectSchema(schema)) return null
+
+  if (isObjectRefSchema(schema)) {
+    if (typeof value === "string") return value
+    if (isRecord(value) && typeof value.primaryId === "string") return value.primaryId
+    return null
+  }
+
+  if (isEnumSchema(schema)) {
+    const matchingOption = schema.values.find((option) => String(option) === String(value))
+    return matchingOption === undefined ? null : String(matchingOption)
+  }
+
+  if (schema === "boolean") {
+    return typeof value === "boolean" ? String(value) : null
+  }
+
+  if (schema === "date" && typeof value === "string") {
+    return value.slice(0, 10)
+  }
+
+  if (schema === "timestamp" && typeof value === "string") {
+    return timestampInputValue(value)
+  }
+
+  if (isPrimitiveSchema(schema) && schema !== "fileRef") {
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      return String(value)
+    }
+    return null
+  }
+
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return null
+  }
+}
+
+function timestampInputValue(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  // datetime-local inputs expect wall-clock time, so preserve the instant by displaying local time.
+  const offsetMs = date.getTimezoneOffset() * 60_000
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16)
 }
 
 function inputTypeForPrimitive(schema: PrimitiveSchema): string {

--- a/packages/sentinel/src/features/workflows/components/nodes/RunNodeRow.tsx
+++ b/packages/sentinel/src/features/workflows/components/nodes/RunNodeRow.tsx
@@ -1,10 +1,11 @@
 import { Badge, Card, CardContent } from "@pario/ui/components"
 import { cn } from "@pario/ui/lib/utils"
-import { ChevronRight, Workflow, Zap } from "lucide-react"
+import { ChevronRight, UserCheck, Workflow, Zap } from "lucide-react"
 import { useState } from "react"
 import { formatNodeDuration, formatRelativeTime, type WorkflowRunNode } from "../../utils/workflows"
 import { RunIOShape } from "../runs/RunIOShape"
 import { NodeStatusBadge } from "../runs/StatusBadge"
+import { WorkflowInterventionPanel } from "./WorkflowInterventionPanel"
 
 export function RunNodeRow({
   node,
@@ -13,8 +14,12 @@ export function RunNodeRow({
   node: WorkflowRunNode
   defaultOpen?: boolean
 }) {
-  const isStep = node.nodeType === "step"
   const [open, setOpen] = useState(defaultOpen)
+  const outputLabel = node.error
+    ? "Error"
+    : node.nodeType === "intervention"
+      ? "Response"
+      : "Output"
 
   return (
     <Card className="gap-0 overflow-hidden py-0">
@@ -35,8 +40,8 @@ export function RunNodeRow({
                 variant="secondary"
                 className="shrink-0 gap-1 rounded-md px-1.5 py-0 text-[10px]"
               >
-                {isStep ? <Workflow className="h-3 w-3" /> : <Zap className="h-3 w-3" />}
-                {isStep ? "step" : "action"}
+                <NodeTypeIcon type={node.nodeType} />
+                {node.nodeType}
               </Badge>
             </div>
             <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
@@ -55,17 +60,26 @@ export function RunNodeRow({
         </button>
 
         {open ? (
-          <div className="grid gap-px border-t border-border/60 bg-border/40 lg:grid-cols-2">
-            <JsonPanel label="Input" value={node.input} />
-            <JsonPanel
-              label={node.error ? "Error" : "Output"}
-              value={node.output ?? node.error ?? null}
-            />
-          </div>
+          <>
+            {node.nodeType === "intervention" && node.status === "waiting" ? (
+              <WorkflowInterventionPanel node={node} />
+            ) : null}
+
+            <div className="grid gap-px border-t border-border/60 bg-border/40 lg:grid-cols-2">
+              <JsonPanel label="Input" value={node.input} />
+              <JsonPanel label={outputLabel} value={node.output ?? node.error ?? null} />
+            </div>
+          </>
         ) : null}
       </CardContent>
     </Card>
   )
+}
+
+function NodeTypeIcon({ type }: { type: WorkflowRunNode["nodeType"] }) {
+  if (type === "step") return <Workflow className="h-3 w-3" />
+  if (type === "intervention") return <UserCheck className="h-3 w-3" />
+  return <Zap className="h-3 w-3" />
 }
 
 function JsonPanel({ label, value }: { label: string; value: unknown }) {

--- a/packages/sentinel/src/features/workflows/components/nodes/WorkflowInterventionPanel.tsx
+++ b/packages/sentinel/src/features/workflows/components/nodes/WorkflowInterventionPanel.tsx
@@ -1,0 +1,233 @@
+import {
+  getWorkflowOptions,
+  getWorkflowQueryKey,
+  getWorkflowRunQueryKey,
+  listWorkflowInterventionsOptions,
+  listWorkflowInterventionsQueryKey,
+  listWorkflowRunsInfiniteQueryKey,
+  listWorkflowRunsQueryKey,
+  listWorkflowsQueryKey,
+  submitWorkflowInterventionMutation,
+} from "@pario/client/hooks"
+import { Alert, AlertDescription, AlertTitle, Button, CardTitle } from "@pario/ui/components"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { AlertCircle, Loader2, Send, UserCheck } from "lucide-react"
+import { type SubmitEvent, useEffect, useState } from "react"
+import { formatDate, type WorkflowRunNode } from "../../utils/workflows"
+import {
+  buildWorkflowInput,
+  createInitialWorkflowInputFormValues,
+  type WorkflowInputFormErrors,
+  type WorkflowInputFormValues,
+  WorkflowRunInputFields,
+  workflowInputPathKey,
+} from "../WorkflowRunInputForm"
+
+const emptyFields: Readonly<Record<string, unknown>> = {}
+
+export function WorkflowInterventionPanel({ node }: { node: WorkflowRunNode }) {
+  const queryClient = useQueryClient()
+  const [values, setValues] = useState<WorkflowInputFormValues>({})
+  const [fieldErrors, setFieldErrors] = useState<WorkflowInputFormErrors>({})
+  const [resultMessage, setResultMessage] = useState("")
+  const [initializedInterventionId, setInitializedInterventionId] = useState<string | null>(null)
+
+  const interventionQueryOptions = {
+    query: {
+      nodeRunId: node.id,
+      status: "pending" as const,
+      limit: "1",
+      order: "desc" as const,
+    },
+  }
+  const interventionsQuery = useQuery({
+    ...listWorkflowInterventionsOptions(interventionQueryOptions),
+    refetchInterval: 5000,
+  })
+  const workflowQuery = useQuery(getWorkflowOptions({ path: { workflowId: node.workflowId } }))
+  const intervention = interventionsQuery.data?.interventions[0]
+  const workflowNode = workflowQuery.data?.nodes.find(
+    (candidate) =>
+      candidate.type === "intervention" &&
+      candidate.id === node.nodeId &&
+      candidate.key === node.nodeKey &&
+      candidate.id === intervention?.nodeId
+  )
+  const responseFields = workflowNode?.type === "intervention" ? workflowNode.response : emptyFields
+  const responseFieldCount = Object.keys(responseFields).length
+  const schemaReady = Boolean(workflowNode)
+  const apiErrorMessage = errorToMessage(interventionsQuery.error ?? workflowQuery.error)
+
+  const submitResponse = useMutation({
+    ...submitWorkflowInterventionMutation(),
+    async onSuccess(data) {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: listWorkflowInterventionsQueryKey(interventionQueryOptions),
+        }),
+        queryClient.invalidateQueries({ queryKey: listWorkflowInterventionsQueryKey() }),
+        queryClient.invalidateQueries({
+          queryKey: getWorkflowRunQueryKey({ path: { runId: node.workflowRunId } }),
+        }),
+        queryClient.invalidateQueries({ queryKey: listWorkflowRunsQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: listWorkflowRunsInfiniteQueryKey() }),
+        queryClient.invalidateQueries({
+          queryKey: getWorkflowQueryKey({ path: { workflowId: node.workflowId } }),
+        }),
+        queryClient.invalidateQueries({ queryKey: listWorkflowsQueryKey() }),
+      ])
+      setResultMessage(`Response submitted. Resume job ${data.jobId} was queued.`)
+    },
+  })
+
+  useEffect(() => {
+    if (!intervention || !schemaReady || initializedInterventionId === intervention.id) return
+
+    setValues(createInitialWorkflowInputFormValues(responseFields, intervention.defaultResponse))
+    setFieldErrors({})
+    setResultMessage("")
+    submitResponse.reset()
+    setInitializedInterventionId(intervention.id)
+  }, [initializedInterventionId, intervention, responseFields, schemaReady, submitResponse.reset])
+
+  function setFieldValue(path: readonly string[], value: string) {
+    const key = workflowInputPathKey(path)
+    setValues((current) => ({ ...current, [key]: value }))
+    setFieldErrors((current) => {
+      if (!(key in current)) return current
+      const next = { ...current }
+      delete next[key]
+      return next
+    })
+  }
+
+  function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!intervention || !schemaReady) return
+
+    submitResponse.reset()
+    setResultMessage("")
+
+    const result = buildWorkflowInput(responseFields, values)
+    setFieldErrors(result.errors)
+    if (Object.keys(result.errors).length > 0) return
+
+    submitResponse.mutate({
+      path: { interventionId: intervention.id },
+      body: {
+        response: result.input,
+        submittedBy: {
+          principalType: "user",
+          principalId: "sentinel-ui",
+        },
+      },
+    })
+  }
+
+  const loading = interventionsQuery.isLoading || (Boolean(intervention) && workflowQuery.isLoading)
+  const canSubmit =
+    intervention?.status === "pending" &&
+    schemaReady &&
+    !submitResponse.isPending &&
+    !interventionsQuery.isError
+
+  return (
+    <div className="border-t border-border/60 bg-card p-4">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300">
+              <UserCheck className="h-4 w-4" />
+            </span>
+            <CardTitle className="truncate text-sm font-medium">Human intervention</CardTitle>
+          </div>
+          {intervention ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Requested {formatDate(intervention.requestedAt)}
+            </p>
+          ) : null}
+        </div>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {responseFieldCount} response field{responseFieldCount === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading pending intervention...</p>
+      ) : apiErrorMessage ? (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Intervention unavailable</AlertTitle>
+          <AlertDescription>{apiErrorMessage}</AlertDescription>
+        </Alert>
+      ) : !intervention ? (
+        <Alert>
+          <UserCheck className="h-4 w-4" />
+          <AlertTitle>No pending intervention</AlertTitle>
+          <AlertDescription>
+            This node is waiting, but Sentinel could not find a pending intervention record.
+          </AlertDescription>
+        </Alert>
+      ) : !schemaReady ? (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Response schema unavailable</AlertTitle>
+          <AlertDescription>
+            The pending intervention does not match the registered workflow definition.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <WorkflowRunInputFields
+            fields={responseFields}
+            values={values}
+            errors={fieldErrors}
+            emptyLabel="This intervention does not require a structured response."
+            onChange={setFieldValue}
+          />
+
+          {resultMessage ? (
+            <Alert>
+              <UserCheck className="h-4 w-4" />
+              <AlertTitle>Response accepted</AlertTitle>
+              <AlertDescription>{resultMessage}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {submitResponse.isError ? (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Submission failed</AlertTitle>
+              <AlertDescription>
+                {errorToMessage(submitResponse.error) ?? "Could not submit the response."}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={!canSubmit}>
+              {submitResponse.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+              {submitResponse.isPending ? "Submitting..." : "Submit response"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  )
+}
+
+function errorToMessage(error: unknown): string | null {
+  if (!error) return null
+  if (isRecord(error) && typeof error.error === "string") return error.error
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  return "Could not load the intervention."
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/sentinel/src/features/workflows/components/runs/RunStatusStrip.tsx
+++ b/packages/sentinel/src/features/workflows/components/runs/RunStatusStrip.tsx
@@ -3,7 +3,7 @@ import { StatusBadge } from "./StatusBadge"
 
 export function RunStatusStrip({ counts }: { counts: Record<WorkflowRunStatus, number> }) {
   return (
-    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-6">
       {allWorkflowRunStatuses.map((status) => (
         <div
           key={status}

--- a/packages/sentinel/src/features/workflows/components/runs/StatusBadge.tsx
+++ b/packages/sentinel/src/features/workflows/components/runs/StatusBadge.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@pario/ui/components"
 import { cn } from "@pario/ui/lib/utils"
-import { Ban, CheckCircle2, CircleDashed, TimerReset, XCircle } from "lucide-react"
+import { Ban, CheckCircle2, CircleDashed, Hourglass, TimerReset, XCircle } from "lucide-react"
 import {
   nodeStatusClasses,
   statusClasses,
@@ -30,6 +30,7 @@ export function NodeStatusBadge({ status }: { status: WorkflowNodeStatus }) {
 function WorkflowRunStatusIcon({ status }: { status: WorkflowRunStatus | WorkflowNodeStatus }) {
   if (status === "queued") return <CircleDashed className="h-3 w-3" />
   if (status === "running") return <TimerReset className="h-3 w-3 animate-spin" />
+  if (status === "waiting") return <Hourglass className="h-3 w-3" />
   if (status === "succeeded") return <CheckCircle2 className="h-3 w-3" />
   if (status === "failed") return <XCircle className="h-3 w-3" />
   return <Ban className="h-3 w-3" />


### PR DESCRIPTION
This is the fourth slice of the workflow intervention stack. It adds a generic Sentinel response panel for waiting intervention nodes and wires the Acme example to a custom review desk.

Sentinel can now render a schema-driven fallback form for pending interventions. The Acme example demonstrates the intended product pattern: a domain-specific app for reviewers, backed by the same workflow intervention API.

**Code Snippets**

```tsx
<WorkflowInterventionPanel node={node} />
```

```ts
const reviewsQuery = useQuery(
  listWorkflowInterventionsOptions({
    query: { interventionId: "review-invoice-reminder", status: "pending" },
  })
)
```

```ts
submitWorkflowInterventionMutation().mutationFn({
  path: { interventionId },
  body: { response: { approved, message, reviewerNote } },
})
```

**Checks**

```bash
bun run typecheck
bun run check
bun test packages/core/tests/workflows.test.ts packages/core/tests/workflow-runtime-validation.test.ts packages/core/tests/workflow-interventions.test.ts packages/core/tests/workflow-runs.test.ts packages/core/tests/workflow-events.test.ts packages/workflow-worker/tests/run-workflow-job.test.ts packages/workflow-worker/tests/worker.test.ts packages/server/tests/httpContract.test.ts packages/server/tests/openapi-docs.test.ts examples/acme-corp/tests/review-app.test.ts
git diff --check origin/main..HEAD
```


<img width="1228" height="992" alt="Screenshot 2026-05-29 at 8 32 29 PM" src="https://github.com/user-attachments/assets/0ff79b3f-1a8a-4f7e-a065-ac6c68430b83" />

<img width="1273" height="794" alt="Screenshot 2026-05-29 at 8 32 08 PM" src="https://github.com/user-attachments/assets/21f3c135-e43e-4fdd-ba28-19f2a8c46c2f" />
<img width="1363" height="426" alt="Screenshot 2026-05-29 at 8 32 05 PM" src="https://github.com/user-attachments/assets/1249c027-ac1f-4b6a-8548-4c396dab1c66" />

