### PR TITLE
docs: document object query

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,10 @@
 # Get Started
 
-Sixb is a TypeScript framework for building operational software around real-world systems.
-
-Use it to model your domain, sync live data, and ship workflows, APIs, and apps from one
+Build operational software around real-world systems. Sixb is a TypeScript framework for
+modeling your domain, syncing live data, and shipping workflows, APIs, and apps from one
 shared runtime.
 
-## Quickstart
+## Concepts
 
 - [Ontology](./concepts/ontology.md)
 - [Object Query](./concepts/object-query.md)
@@ -17,62 +16,7 @@ shared runtime.
 - [Rules](./concepts/rules.md)
 - [Workflow](./concepts/workflows.md)
 
-```bash
-bun create-sixb my-sixb-app
-cd my-sixb-app
-bun install
-bun run dev
-```
+## Coming next
 
-Then open the local development UI:
-
-```txt
-http://localhost:3000
-```
-
-The starter project runs locally and gives you a small working app to edit.
-
-## What gets created
-
-```txt
-my-sixb-app/
-  ontology/
-    counter.ts
-  actions/
-    reset.ts
-  functions/
-    tick.ts
-  app/
-    page.tsx
-  sixb.config.ts
-```
-
-The default project is small on purpose.
-
-| File or folder | What it is for |
-| --- | --- |
-| `sixb.config.ts` | Creates the Sixb runtime |
-| `ontology/` | Defines the objects in your domain |
-| `actions/` | Defines commands users or systems can request |
-| `functions/` | Runs scheduled or reactive logic |
-| `app/` | Contains the custom app UI |
-
-## How Sixb projects work
-
-A Sixb project is built from a few simple pieces:
-
-- define your domain with an [ontology](./concepts/ontology.md)
-- connect to external systems with [connectors](./concepts/connector.md)
-- write external data into [datasets](./concepts/datasets.md)
-- move data with [syncs](./concepts/sync.md)
-- clean or reshape data with [pipelines](./concepts/pipeline.md)
-- turn rows into app objects with [projections](./concepts/projection.md)
-- run business logic with [rules](./concepts/rules.md) and [workflows](./concepts/workflows.md)
-
-You do not need all of these on day one. Start with the pieces your app needs.
-
-## Next steps
-
-- Read [Ontology](./concepts/ontology.md) to understand how domain objects are modeled.
-- Read [Connector](./concepts/connector.md) when you are ready to connect an external system.
-- Read [Sync](./concepts/sync.md) when you want to move data into Sixb.
+- Server and client
+- Apps

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,15 @@ shared runtime.
 
 ## Quickstart
 
-The fastest way to start is with `create-sixb`.
+- [Ontology](./concepts/ontology.md)
+- [Object Query](./concepts/object-query.md)
+- [Dataset](./concepts/datasets.md)
+- [Pipeline](./concepts/pipeline.md)
+- [Projection](./concepts/projection.md)
+- [Connector](./concepts/connector.md)
+- [Sync](./concepts/sync.md)
+- [Rules](./concepts/rules.md)
+- [Workflow](./concepts/workflows.md)
 
 ```bash
 bun create-sixb my-sixb-app

--- a/docs/concepts/object-query.md
+++ b/docs/concepts/object-query.md
@@ -1,0 +1,465 @@
+# Object Query
+
+Object queries read objects from the latest-state graph: filter by properties, search text,
+sort, follow links, and page through results.
+
+Most application code should start from the typed runtime API:
+
+```ts
+const result = await sixb
+  .objects(Project)
+  .query()
+  .where((project) => project.p.status.eq("active"))
+  .orderBy(Project.p.deadline, "asc")
+  .limit(25)
+  .list()
+```
+
+Use object query when you need graph-aware reads. Use `get(id)` when you know the primary
+id, and use `list(...)` for simple storage browsing by object type, id prefix, timestamps,
+or offset.
+
+
+## Make Fields Queryable
+
+Sixb validates queries against your ontology. Properties are not queryable just because they
+exist; declare query metadata on fields you want to filter, sort, or search.
+
+```ts
+import { defineObjectType, link, prop, stringEnum } from "@sixb/core"
+import { Customer } from "./customer"
+import { Employee } from "./employee"
+
+export const Project = defineObjectType({
+  id: "Project",
+  name: "Project",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", {
+      required: true,
+      query: { searchable: true, text: true, exact: true, sortable: true, weight: 5 },
+    }),
+    prop("description", "string", {
+      query: { searchable: true, text: true },
+    }),
+    prop("status", stringEnum(["draft", "active", "paused", "completed"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    prop("phase", "string", {
+      nullable: true,
+      query: { searchable: true, filterable: true, exact: true },
+    }),
+    prop("deadline", "date", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop("budget", "double", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+  ],
+  search: {
+    title: "name",
+    defaultText: ["name", "description"],
+    exact: ["id", "name"],
+  },
+  links: [
+    link("customer", Customer, { cardinality: "one" }),
+    link("lead", Employee, { cardinality: "one" }),
+  ],
+})
+```
+
+| Metadata | Enables |
+| --- | --- |
+| `searchable` | Required gate for the other query flags on a property. |
+| `filterable` | `where(...)` predicates such as `eq`, `neq`, ranges, `in`, `exists`, and `contains`. |
+| `sortable` | `orderBy(...)` on the property. |
+| `text` | `.search(...)` over the property. The field must be static and string-like. |
+| `exact` | Exact-match search profiles such as `search.exact`; primary ids are exact-matchable by default. |
+| `facet` | Marks fields that UI/search surfaces may group by. Object query does not return facet buckets yet. |
+| `vector` | Vector search on numeric-array embedding fields when the storage provider supports it. |
+| `weight` | Relative text-search weight for providers that support ranking. |
+
+Predicate values are still checked against the property schema. For example, range predicates
+and sorting work on orderable schemas such as strings, numbers, dates, timestamps, uuids, and
+enums.
+
+
+## Basic Queries
+
+`sixb.objects(Project).query()` starts with every `Project` object and returns a builder.
+Each chained method narrows or reshapes the current object set.
+
+```ts
+const { objects, total, hasMore } = await sixb
+  .objects(Project)
+  .query()
+  .where((project) =>
+    project.and(
+      project.p.status.eq("active"),
+      project.p.budget.gte(50_000),
+      project.p.deadline.lte(new Date("2026-12-31"))
+    )
+  )
+  .orderBy(Project.p.deadline, "asc")
+  .limit(20)
+  .list()
+
+for (const project of objects) {
+  console.log(project.primaryId, project.properties.name)
+}
+```
+
+Use `first()` when you only need one object:
+
+```ts
+const project = await sixb
+  .objects(Project)
+  .query()
+  .where((project) => project.p.id.eq("proj-001"))
+  .first()
+```
+
+`list()` returns full object rows:
+
+```ts
+type ObjectQueryListResult<T> = {
+  objects: T[]
+  hasMore: boolean
+  total: number
+}
+```
+
+Each object has `primaryId`, `objectTypeId`, `properties`, `createdAt`, and `updatedAt`.
+With the typed API, `properties` is inferred from the object type.
+
+
+## Predicates
+
+Inside `where(...)`, `builder.p` exposes one typed predicate builder per property.
+
+| Method | Meaning |
+| --- | --- |
+| `p.status.eq("active")` | Exact equality. |
+| `p.status.neq("cancelled")` | Exact inequality. |
+| `p.budget.lt(10000)` / `lte` / `gt` / `gte` | Ordered comparisons. |
+| `p.status.in(["active", "paused"])` | Value is in a list. |
+| `p.deadline.exists()` | Property is present. |
+| `p.deadline.exists(false)` | Property is missing. |
+| `p.name.contains("Acme")` | String substring match. |
+| `p.tags.contains("urgent")` | Array contains an item. |
+| `p.metadata.contains("region")` | Map contains a key. |
+
+Combine predicates with `and`, `or`, and `not`:
+
+```ts
+const projects = await sixb
+  .objects(Project)
+  .query()
+  .where((project) =>
+    project.and(
+      project.p.status.in(["active", "paused"]),
+      project.or(
+        project.p.name.contains("dashboard"),
+        project.p.description.contains("dashboard")
+      ),
+      project.not(project.p.status.eq("cancelled"))
+    )
+  )
+  .limit(10)
+  .list()
+```
+
+Returning an array from `where(...)` is treated as an `and` group:
+
+```ts
+const activeLargeProjects = await sixb
+  .objects(Project)
+  .query()
+  .where((project) => [
+    project.p.status.eq("active"),
+    project.p.budget.gte(100_000),
+  ])
+  .list()
+```
+
+
+## Null And Missing Values
+
+Sixb distinguishes an explicit JSON `null` from a missing property.
+
+| Predicate | Matches explicit `null` | Matches missing field |
+| --- | --- | --- |
+| `p.phase.eq(null)` | yes | no |
+| `p.phase.neq(null)` | no | yes |
+| `p.phase.exists()` | yes | no |
+| `p.phase.exists(false)` | no | yes |
+| `p.phase.neq("draft")` | yes | yes |
+| `not(p.phase.eq("draft"))` | yes | yes |
+
+Ordered comparisons such as `lt`, `lte`, `gt`, and `gte` do not match null or missing
+values. Sorting places null or missing sort values after present values in both ascending
+and descending order.
+
+To require a present, non-null field before applying another predicate, combine checks:
+
+```ts
+const projectsWithKnownNonDraftPhase = await sixb
+  .objects(Project)
+  .query()
+  .where((project) =>
+    project.and(
+      project.p.phase.exists(),
+      project.p.phase.neq(null),
+      project.p.phase.neq("draft")
+    )
+  )
+  .list()
+```
+
+
+## Text Search
+
+Text search uses `search.defaultText` by default.
+
+```ts
+const projects = await sixb
+  .objects(Project)
+  .query()
+  .search("energy dashboard")
+  .limit(10)
+  .list()
+```
+
+You can search specific text-enabled fields with property tokens:
+
+```ts
+const projects = await sixb
+  .objects(Project)
+  .query()
+  .search("energy dashboard", { fields: [Project.p.name, Project.p.description] })
+  .limit(10)
+  .list()
+```
+
+Search terms are whitespace-tokenized. Portable text search treats all terms as required
+matches across the selected fields. Providers with ranking support may also use field
+weights and relevance ordering:
+
+```ts
+const ranked = await sixb
+  .objects(Project)
+  .query()
+  .search("energy dashboard")
+  .orderByRelevance("desc")
+  .limit(10)
+  .list()
+```
+
+If the configured storage provider does not support relevance sorting, the query is rejected
+with a structured planning error. Use `orderBy(...)` for portable deterministic ordering.
+
+
+## Traversing Links
+
+`traverse(...)` follows ontology links and changes the current result type to the linked
+object type.
+
+Outgoing traversal starts from the source object and follows one of its links:
+
+```ts
+const customer = await sixb
+  .objects(Project)
+  .query()
+  .where((project) => project.p.id.eq("proj-001"))
+  .traverse(Project.l.customer)
+  .first()
+```
+
+Incoming traversal starts from the target object and finds source objects that point to it:
+
+```ts
+const customerProjects = await sixb
+  .objects(Customer)
+  .query()
+  .where((customer) => customer.p.id.eq("cust-001"))
+  .traverse(Project.l.customer, { direction: "incoming" })
+  .where((project) => project.p.status.eq("active"))
+  .orderBy(Project.p.deadline, "asc")
+  .list()
+```
+
+Traversal is type-aware. After `traverse(Project.l.customer)`, subsequent `where(...)` calls
+use the target object's properties. Wildcard links cannot be traversed through the fluent
+API because the result object type cannot be inferred.
+
+
+## Sorting And Limits
+
+Use `orderBy(propertyToken, direction)` for deterministic ordering:
+
+```ts
+const soonest = await sixb
+  .objects(Project)
+  .query()
+  .where((project) => project.p.status.eq("active"))
+  .orderBy(Project.p.deadline, "asc")
+  .orderBy(Project.p.budget, "desc")
+  .limit(5)
+  .list()
+```
+
+Use `limit(...)` on any query that could return many objects. Some providers can execute
+unbounded queries, but bounded queries are easier to reason about and safer across storage
+adapters.
+
+
+## Validate And Explain
+
+`validate()` checks the query against the registered ontology without executing it.
+
+```ts
+const query = sixb
+  .objects(Project)
+  .query()
+  .where((project) => project.p.status.eq("active"))
+  .search("dashboard")
+  .limit(10)
+
+const validation = query.validate()
+console.log(validation.result.objectTypeIds)
+```
+
+`explain()` returns a structured explanation tree. `formatExplanation()` is useful in logs
+or tests.
+
+```ts
+console.log(query.formatExplanation())
+```
+
+Validation catches problems such as unknown properties, wrong value types, missing query
+metadata, invalid text fields, and unsupported link traversal shapes. Provider capability
+issues, such as unsupported relevance sorting or vector search, are reported when the query
+executes through `.list()`, `.first()`, or the HTTP route.
+
+
+## Raw Query JSON
+
+Most app code should use the fluent API. Raw query JSON is useful when calling
+`POST /api/objects/query`, using generated clients, or constructing queries outside
+TypeScript.
+
+Raw query nodes are nested with an `input` field. This query starts with `Project`, filters,
+sorts, limits, and projects returned properties:
+
+```json
+{
+  "query": {
+    "kind": "project",
+    "properties": ["id", "name", "status", "budget"],
+    "input": {
+      "kind": "limit",
+      "limit": 20,
+      "input": {
+        "kind": "sort",
+        "fields": [{ "kind": "property", "propertyId": "budget", "direction": "desc" }],
+        "input": {
+          "kind": "filter",
+          "predicate": {
+            "op": "and",
+            "items": [
+              { "op": "eq", "propertyId": "status", "value": "active" },
+              { "op": "gte", "propertyId": "budget", "value": 50000 }
+            ]
+          },
+          "input": { "kind": "start", "objectTypeId": "Project" }
+        }
+      }
+    }
+  }
+}
+```
+
+The response includes matching objects and pagination metadata. The HTTP route also returns
+a diagnostic `plan` object for debugging, but application code normally uses the object
+fields below.
+
+```json
+{
+  "objects": [],
+  "hasMore": false,
+  "total": 0
+}
+```
+
+Raw `page` queries return an opaque `nextPageToken` when another page is available:
+
+```json
+{
+  "query": {
+    "kind": "page",
+    "pageSize": 25,
+    "input": {
+      "kind": "sort",
+      "fields": [{ "kind": "property", "propertyId": "deadline", "direction": "asc" }],
+      "input": { "kind": "start", "objectTypeId": "Project" }
+    }
+  }
+}
+```
+
+Send that token back as `pageToken` to read the next page:
+
+```json
+{
+  "query": {
+    "kind": "page",
+    "pageSize": 25,
+    "pageToken": "<nextPageToken>",
+    "input": {
+      "kind": "sort",
+      "fields": [{ "kind": "property", "propertyId": "deadline", "direction": "asc" }],
+      "input": { "kind": "start", "objectTypeId": "Project" }
+    }
+  }
+}
+```
+
+
+## Raw Node Reference
+
+| Node | Purpose |
+| --- | --- |
+| `start` | Begin with all objects of one type. Raw JSON can set `includeSubtypes: true`. |
+| `filter` | Apply property predicates. |
+| `text` | Keyword search over `search.defaultText` or explicit `fields`. |
+| `vector` | Nearest-neighbor search on a numeric-array property when supported. |
+| `traverse` | Follow an outgoing or incoming ontology link. |
+| `set` | Combine compatible object sets with `union`, `intersect`, or `subtract`. |
+| `sort` | Order by properties or provider-supported relevance. |
+| `limit` | Bound the result count. |
+| `page` | Request a cursor page. |
+| `project` | Return only selected properties in raw query responses. |
+
+| Predicate | Raw shape |
+| --- | --- |
+| `and` / `or` | `{ "op": "and", "items": [...] }` |
+| `not` | `{ "op": "not", "item": ... }` |
+| `eq` / `neq` / `lt` / `lte` / `gt` / `gte` | `{ "op": "eq", "propertyId": "status", "value": "active" }` |
+| `in` | `{ "op": "in", "propertyId": "status", "values": ["active", "paused"] }` |
+| `exists` | `{ "op": "exists", "propertyId": "deadline", "value": true }` |
+| `contains` | `{ "op": "contains", "propertyId": "name", "value": "Acme" }` |
+
+
+## Practical Support Notes
+
+SQLite and PostgreSQL object storage support the common graph-query workflow: typed
+property filters, text search, property sorting, limits, raw cursor pages, link traversal,
+set operations, and raw projection.
+
+Vector search and relevance sorting require storage-provider support. If a provider cannot
+execute a requested feature, Sixb returns a structured planning error instead of silently
+returning a partial or approximate result.
+
+For simple bounded filters and sorts, Sixb can sometimes evaluate the query in the core
+runtime when a storage provider lacks native query support. Treat text search, traversal,
+set operations, vector search, and relevance sorting as provider-backed features.

--- a/docs/concepts/ontology.md
+++ b/docs/concepts/ontology.md
@@ -278,6 +278,14 @@ import { Organization } from "./ontology/organization"
 export const sixb = createSixb({
   ontology: [Customer, Organization],
 })
+```
+
+## Typed API
+
+Once registered, access objects through the typed API:
+
+```ts
+const customers = sixb.objects(Customer)
 
 // Create or update
 const customer = await customers.upsert({

--- a/docs/concepts/ontology.md
+++ b/docs/concepts/ontology.md
@@ -278,6 +278,46 @@ import { Organization } from "./ontology/organization"
 export const sixb = createSixb({
   ontology: [Customer, Organization],
 })
+
+// Create or update
+const customer = await customers.upsert({
+  properties: { id: "cust-001", name: "Acme Corp", tier: "business" },
+})
+
+// Read
+const found = await customers.get("cust-001")
+
+// Query with filters
+const results = await customers
+  .query()
+  .where((c) => c.p.tier.eq("enterprise"))
+  .limit(10)
+  .list()
+
+// Telemetry
+await customers.byId("cust-001").telemetry(Customer.p.monthlySpend).append({
+  value: 1250.00,
+  unit: "USD",
+  at: new Date(),
+})
+
+// Batch telemetry
+await customers.appendTelemetryBatch([
+  { id: "cust-001", properties: { monthlySpend: { value: 1250.00, unit: "USD" } } },
+  { id: "cust-002", properties: { monthlySpend: { value: 890.50, unit: "USD" } } },
+])
+
+// Links
+await customers.byId("cust-001").link(Customer.l.belongsTo, {
+  objectTypeId: "Organization",
+  primaryId: "org-1",
+})
+
+// Actions
+await customers.byId("cust-001").requestAction({
+  actionId: "issueCredit",
+  params: { amount: { value: 500.00, unit: "USD" } },
+})
 ```
 
 ## How to model your domain

--- a/examples/acme-corp/ontology/customer.ts
+++ b/examples/acme-corp/ontology/customer.ts
@@ -7,11 +7,29 @@ export const Customer = defineObjectType({
   description: "A company customer.",
   properties: [
     prop("id", "string", { required: true, primary: true }),
-    prop("name", "string", { required: true }),
-    prop("email", "string", { required: true }),
-    prop("company", "string", { required: true }),
-    prop("industry", "string"),
-    prop("tier", stringEnum(["bronze", "silver", "gold", "platinum"])),
+    prop("name", "string", {
+      required: true,
+      query: { searchable: true, text: true, exact: true, sortable: true, weight: 5 },
+    }),
+    prop("email", "string", {
+      required: true,
+      query: { searchable: true, filterable: true, exact: true },
+    }),
+    prop("company", "string", {
+      required: true,
+      query: { searchable: true, text: true, exact: true, filterable: true, sortable: true },
+    }),
+    prop("industry", "string", {
+      query: { searchable: true, text: true, filterable: true, exact: true, facet: true },
+    }),
+    prop("tier", stringEnum(["bronze", "silver", "gold", "platinum"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
   ],
+  search: {
+    title: "company",
+    defaultText: ["company", "name", "industry"],
+    exact: ["id", "email", "company"],
+  },
   links: [link("accountManager", Employee, { cardinality: "one" })],
 })

--- a/examples/acme-corp/ontology/employee.ts
+++ b/examples/acme-corp/ontology/employee.ts
@@ -7,11 +7,29 @@ export const Employee = defineObjectType({
   description: "A company employee.",
   properties: [
     prop("id", "string", { required: true, primary: true }),
-    prop("name", "string", { required: true }),
-    prop("email", "string", { required: true }),
-    prop("role", "string", { required: true }),
-    prop("seniority", stringEnum(["junior", "mid", "senior", "lead", "director"])),
-    prop("hireDate", "date"),
+    prop("name", "string", {
+      required: true,
+      query: { searchable: true, text: true, exact: true, sortable: true, weight: 5 },
+    }),
+    prop("email", "string", {
+      required: true,
+      query: { searchable: true, filterable: true, exact: true },
+    }),
+    prop("role", "string", {
+      required: true,
+      query: { searchable: true, text: true, filterable: true, exact: true, sortable: true },
+    }),
+    prop("seniority", stringEnum(["junior", "mid", "senior", "lead", "director"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    prop("hireDate", "date", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
   ],
+  search: {
+    title: "name",
+    defaultText: ["name", "role"],
+    exact: ["id", "email"],
+  },
   links: [link("department", Department, { cardinality: "one" })],
 })

--- a/examples/acme-corp/ontology/invoice.ts
+++ b/examples/acme-corp/ontology/invoice.ts
@@ -8,20 +8,39 @@ export const Invoice = defineObjectType({
   description: "A billing invoice for a customer.",
   properties: [
     prop("id", "string", { required: true, primary: true }),
-    prop("number", "string", { required: true }),
-    prop("amount", "double", { required: true }),
-    prop("currency", stringEnum(["EUR", "USD", "GBP"])),
-    prop("status", stringEnum(["draft", "sent", "paid", "overdue", "cancelled"])),
-    prop("issuedAt", "timestamp"),
-    prop("dueDate", "date"),
+    prop("number", "string", {
+      required: true,
+      query: { searchable: true, filterable: true, exact: true, sortable: true },
+    }),
+    prop("amount", "double", {
+      required: true,
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop("currency", stringEnum(["EUR", "USD", "GBP"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    prop("status", stringEnum(["draft", "sent", "paid", "overdue", "cancelled"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    prop("issuedAt", "timestamp", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop("dueDate", "date", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
     prop(
       "reminderReviewStatus",
-      stringEnum(["not_requested", "needs_review", "approved", "revision_requested", "cancelled"])
+      stringEnum(["not_requested", "needs_review", "approved", "revision_requested", "cancelled"]),
+      { query: { searchable: true, filterable: true, exact: true, facet: true } }
     ),
     prop("reminderReviewRequestedAt", "timestamp"),
     prop("reminderReviewedAt", "timestamp"),
     prop("reminderReviewerNote", "string"),
   ],
+  search: {
+    title: "number",
+    exact: ["id", "number"],
+  },
   links: [
     link("customer", Customer, { cardinality: "one" }),
     link("project", Project, { cardinality: "one" }),

--- a/examples/acme-corp/ontology/project.ts
+++ b/examples/acme-corp/ontology/project.ts
@@ -8,14 +8,32 @@ export const Project = defineObjectType({
   description: "A client project managed by the company.",
   properties: [
     prop("id", "string", { required: true, primary: true }),
-    prop("name", "string", { required: true }),
-    prop("description", "string"),
-    prop("status", stringEnum(["draft", "active", "paused", "completed", "cancelled"])),
-    prop("startDate", "date"),
-    prop("deadline", "date"),
-    prop("budget", "double"),
+    prop("name", "string", {
+      required: true,
+      query: { searchable: true, text: true, exact: true, sortable: true, weight: 5 },
+    }),
+    prop("description", "string", {
+      query: { searchable: true, text: true },
+    }),
+    prop("status", stringEnum(["draft", "active", "paused", "completed", "cancelled"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    prop("startDate", "date", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop("deadline", "date", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop("budget", "double", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
     prop("progress", "integer", { mode: "telemetry" }),
   ],
+  search: {
+    title: "name",
+    defaultText: ["name", "description"],
+    exact: ["id", "name"],
+  },
   links: [
     link("customer", Customer, { cardinality: "one" }),
     link("lead", Employee, { cardinality: "one" }),

--- a/examples/acme-corp/ontology/task.ts
+++ b/examples/acme-corp/ontology/task.ts
@@ -8,12 +8,28 @@ export const Task = defineObjectType({
   description: "A unit of work within a project.",
   properties: [
     prop("id", "string", { required: true, primary: true }),
-    prop("title", "string", { required: true }),
-    prop("status", stringEnum(["backlog", "todo", "in_progress", "review", "done"])),
-    prop("priority", stringEnum(["low", "medium", "high", "critical"])),
-    prop("estimate", "integer"),
-    prop("dueDate", "date"),
+    prop("title", "string", {
+      required: true,
+      query: { searchable: true, text: true, exact: true, sortable: true, weight: 5 },
+    }),
+    prop("status", stringEnum(["backlog", "todo", "in_progress", "review", "done"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    prop("priority", stringEnum(["low", "medium", "high", "critical"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    prop("estimate", "integer", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
+    prop("dueDate", "date", {
+      query: { searchable: true, filterable: true, sortable: true },
+    }),
   ],
+  search: {
+    title: "title",
+    defaultText: ["title"],
+    exact: ["id", "title"],
+  },
   links: [
     link("project", Project, { cardinality: "one" }),
     link("assignee", Employee, { cardinality: "one" }),

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -124,9 +124,11 @@ await sixb.objects(Room).byId("room:101").telemetry(Room.p.currentTemperature).a
 })
 
 // Query
-const found = await sixb.objects(Room).findFirst({
-  where: (r) => r.p.externalId.eq("RM-101"),
-})
+const found = await sixb
+  .objects(Room)
+  .query()
+  .where((r) => r.p.externalId.eq("RM-101"))
+  .first()
 ```
 
 ## Functions
@@ -417,8 +419,9 @@ src/
 |---|---|
 | `.upsert({ properties })` | Create or update an object (id derived from primary property) |
 | `.get(id)` | Get an object by id |
-| `.findFirst({ where })` | Find first matching object |
-| `.list({ where, limit, ... })` | List objects with filtering and pagination |
+| `.query().where(...).limit(...).list()` | Execute a typed object query |
+| `.query().where(...).first()` | Return the first object from a typed query |
+| `.list({ limit, offset, ... })` | List stored objects with storage-system filtering and pagination |
 | `.byId(id)` | Get a handle for link/telemetry/action operations |
 | `.appendTelemetryBatch(items)` | Batch append telemetry for multiple objects |
 | `.requestAction({ id, actionId, params })` | Request an action on an object |


### PR DESCRIPTION
Depends on #56.

Stack position: 6 of 6. Base branch: `codex/object-query-http-client`.

## What changed

This documents the object query API and updates the ACME example ontology so common fields opt into filtering, sorting, exact matching, text search, and search profiles.

The new concept doc starts from the typed runtime API:

```ts
const result = await sixb
  .objects(Project)
  .query()
  .where((project) => project.p.status.eq("active"))
  .orderBy(Project.p.deadline, "asc")
  .limit(25)
  .list()
```

It also explains how ontology metadata enables query surfaces:

```ts
prop("status", stringEnum(["draft", "active", "paused", "completed"]), {
  query: { searchable: true, filterable: true, exact: true, facet: true },
})

prop("deadline", "date", {
  query: { searchable: true, filterable: true, sortable: true },
})
```

ACME object types now define realistic search profiles:

```ts
export const Project = defineObjectType({
  id: "Project",
  name: "Project",
  search: {
    title: "name",
    defaultText: ["name", "description"],
    exact: ["id", "name"],
  },
  // ...
})
```

## Review notes

- The docs replace old `findFirst({ where })` examples with `query().where(...).first()`.
- `list()` is described as storage browsing, while `query()` is the graph-aware read API.
- The concept doc covers predicates, null/missing behavior, text/vector search, traversal, paging, provider planning, HTTP usage, and generated client usage.
- Example metadata is intentionally selective: only fields likely to be queried are marked.

## Verification

```bash
bun run typecheck
bun run check
```

Both commands passed locally.

