### PR TITLE
app: fix SPA fallback 404 for routes with encoded slashes and dots

### DIFF
--- a/packages/app/src/createCustomApp.ts
+++ b/packages/app/src/createCustomApp.ts
@@ -290,9 +290,57 @@ function isReservedSixbRoute(pathname: string): boolean {
   )
 }
 
+// Static-asset extensions whose absence should 404 rather than fall back to the
+// SPA shell — otherwise the browser would receive HTML for a missing
+// script/style/image and fail with a confusing content-type error.
+const ASSET_EXTENSIONS = new Set([
+  "js",
+  "mjs",
+  "cjs",
+  "css",
+  "map",
+  "json",
+  "wasm",
+  "ico",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "avif",
+  "bmp",
+  "woff",
+  "woff2",
+  "ttf",
+  "otf",
+  "eot",
+  "mp4",
+  "webm",
+  "ogg",
+  "mp3",
+  "wav",
+  "txt",
+  "xml",
+  "webmanifest",
+  "pdf",
+])
+
 function isAssetRequest(pathname: string): boolean {
-  const lastSegment = pathname.split("/").pop() ?? ""
-  return /\.[^/]+$/.test(lastSegment)
+  // Decode first: client routes can carry percent-encoded slashes (`%2F`) inside a
+  // single path segment (e.g. an object id), so the raw pathname's "last segment"
+  // is unreliable. Falling back to the SPA shell for these is the whole point.
+  let decoded = pathname
+  try {
+    decoded = decodeURIComponent(pathname)
+  } catch {
+    // Keep the raw pathname when it isn't valid percent-encoding.
+  }
+  const lastSegment = decoded.split(/[\\/]+/).pop() ?? ""
+  const dot = lastSegment.lastIndexOf(".")
+  // No extension, a leading-dot file, or a trailing dot → not an asset request.
+  if (dot <= 0 || dot === lastSegment.length - 1) return false
+  return ASSET_EXTENSIONS.has(lastSegment.slice(dot + 1).toLowerCase())
 }
 
 function resolveStaticPath(appRoot: string, pathname: string): string | null {

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -93,6 +93,32 @@ describe("createCustomApp.start", () => {
     }
   })
 
+  test("falls back to the SPA shell for deep routes with encoded slashes and dots", async () => {
+    const port = await getFreePort()
+    const app = await createCustomApp({ rootDir: tempRoot, audience: "app" })
+    const server = await app.start({
+      host: "127.0.0.1",
+      port,
+      apiBaseUrl: "http://127.0.0.1:3000",
+    })
+
+    try {
+      // Regression: an object id with percent-encoded slashes (`%2F`) and a dotted
+      // segment (the IP `10.75.35.6`) lives inside a single path segment. On a hard
+      // refresh this must serve the SPA shell, not 404 as a "missing asset".
+      const deepRoute = "/point/point%3Asetty%3Asetty%2Fsetty%2F10.75.35.6-708112%2Fdevice%2F708112"
+      const response = await fetch(`http://127.0.0.1:${port}${deepRoute}`)
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('<div id="root"></div>')
+
+      // A missing asset with a real extension still 404s.
+      const missingCss = await fetch(`http://127.0.0.1:${port}/assets/app.css`)
+      expect(missingCss.status).toBe(404)
+    } finally {
+      await server.stop()
+    }
+  })
+
   test("injects disabled auth state for public local apps", async () => {
     const port = await getFreePort()
     const app = await createCustomApp({ rootDir: tempRoot, audience: "app", authEnabled: false })


### PR DESCRIPTION
## Problem

In the custom app's **production** server (`createCustomApp.start`, `packages/app/src/createCustomApp.ts`), hard-refreshing a deep client route returned `404 Not Found` instead of the SPA shell.

It reproduced on any route whose path segment carries an object id with **percent-encoded slashes** (`%2F`) and a **dotted segment** (e.g. an IP). A real-world example:

```
/point/point%3Asetty_flint_hill_upper%3Asetty%2Fsetty_flint_hill_upper%2F10.75.35.6-708112%2Fdevice%2F708112
```

Symptoms:
- Loads fine on first render and on in-app navigation (React Router resolves the route client-side, no server round-trip).
- **404 on hard refresh**, because the browser then requests the full URL from the server.
- Only affects production. `dev()` serves every path through Bun's `"/*"` catch-all, so the SPA shell is always returned there.

### Root cause

The `start()` fetch handler decides between "missing asset → 404" and "client route → serve `index.html`" via `isAssetRequest(url.pathname)`. That check was wrong on two counts:

1. **It ran on the raw, still-encoded pathname.** Per the URL spec, `URL.pathname` keeps `%2F`/`%3A` encoded, so `pathname.split("/").pop()` did **not** split on the encoded slashes and returned the *entire* encoded id as a single "segment" instead of the real last segment (`708112`).
2. **"Has a dot" is too broad.** That oversized segment contains `10.75.35.6`, so the `\.[^/]+$` regex matched, classifying the navigation as a static-asset request → `notFoundResponse()`, never reaching the `index.html` fallback.

```js
// before
function isAssetRequest(pathname) {
  const lastSegment = pathname.split("/").pop() ?? ""
  return /\.[^/]+$/.test(lastSegment)
}
```

## Solution

Make `isAssetRequest` robust:

1. **Decode the path first**, so percent-encoded slashes split into real segments and the "last segment" is meaningful (the example now resolves to `708112` — no extension → a route, not an asset).
2. **Match against a known set of static-asset extensions** instead of "contains a dot", so SPA route ids that legitimately contain dots (IPs, versions, decimals) fall through to the shell. Genuinely missing assets (`.js`, `.css`, `.svg`, …) still `404` correctly.

```js
// after
function isAssetRequest(pathname) {
  let decoded = pathname
  try { decoded = decodeURIComponent(pathname) } catch {}
  const lastSegment = decoded.split(/[\\/]+/).pop() ?? ""
  const dot = lastSegment.lastIndexOf(".")
  if (dot <= 0 || dot === lastSegment.length - 1) return false
  return ASSET_EXTENSIONS.has(lastSegment.slice(dot + 1).toLowerCase())
}
```

## Tests

Added a regression test in `packages/app/tests/createCustomApp.test.ts` that hard-refreshes a route with encoded slashes + a dotted IP and asserts a `200` SPA shell, while a missing real asset (`/assets/app.css`) still returns `404`.

```
bun test packages/app/tests/createCustomApp.test.ts
 4 pass / 0 fail
```

`@sixb/app` typecheck passes; Biome-formatted.