### PR TITLE
core: link projections from dataset fields

### DIFF
--- a/examples/acme-corp/datasets/erp.ts
+++ b/examples/acme-corp/datasets/erp.ts
@@ -63,8 +63,8 @@ export const erpDocumentsDataset = defineDataset("erp.documents", {
     col("type", "string"),
     col("version", "string"),
     col("createdAt", "timestamp"),
-    col("projectRef", "string"),
-    col("authorRef", "string"),
+    col("project_id", "string"),
+    col("author_id", "string"),
   ],
 })
 
@@ -77,8 +77,8 @@ export const erpInvoicesDataset = defineDataset("erp.invoices", {
     col("status", "string"),
     col("issuedAt", "timestamp"),
     col("dueDate", "date"),
-    col("customerRef", "string"),
-    col("projectRef", "string"),
+    col("customer_id", "string"),
+    col("project_id", "string"),
   ],
 })
 
@@ -90,7 +90,7 @@ export const erpTasksDataset = defineDataset("erp.tasks", {
     col("priority", "string"),
     col("estimate", "int64"),
     col("dueDate", "date"),
-    col("projectRef", "string"),
-    col("assigneeRef", "string"),
+    col("project_id", "string"),
+    col("assignee_id", "string"),
   ],
 })

--- a/examples/acme-corp/lib/acme-erp.ts
+++ b/examples/acme-corp/lib/acme-erp.ts
@@ -47,8 +47,8 @@ export interface ErpDocumentRow {
   readonly type: string
   readonly version: string
   readonly createdAt: string
-  readonly projectRef: string
-  readonly authorRef: string
+  readonly project_id: string
+  readonly author_id: string
 }
 
 export interface ErpInvoiceRow {
@@ -59,8 +59,8 @@ export interface ErpInvoiceRow {
   readonly status: string
   readonly issuedAt: string
   readonly dueDate: string
-  readonly customerRef: string
-  readonly projectRef: string
+  readonly customer_id: string
+  readonly project_id: string
 }
 
 export interface ErpTaskRow {
@@ -70,8 +70,8 @@ export interface ErpTaskRow {
   readonly priority: string
   readonly estimate: number
   readonly dueDate: string
-  readonly projectRef: string
-  readonly assigneeRef: string
+  readonly project_id: string
+  readonly assignee_id: string
 }
 
 export interface AcmeErpClient {
@@ -255,8 +255,8 @@ const documents = [
     type: "proposal",
     version: "2.1",
     createdAt: "2024-01-05T10:00:00Z",
-    projectRef: "proj-techstart-platform",
-    authorRef: "emp-alice",
+    project_id: "proj-techstart-platform",
+    author_id: "emp-alice",
   },
   {
     id: "doc-techstart-contract",
@@ -264,8 +264,8 @@ const documents = [
     type: "contract",
     version: "1.0",
     createdAt: "2024-01-12T14:30:00Z",
-    projectRef: "proj-techstart-platform",
-    authorRef: "emp-clara",
+    project_id: "proj-techstart-platform",
+    author_id: "emp-clara",
   },
   {
     id: "doc-greenenergy-spec",
@@ -273,8 +273,8 @@ const documents = [
     type: "specification",
     version: "1.3",
     createdAt: "2024-02-20T09:00:00Z",
-    projectRef: "proj-greenenergy-dashboard",
-    authorRef: "emp-bob",
+    project_id: "proj-greenenergy-dashboard",
+    author_id: "emp-bob",
   },
   {
     id: "doc-healthfirst-report",
@@ -282,8 +282,8 @@ const documents = [
     type: "report",
     version: "1.0",
     createdAt: "2024-01-28T16:00:00Z",
-    projectRef: "proj-healthfirst-portal",
-    authorRef: "emp-alice",
+    project_id: "proj-healthfirst-portal",
+    author_id: "emp-alice",
   },
 ] satisfies readonly ErpDocumentRow[]
 
@@ -296,8 +296,8 @@ const invoices = [
     status: "paid",
     issuedAt: "2024-04-01T00:00:00Z",
     dueDate: "2024-04-30",
-    customerRef: "cust-techstart",
-    projectRef: "proj-techstart-platform",
+    customer_id: "cust-techstart",
+    project_id: "proj-techstart-platform",
   },
   {
     id: "inv-002",
@@ -307,8 +307,8 @@ const invoices = [
     status: "sent",
     issuedAt: "2024-07-01T00:00:00Z",
     dueDate: "2024-07-31",
-    customerRef: "cust-greenenergy",
-    projectRef: "proj-greenenergy-dashboard",
+    customer_id: "cust-greenenergy",
+    project_id: "proj-greenenergy-dashboard",
   },
   {
     id: "inv-003",
@@ -318,8 +318,8 @@ const invoices = [
     status: "paid",
     issuedAt: "2024-07-01T00:00:00Z",
     dueDate: "2024-07-31",
-    customerRef: "cust-techstart",
-    projectRef: "proj-techstart-platform",
+    customer_id: "cust-techstart",
+    project_id: "proj-techstart-platform",
   },
   {
     id: "inv-004",
@@ -329,8 +329,8 @@ const invoices = [
     status: "overdue",
     issuedAt: "2024-05-01T00:00:00Z",
     dueDate: "2024-05-31",
-    customerRef: "cust-healthfirst",
-    projectRef: "proj-healthfirst-portal",
+    customer_id: "cust-healthfirst",
+    project_id: "proj-healthfirst-portal",
   },
   {
     id: "inv-005",
@@ -340,8 +340,8 @@ const invoices = [
     status: "draft",
     issuedAt: "2024-08-01T00:00:00Z",
     dueDate: "2024-08-31",
-    customerRef: "cust-eduplatform",
-    projectRef: "proj-eduplatform-redesign",
+    customer_id: "cust-eduplatform",
+    project_id: "proj-eduplatform-redesign",
   },
 ] satisfies readonly ErpInvoiceRow[]
 
@@ -353,8 +353,8 @@ const tasks = [
     priority: "high",
     estimate: 8,
     dueDate: "2024-02-01",
-    projectRef: "proj-techstart-platform",
-    assigneeRef: "emp-bob",
+    project_id: "proj-techstart-platform",
+    assignee_id: "emp-bob",
   },
   {
     id: "task-002",
@@ -363,8 +363,8 @@ const tasks = [
     priority: "high",
     estimate: 5,
     dueDate: "2024-02-15",
-    projectRef: "proj-techstart-platform",
-    assigneeRef: "emp-emma",
+    project_id: "proj-techstart-platform",
+    assignee_id: "emp-emma",
   },
   {
     id: "task-003",
@@ -373,8 +373,8 @@ const tasks = [
     priority: "critical",
     estimate: 13,
     dueDate: "2024-04-15",
-    projectRef: "proj-techstart-platform",
-    assigneeRef: "emp-alice",
+    project_id: "proj-techstart-platform",
+    assignee_id: "emp-alice",
   },
   {
     id: "task-004",
@@ -383,8 +383,8 @@ const tasks = [
     priority: "high",
     estimate: 21,
     dueDate: "2024-06-30",
-    projectRef: "proj-greenenergy-dashboard",
-    assigneeRef: "emp-bob",
+    project_id: "proj-greenenergy-dashboard",
+    assignee_id: "emp-bob",
   },
   {
     id: "task-005",
@@ -393,8 +393,8 @@ const tasks = [
     priority: "medium",
     estimate: 8,
     dueDate: "2024-07-15",
-    projectRef: "proj-greenenergy-dashboard",
-    assigneeRef: "emp-emma",
+    project_id: "proj-greenenergy-dashboard",
+    assignee_id: "emp-emma",
   },
   {
     id: "task-006",
@@ -403,8 +403,8 @@ const tasks = [
     priority: "medium",
     estimate: 5,
     dueDate: "2024-07-01",
-    projectRef: "proj-eduplatform-redesign",
-    assigneeRef: "emp-emma",
+    project_id: "proj-eduplatform-redesign",
+    assignee_id: "emp-emma",
   },
   {
     id: "task-007",
@@ -413,8 +413,8 @@ const tasks = [
     priority: "low",
     estimate: 3,
     dueDate: "2024-01-25",
-    projectRef: "proj-healthfirst-portal",
-    assigneeRef: "emp-alice",
+    project_id: "proj-healthfirst-portal",
+    assignee_id: "emp-alice",
   },
 ] satisfies readonly ErpTaskRow[]
 

--- a/examples/acme-corp/ontology/customer.ts
+++ b/examples/acme-corp/ontology/customer.ts
@@ -12,7 +12,6 @@ export const Customer = defineObjectType({
     prop("company", "string", { required: true }),
     prop("industry", "string"),
     prop("tier", stringEnum(["bronze", "silver", "gold", "platinum"])),
-    prop("accountManagerRef", "string"),
   ],
   links: [link("accountManager", Employee, { cardinality: "one" })],
 })

--- a/examples/acme-corp/ontology/document.ts
+++ b/examples/acme-corp/ontology/document.ts
@@ -12,8 +12,6 @@ export const Document = defineObjectType({
     prop("type", stringEnum(["proposal", "contract", "specification", "report", "deliverable"])),
     prop("version", "string"),
     prop("createdAt", "timestamp"),
-    prop("projectRef", "string"),
-    prop("authorRef", "string"),
   ],
   links: [
     link("project", Project, { cardinality: "one" }),

--- a/examples/acme-corp/ontology/employee.ts
+++ b/examples/acme-corp/ontology/employee.ts
@@ -12,7 +12,6 @@ export const Employee = defineObjectType({
     prop("role", "string", { required: true }),
     prop("seniority", stringEnum(["junior", "mid", "senior", "lead", "director"])),
     prop("hireDate", "date"),
-    prop("departmentRef", "string"),
   ],
   links: [link("department", Department, { cardinality: "one" })],
 })

--- a/examples/acme-corp/ontology/invoice.ts
+++ b/examples/acme-corp/ontology/invoice.ts
@@ -14,8 +14,6 @@ export const Invoice = defineObjectType({
     prop("status", stringEnum(["draft", "sent", "paid", "overdue", "cancelled"])),
     prop("issuedAt", "timestamp"),
     prop("dueDate", "date"),
-    prop("customerRef", "string"),
-    prop("projectRef", "string"),
     prop(
       "reminderReviewStatus",
       stringEnum(["not_requested", "needs_review", "approved", "revision_requested", "cancelled"])

--- a/examples/acme-corp/ontology/project.ts
+++ b/examples/acme-corp/ontology/project.ts
@@ -15,8 +15,6 @@ export const Project = defineObjectType({
     prop("deadline", "date"),
     prop("budget", "double"),
     prop("progress", "integer", { mode: "telemetry" }),
-    prop("customerRef", "string"),
-    prop("leadRef", "string"),
   ],
   links: [
     link("customer", Customer, { cardinality: "one" }),

--- a/examples/acme-corp/ontology/task.ts
+++ b/examples/acme-corp/ontology/task.ts
@@ -13,8 +13,6 @@ export const Task = defineObjectType({
     prop("priority", stringEnum(["low", "medium", "high", "critical"])),
     prop("estimate", "integer"),
     prop("dueDate", "date"),
-    prop("projectRef", "string"),
-    prop("assigneeRef", "string"),
   ],
   links: [
     link("project", Project, { cardinality: "one" }),

--- a/examples/acme-corp/projections/customer-projection.ts
+++ b/examples/acme-corp/projections/customer-projection.ts
@@ -1,4 +1,4 @@
-import { defineProjection, fromForeignKey } from "@sixb/core"
+import { defineProjection } from "@sixb/core"
 import { erpCustomersDataset } from "../datasets/erp"
 import { Customer } from "../ontology/customer"
 import { Employee } from "../ontology/employee"
@@ -12,12 +12,11 @@ export const customerProjection = defineProjection("customer-proj", Customer)
     company: "company_name",
     industry: "industry_sector",
     tier: "service_tier",
-    accountManagerRef: "account_mgr_id",
   })
   .withLinks({
-    accountManager: fromForeignKey({
+    accountManager: {
       link: Customer.l.accountManager,
-      sourceProperty: Customer.p.accountManagerRef,
+      sourceField: "account_mgr_id",
       target: Employee,
-    }),
+    },
   })

--- a/examples/acme-corp/projections/document-projection.ts
+++ b/examples/acme-corp/projections/document-projection.ts
@@ -1,4 +1,4 @@
-import { defineProjection, fromForeignKey } from "@sixb/core"
+import { defineProjection } from "@sixb/core"
 import { erpDocumentsDataset } from "../datasets/erp"
 import { Document } from "../ontology/document"
 import { Employee } from "../ontology/employee"
@@ -12,18 +12,16 @@ export const documentProjection = defineProjection("document-proj", Document)
     type: "type",
     version: "version",
     createdAt: "createdAt",
-    projectRef: "projectRef",
-    authorRef: "authorRef",
   })
   .withLinks({
-    project: fromForeignKey({
+    project: {
       link: Document.l.project,
-      sourceProperty: Document.p.projectRef,
+      sourceField: "project_id",
       target: Project,
-    }),
-    author: fromForeignKey({
+    },
+    author: {
       link: Document.l.author,
-      sourceProperty: Document.p.authorRef,
+      sourceField: "author_id",
       target: Employee,
-    }),
+    },
   })

--- a/examples/acme-corp/projections/employee-projection.ts
+++ b/examples/acme-corp/projections/employee-projection.ts
@@ -1,9 +1,13 @@
-import { defineProjection, fromForeignKey } from "@sixb/core"
+import type { ObjectProjectionDefinition } from "@sixb/core"
+import { defineProjection } from "@sixb/core"
 import { erpEmployeesDataset } from "../datasets/erp"
 import { Department } from "../ontology/department"
 import { Employee } from "../ontology/employee"
 
-export const employeeProjection = defineProjection("employee-proj", Employee)
+export const employeeProjection: ObjectProjectionDefinition = defineProjection(
+  "employee-proj",
+  Employee
+)
   .fromDataset(erpEmployeesDataset)
   .properties({
     id: "emp_id",
@@ -12,12 +16,11 @@ export const employeeProjection = defineProjection("employee-proj", Employee)
     role: "job_title",
     seniority: "seniority_level",
     hireDate: "hire_date",
-    departmentRef: "dept_id",
   })
   .withLinks({
-    department: fromForeignKey({
+    department: {
       link: Employee.l.department,
-      sourceProperty: Employee.p.departmentRef,
+      sourceField: "dept_id",
       target: Department,
-    }),
+    },
   })

--- a/examples/acme-corp/projections/invoice-projection.ts
+++ b/examples/acme-corp/projections/invoice-projection.ts
@@ -1,4 +1,4 @@
-import { defineProjection, fromForeignKey } from "@sixb/core"
+import { defineProjection } from "@sixb/core"
 import { erpInvoicesDataset } from "../datasets/erp"
 import { Customer } from "../ontology/customer"
 import { Invoice } from "../ontology/invoice"
@@ -14,18 +14,16 @@ export const invoiceProjection = defineProjection("invoice-proj", Invoice)
     status: "status",
     issuedAt: "issuedAt",
     dueDate: "dueDate",
-    customerRef: "customerRef",
-    projectRef: "projectRef",
   })
   .withLinks({
-    customer: fromForeignKey({
+    customer: {
       link: Invoice.l.customer,
-      sourceProperty: Invoice.p.customerRef,
+      sourceField: "customer_id",
       target: Customer,
-    }),
-    project: fromForeignKey({
+    },
+    project: {
       link: Invoice.l.project,
-      sourceProperty: Invoice.p.projectRef,
+      sourceField: "project_id",
       target: Project,
-    }),
+    },
   })

--- a/examples/acme-corp/projections/project-projection.ts
+++ b/examples/acme-corp/projections/project-projection.ts
@@ -1,4 +1,4 @@
-import { defineProjection, fromForeignKey } from "@sixb/core"
+import { defineProjection } from "@sixb/core"
 import { erpProjectsDataset } from "../datasets/erp"
 import { Customer } from "../ontology/customer"
 import { Employee } from "../ontology/employee"
@@ -14,18 +14,16 @@ export const projectProjection = defineProjection("project-proj", Project)
     startDate: "start_date",
     deadline: "deadline",
     budget: "budget_amount",
-    customerRef: "customer_id",
-    leadRef: "lead_emp_id",
   })
   .withLinks({
-    customer: fromForeignKey({
+    customer: {
       link: Project.l.customer,
-      sourceProperty: Project.p.customerRef,
+      sourceField: "customer_id",
       target: Customer,
-    }),
-    lead: fromForeignKey({
+    },
+    lead: {
       link: Project.l.lead,
-      sourceProperty: Project.p.leadRef,
+      sourceField: "lead_emp_id",
       target: Employee,
-    }),
+    },
   })

--- a/examples/acme-corp/projections/task-projection.ts
+++ b/examples/acme-corp/projections/task-projection.ts
@@ -1,4 +1,4 @@
-import { defineProjection, fromForeignKey } from "@sixb/core"
+import { defineProjection } from "@sixb/core"
 import { erpTasksDataset } from "../datasets/erp"
 import { Employee } from "../ontology/employee"
 import { Project } from "../ontology/project"
@@ -13,18 +13,16 @@ export const taskProjection = defineProjection("task-proj", Task)
     priority: "priority",
     estimate: "estimate",
     dueDate: "dueDate",
-    projectRef: "projectRef",
-    assigneeRef: "assigneeRef",
   })
   .withLinks({
-    project: fromForeignKey({
+    project: {
       link: Task.l.project,
-      sourceProperty: Task.p.projectRef,
+      sourceField: "project_id",
       target: Project,
-    }),
-    assignee: fromForeignKey({
+    },
+    assignee: {
       link: Task.l.assignee,
-      sourceProperty: Task.p.assigneeRef,
+      sourceField: "assignee_id",
       target: Employee,
-    }),
+    },
   })

--- a/packages/atlas/src/pages/ObjectTypeDetail.tsx
+++ b/packages/atlas/src/pages/ObjectTypeDetail.tsx
@@ -556,7 +556,10 @@ function ForeignKeys({
   links,
   onSelectType,
 }: {
-  links: Record<string, { sourcePropertyId: string; targetObjectTypeId: string }>
+  links: Record<
+    string,
+    { sourcePropertyId?: string; sourceField?: string; targetObjectTypeId: string }
+  >
   onSelectType: (id: string) => void
 }) {
   const entries = Object.entries(links)
@@ -583,12 +586,16 @@ function ForeignKeys({
             <span aria-hidden="true" className="text-muted-foreground/40">
               via
             </span>
-            <dd className="text-muted-foreground">{fk.sourcePropertyId}</dd>
+            <dd className="text-muted-foreground">{formatForeignKeySource(fk)}</dd>
           </Fragment>
         ))}
       </dl>
     </div>
   )
+}
+
+function formatForeignKeySource(fk: { sourcePropertyId?: string; sourceField?: string }): string {
+  return fk.sourcePropertyId ?? fk.sourceField ?? "unknown"
 }
 
 function formatSchema(schema: unknown): string {

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -9485,11 +9485,14 @@
                                 "sourcePropertyId": {
                                   "type": "string"
                                 },
+                                "sourceField": {
+                                  "type": "string"
+                                },
                                 "targetObjectTypeId": {
                                   "type": "string"
                                 }
                               },
-                              "required": ["linkId", "sourcePropertyId", "targetObjectTypeId"],
+                              "required": ["linkId", "targetObjectTypeId"],
                               "additionalProperties": false
                             }
                           }
@@ -9615,11 +9618,14 @@
                               "sourcePropertyId": {
                                 "type": "string"
                               },
+                              "sourceField": {
+                                "type": "string"
+                              },
                               "targetObjectTypeId": {
                                 "type": "string"
                               }
                             },
-                            "required": ["linkId", "sourcePropertyId", "targetObjectTypeId"],
+                            "required": ["linkId", "targetObjectTypeId"],
                             "additionalProperties": false
                           }
                         }

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3296,7 +3296,8 @@ export type ListProjectionsResponses = {
       links: {
         [key: string]: {
           linkId: string
-          sourcePropertyId: string
+          sourcePropertyId?: string
+          sourceField?: string
           targetObjectTypeId: string
         }
       }
@@ -3352,7 +3353,8 @@ export type GetProjectionResponses = {
         links: {
           [key: string]: {
             linkId: string
-            sourcePropertyId: string
+            sourcePropertyId?: string
+            sourceField?: string
             targetObjectTypeId: string
           }
         }

--- a/packages/core/src/projections/builders.ts
+++ b/packages/core/src/projections/builders.ts
@@ -11,7 +11,7 @@ import type {
   DatasetDefinition,
 } from "../datasets"
 import type { LinkToken, PropertyToken } from "../ontology/tokens"
-import type { ObjectType, Schema } from "../ontology/types"
+import type { ObjectLink, ObjectType, Schema } from "../ontology/types"
 import { ProjectionValidationError } from "./errors"
 import type {
   ForeignKeyDescriptor,
@@ -57,6 +57,15 @@ type PropertyById<T extends ObjectType, TPropertyId extends PropertyIdOf<T>> = E
 
 /** Union of link ids from an ObjectType. */
 type LinkIdOf<T extends ObjectType> = T["links"][number]["id"]
+
+type LinkById<T extends ObjectType, TLinkId extends LinkIdOf<T>> = Extract<
+  T["links"][number],
+  { id: TLinkId }
+>
+
+type SingleTargetIdOf<TLink extends ObjectLink> = TLink["targetObjectTypeId"] extends string
+  ? TLink["targetObjectTypeId"]
+  : never
 
 type ResolvedProjectionSchema<TSchema extends Schema> = TSchema extends {
   type: "valueTypeRef"
@@ -139,6 +148,85 @@ type ExactProjectionMapping<TObjectType extends ObjectType, TMapping> = TMapping
   readonly [TKey in Exclude<keyof TMapping, PropertyIdOf<TObjectType>>]: never
 }
 
+type ForeignKeyFromSourceProperty = Omit<
+  ForeignKeyDescriptor,
+  "sourcePropertyId" | "sourceField"
+> & {
+  readonly sourcePropertyId: string
+  readonly sourceField?: never
+}
+
+type ForeignKeyFromSourceField<TSourceField extends string = string> = Omit<
+  ForeignKeyDescriptor,
+  "sourcePropertyId" | "sourceField"
+> & {
+  readonly sourcePropertyId?: never
+  readonly sourceField: TSourceField
+}
+
+type ProjectionForeignKeyDescriptor<TDataset extends DatasetDefinition> =
+  | ForeignKeyFromSourceProperty
+  | ForeignKeyFromSourceField<StringDatasetColumnNameOf<TDataset>>
+
+type ProjectionForeignKeyTokenInput<
+  TObjectType extends ObjectType,
+  TDataset extends DatasetDefinition,
+  TLinkId extends LinkIdOf<TObjectType>,
+> =
+  | {
+      readonly link: LinkToken<
+        TObjectType["id"],
+        TLinkId,
+        SingleTargetIdOf<LinkById<TObjectType, TLinkId>>
+      >
+      readonly sourceProperty: PropertyToken<TObjectType["id"]>
+      readonly target: ObjectType &
+        (
+          | { id: NoInfer<SingleTargetIdOf<LinkById<TObjectType, TLinkId>>> }
+          | { extends: NoInfer<SingleTargetIdOf<LinkById<TObjectType, TLinkId>>> }
+        )
+    }
+  | {
+      readonly link: LinkToken<
+        TObjectType["id"],
+        TLinkId,
+        SingleTargetIdOf<LinkById<TObjectType, TLinkId>>
+      >
+      readonly sourceField: StringDatasetColumnNameOf<TDataset>
+      readonly target: ObjectType &
+        (
+          | { id: NoInfer<SingleTargetIdOf<LinkById<TObjectType, TLinkId>>> }
+          | { extends: NoInfer<SingleTargetIdOf<LinkById<TObjectType, TLinkId>>> }
+        )
+    }
+
+type ProjectionForeignKeyInput<
+  TObjectType extends ObjectType,
+  TDataset extends DatasetDefinition,
+  TLinkId extends LinkIdOf<TObjectType>,
+> =
+  | ProjectionForeignKeyDescriptor<TDataset>
+  | ProjectionForeignKeyTokenInput<TObjectType, TDataset, TLinkId>
+
+function lowerForeignKeyMapping<TObjectType extends ObjectType, TDataset extends DatasetDefinition>(
+  mapping: {
+    [K in LinkIdOf<TObjectType>]?: ProjectionForeignKeyInput<TObjectType, TDataset, K>
+  }
+): Record<string, ForeignKeyDescriptor> {
+  const lowered: Record<string, ForeignKeyDescriptor> = {}
+  for (const [linkId, descriptor] of Object.entries(mapping)) {
+    if (!descriptor) continue
+    lowered[linkId] = isForeignKeyDescriptor(descriptor)
+      ? descriptor
+      : fromForeignKey(descriptor as Parameters<typeof fromForeignKey>[0])
+  }
+  return lowered
+}
+
+function isForeignKeyDescriptor(value: unknown): value is ForeignKeyDescriptor {
+  return isRecord(value) && typeof value.linkId === "string"
+}
+
 // ── defineProjection ─────────────────────────────────────────
 
 interface ProjectionSourceBuilder<TObjectType extends ObjectType> {
@@ -153,12 +241,15 @@ interface ProjectionMappingBuilder<
 > {
   properties<const TMapping extends ProjectionMappingFor<TObjectType, TDataset>>(
     mapping: ExactProjectionMapping<TObjectType, TMapping>
-  ): ObjectProjectionDefinition & ProjectionLinkBuilder<TObjectType>
+  ): ObjectProjectionDefinition & ProjectionLinkBuilder<TObjectType, TDataset>
 }
 
-interface ProjectionLinkBuilder<TObjectType extends ObjectType> {
+interface ProjectionLinkBuilder<
+  TObjectType extends ObjectType,
+  TDataset extends DatasetDefinition,
+> {
   withLinks(
-    mapping: { [K in LinkIdOf<TObjectType>]?: ForeignKeyDescriptor }
+    mapping: { [K in LinkIdOf<TObjectType>]?: ProjectionForeignKeyInput<TObjectType, TDataset, K> }
   ): ObjectProjectionDefinition
 }
 
@@ -168,13 +259,13 @@ interface ProjectionLinkBuilder<TObjectType extends ObjectType> {
  * ```ts
  * defineProjection("room-projection", Room)
  *   .fromDataset(canonicalRoomsDataset)
- *   .properties({ id: "room_id", name: "room_name", buildingRef: "building_id" })
+ *   .properties({ id: "room_id", name: "room_name" })
  *   .withLinks({
- *     inBuilding: fromForeignKey({
+ *     inBuilding: {
  *       link: Room.l.inBuilding,
- *       sourceProperty: Room.p.buildingRef,
+ *       sourceField: "building_id",
  *       target: Building,
- *     }),
+ *     },
  *   })
  * ```
  */
@@ -194,7 +285,7 @@ export function defineProjection<const TObjectType extends ObjectType>(
       return {
         properties<const TMapping extends ProjectionMappingFor<TObjectType, TDataset>>(
           mapping: ExactProjectionMapping<TObjectType, TMapping>
-        ): ObjectProjectionDefinition & ProjectionLinkBuilder<TObjectType> {
+        ): ObjectProjectionDefinition & ProjectionLinkBuilder<TObjectType, TDataset> {
           const propertyMapping = mapping as Record<string, string>
           validatePropertyMapping(objectType, propertyMapping)
 
@@ -209,11 +300,14 @@ export function defineProjection<const TObjectType extends ObjectType>(
 
           return Object.assign(definition, {
             withLinks(
-              linkMapping: { [K in LinkIdOf<TObjectType>]?: ForeignKeyDescriptor }
+              linkMapping: {
+                [K in LinkIdOf<TObjectType>]?: ProjectionForeignKeyInput<TObjectType, TDataset, K>
+              }
             ): ObjectProjectionDefinition {
+              const loweredLinkMapping = lowerForeignKeyMapping(linkMapping)
               const validatedLinks = validateAndLowerLinkMapping(
                 objectType,
-                linkMapping as Record<string, ForeignKeyDescriptor>,
+                loweredLinkMapping,
                 propertyMapping
               )
 
@@ -239,7 +333,8 @@ export function defineProjection<const TObjectType extends ObjectType>(
  * Creates a {@link ForeignKeyDescriptor} from typed tokens.
  *
  * Compile-time constraints:
- * - `TObjectTypeId` ties `link` and `sourceProperty` to the same object type.
+ * - `TObjectTypeId` ties `link` and `sourceProperty` to the same object type
+ *   when a projected source property is used.
  * - `TTargetObjectTypeId` (inferred from the link token) constrains `target`
  *   to an ObjectType whose `id` or `extends` matches the link's declared target.
  *   This covers exact type match and direct subtypes. Multi-level inheritance
@@ -261,12 +356,44 @@ export function fromForeignKey<
   sourceProperty: PropertyToken<TObjectTypeId>
   target: ObjectType &
     ({ id: NoInfer<TTargetObjectTypeId> } | { extends: NoInfer<TTargetObjectTypeId> })
+}): ForeignKeyFromSourceProperty
+export function fromForeignKey<
+  TObjectTypeId extends string,
+  TTargetObjectTypeId extends string,
+  const TSourceField extends string,
+>(input: {
+  link: LinkToken<TObjectTypeId, string, TTargetObjectTypeId>
+  sourceField: TSourceField
+  target: ObjectType &
+    ({ id: NoInfer<TTargetObjectTypeId> } | { extends: NoInfer<TTargetObjectTypeId> })
+}): ForeignKeyFromSourceField<TSourceField>
+export function fromForeignKey<
+  TObjectTypeId extends string,
+  TTargetObjectTypeId extends string,
+>(input: {
+  link: LinkToken<TObjectTypeId, string, TTargetObjectTypeId>
+  sourceProperty?: PropertyToken<TObjectTypeId>
+  sourceField?: string
+  target: ObjectType &
+    ({ id: NoInfer<TTargetObjectTypeId> } | { extends: NoInfer<TTargetObjectTypeId> })
 }): ForeignKeyDescriptor {
   validateLinkProjectionTarget(input.link)
 
+  if (input.sourceProperty) {
+    return {
+      linkId: input.link.id,
+      sourcePropertyId: input.sourceProperty.id,
+      targetObjectTypeId: input.target.id,
+    }
+  }
+
+  if (input.sourceField === undefined) {
+    throw new ProjectionValidationError("Foreign key sourceField is required.")
+  }
+  assertNonEmpty(input.sourceField, "source field")
   return {
     linkId: input.link.id,
-    sourcePropertyId: input.sourceProperty.id,
+    sourceField: input.sourceField,
     targetObjectTypeId: input.target.id,
   }
 }

--- a/packages/core/src/projections/types.ts
+++ b/packages/core/src/projections/types.ts
@@ -9,8 +9,9 @@
 /**
  * Describes how a foreign key column in a dataset resolves to a link target.
  *
- * The source property holds a value that equals the target object's primary
- * property value, creating an implicit link between source and target.
+ * The source can be either a projected source property or a raw dataset field.
+ * Its value equals the target object's primary property value, creating an
+ * implicit link between source and target.
  *
  * `targetObjectTypeId` declares the concrete target type for this projection.
  * It must be the same type or a subtype (via `extends`) of the link's declared
@@ -19,7 +20,10 @@
  */
 export interface ForeignKeyDescriptor {
   readonly linkId: string
-  readonly sourcePropertyId: string
+  /** Object property holding the target id. Mutually exclusive with sourceField. */
+  readonly sourcePropertyId?: string
+  /** Dataset column holding the target id. Mutually exclusive with sourcePropertyId. */
+  readonly sourceField?: string
   readonly targetObjectTypeId: string
 }
 
@@ -27,8 +31,8 @@ export interface ForeignKeyDescriptor {
  * Lowered, serializable definition for projecting a dataset into object instances.
  *
  * Each row in the dataset becomes an object upsert, with properties mapped
- * from dataset columns to object type properties. FK links are resolved
- * from source property values to target object primary values.
+ * from dataset columns to object type properties. FK links are resolved from
+ * source property or dataset field values to target object primary values.
  */
 export interface ObjectProjectionDefinition {
   readonly _tag: "ObjectProjectionDefinition"

--- a/packages/core/src/projections/validation.ts
+++ b/packages/core/src/projections/validation.ts
@@ -67,8 +67,9 @@ export function validatePropertyMapping(
  * 1. All keys must be valid link ids on the object type.
  * 2. Record key must match descriptor.linkId.
  * 3. Link target must be a single concrete type (not polymorphic or wildcard).
- * 4. Source property must exist on the object type.
- * 5. Source property must be present in the property mapping.
+ * 4. The descriptor must use exactly one source: sourcePropertyId or sourceField.
+ * 5. Source properties must exist and be present in the property mapping.
+ *    Source fields are validated later against the projection dataset.
  */
 export function validateAndLowerLinkMapping(
   objectType: ObjectType,
@@ -111,19 +112,36 @@ export function validateAndLowerLinkMapping(
       )
     }
 
+    const sourcePropertyId = descriptor.sourcePropertyId
+    const sourceField = descriptor.sourceField
+    if (sourcePropertyId && sourceField) {
+      throw new ProjectionValidationError(
+        `FK link '${key}' must use either sourceProperty or sourceField, not both.`
+      )
+    }
+    if (!sourcePropertyId && !sourceField) {
+      throw new ProjectionValidationError(
+        `FK link '${key}' must declare sourceProperty or sourceField.`
+      )
+    }
+
+    if (!sourcePropertyId) {
+      continue
+    }
+
     // Rule 4: source property exists on the type
-    if (!propertyIds.has(descriptor.sourcePropertyId)) {
+    if (!propertyIds.has(sourcePropertyId)) {
       const available = [...propertyIds].sort().join(", ")
       throw new ProjectionValidationError(
-        `Source property '${descriptor.sourcePropertyId}' does not exist on ` +
+        `Source property '${sourcePropertyId}' does not exist on ` +
           `object type '${objectType.id}'. Available properties: ${available}`
       )
     }
 
     // Rule 5: source property is in the property mapping
-    if (!(descriptor.sourcePropertyId in propertyMapping)) {
+    if (!(sourcePropertyId in propertyMapping)) {
       throw new ProjectionValidationError(
-        `Source property '${descriptor.sourcePropertyId}' for link '${key}' ` +
+        `Source property '${sourcePropertyId}' for link '${key}' ` +
           `must be included in the property mapping.`
       )
     }
@@ -232,14 +250,31 @@ export function validateProjectionsAtStartup(
           `${prefix}: FK link "${linkId}" references unknown link on type "${projection.objectTypeId}"`
         )
       }
-      if (!propertyIds.has(fk.sourcePropertyId)) {
+      const sourcePropertyId = fk.sourcePropertyId
+      const sourceField = fk.sourceField
+      if (sourcePropertyId && sourceField) {
         throw new ProjectionValidationError(
-          `${prefix}: FK link "${linkId}" source property "${fk.sourcePropertyId}" does not exist on type "${projection.objectTypeId}"`
+          `${prefix}: FK link "${linkId}" must use either sourcePropertyId or sourceField, not both`
         )
       }
-      if (!(fk.sourcePropertyId in projection.properties)) {
+      if (!sourcePropertyId && !sourceField) {
         throw new ProjectionValidationError(
-          `${prefix}: FK link "${linkId}" source property "${fk.sourcePropertyId}" must be in property mapping`
+          `${prefix}: FK link "${linkId}" must declare sourcePropertyId or sourceField`
+        )
+      }
+      if (sourcePropertyId && !propertyIds.has(sourcePropertyId)) {
+        throw new ProjectionValidationError(
+          `${prefix}: FK link "${linkId}" source property "${sourcePropertyId}" does not exist on type "${projection.objectTypeId}"`
+        )
+      }
+      if (sourcePropertyId && !(sourcePropertyId in projection.properties)) {
+        throw new ProjectionValidationError(
+          `${prefix}: FK link "${linkId}" source property "${sourcePropertyId}" must be in property mapping`
+        )
+      }
+      if (sourceField && !datasetColumnNames.has(sourceField)) {
+        throw new ProjectionValidationError(
+          `${prefix}: FK link "${linkId}" source field "${sourceField}" references unknown dataset column "${sourceField}" on dataset "${projection.datasetId}"`
         )
       }
       if (!objectTypesById.has(fk.targetObjectTypeId)) {

--- a/packages/core/tests/projection.test.ts
+++ b/packages/core/tests/projection.test.ts
@@ -143,6 +143,48 @@ describe("defineProjection", () => {
     })
   })
 
+  test("builds definition with FK links from dataset fields", () => {
+    const result = defineProjection("room-proj", Room)
+      .fromDataset(canonicalRoomsDataset)
+      .properties({ id: "room_id", name: "room_name" })
+      .withLinks({
+        inBuilding: fromForeignKey({
+          link: Room.l.inBuilding,
+          sourceField: "building_id",
+          target: Building,
+        }),
+      })
+
+    expect(result.links).toEqual({
+      inBuilding: {
+        linkId: "inBuilding",
+        sourceField: "building_id",
+        targetObjectTypeId: "building",
+      },
+    })
+  })
+
+  test("builds definition with typed inline FK links from dataset fields", () => {
+    const result = defineProjection("room-proj", Room)
+      .fromDataset(canonicalRoomsDataset)
+      .properties({ id: "room_id", name: "room_name" })
+      .withLinks({
+        inBuilding: {
+          link: Room.l.inBuilding,
+          sourceField: "building_id",
+          target: Building,
+        },
+      })
+
+    expect(result.links).toEqual({
+      inBuilding: {
+        linkId: "inBuilding",
+        sourceField: "building_id",
+        targetObjectTypeId: "building",
+      },
+    })
+  })
+
   test("rejects unknown link id in withLinks mapping", () => {
     const base = defineProjection("p", Room).fromDataset(genericDataset).properties({ id: "col" })
 

--- a/packages/core/tests/projection.types.ts
+++ b/packages/core/tests/projection.types.ts
@@ -136,20 +136,62 @@ fromForeignKey({
 // 9. @ts-expect-error — cross-type fromForeignKey (Room link + Building property)
 fromForeignKey({ link: _Room.l.inBuilding, sourceProperty: _Building.p.name, target: _Building })
 
-// 10. fromForeignKey rejects unrelated target type
+// 10. fromForeignKey accepts raw dataset source fields
+fromForeignKey({
+  link: _Room.l.inBuilding,
+  sourceField: "building_id",
+  target: _Building,
+}) // OK — standalone descriptors are validated against the projection dataset by .withLinks()
+
+defineProjection("test", _Room)
+  .fromDataset(roomDataset)
+  .properties({ id: "col_id" })
+  .withLinks({
+    inBuilding: {
+      link: _Room.l.inBuilding,
+      sourceField: "col_ref",
+      target: _Building,
+    },
+  }) // OK — sourceField auto-completes string columns from the projection dataset
+
+defineProjection("test", _Room)
+  .fromDataset(roomDataset)
+  .properties({ id: "col_id" })
+  .withLinks({
+    // @ts-expect-error — sourceField must exist on the projection dataset
+    inBuilding: {
+      link: _Room.l.inBuilding,
+      sourceField: "missing_column",
+      target: _Building,
+    },
+  })
+
+defineProjection("test", _Room)
+  .fromDataset(roomDataset)
+  .properties({ id: "col_id" })
+  .withLinks({
+    // @ts-expect-error — FK sourceField must be a string dataset column
+    inBuilding: {
+      link: _Room.l.inBuilding,
+      sourceField: "col_room_number",
+      target: _Building,
+    },
+  })
+
+// 11. fromForeignKey rejects unrelated target type
 const _Unrelated = defineObjectType({
   id: "unrelated",
   name: "Unrelated",
   properties: [prop("id", "string", { required: true, primary: true })],
 })
+// @ts-expect-error — target "unrelated" is not "building" and doesn't extend it
 fromForeignKey({
   link: _Room.l.inBuilding,
   sourceProperty: _Room.p.buildingRef,
-  // @ts-expect-error — target "unrelated" is not "building" and doesn't extend it
   target: _Unrelated,
 })
 
-// 11. fromForeignKey accepts direct subtype (extends matches link target)
+// 12. fromForeignKey accepts direct subtype (extends matches link target)
 const _OfficeBuilding = defineObjectType({
   id: "office-building",
   name: "Office Building",
@@ -162,7 +204,7 @@ fromForeignKey({
   target: _OfficeBuilding,
 }) // OK — extends "building"
 
-// 12. defineLinkProjection with valid single-target link
+// 13. defineLinkProjection with valid single-target link
 const linkProj = defineLinkProjection("test", _Room.l.hasSensors)
   .fromDataset(roomSensorsDataset)
   .sourceField("room_id")

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -21,6 +21,7 @@ export interface ObjectProjectionPlan {
 export interface ProjectedObjectRow {
   readonly properties: Record<string, unknown>
   readonly primaryValue: unknown
+  readonly foreignKeyValues: Readonly<Record<string, unknown>>
 }
 
 export type ProjectObjectRowResult =
@@ -93,6 +94,7 @@ export function projectObjectRow(plan: ObjectProjectionPlan, row: unknown): Proj
     row: {
       properties: collected.properties,
       primaryValue: collected.properties[primaryPropertyId],
+      foreignKeyValues: collectForeignKeyValues(projection, row, collected.properties),
     },
   }
 }
@@ -178,6 +180,27 @@ function collectProperties(
   }
 
   return { ok: true, properties }
+}
+
+function collectForeignKeyValues(
+  projection: ObjectProjectionDefinition,
+  row: DatasetRow,
+  properties: Readonly<Record<string, unknown>>
+): Readonly<Record<string, unknown>> {
+  const values: Record<string, unknown> = {}
+
+  for (const descriptor of Object.values(projection.links)) {
+    if (descriptor.sourceField) {
+      values[descriptor.linkId] = row[descriptor.sourceField]
+      continue
+    }
+
+    if (descriptor.sourcePropertyId) {
+      values[descriptor.linkId] = properties[descriptor.sourcePropertyId]
+    }
+  }
+
+  return values
 }
 
 function isPlainObject(value: unknown): value is DatasetRow {

--- a/packages/projection-worker/src/run-object-projection.ts
+++ b/packages/projection-worker/src/run-object-projection.ts
@@ -138,7 +138,10 @@ export async function runObjectProjection(
 }
 
 function objectProjectionReadColumns(projection: ObjectProjectionDefinition): readonly string[] {
-  return [...new Set(Object.values(projection.properties))]
+  const linkSourceFields = Object.values(projection.links).flatMap((descriptor) =>
+    descriptor.sourceField ? [descriptor.sourceField] : []
+  )
+  return [...new Set([...Object.values(projection.properties), ...linkSourceFields])]
 }
 
 async function upsertForeignKeyLinks(input: {
@@ -159,7 +162,7 @@ async function upsertForeignKeyLinks(input: {
   const linkItems: ForeignKeyLinkItem[] = []
   for (const row of rows) {
     for (const descriptor of descriptors) {
-      const fkValue = row.properties[descriptor.sourcePropertyId]
+      const fkValue = row.foreignKeyValues[descriptor.linkId]
       if (isBlank(fkValue)) {
         continue
       }

--- a/packages/projection-worker/src/schema-validation.ts
+++ b/packages/projection-worker/src/schema-validation.ts
@@ -103,17 +103,41 @@ export function assertProjectionCompatibleWithDataset(input: {
       }
 
       const linkDefinition = requireLink(objectType, descriptor.linkId, projection.id)
-      requireProperty(
-        objectType,
-        descriptor.sourcePropertyId,
-        projection.id,
-        `FK link '${descriptor.linkId}' source property`
-      )
-
-      if (!(descriptor.sourcePropertyId in projection.properties)) {
+      const sourcePropertyId = descriptor.sourcePropertyId
+      const sourceField = descriptor.sourceField
+      if (sourcePropertyId && sourceField) {
         throw new ProjectionWorkerError(
-          `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' source property '${descriptor.sourcePropertyId}' must be mapped as an object property.`
+          `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' must use either sourcePropertyId or sourceField, not both.`
         )
+      }
+      if (!sourcePropertyId && !sourceField) {
+        throw new ProjectionWorkerError(
+          `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' must declare sourcePropertyId or sourceField.`
+        )
+      }
+
+      if (sourcePropertyId) {
+        requireProperty(
+          objectType,
+          sourcePropertyId,
+          projection.id,
+          `FK link '${descriptor.linkId}' source property`
+        )
+
+        if (!(sourcePropertyId in projection.properties)) {
+          throw new ProjectionWorkerError(
+            `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' source property '${sourcePropertyId}' must be mapped as an object property.`
+          )
+        }
+      }
+
+      if (sourceField) {
+        const sourceColumn = requireColumn(columnsByName, dataset.id, sourceField, projection.id)
+        if (sourceColumn.type !== "string") {
+          throw new ProjectionWorkerError(
+            `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' source field '${sourceField}' must be a string dataset column.`
+          )
+        }
       }
 
       requireObjectType(

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -78,6 +78,17 @@ const roomProjectionWithFk = roomProjection.withLinks({
   }),
 })
 
+const roomProjectionWithDatasetFieldFk = defineProjection("room-dataset-field-fk-proj", Room)
+  .fromDataset(roomsDataset)
+  .properties({ id: "room_id", name: "room_name" })
+  .withLinks({
+    inBuilding: fromForeignKey({
+      link: Room.l.inBuilding,
+      sourceField: "building_ref",
+      target: Building,
+    }),
+  })
+
 const roomSensorProjection = defineLinkProjection("room-sensor-proj", Room.l.hasSensors)
   .fromDataset(roomSensorsDataset)
   .sourceField("room_id")
@@ -400,6 +411,51 @@ describe("runProjectionJob", () => {
 
     expect(result.objectsUpserted).toBe(1)
     expect(result.linksUpserted).toBe(1)
+
+    const links = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      linkId: "inBuilding",
+    })
+    expect(links).toHaveLength(1)
+    expect(links[0]?.targetId).toBe("b1")
+  })
+
+  test("materializes FK links from dataset fields without storing FK properties", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjectionWithDatasetFieldFk],
+      },
+      deps
+    )
+    await sixb.upsertObject("Building", { id: "b1", name: "HQ" })
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: "b1" },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-field-fk",
+        projectionId: "room-dataset-field-fk-proj",
+        projectionKind: "object",
+        datasetId: "canonical.rooms",
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.objectsUpserted).toBe(1)
+    expect(result.linksUpserted).toBe(1)
+
+    const room = await deps.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      primaryId: "r1",
+    })
+    expect(room?.properties).toEqual({ id: "r1", name: "Kitchen" })
 
     const links = await deps.storage.objects.listLinks({
       projectId: sixb.id,

--- a/packages/server/src/schemas/projections.ts
+++ b/packages/server/src/schemas/projections.ts
@@ -2,7 +2,8 @@ import { z } from "zod"
 
 export const ForeignKeyDescriptorSchema = z.object({
   linkId: z.string(),
-  sourcePropertyId: z.string(),
+  sourcePropertyId: z.string().optional(),
+  sourceField: z.string().optional(),
   targetObjectTypeId: z.string(),
 })
 


### PR DESCRIPTION
## Summary

While cleaning up the Acme example, we noticed several ontology objects were carrying relationship ids as ordinary string properties: `projectRef`, `authorRef`, `customerRef`, `assigneeRef`, and similar fields.

That felt backwards for the ontology model. These values are not really domain properties of the object; they are source-system foreign keys used to materialize graph edges. In the object graph they should become links, not remain as string properties that consumers have to interpret manually.

This PR lets object projections create links directly from source dataset fields, then updates Acme to use that shape.

## Before

The old projection flow had to store a foreign key as an object property just so the projection worker could create a link from it later:

```ts
export const documentProjection = defineProjection("document-proj", Document)
  .fromDataset(erpDocumentsDataset)
  .properties({
    id: "id",
    title: "title",
    projectRef: "projectRef",
    authorRef: "authorRef",
  })
  .withLinks({
    project: fromForeignKey({
      link: Document.l.project,
      sourceProperty: Document.p.projectRef,
      target: Project,
    }),
    author: fromForeignKey({
      link: Document.l.author,
      sourceProperty: Document.p.authorRef,
      target: Employee,
    }),
  })
```

That makes source-system plumbing leak into the ontology.

## After

Object properties stay clean, while links can be materialized from the dataset row itself:

```ts
export const documentProjection = defineProjection("document-proj", Document)
  .fromDataset(erpDocumentsDataset)
  .properties({
    id: "id",
    title: "title",
    type: "type",
    version: "version",
    createdAt: "createdAt",
  })
  .withLinks({
    project: {
      link: Document.l.project,
      sourceField: "project_id",
      target: Project,
    },
    author: {
      link: Document.l.author,
      sourceField: "author_id",
      target: Employee,
    },
  })
```

`sourceField` is contextually typed from `.fromDataset(...)`, similar to `.properties({ ... })`. Editors should autocomplete dataset string columns, and TypeScript rejects missing fields or non-string fields.

## What changed

- Added `sourceField` support to projection foreign key descriptors.
- Added a dataset-aware inline `.withLinks({ ... })` form for typed `sourceField` autocomplete.
- Kept `fromForeignKey(...)` compatible for existing `sourceProperty` usage.
- Updated projection validation so a foreign key source is exactly one of:
  - `sourcePropertyId`
  - `sourceField`
- Updated the projection worker to:
  - read FK source fields even when they are not projected object properties,
  - carry FK values separately from object properties,
  - create links from those FK values after object upsert.
- Updated Acme so relationship ids are no longer stored as ontology properties.

## Acme cleanup

Acme projections now use source dataset columns such as `project_id`, `author_id`, `customer_id`, `assignee_id`, `lead_emp_id`, and `dept_id` to create links.

The resulting object model is closer to the intended ontology shape:

```ts
links: [
  link("project", Project, { cardinality: "one" }),
  link("author", Employee, { cardinality: "one" }),
]
```

instead of carrying `projectRef` / `authorRef` as object properties.

## Open question

Should we keep `sourceProperty` long term?

I left it in this PR for compatibility and for cases where the foreign key is intentionally part of the domain model. But the cleaner default for source-system FKs is now `sourceField`, because it lets projections build links without storing relationship plumbing as object properties.

Recommendation: keep `sourceProperty` for now, but treat `sourceField` as the preferred form for new object projections. If `sourceProperty` keeps encouraging ref-like ontology properties, we can deprecate it in a follow-up.

## Verification

Ran in the `sixb-projection-link-cleanup` worktree:

```bash
cd packages/core && bun run typecheck
cd packages/projection-worker && bun run typecheck
cd examples/acme-corp && bun run typecheck && bun run check
bun test packages/core/tests/projection.test.ts packages/projection-worker/tests/run-projection-job.test.ts
bunx biome check packages/core/src/projections/builders.ts packages/core/tests/projection.types.ts packages/core/tests/projection.test.ts examples/acme-corp/projections/customer-projection.ts examples/acme-corp/projections/project-projection.ts examples/acme-corp/projections/invoice-projection.ts examples/acme-corp/projections/task-projection.ts examples/acme-corp/projections/document-projection.ts examples/acme-corp/projections/employee-projection.ts
git diff --check
```
