### PR TITLE
core: constrain incoming traversal to the link's source object type

### DIFF
--- a/docs/concepts/object-query.md
+++ b/docs/concepts/object-query.md
@@ -349,6 +349,12 @@ Traversal is type-aware. After `traverse(Project.l.customer)`, subsequent `where
 use the target object's properties. Wildcard links cannot be traversed through the fluent
 API because the result object type cannot be inferred.
 
+Several object types can declare a link with the same id — for example `Project.customer`
+and `Invoice.customer`. The fluent API always pins incoming traversal to the link token's
+owner type, so `traverse(Project.l.customer, { direction: "incoming" })` returns only
+projects. Raw queries opt in with `sourceObjectTypeId` on the `traverse` node; omitting it
+keeps the union of every source type that declares the link.
+
 
 ## Sorting And Limits
 
@@ -606,7 +612,7 @@ Send that token back as `pageToken` to read the next page:
 | `filter` | Apply property predicates. |
 | `text` | Keyword search over `search.defaultText` or explicit `fields`. |
 | `vector` | Nearest-neighbor search on a numeric-array property when supported. |
-| `traverse` | Follow an outgoing or incoming ontology link. |
+| `traverse` | Follow an outgoing or incoming ontology link. Incoming traversal accepts `sourceObjectTypeId` to pin one source type. |
 | `set` | Combine compatible object sets with `union`, `intersect`, or `subtract`. |
 | `sort` | Order by properties or provider-supported relevance. |
 | `limit` | Bound the result count. |

--- a/examples/acme-corp/tests/client-query.test.ts
+++ b/examples/acme-corp/tests/client-query.test.ts
@@ -5,7 +5,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
 import { createServer } from "node:net"
 import { client } from "@sixb/client"
-import { objects, SixbQueryError } from "@sixb/client/query"
+import { createHttpQueryExecutor, objects, SixbQueryError } from "@sixb/client/query"
 import {
   InMemoryBlobStorage,
   InMemoryBroker,
@@ -19,6 +19,7 @@ import { SixbServer } from "@sixb/server"
 import { SqliteObjectStorage, SqliteTimeseriesStorage } from "@sixb/sqlite"
 import { Customer } from "../ontology/customer"
 import { Employee } from "../ontology/employee"
+import { Invoice } from "../ontology/invoice"
 import { Project } from "../ontology/project"
 
 function createSixbInstance<TOntologySources extends readonly OntologySource[]>(
@@ -52,7 +53,7 @@ function getFreePort(): Promise<number> {
 
 const sixb = createSixbInstance({
   id: "acme-client-query-e2e",
-  ontology: [Project, Customer, Employee] as const,
+  ontology: [Project, Customer, Employee, Invoice] as const,
   broker: new InMemoryBroker(),
   storage: {
     objects: new SqliteObjectStorage(),
@@ -111,6 +112,18 @@ beforeAll(async () => {
       targetId: "cust-001",
     })
   }
+
+  // Invoice shares the "customer" link id with Project, so incoming traversal
+  // is ambiguous unless the traverse node pins the source object type.
+  await sixb.objects(Invoice).upsert({
+    properties: { id: "inv-001", number: "INV-001", amount: 1_200, status: "sent" },
+  })
+  await sixb.objects(Invoice).upsertLink({
+    sourceId: "inv-001",
+    linkId: "customer",
+    targetTypeId: Customer.id,
+    targetId: "cust-001",
+  })
 
   const port = await getFreePort()
   const baseUrl = `http://127.0.0.1:${port}`
@@ -203,6 +216,32 @@ describe("client object queries against a live server", () => {
         { value: "completed", count: 1 },
       ])
     )
+  })
+
+  test("incoming traverse returns only the link token's source type", async () => {
+    const viaToken = await objects(Customer)
+      .query()
+      .where((customer) => customer.p.id.eq("cust-001"))
+      .traverse(Project.l.customer, { direction: "incoming" })
+      .list()
+    expect(primaryIds(viaToken.objects).sort()).toEqual(["proj-001", "proj-002"])
+
+    // Raw IR without sourceObjectTypeId keeps the union behavior.
+    const union = await createHttpQueryExecutor().list({
+      kind: "traverse",
+      linkId: "customer",
+      direction: "incoming",
+      input: {
+        kind: "filter",
+        predicate: { op: "eq", propertyId: "id", value: "cust-001" },
+        input: { kind: "start", objectTypeId: Customer.id },
+      },
+    })
+    expect([...union.objects].map((row) => row.primaryId).sort()).toEqual([
+      "inv-001",
+      "proj-001",
+      "proj-002",
+    ])
   })
 
   test("incoming traverse finds a customer's active projects", async () => {

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -389,6 +389,10 @@
               "direction": {
                 "type": "string",
                 "enum": ["outgoing", "incoming"]
+              },
+              "sourceObjectTypeId": {
+                "type": "string",
+                "minLength": 1
               }
             }
           },

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -125,6 +125,7 @@ export type ObjectQuery =
       input: ObjectQuery
       linkId: string
       direction: "outgoing" | "incoming"
+      sourceObjectTypeId?: string
     }
   | {
       kind: "set"

--- a/packages/client/tests/query.test.ts
+++ b/packages/client/tests/query.test.ts
@@ -214,6 +214,7 @@ describe("objects().query()", () => {
           kind: "traverse",
           linkId: "customer",
           direction: "incoming",
+          sourceObjectTypeId: "Project",
           input: {
             kind: "filter",
             predicate: { op: "eq", propertyId: "id", value: "cust-001" },

--- a/packages/core/src/objects/query/explain.ts
+++ b/packages/core/src/objects/query/explain.ts
@@ -115,8 +115,17 @@ function buildExplainNode(query: ObjectQuery, path: string): ObjectQueryExplainN
       return {
         path,
         kind: query.kind,
-        summary: `traverse ${query.direction} ${query.linkId}`,
-        details: { linkId: query.linkId, direction: query.direction },
+        summary:
+          query.sourceObjectTypeId === undefined
+            ? `traverse ${query.direction} ${query.linkId}`
+            : `traverse ${query.direction} ${query.sourceObjectTypeId}.${query.linkId}`,
+        details: {
+          linkId: query.linkId,
+          direction: query.direction,
+          ...(query.sourceObjectTypeId === undefined
+            ? {}
+            : { sourceObjectTypeId: query.sourceObjectTypeId }),
+        },
         children: [buildExplainNode(query.input, `${path}.input`)],
       }
     case "set":

--- a/packages/core/src/objects/query/ir.ts
+++ b/packages/core/src/objects/query/ir.ts
@@ -60,6 +60,13 @@ export interface ObjectQueryTraverse {
   input: ObjectQuery
   linkId: string
   direction: ObjectQueryDirection
+  /**
+   * Constrains incoming traversal to one source object type. Without it,
+   * incoming traversal matches every object type that declares a link with
+   * this `linkId` targeting the input set. The fluent builder always sets it
+   * from the link token's owner type.
+   */
+  sourceObjectTypeId?: string
 }
 
 export interface ObjectQuerySet {

--- a/packages/core/src/objects/query/validate.ts
+++ b/packages/core/src/objects/query/validate.ts
@@ -126,7 +126,14 @@ function validateQueryNode(
     case "traverse": {
       const input = validateQueryNode(query.input, `${path}.input`, ctx)
       return {
-        result: validateTraverse(query.linkId, query.direction, input.result, path, ctx),
+        result: validateTraverse(
+          query.linkId,
+          query.direction,
+          query.sourceObjectTypeId,
+          input.result,
+          path,
+          ctx
+        ),
         query: { ...query, input: input.query },
       }
     }
@@ -489,6 +496,7 @@ function validateVectorQuery(
 function validateTraverse(
   linkId: string,
   direction: "outgoing" | "incoming",
+  sourceObjectTypeId: string | undefined,
   shape: ObjectQueryResultShape,
   path: string,
   ctx: QueryValidationContext
@@ -498,9 +506,19 @@ function validateTraverse(
     return { objectTypeIds: [] }
   }
 
-  return direction === "outgoing"
-    ? validateOutgoingTraverse(linkId, shape, path, ctx)
-    : validateIncomingTraverse(linkId, shape, path, ctx)
+  if (direction === "outgoing") {
+    if (sourceObjectTypeId !== undefined) {
+      addIssue(
+        ctx,
+        path,
+        "traverse_source_not_applicable",
+        "traverse.sourceObjectTypeId only applies to incoming traversal"
+      )
+    }
+    return validateOutgoingTraverse(linkId, shape, path, ctx)
+  }
+
+  return validateIncomingTraverse(linkId, sourceObjectTypeId, shape, path, ctx)
 }
 
 function validateOutgoingTraverse(
@@ -556,13 +574,29 @@ function validateOutgoingTraverse(
 
 function validateIncomingTraverse(
   linkId: string,
+  sourceObjectTypeId: string | undefined,
   shape: ObjectQueryResultShape,
   path: string,
   ctx: QueryValidationContext
 ): ObjectQueryResultShape {
+  let candidateTypes = ctx.ontology.listObjectTypes()
+  if (sourceObjectTypeId !== undefined) {
+    const sourceType = ctx.ontology.getObjectTypeById(sourceObjectTypeId)
+    if (!sourceType) {
+      addIssue(
+        ctx,
+        path,
+        "unknown_traverse_source",
+        `Incoming traversal references unknown source object type '${sourceObjectTypeId}'`
+      )
+      return { objectTypeIds: [] }
+    }
+    candidateTypes = [sourceType]
+  }
+
   const sourceTypeIds: string[] = []
 
-  for (const sourceType of ctx.ontology.listObjectTypes()) {
+  for (const sourceType of candidateTypes) {
     const link = sourceType.links.find((candidate) => candidate.id === linkId)
     if (!link) continue
 

--- a/packages/core/src/objects/sdk/query-builder.ts
+++ b/packages/core/src/objects/sdk/query-builder.ts
@@ -126,6 +126,10 @@ class ObjectQueryBuilderImpl<
         input: this.ir,
         linkId: link.id,
         direction,
+        // Several object types can declare a link with the same id. The token
+        // names exactly one source type, so incoming traversal pins it —
+        // matching the result type the fluent API advertises.
+        ...(direction === "incoming" ? { sourceObjectTypeId: link.objectTypeId } : {}),
       },
     }) as unknown as ObjectQueryBuilder<
       ObjectTypeWithPropertyTokens,

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -184,7 +184,12 @@ export class InMemoryObjectStorage implements ObjectStorage {
         const entries =
           query.direction === "outgoing"
             ? this.traverseOutgoing(projectId, input.entries, query.linkId)
-            : this.traverseIncoming(projectId, input.entries, query.linkId)
+            : this.traverseIncoming(
+                projectId,
+                input.entries,
+                query.linkId,
+                query.sourceObjectTypeId
+              )
         return completeEvaluation(entries)
       }
       case "set":
@@ -314,7 +319,8 @@ export class InMemoryObjectStorage implements ObjectStorage {
   private traverseIncoming(
     projectId: string,
     entries: readonly QueryEntry[],
-    linkId: string
+    linkId: string,
+    sourceObjectTypeId?: string
   ): QueryEntry[] {
     const inputEntriesByTarget = new Map(entries.map((entry) => [rowIdentityKey(entry.row), entry]))
     const resultsByKey = new Map<string, QueryEntry>()
@@ -322,6 +328,7 @@ export class InMemoryObjectStorage implements ObjectStorage {
     for (const bucket of this.links.values()) {
       for (const link of bucket.values()) {
         if (link.projectId !== projectId || link.linkId !== linkId) continue
+        if (sourceObjectTypeId !== undefined && link.sourceTypeId !== sourceObjectTypeId) continue
         const targetEntry = inputEntriesByTarget.get(
           rowIdentityKeyParts(link.targetTypeId, link.targetId)
         )

--- a/packages/core/src/testing/object-query-contract.ts
+++ b/packages/core/src/testing/object-query-contract.ts
@@ -90,6 +90,13 @@ const Room = defineObjectType({
   },
 })
 
+const Zone = defineObjectType({
+  id: "ContractZone",
+  name: "Contract Zone",
+  properties: [prop("id", "string", { required: true, primary: true })],
+  links: [link("hasDevice", Device)],
+})
+
 const Asset = defineObjectType({
   id: "ContractAsset",
   name: "Contract Asset",
@@ -123,7 +130,7 @@ const DefaultTextChild = defineObjectType({
 })
 
 export const objectQueryContractOntology = new OntologyRegistry({
-  sources: [Room, Device, Asset, LaptopAsset, DefaultTextBase, DefaultTextChild],
+  sources: [Room, Device, Zone, Asset, LaptopAsset, DefaultTextBase, DefaultTextChild],
 })
 
 /**
@@ -686,6 +693,32 @@ export function runObjectQueryProviderContractSuite<TStorage extends ObjectStora
           },
           { ontology: objectQueryContractOntology, storage }
         )
+        const incomingRooms = await executeObjectQuery(
+          {
+            projectId,
+            query: {
+              kind: "traverse",
+              direction: "incoming",
+              linkId: "hasDevice",
+              sourceObjectTypeId: Room.id,
+              input: { kind: "start", objectTypeId: Device.id },
+            },
+          },
+          { ontology: objectQueryContractOntology, storage }
+        )
+        const incomingZones = await executeObjectQuery(
+          {
+            projectId,
+            query: {
+              kind: "traverse",
+              direction: "incoming",
+              linkId: "hasDevice",
+              sourceObjectTypeId: Zone.id,
+              input: { kind: "start", objectTypeId: Device.id },
+            },
+          },
+          { ontology: objectQueryContractOntology, storage }
+        )
         const intersect = await executeObjectQuery(
           {
             projectId,
@@ -734,7 +767,10 @@ export function runObjectQueryProviderContractSuite<TStorage extends ObjectStora
         expect(outgoing.plan.mode).toBe("pushdown")
         expect(incoming.plan.mode).toBe("pushdown")
         expect(sortedIds(outgoing)).toEqual(["device-projector", "device-sensor"])
-        expect(sortedIds(incoming)).toEqual(["room-alpha", "room-beta"])
+        expect(sortedIds(incoming)).toEqual(["room-alpha", "room-beta", "zone-one"])
+        expect(incomingRooms.plan.mode).toBe("pushdown")
+        expect(sortedIds(incomingRooms)).toEqual(["room-alpha", "room-beta"])
+        expect(sortedIds(incomingZones)).toEqual(["zone-one"])
         expect(sortedIds(intersect)).toEqual(["room-alpha", "room-beta"])
         expect(ids(subtract)).toEqual(["room-beta"])
       })
@@ -1041,6 +1077,10 @@ export async function seedObjectQueryContractData(storage: ObjectStorage): Promi
   )
   await storage.applyLinkUpserted(
     linkEvent("011", Room.id, "room-beta", "hasDevice", Device.id, "device-sensor")
+  )
+  await storage.applyObjectUpserted(objectEvent("103", Zone.id, "zone-one", { id: "zone-one" }))
+  await storage.applyLinkUpserted(
+    linkEvent("012", Zone.id, "zone-one", "hasDevice", Device.id, "device-projector")
   )
 }
 

--- a/packages/core/tests/object-query.test.ts
+++ b/packages/core/tests/object-query.test.ts
@@ -447,6 +447,65 @@ describe("object query validation", () => {
     expect(incoming.result.objectTypeIds).toEqual(["Customer"])
   })
 
+  test("constrains incoming traversal to a declared source object type", () => {
+    const Reseller = defineObjectType({
+      id: "Reseller",
+      name: "Reseller",
+      properties: [prop("id", "string", { required: true, primary: true })],
+      links: [link("orders", Order)],
+    })
+    const sharedLinkOntology = new OntologyRegistry({ sources: [Customer, Reseller, Order] })
+
+    const unconstrained = validateObjectQuery(
+      {
+        kind: "traverse",
+        direction: "incoming",
+        linkId: "orders",
+        input: { kind: "start", objectTypeId: "Order" },
+      },
+      { ontology: sharedLinkOntology }
+    )
+    expect([...unconstrained.result.objectTypeIds].sort()).toEqual(["Customer", "Reseller"])
+
+    const constrained = validateObjectQuery(
+      {
+        kind: "traverse",
+        direction: "incoming",
+        linkId: "orders",
+        sourceObjectTypeId: "Reseller",
+        input: { kind: "start", objectTypeId: "Order" },
+      },
+      { ontology: sharedLinkOntology }
+    )
+    expect(constrained.result.objectTypeIds).toEqual(["Reseller"])
+  })
+
+  test("rejects traverse source misuse", () => {
+    const unknownSource = collectObjectQueryValidationIssues(
+      {
+        kind: "traverse",
+        direction: "incoming",
+        linkId: "orders",
+        sourceObjectTypeId: "Nope",
+        input: { kind: "start", objectTypeId: "Order" },
+      },
+      { ontology }
+    )
+    expect(unknownSource.map((issue) => issue.code)).toContain("unknown_traverse_source")
+
+    const outgoingSource = collectObjectQueryValidationIssues(
+      {
+        kind: "traverse",
+        direction: "outgoing",
+        linkId: "orders",
+        sourceObjectTypeId: "Customer",
+        input: { kind: "start", objectTypeId: "Customer" },
+      },
+      { ontology }
+    )
+    expect(outgoingSource.map((issue) => issue.code)).toContain("traverse_source_not_applicable")
+  })
+
   test("accepts vector queries for declared vector search profiles", () => {
     const validated = validateObjectQuery(
       {
@@ -1165,6 +1224,52 @@ describe("object query planner and executor", () => {
     expect(union.plan.mode).toBe("pushdown")
     expect(union.objects.map((row) => row.primaryId)).toEqual(["cust-1", "cust-3", "cust-2"])
     expect(storage.queryObjectCalls).toBe(2)
+  })
+
+  test("filters incoming traversal by source object type during execution", async () => {
+    const Reseller = defineObjectType({
+      id: "Reseller",
+      name: "Reseller",
+      properties: [prop("id", "string", { required: true, primary: true })],
+      links: [link("orders", Order)],
+    })
+    const sharedLinkOntology = new OntologyRegistry({ sources: [Customer, Reseller, Order] })
+
+    const storage = new CountingQueryStorage()
+    await seedCustomerOrders(storage)
+    await storage.applyObjectUpserted(
+      makeObjectUpsertedEvent("p1", "Reseller", "reseller-1", { id: "reseller-1" })
+    )
+    await storage.applyLinkUpserted(
+      makeLinkUpsertedEvent("p1", "Reseller", "reseller-1", "orders", "Order", "order-1")
+    )
+
+    const orderOneSources: ObjectQuery = {
+      kind: "traverse",
+      direction: "incoming",
+      linkId: "orders",
+      input: {
+        kind: "filter",
+        predicate: { op: "eq", propertyId: "id", value: "order-1" },
+        input: { kind: "start", objectTypeId: "Order" },
+      },
+    }
+
+    const unconstrained = await executeObjectQuery(
+      { projectId: "p1", query: orderOneSources },
+      { ontology: sharedLinkOntology, storage }
+    )
+    expect(unconstrained.objects.map((row) => row.primaryId).sort()).toEqual([
+      "cust-1",
+      "reseller-1",
+    ])
+
+    const constrained = await executeObjectQuery(
+      { projectId: "p1", query: { ...orderOneSources, sourceObjectTypeId: "Reseller" } },
+      { ontology: sharedLinkOntology, storage }
+    )
+    expect(constrained.plan.mode).toBe("pushdown")
+    expect(constrained.objects.map((row) => row.primaryId)).toEqual(["reseller-1"])
   })
 
   test("rejects fallback for search, traversal, and set nodes", async () => {

--- a/packages/server/src/schemas/objects.ts
+++ b/packages/server/src/schemas/objects.ts
@@ -141,6 +141,7 @@ export const ObjectQuerySchema: z.ZodType<unknown> = z.lazy(() =>
         input: ObjectQuerySchema,
         linkId: z.string().min(1),
         direction: z.enum(["outgoing", "incoming"]),
+        sourceObjectTypeId: z.string().min(1).optional(),
       })
       .strict(),
     z
@@ -479,6 +480,7 @@ export const ObjectQueryOpenApiSchemas = {
           input: objectQueryRef,
           linkId: { type: "string", minLength: 1 },
           direction: { type: "string", enum: ["outgoing", "incoming"] },
+          sourceObjectTypeId: { type: "string", minLength: 1 },
         },
       },
       {

--- a/storage/pg/src/pg-object-query-compiler.ts
+++ b/storage/pg/src/pg-object-query-compiler.ts
@@ -180,7 +180,13 @@ function compileObjectQueryInternal(
     case "page":
       return compilePage(projectId, query.input, query.pageSize, query.pageToken)
     case "traverse":
-      return compileTraversal(projectId, query.input, query.linkId, query.direction)
+      return compileTraversal(
+        projectId,
+        query.input,
+        query.linkId,
+        query.direction,
+        query.sourceObjectTypeId
+      )
     case "set":
       return compileSet(projectId, query.op, query.inputs)
     case "project":
@@ -390,7 +396,8 @@ function compileTraversal(
   projectId: string,
   inputQuery: ObjectQuery,
   linkId: string,
-  direction: "outgoing" | "incoming"
+  direction: "outgoing" | "incoming",
+  sourceObjectTypeId?: string
 ): CompiledPgObjectQuery {
   const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
@@ -412,7 +419,7 @@ function compileTraversal(
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
-         AND edge.link_id = ?
+         AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
         JOIN objects AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
@@ -426,7 +433,12 @@ function compileTraversal(
     ${joinSql}
     ORDER BY ${qualifiedOrder.sql}
   `
-  const args = [...input.args, linkId, ...qualifiedOrder.args]
+  const args = [
+    ...input.args,
+    linkId,
+    ...(sourceObjectTypeId === undefined ? [] : [sourceObjectTypeId]),
+    ...qualifiedOrder.args,
+  ]
 
   return {
     sql,
@@ -545,7 +557,13 @@ function compileAggregateSource(projectId: string, query: ObjectQuery): Compiled
       )
     }
     case "traverse":
-      return compileAggregateTraversal(projectId, query.input, query.linkId, query.direction)
+      return compileAggregateTraversal(
+        projectId,
+        query.input,
+        query.linkId,
+        query.direction,
+        query.sourceObjectTypeId
+      )
     case "set":
       return compileAggregateSet(projectId, query.op, query.inputs)
     case "sort":
@@ -597,7 +615,8 @@ function compileAggregateTraversal(
   projectId: string,
   inputQuery: ObjectQuery,
   linkId: string,
-  direction: "outgoing" | "incoming"
+  direction: "outgoing" | "incoming",
+  sourceObjectTypeId?: string
 ): CompiledAggregateSource {
   const input = compileAggregateSource(projectId, inputQuery)
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
@@ -619,7 +638,7 @@ function compileAggregateTraversal(
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
-         AND edge.link_id = ?
+         AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
         JOIN objects AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
@@ -636,7 +655,11 @@ function compileAggregateTraversal(
       FROM (${input.sql}) AS input
       ${joinSql}
     `,
-    args: [...input.args, linkId],
+    args: [
+      ...input.args,
+      linkId,
+      ...(sourceObjectTypeId === undefined ? [] : [sourceObjectTypeId]),
+    ],
   }
 }
 

--- a/storage/pg/tests/pg-object-query-compiler.test.ts
+++ b/storage/pg/tests/pg-object-query-compiler.test.ts
@@ -3,6 +3,7 @@ import type { ObjectQuery } from "@sixb/core"
 import {
   compilePgObjectCountQuery,
   compilePgObjectFacetQuery,
+  compilePgObjectQuery,
 } from "../src/pg-object-query-compiler"
 
 const sitePointQuery: ObjectQuery = {
@@ -70,4 +71,31 @@ test("facet aggregate SQL projects scalar values without sorting object rows", (
     "objectType",
     100,
   ])
+})
+
+test("incoming traversal SQL filters by source object type when constrained", () => {
+  const incoming: ObjectQuery = {
+    kind: "traverse",
+    direction: "incoming",
+    linkId: "customer",
+    input: { kind: "start", objectTypeId: "Customer" },
+  }
+
+  const unconstrained = compilePgObjectQuery("project-a", incoming)
+  expect(unconstrained.sql).not.toContain("AND edge.source_type_id =")
+  expect(unconstrained.args).toEqual(["project-a", "Customer", "customer"])
+
+  const constrained = compilePgObjectQuery("project-a", {
+    ...incoming,
+    sourceObjectTypeId: "Project",
+  })
+  expect(constrained.sql).toContain("AND edge.source_type_id = $4")
+  expect(constrained.args).toEqual(["project-a", "Customer", "customer", "Project"])
+
+  const constrainedCount = compilePgObjectCountQuery("project-a", {
+    ...incoming,
+    sourceObjectTypeId: "Project",
+  })
+  expect(constrainedCount.sql).toContain("AND edge.source_type_id = $4")
+  expect(constrainedCount.args).toEqual(["project-a", "Customer", "customer", "Project"])
 })

--- a/storage/sqlite/src/object-query-compiler.ts
+++ b/storage/sqlite/src/object-query-compiler.ts
@@ -101,7 +101,13 @@ function compileObjectQueryInternal(
     case "page":
       return compilePage(projectId, query.input, query.pageSize, query.pageToken)
     case "traverse":
-      return compileTraversal(projectId, query.input, query.linkId, query.direction)
+      return compileTraversal(
+        projectId,
+        query.input,
+        query.linkId,
+        query.direction,
+        query.sourceObjectTypeId
+      )
     case "set":
       return compileSet(projectId, query.op, query.inputs)
     case "project":
@@ -316,7 +322,8 @@ function compileTraversal(
   projectId: string,
   inputQuery: ObjectQuery,
   linkId: string,
-  direction: "outgoing" | "incoming"
+  direction: "outgoing" | "incoming",
+  sourceObjectTypeId?: string
 ): CompiledObjectQuery {
   const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
   const outputAlias = direction === "outgoing" ? "target_object" : "source_object"
@@ -338,7 +345,7 @@ function compileTraversal(
           ON edge.project_id = input.project_id
          AND edge.target_type_id = input.object_type_id
          AND edge.target_id = input.primary_id
-         AND edge.link_id = ?
+         AND edge.link_id = ?${sourceObjectTypeId === undefined ? "" : "\n         AND edge.source_type_id = ?"}
         JOIN objects AS source_object
           ON source_object.project_id = edge.project_id
          AND source_object.object_type_id = edge.source_type_id
@@ -352,7 +359,12 @@ function compileTraversal(
     ${joinSql}
     ORDER BY ${qualifiedOrder.sql}
   `
-  const args = [...input.args, linkId, ...qualifiedOrder.args]
+  const args = [
+    ...input.args,
+    linkId,
+    ...(sourceObjectTypeId === undefined ? [] : [sourceObjectTypeId]),
+    ...qualifiedOrder.args,
+  ]
 
   return {
     sql,


### PR DESCRIPTION
> Stacked on #64 (`client-query-builder`) — review only the last commit until that merges.

Incoming link traversal matched links by `linkId` alone. When two object types declare a link with the same id — in acme, `Project` and `Invoice` both link `customer` — traversal returned every matching source type, even though the fluent API names exactly one:

```ts
await objects(Customer)
  .query()
  .where((c) => c.p.id.eq("cust-eduplatform"))
  .traverse(Project.l.customer, { direction: "incoming" })  // typed as Project rows
  .list()

// before: [ Invoice "inv-005", Project "proj-eduplatform-redesign" ]
```

Worse, validation treated the result as the union of all source types, so a follow-up `status.eq("active")` was rejected against Invoice's enum — and the `set`/`intersect` escape hatch was closed too. Found by testing the query routes against a live dev server.

## The change

The `traverse` IR node gains an optional `sourceObjectTypeId`:

```json
{ "kind": "traverse", "linkId": "customer", "direction": "incoming", "sourceObjectTypeId": "Project", "input": ... }
```

- **Fluent builder** always pins it from the link token's owner type, so existing code gets the fix for free and result typing becomes truthful.
- **Raw queries** opt in; omitting the field keeps today's union behavior.
- **Validation** narrows the result type set to the pinned source (re-enabling post-traverse predicates), and rejects unknown source types or the field on outgoing traversal.
- **Providers** — in-memory, SQLite, and PG (including PG's separate count/exists/facets aggregate compiler) — filter link rows by `source_type_id`.
- **HTTP contract** — zod schema, OpenAPI component, and regenerated client types.

## Verification

- Validation narrowing + misuse rejection, and in-memory execution with a shared link id (`packages/core/tests/object-query.test.ts`).
- Provider conformance contract: a new `Zone` type shares `hasDevice` with `Room`, so every provider proves the filter (SQLite runs it in the fast suite; PG in the e2e matrix).
- PG compiler SQL assertions for both the row and aggregate paths (`AND edge.source_type_id = $4`) — local proof without a database.
- Acme e2e registers `Invoice`, recreating the original ambiguity against a real server: the fluent traverse returns only projects; raw IR without the field still returns the union.

1318 tests pass repo-wide; typecheck, build, and Biome clean.
