### PR TITLE
storage: push down object queries

### DIFF
--- a/storage/pg/src/pg-object-query-compiler.ts
+++ b/storage/pg/src/pg-object-query-compiler.ts
@@ -1,0 +1,866 @@
+import {
+  type ObjectQuery,
+  ObjectQueryExecutionError,
+  type ObjectQueryPredicate,
+  type ObjectQuerySetOperation,
+  type ObjectQuerySortField,
+} from "@sixb/core"
+
+export interface PgObjectQueryPageRow {
+  object_type_id: string
+  primary_id: string
+  properties: unknown
+  _cursor_properties?: unknown
+}
+
+export interface CompiledPgObjectQuery {
+  sql: string
+  args: unknown[]
+  totalSql: string
+  totalArgs: unknown[]
+  order: CompiledOrder
+  hasMore(rowCount: number, total: number): boolean
+  trimRows<T>(rows: readonly T[]): readonly T[]
+  nextPageToken(rows: readonly PgObjectQueryPageRow[], rowCount: number): string | undefined
+}
+
+interface CompiledPredicate {
+  sql: string
+  args: unknown[]
+}
+
+interface CompiledOrder {
+  sql: string
+  args: unknown[]
+  fields: readonly CompiledOrderField[]
+  propertyColumn: string
+}
+
+type CompiledOrderField =
+  | {
+      kind: "property"
+      propertyId: string
+      direction: "asc" | "desc"
+    }
+  | {
+      kind: "column"
+      column: "object_type_id" | "primary_id"
+      direction: "asc" | "desc"
+    }
+
+interface EncodedPageToken {
+  version: 1
+  order: readonly string[]
+  values: readonly EncodedCursorValue[]
+}
+
+interface EncodedCursorValue {
+  nullish: boolean
+  value?: unknown
+}
+
+const PAGE_TOKEN_PREFIX = "keyset:"
+
+export function compilePgObjectQuery(projectId: string, query: ObjectQuery): CompiledPgObjectQuery {
+  const compiled = compileObjectQueryInternal(projectId, query)
+  return {
+    ...compiled,
+    sql: numberPlaceholders(compiled.sql),
+    totalSql: numberPlaceholders(compiled.totalSql),
+  }
+}
+
+function compileObjectQueryInternal(projectId: string, query: ObjectQuery): CompiledPgObjectQuery {
+  switch (query.kind) {
+    case "start":
+      return compileStart(projectId, query)
+    case "filter":
+      return compileFilter(projectId, query.input, query.predicate)
+    case "sort":
+      return compileSort(projectId, query.input, query.fields)
+    case "limit":
+      return compileLimit(projectId, query.input, query.limit)
+    case "page":
+      return compilePage(projectId, query.input, query.pageSize, query.pageToken)
+    case "traverse":
+      return compileTraversal(projectId, query.input, query.linkId, query.direction)
+    case "set":
+      return compileSet(projectId, query.op, query.inputs)
+    case "project":
+      return compileProject(projectId, query.input, query.properties)
+    case "text":
+      return compileText(projectId, query.input, query.query, query.fields)
+    case "vector":
+      throw new Error(`[SixbPg] PostgreSQL object storage does not support query node 'vector'`)
+  }
+}
+
+function compileStart(
+  projectId: string,
+  query: Extract<ObjectQuery, { kind: "start" }>
+): CompiledPgObjectQuery {
+  if (query.includeSubtypes === true) {
+    throw new Error("[SixbPg] PostgreSQL object storage does not support start.includeSubtypes")
+  }
+
+  const order = compileOrder(identityOrderFields())
+  const sql = `
+    SELECT *, properties AS _cursor_properties
+    FROM objects
+    WHERE project_id = ? AND object_type_id = ?
+    ORDER BY ${order.sql}
+  `
+
+  return {
+    sql,
+    args: [projectId, query.objectTypeId, ...order.args],
+    totalSql:
+      "SELECT COUNT(*)::bigint AS total FROM objects WHERE project_id = ? AND object_type_id = ?",
+    totalArgs: [projectId, query.objectTypeId],
+    order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileFilter(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  predicateNode: ObjectQueryPredicate
+): CompiledPgObjectQuery {
+  return compileWhere(projectId, inputQuery, compilePredicate(predicateNode))
+}
+
+function compileWhere(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  predicate: CompiledPredicate
+): CompiledPgObjectQuery {
+  const input = compileObjectQueryInternal(projectId, inputQuery)
+  const sql = `
+    SELECT *
+    FROM (${input.sql}) AS input
+    WHERE ${predicate.sql}
+    ORDER BY ${input.order.sql}
+  `
+
+  return {
+    sql,
+    args: [...input.args, ...predicate.args, ...input.order.args],
+    totalSql: `
+      SELECT COUNT(*)::bigint AS total
+      FROM (${input.sql}) AS input
+      WHERE ${predicate.sql}
+    `,
+    totalArgs: [...input.args, ...predicate.args],
+    order: input.order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileText(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  query: string,
+  fields: readonly string[] | undefined
+): CompiledPgObjectQuery {
+  if (!fields || fields.length === 0) {
+    throw new Error("[SixbPg] PostgreSQL object text search requires explicit fields")
+  }
+  return compileWhere(projectId, inputQuery, compileTextPredicate(query, fields))
+}
+
+function compileSort(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  fields: readonly ObjectQuerySortField[]
+): CompiledPgObjectQuery {
+  const input = compileObjectQueryInternal(projectId, inputQuery)
+  const order = compileOrder(sortOrderFields(fields))
+
+  return {
+    sql: `
+      SELECT
+        input.project_id,
+        input.object_type_id,
+        input.primary_id,
+        input.properties,
+        input.properties AS _cursor_properties,
+        input.created_at,
+        input.updated_at,
+        input.version,
+        input.source_event_id
+      FROM (${input.sql}) AS input
+      ORDER BY ${order.sql}
+    `,
+    args: [...input.args, ...order.args],
+    totalSql: input.totalSql,
+    totalArgs: input.totalArgs,
+    order,
+    hasMore: input.hasMore,
+    trimRows: input.trimRows,
+    nextPageToken: input.nextPageToken,
+  }
+}
+
+function compileLimit(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  rawLimit: number
+): CompiledPgObjectQuery {
+  const input = compileObjectQueryInternal(projectId, inputQuery)
+  const limit = Math.max(0, rawLimit)
+
+  return {
+    sql: `
+      SELECT *
+      FROM (${input.sql}) AS input
+      ORDER BY ${input.order.sql}
+      LIMIT ?
+    `,
+    args: [...input.args, ...input.order.args, limit],
+    totalSql: `
+      SELECT COUNT(*)::bigint AS total
+      FROM (${input.sql}) AS input
+    `,
+    totalArgs: input.args,
+    order: input.order,
+    hasMore: (_rowCount, total) => limit < total,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compilePage(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  rawPageSize: number,
+  pageToken: string | undefined
+): CompiledPgObjectQuery {
+  const input = compileObjectQueryInternal(projectId, inputQuery)
+  const pageSize = Math.max(0, rawPageSize)
+  const cursor = pageToken ? decodePageToken(pageToken, input.order.fields) : undefined
+  const cursorPredicate = cursor
+    ? compileKeysetPredicate(input.order.fields, cursor, input.order.propertyColumn)
+    : undefined
+  const whereSql = cursorPredicate ? `WHERE ${cursorPredicate.sql}` : ""
+
+  return {
+    sql: `
+      SELECT *
+      FROM (${input.sql}) AS input
+      ${whereSql}
+      ORDER BY ${input.order.sql}
+      LIMIT ?
+    `,
+    args: [...input.args, ...(cursorPredicate?.args ?? []), ...input.order.args, pageSize + 1],
+    totalSql: `
+      SELECT COUNT(*)::bigint AS total
+      FROM (${input.sql}) AS input
+    `,
+    totalArgs: input.args,
+    order: input.order,
+    hasMore: (rowCount) => rowCount > pageSize,
+    trimRows: (rows) => rows.slice(0, pageSize),
+    nextPageToken: (rows, rowCount) => {
+      if (rowCount <= pageSize || rows.length === 0) return undefined
+      return encodePageToken(rows[rows.length - 1], input.order.fields)
+    },
+  }
+}
+
+function compileTraversal(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  linkId: string,
+  direction: "outgoing" | "incoming"
+): CompiledPgObjectQuery {
+  const input = compileObjectQueryInternal(projectId, inputQuery)
+  const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
+  const joinSql =
+    direction === "outgoing"
+      ? `
+        JOIN links AS edge
+          ON edge.project_id = input.project_id
+         AND edge.source_type_id = input.object_type_id
+         AND edge.source_id = input.primary_id
+         AND edge.link_id = ?
+        JOIN objects AS target_object
+          ON target_object.project_id = edge.project_id
+         AND target_object.object_type_id = edge.target_type_id
+         AND target_object.primary_id = edge.target_id
+      `
+      : `
+        JOIN links AS edge
+          ON edge.project_id = input.project_id
+         AND edge.target_type_id = input.object_type_id
+         AND edge.target_id = input.primary_id
+         AND edge.link_id = ?
+        JOIN objects AS source_object
+          ON source_object.project_id = edge.project_id
+         AND source_object.object_type_id = edge.source_type_id
+         AND source_object.primary_id = edge.source_id
+      `
+  const order = compileOrder(identityOrderFields())
+  const qualifiedOrder = compileOrder(identityOrderFields(), outputAlias)
+  const sql = `
+    SELECT DISTINCT ${outputAlias}.*, ${outputAlias}.properties AS _cursor_properties
+    FROM (${input.sql}) AS input
+    ${joinSql}
+    ORDER BY ${qualifiedOrder.sql}
+  `
+  const args = [...input.args, linkId, ...qualifiedOrder.args]
+
+  return {
+    sql,
+    args,
+    totalSql: `SELECT COUNT(*)::bigint AS total FROM (${sql}) AS traversed`,
+    totalArgs: args,
+    order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileSet(
+  projectId: string,
+  op: ObjectQuerySetOperation,
+  inputs: readonly ObjectQuery[]
+): CompiledPgObjectQuery {
+  if (inputs.length === 0) {
+    const order = compileOrder(identityOrderFields())
+    return {
+      sql: `
+        SELECT *, properties AS _cursor_properties
+        FROM objects
+        WHERE 1 = 0
+        ORDER BY ${order.sql}
+      `,
+      args: order.args,
+      totalSql: "SELECT 0::bigint AS total",
+      totalArgs: [],
+      order,
+      hasMore: () => false,
+      trimRows: identityRows,
+      nextPageToken: () => undefined,
+    }
+  }
+
+  const compiledInputs = inputs.map((input) => compileObjectQueryInternal(projectId, input))
+  const identities = compileSetIdentities(op, compiledInputs)
+  const order = compileOrder(identityOrderFields())
+  const selectedOrder = compileOrder(identityOrderFields(), "selected")
+  const sql = `
+    SELECT selected.*, selected.properties AS _cursor_properties
+    FROM (${identities.sql}) AS ids
+    JOIN objects AS selected
+      ON selected.project_id = ?
+     AND selected.object_type_id = ids.object_type_id
+     AND selected.primary_id = ids.primary_id
+    ORDER BY ${selectedOrder.sql}
+  `
+
+  return {
+    sql,
+    args: [...identities.args, projectId, ...selectedOrder.args],
+    totalSql: `SELECT COUNT(*)::bigint AS total FROM (${identities.sql}) AS ids`,
+    totalArgs: identities.args,
+    order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileProject(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  properties: readonly string[] | undefined
+): CompiledPgObjectQuery {
+  const input = compileObjectQueryInternal(projectId, inputQuery)
+  if (!properties) return input
+
+  const projection = compileProjectionExpression(properties)
+  const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
+  const outputOrder = compileOrder(input.order.fields, undefined, "_cursor_properties")
+
+  return {
+    sql: `
+      SELECT
+        input.project_id,
+        input.object_type_id,
+        input.primary_id,
+        ${projection.sql} AS properties,
+        input._cursor_properties AS _cursor_properties,
+        input.created_at,
+        input.updated_at,
+        input.version,
+        input.source_event_id
+      FROM (${input.sql}) AS input
+      ORDER BY ${inputOrder.sql}
+    `,
+    args: [...projection.args, ...input.args, ...inputOrder.args],
+    totalSql: input.totalSql,
+    totalArgs: input.totalArgs,
+    order: outputOrder,
+    hasMore: input.hasMore,
+    trimRows: input.trimRows,
+    nextPageToken: input.nextPageToken,
+  }
+}
+
+function compileSetIdentities(
+  op: ObjectQuerySetOperation,
+  inputs: readonly CompiledPgObjectQuery[]
+): CompiledPredicate {
+  const operator = op === "union" ? "UNION" : op === "intersect" ? "INTERSECT" : "EXCEPT"
+  const identitySqls = inputs.map(
+    (input) => `SELECT object_type_id, primary_id FROM (${input.sql}) AS input`
+  )
+
+  return {
+    sql: identitySqls.join(` ${operator} `),
+    args: inputs.flatMap((input) => input.args),
+  }
+}
+
+function compileProjectionExpression(properties: readonly string[]): CompiledPredicate {
+  if (properties.length === 0) return { sql: "'{}'::jsonb", args: [] }
+
+  return {
+    sql: `
+      COALESCE(
+        (
+          SELECT jsonb_object_agg(projected.key, projected.value)
+          FROM jsonb_each(input.properties) AS projected(key, value)
+          WHERE projected.key IN (${properties.map(() => "?::text").join(", ")})
+        ),
+        '{}'::jsonb
+      )
+    `,
+    args: [...properties],
+  }
+}
+
+function compilePredicate(predicate: ObjectQueryPredicate): CompiledPredicate {
+  switch (predicate.op) {
+    case "and":
+    case "or": {
+      const items = predicate.items.map(compilePredicate)
+      const joiner = predicate.op === "and" ? " AND " : " OR "
+      return {
+        sql: `(${items.map((item) => item.sql).join(joiner)})`,
+        args: items.flatMap((item) => item.args),
+      }
+    }
+    case "not": {
+      const item = compilePredicate(predicate.item)
+      return negatePredicate(item)
+    }
+    case "eq":
+      return compileEqualityPredicate(predicate.propertyId, "eq", predicate.value)
+    case "neq":
+      return compileEqualityPredicate(predicate.propertyId, "neq", predicate.value)
+    case "lt":
+    case "lte":
+    case "gt":
+    case "gte": {
+      const op = sqlComparisonOperator(predicate.op)
+      return {
+        sql: `${jsonValueExpression()} ${op} ?::text::jsonb`,
+        args: [predicate.propertyId, jsonbValue(predicate.value)],
+      }
+    }
+    case "in":
+      return compileInPredicate(predicate.propertyId, predicate.values)
+    case "exists": {
+      const sql = `jsonb_exists(properties, ?::text)`
+      const item: CompiledPredicate = { sql, args: [predicate.propertyId] }
+      return predicate.value ? item : negatePredicate(item)
+    }
+    case "contains":
+      return compileContainsPredicate(predicate.propertyId, predicate.value)
+  }
+}
+
+function negatePredicate(predicate: CompiledPredicate): CompiledPredicate {
+  return {
+    sql: `(NOT COALESCE((${predicate.sql}), false))`,
+    args: predicate.args,
+  }
+}
+
+function compileEqualityPredicate(
+  propertyId: string,
+  op: "eq" | "neq",
+  value: unknown
+): CompiledPredicate {
+  if (value === null) {
+    const sql = `${jsonTypeExpression()} = 'null'`
+    const item: CompiledPredicate = { sql, args: [propertyId] }
+    return op === "eq" ? item : negatePredicate(item)
+  }
+
+  if (op === "eq") {
+    return {
+      sql: `${jsonValueExpression()} = ?::text::jsonb`,
+      args: [propertyId, jsonbValue(value)],
+    }
+  }
+
+  return {
+    sql: `(${jsonTypeExpression()} IS NULL OR ${jsonTypeExpression()} = 'null' OR ${jsonValueExpression()} <> ?::text::jsonb)`,
+    args: [propertyId, propertyId, propertyId, jsonbValue(value)],
+  }
+}
+
+function compileInPredicate(propertyId: string, values: readonly unknown[]): CompiledPredicate {
+  if (values.length === 0) return { sql: "0 = 1", args: [] }
+
+  const nonNullValues = values.filter((value) => value !== null)
+  const clauses: string[] = []
+  const args: unknown[] = []
+
+  if (values.length !== nonNullValues.length) {
+    clauses.push(`${jsonTypeExpression()} = 'null'`)
+    args.push(propertyId)
+  }
+
+  if (nonNullValues.length > 0) {
+    clauses.push(
+      `${jsonValueExpression()} IN (${nonNullValues.map(() => "?::text::jsonb").join(", ")})`
+    )
+    args.push(propertyId, ...nonNullValues.map(jsonbValue))
+  }
+
+  return {
+    sql: `(${clauses.join(" OR ")})`,
+    args,
+  }
+}
+
+function compileContainsPredicate(propertyId: string, value: unknown): CompiledPredicate {
+  const clauses: string[] = []
+  const args: unknown[] = []
+
+  if (typeof value === "string") {
+    clauses.push(
+      `(${jsonTypeExpression()} = 'string' AND position(?::text in ${jsonTextExpression()}) > 0)`
+    )
+    args.push(propertyId, value, propertyId)
+  }
+
+  clauses.push(
+    `(${jsonTypeExpression()} = 'array' AND ${jsonValueExpression()} @> jsonb_build_array(?::text::jsonb))`
+  )
+  args.push(propertyId, propertyId, jsonbValue(value))
+
+  if (typeof value === "string") {
+    clauses.push(
+      `(${jsonTypeExpression()} = 'object' AND jsonb_exists(${jsonValueExpression()}, ?::text))`
+    )
+    args.push(propertyId, propertyId, value)
+  }
+
+  return { sql: `(${clauses.join(" OR ")})`, args }
+}
+
+function compileTextPredicate(query: string, fields: readonly string[]): CompiledPredicate {
+  const terms = tokenize(query)
+  if (terms.length === 0) return { sql: "0 = 1", args: [] }
+
+  const clauses = terms.map(() => {
+    const fieldClauses = fields.map(
+      () => `position(?::text in lower(coalesce(${jsonTextExpression()}, ''))) > 0`
+    )
+    return `(${fieldClauses.join(" OR ")})`
+  })
+  const args = terms.flatMap((term) => fields.flatMap((field) => [term, field]))
+
+  return { sql: `(${clauses.join(" AND ")})`, args }
+}
+
+function compileOrder(
+  fields: readonly CompiledOrderField[],
+  qualifier?: string,
+  propertyColumn = "properties"
+): CompiledOrder {
+  const clauses: string[] = []
+  const args: unknown[] = []
+
+  for (const field of fields) {
+    if (field.kind === "column") {
+      clauses.push(`${columnExpression(field.column, qualifier)} ${field.direction.toUpperCase()}`)
+      continue
+    }
+
+    const direction = field.direction === "desc" ? "DESC" : "ASC"
+    clauses.push(
+      `CASE WHEN ${jsonTypeExpression(propertyColumn)} IS NULL OR ${jsonTypeExpression(propertyColumn)} = 'null' THEN 1 ELSE 0 END ASC`,
+      `${jsonValueExpression(propertyColumn)} ${direction}`
+    )
+    args.push(field.propertyId, field.propertyId, field.propertyId)
+  }
+
+  return { sql: clauses.join(", "), args, fields, propertyColumn }
+}
+
+function sortOrderFields(fields: readonly ObjectQuerySortField[]): readonly CompiledOrderField[] {
+  const orderFields: CompiledOrderField[] = []
+  for (const field of fields) {
+    if (field.kind !== "property") {
+      throw new Error("[SixbPg] PostgreSQL object storage does not support relevance sorting")
+    }
+
+    orderFields.push({
+      kind: "property",
+      propertyId: field.propertyId,
+      direction: field.direction === "desc" ? "desc" : "asc",
+    })
+  }
+  orderFields.push(...identityOrderFields())
+  return orderFields
+}
+
+function identityOrderFields(): readonly CompiledOrderField[] {
+  return [
+    { kind: "column", column: "object_type_id", direction: "asc" },
+    { kind: "column", column: "primary_id", direction: "asc" },
+  ]
+}
+
+function compileKeysetPredicate(
+  fields: readonly CompiledOrderField[],
+  cursor: readonly EncodedCursorValue[],
+  propertyColumn = "properties"
+): CompiledPredicate {
+  const disjuncts: CompiledPredicate[] = []
+
+  for (let index = 0; index < fields.length; index += 1) {
+    const equalityPredicates = fields
+      .slice(0, index)
+      .map((field, equalityIndex) =>
+        compileFieldEquality(field, cursor[equalityIndex], propertyColumn)
+      )
+    const advancePredicate = compileFieldAfter(fields[index], cursor[index], propertyColumn)
+    if (!advancePredicate) continue
+
+    const parts = [...equalityPredicates, advancePredicate]
+    disjuncts.push({
+      sql: `(${parts.map((part) => part.sql).join(" AND ")})`,
+      args: parts.flatMap((part) => part.args),
+    })
+  }
+
+  if (disjuncts.length === 0) return { sql: "0 = 1", args: [] }
+
+  return {
+    sql: `(${disjuncts.map((part) => part.sql).join(" OR ")})`,
+    args: disjuncts.flatMap((part) => part.args),
+  }
+}
+
+function compileFieldEquality(
+  field: CompiledOrderField,
+  cursor: EncodedCursorValue,
+  propertyColumn = "properties"
+): CompiledPredicate {
+  if (field.kind === "column") {
+    return {
+      sql: `${columnExpression(field.column)} = ?`,
+      args: [cursor.value],
+    }
+  }
+
+  if (cursor.nullish) {
+    return {
+      sql: `(${jsonTypeExpression(propertyColumn)} IS NULL OR ${jsonTypeExpression(propertyColumn)} = 'null')`,
+      args: [field.propertyId, field.propertyId],
+    }
+  }
+
+  return {
+    sql: `(${jsonTypeExpression(propertyColumn)} IS NOT NULL AND ${jsonTypeExpression(propertyColumn)} != 'null' AND ${jsonValueExpression(propertyColumn)} = ?::text::jsonb)`,
+    args: [field.propertyId, field.propertyId, field.propertyId, jsonbValue(cursor.value)],
+  }
+}
+
+function compileFieldAfter(
+  field: CompiledOrderField,
+  cursor: EncodedCursorValue,
+  propertyColumn = "properties"
+): CompiledPredicate | null {
+  if (field.kind === "column") {
+    return {
+      sql: `${columnExpression(field.column)} ${field.direction === "desc" ? "<" : ">"} ?`,
+      args: [cursor.value],
+    }
+  }
+
+  if (cursor.nullish) return null
+
+  const rankSql = `CASE WHEN ${jsonTypeExpression(propertyColumn)} IS NULL OR ${jsonTypeExpression(propertyColumn)} = 'null' THEN 1 ELSE 0 END`
+  const valueOperator = field.direction === "desc" ? "<" : ">"
+
+  return {
+    sql: `(${rankSql} > 0 OR (${rankSql} = 0 AND ${jsonValueExpression(propertyColumn)} ${valueOperator} ?::text::jsonb))`,
+    args: [
+      field.propertyId,
+      field.propertyId,
+      field.propertyId,
+      field.propertyId,
+      field.propertyId,
+      jsonbValue(cursor.value),
+    ],
+  }
+}
+
+function encodePageToken(row: PgObjectQueryPageRow, fields: readonly CompiledOrderField[]): string {
+  const properties = objectProperties(row._cursor_properties ?? row.properties)
+  const token: EncodedPageToken = {
+    version: 1,
+    order: fields.map(orderFieldKey),
+    values: fields.map((field) => cursorValueForField(row, properties, field)),
+  }
+  return `${PAGE_TOKEN_PREFIX}${Buffer.from(JSON.stringify(token)).toString("base64url")}`
+}
+
+function decodePageToken(
+  token: string,
+  fields: readonly CompiledOrderField[]
+): readonly EncodedCursorValue[] {
+  if (!token.startsWith(PAGE_TOKEN_PREFIX)) {
+    throwInvalidPageToken("Invalid PostgreSQL object query page token")
+  }
+
+  const raw = token.slice(PAGE_TOKEN_PREFIX.length)
+  let decoded: unknown
+  try {
+    decoded = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"))
+  } catch {
+    throwInvalidPageToken("Invalid PostgreSQL object query page token")
+  }
+
+  if (!isEncodedPageToken(decoded)) {
+    throwInvalidPageToken("Invalid PostgreSQL object query page token")
+  }
+
+  const expectedOrder = fields.map(orderFieldKey)
+  if (
+    decoded.order.length !== expectedOrder.length ||
+    decoded.order.some((field, index) => field !== expectedOrder[index])
+  ) {
+    throwInvalidPageToken("PostgreSQL object query page token does not match query order")
+  }
+
+  return decoded.values
+}
+
+function throwInvalidPageToken(message: string): never {
+  throw new ObjectQueryExecutionError("invalid_page_token", message, "$.pageToken")
+}
+
+function isEncodedPageToken(value: unknown): value is EncodedPageToken {
+  if (!isPlainObject(value)) return false
+  if (value.version !== 1) return false
+  if (!Array.isArray(value.order) || value.order.some((item) => typeof item !== "string")) {
+    return false
+  }
+  if (!Array.isArray(value.values)) return false
+  return value.values.every(
+    (item) =>
+      isPlainObject(item) &&
+      typeof item.nullish === "boolean" &&
+      (item.nullish || Object.hasOwn(item, "value"))
+  )
+}
+
+function cursorValueForField(
+  row: PgObjectQueryPageRow,
+  properties: Record<string, unknown>,
+  field: CompiledOrderField
+): EncodedCursorValue {
+  const value =
+    field.kind === "column"
+      ? field.column === "object_type_id"
+        ? row.object_type_id
+        : row.primary_id
+      : properties[field.propertyId]
+
+  return value === null || value === undefined ? { nullish: true } : { nullish: false, value }
+}
+
+function orderFieldKey(field: CompiledOrderField): string {
+  return field.kind === "column"
+    ? `column:${field.column}:${field.direction}`
+    : `property:${field.propertyId}:${field.direction}`
+}
+
+function columnExpression(column: "object_type_id" | "primary_id", qualifier?: string): string {
+  return qualifier ? `${qualifier}.${column}` : column
+}
+
+function jsonValueExpression(column = "properties"): string {
+  return `${column} -> (?::text)`
+}
+
+function jsonTextExpression(column = "properties"): string {
+  return `${column} ->> (?::text)`
+}
+
+function jsonTypeExpression(column = "properties"): string {
+  return `jsonb_typeof(${jsonValueExpression(column)})`
+}
+
+function jsonbValue(value: unknown): string {
+  if (value instanceof Date) return JSON.stringify(value.toISOString())
+  const json = JSON.stringify(value)
+  return json === undefined ? "null" : json
+}
+
+function tokenize(query: string): string[] {
+  return query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((term) => term.length > 0)
+}
+
+function sqlComparisonOperator(op: "lt" | "lte" | "gt" | "gte"): "<" | "<=" | ">" | ">=" {
+  switch (op) {
+    case "lt":
+      return "<"
+    case "lte":
+      return "<="
+    case "gt":
+      return ">"
+    case "gte":
+      return ">="
+  }
+}
+
+function numberPlaceholders(sql: string): string {
+  let index = 0
+  return sql.replace(/\?/g, () => `$${++index}`)
+}
+
+function objectProperties(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    const parsed = JSON.parse(value) as unknown
+    return isPlainObject(parsed) ? parsed : {}
+  }
+
+  return isPlainObject(value) ? value : {}
+}
+
+function identityRows<T>(rows: readonly T[]): readonly T[] {
+  return rows
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/storage/pg/src/pg-object-query-compiler.ts
+++ b/storage/pg/src/pg-object-query-compiler.ts
@@ -89,7 +89,13 @@ function compileObjectQueryInternal(projectId: string, query: ObjectQuery): Comp
     case "project":
       return compileProject(projectId, query.input, query.properties)
     case "text":
-      return compileText(projectId, query.input, query.query, query.fields)
+      return compileText(
+        projectId,
+        query.input,
+        query.query,
+        query.fields,
+        query.fieldsByObjectType
+      )
     case "vector":
       throw new Error(`[SixbPg] PostgreSQL object storage does not support query node 'vector'`)
   }
@@ -165,12 +171,20 @@ function compileText(
   projectId: string,
   inputQuery: ObjectQuery,
   query: string,
-  fields: readonly string[] | undefined
+  fields: readonly string[] | undefined,
+  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined
 ): CompiledPgObjectQuery {
-  if (!fields || fields.length === 0) {
-    throw new Error("[SixbPg] PostgreSQL object text search requires explicit fields")
+  const predicate =
+    fields && fields.length > 0
+      ? compileTextPredicate(query, fields)
+      : compileScopedTextPredicate(query, fieldsByObjectType)
+
+  if (!predicate) {
+    throw new Error(
+      "[SixbPg] PostgreSQL object text search requires fields or resolved text defaults"
+    )
   }
-  return compileWhere(projectId, inputQuery, compileTextPredicate(query, fields))
+  return compileWhere(projectId, inputQuery, predicate)
 }
 
 function compileSort(
@@ -582,6 +596,29 @@ function compileTextPredicate(query: string, fields: readonly string[]): Compile
   const args = terms.flatMap((term) => fields.flatMap((field) => [term, field]))
 
   return { sql: `(${clauses.join(" AND ")})`, args }
+}
+
+function compileScopedTextPredicate(
+  query: string,
+  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined
+): CompiledPredicate | null {
+  const scopedPredicates: CompiledPredicate[] = []
+
+  for (const [objectTypeId, fields] of Object.entries(fieldsByObjectType ?? {})) {
+    if (fields.length === 0) continue
+    const predicate = compileTextPredicate(query, fields)
+    scopedPredicates.push({
+      sql: `(object_type_id = ? AND ${predicate.sql})`,
+      args: [objectTypeId, ...predicate.args],
+    })
+  }
+
+  if (scopedPredicates.length === 0) return null
+
+  return {
+    sql: `(${scopedPredicates.map((predicate) => predicate.sql).join(" OR ")})`,
+    args: scopedPredicates.flatMap((predicate) => predicate.args),
+  }
 }
 
 function compileOrder(

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -4,16 +4,63 @@ import type {
   ObjectQueryCapabilities,
   ObjectRow,
   ObjectStorage,
+  QueryObjectsInput,
+  QueryObjectsResult,
   StoredLinkRemovedEvent,
   StoredLinkUpsertedEvent,
   StoredObjectUpsertedEvent,
   StoredTelemetryAppendedEvent,
 } from "@sixb/core"
 import type { SQL } from "bun"
+import { type CompiledPgObjectQuery, compilePgObjectQuery } from "./pg-object-query-compiler"
 
 const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
-  queryObjects: false,
-  notes: ["PostgreSQL object query pushdown is added in a later stacked PR."],
+  queryObjects: true,
+  nodes: {
+    start: true,
+    filter: true,
+    text: true,
+    sort: true,
+    limit: true,
+    page: true,
+    traverse: true,
+    set: true,
+    project: true,
+  },
+  predicateOps: {
+    and: true,
+    or: true,
+    not: true,
+    eq: true,
+    neq: true,
+    lt: true,
+    lte: true,
+    gt: true,
+    gte: true,
+    in: true,
+    exists: true,
+    contains: true,
+  },
+  sortKinds: {
+    property: true,
+  },
+  traversalDirections: {
+    outgoing: true,
+    incoming: true,
+  },
+  setOps: {
+    union: true,
+    intersect: true,
+    subtract: true,
+  },
+  limits: {
+    totalCount: true,
+    stablePageTokens: true,
+  },
+  notes: [
+    "PostgreSQL object query pushdown supports start/filter/text/sort/limit/page/traverse/set/project over JSONB properties and object links.",
+    "Relevance sorting, vector search, and unresolved start.includeSubtypes remain planner fallback or rejection cases.",
+  ],
 }
 
 /**
@@ -59,8 +106,8 @@ function valuesJoin(
 /**
  * PostgreSQL-based ObjectStorage implementation.
  *
- * Stores object projections and links with full query support.
- * Uses JSONB for properties with GIN indexes for efficient `findFirst()` queries.
+ * Stores object projections and links. V1 object-query IR pushdown covers the
+ * scalar JSONB-property and link-traversal subset declared by queryCapabilities().
  *
  * Requires `search_path` to be set to the Sixb schema on the connection.
  *
@@ -78,6 +125,21 @@ export class PgObjectStorage implements ObjectStorage {
 
   queryCapabilities(): ObjectQueryCapabilities {
     return PG_OBJECT_QUERY_CAPABILITIES
+  }
+
+  async queryObjects(params: QueryObjectsInput): Promise<QueryObjectsResult> {
+    const compiled = compilePgObjectQuery(params.projectId, params.query)
+    const total = await readTotal(this.sql, compiled)
+    const rawRows = (await this.sql.unsafe(compiled.sql, compiled.args)) as ObjectQueryDatabaseRow[]
+    const rows = compiled.trimRows(rawRows) as readonly ObjectQueryDatabaseRow[]
+    const hasMore = compiled.hasMore(rawRows.length, total)
+
+    return {
+      objects: rows.map((row) => rowToObject(row)),
+      hasMore,
+      total,
+      nextPageToken: compiled.nextPageToken(rows, rawRows.length),
+    }
   }
 
   async applyObjectUpserted(event: StoredObjectUpsertedEvent): Promise<ObjectRow> {
@@ -447,42 +509,6 @@ export class PgObjectStorage implements ObjectStorage {
     return row ? rowToObject(row) : null
   }
 
-  async findFirst(params: {
-    projectId: string
-    objectTypeId: string
-    where?: readonly { propertyId: string; op: "eq"; value: unknown }[]
-  }): Promise<ObjectRow | null> {
-    if (params.where && params.where.length > 0) {
-      // Build a JSONB containment check using @>
-      const conditions: Record<string, unknown> = {}
-      for (const clause of params.where) {
-        if (clause.op === "eq") {
-          conditions[clause.propertyId] = clause.value
-        }
-      }
-
-      // Pass the JS object directly — Bun SQL auto-serialises it as JSONB
-      const [row] = (await this.sql`
-        SELECT * FROM objects
-        WHERE project_id = ${params.projectId}
-          AND object_type_id = ${params.objectTypeId}
-          AND properties @> ${conditions}
-        LIMIT 1
-      `) as ObjectDatabaseRow[]
-
-      return row ? rowToObject(row) : null
-    }
-
-    const [row] = (await this.sql`
-      SELECT * FROM objects
-      WHERE project_id = ${params.projectId}
-        AND object_type_id = ${params.objectTypeId}
-      LIMIT 1
-    `) as ObjectDatabaseRow[]
-
-    return row ? rowToObject(row) : null
-  }
-
   async listLinks(params: {
     projectId: string
     objectTypeId: string
@@ -645,6 +671,13 @@ export class PgObjectStorage implements ObjectStorage {
   }
 }
 
+async function readTotal(sql: SQL, compiled: CompiledPgObjectQuery): Promise<number> {
+  const [row] = (await sql.unsafe(compiled.totalSql, compiled.totalArgs)) as {
+    total: string | number | bigint
+  }[]
+  return Number(row?.total ?? 0)
+}
+
 function rowToObject(row: ObjectDatabaseRow): ObjectRow {
   return {
     projectId: row.project_id,
@@ -682,6 +715,10 @@ interface ObjectDatabaseRow {
   updated_at: Date | string
   version: number
   source_event_id: string | null
+}
+
+interface ObjectQueryDatabaseRow extends ObjectDatabaseRow {
+  _cursor_properties?: unknown
 }
 
 interface LinkDatabaseRow {

--- a/storage/pg/tests/pg-object-query-conformance.e2e.ts
+++ b/storage/pg/tests/pg-object-query-conformance.e2e.ts
@@ -1,0 +1,19 @@
+import { runObjectQueryProviderContractSuite } from "@sixb/core/testing"
+import type { PostgresStorage } from "../src"
+import { createTestStorage } from "./helpers"
+
+const parentStorage = new WeakMap<PostgresStorage["objects"], PostgresStorage>()
+
+runObjectQueryProviderContractSuite("PgObjectStorage object query provider contract", {
+  createStorage: async () => {
+    const { storage } = await createTestStorage()
+    parentStorage.set(storage.objects, storage)
+    return storage.objects
+  },
+  teardown: async (objects) => {
+    const storage = parentStorage.get(objects)
+    if (!storage) return
+    await storage.dropSchema()
+    await storage.close()
+  },
+})

--- a/storage/pg/tests/pg-object-storage.e2e.ts
+++ b/storage/pg/tests/pg-object-storage.e2e.ts
@@ -179,42 +179,6 @@ describe("PgObjectStorage", () => {
     expect(row).toBeNull()
   })
 
-  test("findFirst returns first matching object", async () => {
-    await storage.objects.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:101", { name: "Room A", floor: "1" }, "1")
-    )
-    await storage.objects.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:102", { name: "Room B", floor: "2" }, "2")
-    )
-    await storage.objects.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:103", { name: "Room C", floor: "2" }, "3")
-    )
-
-    const row = await storage.objects.findFirst({
-      projectId: "project-a",
-      objectTypeId: "Room",
-      where: [{ propertyId: "floor", op: "eq", value: "2" }],
-    })
-
-    expect(row?.properties.floor).toBe("2")
-  })
-
-  test("findFirst without where returns first object", async () => {
-    await storage.objects.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:101", { name: "Room A" }, "1")
-    )
-    await storage.objects.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:102", { name: "Room B" }, "2")
-    )
-
-    const row = await storage.objects.findFirst({
-      projectId: "project-a",
-      objectTypeId: "Room",
-    })
-
-    expect(row).not.toBeNull()
-  })
-
   test("applyTelemetryAppended updates object property", async () => {
     await storage.objects.applyObjectUpserted(
       createObjectEvent("project-a", "Room", "room:101", { name: "Conference" }, "1")
@@ -519,29 +483,6 @@ describe("PgObjectStorage", () => {
     expect(result.objects[0]?.primaryId).toBe("room:a")
     expect(result.objects[1]?.primaryId).toBe("room:b")
     expect(result.objects[2]?.primaryId).toBe("room:c")
-  })
-
-  test("findFirst with JSONB containment query", async () => {
-    await storage.objects.applyObjectUpserted(
-      createObjectEvent("project-a", "Sensor", "s:1", { type: "temperature", zone: "A" }, "1")
-    )
-    await storage.objects.applyObjectUpserted(
-      createObjectEvent("project-a", "Sensor", "s:2", { type: "humidity", zone: "A" }, "2")
-    )
-    await storage.objects.applyObjectUpserted(
-      createObjectEvent("project-a", "Sensor", "s:3", { type: "temperature", zone: "B" }, "3")
-    )
-
-    const row = await storage.objects.findFirst({
-      projectId: "project-a",
-      objectTypeId: "Sensor",
-      where: [
-        { propertyId: "type", op: "eq", value: "temperature" },
-        { propertyId: "zone", op: "eq", value: "B" },
-      ],
-    })
-
-    expect(row?.primaryId).toBe("s:3")
   })
 
   test("applyTelemetryAppendedBatch updates multiple properties on same object", async () => {

--- a/storage/sqlite/src/object-query-compiler.ts
+++ b/storage/sqlite/src/object-query-compiler.ts
@@ -1,0 +1,855 @@
+import {
+  type ObjectQuery,
+  ObjectQueryExecutionError,
+  type ObjectQueryPredicate,
+  type ObjectQuerySetOperation,
+  type ObjectQuerySortField,
+} from "@sixb/core"
+
+export type SqliteValue = string | number | bigint | boolean | null
+
+export interface SqliteObjectQueryPageRow {
+  object_type_id: string
+  primary_id: string
+  properties: string
+  _cursor_properties?: string
+}
+
+export interface CompiledObjectQuery {
+  sql: string
+  args: SqliteValue[]
+  totalSql: string
+  totalArgs: SqliteValue[]
+  order: CompiledOrder
+  hasMore(rowCount: number, total: number): boolean
+  trimRows<T>(rows: readonly T[]): readonly T[]
+  nextPageToken(rows: readonly SqliteObjectQueryPageRow[], rowCount: number): string | undefined
+}
+
+interface CompiledPredicate {
+  sql: string
+  args: SqliteValue[]
+}
+
+interface CompiledOrder {
+  sql: string
+  args: SqliteValue[]
+  fields: readonly CompiledOrderField[]
+  propertyColumn: string
+}
+
+type CompiledOrderField =
+  | {
+      kind: "property"
+      propertyId: string
+      direction: "asc" | "desc"
+    }
+  | {
+      kind: "column"
+      column: "object_type_id" | "primary_id"
+      direction: "asc" | "desc"
+    }
+
+interface EncodedPageToken {
+  version: 1
+  order: readonly string[]
+  values: readonly EncodedCursorValue[]
+}
+
+interface EncodedCursorValue {
+  nullish: boolean
+  value?: unknown
+}
+
+const PAGE_TOKEN_PREFIX = "keyset:"
+
+export function compileObjectQuery(projectId: string, query: ObjectQuery): CompiledObjectQuery {
+  switch (query.kind) {
+    case "start":
+      return compileStart(projectId, query)
+    case "filter":
+      return compileFilter(projectId, query.input, query.predicate)
+    case "sort":
+      return compileSort(projectId, query.input, query.fields)
+    case "limit":
+      return compileLimit(projectId, query.input, query.limit)
+    case "page":
+      return compilePage(projectId, query.input, query.pageSize, query.pageToken)
+    case "traverse":
+      return compileTraversal(projectId, query.input, query.linkId, query.direction)
+    case "set":
+      return compileSet(projectId, query.op, query.inputs)
+    case "project":
+      return compileProject(projectId, query.input, query.properties)
+    case "text":
+      return compileText(projectId, query.input, query.query, query.fields)
+    case "vector":
+      throw new Error(`[Sixb] SQLite object storage does not support query node '${query.kind}'`)
+  }
+}
+
+function compileStart(
+  projectId: string,
+  query: Extract<ObjectQuery, { kind: "start" }>
+): CompiledObjectQuery {
+  if (query.includeSubtypes === true) {
+    throw new Error("[Sixb] SQLite object storage does not support start.includeSubtypes")
+  }
+
+  const order = compileOrder(identityOrderFields())
+  const sql = `
+    SELECT *, properties AS _cursor_properties
+    FROM objects
+    WHERE project_id = ? AND object_type_id = ?
+    ORDER BY ${order.sql}
+  `
+  const args = [projectId, query.objectTypeId, ...order.args]
+
+  return {
+    sql,
+    args,
+    totalSql: "SELECT COUNT(*) as total FROM objects WHERE project_id = ? AND object_type_id = ?",
+    totalArgs: [projectId, query.objectTypeId],
+    order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileFilter(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  predicateNode: ObjectQueryPredicate
+): CompiledObjectQuery {
+  const predicate = compilePredicate(predicateNode)
+  return compileWhere(projectId, inputQuery, predicate)
+}
+
+function compileWhere(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  predicate: CompiledPredicate
+): CompiledObjectQuery {
+  const input = compileObjectQuery(projectId, inputQuery)
+  const sql = `
+    SELECT *
+    FROM (${input.sql}) AS input
+    WHERE ${predicate.sql}
+    ORDER BY ${input.order.sql}
+  `
+
+  return {
+    sql,
+    args: [...input.args, ...predicate.args, ...input.order.args],
+    totalSql: `
+      SELECT COUNT(*) as total
+      FROM (${input.sql}) AS input
+      WHERE ${predicate.sql}
+    `,
+    totalArgs: [...input.args, ...predicate.args],
+    order: input.order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileText(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  query: string,
+  fields: readonly string[] | undefined
+): CompiledObjectQuery {
+  if (!fields || fields.length === 0) {
+    throw new Error("[Sixb] SQLite object text search requires explicit fields")
+  }
+  return compileWhere(projectId, inputQuery, compileTextPredicate(query, fields))
+}
+
+function compileSort(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  fields: readonly ObjectQuerySortField[]
+): CompiledObjectQuery {
+  const input = compileObjectQuery(projectId, inputQuery)
+  const order = compileOrder(sortOrderFields(fields))
+
+  return {
+    sql: `
+      SELECT
+        input.project_id,
+        input.object_type_id,
+        input.primary_id,
+        input.properties,
+        input.properties AS _cursor_properties,
+        input.created_at,
+        input.updated_at,
+        input.version,
+        input.source_event_id
+      FROM (${input.sql}) AS input
+      ORDER BY ${order.sql}
+    `,
+    args: [...input.args, ...order.args],
+    totalSql: input.totalSql,
+    totalArgs: input.totalArgs,
+    order,
+    hasMore: input.hasMore,
+    trimRows: input.trimRows,
+    nextPageToken: input.nextPageToken,
+  }
+}
+
+function compileLimit(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  rawLimit: number
+): CompiledObjectQuery {
+  const input = compileObjectQuery(projectId, inputQuery)
+  const limit = Math.max(0, rawLimit)
+
+  return {
+    sql: `
+      SELECT *
+      FROM (${input.sql}) AS input
+      ORDER BY ${input.order.sql}
+      LIMIT ?
+    `,
+    args: [...input.args, ...input.order.args, limit],
+    totalSql: `
+      SELECT COUNT(*) as total
+      FROM (${input.sql}) AS input
+    `,
+    totalArgs: input.args,
+    order: input.order,
+    hasMore: (_rowCount, total) => limit < total,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compilePage(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  rawPageSize: number,
+  pageToken: string | undefined
+): CompiledObjectQuery {
+  const input = compileObjectQuery(projectId, inputQuery)
+  const pageSize = Math.max(0, rawPageSize)
+  const cursor = pageToken ? decodePageToken(pageToken, input.order.fields) : undefined
+  const cursorPredicate = cursor
+    ? compileKeysetPredicate(input.order.fields, cursor, input.order.propertyColumn)
+    : undefined
+  const whereSql = cursorPredicate ? `WHERE ${cursorPredicate.sql}` : ""
+
+  return {
+    sql: `
+      SELECT *
+      FROM (${input.sql}) AS input
+      ${whereSql}
+      ORDER BY ${input.order.sql}
+      LIMIT ?
+    `,
+    args: [...input.args, ...(cursorPredicate?.args ?? []), ...input.order.args, pageSize + 1],
+    totalSql: `
+      SELECT COUNT(*) as total
+      FROM (${input.sql}) AS input
+    `,
+    totalArgs: input.args,
+    order: input.order,
+    hasMore: (rowCount) => rowCount > pageSize,
+    trimRows: (rows) => rows.slice(0, pageSize),
+    nextPageToken: (rows, rowCount) => {
+      if (rowCount <= pageSize || rows.length === 0) return undefined
+      return encodePageToken(rows[rows.length - 1], input.order.fields)
+    },
+  }
+}
+
+function compileTraversal(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  linkId: string,
+  direction: "outgoing" | "incoming"
+): CompiledObjectQuery {
+  const input = compileObjectQuery(projectId, inputQuery)
+  const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
+  const joinSql =
+    direction === "outgoing"
+      ? `
+        JOIN links AS edge
+          ON edge.project_id = input.project_id
+         AND edge.source_type_id = input.object_type_id
+         AND edge.source_id = input.primary_id
+         AND edge.link_id = ?
+        JOIN objects AS target_object
+          ON target_object.project_id = edge.project_id
+         AND target_object.object_type_id = edge.target_type_id
+         AND target_object.primary_id = edge.target_id
+      `
+      : `
+        JOIN links AS edge
+          ON edge.project_id = input.project_id
+         AND edge.target_type_id = input.object_type_id
+         AND edge.target_id = input.primary_id
+         AND edge.link_id = ?
+        JOIN objects AS source_object
+          ON source_object.project_id = edge.project_id
+         AND source_object.object_type_id = edge.source_type_id
+         AND source_object.primary_id = edge.source_id
+      `
+  const order = compileOrder(identityOrderFields())
+  const qualifiedOrder = compileOrder(identityOrderFields(), outputAlias)
+  const sql = `
+    SELECT DISTINCT ${outputAlias}.*, ${outputAlias}.properties AS _cursor_properties
+    FROM (${input.sql}) AS input
+    ${joinSql}
+    ORDER BY ${qualifiedOrder.sql}
+  `
+  const args = [...input.args, linkId, ...qualifiedOrder.args]
+
+  return {
+    sql,
+    args,
+    totalSql: `SELECT COUNT(*) as total FROM (${sql}) AS traversed`,
+    totalArgs: args,
+    order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileSet(
+  projectId: string,
+  op: ObjectQuerySetOperation,
+  inputs: readonly ObjectQuery[]
+): CompiledObjectQuery {
+  if (inputs.length === 0) {
+    const order = compileOrder(identityOrderFields())
+    return {
+      sql: `
+        SELECT *
+        FROM objects
+        WHERE 1 = 0
+        ORDER BY ${order.sql}
+      `,
+      args: order.args,
+      totalSql: "SELECT 0 as total",
+      totalArgs: [],
+      order,
+      hasMore: () => false,
+      trimRows: identityRows,
+      nextPageToken: () => undefined,
+    }
+  }
+
+  const compiledInputs = inputs.map((input) => compileObjectQuery(projectId, input))
+  const identities = compileSetIdentities(op, compiledInputs)
+  const order = compileOrder(identityOrderFields())
+  const selectedOrder = compileOrder(identityOrderFields(), "selected")
+  const sql = `
+    SELECT selected.*, selected.properties AS _cursor_properties
+    FROM (${identities.sql}) AS ids
+    JOIN objects AS selected
+      ON selected.project_id = ?
+     AND selected.object_type_id = ids.object_type_id
+     AND selected.primary_id = ids.primary_id
+    ORDER BY ${selectedOrder.sql}
+  `
+  const args = [...identities.args, projectId, ...selectedOrder.args]
+
+  return {
+    sql,
+    args,
+    totalSql: `SELECT COUNT(*) as total FROM (${identities.sql}) AS ids`,
+    totalArgs: identities.args,
+    order,
+    hasMore: () => false,
+    trimRows: identityRows,
+    nextPageToken: () => undefined,
+  }
+}
+
+function compileProject(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  properties: readonly string[] | undefined
+): CompiledObjectQuery {
+  const input = compileObjectQuery(projectId, inputQuery)
+  if (!properties) return input
+
+  const projection = compileProjectionExpression(properties)
+  const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
+  const outputOrder = compileOrder(input.order.fields, undefined, "_cursor_properties")
+
+  return {
+    sql: `
+      SELECT
+        input.project_id,
+        input.object_type_id,
+        input.primary_id,
+        ${projection.sql} AS properties,
+        input._cursor_properties AS _cursor_properties,
+        input.created_at,
+        input.updated_at,
+        input.version,
+        input.source_event_id
+      FROM (${input.sql}) AS input
+      ORDER BY ${inputOrder.sql}
+    `,
+    args: [...projection.args, ...input.args, ...inputOrder.args],
+    totalSql: input.totalSql,
+    totalArgs: input.totalArgs,
+    order: outputOrder,
+    hasMore: input.hasMore,
+    trimRows: input.trimRows,
+    nextPageToken: input.nextPageToken,
+  }
+}
+
+function compileSetIdentities(
+  op: ObjectQuerySetOperation,
+  inputs: readonly CompiledObjectQuery[]
+): CompiledPredicate {
+  const operator = op === "union" ? "UNION" : op === "intersect" ? "INTERSECT" : "EXCEPT"
+  const identitySqls = inputs.map(
+    (input) => `SELECT object_type_id, primary_id FROM (${input.sql}) AS input`
+  )
+
+  return {
+    sql: identitySqls.join(` ${operator} `),
+    args: inputs.flatMap((input) => input.args),
+  }
+}
+
+function compileProjectionExpression(properties: readonly string[]): CompiledPredicate {
+  if (properties.length === 0) return { sql: "json('{}')", args: [] }
+
+  return {
+    sql: `
+      COALESCE(
+        (
+          SELECT json_group_object(projected.key, projected.value)
+          FROM json_each(input.properties) AS projected
+          WHERE projected.key IN (${properties.map(() => "?").join(", ")})
+        ),
+        json('{}')
+      )
+    `,
+    args: [...properties],
+  }
+}
+
+function compilePredicate(predicate: ObjectQueryPredicate): CompiledPredicate {
+  switch (predicate.op) {
+    case "and":
+    case "or": {
+      const items = predicate.items.map(compilePredicate)
+      const joiner = predicate.op === "and" ? " AND " : " OR "
+      return {
+        sql: `(${items.map((item) => item.sql).join(joiner)})`,
+        args: items.flatMap((item) => item.args),
+      }
+    }
+    case "not": {
+      const item = compilePredicate(predicate.item)
+      return negatePredicate(item)
+    }
+    case "eq":
+      return compileEqualityPredicate(predicate.propertyId, "eq", predicate.value)
+    case "neq":
+      return compileEqualityPredicate(predicate.propertyId, "neq", predicate.value)
+    case "lt":
+    case "lte":
+    case "gt":
+    case "gte": {
+      const op = sqlComparisonOperator(predicate.op)
+      return {
+        sql: `${jsonValueExpression()} ${op} ?`,
+        args: [jsonPath(predicate.propertyId), sqlValue(predicate.value)],
+      }
+    }
+    case "in":
+      return compileInPredicate(predicate.propertyId, predicate.values)
+    case "exists": {
+      const sql = `${jsonTypeExpression()} IS NOT NULL`
+      const item: CompiledPredicate = { sql, args: [jsonPath(predicate.propertyId)] }
+      return predicate.value ? item : negatePredicate(item)
+    }
+    case "contains":
+      return compileContainsPredicate(predicate.propertyId, predicate.value)
+  }
+}
+
+function negatePredicate(predicate: CompiledPredicate): CompiledPredicate {
+  return {
+    sql: `(NOT COALESCE((${predicate.sql}), 0))`,
+    args: predicate.args,
+  }
+}
+
+function compileEqualityPredicate(
+  propertyId: string,
+  op: "eq" | "neq",
+  value: unknown
+): CompiledPredicate {
+  const path = jsonPath(propertyId)
+  if (value === null) {
+    const sql = `${jsonTypeExpression()} = 'null'`
+    const item: CompiledPredicate = { sql, args: [path] }
+    return op === "eq" ? item : negatePredicate(item)
+  }
+
+  if (op === "eq") {
+    return {
+      sql: `${jsonValueExpression()} = ?`,
+      args: [path, sqlValue(value)],
+    }
+  }
+
+  // JS predicate semantics treat missing/null properties as not equal to any
+  // non-null scalar. SQL three-valued null logic needs those cases explicit.
+  return {
+    sql: `(${jsonTypeExpression()} IS NULL OR ${jsonTypeExpression()} = 'null' OR ${jsonValueExpression()} != ?)`,
+    args: [path, path, path, sqlValue(value)],
+  }
+}
+
+function compileInPredicate(propertyId: string, values: readonly unknown[]): CompiledPredicate {
+  if (values.length === 0) return { sql: "0 = 1", args: [] }
+
+  const path = jsonPath(propertyId)
+  const nonNullValues = values.filter((value) => value !== null)
+  const clauses: string[] = []
+  const args: SqliteValue[] = []
+
+  if (values.length !== nonNullValues.length) {
+    clauses.push(`${jsonTypeExpression()} = 'null'`)
+    args.push(path)
+  }
+
+  if (nonNullValues.length > 0) {
+    clauses.push(`${jsonValueExpression()} IN (${nonNullValues.map(() => "?").join(", ")})`)
+    args.push(path, ...nonNullValues.map(sqlValue))
+  }
+
+  return {
+    sql: `(${clauses.join(" OR ")})`,
+    args,
+  }
+}
+
+function compileContainsPredicate(propertyId: string, value: unknown): CompiledPredicate {
+  const path = jsonPath(propertyId)
+  const clauses: string[] = []
+  const args: SqliteValue[] = []
+
+  if (typeof value === "string") {
+    clauses.push(`(${jsonTypeExpression()} = 'text' AND instr(${jsonValueExpression()}, ?) > 0)`)
+    args.push(path, path, value)
+  }
+
+  clauses.push(
+    `(${jsonTypeExpression()} = 'array' AND EXISTS (SELECT 1 FROM json_each(properties, ?) AS item WHERE item.value IS ?))`
+  )
+  args.push(path, path, sqlValue(value))
+
+  if (typeof value === "string") {
+    clauses.push(
+      `(${jsonTypeExpression()} = 'object' AND EXISTS (SELECT 1 FROM json_each(properties, ?) AS item WHERE item.key = ?))`
+    )
+    args.push(path, path, value)
+  }
+
+  return { sql: `(${clauses.join(" OR ")})`, args }
+}
+
+function compileTextPredicate(query: string, fields: readonly string[]): CompiledPredicate {
+  const terms = tokenize(query)
+  if (terms.length === 0) return { sql: "0 = 1", args: [] }
+
+  const clauses = terms.map(() => {
+    const fieldClauses = fields.map(
+      () => `instr(lower(COALESCE(CAST(${jsonValueExpression()} AS TEXT), '')), ?) > 0`
+    )
+    return `(${fieldClauses.join(" OR ")})`
+  })
+  const args = terms.flatMap((term) => fields.flatMap((field) => [jsonPath(field), term]))
+
+  return { sql: `(${clauses.join(" AND ")})`, args }
+}
+
+function compileOrder(
+  fields: readonly CompiledOrderField[],
+  qualifier?: string,
+  propertyColumn = "properties"
+): CompiledOrder {
+  const clauses: string[] = []
+  const args: SqliteValue[] = []
+
+  for (const field of fields) {
+    if (field.kind === "column") {
+      clauses.push(`${columnExpression(field.column, qualifier)} ${field.direction.toUpperCase()}`)
+      continue
+    }
+
+    const direction = field.direction === "desc" ? "DESC" : "ASC"
+    const path = jsonPath(field.propertyId)
+    clauses.push(
+      `CASE WHEN ${jsonTypeExpression(propertyColumn)} IS NULL OR ${jsonTypeExpression(propertyColumn)} = 'null' THEN 1 ELSE 0 END ASC`,
+      `${jsonValueExpression(propertyColumn)} ${direction}`
+    )
+    args.push(path, path, path)
+  }
+
+  return { sql: clauses.join(", "), args, fields, propertyColumn }
+}
+
+function sortOrderFields(fields: readonly ObjectQuerySortField[]): readonly CompiledOrderField[] {
+  const orderFields: CompiledOrderField[] = []
+  for (const field of fields) {
+    if (field.kind !== "property") {
+      throw new Error("[Sixb] SQLite object storage does not support relevance sorting")
+    }
+
+    orderFields.push({
+      kind: "property",
+      propertyId: field.propertyId,
+      direction: field.direction === "desc" ? "desc" : "asc",
+    })
+  }
+  orderFields.push(...identityOrderFields())
+  return orderFields
+}
+
+function identityOrderFields(): readonly CompiledOrderField[] {
+  return [
+    { kind: "column", column: "object_type_id", direction: "asc" },
+    { kind: "column", column: "primary_id", direction: "asc" },
+  ]
+}
+
+function compileKeysetPredicate(
+  fields: readonly CompiledOrderField[],
+  cursor: readonly EncodedCursorValue[],
+  propertyColumn = "properties"
+): CompiledPredicate {
+  const disjuncts: CompiledPredicate[] = []
+
+  for (let index = 0; index < fields.length; index += 1) {
+    const equalityPredicates = fields
+      .slice(0, index)
+      .map((field, equalityIndex) =>
+        compileFieldEquality(field, cursor[equalityIndex], propertyColumn)
+      )
+    const advancePredicate = compileFieldAfter(fields[index], cursor[index], propertyColumn)
+    if (!advancePredicate) continue
+
+    const parts = [...equalityPredicates, advancePredicate]
+    disjuncts.push({
+      sql: `(${parts.map((part) => part.sql).join(" AND ")})`,
+      args: parts.flatMap((part) => part.args),
+    })
+  }
+
+  if (disjuncts.length === 0) return { sql: "0 = 1", args: [] }
+
+  return {
+    sql: `(${disjuncts.map((part) => part.sql).join(" OR ")})`,
+    args: disjuncts.flatMap((part) => part.args),
+  }
+}
+
+function compileFieldEquality(
+  field: CompiledOrderField,
+  cursor: EncodedCursorValue,
+  propertyColumn = "properties"
+): CompiledPredicate {
+  if (field.kind === "column") {
+    return {
+      sql: `${columnExpression(field.column)} = ?`,
+      args: [sqlValue(cursor.value)],
+    }
+  }
+
+  const path = jsonPath(field.propertyId)
+  if (cursor.nullish) {
+    return {
+      sql: `(${jsonTypeExpression(propertyColumn)} IS NULL OR ${jsonTypeExpression(propertyColumn)} = 'null')`,
+      args: [path, path],
+    }
+  }
+
+  return {
+    sql: `(${jsonTypeExpression(propertyColumn)} IS NOT NULL AND ${jsonTypeExpression(propertyColumn)} != 'null' AND ${jsonValueExpression(propertyColumn)} = ?)`,
+    args: [path, path, path, sqlValue(cursor.value)],
+  }
+}
+
+function compileFieldAfter(
+  field: CompiledOrderField,
+  cursor: EncodedCursorValue,
+  propertyColumn = "properties"
+): CompiledPredicate | null {
+  if (field.kind === "column") {
+    return {
+      sql: `${columnExpression(field.column)} ${field.direction === "desc" ? "<" : ">"} ?`,
+      args: [sqlValue(cursor.value)],
+    }
+  }
+
+  if (cursor.nullish) return null
+
+  const path = jsonPath(field.propertyId)
+  const rankSql = `CASE WHEN ${jsonTypeExpression(propertyColumn)} IS NULL OR ${jsonTypeExpression(propertyColumn)} = 'null' THEN 1 ELSE 0 END`
+  const valueOperator = field.direction === "desc" ? "<" : ">"
+
+  return {
+    sql: `(${rankSql} > 0 OR (${rankSql} = 0 AND ${jsonValueExpression(propertyColumn)} ${valueOperator} ?))`,
+    args: [path, path, path, path, path, sqlValue(cursor.value)],
+  }
+}
+
+function encodePageToken(
+  row: SqliteObjectQueryPageRow,
+  fields: readonly CompiledOrderField[]
+): string {
+  const properties = JSON.parse(row._cursor_properties ?? row.properties) as Record<string, unknown>
+  const token: EncodedPageToken = {
+    version: 1,
+    order: fields.map(orderFieldKey),
+    values: fields.map((field) => cursorValueForField(row, properties, field)),
+  }
+  return `${PAGE_TOKEN_PREFIX}${Buffer.from(JSON.stringify(token)).toString("base64url")}`
+}
+
+function decodePageToken(
+  token: string,
+  fields: readonly CompiledOrderField[]
+): readonly EncodedCursorValue[] {
+  if (!token.startsWith(PAGE_TOKEN_PREFIX)) {
+    throwInvalidPageToken("Invalid SQLite object query page token")
+  }
+
+  const raw = token.slice(PAGE_TOKEN_PREFIX.length)
+  let decoded: unknown
+  try {
+    decoded = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"))
+  } catch {
+    throwInvalidPageToken("Invalid SQLite object query page token")
+  }
+
+  if (!isEncodedPageToken(decoded)) {
+    throwInvalidPageToken("Invalid SQLite object query page token")
+  }
+
+  const expectedOrder = fields.map(orderFieldKey)
+  if (
+    decoded.order.length !== expectedOrder.length ||
+    decoded.order.some((field, index) => field !== expectedOrder[index])
+  ) {
+    throwInvalidPageToken("SQLite object query page token does not match query order")
+  }
+
+  return decoded.values
+}
+
+function throwInvalidPageToken(message: string): never {
+  throw new ObjectQueryExecutionError("invalid_page_token", message, "$.pageToken")
+}
+
+function isEncodedPageToken(value: unknown): value is EncodedPageToken {
+  if (!isPlainObject(value)) return false
+  if (value.version !== 1) return false
+  if (!Array.isArray(value.order) || value.order.some((item) => typeof item !== "string")) {
+    return false
+  }
+  if (!Array.isArray(value.values)) return false
+  return value.values.every(
+    (item) =>
+      isPlainObject(item) &&
+      typeof item.nullish === "boolean" &&
+      (item.nullish || Object.hasOwn(item, "value"))
+  )
+}
+
+function cursorValueForField(
+  row: SqliteObjectQueryPageRow,
+  properties: Record<string, unknown>,
+  field: CompiledOrderField
+): EncodedCursorValue {
+  const value =
+    field.kind === "column"
+      ? field.column === "object_type_id"
+        ? row.object_type_id
+        : row.primary_id
+      : properties[field.propertyId]
+
+  return value === null || value === undefined ? { nullish: true } : { nullish: false, value }
+}
+
+function orderFieldKey(field: CompiledOrderField): string {
+  return field.kind === "column"
+    ? `column:${field.column}:${field.direction}`
+    : `property:${field.propertyId}:${field.direction}`
+}
+
+function columnExpression(column: "object_type_id" | "primary_id", qualifier?: string): string {
+  return qualifier ? `${qualifier}.${column}` : column
+}
+
+function jsonValueExpression(column = "properties"): string {
+  return `json_extract(${column}, ?)`
+}
+
+function jsonTypeExpression(column = "properties"): string {
+  return `json_type(${column}, ?)`
+}
+
+function jsonPath(propertyId: string): string {
+  return `$."${propertyId.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+}
+
+function sqlValue(value: unknown): SqliteValue {
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === "boolean") return value ? 1 : 0
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "bigint" ||
+    value === null
+  ) {
+    return value
+  }
+  return JSON.stringify(value)
+}
+
+function tokenize(query: string): string[] {
+  return query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((term) => term.length > 0)
+}
+
+function sqlComparisonOperator(op: "lt" | "lte" | "gt" | "gte"): "<" | "<=" | ">" | ">=" {
+  switch (op) {
+    case "lt":
+      return "<"
+    case "lte":
+      return "<="
+    case "gt":
+      return ">"
+    case "gte":
+      return ">="
+  }
+}
+
+function identityRows<T>(rows: readonly T[]): readonly T[] {
+  return rows
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/storage/sqlite/src/object-query-compiler.ts
+++ b/storage/sqlite/src/object-query-compiler.ts
@@ -82,7 +82,13 @@ export function compileObjectQuery(projectId: string, query: ObjectQuery): Compi
     case "project":
       return compileProject(projectId, query.input, query.properties)
     case "text":
-      return compileText(projectId, query.input, query.query, query.fields)
+      return compileText(
+        projectId,
+        query.input,
+        query.query,
+        query.fields,
+        query.fieldsByObjectType
+      )
     case "vector":
       throw new Error(`[Sixb] SQLite object storage does not support query node '${query.kind}'`)
   }
@@ -159,12 +165,18 @@ function compileText(
   projectId: string,
   inputQuery: ObjectQuery,
   query: string,
-  fields: readonly string[] | undefined
+  fields: readonly string[] | undefined,
+  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined
 ): CompiledObjectQuery {
-  if (!fields || fields.length === 0) {
-    throw new Error("[Sixb] SQLite object text search requires explicit fields")
+  const predicate =
+    fields && fields.length > 0
+      ? compileTextPredicate(query, fields)
+      : compileScopedTextPredicate(query, fieldsByObjectType)
+
+  if (!predicate) {
+    throw new Error("[Sixb] SQLite object text search requires fields or resolved text defaults")
   }
-  return compileWhere(projectId, inputQuery, compileTextPredicate(query, fields))
+  return compileWhere(projectId, inputQuery, predicate)
 }
 
 function compileSort(
@@ -578,6 +590,29 @@ function compileTextPredicate(query: string, fields: readonly string[]): Compile
   const args = terms.flatMap((term) => fields.flatMap((field) => [jsonPath(field), term]))
 
   return { sql: `(${clauses.join(" AND ")})`, args }
+}
+
+function compileScopedTextPredicate(
+  query: string,
+  fieldsByObjectType: Readonly<Record<string, readonly string[]>> | undefined
+): CompiledPredicate | null {
+  const scopedPredicates: CompiledPredicate[] = []
+
+  for (const [objectTypeId, fields] of Object.entries(fieldsByObjectType ?? {})) {
+    if (fields.length === 0) continue
+    const predicate = compileTextPredicate(query, fields)
+    scopedPredicates.push({
+      sql: `(object_type_id = ? AND ${predicate.sql})`,
+      args: [objectTypeId, ...predicate.args],
+    })
+  }
+
+  if (scopedPredicates.length === 0) return null
+
+  return {
+    sql: `(${scopedPredicates.map((predicate) => predicate.sql).join(" OR ")})`,
+    args: scopedPredicates.flatMap((predicate) => predicate.args),
+  }
 }
 
 function compileOrder(

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -7,12 +7,15 @@ import type {
   ObjectQueryCapabilities,
   ObjectRow,
   ObjectStorage,
+  QueryObjectsInput,
+  QueryObjectsResult,
   StoredLinkRemovedEvent,
   StoredLinkUpsertedEvent,
   StoredObjectUpsertedEvent,
   StoredTelemetryAppendedEvent,
 } from "@sixb/core"
 import { installFreshSqliteSchema } from "./migrations"
+import { type CompiledObjectQuery, compileObjectQuery } from "./object-query-compiler"
 
 export interface SqliteObjectStorageOptions {
   /** Path to SQLite database file. Defaults to ':memory:' for in-memory database. */
@@ -20,14 +23,59 @@ export interface SqliteObjectStorageOptions {
 }
 
 const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
-  queryObjects: false,
-  notes: ["SQLite object query pushdown is added in a later stacked PR."],
+  queryObjects: true,
+  nodes: {
+    start: true,
+    filter: true,
+    text: true,
+    sort: true,
+    limit: true,
+    page: true,
+    traverse: true,
+    set: true,
+    project: true,
+  },
+  predicateOps: {
+    and: true,
+    or: true,
+    not: true,
+    eq: true,
+    neq: true,
+    lt: true,
+    lte: true,
+    gt: true,
+    gte: true,
+    in: true,
+    exists: true,
+    contains: true,
+  },
+  sortKinds: {
+    property: true,
+  },
+  traversalDirections: {
+    outgoing: true,
+    incoming: true,
+  },
+  setOps: {
+    union: true,
+    intersect: true,
+    subtract: true,
+  },
+  limits: {
+    totalCount: true,
+    stablePageTokens: true,
+  },
+  notes: [
+    "SQLite object query pushdown supports start/filter/text/sort/limit/page/traverse/set/project over JSON properties and object links.",
+    "Relevance sorting, vector search, and unresolved start.includeSubtypes remain planner fallback or rejection cases.",
+  ],
 }
 
 /**
  * SQLite-based ObjectStorage implementation.
  *
- * Stores object projections and links with full query support.
+ * Stores object projections and links. V1 object-query IR pushdown covers the
+ * scalar JSON-property and link-traversal subset declared by queryCapabilities().
  */
 export class SqliteObjectStorage implements ObjectStorage {
   private readonly db: Database
@@ -44,6 +92,21 @@ export class SqliteObjectStorage implements ObjectStorage {
 
   queryCapabilities(): ObjectQueryCapabilities {
     return SQLITE_OBJECT_QUERY_CAPABILITIES
+  }
+
+  async queryObjects(params: QueryObjectsInput): Promise<QueryObjectsResult> {
+    const compiled = compileObjectQuery(params.projectId, params.query)
+    const total = readTotal(this.db, compiled)
+    const rawRows = this.db.query(compiled.sql).all(...compiled.args) as DatabaseRow[]
+    const rows = compiled.trimRows(rawRows) as readonly DatabaseRow[]
+    const hasMore = compiled.hasMore(rawRows.length, total)
+
+    return {
+      objects: rows.map((row) => this.rowToObject(row)),
+      hasMore,
+      total,
+      nextPageToken: compiled.nextPageToken(rows, rawRows.length),
+    }
   }
 
   async applyObjectUpserted(event: StoredObjectUpsertedEvent): Promise<ObjectRow> {
@@ -443,31 +506,6 @@ export class SqliteObjectStorage implements ObjectStorage {
     return row ? this.rowToObject(row) : null
   }
 
-  async findFirst(params: {
-    projectId: string
-    objectTypeId: string
-    where?: readonly { propertyId: string; op: "eq"; value: unknown }[]
-  }): Promise<ObjectRow | null> {
-    const rows = this.db
-      .query("SELECT * FROM objects WHERE project_id = ? AND object_type_id = ?")
-      .all(params.projectId, params.objectTypeId) as DatabaseRow[]
-
-    for (const row of rows) {
-      const properties = JSON.parse(row.properties)
-
-      if (params.where && params.where.length > 0) {
-        const matches = params.where.every(
-          (clause) => clause.op === "eq" && properties[clause.propertyId] === clause.value
-        )
-        if (!matches) continue
-      }
-
-      return this.rowToObject(row)
-    }
-
-    return null
-  }
-
   async listLinks(params: {
     projectId: string
     objectTypeId: string
@@ -672,6 +710,11 @@ export class SqliteObjectStorage implements ObjectStorage {
   close(): void {
     this.db.close()
   }
+}
+
+function readTotal(db: Database, compiled: CompiledObjectQuery): number {
+  const row = db.query(compiled.totalSql).get(...compiled.totalArgs) as { total: number }
+  return row.total
 }
 
 interface DatabaseRow {

--- a/storage/sqlite/tests/sqlite-object-query-conformance.test.ts
+++ b/storage/sqlite/tests/sqlite-object-query-conformance.test.ts
@@ -1,0 +1,7 @@
+import { runObjectQueryProviderContractSuite } from "@sixb/core/testing"
+import { SqliteObjectStorage } from "../src"
+
+runObjectQueryProviderContractSuite("SqliteObjectStorage object query provider contract", {
+  createStorage: () => new SqliteObjectStorage(),
+  teardown: (storage) => storage.close(),
+})

--- a/storage/sqlite/tests/sqlite-object-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-object-storage.test.ts
@@ -1,13 +1,83 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { rm } from "node:fs/promises"
-import type {
-  StoredLinkRemovedEvent,
-  StoredLinkUpsertedEvent,
-  StoredObjectUpsertedEvent,
-  StoredTelemetryAppendedEvent,
+import {
+  defineObjectType,
+  executeObjectQuery,
+  link,
+  type ObjectQuery,
+  ObjectQueryExecutionError,
+  OntologyRegistry,
+  prop,
+  type StoredLinkRemovedEvent,
+  type StoredLinkUpsertedEvent,
+  type StoredObjectUpsertedEvent,
+  type StoredTelemetryAppendedEvent,
 } from "@sixb/core"
 import { SqliteObjectStorage } from "../src"
 import { migrateSqliteDatabase } from "../src/migrations"
+
+const Room = defineObjectType({
+  id: "Room",
+  name: "Room",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", {
+      query: { searchable: true, text: true, filterable: true, exact: true, sortable: true },
+    }),
+    prop("floor", "string", {
+      query: { searchable: true, filterable: true, exact: true, sortable: true },
+    }),
+    prop("capacity", "double", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop("occupied", "boolean", {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    prop(
+      "tags",
+      { type: "array", items: "string" },
+      {
+        query: { searchable: true, filterable: true },
+      }
+    ),
+    prop(
+      "metadata",
+      { type: "map", keySchema: "string", valueSchema: "string" },
+      {
+        query: { searchable: true, filterable: true },
+      }
+    ),
+  ],
+  search: { defaultText: ["name"] },
+})
+
+const Department = defineObjectType({
+  id: "Department",
+  name: "Department",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const Employee = defineObjectType({
+  id: "Employee",
+  name: "Employee",
+  properties: [prop("id", "string", { required: true, primary: true })],
+  links: [link("department", Department, { cardinality: "one" })],
+})
+
+const Asset = defineObjectType({
+  id: "Asset",
+  name: "Asset",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const Laptop = defineObjectType({
+  id: "Laptop",
+  name: "Laptop",
+  extends: Asset,
+  properties: [],
+})
+
+const ontology = new OntologyRegistry({ sources: [Room, Department, Employee, Asset, Laptop] })
 
 describe("SqliteObjectStorage", () => {
   let storage: SqliteObjectStorage
@@ -105,6 +175,714 @@ describe("SqliteObjectStorage", () => {
     }
   }
 
+  test("queryCapabilities enables SQLite's native scalar query subset", () => {
+    const capabilities = storage.queryCapabilities()
+
+    expect(capabilities.queryObjects).toBe(true)
+    expect(capabilities.nodes?.start).toBe(true)
+    expect(capabilities.nodes?.filter).toBe(true)
+    expect(capabilities.nodes?.limit).toBe(true)
+    expect(capabilities.nodes?.traverse).toBe(true)
+    expect(capabilities.nodes?.set).toBe(true)
+    expect(capabilities.nodes?.project).toBe(true)
+    expect(capabilities.nodes?.text).toBe(true)
+    expect(capabilities.predicateOps?.eq).toBe(true)
+    expect(capabilities.predicateOps?.contains).toBe(true)
+    expect(capabilities.sortKinds?.property).toBe(true)
+    expect(capabilities.sortKinds?.relevance).toBeUndefined()
+    expect(capabilities.traversalDirections?.incoming).toBe(true)
+    expect(capabilities.traversalDirections?.outgoing).toBe(true)
+    expect(capabilities.setOps?.union).toBe(true)
+    expect(capabilities.setOps?.intersect).toBe(true)
+    expect(capabilities.setOps?.subtract).toBe(true)
+    expect(capabilities.features?.includeSubtypes).toBeUndefined()
+    expect(capabilities.limits?.stablePageTokens).toBe(true)
+  })
+
+  test("queryObjects executes scalar filters, property sorting, and limit in SQLite", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:a",
+        { id: "room:a", name: "Alpha", floor: "2", capacity: 10, occupied: true },
+        "1"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:b",
+        { id: "room:b", name: "Beta", floor: "1", capacity: 30, occupied: false },
+        "2"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:c",
+        { id: "room:c", name: "Gamma", floor: "2", capacity: 25, occupied: true },
+        "3"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:d",
+        { id: "room:d", floor: "2", capacity: 50, occupied: true },
+        "4"
+      )
+    )
+
+    const result = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "limit",
+        limit: 1,
+        input: {
+          kind: "sort",
+          fields: [{ kind: "property", propertyId: "capacity", direction: "desc" }],
+          input: {
+            kind: "filter",
+            predicate: {
+              op: "and",
+              items: [
+                { op: "eq", propertyId: "floor", value: "2" },
+                { op: "gte", propertyId: "capacity", value: 10 },
+                { op: "eq", propertyId: "occupied", value: true },
+                { op: "exists", propertyId: "name", value: true },
+              ],
+            },
+            input: { kind: "start", objectTypeId: "Room" },
+          },
+        },
+      },
+    })
+
+    expect(result.objects.map((row) => row.primaryId)).toEqual(["room:c"])
+    expect(result.total).toBe(2)
+    expect(result.hasMore).toBe(true)
+  })
+
+  test("queryObjects matches null, missing, neq, and in semantics", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:missing", { id: "room:missing" }, "1")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:null", { id: "room:null", floor: null }, "2")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:one",
+        { id: "room:one", floor: "1", capacity: 10 },
+        "3"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:two",
+        { id: "room:two", floor: "2", capacity: 20 },
+        "4"
+      )
+    )
+
+    const nullable = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "limit",
+        limit: 10,
+        input: {
+          kind: "filter",
+          predicate: {
+            op: "or",
+            items: [
+              { op: "eq", propertyId: "floor", value: null },
+              { op: "exists", propertyId: "floor", value: false },
+            ],
+          },
+          input: { kind: "start", objectTypeId: "Room" },
+        },
+      },
+    })
+    const notOneOrTwo = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "limit",
+        limit: 10,
+        input: {
+          kind: "filter",
+          predicate: {
+            op: "and",
+            items: [
+              { op: "neq", propertyId: "floor", value: "1" },
+              { op: "in", propertyId: "floor", values: ["2", null] },
+            ],
+          },
+          input: { kind: "start", objectTypeId: "Room" },
+        },
+      },
+    })
+
+    expect(new Set(nullable.objects.map((row) => row.primaryId))).toEqual(
+      new Set(["room:missing", "room:null"])
+    )
+    expect(notOneOrTwo.objects.map((row) => row.primaryId)).toEqual(["room:null", "room:two"])
+  })
+
+  test("queryObjects treats empty in predicates as no matches", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:a", { id: "room:a", floor: "1" }, "1")
+    )
+
+    const result = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "filter",
+        predicate: { op: "in", propertyId: "floor", values: [] },
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    })
+
+    expect(result.objects).toEqual([])
+    expect(result.total).toBe(0)
+  })
+
+  test("queryObjects executes contains predicates in SQLite", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:a",
+        {
+          id: "room:a",
+          name: "North Conference",
+          tags: ["video", "training"],
+          metadata: { wing: "north" },
+        },
+        "1"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:b",
+        { id: "room:b", name: "South Huddle", tags: ["focus"], metadata: { wing: "south" } },
+        "2"
+      )
+    )
+
+    const stringContains = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "filter",
+        predicate: { op: "contains", propertyId: "name", value: "Conference" },
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    })
+    const arrayContains = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "filter",
+        predicate: { op: "contains", propertyId: "tags", value: "focus" },
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    })
+    const mapContains = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "filter",
+        predicate: { op: "contains", propertyId: "metadata", value: "wing" },
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    })
+
+    expect(stringContains.objects.map((row) => row.primaryId)).toEqual(["room:a"])
+    expect(arrayContains.objects.map((row) => row.primaryId)).toEqual(["room:b"])
+    expect(mapContains.objects.map((row) => row.primaryId)).toEqual(["room:a", "room:b"])
+  })
+
+  test("queryObjects executes basic text search in SQLite", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:a",
+        { id: "room:a", name: "North Conference Room" },
+        "1"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:b", { id: "room:b", name: "South Huddle" }, "2")
+    )
+
+    const result = await executeObjectQuery(
+      {
+        projectId: "project-a",
+        query: {
+          kind: "limit",
+          limit: 10,
+          input: {
+            kind: "text",
+            query: "north room",
+            input: { kind: "start", objectTypeId: "Room" },
+          },
+        },
+      },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    expect(result.objects.map((row) => row.primaryId)).toEqual(["room:a"])
+  })
+
+  test("queryObjects executes stable keyset page tokens", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:a", { id: "room:a" }, "1")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:b", { id: "room:b" }, "2")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:c", { id: "room:c" }, "3")
+    )
+
+    const page1 = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "page",
+        pageSize: 2,
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    })
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:aa", { id: "room:aa" }, "4")
+    )
+    const page2 = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "page",
+        pageSize: 2,
+        pageToken: page1.nextPageToken,
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    })
+
+    expect(page1.objects.map((row) => row.primaryId)).toEqual(["room:a", "room:b"])
+    expect(page1.total).toBe(3)
+    expect(page1.hasMore).toBe(true)
+    expect(page1.nextPageToken?.startsWith("keyset:")).toBe(true)
+    expect(page2.objects.map((row) => row.primaryId)).toEqual(["room:c"])
+    expect(page2.hasMore).toBe(false)
+    expect(page2.nextPageToken).toBeUndefined()
+  })
+
+  test("queryObjects executes keyset page tokens over property sorts", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:a", { id: "room:a", capacity: 10 }, "1")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:b", { id: "room:b", capacity: 30 }, "2")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:c", { id: "room:c", capacity: 20 }, "3")
+    )
+
+    const page1 = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "page",
+        pageSize: 2,
+        input: {
+          kind: "sort",
+          fields: [{ kind: "property", propertyId: "capacity", direction: "desc" }],
+          input: { kind: "start", objectTypeId: "Room" },
+        },
+      },
+    })
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:bb", { id: "room:bb", capacity: 25 }, "4")
+    )
+    const page2 = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "page",
+        pageSize: 2,
+        pageToken: page1.nextPageToken,
+        input: {
+          kind: "sort",
+          fields: [{ kind: "property", propertyId: "capacity", direction: "desc" }],
+          input: { kind: "start", objectTypeId: "Room" },
+        },
+      },
+    })
+
+    expect(page1.objects.map((row) => row.primaryId)).toEqual(["room:b", "room:c"])
+    expect(page1.nextPageToken?.startsWith("keyset:")).toBe(true)
+    expect(page2.objects.map((row) => row.primaryId)).toEqual(["room:a"])
+    expect(page2.hasMore).toBe(false)
+  })
+
+  test("queryObjects preserves keyset page tokens through outer projection", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:a", { id: "room:a", capacity: 10 }, "1")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:b", { id: "room:b", capacity: 30 }, "2")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:c", { id: "room:c", capacity: 20 }, "3")
+    )
+
+    const queryInput: ObjectQuery = {
+      kind: "sort",
+      fields: [{ kind: "property", propertyId: "capacity", direction: "desc" }],
+      input: { kind: "start", objectTypeId: "Room" },
+    }
+    const page1 = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "project",
+        properties: ["id"],
+        input: { kind: "page", pageSize: 2, input: queryInput },
+      },
+    })
+    const page2 = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "project",
+        properties: ["id"],
+        input: { kind: "page", pageSize: 2, pageToken: page1.nextPageToken, input: queryInput },
+      },
+    })
+
+    expect(page1.objects.map((row) => row.properties)).toEqual([{ id: "room:b" }, { id: "room:c" }])
+    expect(page1.nextPageToken?.startsWith("keyset:")).toBe(true)
+    expect(page2.objects.map((row) => row.primaryId)).toEqual(["room:a"])
+  })
+
+  test("queryObjects preserves hidden sort keys when paging projected rows", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:a", { id: "room:a", capacity: 10 }, "1")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:b", { id: "room:b", capacity: 30 }, "2")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:c", { id: "room:c", capacity: 20 }, "3")
+    )
+
+    const queryInput: ObjectQuery = {
+      kind: "project",
+      properties: ["id"],
+      input: {
+        kind: "sort",
+        fields: [{ kind: "property", propertyId: "capacity", direction: "desc" }],
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    }
+    const page1 = await storage.queryObjects({
+      projectId: "project-a",
+      query: { kind: "page", pageSize: 2, input: queryInput },
+    })
+    const page2 = await storage.queryObjects({
+      projectId: "project-a",
+      query: { kind: "page", pageSize: 2, pageToken: page1.nextPageToken, input: queryInput },
+    })
+
+    expect(page1.objects.map((row) => row.properties)).toEqual([{ id: "room:b" }, { id: "room:c" }])
+    expect(page1.hasMore).toBe(true)
+    expect(page1.nextPageToken?.startsWith("keyset:")).toBe(true)
+    expect(page2.objects.map((row) => row.properties)).toEqual([{ id: "room:a" }])
+    expect(page2.hasMore).toBe(false)
+  })
+
+  test("queryObjects rejects mismatched page tokens as client input", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:a", { id: "room:a", capacity: 10 }, "1")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Room", "room:b", { id: "room:b", capacity: 30 }, "2")
+    )
+
+    const page1 = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "page",
+        pageSize: 1,
+        input: {
+          kind: "sort",
+          fields: [{ kind: "property", propertyId: "capacity", direction: "desc" }],
+          input: { kind: "start", objectTypeId: "Room" },
+        },
+      },
+    })
+
+    try {
+      await storage.queryObjects({
+        projectId: "project-a",
+        query: {
+          kind: "page",
+          pageSize: 1,
+          pageToken: page1.nextPageToken,
+          input: {
+            kind: "sort",
+            fields: [{ kind: "property", propertyId: "capacity", direction: "asc" }],
+            input: { kind: "start", objectTypeId: "Room" },
+          },
+        },
+      })
+      throw new Error("Expected mismatched page token to be rejected")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ObjectQueryExecutionError)
+      if (error instanceof ObjectQueryExecutionError) {
+        expect(error.code).toBe("invalid_page_token")
+        expect(error.path).toBe("$.pageToken")
+      }
+    }
+  })
+
+  test("queryObjects executes set operations in SQLite", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:a",
+        { id: "room:a", floor: "1", occupied: true },
+        "1"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:b",
+        { id: "room:b", floor: "2", occupied: true },
+        "2"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:c",
+        { id: "room:c", floor: "2", occupied: false },
+        "3"
+      )
+    )
+
+    const floorTwo: ObjectQuery = {
+      kind: "filter",
+      predicate: { op: "eq", propertyId: "floor", value: "2" },
+      input: { kind: "start", objectTypeId: "Room" },
+    }
+    const occupied: ObjectQuery = {
+      kind: "filter",
+      predicate: { op: "eq", propertyId: "occupied", value: true },
+      input: { kind: "start", objectTypeId: "Room" },
+    }
+
+    const union = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "limit",
+        limit: 10,
+        input: { kind: "set", op: "union", inputs: [floorTwo, occupied] },
+      },
+    })
+    const intersect = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "limit",
+        limit: 10,
+        input: { kind: "set", op: "intersect", inputs: [floorTwo, occupied] },
+      },
+    })
+    const subtract = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "limit",
+        limit: 10,
+        input: { kind: "set", op: "subtract", inputs: [floorTwo, occupied] },
+      },
+    })
+
+    expect(union.objects.map((row) => row.primaryId)).toEqual(["room:a", "room:b", "room:c"])
+    expect(intersect.objects.map((row) => row.primaryId)).toEqual(["room:b"])
+    expect(subtract.objects.map((row) => row.primaryId)).toEqual(["room:c"])
+  })
+
+  test("queryObjects projects object properties in SQLite", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:a",
+        { id: "room:a", name: "Alpha", floor: "1", capacity: 10 },
+        "1"
+      )
+    )
+
+    const result = await storage.queryObjects({
+      projectId: "project-a",
+      query: {
+        kind: "project",
+        properties: ["id", "name"],
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    })
+
+    expect(result.objects).toHaveLength(1)
+    expect(result.objects[0].properties).toEqual({ id: "room:a", name: "Alpha" })
+  })
+
+  test("executeObjectQuery pushes down includeSubtypes starts as concrete unions", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Asset", "asset:a", { id: "asset:a" }, "1")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Laptop", "laptop:a", { id: "laptop:a" }, "2")
+    )
+
+    const result = await executeObjectQuery(
+      {
+        projectId: "project-a",
+        query: {
+          kind: "limit",
+          limit: 10,
+          input: { kind: "start", objectTypeId: "Asset", includeSubtypes: true },
+        },
+      },
+      { ontology, storage, maxFallbackRows: 10 }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    expect(new Set(result.objects.map((row) => row.primaryId))).toEqual(
+      new Set(["asset:a", "laptop:a"])
+    )
+  })
+
+  test("queryObjects traverses object links in SQLite", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Department", "dept-eng", { id: "dept-eng" }, "1")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Department", "dept-sales", { id: "dept-sales" }, "2")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Employee", "emp-alice", { id: "emp-alice" }, "3")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Employee", "emp-bob", { id: "emp-bob" }, "4")
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent("project-a", "Employee", "emp-clara", { id: "emp-clara" }, "5")
+    )
+    await storage.applyLinkUpserted(
+      createLinkUpsertedEvent(
+        "project-a",
+        "Employee",
+        "emp-alice",
+        "department",
+        "Department",
+        "dept-eng",
+        "6"
+      )
+    )
+    await storage.applyLinkUpserted(
+      createLinkUpsertedEvent(
+        "project-a",
+        "Employee",
+        "emp-bob",
+        "department",
+        "Department",
+        "dept-eng",
+        "7"
+      )
+    )
+    await storage.applyLinkUpserted(
+      createLinkUpsertedEvent(
+        "project-a",
+        "Employee",
+        "emp-clara",
+        "department",
+        "Department",
+        "dept-sales",
+        "8"
+      )
+    )
+
+    const result = await executeObjectQuery(
+      {
+        projectId: "project-a",
+        query: {
+          kind: "limit",
+          limit: 10,
+          input: {
+            kind: "traverse",
+            direction: "incoming",
+            linkId: "department",
+            input: {
+              kind: "filter",
+              predicate: { op: "eq", propertyId: "id", value: "dept-eng" },
+              input: { kind: "start", objectTypeId: "Department" },
+            },
+          },
+        },
+      },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    expect(result.objects.map((row) => row.primaryId)).toEqual(["emp-alice", "emp-bob"])
+  })
+
+  test("executeObjectQuery plans supported SQLite queries as pushdown", async () => {
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:a",
+        { id: "room:a", floor: "2", capacity: 10 },
+        "1"
+      )
+    )
+    await storage.applyObjectUpserted(
+      createObjectEvent(
+        "project-a",
+        "Room",
+        "room:b",
+        { id: "room:b", floor: "2", capacity: 30 },
+        "2"
+      )
+    )
+
+    const query: ObjectQuery = {
+      kind: "limit",
+      limit: 5,
+      input: {
+        kind: "filter",
+        predicate: { op: "eq", propertyId: "floor", value: "2" },
+        input: { kind: "start", objectTypeId: "Room" },
+      },
+    }
+    const result = await executeObjectQuery(
+      { projectId: "project-a", query },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    expect(result.plan.providerIssues).toHaveLength(0)
+    expect(result.objects.map((row) => row.primaryId)).toEqual(["room:a", "room:b"])
+  })
+
   test("applyObjectUpserted creates new object", async () => {
     const event = createObjectEvent("project-a", "Room", "room:101", { name: "Conference" }, "1")
     const row = await storage.applyObjectUpserted(event)
@@ -177,42 +955,6 @@ describe("SqliteObjectStorage", () => {
       primaryId: "room:999",
     })
     expect(row).toBeNull()
-  })
-
-  test("findFirst returns first matching object", async () => {
-    await storage.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:101", { name: "Room A", floor: "1" }, "1")
-    )
-    await storage.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:102", { name: "Room B", floor: "2" }, "2")
-    )
-    await storage.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:103", { name: "Room C", floor: "2" }, "3")
-    )
-
-    const row = await storage.findFirst({
-      projectId: "project-a",
-      objectTypeId: "Room",
-      where: [{ propertyId: "floor", op: "eq", value: "2" }],
-    })
-
-    expect(row?.properties.floor).toBe("2")
-  })
-
-  test("findFirst without where returns first object", async () => {
-    await storage.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:101", { name: "Room A" }, "1")
-    )
-    await storage.applyObjectUpserted(
-      createObjectEvent("project-a", "Room", "room:102", { name: "Room B" }, "2")
-    )
-
-    const row = await storage.findFirst({
-      projectId: "project-a",
-      objectTypeId: "Room",
-    })
-
-    expect(row).not.toBeNull()
   })
 
   test("applyTelemetryAppended updates object property", async () => {


### PR DESCRIPTION
Depends on #54.

Stack position: 4 of 6. Base branch: `codex/objectset-query-api`.

## What changed

This implements native object-query pushdown for SQLite and PostgreSQL, using the provider contract introduced earlier in the stack.

Each provider now declares the portable V1 query surface it can execute:

```ts
const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
  queryObjects: true,
  nodes: {
    start: true,
    filter: true,
    text: true,
    sort: true,
    limit: true,
    page: true,
    traverse: true,
    set: true,
    project: true,
  },
  sortKinds: { property: true },
}
```

`queryObjects()` compiles the IR into SQL, reads a total count, trims over-fetched page rows, and returns an opaque page token when needed:

```ts
async queryObjects(params: QueryObjectsInput): Promise<QueryObjectsResult> {
  const compiled = compileObjectQuery(params.projectId, params.query)
  const total = readTotal(this.db, compiled)
  const rawRows = this.db.query(compiled.sql).all(...compiled.args)
  const rows = compiled.trimRows(rawRows)

  return {
    objects: rows.map((row) => this.rowToObject(row)),
    hasMore: compiled.hasMore(rawRows.length, total),
    total,
    nextPageToken: compiled.nextPageToken(rows, rawRows.length),
  }
}
```

The compilers support JSON/JSONB property predicates, text search over explicit/default fields, property sorting, keyset paging, link traversal, set operations, and projection.

## Review notes

- SQLite and PostgreSQL intentionally do not claim vector search or relevance sorting; those remain capability-gated and get structured planning rejection or fallback where safe.
- Page tokens include the order shape so mismatched tokens fail as client input instead of producing unstable results.
- Projection preserves hidden cursor properties internally so sorted pagination remains stable even when returned objects omit the sort field.
- `start.includeSubtypes` is still expanded by the core executor into concrete unions before SQL pushdown.
- The shared provider conformance suite now runs against in-memory, SQLite, and PostgreSQL.

## Verification

```bash
bun --filter @sixb/sqlite test
bun --filter @sixb/sqlite typecheck
bun --filter @sixb/pg typecheck
bun run typecheck
bun --filter @sixb/pg test:e2e
```

All commands passed locally.

