### PR TITLE
Speed up DuckLake version metadata reads

### DIFF
--- a/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
+++ b/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
@@ -7,18 +7,23 @@ import type {
 } from "@sixb/core"
 import { LakeStorageError, planDatasetDefinitionUpdate } from "@sixb/core"
 import type { DuckLakeStorageOptions } from "../types"
-import { getString } from "./duckdb-row"
+import { getBigIntLike, getBoolean, getOptionalBigIntLike, getString } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
+import {
+  type DuckLakeCatalogColumn,
+  duckLakeCatalogColumnsToDatasetSchema,
+} from "./ducklake-catalog-schema"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import { readCurrentDatasetDefinitions } from "./ducklake-current-dataset-definitions"
 import { encodeDatasetTableName } from "./names"
+import { datasetColumnToDuckDbSql, datasetSchemaToDuckDbColumnsSql } from "./schema"
 import {
-  type DuckDbColumnMetadata,
-  datasetColumnToDuckDbSql,
-  datasetSchemaToDuckDbColumnsSql,
-  duckDbColumnsToDatasetSchema,
-} from "./schema"
-import { duckLakeAlias, qualifiedTableName, quoteIdentifier, quoteSqlString } from "./sql"
+  duckLakeAlias,
+  duckLakeMetadataTableName,
+  qualifiedTableName,
+  quoteIdentifier,
+  quoteSqlString,
+} from "./sql"
 
 /**
  * Translates between Sixb dataset definitions and DuckLake table metadata.
@@ -176,12 +181,20 @@ export class DuckLakeDatasetCatalog {
   async getDatasetSchemaAtSnapshot(
     runtime: DuckDbQueryRuntime,
     datasetId: string,
+    tableId: bigint,
     snapshotId: string
   ): Promise<DatasetSchema> {
     assertDuckLakeSnapshotId(snapshotId)
 
     const tableName = encodeDatasetTableName(datasetId)
-    return this.describeDatasetSchema(runtime, tableName, snapshotId)
+    const columns = await this.readDatasetColumnsAtSnapshot(runtime, tableName, tableId, snapshotId)
+    if (columns.length === 0) {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Could not reconstruct schema for dataset '${datasetId}' at DuckLake snapshot '${snapshotId}'.`
+      )
+    }
+
+    return duckLakeCatalogColumnsToDatasetSchema(tableName, columns)
   }
 
   assertSchema(definition: DatasetDefinition): void {
@@ -313,23 +326,37 @@ export class DuckLakeDatasetCatalog {
     }
   }
 
-  private async describeDatasetSchema(
+  private async readDatasetColumnsAtSnapshot(
     runtime: DuckDbQueryRuntime,
     tableName: string,
-    snapshotId?: string
-  ): Promise<DatasetSchema> {
-    const tableSql = qualifiedTableName(this.options, tableName)
-    const versionSql = snapshotId === undefined ? "" : ` AT (VERSION => ${snapshotId})`
-    const relationSql = `${tableSql}${versionSql}`
-    const rows = await runtime.query(`DESCRIBE SELECT * FROM ${relationSql}`)
+    tableId: bigint,
+    snapshotId: string
+  ): Promise<readonly DuckLakeCatalogColumn[]> {
+    const ducklakeColumn = duckLakeMetadataTableName(this.options, "ducklake_column")
+    const rows = await runtime.query(`
+      SELECT
+        column_id,
+        column_order,
+        column_name,
+        column_type,
+        CAST(nulls_allowed AS BOOLEAN) AS nulls_allowed,
+        parent_column
+      FROM ${ducklakeColumn}
+      WHERE table_id = ${tableId}
+        AND begin_snapshot <= ${snapshotId}
+        AND (end_snapshot IS NULL OR end_snapshot > ${snapshotId})
+      ORDER BY column_order
+    `)
 
-    const columns = rows.map((row) => ({
-      name: getString(row, "column_name"),
-      type: getString(row, "column_type"),
-      nullable: getDescribeColumnNullable(row),
-    })) satisfies DuckDbColumnMetadata[]
-
-    return duckDbColumnsToDatasetSchema(columns)
+    return rows.map((row) => ({
+      tableName,
+      columnId: getBigIntLike(row, "column_id"),
+      columnOrder: getBigIntLike(row, "column_order"),
+      columnName: getString(row, "column_name"),
+      columnType: getString(row, "column_type"),
+      nullsAllowed: getBoolean(row, "nulls_allowed"),
+      parentColumnId: getOptionalBigIntLike(row, "parent_column"),
+    }))
   }
 }
 
@@ -337,21 +364,4 @@ function assertDuckLakeSnapshotId(snapshotId: string): void {
   if (!/^\d+$/.test(snapshotId)) {
     throw new LakeStorageError(`[SixbDuckLake] Invalid DuckLake snapshot id '${snapshotId}'.`)
   }
-}
-
-function getDescribeColumnNullable(row: Readonly<Record<string, unknown>>): boolean {
-  // DuckDB DESCRIBE reports nullability as text in a column named "null".
-  // Normalize that provider shape into the boolean used by DatasetColumnDefinition.
-  const value = getString(row, "null")
-  if (value === "YES") {
-    return true
-  }
-
-  if (value === "NO") {
-    return false
-  }
-
-  throw new LakeStorageError(
-    `[SixbDuckLake] Expected DuckDB DESCRIBE column 'null' to be YES or NO.`
-  )
 }

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -13,7 +13,7 @@ import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
 import { encodeDatasetTableName } from "./names"
-import { duckLakeMetadataTableName, qualifiedTableName, quoteSqlString } from "./sql"
+import { duckLakeMetadataTableName, quoteSqlString } from "./sql"
 import {
   parseCommitMetadata,
   parseInlineDataChange,
@@ -24,6 +24,7 @@ import {
 
 interface DatasetSnapshotRow {
   readonly snapshotId: string
+  readonly tableId: bigint
   readonly createdAt: Date
   readonly mode: DatasetVersionMode
   readonly parentSnapshotId?: string
@@ -736,6 +737,7 @@ export class DuckLakeSnapshotReader {
 
       return {
         snapshotId: candidate.snapshotId,
+        tableId,
         createdAt: candidate.createdAt,
         mode: metadata.mode ?? "schema",
         metadata,
@@ -749,6 +751,7 @@ export class DuckLakeSnapshotReader {
 
     return {
       snapshotId: candidate.snapshotId,
+      tableId,
       createdAt: candidate.createdAt,
       mode: candidate.metadata?.mode ?? (hasDeleteChange ? "snapshot" : "append"),
       ...(candidate.metadata !== undefined ? { metadata: candidate.metadata } : {}),
@@ -763,16 +766,14 @@ export class DuckLakeSnapshotReader {
     const schemaAtSnapshot = await this.datasets.getDatasetSchemaAtSnapshot(
       runtime,
       dataset.id,
+      row.tableId,
       row.snapshotId
     )
 
     // DuckLake gives us version id, timestamp, and time travel. Sixb metadata
     // fills in caller intent such as append vs snapshot and producer lineage.
-    // New Sixb commits include exact row counts to avoid full table counts on
-    // the write hot path; legacy or external snapshots still fall back to
-    // DuckLake time travel.
-    const rowCount =
-      row.metadata?.rowCount ?? (await this.countRowsAtSnapshot(runtime, dataset, row.snapshotId))
+    // Version listing is a metadata path, so it only carries row counts already
+    // stored in Sixb commit metadata and never counts historical table contents.
 
     return {
       datasetId: dataset.id,
@@ -784,27 +785,8 @@ export class DuckLakeSnapshotReader {
       schema: schemaAtSnapshot,
       producer: row.metadata?.producer,
       inputs: row.metadata?.inputs,
-      rowCount,
+      ...(row.metadata?.rowCount !== undefined ? { rowCount: row.metadata.rowCount } : {}),
     }
-  }
-
-  private async countRowsAtSnapshot(
-    runtime: DuckDbQueryRuntime,
-    dataset: DatasetDefinition,
-    snapshotId: string
-  ): Promise<number> {
-    const tableName = encodeDatasetTableName(dataset.id)
-    const [result] = await runtime.query(
-      `SELECT count(*) AS row_count FROM ${qualifiedTableName(
-        this.options,
-        tableName
-      )} AT (VERSION => ${snapshotId})`
-    )
-    if (result === undefined) {
-      return 0
-    }
-
-    return Number(getBigIntLike(result, "row_count"))
   }
 
   private withParentSnapshotIds(

--- a/storage/ducklake/tests/ducklake-datasets.e2e.ts
+++ b/storage/ducklake/tests/ducklake-datasets.e2e.ts
@@ -290,8 +290,8 @@ describe("DuckLakeStorage dataset metadata", () => {
       datasetId: initialDataset.id,
       mode: "schema",
       schema: evolvedPartitionedDataset.schema,
-      rowCount: 0,
     })
+    expect(versions[0]).not.toHaveProperty("rowCount")
   })
 
   test("keeps schema evolution transaction exclusive from concurrent commit blocks", async () => {

--- a/storage/ducklake/tests/ducklake-versions.e2e.ts
+++ b/storage/ducklake/tests/ducklake-versions.e2e.ts
@@ -4,10 +4,17 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { col, defineDataset } from "@sixb/core"
 import type { DuckLakeStorage } from "../src"
+import type { DuckDbQueryRuntime } from "../src/internal/duckdb-runtime"
 import { createDuckDbRuntime, setupDuckLake } from "../src/internal/duckdb-runtime"
 import { encodeDatasetTableName } from "../src/internal/names"
 import { quoteSqlString } from "../src/internal/sql"
 import { collectRows, createLocalDuckLakeStorage, localDuckLakeOptions } from "./test-utils"
+
+interface DuckLakeStorageInternals {
+  readonly connections: {
+    attachedRuntime(): Promise<DuckDbQueryRuntime>
+  }
+}
 
 describe("DuckLakeStorage versions and time travel", () => {
   let rootDir: string
@@ -65,13 +72,14 @@ describe("DuckLakeStorage versions and time travel", () => {
       mode: "snapshot",
       rowCount: 1,
     })
-    expect(await storage.getVersion(ordersDataset.id, version2.versionId)).toMatchObject({
+    const appendVersion = await storage.getVersion(ordersDataset.id, version2.versionId)
+    expect(appendVersion).toMatchObject({
       versionId: version2.versionId,
       parentVersionId: version1.versionId,
       mode: "append",
       inputs: [{ datasetId: ordersDataset.id, versionId: version1.versionId }],
-      rowCount: 3,
     })
+    expect(appendVersion).not.toHaveProperty("rowCount")
 
     const versions = await storage.listVersions(ordersDataset.id)
     expect(versions.map((version) => version.versionId)).toEqual([
@@ -104,6 +112,51 @@ describe("DuckLakeStorage versions and time travel", () => {
     expect(await collectRows(storage.readRows({ datasetId: ordersDataset.id }))).toEqual([
       { orderId: "ord_9", customerName: "Dorothy", orderCount: "9", metadata: null },
     ])
+  })
+
+  test("lists versions without historical table scans when row counts are absent", async () => {
+    const snapshotWrite = await storage.beginWrite({
+      dataset: ordersDataset,
+      mode: "snapshot",
+    })
+    await snapshotWrite.writeRows([{ orderId: "ord_1", customerName: "Ada", orderCount: 1 }])
+    const version1 = await snapshotWrite.commit()
+
+    const appendWrite = await storage.beginWrite({
+      dataset: ordersDataset,
+      mode: "append",
+      inputs: [{ datasetId: ordersDataset.id, versionId: version1.versionId }],
+    })
+    await appendWrite.writeRows([{ orderId: "ord_2", customerName: "Grace", orderCount: 2 }])
+    const version2 = await appendWrite.commit()
+    expect(version2).not.toHaveProperty("rowCount")
+
+    const runtime = await (
+      storage as unknown as DuckLakeStorageInternals
+    ).connections.attachedRuntime()
+    const originalQuery = runtime.query.bind(runtime)
+    runtime.query = (async (sql, values) => {
+      if (
+        /SELECT\s+count\(\*\)\s+AS\s+row_count/i.test(sql) ||
+        /DESCRIBE\s+SELECT\s+\*\s+FROM[\s\S]*\bAT\s*\(\s*VERSION\s*=>/i.test(sql)
+      ) {
+        throw new Error(`Unexpected historical table scan in version listing: ${sql}`)
+      }
+
+      return originalQuery(sql, values)
+    }) satisfies DuckDbQueryRuntime["query"]
+
+    try {
+      const versions = await storage.listVersions(ordersDataset.id, 2)
+      expect(versions.map((version) => version.versionId)).toEqual([
+        version2.versionId,
+        version1.versionId,
+      ])
+      expect(versions[0]).not.toHaveProperty("rowCount")
+      expect(versions[1]).toMatchObject({ rowCount: 1 })
+    } finally {
+      runtime.query = originalQuery
+    }
   })
 
   test("discovers data changes and Sixb metadata-only snapshots", async () => {
@@ -146,13 +199,13 @@ describe("DuckLakeStorage versions and time travel", () => {
     expect(versions[0]).toMatchObject({
       datasetId: ordersDataset.id,
       mode: "append",
-      rowCount: 1,
     })
+    expect(versions[0]).not.toHaveProperty("rowCount")
     expect(versions[1]).toMatchObject({
       datasetId: ordersDataset.id,
       mode: "append",
-      rowCount: 1,
     })
+    expect(versions[1]).not.toHaveProperty("rowCount")
     expect(await storage.getLatestVersion(ordersDataset.id)).toEqual(versions[0])
     expect(await collectRows(storage.readRows({ datasetId: ordersDataset.id }))).toEqual([
       { orderId: "raw_1", customerName: "External", orderCount: "1", metadata: null },

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -88,7 +88,7 @@ describe("DuckLakeStorage writes and latest reads", () => {
 
     expect(version2.versionId).toStartWith("ducklake:")
     expect(version2.parentVersionId).toBe(version1.versionId)
-    expect(version2.rowCount).toBe(3)
+    expect(version2).not.toHaveProperty("rowCount")
     expect(version2.inputs).toEqual([
       { datasetId: "raw.erp.orders", versionId: version1.versionId },
     ])
@@ -102,7 +102,7 @@ describe("DuckLakeStorage writes and latest reads", () => {
     ])
   })
 
-  test("does not persist derived row counts for unguarded appends", async () => {
+  test("omits derived row counts for unguarded appends", async () => {
     const snapshotWrite = await storage.beginWrite({
       dataset: ordersDataset,
       mode: "snapshot",
@@ -125,11 +125,12 @@ describe("DuckLakeStorage writes and latest reads", () => {
     await appendWrite.writeRows([{ orderId: "ord_2", customerName: "Grace", orderCount: 2 }])
     const appendVersion = await appendWrite.commit()
 
-    expect(appendVersion.rowCount).toBe(2)
-    expect(await storage.getLatestVersion(ordersDataset.id)).toMatchObject({
+    expect(appendVersion).not.toHaveProperty("rowCount")
+    const latestVersion = await storage.getLatestVersion(ordersDataset.id)
+    expect(latestVersion).toMatchObject({
       versionId: appendVersion.versionId,
-      rowCount: 2,
     })
+    expect(latestVersion).not.toHaveProperty("rowCount")
 
     const metadata = await commitMetadataForVersion(storage, rootDir, appendVersion.versionId)
     expect(metadata).toMatchObject({
@@ -349,9 +350,9 @@ describe("DuckLakeStorage writes and latest reads", () => {
     expect(schemaVersion).toMatchObject({
       mode: "schema",
       parentVersionId: initialVersion.versionId,
-      rowCount: 1,
       schema: storedEvolvedDataset.schema,
     })
+    expect(schemaVersion).not.toHaveProperty("rowCount")
 
     const versionsAfterSchemaEvolution = await storage.listVersions(initialDataset.id)
     expect(versionsAfterSchemaEvolution).toHaveLength(2)
@@ -359,9 +360,9 @@ describe("DuckLakeStorage writes and latest reads", () => {
       versionId: schemaVersion?.versionId,
       mode: "schema",
       parentVersionId: initialVersion.versionId,
-      rowCount: 1,
       schema: storedEvolvedDataset.schema,
     })
+    expect(versionsAfterSchemaEvolution[0]).not.toHaveProperty("rowCount")
     expect(versionsAfterSchemaEvolution[1]).toMatchObject({
       versionId: initialVersion.versionId,
       rowCount: 1,
@@ -378,10 +379,12 @@ describe("DuckLakeStorage writes and latest reads", () => {
 
     expect(evolvedVersion.parentVersionId).toBe(schemaVersion?.versionId)
     expect(evolvedVersion.schema).toEqual(storedEvolvedDataset.schema)
-    await expect(storage.getLatestVersion(initialDataset.id)).resolves.toMatchObject({
+    expect(evolvedVersion).not.toHaveProperty("rowCount")
+    const latestVersionAfterAppend = await storage.getLatestVersion(initialDataset.id)
+    expect(latestVersionAfterAppend).toMatchObject({
       versionId: evolvedVersion.versionId,
-      rowCount: 2,
     })
+    expect(latestVersionAfterAppend).not.toHaveProperty("rowCount")
     await expect(collectRows(storage.readRows({ datasetId: initialDataset.id }))).resolves.toEqual([
       { invoiceId: "inv_1", total: "100", currency: null },
       { invoiceId: "inv_2", total: "200", currency: "EUR" },


### PR DESCRIPTION
# Fast DuckLake Version History

## Summary

This PR makes DuckLake dataset version metadata reads faster and safer for Atlas dataset detail pages.

## What Changed

| Area | Before | After |
| --- | --- | --- |
| Historical schema | `DESCRIBE SELECT * FROM table AT VERSION` | Rebuilt from DuckLake catalog metadata |
| Version row counts | Fallback `COUNT(*) AT VERSION` | Metadata-only, omitted when unknown |
| `/versions?limit=1` | Could still trigger expensive historical table reads | Stays on metadata reads |

## Details

- Reconstruct historical schemas from `ducklake_column` using `begin_snapshot` / `end_snapshot`.
- Carry the DuckLake `table_id` through snapshot hydration so schema lookup targets the exact table metadata.
- Stop deriving missing `rowCount` during version hydration; row counts are returned only when already stored in SixB commit metadata.
- Add a regression test that fails if version listing reintroduces historical table scans.

## Validation

- `bun --filter @sixb/ducklake typecheck`
- `bun --filter @sixb/ducklake test:e2e:local`
- `bun --filter @sixb/ducklake test:e2e:remote`
- `bun run typecheck`
- `bun run check`