### PR TITLE
ducklake: bulk validate dataset definitions

### DIFF
--- a/packages/cli/tests/fixtures/lake-project/sixb.config.ts
+++ b/packages/cli/tests/fixtures/lake-project/sixb.config.ts
@@ -9,6 +9,7 @@ import {
   InMemoryLakeStorage,
   InMemoryQueues,
   InMemoryStorage,
+  LakeStorageError,
   prop,
   Sixb,
 } from "@sixb/core"
@@ -32,11 +33,16 @@ function logFixtureEvent(entry: Record<string, unknown>): void {
 // Mirrors the real lake drift failure without needing a Postgres-backed catalog:
 // the command path is what these tests exercise, not the diff algorithm itself.
 class FixtureLakeStorage extends InMemoryLakeStorage {
-  override async assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void> {
+  override async assertDatasetDefinitionsCompatible(
+    definitions: readonly DatasetDefinition[]
+  ): Promise<void> {
     if (process.env.SIXB_CLI_TEST_LAKE_DRIFT === "1") {
-      throw new Error(`dataset '${definition.id}' has drifted from the lake catalog`)
+      const datasetId = definitions[0]?.id ?? "unknown"
+      throw new LakeStorageError(
+        `[SixbLake] Lake dataset definition check failed for 1 dataset(s).\n- ${datasetId}: dataset '${datasetId}' has drifted from the lake catalog`
+      )
     }
-    return super.assertDatasetDefinitionCompatible(definition)
+    return super.assertDatasetDefinitionsCompatible(definitions)
   }
 
   async close(): Promise<void> {

--- a/packages/cli/tests/fixtures/prod-roles/sixb.config.ts
+++ b/packages/cli/tests/fixtures/prod-roles/sixb.config.ts
@@ -59,9 +59,13 @@ function logFixtureEvent(entry: Record<string, unknown>): void {
 // Logs every lake definition probe so tests can assert role startup never opens
 // the lake catalog (the thundering-herd regression this slice removes).
 class TrackingLakeStorage extends InMemoryLakeStorage {
-  override async assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void> {
-    logFixtureEvent({ type: "lake:assert", datasetId: definition.id })
-    return super.assertDatasetDefinitionCompatible(definition)
+  override async assertDatasetDefinitionsCompatible(
+    definitions: readonly DatasetDefinition[]
+  ): Promise<void> {
+    for (const definition of definitions) {
+      logFixtureEvent({ type: "lake:assert", datasetId: definition.id })
+    }
+    return super.assertDatasetDefinitionsCompatible(definitions)
   }
 
   async close(): Promise<void> {

--- a/packages/core/src/lake-storage/definition-updates.ts
+++ b/packages/core/src/lake-storage/definition-updates.ts
@@ -87,22 +87,7 @@ export interface AssertLakeDatasetDefinitionsCompatibleOptions {
 export async function assertLakeDatasetDefinitionsCompatible(
   options: AssertLakeDatasetDefinitionsCompatibleOptions
 ): Promise<void> {
-  const failures: string[] = []
-
-  for (const definition of options.definitions) {
-    try {
-      await options.lakeStorage.assertDatasetDefinitionCompatible(definition)
-    } catch (error) {
-      failures.push(`- ${definition.id}: ${errorMessage(error)}`)
-    }
-  }
-
-  if (failures.length > 0) {
-    const details = failures.join("\n")
-    throw new LakeStorageError(
-      `[SixbLake] Lake dataset definition check failed for ${failures.length} dataset(s).\n${details}`
-    )
-  }
+  await options.lakeStorage.assertDatasetDefinitionsCompatible(options.definitions)
 }
 
 function assertSameDataset(existing: DatasetDefinition, requested: DatasetDefinition): void {
@@ -275,8 +260,4 @@ function throwUnsupportedSchemaUpdate(datasetId: string, detail: string): never 
   throw new LakeStorageError(
     `[SixbLake] Dataset '${datasetId}' cannot apply schema update because ${detail}. ${SCHEMA_UPDATE_V1_POLICY}`
   )
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
 }

--- a/packages/core/src/lake-storage/in-memory.ts
+++ b/packages/core/src/lake-storage/in-memory.ts
@@ -47,6 +47,10 @@ function assertDatasetId(datasetId: string): void {
   }
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
 class InMemoryLakeWriteSession implements LakeWriteSession {
   private readonly rows: DatasetRow[] = []
   private closed = false
@@ -108,17 +112,34 @@ export class InMemoryLakeStorage implements LakeStorage {
     return cloneDatasetDefinition(stored)
   }
 
-  async assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void> {
-    assertDatasetId(definition.id)
-    const existing = this.datasets.get(definition.id)
-    if (!existing) {
-      return
+  async assertDatasetDefinitionsCompatible(
+    definitions: readonly DatasetDefinition[]
+  ): Promise<void> {
+    const failures: string[] = []
+
+    for (const definition of definitions) {
+      try {
+        assertDatasetId(definition.id)
+        const existing = this.datasets.get(definition.id)
+        if (!existing) {
+          continue
+        }
+
+        mergeStrictDatasetDefinition({
+          existing,
+          next: definition,
+        })
+      } catch (error) {
+        failures.push(`- ${definition.id}: ${errorMessage(error)}`)
+      }
     }
 
-    mergeStrictDatasetDefinition({
-      existing,
-      next: definition,
-    })
+    if (failures.length > 0) {
+      const details = failures.join("\n")
+      throw new LakeStorageError(
+        `[SixbLake] Lake dataset definition check failed for ${failures.length} dataset(s).\n${details}`
+      )
+    }
   }
 
   async getDataset(datasetId: string): Promise<DatasetDefinition | null> {

--- a/packages/core/src/lake-storage/types.ts
+++ b/packages/core/src/lake-storage/types.ts
@@ -87,7 +87,7 @@ export interface LakeStorage {
    * versions from this method. Missing persisted datasets should be treated as
    * compatible because createDataset remains the materialization path.
    */
-  assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void>
+  assertDatasetDefinitionsCompatible(definitions: readonly DatasetDefinition[]): Promise<void>
 
   createDataset(definition: DatasetDefinition): Promise<DatasetDefinition>
   getDataset(datasetId: string): Promise<DatasetDefinition | null>

--- a/packages/core/src/testing/lake-storage-contract.ts
+++ b/packages/core/src/testing/lake-storage-contract.ts
@@ -95,7 +95,7 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
       test("treats same-column declaration reorders as a no-op", async () => {
         await withStorage(async (storage) => {
           await storage.createDataset(definitionDataset)
-          await storage.assertDatasetDefinitionCompatible(reorderedDefinitionDataset)
+          await storage.assertDatasetDefinitionsCompatible([reorderedDefinitionDataset])
 
           expect(await storage.getDataset(definitionDataset.id)).toEqual(definitionDataset)
           await expect(storage.createDataset(reorderedDefinitionDataset)).resolves.toEqual(
@@ -117,7 +117,7 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
           })
 
           await storage.createDataset(minimalDataset)
-          await storage.assertDatasetDefinitionCompatible(documentedDataset)
+          await storage.assertDatasetDefinitionsCompatible([documentedDataset])
 
           expect(await storage.getDataset(minimalDataset.id)).toEqual(minimalDataset)
           await expect(storage.createDataset(documentedDataset)).resolves.toEqual(documentedDataset)
@@ -134,9 +134,9 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
 
           await storage.createDataset(definitionDataset)
 
-          await expect(storage.assertDatasetDefinitionCompatible(changedDataset)).rejects.toThrow(
-            "changing column 'orderId' type"
-          )
+          await expect(
+            storage.assertDatasetDefinitionsCompatible([changedDataset])
+          ).rejects.toThrow("changing column 'orderId' type")
           await expect(storage.createDataset(changedDataset)).rejects.toBeInstanceOf(
             LakeStorageError
           )
@@ -160,7 +160,7 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
 
           if (schemaEvolution === "strict") {
             await expect(
-              storage.assertDatasetDefinitionCompatible(requestedDataset)
+              storage.assertDatasetDefinitionsCompatible([requestedDataset])
             ).rejects.toThrow("incompatible schema")
             await expect(storage.createDataset(requestedDataset)).rejects.toThrow(
               "incompatible schema"
@@ -169,7 +169,7 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
             return
           }
 
-          await storage.assertDatasetDefinitionCompatible(requestedDataset)
+          await storage.assertDatasetDefinitionsCompatible([requestedDataset])
           expect(await storage.getDataset(initialDataset.id)).toEqual(initialDataset)
           expect(await storage.listVersions(initialDataset.id)).toEqual([])
 
@@ -187,7 +187,7 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
 
       test("keeps compatibility checks read-only for missing datasets", async () => {
         await withStorage(async (storage) => {
-          await storage.assertDatasetDefinitionCompatible(definitionDataset)
+          await storage.assertDatasetDefinitionsCompatible([definitionDataset])
 
           expect(await storage.getDataset(definitionDataset.id)).toBeNull()
           expect(await storage.listDatasets()).toEqual([])

--- a/packages/core/tests/lake-storage-definition-updates.test.ts
+++ b/packages/core/tests/lake-storage-definition-updates.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import type { DatasetDefinition, LakeStorage } from "../src"
 import {
   assertLakeDatasetDefinitionsCompatible,
   col,
@@ -208,5 +209,24 @@ describe("dataset definition update planning", () => {
         definitions: [requested],
       })
     ).rejects.toThrow(/Lake dataset definition check failed[\s\S]*incompatible schema/)
+  })
+
+  test("lake compatibility preflight delegates to provider bulk checks", async () => {
+    const dataset = defineDataset("raw.erp.invoices", {
+      schema: [col("invoiceId", "string")],
+    })
+    let bulkDefinitions: readonly DatasetDefinition[] | undefined
+    const storage = {
+      async assertDatasetDefinitionsCompatible(definitions: readonly DatasetDefinition[]) {
+        bulkDefinitions = definitions
+      },
+    } as unknown as LakeStorage
+
+    await assertLakeDatasetDefinitionsCompatible({
+      lakeStorage: storage,
+      definitions: [dataset],
+    })
+
+    expect(bulkDefinitions).toEqual([dataset])
   })
 })

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -91,8 +91,8 @@ class RecordingLakeStorage implements LakeStorage {
     this.standard = delegate.standard
   }
 
-  assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void> {
-    return this.delegate.assertDatasetDefinitionCompatible(definition)
+  assertDatasetDefinitionsCompatible(definitions: readonly DatasetDefinition[]): Promise<void> {
+    return this.delegate.assertDatasetDefinitionsCompatible(definitions)
   }
 
   createDataset(definition: DatasetDefinition): Promise<DatasetDefinition> {

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -117,8 +117,8 @@ describe("runSyncJob", () => {
     const calls: string[] = []
     const lakeStorage = new InMemoryLakeStorage()
     const wrappedLakeStorage: LakeStorage = {
-      assertDatasetDefinitionCompatible(definition) {
-        return lakeStorage.assertDatasetDefinitionCompatible(definition)
+      assertDatasetDefinitionsCompatible(definitions) {
+        return lakeStorage.assertDatasetDefinitionsCompatible(definitions)
       },
       createDataset(definition) {
         calls.push(`create:${definition.id}`)
@@ -482,8 +482,8 @@ describe("runSyncJob", () => {
     let abortCalls = 0
 
     const wrappedLakeStorage: LakeStorage = {
-      assertDatasetDefinitionCompatible(definition) {
-        return lakeStorage.assertDatasetDefinitionCompatible(definition)
+      assertDatasetDefinitionsCompatible(definitions) {
+        return lakeStorage.assertDatasetDefinitionsCompatible(definitions)
       },
       createDataset(definition) {
         return lakeStorage.createDataset(definition)

--- a/storage/ducklake/src/ducklake-storage.ts
+++ b/storage/ducklake/src/ducklake-storage.ts
@@ -76,8 +76,10 @@ export class DuckLakeStorage implements LakeStorageWithSql<"duckdb"> {
     return this.datasets.createDataset(definition)
   }
 
-  async assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void> {
-    await this.datasets.assertDatasetDefinitionCompatible(definition)
+  async assertDatasetDefinitionsCompatible(
+    definitions: readonly DatasetDefinition[]
+  ): Promise<void> {
+    await this.datasets.assertDatasetDefinitionsCompatible(definitions)
   }
 
   async getDataset(datasetId: string): Promise<DatasetDefinition | null> {

--- a/storage/ducklake/src/internal/duckdb-row.ts
+++ b/storage/ducklake/src/internal/duckdb-row.ts
@@ -58,6 +58,15 @@ export function getBigIntLike(row: DuckDbRow, key: string): bigint {
   )
 }
 
+export function getOptionalBigIntLike(row: DuckDbRow, key: string): bigint | undefined {
+  const value = row[key]
+  if (value === null || value === undefined) {
+    return undefined
+  }
+
+  return getBigIntLike(row, key)
+}
+
 export function getDate(row: DuckDbRow, key: string): Date {
   const value = row[key]
   if (value instanceof Date) {

--- a/storage/ducklake/src/internal/ducklake-catalog-schema.ts
+++ b/storage/ducklake/src/internal/ducklake-catalog-schema.ts
@@ -1,0 +1,116 @@
+import type { DatasetColumnDefinition, DatasetSchema } from "@sixb/core"
+import { LakeStorageError } from "@sixb/core"
+import { duckDbTypeToDatasetColumnType } from "./schema"
+
+export interface DuckLakeCatalogColumn {
+  readonly tableName: string
+  readonly columnId: bigint
+  readonly columnOrder: bigint
+  readonly columnName: string
+  readonly columnType: string
+  readonly nullsAllowed: boolean
+  readonly parentColumnId?: bigint
+}
+
+const FILE_REF_STRUCT_CHILDREN = [
+  { name: "blobId", type: "string" },
+  { name: "digest", type: "string" },
+  { name: "sizeBytes", type: "int64" },
+  { name: "fileName", type: "string" },
+  { name: "mediaType", type: "string" },
+  { name: "logicalPath", type: "string" },
+] satisfies readonly { readonly name: string; readonly type: DatasetColumnDefinition["type"] }[]
+
+export function duckLakeCatalogColumnsToDatasetSchema(
+  tableName: string,
+  rows: readonly DuckLakeCatalogColumn[]
+): DatasetSchema {
+  const childrenByParentId = new Map<bigint, DuckLakeCatalogColumn[]>()
+  const topLevelColumns: DuckLakeCatalogColumn[] = []
+
+  for (const row of rows) {
+    if (row.parentColumnId === undefined) {
+      topLevelColumns.push(row)
+      continue
+    }
+
+    const children = childrenByParentId.get(row.parentColumnId) ?? []
+    children.push(row)
+    childrenByParentId.set(row.parentColumnId, children)
+  }
+
+  return {
+    columns: topLevelColumns
+      .sort(compareDuckLakeCatalogColumnOrder)
+      .map((column) => duckLakeCatalogColumnToDefinition(tableName, column, childrenByParentId)),
+  }
+}
+
+function duckLakeCatalogColumnToDefinition(
+  tableName: string,
+  column: DuckLakeCatalogColumn,
+  childrenByParentId: ReadonlyMap<bigint, readonly DuckLakeCatalogColumn[]>
+): DatasetColumnDefinition {
+  const children = [...(childrenByParentId.get(column.columnId) ?? [])].sort(
+    compareDuckLakeCatalogColumnOrder
+  )
+  return {
+    name: column.columnName,
+    type: duckLakeCatalogColumnTypeToDatasetType(tableName, column, children),
+    ...(column.nullsAllowed ? { nullable: true } : {}),
+  }
+}
+
+function duckLakeCatalogColumnTypeToDatasetType(
+  tableName: string,
+  column: DuckLakeCatalogColumn,
+  children: readonly DuckLakeCatalogColumn[]
+): DatasetColumnDefinition["type"] {
+  if (children.length === 0 && column.columnType.toLowerCase() !== "struct") {
+    return duckDbTypeToDatasetColumnType(column.columnType)
+  }
+
+  if (isFileRefStruct(children)) {
+    return "fileRef"
+  }
+
+  throw new LakeStorageError(
+    `[SixbDuckLake] DuckDB column type '${formatDuckLakeCatalogColumnType(
+      column,
+      children
+    )}' in dataset table '${tableName}' cannot be mapped to a Sixb dataset column type.`
+  )
+}
+
+function compareDuckLakeCatalogColumnOrder(
+  left: DuckLakeCatalogColumn,
+  right: DuckLakeCatalogColumn
+): number {
+  return Number(left.columnOrder - right.columnOrder)
+}
+
+function isFileRefStruct(children: readonly DuckLakeCatalogColumn[]): boolean {
+  if (children.length !== FILE_REF_STRUCT_CHILDREN.length) {
+    return false
+  }
+
+  return FILE_REF_STRUCT_CHILDREN.every((expected, index) => {
+    const child = children[index]
+    return (
+      child !== undefined &&
+      child.columnName === expected.name &&
+      duckDbTypeToDatasetColumnType(child.columnType) === expected.type
+    )
+  })
+}
+
+function formatDuckLakeCatalogColumnType(
+  column: DuckLakeCatalogColumn,
+  children: readonly DuckLakeCatalogColumn[]
+): string {
+  if (children.length === 0) {
+    return column.columnType
+  }
+
+  return `STRUCT(${children.map((child) => `${child.columnName} ${child.columnType}`).join(", ")})`
+}

--- a/storage/ducklake/src/internal/ducklake-current-dataset-definitions.ts
+++ b/storage/ducklake/src/internal/ducklake-current-dataset-definitions.ts
@@ -1,0 +1,228 @@
+import type { DatasetDefinition } from "@sixb/core"
+import { LakeStorageError } from "@sixb/core"
+import type { DuckLakeStorageOptions } from "../types"
+import {
+  getBigIntLike,
+  getBoolean,
+  getOptionalBigIntLike,
+  getOptionalString,
+  getString,
+} from "./duckdb-row"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
+import {
+  type DuckLakeCatalogColumn,
+  duckLakeCatalogColumnsToDatasetSchema,
+} from "./ducklake-catalog-schema"
+import { decodeDatasetTableName, encodeDatasetTableName } from "./names"
+import { duckLakeAlias, duckLakeMetadataTableName, quoteSqlString, quoteSqlStringList } from "./sql"
+
+interface CurrentDatasetTable {
+  readonly datasetId: string
+  readonly tableName: string
+  readonly comment?: string
+}
+
+interface CurrentDatasetPartition {
+  readonly tableName: string
+  readonly columnName: string
+  readonly transform: string
+}
+
+export interface ReadCurrentDatasetDefinitionsInput {
+  readonly options: DuckLakeStorageOptions
+  readonly runtime: DuckDbQueryRuntime
+  readonly datasetIds?: readonly string[]
+}
+
+export async function readCurrentDatasetDefinitions(
+  input: ReadCurrentDatasetDefinitionsInput
+): Promise<Map<string, DatasetDefinition>> {
+  if (input.datasetIds?.length === 0) {
+    return new Map()
+  }
+
+  const tables = await readCurrentDatasetTables(input, input.datasetIds)
+  if (tables.length === 0) {
+    return new Map()
+  }
+
+  const tableNames = tables.map((table) => table.tableName)
+  const columnsByTableName = groupColumnsByTableName(
+    await readCurrentDatasetColumns(input, tableNames)
+  )
+  const partitionByTableName = groupPartitionsByTableName(
+    await readCurrentDatasetPartitions(input, tableNames)
+  )
+  const definitions = new Map<string, DatasetDefinition>()
+
+  for (const table of tables) {
+    const partitionBy = partitionByTableName.get(table.tableName) ?? []
+    definitions.set(table.datasetId, {
+      kind: "dataset",
+      id: table.datasetId,
+      schema: duckLakeCatalogColumnsToDatasetSchema(
+        table.tableName,
+        columnsByTableName.get(table.tableName) ?? []
+      ),
+      ...(partitionBy.length > 0 ? { partitionBy } : {}),
+      ...(table.comment !== undefined ? { description: table.comment } : {}),
+    })
+  }
+
+  return definitions
+}
+
+async function readCurrentDatasetTables(
+  input: ReadCurrentDatasetDefinitionsInput,
+  datasetIds: readonly string[] | undefined
+): Promise<readonly CurrentDatasetTable[]> {
+  if (datasetIds !== undefined && datasetIds.length === 0) {
+    return []
+  }
+
+  const tableNameFilter =
+    datasetIds === undefined
+      ? ""
+      : `AND table_name IN (${quoteSqlStringList(
+          [...new Set(datasetIds)].map((datasetId) => encodeDatasetTableName(datasetId))
+        )})`
+
+  const rows = await input.runtime.query(
+    `SELECT table_name, comment FROM duckdb_tables() WHERE database_name = ${quoteSqlString(
+      duckLakeAlias(input.options)
+    )} AND schema_name = 'main' ${tableNameFilter} AND NOT internal ORDER BY table_name`
+  )
+
+  const tables: CurrentDatasetTable[] = []
+  for (const row of rows) {
+    const tableName = getString(row, "table_name")
+    const datasetId = decodeDatasetTableName(tableName)
+    if (datasetId === null) {
+      continue
+    }
+
+    tables.push({
+      datasetId,
+      tableName,
+      comment: getOptionalString(row, "comment"),
+    })
+  }
+
+  return tables
+}
+
+async function readCurrentDatasetColumns(
+  input: ReadCurrentDatasetDefinitionsInput,
+  tableNames: readonly string[]
+): Promise<readonly DuckLakeCatalogColumn[]> {
+  if (tableNames.length === 0) {
+    return []
+  }
+
+  const ducklakeTable = duckLakeMetadataTableName(input.options, "ducklake_table")
+  const ducklakeColumn = duckLakeMetadataTableName(input.options, "ducklake_column")
+  const rows = await input.runtime.query(`
+    SELECT
+      table_meta.table_name,
+      column_meta.column_id,
+      column_meta.column_order,
+      column_meta.column_name,
+      column_meta.column_type,
+      CAST(column_meta.nulls_allowed AS BOOLEAN) AS nulls_allowed,
+      column_meta.parent_column
+    FROM ${ducklakeTable} table_meta
+    JOIN ${ducklakeColumn} column_meta
+      ON column_meta.table_id = table_meta.table_id
+      AND column_meta.end_snapshot IS NULL
+    WHERE table_meta.end_snapshot IS NULL
+      AND table_meta.table_name IN (${quoteSqlStringList(tableNames)})
+    ORDER BY table_meta.table_name, column_meta.column_order
+  `)
+
+  return rows.map((row) => ({
+    tableName: getString(row, "table_name"),
+    columnId: getBigIntLike(row, "column_id"),
+    columnOrder: getBigIntLike(row, "column_order"),
+    columnName: getString(row, "column_name"),
+    columnType: getString(row, "column_type"),
+    nullsAllowed: getBoolean(row, "nulls_allowed"),
+    parentColumnId: getOptionalBigIntLike(row, "parent_column"),
+  }))
+}
+
+async function readCurrentDatasetPartitions(
+  input: ReadCurrentDatasetDefinitionsInput,
+  tableNames: readonly string[]
+): Promise<readonly CurrentDatasetPartition[]> {
+  if (tableNames.length === 0) {
+    return []
+  }
+
+  const ducklakeTable = duckLakeMetadataTableName(input.options, "ducklake_table")
+  const ducklakePartitionInfo = duckLakeMetadataTableName(input.options, "ducklake_partition_info")
+  const ducklakePartitionColumn = duckLakeMetadataTableName(
+    input.options,
+    "ducklake_partition_column"
+  )
+  const ducklakeColumn = duckLakeMetadataTableName(input.options, "ducklake_column")
+  const rows = await input.runtime.query(`
+    SELECT
+      table_meta.table_name,
+      column_meta.column_name,
+      partition_column.transform
+    FROM ${ducklakeTable} table_meta
+    JOIN ${ducklakePartitionInfo} partition_info
+      ON partition_info.table_id = table_meta.table_id
+      AND partition_info.end_snapshot IS NULL
+    JOIN ${ducklakePartitionColumn} partition_column
+      ON partition_column.table_id = table_meta.table_id
+      AND partition_column.partition_id = partition_info.partition_id
+    JOIN ${ducklakeColumn} column_meta
+      ON column_meta.table_id = table_meta.table_id
+      AND column_meta.column_id = partition_column.column_id
+      AND column_meta.end_snapshot IS NULL
+    WHERE table_meta.end_snapshot IS NULL
+      AND table_meta.table_name IN (${quoteSqlStringList(tableNames)})
+    ORDER BY table_meta.table_name, partition_column.partition_key_index
+  `)
+
+  return rows.map((row) => {
+    const partition = {
+      tableName: getString(row, "table_name"),
+      columnName: getString(row, "column_name"),
+      transform: getString(row, "transform"),
+    } satisfies CurrentDatasetPartition
+
+    if (partition.transform !== "identity") {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Dataset table '${partition.tableName}' uses unsupported DuckLake partition transform '${partition.transform}'.`
+      )
+    }
+
+    return partition
+  })
+}
+
+function groupColumnsByTableName(
+  rows: readonly DuckLakeCatalogColumn[]
+): Map<string, DuckLakeCatalogColumn[]> {
+  const result = new Map<string, DuckLakeCatalogColumn[]>()
+  for (const row of rows) {
+    const tableRows = result.get(row.tableName) ?? []
+    tableRows.push(row)
+    result.set(row.tableName, tableRows)
+  }
+  return result
+}
+
+function groupPartitionsByTableName(
+  rows: readonly CurrentDatasetPartition[]
+): Map<string, string[]> {
+  const result = new Map<string, string[]>()
+  for (const row of rows) {
+    const tablePartitions = result.get(row.tableName) ?? []
+    tablePartitions.push(row.columnName)
+    result.set(row.tableName, tablePartitions)
+  }
+  return result
+}

--- a/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
+++ b/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
@@ -7,32 +7,18 @@ import type {
 } from "@sixb/core"
 import { LakeStorageError, planDatasetDefinitionUpdate } from "@sixb/core"
 import type { DuckLakeStorageOptions } from "../types"
-import { getOptionalString, getString } from "./duckdb-row"
+import { getString } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
-import { decodeDatasetTableName, encodeDatasetTableName } from "./names"
+import { readCurrentDatasetDefinitions } from "./ducklake-current-dataset-definitions"
+import { encodeDatasetTableName } from "./names"
 import {
   type DuckDbColumnMetadata,
   datasetColumnToDuckDbSql,
   datasetSchemaToDuckDbColumnsSql,
   duckDbColumnsToDatasetSchema,
 } from "./schema"
-import {
-  duckLakeAlias,
-  duckLakeMetadataTableName,
-  qualifiedTableName,
-  quoteIdentifier,
-  quoteSqlString,
-} from "./sql"
-
-interface DatasetTableRow {
-  readonly comment?: string
-}
-
-interface PartitionColumnRow {
-  readonly columnName: string
-  readonly transform: string
-}
+import { duckLakeAlias, qualifiedTableName, quoteIdentifier, quoteSqlString } from "./sql"
 
 /**
  * Translates between Sixb dataset definitions and DuckLake table metadata.
@@ -91,15 +77,46 @@ export class DuckLakeDatasetCatalog {
     return structuredClone(definition)
   }
 
-  async assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void> {
-    this.assertSchema(definition)
+  async assertDatasetDefinitionsCompatible(
+    definitions: readonly DatasetDefinition[]
+  ): Promise<void> {
+    const failures: string[] = []
+    const checkedDefinitions: DatasetDefinition[] = []
 
-    const existing = await this.getDataset(definition.id)
-    if (!existing) {
-      return
+    for (const definition of definitions) {
+      try {
+        this.assertSchema(definition)
+        checkedDefinitions.push(definition)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        failures.push(`- ${definition.id}: ${message}`)
+      }
     }
 
-    planDatasetDefinitionUpdate(existing, definition)
+    const existingById = await this.readCurrentDatasetDefinitions({
+      datasetIds: checkedDefinitions.map((definition) => definition.id),
+    })
+
+    for (const definition of checkedDefinitions) {
+      const existing = existingById.get(definition.id)
+      if (!existing) {
+        continue
+      }
+
+      try {
+        planDatasetDefinitionUpdate(existing, definition)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        failures.push(`- ${definition.id}: ${message}`)
+      }
+    }
+
+    if (failures.length > 0) {
+      const details = failures.join("\n")
+      throw new LakeStorageError(
+        `[SixbLake] Lake dataset definition check failed for ${failures.length} dataset(s).\n${details}`
+      )
+    }
   }
 
   async getDataset(datasetId: string): Promise<DatasetDefinition | null> {
@@ -114,53 +131,45 @@ export class DuckLakeDatasetCatalog {
     runtime: DuckDbQueryRuntime,
     datasetId: string
   ): Promise<DatasetDefinition | null> {
-    // Reconstruct definitions from DuckLake instead of trusting caller input.
-    // This keeps repeated createDataset calls honest across provider instances.
-    const tableName = encodeDatasetTableName(datasetId)
-    const table = await this.getDatasetTable(runtime, tableName)
-    if (!table) {
-      return null
-    }
-
-    const schema = await this.describeDatasetSchema(runtime, tableName)
-    const partitionBy = await this.getDatasetPartitionBy(runtime, tableName)
-
-    return {
-      kind: "dataset",
-      id: datasetId,
-      schema,
-      ...(partitionBy.length > 0 ? { partitionBy } : {}),
-      ...(table.comment !== undefined ? { description: table.comment } : {}),
-    }
+    return (
+      (
+        await this.readCurrentDatasetDefinitionsOnRuntime(runtime, {
+          datasetIds: [datasetId],
+        })
+      ).get(datasetId) ?? null
+    )
   }
 
   async listDatasets(): Promise<readonly DatasetDefinition[]> {
     this.connections.assertOpen()
 
     return this.connections.withAttachedRuntime(async (runtime) => {
-      // Only Sixb-encoded dataset tables are surfaced. Any DuckLake metadata,
-      // internal tables, or unrelated user tables remain invisible to LakeStorage.
-      const rows = await runtime.query(
-        `SELECT table_name FROM duckdb_tables() WHERE database_name = ${quoteSqlString(
-          duckLakeAlias(this.options)
-        )} AND schema_name = 'main' AND NOT internal ORDER BY table_name`
+      return [...(await this.readCurrentDatasetDefinitionsOnRuntime(runtime)).values()].sort(
+        (left, right) => left.id.localeCompare(right.id)
       )
+    })
+  }
 
-      const datasets: DatasetDefinition[] = []
-      for (const row of rows) {
-        const tableName = getString(row, "table_name")
-        const datasetId = decodeDatasetTableName(tableName)
-        if (datasetId === null) {
-          continue
-        }
+  private async readCurrentDatasetDefinitions(options?: {
+    readonly datasetIds?: readonly string[]
+  }): Promise<Map<string, DatasetDefinition>> {
+    if (options?.datasetIds?.length === 0) {
+      return new Map()
+    }
 
-        const definition = await this.getDatasetOnRuntime(runtime, datasetId)
-        if (definition) {
-          datasets.push(definition)
-        }
-      }
+    return this.connections.withAttachedRuntime((runtime) =>
+      this.readCurrentDatasetDefinitionsOnRuntime(runtime, options)
+    )
+  }
 
-      return datasets.sort((left, right) => left.id.localeCompare(right.id))
+  private async readCurrentDatasetDefinitionsOnRuntime(
+    runtime: DuckDbQueryRuntime,
+    options?: { readonly datasetIds?: readonly string[] }
+  ): Promise<Map<string, DatasetDefinition>> {
+    return readCurrentDatasetDefinitions({
+      options: this.options,
+      runtime,
+      datasetIds: options?.datasetIds,
     })
   }
 
@@ -304,28 +313,6 @@ export class DuckLakeDatasetCatalog {
     }
   }
 
-  private async getDatasetTable(
-    runtime: DuckDbQueryRuntime,
-    tableName: string
-  ): Promise<DatasetTableRow | null> {
-    // duckdb_tables() gives us the user-facing table comment without reaching
-    // into DuckLake's private metadata tables.
-    const rows = await runtime.query(
-      `SELECT table_name, comment FROM duckdb_tables() WHERE database_name = ${quoteSqlString(
-        duckLakeAlias(this.options)
-      )} AND schema_name = 'main' AND table_name = ${quoteSqlString(tableName)} AND NOT internal`
-    )
-
-    const row = rows[0]
-    if (row === undefined) {
-      return null
-    }
-
-    return {
-      comment: getOptionalString(row, "comment"),
-    }
-  }
-
   private async describeDatasetSchema(
     runtime: DuckDbQueryRuntime,
     tableName: string,
@@ -343,56 +330,6 @@ export class DuckLakeDatasetCatalog {
     })) satisfies DuckDbColumnMetadata[]
 
     return duckDbColumnsToDatasetSchema(columns)
-  }
-
-  private async getDatasetPartitionBy(
-    runtime: DuckDbQueryRuntime,
-    tableName: string
-  ): Promise<readonly string[]> {
-    const ducklakeTable = duckLakeMetadataTableName(this.options, "ducklake_table")
-    const ducklakePartitionInfo = duckLakeMetadataTableName(this.options, "ducklake_partition_info")
-    const ducklakePartitionColumn = duckLakeMetadataTableName(
-      this.options,
-      "ducklake_partition_column"
-    )
-    const ducklakeColumn = duckLakeMetadataTableName(this.options, "ducklake_column")
-
-    // DuckLake exposes current partition metadata through the metadata catalog
-    // attached beside the user-facing lake catalog. V1 only accepts identity
-    // transforms because Sixb's dataset definition stores partition columns,
-    // not arbitrary partition expressions such as year(orderDate).
-    const rows = await runtime.query(`
-      SELECT column_meta.column_name, partition_column.transform
-      FROM ${ducklakeTable} table_meta
-      JOIN ${ducklakePartitionInfo} partition_info
-        ON partition_info.table_id = table_meta.table_id
-        AND partition_info.end_snapshot IS NULL
-      JOIN ${ducklakePartitionColumn} partition_column
-        ON partition_column.table_id = table_meta.table_id
-        AND partition_column.partition_id = partition_info.partition_id
-      JOIN ${ducklakeColumn} column_meta
-        ON column_meta.table_id = table_meta.table_id
-        AND column_meta.column_id = partition_column.column_id
-        AND column_meta.end_snapshot IS NULL
-      WHERE table_meta.end_snapshot IS NULL
-        AND table_meta.table_name = ${quoteSqlString(tableName)}
-      ORDER BY partition_column.partition_key_index
-    `)
-
-    return rows.map((row) => {
-      const partition = {
-        columnName: getString(row, "column_name"),
-        transform: getString(row, "transform"),
-      } satisfies PartitionColumnRow
-
-      if (partition.transform !== "identity") {
-        throw new LakeStorageError(
-          `[SixbDuckLake] Dataset table '${tableName}' uses unsupported DuckLake partition transform '${partition.transform}'.`
-        )
-      }
-
-      return partition.columnName
-    })
   }
 }
 

--- a/storage/ducklake/src/internal/sql.ts
+++ b/storage/ducklake/src/internal/sql.ts
@@ -96,6 +96,10 @@ export function quoteSqlString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`
 }
 
+export function quoteSqlStringList(values: readonly string[]): string {
+  return values.map((value) => quoteSqlString(value)).join(", ")
+}
+
 /**
  * Render a fully-qualified table path.
  */

--- a/storage/ducklake/tests/ducklake-datasets.e2e.ts
+++ b/storage/ducklake/tests/ducklake-datasets.e2e.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { col, defineDataset, LakeStorageError } from "@sixb/core"
+import { col, type DatasetDefinition, defineDataset, LakeStorageError } from "@sixb/core"
 import type { DuckLakeStorage } from "../src"
 import {
   createDuckDbRuntime,
@@ -12,6 +12,39 @@ import {
 } from "../src/internal/duckdb-runtime"
 import { encodeDatasetTableName } from "../src/internal/names"
 import { createLocalDuckLakeStorage, localDuckLakeOptions } from "./test-utils"
+
+interface DuckLakeStorageInternals {
+  readonly connections: {
+    runtime(): Promise<{
+      query: (
+        sql: string,
+        values?: readonly unknown[]
+      ) => Promise<readonly Record<string, unknown>[]>
+    }>
+  }
+}
+
+async function captureStorageQueries(
+  storage: DuckLakeStorage,
+  run: () => Promise<unknown>
+): Promise<readonly string[]> {
+  const runtime = await (storage as unknown as DuckLakeStorageInternals).connections.runtime()
+  const originalQuery = runtime.query.bind(runtime)
+  const queries: string[] = []
+
+  runtime.query = async (sql, values) => {
+    queries.push(sql)
+    return originalQuery(sql, values)
+  }
+
+  try {
+    await run()
+  } finally {
+    runtime.query = originalQuery
+  }
+
+  return queries
+}
 
 describe("DuckLakeStorage dataset metadata", () => {
   let rootDir: string
@@ -171,6 +204,64 @@ describe("DuckLakeStorage dataset metadata", () => {
     ).rejects.toThrow("changing column 'notes' nullability is not supported")
 
     await expect(storage.getDataset(initialDataset.id)).resolves.toEqual(initialDataset)
+  })
+
+  test("checks many dataset definitions with bounded catalog metadata reads", async () => {
+    const definitions: DatasetDefinition[] = []
+
+    for (let index = 0; index < 12; index += 1) {
+      const dataset = defineDataset(`raw.erp.compat_${index}`, {
+        schema: [
+          col("id", "string"),
+          col("isActive", "boolean"),
+          col("count", "int64"),
+          col("score", "float64"),
+          col("amount", "decimal"),
+          col("orderDate", "date"),
+          col("createdAt", "timestamp"),
+          col("metadata", "json", { nullable: true }),
+          col("attachment", "fileRef", { nullable: true }),
+        ],
+      })
+      await storage.createDataset(dataset)
+      definitions.push(dataset)
+    }
+
+    const missingDataset = defineDataset("raw.erp.compat_missing", {
+      schema: [col("id", "string")],
+    })
+    const queries = await captureStorageQueries(storage, () =>
+      storage.assertDatasetDefinitionsCompatible([...definitions, missingDataset])
+    )
+
+    expect(queries.length).toBeLessThanOrEqual(3)
+    for (const sql of queries) {
+      expect(sql).not.toContain("DESCRIBE SELECT")
+      expect(sql).not.toContain("AT (VERSION")
+    }
+  })
+
+  test("bulk definition compatibility rejects incompatible materialized definitions", async () => {
+    await storage.createDataset(ordersDataset)
+
+    await expect(
+      storage.assertDatasetDefinitionsCompatible([
+        defineDataset(ordersDataset.id, {
+          schema: [
+            col("orderId", "int64"),
+            col("customerId", "string", { nullable: true }),
+            col("isOpen", "boolean"),
+            col("count", "int64"),
+            col("score", "float64"),
+            col("amount", "decimal"),
+            col("orderDate", "date"),
+            col("createdAt", "timestamp"),
+            col("metadata", "json", { nullable: true }),
+            col("attachment", "fileRef", { nullable: true }),
+          ],
+        }),
+      ])
+    ).rejects.toThrow(/Lake dataset definition check failed[\s\S]*changing column 'orderId' type/)
   })
 
   test("applies schema evolution and partition changes in one definition update", async () => {

--- a/storage/lake-local/src/local-lake-storage.ts
+++ b/storage/lake-local/src/local-lake-storage.ts
@@ -134,18 +134,34 @@ export class LocalLakeStorage implements LakeStorage {
     return structuredClone(merged)
   }
 
-  async assertDatasetDefinitionCompatible(definition: DatasetDefinition): Promise<void> {
-    assertDatasetId(definition.id)
+  async assertDatasetDefinitionsCompatible(
+    definitions: readonly DatasetDefinition[]
+  ): Promise<void> {
+    const failures: string[] = []
 
-    const existing = await this.getDataset(definition.id)
-    if (!existing) {
-      return
+    for (const definition of definitions) {
+      try {
+        assertDatasetId(definition.id)
+        const existing = await this.getDataset(definition.id)
+        if (!existing) {
+          continue
+        }
+
+        mergeStrictDatasetDefinition({
+          existing,
+          next: definition,
+        })
+      } catch (error) {
+        failures.push(`- ${definition.id}: ${errorMessage(error)}`)
+      }
     }
 
-    mergeStrictDatasetDefinition({
-      existing,
-      next: definition,
-    })
+    if (failures.length > 0) {
+      const details = failures.join("\n")
+      throw new LakeStorageError(
+        `[SixbLake] Lake dataset definition check failed for ${failures.length} dataset(s).\n${details}`
+      )
+    }
   }
 
   async getDataset(datasetId: string): Promise<DatasetDefinition | null> {
@@ -461,4 +477,8 @@ export class LocalLakeStorage implements LakeStorage {
   private rowsPath(datasetId: string, versionId: string): string {
     return join(this.rowsDir(datasetId), `${encodeSegment(versionId)}.jsonl`)
   }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }


### PR DESCRIPTION
# Pull Request Summary

## Overview

This PR removes the startup N+1 dataset compatibility check and replaces it with
a single bulk validation path across `LakeStorage`.

## What Changed

| Area | Change |
| --- | --- |
| Core API | Replaced the singular dataset compatibility method with `assertDatasetDefinitionsCompatible(...)`. |
| Startup check | `assertLakeDatasetDefinitionsCompatible(...)` now delegates directly to the provider bulk method. |
| DuckLake | Reads current dataset definitions from DuckLake catalog metadata in bounded queries, then validates in memory. |
| Structure | Split DuckLake catalog metadata reconstruction into focused internal modules. |
| Providers | Updated in-memory and local lake providers to implement the bulk contract. |
| Tests | Added coverage for bounded DuckLake metadata reads and bulk incompatibility failures. |

## Why

Production startup could block for minutes because compatibility validation still
checked each dataset one by one. Even though bulk catalog reads were fast, the
boot path still triggered repeated DuckLake/Postgres metadata reads.

The new path keeps startup validation read-only, but makes it scale with the
catalog instead of the number of sequential provider calls.

## Validation

```txt
bun test packages/core/tests/lake-storage-definition-updates.test.ts
bun test ./storage/ducklake/tests/ducklake-datasets.e2e.ts
bun test ./packages/cli/tests/lake.test.ts
bun test ./packages/cli/tests/runtime.test.ts
bun run typecheck
bun run build
bun run test
bun run check
```
