### PR TITLE
Avoid DuckLake catalog introspection for version reads

### DIFF
--- a/storage/ducklake/src/ducklake-storage.ts
+++ b/storage/ducklake/src/ducklake-storage.ts
@@ -51,12 +51,7 @@ export class DuckLakeStorage implements LakeStorageWithSql<"duckdb"> {
       this.connections,
       this.datasets
     )
-    this.rows = new DuckLakeRowReader(
-      normalizedOptions,
-      this.connections,
-      this.datasets,
-      this.snapshotReader
-    )
+    this.rows = new DuckLakeRowReader(normalizedOptions, this.connections, this.snapshotReader)
     this.writes = new DuckLakeWriteCoordinator(
       normalizedOptions,
       this.connections,

--- a/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
+++ b/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
@@ -181,12 +181,12 @@ export class DuckLakeDatasetCatalog {
   async getDatasetSchemaAtSnapshot(
     runtime: DuckDbQueryRuntime,
     datasetId: string,
+    tableName: string,
     tableId: bigint,
     snapshotId: string
   ): Promise<DatasetSchema> {
     assertDuckLakeSnapshotId(snapshotId)
 
-    const tableName = encodeDatasetTableName(datasetId)
     const columns = await this.readDatasetColumnsAtSnapshot(runtime, tableName, tableId, snapshotId)
     if (columns.length === 0) {
       throw new LakeStorageError(

--- a/storage/ducklake/src/internal/ducklake-dataset-table-ref.ts
+++ b/storage/ducklake/src/internal/ducklake-dataset-table-ref.ts
@@ -1,0 +1,35 @@
+import type { DuckLakeStorageOptions } from "../types"
+import { getBigIntLike } from "./duckdb-row"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
+import { encodeDatasetTableName } from "./names"
+import { duckLakeMetadataTableName, quoteSqlString } from "./sql"
+
+export interface DatasetTableRef {
+  readonly datasetId: string
+  readonly tableName: string
+  readonly tableId: bigint
+}
+
+export async function resolveDatasetTableRef(
+  options: DuckLakeStorageOptions,
+  runtime: DuckDbQueryRuntime,
+  datasetId: string
+): Promise<DatasetTableRef | null> {
+  const tableName = encodeDatasetTableName(datasetId)
+  const ducklakeTable = duckLakeMetadataTableName(options, "ducklake_table")
+  const [row] = await runtime.query(`
+    SELECT table_id
+    FROM ${ducklakeTable}
+    WHERE table_name = ${quoteSqlString(tableName)}
+      AND end_snapshot IS NULL
+    LIMIT 1
+  `)
+
+  return row === undefined
+    ? null
+    : {
+        datasetId,
+        tableName,
+        tableId: getBigIntLike(row, "table_id"),
+      }
+}

--- a/storage/ducklake/src/internal/ducklake-row-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-row-reader.ts
@@ -1,17 +1,15 @@
 import type {
   DatasetColumnDefinition,
-  DatasetDefinition,
   DatasetRow,
   DatasetVersion,
   ReadDatasetRowsInput,
 } from "@sixb/core"
 import { LakeStorageError } from "@sixb/core"
 import type { DuckLakeStorageOptions } from "../types"
-import type { DuckDbRuntime } from "./duckdb-runtime"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
-import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
+import { type DatasetTableRef, resolveDatasetTableRef } from "./ducklake-dataset-table-ref"
 import type { DuckLakeSnapshotReader } from "./ducklake-snapshot-reader"
-import { encodeDatasetTableName } from "./names"
 import { normalizeReadValue } from "./schema"
 import { qualifiedTableName, quoteIdentifier } from "./sql"
 import { parseVersionId } from "./versions"
@@ -27,7 +25,6 @@ export class DuckLakeRowReader {
   constructor(
     private readonly options: DuckLakeStorageOptions,
     private readonly connections: DuckLakeConnectionManager,
-    private readonly datasets: DuckLakeDatasetCatalog,
     private readonly snapshots: DuckLakeSnapshotReader
   ) {}
 
@@ -38,62 +35,75 @@ export class DuckLakeRowReader {
     try {
       const runtime = lease.runtime
 
-      // Step 1: use the catalog definition, not caller-provided shape. That
-      // keeps projection validation and value normalization aligned with the
-      // physical DuckLake table.
-      const definition = await this.datasets.getDatasetOnRuntime(runtime, input.datasetId)
-      if (!definition) {
+      // Step 1: resolve the physical table from DuckLake metadata directly. Row
+      // previews must not go through broad catalog introspection.
+      const tableRef = await resolveDatasetTableRef(this.options, runtime, input.datasetId)
+      if (!tableRef) {
         throw new LakeStorageError(`[SixbDuckLake] Unknown dataset '${input.datasetId}'.`)
       }
 
-      const version = await this.resolveVersion(runtime, definition, input.versionId)
+      const version = await this.resolveVersion(runtime, tableRef, input.versionId)
       const snapshotId = parseVersionId(version.versionId)
-      const selectedColumns = this.resolveReadColumns(definition.id, version.schema, input.columns)
+      const selectedColumns = this.resolveReadColumns(
+        tableRef.datasetId,
+        version.schema,
+        input.columns
+      )
 
       // Step 2: query DuckLake at the exact snapshot id. Version ids are just
       // `ducklake:<snapshot_id>`, so reads can use native DuckLake time travel
       // directly after validation.
-      const tableName = encodeDatasetTableName(input.datasetId)
       const columnsSql = selectedColumns.map((column) => quoteIdentifier(column.name)).join(", ")
-      const tableSql = qualifiedTableName(this.options, tableName)
-      const limitSql = input.limit === undefined ? "" : ` LIMIT ${Math.max(0, input.limit)}`
-      const offsetSql = input.offset === undefined ? "" : ` OFFSET ${Math.max(0, input.offset)}`
-      const rows = runtime.streamRows(
-        `SELECT ${columnsSql} FROM ${tableSql} AT (VERSION => ${snapshotId})${limitSql}${offsetSql}`
-      )
+      const tableSql = qualifiedTableName(this.options, tableRef.tableName)
+      const limitSql =
+        input.limit === undefined ? "" : ` LIMIT ${Math.max(0, Math.trunc(input.limit))}`
+      const offsetSql =
+        input.offset === undefined ? "" : ` OFFSET ${Math.max(0, Math.trunc(input.offset))}`
+      const sql = `SELECT ${columnsSql} FROM ${tableSql} AT (VERSION => ${snapshotId})${limitSql}${offsetSql}`
+
+      // HTTP previews are bounded, so materialize them eagerly and release the
+      // runtime queue as soon as DuckDB has returned the small page.
+      const rows = input.limit === undefined ? runtime.streamRows(sql) : await runtime.query(sql)
 
       // Step 3: DuckDB returns driver-native values. Normalize each projected
       // column through the schema that was active at the resolved version.
-      for await (const row of rows) {
-        const output: Record<string, unknown> = {}
-        for (const column of selectedColumns) {
-          output[column.name] = normalizeReadValue(row[column.name], column)
-        }
-        yield output
-      }
+      yield* this.normalizeRows(rows, selectedColumns)
     } finally {
       await lease.release()
     }
   }
 
+  private async *normalizeRows(
+    rows: Iterable<Record<string, unknown>> | AsyncIterable<Record<string, unknown>>,
+    selectedColumns: readonly DatasetColumnDefinition[]
+  ): AsyncIterable<DatasetRow> {
+    for await (const row of rows) {
+      const output: Record<string, unknown> = {}
+      for (const column of selectedColumns) {
+        output[column.name] = normalizeReadValue(row[column.name], column)
+      }
+      yield output
+    }
+  }
+
   private async resolveVersion(
-    runtime: DuckDbRuntime,
-    definition: DatasetDefinition,
+    runtime: DuckDbQueryRuntime,
+    tableRef: DatasetTableRef,
     versionId?: string
   ): Promise<DatasetVersion> {
     if (versionId !== undefined) {
       const snapshotId = parseVersionId(versionId)
-      const version = await this.snapshots.getVersionForSnapshot(runtime, definition, snapshotId)
+      const version = await this.snapshots.getVersionForTableRef(runtime, tableRef, snapshotId)
       if (!version) {
-        this.throwNoCommittedVersion(definition.id)
+        this.throwNoCommittedVersion(tableRef.datasetId)
       }
 
       return version
     }
 
-    const latestVersion = await this.snapshots.getLatestVersionForDefinition(runtime, definition)
+    const latestVersion = await this.snapshots.getLatestVersionForTableRef(runtime, tableRef)
     if (!latestVersion) {
-      this.throwNoCommittedVersion(definition.id)
+      this.throwNoCommittedVersion(tableRef.datasetId)
     }
 
     return latestVersion

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -31,6 +31,12 @@ interface DatasetSnapshotRow {
   readonly metadata?: SixbCommitMetadata
 }
 
+interface DatasetTableRef {
+  readonly datasetId: string
+  readonly tableName: string
+  readonly tableId: bigint
+}
+
 interface DatasetSnapshotCandidateRow {
   readonly snapshotId: string
   readonly createdAt: Date
@@ -107,12 +113,12 @@ export class DuckLakeSnapshotReader {
     this.connections.assertOpen()
 
     return this.connections.withAttachedRuntime(async (runtime) => {
-      const definition = await this.datasets.getDatasetOnRuntime(runtime, datasetId)
-      if (!definition) {
+      const tableRef = await this.getDatasetTableRef(runtime, datasetId)
+      if (!tableRef) {
         return []
       }
 
-      return this.listVersionsForDefinition(runtime, definition, limit)
+      return this.listVersionsForTableRef(runtime, tableRef, limit)
     })
   }
 
@@ -120,12 +126,12 @@ export class DuckLakeSnapshotReader {
     this.connections.assertOpen()
 
     return this.connections.withAttachedRuntime(async (runtime) => {
-      const definition = await this.datasets.getDatasetOnRuntime(runtime, datasetId)
-      if (!definition) {
+      const tableRef = await this.getDatasetTableRef(runtime, datasetId)
+      if (!tableRef) {
         return null
       }
 
-      return this.getLatestVersionForDefinition(runtime, definition)
+      return this.getLatestVersionForTableRef(runtime, tableRef)
     })
   }
 
@@ -134,12 +140,12 @@ export class DuckLakeSnapshotReader {
     this.connections.assertOpen()
 
     return this.connections.withAttachedRuntime(async (runtime) => {
-      const definition = await this.datasets.getDatasetOnRuntime(runtime, datasetId)
-      if (!definition) {
+      const tableRef = await this.getDatasetTableRef(runtime, datasetId)
+      if (!tableRef) {
         return null
       }
 
-      return this.getVersionForSnapshot(runtime, definition, snapshotId)
+      return this.getVersionForTableRef(runtime, tableRef, snapshotId)
     })
   }
 
@@ -413,8 +419,8 @@ export class DuckLakeSnapshotReader {
     runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition
   ): Promise<DatasetVersion | null> {
-    const [latest] = await this.listVersionsForDefinition(runtime, dataset, 1)
-    return latest ?? null
+    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    return tableRef ? this.getLatestVersionForTableRef(runtime, tableRef) : null
   }
 
   async getLatestVersionRefForDefinition(
@@ -429,13 +435,18 @@ export class DuckLakeSnapshotReader {
     runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition
   ): Promise<DuckLakeVersionSummary | null> {
-    const row = await this.getLatestSnapshotRowForDefinition(runtime, dataset)
+    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    if (!tableRef) {
+      return null
+    }
+
+    const row = await this.getLatestSnapshotRowForTableRef(runtime, tableRef)
     if (!row) {
       return null
     }
 
     return {
-      datasetId: dataset.id,
+      datasetId: tableRef.datasetId,
       versionId: toVersionId(row.snapshotId),
       ...(row.metadata?.rowCount !== undefined ? { rowCount: row.metadata.rowCount } : {}),
     }
@@ -446,10 +457,21 @@ export class DuckLakeSnapshotReader {
     dataset: DatasetDefinition,
     snapshotId: string
   ): Promise<DatasetVersion | null> {
-    const match = await this.getSnapshotRowForDefinition(runtime, dataset, snapshotId, {
+    assertDuckLakeSnapshotId(snapshotId)
+
+    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    return tableRef ? this.getVersionForTableRef(runtime, tableRef, snapshotId) : null
+  }
+
+  private async getVersionForTableRef(
+    runtime: DuckDbQueryRuntime,
+    tableRef: DatasetTableRef,
+    snapshotId: string
+  ): Promise<DatasetVersion | null> {
+    const match = await this.getSnapshotRowForTableRef(runtime, tableRef, snapshotId, {
       includeParent: true,
     })
-    return match ? this.snapshotToVersion(runtime, dataset, match) : null
+    return match ? this.snapshotToVersion(runtime, tableRef, match) : null
   }
 
   async getVersionRefForSnapshot(
@@ -457,10 +479,17 @@ export class DuckLakeSnapshotReader {
     dataset: DatasetDefinition,
     snapshotId: string
   ): Promise<DatasetVersionRef | null> {
-    const row = await this.getSnapshotRowForDefinition(runtime, dataset, snapshotId, {
+    assertDuckLakeSnapshotId(snapshotId)
+
+    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    if (!tableRef) {
+      return null
+    }
+
+    const row = await this.getSnapshotRowForTableRef(runtime, tableRef, snapshotId, {
       includeParent: false,
     })
-    return row ? { datasetId: dataset.id, versionId: toVersionId(row.snapshotId) } : null
+    return row ? { datasetId: tableRef.datasetId, versionId: toVersionId(row.snapshotId) } : null
   }
 
   async listVersionsForDefinition(
@@ -468,51 +497,56 @@ export class DuckLakeSnapshotReader {
     dataset: DatasetDefinition,
     limit?: number
   ): Promise<readonly DatasetVersion[]> {
-    const limitedRows = await this.getSnapshotRowsForDefinition(runtime, dataset, limit)
+    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    return tableRef ? this.listVersionsForTableRef(runtime, tableRef, limit) : []
+  }
+
+  private async listVersionsForTableRef(
+    runtime: DuckDbQueryRuntime,
+    tableRef: DatasetTableRef,
+    limit?: number
+  ): Promise<readonly DatasetVersion[]> {
+    const limitedRows = await this.getSnapshotRowsForTableRef(runtime, tableRef, limit)
     const versions: DatasetVersion[] = []
 
     for (const row of limitedRows) {
-      versions.push(await this.snapshotToVersion(runtime, dataset, row))
+      versions.push(await this.snapshotToVersion(runtime, tableRef, row))
     }
 
     return versions
   }
 
-  private async getLatestSnapshotRowForDefinition(
+  private async getLatestVersionForTableRef(
     runtime: DuckDbQueryRuntime,
-    dataset: DatasetDefinition
-  ): Promise<DatasetSnapshotRow | null> {
-    const tableName = encodeDatasetTableName(dataset.id)
-    const tableId = await this.getTableId(runtime, tableName)
-    if (tableId === null) {
-      return null
-    }
+    tableRef: DatasetTableRef
+  ): Promise<DatasetVersion | null> {
+    const [latest] = await this.listVersionsForTableRef(runtime, tableRef, 1)
+    return latest ?? null
+  }
 
+  private async getLatestSnapshotRowForTableRef(
+    runtime: DuckDbQueryRuntime,
+    tableRef: DatasetTableRef
+  ): Promise<DatasetSnapshotRow | null> {
     const [row] = await this.collectVisibleSnapshotRows(runtime, {
-      datasetId: dataset.id,
-      tableId,
+      datasetId: tableRef.datasetId,
+      tableId: tableRef.tableId,
       visibleRowLimit: 1,
     })
     return row ?? null
   }
 
-  private async getSnapshotRowForDefinition(
+  private async getSnapshotRowForTableRef(
     runtime: DuckDbQueryRuntime,
-    dataset: DatasetDefinition,
+    tableRef: DatasetTableRef,
     snapshotId: string,
     options: { readonly includeParent: boolean }
   ): Promise<DatasetSnapshotRow | null> {
     assertDuckLakeSnapshotId(snapshotId)
 
-    const tableName = encodeDatasetTableName(dataset.id)
-    const tableId = await this.getTableId(runtime, tableName)
-    if (tableId === null) {
-      return null
-    }
-
     const [row] = await this.collectVisibleSnapshotRows(runtime, {
-      datasetId: dataset.id,
-      tableId,
+      datasetId: tableRef.datasetId,
+      tableId: tableRef.tableId,
       exactSnapshotId: snapshotId,
       visibleRowLimit: 1,
     })
@@ -525,8 +559,8 @@ export class DuckLakeSnapshotReader {
     }
 
     const [parent] = await this.collectVisibleSnapshotRows(runtime, {
-      datasetId: dataset.id,
-      tableId,
+      datasetId: tableRef.datasetId,
+      tableId: tableRef.tableId,
       beforeSnapshotId: snapshotId,
       visibleRowLimit: 1,
     })
@@ -534,9 +568,9 @@ export class DuckLakeSnapshotReader {
     return parent ? { ...row, parentSnapshotId: parent.snapshotId } : row
   }
 
-  private async getSnapshotRowsForDefinition(
+  private async getSnapshotRowsForTableRef(
     runtime: DuckDbQueryRuntime,
-    dataset: DatasetDefinition,
+    tableRef: DatasetTableRef,
     limit?: number
   ): Promise<readonly DatasetSnapshotRow[]> {
     const visibleLimit = limit === undefined ? undefined : Math.max(0, limit)
@@ -544,15 +578,9 @@ export class DuckLakeSnapshotReader {
       return []
     }
 
-    const tableName = encodeDatasetTableName(dataset.id)
-    const tableId = await this.getTableId(runtime, tableName)
-    if (tableId === null) {
-      return []
-    }
-
     const rows = await this.collectVisibleSnapshotRows(runtime, {
-      datasetId: dataset.id,
-      tableId,
+      datasetId: tableRef.datasetId,
+      tableId: tableRef.tableId,
       visibleRowLimit: visibleLimit === undefined ? undefined : visibleLimit + 1,
     })
     const rowsWithParents = this.withParentSnapshotIds(rows)
@@ -704,7 +732,11 @@ export class DuckLakeSnapshotReader {
     })
   }
 
-  private async getTableId(runtime: DuckDbQueryRuntime, tableName: string): Promise<bigint | null> {
+  private async getDatasetTableRef(
+    runtime: DuckDbQueryRuntime,
+    datasetId: string
+  ): Promise<DatasetTableRef | null> {
+    const tableName = encodeDatasetTableName(datasetId)
     const ducklakeTable = duckLakeMetadataTableName(this.options, "ducklake_table")
     const [row] = await runtime.query(`
       SELECT table_id
@@ -714,7 +746,13 @@ export class DuckLakeSnapshotReader {
       LIMIT 1
     `)
 
-    return row === undefined ? null : getBigIntLike(row, "table_id")
+    return row === undefined
+      ? null
+      : {
+          datasetId,
+          tableName,
+          tableId: getBigIntLike(row, "table_id"),
+        }
   }
 
   private candidateToSnapshotRow(
@@ -760,13 +798,14 @@ export class DuckLakeSnapshotReader {
 
   private async snapshotToVersion(
     runtime: DuckDbQueryRuntime,
-    dataset: DatasetDefinition,
+    tableRef: DatasetTableRef,
     row: DatasetSnapshotRow
   ): Promise<DatasetVersion> {
     const schemaAtSnapshot = await this.datasets.getDatasetSchemaAtSnapshot(
       runtime,
-      dataset.id,
-      row.tableId,
+      tableRef.datasetId,
+      tableRef.tableName,
+      tableRef.tableId,
       row.snapshotId
     )
 
@@ -776,7 +815,7 @@ export class DuckLakeSnapshotReader {
     // stored in Sixb commit metadata and never counts historical table contents.
 
     return {
-      datasetId: dataset.id,
+      datasetId: tableRef.datasetId,
       versionId: toVersionId(row.snapshotId),
       parentVersionId:
         row.parentSnapshotId === undefined ? undefined : toVersionId(row.parentSnapshotId),

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -12,6 +12,7 @@ import { getBigIntLike, getBoolean, getDate, getOptionalString, getString } from
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
+import { type DatasetTableRef, resolveDatasetTableRef } from "./ducklake-dataset-table-ref"
 import { encodeDatasetTableName } from "./names"
 import { duckLakeMetadataTableName, quoteSqlString } from "./sql"
 import {
@@ -29,12 +30,6 @@ interface DatasetSnapshotRow {
   readonly mode: DatasetVersionMode
   readonly parentSnapshotId?: string
   readonly metadata?: SixbCommitMetadata
-}
-
-interface DatasetTableRef {
-  readonly datasetId: string
-  readonly tableName: string
-  readonly tableId: bigint
 }
 
 interface DatasetSnapshotCandidateRow {
@@ -113,7 +108,7 @@ export class DuckLakeSnapshotReader {
     this.connections.assertOpen()
 
     return this.connections.withAttachedRuntime(async (runtime) => {
-      const tableRef = await this.getDatasetTableRef(runtime, datasetId)
+      const tableRef = await resolveDatasetTableRef(this.options, runtime, datasetId)
       if (!tableRef) {
         return []
       }
@@ -126,7 +121,7 @@ export class DuckLakeSnapshotReader {
     this.connections.assertOpen()
 
     return this.connections.withAttachedRuntime(async (runtime) => {
-      const tableRef = await this.getDatasetTableRef(runtime, datasetId)
+      const tableRef = await resolveDatasetTableRef(this.options, runtime, datasetId)
       if (!tableRef) {
         return null
       }
@@ -140,7 +135,7 @@ export class DuckLakeSnapshotReader {
     this.connections.assertOpen()
 
     return this.connections.withAttachedRuntime(async (runtime) => {
-      const tableRef = await this.getDatasetTableRef(runtime, datasetId)
+      const tableRef = await resolveDatasetTableRef(this.options, runtime, datasetId)
       if (!tableRef) {
         return null
       }
@@ -419,7 +414,7 @@ export class DuckLakeSnapshotReader {
     runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition
   ): Promise<DatasetVersion | null> {
-    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    const tableRef = await resolveDatasetTableRef(this.options, runtime, dataset.id)
     return tableRef ? this.getLatestVersionForTableRef(runtime, tableRef) : null
   }
 
@@ -435,7 +430,7 @@ export class DuckLakeSnapshotReader {
     runtime: DuckDbQueryRuntime,
     dataset: DatasetDefinition
   ): Promise<DuckLakeVersionSummary | null> {
-    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    const tableRef = await resolveDatasetTableRef(this.options, runtime, dataset.id)
     if (!tableRef) {
       return null
     }
@@ -459,11 +454,11 @@ export class DuckLakeSnapshotReader {
   ): Promise<DatasetVersion | null> {
     assertDuckLakeSnapshotId(snapshotId)
 
-    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    const tableRef = await resolveDatasetTableRef(this.options, runtime, dataset.id)
     return tableRef ? this.getVersionForTableRef(runtime, tableRef, snapshotId) : null
   }
 
-  private async getVersionForTableRef(
+  async getVersionForTableRef(
     runtime: DuckDbQueryRuntime,
     tableRef: DatasetTableRef,
     snapshotId: string
@@ -481,7 +476,7 @@ export class DuckLakeSnapshotReader {
   ): Promise<DatasetVersionRef | null> {
     assertDuckLakeSnapshotId(snapshotId)
 
-    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    const tableRef = await resolveDatasetTableRef(this.options, runtime, dataset.id)
     if (!tableRef) {
       return null
     }
@@ -497,7 +492,7 @@ export class DuckLakeSnapshotReader {
     dataset: DatasetDefinition,
     limit?: number
   ): Promise<readonly DatasetVersion[]> {
-    const tableRef = await this.getDatasetTableRef(runtime, dataset.id)
+    const tableRef = await resolveDatasetTableRef(this.options, runtime, dataset.id)
     return tableRef ? this.listVersionsForTableRef(runtime, tableRef, limit) : []
   }
 
@@ -516,7 +511,7 @@ export class DuckLakeSnapshotReader {
     return versions
   }
 
-  private async getLatestVersionForTableRef(
+  async getLatestVersionForTableRef(
     runtime: DuckDbQueryRuntime,
     tableRef: DatasetTableRef
   ): Promise<DatasetVersion | null> {
@@ -730,29 +725,6 @@ export class DuckLakeSnapshotReader {
         ...(metadata !== undefined ? { metadata } : {}),
       }
     })
-  }
-
-  private async getDatasetTableRef(
-    runtime: DuckDbQueryRuntime,
-    datasetId: string
-  ): Promise<DatasetTableRef | null> {
-    const tableName = encodeDatasetTableName(datasetId)
-    const ducklakeTable = duckLakeMetadataTableName(this.options, "ducklake_table")
-    const [row] = await runtime.query(`
-      SELECT table_id
-      FROM ${ducklakeTable}
-      WHERE table_name = ${quoteSqlString(tableName)}
-        AND end_snapshot IS NULL
-      LIMIT 1
-    `)
-
-    return row === undefined
-      ? null
-      : {
-          datasetId,
-          tableName,
-          tableId: getBigIntLike(row, "table_id"),
-        }
   }
 
   private candidateToSnapshotRow(

--- a/storage/ducklake/tests/ducklake-versions.e2e.ts
+++ b/storage/ducklake/tests/ducklake-versions.e2e.ts
@@ -114,7 +114,7 @@ describe("DuckLakeStorage versions and time travel", () => {
     ])
   })
 
-  test("lists versions without historical table scans when row counts are absent", async () => {
+  test("reads version metadata without catalog introspection or historical table scans", async () => {
     const snapshotWrite = await storage.beginWrite({
       dataset: ordersDataset,
       mode: "snapshot",
@@ -137,10 +137,11 @@ describe("DuckLakeStorage versions and time travel", () => {
     const originalQuery = runtime.query.bind(runtime)
     runtime.query = (async (sql, values) => {
       if (
+        /\bduckdb_tables\s*\(/i.test(sql) ||
         /SELECT\s+count\(\*\)\s+AS\s+row_count/i.test(sql) ||
         /DESCRIBE\s+SELECT\s+\*\s+FROM[\s\S]*\bAT\s*\(\s*VERSION\s*=>/i.test(sql)
       ) {
-        throw new Error(`Unexpected historical table scan in version listing: ${sql}`)
+        throw new Error(`Unexpected expensive version metadata read: ${sql}`)
       }
 
       return originalQuery(sql, values)
@@ -154,6 +155,18 @@ describe("DuckLakeStorage versions and time travel", () => {
       ])
       expect(versions[0]).not.toHaveProperty("rowCount")
       expect(versions[1]).toMatchObject({ rowCount: 1 })
+
+      await expect(storage.getLatestVersion(ordersDataset.id)).resolves.toMatchObject({
+        versionId: version2.versionId,
+      })
+      await expect(storage.getVersion(ordersDataset.id, version2.versionId)).resolves.toMatchObject(
+        {
+          versionId: version2.versionId,
+          parentVersionId: version1.versionId,
+        }
+      )
+      await expect(storage.listVersions("missing.dataset")).resolves.toEqual([])
+      await expect(storage.getLatestVersion("missing.dataset")).resolves.toBeNull()
     } finally {
       runtime.query = originalQuery
     }

--- a/storage/ducklake/tests/ducklake-versions.e2e.ts
+++ b/storage/ducklake/tests/ducklake-versions.e2e.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { col, defineDataset } from "@sixb/core"
 import type { DuckLakeStorage } from "../src"
-import type { DuckDbQueryRuntime } from "../src/internal/duckdb-runtime"
+import type { DuckDbQueryRuntime, DuckDbRuntime } from "../src/internal/duckdb-runtime"
 import { createDuckDbRuntime, setupDuckLake } from "../src/internal/duckdb-runtime"
 import { encodeDatasetTableName } from "../src/internal/names"
 import { quoteSqlString } from "../src/internal/sql"
@@ -12,7 +12,7 @@ import { collectRows, createLocalDuckLakeStorage, localDuckLakeOptions } from ".
 
 interface DuckLakeStorageInternals {
   readonly connections: {
-    attachedRuntime(): Promise<DuckDbQueryRuntime>
+    attachedRuntime(): Promise<DuckDbRuntime>
   }
 }
 
@@ -169,6 +169,56 @@ describe("DuckLakeStorage versions and time travel", () => {
       await expect(storage.getLatestVersion("missing.dataset")).resolves.toBeNull()
     } finally {
       runtime.query = originalQuery
+    }
+  })
+
+  test("reads limited rows without catalog introspection or streaming", async () => {
+    const snapshotWrite = await storage.beginWrite({
+      dataset: ordersDataset,
+      mode: "snapshot",
+    })
+    await snapshotWrite.writeRows([
+      { orderId: "ord_1", customerName: "Ada", orderCount: 1 },
+      { orderId: "ord_2", customerName: "Grace", orderCount: 2 },
+    ])
+    const version = await snapshotWrite.commit()
+
+    const runtime = await (
+      storage as unknown as DuckLakeStorageInternals
+    ).connections.attachedRuntime()
+    const originalQuery = runtime.query.bind(runtime)
+    const originalStreamRows = runtime.streamRows.bind(runtime)
+    runtime.query = (async (sql, values) => {
+      if (
+        /\bduckdb_tables\s*\(/i.test(sql) ||
+        /SELECT\s+count\(\*\)\s+AS\s+row_count/i.test(sql) ||
+        /DESCRIBE\s+SELECT\s+\*\s+FROM[\s\S]*\bAT\s*\(\s*VERSION\s*=>/i.test(sql)
+      ) {
+        throw new Error(`Unexpected expensive row read: ${sql}`)
+      }
+
+      return originalQuery(sql, values)
+    }) satisfies DuckDbQueryRuntime["query"]
+    runtime.streamRows = ((sql, values) => {
+      void values
+      throw new Error(`Unexpected streaming row preview: ${sql}`)
+    }) satisfies DuckDbRuntime["streamRows"]
+
+    try {
+      await expect(
+        collectRows(
+          storage.readRows({
+            datasetId: ordersDataset.id,
+            versionId: version.versionId,
+            limit: 1,
+          })
+        )
+      ).resolves.toEqual([
+        { orderId: "ord_1", customerName: "Ada", orderCount: "1", metadata: null },
+      ])
+    } finally {
+      runtime.query = originalQuery
+      runtime.streamRows = originalStreamRows
     }
   })
 

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -16,7 +16,7 @@ interface DuckLakeStorageInternals {
     }>
   }
   readonly snapshotReader: {
-    getLatestVersionForDefinition: DuckLakeSnapshotReader["getLatestVersionForDefinition"]
+    getLatestVersionForTableRef: DuckLakeSnapshotReader["getLatestVersionForTableRef"]
   }
 }
 
@@ -421,16 +421,16 @@ describe("DuckLakeStorage writes and latest reads", () => {
     await appendWrite.commit()
 
     const snapshotReader = (storage as unknown as DuckLakeStorageInternals).snapshotReader
-    const getLatestVersionForDefinition =
-      snapshotReader.getLatestVersionForDefinition.bind(snapshotReader)
-    snapshotReader.getLatestVersionForDefinition = async () => version1
+    const getLatestVersionForTableRef =
+      snapshotReader.getLatestVersionForTableRef.bind(snapshotReader)
+    snapshotReader.getLatestVersionForTableRef = async () => version1
 
     try {
       await expect(collectRows(storage.readRows({ datasetId: ordersDataset.id }))).resolves.toEqual(
         [{ orderId: "ord_1", customerName: "Ada", orderCount: "1", metadata: null }]
       )
     } finally {
-      snapshotReader.getLatestVersionForDefinition = getLatestVersionForDefinition
+      snapshotReader.getLatestVersionForTableRef = getLatestVersionForTableRef
     }
   })
 


### PR DESCRIPTION
# DuckLake Version Metadata Reads

## Summary

This PR makes DuckLake dataset version endpoints avoid broad catalog introspection.

## What Changed

| Path | Before | After |
| --- | --- | --- |
| `listVersions` | Rebuilt the current dataset definition first | Resolves the DuckLake table directly from metadata |
| `getLatestVersion` | Could call `duckdb_tables()` before reading snapshots | Reads from `ducklake_table` + snapshot metadata |
| `getVersion` | Depended on current catalog definition hydration | Uses `datasetId`, `tableName`, and `tableId` |

## Details

- Introduce an internal `DatasetTableRef` for version reads.
- Keep historical schema hydration on `ducklake_column`.
- Preserve existing version payloads: schema, parent version, producer, inputs, and metadata row counts.
- Leave full dataset definition reads unchanged for now, including table comments.
- Add a regression test that fails if version metadata reads reintroduce:
  - `duckdb_tables()`
  - historical `DESCRIBE ... AT VERSION`
  - historical `COUNT(*) AT VERSION`

## Validation

- `bun test ./storage/ducklake/tests/ducklake-versions.e2e.ts`
- `bun --filter @sixb/ducklake typecheck`
- `bun test ./storage/ducklake/tests/ducklake-versions.e2e.ts ./storage/ducklake/tests/ducklake-writes.e2e.ts ./storage/ducklake/tests/ducklake-catalog-state.e2e.ts ./storage/ducklake/tests/ducklake-datasets.e2e.ts`
- `bun --filter @sixb/ducklake test:e2e:local`
- `bun --filter @sixb/ducklake test:e2e:remote`
- `bun run typecheck`
- `bun run check`