### PR TITLE
actions: route requests through durable queue lane

### DIFF
--- a/packages/action-worker/src/errors.ts
+++ b/packages/action-worker/src/errors.ts
@@ -1,0 +1,6 @@
+export class ActionWorkerError extends Error {
+  readonly name = "ActionWorkerError"
+  constructor(message: string, options?: ErrorOptions) {
+    super(`[SixbActionWorker] ${message}`, options)
+  }
+}

--- a/packages/action-worker/src/index.ts
+++ b/packages/action-worker/src/index.ts
@@ -1,3 +1,4 @@
+export { ActionWorkerError } from "./errors"
 export { runActionJob } from "./run-action-job"
 export type {
   ActionJob,

--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -1,5 +1,6 @@
 import type { ActionRunFailure, ActionRunRecord, ActionTargetObject } from "@sixb/core"
 import { isObjectActionDefinition, isTerminalActionRun, ObjectNotFoundError } from "@sixb/core"
+import { ActionWorkerError } from "./errors"
 import { throwIfAborted, toActionRunFailure } from "./normalize"
 import type { ActionRunResult, RunActionJobInput } from "./types"
 
@@ -27,9 +28,7 @@ function requireFinishedAt(runId: string, finishedAt: Date | undefined): Date {
     return finishedAt
   }
 
-  throw new Error(
-    `[SixbActionWorker] Action run '${runId}' finished without a finishedAt timestamp.`
-  )
+  throw new ActionWorkerError(`Action run '${runId}' finished without a finishedAt timestamp.`)
 }
 
 export async function runActionJob(input: RunActionJobInput): Promise<ActionRunResult> {
@@ -43,11 +42,11 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
     id: job.id,
   })
   if (!existingRun) {
-    throw new Error(`[SixbActionWorker] Action run '${job.id}' was not found.`)
+    throw new ActionWorkerError(`Action run '${job.id}' was not found.`)
   }
   if (existingRun.actionId !== job.actionId) {
-    throw new Error(
-      `[SixbActionWorker] Action job '${job.id}' references action '${job.actionId}' but the stored run references '${existingRun.actionId}'.`
+    throw new ActionWorkerError(
+      `Action job '${job.id}' references action '${job.actionId}' but the stored run references '${existingRun.actionId}'.`
     )
   }
   if (isTerminalActionRun(existingRun)) {
@@ -64,15 +63,15 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
     return failRedeliveredRunningRun(input, existingRun)
   }
   if (existingRun.status !== "queued") {
-    throw new Error(
-      `[SixbActionWorker] Action run '${job.id}' cannot execute from status '${existingRun.status}'.`
+    throw new ActionWorkerError(
+      `Action run '${job.id}' cannot execute from status '${existingRun.status}'.`
     )
   }
 
   const action = runtime.getActionById(job.actionId)
   if (!action) {
     const failure = toActionRunFailure(
-      new Error(`[SixbActionWorker] Unknown action '${job.actionId}'.`),
+      new ActionWorkerError(`Unknown action '${job.actionId}'.`),
       "handler"
     )
     const finishedRun = await runtime.actionRunsStorage.finish({
@@ -104,7 +103,7 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
 
     if (!isObjectActionDefinition(action)) {
       if (startedRun.subject.kind !== "none") {
-        throw new Error(`[SixbActionWorker] Action '${job.actionId}' does not accept a subject.`)
+        throw new ActionWorkerError(`Action '${job.actionId}' does not accept a subject.`)
       }
 
       await action.handler({
@@ -114,13 +113,13 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       })
     } else {
       if (startedRun.subject.kind !== "object") {
-        throw new Error(`[SixbActionWorker] Action '${job.actionId}' requires an object subject.`)
+        throw new ActionWorkerError(`Action '${job.actionId}' requires an object subject.`)
       }
 
       const subjectObjectType = runtime.sixb.getObjectTypeById(startedRun.subject.objectTypeId)
       if (!subjectObjectType) {
-        throw new Error(
-          `[SixbActionWorker] Unknown object type '${startedRun.subject.objectTypeId}' for action '${job.actionId}'.`
+        throw new ActionWorkerError(
+          `Unknown object type '${startedRun.subject.objectTypeId}' for action '${job.actionId}'.`
         )
       }
 
@@ -128,8 +127,8 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
         .getActionsForType(subjectObjectType)
         .some((candidate) => candidate.id === action.id)
       if (!actionAppliesToSubject) {
-        throw new Error(
-          `[SixbActionWorker] Action '${job.actionId}' is not valid for object type '${subjectObjectType.id}'.`
+        throw new ActionWorkerError(
+          `Action '${job.actionId}' is not valid for object type '${subjectObjectType.id}'.`
         )
       }
 
@@ -208,9 +207,12 @@ async function failRedeliveredRunningRun(
   existingRun: ActionRunRecord
 ): Promise<ActionRunResult> {
   const { runtime, job } = input
+  const error = new ActionWorkerError(
+    `Action run '${job.id}' was redelivered while already running. The previous worker may have lost its queue lease or crashed.`
+  )
   const failure: ActionRunFailure = {
     name: "ActionRunLeaseLostError",
-    message: `[SixbActionWorker] Action run '${job.id}' was redelivered while already running. The previous worker may have lost its queue lease or crashed.`,
+    message: error.message,
     phase: "handler",
   }
 

--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -1,5 +1,5 @@
 import type { ActionRunRecord, ActionTargetObject } from "@sixb/core"
-import { ActionRunError, isObjectActionDefinition, ObjectNotFoundError } from "@sixb/core"
+import { isObjectActionDefinition, ObjectNotFoundError } from "@sixb/core"
 import { throwIfAborted, toActionRunFailure } from "./normalize"
 import type { ActionRunResult, RunActionJobInput } from "./types"
 
@@ -32,71 +32,98 @@ function requireFinishedAt(runId: string, finishedAt: Date | undefined): Date {
   )
 }
 
-function isDuplicateStartError(error: unknown): boolean {
-  return error instanceof ActionRunError && /already exists/i.test(error.message)
+function isTerminalRun(record: ActionRunRecord): boolean {
+  return (
+    record.status === "succeeded" || record.status === "failed" || record.status === "cancelled"
+  )
 }
 
 export async function runActionJob(input: RunActionJobInput): Promise<ActionRunResult> {
   const { runtime, job } = input
   const signal = input.signal ?? new AbortController().signal
-  const action = runtime.getActionById(job.actionId)
-
-  if (!action) {
-    throw new Error(`[SixbActionWorker] Unknown action '${job.actionId}'.`)
-  }
 
   throwIfAborted(signal)
 
-  let startedRun: ActionRunRecord
+  const existingRun = await runtime.actionRunsStorage.getById({
+    projectId: runtime.id,
+    id: job.id,
+  })
+  if (!existingRun) {
+    throw new Error(`[SixbActionWorker] Action run '${job.id}' was not found.`)
+  }
+  if (existingRun.actionId !== job.actionId) {
+    throw new Error(
+      `[SixbActionWorker] Action job '${job.id}' references action '${job.actionId}' but the stored run references '${existingRun.actionId}'.`
+    )
+  }
+  if (isTerminalRun(existingRun)) {
+    return {
+      id: job.id,
+      actionId: job.actionId,
+      subject: existingRun.subject,
+      status: existingRun.status,
+      skipped: true,
+      record: existingRun,
+    }
+  }
+  if (existingRun.status !== "queued") {
+    throw new Error(
+      `[SixbActionWorker] Action run '${job.id}' cannot execute from status '${existingRun.status}'.`
+    )
+  }
+
+  const action = runtime.getActionById(job.actionId)
+  if (!action) {
+    const failure = toActionRunFailure(
+      new Error(`[SixbActionWorker] Unknown action '${job.actionId}'.`),
+      "handler"
+    )
+    const finishedRun = await runtime.actionRunsStorage.finish({
+      projectId: runtime.id,
+      id: job.id,
+      status: "failed",
+      error: failure,
+    })
+
+    return {
+      id: job.id,
+      actionId: job.actionId,
+      subject: finishedRun.subject,
+      status: "failed",
+      startedAt: finishedRun.startedAt ?? finishedRun.queuedAt,
+      finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
+      error: failure,
+      record: finishedRun,
+    }
+  }
+
+  let startedRun: ActionRunRecord | null = null
   try {
     startedRun = await runtime.actionRunsStorage.start({
       projectId: runtime.id,
       id: job.id,
-      actionId: job.actionId,
-      subject: job.subject,
-      params: job.params,
     })
-  } catch (error) {
-    const existing = await runtime.actionRunsStorage.getById({
-      projectId: runtime.id,
-      id: job.id,
-    })
-    if (existing && isDuplicateStartError(error)) {
-      return {
-        id: job.id,
-        actionId: job.actionId,
-        subject: job.subject,
-        status: existing.status,
-        skipped: true,
-        record: existing,
-      }
-    }
-
-    throw error
-  }
-
-  try {
     throwIfAborted(signal)
 
     if (!isObjectActionDefinition(action)) {
-      if (job.subject.kind !== "none") {
+      if (startedRun.subject.kind !== "none") {
         throw new Error(`[SixbActionWorker] Action '${job.actionId}' does not accept a subject.`)
       }
 
       await action.handler({
-        params: job.params,
+        params: startedRun.params,
         sixb: runtime.sixb,
         signal,
       })
     } else {
-      if (job.subject.kind !== "object") {
+      if (startedRun.subject.kind !== "object") {
         throw new Error(`[SixbActionWorker] Action '${job.actionId}' requires an object subject.`)
       }
 
-      const subjectObjectType = runtime.sixb.getObjectTypeById(job.subject.objectTypeId)
+      const subjectObjectType = runtime.sixb.getObjectTypeById(startedRun.subject.objectTypeId)
       if (!subjectObjectType) {
         throw new Error(
-          `[SixbActionWorker] Unknown object type '${job.subject.objectTypeId}' for action '${job.actionId}'.`
+          `[SixbActionWorker] Unknown object type '${startedRun.subject.objectTypeId}' for action '${job.actionId}'.`
         )
       }
 
@@ -112,19 +139,19 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       const targetRow = await runtime.storage.objects.getByPrimaryId({
         projectId: runtime.id,
         objectTypeId: subjectObjectType.id,
-        primaryId: job.subject.primaryId,
+        primaryId: startedRun.subject.primaryId,
       })
 
       if (!targetRow) {
         throw new ObjectNotFoundError(
-          job.subject.objectTypeId,
-          job.subject.primaryId,
+          startedRun.subject.objectTypeId,
+          startedRun.subject.primaryId,
           "Object not found for action run"
         )
       }
 
       await action.handler({
-        params: job.params,
+        params: startedRun.params,
         target: toActionTargetObject(targetRow, action.target.id),
         sixb: runtime.sixb,
         signal,
@@ -142,9 +169,9 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
     return {
       id: job.id,
       actionId: job.actionId,
-      subject: job.subject,
+      subject: startedRun.subject,
       status: "succeeded",
-      startedAt: startedRun.startedAt,
+      startedAt: startedRun.startedAt ?? startedRun.queuedAt,
       finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
       record: finishedRun,
     }
@@ -165,12 +192,13 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       throw error
     }
 
+    const startedAt = startedRun?.startedAt ?? finishedRun.startedAt ?? finishedRun.queuedAt
     return {
       id: job.id,
       actionId: job.actionId,
-      subject: job.subject,
+      subject: finishedRun.subject,
       status,
-      startedAt: startedRun.startedAt,
+      startedAt,
       finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
       error: failure,
       record: finishedRun,

--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -1,5 +1,5 @@
-import type { ActionRunRecord, ActionTargetObject } from "@sixb/core"
-import { isObjectActionDefinition, ObjectNotFoundError } from "@sixb/core"
+import type { ActionRunFailure, ActionRunRecord, ActionTargetObject } from "@sixb/core"
+import { isObjectActionDefinition, isTerminalActionRun, ObjectNotFoundError } from "@sixb/core"
 import { throwIfAborted, toActionRunFailure } from "./normalize"
 import type { ActionRunResult, RunActionJobInput } from "./types"
 
@@ -32,12 +32,6 @@ function requireFinishedAt(runId: string, finishedAt: Date | undefined): Date {
   )
 }
 
-function isTerminalRun(record: ActionRunRecord): boolean {
-  return (
-    record.status === "succeeded" || record.status === "failed" || record.status === "cancelled"
-  )
-}
-
 export async function runActionJob(input: RunActionJobInput): Promise<ActionRunResult> {
   const { runtime, job } = input
   const signal = input.signal ?? new AbortController().signal
@@ -56,7 +50,7 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       `[SixbActionWorker] Action job '${job.id}' references action '${job.actionId}' but the stored run references '${existingRun.actionId}'.`
     )
   }
-  if (isTerminalRun(existingRun)) {
+  if (isTerminalActionRun(existingRun)) {
     return {
       id: job.id,
       actionId: job.actionId,
@@ -65,6 +59,9 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       skipped: true,
       record: existingRun,
     }
+  }
+  if (existingRun.status === "running") {
+    return failRedeliveredRunningRun(input, existingRun)
   }
   if (existingRun.status !== "queued") {
     throw new Error(
@@ -203,5 +200,60 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       error: failure,
       record: finishedRun,
     }
+  }
+}
+
+async function failRedeliveredRunningRun(
+  input: RunActionJobInput,
+  existingRun: ActionRunRecord
+): Promise<ActionRunResult> {
+  const { runtime, job } = input
+  const failure: ActionRunFailure = {
+    name: "ActionRunLeaseLostError",
+    message: `[SixbActionWorker] Action run '${job.id}' was redelivered while already running. The previous worker may have lost its queue lease or crashed.`,
+    phase: "handler",
+  }
+
+  const finishedRun = await runtime.actionRunsStorage
+    .finish({
+      projectId: runtime.id,
+      id: job.id,
+      status: "failed",
+      phase: "handler",
+      error: failure,
+    })
+    .catch(async (error) => {
+      const latest = await runtime.actionRunsStorage.getById({
+        projectId: runtime.id,
+        id: job.id,
+      })
+
+      if (latest && isTerminalActionRun(latest)) {
+        return latest
+      }
+
+      throw error
+    })
+
+  if (finishedRun.status !== "failed") {
+    return {
+      id: job.id,
+      actionId: job.actionId,
+      subject: finishedRun.subject,
+      status: finishedRun.status,
+      skipped: true,
+      record: finishedRun,
+    }
+  }
+
+  return {
+    id: job.id,
+    actionId: job.actionId,
+    subject: finishedRun.subject,
+    status: "failed",
+    startedAt: existingRun.startedAt ?? existingRun.queuedAt,
+    finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
+    error: finishedRun.error ?? failure,
+    record: finishedRun,
   }
 }

--- a/packages/action-worker/src/types.ts
+++ b/packages/action-worker/src/types.ts
@@ -23,8 +23,6 @@ export interface ActionWorkerContext {
 export interface ActionJob {
   readonly id: string
   readonly actionId: string
-  readonly subject: ActionSubject
-  readonly params: Readonly<Record<string, unknown>>
 }
 
 interface BaseActionRunResult {

--- a/packages/action-worker/src/worker.ts
+++ b/packages/action-worker/src/worker.ts
@@ -23,10 +23,9 @@ export interface ActionWorkerSixb {
 }
 
 export interface ActionWorkerOptions {
-  readonly maxConcurrency?: number
+  readonly leaseMs?: number
+  readonly idlePollMs?: number
 }
-
-const DEFAULT_MAX_CONCURRENCY = 16
 
 export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
   private readonly context: ActionWorkerContext | null
@@ -34,16 +33,13 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
   private readonly idleWithoutDefinitions: boolean
 
   constructor(sixb: ActionWorkerSixb, options: ActionWorkerOptions = {}) {
-    const maxConcurrency = options.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY
-    if (maxConcurrency <= 0) {
-      throw new Error("[SixbActionWorker] maxConcurrency must be greater than 0.")
-    }
-
     super({
       projectId: sixb.id,
       queue: sixb.queues.actions,
       workerId: `action-worker-${sixb.id}`,
-      claimLimit: maxConcurrency,
+      claimLimit: 1,
+      leaseMs: options.leaseMs,
+      idlePollMs: options.idlePollMs,
     })
 
     const actions = sixb.getActionDefinitions()

--- a/packages/action-worker/src/worker.ts
+++ b/packages/action-worker/src/worker.ts
@@ -1,12 +1,15 @@
 import type {
   ActionDefinition,
+  ActionRunRequestedQueueJob,
+  ClaimedQueueJob,
   EventsRuntime,
   OntologySource,
+  Queues,
+  QueueWorkerFailureDecision,
   Sixb,
   Storage,
-  StoredActionRequestedEvent,
 } from "@sixb/core"
-import { Worker } from "@sixb/core"
+import { QueueWorker } from "@sixb/core"
 import { runActionJob } from "./run-action-job"
 import type { ActionJob, ActionRunResult, ActionWorkerContext } from "./types"
 
@@ -14,6 +17,7 @@ export interface ActionWorkerSixb {
   readonly id: string
   readonly events: EventsRuntime
   readonly storage: Storage
+  readonly queues: Queues
   getActionDefinitions(): readonly ActionDefinition[]
   getActionById(actionId: string): ActionDefinition | null
 }
@@ -24,14 +28,23 @@ export interface ActionWorkerOptions {
 
 const DEFAULT_MAX_CONCURRENCY = 16
 
-export class ActionWorker extends Worker {
+export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
   private readonly context: ActionWorkerContext | null
   private readonly sixb: ActionWorkerSixb
-  private readonly actionIds: ReadonlySet<string>
-  private readonly maxConcurrency: number
+  private readonly idleWithoutDefinitions: boolean
 
   constructor(sixb: ActionWorkerSixb, options: ActionWorkerOptions = {}) {
-    super()
+    const maxConcurrency = options.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY
+    if (maxConcurrency <= 0) {
+      throw new Error("[SixbActionWorker] maxConcurrency must be greater than 0.")
+    }
+
+    super({
+      projectId: sixb.id,
+      queue: sixb.queues.actions,
+      workerId: `action-worker-${sixb.id}`,
+      claimLimit: maxConcurrency,
+    })
 
     const actions = sixb.getActionDefinitions()
     if (actions.length === 0) {
@@ -40,92 +53,68 @@ export class ActionWorker extends Worker {
 
     this.context = actions.length > 0 ? buildActionContext(sixb) : null
     this.sixb = sixb
-    this.actionIds = new Set(actions.map((action) => action.id))
-    this.maxConcurrency = options.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY
-
-    if (this.maxConcurrency <= 0) {
-      throw new Error("[SixbActionWorker] maxConcurrency must be greater than 0.")
-    }
+    this.idleWithoutDefinitions = actions.length === 0
   }
 
-  protected async run(signal: AbortSignal): Promise<void> {
-    const inFlight = new Set<Promise<void>>()
-    const pending: StoredActionRequestedEvent[] = []
-    const dispatch = (event: StoredActionRequestedEvent): void => {
-      const task = this.handleActionRequested(event, signal).finally(() => {
-        inFlight.delete(task)
-        const next = pending.shift()
-        if (next && !signal.aborted) dispatch(next)
-      })
-      inFlight.add(task)
+  protected override async run(signal: AbortSignal): Promise<void> {
+    if (!this.idleWithoutDefinitions) {
+      await super.run(signal)
+      return
     }
 
-    const unsubscribe = await this.sixb.events.subscribe(
-      {
-        types: ["action.requested"],
-      },
-      (events) => {
-        for (const event of events) {
-          if (event.type !== "action.requested") continue
-          if (!this.actionIds.has(event.payload.actionId)) continue
-          if (!this.context) continue
-          if (signal.aborted) continue
-
-          if (inFlight.size < this.maxConcurrency) {
-            dispatch(event)
-          } else {
-            pending.push(event)
-          }
-        }
+    await new Promise<void>((resolve) => {
+      if (signal.aborted) {
+        resolve()
+        return
       }
-    )
-
-    try {
-      await new Promise<void>((resolve) => {
-        if (signal.aborted) {
-          resolve()
-          return
-        }
-        signal.addEventListener("abort", () => resolve(), { once: true })
-      })
-    } finally {
-      unsubscribe()
-      pending.length = 0
-      await Promise.allSettled(inFlight)
-    }
+      signal.addEventListener("abort", () => resolve(), { once: true })
+    })
   }
 
-  private async handleActionRequested(
-    event: StoredActionRequestedEvent,
+  protected async execute(
+    claimed: ClaimedQueueJob<ActionRunRequestedQueueJob>,
     signal: AbortSignal
   ): Promise<void> {
     const context = this.context
     if (!context) {
+      throw new Error("[SixbActionWorker] No action definitions are registered.")
+    }
+
+    const { job } = claimed
+    if (job.type !== "action.run.requested") {
+      throw new Error(`[SixbActionWorker] Unsupported action job type '${job.type}'.`)
+    }
+
+    const actionJob: ActionJob = {
+      id: job.payload.runId,
+      actionId: job.payload.actionId,
+    }
+
+    const result = await runActionJob({
+      runtime: context,
+      job: actionJob,
+      signal,
+    })
+
+    if ("skipped" in result) {
       return
     }
 
-    const job: ActionJob = {
-      id: event.payload.runId,
-      actionId: event.payload.actionId,
-      subject: event.payload.subject,
-      params: event.payload.params,
-    }
+    await emitActionTerminalEvent(this.sixb, result)
+  }
 
-    try {
-      const result = await runActionJob({
-        runtime: context,
-        job,
-        signal,
-      })
+  protected override async onExecutionError(
+    _claimed: ClaimedQueueJob<ActionRunRequestedQueueJob>,
+    _error: unknown
+  ): Promise<QueueWorkerFailureDecision> {
+    return { kind: "fail" }
+  }
 
-      if ("skipped" in result) {
-        return
-      }
-
-      await emitActionTerminalEvent(this.sixb, result)
-    } catch (error) {
-      console.error("[SixbActionWorker] Failed to execute action run:", error)
-    }
+  protected override async onAbortError(
+    _claimed: ClaimedQueueJob<ActionRunRequestedQueueJob>,
+    _error: unknown
+  ): Promise<QueueWorkerFailureDecision> {
+    return { kind: "fail" }
   }
 }
 

--- a/packages/action-worker/src/worker.ts
+++ b/packages/action-worker/src/worker.ts
@@ -10,6 +10,7 @@ import type {
   Storage,
 } from "@sixb/core"
 import { QueueWorker } from "@sixb/core"
+import { ActionWorkerError } from "./errors"
 import { runActionJob } from "./run-action-job"
 import type { ActionJob, ActionRunResult, ActionWorkerContext } from "./types"
 
@@ -73,12 +74,12 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
   ): Promise<void> {
     const context = this.context
     if (!context) {
-      throw new Error("[SixbActionWorker] No action definitions are registered.")
+      throw new ActionWorkerError("No action definitions are registered.")
     }
 
     const { job } = claimed
     if (job.type !== "action.run.requested") {
-      throw new Error(`[SixbActionWorker] Unsupported action job type '${job.type}'.`)
+      throw new ActionWorkerError(`Unsupported action job type '${job.type}'.`)
     }
 
     const actionJob: ActionJob = {
@@ -162,7 +163,7 @@ async function emitActionTerminalEvent(
 function buildActionContext(sixb: ActionWorkerSixb): ActionWorkerContext {
   const actionRunsStorage = sixb.storage.actionRuns
   if (!actionRunsStorage) {
-    throw new Error("[SixbActionWorker] Action workers require storage.actionRuns support.")
+    throw new ActionWorkerError("Action workers require storage.actionRuns support.")
   }
 
   return {

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -16,7 +16,7 @@ import {
   prop,
   Sixb,
 } from "@sixb/core"
-import { type ActionWorkerContext, runActionJob } from "../src"
+import { type ActionWorkerContext, ActionWorkerError, runActionJob } from "../src"
 
 const Device = defineObjectType({
   id: "Device",
@@ -107,6 +107,23 @@ async function queueActionRun(
 }
 
 describe("runActionJob", () => {
+  test("throws ActionWorkerError when the stored run is missing", async () => {
+    const count = defineAction("count")
+      .params({})
+      .run(() => {})
+    const sixb = createSixb([count])
+
+    await expect(
+      runActionJob({
+        runtime: createContext(sixb),
+        job: {
+          id: "act_missing",
+          actionId: "count",
+        },
+      })
+    ).rejects.toBeInstanceOf(ActionWorkerError)
+  })
+
   test("runs the handler, applies object writes, and stores a succeeded run", async () => {
     const setStatus = defineAction("setStatus")
       .target(Device)

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -304,6 +304,47 @@ describe("runActionJob", () => {
     expect(run?.phase).toBe("handler")
   })
 
+  test("marks redelivered running runs failed without invoking the handler again", async () => {
+    let invoked = 0
+    const count = defineAction("count")
+      .params({})
+      .run(() => {
+        invoked += 1
+      })
+
+    const sixb = createSixb([count])
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "count",
+      subject: { kind: "none" },
+      params: {},
+    })
+    await sixb.storage.actionRuns!.start({
+      projectId: sixb.id,
+      id: "act_1",
+    })
+
+    const result = await runActionJob({
+      runtime: createContext(sixb),
+      job: {
+        id: "act_1",
+        actionId: "count",
+      },
+    })
+
+    expect(result.status).toBe("failed")
+    if ("error" in result) {
+      expect(result.error.name).toBe("ActionRunLeaseLostError")
+      expect(result.error.phase).toBe("handler")
+    }
+    expect(invoked).toBe(0)
+
+    const run = await sixb.storage.actionRuns!.getById({ projectId: sixb.id, id: "act_1" })
+    expect(run?.status).toBe("failed")
+    expect(run?.phase).toBe("handler")
+    expect(run?.finishedAt).toBeInstanceOf(Date)
+  })
+
   test("rejects forged object subjects outside the action target hierarchy", async () => {
     let invoked = 0
     const setStatus = defineAction("setStatus")

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import {
   type ActionDefinition,
+  type ActionRunParams,
+  type ActionSubject,
   actionParam,
   defineAction,
   defineObjectType,
@@ -85,6 +87,25 @@ function createContext(sixb: TestSixb): ActionWorkerContext {
   }
 }
 
+async function queueActionRun(
+  sixb: TestSixb,
+  input: {
+    readonly id: string
+    readonly actionId: string
+    readonly subject: ActionSubject
+    readonly params: ActionRunParams
+  }
+): Promise<void> {
+  await sixb.storage.actionRuns!.queue({
+    projectId: sixb.id,
+    id: input.id,
+    actionId: input.actionId,
+    subject: input.subject,
+    params: input.params,
+    idempotencyKey: `action:${sixb.id}:${input.id}`,
+  })
+}
+
 describe("runActionJob", () => {
   test("runs the handler, applies object writes, and stores a succeeded run", async () => {
     const setStatus = defineAction("setStatus")
@@ -106,14 +127,18 @@ describe("runActionJob", () => {
       id: "device-1",
       name: "Device 1",
     })
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "setStatus",
+      subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
+      params: { status: "ready" },
+    })
 
     const result = await runActionJob({
       runtime: createContext(sixb),
       job: {
         id: "act_1",
         actionId: "setStatus",
-        subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
-        params: { status: "ready" },
       },
     })
 
@@ -146,14 +171,18 @@ describe("runActionJob", () => {
       id: "device-1",
       name: "Device 1",
     })
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "failAfterWrite",
+      subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
+      params: {},
+    })
 
     const result = await runActionJob({
       runtime: createContext(sixb),
       job: {
         id: "act_1",
         actionId: "failAfterWrite",
-        subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
-        params: {},
       },
     })
 
@@ -185,14 +214,18 @@ describe("runActionJob", () => {
       name: "Device 1",
     })
     const context = createContext(sixb)
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "count",
+      subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
+      params: {},
+    })
 
     await runActionJob({
       runtime: context,
       job: {
         id: "act_1",
         actionId: "count",
-        subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
-        params: {},
       },
     })
 
@@ -201,8 +234,6 @@ describe("runActionJob", () => {
       job: {
         id: "act_1",
         actionId: "count",
-        subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
-        params: {},
       },
     })
 
@@ -225,13 +256,17 @@ describe("runActionJob", () => {
       })
 
     const sixb = createSixb([createDevice])
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "createDevice",
+      subject: { kind: "none" },
+      params: { id: "device-1" },
+    })
     const result = await runActionJob({
       runtime: createContext(sixb),
       job: {
         id: "act_1",
         actionId: "createDevice",
-        subject: { kind: "none" },
-        params: { id: "device-1" },
       },
     })
 
@@ -241,6 +276,32 @@ describe("runActionJob", () => {
 
     const created = await deviceObjects(sixb).get("device-1")
     expect(created?.properties.status).toBe("created")
+  })
+
+  test("marks queued runs failed when the action definition is missing", async () => {
+    const sixb = createSixb([])
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "missingAction",
+      subject: { kind: "none" },
+      params: {},
+    })
+
+    const result = await runActionJob({
+      runtime: createContext(sixb),
+      job: {
+        id: "act_1",
+        actionId: "missingAction",
+      },
+    })
+
+    expect(result.status).toBe("failed")
+    if ("error" in result) {
+      expect(result.error.message).toBe("[SixbActionWorker] Unknown action 'missingAction'.")
+    }
+    const run = await sixb.storage.actionRuns!.getById({ projectId: sixb.id, id: "act_1" })
+    expect(run?.status).toBe("failed")
+    expect(run?.phase).toBe("handler")
   })
 
   test("rejects forged object subjects outside the action target hierarchy", async () => {
@@ -257,14 +318,18 @@ describe("runActionJob", () => {
       id: "sensor-1",
       name: "Sensor 1",
     })
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "setStatus",
+      subject: { kind: "object", objectTypeId: "Sensor", primaryId: "sensor-1" },
+      params: {},
+    })
 
     const result = await runActionJob({
       runtime: createContext(sixb),
       job: {
         id: "act_1",
         actionId: "setStatus",
-        subject: { kind: "object", objectTypeId: "Sensor", primaryId: "sensor-1" },
-        params: {},
       },
     })
 

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   type ActionDefinition,
-  ActionRunFailedError,
+  type ActionRunRecord,
   actionParam,
   defineAction,
   defineObjectType,
@@ -39,13 +39,14 @@ interface DeviceObjectSet {
     id: string
     actionId: string
     params?: Record<string, unknown>
-  }): Promise<{ runId: string }>
+  }): Promise<ActionRunRecord>
 }
 
 interface TestSixb {
   readonly id: string
   readonly events: EventsRuntime
   readonly storage: InMemoryStorage
+  readonly queues: InMemoryQueues
   upsertObject(objectTypeId: string, properties: Record<string, unknown>): Promise<ObjectRow>
   getActionDefinitions(): readonly ActionDefinition[]
   getActionById(actionId: string): ActionDefinition | null
@@ -82,6 +83,7 @@ describe("ActionWorker", () => {
         objects: storage.objects,
         timeseries: storage.timeseries,
       },
+      queues: new InMemoryQueues(),
       getActionDefinitions() {
         return []
       },
@@ -94,7 +96,7 @@ describe("ActionWorker", () => {
     await worker.stop()
   })
 
-  test("subscribes to action.requested and emits action.completed", async () => {
+  test("claims requested action runs and emits action.completed", async () => {
     const setStatus = defineAction("setStatus")
       .target(Device)
       .params({ status: actionParam("string", { required: true }) })
@@ -149,7 +151,7 @@ describe("ActionWorker", () => {
     await worker.stop()
   })
 
-  test("requestActionAndWait resolves on completion and rejects on failed runs", async () => {
+  test("requestActionAndWait resolves with the terminal action run", async () => {
     const setStatus = defineAction("setStatus")
       .target(Device)
       .params({ status: actionParam("string", { required: true }) })
@@ -183,14 +185,15 @@ describe("ActionWorker", () => {
       actionId: "setStatus",
       params: { status: "ready" },
     })
-    expect(succeeded.runId.startsWith("act_")).toBe(true)
+    expect(succeeded.id.startsWith("act_")).toBe(true)
+    expect(succeeded.status).toBe("succeeded")
 
-    await expect(
-      deviceObjects(sixb).requestActionAndWait({
-        id: "device-1",
-        actionId: "fail",
-      })
-    ).rejects.toBeInstanceOf(ActionRunFailedError)
+    const failed = await deviceObjects(sixb).requestActionAndWait({
+      id: "device-1",
+      actionId: "fail",
+    })
+    expect(failed.status).toBe("failed")
+    expect(failed.error?.message).toBe("handler failed")
 
     await worker.stop()
   })

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -15,7 +15,7 @@ import {
   prop,
   Sixb,
 } from "@sixb/core"
-import { ActionWorker } from "../src"
+import { ActionWorker, ActionWorkerError } from "../src"
 import { waitFor } from "./helpers"
 
 const Device = defineObjectType({
@@ -94,6 +94,36 @@ describe("ActionWorker", () => {
 
     await worker.start()
     await worker.stop()
+  })
+
+  test("throws ActionWorkerError when action-run storage is missing", () => {
+    const noop = defineAction("noop")
+      .target(Device)
+      .params({})
+      .run(() => {})
+    const storage = new InMemoryStorage()
+
+    expect(
+      () =>
+        new ActionWorker({
+          id: "missing-action-runs",
+          events: new EventsRuntime({
+            projectId: "missing-action-runs",
+            broker: new InMemoryBroker(),
+          }),
+          storage: {
+            objects: storage.objects,
+            timeseries: storage.timeseries,
+          },
+          queues: new InMemoryQueues(),
+          getActionDefinitions() {
+            return [noop]
+          },
+          getActionById(actionId) {
+            return actionId === noop.id ? noop : null
+          },
+        })
+    ).toThrow(ActionWorkerError)
   })
 
   test("claims requested action runs and emits action.completed", async () => {

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -9501,9 +9501,18 @@
                     },
                     "runId": {
                       "type": "string"
+                    },
+                    "queuedAt": {
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "type": "string"
+                    },
+                    "created": {
+                      "type": "boolean"
                     }
                   },
-                  "required": ["success", "runId"],
+                  "required": ["success", "runId", "queuedAt", "created"],
                   "additionalProperties": false
                 }
               }

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3301,6 +3301,9 @@ export type RequestActionResponses = {
   200: {
     success: boolean
     runId: string
+    queuedAt: string
+    jobId?: string
+    created: boolean
   }
 }
 

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -6,8 +6,10 @@ export type {
   RequestActionAndWaitOptions,
   RequestActionInput,
   RequestActionOptions,
+  RequestActionResult,
+  WaitForActionRunInput,
 } from "./request"
-export { requestAction, requestActionAndWait } from "./request"
+export { requestAction, requestActionAndWait, waitForActionRun } from "./request"
 export { ActionsRuntime } from "./runtime"
 export type {
   ActionBinding,

--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -1,14 +1,17 @@
 import { randomUUID } from "node:crypto"
-import type { StoredActionCompletedEvent, StoredActionFailedEvent } from "../events"
-import {
-  ActionRunFailedError,
-  ActionRunTimeoutError,
-  ActionValidationError,
-} from "../objects/action/errors"
+import type { SecurityContext } from "../auth"
+import type { EventActor } from "../events"
+import { ActionRunTimeoutError, ActionValidationError } from "../objects/action/errors"
 import { requireObject } from "../objects/helpers"
 import { OntologyValidationError } from "../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
 import type { SixbRuntimeContext } from "../runtime/types"
+import {
+  ActionRunError,
+  type ActionRunParams,
+  type ActionRunRecord,
+  type ActionRunStorage,
+} from "../storage"
 import type {
   ActionDefinition,
   ActionSubject,
@@ -18,14 +21,22 @@ import type {
 import {
   isGlobalActionDefinition,
   isObjectActionDefinition,
+  normalizeActionParams,
   resolveObjectActionSubject,
-  validateActionParams,
   validateActionSubject,
 } from "./validation"
+
+export interface RequestActionResult {
+  readonly runId: string
+  readonly queuedAt: string
+  readonly jobId?: string
+  readonly created: boolean
+}
 
 export interface RequestActionOptions {
   readonly runId?: string
   readonly signal?: AbortSignal
+  readonly securityContext?: SecurityContext
 }
 
 export interface RequestActionAndWaitOptions extends RequestActionOptions {
@@ -39,11 +50,18 @@ export interface RequestActionInput {
   readonly params?: Record<string, unknown>
   readonly runId?: string
   readonly signal?: AbortSignal
+  readonly securityContext?: SecurityContext
 }
 
 export interface RequestActionAndWaitInput extends RequestActionInput {
   readonly timeoutMs?: number
   readonly onRequested?: (runId: string) => void | Promise<void>
+}
+
+export interface WaitForActionRunInput {
+  readonly runId: string
+  readonly timeoutMs?: number
+  readonly signal?: AbortSignal
 }
 
 const DEFAULT_ACTION_WAIT_TIMEOUT_MS = 60_000
@@ -104,20 +122,14 @@ async function loadActionTarget(params: {
   return toActionTargetObject(targetRow, action.target.id)
 }
 
-function isTerminalActionEvent(
-  event: StoredActionCompletedEvent | StoredActionFailedEvent,
-  runId: string
-): boolean {
-  return event.payload.runId === runId
-}
-
 export async function requestAction(
   runtime: SixbRuntimeContext,
   input: RequestActionInput
-): Promise<{ runId: string }> {
+): Promise<RequestActionResult> {
+  const actionRuns = requireActionRunStorage(runtime)
   const action = getActionDefinition(runtime, input.actionId)
   const actionId = action.id
-  const actionParams: Record<string, unknown> = input.params ?? {}
+  const rawParams: Record<string, unknown> = input.params ?? {}
   const subject: ActionSubject = input.subject ?? { kind: "none" }
   const signal = input.signal ?? new AbortController().signal
 
@@ -131,7 +143,7 @@ export async function requestAction(
     pathPrefix = `${objectType.id}.${action.id}`
   }
 
-  validateActionParams(runtime, action, actionParams, pathPrefix)
+  const actionParams = normalizeActionParams(runtime, action.params, rawParams, pathPrefix)
 
   if (isGlobalActionDefinition(action)) {
     for (const validator of action.validators) {
@@ -153,113 +165,324 @@ export async function requestAction(
   }
 
   const runId = createActionRunId(input.runId)
+  const existing = await actionRuns.getById({ projectId: runtime.projectId, id: runId })
+  if (existing) {
+    assertExistingRunMatchesRequest(existing, {
+      actionId,
+      subject,
+      params: actionParams,
+    })
+    if (isRetryableEnqueueFailure(existing)) {
+      const queuedAt = new Date()
+      await actionRuns.queue({
+        projectId: runtime.projectId,
+        id: runId,
+        actionId,
+        subject,
+        params: actionParams,
+        idempotencyKey: existing.idempotencyKey,
+        securityContext: existing.securityContext,
+        queuedAt,
+      })
+      return enqueueActionRunJob(runtime, {
+        actionRuns,
+        actionId,
+        subject,
+        params: actionParams,
+        runId,
+        queuedAt,
+        created: false,
+        securityContext: input.securityContext,
+      })
+    }
+    return {
+      runId,
+      queuedAt: existing.queuedAt.toISOString(),
+      created: false,
+    }
+  }
+
+  const queuedAt = new Date()
+  const idempotencyKey = createActionRunIdempotencyKey(runtime.projectId, runId)
+
+  await actionRuns.queue({
+    projectId: runtime.projectId,
+    id: runId,
+    actionId,
+    subject,
+    params: actionParams,
+    idempotencyKey,
+    securityContext: input.securityContext,
+    queuedAt,
+  })
+
+  return enqueueActionRunJob(runtime, {
+    actionRuns,
+    actionId,
+    subject,
+    params: actionParams,
+    runId,
+    queuedAt,
+    created: true,
+    securityContext: input.securityContext,
+  })
+}
+
+async function enqueueActionRunJob(
+  runtime: SixbRuntimeContext,
+  params: {
+    readonly actionRuns: ActionRunStorage
+    readonly actionId: string
+    readonly subject: ActionSubject
+    readonly params: ActionRunParams
+    readonly runId: string
+    readonly queuedAt: Date
+    readonly created: boolean
+    readonly securityContext?: SecurityContext
+  }
+): Promise<RequestActionResult> {
+  let jobId: string | undefined
+  try {
+    const [job] = await runtime.queues.actions.enqueue({
+      projectId: runtime.projectId,
+      jobs: [
+        {
+          type: "action.run.requested",
+          payload: {
+            actionId: params.actionId,
+            runId: params.runId,
+          },
+        },
+      ],
+    })
+    jobId = job?.id
+  } catch (error) {
+    await params.actionRuns.finish({
+      projectId: runtime.projectId,
+      id: params.runId,
+      status: "failed",
+      phase: "enqueue",
+      error: toActionRunFailure(error, "enqueue"),
+    })
+    throw error
+  }
 
   await runtime.events.append({
+    actor: params.securityContext ? toEventActor(params.securityContext) : undefined,
+    correlationId: params.securityContext?.correlationId,
     events: [
       {
         type: "action.requested",
         payload: {
-          actionId,
-          subject,
-          params: actionParams,
-          runId,
+          actionId: params.actionId,
+          subject: params.subject,
+          params: params.params,
+          runId: params.runId,
         },
       },
     ],
   })
 
-  return { runId }
+  return {
+    runId: params.runId,
+    queuedAt: params.queuedAt.toISOString(),
+    ...(jobId ? { jobId } : {}),
+    created: params.created,
+  }
 }
 
 export async function requestActionAndWait(
   runtime: SixbRuntimeContext,
   input: RequestActionAndWaitInput
-): Promise<{ runId: string }> {
+): Promise<ActionRunRecord> {
   const runId = createActionRunId(input.runId)
+
+  await requestAction(runtime, {
+    ...input,
+    runId,
+  })
+  await input.onRequested?.(runId)
+
+  return waitForActionRun(runtime, {
+    runId,
+    timeoutMs: input.timeoutMs,
+    signal: input.signal,
+  })
+}
+
+export async function waitForActionRun(
+  runtime: SixbRuntimeContext,
+  input: WaitForActionRunInput
+): Promise<ActionRunRecord> {
+  const actionRuns = requireActionRunStorage(runtime)
   const timeoutMs = input.timeoutMs ?? DEFAULT_ACTION_WAIT_TIMEOUT_MS
   const signal = input.signal
+  const startedAt = Date.now()
 
   if (signal?.aborted) {
     throw signal.reason ?? new Error("aborted")
   }
 
-  let unsubscribe: (() => void) | undefined
-  let timer: ReturnType<typeof setTimeout> | undefined
-  let abortListener: (() => void) | undefined
-  let settled = false
+  return new Promise<ActionRunRecord>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let pollTimer: ReturnType<typeof setTimeout> | undefined
+    let unsubscribe: (() => void) | undefined
+    let settled = false
 
-  const cleanup = () => {
-    if (settled) {
-      return
+    const cleanup = () => {
+      if (settled) return
+      settled = true
+      clearTimer(timer)
+      clearTimer(pollTimer)
+      unsubscribe?.()
+      signal?.removeEventListener("abort", onAbort)
     }
-    settled = true
-    clearTimer(timer)
-    unsubscribe?.()
-    if (abortListener && signal) {
-      signal.removeEventListener("abort", abortListener)
-      abortListener = undefined
-    }
-  }
 
-  let resolveTerminal!: (value: { runId: string }) => void
-  let rejectTerminal!: (reason?: unknown) => void
-  const terminal = new Promise<{ runId: string }>((resolve, reject) => {
-    resolveTerminal = resolve
-    rejectTerminal = reject
-  })
-
-  unsubscribe = await runtime.events.subscribe(
-    {
-      types: ["action.completed", "action.failed"],
-    },
-    (events) => {
-      for (const event of events) {
-        if (event.type !== "action.completed" && event.type !== "action.failed") {
-          continue
-        }
-        if (!isTerminalActionEvent(event, runId)) {
-          continue
-        }
-
-        cleanup()
-        if (event.type === "action.completed") {
-          resolveTerminal({ runId: event.payload.runId })
-        } else {
-          rejectTerminal(new ActionRunFailedError(event.payload))
-        }
-      }
-    }
-  )
-
-  timer = setTimeout(() => {
-    cleanup()
-    rejectTerminal(new ActionRunTimeoutError({ runId, timeoutMs }))
-  }, timeoutMs)
-
-  if (signal) {
-    if (signal.aborted) {
+    const rejectWith = (error: unknown) => {
       cleanup()
-      rejectTerminal(signal.reason ?? new Error("aborted"))
-    } else {
-      abortListener = () => {
-        cleanup()
-        rejectTerminal(signal.reason ?? new Error("aborted"))
+      reject(error)
+    }
+
+    const check = async () => {
+      try {
+        const record = await actionRuns.getById({
+          projectId: runtime.projectId,
+          id: input.runId,
+        })
+        if (record && isTerminalActionRun(record)) {
+          cleanup()
+          resolve(record)
+          return
+        }
+        if (!settled) {
+          pollTimer = setTimeout(check, 100)
+        }
+      } catch (error) {
+        rejectWith(error)
       }
-      signal.addEventListener("abort", abortListener, { once: true })
+    }
+
+    const onAbort = () => {
+      rejectWith(signal?.reason ?? new Error("aborted"))
+    }
+
+    timer = setTimeout(
+      () => {
+        rejectWith(new ActionRunTimeoutError({ runId: input.runId, timeoutMs }))
+      },
+      Math.max(0, timeoutMs - (Date.now() - startedAt))
+    )
+
+    if (signal) {
+      signal.addEventListener("abort", onAbort, { once: true })
+    }
+
+    runtime.events
+      .subscribe({ types: ["action.completed", "action.failed"] }, (events) => {
+        if (
+          events.some(
+            (event) =>
+              (event.type === "action.completed" || event.type === "action.failed") &&
+              event.payload.runId === input.runId
+          )
+        ) {
+          void check()
+        }
+      })
+      .then((unsubscribeEvents) => {
+        unsubscribe = unsubscribeEvents
+        void check()
+      })
+      .catch(rejectWith)
+  })
+}
+
+function requireActionRunStorage(runtime: SixbRuntimeContext): ActionRunStorage {
+  const actionRuns = runtime.storage.actionRuns
+  if (!actionRuns) {
+    throw new ActionRunError("[Sixb] Action run storage is not configured.")
+  }
+  return actionRuns
+}
+
+function createActionRunIdempotencyKey(projectId: string, runId: string): string {
+  return `action:${projectId}:${runId}`
+}
+
+function assertExistingRunMatchesRequest(
+  existing: ActionRunRecord,
+  request: {
+    readonly actionId: string
+    readonly subject: ActionSubject
+    readonly params: ActionRunParams
+  }
+): void {
+  const matches =
+    existing.actionId === request.actionId &&
+    subjectsEqual(existing.subject, request.subject) &&
+    jsonEqual(existing.params, request.params)
+
+  if (!matches) {
+    throw new ActionRunError(
+      `[Sixb] Action run '${existing.id}' already exists with a different request payload.`
+    )
+  }
+}
+
+function subjectsEqual(left: ActionSubject, right: ActionSubject): boolean {
+  if (left.kind !== right.kind) return false
+  if (left.kind === "none") return true
+  if (right.kind === "none") return false
+  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
+}
+
+function jsonEqual(left: unknown, right: unknown): boolean {
+  return stableJsonStringify(left) === stableJsonStringify(right)
+}
+
+function stableJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringify).join(",")}]`
+  }
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
+    .join(",")}}`
+}
+
+function isTerminalActionRun(record: ActionRunRecord): boolean {
+  return (
+    record.status === "succeeded" || record.status === "failed" || record.status === "cancelled"
+  )
+}
+
+function isRetryableEnqueueFailure(record: ActionRunRecord): boolean {
+  return record.status === "failed" && record.phase === "enqueue"
+}
+
+function toActionRunFailure(
+  error: unknown,
+  phase: "enqueue"
+): { name?: string; message: string; phase: "enqueue" } {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      phase,
     }
   }
-  terminal.catch(() => {})
-
-  try {
-    await requestAction(runtime, {
-      ...input,
-      runId,
-    })
-    await input.onRequested?.(runId)
-  } catch (error) {
-    cleanup()
-    throw error
+  return {
+    message: String(error),
+    phase,
   }
+}
 
-  return terminal
+function toEventActor(securityContext: SecurityContext): EventActor {
+  if (securityContext.principal.type === "serviceAccount") {
+    return { type: "service", id: securityContext.principal.id }
+  }
+  return securityContext.principal
 }

--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -11,6 +11,9 @@ import {
   type ActionRunParams,
   type ActionRunRecord,
   type ActionRunStorage,
+  actionRunParamsEqual,
+  actionSubjectsEqual,
+  isTerminalActionRun,
 } from "../storage"
 import type {
   ActionDefinition,
@@ -65,6 +68,7 @@ export interface WaitForActionRunInput {
 }
 
 const DEFAULT_ACTION_WAIT_TIMEOUT_MS = 60_000
+const DEFAULT_ACTION_WAIT_POLL_MS = 1_000
 
 function createActionRunId(runId: string | undefined): string {
   if (runId !== undefined) {
@@ -267,21 +271,25 @@ async function enqueueActionRunJob(
     throw error
   }
 
-  await runtime.events.append({
-    actor: params.securityContext ? toEventActor(params.securityContext) : undefined,
-    correlationId: params.securityContext?.correlationId,
-    events: [
-      {
-        type: "action.requested",
-        payload: {
-          actionId: params.actionId,
-          subject: params.subject,
-          params: params.params,
-          runId: params.runId,
+  try {
+    await runtime.events.append({
+      actor: params.securityContext ? toEventActor(params.securityContext) : undefined,
+      correlationId: params.securityContext?.correlationId,
+      events: [
+        {
+          type: "action.requested",
+          payload: {
+            actionId: params.actionId,
+            subject: params.subject,
+            params: params.params,
+            runId: params.runId,
+          },
         },
-      },
-    ],
-  })
+      ],
+    })
+  } catch (error) {
+    console.error("[Sixb] Failed to append action.requested observation event:", error)
+  }
 
   return {
     runId: params.runId,
@@ -328,6 +336,7 @@ export async function waitForActionRun(
     let pollTimer: ReturnType<typeof setTimeout> | undefined
     let unsubscribe: (() => void) | undefined
     let settled = false
+    let checking = false
 
     const cleanup = () => {
       if (settled) return
@@ -343,7 +352,20 @@ export async function waitForActionRun(
       reject(error)
     }
 
+    const schedulePoll = () => {
+      if (!settled && !pollTimer) {
+        pollTimer = setTimeout(() => {
+          pollTimer = undefined
+          void check()
+        }, DEFAULT_ACTION_WAIT_POLL_MS)
+      }
+    }
+
     const check = async () => {
+      if (settled || checking) {
+        return
+      }
+      checking = true
       try {
         const record = await actionRuns.getById({
           projectId: runtime.projectId,
@@ -354,11 +376,11 @@ export async function waitForActionRun(
           resolve(record)
           return
         }
-        if (!settled) {
-          pollTimer = setTimeout(check, 100)
-        }
+        schedulePoll()
       } catch (error) {
         rejectWith(error)
+      } finally {
+        checking = false
       }
     }
 
@@ -419,44 +441,14 @@ function assertExistingRunMatchesRequest(
 ): void {
   const matches =
     existing.actionId === request.actionId &&
-    subjectsEqual(existing.subject, request.subject) &&
-    jsonEqual(existing.params, request.params)
+    actionSubjectsEqual(existing.subject, request.subject) &&
+    actionRunParamsEqual(existing.params, request.params)
 
   if (!matches) {
     throw new ActionRunError(
       `[Sixb] Action run '${existing.id}' already exists with a different request payload.`
     )
   }
-}
-
-function subjectsEqual(left: ActionSubject, right: ActionSubject): boolean {
-  if (left.kind !== right.kind) return false
-  if (left.kind === "none") return true
-  if (right.kind === "none") return false
-  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
-}
-
-function jsonEqual(left: unknown, right: unknown): boolean {
-  return stableJsonStringify(left) === stableJsonStringify(right)
-}
-
-function stableJsonStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value)
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableJsonStringify).join(",")}]`
-  }
-  return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
-    .join(",")}}`
-}
-
-function isTerminalActionRun(record: ActionRunRecord): boolean {
-  return (
-    record.status === "succeeded" || record.status === "failed" || record.status === "cancelled"
-  )
 }
 
 function isRetryableEnqueueFailure(record: ActionRunRecord): boolean {

--- a/packages/core/src/actions/runtime.ts
+++ b/packages/core/src/actions/runtime.ts
@@ -1,9 +1,13 @@
 import type { SixbRuntimeContext } from "../runtime/types"
+import type { ActionRunRecord } from "../storage"
 import {
   type RequestActionAndWaitInput,
   type RequestActionInput,
+  type RequestActionResult,
   requestAction,
   requestActionAndWait,
+  type WaitForActionRunInput,
+  waitForActionRun,
 } from "./request"
 
 export class ActionsRuntime {
@@ -13,11 +17,15 @@ export class ActionsRuntime {
     this.runtime = runtime
   }
 
-  request(input: RequestActionInput): Promise<{ runId: string }> {
+  request(input: RequestActionInput): Promise<RequestActionResult> {
     return requestAction(this.runtime, input)
   }
 
-  requestAndWait(input: RequestActionAndWaitInput): Promise<{ runId: string }> {
+  waitFor(input: WaitForActionRunInput): Promise<ActionRunRecord> {
+    return waitForActionRun(this.runtime, input)
+  }
+
+  requestAndWait(input: RequestActionAndWaitInput): Promise<ActionRunRecord> {
     return requestActionAndWait(this.runtime, input)
   }
 }

--- a/packages/core/src/actions/validation.ts
+++ b/packages/core/src/actions/validation.ts
@@ -1,9 +1,13 @@
-import { type ValueType, validateSchemaOrRefValue } from "../ontology"
+import { assertJsonValue, cloneJsonValue, type JsonValue } from "../json"
+import { type SchemaOrRef, type ValueType, validateSchemaOrRefValue } from "../ontology"
 import { OntologyValidationError } from "../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
+import type { ObjectFieldSchema, Schema } from "../ontology/types"
+import type { ActionRunParams } from "../storage/action-runs"
 import { ActionDefinitionError } from "./errors"
 import type {
   ActionDefinition,
+  ActionParamsConfig,
   ActionSubject,
   GlobalActionDefinition,
   ObjectActionDefinition,
@@ -75,6 +79,51 @@ export function validateActionParams(
   }
 }
 
+export function normalizeActionParams(
+  runtime: Pick<ActionValidationRuntime, "ontology">,
+  paramsConfig: ActionParamsConfig,
+  params: Record<string, unknown>,
+  pathPrefix: string
+): ActionRunParams {
+  const knownParamIds = new Set(Object.keys(paramsConfig))
+  const normalized: Record<string, JsonValue> = {}
+
+  for (const paramId of Object.keys(params)) {
+    if (!knownParamIds.has(paramId)) {
+      throw new OntologyValidationError(`Unknown param '${paramId}' for action '${pathPrefix}'`)
+    }
+  }
+
+  for (const [paramId, paramDef] of Object.entries(paramsConfig)) {
+    const value = params[paramId]
+
+    if (value === undefined) {
+      if (paramDef.required) {
+        throw new OntologyValidationError(
+          `Missing required param '${paramId}' for action '${pathPrefix}'`
+        )
+      }
+      continue
+    }
+
+    validateSchemaOrRefValue(
+      paramDef.schema,
+      value,
+      `${pathPrefix}.${paramId}`,
+      runtime.ontology.getValueTypesById()
+    )
+
+    normalized[paramId] = normalizeSchemaOrRefValue(
+      paramDef.schema,
+      value,
+      `${pathPrefix}.${paramId}`,
+      runtime.ontology.getValueTypesById()
+    )
+  }
+
+  return normalized
+}
+
 export function validateActionSubject(action: ActionDefinition, subject: ActionSubject): void {
   if (isGlobalActionDefinition(action) && subject.kind !== "none") {
     throw new OntologyValidationError(`Action '${action.id}' does not accept an object subject.`)
@@ -110,4 +159,115 @@ function actionAppliesToObjectType(
   return runtime.actionRegistry
     .getActionsForType(objectType)
     .some((candidate) => candidate.id === action.id)
+}
+
+function normalizeSchemaOrRefValue(
+  schema: SchemaOrRef,
+  value: unknown,
+  path: string,
+  valueTypesById: ReadonlyMap<string, ValueType>
+): JsonValue {
+  if (typeof schema === "object" && schema !== null && schema.type === "objectRef") {
+    const refValue = value as { objectTypeId: string; primaryId: string }
+    return {
+      objectTypeId: refValue.objectTypeId,
+      primaryId: refValue.primaryId,
+    }
+  }
+
+  return normalizeSchemaValue(schema as Schema, value, path, valueTypesById)
+}
+
+function normalizeSchemaValue(
+  schema: Schema,
+  value: unknown,
+  path: string,
+  valueTypesById: ReadonlyMap<string, ValueType>
+): JsonValue {
+  if (typeof schema === "string") {
+    switch (schema) {
+      case "date":
+        return normalizeDateValue(value, path)
+      case "timestamp":
+        return normalizeTimestampValue(value, path)
+      default:
+        assertJsonValue(value, path)
+        return cloneJsonValue(value)
+    }
+  }
+
+  if (schema.type === "valueTypeRef") {
+    const valueType = valueTypesById.get(schema.valueTypeId)
+    if (!valueType) {
+      throw new OntologyValidationError(
+        `[Sixb] Unknown valueTypeRef '${schema.valueTypeId}' at ${path}`
+      )
+    }
+    return normalizeSchemaValue(valueType.schema, value, path, valueTypesById)
+  }
+
+  if (schema.type === "enum") {
+    assertJsonValue(value, path)
+    return cloneJsonValue(value)
+  }
+
+  if (schema.type === "array") {
+    return (value as readonly unknown[]).map((entry, index) =>
+      normalizeSchemaValue(schema.items, entry, `${path}[${index}]`, valueTypesById)
+    )
+  }
+
+  if (schema.type === "map") {
+    const entries = Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+      key,
+      normalizeSchemaValue(schema.valueSchema, entry, `${path}.${key}`, valueTypesById),
+    ])
+    return Object.fromEntries(entries)
+  }
+
+  const fields = schema.properties
+  const output: Record<string, JsonValue> = {}
+  for (const [fieldId, field] of Object.entries(fields)) {
+    const fieldValue = (value as Record<string, unknown>)[fieldId]
+    if (fieldValue === undefined) {
+      continue
+    }
+    output[fieldId] = normalizeObjectFieldValue(
+      field,
+      fieldValue,
+      `${path}.${fieldId}`,
+      valueTypesById
+    )
+  }
+  return output
+}
+
+function normalizeObjectFieldValue(
+  field: ObjectFieldSchema,
+  value: unknown,
+  path: string,
+  valueTypesById: ReadonlyMap<string, ValueType>
+): JsonValue {
+  if (value === null) {
+    return null
+  }
+
+  return normalizeSchemaValue(field.schema, value, path, valueTypesById)
+}
+
+function normalizeDateValue(value: unknown, path: string): string {
+  const date = normalizeDateLike(value, path)
+  return date.toISOString().slice(0, 10)
+}
+
+function normalizeTimestampValue(value: unknown, path: string): string {
+  return normalizeDateLike(value, path).toISOString()
+}
+
+function normalizeDateLike(value: unknown, path: string): Date {
+  const date = value instanceof Date ? value : new Date(String(value))
+  if (Number.isNaN(date.getTime())) {
+    throw new OntologyValidationError(`[Sixb] Property ${path} must be a valid date`)
+  }
+  return date
 }

--- a/packages/core/src/actions/validation.ts
+++ b/packages/core/src/actions/validation.ts
@@ -47,38 +47,6 @@ export function isObjectActionDefinition(value: ActionDefinition): value is Obje
   return value.binding.kind === "object"
 }
 
-export function validateActionParams(
-  runtime: Pick<ActionValidationRuntime, "ontology">,
-  action: ActionDefinition,
-  params: Record<string, unknown>,
-  pathPrefix: string
-): void {
-  const knownParamIds = new Set(Object.keys(action.params))
-
-  for (const paramId of Object.keys(params)) {
-    if (!knownParamIds.has(paramId)) {
-      throw new OntologyValidationError(`Unknown param '${paramId}' for action '${pathPrefix}'`)
-    }
-  }
-
-  for (const [paramId, paramDef] of Object.entries(action.params)) {
-    if (paramDef.required && params[paramId] === undefined) {
-      throw new OntologyValidationError(
-        `Missing required param '${paramId}' for action '${pathPrefix}'`
-      )
-    }
-
-    if (params[paramId] !== undefined) {
-      validateSchemaOrRefValue(
-        paramDef.schema,
-        params[paramId],
-        `${pathPrefix}.${paramId}`,
-        runtime.ontology.getValueTypesById()
-      )
-    }
-  }
-}
-
 export function normalizeActionParams(
   runtime: Pick<ActionValidationRuntime, "ontology">,
   paramsConfig: ActionParamsConfig,

--- a/packages/core/src/events/types/actions.ts
+++ b/packages/core/src/events/types/actions.ts
@@ -36,7 +36,7 @@ export interface ActionFailedEvent extends EventEnvelope {
     error: {
       name?: string
       message: string
-      phase?: "handler" | "cancelled"
+      phase?: "request" | "enqueue" | "handler" | "cancelled"
     }
     finishedAt: string
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,8 @@ export type {
   RequestActionAndWaitOptions,
   RequestActionInput,
   RequestActionOptions,
+  RequestActionResult,
+  WaitForActionRunInput,
 } from "./actions"
 export {
   ActionDefinitionError,
@@ -94,6 +96,7 @@ export {
   isObjectActionDefinition,
   requestAction,
   requestActionAndWait,
+  waitForActionRun,
 } from "./actions"
 export {
   ActionRunFailedError,
@@ -391,6 +394,8 @@ export {
 
 export type {
   ActionRunFailure,
+  ActionRunParams,
+  ActionRunPhase,
   ActionRunRecord,
   ActionRunStatus,
   ActionRunStorage,
@@ -497,6 +502,7 @@ export type {
   ProjectionRunStorage,
   QueryObjectsInput,
   QueryObjectsResult,
+  QueueActionRunInput,
   QueueWorkflowRunInput,
   ResumeWorkflowRunInput,
   RuleStateRecord,
@@ -646,6 +652,7 @@ export {
 // ── Queues ─────────────────────────────────────────────────
 
 export type {
+  ActionRunRequestedQueueJob,
   ClaimedQueueJob,
   NewQueueJob,
   PipelineRunRequestedQueueJob,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -561,6 +561,9 @@ export type {
 export {
   ActionRunError,
   AuthStorageError,
+  actionRunParamsEqual,
+  actionSubjectsEqual,
+  canRequeueActionRunAfterEnqueueFailure,
   defineMigrations,
   InMemoryActionRunStorage,
   InMemoryAuthStorage,
@@ -577,6 +580,7 @@ export {
   InMemoryWorkflowNodeRunStorage,
   InMemoryWorkflowRunStorage,
   isMigrationCapableStorage,
+  isTerminalActionRun,
   migrateStorage,
   PipelineRunError,
   ProjectionRunError,

--- a/packages/core/src/objects/action/request.ts
+++ b/packages/core/src/objects/action/request.ts
@@ -7,9 +7,11 @@
 import {
   type RequestActionAndWaitOptions,
   type RequestActionOptions,
+  type RequestActionResult,
   requestAction as requestRuntimeAction,
   requestActionAndWait as requestRuntimeActionAndWait,
 } from "../../actions/request"
+import type { ActionRunRecord } from "../../storage"
 import type { ResolvedObjectContext } from "../context"
 
 export type { RequestActionAndWaitOptions, RequestActionOptions }
@@ -22,7 +24,7 @@ export async function requestAction(
     params?: Record<string, unknown>
     options?: RequestActionOptions
   }
-): Promise<{ runId: string }> {
+): Promise<RequestActionResult> {
   return requestRuntimeAction(ctx, {
     actionId: params.actionId,
     subject: {
@@ -33,6 +35,7 @@ export async function requestAction(
     params: params.params,
     runId: params.options?.runId,
     signal: params.options?.signal,
+    securityContext: params.options?.securityContext,
   })
 }
 
@@ -44,7 +47,7 @@ export async function requestActionAndWait(
     params?: Record<string, unknown>
     options?: RequestActionAndWaitOptions
   }
-): Promise<{ runId: string }> {
+): Promise<ActionRunRecord> {
   return requestRuntimeActionAndWait(ctx, {
     actionId: params.actionId,
     subject: {
@@ -56,6 +59,7 @@ export async function requestActionAndWait(
     runId: params.options?.runId,
     timeoutMs: params.options?.timeoutMs,
     signal: params.options?.signal,
+    securityContext: params.options?.securityContext,
     onRequested: params.options?.onRequested,
   })
 }

--- a/packages/core/src/objects/service/action-service.ts
+++ b/packages/core/src/objects/service/action-service.ts
@@ -3,7 +3,10 @@
  *
  * Resolves objectTypeId to a typed context and delegates to the leaf function.
  */
+
+import type { RequestActionResult } from "../../actions/request"
 import type { SixbRuntimeContext } from "../../runtime/types"
+import type { ActionRunRecord } from "../../storage"
 import {
   type RequestActionAndWaitOptions,
   type RequestActionOptions,
@@ -19,7 +22,7 @@ export async function requestAction(
   actionId: string,
   params?: Record<string, unknown>,
   options?: RequestActionOptions
-): Promise<{ runId: string }> {
+): Promise<RequestActionResult> {
   const ctx = resolveObjectContext(runtime, objectTypeId)
   return requestActionLeaf(ctx, { primaryId, actionId, params, options })
 }
@@ -31,7 +34,7 @@ export async function requestActionAndWait(
   actionId: string,
   params?: Record<string, unknown>,
   options?: RequestActionAndWaitOptions
-): Promise<{ runId: string }> {
+): Promise<ActionRunRecord> {
   const ctx = resolveObjectContext(runtime, objectTypeId)
   return requestActionAndWaitLeaf(ctx, { primaryId, actionId, params, options })
 }

--- a/packages/core/src/queues/in-memory.ts
+++ b/packages/core/src/queues/in-memory.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { QueueError } from "./errors"
 import type {
+  ActionRunRequestedQueueJob,
   ClaimedQueueJob,
   NewQueueJob,
   PipelineRunRequestedQueueJob,
@@ -346,4 +347,5 @@ export class InMemoryQueues implements Queues {
     "projection.runs"
   )
   readonly workflows = new InMemoryQueue<WorkflowQueueJob>(this.store, "workflow.runs")
+  readonly actions = new InMemoryQueue<ActionRunRequestedQueueJob>(this.store, "action.runs")
 }

--- a/packages/core/src/queues/index.ts
+++ b/packages/core/src/queues/index.ts
@@ -1,6 +1,7 @@
 export { QueueError } from "./errors"
 export { InMemoryQueues } from "./in-memory"
 export type {
+  ActionRunRequestedQueueJob,
   ClaimedQueueJob,
   NewQueueJob,
   PipelineRunRequestedQueueJob,

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -150,9 +150,19 @@ export interface WorkflowRunResumeRequestedQueueJob
 
 export type WorkflowQueueJob = WorkflowRunRequestedQueueJob | WorkflowRunResumeRequestedQueueJob
 
+export interface ActionRunRequestedQueueJob
+  extends QueueJob<
+    "action.run.requested",
+    {
+      readonly actionId: string
+      readonly runId: string
+    }
+  > {}
+
 export interface Queues {
   readonly syncRuns: Queue<SyncRunRequestedQueueJob>
   readonly pipelines: Queue<PipelineRunRequestedQueueJob>
   readonly projections: Queue<ProjectionRunRequestedQueueJob>
   readonly workflows: Queue<WorkflowQueueJob>
+  readonly actions: Queue<ActionRunRequestedQueueJob>
 }

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -11,6 +11,7 @@ import type {
   ActionRegistry,
   ActionsRuntime,
   InferActionParams,
+  RequestActionResult,
 } from "../actions"
 import type { AuthRuntime } from "../auth"
 import type { BlobStorage } from "../blob-storage"
@@ -52,7 +53,7 @@ import type { Queues } from "../queues"
 import type { RuleDefinition } from "../rules"
 import type { ScheduleDefinition } from "../schedules"
 import type { SecurityRegistry } from "../security"
-import type { ObjectLinkRow, ObjectRow, Storage } from "../storage"
+import type { ActionRunRecord, ObjectLinkRow, ObjectRow, Storage } from "../storage"
 import type { SyncDefinition } from "../syncs"
 import type { RegisteredWebhook } from "../webhooks"
 import type { WorkflowsRuntime } from "../workflows"
@@ -571,7 +572,7 @@ export interface ObjectByIdHandle<
     actionId: string
     params?: Record<string, unknown>
     runId?: string
-  }): Promise<{ runId: string }>
+  }): Promise<RequestActionResult>
 
   /**
    * Request an action on this object using a typed action reference.
@@ -581,7 +582,7 @@ export interface ObjectByIdHandle<
     action: TAction
     params: NoInfer<TypedActionParams<TAction>>
     runId?: string
-  }): Promise<{ runId: string }>
+  }): Promise<RequestActionResult>
 
   /** Request an action and wait for the terminal lifecycle event. */
   requestActionAndWait(input: {
@@ -589,7 +590,7 @@ export interface ObjectByIdHandle<
     params?: Record<string, unknown>
     timeoutMs?: number
     signal?: AbortSignal
-  }): Promise<{ runId: string }>
+  }): Promise<ActionRunRecord>
 
   /** Request a typed action and wait for the terminal lifecycle event. */
   requestActionAndWait<const TAction extends TypedActionReference>(input: {
@@ -597,7 +598,7 @@ export interface ObjectByIdHandle<
     params: NoInfer<TypedActionParams<TAction>>
     timeoutMs?: number
     signal?: AbortSignal
-  }): Promise<{ runId: string }>
+  }): Promise<ActionRunRecord>
 
   /** Append telemetry to a telemetry-mode property token. */
   telemetry<TToken extends TelemetryPropertyToken<TObjectType>>(
@@ -836,7 +837,7 @@ export interface ObjectSet<
     actionId: string
     params?: Record<string, unknown>
     runId?: string
-  }): Promise<{ runId: string }>
+  }): Promise<RequestActionResult>
 
   /**
    * Request an action on an object of this type using a typed action reference.
@@ -847,7 +848,7 @@ export interface ObjectSet<
     action: TAction
     params: NoInfer<TypedActionParams<TAction>>
     runId?: string
-  }): Promise<{ runId: string }>
+  }): Promise<RequestActionResult>
 
   /** Request an action on an object and wait for the terminal lifecycle event. */
   requestActionAndWait(input: {
@@ -856,7 +857,7 @@ export interface ObjectSet<
     params?: Record<string, unknown>
     timeoutMs?: number
     signal?: AbortSignal
-  }): Promise<{ runId: string }>
+  }): Promise<ActionRunRecord>
 
   /** Request a typed action and wait for the terminal lifecycle event. */
   requestActionAndWait<const TAction extends TypedActionReference>(input: {
@@ -865,7 +866,7 @@ export interface ObjectSet<
     params: NoInfer<TypedActionParams<TAction>>
     timeoutMs?: number
     signal?: AbortSignal
-  }): Promise<{ runId: string }>
+  }): Promise<ActionRunRecord>
 
   /** Create or update a link (string-based, for server/dynamic usage). */
   upsertLink(input: {

--- a/packages/core/src/storage/action-runs/idempotency.ts
+++ b/packages/core/src/storage/action-runs/idempotency.ts
@@ -1,0 +1,52 @@
+import type { ActionSubject } from "../../actions"
+import type { ActionRunRecord, QueueActionRunInput } from "./types"
+
+export function actionSubjectsEqual(left: ActionSubject, right: ActionSubject): boolean {
+  if (left.kind !== right.kind) return false
+  if (left.kind === "none") return true
+  if (right.kind === "none") return false
+  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
+}
+
+export function actionRunParamsEqual(left: unknown, right: unknown): boolean {
+  return stableJsonStringify(left) === stableJsonStringify(right)
+}
+
+export function canRequeueActionRunAfterEnqueueFailure(
+  existing: ActionRunRecord,
+  input: QueueActionRunInput
+): boolean {
+  return (
+    existing.status === "failed" &&
+    existing.phase === "enqueue" &&
+    existing.actionId === input.actionId &&
+    existing.idempotencyKey === input.idempotencyKey &&
+    actionSubjectsEqual(existing.subject, input.subject) &&
+    actionRunParamsEqual(existing.params, input.params)
+  )
+}
+
+export function isTerminalActionRun(record: Pick<ActionRunRecord, "status">): boolean {
+  return (
+    record.status === "succeeded" || record.status === "failed" || record.status === "cancelled"
+  )
+}
+
+function stableJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringify).join(",")}]`
+  }
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
+    .join(",")}}`
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}

--- a/packages/core/src/storage/action-runs/in-memory.ts
+++ b/packages/core/src/storage/action-runs/in-memory.ts
@@ -1,4 +1,9 @@
 import { ActionRunError } from "./errors"
+import {
+  actionSubjectsEqual,
+  canRequeueActionRunAfterEnqueueFailure,
+  isTerminalActionRun,
+} from "./idempotency"
 import type {
   ActionRunFailure,
   ActionRunParams,
@@ -52,7 +57,7 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
   async queue(input: QueueActionRunInput): Promise<ActionRunRecord> {
     const key = actionRunKey(input.projectId, input.id)
     const existing = this.rows.get(key)
-    if (existing && !canRequeueAfterEnqueueFailure(existing, input)) {
+    if (existing && !canRequeueActionRunAfterEnqueueFailure(existing, input)) {
       throw new ActionRunError(
         `[Sixb] Action run '${input.id}' already exists for project '${input.projectId}'.`
       )
@@ -128,6 +133,12 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
       )
     }
 
+    if (isTerminalActionRun(existing)) {
+      throw new ActionRunError(
+        `[Sixb] Action run '${input.id}' cannot finish from terminal status '${existing.status}'.`
+      )
+    }
+
     const phase =
       input.status === "succeeded"
         ? (input.phase ?? existing.phase)
@@ -169,7 +180,9 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
     const filtered = [...this.rows.values()]
       .filter((record) => record.projectId === input.projectId)
       .filter((record) => (input.actionId ? record.actionId === input.actionId : true))
-      .filter((record) => (input.subject ? subjectsEqual(record.subject, input.subject) : true))
+      .filter((record) =>
+        input.subject ? actionSubjectsEqual(record.subject, input.subject) : true
+      )
       .filter((record) =>
         input.objectTypeId
           ? record.subject.kind === "object" && record.subject.objectTypeId === input.objectTypeId
@@ -198,50 +211,4 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
       total,
     }
   }
-}
-
-function subjectsEqual(
-  left: QueueActionRunInput["subject"],
-  right: QueueActionRunInput["subject"]
-): boolean {
-  if (left.kind !== right.kind) {
-    return false
-  }
-
-  if (left.kind === "none") {
-    return true
-  }
-
-  if (right.kind === "none") {
-    return false
-  }
-
-  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
-}
-
-function canRequeueAfterEnqueueFailure(
-  existing: ActionRunRecord,
-  input: QueueActionRunInput
-): boolean {
-  return (
-    existing.status === "failed" &&
-    existing.phase === "enqueue" &&
-    existing.actionId === input.actionId &&
-    existing.idempotencyKey === input.idempotencyKey &&
-    subjectsEqual(existing.subject, input.subject) &&
-    stableJsonStringify(existing.params) === stableJsonStringify(input.params)
-  )
-}
-
-function stableJsonStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value)
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableJsonStringify).join(",")}]`
-  }
-  return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
-    .join(",")}}`
 }

--- a/packages/core/src/storage/action-runs/in-memory.ts
+++ b/packages/core/src/storage/action-runs/in-memory.ts
@@ -1,12 +1,13 @@
-import type { JsonValue } from "../../json"
 import { ActionRunError } from "./errors"
 import type {
   ActionRunFailure,
+  ActionRunParams,
   ActionRunRecord,
   ActionRunStorage,
   FinishActionRunInput,
   ListActionRunsInput,
   ListActionRunsResult,
+  QueueActionRunInput,
   StartActionRunInput,
 } from "./types"
 
@@ -18,20 +19,12 @@ function cloneActionRunRecord(record: ActionRunRecord): ActionRunRecord {
   return structuredClone(record)
 }
 
-function normalizeParams(
-  params: Readonly<Record<string, unknown>>
-): Readonly<Record<string, unknown>> {
+function normalizeParams(params: ActionRunParams): ActionRunParams {
   return structuredClone(params)
 }
 
-function normalizeSubject(subject: StartActionRunInput["subject"]): StartActionRunInput["subject"] {
+function normalizeSubject(subject: QueueActionRunInput["subject"]): QueueActionRunInput["subject"] {
   return structuredClone(subject)
-}
-
-function normalizeMetadata(
-  metadata: Readonly<Record<string, JsonValue>> | undefined
-): Readonly<Record<string, JsonValue>> | undefined {
-  return metadata ? structuredClone(metadata) : undefined
 }
 
 function normalizeError(error: ActionRunFailure | undefined): ActionRunFailure | undefined {
@@ -39,7 +32,9 @@ function normalizeError(error: ActionRunFailure | undefined): ActionRunFailure |
 }
 
 function compareRuns(a: ActionRunRecord, b: ActionRunRecord, order: "asc" | "desc"): number {
-  const delta = a.startedAt.getTime() - b.startedAt.getTime()
+  const leftAt = a.startedAt ?? a.queuedAt
+  const rightAt = b.startedAt ?? b.queuedAt
+  const delta = leftAt.getTime() - rightAt.getTime()
   if (delta !== 0) {
     return order === "asc" ? delta : -delta
   }
@@ -54,9 +49,10 @@ function compareRuns(a: ActionRunRecord, b: ActionRunRecord, order: "asc" | "des
 export class InMemoryActionRunStorage implements ActionRunStorage {
   private readonly rows = new Map<string, ActionRunRecord>()
 
-  async start(input: StartActionRunInput): Promise<ActionRunRecord> {
+  async queue(input: QueueActionRunInput): Promise<ActionRunRecord> {
     const key = actionRunKey(input.projectId, input.id)
-    if (this.rows.has(key)) {
+    const existing = this.rows.get(key)
+    if (existing && !canRequeueAfterEnqueueFailure(existing, input)) {
       throw new ActionRunError(
         `[Sixb] Action run '${input.id}' already exists for project '${input.projectId}'.`
       )
@@ -67,14 +63,59 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
       projectId: input.projectId,
       actionId: input.actionId,
       subject: normalizeSubject(input.subject),
-      status: "running",
-      startedAt: new Date(input.startedAt ?? new Date()),
+      status: "queued",
+      phase: "request",
+      queuedAt: new Date(input.queuedAt ?? new Date()),
       params: normalizeParams(input.params),
-      metadata: normalizeMetadata(input.metadata),
+      idempotencyKey: input.idempotencyKey,
+      securityContext: input.securityContext ? structuredClone(input.securityContext) : undefined,
+    }
+
+    if (existing) {
+      const next: ActionRunRecord = {
+        ...existing,
+        status: "queued",
+        phase: "request",
+        queuedAt: record.queuedAt,
+        startedAt: undefined,
+        finishedAt: undefined,
+        error: undefined,
+        securityContext: record.securityContext,
+      }
+      this.rows.set(key, structuredClone(next))
+      return cloneActionRunRecord(next)
     }
 
     this.rows.set(key, structuredClone(record))
     return cloneActionRunRecord(record)
+  }
+
+  async start(input: StartActionRunInput): Promise<ActionRunRecord> {
+    const key = actionRunKey(input.projectId, input.id)
+    const existing = this.rows.get(key)
+
+    if (!existing) {
+      throw new ActionRunError(
+        `[Sixb] Action run '${input.id}' not found for project '${input.projectId}'.`
+      )
+    }
+
+    if (existing.status !== "queued") {
+      throw new ActionRunError(
+        `[Sixb] Action run '${input.id}' cannot start from status '${existing.status}'.`
+      )
+    }
+
+    const next: ActionRunRecord = {
+      ...existing,
+      status: "running",
+      phase: "handler",
+      startedAt: new Date(input.startedAt ?? new Date()),
+      error: undefined,
+    }
+
+    this.rows.set(key, structuredClone(next))
+    return cloneActionRunRecord(next)
   }
 
   async finish(input: FinishActionRunInput): Promise<ActionRunRecord> {
@@ -87,19 +128,16 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
       )
     }
 
-    const metadata =
-      existing.metadata || input.metadata
-        ? {
-            ...(existing.metadata ?? {}),
-            ...(normalizeMetadata(input.metadata) ?? {}),
-          }
-        : undefined
+    const phase =
+      input.status === "succeeded"
+        ? (input.phase ?? existing.phase)
+        : (input.phase ?? input.error?.phase ?? existing.phase)
 
     const base: ActionRunRecord = {
       ...existing,
       status: input.status,
+      phase,
       finishedAt: new Date(input.finishedAt ?? new Date()),
-      metadata,
     }
 
     const next: ActionRunRecord =
@@ -143,8 +181,12 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
           : true
       )
       .filter((record) => (statuses ? statuses.has(record.status) : true))
-      .filter((record) => (input.startedAfter ? record.startedAt >= input.startedAfter : true))
-      .filter((record) => (input.startedBefore ? record.startedAt <= input.startedBefore : true))
+      .filter((record) =>
+        input.startedAfter ? (record.startedAt ?? record.queuedAt) >= input.startedAfter : true
+      )
+      .filter((record) =>
+        input.startedBefore ? (record.startedAt ?? record.queuedAt) <= input.startedBefore : true
+      )
       .sort((a, b) => compareRuns(a, b, order))
 
     const total = filtered.length
@@ -159,8 +201,8 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
 }
 
 function subjectsEqual(
-  left: StartActionRunInput["subject"],
-  right: StartActionRunInput["subject"]
+  left: QueueActionRunInput["subject"],
+  right: QueueActionRunInput["subject"]
 ): boolean {
   if (left.kind !== right.kind) {
     return false
@@ -175,4 +217,31 @@ function subjectsEqual(
   }
 
   return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
+}
+
+function canRequeueAfterEnqueueFailure(
+  existing: ActionRunRecord,
+  input: QueueActionRunInput
+): boolean {
+  return (
+    existing.status === "failed" &&
+    existing.phase === "enqueue" &&
+    existing.actionId === input.actionId &&
+    existing.idempotencyKey === input.idempotencyKey &&
+    subjectsEqual(existing.subject, input.subject) &&
+    stableJsonStringify(existing.params) === stableJsonStringify(input.params)
+  )
+}
+
+function stableJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringify).join(",")}]`
+  }
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
+    .join(",")}}`
 }

--- a/packages/core/src/storage/action-runs/index.ts
+++ b/packages/core/src/storage/action-runs/index.ts
@@ -2,11 +2,14 @@ export { ActionRunError } from "./errors"
 export { InMemoryActionRunStorage } from "./in-memory"
 export type {
   ActionRunFailure,
+  ActionRunParams,
+  ActionRunPhase,
   ActionRunRecord,
   ActionRunStatus,
   ActionRunStorage,
   FinishActionRunInput,
   ListActionRunsInput,
   ListActionRunsResult,
+  QueueActionRunInput,
   StartActionRunInput,
 } from "./types"

--- a/packages/core/src/storage/action-runs/index.ts
+++ b/packages/core/src/storage/action-runs/index.ts
@@ -1,4 +1,10 @@
 export { ActionRunError } from "./errors"
+export {
+  actionRunParamsEqual,
+  actionSubjectsEqual,
+  canRequeueActionRunAfterEnqueueFailure,
+  isTerminalActionRun,
+} from "./idempotency"
 export { InMemoryActionRunStorage } from "./in-memory"
 export type {
   ActionRunFailure,

--- a/packages/core/src/storage/action-runs/types.ts
+++ b/packages/core/src/storage/action-runs/types.ts
@@ -1,12 +1,17 @@
 import type { ActionSubject } from "../../actions"
+import type { SecurityContext } from "../../auth"
 import type { JsonValue } from "../../json"
 
-export type ActionRunStatus = "running" | "succeeded" | "failed" | "cancelled"
+export type ActionRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled"
+
+export type ActionRunPhase = "request" | "enqueue" | "handler" | "cancelled"
+
+export type ActionRunParams = Readonly<Record<string, JsonValue>>
 
 export interface ActionRunFailure {
   readonly name?: string
   readonly message: string
-  readonly phase?: "handler" | "cancelled"
+  readonly phase?: ActionRunPhase
 }
 
 export interface ActionRunRecord {
@@ -15,21 +20,31 @@ export interface ActionRunRecord {
   readonly actionId: string
   readonly subject: ActionSubject
   readonly status: ActionRunStatus
-  readonly startedAt: Date
+  readonly phase?: ActionRunPhase
+  readonly queuedAt: Date
+  readonly startedAt?: Date
   readonly finishedAt?: Date
-  readonly params: Readonly<Record<string, unknown>>
+  readonly params: ActionRunParams
+  readonly idempotencyKey: string
+  readonly securityContext?: SecurityContext
   readonly error?: ActionRunFailure
-  readonly metadata?: Readonly<Record<string, JsonValue>>
+}
+
+export interface QueueActionRunInput {
+  readonly id: string
+  readonly projectId: string
+  readonly actionId: string
+  readonly subject: ActionSubject
+  readonly params: ActionRunParams
+  readonly idempotencyKey: string
+  readonly securityContext?: SecurityContext
+  readonly queuedAt?: Date
 }
 
 export interface StartActionRunInput {
   readonly id: string
   readonly projectId: string
-  readonly actionId: string
-  readonly subject: ActionSubject
-  readonly params: Readonly<Record<string, unknown>>
   readonly startedAt?: Date
-  readonly metadata?: Readonly<Record<string, JsonValue>>
 }
 
 export type FinishActionRunInput =
@@ -38,7 +53,7 @@ export type FinishActionRunInput =
       readonly projectId: string
       readonly status: "succeeded"
       readonly finishedAt?: Date
-      readonly metadata?: Readonly<Record<string, JsonValue>>
+      readonly phase?: ActionRunPhase
     }
   | {
       readonly id: string
@@ -46,7 +61,7 @@ export type FinishActionRunInput =
       readonly status: "failed" | "cancelled"
       readonly finishedAt?: Date
       readonly error?: ActionRunFailure
-      readonly metadata?: Readonly<Record<string, JsonValue>>
+      readonly phase?: ActionRunPhase
     }
 
 export interface ListActionRunsInput {
@@ -70,6 +85,7 @@ export interface ListActionRunsResult {
 }
 
 export interface ActionRunStorage {
+  queue(input: QueueActionRunInput): Promise<ActionRunRecord>
   start(input: StartActionRunInput): Promise<ActionRunRecord>
   finish(input: FinishActionRunInput): Promise<ActionRunRecord>
   getById(params: { projectId: string; id: string }): Promise<ActionRunRecord | null>

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,11 +1,14 @@
 export type {
   ActionRunFailure,
+  ActionRunParams,
+  ActionRunPhase,
   ActionRunRecord,
   ActionRunStatus,
   ActionRunStorage,
   FinishActionRunInput,
   ListActionRunsInput,
   ListActionRunsResult,
+  QueueActionRunInput,
   StartActionRunInput,
 } from "./action-runs"
 export { ActionRunError, InMemoryActionRunStorage } from "./action-runs"

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -11,7 +11,14 @@ export type {
   QueueActionRunInput,
   StartActionRunInput,
 } from "./action-runs"
-export { ActionRunError, InMemoryActionRunStorage } from "./action-runs"
+export {
+  ActionRunError,
+  actionRunParamsEqual,
+  actionSubjectsEqual,
+  canRequeueActionRunAfterEnqueueFailure,
+  InMemoryActionRunStorage,
+  isTerminalActionRun,
+} from "./action-runs"
 export type {
   AuthGroupMembershipStore,
   AuthInvitationStore,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -13,12 +13,15 @@ import type { WorkflowRunStorage } from "./workflow-runs"
 
 export type {
   ActionRunFailure,
+  ActionRunParams,
+  ActionRunPhase,
   ActionRunRecord,
   ActionRunStatus,
   ActionRunStorage,
   FinishActionRunInput,
   ListActionRunsInput,
   ListActionRunsResult,
+  QueueActionRunInput,
   StartActionRunInput,
 } from "./action-runs"
 export { ActionRunError } from "./action-runs"

--- a/packages/core/src/testing/queues-contract.ts
+++ b/packages/core/src/testing/queues-contract.ts
@@ -199,7 +199,7 @@ export function runQueueContractSuite(label: string, options: QueueContractSuite
         })
       })
 
-      test("keeps syncRuns, pipelines, projections, and workflows lanes independent", async () => {
+      test("keeps syncRuns, pipelines, projections, workflows, and actions lanes independent", async () => {
         await withQueues(async (queues) => {
           await queues.syncRuns.enqueue({
             projectId: "project-a",
@@ -237,6 +237,18 @@ export function runQueueContractSuite(label: string, options: QueueContractSuite
               },
             ],
           })
+          await queues.actions.enqueue({
+            projectId: "project-a",
+            jobs: [
+              {
+                type: "action.run.requested",
+                payload: {
+                  actionId: "mark-paid",
+                  runId: "act_1",
+                },
+              },
+            ],
+          })
 
           const crossLane = await queues.pipelines.claim({
             projectId: "project-a",
@@ -253,6 +265,11 @@ export function runQueueContractSuite(label: string, options: QueueContractSuite
             workerId: "workflow-worker-1",
             limit: 10,
           })
+          const actionLane = await queues.actions.claim({
+            projectId: "project-a",
+            workerId: "action-worker-1",
+            limit: 10,
+          })
           const sameLane = await queues.syncRuns.claim({
             projectId: "project-a",
             workerId: "sync-worker-1",
@@ -265,6 +282,8 @@ export function runQueueContractSuite(label: string, options: QueueContractSuite
           expect(projectionLane[0]?.job.payload.projectionId).toBe("room-projection")
           expect(workflowLane).toHaveLength(1)
           expect(workflowLane[0]?.job.payload.workflowId).toBe("reconcile-transaction")
+          expect(actionLane).toHaveLength(1)
+          expect(actionLane[0]?.job.payload.actionId).toBe("mark-paid")
           expect(sameLane).toHaveLength(1)
         })
       })

--- a/packages/core/tests/action-runs.test.ts
+++ b/packages/core/tests/action-runs.test.ts
@@ -98,6 +98,40 @@ describe("InMemoryActionRunStorage", () => {
     ).rejects.toBeInstanceOf(ActionRunError)
   })
 
+  test("rejects finishing terminal runs", async () => {
+    const storage = new InMemoryActionRunStorage()
+
+    await storage.queue({
+      id: "act_1",
+      projectId: "my-app",
+      actionId: "sendQuote",
+      subject: { kind: "none" },
+      params: {},
+      idempotencyKey: "action:my-app:act_1",
+    })
+    await storage.start({
+      id: "act_1",
+      projectId: "my-app",
+    })
+    await storage.finish({
+      id: "act_1",
+      projectId: "my-app",
+      status: "failed",
+      error: {
+        message: "handler failed",
+        phase: "handler",
+      },
+    })
+
+    await expect(
+      storage.finish({
+        id: "act_1",
+        projectId: "my-app",
+        status: "succeeded",
+      })
+    ).rejects.toBeInstanceOf(ActionRunError)
+  })
+
   test("stores failed runs and lists with filters, ordering, and paging", async () => {
     const storage = new InMemoryActionRunStorage()
 

--- a/packages/core/tests/action-runs.test.ts
+++ b/packages/core/tests/action-runs.test.ts
@@ -2,21 +2,28 @@ import { describe, expect, test } from "bun:test"
 import { ActionRunError, InMemoryActionRunStorage } from "../src"
 
 describe("InMemoryActionRunStorage", () => {
-  test("starts and finishes a successful action run with merged metadata", async () => {
+  test("queues, starts, and finishes a successful action run", async () => {
     const storage = new InMemoryActionRunStorage()
+    const queuedAt = new Date("2026-04-29T10:14:00.000Z")
     const startedAt = new Date("2026-04-29T10:14:01.000Z")
     const finishedAt = new Date("2026-04-29T10:14:03.842Z")
 
-    const started = await storage.start({
+    const queued = await storage.queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
       subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
       params: { amount: 50_000 },
+      idempotencyKey: "action:my-app:act_1",
+      queuedAt,
+    })
+
+    ;(queued.params as { amount: number }).amount = 1
+
+    const started = await storage.start({
+      id: "act_1",
+      projectId: "my-app",
       startedAt,
-      metadata: {
-        source: "ui",
-      },
     })
 
     ;(started.params as { amount: number }).amount = 1
@@ -26,9 +33,6 @@ describe("InMemoryActionRunStorage", () => {
       projectId: "my-app",
       status: "succeeded",
       finishedAt,
-      metadata: {
-        durationMs: 2842,
-      },
     })
 
     expect(finished).toMatchObject({
@@ -37,34 +41,47 @@ describe("InMemoryActionRunStorage", () => {
       actionId: "sendQuote",
       subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
       status: "succeeded",
+      phase: "handler",
       params: { amount: 50_000 },
-      metadata: {
-        source: "ui",
-        durationMs: 2842,
-      },
+      idempotencyKey: "action:my-app:act_1",
     })
-    expect(finished.startedAt.toISOString()).toBe(startedAt.toISOString())
+    expect(finished.queuedAt.toISOString()).toBe(queuedAt.toISOString())
+    expect(finished.startedAt?.toISOString()).toBe(startedAt.toISOString())
     expect(finished.finishedAt?.toISOString()).toBe(finishedAt.toISOString())
   })
 
-  test("rejects duplicate starts and missing finishes", async () => {
+  test("rejects duplicate queues, invalid starts, and missing finishes", async () => {
     const storage = new InMemoryActionRunStorage()
 
-    await storage.start({
+    await storage.queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
       subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
       params: {},
+      idempotencyKey: "action:my-app:act_1",
+    })
+
+    await expect(
+      storage.queue({
+        id: "act_1",
+        projectId: "my-app",
+        actionId: "sendQuote",
+        subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
+        params: {},
+        idempotencyKey: "action:my-app:act_1",
+      })
+    ).rejects.toBeInstanceOf(ActionRunError)
+
+    await storage.start({
+      id: "act_1",
+      projectId: "my-app",
     })
 
     await expect(
       storage.start({
         id: "act_1",
         projectId: "my-app",
-        actionId: "sendQuote",
-        subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
-        params: {},
       })
     ).rejects.toBeInstanceOf(ActionRunError)
 
@@ -84,12 +101,18 @@ describe("InMemoryActionRunStorage", () => {
   test("stores failed runs and lists with filters, ordering, and paging", async () => {
     const storage = new InMemoryActionRunStorage()
 
-    await storage.start({
+    await storage.queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
       subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-1" },
       params: {},
+      idempotencyKey: "action:my-app:act_1",
+      queuedAt: new Date("2026-04-29T09:59:59.000Z"),
+    })
+    await storage.start({
+      id: "act_1",
+      projectId: "my-app",
       startedAt: new Date("2026-04-29T10:00:00.000Z"),
     })
     await storage.finish({
@@ -103,21 +126,33 @@ describe("InMemoryActionRunStorage", () => {
       },
     })
 
-    await storage.start({
+    await storage.queue({
       id: "act_2",
       projectId: "my-app",
       actionId: "sendQuote",
       subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-2" },
       params: {},
+      idempotencyKey: "action:my-app:act_2",
+      queuedAt: new Date("2026-04-29T10:59:59.000Z"),
+    })
+    await storage.start({
+      id: "act_2",
+      projectId: "my-app",
       startedAt: new Date("2026-04-29T11:00:00.000Z"),
     })
 
-    await storage.start({
+    await storage.queue({
       id: "act_3",
       projectId: "my-app",
       actionId: "closeOpportunity",
       subject: { kind: "none" },
       params: {},
+      idempotencyKey: "action:my-app:act_3",
+      queuedAt: new Date("2026-04-29T11:59:59.000Z"),
+    })
+    await storage.start({
+      id: "act_3",
+      projectId: "my-app",
       startedAt: new Date("2026-04-29T12:00:00.000Z"),
     })
 

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   ActionDefinitionError,
+  ActionRunError,
   ActionValidationError,
   actionParam,
   defineAction,
@@ -435,6 +436,35 @@ describe("requestAction", () => {
     })
     expect(invoked).toBe(0)
     expect(result.runId.startsWith("act_")).toBe(true)
+    expect(result.created).toBe(true)
+    expect(new Date(result.queuedAt).toISOString()).toBe(result.queuedAt)
+    const run = await runtimeDeps.storage.actionRuns!.getById({
+      projectId: "action-test",
+      id: result.runId,
+    })
+    expect(run).toMatchObject({
+      id: result.runId,
+      actionId: "counted",
+      status: "queued",
+      phase: "request",
+      subject: {
+        kind: "object",
+        objectTypeId: "Room",
+        primaryId: "room:1",
+      },
+      params: {},
+      idempotencyKey: `action:action-test:${result.runId}`,
+    })
+    const jobs = await runtimeDeps.queues.actions.claim({
+      projectId: "action-test",
+      workerId: "test-worker",
+      limit: 1,
+    })
+    expect(jobs).toHaveLength(1)
+    expect(jobs[0].job.payload).toEqual({
+      actionId: "counted",
+      runId: result.runId,
+    })
     expect(events.length).toBe(1)
     expect(events[0].type).toBe("action.requested")
     if (events[0].type === "action.requested") {
@@ -447,6 +477,127 @@ describe("requestAction", () => {
       expect(events[0].payload.params).toEqual({})
       expect(events[0].payload.runId).toBe(result.runId)
     }
+  })
+
+  test("reuses a matching run id and rejects conflicting payloads", async () => {
+    const runtimeDeps = createTestRuntimeDeps()
+    const sixb = new Sixb({
+      id: "action-idempotency-test",
+      ontology: [Room],
+      actions: [setTemperature],
+      ...runtimeDeps,
+    })
+
+    await sixb.objects(Room).upsert({
+      properties: { id: "room:1", externalId: "R1", name: "Room 1" },
+    })
+
+    const first = await sixb.objects(Room).requestAction({
+      id: "room:1",
+      actionId: "setTemperature",
+      params: { target: 72 },
+      runId: "act_fixed",
+    })
+    const second = await sixb.objects(Room).requestAction({
+      id: "room:1",
+      actionId: "setTemperature",
+      params: { target: 72 },
+      runId: "act_fixed",
+    })
+
+    expect(first.created).toBe(true)
+    expect(second).toEqual({
+      runId: "act_fixed",
+      queuedAt: first.queuedAt,
+      created: false,
+    })
+
+    await expect(
+      sixb.objects(Room).requestAction({
+        id: "room:1",
+        actionId: "setTemperature",
+        params: { target: 73 },
+        runId: "act_fixed",
+      })
+    ).rejects.toBeInstanceOf(ActionRunError)
+  })
+
+  test("retries enqueue failures for the same run id and payload", async () => {
+    const runtimeDeps = createTestRuntimeDeps()
+    const enqueue = runtimeDeps.queues.actions.enqueue.bind(runtimeDeps.queues.actions)
+    let shouldFailEnqueue = true
+    runtimeDeps.queues.actions.enqueue = async (input) => {
+      if (shouldFailEnqueue) {
+        shouldFailEnqueue = false
+        throw new Error("queue unavailable")
+      }
+
+      return enqueue(input)
+    }
+
+    const sixb = new Sixb({
+      id: "action-enqueue-retry-test",
+      ontology: [Room],
+      actions: [setTemperature],
+      ...runtimeDeps,
+    })
+
+    await sixb.objects(Room).upsert({
+      properties: { id: "room:1", externalId: "R1", name: "Room 1" },
+    })
+
+    await expect(
+      sixb.objects(Room).requestAction({
+        id: "room:1",
+        actionId: "setTemperature",
+        params: { target: 72 },
+        runId: "act_enqueue_retry",
+      })
+    ).rejects.toThrow("queue unavailable")
+
+    const failed = await runtimeDeps.storage.actionRuns!.getById({
+      projectId: "action-enqueue-retry-test",
+      id: "act_enqueue_retry",
+    })
+    expect(failed).toMatchObject({
+      status: "failed",
+      phase: "enqueue",
+      error: {
+        name: "Error",
+        message: "queue unavailable",
+        phase: "enqueue",
+      },
+    })
+
+    const retry = await sixb.objects(Room).requestAction({
+      id: "room:1",
+      actionId: "setTemperature",
+      params: { target: 72 },
+      runId: "act_enqueue_retry",
+    })
+
+    expect(retry.created).toBe(false)
+    expect(retry.jobId).toBeTruthy()
+    const queued = await runtimeDeps.storage.actionRuns!.getById({
+      projectId: "action-enqueue-retry-test",
+      id: "act_enqueue_retry",
+    })
+    expect(queued).toMatchObject({
+      status: "queued",
+      phase: "request",
+      error: undefined,
+      finishedAt: undefined,
+    })
+
+    const jobs = await runtimeDeps.queues.actions.claim({
+      projectId: "action-enqueue-retry-test",
+      workerId: "test-worker",
+      limit: 1,
+    })
+    expect(jobs[0]?.job.payload).toEqual({
+      actionId: "setTemperature",
+      runId: "act_enqueue_retry",
+    })
   })
 
   test("runs validators request-side and emits no event when validation fails", async () => {

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -479,6 +479,64 @@ describe("requestAction", () => {
     }
   })
 
+  test("keeps a queued run when the action.requested observation event fails", async () => {
+    const runtimeDeps = createTestRuntimeDeps()
+    const sixb = new Sixb({
+      id: "action-event-best-effort-test",
+      ontology: [Room],
+      actions: [createRoom],
+      ...runtimeDeps,
+    })
+    const originalAppend = sixb.events.append.bind(sixb.events)
+    const originalConsoleError = console.error
+
+    sixb.events.append = async (input) => {
+      if (input.events.some((event) => event.type === "action.requested")) {
+        throw new Error("event store unavailable")
+      }
+
+      return originalAppend(input)
+    }
+    console.error = () => {}
+
+    try {
+      const result = await sixb.actions.request({
+        actionId: "createRoom",
+        params: { id: "room:1", name: "Room 1" },
+        runId: "act_event_failure",
+      })
+
+      expect(result).toMatchObject({
+        runId: "act_event_failure",
+        created: true,
+      })
+
+      const run = await runtimeDeps.storage.actionRuns!.getById({
+        projectId: "action-event-best-effort-test",
+        id: "act_event_failure",
+      })
+      expect(run?.status).toBe("queued")
+
+      const jobs = await runtimeDeps.queues.actions.claim({
+        projectId: "action-event-best-effort-test",
+        workerId: "test-worker",
+        limit: 1,
+      })
+      expect(jobs[0]?.job.payload).toEqual({
+        actionId: "createRoom",
+        runId: "act_event_failure",
+      })
+
+      const events = await sixb.events.read({
+        types: ["action.requested"],
+      })
+      expect(events).toHaveLength(0)
+    } finally {
+      sixb.events.append = originalAppend
+      console.error = originalConsoleError
+    }
+  })
+
   test("reuses a matching run id and rejects conflicting payloads", async () => {
     const runtimeDeps = createTestRuntimeDeps()
     const sixb = new Sixb({

--- a/packages/server/src/routes/actions.ts
+++ b/packages/server/src/routes/actions.ts
@@ -73,14 +73,14 @@ export function registerActionRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
       async ({ params, body, set }) => {
         try {
           const parsedBody = RequestActionBodySchema.parse(body)
-          const { runId } = await sixb.actions.request({
+          const result = await sixb.actions.request({
             actionId: params.actionId,
             subject: parsedBody.subject,
             params: parsedBody.params,
             runId: parsedBody.runId,
           })
 
-          return { success: true, runId }
+          return { success: true, ...result }
         } catch (error) {
           return handleRouteError(error, set)
         }

--- a/packages/server/src/schemas/common.ts
+++ b/packages/server/src/schemas/common.ts
@@ -7,4 +7,7 @@ export const SuccessResponseSchema = z.object({ success: z.boolean() })
 export const ActionRequestedResponseSchema = z.object({
   success: z.boolean(),
   runId: z.string(),
+  queuedAt: z.string(),
+  jobId: z.string().optional(),
+  created: z.boolean(),
 })

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -33,6 +33,7 @@ import {
   type SixbOptions,
 } from "@sixb/core"
 import {
+  SqliteActionRunStorage,
   SqliteObjectStorage,
   SqlitePipelineRunStorage,
   SqliteRulesStorage,
@@ -297,6 +298,7 @@ describe("SixbServer HTTP contract", () => {
         workflowRuns: new SqliteWorkflowRunStorage(),
         workflowInterventions: new SqliteWorkflowInterventionStorage(),
         webhookRuns: new SqliteWebhookRunStorage(),
+        actionRuns: new SqliteActionRunStorage(),
         rules: new SqliteRulesStorage(),
       },
       lakeStorage,
@@ -1583,9 +1585,15 @@ describe("SixbServer HTTP contract", () => {
       const requestActionBody = (await requestActionResponse.json()) as {
         success: boolean
         runId: string
+        queuedAt: string
+        created: boolean
+        jobId?: string
       }
       expect(requestActionBody.success).toBe(true)
       expect(requestActionBody.runId.startsWith("act_")).toBe(true)
+      expect(new Date(requestActionBody.queuedAt).toISOString()).toBe(requestActionBody.queuedAt)
+      expect(requestActionBody.created).toBe(true)
+      expect(requestActionBody.jobId).toBeTruthy()
 
       const requestCreateMaintenanceRunResponse = await fetch(
         `${baseUrl}/api/actions/createMaintenanceRun`,
@@ -1602,6 +1610,9 @@ describe("SixbServer HTTP contract", () => {
       expect(await requestCreateMaintenanceRunResponse.json()).toEqual({
         success: true,
         runId: "act_contract_global",
+        queuedAt: expect.any(String),
+        jobId: expect.any(String),
+        created: true,
       })
 
       const missingSubjectResponse = await fetch(`${baseUrl}/api/actions/setSpeed`, {

--- a/packages/workflow-worker/src/nodes/action-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/action-node-executor.ts
@@ -1,5 +1,5 @@
-import type { WorkflowActionNodeDefinition } from "@sixb/core"
-import { objectService, snapshotWorkflowActionInput } from "@sixb/core"
+import type { ActionRunFailure, WorkflowActionNodeDefinition } from "@sixb/core"
+import { ActionRunFailedError, objectService, snapshotWorkflowActionInput } from "@sixb/core"
 import { WorkflowWorkerError } from "../errors"
 import type { WorkflowNodeExecutor } from "../execution/node-executor"
 import { isRecord } from "../normalize"
@@ -48,7 +48,7 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
     })
     const actionRunId = `${context.job.id}:action:${nodeIndex}`
 
-    await objectService.requestActionAndWait(
+    const run = await objectService.requestActionAndWait(
       context.runtime,
       mapperResult.target.objectTypeId,
       mapperResult.target.primaryId,
@@ -60,9 +60,28 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
         onRequested: () => context.markSideEffectBoundaryPassed(),
       }
     )
+    if (run.status !== "succeeded") {
+      throw new ActionRunFailedError({
+        runId: run.id,
+        actionId: run.actionId,
+        subject: run.subject,
+        error: run.error ?? actionRunStatusFailure(run.status, run.phase),
+        finishedAt: (run.finishedAt ?? new Date()).toISOString(),
+      })
+    }
 
     return {}
   },
+}
+
+function actionRunStatusFailure(
+  status: "queued" | "running" | "failed" | "cancelled",
+  phase: ActionRunFailure["phase"]
+): ActionRunFailure {
+  return {
+    message: `Action run finished with status '${status}'.`,
+    phase,
+  }
 }
 
 function normalizeActionMapperResult(input: {

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  type ActionRunStorage,
   actionParam,
   defineAction,
   defineIntervention,
@@ -199,10 +200,19 @@ function createRuntime(sixb: {
 }
 
 async function completeRequestedActions(
-  sixb: { readonly id: string; readonly events: EventsRuntime },
+  sixb: {
+    readonly id: string
+    readonly events: EventsRuntime
+    readonly storage: { readonly actionRuns?: ActionRunStorage }
+  },
   status: "succeeded" | "failed",
   errorMessage = "action failed"
 ): Promise<() => void> {
+  const actionRuns = sixb.storage.actionRuns
+  if (!actionRuns) {
+    throw new Error("Expected action run storage in test runtime.")
+  }
+
   return sixb.events.subscribe(
     {
       types: ["action.requested"],
@@ -213,33 +223,66 @@ async function completeRequestedActions(
           continue
         }
 
-        void sixb.events.append({
-          events: [
+        void (async () => {
+          const run = await actionRuns.getById({
+            projectId: sixb.id,
+            id: event.payload.runId,
+          })
+          if (run?.status === "queued") {
+            await actionRuns.start({
+              projectId: sixb.id,
+              id: event.payload.runId,
+            })
+          }
+
+          await actionRuns.finish(
             status === "succeeded"
               ? {
-                  type: "action.completed",
-                  payload: {
-                    actionId: event.payload.actionId,
-                    runId: event.payload.runId,
-                    subject: event.payload.subject,
-                    finishedAt: "2026-05-08T10:00:00.000Z",
-                  },
+                  projectId: sixb.id,
+                  id: event.payload.runId,
+                  status: "succeeded",
+                  finishedAt: new Date("2026-05-08T10:00:00.000Z"),
                 }
               : {
-                  type: "action.failed",
-                  payload: {
-                    actionId: event.payload.actionId,
-                    runId: event.payload.runId,
-                    subject: event.payload.subject,
-                    error: {
-                      message: errorMessage,
-                      phase: "handler",
-                    },
-                    finishedAt: "2026-05-08T10:00:00.000Z",
+                  projectId: sixb.id,
+                  id: event.payload.runId,
+                  status: "failed",
+                  finishedAt: new Date("2026-05-08T10:00:00.000Z"),
+                  error: {
+                    message: errorMessage,
+                    phase: "handler",
                   },
-                },
-          ],
-        })
+                }
+          )
+
+          await sixb.events.append({
+            events: [
+              status === "succeeded"
+                ? {
+                    type: "action.completed",
+                    payload: {
+                      actionId: event.payload.actionId,
+                      runId: event.payload.runId,
+                      subject: event.payload.subject,
+                      finishedAt: "2026-05-08T10:00:00.000Z",
+                    },
+                  }
+                : {
+                    type: "action.failed",
+                    payload: {
+                      actionId: event.payload.actionId,
+                      runId: event.payload.runId,
+                      subject: event.payload.subject,
+                      error: {
+                        message: errorMessage,
+                        phase: "handler",
+                      },
+                      finishedAt: "2026-05-08T10:00:00.000Z",
+                    },
+                  },
+            ],
+          })
+        })()
       }
     }
   )

--- a/queues/bullmq/src/bullmq-queues.ts
+++ b/queues/bullmq/src/bullmq-queues.ts
@@ -1,9 +1,10 @@
 import type {
+  ActionRunRequestedQueueJob,
   PipelineRunRequestedQueueJob,
   ProjectionRunRequestedQueueJob,
   Queues,
   SyncRunRequestedQueueJob,
-  WorkflowRunRequestedQueueJob,
+  WorkflowQueueJob,
 } from "@sixb/core"
 import type { KeepJobs } from "bullmq"
 import { type BullMqLaneShared, BullMqQueue } from "./bullmq-queue"
@@ -70,7 +71,8 @@ export class BullMqQueues implements Queues {
   readonly syncRuns: BullMqQueue<SyncRunRequestedQueueJob>
   readonly pipelines: BullMqQueue<PipelineRunRequestedQueueJob>
   readonly projections: BullMqQueue<ProjectionRunRequestedQueueJob>
-  readonly workflows: BullMqQueue<WorkflowRunRequestedQueueJob>
+  readonly workflows: BullMqQueue<WorkflowQueueJob>
+  readonly actions: BullMqQueue<ActionRunRequestedQueueJob>
 
   private readonly connections: BullMqConnections
 
@@ -90,7 +92,8 @@ export class BullMqQueues implements Queues {
     this.syncRuns = new BullMqQueue<SyncRunRequestedQueueJob>(shared, "sync.runs")
     this.pipelines = new BullMqQueue<PipelineRunRequestedQueueJob>(shared, "pipeline.runs")
     this.projections = new BullMqQueue<ProjectionRunRequestedQueueJob>(shared, "projection.runs")
-    this.workflows = new BullMqQueue<WorkflowRunRequestedQueueJob>(shared, "workflow.runs")
+    this.workflows = new BullMqQueue<WorkflowQueueJob>(shared, "workflow.runs")
+    this.actions = new BullMqQueue<ActionRunRequestedQueueJob>(shared, "action.runs")
   }
 
   async close(): Promise<void> {
@@ -99,6 +102,7 @@ export class BullMqQueues implements Queues {
       this.pipelines.close(),
       this.projections.close(),
       this.workflows.close(),
+      this.actions.close(),
     ])
     // Short grace so a just-dispatched Redis command (typically the final stalled-check tick)
     // can settle on the socket before owned IORedis handles are quit. No-op when connections

--- a/storage/pg/src/migrations/001-initial-schema.sql
+++ b/storage/pg/src/migrations/001-initial-schema.sql
@@ -338,14 +338,19 @@ CREATE TABLE IF NOT EXISTS action_runs (
   subject_kind TEXT NOT NULL CHECK (subject_kind IN ('none', 'object')),
   object_type_id TEXT,
   primary_id TEXT,
-  status TEXT NOT NULL CHECK (status IN ('running', 'succeeded', 'failed', 'cancelled')),
-  started_at TIMESTAMPTZ NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+  phase TEXT CHECK (phase IS NULL OR phase IN ('request', 'enqueue', 'handler', 'cancelled')),
+  queued_at TIMESTAMPTZ NOT NULL,
+  started_at TIMESTAMPTZ,
   finished_at TIMESTAMPTZ,
   params JSONB NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  security_context JSONB,
   error_name TEXT,
   error_message TEXT,
-  error_phase TEXT CHECK (error_phase IS NULL OR error_phase IN ('handler', 'cancelled')),
-  metadata JSONB,
+  error_phase TEXT CHECK (
+    error_phase IS NULL OR error_phase IN ('request', 'enqueue', 'handler', 'cancelled')
+  ),
   CHECK (
     (subject_kind = 'none' AND object_type_id IS NULL AND primary_id IS NULL)
     OR (subject_kind = 'object' AND object_type_id IS NOT NULL AND primary_id IS NOT NULL)
@@ -354,13 +359,13 @@ CREATE TABLE IF NOT EXISTS action_runs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_action_runs_project_started
-  ON action_runs (project_id, started_at DESC);
+  ON action_runs (project_id, (COALESCE(started_at, queued_at)) DESC);
 CREATE INDEX IF NOT EXISTS idx_action_runs_project_action_started
-  ON action_runs (project_id, action_id, started_at DESC);
+  ON action_runs (project_id, action_id, (COALESCE(started_at, queued_at)) DESC);
 CREATE INDEX IF NOT EXISTS idx_action_runs_project_object_started
-  ON action_runs (project_id, object_type_id, primary_id, started_at DESC);
+  ON action_runs (project_id, object_type_id, primary_id, (COALESCE(started_at, queued_at)) DESC);
 CREATE INDEX IF NOT EXISTS idx_action_runs_project_status_started
-  ON action_runs (project_id, status, started_at DESC);
+  ON action_runs (project_id, status, (COALESCE(started_at, queued_at)) DESC);
 
 CREATE TABLE IF NOT EXISTS auth_users (
   project_id TEXT NOT NULL,

--- a/storage/pg/src/pg-action-run-storage.ts
+++ b/storage/pg/src/pg-action-run-storage.ts
@@ -1,12 +1,15 @@
 import type {
   ActionRunFailure,
+  ActionRunParams,
+  ActionRunPhase,
   ActionRunRecord,
   ActionRunStorage,
   ActionSubject,
   FinishActionRunInput,
-  JsonValue,
   ListActionRunsInput,
   ListActionRunsResult,
+  QueueActionRunInput,
+  SecurityContext,
   StartActionRunInput,
 } from "@sixb/core"
 import { ActionRunError } from "@sixb/core"
@@ -16,7 +19,7 @@ import { isUniqueViolation } from "./storage-errors"
 export class PgActionRunStorage implements ActionRunStorage {
   constructor(private readonly sql: SQL) {}
 
-  async start(input: StartActionRunInput): Promise<ActionRunRecord> {
+  async queue(input: QueueActionRunInput): Promise<ActionRunRecord> {
     try {
       const [row] = await this.sql<DatabaseRow[]>`
         INSERT INTO action_runs (
@@ -27,9 +30,16 @@ export class PgActionRunStorage implements ActionRunStorage {
           object_type_id,
           primary_id,
           status,
+          phase,
+          queued_at,
           started_at,
+          finished_at,
           params,
-          metadata
+          idempotency_key,
+          security_context,
+          error_name,
+          error_message,
+          error_phase
         ) VALUES (
           ${input.projectId},
           ${input.id},
@@ -37,10 +47,17 @@ export class PgActionRunStorage implements ActionRunStorage {
           ${input.subject.kind},
           ${input.subject.kind === "object" ? input.subject.objectTypeId : null},
           ${input.subject.kind === "object" ? input.subject.primaryId : null},
-          ${"running"},
-          ${input.startedAt ?? new Date()},
+          ${"queued"},
+          ${"request"},
+          ${input.queuedAt ?? new Date()},
+          ${null},
+          ${null},
           ${JSON.stringify(input.params)}::text::jsonb,
-          ${serializeMetadata(input.metadata)}::text::jsonb
+          ${input.idempotencyKey},
+          ${serializeSecurityContext(input.securityContext)}::text::jsonb,
+          ${null},
+          ${null},
+          ${null}
         )
         RETURNING *
       `
@@ -48,13 +65,76 @@ export class PgActionRunStorage implements ActionRunStorage {
       return rowToActionRunRecord(row)
     } catch (error) {
       if (isUniqueViolation(error)) {
+        return this.requeueAfterEnqueueFailure(input)
+      }
+
+      throw error
+    }
+  }
+
+  private async requeueAfterEnqueueFailure(input: QueueActionRunInput): Promise<ActionRunRecord> {
+    return this.sql.begin(async (tx) => {
+      const [existing] = await tx<DatabaseRow[]>`
+        SELECT * FROM action_runs
+        WHERE project_id = ${input.projectId} AND id = ${input.id}
+      `
+
+      if (!existing || !canRequeueAfterEnqueueFailure(rowToActionRunRecord(existing), input)) {
         throw new ActionRunError(
           `[SixbPg] Action run '${input.id}' already exists for project '${input.projectId}'.`
         )
       }
 
-      throw error
+      const [updated] = await tx<DatabaseRow[]>`
+        UPDATE action_runs
+        SET
+          status = ${"queued"},
+          phase = ${"request"},
+          queued_at = ${input.queuedAt ?? new Date()},
+          started_at = ${null},
+          finished_at = ${null},
+          security_context = ${serializeSecurityContext(input.securityContext)}::text::jsonb,
+          error_name = ${null},
+          error_message = ${null},
+          error_phase = ${null}
+        WHERE project_id = ${input.projectId} AND id = ${input.id}
+        RETURNING *
+      `
+
+      return rowToActionRunRecord(updated)
+    })
+  }
+
+  async start(input: StartActionRunInput): Promise<ActionRunRecord> {
+    const [updated] = await this.sql<DatabaseRow[]>`
+      UPDATE action_runs
+      SET
+        status = ${"running"},
+        phase = ${"handler"},
+        started_at = ${input.startedAt ?? new Date()},
+        error_name = ${null},
+        error_message = ${null},
+        error_phase = ${null}
+      WHERE project_id = ${input.projectId}
+        AND id = ${input.id}
+        AND status = ${"queued"}
+      RETURNING *
+    `
+
+    if (updated) {
+      return rowToActionRunRecord(updated)
     }
+
+    const existing = await this.getById({ projectId: input.projectId, id: input.id })
+    if (!existing) {
+      throw new ActionRunError(
+        `[SixbPg] Action run '${input.id}' not found for project '${input.projectId}'.`
+      )
+    }
+
+    throw new ActionRunError(
+      `[SixbPg] Action run '${input.id}' cannot start from status '${existing.status}'.`
+    )
   }
 
   async finish(input: FinishActionRunInput): Promise<ActionRunRecord> {
@@ -70,34 +150,20 @@ export class PgActionRunStorage implements ActionRunStorage {
         )
       }
 
-      const metadata = mergeMetadata(existing.metadata, input.metadata)
+      const phase = finishPhase(input, existing.phase)
 
-      const [updated] =
-        input.status === "succeeded"
-          ? await tx<DatabaseRow[]>`
-              UPDATE action_runs
-              SET
-                status = ${input.status},
-                finished_at = ${input.finishedAt ?? new Date()},
-                error_name = ${null},
-                error_message = ${null},
-                error_phase = ${null},
-                metadata = ${serializeMetadata(metadata)}::text::jsonb
-              WHERE project_id = ${input.projectId} AND id = ${input.id}
-              RETURNING *
-            `
-          : await tx<DatabaseRow[]>`
-              UPDATE action_runs
-              SET
-                status = ${input.status},
-                finished_at = ${input.finishedAt ?? new Date()},
-                error_name = ${input.error?.name ?? null},
-                error_message = ${input.error?.message ?? null},
-                error_phase = ${input.error?.phase ?? null},
-                metadata = ${serializeMetadata(metadata)}::text::jsonb
-              WHERE project_id = ${input.projectId} AND id = ${input.id}
-              RETURNING *
-            `
+      const [updated] = await tx<DatabaseRow[]>`
+        UPDATE action_runs
+        SET
+          status = ${input.status},
+          phase = ${phase},
+          finished_at = ${input.finishedAt ?? new Date()},
+          error_name = ${input.status === "succeeded" ? null : (input.error?.name ?? null)},
+          error_message = ${input.status === "succeeded" ? null : (input.error?.message ?? null)},
+          error_phase = ${input.status === "succeeded" ? null : (input.error?.phase ?? phase)}
+        WHERE project_id = ${input.projectId} AND id = ${input.id}
+        RETURNING *
+      `
 
       return rowToActionRunRecord(updated)
     })
@@ -162,12 +228,12 @@ export class PgActionRunStorage implements ActionRunStorage {
     }
 
     if (input.startedAfter) {
-      whereClauses.push(`started_at >= $${index++}`)
+      whereClauses.push(`COALESCE(started_at, queued_at) >= $${index++}`)
       params.push(input.startedAfter)
     }
 
     if (input.startedBefore) {
-      whereClauses.push(`started_at <= $${index++}`)
+      whereClauses.push(`COALESCE(started_at, queued_at) <= $${index++}`)
       params.push(input.startedBefore)
     }
 
@@ -184,7 +250,7 @@ export class PgActionRunStorage implements ActionRunStorage {
     let query = `
       SELECT * FROM action_runs
       ${where}
-      ORDER BY started_at ${order}, id ${order}
+      ORDER BY COALESCE(started_at, queued_at) ${order}, id ${order}
     `
 
     if (input.limit !== undefined) {
@@ -207,24 +273,25 @@ export class PgActionRunStorage implements ActionRunStorage {
   }
 }
 
-function serializeMetadata(
-  metadata: Readonly<Record<string, JsonValue>> | undefined
-): string | null {
-  return metadata ? JSON.stringify(metadata) : null
+function finishPhase(input: FinishActionRunInput, current: ActionRunPhase | null): ActionRunPhase {
+  if (input.status === "succeeded") {
+    return input.phase ?? current ?? "handler"
+  }
+
+  return input.phase ?? input.error?.phase ?? current ?? "handler"
 }
 
-function mergeMetadata(
-  existing: Readonly<Record<string, JsonValue>> | null | undefined,
-  next: Readonly<Record<string, JsonValue>> | undefined
-): Readonly<Record<string, JsonValue>> | undefined {
-  if (!existing && !next) {
+function serializeSecurityContext(securityContext: SecurityContext | undefined): string | null {
+  return securityContext ? JSON.stringify(securityContext) : null
+}
+
+function normalizeSecurityContext(
+  value: SecurityContext | string | null
+): SecurityContext | undefined {
+  if (!value) {
     return undefined
   }
-
-  return {
-    ...(existing ?? {}),
-    ...(next ?? {}),
-  }
+  return typeof value === "string" ? (JSON.parse(value) as SecurityContext) : value
 }
 
 function toActionRunFailure(row: DatabaseRow): ActionRunFailure | undefined {
@@ -246,11 +313,14 @@ function rowToActionRunRecord(row: DatabaseRow): ActionRunRecord {
     actionId: row.action_id,
     subject: rowToActionSubject(row),
     status: row.status,
-    startedAt: new Date(row.started_at),
+    phase: row.phase ?? undefined,
+    queuedAt: new Date(row.queued_at),
+    startedAt: row.started_at ? new Date(row.started_at) : undefined,
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     params: row.params,
+    idempotencyKey: row.idempotency_key,
+    securityContext: normalizeSecurityContext(row.security_context),
     error: toActionRunFailure(row),
-    metadata: row.metadata ?? undefined,
   }
 }
 
@@ -270,6 +340,40 @@ function rowToActionSubject(row: DatabaseRow): ActionSubject {
   }
 }
 
+function canRequeueAfterEnqueueFailure(
+  existing: ActionRunRecord,
+  input: QueueActionRunInput
+): boolean {
+  return (
+    existing.status === "failed" &&
+    existing.phase === "enqueue" &&
+    existing.actionId === input.actionId &&
+    existing.idempotencyKey === input.idempotencyKey &&
+    subjectsEqual(existing.subject, input.subject) &&
+    stableJsonStringify(existing.params) === stableJsonStringify(input.params)
+  )
+}
+
+function subjectsEqual(left: ActionSubject, right: ActionSubject): boolean {
+  if (left.kind !== right.kind) return false
+  if (left.kind === "none") return true
+  if (right.kind === "none") return false
+  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
+}
+
+function stableJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringify).join(",")}]`
+  }
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
+    .join(",")}}`
+}
+
 interface DatabaseRow {
   project_id: string
   id: string
@@ -278,11 +382,14 @@ interface DatabaseRow {
   object_type_id: string | null
   primary_id: string | null
   status: ActionRunRecord["status"]
-  started_at: Date | string
+  phase: ActionRunPhase | null
+  queued_at: Date | string
+  started_at: Date | string | null
   finished_at: Date | string | null
-  params: Readonly<Record<string, unknown>>
+  params: ActionRunParams
+  idempotency_key: string
+  security_context: SecurityContext | string | null
   error_name: string | null
   error_message: string | null
   error_phase: ActionRunFailure["phase"] | null
-  metadata: Readonly<Record<string, JsonValue>> | null
 }

--- a/storage/pg/src/pg-action-run-storage.ts
+++ b/storage/pg/src/pg-action-run-storage.ts
@@ -12,7 +12,11 @@ import type {
   SecurityContext,
   StartActionRunInput,
 } from "@sixb/core"
-import { ActionRunError } from "@sixb/core"
+import {
+  ActionRunError,
+  canRequeueActionRunAfterEnqueueFailure,
+  isTerminalActionRun,
+} from "@sixb/core"
 import type { SQL, SqlParameter } from "./pg-client"
 import { isUniqueViolation } from "./storage-errors"
 
@@ -77,9 +81,13 @@ export class PgActionRunStorage implements ActionRunStorage {
       const [existing] = await tx<DatabaseRow[]>`
         SELECT * FROM action_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
+        FOR UPDATE
       `
 
-      if (!existing || !canRequeueAfterEnqueueFailure(rowToActionRunRecord(existing), input)) {
+      if (
+        !existing ||
+        !canRequeueActionRunAfterEnqueueFailure(rowToActionRunRecord(existing), input)
+      ) {
         throw new ActionRunError(
           `[SixbPg] Action run '${input.id}' already exists for project '${input.projectId}'.`
         )
@@ -142,11 +150,18 @@ export class PgActionRunStorage implements ActionRunStorage {
       const [existing] = await tx<DatabaseRow[]>`
         SELECT * FROM action_runs
         WHERE project_id = ${input.projectId} AND id = ${input.id}
+        FOR UPDATE
       `
 
       if (!existing) {
         throw new ActionRunError(
           `[SixbPg] Action run '${input.id}' not found for project '${input.projectId}'.`
+        )
+      }
+
+      if (isTerminalActionRun({ status: existing.status })) {
+        throw new ActionRunError(
+          `[SixbPg] Action run '${input.id}' cannot finish from terminal status '${existing.status}'.`
         )
       }
 
@@ -338,40 +353,6 @@ function rowToActionSubject(row: DatabaseRow): ActionSubject {
     objectTypeId: row.object_type_id,
     primaryId: row.primary_id,
   }
-}
-
-function canRequeueAfterEnqueueFailure(
-  existing: ActionRunRecord,
-  input: QueueActionRunInput
-): boolean {
-  return (
-    existing.status === "failed" &&
-    existing.phase === "enqueue" &&
-    existing.actionId === input.actionId &&
-    existing.idempotencyKey === input.idempotencyKey &&
-    subjectsEqual(existing.subject, input.subject) &&
-    stableJsonStringify(existing.params) === stableJsonStringify(input.params)
-  )
-}
-
-function subjectsEqual(left: ActionSubject, right: ActionSubject): boolean {
-  if (left.kind !== right.kind) return false
-  if (left.kind === "none") return true
-  if (right.kind === "none") return false
-  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
-}
-
-function stableJsonStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value)
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableJsonStringify).join(",")}]`
-  }
-  return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
-    .join(",")}}`
 }
 
 interface DatabaseRow {

--- a/storage/sqlite/src/action-run-storage.ts
+++ b/storage/sqlite/src/action-run-storage.ts
@@ -3,13 +3,16 @@ import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import type {
   ActionRunFailure,
+  ActionRunParams,
+  ActionRunPhase,
   ActionRunRecord,
   ActionRunStorage,
   ActionSubject,
   FinishActionRunInput,
-  JsonValue,
   ListActionRunsInput,
   ListActionRunsResult,
+  QueueActionRunInput,
+  SecurityContext,
   StartActionRunInput,
 } from "@sixb/core"
 import { ActionRunError } from "@sixb/core"
@@ -33,8 +36,8 @@ export class SqliteActionRunStorage implements ActionRunStorage {
     }
   }
 
-  async start(input: StartActionRunInput): Promise<ActionRunRecord> {
-    const startedAt = input.startedAt ?? new Date()
+  async queue(input: QueueActionRunInput): Promise<ActionRunRecord> {
+    const queuedAt = input.queuedAt ?? new Date()
 
     try {
       this.db
@@ -48,10 +51,17 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             object_type_id,
             primary_id,
             status,
+            phase,
+            queued_at,
             started_at,
+            finished_at,
             params,
-            metadata
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            idempotency_key,
+            security_context,
+            error_name,
+            error_message,
+            error_phase
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, NULL, NULL, NULL)
         `
         )
         .run(
@@ -61,16 +71,16 @@ export class SqliteActionRunStorage implements ActionRunStorage {
           input.subject.kind,
           input.subject.kind === "object" ? input.subject.objectTypeId : null,
           input.subject.kind === "object" ? input.subject.primaryId : null,
-          "running",
-          startedAt.toISOString(),
+          "queued",
+          "request",
+          queuedAt.toISOString(),
           JSON.stringify(input.params),
-          serializeMetadata(input.metadata)
+          input.idempotencyKey,
+          serializeSecurityContext(input.securityContext)
         )
     } catch (error) {
       if (isUniqueConstraintError(error)) {
-        throw new ActionRunError(
-          `[SixbSqlite] Action run '${input.id}' already exists for project '${input.projectId}'.`
-        )
+        return this.requeueAfterEnqueueFailure(input, queuedAt)
       }
 
       throw error
@@ -86,6 +96,103 @@ export class SqliteActionRunStorage implements ActionRunStorage {
     return record
   }
 
+  private async requeueAfterEnqueueFailure(
+    input: QueueActionRunInput,
+    queuedAt: Date
+  ): Promise<ActionRunRecord> {
+    return this.db.transaction(() => {
+      const existing = this.db
+        .query("SELECT * FROM action_runs WHERE project_id = ? AND id = ?")
+        .get(input.projectId, input.id) as DatabaseRow | null
+
+      if (!existing || !canRequeueAfterEnqueueFailure(rowToActionRunRecord(existing), input)) {
+        throw new ActionRunError(
+          `[SixbSqlite] Action run '${input.id}' already exists for project '${input.projectId}'.`
+        )
+      }
+
+      this.db
+        .query(
+          `
+          UPDATE action_runs
+          SET
+            status = ?,
+            phase = ?,
+            queued_at = ?,
+            started_at = NULL,
+            finished_at = NULL,
+            security_context = ?,
+            error_name = NULL,
+            error_message = NULL,
+            error_phase = NULL
+          WHERE project_id = ? AND id = ?
+        `
+        )
+        .run(
+          "queued",
+          "request",
+          queuedAt.toISOString(),
+          serializeSecurityContext(input.securityContext),
+          input.projectId,
+          input.id
+        )
+
+      const updated = this.db
+        .query("SELECT * FROM action_runs WHERE project_id = ? AND id = ?")
+        .get(input.projectId, input.id) as DatabaseRow
+
+      return rowToActionRunRecord(updated)
+    })()
+  }
+
+  async start(input: StartActionRunInput): Promise<ActionRunRecord> {
+    return this.db.transaction(() => {
+      const existing = this.db
+        .query("SELECT * FROM action_runs WHERE project_id = ? AND id = ?")
+        .get(input.projectId, input.id) as DatabaseRow | null
+
+      if (!existing) {
+        throw new ActionRunError(
+          `[SixbSqlite] Action run '${input.id}' not found for project '${input.projectId}'.`
+        )
+      }
+
+      if (existing.status !== "queued") {
+        throw new ActionRunError(
+          `[SixbSqlite] Action run '${input.id}' cannot start from status '${existing.status}'.`
+        )
+      }
+
+      this.db
+        .query(
+          `
+          UPDATE action_runs
+          SET
+            status = ?,
+            phase = ?,
+            started_at = ?,
+            error_name = NULL,
+            error_message = NULL,
+            error_phase = NULL
+          WHERE project_id = ? AND id = ?
+        `
+        )
+        .run(
+          "running",
+          "handler",
+          (input.startedAt ?? new Date()).toISOString(),
+          input.projectId,
+          input.id
+        )
+
+      const updated = this.db
+        .query("SELECT * FROM action_runs WHERE project_id = ? AND id = ?")
+        .get(input.projectId, input.id) as DatabaseRow
+
+      return rowToActionRunRecord(updated)
+    })()
+  }
+
   async finish(input: FinishActionRunInput): Promise<ActionRunRecord> {
     return this.db.transaction(() => {
       const existing = this.db
@@ -98,7 +205,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
         )
       }
 
-      const metadata = mergeMetadata(parseMetadata(existing.metadata), input.metadata)
+      const phase = finishPhase(input, existing.phase)
 
       this.db
         .query(
@@ -106,21 +213,21 @@ export class SqliteActionRunStorage implements ActionRunStorage {
           UPDATE action_runs
           SET
             status = ?,
+            phase = ?,
             finished_at = ?,
             error_name = ?,
             error_message = ?,
-            error_phase = ?,
-            metadata = ?
+            error_phase = ?
           WHERE project_id = ? AND id = ?
         `
         )
         .run(
           input.status,
+          phase,
           (input.finishedAt ?? new Date()).toISOString(),
           input.status === "succeeded" ? null : (input.error?.name ?? null),
           input.status === "succeeded" ? null : (input.error?.message ?? null),
-          input.status === "succeeded" ? null : (input.error?.phase ?? null),
-          serializeMetadata(metadata),
+          input.status === "succeeded" ? null : (input.error?.phase ?? phase),
           input.projectId,
           input.id
         )
@@ -189,12 +296,12 @@ export class SqliteActionRunStorage implements ActionRunStorage {
     }
 
     if (input.startedAfter) {
-      whereClauses.push("started_at >= ?")
+      whereClauses.push("COALESCE(started_at, queued_at) >= ?")
       args.push(input.startedAfter.toISOString())
     }
 
     if (input.startedBefore) {
-      whereClauses.push("started_at <= ?")
+      whereClauses.push("COALESCE(started_at, queued_at) <= ?")
       args.push(input.startedBefore.toISOString())
     }
 
@@ -210,7 +317,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
     let query = `
       SELECT * FROM action_runs
       ${where}
-      ORDER BY started_at ${order}, id ${order}
+      ORDER BY COALESCE(started_at, queued_at) ${order}, id ${order}
     `
     const queryArgs = [...args]
 
@@ -237,28 +344,20 @@ export class SqliteActionRunStorage implements ActionRunStorage {
   }
 }
 
-function serializeMetadata(
-  metadata: Readonly<Record<string, JsonValue>> | undefined
-): string | null {
-  return metadata ? JSON.stringify(metadata) : null
-}
-
-function parseMetadata(value: string | null): Readonly<Record<string, JsonValue>> | undefined {
-  return value ? (JSON.parse(value) as Readonly<Record<string, JsonValue>>) : undefined
-}
-
-function mergeMetadata(
-  existing: Readonly<Record<string, JsonValue>> | undefined,
-  next: Readonly<Record<string, JsonValue>> | undefined
-): Readonly<Record<string, JsonValue>> | undefined {
-  if (!existing && !next) {
-    return undefined
+function finishPhase(input: FinishActionRunInput, current: ActionRunPhase | null): ActionRunPhase {
+  if (input.status === "succeeded") {
+    return input.phase ?? current ?? "handler"
   }
 
-  return {
-    ...(existing ?? {}),
-    ...(next ?? {}),
-  }
+  return input.phase ?? input.error?.phase ?? current ?? "handler"
+}
+
+function serializeSecurityContext(securityContext: SecurityContext | undefined): string | null {
+  return securityContext ? JSON.stringify(securityContext) : null
+}
+
+function parseSecurityContext(value: string | null): SecurityContext | undefined {
+  return value ? (JSON.parse(value) as SecurityContext) : undefined
 }
 
 function toActionRunFailure(row: DatabaseRow): ActionRunFailure | undefined {
@@ -280,11 +379,14 @@ function rowToActionRunRecord(row: DatabaseRow): ActionRunRecord {
     actionId: row.action_id,
     subject: rowToActionSubject(row),
     status: row.status,
-    startedAt: new Date(row.started_at),
+    phase: row.phase ?? undefined,
+    queuedAt: new Date(row.queued_at),
+    startedAt: row.started_at ? new Date(row.started_at) : undefined,
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
-    params: JSON.parse(row.params) as Readonly<Record<string, unknown>>,
+    params: JSON.parse(row.params) as ActionRunParams,
+    idempotencyKey: row.idempotency_key,
+    securityContext: parseSecurityContext(row.security_context),
     error: toActionRunFailure(row),
-    metadata: parseMetadata(row.metadata),
   }
 }
 
@@ -308,6 +410,40 @@ function isUniqueConstraintError(error: unknown): boolean {
   return error instanceof Error && error.message.includes("UNIQUE constraint failed")
 }
 
+function canRequeueAfterEnqueueFailure(
+  existing: ActionRunRecord,
+  input: QueueActionRunInput
+): boolean {
+  return (
+    existing.status === "failed" &&
+    existing.phase === "enqueue" &&
+    existing.actionId === input.actionId &&
+    existing.idempotencyKey === input.idempotencyKey &&
+    subjectsEqual(existing.subject, input.subject) &&
+    stableJsonStringify(existing.params) === stableJsonStringify(input.params)
+  )
+}
+
+function subjectsEqual(left: ActionSubject, right: ActionSubject): boolean {
+  if (left.kind !== right.kind) return false
+  if (left.kind === "none") return true
+  if (right.kind === "none") return false
+  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
+}
+
+function stableJsonStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringify).join(",")}]`
+  }
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
+    .join(",")}}`
+}
+
 interface DatabaseRow {
   project_id: string
   id: string
@@ -316,11 +452,14 @@ interface DatabaseRow {
   object_type_id: string | null
   primary_id: string | null
   status: ActionRunRecord["status"]
-  started_at: string
+  phase: ActionRunPhase | null
+  queued_at: string
+  started_at: string | null
   finished_at: string | null
   params: string
+  idempotency_key: string
+  security_context: string | null
   error_name: string | null
   error_message: string | null
   error_phase: ActionRunFailure["phase"] | null
-  metadata: string | null
 }

--- a/storage/sqlite/src/action-run-storage.ts
+++ b/storage/sqlite/src/action-run-storage.ts
@@ -15,7 +15,11 @@ import type {
   SecurityContext,
   StartActionRunInput,
 } from "@sixb/core"
-import { ActionRunError } from "@sixb/core"
+import {
+  ActionRunError,
+  canRequeueActionRunAfterEnqueueFailure,
+  isTerminalActionRun,
+} from "@sixb/core"
 import { installFreshSqliteSchema } from "./migrations"
 
 export interface SqliteActionRunStorageOptions {
@@ -105,7 +109,10 @@ export class SqliteActionRunStorage implements ActionRunStorage {
         .query("SELECT * FROM action_runs WHERE project_id = ? AND id = ?")
         .get(input.projectId, input.id) as DatabaseRow | null
 
-      if (!existing || !canRequeueAfterEnqueueFailure(rowToActionRunRecord(existing), input)) {
+      if (
+        !existing ||
+        !canRequeueActionRunAfterEnqueueFailure(rowToActionRunRecord(existing), input)
+      ) {
         throw new ActionRunError(
           `[SixbSqlite] Action run '${input.id}' already exists for project '${input.projectId}'.`
         )
@@ -202,6 +209,12 @@ export class SqliteActionRunStorage implements ActionRunStorage {
       if (!existing) {
         throw new ActionRunError(
           `[SixbSqlite] Action run '${input.id}' not found for project '${input.projectId}'.`
+        )
+      }
+
+      if (isTerminalActionRun({ status: existing.status })) {
+        throw new ActionRunError(
+          `[SixbSqlite] Action run '${input.id}' cannot finish from terminal status '${existing.status}'.`
         )
       }
 
@@ -408,40 +421,6 @@ function rowToActionSubject(row: DatabaseRow): ActionSubject {
 
 function isUniqueConstraintError(error: unknown): boolean {
   return error instanceof Error && error.message.includes("UNIQUE constraint failed")
-}
-
-function canRequeueAfterEnqueueFailure(
-  existing: ActionRunRecord,
-  input: QueueActionRunInput
-): boolean {
-  return (
-    existing.status === "failed" &&
-    existing.phase === "enqueue" &&
-    existing.actionId === input.actionId &&
-    existing.idempotencyKey === input.idempotencyKey &&
-    subjectsEqual(existing.subject, input.subject) &&
-    stableJsonStringify(existing.params) === stableJsonStringify(input.params)
-  )
-}
-
-function subjectsEqual(left: ActionSubject, right: ActionSubject): boolean {
-  if (left.kind !== right.kind) return false
-  if (left.kind === "none") return true
-  if (right.kind === "none") return false
-  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
-}
-
-function stableJsonStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value)
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableJsonStringify).join(",")}]`
-  }
-  return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
-    .join(",")}}`
 }
 
 interface DatabaseRow {

--- a/storage/sqlite/src/migrations/001-initial-schema.sql
+++ b/storage/sqlite/src/migrations/001-initial-schema.sql
@@ -336,14 +336,19 @@ CREATE TABLE IF NOT EXISTS action_runs (
   subject_kind TEXT NOT NULL CHECK (subject_kind IN ('none', 'object')),
   object_type_id TEXT,
   primary_id TEXT,
-  status TEXT NOT NULL CHECK (status IN ('running', 'succeeded', 'failed', 'cancelled')),
-  started_at TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+  phase TEXT CHECK (phase IS NULL OR phase IN ('request', 'enqueue', 'handler', 'cancelled')),
+  queued_at TEXT NOT NULL,
+  started_at TEXT,
   finished_at TEXT,
   params TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  security_context TEXT,
   error_name TEXT,
   error_message TEXT,
-  error_phase TEXT CHECK (error_phase IS NULL OR error_phase IN ('handler', 'cancelled')),
-  metadata TEXT,
+  error_phase TEXT CHECK (
+    error_phase IS NULL OR error_phase IN ('request', 'enqueue', 'handler', 'cancelled')
+  ),
   CHECK (
     (subject_kind = 'none' AND object_type_id IS NULL AND primary_id IS NULL)
     OR (subject_kind = 'object' AND object_type_id IS NOT NULL AND primary_id IS NOT NULL)
@@ -352,13 +357,13 @@ CREATE TABLE IF NOT EXISTS action_runs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_action_runs_project_started
-  ON action_runs(project_id, started_at DESC);
+  ON action_runs(project_id, COALESCE(started_at, queued_at) DESC);
 CREATE INDEX IF NOT EXISTS idx_action_runs_project_action_started
-  ON action_runs(project_id, action_id, started_at DESC);
+  ON action_runs(project_id, action_id, COALESCE(started_at, queued_at) DESC);
 CREATE INDEX IF NOT EXISTS idx_action_runs_project_object_started
-  ON action_runs(project_id, object_type_id, primary_id, started_at DESC);
+  ON action_runs(project_id, object_type_id, primary_id, COALESCE(started_at, queued_at) DESC);
 CREATE INDEX IF NOT EXISTS idx_action_runs_project_status_started
-  ON action_runs(project_id, status, started_at DESC);
+  ON action_runs(project_id, status, COALESCE(started_at, queued_at) DESC);
 
 CREATE TABLE IF NOT EXISTS auth_users (
   project_id TEXT NOT NULL,

--- a/storage/sqlite/tests/sqlite-action-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-action-run-storage.test.ts
@@ -13,8 +13,8 @@ describe("SqliteActionRunStorage", () => {
     storage.close()
   })
 
-  test("starts and finishes runs with merged metadata", async () => {
-    await storage.start({
+  test("queues, starts, and finishes runs", async () => {
+    await storage.queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -22,10 +22,14 @@ describe("SqliteActionRunStorage", () => {
       params: {
         amount: 50_000,
       },
+      idempotencyKey: "action:my-app:act_1",
+      queuedAt: new Date("2026-04-29T10:14:00.000Z"),
+    })
+
+    await storage.start({
+      id: "act_1",
+      projectId: "my-app",
       startedAt: new Date("2026-04-29T10:14:01.000Z"),
-      metadata: {
-        source: "ui",
-      },
     })
 
     const finished = await storage.finish({
@@ -33,26 +37,29 @@ describe("SqliteActionRunStorage", () => {
       projectId: "my-app",
       status: "succeeded",
       finishedAt: new Date("2026-04-29T10:14:03.842Z"),
-      metadata: {
-        durationMs: 2842,
-      },
     })
 
     expect(finished.status).toBe("succeeded")
+    expect(finished.phase).toBe("handler")
     expect(finished.params).toEqual({ amount: 50_000 })
-    expect(finished.metadata).toEqual({
-      source: "ui",
-      durationMs: 2842,
-    })
+    expect(finished.idempotencyKey).toBe("action:my-app:act_1")
+    expect(finished.queuedAt.toISOString()).toBe("2026-04-29T10:14:00.000Z")
+    expect(finished.startedAt?.toISOString()).toBe("2026-04-29T10:14:01.000Z")
   })
 
   test("stores failures and supports filtered paging", async () => {
-    await storage.start({
+    await storage.queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
       subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
       params: {},
+      idempotencyKey: "action:my-app:act_1",
+      queuedAt: new Date("2026-04-29T09:59:59.000Z"),
+    })
+    await storage.start({
+      id: "act_1",
+      projectId: "my-app",
       startedAt: new Date("2026-04-29T10:00:00.000Z"),
     })
     await storage.finish({
@@ -66,12 +73,18 @@ describe("SqliteActionRunStorage", () => {
       },
     })
 
-    await storage.start({
+    await storage.queue({
       id: "act_2",
       projectId: "my-app",
       actionId: "sendQuote",
       subject: { kind: "none" },
       params: {},
+      idempotencyKey: "action:my-app:act_2",
+      queuedAt: new Date("2026-04-29T10:59:59.000Z"),
+    })
+    await storage.start({
+      id: "act_2",
+      projectId: "my-app",
       startedAt: new Date("2026-04-29T11:00:00.000Z"),
     })
 
@@ -97,21 +110,35 @@ describe("SqliteActionRunStorage", () => {
   })
 
   test("rejects duplicates and missing runs", async () => {
-    await storage.start({
+    await storage.queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
       subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
       params: {},
+      idempotencyKey: "action:my-app:act_1",
+    })
+
+    await expect(
+      storage.queue({
+        id: "act_1",
+        projectId: "my-app",
+        actionId: "sendQuote",
+        subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
+        params: {},
+        idempotencyKey: "action:my-app:act_1",
+      })
+    ).rejects.toBeInstanceOf(ActionRunError)
+
+    await storage.start({
+      id: "act_1",
+      projectId: "my-app",
     })
 
     await expect(
       storage.start({
         id: "act_1",
         projectId: "my-app",
-        actionId: "sendQuote",
-        subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
-        params: {},
       })
     ).rejects.toBeInstanceOf(ActionRunError)
 
@@ -123,6 +150,58 @@ describe("SqliteActionRunStorage", () => {
         error: {
           message: "boom",
         },
+      })
+    ).rejects.toBeInstanceOf(ActionRunError)
+  })
+
+  test("requeues matching runs that failed during enqueue", async () => {
+    await storage.queue({
+      id: "act_1",
+      projectId: "my-app",
+      actionId: "sendQuote",
+      subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
+      params: { amount: 50_000 },
+      idempotencyKey: "action:my-app:act_1",
+      queuedAt: new Date("2026-04-29T10:00:00.000Z"),
+    })
+    await storage.finish({
+      id: "act_1",
+      projectId: "my-app",
+      status: "failed",
+      phase: "enqueue",
+      finishedAt: new Date("2026-04-29T10:00:01.000Z"),
+      error: {
+        message: "queue unavailable",
+        phase: "enqueue",
+      },
+    })
+
+    const requeued = await storage.queue({
+      id: "act_1",
+      projectId: "my-app",
+      actionId: "sendQuote",
+      subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
+      params: { amount: 50_000 },
+      idempotencyKey: "action:my-app:act_1",
+      queuedAt: new Date("2026-04-29T10:00:02.000Z"),
+    })
+
+    expect(requeued).toMatchObject({
+      status: "queued",
+      phase: "request",
+      error: undefined,
+      finishedAt: undefined,
+    })
+    expect(requeued.queuedAt.toISOString()).toBe("2026-04-29T10:00:02.000Z")
+
+    await expect(
+      storage.queue({
+        id: "act_1",
+        projectId: "my-app",
+        actionId: "sendQuote",
+        subject: { kind: "object", objectTypeId: "Opportunity", primaryId: "opp-123" },
+        params: { amount: 60_000 },
+        idempotencyKey: "action:my-app:act_1",
       })
     ).rejects.toBeInstanceOf(ActionRunError)
   })

--- a/storage/sqlite/tests/sqlite-action-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-action-run-storage.test.ts
@@ -154,6 +154,38 @@ describe("SqliteActionRunStorage", () => {
     ).rejects.toBeInstanceOf(ActionRunError)
   })
 
+  test("rejects finishing terminal runs", async () => {
+    await storage.queue({
+      id: "act_1",
+      projectId: "my-app",
+      actionId: "sendQuote",
+      subject: { kind: "none" },
+      params: {},
+      idempotencyKey: "action:my-app:act_1",
+    })
+    await storage.start({
+      id: "act_1",
+      projectId: "my-app",
+    })
+    await storage.finish({
+      id: "act_1",
+      projectId: "my-app",
+      status: "failed",
+      error: {
+        message: "handler failed",
+        phase: "handler",
+      },
+    })
+
+    await expect(
+      storage.finish({
+        id: "act_1",
+        projectId: "my-app",
+        status: "succeeded",
+      })
+    ).rejects.toBeInstanceOf(ActionRunError)
+  })
+
   test("requeues matching runs that failed during enqueue", async () => {
     await storage.queue({
       id: "act_1",


### PR DESCRIPTION
# Pull Request Summary

## Action Queue Lane And Orchestrated Requests

This PR moves action requests onto the durable execution path.

## What Changed

- Adds a dedicated `queues.actions` lane for `action.run.requested` jobs.
- Updates action requests to persist an `ActionRun` before enqueueing work.
- Introduces the new ActionRun lifecycle:
  `queued -> running -> succeeded | failed | cancelled`.
- Makes `ActionWorker` claim durable queue jobs instead of subscribing to `action.requested`.
- Changes `requestActionAndWait` to wait on the terminal `ActionRunRecord`.
- Supports strict run idempotency and safe requeue after `failed/enqueue`.
- Updates the initial SQLite and Postgres schemas for ActionRun V2.
- Updates the action HTTP response and generated client types.
- Keeps workflow action nodes aligned with the new terminal run semantics.

## API Shape

```ts
await sixb.actions.request({
  actionId: "createInvoice",
  params,
})

// -> { runId, queuedAt, jobId?, created }
```

## Verification

- `bun run generate:client`
- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun run test`

Postgres e2e migration tests were not run locally because `DATABASE_URL` was not configured.
