### PR TITLE
pg: migrate storage from bun:sql to porsager postgres

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -494,6 +494,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@sixb/core": "workspace:*",
+        "postgres": "^3.4.5",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -1294,6 +1295,8 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
+
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -30,6 +30,7 @@ export type { AuthRuntimeOptions } from "./runtime"
 export {
   AuthRuntime,
   DEFAULT_AUTH_INVITATION_TTL_MS,
+  DEFAULT_AUTH_SESSION_CACHE_TTL_MS,
   DEFAULT_AUTH_SESSION_TTL_MS,
   MAX_AUTH_INVITATION_TTL_MS,
   resolveAuthConfig,

--- a/packages/core/src/auth/runtime.ts
+++ b/packages/core/src/auth/runtime.ts
@@ -14,6 +14,7 @@ import {
   resolveAuthCookieOptionsForAudience,
 } from "./cookies"
 import { AuthRuntimeError } from "./errors"
+import { SessionCache } from "./session-cache"
 import { hashSessionSecret, parseSessionCookieValue } from "./sessions"
 import type {
   AuthenticatedAuthSession,
@@ -49,6 +50,7 @@ import {
 
 export {
   DEFAULT_AUTH_INVITATION_TTL_MS,
+  DEFAULT_AUTH_SESSION_CACHE_TTL_MS,
   DEFAULT_AUTH_SESSION_TTL_MS,
   MAX_AUTH_INVITATION_TTL_MS,
   resolveAuthConfig,
@@ -66,12 +68,15 @@ export class AuthRuntime {
   private readonly storage: Storage
   private readonly security: SecurityRegistry
   private readonly config: ResolvedAuthConfig
+  private readonly sessionCache: SessionCache | null
 
   constructor(options: AuthRuntimeOptions) {
     this.projectId = options.projectId
     this.storage = options.storage
     this.security = options.security
     this.config = resolveAuthConfig(options.config)
+    this.sessionCache =
+      this.config.session.cacheTtlMs > 0 ? new SessionCache(this.config.session.cacheTtlMs) : null
 
     if (this.isEnabled() && !this.storage.auth) {
       throw new AuthRuntimeError(
@@ -150,13 +155,26 @@ export class AuthRuntime {
       return { authenticated: false, reason: "invalid_cookie" }
     }
 
+    const tokenHash = hashSessionSecret(parts.sessionSecret)
+    const nowMs = Date.now()
+
+    const cached = this.sessionCache?.get({
+      sessionId: parts.sessionId,
+      tokenHash,
+      audience,
+      nowMs,
+    })
+    if (cached) {
+      return cached
+    }
+
     const storage = this.requireAuthStorage()
     const session = await storage.sessions.findValidByTokenHash({
       projectId: this.projectId,
       id: parts.sessionId,
       audience,
-      tokenHash: hashSessionSecret(parts.sessionSecret),
-      now: new Date(),
+      tokenHash,
+      now: new Date(nowMs),
     })
 
     if (!session) {
@@ -181,13 +199,32 @@ export class AuthRuntime {
       userId: user.id,
     })
 
-    return {
+    const result: AuthenticatedAuthSession = {
       authenticated: true,
       principal: { type: "user", id: user.id },
       user,
       session,
       groupIds: memberships.map((membership) => membership.groupId),
     }
+
+    this.sessionCache?.set({
+      sessionId: parts.sessionId,
+      tokenHash,
+      audience,
+      session: result,
+      nowMs,
+      sessionExpiresAtMs: session.expiresAt.getTime(),
+    })
+
+    return result
+  }
+
+  /**
+   * Evict a session from the in-process cache. Call this when a session is revoked
+   * (e.g. sign-out) so the cached result is dropped before its TTL would expire.
+   */
+  invalidateSession(sessionId: string): void {
+    this.sessionCache?.invalidate(sessionId)
   }
 
   async requirePrincipal(

--- a/packages/core/src/auth/session-cache.ts
+++ b/packages/core/src/auth/session-cache.ts
@@ -1,0 +1,93 @@
+import type { AuthenticatedAuthSession } from "./types"
+
+interface SessionCacheEntry {
+  readonly tokenHash: string
+  readonly audience: string
+  readonly session: AuthenticatedAuthSession
+  readonly expiresAtMs: number
+}
+
+export interface SessionCacheGetInput {
+  readonly sessionId: string
+  readonly tokenHash: string
+  readonly audience: string
+  readonly nowMs: number
+}
+
+export interface SessionCacheSetInput extends SessionCacheGetInput {
+  readonly session: AuthenticatedAuthSession
+  readonly sessionExpiresAtMs: number
+}
+
+/**
+ * Tiny in-process TTL cache for resolved auth sessions, keyed by session id.
+ *
+ * Every authenticated request resolves its session through the shared storage pool
+ * (a session lookup plus user and group-membership reads). Under request bursts that
+ * triples the pool pressure and, with a small pool, can starve the pool so the entire
+ * API stalls. Caching the resolved result for a short TTL collapses those reads to one
+ * per session per window.
+ *
+ * Safety: entries are pinned to the exact token hash + audience that produced them and
+ * are never served past the session's real `expiresAt`. The short TTL bounds how long a
+ * revoked session can linger; sign-out additionally invalidates eagerly via
+ * {@link SessionCache.invalidate}.
+ */
+export class SessionCache {
+  private readonly entries = new Map<string, SessionCacheEntry>()
+
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries: number = 4096
+  ) {}
+
+  get(input: SessionCacheGetInput): AuthenticatedAuthSession | undefined {
+    const entry = this.entries.get(input.sessionId)
+    if (!entry) {
+      return undefined
+    }
+
+    if (
+      entry.expiresAtMs <= input.nowMs ||
+      entry.tokenHash !== input.tokenHash ||
+      entry.audience !== input.audience
+    ) {
+      this.entries.delete(input.sessionId)
+      return undefined
+    }
+
+    return entry.session
+  }
+
+  set(input: SessionCacheSetInput): void {
+    // Never let a cached session outlive the real session it represents.
+    const expiresAtMs = Math.min(input.nowMs + this.ttlMs, input.sessionExpiresAtMs)
+    if (expiresAtMs <= input.nowMs) {
+      return
+    }
+
+    // Re-insert so the freshest key sorts last for insertion-order LRU eviction.
+    this.entries.delete(input.sessionId)
+    this.entries.set(input.sessionId, {
+      tokenHash: input.tokenHash,
+      audience: input.audience,
+      session: input.session,
+      expiresAtMs,
+    })
+
+    if (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value
+      if (oldest !== undefined) {
+        this.entries.delete(oldest)
+      }
+    }
+  }
+
+  invalidate(sessionId: string): void {
+    this.entries.delete(sessionId)
+  }
+
+  clear(): void {
+    this.entries.clear()
+  }
+}

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -227,6 +227,13 @@ export interface RevokeInvitationResult {
 
 export interface AuthSessionOptions {
   readonly ttlMs?: number
+  /**
+   * How long (ms) a resolved session is cached in-process before it is re-validated
+   * against storage. Collapses the per-request auth reads (session + user + memberships)
+   * during request bursts so they cannot starve the storage pool. Set to 0 to disable.
+   * Defaults to {@link DEFAULT_AUTH_SESSION_CACHE_TTL_MS}.
+   */
+  readonly cacheTtlMs?: number
 }
 
 export interface AuthCookieOptions {

--- a/packages/core/src/auth/validation.ts
+++ b/packages/core/src/auth/validation.ts
@@ -13,6 +13,11 @@ import type {
 export const DEFAULT_AUTH_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000
 export const DEFAULT_AUTH_INVITATION_TTL_MS = 7 * 24 * 60 * 60 * 1000
 export const MAX_AUTH_INVITATION_TTL_MS = 30 * 24 * 60 * 60 * 1000
+/**
+ * Default in-process session cache window. Short enough that a revoked session lingers
+ * only briefly, long enough to collapse a burst of requests to a single auth resolution.
+ */
+export const DEFAULT_AUTH_SESSION_CACHE_TTL_MS = 5_000
 
 export { resolveAuthSessionAudience } from "./audience"
 
@@ -125,7 +130,15 @@ function resolveAuthSessionOptions(
     )
   }
 
-  return { ttlMs }
+  const cacheTtlMs = options?.cacheTtlMs ?? DEFAULT_AUTH_SESSION_CACHE_TTL_MS
+  if (!Number.isFinite(cacheTtlMs) || cacheTtlMs < 0) {
+    throw new AuthRuntimeError(
+      "invalid_auth_config",
+      "[Sixb] Auth session cacheTtlMs must be a non-negative finite number."
+    )
+  }
+
+  return { ttlMs, cacheTtlMs }
 }
 
 export function isMagicLinkAuthStrategy(

--- a/packages/core/tests/auth-runtime.test.ts
+++ b/packages/core/tests/auth-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import {
   type AuthStrategy,
   createCsrfCookieHeader,
@@ -576,6 +576,126 @@ describe("Sixb auth runtime", () => {
         cookieName: "sixb_csrf",
       })
     ).toBe(true)
+  })
+
+  test("caches resolved sessions and re-validates after invalidation", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({ ontology: [], ...deps, auth: authStrategy })
+    const credential = createSessionCredential("ses_cache")
+    await deps.storage.auth.users.create({
+      id: "usr_1",
+      projectId: sixb.id,
+      email: "ava@acme.com",
+    })
+    await deps.storage.auth.sessions.create({
+      id: credential.sessionId,
+      projectId: sixb.id,
+      userId: "usr_1",
+      strategyId: "test",
+      audience: "atlas",
+      tokenHash: credential.tokenHash,
+      createdAt: new Date("2026-05-16T10:00:00.000Z"),
+      expiresAt: new Date("2099-05-16T10:00:00.000Z"),
+    })
+    const spy = spyOn(deps.storage.auth.sessions, "findValidByTokenHash")
+    const request = () =>
+      new Request("http://localhost/api/project", {
+        headers: { cookie: `sixb_session=${credential.cookieValue}` },
+      })
+
+    await expect(sixb.auth.getSession(request())).resolves.toMatchObject({ authenticated: true })
+    await expect(sixb.auth.getSession(request())).resolves.toMatchObject({ authenticated: true })
+    // Second resolution served from cache — storage hit only once.
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    sixb.auth.invalidateSession(credential.sessionId)
+    await expect(sixb.auth.getSession(request())).resolves.toMatchObject({ authenticated: true })
+    expect(spy).toHaveBeenCalledTimes(2)
+    spy.mockRestore()
+  })
+
+  test("session cache is bound to the token secret, not just the session id", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({ ontology: [], ...deps, auth: authStrategy })
+    const credential = createSessionCredential("ses_bind")
+    await deps.storage.auth.users.create({
+      id: "usr_1",
+      projectId: sixb.id,
+      email: "ava@acme.com",
+    })
+    await deps.storage.auth.sessions.create({
+      id: credential.sessionId,
+      projectId: sixb.id,
+      userId: "usr_1",
+      strategyId: "test",
+      audience: "atlas",
+      tokenHash: credential.tokenHash,
+      createdAt: new Date("2026-05-16T10:00:00.000Z"),
+      expiresAt: new Date("2099-05-16T10:00:00.000Z"),
+    })
+    // Prime the cache with the valid cookie.
+    await sixb.auth.getSession(
+      new Request("http://localhost/api/project", {
+        headers: { cookie: `sixb_session=${credential.cookieValue}` },
+      })
+    )
+
+    // A forged cookie reusing the session id but a different secret must not hit the cache.
+    const forged = formatSessionCookieValue(credential.sessionId, "wrong-secret")
+    await expect(
+      sixb.auth.getSession(
+        new Request("http://localhost/api/project", {
+          headers: { cookie: `sixb_session=${forged}` },
+        })
+      )
+    ).resolves.toEqual({ authenticated: false, reason: "invalid_session" })
+  })
+
+  test("cacheTtlMs: 0 disables session caching", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({
+      ontology: [],
+      ...deps,
+      auth: { strategy: authStrategy, session: { cacheTtlMs: 0 } },
+    })
+    const credential = createSessionCredential("ses_nocache")
+    await deps.storage.auth.users.create({
+      id: "usr_1",
+      projectId: sixb.id,
+      email: "ava@acme.com",
+    })
+    await deps.storage.auth.sessions.create({
+      id: credential.sessionId,
+      projectId: sixb.id,
+      userId: "usr_1",
+      strategyId: "test",
+      audience: "atlas",
+      tokenHash: credential.tokenHash,
+      createdAt: new Date("2026-05-16T10:00:00.000Z"),
+      expiresAt: new Date("2099-05-16T10:00:00.000Z"),
+    })
+    const spy = spyOn(deps.storage.auth.sessions, "findValidByTokenHash")
+    const request = () =>
+      new Request("http://localhost/api/project", {
+        headers: { cookie: `sixb_session=${credential.cookieValue}` },
+      })
+
+    await sixb.auth.getSession(request())
+    await sixb.auth.getSession(request())
+    expect(spy).toHaveBeenCalledTimes(2)
+    spy.mockRestore()
+  })
+
+  test("rejects invalid session cacheTtlMs", () => {
+    const deps = createTestRuntimeDeps()
+    expect(
+      () =>
+        new Sixb<readonly []>({
+          ontology: [] as const,
+          ...deps,
+          auth: { strategy: authStrategy, session: { cacheTtlMs: -1 } },
+        })
+    ).toThrow("cacheTtlMs must be a non-negative finite number")
   })
 
   test("serializes auth cookies with strict same-site defaults", () => {

--- a/packages/core/tests/session-cache.test.ts
+++ b/packages/core/tests/session-cache.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import { SessionCache } from "../src/auth/session-cache"
+import type { AuthenticatedAuthSession } from "../src/auth/types"
+
+function fakeSession(id: string): AuthenticatedAuthSession {
+  return {
+    authenticated: true,
+    principal: { type: "user", id },
+    user: { id, projectId: "p", email: `${id}@acme.com` },
+    session: { id: `ses_${id}` },
+    groupIds: [],
+  } as unknown as AuthenticatedAuthSession
+}
+
+const base = {
+  sessionId: "ses_1",
+  tokenHash: "hash_1",
+  audience: "atlas",
+}
+
+describe("SessionCache", () => {
+  test("returns undefined on miss, hit after set within ttl", () => {
+    const cache = new SessionCache(5_000)
+    const session = fakeSession("usr_1")
+
+    expect(cache.get({ ...base, nowMs: 0 })).toBeUndefined()
+    cache.set({ ...base, session, nowMs: 0, sessionExpiresAtMs: 1_000_000 })
+    expect(cache.get({ ...base, nowMs: 4_999 })).toBe(session)
+  })
+
+  test("expires entries after ttl", () => {
+    const cache = new SessionCache(5_000)
+    cache.set({ ...base, session: fakeSession("usr_1"), nowMs: 0, sessionExpiresAtMs: 1_000_000 })
+
+    expect(cache.get({ ...base, nowMs: 5_000 })).toBeUndefined()
+    // Expired read evicts the entry.
+    expect(cache.get({ ...base, nowMs: 1 })).toBeUndefined()
+  })
+
+  test("never serves a cached session past its real expiry", () => {
+    const cache = new SessionCache(60_000)
+    // Session expires at 2s even though ttl is 60s.
+    cache.set({ ...base, session: fakeSession("usr_1"), nowMs: 0, sessionExpiresAtMs: 2_000 })
+
+    expect(cache.get({ ...base, nowMs: 1_999 })).toBeDefined()
+    expect(cache.get({ ...base, nowMs: 2_000 })).toBeUndefined()
+  })
+
+  test("does not store an already-expired session", () => {
+    const cache = new SessionCache(5_000)
+    cache.set({ ...base, session: fakeSession("usr_1"), nowMs: 10_000, sessionExpiresAtMs: 9_000 })
+    expect(cache.get({ ...base, nowMs: 10_000 })).toBeUndefined()
+  })
+
+  test("is bound to the exact token hash and audience", () => {
+    const cache = new SessionCache(5_000)
+    cache.set({ ...base, session: fakeSession("usr_1"), nowMs: 0, sessionExpiresAtMs: 1_000_000 })
+
+    expect(cache.get({ ...base, tokenHash: "other", nowMs: 1 })).toBeUndefined()
+    cache.set({ ...base, session: fakeSession("usr_1"), nowMs: 0, sessionExpiresAtMs: 1_000_000 })
+    expect(cache.get({ ...base, audience: "app", nowMs: 1 })).toBeUndefined()
+  })
+
+  test("invalidate and clear drop entries", () => {
+    const cache = new SessionCache(5_000)
+    cache.set({ ...base, session: fakeSession("usr_1"), nowMs: 0, sessionExpiresAtMs: 1_000_000 })
+    cache.invalidate("ses_1")
+    expect(cache.get({ ...base, nowMs: 1 })).toBeUndefined()
+
+    cache.set({ ...base, session: fakeSession("usr_1"), nowMs: 0, sessionExpiresAtMs: 1_000_000 })
+    cache.clear()
+    expect(cache.get({ ...base, nowMs: 1 })).toBeUndefined()
+  })
+
+  test("evicts the oldest entry past maxEntries", () => {
+    const cache = new SessionCache(5_000, 2)
+    const mk = (id: string) => ({
+      sessionId: id,
+      tokenHash: `h_${id}`,
+      audience: "atlas",
+      session: fakeSession(id),
+      nowMs: 0,
+      sessionExpiresAtMs: 1_000_000,
+    })
+    cache.set(mk("a"))
+    cache.set(mk("b"))
+    cache.set(mk("c")) // evicts "a" (oldest)
+
+    expect(
+      cache.get({ sessionId: "a", tokenHash: "h_a", audience: "atlas", nowMs: 1 })
+    ).toBeUndefined()
+    expect(
+      cache.get({ sessionId: "b", tokenHash: "h_b", audience: "atlas", nowMs: 1 })
+    ).toBeDefined()
+    expect(
+      cache.get({ sessionId: "c", tokenHash: "h_c", audience: "atlas", nowMs: 1 })
+    ).toBeDefined()
+  })
+})

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -128,6 +128,8 @@ export function registerAuthRoutes(
             id: session.session.id,
             revokedAt: new Date(),
           })
+          // Drop the cached session immediately so it isn't honored for the cache TTL.
+          sixb.auth.invalidateSession(session.session.id)
         }
 
         const headers = new Headers({ "content-type": "application/json; charset=utf-8" })

--- a/storage/pg/package.json
+++ b/storage/pg/package.json
@@ -19,7 +19,8 @@
     "prepack": "bun run build"
   },
   "dependencies": {
-    "@sixb/core": "workspace:*"
+    "@sixb/core": "workspace:*",
+    "postgres": "^3.4.5"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/storage/pg/src/auth-storage/auth-storage.ts
+++ b/storage/pg/src/auth-storage/auth-storage.ts
@@ -11,7 +11,7 @@ import type {
   UserRecord,
 } from "@sixb/core"
 import { AuthStorageError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL, SQLClient } from "../pg-client"
 import { authLockKey, lockAdvisoryKeys, runPgTransaction } from "../transactions"
 import { PgAuthGroupMembershipStore } from "./group-memberships"
 import { PgAuthUserIdentityStore } from "./identities"
@@ -499,14 +499,14 @@ export class PgAuthStorage implements AuthStorage {
         )
       }
 
-      const [updated] = (await tx`
+      const [updated] = await tx<PgAuthUserRow[]>`
         UPDATE auth_users
         SET status = 'suspended',
             updated_at = ${input.suspendedAt}
         WHERE project_id = ${input.projectId}
           AND id = ${input.userId}
         RETURNING *
-      `) as PgAuthUserRow[]
+      `
 
       await revokeActiveSessionsForUser(tx, {
         projectId: input.projectId,
@@ -553,7 +553,7 @@ export class PgAuthStorage implements AuthStorage {
   }
 
   private async insertUser(
-    sql: SQL,
+    sql: SQLClient,
     input: {
       readonly id: string
       readonly projectId: string
@@ -564,7 +564,7 @@ export class PgAuthStorage implements AuthStorage {
     }
   ): Promise<UserRecord> {
     try {
-      const [row] = (await sql`
+      const [row] = await sql<PgAuthUserRow[]>`
         INSERT INTO auth_users (
           project_id,
           id,
@@ -585,7 +585,7 @@ export class PgAuthStorage implements AuthStorage {
           ${input.createdAt}
         )
         RETURNING *
-      `) as PgAuthUserRow[]
+      `
 
       return rowToUserRecord(row)
     } catch (error) {
@@ -598,7 +598,7 @@ export class PgAuthStorage implements AuthStorage {
   }
 
   private async acceptInvitationAndApplyGroups(
-    sql: SQL,
+    sql: SQLClient,
     input: {
       readonly activeInvitation: InvitationRecord | null
       readonly completedAt: Date
@@ -645,7 +645,7 @@ export class PgAuthStorage implements AuthStorage {
   }
 
   private async applyManualGroups(
-    sql: SQL,
+    sql: SQLClient,
     input: {
       readonly completedAt: Date
       readonly existing: readonly GroupMembershipRecord[]
@@ -672,7 +672,7 @@ export class PgAuthStorage implements AuthStorage {
   }
 
   private async createSignInSession(
-    sql: SQL,
+    sql: SQLClient,
     input: {
       readonly projectId: string
       readonly strategyId: string
@@ -701,7 +701,7 @@ export class PgAuthStorage implements AuthStorage {
     input: CompleteOidcSignInInput,
     completedAt: Date,
     projectId: string,
-    sql: SQL
+    sql: SQLClient
   ): Promise<void> {
     await consumeOidcAttempt(sql, {
       projectId,
@@ -712,7 +712,7 @@ export class PgAuthStorage implements AuthStorage {
   }
 
   private async upsertIdentity(
-    sql: SQL,
+    sql: SQLClient,
     input: {
       readonly projectId: string
       readonly strategyId: string
@@ -723,7 +723,7 @@ export class PgAuthStorage implements AuthStorage {
       readonly updatedAt: Date
     }
   ): Promise<UserIdentityRecord> {
-    const [row] = (await sql`
+    const [row] = await sql<PgAuthUserIdentityRow[]>`
       INSERT INTO auth_user_identities (
         project_id,
         strategy_id,
@@ -747,13 +747,13 @@ export class PgAuthStorage implements AuthStorage {
         claims = excluded.claims,
         updated_at = excluded.updated_at
       RETURNING *
-    `) as PgAuthUserIdentityRow[]
+    `
 
     return rowToIdentityRecord(row)
   }
 }
 
-async function hasActiveUsers(sql: SQL, projectId: string): Promise<boolean> {
+async function hasActiveUsers(sql: SQLClient, projectId: string): Promise<boolean> {
   const rows = (await sql`
     SELECT 1 AS active
     FROM auth_users

--- a/storage/pg/src/auth-storage/group-memberships.ts
+++ b/storage/pg/src/auth-storage/group-memberships.ts
@@ -3,7 +3,7 @@ import type {
   GroupMembershipRecord,
   UpsertAuthGroupMembershipInput,
 } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL } from "../pg-client"
 import type { PgAuthGroupMembershipRow } from "./rows"
 import { rowToGroupMembershipRecord } from "./rows"
 import { listMembershipsForUser, upsertGroupMembership } from "./shared"
@@ -26,13 +26,13 @@ export class PgAuthGroupMembershipStore implements AuthGroupMembershipStore {
     readonly projectId: string
     readonly groupId: string
   }): Promise<readonly GroupMembershipRecord[]> {
-    const rows = (await this.sql`
+    const rows = await this.sql<PgAuthGroupMembershipRow[]>`
       SELECT *
       FROM auth_group_memberships
       WHERE project_id = ${params.projectId}
         AND group_id = ${params.groupId}
       ORDER BY user_id ASC
-    `) as PgAuthGroupMembershipRow[]
+    `
 
     return rows.map(rowToGroupMembershipRecord)
   }

--- a/storage/pg/src/auth-storage/identities.ts
+++ b/storage/pg/src/auth-storage/identities.ts
@@ -3,7 +3,7 @@ import type {
   UpsertAuthUserIdentityInput,
   UserIdentityRecord,
 } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL } from "../pg-client"
 import type { PgAuthUserIdentityRow } from "./rows"
 import { rowToIdentityRecord, serializeOptionalRecord } from "./rows"
 import { assertNonEmpty, dateOrNow, getIdentityRowBySubject, requireUserById } from "./shared"
@@ -30,7 +30,7 @@ export class PgAuthUserIdentityStore implements AuthUserIdentityStore {
 
     await requireUserById(this.sql, { projectId, id: userId })
 
-    const [row] = (await this.sql`
+    const [row] = await this.sql<PgAuthUserIdentityRow[]>`
       INSERT INTO auth_user_identities (
         project_id,
         strategy_id,
@@ -54,7 +54,7 @@ export class PgAuthUserIdentityStore implements AuthUserIdentityStore {
         claims = excluded.claims,
         updated_at = excluded.updated_at
       RETURNING *
-    `) as PgAuthUserIdentityRow[]
+    `
 
     return rowToIdentityRecord(row)
   }
@@ -72,13 +72,13 @@ export class PgAuthUserIdentityStore implements AuthUserIdentityStore {
     readonly projectId: string
     readonly userId: string
   }): Promise<readonly UserIdentityRecord[]> {
-    const rows = (await this.sql`
+    const rows = await this.sql<PgAuthUserIdentityRow[]>`
       SELECT *
       FROM auth_user_identities
       WHERE project_id = ${params.projectId}
         AND user_id = ${params.userId}
       ORDER BY created_at ASC, strategy_id ASC, subject ASC
-    `) as PgAuthUserIdentityRow[]
+    `
 
     return rows.map(rowToIdentityRecord)
   }

--- a/storage/pg/src/auth-storage/invitations.ts
+++ b/storage/pg/src/auth-storage/invitations.ts
@@ -6,7 +6,7 @@ import type {
   ListAuthInvitationsResult,
 } from "@sixb/core"
 import { AuthStorageError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL, SQLClient } from "../pg-client"
 import { authLockKey, lockAdvisoryKeys, runPgTransaction } from "../transactions"
 import type { PgAuthInvitationRow } from "./rows"
 import { rowToInvitationRecord } from "./rows"
@@ -179,10 +179,10 @@ export class PgAuthInvitationStore implements AuthInvitationStore {
 
     const where = `WHERE ${whereClauses.join(" AND ")}`
     const order = input.order === "asc" ? "ASC" : "DESC"
-    const [totalRow] = (await this.sql.unsafe(
+    const [totalRow] = await this.sql.unsafe<{ readonly count: string | number }[]>(
       `SELECT COUNT(*)::bigint AS count FROM auth_invitations ${where}`,
       [...params]
-    )) as { readonly count: string | number }[]
+    )
 
     const queryParams = [...params]
     const query = appendPagination(
@@ -196,7 +196,7 @@ export class PgAuthInvitationStore implements AuthInvitationStore {
       nextIndex,
       input
     )
-    const rows = (await this.sql.unsafe(query, queryParams)) as PgAuthInvitationRow[]
+    const rows = await this.sql.unsafe<PgAuthInvitationRow[]>(query, queryParams)
     const invitations = await Promise.all(
       rows.map(async (row) =>
         rowToInvitationRecord(
@@ -260,7 +260,7 @@ export class PgAuthInvitationStore implements AuthInvitationStore {
   }
 
   private async validateCreator(
-    sql: SQL,
+    sql: SQLClient,
     projectId: string,
     input: CreateOrUpdateAuthInvitationInput
   ): Promise<void> {

--- a/storage/pg/src/auth-storage/magic-links.ts
+++ b/storage/pg/src/auth-storage/magic-links.ts
@@ -1,6 +1,6 @@
 import type { AuthMagicLinkStore, CreateAuthMagicLinkInput, MagicLinkRecord } from "@sixb/core"
 import { AuthStorageError, resolveAuthSessionAudience } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL } from "../pg-client"
 import { authLockKey, lockAdvisoryKeys, runPgTransaction } from "../transactions"
 import type { PgAuthMagicLinkRow } from "./rows"
 import { rowToMagicLinkRecord } from "./rows"
@@ -42,7 +42,7 @@ export class PgAuthMagicLinkStore implements AuthMagicLinkStore {
       })
 
       try {
-        const [row] = (await tx`
+        const [row] = await tx<PgAuthMagicLinkRow[]>`
           INSERT INTO auth_magic_links (
             project_id,
             id,
@@ -65,7 +65,7 @@ export class PgAuthMagicLinkStore implements AuthMagicLinkStore {
             ${input.expiresAt}
           )
           RETURNING *
-        `) as PgAuthMagicLinkRow[]
+        `
 
         return rowToMagicLinkRecord(row)
       } catch (error) {
@@ -90,7 +90,7 @@ export class PgAuthMagicLinkStore implements AuthMagicLinkStore {
     readonly email: string
     readonly now: Date
   }): Promise<MagicLinkRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<PgAuthMagicLinkRow[]>`
       SELECT *
       FROM auth_magic_links
       WHERE project_id = ${params.projectId}
@@ -100,7 +100,7 @@ export class PgAuthMagicLinkStore implements AuthMagicLinkStore {
         AND expires_at > ${params.now}
       ORDER BY created_at DESC, id DESC
       LIMIT 1
-    `) as PgAuthMagicLinkRow[]
+    `
 
     return row ? rowToMagicLinkRecord(row) : null
   }

--- a/storage/pg/src/auth-storage/oidc-attempts.ts
+++ b/storage/pg/src/auth-storage/oidc-attempts.ts
@@ -4,7 +4,7 @@ import type {
   OidcAuthorizationAttemptRecord,
 } from "@sixb/core"
 import { AuthStorageError, resolveAuthSessionAudience } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL } from "../pg-client"
 import { runPgTransaction } from "../transactions"
 import type { PgAuthOidcAttemptRow } from "./rows"
 import { rowToOidcAuthorizationAttemptRecord } from "./rows"
@@ -38,7 +38,7 @@ export class PgAuthOidcAuthorizationAttemptStore implements AuthOidcAuthorizatio
     }
 
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<PgAuthOidcAttemptRow[]>`
         INSERT INTO auth_oidc_authorization_attempts (
           project_id,
           id,
@@ -63,7 +63,7 @@ export class PgAuthOidcAuthorizationAttemptStore implements AuthOidcAuthorizatio
           ${input.expiresAt}
         )
         RETURNING *
-      `) as PgAuthOidcAttemptRow[]
+      `
 
       return rowToOidcAuthorizationAttemptRecord(row)
     } catch (error) {

--- a/storage/pg/src/auth-storage/sessions.ts
+++ b/storage/pg/src/auth-storage/sessions.ts
@@ -1,6 +1,6 @@
 import type { AuthSessionStore, CreateAuthSessionInput, SessionRecord } from "@sixb/core"
 import { AuthStorageError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL } from "../pg-client"
 import { authLockKey, lockAdvisoryKeys, runPgTransaction } from "../transactions"
 import type { PgAuthSessionRow } from "./rows"
 import { rowToSessionRecord } from "./rows"
@@ -38,7 +38,7 @@ export class PgAuthSessionStore implements AuthSessionStore {
     readonly audience: string
     readonly now: Date
   }): Promise<SessionRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<PgAuthSessionRow[]>`
       SELECT *
       FROM auth_sessions
       WHERE project_id = ${params.projectId}
@@ -48,7 +48,7 @@ export class PgAuthSessionStore implements AuthSessionStore {
         AND expires_at > ${params.now}
       ORDER BY created_at DESC, id DESC
       LIMIT 1
-    `) as PgAuthSessionRow[]
+    `
 
     return row ? rowToSessionRecord(row) : null
   }
@@ -90,13 +90,13 @@ export class PgAuthSessionStore implements AuthSessionStore {
         )
       }
 
-      const [row] = (await tx`
+      const [row] = await tx<PgAuthSessionRow[]>`
         UPDATE auth_sessions
         SET revoked_at = ${params.revokedAt}
         WHERE project_id = ${params.projectId}
           AND id = ${params.id}
         RETURNING *
-      `) as PgAuthSessionRow[]
+      `
 
       return rowToSessionRecord(row)
     })
@@ -126,13 +126,13 @@ export class PgAuthSessionStore implements AuthSessionStore {
     return runPgTransaction(this.sql, async (tx) => {
       await requireSessionById(tx, params)
 
-      const [row] = (await tx`
+      const [row] = await tx<PgAuthSessionRow[]>`
         UPDATE auth_sessions
         SET last_seen_at = ${params.lastSeenAt}
         WHERE project_id = ${params.projectId}
           AND id = ${params.id}
         RETURNING *
-      `) as PgAuthSessionRow[]
+      `
 
       return rowToSessionRecord(row)
     })

--- a/storage/pg/src/auth-storage/shared.ts
+++ b/storage/pg/src/auth-storage/shared.ts
@@ -11,7 +11,7 @@ import type {
   UserRecord,
 } from "@sixb/core"
 import { AuthStorageError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQLClient } from "../pg-client"
 import { isUniqueViolation } from "../storage-errors"
 import type {
   PgAuthGroupMembershipRow,
@@ -83,11 +83,11 @@ export function placeholders(startIndex: number, count: number): readonly string
 }
 
 export async function getUserRowById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<PgAuthUserRow | null> {
-  const [row] = (await sql.unsafe(
+  const [row] = await sql.unsafe<PgAuthUserRow[]>(
     `
       SELECT *
       FROM auth_users
@@ -96,13 +96,13 @@ export async function getUserRowById(
       ${options.forUpdate ? "FOR UPDATE" : ""}
     `,
     [params.projectId, params.id]
-  )) as PgAuthUserRow[]
+  )
 
   return row ?? null
 }
 
 export async function getUserById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string }
 ): Promise<UserRecord | null> {
   const row = await getUserRowById(sql, params)
@@ -110,11 +110,11 @@ export async function getUserById(
 }
 
 export async function getUserRowByEmail(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly email: string },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<PgAuthUserRow | null> {
-  const [row] = (await sql.unsafe(
+  const [row] = await sql.unsafe<PgAuthUserRow[]>(
     `
       SELECT *
       FROM auth_users
@@ -123,13 +123,13 @@ export async function getUserRowByEmail(
       ${options.forUpdate ? "FOR UPDATE" : ""}
     `,
     [params.projectId, normalizeEmail(params.email)]
-  )) as PgAuthUserRow[]
+  )
 
   return row ?? null
 }
 
 export async function getUserByEmail(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly email: string }
 ): Promise<UserRecord | null> {
   const row = await getUserRowByEmail(sql, params)
@@ -137,7 +137,7 @@ export async function getUserByEmail(
 }
 
 export async function requireUserById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string }
 ): Promise<UserRecord> {
   const user = await getUserById(sql, params)
@@ -151,7 +151,7 @@ export async function requireUserById(
 }
 
 export async function getIdentityRowBySubject(
-  sql: SQL,
+  sql: SQLClient,
   params: {
     readonly projectId: string
     readonly strategyId: string
@@ -159,7 +159,7 @@ export async function getIdentityRowBySubject(
   },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<PgAuthUserIdentityRow | null> {
-  const [row] = (await sql.unsafe(
+  const [row] = await sql.unsafe<PgAuthUserIdentityRow[]>(
     `
       SELECT *
       FROM auth_user_identities
@@ -169,17 +169,17 @@ export async function getIdentityRowBySubject(
       ${options.forUpdate ? "FOR UPDATE" : ""}
     `,
     [params.projectId, params.strategyId, params.subject]
-  )) as PgAuthUserIdentityRow[]
+  )
 
   return row ?? null
 }
 
 export async function getSessionRowById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<PgAuthSessionRow | null> {
-  const [row] = (await sql.unsafe(
+  const [row] = await sql.unsafe<PgAuthSessionRow[]>(
     `
       SELECT *
       FROM auth_sessions
@@ -188,13 +188,13 @@ export async function getSessionRowById(
       ${options.forUpdate ? "FOR UPDATE" : ""}
     `,
     [params.projectId, params.id]
-  )) as PgAuthSessionRow[]
+  )
 
   return row ?? null
 }
 
 export async function getSessionById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string }
 ): Promise<ReturnType<typeof rowToSessionRecord> | null> {
   const row = await getSessionRowById(sql, params)
@@ -202,7 +202,7 @@ export async function getSessionById(
 }
 
 export async function requireSessionById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string }
 ): Promise<ReturnType<typeof rowToSessionRecord>> {
   const session = await getSessionById(sql, params)
@@ -216,7 +216,7 @@ export async function requireSessionById(
 }
 
 export async function getInvitationGroupIds(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly invitationId: string }
 ): Promise<readonly string[]> {
   const rows = (await sql`
@@ -231,11 +231,11 @@ export async function getInvitationGroupIds(
 }
 
 export async function getInvitationById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<InvitationRecord | null> {
-  const [row] = (await sql.unsafe(
+  const [row] = await sql.unsafe<PgAuthInvitationRow[]>(
     `
       SELECT *
       FROM auth_invitations
@@ -244,13 +244,13 @@ export async function getInvitationById(
       ${options.forUpdate ? "FOR UPDATE" : ""}
     `,
     [params.projectId, params.id]
-  )) as PgAuthInvitationRow[]
+  )
 
   return row ? invitationRowToRecord(sql, row) : null
 }
 
 export async function requireInvitationById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<InvitationRecord> {
@@ -265,11 +265,11 @@ export async function requireInvitationById(
 }
 
 export async function getActiveInvitationByEmail(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly email: string; readonly now: Date },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<InvitationRecord | null> {
-  const [row] = (await sql.unsafe(
+  const [row] = await sql.unsafe<PgAuthInvitationRow[]>(
     `
       SELECT *
       FROM auth_invitations
@@ -282,13 +282,13 @@ export async function getActiveInvitationByEmail(
       ${options.forUpdate ? "FOR UPDATE" : ""}
     `,
     [params.projectId, normalizeEmail(params.email), params.now]
-  )) as PgAuthInvitationRow[]
+  )
 
   return row ? invitationRowToRecord(sql, row) : null
 }
 
 export async function replaceInvitationGroups(
-  sql: SQL,
+  sql: SQLClient,
   params: {
     readonly projectId: string
     readonly invitationId: string
@@ -319,11 +319,11 @@ export async function replaceInvitationGroups(
 }
 
 export async function getMagicLinkRowById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<PgAuthMagicLinkRow | null> {
-  const [row] = (await sql.unsafe(
+  const [row] = await sql.unsafe<PgAuthMagicLinkRow[]>(
     `
       SELECT *
       FROM auth_magic_links
@@ -332,13 +332,13 @@ export async function getMagicLinkRowById(
       ${options.forUpdate ? "FOR UPDATE" : ""}
     `,
     [params.projectId, params.id]
-  )) as PgAuthMagicLinkRow[]
+  )
 
   return row ?? null
 }
 
 export async function getMagicLinkById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string }
 ): Promise<MagicLinkRecord | null> {
   const row = await getMagicLinkRowById(sql, params)
@@ -346,7 +346,7 @@ export async function getMagicLinkById(
 }
 
 export async function consumeMagicLink(
-  sql: SQL,
+  sql: SQLClient,
   params: {
     readonly projectId: string
     readonly id: string
@@ -382,11 +382,11 @@ export async function consumeMagicLink(
 }
 
 export async function getOidcAttemptRowById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string },
   options: { readonly forUpdate?: boolean } = {}
 ): Promise<PgAuthOidcAttemptRow | null> {
-  const [row] = (await sql.unsafe(
+  const [row] = await sql.unsafe<PgAuthOidcAttemptRow[]>(
     `
       SELECT *
       FROM auth_oidc_authorization_attempts
@@ -395,13 +395,13 @@ export async function getOidcAttemptRowById(
       ${options.forUpdate ? "FOR UPDATE" : ""}
     `,
     [params.projectId, params.id]
-  )) as PgAuthOidcAttemptRow[]
+  )
 
   return row ?? null
 }
 
 export async function getOidcAttemptById(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly id: string }
 ): Promise<OidcAuthorizationAttemptRecord | null> {
   const row = await getOidcAttemptRowById(sql, params)
@@ -409,7 +409,7 @@ export async function getOidcAttemptById(
 }
 
 export async function consumeOidcAttempt(
-  sql: SQL,
+  sql: SQLClient,
   params: {
     readonly projectId: string
     readonly id: string
@@ -445,7 +445,7 @@ export async function consumeOidcAttempt(
 }
 
 export async function validateCompleteSessionInput(
-  sql: SQL,
+  sql: SQLClient,
   projectId: string,
   session: CompleteAuthSessionInput
 ): Promise<void> {
@@ -456,7 +456,7 @@ export async function validateCompleteSessionInput(
 }
 
 export async function assertSessionIdAvailable(
-  sql: SQL,
+  sql: SQLClient,
   projectId: string,
   sessionId: string
 ): Promise<void> {
@@ -469,7 +469,7 @@ export async function assertSessionIdAvailable(
 }
 
 export async function createSession(
-  sql: SQL,
+  sql: SQLClient,
   input: CreateAuthSessionInput
 ): Promise<SessionRecord> {
   const id = assertNonEmpty(input.id, "Session id")
@@ -489,7 +489,7 @@ export async function createSession(
   })
 
   try {
-    const [row] = (await sql`
+    const [row] = await sql<PgAuthSessionRow[]>`
       INSERT INTO auth_sessions (
         project_id,
         id,
@@ -510,7 +510,7 @@ export async function createSession(
         ${input.expiresAt}
       )
       RETURNING *
-    `) as PgAuthSessionRow[]
+    `
 
     return rowToSessionRecord(row)
   } catch (error) {
@@ -523,7 +523,7 @@ export async function createSession(
 }
 
 export async function revokeActiveSessionsForUser(
-  sql: SQL,
+  sql: SQLClient,
   params: {
     readonly projectId: string
     readonly userId: string
@@ -533,7 +533,7 @@ export async function revokeActiveSessionsForUser(
 ): Promise<readonly SessionRecord[]> {
   const rows =
     params.audience === undefined
-      ? ((await sql`
+      ? await sql<PgAuthSessionRow[]>`
       SELECT *
       FROM auth_sessions
       WHERE project_id = ${params.projectId}
@@ -542,8 +542,8 @@ export async function revokeActiveSessionsForUser(
         AND expires_at > ${params.revokedAt}
       ORDER BY created_at ASC, id ASC
       FOR UPDATE
-    `) as PgAuthSessionRow[])
-      : ((await sql`
+    `
+      : await sql<PgAuthSessionRow[]>`
       SELECT *
       FROM auth_sessions
       WHERE project_id = ${params.projectId}
@@ -553,7 +553,7 @@ export async function revokeActiveSessionsForUser(
         AND expires_at > ${params.revokedAt}
       ORDER BY created_at ASC, id ASC
       FOR UPDATE
-    `) as PgAuthSessionRow[])
+    `
 
   if (params.audience === undefined) {
     await sql`
@@ -585,7 +585,7 @@ export async function revokeActiveSessionsForUser(
 }
 
 export async function upsertGroupMembership(
-  sql: SQL,
+  sql: SQLClient,
   input: UpsertAuthGroupMembershipInput
 ): Promise<GroupMembershipRecord> {
   const projectId = assertNonEmpty(input.projectId, "Project id")
@@ -622,41 +622,41 @@ export async function upsertGroupMembership(
 }
 
 export async function getGroupMembership(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly userId: string; readonly groupId: string }
 ): Promise<GroupMembershipRecord | null> {
-  const [row] = (await sql`
+  const [row] = await sql<PgAuthGroupMembershipRow[]>`
     SELECT *
     FROM auth_group_memberships
     WHERE project_id = ${params.projectId}
       AND user_id = ${params.userId}
       AND group_id = ${params.groupId}
-  `) as PgAuthGroupMembershipRow[]
+  `
 
   return row ? rowToGroupMembershipRecord(row) : null
 }
 
 export async function listMembershipsForUser(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly userId: string }
 ): Promise<readonly GroupMembershipRecord[]> {
-  const rows = (await sql`
+  const rows = await sql<PgAuthGroupMembershipRow[]>`
     SELECT *
     FROM auth_group_memberships
     WHERE project_id = ${params.projectId}
       AND user_id = ${params.userId}
     ORDER BY group_id ASC
-  `) as PgAuthGroupMembershipRow[]
+  `
 
   return rows.map(rowToGroupMembershipRecord)
 }
 
 export async function revokeActiveMagicLinksForEmail(
-  sql: SQL,
+  sql: SQLClient,
   params: { readonly projectId: string; readonly email: string; readonly revokedAt: Date }
 ): Promise<readonly MagicLinkRecord[]> {
   const email = normalizeEmail(params.email)
-  const rows = (await sql`
+  const rows = await sql<PgAuthMagicLinkRow[]>`
     SELECT *
     FROM auth_magic_links
     WHERE project_id = ${params.projectId}
@@ -666,7 +666,7 @@ export async function revokeActiveMagicLinksForEmail(
       AND expires_at > ${params.revokedAt}
     ORDER BY created_at ASC, id ASC
     FOR UPDATE
-  `) as PgAuthMagicLinkRow[]
+  `
 
   await sql`
     UPDATE auth_magic_links
@@ -761,7 +761,7 @@ export function mapUniqueConstraintError(
 }
 
 async function invitationRowToRecord(
-  sql: SQL,
+  sql: SQLClient,
   row: PgAuthInvitationRow
 ): Promise<InvitationRecord> {
   return rowToInvitationRecord(

--- a/storage/pg/src/auth-storage/users.ts
+++ b/storage/pg/src/auth-storage/users.ts
@@ -8,7 +8,7 @@ import type {
   UserRecord,
 } from "@sixb/core"
 import { AuthStorageError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL } from "../pg-client"
 import type { PgAuthUserRow } from "./rows"
 import { rowToUserRecord } from "./rows"
 import {
@@ -49,7 +49,7 @@ export class PgAuthUserStore implements AuthUserStore {
     const updatedAt = input.updatedAt ? new Date(input.updatedAt) : createdAt
 
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<PgAuthUserRow[]>`
         INSERT INTO auth_users (
           project_id,
           id,
@@ -70,7 +70,7 @@ export class PgAuthUserStore implements AuthUserStore {
           ${updatedAt}
         )
         RETURNING *
-      `) as PgAuthUserRow[]
+      `
 
       return rowToUserRecord(row)
     } catch (error) {
@@ -112,7 +112,7 @@ export class PgAuthUserStore implements AuthUserStore {
     }
 
     const updatedAt = dateOrNow(input.updatedAt)
-    const [row] = (await this.sql`
+    const [row] = await this.sql<PgAuthUserRow[]>`
       UPDATE auth_users
       SET display_name = ${input.displayName ?? null},
           avatar_url = ${input.avatarUrl ?? null},
@@ -120,7 +120,7 @@ export class PgAuthUserStore implements AuthUserStore {
       WHERE project_id = ${input.projectId}
         AND id = ${input.id}
       RETURNING *
-    `) as PgAuthUserRow[]
+    `
 
     return rowToUserRecord(row)
   }
@@ -139,14 +139,14 @@ export class PgAuthUserStore implements AuthUserStore {
     }
 
     const updatedAt = dateOrNow(input.updatedAt)
-    const [row] = (await this.sql`
+    const [row] = await this.sql<PgAuthUserRow[]>`
       UPDATE auth_users
       SET status = ${input.status},
           updated_at = ${updatedAt}
       WHERE project_id = ${input.projectId}
         AND id = ${input.id}
       RETURNING *
-    `) as PgAuthUserRow[]
+    `
 
     return rowToUserRecord(row)
   }
@@ -167,10 +167,10 @@ export class PgAuthUserStore implements AuthUserStore {
 
     const where = `WHERE ${whereClauses.join(" AND ")}`
     const order = input.order === "asc" ? "ASC" : "DESC"
-    const [totalRow] = (await this.sql.unsafe(
+    const [totalRow] = await this.sql.unsafe<{ readonly count: string | number }[]>(
       `SELECT COUNT(*)::bigint AS count FROM auth_users ${where}`,
       [...params]
-    )) as { readonly count: string | number }[]
+    )
 
     const queryParams = [...params]
     const query = appendPagination(
@@ -184,7 +184,7 @@ export class PgAuthUserStore implements AuthUserStore {
       nextIndex,
       input
     )
-    const rows = (await this.sql.unsafe(query, queryParams)) as PgAuthUserRow[]
+    const rows = await this.sql.unsafe<PgAuthUserRow[]>(query, queryParams)
     const total = Number(totalRow?.count ?? 0)
 
     return {

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -3,10 +3,10 @@
 /// <reference path="./sql.d.ts" />
 
 import type { MigrationCapableStorage, StorageMigrator } from "@sixb/core"
-import { SQL } from "bun"
-import { createPostgresStorageMigrators, dropSchema, quoteIdent } from "./migrations"
+import { createPostgresStorageMigrators, dropSchema } from "./migrations"
 import { PgActionRunStorage } from "./pg-action-run-storage"
 import { PgAuthStorage } from "./pg-auth-storage"
+import { createPgClient, type SQL } from "./pg-client"
 import { PgObjectStorage } from "./pg-object-storage"
 import { PgPipelineRunStorage } from "./pg-pipeline-run-storage"
 import { PgProjectionRunStorage } from "./pg-projection-run-storage"
@@ -38,6 +38,39 @@ export interface PostgresStorageOptions {
   /** Idle connection timeout in milliseconds. Defaults to 30000. */
   idleTimeoutMillis?: number
 
+  /**
+   * Server-side `statement_timeout` (ms) applied to every connection in the pool. A query
+   * exceeding it is cancelled by PostgreSQL, which frees its pooled connection instead of
+   * pinning it indefinitely. Without this, a single stalled query can starve a small pool
+   * until the process is restarted. Unset by default (no timeout). Set per role — keep it
+   * generous or unset for workers that run long migrations/bulk writes.
+   */
+  statementTimeoutMillis?: number
+  /**
+   * Server-side `idle_in_transaction_session_timeout` (ms) applied to every connection. A
+   * transaction left open and idle beyond it is aborted by PostgreSQL, releasing the
+   * connection. Unset by default (no timeout).
+   */
+  idleInTransactionSessionTimeoutMillis?: number
+
+  /**
+   * Grace period (ms) for {@link PostgresStorage.close}. On shutdown the pool stops
+   * accepting new queries and waits up to this long for in-flight queries to finish before
+   * destroying the connections, so a restart drains cleanly instead of severing live work.
+   * Defaults to 5000.
+   */
+  shutdownTimeoutMillis?: number
+
+  /** Seconds to wait when establishing a connection. Defaults to 10000. */
+  connectTimeoutMillis?: number
+  /**
+   * Whether to use server-side prepared statements (porsager's default, faster against a
+   * direct Postgres connection). Behind PgBouncer transaction mode they require PgBouncer
+   * >= 1.21 with `max_prepared_statements > 0`; set `false` for an older PgBouncer or when
+   * that setting is 0. Defaults to `true`.
+   */
+  prepare?: boolean
+
   /** PostgreSQL schema name for all Sixb tables. Defaults to 'sixb'. */
   schemaName?: string
 
@@ -48,8 +81,8 @@ export interface PostgresStorageOptions {
 /**
  * PostgreSQL storage provider for Sixb.
  *
- * Bundles Sixb storage adapters backed by a shared PostgreSQL connection pool using Bun's
- * native SQL client.
+ * Bundles Sixb storage adapters backed by a shared PostgreSQL connection pool (porsager
+ * `postgres`), which reliably reclaims connections under load.
  *
  * The storage exposes a core `StorageMigrator`. Sixb CLI startup and
  * `sixb db migrate` run it automatically through `migrateStorage(storage)`.
@@ -83,49 +116,45 @@ export class PostgresStorage implements MigrationCapableStorage {
 
   private readonly sql: SQL
   private readonly schemaName: string
+  private readonly shutdownTimeoutSeconds: number
 
   constructor(options: PostgresStorageOptions) {
     this.schemaName = options.schemaName ?? "sixb"
-
-    const quotedSchemaName = quoteIdent(this.schemaName)
-
-    // Build connection URL — either from connectionString or individual fields.
-    // search_path is set via PostgreSQL's standard `options` connection parameter,
-    // which applies at the wire-protocol level to every connection in the pool.
-    let url: URL
-    if (options.connectionString) {
-      url = new URL(options.connectionString)
-    } else {
-      const host = options.host ?? "localhost"
-      const port = options.port ?? 5432
-      const db = options.database ?? ""
-      url = new URL(`postgres://${host}:${port}/${db}`)
-      if (options.user) url.username = options.user
-      if (options.password) url.password = options.password
-    }
-
-    const existingOptions = url.searchParams.get("options") ?? ""
-    const searchPathOption = `-csearch_path=${quotedSchemaName}`
-    url.searchParams.set(
-      "options",
-      existingOptions ? `${existingOptions} ${searchPathOption}` : searchPathOption
+    this.shutdownTimeoutSeconds = Math.max(
+      1,
+      Math.round((options.shutdownTimeoutMillis ?? 5000) / 1000)
     )
 
-    const sqlOptions: Record<string, unknown> = {
-      url: url.toString(),
+    this.sql = createPgClient({
+      ...(options.connectionString !== undefined
+        ? { connectionString: options.connectionString }
+        : {}),
+      ...(options.host !== undefined ? { host: options.host } : {}),
+      ...(options.port !== undefined ? { port: options.port } : {}),
+      ...(options.database !== undefined ? { database: options.database } : {}),
+      ...(options.user !== undefined ? { user: options.user } : {}),
+      ...(options.password !== undefined ? { password: options.password } : {}),
       max: options.max ?? 10,
-      idleTimeout: options.idleTimeoutMillis ? Math.round(options.idleTimeoutMillis / 1000) : 30,
-    }
-
-    if (options.ssl) {
-      if (typeof options.ssl === "string") {
-        sqlOptions.ssl = options.ssl
-      } else {
-        sqlOptions.tls = true
-      }
-    }
-
-    this.sql = new SQL(sqlOptions)
+      schemaName: this.schemaName,
+      ...(options.idleTimeoutMillis !== undefined
+        ? { idleTimeoutMillis: options.idleTimeoutMillis }
+        : {}),
+      ...(resolveTimeoutMillis(options.statementTimeoutMillis, "statementTimeoutMillis") !==
+      undefined
+        ? { statementTimeoutMillis: options.statementTimeoutMillis }
+        : {}),
+      ...(resolveTimeoutMillis(
+        options.idleInTransactionSessionTimeoutMillis,
+        "idleInTransactionSessionTimeoutMillis"
+      ) !== undefined
+        ? { idleInTransactionSessionTimeoutMillis: options.idleInTransactionSessionTimeoutMillis }
+        : {}),
+      ...(resolveTimeoutMillis(options.connectTimeoutMillis, "connectTimeoutMillis") !== undefined
+        ? { connectTimeoutMillis: options.connectTimeoutMillis }
+        : {}),
+      ...(options.prepare !== undefined ? { prepare: options.prepare } : {}),
+      ...(options.ssl !== undefined ? { ssl: options.ssl } : {}),
+    })
 
     this.migrators = createPostgresStorageMigrators(this.sql, this.schemaName)
     this.objects = new PgObjectStorage(this.sql)
@@ -144,9 +173,12 @@ export class PostgresStorage implements MigrationCapableStorage {
 
   /**
    * Close the connection pool. Should be called on shutdown.
+   *
+   * Stops accepting new queries and waits up to `shutdownTimeoutMillis` for in-flight
+   * queries to finish before destroying connections.
    */
   async close(): Promise<void> {
-    await this.sql.close()
+    await this.sql.end({ timeout: this.shutdownTimeoutSeconds })
   }
 
   /**
@@ -156,6 +188,18 @@ export class PostgresStorage implements MigrationCapableStorage {
   async dropSchema(): Promise<void> {
     await dropSchema(this.sql, this.schemaName)
   }
+}
+
+function resolveTimeoutMillis(value: number | undefined, label: string): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`[Sixb] PostgresStorage ${label} must be a non-negative finite number.`)
+  }
+
+  return Math.trunc(value)
 }
 
 export type { PostgresMigrationContext } from "./migrations"

--- a/storage/pg/src/latest-run-query.ts
+++ b/storage/pg/src/latest-run-query.ts
@@ -1,4 +1,4 @@
-import type { SQL } from "bun"
+import type { SQL, SqlParameter } from "./pg-client"
 
 type PgLatestRunTarget =
   | { readonly tableName: "pipeline_runs"; readonly ownerColumn: "pipeline_id" }
@@ -22,15 +22,15 @@ export async function queryLatestRunsByOwnerId<TRow>(
   }
 
   const placeholders = ownerIds.map((_, index) => `$${index + 2}`).join(", ")
-  const rows = (await input.sql.unsafe(
+  const rows = await input.sql.unsafe<TRow[]>(
     `
       SELECT DISTINCT ON (${input.ownerColumn}) ${input.selectList ?? "*"}
       FROM ${input.tableName}
       WHERE project_id = $1 AND ${input.ownerColumn} IN (${placeholders})
       ORDER BY ${input.ownerColumn}, started_at DESC, id DESC
     `,
-    [input.projectId, ...ownerIds]
-  )) as TRow[]
+    [input.projectId, ...ownerIds] as SqlParameter[]
+  )
 
   const latestByOwnerId = new Map(rows.map((row) => [input.ownerIdFor(row), row]))
 

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -8,8 +8,8 @@ import type {
   StorageMigrator,
 } from "@sixb/core"
 import { defineMigrations, planMigrationSet, runMigrationSet, step } from "@sixb/core"
-import type { SQL } from "bun"
 import initialSchemaSql from "./migrations/001-initial-schema.sql" with { type: "text" }
+import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
   exec(sqlText: string): Promise<void>
@@ -98,8 +98,8 @@ function postgresMigrationSession(
   const schema = quoteIdent(schemaName)
   const migrationsTable = `${schema}.sixb_migrations`
   // Migration steps receive a stable context; route exec() through the active transaction.
-  let active: SQL | null = null
-  const connection = () => active ?? sql
+  let active: SQLClient | null = null
+  const connection = (): SQLClient => active ?? sql
 
   return {
     context: {
@@ -125,10 +125,10 @@ function postgresMigrationSession(
         `)
       },
       async readHistory(adapterId) {
-        const rows = (await sql.unsafe(
+        const rows = await sql.unsafe<PostgresMigrationRow[]>(
           `SELECT * FROM ${migrationsTable} WHERE adapter_id = $1 ORDER BY version`,
           [adapterId]
-        )) as PostgresMigrationRow[]
+        )
         return rows.map(rowToMigrationRecord)
       },
       async markStarted(adapterId, migration, at) {
@@ -158,17 +158,23 @@ function postgresMigrationSession(
         )
       },
       async transaction(run) {
-        return sql.begin(async (tx) => {
-          const previous = active
-          active = tx
-
-          try {
-            await tx.unsafe(`SET LOCAL search_path TO ${schema}`)
-            return await run()
-          } finally {
-            active = previous
-          }
-        })
+        // `sql` is the reserved connection holding the migration advisory lock. porsager's
+        // reserved connection has no `.begin`, so drive the transaction manually on it and
+        // route exec()/markStarted()/markApplied() through the same connection via `active`.
+        const previous = active
+        active = sql
+        await sql.unsafe("BEGIN")
+        try {
+          await sql.unsafe(`SET LOCAL search_path TO ${schema}`)
+          const result = await run()
+          await sql.unsafe("COMMIT")
+          return result
+        } catch (error) {
+          await sql.unsafe("ROLLBACK")
+          throw error
+        } finally {
+          active = previous
+        }
       },
     },
   }

--- a/storage/pg/src/pg-action-run-storage.ts
+++ b/storage/pg/src/pg-action-run-storage.ts
@@ -10,14 +10,15 @@ import type {
   StartActionRunInput,
 } from "@sixb/core"
 import { ActionRunError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL, SqlParameter } from "./pg-client"
+import { isUniqueViolation } from "./storage-errors"
 
 export class PgActionRunStorage implements ActionRunStorage {
   constructor(private readonly sql: SQL) {}
 
   async start(input: StartActionRunInput): Promise<ActionRunRecord> {
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<DatabaseRow[]>`
         INSERT INTO action_runs (
           project_id,
           id,
@@ -42,7 +43,7 @@ export class PgActionRunStorage implements ActionRunStorage {
           ${serializeMetadata(input.metadata)}::text::jsonb
         )
         RETURNING *
-      `) as DatabaseRow[]
+      `
 
       return rowToActionRunRecord(row)
     } catch (error) {
@@ -58,10 +59,10 @@ export class PgActionRunStorage implements ActionRunStorage {
 
   async finish(input: FinishActionRunInput): Promise<ActionRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<DatabaseRow[]>`
         SELECT * FROM action_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
-      `) as DatabaseRow[]
+      `
 
       if (!existing) {
         throw new ActionRunError(
@@ -73,7 +74,7 @@ export class PgActionRunStorage implements ActionRunStorage {
 
       const [updated] =
         input.status === "succeeded"
-          ? ((await tx`
+          ? await tx<DatabaseRow[]>`
               UPDATE action_runs
               SET
                 status = ${input.status},
@@ -84,8 +85,8 @@ export class PgActionRunStorage implements ActionRunStorage {
                 metadata = ${serializeMetadata(metadata)}::text::jsonb
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as DatabaseRow[])
-          : ((await tx`
+            `
+          : await tx<DatabaseRow[]>`
               UPDATE action_runs
               SET
                 status = ${input.status},
@@ -96,17 +97,17 @@ export class PgActionRunStorage implements ActionRunStorage {
                 metadata = ${serializeMetadata(metadata)}::text::jsonb
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as DatabaseRow[])
+            `
 
       return rowToActionRunRecord(updated)
     })
   }
 
   async getById(params: { projectId: string; id: string }): Promise<ActionRunRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<DatabaseRow[]>`
       SELECT * FROM action_runs
       WHERE project_id = ${params.projectId} AND id = ${params.id}
-    `) as DatabaseRow[]
+    `
 
     return row ? rowToActionRunRecord(row) : null
   }
@@ -121,7 +122,7 @@ export class PgActionRunStorage implements ActionRunStorage {
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.actionId) {
@@ -174,10 +175,10 @@ export class PgActionRunStorage implements ActionRunStorage {
     const order = input.order === "asc" ? "ASC" : "DESC"
     const offset = input.offset ?? 0
 
-    const [totalRow] = (await this.sql.unsafe(
+    const [totalRow] = await this.sql.unsafe<{ count: string | number }[]>(
       `SELECT COUNT(*)::bigint AS count FROM action_runs ${where}`,
       params
-    )) as { count: string | number }[]
+    )
 
     const queryParams = [...params]
     let query = `
@@ -194,7 +195,7 @@ export class PgActionRunStorage implements ActionRunStorage {
       queryParams.push(offset)
     }
 
-    const rows = (await this.sql.unsafe(query, queryParams)) as DatabaseRow[]
+    const rows = await this.sql.unsafe<DatabaseRow[]>(query, queryParams)
     const total = Number(totalRow?.count ?? 0)
     const runs = rows.map(rowToActionRunRecord)
 
@@ -267,10 +268,6 @@ function rowToActionSubject(row: DatabaseRow): ActionSubject {
     objectTypeId: row.object_type_id,
     primaryId: row.primary_id,
   }
-}
-
-function isUniqueViolation(error: unknown): boolean {
-  return error instanceof Error && /duplicate key value|unique/i.test(error.message)
 }
 
 interface DatabaseRow {

--- a/storage/pg/src/pg-client.ts
+++ b/storage/pg/src/pg-client.ts
@@ -1,0 +1,124 @@
+import postgres from "postgres"
+
+// Data-type policy (porsager defaults, deliberately not overridden):
+// - `timestamptz` -> JS `Date`. Row mappers normalize via `toIsoString(Date | string)`.
+// - `bigint` -> string (porsager avoids `Number` precision loss). The only bigint values
+//   read here are `COUNT(*)` results, which fit safely in `Number`, so callers use
+//   `Number(...)`. We do NOT register `postgres.BigInt` — it would break those `Number()`
+//   conversions and JSON serialization.
+// - `numeric`/`decimal` -> string. The schema has no such columns; revisit if one is added.
+// - `jsonb` -> parsed JS value (objects/arrays/scalars), same as before.
+
+/**
+ * Connection handle backing every Postgres storage adapter.
+ *
+ * This is the porsager `postgres` pool — not Bun's built-in SQL. bun:sql's pool orphaned
+ * connections under request bursts (a query whose client disconnected mid-flight left its
+ * connection checked out but never returned), so the pool drained to zero usable slots and
+ * the whole API hung until a restart. porsager's pool reclaims connections reliably, which
+ * is the actual fix for that wedge.
+ *
+ * Queries declare their row type per call (`` sql<RowType[]>`...` ``) rather than via an open
+ * generic, so results are typed without `as` casts.
+ */
+export type SQL = postgres.Sql<Record<string, never>>
+
+/**
+ * A query runner that may be the pool or an open transaction. Adapters that run the same
+ * statement on either should accept this rather than {@link SQL} (only the pool exposes
+ * `begin`/`reserve`/`end`).
+ */
+export type SQLClient = postgres.ISql<Record<string, never>>
+
+/**
+ * A value accepted as a positional parameter by {@link SQLClient.unsafe}. Dynamically built
+ * parameter arrays (from the query-IR compiler / run-list helpers) are cast to this since
+ * their element types can't be inferred statically.
+ */
+export type SqlParameter = postgres.ParameterOrJSON<never>
+
+export interface CreatePgClientOptions {
+  readonly connectionString?: string
+  readonly host?: string
+  readonly port?: number
+  readonly database?: string
+  readonly user?: string
+  readonly password?: string
+  /** Maximum pooled connections. */
+  readonly max: number
+  /** Schema pinned via `search_path` on every connection. */
+  readonly schemaName: string
+  /** Close idle connections after this many ms (frees slots back to the server). Default 30s. */
+  readonly idleTimeoutMillis?: number
+  /** Per-connection `statement_timeout` (ms). Unset = no timeout. */
+  readonly statementTimeoutMillis?: number
+  /** Per-connection `idle_in_transaction_session_timeout` (ms). Unset = no timeout. */
+  readonly idleInTransactionSessionTimeoutMillis?: number
+  /** Seconds to wait when establishing a connection. Default 10. */
+  readonly connectTimeoutMillis?: number
+  /**
+   * Whether porsager creates server-side prepared statements (its default; faster against a
+   * direct Postgres connection). Keep `true` for a direct connection. Behind a transaction-mode
+   * pooler, prepared statements are supported by PgBouncer >= 1.21 (Oct 2023) when
+   * `max_prepared_statements > 0`; set `false` only for an older PgBouncer or when that setting
+   * is 0. (The blanket incompatibility in porsager#93 predates PgBouncer 1.21.)
+   */
+  readonly prepare?: boolean
+  readonly ssl?: boolean | "require" | "prefer"
+}
+
+const DEFAULT_IDLE_TIMEOUT_SECONDS = 30
+const DEFAULT_CONNECT_TIMEOUT_SECONDS = 10
+
+/** Build a configured porsager `postgres` pool. */
+export function createPgClient(options: CreatePgClientOptions): SQL {
+  // GUCs applied to every connection at startup.
+  const connection: Record<string, string | number | boolean> = {
+    search_path: options.schemaName,
+  }
+  if (options.statementTimeoutMillis !== undefined) {
+    connection.statement_timeout = options.statementTimeoutMillis
+  }
+  if (options.idleInTransactionSessionTimeoutMillis !== undefined) {
+    connection.idle_in_transaction_session_timeout = options.idleInTransactionSessionTimeoutMillis
+  }
+
+  const idleTimeout =
+    options.idleTimeoutMillis !== undefined
+      ? Math.max(1, Math.round(options.idleTimeoutMillis / 1000))
+      : DEFAULT_IDLE_TIMEOUT_SECONDS
+
+  const connectTimeout =
+    options.connectTimeoutMillis !== undefined
+      ? Math.max(1, Math.round(options.connectTimeoutMillis / 1000))
+      : DEFAULT_CONNECT_TIMEOUT_SECONDS
+
+  const base = {
+    max: options.max,
+    // `idle_timeout` is important on managed Postgres (e.g. DigitalOcean), which closes idle
+    // server-side connections — without it porsager can hand out a dead socket (porsager#179).
+    idle_timeout: idleTimeout,
+    connect_timeout: connectTimeout,
+    // `max_lifetime` is intentionally left at porsager's default (a random 45–90 min): it
+    // cycles connections to avoid server-side memory bloat from long-lived prepared
+    // statements and plays nicely with managed databases. Disabling it is discouraged.
+    connection,
+    // Match the previous (bun:sql) behavior of not surfacing routine PostgreSQL NOTICEs.
+    onnotice: () => {},
+    ...(options.prepare !== undefined ? { prepare: options.prepare } : {}),
+    ...(options.ssl ? { ssl: options.ssl } : {}),
+  }
+
+  if (options.connectionString) {
+    return postgres(options.connectionString, base)
+  }
+
+  return postgres({
+    ...base,
+    host: options.host ?? "localhost",
+    port: options.port ?? 5432,
+    ...(options.database !== undefined ? { database: options.database } : {}),
+    ...(options.user !== undefined ? { username: options.user } : {}),
+    ...(options.password !== undefined ? { password: options.password } : {}),
+  })
+}

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -18,7 +18,7 @@ import type {
   StoredObjectUpsertedEvent,
   StoredTelemetryAppendedEvent,
 } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL, SQLClient, SqlParameter } from "./pg-client"
 import {
   type CompiledPgObjectQuery,
   compilePgObjectCountQuery,
@@ -85,14 +85,14 @@ const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
  * support VALUES inside SELECT/JOIN, so we construct the query string
  * manually while keeping all user data in the parameter array.
  */
-function valuesJoin(
-  sql: SQL,
+function valuesJoin<Row = unknown>(
+  sql: SQLClient,
   select: string,
   columns: string[],
   tuples: unknown[][],
   where: string,
   whereParams: unknown[]
-) {
+): Promise<Row[]> {
   const alias = "t"
   const colWidth = columns.length
 
@@ -116,7 +116,7 @@ function valuesJoin(
   const query = `${select} JOIN (VALUES ${valuePlaceholders}) AS ${alias}(${columns.join(",")}) ON ${onClause} ${where}`
   const params = [...whereParams, ...tuples.flat()]
 
-  return sql.unsafe(query, params)
+  return sql.unsafe(query, params as SqlParameter[]) as unknown as Promise<Row[]>
 }
 
 /**
@@ -148,12 +148,20 @@ export class PgObjectStorage implements ObjectStorage {
       includeTotal: params.includeTotal,
     })
     const total = params.includeTotal === false ? undefined : await readTotal(this.sql, compiled)
-    const rawRows = (await this.sql.unsafe(compiled.sql, compiled.args)) as ObjectQueryDatabaseRow[]
+    const rawRows = await this.sql.unsafe<ObjectQueryDatabaseRow[]>(
+      compiled.sql,
+      compiled.args as SqlParameter[]
+    )
     const rows = compiled.trimRows(rawRows) as readonly ObjectQueryDatabaseRow[]
     const hasMore =
       total === undefined && compiled.hasMoreProbe
         ? compiled.hasMoreProbe.hasMore(
-            (await this.sql.unsafe(compiled.hasMoreProbe.sql, compiled.hasMoreProbe.args)).length
+            (
+              await this.sql.unsafe(
+                compiled.hasMoreProbe.sql,
+                compiled.hasMoreProbe.args as SqlParameter[]
+              )
+            ).length
           )
         : compiled.hasMore(rawRows.length, total)
 
@@ -167,15 +175,16 @@ export class PgObjectStorage implements ObjectStorage {
 
   async countObjects(params: CountObjectsInput): Promise<CountObjectsResult> {
     const compiled = compilePgObjectCountQuery(params.projectId, stripOuterRowShape(params.query))
-    const [row] = (await this.sql.unsafe(compiled.sql, compiled.args)) as {
-      count: string | number | bigint
-    }[]
+    const [row] = await this.sql.unsafe<{ count: string | number | bigint }[]>(
+      compiled.sql,
+      compiled.args as SqlParameter[]
+    )
     return { count: Number(row?.count ?? 0) }
   }
 
   async existsObjects(params: ExistsObjectsInput): Promise<ExistsObjectsResult> {
     const compiled = compilePgObjectExistsQuery(params.projectId, stripOuterRowShape(params.query))
-    const [row] = (await this.sql.unsafe(compiled.sql, compiled.args)) as unknown[]
+    const [row] = await this.sql.unsafe<unknown[]>(compiled.sql, compiled.args as SqlParameter[])
     return { exists: row !== undefined }
   }
 
@@ -208,28 +217,30 @@ export class PgObjectStorage implements ObjectStorage {
       `
 
       if (applied) {
-        const [existing] = (await tx`
+        const [existing] = await tx<ObjectDatabaseRow[]>`
           SELECT * FROM objects
           WHERE project_id = ${event.projectId}
             AND object_type_id = ${event.payload.objectTypeId}
             AND primary_id = ${event.payload.primaryId}
-        `) as ObjectDatabaseRow[]
+        `
         return existing ? rowToObject(existing) : null
       }
 
-      const [existing] = (await tx`
+      const [existing] = await tx<
+        { properties: Record<string, unknown>; created_at: Date; version: number }[]
+      >`
         SELECT properties, created_at, version FROM objects
         WHERE project_id = ${event.projectId}
           AND object_type_id = ${event.payload.objectTypeId}
           AND primary_id = ${event.payload.primaryId}
-      `) as { properties: Record<string, unknown>; created_at: Date; version: number }[]
+      `
 
       const existingProperties = existing ? existing.properties : {}
       const mergedProperties = { ...existingProperties, ...event.payload.properties }
       const createdAt = existing ? existing.created_at : occurredAt
       const version = (existing?.version ?? 0) + 1
 
-      const [upserted] = (await tx`
+      const [upserted] = await tx<ObjectDatabaseRow[]>`
         INSERT INTO objects (
           project_id, object_type_id, primary_id, properties, created_at, updated_at,
           version, source_event_id
@@ -245,7 +256,7 @@ export class PgObjectStorage implements ObjectStorage {
           version = objects.version + 1,
           source_event_id = EXCLUDED.source_event_id
         RETURNING *
-      `) as ObjectDatabaseRow[]
+      `
 
       await tx`
         INSERT INTO applied_events_objects (event_id)
@@ -265,7 +276,7 @@ export class PgObjectStorage implements ObjectStorage {
     if (events.length === 0) return []
     return this.sql.begin(async (tx) => {
       // 1. Bulk claim: single INSERT returns only the event_ids we now own.
-      const claimedRows = await tx`
+      const claimedRows = await tx<{ event_id: string }[]>`
         INSERT INTO applied_events_objects
         ${this.sql(events.map((e) => ({ event_id: e.id })))}
         ON CONFLICT DO NOTHING
@@ -278,14 +289,14 @@ export class PgObjectStorage implements ObjectStorage {
       const results: ObjectRow[] = []
 
       if (alreadyApplied.length > 0) {
-        const existingRows = (await valuesJoin(
+        const existingRows = await valuesJoin<ObjectDatabaseRow>(
           tx,
           "SELECT o.* FROM objects o",
           ["object_type_id", "primary_id"],
           alreadyApplied.map((e) => [e.payload.objectTypeId, e.payload.primaryId]),
           `WHERE o.project_id = $1`,
           [events[0].projectId]
-        )) as ObjectDatabaseRow[]
+        )
 
         for (const row of existingRows) results.push(rowToObject(row))
       }
@@ -297,7 +308,7 @@ export class PgObjectStorage implements ObjectStorage {
 
         const occurredAt = new Date(event.occurredAt)
 
-        const [upserted] = (await tx`
+        const [upserted] = await tx<ObjectDatabaseRow[]>`
           INSERT INTO objects (
             project_id, object_type_id, primary_id, properties, created_at, updated_at,
             version, source_event_id
@@ -313,7 +324,7 @@ export class PgObjectStorage implements ObjectStorage {
             version = objects.version + 1,
             source_event_id = EXCLUDED.source_event_id
           RETURNING *
-        `) as ObjectDatabaseRow[]
+        `
 
         results.push(rowToObject(upserted))
       }
@@ -330,12 +341,12 @@ export class PgObjectStorage implements ObjectStorage {
       `
       if (applied) return
 
-      const [existing] = (await tx`
+      const [existing] = await tx<{ properties: Record<string, unknown> }[]>`
         SELECT properties FROM objects
         WHERE project_id = ${event.projectId}
           AND object_type_id = ${event.payload.objectTypeId}
           AND primary_id = ${event.payload.objectId}
-      `) as { properties: Record<string, unknown> }[]
+      `
 
       if (!existing) return
 
@@ -368,10 +379,10 @@ export class PgObjectStorage implements ObjectStorage {
     await this.sql.begin(async (tx) => {
       // Batch idempotence check: single query instead of N individual SELECTs
       const allEventIds = events.map((e) => e.id)
-      const appliedRows = (await tx`
+      const appliedRows = await tx<{ event_id: string }[]>`
         SELECT event_id FROM applied_events_objects
         WHERE event_id IN ${this.sql(allEventIds)}
-      `) as { event_id: string }[]
+      `
       const appliedSet = new Set(appliedRows.map((r) => r.event_id))
 
       // Group non-applied events by unique object to minimize reads/writes
@@ -403,12 +414,12 @@ export class PgObjectStorage implements ObjectStorage {
       }
 
       for (const group of objectGroups.values()) {
-        const [existing] = (await tx`
+        const [existing] = await tx<{ properties: Record<string, unknown> }[]>`
           SELECT properties FROM objects
           WHERE project_id = ${group.projectId}
             AND object_type_id = ${group.objectTypeId}
             AND primary_id = ${group.objectId}
-        `) as { properties: Record<string, unknown> }[]
+        `
 
         if (!existing) continue
 
@@ -488,7 +499,7 @@ export class PgObjectStorage implements ObjectStorage {
     if (events.length === 0) return
     await this.sql.begin(async (tx) => {
       // 1. Bulk claim: single INSERT returns only the event_ids we now own.
-      const claimedRows = await tx`
+      const claimedRows = await tx<{ event_id: string }[]>`
         INSERT INTO applied_events_objects
         ${this.sql(events.map((e) => ({ event_id: e.id })))}
         ON CONFLICT DO NOTHING
@@ -555,12 +566,12 @@ export class PgObjectStorage implements ObjectStorage {
     objectTypeId: string
     primaryId: string
   }): Promise<ObjectRow | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<ObjectDatabaseRow[]>`
       SELECT * FROM objects
       WHERE project_id = ${params.projectId}
         AND object_type_id = ${params.objectTypeId}
         AND primary_id = ${params.primaryId}
-    `) as ObjectDatabaseRow[]
+    `
 
     return row ? rowToObject(row) : null
   }
@@ -585,7 +596,7 @@ export class PgObjectStorage implements ObjectStorage {
     const args = params.linkId
       ? [params.projectId, params.objectTypeId, params.objectId, params.linkId]
       : [params.projectId, params.objectTypeId, params.objectId]
-    const rows = (await this.sql.unsafe(query, args)) as LinkDatabaseRow[]
+    const rows = await this.sql.unsafe<LinkDatabaseRow[]>(query, args)
 
     return rows.map((row) => rowToLink(row))
   }
@@ -596,14 +607,14 @@ export class PgObjectStorage implements ObjectStorage {
   }): Promise<Map<string, ObjectRow>> {
     const result = new Map<string, ObjectRow>()
     if (params.items.length === 0) return result
-    const rows = (await valuesJoin(
+    const rows = await valuesJoin<ObjectDatabaseRow>(
       this.sql,
       "SELECT o.* FROM objects o",
       ["object_type_id", "primary_id"],
       params.items.map((i) => [i.objectTypeId, i.primaryId]),
       `WHERE o.project_id = $1`,
       [params.projectId]
-    )) as ObjectDatabaseRow[]
+    )
 
     for (const row of rows) {
       result.set(`${row.object_type_id}:${row.primary_id}`, rowToObject(row))
@@ -617,14 +628,14 @@ export class PgObjectStorage implements ObjectStorage {
   }): Promise<Map<string, ObjectLinkRow[]>> {
     const result = new Map<string, ObjectLinkRow[]>()
     if (params.items.length === 0) return result
-    const rows = (await valuesJoin(
+    const rows = await valuesJoin<LinkDatabaseRow>(
       this.sql,
       "SELECT l.* FROM links l",
       ["source_type_id", "source_id", "link_id"],
       params.items.map((i) => [i.objectTypeId, i.objectId, i.linkId]),
       `WHERE l.project_id = $1`,
       [params.projectId]
-    )) as LinkDatabaseRow[]
+    )
 
     for (const row of rows) {
       const key = `${row.source_type_id}:${row.source_id}:${row.link_id}`
@@ -699,11 +710,11 @@ export class PgObjectStorage implements ObjectStorage {
     `
 
     // Get total count
-    const [countResult] = (await this.sql`
+    const [countResult] = await this.sql<{ total: number }[]>`
       SELECT COUNT(*)::int AS total FROM objects
       WHERE project_id = ${params.projectId}
       ${filters}
-    `) as { total: number }[]
+    `
     const total = countResult.total
 
     if (limit === 0) return { objects: [], hasMore: queryOffset < total, total }
@@ -711,14 +722,14 @@ export class PgObjectStorage implements ObjectStorage {
     // Get paginated results (+1 for hasMore check)
     // Column and direction derived from a fixed mapping — safe to use as identifiers
     const fetchLimit = limit + 1
-    const rows = (await this.sql`
+    const rows = await this.sql<ObjectDatabaseRow[]>`
       SELECT * FROM objects
       WHERE project_id = ${params.projectId}
       ${filters}
       ORDER BY ${this.sql(orderColumn)} ${order === "asc" ? this.sql`ASC` : this.sql`DESC`}
       LIMIT ${fetchLimit}
       OFFSET ${queryOffset}
-    `) as ObjectDatabaseRow[]
+    `
 
     const hasMore = rows.length > limit
     const objects = rows.slice(0, limit).map((row) => rowToObject(row))
@@ -728,9 +739,11 @@ export class PgObjectStorage implements ObjectStorage {
 }
 
 async function readTotal(sql: SQL, compiled: CompiledPgObjectQuery): Promise<number> {
-  const [row] = (await sql.unsafe(compiled.totalSql, compiled.totalArgs)) as {
-    total: string | number | bigint
-  }[]
+  const [row] = await sql.unsafe<
+    {
+      total: string | number | bigint
+    }[]
+  >(compiled.totalSql, compiled.totalArgs as SqlParameter[])
   return Number(row?.total ?? 0)
 }
 
@@ -738,7 +751,9 @@ async function readFacetBuckets(
   sql: SQL,
   compiled: { sql: string; args: readonly unknown[] }
 ): Promise<{ value: unknown; count: number }[]> {
-  const rows = (await sql.unsafe(compiled.sql, [...compiled.args])) as FacetDatabaseRow[]
+  const rows = await sql.unsafe<FacetDatabaseRow[]>(compiled.sql, [
+    ...compiled.args,
+  ] as SqlParameter[])
 
   return rows.map((row) => ({
     value: pgFacetValue(row.value_type, row.value_text),

--- a/storage/pg/src/pg-pipeline-run-storage.ts
+++ b/storage/pg/src/pg-pipeline-run-storage.ts
@@ -16,8 +16,8 @@ import type {
   StartPipelineStepRunInput,
 } from "@sixb/core"
 import { PipelineRunError } from "@sixb/core"
-import type { SQL } from "bun"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
+import type { SQL, SqlParameter } from "./pg-client"
 import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
 import { isUniqueViolation } from "./storage-errors"
 
@@ -26,7 +26,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
 
   async start(input: StartPipelineRunInput): Promise<PipelineRunRecord> {
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<PipelineRunDatabaseRow[]>`
         INSERT INTO pipeline_runs (
           project_id,
           id,
@@ -41,7 +41,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
           ${input.startedAt ?? new Date()}
         )
         RETURNING *
-      `) as PipelineRunDatabaseRow[]
+      `
 
       return rowToPipelineRunRecord(row)
     } catch (error) {
@@ -57,10 +57,10 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
 
   async finish(input: FinishPipelineRunInput): Promise<PipelineRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<PipelineRunDatabaseRow[]>`
         SELECT * FROM pipeline_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
-      `) as PipelineRunDatabaseRow[]
+      `
 
       if (!existing) {
         throw new PipelineRunError(
@@ -76,7 +76,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
 
       const [updated] =
         input.status === "succeeded"
-          ? ((await tx`
+          ? await tx<PipelineRunDatabaseRow[]>`
               UPDATE pipeline_runs
               SET
                 status = ${input.status},
@@ -87,8 +87,8 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
                 error_message = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as PipelineRunDatabaseRow[])
-          : ((await tx`
+            `
+          : await tx<PipelineRunDatabaseRow[]>`
               UPDATE pipeline_runs
               SET
                 status = ${input.status},
@@ -99,7 +99,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
                 error_message = ${input.error?.message ?? null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as PipelineRunDatabaseRow[])
+            `
 
       return rowToPipelineRunRecord(updated)
     })
@@ -107,10 +107,10 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
 
   async startStep(input: StartPipelineStepRunInput): Promise<PipelineStepRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [pipelineRun] = (await tx`
+      const [pipelineRun] = await tx<PipelineRunDatabaseRow[]>`
         SELECT * FROM pipeline_runs
         WHERE project_id = ${input.projectId} AND id = ${input.pipelineRunId}
-      `) as PipelineRunDatabaseRow[]
+      `
 
       if (!pipelineRun) {
         throw new PipelineRunError(
@@ -131,7 +131,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
       }
 
       try {
-        const [row] = (await tx`
+        const [row] = await tx<PipelineStepRunDatabaseRow[]>`
           INSERT INTO pipeline_step_runs (
             project_id,
             id,
@@ -156,7 +156,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
             ${JSON.stringify(input.inputs)}::text::jsonb
           )
           RETURNING *
-        `) as PipelineStepRunDatabaseRow[]
+        `
 
         return rowToPipelineStepRunRecord(row)
       } catch (error) {
@@ -175,10 +175,10 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
     assertOptionalNonNegativeInteger(input.rowsWritten, "rowsWritten")
 
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<PipelineStepRunDatabaseRow[]>`
         SELECT * FROM pipeline_step_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
-      `) as PipelineStepRunDatabaseRow[]
+      `
 
       if (!existing) {
         throw new PipelineRunError(
@@ -200,7 +200,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
 
       const [updated] =
         input.status === "succeeded"
-          ? ((await tx`
+          ? await tx<PipelineStepRunDatabaseRow[]>`
               UPDATE pipeline_step_runs
               SET
                 status = ${input.status},
@@ -211,8 +211,8 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
                 error_message = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as PipelineStepRunDatabaseRow[])
-          : ((await tx`
+            `
+          : await tx<PipelineStepRunDatabaseRow[]>`
               UPDATE pipeline_step_runs
               SET
                 status = ${input.status},
@@ -223,17 +223,17 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
                 error_message = ${input.error?.message ?? null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as PipelineStepRunDatabaseRow[])
+            `
 
       return rowToPipelineStepRunRecord(updated)
     })
   }
 
   async getById(params: { projectId: string; id: string }): Promise<PipelineRunRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<PipelineRunDatabaseRow[]>`
       SELECT * FROM pipeline_runs
       WHERE project_id = ${params.projectId} AND id = ${params.id}
-    `) as PipelineRunDatabaseRow[]
+    `
 
     return row ? rowToPipelineRunRecord(row) : null
   }
@@ -248,7 +248,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.pipelineId) {
@@ -304,7 +304,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.pipelineRunId) {

--- a/storage/pg/src/pg-projection-run-storage.ts
+++ b/storage/pg/src/pg-projection-run-storage.ts
@@ -11,7 +11,8 @@ import type {
   UpdateProjectionRunInput,
 } from "@sixb/core"
 import { ProjectionRunError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL, SQLClient, SqlParameter } from "./pg-client"
+import { isUniqueViolation } from "./storage-errors"
 
 type CounterKey = keyof ProjectionRunCounters
 
@@ -33,7 +34,7 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
     assertNonEmpty(input.datasetVersionId, "datasetVersionId")
 
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<DatabaseRow[]>`
         INSERT INTO projection_runs (
           project_id,
           id,
@@ -62,7 +63,7 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
           ${0}
         )
         RETURNING *
-      `) as DatabaseRow[]
+      `
 
       return rowToProjectionRunRecord(row)
     } catch (error) {
@@ -81,7 +82,7 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
       const existing = await requireRunning(tx, input.projectId, input.id)
       const counters = mergeCounters(rowToCounters(existing), input)
 
-      const [updated] = (await tx`
+      const [updated] = await tx<DatabaseRow[]>`
         UPDATE projection_runs
         SET
           rows_processed = ${counters.rowsProcessed},
@@ -90,7 +91,7 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
           links_upserted = ${counters.linksUpserted}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as DatabaseRow[]
+      `
 
       return rowToProjectionRunRecord(updated)
     })
@@ -101,7 +102,7 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
       const existing = await requireRunning(tx, input.projectId, input.id)
       const counters = mergeCounters(rowToCounters(existing), input)
 
-      const [updated] = (await tx`
+      const [updated] = await tx<DatabaseRow[]>`
         UPDATE projection_runs
         SET
           status = ${input.status},
@@ -113,17 +114,17 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
           error_message = ${input.status === "succeeded" ? null : (input.errorMessage ?? null)}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as DatabaseRow[]
+      `
 
       return rowToProjectionRunRecord(updated)
     })
   }
 
   async getById(params: { projectId: string; id: string }): Promise<ProjectionRunRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<DatabaseRow[]>`
       SELECT * FROM projection_runs
       WHERE project_id = ${params.projectId} AND id = ${params.id}
-    `) as DatabaseRow[]
+    `
 
     return row ? rowToProjectionRunRecord(row) : null
   }
@@ -140,7 +141,7 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.projectionId) {
@@ -185,10 +186,10 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
     assertOptionalWindowValue(input.limit, "limit")
     assertOptionalWindowValue(offset, "offset")
 
-    const [totalRow] = (await this.sql.unsafe(
+    const [totalRow] = await this.sql.unsafe<{ count: string | number }[]>(
       `SELECT COUNT(*)::bigint AS count FROM projection_runs ${where}`,
       params
-    )) as { count: string | number }[]
+    )
 
     const queryParams = [...params]
     let query = `
@@ -205,7 +206,7 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
       queryParams.push(offset)
     }
 
-    const rows = (await this.sql.unsafe(query, queryParams)) as DatabaseRow[]
+    const rows = await this.sql.unsafe<DatabaseRow[]>(query, queryParams)
     const total = Number(totalRow?.count ?? 0)
     const runs = rows.map(rowToProjectionRunRecord)
 
@@ -217,15 +218,15 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
   }
 }
 
-async function requireRunning(sql: SQL, projectId: string, id: string): Promise<DatabaseRow> {
+async function requireRunning(sql: SQLClient, projectId: string, id: string): Promise<DatabaseRow> {
   assertNonEmpty(projectId, "projectId")
   assertNonEmpty(id, "id")
 
-  const [row] = (await sql`
+  const [row] = await sql<DatabaseRow[]>`
     SELECT * FROM projection_runs
     WHERE project_id = ${projectId} AND id = ${id}
     FOR UPDATE
-  `) as DatabaseRow[]
+  `
 
   if (!row) {
     throw new ProjectionRunError(
@@ -307,10 +308,6 @@ function assertOptionalWindowValue(value: number | undefined, fieldName: string)
   if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
     throw new ProjectionRunError(`[SixbPg] Projection run list ${fieldName} must be >= 0.`)
   }
-}
-
-function isUniqueViolation(error: unknown): boolean {
-  return error instanceof Error && /duplicate key value|unique/i.test(error.message)
 }
 
 interface DatabaseRow {

--- a/storage/pg/src/pg-rules-storage.ts
+++ b/storage/pg/src/pg-rules-storage.ts
@@ -7,7 +7,7 @@ import type {
   StoredRuleResolvedEvent,
   StoredRuleTriggeredEvent,
 } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL, SqlParameter } from "./pg-client"
 
 export class PgRulesStorage implements RulesStorage {
   constructor(private readonly sql: SQL) {}
@@ -17,7 +17,7 @@ export class PgRulesStorage implements RulesStorage {
     ruleId: string
     subject: RuleEventSubject
   }): Promise<RuleStateRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<RuleStateRow[]>`
       SELECT
         project_id,
         rule_id,
@@ -31,14 +31,14 @@ export class PgRulesStorage implements RulesStorage {
         AND subject_kind = ${params.subject.kind}
         AND object_type_id = ${params.subject.objectTypeId}
         AND primary_id = ${params.subject.primaryId}
-    `) as RuleStateRow[]
+    `
 
     return row ? rowToRuleStateRecord(row) : null
   }
 
   async listActive(input: ListActiveRuleStatesInput): Promise<ListActiveRuleStatesResult> {
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.ruleId) {
@@ -60,10 +60,10 @@ export class PgRulesStorage implements RulesStorage {
     const order = input.order === "asc" ? "ASC" : "DESC"
     const offset = input.offset ?? 0
 
-    const [totalRow] = (await this.sql.unsafe(
+    const [totalRow] = await this.sql.unsafe<{ count: string | number }[]>(
       `SELECT COUNT(*)::bigint AS count FROM rule_states ${where}`,
       params
-    )) as { count: string | number }[]
+    )
 
     const queryParams = [...params]
     let query = `
@@ -87,7 +87,7 @@ export class PgRulesStorage implements RulesStorage {
       queryParams.push(offset)
     }
 
-    const rows = (await this.sql.unsafe(query, queryParams)) as RuleStateRow[]
+    const rows = await this.sql.unsafe<RuleStateRow[]>(query, queryParams)
     const total = Number(totalRow?.count ?? 0)
     const states = rows.map(rowToRuleStateRecord)
 

--- a/storage/pg/src/pg-sync-run-storage.ts
+++ b/storage/pg/src/pg-sync-run-storage.ts
@@ -11,15 +11,16 @@ import type {
   SyncRunStorage,
 } from "@sixb/core"
 import { SyncRunError } from "@sixb/core"
-import type { SQL } from "bun"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
+import type { SQL, SqlParameter } from "./pg-client"
+import { isUniqueViolation } from "./storage-errors"
 
 export class PgSyncRunStorage implements SyncRunStorage {
   constructor(private readonly sql: SQL) {}
 
   async start(input: StartSyncRunInput): Promise<SyncRunRecord> {
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<DatabaseRow[]>`
         INSERT INTO sync_runs (
           project_id,
           id,
@@ -42,7 +43,7 @@ export class PgSyncRunStorage implements SyncRunStorage {
           ${input.commitMessage ?? null}
         )
         RETURNING *, checkpoint IS NOT NULL AS checkpoint_present
-      `) as DatabaseRow[]
+      `
 
       return rowToSyncRunRecord(row)
     } catch (error) {
@@ -58,10 +59,10 @@ export class PgSyncRunStorage implements SyncRunStorage {
 
   async finish(input: FinishSyncRunInput): Promise<SyncRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<DatabaseRow[]>`
         SELECT *, checkpoint IS NOT NULL AS checkpoint_present FROM sync_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
-      `) as DatabaseRow[]
+      `
 
       if (!existing) {
         throw new SyncRunError(
@@ -77,7 +78,7 @@ export class PgSyncRunStorage implements SyncRunStorage {
 
       const [updated] =
         input.status === "succeeded"
-          ? ((await tx`
+          ? await tx<DatabaseRow[]>`
               UPDATE sync_runs
               SET
                 status = ${input.status},
@@ -89,8 +90,8 @@ export class PgSyncRunStorage implements SyncRunStorage {
                 checkpoint = ${serializeCheckpoint(input.checkpoint)}::text::jsonb
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *, checkpoint IS NOT NULL AS checkpoint_present
-            `) as DatabaseRow[])
-          : ((await tx`
+            `
+          : await tx<DatabaseRow[]>`
               UPDATE sync_runs
               SET
                 status = ${input.status},
@@ -102,17 +103,17 @@ export class PgSyncRunStorage implements SyncRunStorage {
                 checkpoint = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *, checkpoint IS NOT NULL AS checkpoint_present
-            `) as DatabaseRow[])
+            `
 
       return rowToSyncRunRecord(updated)
     })
   }
 
   async getById(params: { projectId: string; id: string }): Promise<SyncRunRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<DatabaseRow[]>`
       SELECT *, checkpoint IS NOT NULL AS checkpoint_present FROM sync_runs
       WHERE project_id = ${params.projectId} AND id = ${params.id}
-    `) as DatabaseRow[]
+    `
 
     return row ? rowToSyncRunRecord(row) : null
   }
@@ -127,7 +128,7 @@ export class PgSyncRunStorage implements SyncRunStorage {
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.syncId) {
@@ -160,10 +161,10 @@ export class PgSyncRunStorage implements SyncRunStorage {
     const order = input.order === "asc" ? "ASC" : "DESC"
     const offset = input.offset ?? 0
 
-    const [totalRow] = (await this.sql.unsafe(
+    const [totalRow] = await this.sql.unsafe<{ count: string | number }[]>(
       `SELECT COUNT(*)::bigint AS count FROM sync_runs ${where}`,
       params
-    )) as { count: string | number }[]
+    )
 
     const queryParams = [...params]
     let query = `
@@ -180,7 +181,7 @@ export class PgSyncRunStorage implements SyncRunStorage {
       queryParams.push(offset)
     }
 
-    const rows = (await this.sql.unsafe(query, queryParams)) as DatabaseRow[]
+    const rows = await this.sql.unsafe<DatabaseRow[]>(query, queryParams)
     const total = Number(totalRow?.count ?? 0)
     const runs = rows.map(rowToSyncRunRecord)
 
@@ -255,10 +256,6 @@ function hasCheckpoint(row: DatabaseRow): boolean {
     row.checkpoint_present === "t" ||
     row.checkpoint_present === "true"
   )
-}
-
-function isUniqueViolation(error: unknown): boolean {
-  return error instanceof Error && /duplicate key value|unique/i.test(error.message)
 }
 
 interface DatabaseRow {

--- a/storage/pg/src/pg-timeseries-storage.ts
+++ b/storage/pg/src/pg-timeseries-storage.ts
@@ -1,5 +1,5 @@
 import type { StoredTelemetryAppendedEvent, TimeseriesPoint, TimeseriesStorage } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL } from "./pg-client"
 
 /**
  * PostgreSQL-based TimeseriesStorage implementation.
@@ -50,10 +50,10 @@ export class PgTimeseriesStorage implements TimeseriesStorage {
     await this.sql.begin(async (tx) => {
       // Batch idempotence check: single query instead of N individual SELECTs
       const allEventIds = events.map((e) => e.id)
-      const appliedRows = (await tx`
+      const appliedRows = await tx<{ event_id: string }[]>`
         SELECT event_id FROM applied_events_timeseries
         WHERE event_id IN ${this.sql(allEventIds)}
-      `) as { event_id: string }[]
+      `
       const appliedSet = new Set(appliedRows.map((r) => r.event_id))
 
       for (const event of events) {
@@ -100,7 +100,7 @@ export class PgTimeseriesStorage implements TimeseriesStorage {
     const toFilter = params.to ? this.sql`AND at <= ${params.to}` : this.sql``
     const limitFilter = params.limit !== undefined ? this.sql`LIMIT ${params.limit}` : this.sql``
 
-    const rows = (await this.sql`
+    const rows = await this.sql<TimeseriesDatabaseRow[]>`
       SELECT * FROM timeseries
       WHERE project_id = ${params.projectId}
         AND object_type_id = ${params.objectTypeId}
@@ -110,7 +110,7 @@ export class PgTimeseriesStorage implements TimeseriesStorage {
         ${toFilter}
       ORDER BY at ${order === "asc" ? this.sql`ASC` : this.sql`DESC`}
       ${limitFilter}
-    `) as TimeseriesDatabaseRow[]
+    `
 
     return rows.map((row) => rowToPoint(row))
   }
@@ -121,7 +121,7 @@ export class PgTimeseriesStorage implements TimeseriesStorage {
     objectId: string
     propertyId: string
   }): Promise<TimeseriesPoint | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<TimeseriesDatabaseRow[]>`
       SELECT * FROM timeseries
       WHERE project_id = ${params.projectId}
         AND object_type_id = ${params.objectTypeId}
@@ -129,7 +129,7 @@ export class PgTimeseriesStorage implements TimeseriesStorage {
         AND property_id = ${params.propertyId}
       ORDER BY at DESC, source_event_id DESC
       LIMIT 1
-    `) as TimeseriesDatabaseRow[]
+    `
 
     return row ? rowToPoint(row) : null
   }

--- a/storage/pg/src/pg-webhook-delivery-storage.ts
+++ b/storage/pg/src/pg-webhook-delivery-storage.ts
@@ -5,7 +5,7 @@ import type {
   WebhookDeliveryRecord,
   WebhookDeliveryStorage,
 } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL } from "./pg-client"
 
 export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
   constructor(private readonly sql: SQL) {}
@@ -15,7 +15,7 @@ export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
   ): Promise<WebhookDeliveryClaimRecord> {
     return this.sql.begin(async (tx) => {
       // Atomic first claim: only one transaction can insert this scoped delivery key.
-      const [inserted] = (await tx`
+      const [inserted] = await tx<WebhookDeliveryRow[]>`
         INSERT INTO webhook_deliveries (
           project_id,
           connector_id,
@@ -33,20 +33,20 @@ export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
         )
         ON CONFLICT (project_id, connector_id, webhook_id, idempotency_key) DO NOTHING
         RETURNING *
-      `) as WebhookDeliveryRow[]
+      `
 
       if (inserted) {
         return toWebhookDeliveryClaimRecord(inserted, "claimed")
       }
 
-      const [existing] = (await tx`
+      const [existing] = await tx<WebhookDeliveryRow[]>`
         SELECT * FROM webhook_deliveries
         WHERE project_id = ${input.projectId}
           AND connector_id = ${input.connectorId}
           AND webhook_id = ${input.webhookId}
           AND idempotency_key = ${input.idempotencyKey}
         FOR UPDATE
-      `) as WebhookDeliveryRow[]
+      `
 
       if (existing?.status === "completed") {
         return toWebhookDeliveryClaimRecord(existing, "duplicate")
@@ -61,7 +61,7 @@ export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
       }
 
       // Failed deliveries are intentionally claimable so provider retries can run again.
-      const [updated] = (await tx`
+      const [updated] = await tx<WebhookDeliveryRow[]>`
         UPDATE webhook_deliveries
         SET status = ${"in_progress"},
             received_at = ${input.receivedAt},
@@ -73,7 +73,7 @@ export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
           AND webhook_id = ${input.webhookId}
           AND idempotency_key = ${input.idempotencyKey}
         RETURNING *
-      `) as WebhookDeliveryRow[]
+      `
 
       if (!updated) {
         throw new Error(
@@ -88,7 +88,7 @@ export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
   async complete(
     input: WebhookDeliveryKey & { completedAt: string }
   ): Promise<WebhookDeliveryRecord> {
-    const [updated] = (await this.sql`
+    const [updated] = await this.sql<WebhookDeliveryRow[]>`
       UPDATE webhook_deliveries
       SET status = ${"completed"},
           completed_at = ${input.completedAt},
@@ -99,7 +99,7 @@ export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
         AND webhook_id = ${input.webhookId}
         AND idempotency_key = ${input.idempotencyKey}
       RETURNING *
-    `) as WebhookDeliveryRow[]
+    `
 
     if (!updated) {
       throw new Error(
@@ -113,7 +113,7 @@ export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
   async fail(
     input: WebhookDeliveryKey & { failedAt: string; error: string }
   ): Promise<WebhookDeliveryRecord> {
-    const [updated] = (await this.sql`
+    const [updated] = await this.sql<WebhookDeliveryRow[]>`
       UPDATE webhook_deliveries
       SET status = ${"failed"},
           failed_at = ${input.failedAt},
@@ -123,7 +123,7 @@ export class PgWebhookDeliveryStorage implements WebhookDeliveryStorage {
         AND webhook_id = ${input.webhookId}
         AND idempotency_key = ${input.idempotencyKey}
       RETURNING *
-    `) as WebhookDeliveryRow[]
+    `
 
     if (!updated) {
       throw new Error(

--- a/storage/pg/src/pg-webhook-run-storage.ts
+++ b/storage/pg/src/pg-webhook-run-storage.ts
@@ -7,7 +7,7 @@ import type {
   WebhookRunStorage,
 } from "@sixb/core"
 import { WebhookRunError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL, SqlParameter } from "./pg-client"
 import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
 import { isUniqueViolation } from "./storage-errors"
 
@@ -16,7 +16,7 @@ export class PgWebhookRunStorage implements WebhookRunStorage {
 
   async start(input: StartWebhookRunInput): Promise<WebhookRunRecord> {
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<WebhookRunDatabaseRow[]>`
         INSERT INTO webhook_runs (
           project_id,
           id,
@@ -37,7 +37,7 @@ export class PgWebhookRunStorage implements WebhookRunStorage {
           ${input.startedAt ?? new Date()}
         )
         RETURNING *
-      `) as WebhookRunDatabaseRow[]
+      `
 
       return rowToWebhookRunRecord(row)
     } catch (error) {
@@ -53,11 +53,11 @@ export class PgWebhookRunStorage implements WebhookRunStorage {
 
   async finish(input: FinishWebhookRunInput): Promise<WebhookRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<WebhookRunDatabaseRow[]>`
         SELECT * FROM webhook_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         FOR UPDATE
-      `) as WebhookRunDatabaseRow[]
+      `
 
       if (!existing) {
         throw new WebhookRunError(
@@ -71,7 +71,7 @@ export class PgWebhookRunStorage implements WebhookRunStorage {
         )
       }
 
-      const [updated] = (await tx`
+      const [updated] = await tx<WebhookRunDatabaseRow[]>`
         UPDATE webhook_runs
         SET
           status = ${input.status},
@@ -83,17 +83,17 @@ export class PgWebhookRunStorage implements WebhookRunStorage {
           error = ${input.status === "succeeded" ? null : (input.error ?? null)}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as WebhookRunDatabaseRow[]
+      `
 
       return rowToWebhookRunRecord(updated)
     })
   }
 
   async getById(params: { projectId: string; id: string }): Promise<WebhookRunRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<WebhookRunDatabaseRow[]>`
       SELECT * FROM webhook_runs
       WHERE project_id = ${params.projectId} AND id = ${params.id}
-    `) as WebhookRunDatabaseRow[]
+    `
 
     return row ? rowToWebhookRunRecord(row) : null
   }
@@ -108,7 +108,7 @@ export class PgWebhookRunStorage implements WebhookRunStorage {
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.connectorId) {

--- a/storage/pg/src/pg-workflow-intervention-storage.ts
+++ b/storage/pg/src/pg-workflow-intervention-storage.ts
@@ -11,7 +11,7 @@ import type {
   WorkflowIOSnapshot,
 } from "@sixb/core"
 import { WorkflowInterventionError } from "@sixb/core"
-import type { SQL } from "bun"
+import type { SQL, SQLClient, SqlParameter } from "./pg-client"
 import { isUniqueViolation } from "./storage-errors"
 
 export class PgWorkflowInterventionStorage implements WorkflowInterventionStorage {
@@ -21,7 +21,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
     assertNonNegativeInteger(input.nodeIndex, "nodeIndex")
 
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<WorkflowInterventionDatabaseRow[]>`
         INSERT INTO workflow_interventions (
           project_id,
           id,
@@ -54,7 +54,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
           ${input.expiresAt ?? null}
         )
         RETURNING *
-      `) as WorkflowInterventionDatabaseRow[]
+      `
 
       return rowToWorkflowInterventionRecord(row)
     } catch (error) {
@@ -72,7 +72,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
     return this.sql.begin(async (tx) => {
       await requirePendingIntervention(tx, input.projectId, input.id)
 
-      const [updated] = (await tx`
+      const [updated] = await tx<WorkflowInterventionDatabaseRow[]>`
         UPDATE workflow_interventions
         SET
           status = ${"submitted"},
@@ -81,7 +81,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
           response = ${serializeRecord(input.response)}::text::jsonb
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as WorkflowInterventionDatabaseRow[]
+      `
 
       return rowToWorkflowInterventionRecord(updated)
     })
@@ -91,7 +91,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
     return this.sql.begin(async (tx) => {
       await requirePendingIntervention(tx, input.projectId, input.id)
 
-      const [updated] = (await tx`
+      const [updated] = await tx<WorkflowInterventionDatabaseRow[]>`
         UPDATE workflow_interventions
         SET
           status = ${"cancelled"},
@@ -99,7 +99,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
           cancelled_by = ${serializeActor(input.cancelledBy)}::text::jsonb
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as WorkflowInterventionDatabaseRow[]
+      `
 
       return rowToWorkflowInterventionRecord(updated)
     })
@@ -109,14 +109,14 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
     return this.sql.begin(async (tx) => {
       await requirePendingIntervention(tx, input.projectId, input.id)
 
-      const [updated] = (await tx`
+      const [updated] = await tx<WorkflowInterventionDatabaseRow[]>`
         UPDATE workflow_interventions
         SET
           status = ${"expired"},
           expired_at = ${input.expiredAt ?? new Date()}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as WorkflowInterventionDatabaseRow[]
+      `
 
       return rowToWorkflowInterventionRecord(updated)
     })
@@ -126,10 +126,10 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
     projectId: string
     id: string
   }): Promise<WorkflowInterventionRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<WorkflowInterventionDatabaseRow[]>`
       SELECT * FROM workflow_interventions
       WHERE project_id = ${params.projectId} AND id = ${params.id}
-    `) as WorkflowInterventionDatabaseRow[]
+    `
 
     return row ? rowToWorkflowInterventionRecord(row) : null
   }
@@ -144,7 +144,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.statuses) {
@@ -196,10 +196,10 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
     const where = `WHERE ${whereClauses.join(" AND ")}`
     const order = input.order === "asc" ? "ASC" : "DESC"
     const offset = input.offset ?? 0
-    const [totalRow] = (await this.sql.unsafe(
+    const [totalRow] = await this.sql.unsafe<{ count: string | number }[]>(
       `SELECT COUNT(*)::bigint AS count FROM workflow_interventions ${where}`,
       params
-    )) as { count: string | number }[]
+    )
 
     const queryParams = [...params]
     let query = `
@@ -216,7 +216,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
       queryParams.push(offset)
     }
 
-    const rows = (await this.sql.unsafe(query, queryParams)) as WorkflowInterventionDatabaseRow[]
+    const rows = await this.sql.unsafe<WorkflowInterventionDatabaseRow[]>(query, queryParams)
     const total = Number(totalRow?.count ?? 0)
 
     return {
@@ -228,15 +228,15 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
 }
 
 async function requirePendingIntervention(
-  sql: SQL,
+  sql: SQLClient,
   projectId: string,
   id: string
 ): Promise<WorkflowInterventionDatabaseRow> {
-  const [row] = (await sql`
+  const [row] = await sql<WorkflowInterventionDatabaseRow[]>`
     SELECT * FROM workflow_interventions
     WHERE project_id = ${projectId} AND id = ${id}
     FOR UPDATE
-  `) as WorkflowInterventionDatabaseRow[]
+  `
 
   if (!row) {
     throw new WorkflowInterventionError(

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -21,8 +21,8 @@ import type {
   WorkflowRunStorage,
 } from "@sixb/core"
 import { WorkflowRunError } from "@sixb/core"
-import type { SQL } from "bun"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
+import type { SQL, SqlParameter } from "./pg-client"
 import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
 import { isUniqueViolation } from "./storage-errors"
 
@@ -37,7 +37,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
     const queuedAt = input.queuedAt ?? new Date()
 
     try {
-      const [row] = (await this.sql`
+      const [row] = await this.sql<WorkflowRunDatabaseRow[]>`
         INSERT INTO workflow_runs (
           project_id,
           id,
@@ -58,7 +58,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           ${input.source ? JSON.stringify(input.source) : null}::text::jsonb
         )
         RETURNING *
-      `) as WorkflowRunDatabaseRow[]
+      `
 
       return rowToWorkflowRunRecord(row)
     } catch (error) {
@@ -75,11 +75,11 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
   async start(input: StartWorkflowRunInput): Promise<WorkflowRunRecord> {
     return this.sql.begin(async (tx) => {
       const startedAt = input.startedAt ?? new Date()
-      const [existing] = (await tx`
+      const [existing] = await tx<WorkflowRunDatabaseRow[]>`
         SELECT * FROM workflow_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         FOR UPDATE
-      `) as WorkflowRunDatabaseRow[]
+      `
 
       if (existing) {
         if (existing.status !== "queued") {
@@ -94,7 +94,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           )
         }
 
-        const [updated] = (await tx`
+        const [updated] = await tx<WorkflowRunDatabaseRow[]>`
           UPDATE workflow_runs
           SET
             status = ${"running"},
@@ -104,13 +104,13 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
             error = ${null}
           WHERE project_id = ${input.projectId} AND id = ${input.id}
           RETURNING *
-        `) as WorkflowRunDatabaseRow[]
+        `
 
         return rowToWorkflowRunRecord(updated)
       }
 
       try {
-        const [row] = (await tx`
+        const [row] = await tx<WorkflowRunDatabaseRow[]>`
           INSERT INTO workflow_runs (
             project_id,
             id,
@@ -127,7 +127,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
             ${startedAt}
           )
           RETURNING *
-        `) as WorkflowRunDatabaseRow[]
+        `
 
         return rowToWorkflowRunRecord(row)
       } catch (error) {
@@ -144,11 +144,11 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
 
   async finish(input: FinishWorkflowRunInput): Promise<WorkflowRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<WorkflowRunDatabaseRow[]>`
         SELECT * FROM workflow_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         FOR UPDATE
-      `) as WorkflowRunDatabaseRow[]
+      `
 
       if (!existing) {
         throw new WorkflowRunError(
@@ -164,7 +164,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
 
       const [updated] =
         input.status === "succeeded"
-          ? ((await tx`
+          ? await tx<WorkflowRunDatabaseRow[]>`
               UPDATE workflow_runs
               SET
                 status = ${input.status},
@@ -172,8 +172,8 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
                 error = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as WorkflowRunDatabaseRow[])
-          : ((await tx`
+            `
+          : await tx<WorkflowRunDatabaseRow[]>`
               UPDATE workflow_runs
               SET
                 status = ${input.status},
@@ -181,7 +181,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
                 error = ${input.error ?? null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as WorkflowRunDatabaseRow[])
+            `
 
       return rowToWorkflowRunRecord(updated)
     })
@@ -189,11 +189,11 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
 
   async wait(input: WaitWorkflowRunInput): Promise<WorkflowRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<WorkflowRunDatabaseRow[]>`
         SELECT * FROM workflow_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         FOR UPDATE
-      `) as WorkflowRunDatabaseRow[]
+      `
 
       if (!existing) {
         throw new WorkflowRunError(
@@ -207,7 +207,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
         )
       }
 
-      const [updated] = (await tx`
+      const [updated] = await tx<WorkflowRunDatabaseRow[]>`
         UPDATE workflow_runs
         SET
           status = ${"waiting"},
@@ -215,7 +215,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           error = ${null}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as WorkflowRunDatabaseRow[]
+      `
 
       return rowToWorkflowRunRecord(updated)
     })
@@ -223,11 +223,11 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
 
   async resume(input: ResumeWorkflowRunInput): Promise<WorkflowRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<WorkflowRunDatabaseRow[]>`
         SELECT * FROM workflow_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         FOR UPDATE
-      `) as WorkflowRunDatabaseRow[]
+      `
 
       if (!existing) {
         throw new WorkflowRunError(
@@ -241,7 +241,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
         )
       }
 
-      const [updated] = (await tx`
+      const [updated] = await tx<WorkflowRunDatabaseRow[]>`
         UPDATE workflow_runs
         SET
           status = ${"running"},
@@ -249,17 +249,17 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           error = ${null}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as WorkflowRunDatabaseRow[]
+      `
 
       return rowToWorkflowRunRecord(updated)
     })
   }
 
   async getById(params: { projectId: string; id: string }): Promise<WorkflowRunRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<WorkflowRunDatabaseRow[]>`
       SELECT * FROM workflow_runs
       WHERE project_id = ${params.projectId} AND id = ${params.id}
-    `) as WorkflowRunDatabaseRow[]
+    `
 
     return row ? rowToWorkflowRunRecord(row) : null
   }
@@ -274,7 +274,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.workflowId) {
@@ -328,11 +328,11 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
     assertNonNegativeInteger(input.nodeIndex, "nodeIndex")
 
     return this.sql.begin(async (tx) => {
-      const [workflowRun] = (await tx`
+      const [workflowRun] = await tx<WorkflowRunDatabaseRow[]>`
         SELECT * FROM workflow_runs
         WHERE project_id = ${input.projectId} AND id = ${input.workflowRunId}
         FOR UPDATE
-      `) as WorkflowRunDatabaseRow[]
+      `
 
       if (!workflowRun) {
         throw new WorkflowRunError(
@@ -353,7 +353,7 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
       }
 
       try {
-        const [row] = (await tx`
+        const [row] = await tx<WorkflowNodeRunDatabaseRow[]>`
           INSERT INTO workflow_node_runs (
             project_id,
             id,
@@ -380,7 +380,7 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
             ${input.startedAt ?? new Date()}
           )
           RETURNING *
-        `) as WorkflowNodeRunDatabaseRow[]
+        `
 
         return rowToWorkflowNodeRunRecord(row)
       } catch (error) {
@@ -397,11 +397,11 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
 
   async finish(input: FinishWorkflowNodeRunInput): Promise<WorkflowNodeRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<WorkflowNodeRunDatabaseRow[]>`
         SELECT * FROM workflow_node_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         FOR UPDATE
-      `) as WorkflowNodeRunDatabaseRow[]
+      `
 
       if (!existing) {
         throw new WorkflowRunError(
@@ -417,7 +417,7 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
 
       const [updated] =
         input.status === "succeeded"
-          ? ((await tx`
+          ? await tx<WorkflowNodeRunDatabaseRow[]>`
               UPDATE workflow_node_runs
               SET
                 status = ${input.status},
@@ -426,8 +426,8 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
                 error = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as WorkflowNodeRunDatabaseRow[])
-          : ((await tx`
+            `
+          : await tx<WorkflowNodeRunDatabaseRow[]>`
               UPDATE workflow_node_runs
               SET
                 status = ${input.status},
@@ -436,7 +436,7 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
                 error = ${input.error ?? null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
-            `) as WorkflowNodeRunDatabaseRow[])
+            `
 
       return rowToWorkflowNodeRunRecord(updated)
     })
@@ -444,11 +444,11 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
 
   async wait(input: WaitWorkflowNodeRunInput): Promise<WorkflowNodeRunRecord> {
     return this.sql.begin(async (tx) => {
-      const [existing] = (await tx`
+      const [existing] = await tx<WorkflowNodeRunDatabaseRow[]>`
         SELECT * FROM workflow_node_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         FOR UPDATE
-      `) as WorkflowNodeRunDatabaseRow[]
+      `
 
       if (!existing) {
         throw new WorkflowRunError(
@@ -462,7 +462,7 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
         )
       }
 
-      const [updated] = (await tx`
+      const [updated] = await tx<WorkflowNodeRunDatabaseRow[]>`
         UPDATE workflow_node_runs
         SET
           status = ${"waiting"},
@@ -471,17 +471,17 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
           error = ${null}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
-      `) as WorkflowNodeRunDatabaseRow[]
+      `
 
       return rowToWorkflowNodeRunRecord(updated)
     })
   }
 
   async getById(params: { projectId: string; id: string }): Promise<WorkflowNodeRunRecord | null> {
-    const [row] = (await this.sql`
+    const [row] = await this.sql<WorkflowNodeRunDatabaseRow[]>`
       SELECT * FROM workflow_node_runs
       WHERE project_id = ${params.projectId} AND id = ${params.id}
-    `) as WorkflowNodeRunDatabaseRow[]
+    `
 
     return row ? rowToWorkflowNodeRunRecord(row) : null
   }
@@ -496,7 +496,7 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
     }
 
     const whereClauses = ["project_id = $1"]
-    const params: unknown[] = [input.projectId]
+    const params: SqlParameter[] = [input.projectId]
     let index = 2
 
     if (input.workflowRunId) {

--- a/storage/pg/src/run-list-query.ts
+++ b/storage/pg/src/run-list-query.ts
@@ -1,4 +1,4 @@
-import type { SQL } from "bun"
+import type { SQL, SqlParameter } from "./pg-client"
 
 type PgRunListTable =
   | "pipeline_runs"
@@ -60,12 +60,12 @@ export async function queryRunList<TRow>(input: {
   const order = input.order === "asc" ? "ASC" : "DESC"
   const offset = input.offset ?? 0
 
-  const [totalRow] = (await input.sql.unsafe(
+  const [totalRow] = await input.sql.unsafe<{ count: string | number }[]>(
     `SELECT COUNT(*)::bigint AS count FROM ${input.tableName} ${where}`,
-    [...input.params]
-  )) as { count: string | number }[]
+    [...input.params] as SqlParameter[]
+  )
 
-  const queryParams = [...input.params]
+  const queryParams = [...input.params] as SqlParameter[]
   let query = `
     SELECT * FROM ${input.tableName}
     ${where}
@@ -81,7 +81,7 @@ export async function queryRunList<TRow>(input: {
     queryParams.push(offset)
   }
 
-  const rows = (await input.sql.unsafe(query, queryParams)) as TRow[]
+  const rows = await input.sql.unsafe<TRow[]>(query, queryParams)
   const total = Number(totalRow?.count ?? 0)
 
   return {

--- a/storage/pg/src/storage-errors.ts
+++ b/storage/pg/src/storage-errors.ts
@@ -1,8 +1,52 @@
-export function isUniqueViolation(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false
-  }
+// Map thrown errors to their PostgreSQL/porsager meaning by code rather than by matching
+// message text. Database errors arrive in the native Postgres format with a SQLSTATE on
+// `.code`; connection-layer failures arrive with porsager's own codes or, for Node socket
+// errors, as an `AggregateError` of `ECONNREFUSED`/`ETIMEDOUT`/… entries.
 
-  const code = (error as { readonly code?: unknown }).code
-  return code === "23505" || /duplicate key value|unique/i.test(error.message)
+/** PostgreSQL SQLSTATE for a unique-constraint violation. */
+const UNIQUE_VIOLATION = "23505"
+
+const CONNECTION_ERROR_CODES = new Set([
+  // porsager-specific
+  "CONNECT_TIMEOUT",
+  "CONNECTION_CLOSED",
+  "CONNECTION_DESTROYED",
+  "CONNECTION_ENDED",
+  // Node socket errors
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+])
+
+/** The SQLSTATE / system error code carried by a thrown database or connection error. */
+export function pgErrorCode(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    const code = (error as { readonly code?: unknown }).code
+    if (typeof code === "string") {
+      return code
+    }
+  }
+  return undefined
+}
+
+/** True when the error is a PostgreSQL unique-constraint violation (SQLSTATE 23505). */
+export function isUniqueViolation(error: unknown): boolean {
+  return pgErrorCode(error) === UNIQUE_VIOLATION
+}
+
+/**
+ * True when the error originates from the connection layer (porsager connection codes, or a
+ * Node socket failure surfaced as an `AggregateError`) rather than from a SQL statement.
+ */
+export function isConnectionError(error: unknown): boolean {
+  const code = pgErrorCode(error)
+  if (code !== undefined && CONNECTION_ERROR_CODES.has(code)) {
+    return true
+  }
+  if (error instanceof AggregateError) {
+    return error.errors.some(isConnectionError)
+  }
+  return false
 }

--- a/storage/pg/src/transactions.ts
+++ b/storage/pg/src/transactions.ts
@@ -1,15 +1,21 @@
 import { createHash } from "node:crypto"
-import type { SQL } from "bun"
+import type { SQL, SQLClient } from "./pg-client"
 
-export async function runPgTransaction<T>(sql: SQL, run: (tx: SQL) => Promise<T>): Promise<T> {
-  return sql.begin(run)
+export async function runPgTransaction<T>(
+  sql: SQL,
+  run: (tx: SQLClient) => Promise<T>
+): Promise<T> {
+  // porsager passes the callback a transaction-scoped client (a TransactionSql, which is an
+  // ISql == SQLClient). The `as Promise<T>` only unwraps porsager's UnwrapPromiseArray return
+  // type (our callbacks never return the pipelined-array form), not a structural cast.
+  return sql.begin(run) as Promise<T>
 }
 
 export function authLockKey(kind: string, ...parts: readonly string[]): string {
   return ["auth", kind, ...parts].join(":")
 }
 
-export async function lockAdvisoryKeys(sql: SQL, keys: readonly string[]): Promise<void> {
+export async function lockAdvisoryKeys(sql: SQLClient, keys: readonly string[]): Promise<void> {
   for (const key of [...new Set(keys)].sort()) {
     const [first, second] = advisoryLockParts(key)
     await sql`SELECT pg_advisory_xact_lock(${first}, ${second})`


### PR DESCRIPTION
## Summary

`@sixb/pg` used Bun's built-in SQL client (`bun:sql`) for its connection pool. Under bursts of concurrent queries that pool **orphaned connections** and drained to zero usable slots, so every query — including the per-request auth/session lookup — hung and the **entire API froze until a manual restart**.

This swaps the engine to **porsager `postgres`**, whose pool reliably reclaims connections. porsager mirrors `bun:sql`'s tagged-template API, so the query call-sites are essentially unchanged — this is an engine swap plus a typing/error/ergonomics cleanup.

## Why it was needed

Reproduced and root-caused against the live API (concurrent heavy `/api/objects/query` workers + a 1 Hz probe of a trivial `count` and of `/api/status`):

- **The pool wedged and never recovered.** The trivial `count` went `60ms → 5.8s → 30s timeout`, and stayed timed out for **185s+ after load stopped** (zero traffic). Only a restart fixed it — not transient queueing; connections were never returned to the pool.
- **The whole app died because auth rides the same pool.** The server validates the session token against Postgres on every request, so once the pool wedged, every authenticated route 502'd — even `/api/status`. Tell-tale: anonymous `/api/status` returned `401` in ~50ms (rejected before the Postgres check) while authenticated returned 502 at ~10s.
- **It's a connection-level wedge, not slow queries** — there was no running statement for `statement_timeout` to cancel. This is the documented `bun:sql` behavior (`oven-sh/bun#30646`, `#17178`); the consuming app had a 24h-idle-timeout hack solely to dodge it.

## Result — same load test, before vs after

| Build | After load stops (zero traffic) |
|---|---|
| `bun:sql` | never recovers — wedged 8+ min, **manual restart required** |
| **porsager (this PR)** | **recovers to baseline (~55ms) in ~22s, no restart** |

`@sixb/pg` e2e suite: **125 passed / 0 failed** against a real Postgres 17.

## Key changes

**Engine** — porsager pool in `pg-client.ts`. `search_path` + optional `statement_timeout` / `idle_in_transaction_session_timeout` are set as connection GUCs; `idle_timeout`, `connect_timeout`, `prepare`, and `ssl` are configurable.

**Typed rows** — queries declare their row type per call, removing the open `any` generic and the `as Row[]` result casts:

```ts
// before
const rows = (await sql`SELECT * FROM objects WHERE …`) as ObjectRow[]
// after
const rows = await sql<ObjectRow[]>`SELECT * FROM objects WHERE …`
```

**Migrations** — porsager's *reserved* connection has no `.begin` at runtime, so the advisory-lock migration drives `BEGIN`/`COMMIT`/`ROLLBACK` on the reserved connection explicitly.

**Error mapping** (`storage-errors.ts`) — keyed on SQLSTATE `.code` (`23505` = unique violation) instead of matching message text; deduped three copies into one module.

**Transactions** — native `TransactionSql` typing; dropped the `as unknown as SQL` cast in the transaction helper.

**Graceful shutdown** — `close()` now uses `sql.end({ timeout })` so a restart drains in-flight queries instead of severing them.

**Session cache** (`@sixb/core`) — short-TTL in-process cache of resolved sessions so auth doesn't hit the data pool on every request (entries are bound to the exact token hash + audience and never served past the session's real expiry; sign-out invalidates eagerly).

## Testing

- **e2e: 125/0** against real Postgres (every storage adapter, unique-violation paths, transactions, object-query conformance).
- **Typecheck + Biome** clean across `@sixb/pg`, `@sixb/core`, `@sixb/server`, and the consuming app.
- **Prod load test** — see the before/after table above.

## Notes

- **Stacked on `codex/object-query-include-total`.** The refactor touches the object-query methods/compiler that branch introduces, so this should merge after (or together with) it.
- **Follow-ups (out of scope):** the same load test surfaced a separate weak link — the Redis broker behind `/api/events` doesn't recover resiliently under load and that endpoint does an unbounded read; both want a follow-up.
