### PR TITLE
redis: serialize shared broker client commands

### DIFF
--- a/broker/redis/src/connection.ts
+++ b/broker/redis/src/connection.ts
@@ -18,6 +18,8 @@ export class RedisConnectionManager {
   private readonly options: RedisOptions | undefined
   private connectPromise: Promise<RedisBrokerClient> | undefined
   private client: RedisBrokerClient | undefined
+  private commandQueue: Promise<void> = Promise.resolve()
+  private closed = false
 
   constructor(options: RedisBrokerConnectionOptions = {}) {
     const { url, ...redisOptions } = options
@@ -25,7 +27,7 @@ export class RedisConnectionManager {
     this.options = Object.keys(redisOptions).length === 0 ? undefined : redisOptions
   }
 
-  async connect(): Promise<RedisBrokerClient> {
+  private async connect(): Promise<RedisBrokerClient> {
     if (this.client !== undefined) {
       // Bun owns reconnects and offline queueing for the client. Keep returning
       // the same main client while it reconnects instead of opening duplicates.
@@ -53,10 +55,49 @@ export class RedisConnectionManager {
   }
 
   async createSubscriptionClient(): Promise<RedisBrokerClient> {
-    return this.openClient("Failed to connect Redis subscription client")
+    this.assertOpen()
+    const client = await this.openClient("Failed to connect Redis subscription client")
+    if (this.closed) {
+      this.closeClient(client)
+      this.assertOpen()
+    }
+    return client
+  }
+
+  /**
+   * Serializes commands sent through the shared main client.
+   *
+   * Subscription pumps use dedicated clients, but ordinary broker reads/appends share one
+   * Bun Redis client. Keeping one in-flight command at a time avoids response interleaving
+   * across mixed `send()` calls under concurrent API traffic.
+   */
+  async useCommandClient<T>(operation: (client: RedisBrokerClient) => Promise<T>): Promise<T> {
+    this.assertOpen()
+
+    const previous = this.commandQueue
+    let release!: () => void
+    this.commandQueue = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    await previous
+    try {
+      this.assertOpen()
+      const client = await this.connect()
+      return await operation(client)
+    } finally {
+      release()
+    }
   }
 
   async close(): Promise<void> {
+    if (this.closed) {
+      await this.commandQueue
+      return
+    }
+    this.closed = true
+    await this.commandQueue
+
     const client = this.client
     this.client = undefined
     this.connectPromise = undefined
@@ -82,6 +123,12 @@ export class RedisConnectionManager {
     } catch (error) {
       this.closeClient(client)
       throw new RedisBrokerError(errorMessage, { cause: error })
+    }
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new RedisBrokerError("broker connection has been closed")
     }
   }
 }

--- a/broker/redis/src/redis-broker.ts
+++ b/broker/redis/src/redis-broker.ts
@@ -114,7 +114,6 @@ export class RedisBroker implements Broker {
     }
 
     const ensured = await this.streamManager.requireStream(params.projectId, params.streamId)
-    const client = await this.connectionManager.connect()
     const encodedRecords: EncodedAppendRecord[] = params.records.map((input) => {
       const publishedAt = new Date().toISOString()
       return {
@@ -124,11 +123,13 @@ export class RedisBroker implements Broker {
       }
     })
 
-    const appendResults = await this.appendBatch({
-      client,
-      ensured,
-      records: encodedRecords,
-    })
+    const appendResults = await this.connectionManager.useCommandClient((client) =>
+      this.appendBatch({
+        client,
+        ensured,
+        records: encodedRecords,
+      })
+    )
 
     if (appendResults.length !== encodedRecords.length) {
       throw new RedisBrokerError(
@@ -150,7 +151,9 @@ export class RedisBroker implements Broker {
                 cursor: result.cursor,
                 fallbackPublishedAt: new Date().toISOString(),
               })
-            : await this.fetchRecordByCursor(client, ensured, result.cursor)
+            : await this.connectionManager.useCommandClient((client) =>
+                this.fetchRecordByCursor(client, ensured, result.cursor)
+              )
         )
         continue
       }
@@ -189,9 +192,12 @@ export class RedisBroker implements Broker {
       return []
     }
 
-    const client = await this.connectionManager.connect()
-    await this.enforceAgeRetention(client, ensured)
-    const lastTrimmedId = await this.readLastTrimmedId(client, ensured)
+    await this.connectionManager.useCommandClient((client) =>
+      this.enforceAgeRetention(client, ensured)
+    )
+    const lastTrimmedId = await this.connectionManager.useCommandClient((client) =>
+      this.readLastTrimmedId(client, ensured)
+    )
     this.assertCursorInRetainedRange(ensured.streamId, params.afterCursor, lastTrimmedId)
 
     const names = params.names && params.names.length > 0 ? new Set(params.names) : undefined
@@ -205,7 +211,9 @@ export class RedisBroker implements Broker {
         : `(${params.afterCursor}`
 
     while (params.limit === undefined || records.length < params.limit) {
-      const entries = await this.readRange(client, ensured, start, this.readBatchSize)
+      const entries = await this.connectionManager.useCommandClient((client) =>
+        this.readRange(client, ensured, start, this.readBatchSize)
+      )
       if (entries.length === 0) {
         break
       }
@@ -257,73 +265,17 @@ export class RedisBroker implements Broker {
     assertCursor(params.afterCursor)
 
     const ensured = await this.streamManager.requireStream(params.projectId, params.streamId)
-    const commandClient = await this.connectionManager.connect()
-    await this.enforceAgeRetention(commandClient, ensured)
-    const lastTrimmedId = await this.readLastTrimmedId(commandClient, ensured)
+    const lastTrimmedId = await this.connectionManager.useCommandClient(async (commandClient) => {
+      await this.enforceAgeRetention(commandClient, ensured)
+      return this.readLastTrimmedId(commandClient, ensured)
+    })
     if (params.afterCursor !== undefined) {
       this.assertCursorInRetainedRange(ensured.streamId, params.afterCursor, lastTrimmedId)
     }
 
     const client = await this.connectionManager.createSubscriptionClient()
-    const names = params.names && params.names.length > 0 ? new Set(params.names) : undefined
-    // Resolve "latest" to a concrete id once. Reusing "$" after each BLOCK
-    // timeout can skip records written between two XREAD calls.
-    let lastSeenId =
-      params.afterCursor ??
-      (params.from === "earliest"
-        ? (lastTrimmedId ?? "0-0")
-        : await this.latestCursor(client, ensured))
     let stopped = false
-
-    const pump = (async () => {
-      try {
-        while (!stopped) {
-          const entries = await this.xread(client, ensured, lastSeenId)
-          const records: BrokerRecord[] = []
-
-          for (const entry of entries) {
-            // Advance even for records filtered out by name so the loop never
-            // replays unmatched entries forever.
-            lastSeenId = entry.id
-
-            let record: BrokerRecord
-            try {
-              record = decodeRecord({
-                streamId: ensured.streamId,
-                body: bodyFromEntry(entry),
-                cursor: entry.id,
-                fallbackPublishedAt: new Date().toISOString(),
-              })
-            } catch (error) {
-              console.error("[RedisBroker] Failed to decode subscribed record:", error)
-              continue
-            }
-
-            if (names && (!record.name || !names.has(record.name))) {
-              continue
-            }
-            records.push(record)
-          }
-
-          if (records.length === 0) {
-            continue
-          }
-
-          try {
-            handler(records)
-          } catch {
-            // Handler failures are swallowed per the Broker subscribe contract.
-          }
-        }
-      } catch (error) {
-        if (!stopped) {
-          console.error("[RedisBroker] Subscription pump failed:", error)
-        }
-      } finally {
-        this.connectionManager.closeClient(client)
-      }
-    })()
-
+    let pump: Promise<void> = Promise.resolve()
     const subscription: ActiveSubscription = {
       stop: () => {
         if (stopped) {
@@ -336,8 +288,73 @@ export class RedisBroker implements Broker {
         await pump
       },
     }
+    const unsubscribe = this.subscriptionRegistry.register(subscription)
 
-    return this.subscriptionRegistry.register(subscription)
+    try {
+      const names = params.names && params.names.length > 0 ? new Set(params.names) : undefined
+      // Resolve "latest" to a concrete id once. Reusing "$" after each BLOCK
+      // timeout can skip records written between two XREAD calls.
+      let lastSeenId =
+        params.afterCursor ??
+        (params.from === "earliest"
+          ? (lastTrimmedId ?? "0-0")
+          : await this.latestCursor(client, ensured))
+      this.assertOpen()
+
+      pump = (async () => {
+        try {
+          while (!stopped) {
+            const entries = await this.xread(client, ensured, lastSeenId)
+            const records: BrokerRecord[] = []
+
+            for (const entry of entries) {
+              // Advance even for records filtered out by name so the loop never
+              // replays unmatched entries forever.
+              lastSeenId = entry.id
+
+              let record: BrokerRecord
+              try {
+                record = decodeRecord({
+                  streamId: ensured.streamId,
+                  body: bodyFromEntry(entry),
+                  cursor: entry.id,
+                  fallbackPublishedAt: new Date().toISOString(),
+                })
+              } catch (error) {
+                console.error("[RedisBroker] Failed to decode subscribed record:", error)
+                continue
+              }
+
+              if (names && (!record.name || !names.has(record.name))) {
+                continue
+              }
+              records.push(record)
+            }
+
+            if (records.length === 0) {
+              continue
+            }
+
+            try {
+              handler(records)
+            } catch {
+              // Handler failures are swallowed per the Broker subscribe contract.
+            }
+          }
+        } catch (error) {
+          if (!stopped) {
+            console.error("[RedisBroker] Subscription pump failed:", error)
+          }
+        } finally {
+          this.connectionManager.closeClient(client)
+        }
+      })()
+
+      return unsubscribe
+    } catch (error) {
+      unsubscribe()
+      throw error
+    }
   }
 
   async close(): Promise<void> {
@@ -346,9 +363,9 @@ export class RedisBroker implements Broker {
     }
     this.closed = true
     try {
-      await this.subscriptionRegistry.drain()
-    } finally {
       await this.connectionManager.close()
+    } finally {
+      await this.subscriptionRegistry.drain()
     }
   }
 

--- a/broker/redis/src/stream-manager.ts
+++ b/broker/redis/src/stream-manager.ts
@@ -39,25 +39,25 @@ export class StreamManager {
     }
 
     const retention = normalizeRetention(stream.retention)
-    const client = await this.connectionManager.connect()
-
-    try {
-      // The script creates metadata only when absent. That mirrors NATS'
-      // "bind to existing stream config" behavior and avoids changing
-      // production retention if a later runtime starts with different options.
-      await client.send("EVAL", [
-        ENSURE_STREAM_SCRIPT,
-        "1",
-        keys.metaKey,
-        projectId,
-        stream.id,
-        new Date().toISOString(),
-        retention.maxAgeMs === undefined ? "" : String(retention.maxAgeMs),
-        retention.maxRecords === undefined ? "" : String(retention.maxRecords),
-      ])
-    } catch (error) {
-      throw new RedisBrokerError(`Failed to ensure stream "${stream.id}"`, { cause: error })
-    }
+    await this.connectionManager.useCommandClient(async (client) => {
+      try {
+        // The script creates metadata only when absent. That mirrors NATS'
+        // "bind to existing stream config" behavior and avoids changing
+        // production retention if a later runtime starts with different options.
+        await client.send("EVAL", [
+          ENSURE_STREAM_SCRIPT,
+          "1",
+          keys.metaKey,
+          projectId,
+          stream.id,
+          new Date().toISOString(),
+          retention.maxAgeMs === undefined ? "" : String(retention.maxAgeMs),
+          retention.maxRecords === undefined ? "" : String(retention.maxRecords),
+        ])
+      } catch (error) {
+        throw new RedisBrokerError(`Failed to ensure stream "${stream.id}"`, { cause: error })
+      }
+    })
 
     const ensured = { projectId, streamId: stream.id, keys }
     this.knownStreams.set(keys.metaKey, ensured)
@@ -74,13 +74,13 @@ export class StreamManager {
       return cached
     }
 
-    const client = await this.connectionManager.connect()
-    let exists: boolean
-    try {
-      exists = await client.exists(keys.metaKey)
-    } catch (error) {
-      throw new RedisBrokerError(`Failed to inspect stream "${streamId}"`, { cause: error })
-    }
+    const exists = await this.connectionManager.useCommandClient(async (client) => {
+      try {
+        return await client.exists(keys.metaKey)
+      } catch (error) {
+        throw new RedisBrokerError(`Failed to inspect stream "${streamId}"`, { cause: error })
+      }
+    })
 
     if (!exists) {
       return null

--- a/broker/redis/tests/redis-broker.e2e.ts
+++ b/broker/redis/tests/redis-broker.e2e.ts
@@ -95,6 +95,44 @@ describe("RedisBroker", () => {
     }
   })
 
+  test("handles concurrent appends and retained reads on the shared command client", async () => {
+    const { broker, projectId, cleanup } = createTestBroker()
+    const stream = { id: "__concurrent_events" }
+    try {
+      await broker.ensureStream({ projectId, stream })
+
+      const appendTasks = Array.from({ length: 100 }, (_, index) =>
+        broker.append({
+          projectId,
+          streamId: stream.id,
+          records: [
+            {
+              name: "workflow.run.queued",
+              key: `workflow:run-${index}`,
+              payload: {
+                workflowId: "workflow",
+                runId: `run-${index}`,
+                queuedAt: new Date().toISOString(),
+                source: { type: "manual" },
+              },
+            },
+          ],
+        })
+      )
+      const readTasks = Array.from({ length: 50 }, () =>
+        broker.read({ projectId, streamId: stream.id, limit: 25 })
+      )
+
+      const results = await Promise.all([...appendTasks, ...readTasks])
+      expect(results.slice(0, appendTasks.length).flat()).toHaveLength(100)
+
+      const retained = await broker.read({ projectId, streamId: stream.id, limit: 200 })
+      expect(retained).toHaveLength(100)
+    } finally {
+      await cleanup()
+    }
+  })
+
   test("deduplicates records inside a bulk append before retention trims them", async () => {
     const { broker, projectId, cleanup } = createTestBroker()
     const stream = { id: "__bulk_dedupe_retained", retention: { maxRecords: 1 } }
@@ -217,6 +255,75 @@ describe("RedisBroker", () => {
     ).rejects.toThrow("broker has been closed")
 
     expect(received).toEqual([{ id: "room-before-close" }])
+  })
+
+  test("close rejects operations that have not enqueued their command yet", async () => {
+    const { broker, projectId } = createTestBroker()
+    const stream = { id: "__close_race" }
+    await broker.ensureStream({ projectId, stream })
+
+    const manager = (
+      broker as unknown as {
+        streamManager: {
+          requireStream(projectId: string, streamId: string): Promise<unknown>
+        }
+      }
+    ).streamManager
+    const originalRequireStream = manager.requireStream.bind(manager)
+    let releaseRequireStream!: () => void
+    const requireStreamGate = new Promise<void>((resolve) => {
+      releaseRequireStream = resolve
+    })
+    const blockedInRequireStream = new Promise<void>((resolve) => {
+      manager.requireStream = async (projectId, streamId) => {
+        const ensured = await originalRequireStream(projectId, streamId)
+        resolve()
+        await requireStreamGate
+        return ensured
+      }
+    })
+
+    const append = broker.append({
+      projectId,
+      streamId: stream.id,
+      records: [{ name: "object.upserted", payload: { id: "room-after-close" } }],
+    })
+
+    await blockedInRequireStream
+    await broker.close()
+    releaseRequireStream()
+
+    await expect(append).rejects.toThrow("closed")
+  })
+
+  test("close rejects subscriptions that are still resolving their starting cursor", async () => {
+    const { broker, projectId } = createTestBroker()
+    const stream = { id: "__subscribe_close_race" }
+    await broker.ensureStream({ projectId, stream })
+
+    const brokerInternals = broker as unknown as {
+      latestCursor(client: unknown, ensured: unknown): Promise<string>
+    }
+    const originalLatestCursor = brokerInternals.latestCursor.bind(broker)
+    let releaseLatestCursor!: () => void
+    const latestCursorGate = new Promise<void>((resolve) => {
+      releaseLatestCursor = resolve
+    })
+    const blockedInLatestCursor = new Promise<void>((resolve) => {
+      brokerInternals.latestCursor = async (client, ensured) => {
+        resolve()
+        await latestCursorGate
+        return originalLatestCursor(client, ensured)
+      }
+    })
+
+    const subscribe = broker.subscribe({ projectId, streamId: stream.id }, () => {})
+
+    await blockedInLatestCursor
+    await broker.close()
+    releaseLatestCursor()
+
+    await expect(subscribe).rejects.toThrow()
   })
 
   test("allows reads after the latest trimmed cursor boundary", async () => {


### PR DESCRIPTION
## Problem

Production Redis broker appends could receive the wrong Redis reply under concurrent API traffic. The workflow-run API was failing while appending `workflow.run.queued` because the append parser expected the Lua script tuple but received an `XRANGE`-style stream reply from another command.

Observed log:

```txt
[RedisBroker] append EVAL malformed raw reply {"streamId":"__events","reply":[["1780403280057-0",["body","{\"name\":\"sync.run.started\"..."]]]}
```

Expected append script shape:

```txt
[["stored","<cursor>",""]]
```

## Change

- Serialize ordinary Redis broker commands on the shared Bun Redis client.
- Keep blocking subscription `XREAD` calls on dedicated clients.
- Avoid holding the shared command queue across whole retained reads; lock per Redis command/page.
- Reject late operations/subscriptions once broker close starts, and register subscription clients before async cursor setup.
- Add e2e coverage for concurrent append/read traffic and close races.

## Validation

```bash
bun --filter @sixb/broker-redis typecheck
bun --filter @sixb/broker-redis test:e2e
bun --filter @sixb/broker-redis build
bun run check
```
