### PR TITLE
Remove visual styles from custom app shell

### DIFF
--- a/packages/app/src/codegen.ts
+++ b/packages/app/src/codegen.ts
@@ -164,8 +164,8 @@ if (canRenderApp) {
   const mainPath = join(generatedDir, "main.tsx")
   await writeFile(mainPath, mainContent, "utf-8")
 
-  // Generate index.html with a styled fallback shell so pages still look intentional
-  // when projects don't define `app/globals.css`.
+  // Generate index.html with only structural reset rules. Apps own visual
+  // styling through app/globals.css.
   const htmlContent = `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -174,12 +174,6 @@ if (canRenderApp) {
     <title>Sixb</title>
     ${runtimeConfigScript}
     <style>
-      :root {
-        font-family: "Space Grotesk", "Manrope", "Avenir Next", "Segoe UI", sans-serif;
-        color: #ebf1ff;
-        background-color: #05070c;
-        text-rendering: optimizeLegibility;
-      }
       * {
         box-sizing: border-box;
       }
@@ -191,13 +185,6 @@ if (canRenderApp) {
       }
       body {
         min-height: 100vh;
-        background:
-          radial-gradient(circle at 14% 18%, rgba(24, 79, 255, 0.24), transparent 42%),
-          radial-gradient(circle at 82% 7%, rgba(0, 209, 255, 0.2), transparent 38%),
-          linear-gradient(155deg, #060913 0%, #0b1222 48%, #090d16 100%);
-      }
-      a {
-        color: inherit;
       }
     </style>
   </head>

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { generateAppEntry } from "../src/codegen"
 import { createCustomApp } from "../src/createCustomApp"
 
 async function getFreePort(): Promise<number> {
@@ -178,5 +179,21 @@ describe("createCustomApp.dev", () => {
     } finally {
       await server.stop()
     }
+  })
+
+  test("generates a structural shell without framework visual styles", async () => {
+    const { htmlPath } = await generateAppEntry(tempRoot, join(tempRoot, ".sixb", "generated"))
+    const html = await readFile(htmlPath, "utf-8")
+
+    expect(html).toContain("box-sizing: border-box")
+    expect(html).toContain("margin: 0")
+    expect(html).toContain("min-height: 100vh")
+    expect(html).not.toContain("theme-color")
+    expect(html).not.toContain("font-family")
+    expect(html).not.toContain("background")
+    expect(html).not.toContain("color:")
+    expect(html).not.toContain("#05070c")
+    expect(html).not.toContain("#0b1222")
+    expect(html).not.toContain("radial-gradient")
   })
 })


### PR DESCRIPTION
## Summary
- Remove framework-owned font, color, background, and link styling from the generated custom app HTML shell.
- Keep only structural reset rules in the framework shell.
- Add a regression test so app visuals continue to come from `app/globals.css`.

## Testing
- `bun test packages/app/tests/createCustomApp.test.ts`
- `bun run typecheck` in `packages/app`