### PR TITLE
Add scoped authorization layer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ shared runtime.
 - [Sync](./concepts/sync.md)
 - [Rules](./concepts/rules.md)
 - [Workflow](./concepts/workflows.md)
+- [Authentication](./concepts/authentication.md)
+- [Authorization](./concepts/authorization.md)
 
 ## Coming next
 

--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -1,0 +1,194 @@
+# Authentication
+
+Authentication establishes **who** a principal is. [Authorization](./authorization.md) is the
+separate layer that decides **what** that principal may do.
+
+Sixb builds authentication from a few small layers:
+
+- **Strategy** decides how a user proves who they are — a magic link, an OIDC provider, or none.
+- **Sessions** carry the signed-in state in a cookie and resolve it on each request.
+- **Allowed domains and bootstrap** decide who may sign in, and who gets the first account.
+- **Invitations** let the team grow after the first user is in.
+
+You configure all of this through the `auth` option on `createSixb()`. The server ships the
+sign-in, callback, and sign-out endpoints, so you rarely write request handling yourself.
+
+## Why it is useful
+
+Operational software needs a real identity behind every request:
+
+- restrict sign-in to your company's email domain
+- seed the first administrator without a chicken-and-egg problem
+- invite teammates and place them into the right group
+- keep people signed in across restarts, and sign them out everywhere when needed
+
+Authentication gives you one place to declare the strategy, and a typed principal that flows into
+every grant check.
+
+## Pick a strategy
+
+A strategy is the value you pass to `auth`. Each lives in its own package.
+
+**Magic link** — email a one-time sign-in link. No external identity provider to set up.
+
+```ts
+import { createSixb } from "@sixb/core"
+import { magicLink } from "@sixb/auth-magic-link"
+
+export const sixb = createSixb({
+  // ...storage, broker, and the rest of the runtime
+  auth: magicLink({
+    allowedDomains: ["example.com"],
+    bootstrapUsers: ["admin@example.com"],
+    sendMagicLink: async ({ email, url }) => {
+      // In development, print it. In production, email it.
+      console.log(`Sign-in link for ${email}: ${url}`)
+    },
+  }),
+})
+```
+
+**OIDC** — sign in through an existing provider such as Google Workspace.
+
+```ts
+import { oidc } from "@sixb/auth-oidc"
+
+auth: oidc({
+  issuer: "https://accounts.google.com",
+  clientId: process.env.SIXB_GOOGLE_CLIENT_ID ?? "",
+  clientSecret: process.env.SIXB_GOOGLE_CLIENT_SECRET ?? "",
+  allowedDomains: ["yourcompany.com"],
+  bootstrapUsers: ["you@yourcompany.com"],
+})
+```
+
+## What each part does
+
+Common options, using magic link as the example:
+
+| Option | Meaning |
+| --- | --- |
+| `allowedDomains` | Email domains permitted to sign in |
+| `bootstrapUsers` | Emails allowed to create the very first account |
+| `bootstrapGroups` | Groups the first user is placed into on sign-in |
+| `sendMagicLink` | Delivers the sign-in link (magic link only) |
+| `from` / `subject` | Sender and subject line for the email |
+
+OIDC swaps `sendMagicLink` for the provider connection — `issuer`, `clientId`, and
+`clientSecret` — and uses `sendInvitation` to deliver invitation emails.
+
+## Auth needs storage
+
+Auth state — users, sessions, group memberships, and invitations — lives in the runtime's auth
+storage. Use a persistent adapter so people stay signed in across restarts.
+
+```ts
+import { migrateSqliteStorage, SqliteStorage } from "@sixb/sqlite"
+
+await migrateSqliteStorage(".sixb")
+
+export const sixb = createSixb({
+  storage: new SqliteStorage({ path: ".sixb" }),
+  // ...auth, broker, and the rest of the runtime
+})
+```
+
+Enabling auth without a storage adapter that provides auth storage is an error at startup.
+
+## Allowed domains and bootstrap
+
+`allowedDomains` is the gate: only emails on those domains can sign in. `bootstrapUsers` is the
+exception that solves the first-account problem — those specific emails can create the first
+account, and `bootstrapGroups` places that user into a group immediately.
+
+```ts
+import { magicLink } from "@sixb/auth-magic-link"
+import { securityAdmins } from "./security/groups/security-admins"
+
+auth: magicLink({
+  allowedDomains: ["example.com"],
+  bootstrapUsers: ["admin@example.com"],
+  bootstrapGroups: [securityAdmins],
+  sendMagicLink: async ({ email, url }) => console.log(`${email}: ${url}`),
+})
+```
+
+The first sign-in as `admin@example.com` lands in `security-admins`. That group's
+[role grants](./authorization.md) are what let it administer everything else — including inviting
+the rest of the team.
+
+## Invitations
+
+After bootstrap, the team grows through invitations rather than more bootstrap users. Who can
+invite whom into which groups is governed by [invite policies](./authorization.md). The active
+strategy must support invitation delivery (magic link and OIDC both do).
+
+The server exposes invitation management under `/api/auth/invitations`, and the built-in admin UI
+uses it, so you usually do not call it directly.
+
+## Sessions and cookies
+
+A successful sign-in sets a session cookie that the server resolves on every request. Pass the
+object form of `auth` to tune session lifetime or cookie behavior.
+
+```ts
+auth: {
+  strategy: magicLink({ /* ... */ }),
+  session: {
+    ttlMs: 7 * 24 * 60 * 60 * 1000, // default: 7 days
+  },
+  cookies: {
+    sameSite: "strict",
+    secure: "auto", // secure cookies when served over HTTPS
+  },
+}
+```
+
+Sessions are cached in-process briefly to absorb request bursts; the defaults are sensible, so
+most apps leave `session` and `cookies` unset.
+
+## Sign-in endpoints
+
+When you serve the runtime, these endpoints are registered for you:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /auth/sign-in` | Sign-in form (magic link) or redirect to the provider (OIDC) |
+| `POST /auth/sign-in` | Request a magic link, or start the OIDC flow |
+| `GET /auth/callback` | Complete the link or provider redirect and start a session |
+| `POST /api/auth/sign-out` | End the current session |
+| `POST /api/auth/sign-out-all` | End every session for the current user |
+
+## Development and production
+
+In development you can run without auth — omit `auth` entirely and every request is treated as
+privileged. The server refuses to do this in production: a deployed runtime must configure a real
+strategy.
+
+To run a deployed runtime without auth on purpose, opt in explicitly:
+
+```ts
+auth: { id: "disabled", kind: "disabled", allowDisabledInProduction: true }
+```
+
+This is deliberate — disabling auth in production should never happen by omission.
+
+## From sign-in to authorization
+
+Once a principal is signed in, its identity and group memberships resolve into an authorization
+context. The server attaches that context to the request automatically, so grant checks apply
+without extra wiring. See [Authorization](./authorization.md) for groups, roles, and grants.
+
+## Extra details
+
+- the strategy is the value passed to `auth`; the object form `{ strategy, session, cookies }`
+  adds session and cookie tuning.
+- `allowedDomains` is enforced on both sign-in and invitations.
+- `bootstrapGroups` must reference groups registered with the runtime, or startup fails.
+- sessions default to a 7-day lifetime; signing out everywhere revokes them across all devices.
+- state-changing API routes are CSRF-protected with a double-submit token.
+- auth and authorization are independent layers: authentication says who you are; authorization
+  says what you may do.
+
+The important first step is to pick a strategy, set `allowedDomains` and `bootstrapUsers`, then
+let invitations and groups grow the team from there.

--- a/docs/concepts/authorization.md
+++ b/docs/concepts/authorization.md
@@ -1,0 +1,281 @@
+# Authorization
+
+Authorization decides what each signed-in principal is allowed to see and do.
+
+Sixb builds authorization from a few small layers:
+
+- **Groups** place principals into named buckets.
+- **Roles** give capabilities to groups.
+- **Grants** are the capabilities a role gives — view objects, apply actions, run workflows.
+- **Invite policies** decide who can invite new people into which groups.
+
+At request time these definitions resolve into one set of grants per principal, and a scoped
+runtime enforces them.
+
+## Why it is useful
+
+Most operational software needs more than "signed in or not":
+
+- team members should see notes, but not admin records
+- only security admins should run sensitive workflows
+- support staff should apply some actions, not all of them
+- new teammates should be invited into the right group, by the right people
+
+Grants give those rules one typed place to live. You describe access next to the ontology,
+actions, and workflows it protects, and the runtime applies it the same way everywhere.
+
+## Define a group
+
+A group is a named bucket. Principals belong to groups; roles and invite policies are written
+against groups, never against individual users.
+
+Files: `security/groups/team-members.ts` and `security/groups/security-admins.ts`
+
+```ts
+import { defineGroup } from "@sixb/core"
+
+export const teamMembers = defineGroup("team-members", {
+  label: "Team members",
+})
+```
+
+```ts
+import { defineGroup } from "@sixb/core"
+
+export const securityAdmins = defineGroup("security-admins", {
+  label: "Security admins",
+})
+```
+
+## Define a role
+
+A role bundles grants and attaches them to one or more groups. Every member of a `grantedTo`
+group receives the role's grants.
+
+File: `security/roles/access.ts`
+
+```ts
+import { can, defineRole } from "@sixb/core"
+import { acknowledgeNote } from "../../actions/acknowledge-note"
+import { Note } from "../../ontology/note"
+import { teamMembers } from "../groups/team-members"
+
+export const teamMemberAccess = defineRole("team-member.access", {
+  grantedTo: [teamMembers],
+  grants: [can.view(Note), can.apply(acknowledgeNote)],
+})
+```
+
+This role lets every member of `team-members` view `Note` objects and apply the
+`acknowledge-note` action — nothing else.
+
+## What each part does
+
+| Part | Meaning |
+| --- | --- |
+| `defineRole("team-member.access")` | Names the role |
+| `grantedTo: [teamMembers]` | Groups whose members receive the role |
+| `grants: [...]` | The capabilities the role gives |
+| `can.view(Note)` | Allow viewing `Note` objects |
+| `can.apply(acknowledgeNote)` | Allow applying the `acknowledge-note` action |
+
+## Grants
+
+A grant pairs a capability with the definitions it covers. There are three capabilities, one per
+protected surface.
+
+| Capability | Allows | Targets |
+| --- | --- | --- |
+| `can.view(...)` | Read objects: `get`, `list`, `query`, and related events | Object types |
+| `can.apply(...)` | Request actions | Actions |
+| `can.run(...)` | Start workflows | Workflows |
+
+Each builder takes one definition, a list, or a breadth selector.
+
+| Want | Write |
+| --- | --- |
+| One definition | `can.view(Note)` |
+| Several definitions | `can.view([Note, Invoice])` |
+| Every object type | `can.view(ontology.objects())` |
+| Every action | `can.apply(actions())` |
+| Every workflow | `can.run(workflows())` |
+| Everything but a few | `can.view(ontology.objects().except([AdminNote]))` |
+
+`ontology.objects()`, `actions()`, and `workflows()` select a capability's whole registered
+universe. They are type-checked against the capability, so `can.view(actions())` does not
+compile.
+
+## Broad grants
+
+Use breadth selectors for roles that should reach most of the system.
+
+File: `security/roles/access.ts`
+
+```ts
+import { actions, can, defineRole, ontology, workflows } from "@sixb/core"
+import { securityAdmins } from "../groups/security-admins"
+
+export const securityAdminAccess = defineRole("security-admin.full-access", {
+  grantedTo: [securityAdmins],
+  grants: [can.view(ontology.objects()), can.apply(actions()), can.run(workflows())],
+})
+```
+
+Add `.except([...])` to keep a selection broad while carving out a few definitions.
+
+```ts
+can.view(ontology.objects().except([AdminNote]))
+```
+
+This grants every object type except `AdminNote`.
+
+## Invite policies
+
+An invite policy says which groups can invite new people, and which groups they can place them
+into. Without a matching policy, a principal cannot send invitations.
+
+File: `security/invite-policies/default-invites.ts`
+
+```ts
+import { defineInvitePolicy } from "@sixb/core"
+import { securityAdmins } from "../groups/security-admins"
+import { teamMembers } from "../groups/team-members"
+
+export const defaultInvites = defineInvitePolicy("default-invites", {
+  grantedTo: [securityAdmins],
+  canInviteTo: [teamMembers],
+})
+```
+
+Security admins can now invite people into `team-members`. A policy must declare `canInviteTo`
+groups, set `canInviteWithoutGroups: true`, or both.
+
+## How principals join groups
+
+Roles and invite policies act on group membership, so principals need a way into a group.
+
+- **Bootstrap** — the auth strategy's `bootstrapGroups` are applied to the first allowed user to
+  sign in. This seeds the initial admins.
+- **Invitations** — after that, members covered by an invite policy invite teammates into the
+  groups that policy allows.
+
+```ts
+import { magicLink } from "@sixb/auth-magic-link"
+import { securityAdmins } from "./security/groups/security-admins"
+
+auth: magicLink({
+  allowedDomains: ["example.com"],
+  bootstrapUsers: ["admin@example.com"],
+  bootstrapGroups: [securityAdmins],
+})
+```
+
+The first user to sign in as `admin@example.com` lands in `security-admins`, which (via the role
+above) can then invite the rest of the team.
+
+## How grants are enforced
+
+Grants are enforced through a **scoped runtime**. The raw `sixb` instance is privileged — it has
+no authorization context and bypasses all grant checks. That is intended for trusted system code
+(startup, syncs, projections, workers, tests).
+
+To enforce a principal's grants, derive a scoped runtime with `sixb.as(context)`:
+
+```ts
+const scoped = sixb.as(authorizationContext)
+
+await scoped.objects(Note).list()    // only if can.view(Note)
+await scoped.requestAction(input)     // only if can.apply(...)
+await scoped.runWorkflow(input)       // only if can.run(...)
+```
+
+The scoped runtime is **default-deny**: any request without a covering grant throws, and listing
+APIs return only the definitions the principal can reach. It exposes only operations whose grants
+are enforceable end to end — reads, actions, workflows, and events. Writes, links, telemetry, and
+auth administration stay on the privileged runtime.
+
+## With the server
+
+The Sixb server does this for you. It resolves the session once per request and routes
+authenticated traffic through `sixb.as(context)` automatically, so grants are enforced without
+extra wiring. You define groups, roles, and invite policies; the server applies them.
+
+To build a context yourself in a custom integration, resolve it from the request:
+
+```ts
+const context = await sixb.auth.createAuthorizationContext(request)
+const scoped = sixb.as(context)
+```
+
+## Convention
+
+Put security definitions under `security/`, split by kind, and export them.
+
+```txt
+your-project/
+  ontology/
+    note.ts
+  actions/
+    acknowledge-note.ts
+  security/
+    groups/
+      team-members.ts
+      security-admins.ts
+    roles/
+      access.ts
+    invite-policies/
+      default-invites.ts
+  sixb.config.ts
+```
+
+`createSixb()` discovers exported definitions from `security/groups/`, `security/roles/`, and
+`security/invite-policies/` automatically.
+
+You can also register them explicitly:
+
+```ts
+import { createSixb } from "@sixb/core"
+import { defaultInvites } from "./security/invite-policies/default-invites"
+import { securityAdmins } from "./security/groups/security-admins"
+import { teamMembers } from "./security/groups/team-members"
+import { securityAdminAccess, teamMemberAccess } from "./security/roles/access"
+
+export const sixb = createSixb({
+  groups: [teamMembers, securityAdmins],
+  roles: [teamMemberAccess, securityAdminAccess],
+  invitePolicies: [defaultInvites],
+})
+```
+
+## How to model authorization
+
+Start from the people, not the permissions.
+
+1. List the kinds of user your app has, and turn each into a group.
+2. For each group, write one role describing what it can view, apply, and run.
+3. Start narrow with explicit grants; widen to `ontology.objects()` or `.except([...])` only
+   when a group really needs broad reach.
+4. Add an invite policy so the right group can grow the others.
+5. Set `bootstrapGroups` so the first sign-in can administer everything else.
+
+Good group and role names describe the people and their access:
+
+- `team-members`, `security-admins`
+- `team-member.access`
+- `security-admin.full-access`
+
+## Extra details
+
+- group, role, and invite policy ids must be unique.
+- a role must list at least one group in `grantedTo` and at least one grant.
+- grants reference ontology, action, and workflow definitions by id and are validated against the
+  registered runtime at startup.
+- `can.view(Type)` also grants the type's subtypes.
+- a principal's grants are the union of every role whose `grantedTo` groups it belongs to.
+- there is no separate "view events" capability: a principal sees a domain event only when it can
+  view, apply, or run the event's subject.
+- the privileged runtime is the silent default — any authenticated route must run through
+  `sixb.as(context)` (the server does this for you) or it bypasses grant checks.
+
+The important first step is to name your groups clearly, then describe each group's access as one
+role.

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -37,10 +37,21 @@ whole flow, not just sign-in:
   `security-admins`.
 - **Invite policy** — security admins can invite people into `team-members`
   (`security/invite-policies/default-invites.ts`).
+- **Roles** — `team-members` can view `Note` and apply `acknowledge-note`.
+  `security-admins` use wildcard grants: view all objects, apply all actions,
+  run all workflows, and view events
+  (`security/roles/atlas-access.ts`).
+- **Seed data** — startup writes one `Note`, one `AdminNote`, and one
+  `AccessRequest` (`seed.ts`).
 
 So: sign in as `admin@example.com`, then use the admin UI in Atlas to invite a
 teammate. They receive their own sign-in link — printed to the terminal, or
 emailed if Resend is configured.
+
+In Atlas, the teammate's object list should only include `Note` objects and the
+`acknowledge-note` action. Requests for `AdminNote`, `AccessRequest`, admin
+actions, workflows, and events are denied by the scoped SDK that backs the
+server routes.
 
 ## Use OIDC instead (Google Workspace)
 

--- a/examples/auth/actions/acknowledge-note.ts
+++ b/examples/auth/actions/acknowledge-note.ts
@@ -1,0 +1,9 @@
+import { defineAction } from "@sixb/core"
+import { Note } from "../ontology/note"
+
+export const acknowledgeNote = defineAction("acknowledge-note", {
+  description: "Acknowledge that a team note was read.",
+})
+  .on(Note)
+  .params({})
+  .edits(() => {})

--- a/examples/auth/actions/resolve-access-request.ts
+++ b/examples/auth/actions/resolve-access-request.ts
@@ -1,0 +1,9 @@
+import { defineAction } from "@sixb/core"
+import { AccessRequest } from "../ontology/access-request"
+
+export const resolveAccessRequest = defineAction("resolve-access-request", {
+  description: "Resolve an access request.",
+})
+  .on(AccessRequest)
+  .params({})
+  .edits(() => {})

--- a/examples/auth/ontology/access-request.ts
+++ b/examples/auth/ontology/access-request.ts
@@ -1,0 +1,12 @@
+import { defineObjectType, prop } from "@sixb/core"
+
+export const AccessRequest = defineObjectType({
+  id: "access-request",
+  name: "Access Request",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("requesterEmail", "string", { required: true }),
+    prop("reason", "string"),
+    prop("status", "string", { required: true }),
+  ],
+})

--- a/examples/auth/ontology/admin-note.ts
+++ b/examples/auth/ontology/admin-note.ts
@@ -1,0 +1,13 @@
+import { defineObjectType, prop } from "@sixb/core"
+
+// Restricted object type used by the auth example to prove Atlas object
+// listings are narrowed by authorization grants.
+export const AdminNote = defineObjectType({
+  id: "admin-note",
+  name: "Admin Note",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("title", "string", { required: true }),
+    prop("body", "string"),
+  ],
+})

--- a/examples/auth/security/roles/atlas-access.ts
+++ b/examples/auth/security/roles/atlas-access.ts
@@ -1,0 +1,15 @@
+import { actions, can, defineRole, ontology, workflows } from "@sixb/core"
+import { acknowledgeNote } from "../../actions/acknowledge-note"
+import { Note } from "../../ontology/note"
+import { securityAdmins } from "../groups/security-admins"
+import { teamMembers } from "../groups/team-members"
+
+export const teamMemberAtlasAccess = defineRole("team-member.atlas-access", {
+  grantedTo: [teamMembers],
+  grants: [can.view(Note), can.apply(acknowledgeNote)],
+})
+
+export const securityAdminFullAccess = defineRole("security-admin.full-access", {
+  grantedTo: [securityAdmins],
+  grants: [can.view(ontology.objects()), can.apply(actions()), can.start(workflows())],
+})

--- a/examples/auth/security/roles/atlas-access.ts
+++ b/examples/auth/security/roles/atlas-access.ts
@@ -11,5 +11,5 @@ export const teamMemberAtlasAccess = defineRole("team-member.atlas-access", {
 
 export const securityAdminFullAccess = defineRole("security-admin.full-access", {
   grantedTo: [securityAdmins],
-  grants: [can.view(ontology.objects()), can.apply(actions()), can.start(workflows())],
+  grants: [can.view(ontology.objects()), can.apply(actions()), can.run(workflows())],
 })

--- a/examples/auth/seed.ts
+++ b/examples/auth/seed.ts
@@ -1,0 +1,27 @@
+import type { OntologySource, Sixb } from "@sixb/core"
+import { AccessRequest } from "./ontology/access-request"
+import { AdminNote } from "./ontology/admin-note"
+import { Note } from "./ontology/note"
+
+type SeedRuntime = Pick<Sixb<readonly OntologySource[]>, "upsertObject">
+
+export async function seedAuthExampleObjects(sixb: SeedRuntime): Promise<void> {
+  await sixb.upsertObject(Note.id, {
+    id: "team-note",
+    title: "Team note",
+    body: "Visible to team members and security admins.",
+  })
+
+  await sixb.upsertObject(AdminNote.id, {
+    id: "admin-note",
+    title: "Admin note",
+    body: "Visible only to security admins.",
+  })
+
+  await sixb.upsertObject(AccessRequest.id, {
+    id: "access-request",
+    requesterEmail: "teammate@example.com",
+    reason: "Needs access to the auth example.",
+    status: "pending",
+  })
+}

--- a/examples/auth/sixb.config.ts
+++ b/examples/auth/sixb.config.ts
@@ -7,8 +7,9 @@ import {
   InMemoryLakeStorage,
   InMemoryQueues,
 } from "@sixb/core"
-import { SqliteStorage } from "@sixb/sqlite"
+import { migrateSqliteStorage, SqliteStorage } from "@sixb/sqlite"
 import { securityAdmins } from "./security/groups/security-admins"
+import { seedAuthExampleObjects } from "./seed"
 
 // Switch the auth strategy with SIXB_AUTH_MODE:
 //   magic-link (default) — zero setup; the sign-in link is printed to this terminal.
@@ -19,35 +20,45 @@ const fromEmail = process.env.SIXB_AUTH_EMAIL_FROM?.trim()
 
 const allowedDomains = listEnv("SIXB_AUTH_ALLOWED_DOMAINS", ["example.com"])
 const bootstrapUsers = listEnv("SIXB_AUTH_BOOTSTRAP_USERS", ["admin@example.com"])
+const storagePath = ".sixb"
 
-export const sixb = createSixb({
-  id: "auth-example",
-  broker: new InMemoryBroker(),
-  storage: new SqliteStorage({ path: ".sixb" }),
-  lakeStorage: new InMemoryLakeStorage(),
-  blobStorage: new InMemoryBlobStorage(),
-  queues: new InMemoryQueues(),
-  auth:
-    authMode === "oidc"
-      ? oidc({
-          id: "google-workspace",
-          issuer: "https://accounts.google.com",
-          clientId: requiredEnv("SIXB_GOOGLE_CLIENT_ID"),
-          clientSecret: requiredEnv("SIXB_GOOGLE_CLIENT_SECRET"),
-          allowedDomains,
-          bootstrapUsers,
-          bootstrapGroups: [securityAdmins],
-          from: fromEmail,
-          sendInvitation: sendAuthInvitation,
-        })
-      : magicLink({
-          allowedDomains,
-          bootstrapUsers,
-          bootstrapGroups: [securityAdmins],
-          from: fromEmail,
-          sendMagicLink: sendMagicLinkEmail,
-        }),
-})
+export const sixb = createAuthExampleSixb()
+
+async function createAuthExampleSixb() {
+  await migrateSqliteStorage(storagePath)
+
+  const runtime = await createSixb({
+    id: "auth-example",
+    broker: new InMemoryBroker(),
+    storage: new SqliteStorage({ path: storagePath }),
+    lakeStorage: new InMemoryLakeStorage(),
+    blobStorage: new InMemoryBlobStorage(),
+    queues: new InMemoryQueues(),
+    auth:
+      authMode === "oidc"
+        ? oidc({
+            id: "google-workspace",
+            issuer: "https://accounts.google.com",
+            clientId: requiredEnv("SIXB_GOOGLE_CLIENT_ID"),
+            clientSecret: requiredEnv("SIXB_GOOGLE_CLIENT_SECRET"),
+            allowedDomains,
+            bootstrapUsers,
+            bootstrapGroups: [securityAdmins],
+            from: fromEmail,
+            sendInvitation: sendAuthInvitation,
+          })
+        : magicLink({
+            allowedDomains,
+            bootstrapUsers,
+            bootstrapGroups: [securityAdmins],
+            from: fromEmail,
+            sendMagicLink: sendMagicLinkEmail,
+          }),
+  })
+
+  await seedAuthExampleObjects(runtime)
+  return runtime
+}
 
 async function sendMagicLinkEmail(message: SendMagicLinkInput): Promise<void> {
   // Print the link so you can sign in even without an email provider configured.

--- a/examples/auth/tests/atlas-authorization.test.ts
+++ b/examples/auth/tests/atlas-authorization.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test"
+import { resolve } from "node:path"
+import {
+  createSixb,
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  InMemoryStorage,
+  type OntologySource,
+  resolveAuthorizationContext,
+  type Sixb,
+} from "@sixb/core"
+import { seedAuthExampleObjects } from "../seed"
+
+async function createAuthExampleRuntime() {
+  return createSixb({
+    id: "auth-example-test",
+    projectRoot: resolve(import.meta.dir, ".."),
+    broker: new InMemoryBroker(),
+    storage: new InMemoryStorage(),
+    lakeStorage: new InMemoryLakeStorage(),
+    blobStorage: new InMemoryBlobStorage(),
+    queues: new InMemoryQueues(),
+  })
+}
+
+function atlasContext(
+  sixb: Sixb<readonly OntologySource[]>,
+  groupIds: readonly string[],
+  userId = "atlas-user"
+) {
+  return resolveAuthorizationContext({
+    principal: { type: "user", id: userId },
+    groupIds,
+    roles: sixb.security.getResolvedRoles(),
+  })
+}
+
+describe("auth example Atlas authorization", () => {
+  test("team members only see and do what their roles grant", async () => {
+    const sixb = await createAuthExampleRuntime()
+    await seedAuthExampleObjects(sixb)
+
+    const teamMember = sixb.as(atlasContext(sixb, ["team-members"]))
+    const admin = sixb.as(atlasContext(sixb, ["security-admins"]))
+    const noGroups = sixb.as(atlasContext(sixb, []))
+
+    expect((await teamMember.list({})).objects.map((object) => object.objectTypeId)).toEqual([
+      "note",
+    ])
+    await expect(teamMember.getObject("admin-note", "admin-note")).rejects.toThrow(
+      "not allowed to view object type 'admin-note'"
+    )
+    await expect(teamMember.getObject("access-request", "access-request")).rejects.toThrow(
+      "not allowed to view object type 'access-request'"
+    )
+
+    expect(teamMember.listActions().map((action) => action.id)).toEqual(["acknowledge-note"])
+    await expect(
+      teamMember.requestAction({
+        actionId: "acknowledge-note",
+        subject: { kind: "object", objectTypeId: "note", primaryId: "team-note" },
+      })
+    ).resolves.toMatchObject({ runId: expect.any(String) })
+    await expect(
+      teamMember.requestAction({
+        actionId: "resolve-access-request",
+        subject: { kind: "object", objectTypeId: "access-request", primaryId: "access-request" },
+      })
+    ).rejects.toThrow("not allowed to apply action 'resolve-access-request'")
+    await expect(
+      teamMember.runWorkflow({
+        workflowId: "run-access-review",
+        input: {
+          accessRequest: { objectTypeId: "access-request", primaryId: "access-request" },
+        },
+      })
+    ).rejects.toThrow("not allowed to start workflow 'run-access-review'")
+    // Event visibility is derived from grants: team members see events for the
+    // objects they can view (Note), but not for AdminNote or AccessRequest.
+    const teamMemberObjectEvents = (await teamMember.readEvents())
+      .filter((event) => event.type === "object.upserted")
+      .map((event) => event.payload.objectTypeId)
+    expect(new Set(teamMemberObjectEvents)).toEqual(new Set(["note"]))
+
+    expect(new Set((await admin.list({})).objects.map((object) => object.objectTypeId))).toEqual(
+      new Set(["note", "admin-note", "access-request"])
+    )
+    expect(
+      admin
+        .listActions()
+        .map((action) => action.id)
+        .sort()
+    ).toEqual(["acknowledge-note", "resolve-access-request"])
+    await expect(
+      admin.requestAction({
+        actionId: "resolve-access-request",
+        subject: { kind: "object", objectTypeId: "access-request", primaryId: "access-request" },
+      })
+    ).resolves.toMatchObject({ runId: expect.any(String) })
+    await expect(
+      admin.runWorkflow({
+        workflowId: "run-access-review",
+        input: {
+          accessRequest: { objectTypeId: "access-request", primaryId: "access-request" },
+        },
+      })
+    ).resolves.toMatchObject({ runId: expect.any(String) })
+    expect((await admin.readEvents()).map((event) => event.type)).toContain("object.upserted")
+
+    expect(await noGroups.list({})).toEqual({ objects: [], hasMore: false, total: 0 })
+    expect(noGroups.listActions()).toEqual([])
+  })
+})

--- a/examples/auth/tests/atlas-authorization.test.ts
+++ b/examples/auth/tests/atlas-authorization.test.ts
@@ -76,7 +76,7 @@ describe("auth example Atlas authorization", () => {
           accessRequest: { objectTypeId: "access-request", primaryId: "access-request" },
         },
       })
-    ).rejects.toThrow("not allowed to start workflow 'run-access-review'")
+    ).rejects.toThrow("not allowed to run workflow 'run-access-review'")
     // Event visibility is derived from grants: team members see events for the
     // objects they can view (Note), but not for AdminNote or AccessRequest.
     const teamMemberObjectEvents = (await teamMember.readEvents())

--- a/examples/auth/workflows/access-review.ts
+++ b/examples/auth/workflows/access-review.ts
@@ -1,0 +1,11 @@
+import { defineWorkflow, defineWorkflowStep, ref, type WorkflowDefinition } from "@sixb/core"
+import { AccessRequest } from "../ontology/access-request"
+
+const recordAccessReview = defineWorkflowStep("record-access-review")
+  .input({ accessRequest: ref(AccessRequest) })
+  .output({ accessRequest: ref(AccessRequest), reviewed: "boolean" })
+  .run(async ({ input }) => ({ accessRequest: input.accessRequest, reviewed: true }))
+
+export const runAccessReview: WorkflowDefinition = defineWorkflow("run-access-review")
+  .input({ accessRequest: ref(AccessRequest) })
+  .then(recordAccessReview)

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -6870,6 +6870,23 @@
               }
             }
           },
+          "403": {
+            "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
           "404": {
             "description": "Response for status 404",
             "content": {
@@ -8865,6 +8882,23 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }
@@ -8906,6 +8940,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ObjectQueryErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -8964,6 +9008,16 @@
               }
             }
           },
+          "403": {
+            "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Response for status 500",
             "content": {
@@ -9018,6 +9072,16 @@
               }
             }
           },
+          "403": {
+            "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Response for status 500",
             "content": {
@@ -9068,6 +9132,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ObjectQueryErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -9755,6 +9829,23 @@
           },
           "400": {
             "description": "Response for status 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Response for status 403",
             "content": {
               "application/json": {
                 "schema": {
@@ -11333,6 +11424,23 @@
           },
           "400": {
             "description": "Response for status 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Response for status 403",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2423,6 +2423,12 @@ export type RequestWorkflowRunErrors = {
     error: string
   }
   /**
+   * Response for status 403
+   */
+  403: {
+    error: string
+  }
+  /**
    * Response for status 404
    */
   404: {
@@ -3000,6 +3006,12 @@ export type ListObjectsErrors = {
   400: {
     error: string
   }
+  /**
+   * Response for status 403
+   */
+  403: {
+    error: string
+  }
 }
 
 export type ListObjectsError = ListObjectsErrors[keyof ListObjectsErrors]
@@ -3038,6 +3050,10 @@ export type QueryObjectsErrors = {
    */
   400: ObjectQueryErrorResponse
   /**
+   * Response for status 403
+   */
+  403: ErrorResponse
+  /**
    * Response for status 500
    */
   500: ErrorResponse
@@ -3066,6 +3082,10 @@ export type CountObjectsErrors = {
    * Response for status 400
    */
   400: ObjectQueryErrorResponse
+  /**
+   * Response for status 403
+   */
+  403: ErrorResponse
   /**
    * Response for status 500
    */
@@ -3096,6 +3116,10 @@ export type ExistsObjectsErrors = {
    */
   400: ObjectQueryErrorResponse
   /**
+   * Response for status 403
+   */
+  403: ErrorResponse
+  /**
    * Response for status 500
    */
   500: ErrorResponse
@@ -3124,6 +3148,10 @@ export type FacetObjectsErrors = {
    * Response for status 400
    */
   400: ObjectQueryErrorResponse
+  /**
+   * Response for status 403
+   */
+  403: ErrorResponse
   /**
    * Response for status 500
    */
@@ -3354,6 +3382,12 @@ export type RequestActionErrors = {
    * Response for status 400
    */
   400: {
+    error: string
+  }
+  /**
+   * Response for status 403
+   */
+  403: {
     error: string
   }
   /**
@@ -3911,6 +3945,12 @@ export type ListEventsErrors = {
    * Response for status 400
    */
   400: {
+    error: string
+  }
+  /**
+   * Response for status 403
+   */
+  403: {
     error: string
   }
 }

--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -99,6 +99,12 @@ export async function requestAction(
   const rawParams: Record<string, unknown> = input.params ?? {}
   const subject: ActionSubject = input.subject ?? { kind: "none" }
 
+  assertAuthorized(runtime, { kind: "action.apply", actionId })
+  if (action.binding.kind === "object") {
+    // Object actions also require visibility of the subject's object type.
+    assertAuthorized(runtime, { kind: "object.view", objectTypeId: action.binding.objectType.id })
+  }
+
   validateActionSubject(action, subject)
 
   let pathPrefix = action.id
@@ -110,12 +116,6 @@ export async function requestAction(
   }
 
   const actionParams = normalizeActionParams(runtime, action.params, rawParams, pathPrefix)
-
-  assertAuthorized(runtime, { kind: "action.apply", actionId: action.id })
-  if (objectType) {
-    // Object actions also require visibility of the subject's object type.
-    assertAuthorized(runtime, { kind: "object.view", objectTypeId: objectType.id })
-  }
 
   const runId = createActionRunId(input.runId)
   const existing = await actionRuns.getById({ projectId: runtime.projectId, id: runId })

--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto"
 import type { SecurityContext } from "../auth"
+import { assertAuthorized } from "../authorization"
 import type { EventActor } from "../events"
 import { ActionRunTimeoutError } from "../objects/action/errors"
 import { OntologyValidationError } from "../ontology/errors"
@@ -109,6 +110,12 @@ export async function requestAction(
   }
 
   const actionParams = normalizeActionParams(runtime, action.params, rawParams, pathPrefix)
+
+  assertAuthorized(runtime, { kind: "action.apply", actionId: action.id })
+  if (objectType) {
+    // Object actions also require visibility of the subject's object type.
+    assertAuthorized(runtime, { kind: "object.view", objectTypeId: objectType.id })
+  }
 
   const runId = createActionRunId(input.runId)
   const existing = await actionRuns.getById({ projectId: runtime.projectId, id: runId })

--- a/packages/core/src/auth/runtime.ts
+++ b/packages/core/src/auth/runtime.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { type AuthorizationContext, resolveAuthorizationContext } from "../authorization"
 import {
   canInviteGroupIds,
   missingInviteGroupIds,
@@ -287,6 +288,34 @@ export class AuthRuntime {
       projectId: this.projectId,
       correlationId: resolveCorrelationId(request),
     }
+  }
+
+  /**
+   * Resolve the authenticated principal's authorization context for a request.
+   *
+   * Grants resolve eagerly (`groups -> roles -> grants`, subtype-expanded), so
+   * the returned context supports synchronous set-lookup checks and `sixb.as()`.
+   */
+  async createAuthorizationContext(
+    request: Request,
+    options: AuthSessionResolutionOptions = {}
+  ): Promise<AuthorizationContext> {
+    const session = await this.requireUser(request, options)
+    return this.contextFromSession(session)
+  }
+
+  /**
+   * Build an authorization context from an already-resolved session, so callers
+   * that resolve the session themselves (e.g. the server auth guard) don't read
+   * the request twice.
+   */
+  contextFromSession(session: AuthenticatedAuthSession): AuthorizationContext {
+    return resolveAuthorizationContext({
+      principal: session.principal,
+      sessionId: session.session.id,
+      groupIds: session.groupIds,
+      roles: this.security.getResolvedRoles(),
+    })
   }
 
   async getInvitationOptions(

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -8,6 +8,12 @@
  * A missing authorization context means a privileged caller (raw `sixb`,
  * syncs, workers, tests) — everything is allowed. Scoped contexts are
  * default-deny: a request without a covering grant is denied.
+ *
+ * SECURITY — this makes "privileged" the silent default: any caller that
+ * reaches a leaf without an authorization context bypasses all grant checks.
+ * That is intended for internal callers, but it means HTTP routes serving
+ * authenticated principals must go through the scoped runtime (`sixb.as(ctx)`),
+ * never the raw runtime. See `RequestAuthState` in the server for the rule.
  */
 
 import { AuthorizationError } from "./errors"
@@ -17,7 +23,7 @@ import type { AuthorizationContext, GrantIndex } from "./types"
 export type AuthzRequest =
   | { readonly kind: "object.view"; readonly objectTypeId: string }
   | { readonly kind: "action.apply"; readonly actionId: string }
-  | { readonly kind: "workflow.start"; readonly workflowId: string }
+  | { readonly kind: "workflow.run"; readonly workflowId: string }
   | { readonly kind: "object.query"; readonly touchedObjectTypeIds: readonly string[] }
 
 export interface AuthzDecision {
@@ -38,7 +44,7 @@ interface AuthorizedRuntime {
 type Atom =
   | { readonly capability: "view"; readonly id: string }
   | { readonly capability: "apply"; readonly id: string }
-  | { readonly capability: "start"; readonly id: string }
+  | { readonly capability: "run"; readonly id: string }
 
 function atomsFor(request: AuthzRequest): readonly Atom[] {
   switch (request.kind) {
@@ -46,8 +52,8 @@ function atomsFor(request: AuthzRequest): readonly Atom[] {
       return [{ capability: "view", id: request.objectTypeId }]
     case "action.apply":
       return [{ capability: "apply", id: request.actionId }]
-    case "workflow.start":
-      return [{ capability: "start", id: request.workflowId }]
+    case "workflow.run":
+      return [{ capability: "run", id: request.workflowId }]
     case "object.query":
       return request.touchedObjectTypeIds.map((id) => ({ capability: "view", id }))
   }
@@ -59,8 +65,8 @@ function atomKey(atom: Atom): string {
       return `view:object:${atom.id}`
     case "apply":
       return `apply:action:${atom.id}`
-    case "start":
-      return `start:workflow:${atom.id}`
+    case "run":
+      return `run:workflow:${atom.id}`
   }
 }
 
@@ -70,8 +76,8 @@ function holds(grants: GrantIndex, atom: Atom): boolean {
       return grants.objectTypes.view.has(atom.id)
     case "apply":
       return grants.actions.apply.has(atom.id)
-    case "start":
-      return grants.workflows.start.has(atom.id)
+    case "run":
+      return grants.workflows.run.has(atom.id)
   }
 }
 
@@ -133,8 +139,8 @@ function deniedMessage(
       return `[Sixb] Principal '${principalId}' is not allowed to view object type '${request.objectTypeId}'.`
     case "action.apply":
       return `[Sixb] Principal '${principalId}' is not allowed to apply action '${request.actionId}'.`
-    case "workflow.start":
-      return `[Sixb] Principal '${principalId}' is not allowed to start workflow '${request.workflowId}'.`
+    case "workflow.run":
+      return `[Sixb] Principal '${principalId}' is not allowed to run workflow '${request.workflowId}'.`
     case "object.query": {
       // Name the first touched type the principal cannot view.
       const blocked = request.touchedObjectTypeIds.find(

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -1,0 +1,146 @@
+/**
+ * Authorization decisions for the core data path.
+ *
+ * `evaluate` is the single place that maps a request to the resolved grant
+ * index. `can` (boolean) and `assertAuthorized` (throw) are the two ways to
+ * consume a decision; every enforcement site goes through one of them.
+ *
+ * A missing authorization context means a privileged caller (raw `sixb`,
+ * syncs, workers, tests) — everything is allowed. Scoped contexts are
+ * default-deny: a request without a covering grant is denied.
+ */
+
+import { AuthorizationError } from "./errors"
+import type { AuthorizationContext, GrantIndex } from "./types"
+
+/** Something a principal may attempt, paired with the resource it targets. */
+export type AuthzRequest =
+  | { readonly kind: "object.view"; readonly objectTypeId: string }
+  | { readonly kind: "action.apply"; readonly actionId: string }
+  | { readonly kind: "workflow.start"; readonly workflowId: string }
+  | { readonly kind: "object.query"; readonly touchedObjectTypeIds: readonly string[] }
+
+export interface AuthzDecision {
+  readonly allowed: boolean
+  /** Grant keys the request needs, e.g. `view:object:quote`. */
+  readonly requirements: readonly string[]
+  /** Required keys the principal lacks; empty when allowed. */
+  readonly missing: readonly string[]
+}
+
+interface AuthorizedRuntime {
+  readonly authorization?: AuthorizationContext
+}
+
+// A request expands to one or more atomic (capability, id) checks. The atom is
+// the single unit that both names a requirement and tests the grant index, so
+// the two can never drift.
+type Atom =
+  | { readonly capability: "view"; readonly id: string }
+  | { readonly capability: "apply"; readonly id: string }
+  | { readonly capability: "start"; readonly id: string }
+
+function atomsFor(request: AuthzRequest): readonly Atom[] {
+  switch (request.kind) {
+    case "object.view":
+      return [{ capability: "view", id: request.objectTypeId }]
+    case "action.apply":
+      return [{ capability: "apply", id: request.actionId }]
+    case "workflow.start":
+      return [{ capability: "start", id: request.workflowId }]
+    case "object.query":
+      return request.touchedObjectTypeIds.map((id) => ({ capability: "view", id }))
+  }
+}
+
+function atomKey(atom: Atom): string {
+  switch (atom.capability) {
+    case "view":
+      return `view:object:${atom.id}`
+    case "apply":
+      return `apply:action:${atom.id}`
+    case "start":
+      return `start:workflow:${atom.id}`
+  }
+}
+
+function holds(grants: GrantIndex, atom: Atom): boolean {
+  switch (atom.capability) {
+    case "view":
+      return grants.objectTypes.view.has(atom.id)
+    case "apply":
+      return grants.actions.apply.has(atom.id)
+    case "start":
+      return grants.workflows.start.has(atom.id)
+  }
+}
+
+/** Resolve a request against a principal's grants. Never throws. */
+export function evaluate(
+  authorization: AuthorizationContext | null | undefined,
+  request: AuthzRequest
+): AuthzDecision {
+  const atoms = atomsFor(request)
+  const requirements = atoms.map(atomKey)
+  const missing = authorization
+    ? atoms.filter((atom) => !holds(authorization.grants, atom)).map(atomKey)
+    : []
+  return { allowed: missing.length === 0, requirements, missing }
+}
+
+export function isAllowed(
+  authorization: AuthorizationContext | null | undefined,
+  request: AuthzRequest
+): boolean {
+  return evaluate(authorization, request).allowed
+}
+
+export function assertAuthorized(runtime: AuthorizedRuntime, request: AuthzRequest): void {
+  const decision = evaluate(runtime.authorization, request)
+  if (decision.allowed) {
+    return
+  }
+
+  throw new AuthorizationError(
+    decision.missing[0] ?? request.kind,
+    deniedMessage(runtime.authorization, request)
+  )
+}
+
+/**
+ * Fail closed for operations that have no grant semantics yet (writes, links,
+ * telemetry). Keeps unsupported surfaces denied even if a scoped runtime
+ * context reaches a code path the scoped SDK does not expose.
+ */
+export function assertPrivileged(runtime: AuthorizedRuntime, operation: string): void {
+  if (!runtime.authorization) {
+    return
+  }
+
+  throw new AuthorizationError(
+    `privileged:${operation}`,
+    `[Sixb] Operation '${operation}' is not covered by scoped authorization grants.`
+  )
+}
+
+function deniedMessage(
+  authorization: AuthorizationContext | null | undefined,
+  request: AuthzRequest
+): string {
+  const principalId = authorization?.principal.id ?? "unknown"
+  switch (request.kind) {
+    case "object.view":
+      return `[Sixb] Principal '${principalId}' is not allowed to view object type '${request.objectTypeId}'.`
+    case "action.apply":
+      return `[Sixb] Principal '${principalId}' is not allowed to apply action '${request.actionId}'.`
+    case "workflow.start":
+      return `[Sixb] Principal '${principalId}' is not allowed to start workflow '${request.workflowId}'.`
+    case "object.query": {
+      // Name the first touched type the principal cannot view.
+      const blocked = request.touchedObjectTypeIds.find(
+        (objectTypeId) => !isAllowed(authorization, { kind: "object.view", objectTypeId })
+      )
+      return `[Sixb] Principal '${principalId}' is not allowed to view object type '${blocked}'.`
+    }
+  }
+}

--- a/packages/core/src/authorization/errors.ts
+++ b/packages/core/src/authorization/errors.ts
@@ -1,0 +1,12 @@
+/** Thrown when a scoped operation is not covered by the principal's grants. Maps to HTTP 403. */
+export class AuthorizationError extends Error {
+  readonly name = "AuthorizationError"
+
+  constructor(
+    /** Stable key of the missing grant, e.g. `view:object:Contract`. */
+    readonly grantKey: string,
+    message: string
+  ) {
+    super(message)
+  }
+}

--- a/packages/core/src/authorization/event-visibility.ts
+++ b/packages/core/src/authorization/event-visibility.ts
@@ -2,8 +2,13 @@
  * Event visibility derived from grants.
  *
  * There is no standalone "view events" capability: a principal sees a domain
- * event when it can view/apply/start the event's subject. A privileged caller
- * (no authorization context) sees everything.
+ * event only when it can view/apply/run the event's subject. A privileged
+ * caller (no authorization context) sees everything.
+ *
+ * The topic switch is fail-closed: an unrecognized topic is hidden, because a
+ * topic we don't yet model may carry a subject the principal is not allowed to
+ * see. Adding an event topic therefore requires an explicit visibility decision
+ * here, never a silent default.
  */
 
 import type { StoredDomainEvent } from "../events"
@@ -33,18 +38,40 @@ export function canViewEvent(
         }) &&
         isAllowed(authorization, { kind: "object.view", objectTypeId: event.payload.targetTypeId })
       )
-    case "actions":
-      return isAllowed(authorization, { kind: "action.apply", actionId: event.payload.actionId })
+    case "actions": {
+      // Apply is necessary; for object-bound actions the principal must also be
+      // able to view the subject type, or the event would leak a hidden
+      // object's id/type — mirroring the rule in `canListAction`.
+      if (!isAllowed(authorization, { kind: "action.apply", actionId: event.payload.actionId })) {
+        return false
+      }
+      const subject = event.payload.subject
+      return subject.kind === "object"
+        ? isAllowed(authorization, { kind: "object.view", objectTypeId: subject.objectTypeId })
+        : true
+    }
     case "workflows":
       return isAllowed(authorization, {
-        kind: "workflow.start",
+        kind: "workflow.run",
         workflowId: event.payload.workflowId,
       })
-    default:
-      // Infra topics (schedules, rules, syncs, pipelines, datasets) carry no
-      // object/action/workflow subject, so no grant governs them yet and they
-      // stay visible to any authorized reader. When those subjects gain their
-      // own grants, add their checks here so event visibility tracks them.
+    case "rules":
+      // Rule events carry the object they fired on, so gate on viewing it —
+      // otherwise they leak the existence and id of hidden-type objects.
+      return isAllowed(authorization, {
+        kind: "object.view",
+        objectTypeId: event.payload.subject.objectTypeId,
+      })
+    case "schedules":
+    case "syncs":
+    case "pipelines":
+    case "datasets":
+      // Infra topics with no object/action/workflow subject: no grant governs
+      // them yet, so they stay visible to any authorized reader. When they gain
+      // their own grants, add the checks here.
       return true
+    default:
+      // Fail closed: an unmodeled topic may carry a subject we don't yet gate.
+      return false
   }
 }

--- a/packages/core/src/authorization/event-visibility.ts
+++ b/packages/core/src/authorization/event-visibility.ts
@@ -1,0 +1,50 @@
+/**
+ * Event visibility derived from grants.
+ *
+ * There is no standalone "view events" capability: a principal sees a domain
+ * event when it can view/apply/start the event's subject. A privileged caller
+ * (no authorization context) sees everything.
+ */
+
+import type { StoredDomainEvent } from "../events"
+import { isAllowed } from "./decision"
+import type { AuthorizationContext } from "./types"
+
+export function canViewEvent(
+  authorization: AuthorizationContext | null | undefined,
+  event: StoredDomainEvent
+): boolean {
+  if (!authorization) {
+    return true
+  }
+
+  switch (event.topic) {
+    case "objects":
+    case "telemetry":
+      return isAllowed(authorization, {
+        kind: "object.view",
+        objectTypeId: event.payload.objectTypeId,
+      })
+    case "links":
+      return (
+        isAllowed(authorization, {
+          kind: "object.view",
+          objectTypeId: event.payload.sourceTypeId,
+        }) &&
+        isAllowed(authorization, { kind: "object.view", objectTypeId: event.payload.targetTypeId })
+      )
+    case "actions":
+      return isAllowed(authorization, { kind: "action.apply", actionId: event.payload.actionId })
+    case "workflows":
+      return isAllowed(authorization, {
+        kind: "workflow.start",
+        workflowId: event.payload.workflowId,
+      })
+    default:
+      // Infra topics (schedules, rules, syncs, pipelines, datasets) carry no
+      // object/action/workflow subject, so no grant governs them yet and they
+      // stay visible to any authorized reader. When those subjects gain their
+      // own grants, add their checks here so event visibility tracks them.
+      return true
+  }
+}

--- a/packages/core/src/authorization/index.ts
+++ b/packages/core/src/authorization/index.ts
@@ -1,0 +1,6 @@
+export type { AuthzDecision, AuthzRequest } from "./decision"
+export { assertAuthorized, assertPrivileged, evaluate, isAllowed } from "./decision"
+export { AuthorizationError } from "./errors"
+export { canViewEvent } from "./event-visibility"
+export { resolveAuthorizationContext, resolveRoleGrants } from "./resolve"
+export type { AuthorizationContext, GrantIndex, ResolvedRole } from "./types"

--- a/packages/core/src/authorization/resolve.ts
+++ b/packages/core/src/authorization/resolve.ts
@@ -1,5 +1,5 @@
 import type { Principal } from "../auth/types"
-import type { RoleDefinition, Selection } from "../security"
+import type { GrantCapability, RoleDefinition, Selection } from "../security"
 import type { AuthorizationContext, GrantIndex, ResolvedRole } from "./types"
 
 /**
@@ -20,19 +20,30 @@ export function resolveRoleGrants(
 ): GrantIndex {
   const view = new Set<string>()
   const apply = new Set<string>()
-  const start = new Set<string>()
+  const run = new Set<string>()
 
-  for (const grant of role.grants) {
-    if (grant.capability === "view") {
-      expandSelection(grant.selection, universe.objectTypeIds, view, universe.getSubTypes)
-    } else if (grant.capability === "apply") {
-      expandSelection(grant.selection, universe.actionIds, apply)
-    } else {
-      expandSelection(grant.selection, universe.workflowIds, start)
+  // Capability -> the universe it ranges over, the set it expands into, and any
+  // subtype expansion. A Record keeps this exhaustive:
+  // adding a capability is a compile error until it is wired here.
+  const targets: Record<
+    GrantCapability,
+    {
+      readonly universe: ReadonlySet<string>
+      readonly into: Set<string>
+      readonly expand?: (id: string) => readonly string[]
     }
+  > = {
+    view: { universe: universe.objectTypeIds, into: view, expand: universe.getSubTypes },
+    apply: { universe: universe.actionIds, into: apply },
+    run: { universe: universe.workflowIds, into: run },
   }
 
-  return { objectTypes: { view }, actions: { apply }, workflows: { start } }
+  for (const grant of role.grants) {
+    const target = targets[grant.capability]
+    expandSelection(grant.selection, target.universe, target.into, target.expand)
+  }
+
+  return { objectTypes: { view }, actions: { apply }, workflows: { run } }
 }
 
 function expandSelection(
@@ -78,7 +89,7 @@ export function resolveAuthorizationContext(input: {
   const roleIds: string[] = []
   const view = new Set<string>()
   const apply = new Set<string>()
-  const start = new Set<string>()
+  const run = new Set<string>()
 
   for (const role of input.roles) {
     if (!role.grantedToGroupIds.some((groupId) => memberGroupIds.has(groupId))) {
@@ -92,8 +103,8 @@ export function resolveAuthorizationContext(input: {
     for (const id of role.grants.actions.apply) {
       apply.add(id)
     }
-    for (const id of role.grants.workflows.start) {
-      start.add(id)
+    for (const id of role.grants.workflows.run) {
+      run.add(id)
     }
   }
 
@@ -102,6 +113,6 @@ export function resolveAuthorizationContext(input: {
     ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
     groupIds: input.groupIds,
     roleIds,
-    grants: { objectTypes: { view }, actions: { apply }, workflows: { start } },
+    grants: { objectTypes: { view }, actions: { apply }, workflows: { run } },
   }
 }

--- a/packages/core/src/authorization/resolve.ts
+++ b/packages/core/src/authorization/resolve.ts
@@ -1,0 +1,107 @@
+import type { Principal } from "../auth/types"
+import type { RoleDefinition, Selection } from "../security"
+import type { AuthorizationContext, GrantIndex, ResolvedRole } from "./types"
+
+/**
+ * Expand a role's grants into concrete id sets once at startup.
+ *
+ * Broad grants (`ontology.objects().except(...)`) expand against the registered
+ * universe; explicit object grants expand to subtypes. The result holds only
+ * `Set`s, so per-request resolution and runtime checks stay simple `set.has`.
+ */
+export function resolveRoleGrants(
+  role: RoleDefinition,
+  universe: {
+    readonly objectTypeIds: ReadonlySet<string>
+    readonly actionIds: ReadonlySet<string>
+    readonly workflowIds: ReadonlySet<string>
+    readonly getSubTypes: (objectTypeId: string) => readonly string[]
+  }
+): GrantIndex {
+  const view = new Set<string>()
+  const apply = new Set<string>()
+  const start = new Set<string>()
+
+  for (const grant of role.grants) {
+    if (grant.capability === "view") {
+      expandSelection(grant.selection, universe.objectTypeIds, view, universe.getSubTypes)
+    } else if (grant.capability === "apply") {
+      expandSelection(grant.selection, universe.actionIds, apply)
+    } else {
+      expandSelection(grant.selection, universe.workflowIds, start)
+    }
+  }
+
+  return { objectTypes: { view }, actions: { apply }, workflows: { start } }
+}
+
+function expandSelection(
+  selection: Selection,
+  universe: ReadonlySet<string>,
+  into: Set<string>,
+  expand?: (id: string) => readonly string[]
+): void {
+  if (selection.all) {
+    const except = new Set(selection.except)
+    for (const id of universe) {
+      if (!except.has(id)) {
+        into.add(id)
+      }
+    }
+    return
+  }
+
+  for (const id of selection.ids) {
+    into.add(id)
+    if (expand) {
+      for (const subTypeId of expand(id)) {
+        into.add(subTypeId)
+      }
+    }
+  }
+}
+
+/**
+ * Resolve a principal's authorization context from its group memberships.
+ *
+ * Pure set-union over pre-resolved roles: roles match when their grantedTo
+ * groups intersect the principal's memberships, and their concrete id sets
+ * union into the principal's grant index.
+ */
+export function resolveAuthorizationContext(input: {
+  readonly principal: Principal
+  readonly sessionId?: string
+  readonly groupIds: readonly string[]
+  readonly roles: readonly ResolvedRole[]
+}): AuthorizationContext {
+  const memberGroupIds = new Set(input.groupIds)
+  const roleIds: string[] = []
+  const view = new Set<string>()
+  const apply = new Set<string>()
+  const start = new Set<string>()
+
+  for (const role of input.roles) {
+    if (!role.grantedToGroupIds.some((groupId) => memberGroupIds.has(groupId))) {
+      continue
+    }
+
+    roleIds.push(role.id)
+    for (const id of role.grants.objectTypes.view) {
+      view.add(id)
+    }
+    for (const id of role.grants.actions.apply) {
+      apply.add(id)
+    }
+    for (const id of role.grants.workflows.start) {
+      start.add(id)
+    }
+  }
+
+  return {
+    principal: input.principal,
+    ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+    groupIds: input.groupIds,
+    roleIds,
+    grants: { objectTypes: { view }, actions: { apply }, workflows: { start } },
+  }
+}

--- a/packages/core/src/authorization/types.ts
+++ b/packages/core/src/authorization/types.ts
@@ -14,8 +14,8 @@ export interface GrantIndex {
   readonly objectTypes: { readonly view: ReadonlySet<string> }
   /** Action ids this principal may request. */
   readonly actions: { readonly apply: ReadonlySet<string> }
-  /** Workflow ids this principal may start. */
-  readonly workflows: { readonly start: ReadonlySet<string> }
+  /** Workflow ids this principal may run. */
+  readonly workflows: { readonly run: ReadonlySet<string> }
 }
 
 /** A role with its grants pre-expanded to concrete id sets at startup. */

--- a/packages/core/src/authorization/types.ts
+++ b/packages/core/src/authorization/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Authorization context types.
+ *
+ * The context is plain, immutable data resolved once per request
+ * (`principal -> groups -> roles -> grants`). Grants resolve eagerly into set
+ * lookups so enforcement on the hot path is synchronous and allocation-free.
+ * Group and role ids are retained so decisions stay explainable.
+ */
+
+import type { Principal } from "../auth/types"
+
+export interface GrantIndex {
+  /** Object type ids viewable, expanded from grants (broad grants + subtypes). */
+  readonly objectTypes: { readonly view: ReadonlySet<string> }
+  /** Action ids this principal may request. */
+  readonly actions: { readonly apply: ReadonlySet<string> }
+  /** Workflow ids this principal may start. */
+  readonly workflows: { readonly start: ReadonlySet<string> }
+}
+
+/** A role with its grants pre-expanded to concrete id sets at startup. */
+export interface ResolvedRole {
+  readonly id: string
+  readonly grantedToGroupIds: readonly string[]
+  readonly grants: GrantIndex
+}
+
+export interface AuthorizationContext {
+  readonly principal: Principal
+  readonly sessionId?: string
+  readonly groupIds: readonly string[]
+  /** Roles whose grantedTo groups intersect the principal's memberships. */
+  readonly roleIds: readonly string[]
+  readonly grants: GrantIndex
+}

--- a/packages/core/src/bootstrap/discovery.ts
+++ b/packages/core/src/bootstrap/discovery.ts
@@ -28,8 +28,8 @@ import type { RuleDefinition } from "../rules/types"
 import { RuntimeError } from "../runtime/errors"
 import type { ScheduleDefinition } from "../schedules"
 import { isScheduleDefinition } from "../schedules"
-import type { GroupDefinition, InvitePolicyDefinition } from "../security"
-import { isGroupDefinition, isInvitePolicyDefinition } from "../security"
+import type { GroupDefinition, InvitePolicyDefinition, RoleDefinition } from "../security"
+import { isGroupDefinition, isInvitePolicyDefinition, isRoleDefinition } from "../security"
 import type { SyncDefinition } from "../syncs"
 import { isSyncDefinition } from "../syncs"
 import type { WorkflowDefinition } from "../workflows"
@@ -283,6 +283,25 @@ export async function discoverGroups(projectRoot: string): Promise<readonly Grou
   return groups
 }
 
+export async function discoverRoles(projectRoot: string): Promise<readonly RoleDefinition[]> {
+  const rolesDir = join(projectRoot, "security", "roles")
+  const modulePaths = await listModuleFiles(rolesDir)
+  const exportedCandidates = await loadModuleExports({
+    modulePaths,
+    projectRoot,
+    kind: "role",
+  })
+
+  const roles: RoleDefinition[] = []
+  for (const candidate of exportedCandidates) {
+    if (isRoleDefinition(candidate)) {
+      roles.push(candidate)
+    }
+  }
+
+  return roles
+}
+
 export async function discoverInvitePolicies(
   projectRoot: string
 ): Promise<readonly InvitePolicyDefinition[]> {
@@ -342,6 +361,7 @@ async function loadModuleExports(options: {
     | "pipeline"
     | "rule"
     | "group"
+    | "role"
     | "invitePolicy"
     | "workflow"
 }): Promise<unknown[]> {

--- a/packages/core/src/bootstrap/index.ts
+++ b/packages/core/src/bootstrap/index.ts
@@ -8,6 +8,7 @@ export {
   discoverOntologySources,
   discoverPipelines,
   discoverProjections,
+  discoverRoles,
   discoverRules,
   discoverSchedules,
   discoverSyncs,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -468,11 +468,11 @@ export type {
   InvitePolicyScope,
   RegisteredSecurityDefinitions,
   RoleDefinition,
+  RunGrant,
   Scope,
   ScopeTarget,
   SecurityRegistry,
   Selection,
-  StartGrant,
   ViewGrant,
 } from "./security"
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -435,28 +435,65 @@ export {
   verifyDoubleSubmitCsrf,
 } from "./auth"
 
+// ── Authorization ──────────────────────────────────────────
+
+export type {
+  AuthorizationContext,
+  AuthzDecision,
+  AuthzRequest,
+  GrantIndex,
+  ResolvedRole,
+} from "./authorization"
+export {
+  AuthorizationError,
+  assertAuthorized,
+  canViewEvent,
+  evaluate,
+  isAllowed,
+  resolveAuthorizationContext,
+  resolveRoleGrants,
+} from "./authorization"
+
 // ── Security Definitions ───────────────────────────────────
 
 export type {
+  ApplyGrant,
   DefineGroupOptions,
   DefineInvitePolicyOptions,
+  DefineRoleOptions,
+  GrantCapability,
+  GrantDefinition,
   GroupDefinition,
   InvitePolicyDefinition,
   InvitePolicyScope,
   RegisteredSecurityDefinitions,
+  RoleDefinition,
+  Scope,
+  ScopeTarget,
   SecurityRegistry,
+  Selection,
+  StartGrant,
+  ViewGrant,
 } from "./security"
 export {
+  actions,
+  assertGrantDefinition,
   assertGroupDefinition,
   assertInvitePolicyDefinition,
+  assertRoleDefinition,
+  can,
   canInviteGroupIds,
   defineGroup,
   defineInvitePolicy,
+  defineRole,
   isGroupDefinition,
   isInvitePolicyDefinition,
+  isRoleDefinition,
   missingInviteGroupIds,
+  ontology,
   resolveInvitePolicyScope,
   SecurityValidationError,
+  workflows,
 } from "./security"
 
 // ── Storage ────────────────────────────────────────────────
@@ -1041,6 +1078,9 @@ export type {
   OntologySource,
   RegisteredObjectType,
   RegisteredValueTypes,
+  ScopedObjectByIdHandle,
+  ScopedObjectSet,
+  ScopedSixb,
   SixbInstance,
   SixbOptions,
   SixbRuntimeContext,

--- a/packages/core/src/objects/link/remove.ts
+++ b/packages/core/src/objects/link/remove.ts
@@ -1,6 +1,7 @@
 /**
  * Leaf operation: remove a single link.
  */
+import { assertPrivileged } from "../../authorization"
 import { assertLinkTargetType } from "../../ontology/validation"
 import type { ResolvedLinkContext } from "../context"
 import { ObjectError } from "../errors"
@@ -14,6 +15,7 @@ export async function removeLink(
     targetId: string
   }
 ): Promise<void> {
+  assertPrivileged(ctx, "removeLink")
   const { events, storage, objectType, linkDefinition, ontology } = ctx
   const { sourceId, linkId, targetTypeId, targetId } = params
 

--- a/packages/core/src/objects/link/upsert-batch.ts
+++ b/packages/core/src/objects/link/upsert-batch.ts
@@ -5,6 +5,7 @@
  * because each item can target a different objectType + linkDefinition.
  */
 
+import { assertPrivileged } from "../../authorization"
 import type { NewDomainEvent } from "../../events"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
 import { validateLinkBatch } from "../../ontology/validation"
@@ -16,6 +17,7 @@ export async function upsertLinkBatch(
   ctx: SixbRuntimeContext,
   items: readonly ResolvedLinkBatchItem[]
 ): Promise<readonly BatchItemResult<void>[]> {
+  assertPrivileged(ctx, "upsertLinkBatch")
   const { events: eventsRuntime, storage, projectId, ontology } = ctx
 
   if (items.length === 0) return []

--- a/packages/core/src/objects/link/upsert.ts
+++ b/packages/core/src/objects/link/upsert.ts
@@ -1,6 +1,7 @@
 /**
  * Leaf operation: upsert a single link.
  */
+import { assertPrivileged } from "../../authorization"
 import { OntologyValidationError } from "../../ontology/errors"
 import { assertLinkTargetType, validateLinkProperties } from "../../ontology/validation"
 import type { ResolvedLinkContext } from "../context"
@@ -17,6 +18,7 @@ export async function upsertLink(
     properties?: Record<string, unknown>
   }
 ): Promise<void> {
+  assertPrivileged(ctx, "upsertLink")
   const { events, storage, projectId, objectType, linkDefinition, ontology } = ctx
   const { sourceId, linkId, targetTypeId, targetId, properties } = params
 

--- a/packages/core/src/objects/object/upsert-batch.ts
+++ b/packages/core/src/objects/object/upsert-batch.ts
@@ -1,6 +1,7 @@
 /**
  * Leaf operation: batch upsert objects of a single type.
  */
+import { assertPrivileged } from "../../authorization"
 import type { NewDomainEvent } from "../../events"
 import { validateObjectBatch } from "../../ontology/validation"
 import type { BatchItemResult } from "../../runtime/types"
@@ -11,6 +12,7 @@ export async function upsertObjectBatch(
   ctx: ResolvedObjectContext,
   items: readonly { properties: Record<string, unknown> }[]
 ): Promise<readonly BatchItemResult<ObjectRow>[]> {
+  assertPrivileged(ctx, "upsertObjectBatch")
   const { events: eventsRuntime, storage, projectId, objectType, primaryPropertyId, ontology } = ctx
 
   if (items.length === 0) return []

--- a/packages/core/src/objects/object/upsert.ts
+++ b/packages/core/src/objects/object/upsert.ts
@@ -2,6 +2,7 @@
  * Leaf operation: upsert a single object.
  */
 
+import { assertPrivileged } from "../../authorization"
 import {
   assertKnownProperties,
   assertRequiredProperties,
@@ -16,6 +17,7 @@ export async function upsertObject(
   primaryId: string,
   properties: Record<string, unknown>
 ): Promise<ObjectRow> {
+  assertPrivileged(ctx, "upsertObject")
   const { events, storage, projectId, objectType, ontology } = ctx
 
   assertKnownProperties(objectType, properties)

--- a/packages/core/src/objects/query/executor.ts
+++ b/packages/core/src/objects/query/executor.ts
@@ -1,3 +1,4 @@
+import { type AuthorizationContext, assertAuthorized } from "../../authorization"
 import type { OntologyRegistry } from "../../ontology"
 import type {
   CountObjectsResult,
@@ -18,7 +19,11 @@ import {
 import type { ObjectQuery, ObjectQueryPredicate, ObjectQuerySortField } from "./ir"
 import { normalizeObjectQuery } from "./normalize"
 import { type ObjectQueryPlan, type ObjectQueryPlanningOptions, planObjectQuery } from "./planner"
-import { type ObjectQueryValidationIssue, validateObjectQuery } from "./validate"
+import {
+  type ObjectQueryValidationIssue,
+  type ValidatedObjectQuery,
+  validateObjectQuery,
+} from "./validate"
 
 export interface QueryExecutorOptions
   extends Omit<
@@ -35,6 +40,8 @@ export interface QueryExecutorOptions
   maxLimit?: number
   maxPageSize?: number
   maxFacetLimit?: number
+  /** When present, every object type the query touches must be viewable. */
+  authorization?: AuthorizationContext
 }
 
 export interface ExecuteObjectQueryInput {
@@ -125,6 +132,7 @@ export async function executeObjectQuery(
     maxPageSize: options.maxPageSize,
     normalize: false,
   })
+  assertQueryViewable(validated, options.authorization)
   const capabilities = options.storage.queryCapabilities()
   const hasQueryObjects = typeof options.storage.queryObjects === "function"
   const hasCountObjects = typeof options.storage.countObjects === "function"
@@ -185,6 +193,7 @@ export async function countObjects(
     maxPageSize: options.maxPageSize,
     normalize: false,
   })
+  assertQueryViewable(validated, options.authorization)
   const capabilities = options.storage.queryCapabilities()
   const hasQueryObjects = typeof options.storage.queryObjects === "function"
   const hasCountObjects = typeof options.storage.countObjects === "function"
@@ -244,6 +253,7 @@ export async function existsObjects(
     maxPageSize: options.maxPageSize,
     normalize: false,
   })
+  assertQueryViewable(validated, options.authorization)
   const capabilities = options.storage.queryCapabilities()
   const hasQueryObjects = typeof options.storage.queryObjects === "function"
   const hasCountObjects = typeof options.storage.countObjects === "function"
@@ -303,6 +313,7 @@ export async function facetObjects(
     maxPageSize: options.maxPageSize,
     normalize: false,
   })
+  assertQueryViewable(validated, options.authorization)
   const facets = validateFacetRequests(input.facets, validated.result.objectTypeIds, options)
   const aggregateQuery = stripOuterRowShape(validated.query)
   const capabilities = options.storage.queryCapabilities()
@@ -357,6 +368,18 @@ export async function facetObjects(
     ),
     plan,
   }
+}
+
+// Authorization happens at planning time: a scoped query must hold a view
+// grant for every object type it touches, before any storage call runs.
+function assertQueryViewable(
+  validated: ValidatedObjectQuery,
+  authorization: AuthorizationContext | undefined
+): void {
+  assertAuthorized(
+    { authorization },
+    { kind: "object.query", touchedObjectTypeIds: validated.touchedObjectTypeIds }
+  )
 }
 
 function expandPushdownQuery(

--- a/packages/core/src/objects/query/validate.ts
+++ b/packages/core/src/objects/query/validate.ts
@@ -18,6 +18,8 @@ export interface ObjectQueryValidationIssue {
 export interface ValidatedObjectQuery {
   query: ObjectQuery
   result: ObjectQueryResultShape
+  /** Every object type the query touches, including intermediate traversal types. */
+  touchedObjectTypeIds: readonly string[]
 }
 
 export interface ObjectQueryValidationOptions {
@@ -33,6 +35,7 @@ type QueryValidationContext = Required<
   ontology: OntologyRegistry
   valueTypesById: ReadonlyMap<string, ValueType>
   issues: ObjectQueryValidationIssue[]
+  touchedObjectTypeIds: Set<string>
 }
 
 interface QueryValidationResult {
@@ -62,6 +65,7 @@ export function validateObjectQuery(
   return {
     query: validation.query,
     result: validation.result,
+    touchedObjectTypeIds: [...ctx.touchedObjectTypeIds],
   }
 }
 
@@ -89,10 +93,27 @@ function createValidationContext(options: ObjectQueryValidationOptions): QueryVa
     maxLimit: options.maxLimit ?? DEFAULT_MAX_LIMIT,
     maxPageSize: options.maxPageSize ?? DEFAULT_MAX_PAGE_SIZE,
     issues: [],
+    touchedObjectTypeIds: new Set<string>(),
   }
 }
 
 function validateQueryNode(
+  query: ObjectQuery,
+  path: string,
+  ctx: QueryValidationContext
+): QueryValidationResult {
+  const validation = dispatchQueryNode(query, path, ctx)
+
+  // Record every intermediate result shape so callers can authorize all
+  // object types a query touches, not just the types it returns.
+  for (const objectTypeId of validation.result.objectTypeIds) {
+    ctx.touchedObjectTypeIds.add(objectTypeId)
+  }
+
+  return validation
+}
+
+function dispatchQueryNode(
   query: ObjectQuery,
   path: string,
   ctx: QueryValidationContext

--- a/packages/core/src/objects/sdk/object-handle.ts
+++ b/packages/core/src/objects/sdk/object-handle.ts
@@ -4,6 +4,7 @@
  * per-property telemetry appenders with compile-time unit and value type safety.
  */
 import type { ActionDefinition } from "../../actions"
+import { assertAuthorized, assertPrivileged } from "../../authorization"
 import type { ObjectLink, ObjectRef, ValueType } from "../../ontology"
 import { OntologyValidationError } from "../../ontology/errors"
 import type { LinkToken, ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
@@ -25,6 +26,7 @@ export function createObjectByIdHandle<
 >(ctx: ResolvedObjectContext, primaryId: string): ObjectByIdHandle<TObjectType, TValueTypes> {
   const objectHandle = {
     get: async () => {
+      assertAuthorized(ctx, { kind: "object.view", objectTypeId: ctx.objectType.id })
       const row = await ctx.storage.objects.getByPrimaryId({
         projectId: ctx.projectId,
         objectTypeId: ctx.objectType.id,
@@ -34,6 +36,8 @@ export function createObjectByIdHandle<
     },
 
     listLinks: async (linkToken?: LinkToken<string, string, string, ObjectLink>) => {
+      // Link rows reveal target types; no link grant semantics exist yet.
+      assertPrivileged(ctx, "listLinks")
       if (linkToken) {
         assertLinkTokenBelongsToObjectType(ctx.objectType, linkToken)
       }

--- a/packages/core/src/objects/sdk/object-set.ts
+++ b/packages/core/src/objects/sdk/object-set.ts
@@ -4,16 +4,18 @@
  * while preserving compile-time property types inferred from the ontology definition.
  */
 
-import type { ActionDefinition, ActionRegistry } from "../../actions"
-import type { BlobStorage } from "../../blob-storage"
-import type { EventsRuntime } from "../../events"
-import type { LakeStorage } from "../../lake-storage"
-import type { OntologyRegistry, ValueType } from "../../ontology"
+import type { ActionDefinition } from "../../actions"
+import type { AuthorizationContext } from "../../authorization"
+import { assertAuthorized } from "../../authorization"
+import type { ValueType } from "../../ontology"
 import { OntologyValidationError } from "../../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
-import type { Queues } from "../../queues"
-import type { ObjectSet, ObjectSetListInput, TwinObject } from "../../runtime/types"
-import type { Storage } from "../../storage"
+import type {
+  ObjectSet,
+  ObjectSetListInput,
+  SixbRuntimeContext,
+  TwinObject,
+} from "../../runtime/types"
 import {
   requestActionAndWait as requestActionAndWaitLeaf,
   requestAction as requestActionLeaf,
@@ -31,19 +33,20 @@ export function createObjectSet<
   TObjectType extends ObjectTypeWithPropertyTokens,
   TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
   TValueTypes extends readonly ValueType[],
->(params: {
-  objectType: TObjectType
-  projectId: string
-  ontology: OntologyRegistry
-  actionRegistry: ActionRegistry
-  events: EventsRuntime
-  lakeStorage: LakeStorage
-  blobStorage: BlobStorage
-  storage: Storage
-  queues: Queues
-}): ObjectSet<TObjectType, TValueTypes, TRegisteredObjectTypes> {
+>(
+  params: SixbRuntimeContext & {
+    readonly objectType: TObjectType
+    readonly authorization?: AuthorizationContext
+  }
+): ObjectSet<TObjectType, TValueTypes, TRegisteredObjectTypes> {
+  const { objectType } = params
+  const primaryProp = objectType.properties.find((p) => p.primary)
+  if (!primaryProp) {
+    throw new OntologyValidationError(`Object type '${objectType.id}' has no primary property`)
+  }
+  const primaryPropertyId = primaryProp.id
+
   const {
-    objectType,
     projectId,
     ontology,
     actionRegistry,
@@ -52,15 +55,9 @@ export function createObjectSet<
     blobStorage,
     storage,
     queues,
+    authorization,
   } = params
-
-  const primaryProp = objectType.properties.find((p) => p.primary)
-  if (!primaryProp) {
-    throw new OntologyValidationError(`Object type '${objectType.id}' has no primary property`)
-  }
-  const primaryPropertyId = primaryProp.id
-
-  const queryExecutor = createRuntimeQueryExecutor({ projectId, ontology, storage })
+  const queryExecutor = createRuntimeQueryExecutor({ projectId, ontology, storage, authorization })
 
   const resolvedCtx: ResolvedObjectContext = {
     projectId,
@@ -71,12 +68,14 @@ export function createObjectSet<
     blobStorage,
     storage,
     queues,
+    authorization,
     objectType,
     primaryPropertyId,
   }
 
   const objectSet = {
     get: async (id: string) => {
+      assertAuthorized(resolvedCtx, { kind: "object.view", objectTypeId: objectType.id })
       const row = await storage.objects.getByPrimaryId({
         projectId,
         objectTypeId: objectType.id,
@@ -105,6 +104,7 @@ export function createObjectSet<
     byId: (id: string) => createObjectByIdHandle<TObjectType, TValueTypes>(resolvedCtx, id),
 
     list: async (input?: ObjectSetListInput) => {
+      assertAuthorized(resolvedCtx, { kind: "object.view", objectTypeId: objectType.id })
       const result = await storage.objects.list({
         projectId,
         objectTypeId: objectType.id,

--- a/packages/core/src/objects/sdk/runtime-query-executor.ts
+++ b/packages/core/src/objects/sdk/runtime-query-executor.ts
@@ -3,6 +3,8 @@
  * Validation, planning, fallback, and execution all run in-process here; the
  * HTTP executor in `@sixb/client` is the remote counterpart.
  */
+
+import type { AuthorizationContext } from "../../authorization"
 import type { OntologyRegistry } from "../../ontology"
 import type { Storage } from "../../storage"
 import {
@@ -21,9 +23,10 @@ export function createRuntimeQueryExecutor(params: {
   projectId: string
   ontology: OntologyRegistry
   storage: Storage
+  authorization?: AuthorizationContext
 }): ObjectQueryExecutor {
-  const { projectId, ontology, storage } = params
-  const executorOptions = { ontology, storage: storage.objects }
+  const { projectId, ontology, storage, authorization } = params
+  const executorOptions = { ontology, storage: storage.objects, authorization }
 
   return {
     async list(query: ObjectQuery, options?: { includeTotal?: boolean }) {

--- a/packages/core/src/objects/service/index.ts
+++ b/packages/core/src/objects/service/index.ts
@@ -1,4 +1,6 @@
 export { requestAction, requestActionAndWait } from "./action-service"
 export { removeLink, upsertLink, upsertLinkBatch } from "./link-service"
+export type { ListObjectsParams } from "./list-service"
+export { listObjects } from "./list-service"
 export { upsertObject, upsertObjectBatch } from "./object-service"
 export { appendTelemetry } from "./telemetry-service"

--- a/packages/core/src/objects/service/list-service.ts
+++ b/packages/core/src/objects/service/list-service.ts
@@ -1,0 +1,83 @@
+/**
+ * Cross-type object listing for dashboards and search.
+ *
+ * On scoped runtimes the type filter is authorized before the storage call:
+ * explicitly requested types must all be viewable, and unfiltered listings
+ * narrow to the principal's viewable types instead of post-filtering rows.
+ */
+
+import { assertAuthorized } from "../../authorization"
+import type { ListResult, SixbRuntimeContext } from "../../runtime/types"
+import type { ObjectRow } from "../../storage"
+
+export interface ListObjectsParams {
+  objectTypeIds?: readonly string[]
+  idPrefix?: string
+  idSuffix?: string
+  updatedAfter?: Date
+  updatedBefore?: Date
+  createdAfter?: Date
+  createdBefore?: Date
+  limit?: number
+  offset?: number
+  orderBy?: "createdAt" | "updatedAt" | "primaryId"
+  order?: "asc" | "desc"
+}
+
+export async function listObjects(
+  runtime: SixbRuntimeContext,
+  params: ListObjectsParams
+): Promise<ListResult<ObjectRow>> {
+  const objectTypeIds = resolveAuthorizedTypeFilter(runtime, params.objectTypeIds)
+
+  if (runtime.authorization && objectTypeIds !== undefined && objectTypeIds.length === 0) {
+    return { objects: [], hasMore: false, total: 0 }
+  }
+
+  const result = await runtime.storage.objects.list({
+    projectId: runtime.projectId,
+    objectTypeId: objectTypeIds?.length === 1 ? objectTypeIds[0] : objectTypeIds,
+    primaryIdPrefix: params.idPrefix,
+    primaryIdSuffix: params.idSuffix,
+    updatedAfter: params.updatedAfter,
+    updatedBefore: params.updatedBefore,
+    createdAfter: params.createdAfter,
+    createdBefore: params.createdBefore,
+    limit: params.limit,
+    offset: params.offset,
+    orderBy: params.orderBy,
+    order: params.order,
+  })
+
+  return {
+    objects: [...result.objects],
+    hasMore: result.hasMore,
+    total: result.total,
+  }
+}
+
+function resolveAuthorizedTypeFilter(
+  runtime: SixbRuntimeContext,
+  requested: readonly string[] | undefined
+): readonly string[] | undefined {
+  const expanded = requested
+    ? [...new Set(requested.flatMap((id) => [id, ...runtime.ontology.getSubTypes(id)]))]
+    : undefined
+
+  if (!runtime.authorization) {
+    return expanded
+  }
+
+  if (!expanded) {
+    // Broad listings narrow to the visible universe rather than failing. The
+    // set already contains every registered type when "all" was granted.
+    return [...runtime.authorization.grants.objectTypes.view]
+  }
+
+  // Explicitly requested types must all be viewable.
+  for (const objectTypeId of expanded) {
+    assertAuthorized(runtime, { kind: "object.view", objectTypeId })
+  }
+
+  return expanded
+}

--- a/packages/core/src/objects/telemetry/append-batch.ts
+++ b/packages/core/src/objects/telemetry/append-batch.ts
@@ -1,6 +1,7 @@
 /**
  * Leaf operation: batch telemetry append for multiple objects of a single type.
  */
+import { assertPrivileged } from "../../authorization"
 import type { NewDomainEvent } from "../../events"
 import { OntologyValidationError } from "../../ontology/errors"
 import {
@@ -25,6 +26,7 @@ export async function appendTelemetryBatch(
     at?: Date
   }[]
 ): Promise<void> {
+  assertPrivileged(ctx, "appendTelemetry")
   const { storage, projectId, objectType, ontology } = ctx
   const checkedIds = new Set<string>()
   const events: NewDomainEvent[] = []

--- a/packages/core/src/objects/telemetry/write-batch.ts
+++ b/packages/core/src/objects/telemetry/write-batch.ts
@@ -3,13 +3,15 @@
  *
  * Shared by both the batch operation and per-property appenders in ObjectByIdHandle.
  */
+import { assertPrivileged } from "../../authorization"
 import type { NewDomainEvent, StoredTelemetryAppendedEvent } from "../../events"
 import type { ResolvedObjectContext } from "../context"
 
 export async function writeTelemetryBatch(
-  ctx: Pick<ResolvedObjectContext, "events" | "storage">,
+  ctx: Pick<ResolvedObjectContext, "events" | "storage" | "authorization">,
   events: readonly NewDomainEvent[]
 ): Promise<readonly StoredTelemetryAppendedEvent[]> {
+  assertPrivileged(ctx, "appendTelemetry")
   const { events: eventsRuntime, storage } = ctx
   const appended = await eventsRuntime.append({ events })
   const telemetryEvents = appended.filter(

--- a/packages/core/src/runtime/create.ts
+++ b/packages/core/src/runtime/create.ts
@@ -12,6 +12,7 @@ import {
   discoverOntologySources,
   discoverPipelines,
   discoverProjections,
+  discoverRoles,
   discoverRules,
   discoverSchedules,
   discoverSyncs,
@@ -27,7 +28,7 @@ import type { ProjectionDefinition } from "../projections/types"
 import type { Queues } from "../queues"
 import type { RuleDefinition } from "../rules"
 import type { ScheduleDefinition } from "../schedules"
-import type { GroupDefinition, InvitePolicyDefinition } from "../security"
+import type { GroupDefinition, InvitePolicyDefinition, RoleDefinition } from "../security"
 import type { Storage } from "../storage"
 import type { SyncDefinition } from "../syncs"
 import type { WorkflowDefinition } from "../workflows"
@@ -55,6 +56,7 @@ export interface CreateSixbOptions {
   rules?: readonly RuleDefinition[]
   workflows?: readonly WorkflowDefinition[]
   groups?: readonly GroupDefinition[]
+  roles?: readonly RoleDefinition[]
   invitePolicies?: readonly InvitePolicyDefinition[]
   auth?: SixbAuthConfig
   projectRoot?: string
@@ -92,6 +94,7 @@ export async function createSixb(
     rules,
     workflows,
     groups,
+    roles,
     invitePolicies,
   ] = await Promise.all([
     options.actions ?? discoverActions(projectRoot),
@@ -105,6 +108,7 @@ export async function createSixb(
     discoverRules(projectRoot),
     discoverWorkflows(projectRoot),
     discoverGroups(projectRoot),
+    discoverRoles(projectRoot),
     discoverInvitePolicies(projectRoot),
   ])
 
@@ -129,6 +133,7 @@ export async function createSixb(
     rules: [...(options.rules ?? []), ...rules],
     workflows: [...(options.workflows ?? []), ...workflows],
     groups: [...(options.groups ?? []), ...groups],
+    roles: [...(options.roles ?? []), ...roles],
     invitePolicies: [...(options.invitePolicies ?? []), ...invitePolicies],
     auth: options.auth,
   })

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -32,6 +32,7 @@ export { WebhookValidationError } from "../webhooks"
 export type { CreateSixbOptions } from "./create"
 export { createSixb } from "./create"
 export { RuntimeError } from "./errors"
+export type { ScopedObjectByIdHandle, ScopedObjectSet, ScopedSixb } from "./scoped"
 export type { SixbOptions } from "./sixb"
 export { Sixb } from "./sixb"
 export type {

--- a/packages/core/src/runtime/scoped.ts
+++ b/packages/core/src/runtime/scoped.ts
@@ -25,6 +25,7 @@ import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
 import type { ObjectRow } from "../storage"
 import type {
   RequestWorkflowRunInput,
+  WorkflowDefinition,
   WorkflowRunRequestResult,
   WorkflowsRuntime,
 } from "../workflows"
@@ -105,8 +106,14 @@ export interface ScopedSixb<TOntologySources extends readonly OntologySource[]> 
   /** Request an action by id (server / dynamic contexts). Requires `can.apply`. */
   requestAction(input: RequestActionInput): Promise<RequestActionResult>
 
-  /** Start a workflow run. Requires `can.start`. */
+  /** Start a workflow run. Requires `can.run`. */
   runWorkflow(input: RequestWorkflowRunInput): Promise<WorkflowRunRequestResult>
+
+  /** Workflow definitions the principal may run. */
+  listWorkflows(): readonly WorkflowDefinition[]
+
+  /** Look up a runnable workflow definition; null hides workflows the principal cannot run. */
+  getWorkflowById(workflowId: string): WorkflowDefinition | null
 
   /** Read the domain events the principal is allowed to see (derived from grants). */
   readEvents(input?: EventsReadInput): Promise<readonly StoredDomainEvent[]>
@@ -159,10 +166,27 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
 
     runWorkflow: (input: RequestWorkflowRunInput) => deps.workflows.requestByIdAs(runtime, input),
 
+    // Run grant doubles as catalog visibility: a workflow you cannot run is not
+    // worth surfacing, and hiding it also hides the (possibly ungranted) object
+    // types and action params its node graph references.
+    listWorkflows: () =>
+      deps.workflows
+        .list()
+        .filter((workflow) =>
+          isAllowed(runtime.authorization, { kind: "workflow.run", workflowId: workflow.id })
+        ),
+
+    getWorkflowById: (workflowId: string) => {
+      const workflow = deps.workflows.getById(workflowId)
+      return workflow && isAllowed(runtime.authorization, { kind: "workflow.run", workflowId })
+        ? workflow
+        : null
+    },
+
     // No standalone events grant: the stream is filtered to events whose
-    // subject the principal may view/apply/start. `limit` applies before this
+    // subject the principal may view/apply/run. `limit` applies before this
     // filter, so a page may return fewer events than requested — acceptable for
-    // a best-effort recent log.
+    // a best-effort recent log (storage-level filtering is the planned fix).
     readEvents: async (input?: EventsReadInput) => {
       const events = await runtime.events.read(input)
       return events.filter((event) => canViewEvent(runtime.authorization, event))

--- a/packages/core/src/runtime/scoped.ts
+++ b/packages/core/src/runtime/scoped.ts
@@ -1,0 +1,176 @@
+/**
+ * Scoped SDK surface returned by `sixb.as(context)`.
+ *
+ * The scoped types are masks over the full SDK types — derived from the same
+ * declarations, never copies — so signatures cannot drift and new surface area
+ * stays hidden until its grants are enforceable end to end. The runtime values
+ * are the same factories running over an authorization-carrying runtime
+ * context; leaf asserts and query planning enforce the grants.
+ */
+
+import type { ActionDefinition, RequestActionInput, RequestActionResult } from "../actions"
+import { requestAction as requestRuntimeAction } from "../actions/request"
+import {
+  type AuthorizationContext,
+  assertAuthorized,
+  canViewEvent,
+  isAllowed,
+} from "../authorization"
+import type { EventsReadInput, StoredDomainEvent } from "../events"
+import { createObjectSet, objectService } from "../objects"
+import type { ListObjectsParams } from "../objects/service"
+import type { ValueType } from "../ontology"
+import { assertObjectTypeRegistered } from "../ontology"
+import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
+import type { ObjectRow } from "../storage"
+import type {
+  RequestWorkflowRunInput,
+  WorkflowRunRequestResult,
+  WorkflowsRuntime,
+} from "../workflows"
+import type {
+  ListResult,
+  ObjectByIdHandle,
+  ObjectSet,
+  OntologySource,
+  RegisteredObjectType,
+  RegisteredValueTypes,
+  SixbRuntimeContext,
+} from "./types"
+
+// Scoped members are indexed accesses of the full SDK types rather than
+// `Pick`s: signatures stay single-sourced (no drift), while indexed access
+// stays lazy — mapped types would eagerly materialize every method's deep
+// query/telemetry conditionals and blow the instantiation depth limit.
+export interface ScopedObjectByIdHandle<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TValueTypes extends readonly ValueType[],
+> {
+  get: ObjectByIdHandle<TObjectType, TValueTypes>["get"]
+  requestAction: ObjectByIdHandle<TObjectType, TValueTypes>["requestAction"]
+  requestActionAndWait: ObjectByIdHandle<TObjectType, TValueTypes>["requestActionAndWait"]
+}
+
+export interface ScopedObjectSet<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TValueTypes extends readonly ValueType[],
+  TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens = TObjectType,
+> {
+  get: ObjectSet<TObjectType, TValueTypes, TRegisteredObjectTypes>["get"]
+  list: ObjectSet<TObjectType, TValueTypes, TRegisteredObjectTypes>["list"]
+  query: ObjectSet<TObjectType, TValueTypes, TRegisteredObjectTypes>["query"]
+  requestAction: ObjectSet<TObjectType, TValueTypes, TRegisteredObjectTypes>["requestAction"]
+  requestActionAndWait: ObjectSet<
+    TObjectType,
+    TValueTypes,
+    TRegisteredObjectTypes
+  >["requestActionAndWait"]
+
+  /** Bind read and action operations to a specific object id. */
+  byId(id: string): ScopedObjectByIdHandle<TObjectType, TValueTypes>
+}
+
+/**
+ * Principal-scoped runtime surface.
+ *
+ * Exposes only operations whose grants are enforceable end to end
+ * (`can.view`, `can.apply`). Everything else — writes, links, telemetry,
+ * infra handles, lifecycle, auth — stays on the privileged runtime.
+ */
+export interface ScopedSixb<TOntologySources extends readonly OntologySource[]> {
+  /** The authorization context this SDK instance enforces. */
+  readonly authorization: AuthorizationContext
+
+  /** Type-safe ObjectSet narrowed to grant-enforceable operations. */
+  objects<TObjectType extends RegisteredObjectType<TOntologySources>>(
+    objectType: TObjectType
+  ): ScopedObjectSet<
+    TObjectType,
+    RegisteredValueTypes<TOntologySources>,
+    RegisteredObjectType<TOntologySources>
+  >
+
+  /** Cross-type listing narrowed to the principal's viewable object types. */
+  list(params: ListObjectsParams): Promise<ListResult<ObjectRow>>
+
+  /** Get an object by type id and primary id (server / dynamic contexts). */
+  getObject(objectTypeId: string, primaryId: string): Promise<ObjectRow | null>
+
+  /** Action definitions the principal may apply. */
+  listActions(): readonly ActionDefinition[]
+
+  /** Look up an applicable action definition; null hides ungranted actions. */
+  getActionById(actionId: string): ActionDefinition | null
+
+  /** Request an action by id (server / dynamic contexts). Requires `can.apply`. */
+  requestAction(input: RequestActionInput): Promise<RequestActionResult>
+
+  /** Start a workflow run. Requires `can.start`. */
+  runWorkflow(input: RequestWorkflowRunInput): Promise<WorkflowRunRequestResult>
+
+  /** Read the domain events the principal is allowed to see (derived from grants). */
+  readEvents(input?: EventsReadInput): Promise<readonly StoredDomainEvent[]>
+}
+
+export function createScopedSixb<TOntologySources extends readonly OntologySource[]>(
+  runtime: SixbRuntimeContext & { readonly authorization: AuthorizationContext },
+  deps: { readonly workflows: WorkflowsRuntime }
+): ScopedSixb<TOntologySources> {
+  const canListAction = (action: ActionDefinition) =>
+    isAllowed(runtime.authorization, { kind: "action.apply", actionId: action.id }) &&
+    (action.binding.kind === "global" ||
+      isAllowed(runtime.authorization, {
+        kind: "object.view",
+        objectTypeId: action.binding.objectType.id,
+      }))
+
+  const scoped = {
+    authorization: runtime.authorization,
+
+    objects<TObjectType extends RegisteredObjectType<TOntologySources>>(objectType: TObjectType) {
+      assertObjectTypeRegistered(runtime.ontology.getObjectTypesById(), objectType)
+
+      return createObjectSet<
+        TObjectType,
+        RegisteredObjectType<TOntologySources>,
+        RegisteredValueTypes<TOntologySources>
+      >({ ...runtime, objectType })
+    },
+
+    list: (params: ListObjectsParams) => objectService.listObjects(runtime, params),
+
+    getObject: async (objectTypeId: string, primaryId: string) => {
+      assertAuthorized(runtime, { kind: "object.view", objectTypeId })
+      return runtime.storage.objects.getByPrimaryId({
+        projectId: runtime.projectId,
+        objectTypeId,
+        primaryId,
+      })
+    },
+
+    listActions: () => runtime.actionRegistry.list().filter((action) => canListAction(action)),
+
+    getActionById: (actionId: string) => {
+      const action = runtime.actionRegistry.getById(actionId)
+      return action && canListAction(action) ? action : null
+    },
+
+    requestAction: (input: RequestActionInput) => requestRuntimeAction(runtime, input),
+
+    runWorkflow: (input: RequestWorkflowRunInput) => deps.workflows.requestByIdAs(runtime, input),
+
+    // No standalone events grant: the stream is filtered to events whose
+    // subject the principal may view/apply/start. `limit` applies before this
+    // filter, so a page may return fewer events than requested — acceptable for
+    // a best-effort recent log.
+    readEvents: async (input?: EventsReadInput) => {
+      const events = await runtime.events.read(input)
+      return events.filter((event) => canViewEvent(runtime.authorization, event))
+    },
+  }
+
+  // Boundary cast: checking the literal against ScopedSixb<TOntologySources>
+  // triggers excessively deep ObjectSet instantiation (same constraint noted
+  // on SixbInstance). The mask only hides members of the full SDK values.
+  return scoped as unknown as ScopedSixb<TOntologySources>
+}

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -15,6 +15,7 @@ import {
   isOidcAuthStrategy,
   type SixbAuthConfig,
 } from "../auth"
+import type { AuthorizationContext } from "../authorization"
 import type { BlobStorage } from "../blob-storage"
 import type { Broker } from "../broker"
 import { ConnectorRuntime } from "../connectors/runtime"
@@ -46,7 +47,12 @@ import type { RuleDefinition } from "../rules"
 import { validateRulesAtStartup } from "../rules"
 import { SchedulerRuntime } from "../scheduler"
 import type { ScheduleDefinition } from "../schedules"
-import type { GroupDefinition, InvitePolicyDefinition, SecurityRegistry } from "../security"
+import type {
+  GroupDefinition,
+  InvitePolicyDefinition,
+  RoleDefinition,
+  SecurityRegistry,
+} from "../security"
 import { createRuntimeSecurityRegistry } from "../security/runtime"
 import type { ObjectRow, Storage } from "../storage"
 import type { SyncDefinition } from "../syncs"
@@ -55,6 +61,7 @@ import { registerWebhooks, WebhookValidationError, webhookRoute } from "../webho
 import type { WorkflowDefinition } from "../workflows"
 import { validateWorkflowsAtStartup, WorkflowsRuntime } from "../workflows"
 import { RuntimeError } from "./errors"
+import { createScopedSixb, type ScopedSixb } from "./scoped"
 import type {
   BatchItemResult,
   ListResult,
@@ -86,6 +93,7 @@ export interface SixbOptions<TOntologySources extends readonly OntologySource[]>
   rules?: readonly RuleDefinition[]
   workflows?: readonly WorkflowDefinition[]
   groups?: readonly GroupDefinition[]
+  roles?: readonly RoleDefinition[]
   invitePolicies?: readonly InvitePolicyDefinition[]
   auth?: SixbAuthConfig
 }
@@ -135,9 +143,19 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     this.blobStorage = options.blobStorage
     this.queues = options.queues
     this.rules = options.rules ?? []
+    // Ontology and actions resolve first so every later registry (security,
+    // rules, workflows, projections) can validate its references against them.
+    this.ontology = new OntologyRegistry({ sources: this.ontologySources })
+    this.actionRegistry = new ActionRegistry(options.actions ?? [], this.ontology)
+    const registeredActionIds = new Set(this.actionRegistry.list().map((action) => action.id))
     this.security = createRuntimeSecurityRegistry({
       groups: options.groups ?? [],
+      roles: options.roles ?? [],
       invitePolicies: options.invitePolicies ?? [],
+      objectTypeIds: new Set(this.ontology.getObjectTypesById().keys()),
+      actionIds: registeredActionIds,
+      workflowIds: new Set((options.workflows ?? []).map((workflow) => workflow.id)),
+      getSubTypes: (objectTypeId) => this.ontology.getSubTypes(objectTypeId),
     })
     this.auth = new AuthRuntime({
       projectId: this.projectId,
@@ -226,9 +244,6 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       this.pipelinesById.set(pipeline.id, pipeline)
     }
 
-    this.ontology = new OntologyRegistry({ sources: this.ontologySources })
-    this.actionRegistry = new ActionRegistry(options.actions ?? [], this.ontology)
-
     // Rules validate against the resolved ontology so inherited properties and
     // links are available before checking predicate references.
     validateRulesAtStartup(this.rules, this.ontology)
@@ -239,7 +254,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     const workflows = validateWorkflowsAtStartup({
       workflows: options.workflows ?? [],
       registeredScheduleIds: new Set(this.schedulesById.keys()),
-      registeredActionIds: new Set(this.actionRegistry.list().map((action) => action.id)),
+      registeredActionIds,
     })
 
     const workflowIds = new Set<string>()
@@ -448,6 +463,20 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     await this.broker.close?.()
   }
 
+  /**
+   * Derive a principal-scoped SDK from this runtime.
+   *
+   * The scoped surface is default-deny: operations run only when covered by
+   * the context's grants. This raw runtime stays privileged for trusted
+   * system code (startup, syncs, projections, workers, webhooks, tests).
+   */
+  as(context: AuthorizationContext): ScopedSixb<TOntologySources> {
+    return createScopedSixb<TOntologySources>(
+      { ...this.runtimeContext, authorization: context },
+      { workflows: this.workflows }
+    )
+  }
+
   objects<TObjectType extends RegisteredObjectType<TOntologySources>>(
     objectType: TObjectType
   ): ObjectSet<
@@ -461,17 +490,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       TObjectType,
       RegisteredObjectType<TOntologySources>,
       RegisteredValueTypes<TOntologySources>
-    >({
-      objectType,
-      projectId: this.projectId,
-      ontology: this.ontology,
-      actionRegistry: this.actionRegistry,
-      events: this.events,
-      lakeStorage: this.lakeStorage,
-      blobStorage: this.blobStorage,
-      storage: this.storage,
-      queues: this.queues,
-    })
+    >({ ...this.runtimeContext, objectType })
   }
 
   async upsertObject(
@@ -557,30 +576,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     orderBy?: "createdAt" | "updatedAt" | "primaryId"
     order?: "asc" | "desc"
   }): Promise<ListResult<ObjectRow>> {
-    const expandedTypeIds = params.objectTypeIds
-      ? [...new Set(params.objectTypeIds.flatMap((id) => [id, ...this.ontology.getSubTypes(id)]))]
-      : undefined
-
-    const result = await this.storage.objects.list({
-      projectId: this.projectId,
-      objectTypeId: expandedTypeIds?.length === 1 ? expandedTypeIds[0] : expandedTypeIds,
-      primaryIdPrefix: params.idPrefix,
-      primaryIdSuffix: params.idSuffix,
-      updatedAfter: params.updatedAfter,
-      updatedBefore: params.updatedBefore,
-      createdAfter: params.createdAfter,
-      createdBefore: params.createdBefore,
-      limit: params.limit,
-      offset: params.offset,
-      orderBy: params.orderBy,
-      order: params.order,
-    })
-
-    return {
-      objects: [...result.objects],
-      hasMore: result.hasMore,
-      total: result.total,
-    }
+    return objectService.listObjects(this.runtimeContext, params)
   }
 
   getSubTypes(objectTypeId: string): string[] {

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -14,6 +14,7 @@ import type {
   RequestActionResult,
 } from "../actions"
 import type { AuthRuntime } from "../auth"
+import type { AuthorizationContext } from "../authorization"
 import type { BlobStorage } from "../blob-storage"
 import type { Broker } from "../broker"
 import type { ConnectorAdapter, ConnectorClient, ConnectorDefinition } from "../connectors"
@@ -57,6 +58,7 @@ import type { ActionRunRecord, ObjectLinkRow, ObjectRow, Storage } from "../stor
 import type { SyncDefinition } from "../syncs"
 import type { RegisteredWebhook } from "../webhooks"
 import type { WorkflowsRuntime } from "../workflows"
+import type { ScopedSixb } from "./scoped"
 
 // ── Shared runtime context ──────────────────────────────────
 
@@ -79,6 +81,12 @@ export interface SixbRuntimeContext {
   readonly blobStorage: BlobStorage
   readonly queues: Queues
   readonly rules?: readonly RuleDefinition[]
+  /**
+   * Principal scope for this context. Absent on privileged runtimes (raw
+   * `sixb`, syncs, workers, tests); present on contexts created by
+   * `sixb.as(context)`, where data operations enforce default-deny grants.
+   */
+  readonly authorization?: AuthorizationContext
 }
 
 // ── Batch result envelopes ──────────────────────────────────
@@ -626,6 +634,9 @@ export interface SixbInstance<_ extends readonly OntologySource[]> {
   readonly auth: AuthRuntime
   readonly actions: ActionsRuntime
   readonly workflows: WorkflowsRuntime
+
+  /** Create a principal-scoped runtime surface that enforces authorization grants. */
+  as(context: AuthorizationContext): ScopedSixb<_>
 
   /** All registered object types. */
   listObjectTypes(): readonly ObjectTypeWithPropertyTokens[]

--- a/packages/core/src/security/builders.ts
+++ b/packages/core/src/security/builders.ts
@@ -1,9 +1,22 @@
 import { SecurityValidationError } from "./errors"
-import type { GroupDefinition, InvitePolicyDefinition } from "./types"
+import type {
+  GrantDefinition,
+  GroupDefinition,
+  InvitePolicyDefinition,
+  RoleDefinition,
+} from "./types"
+import { assertGrantDefinition } from "./validation"
 
 export interface DefineGroupOptions {
   readonly label?: string
   readonly description?: string
+}
+
+export interface DefineRoleOptions {
+  readonly label?: string
+  readonly description?: string
+  readonly grantedTo: readonly GroupDefinition[]
+  readonly grants: readonly GrantDefinition[]
 }
 
 export interface DefineInvitePolicyOptions {
@@ -71,6 +84,35 @@ export function defineGroup<const TId extends string>(
     id,
     ...(options.label !== undefined ? { label: options.label } : {}),
     ...(options.description !== undefined ? { description: options.description } : {}),
+  }
+}
+
+export function defineRole<const TId extends string>(
+  id: TId,
+  options: DefineRoleOptions
+): RoleDefinition<TId> {
+  assertNonEmptyString(id, "Role id")
+  assertOptionalString(options.label, `Role '${id}' label`)
+  assertOptionalString(options.description, `Role '${id}' description`)
+  assertNonEmptyArray(options.grantedTo, `Role '${id}' grantedTo`)
+
+  const grantedToGroupIds = groupIdsFrom(options.grantedTo, `Role '${id}' grantedTo`)
+
+  for (const grant of options.grants) {
+    assertGrantDefinition(grant, `Role '${id}' grants`)
+  }
+
+  if (options.grants.length === 0) {
+    throw new SecurityValidationError(`Role '${id}' grants must not be empty.`)
+  }
+
+  return {
+    kind: "role",
+    id,
+    ...(options.label !== undefined ? { label: options.label } : {}),
+    ...(options.description !== undefined ? { description: options.description } : {}),
+    grantedToGroupIds,
+    grants: options.grants,
   }
 }
 

--- a/packages/core/src/security/builders.ts
+++ b/packages/core/src/security/builders.ts
@@ -5,7 +5,13 @@ import type {
   InvitePolicyDefinition,
   RoleDefinition,
 } from "./types"
-import { assertGrantDefinition } from "./validation"
+import {
+  assertGrantDefinition,
+  assertNonEmptyString,
+  assertOptionalBoolean,
+  assertOptionalString,
+  isRecord,
+} from "./validation"
 
 export interface DefineGroupOptions {
   readonly label?: string
@@ -25,45 +31,16 @@ export interface DefineInvitePolicyOptions {
   readonly canInviteWithoutGroups?: boolean
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
-function assertNonEmptyString(value: unknown, field: string): asserts value is string {
-  if (typeof value !== "string" || !value.trim()) {
-    throw new SecurityValidationError(`${field} must not be empty.`)
-  }
-}
-
-function assertOptionalString(value: unknown, field: string): asserts value is string | undefined {
-  if (value === undefined) {
-    return
-  }
-
-  if (typeof value !== "string") {
-    throw new SecurityValidationError(`${field} must be a string.`)
-  }
-}
-
-function assertOptionalBoolean(
-  value: unknown,
-  field: string
-): asserts value is boolean | undefined {
-  if (value !== undefined && typeof value !== "boolean") {
-    throw new SecurityValidationError(`${field} must be a boolean.`)
-  }
-}
-
 function assertNonEmptyArray<T>(value: readonly T[], field: string): void {
   if (value.length === 0) {
-    throw new SecurityValidationError(`${field} must not be empty.`)
+    throw new SecurityValidationError(`[Sixb] ${field} must not be empty.`)
   }
 }
 
 function groupIdsFrom(groups: readonly GroupDefinition[], field: string): readonly string[] {
   return groups.map((group) => {
     if (!isRecord(group) || group.kind !== "group") {
-      throw new SecurityValidationError(`${field} must contain only group definitions.`)
+      throw new SecurityValidationError(`[Sixb] ${field} must contain only group definitions.`)
     }
 
     assertNonEmptyString(group.id, `${field} group id`)
@@ -103,7 +80,7 @@ export function defineRole<const TId extends string>(
   }
 
   if (options.grants.length === 0) {
-    throw new SecurityValidationError(`Role '${id}' grants must not be empty.`)
+    throw new SecurityValidationError(`[Sixb] Role '${id}' grants must not be empty.`)
   }
 
   return {
@@ -135,7 +112,7 @@ export function defineInvitePolicy<const TId extends string>(
 
   if (canInviteToGroupIds.length === 0 && options.canInviteWithoutGroups !== true) {
     throw new SecurityValidationError(
-      `Invite policy '${id}' must declare canInviteTo groups or canInviteWithoutGroups.`
+      `[Sixb] Invite policy '${id}' must declare canInviteTo groups or canInviteWithoutGroups.`
     )
   }
 

--- a/packages/core/src/security/grants.ts
+++ b/packages/core/src/security/grants.ts
@@ -12,7 +12,7 @@ import type { ObjectType } from "../ontology"
 import type { WorkflowDefinition } from "../workflows/types"
 import { SecurityValidationError } from "./errors"
 import { isScope, type Scope, scopeIdOf } from "./scopes"
-import type { ApplyGrant, Selection, StartGrant, ViewGrant } from "./types"
+import type { ApplyGrant, RunGrant, Selection, ViewGrant } from "./types"
 
 type GrantInput<TDefinition, TTarget extends Scope["target"]> =
   | TDefinition
@@ -29,7 +29,7 @@ function selectionFrom<TDefinition extends { readonly id?: unknown }>(
 
   const items = Array.isArray(input) ? input : [input as TDefinition]
   if (items.length === 0) {
-    throw new SecurityValidationError(`${label} requires at least one definition.`)
+    throw new SecurityValidationError(`[Sixb] ${label} requires at least one definition.`)
   }
 
   // Dedupe explicit ids up front; resolution would dedupe via Set anyway.
@@ -45,12 +45,12 @@ function apply(input: GrantInput<ActionDefinition, "action">): ApplyGrant {
   return { kind: "grant", capability: "apply", selection: selectionFrom(input, "can.apply") }
 }
 
-function start(input: GrantInput<WorkflowDefinition, "workflow">): StartGrant {
-  return { kind: "grant", capability: "start", selection: selectionFrom(input, "can.start") }
+function run(input: GrantInput<WorkflowDefinition, "workflow">): RunGrant {
+  return { kind: "grant", capability: "run", selection: selectionFrom(input, "can.run") }
 }
 
 export const can = {
   view,
   apply,
-  start,
+  run,
 }

--- a/packages/core/src/security/grants.ts
+++ b/packages/core/src/security/grants.ts
@@ -1,0 +1,56 @@
+/**
+ * Grant builders for role definitions.
+ *
+ * Grants are plain data referencing ontology, action, and workflow definitions
+ * by id. They carry no enforcement logic — the authorization engine expands
+ * each grant's selection into per-principal id sets at startup, so runtime
+ * checks stay simple `set.has(id)` lookups.
+ */
+
+import type { ActionDefinition } from "../actions/types"
+import type { ObjectType } from "../ontology"
+import type { WorkflowDefinition } from "../workflows/types"
+import { SecurityValidationError } from "./errors"
+import { isScope, type Scope, scopeIdOf } from "./scopes"
+import type { ApplyGrant, Selection, StartGrant, ViewGrant } from "./types"
+
+type GrantInput<TDefinition, TTarget extends Scope["target"]> =
+  | TDefinition
+  | readonly TDefinition[]
+  | Scope<TTarget>
+
+function selectionFrom<TDefinition extends { readonly id?: unknown }>(
+  input: GrantInput<TDefinition, Scope["target"]>,
+  label: string
+): Selection {
+  if (isScope(input)) {
+    return input.selection
+  }
+
+  const items = Array.isArray(input) ? input : [input as TDefinition]
+  if (items.length === 0) {
+    throw new SecurityValidationError(`${label} requires at least one definition.`)
+  }
+
+  // Dedupe explicit ids up front; resolution would dedupe via Set anyway.
+  const ids = [...new Set(items.map((item) => scopeIdOf(item, label)))]
+  return { all: false, ids }
+}
+
+function view(input: GrantInput<ObjectType, "object">): ViewGrant {
+  return { kind: "grant", capability: "view", selection: selectionFrom(input, "can.view") }
+}
+
+function apply(input: GrantInput<ActionDefinition, "action">): ApplyGrant {
+  return { kind: "grant", capability: "apply", selection: selectionFrom(input, "can.apply") }
+}
+
+function start(input: GrantInput<WorkflowDefinition, "workflow">): StartGrant {
+  return { kind: "grant", capability: "start", selection: selectionFrom(input, "can.start") }
+}
+
+export const can = {
+  view,
+  apply,
+  start,
+}

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -18,9 +18,9 @@ export type {
   InvitePolicyDefinition,
   RegisteredSecurityDefinitions,
   RoleDefinition,
+  RunGrant,
   SecurityRegistry,
   Selection,
-  StartGrant,
   ViewGrant,
 } from "./types"
 export {

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -1,22 +1,35 @@
-export type { DefineGroupOptions, DefineInvitePolicyOptions } from "./builders"
-export { defineGroup, defineInvitePolicy } from "./builders"
+export type { DefineGroupOptions, DefineInvitePolicyOptions, DefineRoleOptions } from "./builders"
+export { defineGroup, defineInvitePolicy, defineRole } from "./builders"
 export { SecurityValidationError } from "./errors"
+export { can } from "./grants"
 export type { InvitePolicyScope } from "./invite-policies"
 export {
   canInviteGroupIds,
   missingInviteGroupIds,
   resolveInvitePolicyScope,
 } from "./invite-policies"
+export type { Scope, ScopeTarget } from "./scopes"
+export { actions, ontology, workflows } from "./scopes"
 export type {
+  ApplyGrant,
+  GrantCapability,
+  GrantDefinition,
   GroupDefinition,
   InvitePolicyDefinition,
   RegisteredSecurityDefinitions,
+  RoleDefinition,
   SecurityRegistry,
+  Selection,
+  StartGrant,
+  ViewGrant,
 } from "./types"
 export {
+  assertGrantDefinition,
   assertGroupDefinition,
   assertInvitePolicyDefinition,
+  assertRoleDefinition,
   isGroupDefinition,
   isInvitePolicyDefinition,
+  isRoleDefinition,
   validateSecurityDefinitionsAtStartup,
 } from "./validation"

--- a/packages/core/src/security/runtime.ts
+++ b/packages/core/src/security/runtime.ts
@@ -1,10 +1,18 @@
-import type { GroupDefinition, InvitePolicyDefinition, SecurityRegistry } from "./types"
+import { type ResolvedRole, resolveRoleGrants } from "../authorization"
+import type {
+  GroupDefinition,
+  InvitePolicyDefinition,
+  RoleDefinition,
+  SecurityRegistry,
+} from "./types"
 import { validateSecurityDefinitionsAtStartup } from "./validation"
 
 class RuntimeSecurityRegistry implements SecurityRegistry {
   constructor(
     private readonly groupsById: ReadonlyMap<string, GroupDefinition>,
-    private readonly invitePoliciesById: ReadonlyMap<string, InvitePolicyDefinition>
+    private readonly rolesById: ReadonlyMap<string, RoleDefinition>,
+    private readonly invitePoliciesById: ReadonlyMap<string, InvitePolicyDefinition>,
+    private readonly resolvedRoles: readonly ResolvedRole[]
   ) {}
 
   getGroupDefinitions(): readonly GroupDefinition[] {
@@ -13,6 +21,18 @@ class RuntimeSecurityRegistry implements SecurityRegistry {
 
   getGroupById(groupId: string): GroupDefinition | null {
     return this.groupsById.get(groupId) ?? null
+  }
+
+  getRoleDefinitions(): readonly RoleDefinition[] {
+    return [...this.rolesById.values()]
+  }
+
+  getRoleById(roleId: string): RoleDefinition | null {
+    return this.rolesById.get(roleId) ?? null
+  }
+
+  getResolvedRoles(): readonly ResolvedRole[] {
+    return this.resolvedRoles
   }
 
   getInvitePolicyDefinitions(): readonly InvitePolicyDefinition[] {
@@ -26,15 +46,38 @@ class RuntimeSecurityRegistry implements SecurityRegistry {
 
 export function createRuntimeSecurityRegistry(input: {
   readonly groups?: readonly GroupDefinition[]
+  readonly roles?: readonly RoleDefinition[]
   readonly invitePolicies?: readonly InvitePolicyDefinition[]
+  readonly objectTypeIds?: ReadonlySet<string>
+  readonly actionIds?: ReadonlySet<string>
+  readonly workflowIds?: ReadonlySet<string>
+  readonly getSubTypes?: (objectTypeId: string) => readonly string[]
 }): SecurityRegistry {
   const securityDefinitions = validateSecurityDefinitionsAtStartup({
     groups: input.groups ?? [],
+    roles: input.roles ?? [],
     invitePolicies: input.invitePolicies ?? [],
+    objectTypeIds: input.objectTypeIds,
+    actionIds: input.actionIds,
+    workflowIds: input.workflowIds,
   })
+
+  const universe = {
+    objectTypeIds: input.objectTypeIds ?? new Set<string>(),
+    actionIds: input.actionIds ?? new Set<string>(),
+    workflowIds: input.workflowIds ?? new Set<string>(),
+    getSubTypes: input.getSubTypes ?? (() => []),
+  }
+  const resolvedRoles = securityDefinitions.roles.map((role) => ({
+    id: role.id,
+    grantedToGroupIds: role.grantedToGroupIds,
+    grants: resolveRoleGrants(role, universe),
+  }))
 
   return new RuntimeSecurityRegistry(
     securityDefinitions.groupsById,
-    securityDefinitions.invitePoliciesById
+    securityDefinitions.rolesById,
+    securityDefinitions.invitePoliciesById,
+    resolvedRoles
   )
 }

--- a/packages/core/src/security/scopes.ts
+++ b/packages/core/src/security/scopes.ts
@@ -1,0 +1,75 @@
+/**
+ * Breadth selectors for role grants.
+ *
+ * `ontology.objects()`, `actions()`, and `workflows()` select a capability's
+ * whole registered universe; `.except([...])` removes specific definitions.
+ * They are plain data carrying no enforcement logic — `can.view/apply/start`
+ * turn them into grants, and the authorization engine expands them to concrete
+ * id sets at startup (after applying `except`).
+ */
+
+import type { ActionDefinition } from "../actions/types"
+import type { ObjectType } from "../ontology"
+import type { WorkflowDefinition } from "../workflows/types"
+import { SecurityValidationError } from "./errors"
+
+/** Capability targets a scope can range over. */
+export type ScopeTarget = "object" | "action" | "workflow"
+
+interface ScopeTargetInput {
+  object: ObjectType
+  action: ActionDefinition
+  workflow: WorkflowDefinition
+}
+
+/**
+ * An "all except" selection over a capability target. Branded by `target` so
+ * `can.view(actions())` fails to typecheck.
+ */
+export interface Scope<TTarget extends ScopeTarget = ScopeTarget> {
+  readonly target: TTarget
+  readonly selection: { readonly all: true; readonly except: readonly string[] }
+  /** Exclude specific definitions from an otherwise-complete selection. */
+  except(items: readonly ScopeTargetInput[TTarget][]): Scope<TTarget>
+}
+
+export function isScope(value: unknown): value is Scope {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "target" in value &&
+    "selection" in value &&
+    (value as Scope).selection?.all === true
+  )
+}
+
+export function scopeIdOf(item: { readonly id?: unknown }, label: string): string {
+  if (typeof item?.id !== "string" || !item.id.trim()) {
+    throw new SecurityValidationError(`${label} requires definitions with a non-empty id.`)
+  }
+  return item.id
+}
+
+function allScope<TTarget extends ScopeTarget>(
+  target: TTarget,
+  except: readonly string[] = []
+): Scope<TTarget> {
+  return {
+    target,
+    selection: { all: true, except },
+    except(items) {
+      return allScope(target, [
+        ...except,
+        ...items.map((item) => scopeIdOf(item, `${target} scope except`)),
+      ])
+    },
+  }
+}
+
+export const ontology = {
+  objects: (): Scope<"object"> => allScope("object"),
+}
+
+export const actions = (): Scope<"action"> => allScope("action")
+
+export const workflows = (): Scope<"workflow"> => allScope("workflow")

--- a/packages/core/src/security/scopes.ts
+++ b/packages/core/src/security/scopes.ts
@@ -45,7 +45,7 @@ export function isScope(value: unknown): value is Scope {
 
 export function scopeIdOf(item: { readonly id?: unknown }, label: string): string {
   if (typeof item?.id !== "string" || !item.id.trim()) {
-    throw new SecurityValidationError(`${label} requires definitions with a non-empty id.`)
+    throw new SecurityValidationError(`[Sixb] ${label} requires definitions with a non-empty id.`)
   }
   return item.id
 }

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -1,8 +1,51 @@
+import type { ResolvedRole } from "../authorization/types"
+
 export interface GroupDefinition<TId extends string = string> {
   readonly kind: "group"
   readonly id: TId
   readonly label?: string
   readonly description?: string
+}
+
+/**
+ * A capability's reach over its target's id space. Either the whole registered
+ * universe minus an exclusion list (`ontology.objects().except([...])`) or an
+ * explicit set of ids (`can.view([A, B])`). Both forms expand to a concrete set
+ * of ids at startup, so the resolved index only ever holds plain `Set`s.
+ */
+export type Selection =
+  | { readonly all: true; readonly except: readonly string[] }
+  | { readonly all: false; readonly ids: readonly string[] }
+
+export interface ViewGrant {
+  readonly kind: "grant"
+  readonly capability: "view"
+  readonly selection: Selection
+}
+
+export interface ApplyGrant {
+  readonly kind: "grant"
+  readonly capability: "apply"
+  readonly selection: Selection
+}
+
+export interface StartGrant {
+  readonly kind: "grant"
+  readonly capability: "start"
+  readonly selection: Selection
+}
+
+export type GrantDefinition = ViewGrant | ApplyGrant | StartGrant
+
+export type GrantCapability = GrantDefinition["capability"]
+
+export interface RoleDefinition<TId extends string = string> {
+  readonly kind: "role"
+  readonly id: TId
+  readonly label?: string
+  readonly description?: string
+  readonly grantedToGroupIds: readonly string[]
+  readonly grants: readonly GrantDefinition[]
 }
 
 export interface InvitePolicyDefinition<TId extends string = string> {
@@ -16,6 +59,8 @@ export interface InvitePolicyDefinition<TId extends string = string> {
 export interface RegisteredSecurityDefinitions {
   readonly groups: readonly GroupDefinition[]
   readonly groupsById: ReadonlyMap<string, GroupDefinition>
+  readonly roles: readonly RoleDefinition[]
+  readonly rolesById: ReadonlyMap<string, RoleDefinition>
   readonly invitePolicies: readonly InvitePolicyDefinition[]
   readonly invitePoliciesById: ReadonlyMap<string, InvitePolicyDefinition>
 }
@@ -23,6 +68,10 @@ export interface RegisteredSecurityDefinitions {
 export interface SecurityRegistry {
   getGroupDefinitions(): readonly GroupDefinition[]
   getGroupById(groupId: string): GroupDefinition | null
+  getRoleDefinitions(): readonly RoleDefinition[]
+  getRoleById(roleId: string): RoleDefinition | null
+  /** Roles with their grants pre-expanded to concrete id sets for resolution. */
+  getResolvedRoles(): readonly ResolvedRole[]
   getInvitePolicyDefinitions(): readonly InvitePolicyDefinition[]
   getInvitePolicyById(policyId: string): InvitePolicyDefinition | null
 }

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -29,13 +29,13 @@ export interface ApplyGrant {
   readonly selection: Selection
 }
 
-export interface StartGrant {
+export interface RunGrant {
   readonly kind: "grant"
-  readonly capability: "start"
+  readonly capability: "run"
   readonly selection: Selection
 }
 
-export type GrantDefinition = ViewGrant | ApplyGrant | StartGrant
+export type GrantDefinition = ViewGrant | ApplyGrant | RunGrant
 
 export type GrantCapability = GrantDefinition["capability"]
 

--- a/packages/core/src/security/validation.ts
+++ b/packages/core/src/security/validation.ts
@@ -1,8 +1,10 @@
 import { SecurityValidationError } from "./errors"
 import type {
+  GrantDefinition,
   GroupDefinition,
   InvitePolicyDefinition,
   RegisteredSecurityDefinitions,
+  RoleDefinition,
 } from "./types"
 
 type CreateSecurityError = (message: string) => Error
@@ -134,11 +136,89 @@ export function isInvitePolicyDefinition(value: unknown): value is InvitePolicyD
   }
 }
 
+export function assertGrantDefinition(
+  value: unknown,
+  field: string,
+  createError: CreateSecurityError = (message) => new SecurityValidationError(message)
+): asserts value is GrantDefinition {
+  if (!isRecord(value) || value.kind !== "grant") {
+    throw createError(`${field} must contain only grant definitions from 'can'.`)
+  }
+
+  if (value.capability !== "view" && value.capability !== "apply" && value.capability !== "start") {
+    throw createError(`${field} grant capability must be 'view', 'apply', or 'start'.`)
+  }
+
+  assertSelection(value.selection, field, createError)
+}
+
+function assertSelection(
+  value: unknown,
+  field: string,
+  createError: CreateSecurityError
+): asserts value is GrantDefinition["selection"] {
+  if (!isRecord(value) || typeof value.all !== "boolean") {
+    throw createError(`${field} grant must carry a selection from 'can' or a scope.`)
+  }
+
+  const ids = value.all ? value.except : value.ids
+  if (!Array.isArray(ids)) {
+    throw createError(`${field} grant selection must list ids.`)
+  }
+
+  for (const id of ids) {
+    assertNonEmptyString(id, `${field} grant selection id`, createError)
+  }
+}
+
+export function assertRoleDefinition(
+  value: unknown,
+  createError: CreateSecurityError = (message) => new SecurityValidationError(message)
+): asserts value is RoleDefinition {
+  if (!isRecord(value)) {
+    throw createError("Role definition must be an object.")
+  }
+
+  if (value.kind !== "role") {
+    throw createError("Role definition kind must be 'role'.")
+  }
+
+  assertNonEmptyString(value.id, "Role id", createError)
+  assertOptionalString(value.label, `Role '${value.id}' label`, createError)
+  assertOptionalString(value.description, `Role '${value.id}' description`, createError)
+  assertStringArray(value.grantedToGroupIds, `Role '${value.id}' grantedTo`, createError)
+
+  if (!Array.isArray(value.grants)) {
+    throw createError(`Role '${value.id}' grants must be an array.`)
+  }
+
+  for (const grant of value.grants) {
+    assertGrantDefinition(grant, `Role '${value.id}' grants`, createError)
+  }
+}
+
+export function isRoleDefinition(value: unknown): value is RoleDefinition {
+  try {
+    assertRoleDefinition(value, (message) => new Error(message))
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function validateSecurityDefinitionsAtStartup(input: {
   readonly groups: readonly GroupDefinition[]
   readonly invitePolicies: readonly InvitePolicyDefinition[]
+  readonly roles?: readonly RoleDefinition[]
+  /** Registered object type ids — when provided, view grants must reference them. */
+  readonly objectTypeIds?: ReadonlySet<string>
+  /** Registered action ids — when provided, apply grants must reference them. */
+  readonly actionIds?: ReadonlySet<string>
+  /** Registered workflow ids — when provided, run grants must reference them. */
+  readonly workflowIds?: ReadonlySet<string>
 }): RegisteredSecurityDefinitions {
   const groupsById = new Map<string, GroupDefinition>()
+  const rolesById = new Map<string, RoleDefinition>()
   const invitePoliciesById = new Map<string, InvitePolicyDefinition>()
 
   for (const group of input.groups) {
@@ -149,6 +229,38 @@ export function validateSecurityDefinitionsAtStartup(input: {
     }
 
     groupsById.set(group.id, group)
+  }
+
+  for (const role of input.roles ?? []) {
+    assertRoleDefinition(role)
+
+    if (rolesById.has(role.id)) {
+      throw new SecurityValidationError(`Duplicate role id: ${role.id}`)
+    }
+
+    if (role.grantedToGroupIds.length === 0) {
+      throw new SecurityValidationError(`Role '${role.id}' must be granted to at least one group.`)
+    }
+
+    if (role.grants.length === 0) {
+      throw new SecurityValidationError(`Role '${role.id}' must declare at least one grant.`)
+    }
+
+    assertNoDuplicateIds(role.grantedToGroupIds, `Role '${role.id}' grantedTo`)
+
+    for (const groupId of role.grantedToGroupIds) {
+      if (!groupsById.has(groupId)) {
+        throw new SecurityValidationError(
+          `Role '${role.id}' grantedTo references unknown group '${groupId}'. Add it to 'security/groups/' or pass it to createSixb({ groups }).`
+        )
+      }
+    }
+
+    for (const grant of role.grants) {
+      assertGrantReferences(role.id, grant, input)
+    }
+
+    rolesById.set(role.id, role)
   }
 
   for (const policy of input.invitePolicies) {
@@ -195,7 +307,59 @@ export function validateSecurityDefinitionsAtStartup(input: {
   return {
     groups: [...groupsById.values()],
     groupsById,
+    roles: [...rolesById.values()],
+    rolesById,
     invitePolicies: [...invitePoliciesById.values()],
     invitePoliciesById,
+  }
+}
+
+const GRANT_REFERENCE_HINTS: Record<
+  GrantDefinition["capability"],
+  { readonly subject: string; readonly fix: string }
+> = {
+  view: {
+    subject: "object type",
+    fix: "Register it in 'ontology/' or pass it to createSixb({ ontologies }).",
+  },
+  apply: { subject: "action", fix: "Add it to 'actions/' or pass it to createSixb({ actions })." },
+  start: {
+    subject: "workflow",
+    fix: "Add it to 'workflows/' or pass it to createSixb({ workflows }).",
+  },
+}
+
+function assertGrantReferences(
+  roleId: string,
+  grant: GrantDefinition,
+  registered: {
+    readonly objectTypeIds?: ReadonlySet<string>
+    readonly actionIds?: ReadonlySet<string>
+    readonly workflowIds?: ReadonlySet<string>
+  }
+): void {
+  const universe =
+    grant.capability === "view"
+      ? registered.objectTypeIds
+      : grant.capability === "apply"
+        ? registered.actionIds
+        : registered.workflowIds
+
+  if (!universe) {
+    return
+  }
+
+  // Explicit selections list ids to include; "all except" selections list ids
+  // to exclude. Either way every named id must be registered — an unknown id is
+  // a typo that would silently widen or no-op the grant.
+  const ids = grant.selection.all ? grant.selection.except : grant.selection.ids
+  const { subject, fix } = GRANT_REFERENCE_HINTS[grant.capability]
+
+  for (const id of ids) {
+    if (!universe.has(id)) {
+      throw new SecurityValidationError(
+        `Role '${roleId}' grants ${grant.capability} on unknown ${subject} '${id}'. ${fix}`
+      )
+    }
   }
 }

--- a/packages/core/src/security/validation.ts
+++ b/packages/core/src/security/validation.ts
@@ -1,5 +1,6 @@
 import { SecurityValidationError } from "./errors"
 import type {
+  GrantCapability,
   GrantDefinition,
   GroupDefinition,
   InvitePolicyDefinition,
@@ -7,33 +8,35 @@ import type {
   RoleDefinition,
 } from "./types"
 
-type CreateSecurityError = (message: string) => Error
+export type CreateSecurityError = (message: string) => Error
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+// Shared, single-source validation primitives. The builders reuse these too, so
+// authoring-time and startup-time checks can never drift apart.
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function assertNonEmptyString(
+export function assertNonEmptyString(
   value: unknown,
   field: string,
-  createError: CreateSecurityError
+  createError: CreateSecurityError = (message) => new SecurityValidationError(message)
 ): asserts value is string {
   if (typeof value !== "string" || value.trim().length === 0) {
-    throw createError(`${field} must not be empty.`)
+    throw createError(`[Sixb] ${field} must not be empty.`)
   }
 }
 
-function assertOptionalString(
+export function assertOptionalString(
   value: unknown,
   field: string,
-  createError: CreateSecurityError
+  createError: CreateSecurityError = (message) => new SecurityValidationError(message)
 ): asserts value is string | undefined {
   if (value === undefined) {
     return
   }
 
   if (typeof value !== "string") {
-    throw createError(`${field} must be a string.`)
+    throw createError(`[Sixb] ${field} must be a string.`)
   }
 }
 
@@ -43,7 +46,7 @@ function assertStringArray(
   createError: CreateSecurityError
 ): asserts value is readonly string[] {
   if (!Array.isArray(value)) {
-    throw createError(`${field} must be an array of group ids.`)
+    throw createError(`[Sixb] ${field} must be an array of group ids.`)
   }
 
   for (const item of value) {
@@ -51,17 +54,17 @@ function assertStringArray(
   }
 }
 
-function assertOptionalBoolean(
+export function assertOptionalBoolean(
   value: unknown,
   field: string,
-  createError: CreateSecurityError
+  createError: CreateSecurityError = (message) => new SecurityValidationError(message)
 ): asserts value is boolean | undefined {
   if (value === undefined) {
     return
   }
 
   if (typeof value !== "boolean") {
-    throw createError(`${field} must be a boolean.`)
+    throw createError(`[Sixb] ${field} must be a boolean.`)
   }
 }
 
@@ -69,7 +72,7 @@ function assertNoDuplicateIds(ids: readonly string[], field: string): void {
   const seen = new Set<string>()
   for (const id of ids) {
     if (seen.has(id)) {
-      throw new SecurityValidationError(`${field} contains duplicate group id '${id}'.`)
+      throw new SecurityValidationError(`[Sixb] ${field} contains duplicate group id '${id}'.`)
     }
     seen.add(id)
   }
@@ -80,11 +83,11 @@ export function assertGroupDefinition(
   createError: CreateSecurityError = (message) => new SecurityValidationError(message)
 ): asserts value is GroupDefinition {
   if (!isRecord(value)) {
-    throw createError("Group definition must be an object.")
+    throw createError("[Sixb] Group definition must be an object.")
   }
 
   if (value.kind !== "group") {
-    throw createError("Group definition kind must be 'group'.")
+    throw createError("[Sixb] Group definition kind must be 'group'.")
   }
 
   assertNonEmptyString(value.id, "Group id", createError)
@@ -106,11 +109,11 @@ export function assertInvitePolicyDefinition(
   createError: CreateSecurityError = (message) => new SecurityValidationError(message)
 ): asserts value is InvitePolicyDefinition {
   if (!isRecord(value)) {
-    throw createError("Invite policy definition must be an object.")
+    throw createError("[Sixb] Invite policy definition must be an object.")
   }
 
   if (value.kind !== "invitePolicy") {
-    throw createError("Invite policy definition kind must be 'invitePolicy'.")
+    throw createError("[Sixb] Invite policy definition kind must be 'invitePolicy'.")
   }
 
   assertNonEmptyString(value.id, "Invite policy id", createError)
@@ -142,11 +145,11 @@ export function assertGrantDefinition(
   createError: CreateSecurityError = (message) => new SecurityValidationError(message)
 ): asserts value is GrantDefinition {
   if (!isRecord(value) || value.kind !== "grant") {
-    throw createError(`${field} must contain only grant definitions from 'can'.`)
+    throw createError(`[Sixb] ${field} must contain only grant definitions from 'can'.`)
   }
 
-  if (value.capability !== "view" && value.capability !== "apply" && value.capability !== "start") {
-    throw createError(`${field} grant capability must be 'view', 'apply', or 'start'.`)
+  if (value.capability !== "view" && value.capability !== "apply" && value.capability !== "run") {
+    throw createError(`[Sixb] ${field} grant capability must be 'view', 'apply', or 'run'.`)
   }
 
   assertSelection(value.selection, field, createError)
@@ -158,12 +161,12 @@ function assertSelection(
   createError: CreateSecurityError
 ): asserts value is GrantDefinition["selection"] {
   if (!isRecord(value) || typeof value.all !== "boolean") {
-    throw createError(`${field} grant must carry a selection from 'can' or a scope.`)
+    throw createError(`[Sixb] ${field} grant must carry a selection from 'can' or a scope.`)
   }
 
   const ids = value.all ? value.except : value.ids
   if (!Array.isArray(ids)) {
-    throw createError(`${field} grant selection must list ids.`)
+    throw createError(`[Sixb] ${field} grant selection must list ids.`)
   }
 
   for (const id of ids) {
@@ -176,11 +179,11 @@ export function assertRoleDefinition(
   createError: CreateSecurityError = (message) => new SecurityValidationError(message)
 ): asserts value is RoleDefinition {
   if (!isRecord(value)) {
-    throw createError("Role definition must be an object.")
+    throw createError("[Sixb] Role definition must be an object.")
   }
 
   if (value.kind !== "role") {
-    throw createError("Role definition kind must be 'role'.")
+    throw createError("[Sixb] Role definition kind must be 'role'.")
   }
 
   assertNonEmptyString(value.id, "Role id", createError)
@@ -189,7 +192,7 @@ export function assertRoleDefinition(
   assertStringArray(value.grantedToGroupIds, `Role '${value.id}' grantedTo`, createError)
 
   if (!Array.isArray(value.grants)) {
-    throw createError(`Role '${value.id}' grants must be an array.`)
+    throw createError(`[Sixb] Role '${value.id}' grants must be an array.`)
   }
 
   for (const grant of value.grants) {
@@ -225,7 +228,7 @@ export function validateSecurityDefinitionsAtStartup(input: {
     assertGroupDefinition(group)
 
     if (groupsById.has(group.id)) {
-      throw new SecurityValidationError(`Duplicate group id: ${group.id}`)
+      throw new SecurityValidationError(`[Sixb] Duplicate group id: ${group.id}`)
     }
 
     groupsById.set(group.id, group)
@@ -235,15 +238,17 @@ export function validateSecurityDefinitionsAtStartup(input: {
     assertRoleDefinition(role)
 
     if (rolesById.has(role.id)) {
-      throw new SecurityValidationError(`Duplicate role id: ${role.id}`)
+      throw new SecurityValidationError(`[Sixb] Duplicate role id: ${role.id}`)
     }
 
     if (role.grantedToGroupIds.length === 0) {
-      throw new SecurityValidationError(`Role '${role.id}' must be granted to at least one group.`)
+      throw new SecurityValidationError(
+        `[Sixb] Role '${role.id}' must be granted to at least one group.`
+      )
     }
 
     if (role.grants.length === 0) {
-      throw new SecurityValidationError(`Role '${role.id}' must declare at least one grant.`)
+      throw new SecurityValidationError(`[Sixb] Role '${role.id}' must declare at least one grant.`)
     }
 
     assertNoDuplicateIds(role.grantedToGroupIds, `Role '${role.id}' grantedTo`)
@@ -251,7 +256,7 @@ export function validateSecurityDefinitionsAtStartup(input: {
     for (const groupId of role.grantedToGroupIds) {
       if (!groupsById.has(groupId)) {
         throw new SecurityValidationError(
-          `Role '${role.id}' grantedTo references unknown group '${groupId}'. Add it to 'security/groups/' or pass it to createSixb({ groups }).`
+          `[Sixb] Role '${role.id}' grantedTo references unknown group '${groupId}'. Add it to 'security/groups/' or pass it to createSixb({ groups }).`
         )
       }
     }
@@ -267,18 +272,18 @@ export function validateSecurityDefinitionsAtStartup(input: {
     assertInvitePolicyDefinition(policy)
 
     if (invitePoliciesById.has(policy.id)) {
-      throw new SecurityValidationError(`Duplicate invite policy id: ${policy.id}`)
+      throw new SecurityValidationError(`[Sixb] Duplicate invite policy id: ${policy.id}`)
     }
 
     if (policy.grantedToGroupIds.length === 0) {
       throw new SecurityValidationError(
-        `Invite policy '${policy.id}' must grant invitation authority to at least one group.`
+        `[Sixb] Invite policy '${policy.id}' must grant invitation authority to at least one group.`
       )
     }
 
     if (policy.canInviteToGroupIds.length === 0 && policy.canInviteWithoutGroups !== true) {
       throw new SecurityValidationError(
-        `Invite policy '${policy.id}' must declare canInviteTo groups or canInviteWithoutGroups.`
+        `[Sixb] Invite policy '${policy.id}' must declare canInviteTo groups or canInviteWithoutGroups.`
       )
     }
 
@@ -288,7 +293,7 @@ export function validateSecurityDefinitionsAtStartup(input: {
     for (const groupId of policy.grantedToGroupIds) {
       if (!groupsById.has(groupId)) {
         throw new SecurityValidationError(
-          `Invite policy '${policy.id}' grantedTo references unknown group '${groupId}'. Add it to 'security/groups/' or pass it to createSixb({ groups }).`
+          `[Sixb] Invite policy '${policy.id}' grantedTo references unknown group '${groupId}'. Add it to 'security/groups/' or pass it to createSixb({ groups }).`
         )
       }
     }
@@ -296,7 +301,7 @@ export function validateSecurityDefinitionsAtStartup(input: {
     for (const groupId of policy.canInviteToGroupIds) {
       if (!groupsById.has(groupId)) {
         throw new SecurityValidationError(
-          `Invite policy '${policy.id}' canInviteTo references unknown group '${groupId}'. Add it to 'security/groups/' or pass it to createSixb({ groups }).`
+          `[Sixb] Invite policy '${policy.id}' canInviteTo references unknown group '${groupId}'. Add it to 'security/groups/' or pass it to createSixb({ groups }).`
         )
       }
     }
@@ -323,7 +328,7 @@ const GRANT_REFERENCE_HINTS: Record<
     fix: "Register it in 'ontology/' or pass it to createSixb({ ontologies }).",
   },
   apply: { subject: "action", fix: "Add it to 'actions/' or pass it to createSixb({ actions })." },
-  start: {
+  run: {
     subject: "workflow",
     fix: "Add it to 'workflows/' or pass it to createSixb({ workflows }).",
   },
@@ -338,12 +343,14 @@ function assertGrantReferences(
     readonly workflowIds?: ReadonlySet<string>
   }
 ): void {
-  const universe =
-    grant.capability === "view"
-      ? registered.objectTypeIds
-      : grant.capability === "apply"
-        ? registered.actionIds
-        : registered.workflowIds
+  // Capability -> its registered id universe. A Record keeps this exhaustive:
+  // a new capability is a compile error until wired here.
+  const universeByCapability: Record<GrantCapability, ReadonlySet<string> | undefined> = {
+    view: registered.objectTypeIds,
+    apply: registered.actionIds,
+    run: registered.workflowIds,
+  }
+  const universe = universeByCapability[grant.capability]
 
   if (!universe) {
     return
@@ -358,7 +365,7 @@ function assertGrantReferences(
   for (const id of ids) {
     if (!universe.has(id)) {
       throw new SecurityValidationError(
-        `Role '${roleId}' grants ${grant.capability} on unknown ${subject} '${id}'. ${fix}`
+        `[Sixb] Role '${roleId}' grants ${grant.capability} on unknown ${subject} '${id}'. ${fix}`
       )
     }
   }

--- a/packages/core/src/workflows/request.ts
+++ b/packages/core/src/workflows/request.ts
@@ -38,7 +38,7 @@ export async function requestWorkflowRun(
   workflow: WorkflowDefinition,
   options: WorkflowRunRequestOptions = {}
 ): Promise<WorkflowRunRequestResult> {
-  assertAuthorized(runtime, { kind: "workflow.start", workflowId: workflow.id })
+  assertAuthorized(runtime, { kind: "workflow.run", workflowId: workflow.id })
   const storage = runtime.storage.workflowRuns
   if (!storage) {
     throw new WorkflowValidationError("[Sixb] Workflow run storage is not configured.")

--- a/packages/core/src/workflows/request.ts
+++ b/packages/core/src/workflows/request.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { assertAuthorized } from "../authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import { WorkflowValidationError } from "./errors"
 import { snapshotWorkflowInput } from "./snapshot"
@@ -37,6 +38,7 @@ export async function requestWorkflowRun(
   workflow: WorkflowDefinition,
   options: WorkflowRunRequestOptions = {}
 ): Promise<WorkflowRunRequestResult> {
+  assertAuthorized(runtime, { kind: "workflow.start", workflowId: workflow.id })
   const storage = runtime.storage.workflowRuns
   if (!storage) {
     throw new WorkflowValidationError("[Sixb] Workflow run storage is not configured.")

--- a/packages/core/src/workflows/runtime.ts
+++ b/packages/core/src/workflows/runtime.ts
@@ -47,11 +47,22 @@ export class WorkflowsRuntime {
 
   /** Start a run by workflow id (server routes and dynamic use cases). */
   async requestById(input: RequestWorkflowRunInput): Promise<WorkflowRunRequestResult> {
+    return this.requestByIdAs(this.runtime, input)
+  }
+
+  /**
+   * Start a run by id on behalf of an explicit runtime context, so the scoped
+   * SDK can enforce run grants while reusing the registered definitions.
+   */
+  async requestByIdAs(
+    runtime: SixbRuntimeContext,
+    input: RequestWorkflowRunInput
+  ): Promise<WorkflowRunRequestResult> {
     const workflow = this.getById(input.workflowId)
     if (!workflow) {
       throw new WorkflowValidationError(`[Sixb] Unknown workflow '${input.workflowId}'`)
     }
 
-    return requestWorkflowRun(this.runtime, workflow, input)
+    return requestWorkflowRun(runtime, workflow, input)
   }
 }

--- a/packages/core/tests/authorization-context.test.ts
+++ b/packages/core/tests/authorization-context.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "bun:test"
+import {
+  actions,
+  can,
+  createSessionCredential,
+  defineAction,
+  defineGroup,
+  defineObjectType,
+  defineRole,
+  ontology,
+  prop,
+  type RoleDefinition,
+  resolveAuthorizationContext,
+  resolveRoleGrants,
+  Sixb,
+  workflows,
+} from "../src"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const Contract = defineObjectType({
+  id: "contract",
+  name: "Contract",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const SignedContract = defineObjectType({
+  id: "signed-contract",
+  name: "Signed Contract",
+  extends: Contract,
+  properties: [prop("countersigned", "boolean")],
+})
+
+const Invoice = defineObjectType({
+  id: "invoice",
+  name: "Invoice",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const sendContract = defineAction("send-contract")
+  .params({})
+  .edits(() => {})
+
+const commercial = defineGroup("commercial")
+const finance = defineGroup("finance")
+const admins = defineGroup("admins")
+
+const contractOperator = defineRole("contract.operator", {
+  grantedTo: [commercial],
+  grants: [can.view(Contract), can.apply(sendContract)],
+})
+
+const invoiceViewer = defineRole("invoice.viewer", {
+  grantedTo: [finance],
+  grants: [can.view(Invoice)],
+})
+
+const adminOperator = defineRole("admin.operator", {
+  grantedTo: [admins],
+  grants: [can.view(ontology.objects()), can.apply(actions()), can.start(workflows())],
+})
+
+const principal = { type: "user", id: "adam" } as const
+
+describe("resolveAuthorizationContext", () => {
+  // The registry expands grants against the registered universe at startup;
+  // here we expand by hand so the resolver can be exercised in isolation.
+  const universe = {
+    objectTypeIds: new Set(["contract", "signed-contract", "invoice"]),
+    actionIds: new Set(["send-contract"]),
+    workflowIds: new Set<string>(),
+    getSubTypes: (objectTypeId: string) => (objectTypeId === "contract" ? ["signed-contract"] : []),
+  }
+
+  const resolve = (
+    groupIds: readonly string[],
+    roles: readonly RoleDefinition[],
+    sessionId?: string
+  ) =>
+    resolveAuthorizationContext({
+      principal,
+      ...(sessionId ? { sessionId } : {}),
+      groupIds,
+      roles: roles.map((role) => ({
+        id: role.id,
+        grantedToGroupIds: role.grantedToGroupIds,
+        grants: resolveRoleGrants(role, universe),
+      })),
+    })
+
+  test("matches roles by group membership and expands view grants to subtypes", () => {
+    const context = resolve(["commercial"], [contractOperator, invoiceViewer], "ses_adam")
+
+    expect(context.principal).toEqual(principal)
+    expect(context.sessionId).toBe("ses_adam")
+    expect(context.groupIds).toEqual(["commercial"])
+    expect(context.roleIds).toEqual(["contract.operator"])
+    expect(context.grants.objectTypes.view).toEqual(new Set(["contract", "signed-contract"]))
+    expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
+  })
+
+  test("unions grants across all matched roles", () => {
+    const context = resolve(["commercial", "finance"], [contractOperator, invoiceViewer])
+
+    expect(context.roleIds).toEqual(["contract.operator", "invoice.viewer"])
+    expect(context.grants.objectTypes.view).toEqual(
+      new Set(["contract", "signed-contract", "invoice"])
+    )
+  })
+
+  test("principals without matching roles resolve to empty grants", () => {
+    const context = resolve(["engineering"], [contractOperator, invoiceViewer, adminOperator])
+
+    expect(context.roleIds).toEqual([])
+    expect(context.grants.objectTypes.view.size).toBe(0)
+    expect(context.grants.actions.apply.size).toBe(0)
+    expect(context.grants.workflows.start.size).toBe(0)
+  })
+
+  test("expands broad grants to the registered universe", () => {
+    const context = resolve(["admins"], [contractOperator, invoiceViewer, adminOperator])
+
+    expect(context.roleIds).toEqual(["admin.operator"])
+    expect(context.grants.objectTypes.view).toEqual(
+      new Set(["contract", "signed-contract", "invoice"])
+    )
+    expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
+    expect(context.grants.workflows.start.size).toBe(0)
+  })
+
+  test("except() excludes the named types and keeps the rest of the universe", () => {
+    const mostObjects = defineRole("most.objects", {
+      grantedTo: [admins],
+      grants: [can.view(ontology.objects().except([Invoice]))],
+    })
+
+    const context = resolve(["admins"], [mostObjects])
+
+    expect(context.grants.objectTypes.view).toEqual(new Set(["contract", "signed-contract"]))
+    expect(context.grants.objectTypes.view.has("invoice")).toBe(false)
+  })
+
+  test("except is per-grant: another role can re-grant an excluded type", () => {
+    const allButInvoice = defineRole("all.but.invoice", {
+      grantedTo: [admins],
+      grants: [can.view(ontology.objects().except([Invoice]))],
+    })
+    const invoiceOnly = defineRole("invoice.only", {
+      grantedTo: [finance],
+      grants: [can.view(Invoice)],
+    })
+
+    const context = resolve(["admins", "finance"], [allButInvoice, invoiceOnly])
+
+    expect(context.grants.objectTypes.view).toEqual(
+      new Set(["contract", "signed-contract", "invoice"])
+    )
+  })
+})
+
+describe("auth.createAuthorizationContext", () => {
+  function createRuntime() {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({
+      ontology: [Contract, SignedContract, Invoice],
+      actions: [sendContract],
+      groups: [commercial, finance],
+      roles: [contractOperator, invoiceViewer],
+      auth: { id: "test", kind: "dev" },
+      ...deps,
+    })
+    return { sixb, deps }
+  }
+
+  async function seedAuthenticatedUser(
+    projectId: string,
+    deps: ReturnType<typeof createTestRuntimeDeps>,
+    params: {
+      readonly userId: string
+      readonly email: string
+      readonly groupIds: readonly string[]
+    }
+  ): Promise<{ request: Request; sessionId: string }> {
+    const credential = createSessionCredential(`ses_${params.userId}`)
+    await deps.storage.auth.users.create({
+      id: params.userId,
+      projectId,
+      email: params.email,
+    })
+    for (const groupId of params.groupIds) {
+      await deps.storage.auth.groupMemberships.upsert({
+        projectId,
+        userId: params.userId,
+        groupId,
+        source: "manual",
+      })
+    }
+    await deps.storage.auth.sessions.create({
+      id: credential.sessionId,
+      projectId,
+      userId: params.userId,
+      strategyId: "test",
+      audience: "atlas",
+      tokenHash: credential.tokenHash,
+      createdAt: new Date("2026-05-16T10:00:00.000Z"),
+      expiresAt: new Date("2099-05-16T10:00:00.000Z"),
+    })
+
+    return {
+      request: new Request("http://localhost/api/objects", {
+        headers: { cookie: `sixb_session=${credential.cookieValue}` },
+      }),
+      sessionId: credential.sessionId,
+    }
+  }
+
+  test("resolves the context from an authenticated request", async () => {
+    const { sixb, deps } = createRuntime()
+    const { request, sessionId } = await seedAuthenticatedUser(sixb.id, deps, {
+      userId: "adam",
+      email: "adam@example.com",
+      groupIds: ["commercial"],
+    })
+
+    const context = await sixb.auth.createAuthorizationContext(request)
+
+    expect(context.principal).toEqual({ type: "user", id: "adam" })
+    expect(context.sessionId).toBe(sessionId)
+    expect(context.groupIds).toEqual(["commercial"])
+    expect(context.roleIds).toEqual(["contract.operator"])
+    expect(context.grants.objectTypes.view).toEqual(new Set(["contract", "signed-contract"]))
+    expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
+  })
+
+  test("rejects unauthenticated requests", async () => {
+    const { sixb } = createRuntime()
+
+    expect(
+      sixb.auth.createAuthorizationContext(new Request("http://localhost/api/objects"))
+    ).rejects.toThrow("[Sixb] Authentication is required.")
+  })
+
+  test("contextFromSession matches the request-based context", async () => {
+    const { sixb, deps } = createRuntime()
+    const { request } = await seedAuthenticatedUser(sixb.id, deps, {
+      userId: "adam",
+      email: "adam@example.com",
+      groupIds: ["commercial", "finance"],
+    })
+
+    const session = await sixb.auth.getSession(request)
+    if (!session.authenticated) {
+      throw new Error("Expected an authenticated session.")
+    }
+
+    expect(sixb.auth.contextFromSession(session)).toEqual(
+      await sixb.auth.createAuthorizationContext(request)
+    )
+  })
+})

--- a/packages/core/tests/authorization-context.test.ts
+++ b/packages/core/tests/authorization-context.test.ts
@@ -56,7 +56,7 @@ const invoiceViewer = defineRole("invoice.viewer", {
 
 const adminOperator = defineRole("admin.operator", {
   grantedTo: [admins],
-  grants: [can.view(ontology.objects()), can.apply(actions()), can.start(workflows())],
+  grants: [can.view(ontology.objects()), can.apply(actions()), can.run(workflows())],
 })
 
 const principal = { type: "user", id: "adam" } as const
@@ -113,7 +113,7 @@ describe("resolveAuthorizationContext", () => {
     expect(context.roleIds).toEqual([])
     expect(context.grants.objectTypes.view.size).toBe(0)
     expect(context.grants.actions.apply.size).toBe(0)
-    expect(context.grants.workflows.start.size).toBe(0)
+    expect(context.grants.workflows.run.size).toBe(0)
   })
 
   test("expands broad grants to the registered universe", () => {
@@ -124,7 +124,7 @@ describe("resolveAuthorizationContext", () => {
       new Set(["contract", "signed-contract", "invoice"])
     )
     expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
-    expect(context.grants.workflows.start.size).toBe(0)
+    expect(context.grants.workflows.run.size).toBe(0)
   })
 
   test("except() excludes the named types and keeps the rest of the universe", () => {

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test"
+import {
+  type AuthorizationContext,
+  canViewEvent,
+  evaluate,
+  isAllowed,
+  type StoredActionRequestedEvent,
+  type StoredLinkUpsertedEvent,
+  type StoredObjectUpsertedEvent,
+  type StoredScheduleTriggeredEvent,
+  type StoredTelemetryAppendedEvent,
+  type StoredWorkflowRunStartedEvent,
+} from "../src"
+
+function context(grants: {
+  view?: readonly string[]
+  apply?: readonly string[]
+  start?: readonly string[]
+}): AuthorizationContext {
+  return {
+    principal: { type: "user", id: "u1" },
+    groupIds: [],
+    roleIds: [],
+    grants: {
+      objectTypes: { view: new Set(grants.view ?? []) },
+      actions: { apply: new Set(grants.apply ?? []) },
+      workflows: { start: new Set(grants.start ?? []) },
+    },
+  }
+}
+
+describe("evaluate", () => {
+  test("reports the requirement and allows when the grant is held", () => {
+    expect(
+      evaluate(context({ view: ["quote"] }), { kind: "object.view", objectTypeId: "quote" })
+    ).toEqual({ allowed: true, requirements: ["view:object:quote"], missing: [] })
+  })
+
+  test("reports the missing requirement when the grant is absent", () => {
+    expect(evaluate(context({}), { kind: "object.view", objectTypeId: "quote" })).toEqual({
+      allowed: false,
+      requirements: ["view:object:quote"],
+      missing: ["view:object:quote"],
+    })
+  })
+
+  test("object.query requires every touched type and lists only the unviewable ones", () => {
+    const decision = evaluate(context({ view: ["quote"] }), {
+      kind: "object.query",
+      touchedObjectTypeIds: ["quote", "contact"],
+    })
+
+    expect(decision.allowed).toBe(false)
+    expect(decision.requirements).toEqual(["view:object:quote", "view:object:contact"])
+    expect(decision.missing).toEqual(["view:object:contact"])
+  })
+
+  test("a missing authorization context (privileged caller) allows everything", () => {
+    expect(evaluate(null, { kind: "object.view", objectTypeId: "anything" })).toEqual({
+      allowed: true,
+      requirements: ["view:object:anything"],
+      missing: [],
+    })
+    expect(isAllowed(undefined, { kind: "workflow.start", workflowId: "w" })).toBe(true)
+  })
+})
+
+const envelope = {
+  id: "evt_1",
+  schemaVersion: 1 as const,
+  projectId: "p1",
+  occurredAt: "2026-01-01T00:00:00.000Z",
+  cursor: "c1",
+}
+
+const objectEvent: StoredObjectUpsertedEvent = {
+  ...envelope,
+  type: "object.upserted",
+  topic: "objects",
+  partitionKey: "note/n1",
+  payload: { objectTypeId: "note", primaryId: "n1", properties: {} },
+}
+
+const telemetryEvent: StoredTelemetryAppendedEvent = {
+  ...envelope,
+  type: "telemetry.appended",
+  topic: "telemetry",
+  partitionKey: "note/n1",
+  payload: {
+    objectTypeId: "note",
+    objectId: "n1",
+    propertyId: "temp",
+    value: 1,
+    at: envelope.occurredAt,
+  },
+}
+
+const linkEvent: StoredLinkUpsertedEvent = {
+  ...envelope,
+  type: "link.upserted",
+  topic: "links",
+  partitionKey: "note/n1",
+  payload: {
+    sourceTypeId: "note",
+    sourceId: "n1",
+    linkId: "author",
+    targetTypeId: "user",
+    targetId: "u1",
+  },
+}
+
+const actionEvent: StoredActionRequestedEvent = {
+  ...envelope,
+  type: "action.requested",
+  topic: "actions",
+  partitionKey: "note/n1",
+  payload: {
+    actionId: "acknowledge-note",
+    subject: { kind: "object", objectTypeId: "note", primaryId: "n1" },
+    params: {},
+    runId: "r1",
+  },
+}
+
+const workflowEvent: StoredWorkflowRunStartedEvent = {
+  ...envelope,
+  type: "workflow.run.started",
+  topic: "workflows",
+  partitionKey: "review/r1",
+  payload: { workflowId: "review", runId: "r1", startedAt: envelope.occurredAt },
+}
+
+const scheduleEvent: StoredScheduleTriggeredEvent = {
+  ...envelope,
+  type: "schedule.triggered",
+  topic: "schedules",
+  partitionKey: "nightly",
+  payload: {
+    scheduleId: "nightly",
+    occurrenceAt: envelope.occurredAt,
+    triggeredAt: envelope.occurredAt,
+    occurrenceKey: "k1",
+  },
+}
+
+describe("canViewEvent", () => {
+  test("object and telemetry events require viewing the subject type", () => {
+    expect(canViewEvent(context({ view: ["note"] }), objectEvent)).toBe(true)
+    expect(canViewEvent(context({}), objectEvent)).toBe(false)
+    expect(canViewEvent(context({ view: ["note"] }), telemetryEvent)).toBe(true)
+    expect(canViewEvent(context({}), telemetryEvent)).toBe(false)
+  })
+
+  test("link events require viewing BOTH the source and the target type", () => {
+    expect(canViewEvent(context({ view: ["note", "user"] }), linkEvent)).toBe(true)
+    // Seeing the source but not the target must not leak the link (or the target id).
+    expect(canViewEvent(context({ view: ["note"] }), linkEvent)).toBe(false)
+    expect(canViewEvent(context({ view: ["user"] }), linkEvent)).toBe(false)
+  })
+
+  test("action events require apply; workflow events require start", () => {
+    expect(canViewEvent(context({ apply: ["acknowledge-note"] }), actionEvent)).toBe(true)
+    expect(canViewEvent(context({ view: ["note"] }), actionEvent)).toBe(false)
+    expect(canViewEvent(context({ start: ["review"] }), workflowEvent)).toBe(true)
+    expect(canViewEvent(context({}), workflowEvent)).toBe(false)
+  })
+
+  test("infra-topic events stay visible to any scoped principal (no grant governs them yet)", () => {
+    expect(canViewEvent(context({}), scheduleEvent)).toBe(true)
+  })
+
+  test("a privileged caller (no context) sees every event", () => {
+    expect(canViewEvent(null, linkEvent)).toBe(true)
+    expect(canViewEvent(null, scheduleEvent)).toBe(true)
+  })
+})

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -7,6 +7,7 @@ import {
   type StoredActionRequestedEvent,
   type StoredLinkUpsertedEvent,
   type StoredObjectUpsertedEvent,
+  type StoredRuleTriggeredEvent,
   type StoredScheduleTriggeredEvent,
   type StoredTelemetryAppendedEvent,
   type StoredWorkflowRunStartedEvent,
@@ -15,7 +16,7 @@ import {
 function context(grants: {
   view?: readonly string[]
   apply?: readonly string[]
-  start?: readonly string[]
+  run?: readonly string[]
 }): AuthorizationContext {
   return {
     principal: { type: "user", id: "u1" },
@@ -24,7 +25,7 @@ function context(grants: {
     grants: {
       objectTypes: { view: new Set(grants.view ?? []) },
       actions: { apply: new Set(grants.apply ?? []) },
-      workflows: { start: new Set(grants.start ?? []) },
+      workflows: { run: new Set(grants.run ?? []) },
     },
   }
 }
@@ -61,7 +62,7 @@ describe("evaluate", () => {
       requirements: ["view:object:anything"],
       missing: [],
     })
-    expect(isAllowed(undefined, { kind: "workflow.start", workflowId: "w" })).toBe(true)
+    expect(isAllowed(undefined, { kind: "workflow.run", workflowId: "w" })).toBe(true)
   })
 })
 
@@ -130,6 +131,18 @@ const workflowEvent: StoredWorkflowRunStartedEvent = {
   payload: { workflowId: "review", runId: "r1", startedAt: envelope.occurredAt },
 }
 
+const ruleEvent: StoredRuleTriggeredEvent = {
+  ...envelope,
+  type: "rule.triggered",
+  topic: "rules",
+  partitionKey: "note/n1",
+  payload: {
+    ruleId: "stale-note",
+    subject: { kind: "object", objectTypeId: "note", primaryId: "n1" },
+    triggeredAt: envelope.occurredAt,
+  },
+}
+
 const scheduleEvent: StoredScheduleTriggeredEvent = {
   ...envelope,
   type: "schedule.triggered",
@@ -158,14 +171,27 @@ describe("canViewEvent", () => {
     expect(canViewEvent(context({ view: ["user"] }), linkEvent)).toBe(false)
   })
 
-  test("action events require apply; workflow events require start", () => {
-    expect(canViewEvent(context({ apply: ["acknowledge-note"] }), actionEvent)).toBe(true)
+  test("object-bound action events require BOTH apply and viewing the subject type", () => {
+    expect(
+      canViewEvent(context({ apply: ["acknowledge-note"], view: ["note"] }), actionEvent)
+    ).toBe(true)
+    // Apply without view must not leak the bound object's id/type via the event.
+    expect(canViewEvent(context({ apply: ["acknowledge-note"] }), actionEvent)).toBe(false)
     expect(canViewEvent(context({ view: ["note"] }), actionEvent)).toBe(false)
-    expect(canViewEvent(context({ start: ["review"] }), workflowEvent)).toBe(true)
+  })
+
+  test("workflow events require running the workflow", () => {
+    expect(canViewEvent(context({ run: ["review"] }), workflowEvent)).toBe(true)
     expect(canViewEvent(context({}), workflowEvent)).toBe(false)
   })
 
-  test("infra-topic events stay visible to any scoped principal (no grant governs them yet)", () => {
+  test("rule events require viewing the object the rule fired on", () => {
+    expect(canViewEvent(context({ view: ["note"] }), ruleEvent)).toBe(true)
+    // No view of the subject type must not leak the hidden object's existence/id.
+    expect(canViewEvent(context({}), ruleEvent)).toBe(false)
+  })
+
+  test("subject-free infra events stay visible to any scoped principal (no grant governs them)", () => {
     expect(canViewEvent(context({}), scheduleEvent)).toBe(true)
   })
 

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, test } from "bun:test"
+import {
+  type ActionDefinition,
+  AuthorizationError,
+  can,
+  defineAction,
+  defineGroup,
+  defineObjectType,
+  defineRole,
+  defineWorkflow,
+  defineWorkflowStep,
+  link,
+  prop,
+  ref,
+  resolveAuthorizationContext,
+  type SecurityRegistry,
+  Sixb,
+  type WorkflowDefinition,
+} from "../src"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const Contract = defineObjectType({
+  id: "contract",
+  name: "Contract",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const SignedContract = defineObjectType({
+  id: "signed-contract",
+  name: "Signed Contract",
+  extends: Contract,
+  properties: [prop("countersigned", "boolean")],
+})
+
+const Invoice = defineObjectType({
+  id: "invoice",
+  name: "Invoice",
+  properties: [prop("id", "string", { required: true, primary: true })],
+  links: [link("contract", Contract)],
+})
+
+// Widened to the base type, like renewContract below: keeps the registered
+// actions array out of the deep Sixb<tuple> instantiation (TS2589).
+const sendContract: ActionDefinition = defineAction("send-contract")
+  .on(Contract)
+  .params({})
+  .edits(() => {})
+
+const archiveInvoice: ActionDefinition = defineAction("archive-invoice")
+  .on(Invoice)
+  .params({})
+  .edits(() => {})
+
+const reviewContract = defineWorkflowStep("review-contract")
+  .input({ contract: ref(Contract) })
+  .output({ contract: ref(Contract) })
+  .run(async () => ({ contract: { objectTypeId: "contract", primaryId: "c1" } }))
+
+// Widened to the base type: only used for registration and grants, so the
+// registered workflow array avoids instantiating the deep chain type.
+const renewContract: WorkflowDefinition = defineWorkflow("renew-contract")
+  .input({ contract: ref(Contract) })
+  .then(reviewContract)
+
+const commercial = defineGroup("commercial")
+const finance = defineGroup("finance")
+const ops = defineGroup("ops")
+const operations = defineGroup("operations")
+
+const contractOperator = defineRole("contract.operator", {
+  grantedTo: [commercial],
+  grants: [can.view(Contract), can.apply(sendContract)],
+})
+
+const invoiceViewer = defineRole("invoice.viewer", {
+  grantedTo: [finance],
+  grants: [can.view(Invoice)],
+})
+
+// Apply without view — object actions must require both grants.
+const contractSender = defineRole("contract.sender", {
+  grantedTo: [ops],
+  grants: [can.apply(sendContract)],
+})
+
+const operationsRunner = defineRole("operations.runner", {
+  grantedTo: [operations],
+  grants: [can.start(renewContract)],
+})
+
+const principal = { type: "user", id: "adam" } as const
+
+// No explicit instance annotations anywhere in this file: naming
+// Sixb<three-type tuple> in a type position (alias, param, ReturnType) trips
+// TS2589 instantiation depth. Inference handles it fine.
+function createRuntime() {
+  return new Sixb<readonly [typeof Contract, typeof SignedContract, typeof Invoice]>({
+    ontology: [Contract, SignedContract, Invoice],
+    actions: [sendContract, archiveInvoice],
+    workflows: [renewContract],
+    groups: [commercial, finance, ops, operations],
+    roles: [contractOperator, invoiceViewer, contractSender, operationsRunner],
+    ...createTestRuntimeDeps(),
+  })
+}
+
+function contextFor(sixb: { security: SecurityRegistry }, groupIds: readonly string[]) {
+  return resolveAuthorizationContext({
+    principal,
+    groupIds,
+    roles: sixb.security.getResolvedRoles(),
+  })
+}
+
+describe("sixb.as() object reads", () => {
+  test("granted types support get, list, byId.get, and query", async () => {
+    const sixb = createRuntime()
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+    const scoped = sixb.as(contextFor(sixb, ["commercial"]))
+
+    expect(await scoped.objects(Contract).get("c1")).toMatchObject({ primaryId: "c1" })
+    expect((await scoped.objects(Contract).list()).objects).toHaveLength(1)
+    expect(await scoped.objects(Contract).byId("c1").get()).toMatchObject({ primaryId: "c1" })
+    expect((await scoped.objects(Contract).query().list()).objects).toHaveLength(1)
+  })
+
+  test("view grants include subtypes", async () => {
+    const sixb = createRuntime()
+    const scoped = sixb.as(contextFor(sixb, ["commercial"]))
+
+    expect((await scoped.objects(SignedContract).list()).objects).toEqual([])
+  })
+
+  test("ungranted types deny get, list, and query", async () => {
+    const sixb = createRuntime()
+    await sixb.objects(Invoice).upsert({ properties: { id: "i1" } })
+    const scoped = sixb.as(contextFor(sixb, ["commercial"]))
+
+    expect(scoped.objects(Invoice).list()).rejects.toThrow(AuthorizationError)
+    expect(scoped.objects(Invoice).get("i1")).rejects.toThrow(AuthorizationError)
+    expect(scoped.objects(Invoice).byId("i1").get()).rejects.toThrow(AuthorizationError)
+    expect(scoped.objects(Invoice).query().list()).rejects.toThrow(AuthorizationError)
+  })
+
+  test("queries require every touched type, not just the result type", async () => {
+    const sixb = createRuntime()
+    const scoped = sixb.as(contextFor(sixb, ["commercial"]))
+
+    // Starts at Invoice and ends at viewable Contract — still requires can.view(Invoice).
+    const query = scoped.objects(Invoice).query()
+
+    expect(query.list()).rejects.toThrow(AuthorizationError)
+  })
+})
+
+describe("sixb.as() cross-type list", () => {
+  async function createSeededRuntime() {
+    const sixb = createRuntime()
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+    await sixb.objects(Invoice).upsert({ properties: { id: "i1" } })
+    return sixb
+  }
+
+  test("broad listings narrow to viewable types", async () => {
+    const sixb = await createSeededRuntime()
+    const scoped = sixb.as(contextFor(sixb, ["commercial"]))
+
+    const result = await scoped.list({})
+
+    expect(result.objects.map((row) => row.objectTypeId)).toEqual(["contract"])
+  })
+
+  test("explicitly requesting a forbidden type fails", async () => {
+    const sixb = await createSeededRuntime()
+    const scoped = sixb.as(contextFor(sixb, ["commercial"]))
+
+    expect(scoped.list({ objectTypeIds: ["invoice"] })).rejects.toThrow(AuthorizationError)
+    expect(
+      (await scoped.list({ objectTypeIds: ["contract"] })).objects.map((row) => row.primaryId)
+    ).toEqual(["c1"])
+  })
+
+  test("principals with no grants list nothing", async () => {
+    const sixb = await createSeededRuntime()
+    const scoped = sixb.as(contextFor(sixb, []))
+
+    expect(await scoped.list({})).toEqual({ objects: [], hasMore: false, total: 0 })
+  })
+})
+
+describe("sixb.as() actions", () => {
+  test("object actions require apply and view together", async () => {
+    const sixb = createRuntime()
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    const { runId } = await operator
+      .objects(Contract)
+      .requestAction({ id: "c1", actionId: "send-contract" })
+    expect(runId).toBeString()
+
+    // view without apply
+    await sixb.objects(Invoice).upsert({ properties: { id: "i1" } })
+    const viewerOnly = sixb.as(contextFor(sixb, ["finance"]))
+    expect(
+      viewerOnly.objects(Invoice).requestAction({ id: "i1", actionId: "archive-invoice" })
+    ).rejects.toThrow(AuthorizationError)
+
+    // apply without view
+    const senderOnly = sixb.as(contextFor(sixb, ["ops"]))
+    expect(senderOnly.listActions()).toEqual([])
+    expect(senderOnly.getActionById("send-contract")).toBeNull()
+    expect(
+      senderOnly.objects(Contract).requestAction({ id: "c1", actionId: "send-contract" })
+    ).rejects.toThrow(AuthorizationError)
+  })
+})
+
+describe("sixb.as() operational access", () => {
+  test("workflow runs require can.start", async () => {
+    const sixb = createRuntime()
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+    const input = {
+      workflowId: "renew-contract",
+      input: { contract: { objectTypeId: "contract", primaryId: "c1" } },
+    }
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    const result = await runner.runWorkflow(input)
+    expect(result.runId).toBeString()
+
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    expect(operator.runWorkflow(input)).rejects.toThrow(AuthorizationError)
+  })
+
+  test("event visibility is derived from grants", async () => {
+    const sixb = createRuntime()
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+
+    // The operator can view Contract, so it sees the object's event.
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    expect((await operator.readEvents()).map((event) => event.type)).toContain("object.upserted")
+
+    // The runner can start workflows but cannot view Contract, so the contract
+    // event is filtered out (no workflow has run, so it sees nothing here).
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    expect((await runner.readEvents()).filter((event) => event.type === "object.upserted")).toEqual(
+      []
+    )
+  })
+
+  test("action metadata narrows to applicable actions", () => {
+    const sixb = createRuntime()
+
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    expect(operator.listActions().map((action) => action.id)).toEqual(["send-contract"])
+    expect(operator.getActionById("send-contract")?.id).toBe("send-contract")
+    expect(operator.getActionById("archive-invoice")).toBeNull()
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    expect(runner.listActions()).toEqual([])
+  })
+
+  test("dynamic action requests enforce apply and view", async () => {
+    const sixb = createRuntime()
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    const { runId } = await operator.requestAction({
+      actionId: "send-contract",
+      subject: { kind: "object", objectTypeId: "contract", primaryId: "c1" },
+    })
+    expect(runId).toBeString()
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    expect(
+      runner.requestAction({
+        actionId: "send-contract",
+        subject: { kind: "object", objectTypeId: "contract", primaryId: "c1" },
+      })
+    ).rejects.toThrow(AuthorizationError)
+  })
+})
+
+describe("sixb.as() fails closed on ungranted surfaces", () => {
+  test("writes, links, telemetry, and listLinks deny even when reached at runtime", async () => {
+    const sixb = createRuntime()
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+    const scoped = sixb.as(contextFor(sixb, ["commercial"]))
+
+    // The scoped types hide these members; the casts simulate a scoped runtime
+    // context leaking into an unexposed code path.
+    const objectSet = scoped.objects(Contract) as unknown as {
+      upsert(input: { properties: Record<string, unknown> }): Promise<unknown>
+      appendTelemetryBatch(items: readonly Record<string, unknown>[]): Promise<void>
+    }
+
+    expect(objectSet.upsert({ properties: { id: "c2" } })).rejects.toThrow(AuthorizationError)
+    expect(
+      objectSet.appendTelemetryBatch([{ id: "c1", properties: {}, at: new Date() }])
+    ).rejects.toThrow(AuthorizationError)
+
+    const invoiceSet = scoped.objects(Invoice) as unknown as {
+      upsertLink(input: Record<string, unknown>): Promise<void>
+    }
+    expect(
+      invoiceSet.upsertLink({
+        sourceId: "i1",
+        linkId: "contract",
+        targetTypeId: "contract",
+        targetId: "c1",
+      })
+    ).rejects.toThrow(AuthorizationError)
+
+    const handle = scoped.objects(Contract).byId("c1") as unknown as {
+      listLinks(): Promise<unknown>
+    }
+    expect(handle.listLinks()).rejects.toThrow(AuthorizationError)
+  })
+
+  test("the raw runtime stays privileged", async () => {
+    const sixb = createRuntime()
+
+    await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
+    expect((await sixb.list({})).objects).toHaveLength(1)
+  })
+})

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -85,7 +85,7 @@ const contractSender = defineRole("contract.sender", {
 
 const operationsRunner = defineRole("operations.runner", {
   grantedTo: [operations],
-  grants: [can.start(renewContract)],
+  grants: [can.run(renewContract)],
 })
 
 const principal = { type: "user", id: "adam" } as const
@@ -217,7 +217,7 @@ describe("sixb.as() actions", () => {
 })
 
 describe("sixb.as() operational access", () => {
-  test("workflow runs require can.start", async () => {
+  test("workflow runs require can.run", async () => {
     const sixb = createRuntime()
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
     const input = {
@@ -241,7 +241,7 @@ describe("sixb.as() operational access", () => {
     const operator = sixb.as(contextFor(sixb, ["commercial"]))
     expect((await operator.readEvents()).map((event) => event.type)).toContain("object.upserted")
 
-    // The runner can start workflows but cannot view Contract, so the contract
+    // The runner can run workflows but cannot view Contract, so the contract
     // event is filtered out (no workflow has run, so it sees nothing here).
     const runner = sixb.as(contextFor(sixb, ["operations"]))
     expect((await runner.readEvents()).filter((event) => event.type === "object.upserted")).toEqual(
@@ -279,6 +279,19 @@ describe("sixb.as() operational access", () => {
         subject: { kind: "object", objectTypeId: "contract", primaryId: "c1" },
       })
     ).rejects.toThrow(AuthorizationError)
+  })
+
+  test("workflow catalog narrows to runnable workflows", () => {
+    const sixb = createRuntime()
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    expect(runner.listWorkflows().map((workflow) => workflow.id)).toEqual(["renew-contract"])
+    expect(runner.getWorkflowById("renew-contract")?.id).toBe("renew-contract")
+
+    // No run grant: the workflow is hidden from both listing and lookup.
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    expect(operator.listWorkflows()).toEqual([])
+    expect(operator.getWorkflowById("renew-contract")).toBeNull()
   })
 })
 
@@ -323,5 +336,31 @@ describe("sixb.as() fails closed on ungranted surfaces", () => {
 
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
     expect((await sixb.list({})).objects).toHaveLength(1)
+  })
+})
+
+describe("ScopedSixb surface", () => {
+  // The scoped value is built then `as unknown as ScopedSixb`-cast, so neither
+  // the compiler nor the mask catches a member added to one side but not the
+  // other. Pin the exposed members so any drift fails loudly here.
+  test("exposes exactly the allowlisted members", () => {
+    const sixb = createRuntime()
+    const scoped = sixb.as(contextFor(sixb, ["commercial"]))
+
+    expect(Object.keys(scoped).sort()).toEqual(
+      [
+        "authorization",
+        "getActionById",
+        "getObject",
+        "getWorkflowById",
+        "list",
+        "listActions",
+        "listWorkflows",
+        "objects",
+        "readEvents",
+        "requestAction",
+        "runWorkflow",
+      ].sort()
+    )
   })
 })

--- a/packages/core/tests/security-definitions.test.ts
+++ b/packages/core/tests/security-definitions.test.ts
@@ -4,14 +4,20 @@ import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import {
+  type ActionDefinition,
+  can,
   canInviteGroupIds,
   createSixb,
+  defineAction,
   defineGroup,
   defineInvitePolicy,
   defineObjectType,
+  defineRole,
   type GroupDefinition,
   type InvitePolicyDefinition,
+  ontology,
   prop,
+  type RoleDefinition,
   resolveInvitePolicyScope,
   SecurityValidationError,
   Sixb,
@@ -251,7 +257,202 @@ export const defaultInvites = defineInvitePolicy("default-invites", {
     const sixb = createRuntime()
 
     expect(sixb.security.getGroupDefinitions()).toEqual([])
+    expect(sixb.security.getRoleDefinitions()).toEqual([])
     expect(sixb.security.getInvitePolicyDefinitions()).toEqual([])
+  })
+})
+
+describe("role definitions", () => {
+  const commercial = defineGroup("commercial")
+  const finance = defineGroup("finance")
+  const reboot = defineAction("reboot")
+    .params({})
+    .edits(() => {})
+
+  test("defineRole normalizes groups and preserves grants in order", () => {
+    expect(
+      defineRole("contract.operator", {
+        label: "Contract operator",
+        grantedTo: [commercial, finance],
+        grants: [can.view([Account]), can.apply(reboot)],
+      })
+    ).toEqual({
+      kind: "role",
+      id: "contract.operator",
+      label: "Contract operator",
+      grantedToGroupIds: ["commercial", "finance"],
+      grants: [
+        { kind: "grant", capability: "view", selection: { all: false, ids: ["account"] } },
+        { kind: "grant", capability: "apply", selection: { all: false, ids: ["reboot"] } },
+      ],
+    })
+  })
+
+  test("can.view dedupes ids within an explicit selection", () => {
+    expect(can.view([Account, Account])).toEqual({
+      kind: "grant",
+      capability: "view",
+      selection: { all: false, ids: ["account"] },
+    })
+  })
+
+  test("scopes select the whole universe, with optional exclusions", () => {
+    expect(can.view(ontology.objects()).selection).toEqual({ all: true, except: [] })
+    expect(can.view(ontology.objects().except([Account])).selection).toEqual({
+      all: true,
+      except: ["account"],
+    })
+  })
+
+  test("defineRole rejects roles granted to no groups", () => {
+    expect(() => defineRole("empty", { grantedTo: [], grants: [can.view(Account)] })).toThrow(
+      SecurityValidationError
+    )
+  })
+
+  test("defineRole rejects roles with no grants", () => {
+    expect(() => defineRole("empty", { grantedTo: [commercial], grants: [] })).toThrow(
+      SecurityValidationError
+    )
+  })
+
+  test("defineRole rejects grant items that are not grants", () => {
+    expect(() =>
+      defineRole("invalid", {
+        grantedTo: [commercial],
+        grants: [{ kind: "group", id: "commercial" } as unknown as GroupDefinition & never],
+      })
+    ).toThrow("must contain only grant definitions from 'can'")
+  })
+
+  test("runtime registration rejects duplicate role ids", () => {
+    const role = defineRole("contract.operator", {
+      grantedTo: [commercial],
+      grants: [can.view(Account)],
+    })
+
+    expect(() => createRuntime({ groups: [commercial], roles: [role, role] })).toThrow(
+      "Duplicate role id"
+    )
+  })
+
+  test("runtime registration rejects roles referencing unknown groups", () => {
+    const role = defineRole("contract.operator", {
+      grantedTo: [commercial],
+      grants: [can.view(Account)],
+    })
+
+    expect(() => createRuntime({ roles: [role] })).toThrow("unknown group 'commercial'")
+  })
+
+  test("runtime registration rejects view grants on unknown object types", () => {
+    const role: RoleDefinition = {
+      kind: "role",
+      id: "contract.operator",
+      grantedToGroupIds: ["commercial"],
+      grants: [{ kind: "grant", capability: "view", selection: { all: false, ids: ["missing"] } }],
+    }
+
+    expect(() => createRuntime({ groups: [commercial], roles: [role] })).toThrow(
+      "unknown object type 'missing'"
+    )
+  })
+
+  test("runtime registration rejects apply grants on unknown actions", () => {
+    const role: RoleDefinition = {
+      kind: "role",
+      id: "contract.operator",
+      grantedToGroupIds: ["commercial"],
+      grants: [{ kind: "grant", capability: "apply", selection: { all: false, ids: ["missing"] } }],
+    }
+
+    expect(() => createRuntime({ groups: [commercial], roles: [role] })).toThrow(
+      "unknown action 'missing'"
+    )
+  })
+
+  test("valid roles register and resolve from the security registry", () => {
+    const role = defineRole("contract.operator", {
+      grantedTo: [commercial],
+      grants: [can.view(Account), can.apply(reboot)],
+    })
+
+    const sixb = createRuntime({
+      groups: [commercial],
+      roles: [role],
+      actions: [reboot],
+    })
+
+    expect(sixb.security.getRoleDefinitions()).toEqual([role])
+    expect(sixb.security.getRoleById("contract.operator")).toEqual(role)
+    expect(sixb.security.getRoleById("missing")).toBeNull()
+  })
+
+  test("createSixb discovers roles from security/roles", async () => {
+    const projectRoot = await createTempProjectRoot()
+
+    await writeProjectFile(
+      projectRoot,
+      "ontology/account.ts",
+      `import { defineObjectType, prop } from "${coreModuleUrl}"
+
+export const Account = defineObjectType({
+  id: "account",
+  name: "Account",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+`
+    )
+
+    await writeProjectFile(
+      projectRoot,
+      "actions/reboot.ts",
+      `import { defineAction } from "${coreModuleUrl}"
+
+export const reboot = defineAction("reboot")
+  .params({})
+  .edits(() => {})
+`
+    )
+
+    await writeProjectFile(
+      projectRoot,
+      "security/groups/team.ts",
+      `import { defineGroup } from "${coreModuleUrl}"
+
+export const commercial = defineGroup("commercial")
+`
+    )
+
+    await writeProjectFile(
+      projectRoot,
+      "security/roles/contract-operator.ts",
+      `import { can, defineRole } from "${coreModuleUrl}"
+import { reboot } from "../../actions/reboot"
+import { Account } from "../../ontology/account"
+import { commercial } from "../groups/team"
+
+export const contractOperator = defineRole("contract.operator", {
+  grantedTo: [commercial],
+  grants: [can.view(Account), can.apply(reboot)],
+})
+`
+    )
+
+    const sixb = await createSixb({
+      projectRoot,
+      ...createTestRuntimeDeps(),
+    })
+
+    expect(sixb.security.getRoleById("contract.operator")).toEqual({
+      kind: "role",
+      id: "contract.operator",
+      grantedToGroupIds: ["commercial"],
+      grants: [
+        { kind: "grant", capability: "view", selection: { all: false, ids: ["account"] } },
+        { kind: "grant", capability: "apply", selection: { all: false, ids: ["reboot"] } },
+      ],
+    })
   })
 })
 
@@ -264,7 +465,9 @@ async function createTempProjectRoot(): Promise<string> {
 function createRuntime(
   options: {
     groups?: readonly GroupDefinition[]
+    roles?: readonly RoleDefinition[]
     invitePolicies?: readonly InvitePolicyDefinition[]
+    actions?: readonly ActionDefinition[]
   } = {}
 ): Sixb<readonly [typeof Account]> {
   return new Sixb<readonly [typeof Account]>({

--- a/packages/server/src/auth/guard.ts
+++ b/packages/server/src/auth/guard.ts
@@ -19,6 +19,17 @@ export interface ServerAuthGuardOptions {
   readonly resolveAuthContext: ResolveRequestAuthContext
 }
 
+/**
+ * Per-request authentication decision.
+ *
+ * `deny` carries the short-circuit response. `allow` carries the resolved
+ * session so downstream handlers can use it without resolving it again
+ * (null when auth is disabled or the route is public).
+ */
+export type ServerAuthGuardDecision =
+  | { readonly kind: "deny"; readonly response: Response }
+  | { readonly kind: "allow"; readonly session: AuthSessionResult | null }
+
 export class ServerAuthGuard {
   private readonly sixb: Sixb<readonly OntologySource[]>
   private readonly resolveAuthContext: ResolveRequestAuthContext
@@ -36,19 +47,19 @@ export class ServerAuthGuard {
     this.sixb.auth.assertCanServeHttp(params)
   }
 
-  async handle(request: Request): Promise<Response | undefined> {
+  async resolve(request: Request): Promise<ServerAuthGuardDecision> {
     if (!this.isAuthEnabled()) {
-      return undefined
+      return { kind: "allow", session: null }
     }
 
     const route = classifyRoute(request)
     if (route.kind === "public") {
-      return undefined
+      return { kind: "allow", session: null }
     }
 
     const authContext = this.tryResolveAuthContext(request)
     if (authContext instanceof Response) {
-      return authContext
+      return { kind: "deny", response: authContext }
     }
 
     const session = await this.sixb.auth.getSession(request, {
@@ -56,29 +67,27 @@ export class ServerAuthGuard {
     })
     if (!session.authenticated) {
       if (route.kind === "html") {
-        return htmlAuthRedirectResponse(request, {
-          absoluteReturnTo: authContext.absoluteReturnTo ?? false,
-          audience: authContext.audience,
-        })
+        return {
+          kind: "deny",
+          response: htmlAuthRedirectResponse(request, {
+            absoluteReturnTo: authContext.absoluteReturnTo ?? false,
+            audience: authContext.audience,
+          }),
+        }
       }
 
       if (route.kind === "websocket") {
-        return websocketAuthFailedResponse()
+        return { kind: "deny", response: websocketAuthFailedResponse() }
       }
 
-      return jsonAuthRequiredResponse()
+      return { kind: "deny", response: jsonAuthRequiredResponse() }
     }
 
     if (route.csrfProtected && !this.verifyCsrf(request, session)) {
-      return jsonCsrfFailedResponse()
+      return { kind: "deny", response: jsonCsrfFailedResponse() }
     }
 
-    return undefined
-  }
-
-  async getSession(request: Request): Promise<AuthSessionResult> {
-    const authContext = this.resolveAuthContext(request)
-    return this.sixb.auth.getSession(request, { audience: authContext.audience })
+    return { kind: "allow", session }
   }
 
   getCsrfCookieName(request: Request): string {

--- a/packages/server/src/auth/scope.ts
+++ b/packages/server/src/auth/scope.ts
@@ -6,6 +6,24 @@ import type { AuthorizationContext, OntologySource, ScopedSixb } from "@sixb/cor
  * Both fields are null when auth is disabled or the route is public — those
  * requests run against the privileged runtime, preserving authenticated-only
  * behavior for surfaces that are not grant-enforced yet.
+ *
+ * SECURITY — privileged is the silent default. The core runtime treats a
+ * missing authorization context as fully privileged (workers, syncs, tests
+ * need that). A scoped principal therefore gains no protection unless the route
+ * actively routes through `scoped`. Concretely:
+ *
+ *   - A grant-enforced read/list/query/action/workflow handler MUST use
+ *     `scoped` (falling back to the raw `sixb` only when `scoped` is null).
+ *     Using the raw `sixb` on a path an authenticated principal can reach is a
+ *     silent god-mode bypass — it will not fail to compile or to run.
+ *   - Surfaces with no grant family yet (object/link/telemetry writes,
+ *     datasets, syncs, pipelines, projections, workflow run history, auth
+ *     admin) stay authenticated-only by design and use the raw `sixb`
+ *     deliberately, not by omission. Add such a route consciously, and lock it
+ *     down when its grant family lands.
+ *
+ * This implicit default is a known V1 trade-off (kept for runtime ergonomics);
+ * if it proves error-prone, make privileged access explicit at this boundary.
  */
 export interface RequestAuthState {
   readonly authz: AuthorizationContext | null

--- a/packages/server/src/auth/scope.ts
+++ b/packages/server/src/auth/scope.ts
@@ -1,0 +1,25 @@
+import type { AuthorizationContext, OntologySource, ScopedSixb } from "@sixb/core"
+
+/**
+ * Per-request authorization state attached by the server's auth derive.
+ *
+ * Both fields are null when auth is disabled or the route is public — those
+ * requests run against the privileged runtime, preserving authenticated-only
+ * behavior for surfaces that are not grant-enforced yet.
+ */
+export interface RequestAuthState {
+  readonly authz: AuthorizationContext | null
+  readonly scoped: ScopedSixb<readonly OntologySource[]> | null
+}
+
+/**
+ * Read the derived auth state from a route handler's context.
+ *
+ * Route registrars type `app` as plain `Elysia`, so the derived properties are
+ * not visible to handler signatures; this helper is the single typed access
+ * point until route registration carries the derived context type.
+ */
+export function requestAuthState(context: unknown): RequestAuthState {
+  const { authz = null, scoped = null } = context as Partial<RequestAuthState>
+  return { authz, scoped }
+}

--- a/packages/server/src/routes/actions.ts
+++ b/packages/server/src/routes/actions.ts
@@ -1,5 +1,6 @@
 import type { ActionDefinition, OntologySource, Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import {
   ActionCatalogItemSchema,
@@ -60,8 +61,10 @@ export function registerActionRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
   return app
     .get(
       "/api/actions",
-      async () => {
-        return sixb.getActionDefinitions().map(serializeAction)
+      async (context) => {
+        const { scoped } = requestAuthState(context)
+        const actions = scoped ? scoped.listActions() : sixb.getActionDefinitions()
+        return actions.map(serializeAction)
       },
       {
         response: { 200: ActionCatalogItemSchema.array() },
@@ -74,8 +77,12 @@ export function registerActionRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
     )
     .get(
       "/api/actions/:actionId",
-      async ({ params, set }) => {
-        const action = sixb.getActionById(params.actionId)
+      async (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
+        const action = scoped
+          ? scoped.getActionById(params.actionId)
+          : sixb.getActionById(params.actionId)
         if (!action) {
           set.status = 404
           return { error: "Action not found" }
@@ -95,15 +102,20 @@ export function registerActionRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
     )
     .post(
       "/api/actions/:actionId",
-      async ({ params, body, set }) => {
+      async (context) => {
+        const { params, body, set } = context
+        const { scoped } = requestAuthState(context)
         try {
           const parsedBody = RequestActionBodySchema.parse(body)
-          const result = await sixb.actions.request({
+          const input = {
             actionId: params.actionId,
             subject: parsedBody.subject,
             params: parsedBody.params,
             runId: parsedBody.runId,
-          })
+          }
+          const result = scoped
+            ? await scoped.requestAction(input)
+            : await sixb.actions.request(input)
 
           set.status = 202
           return RequestActionResponseSchema.parse(result)
@@ -117,6 +129,7 @@ export function registerActionRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
         response: {
           202: RequestActionResponseSchema,
           400: ErrorResponseSchema,
+          403: ErrorResponseSchema,
           404: ErrorResponseSchema,
         },
         detail: {

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1,5 +1,6 @@
-import type { OntologySource, Sixb } from "@sixb/core"
+import { AuthorizationError, type OntologySource, type Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { ErrorResponseSchema } from "../schemas/common"
 import { EventsQuerySchema, EventsResponseSchema } from "../schemas/events"
 import { parseOptionalInt } from "../utils/http"
@@ -7,28 +8,41 @@ import { parseOptionalInt } from "../utils/http"
 export function registerEventRoutes(app: Elysia, sixb: Sixb<readonly OntologySource[]>) {
   return app.get(
     "/api/events",
-    async ({ query, set }) => {
+    async (context) => {
+      const { query, set } = context
+      const { scoped } = requestAuthState(context)
+
       try {
         const parsed = EventsQuerySchema.parse(query)
-        const events = await sixb.events.read({
+        const input = {
           topics: parsed.topic ? [parsed.topic] : undefined,
           types: parsed.type ? [parsed.type] : undefined,
           afterCursor: parsed.afterCursor,
           limit: parseOptionalInt(parsed.limit),
-        })
+        }
+        const events = scoped ? await scoped.readEvents(input) : await sixb.events.read(input)
 
         return {
           count: events.length,
           events: [...events],
         }
       } catch (error) {
+        if (error instanceof AuthorizationError) {
+          set.status = 403
+          return { error: error.message }
+        }
+
         set.status = 400
         return { error: error instanceof Error ? error.message : String(error) }
       }
     },
     {
       query: EventsQuerySchema,
-      response: { 200: EventsResponseSchema, 400: ErrorResponseSchema },
+      response: {
+        200: EventsResponseSchema,
+        400: ErrorResponseSchema,
+        403: ErrorResponseSchema,
+      },
       detail: {
         summary: "Read domain events",
         tags: ["Events"],

--- a/packages/server/src/routes/objects.ts
+++ b/packages/server/src/routes/objects.ts
@@ -1,4 +1,5 @@
 import {
+  AuthorizationError,
   countObjects,
   executeObjectQuery,
   existsObjects,
@@ -12,6 +13,7 @@ import {
 } from "@sixb/core"
 import type { Elysia } from "elysia"
 import { ZodError } from "zod"
+import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
@@ -54,6 +56,11 @@ function serializePlan(plan: Awaited<ReturnType<typeof executeObjectQuery>>["pla
 }
 
 function handleObjectQueryError(error: unknown, set: { status?: number | string }) {
+  if (error instanceof AuthorizationError) {
+    set.status = 403
+    return { error: error.message }
+  }
+
   if (error instanceof ZodError) {
     set.status = 400
     return {
@@ -102,14 +109,33 @@ function formatZodIssuePath(path: readonly (string | number)[]): string {
   }, "$")
 }
 
+async function getObjectRow(
+  sixb: Sixb<readonly OntologySource[]>,
+  scoped: ReturnType<typeof requestAuthState>["scoped"],
+  params: { objectTypeId: string; objectId: string }
+) {
+  if (scoped) {
+    return scoped.getObject(params.objectTypeId, params.objectId)
+  }
+
+  return sixb.storage.objects.getByPrimaryId({
+    projectId: sixb.id,
+    objectTypeId: params.objectTypeId,
+    primaryId: params.objectId,
+  })
+}
+
 export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySource[]>) {
   return app
     .get(
       "/api/objects",
-      async ({ query, set }) => {
+      async (context) => {
+        const { query, set } = context
+        const { scoped } = requestAuthState(context)
+
         try {
           const parsed = ObjectsQuerySchema.parse(query)
-          const result = await sixb.list({
+          const params = {
             objectTypeIds: parsed.objectTypeId ? [parsed.objectTypeId] : undefined,
             idPrefix: parsed.idPrefix,
             idSuffix: parsed.idSuffix,
@@ -121,7 +147,8 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
             offset: parseOptionalInt(parsed.offset),
             orderBy: parsed.orderBy,
             order: parsed.order,
-          })
+          }
+          const result = scoped ? await scoped.list(params) : await sixb.list(params)
 
           return {
             objects: result.objects.map(serializeObject),
@@ -129,13 +156,22 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
             total: result.total,
           }
         } catch (error) {
+          if (error instanceof AuthorizationError) {
+            set.status = 403
+            return { error: error.message }
+          }
+
           set.status = 400
           return { error: error instanceof Error ? error.message : String(error) }
         }
       },
       {
         query: ObjectsQuerySchema,
-        response: { 200: ObjectListResponseSchema, 400: ErrorResponseSchema },
+        response: {
+          200: ObjectListResponseSchema,
+          400: ErrorResponseSchema,
+          403: ErrorResponseSchema,
+        },
         detail: {
           summary: "List objects",
           tags: ["Objects"],
@@ -145,7 +181,8 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
     )
     .post(
       "/api/objects/query",
-      async ({ body, set }) => {
+      async (context) => {
+        const { body, set } = context
         try {
           const parsed = ObjectQueryRequestSchema.parse(body) as {
             query: ObjectQuery
@@ -160,6 +197,7 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
             {
               ontology: sixb.ontology,
               storage: sixb.storage.objects,
+              authorization: requestAuthState(context).authz ?? undefined,
             }
           )
 
@@ -205,6 +243,14 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
                 },
               },
             },
+            403: {
+              description: "Response for status 403",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
             500: {
               description: "Response for status 500",
               content: {
@@ -219,7 +265,8 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
     )
     .post(
       "/api/objects/query/count",
-      async ({ body, set }) => {
+      async (context) => {
+        const { body, set } = context
         try {
           const parsed = ObjectQueryCountRequestSchema.parse(body) as {
             query: ObjectQuery
@@ -232,6 +279,7 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
             {
               ontology: sixb.ontology,
               storage: sixb.storage.objects,
+              authorization: requestAuthState(context).authz ?? undefined,
             }
           )
 
@@ -274,6 +322,14 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
                 },
               },
             },
+            403: {
+              description: "Response for status 403",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
             500: {
               description: "Response for status 500",
               content: {
@@ -288,7 +344,8 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
     )
     .post(
       "/api/objects/query/exists",
-      async ({ body, set }) => {
+      async (context) => {
+        const { body, set } = context
         try {
           const parsed = ObjectQueryExistsRequestSchema.parse(body) as {
             query: ObjectQuery
@@ -301,6 +358,7 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
             {
               ontology: sixb.ontology,
               storage: sixb.storage.objects,
+              authorization: requestAuthState(context).authz ?? undefined,
             }
           )
 
@@ -343,6 +401,14 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
                 },
               },
             },
+            403: {
+              description: "Response for status 403",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
             500: {
               description: "Response for status 500",
               content: {
@@ -357,7 +423,8 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
     )
     .post(
       "/api/objects/query/facets",
-      async ({ body, set }) => {
+      async (context) => {
+        const { body, set } = context
         try {
           const parsed = ObjectQueryFacetsRequestSchema.parse(body) as {
             query: ObjectQuery
@@ -372,6 +439,7 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
             {
               ontology: sixb.ontology,
               storage: sixb.storage.objects,
+              authorization: requestAuthState(context).authz ?? undefined,
             }
           )
 
@@ -414,6 +482,14 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
                 },
               },
             },
+            403: {
+              description: "Response for status 403",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
             500: {
               description: "Response for status 500",
               content: {
@@ -428,19 +504,27 @@ export function registerObjectRoutes(app: Elysia, sixb: Sixb<readonly OntologySo
     )
     .get(
       "/api/objects/:objectTypeId/:objectId",
-      async ({ params, set }) => {
-        const row = await sixb.storage.objects.getByPrimaryId({
-          projectId: sixb.id,
-          objectTypeId: params.objectTypeId,
-          primaryId: params.objectId,
-        })
+      async (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
 
-        if (!row) {
-          set.status = 404
-          return { error: "Object not found" }
+        try {
+          const row = await getObjectRow(sixb, scoped, params)
+          if (!row) {
+            set.status = 404
+            return { error: "Object not found" }
+          }
+
+          return serializeObject(row)
+        } catch (error) {
+          // Identity reads hide existence: forbidden and missing look the same.
+          if (error instanceof AuthorizationError) {
+            set.status = 404
+            return { error: "Object not found" }
+          }
+
+          throw error
         }
-
-        return serializeObject(row)
       },
       {
         params: ObjectParamsSchema,

--- a/packages/server/src/routes/ontology.ts
+++ b/packages/server/src/routes/ontology.ts
@@ -1,5 +1,6 @@
-import type { OntologySource, Sixb } from "@sixb/core"
+import { type AuthorizationContext, isAllowed, type OntologySource, type Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { ErrorResponseSchema } from "../schemas/common"
 import { ObjectTypeParamsSchema, ObjectTypeSchema } from "../schemas/ontology"
 
@@ -41,7 +42,8 @@ function serializeSearch(
 
 function serializeObjectType(
   sixb: Sixb<readonly OntologySource[]>,
-  objectType: ReturnType<Sixb<readonly OntologySource[]>["listObjectTypes"]>[number]
+  objectType: ReturnType<Sixb<readonly OntologySource[]>["listObjectTypes"]>[number],
+  authorization: AuthorizationContext | null
 ) {
   return {
     id: objectType.id,
@@ -61,19 +63,22 @@ function serializeObjectType(
       cardinality: link.cardinality,
       properties: link.properties?.map(serializeProperty),
     })),
-    actions: sixb.getActionsForType(objectType).map((action) => ({
-      id: action.id,
-      name: action.id,
-      description: action.description,
-      params: Object.entries(action.params).map(([id, config]) => ({
-        id,
-        name: id,
-        schema: config.schema,
-        required: config.required ?? false,
-        description: config.description,
-        semanticType: config.semanticType,
+    actions: sixb
+      .getActionsForType(objectType)
+      .filter((action) => isAllowed(authorization, { kind: "action.apply", actionId: action.id }))
+      .map((action) => ({
+        id: action.id,
+        name: action.id,
+        description: action.description,
+        params: Object.entries(action.params).map(([id, config]) => ({
+          id,
+          name: id,
+          schema: config.schema,
+          required: config.required ?? false,
+          description: config.description,
+          semanticType: config.semanticType,
+        })),
       })),
-    })),
   }
 }
 
@@ -81,8 +86,14 @@ export function registerOntologyRoutes(app: Elysia, sixb: Sixb<readonly Ontology
   return app
     .get(
       "/api/object-types",
-      async () => {
-        return sixb.listObjectTypes().map((objectType) => serializeObjectType(sixb, objectType))
+      async (context) => {
+        const { authz } = requestAuthState(context)
+        return sixb
+          .listObjectTypes()
+          .filter((objectType) =>
+            isAllowed(authz, { kind: "object.view", objectTypeId: objectType.id })
+          )
+          .map((objectType) => serializeObjectType(sixb, objectType, authz))
       },
       {
         response: { 200: ObjectTypeSchema.array() },
@@ -95,14 +106,19 @@ export function registerOntologyRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/object-types/:objectTypeId",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { authz } = requestAuthState(context)
         const objectType = sixb.getObjectTypeById(params.objectTypeId)
-        if (!objectType) {
+        if (
+          !objectType ||
+          !isAllowed(authz, { kind: "object.view", objectTypeId: objectType.id })
+        ) {
           set.status = 404
           return { error: "Object type not found" }
         }
 
-        return serializeObjectType(sixb, objectType)
+        return serializeObjectType(sixb, objectType, authz)
       },
       {
         params: ObjectTypeParamsSchema,

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -286,8 +286,9 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
   return app
     .get(
       "/api/workflows",
-      async () => {
-        const workflows = sixb.workflows.list()
+      async (context) => {
+        const { scoped } = requestAuthState(context)
+        const workflows = scoped ? scoped.listWorkflows() : sixb.workflows.list()
         const latestRuns = await getLatestWorkflowRuns(
           sixb,
           workflows.map((workflow) => workflow.id)
@@ -308,8 +309,14 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/workflows/:workflowId",
-      async ({ params, set }) => {
-        const workflow = sixb.workflows.getById(params.workflowId)
+      async (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
+        // Non-runnable workflows are hidden as 404 (existence-hiding), matching
+        // the object/action read routes.
+        const workflow = scoped
+          ? scoped.getWorkflowById(params.workflowId)
+          : sixb.workflows.getById(params.workflowId)
         if (!workflow) {
           set.status = 404
           return { error: "Workflow not found" }

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -9,6 +9,7 @@ import type {
 } from "@sixb/core"
 import { snapshotWorkflowInterventionResponse } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
@@ -691,7 +692,9 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .post(
       "/api/workflows/:workflowId/runs",
-      async ({ params, body, set }) => {
+      async (context) => {
+        const { params, body, set } = context
+        const { scoped } = requestAuthState(context)
         try {
           const workflow = sixb.workflows.getById(params.workflowId)
           if (!workflow) {
@@ -705,11 +708,14 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
           }
 
           const parsedBody = RequestWorkflowRunBodySchema.parse(body)
-          const result = await sixb.workflows.requestById({
+          const input = {
             workflowId: workflow.id,
             input: parsedBody.input ?? {},
-            source: { type: "manual" },
-          })
+            source: { type: "manual" } as const,
+          }
+          const result = scoped
+            ? await scoped.runWorkflow(input)
+            : await sixb.workflows.requestById(input)
 
           set.status = 202
           return RequestWorkflowRunResponseSchema.parse({
@@ -728,6 +734,7 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
         response: {
           202: RequestWorkflowRunResponseSchema,
           400: ErrorResponseSchema,
+          403: ErrorResponseSchema,
           404: ErrorResponseSchema,
         },
         detail: {

--- a/packages/server/src/routes/ws.ts
+++ b/packages/server/src/routes/ws.ts
@@ -1,4 +1,4 @@
-import type { DomainEvent } from "@sixb/core"
+import { type AuthorizationContext, canViewEvent, type DomainEvent } from "@sixb/core"
 import type { Elysia } from "elysia"
 import { z } from "zod"
 import { EVENT_TOPICS, EVENT_TYPES } from "../schemas/events"
@@ -90,6 +90,8 @@ export function registerWsRoutes(app: Elysia, server: SixbServer) {
       return
     }
 
+    const authz = wsAuthz(ws)
+
     const tick = async () => {
       if (state.polling) {
         return
@@ -105,8 +107,13 @@ export function registerWsRoutes(app: Elysia, server: SixbServer) {
           types: state.types,
         })
 
+        // Each event payload may carry object data, so visibility is derived
+        // per-event from the principal's grants (see `canViewEvent`). The cursor
+        // advances over every event read, not just the ones sent.
         for (const event of events) {
-          safeSend(ws, { type: "event", event })
+          if (canViewEvent(authz, event)) {
+            safeSend(ws, { type: "event", event })
+          }
         }
 
         const last = events[events.length - 1]
@@ -130,6 +137,8 @@ export function registerWsRoutes(app: Elysia, server: SixbServer) {
 
   return app.ws("/ws/events", {
     async open(ws) {
+      // Any authenticated principal may connect; events are filtered per-event
+      // by grants as they stream (see the poll loop in `startPolling`).
       const state = createDefaultState()
       state.afterCursor = await resolveLatestCursor(server)
       states.set(wsStateKey(ws), state)
@@ -183,4 +192,10 @@ export function registerWsRoutes(app: Elysia, server: SixbServer) {
 function wsStateKey(ws: object): object {
   const raw = (ws as { raw?: unknown }).raw
   return raw && typeof raw === "object" ? raw : ws
+}
+
+/** Read the authorization context the auth derive attached to the upgrade request. */
+function wsAuthz(ws: object): AuthorizationContext | null {
+  const data = (ws as { data?: { authz?: AuthorizationContext | null } }).data
+  return data?.authz ?? null
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -150,7 +150,20 @@ export function createSixbApi(server: SixbServer) {
     })
   )
 
-  app.onBeforeHandle(({ request }) => guard.handle(request))
+  // Resolve the session once per request and attach the principal's scoped SDK.
+  // The beforeHandle enforces the auth decision before any route runs; `scoped`
+  // and `authz` stay null for public routes and disabled auth (privileged mode).
+  app
+    .derive(async ({ request }) => {
+      const auth = await guard.resolve(request)
+      if (auth.kind === "deny" || !auth.session?.authenticated) {
+        return { auth, authz: null, scoped: null }
+      }
+
+      const authz = sixb.auth.contextFromSession(auth.session)
+      return { auth, authz, scoped: sixb.as(authz) }
+    })
+    .onBeforeHandle(({ auth }) => (auth.kind === "deny" ? auth.response : undefined))
 
   app.use(
     openapi({

--- a/packages/server/src/utils/http.ts
+++ b/packages/server/src/utils/http.ts
@@ -1,3 +1,5 @@
+import { AuthorizationError } from "@sixb/core"
+
 export function toIsoString(value: Date): string {
   return value.toISOString()
 }
@@ -34,6 +36,11 @@ export function handleRouteError(
 ): {
   error: string
 } {
+  if (error instanceof AuthorizationError) {
+    set.status = 403
+    return { error: error.message }
+  }
+
   const message = error instanceof Error ? error.message : String(error)
   set.status = message.includes("not found") || message.includes("Unknown") ? 404 : 400
   return { error: message }

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -1,0 +1,472 @@
+import { describe, expect, test } from "bun:test"
+import { createServer } from "node:net"
+import {
+  actions,
+  can,
+  createSessionCredential,
+  defineAction,
+  defineGroup,
+  defineObjectType,
+  defineRole,
+  defineWorkflow,
+  defineWorkflowStep,
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  InMemoryStorage,
+  type OntologySource,
+  ontology,
+  prop,
+  ref,
+  Sixb,
+  type WorkflowDefinition,
+  workflows,
+} from "@sixb/core"
+import { createSixbApi, SixbServer } from "../src/server"
+import { createTestBrowserPolicy } from "./helpers"
+
+const Contract = defineObjectType({
+  id: "contract",
+  name: "Contract",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const Invoice = defineObjectType({
+  id: "invoice",
+  name: "Invoice",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const sendContract = defineAction("send-contract")
+  .on(Contract)
+  .params({})
+  .edits(() => {})
+
+const reviewContract = defineWorkflowStep("review-contract")
+  .input({ contract: ref(Contract) })
+  .output({ contract: ref(Contract) })
+  .run(async () => ({ contract: { objectTypeId: "contract", primaryId: "c1" } }))
+
+// Widened to the base type so the registered array avoids the deep chain type.
+const renewContract: WorkflowDefinition = defineWorkflow("renew-contract")
+  .input({ contract: ref(Contract) })
+  .then(reviewContract)
+
+const commercial = defineGroup("commercial")
+const operations = defineGroup("operations")
+const admins = defineGroup("admins")
+
+const contractOperator = defineRole("contract.operator", {
+  grantedTo: [commercial],
+  grants: [can.view(Contract), can.apply(sendContract)],
+})
+
+const operationsRunner = defineRole("operations.runner", {
+  grantedTo: [operations],
+  grants: [can.start(renewContract)],
+})
+
+const adminOperator = defineRole("admin.operator", {
+  grantedTo: [admins],
+  grants: [can.view(ontology.objects()), can.apply(actions()), can.start(workflows())],
+})
+
+async function createRuntime(options: { readonly auth?: boolean } = {}) {
+  const storage = new InMemoryStorage()
+  const sixb = new Sixb<readonly OntologySource[]>({
+    id: "test-project",
+    ontology: [Contract, Invoice],
+    broker: new InMemoryBroker(),
+    storage,
+    lakeStorage: new InMemoryLakeStorage(),
+    blobStorage: new InMemoryBlobStorage(),
+    queues: new InMemoryQueues(),
+    actions: [sendContract],
+    workflows: [renewContract],
+    groups: [commercial, operations, admins],
+    roles: [contractOperator, operationsRunner, adminOperator],
+    auth: options.auth === false ? undefined : { id: "test", kind: "dev" as const },
+  })
+
+  await sixb.upsertObject("contract", { id: "c1" })
+  await sixb.upsertObject("invoice", { id: "i1" })
+
+  return { sixb, storage }
+}
+
+async function createApp(options: { readonly auth?: boolean } = {}) {
+  const { sixb, storage } = await createRuntime(options)
+  const app = createSixbApi(
+    new SixbServer({ sixb, quiet: true, browser: createTestBrowserPolicy() })
+  )
+
+  return { app, storage }
+}
+
+async function seedSession(
+  storage: InMemoryStorage,
+  groupIds: readonly string[],
+  userId = "usr_1"
+) {
+  const credential = createSessionCredential(`ses_${userId}`)
+  await storage.auth.users.create({
+    id: userId,
+    projectId: "test-project",
+    email: `${userId}@acme.com`,
+  })
+  for (const groupId of groupIds) {
+    await storage.auth.groupMemberships.upsert({
+      projectId: "test-project",
+      userId,
+      groupId,
+      source: "manual",
+    })
+  }
+  await storage.auth.sessions.create({
+    id: credential.sessionId,
+    projectId: "test-project",
+    userId,
+    strategyId: "test",
+    audience: "atlas",
+    tokenHash: credential.tokenHash,
+    createdAt: new Date("2026-05-16T10:00:00.000Z"),
+    expiresAt: new Date("2099-05-16T10:00:00.000Z"),
+  })
+
+  return {
+    headers: { cookie: `sixb_session=${credential.cookieValue}` },
+    csrfHeaders: {
+      cookie: `sixb_session=${credential.cookieValue}; sixb_csrf=csrf_1`,
+      "x-sixb-csrf": "csrf_1",
+      "content-type": "application/json",
+    },
+  }
+}
+
+describe("authorized object routes", () => {
+  test("object type metadata narrows to viewable types", async () => {
+    const { app, storage } = await createApp()
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+
+    const operatorList = await app.fetch(
+      new Request("http://localhost/api/object-types", { headers: operator.headers })
+    )
+    const operatorBody = (await operatorList.json()) as {
+      id: string
+      actions: { id: string }[]
+    }[]
+
+    expect(operatorList.status).toBe(200)
+    expect(operatorBody.map((objectType) => objectType.id)).toEqual(["contract"])
+    expect(operatorBody[0].actions.map((action) => action.id)).toEqual(["send-contract"])
+
+    const hidden = await app.fetch(
+      new Request("http://localhost/api/object-types/invoice", { headers: operator.headers })
+    )
+    expect(hidden.status).toBe(404)
+
+    const runnerList = await app.fetch(
+      new Request("http://localhost/api/object-types", { headers: runner.headers })
+    )
+    expect(await runnerList.json()).toEqual([])
+  })
+
+  test("wildcard object and action grants expose all object metadata", async () => {
+    const { app, storage } = await createApp()
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    const response = await app.fetch(
+      new Request("http://localhost/api/object-types", { headers: admin.headers })
+    )
+    const body = (await response.json()) as {
+      id: string
+      actions: { id: string }[]
+    }[]
+
+    expect(response.status).toBe(200)
+    expect(body.map((objectType) => objectType.id)).toEqual(["contract", "invoice"])
+    expect(body.find((objectType) => objectType.id === "contract")?.actions).toEqual([
+      expect.objectContaining({ id: "send-contract" }),
+    ])
+  })
+
+  test("broad listings narrow to the principal's viewable types", async () => {
+    const { app, storage } = await createApp()
+    const session = await seedSession(storage, ["commercial"])
+
+    const response = await app.fetch(
+      new Request("http://localhost/api/objects", { headers: session.headers })
+    )
+    const body = (await response.json()) as { objects: { objectTypeId: string }[] }
+
+    expect(response.status).toBe(200)
+    expect(body.objects.map((row) => row.objectTypeId)).toEqual(["contract"])
+  })
+
+  test("explicitly requesting a forbidden type returns 403", async () => {
+    const { app, storage } = await createApp()
+    const session = await seedSession(storage, ["commercial"])
+
+    const response = await app.fetch(
+      new Request("http://localhost/api/objects?objectTypeId=invoice", {
+        headers: session.headers,
+      })
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  test("principals with no grants list nothing", async () => {
+    const { app, storage } = await createApp()
+    const session = await seedSession(storage, [])
+
+    const response = await app.fetch(
+      new Request("http://localhost/api/objects", { headers: session.headers })
+    )
+    const body = (await response.json()) as { objects: unknown[]; total: number }
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ objects: [], hasMore: false, total: 0 })
+  })
+
+  test("identity reads return 404 for both forbidden and missing objects", async () => {
+    const { app, storage } = await createApp()
+    const session = await seedSession(storage, ["commercial"])
+
+    const allowed = await app.fetch(
+      new Request("http://localhost/api/objects/contract/c1", { headers: session.headers })
+    )
+    expect(allowed.status).toBe(200)
+
+    const forbidden = await app.fetch(
+      new Request("http://localhost/api/objects/invoice/i1", { headers: session.headers })
+    )
+    expect(forbidden.status).toBe(404)
+    expect(await forbidden.json()).toEqual({ error: "Object not found" })
+
+    const missing = await app.fetch(
+      new Request("http://localhost/api/objects/contract/missing", { headers: session.headers })
+    )
+    expect(missing.status).toBe(404)
+    expect(await missing.json()).toEqual({ error: "Object not found" })
+  })
+
+  test("object queries deny forbidden touched types with 403", async () => {
+    const { app, storage } = await createApp()
+    const session = await seedSession(storage, ["commercial"])
+
+    const denied = await app.fetch(
+      new Request("http://localhost/api/objects/query", {
+        method: "POST",
+        headers: session.csrfHeaders,
+        body: JSON.stringify({ query: { kind: "start", objectTypeId: "invoice" } }),
+      })
+    )
+    expect(denied.status).toBe(403)
+
+    const allowed = await app.fetch(
+      new Request("http://localhost/api/objects/query", {
+        method: "POST",
+        headers: session.csrfHeaders,
+        body: JSON.stringify({
+          query: {
+            kind: "limit",
+            input: { kind: "start", objectTypeId: "contract" },
+            limit: 10,
+          },
+        }),
+      })
+    )
+    expect(allowed.status).toBe(200)
+    const body = (await allowed.json()) as { objects: { primaryId: string }[] }
+    expect(body.objects.map((row) => row.primaryId)).toEqual(["c1"])
+  })
+
+  test("disabled auth keeps object routes privileged", async () => {
+    const { app } = await createApp({ auth: false })
+
+    const response = await app.fetch(new Request("http://localhost/api/objects"))
+    const body = (await response.json()) as { objects: { objectTypeId: string }[] }
+
+    expect(response.status).toBe(200)
+    expect(new Set(body.objects.map((row) => row.objectTypeId))).toEqual(
+      new Set(["contract", "invoice"])
+    )
+  })
+})
+
+describe("authorized action routes", () => {
+  test("action metadata narrows to applicable actions", async () => {
+    const { app, storage } = await createApp()
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+
+    const operatorList = await app.fetch(
+      new Request("http://localhost/api/actions", { headers: operator.headers })
+    )
+    expect(((await operatorList.json()) as { id: string }[]).map((a) => a.id)).toEqual([
+      "send-contract",
+    ])
+
+    const runnerList = await app.fetch(
+      new Request("http://localhost/api/actions", { headers: runner.headers })
+    )
+    expect(await runnerList.json()).toEqual([])
+
+    const hidden = await app.fetch(
+      new Request("http://localhost/api/actions/send-contract", { headers: runner.headers })
+    )
+    expect(hidden.status).toBe(404)
+  })
+
+  test("action requests require can.apply", async () => {
+    const { app, storage } = await createApp()
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const body = JSON.stringify({
+      subject: { kind: "object", objectTypeId: "contract", primaryId: "c1" },
+    })
+
+    const allowed = await app.fetch(
+      new Request("http://localhost/api/actions/send-contract", {
+        method: "POST",
+        headers: operator.csrfHeaders,
+        body,
+      })
+    )
+    // Action requests enqueue asynchronously, so the route returns 202 Accepted.
+    expect(allowed.status).toBe(202)
+
+    const denied = await app.fetch(
+      new Request("http://localhost/api/actions/send-contract", {
+        method: "POST",
+        headers: runner.csrfHeaders,
+        body,
+      })
+    )
+    expect(denied.status).toBe(403)
+  })
+})
+
+describe("authorized event and workflow routes", () => {
+  test("event reads return only the events the principal may see", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+
+    // The operator can view Contract, so contract events are visible.
+    const operatorEvents = await app.fetch(
+      new Request("http://localhost/api/events", { headers: operator.headers })
+    )
+    expect(operatorEvents.status).toBe(200)
+    const operatorBody = (await operatorEvents.json()) as { events: { type: string }[] }
+    expect(operatorBody.events.map((event) => event.type)).toContain("object.upserted")
+
+    // The runner has no object grants, so object events are filtered out.
+    const runnerEvents = await app.fetch(
+      new Request("http://localhost/api/events", { headers: runner.headers })
+    )
+    expect(runnerEvents.status).toBe(200)
+    const runnerBody = (await runnerEvents.json()) as { events: { type: string }[] }
+    expect(runnerBody.events.filter((event) => event.type === "object.upserted")).toEqual([])
+  })
+
+  test("workflow runs require can.start", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const body = JSON.stringify({
+      input: { contract: { objectTypeId: "contract", primaryId: "c1" } },
+    })
+
+    const allowed = await app.fetch(
+      new Request("http://localhost/api/workflows/renew-contract/runs", {
+        method: "POST",
+        headers: runner.csrfHeaders,
+        body,
+      })
+    )
+    expect(allowed.status).toBe(202)
+
+    const denied = await app.fetch(
+      new Request("http://localhost/api/workflows/renew-contract/runs", {
+        method: "POST",
+        headers: operator.csrfHeaders,
+        body,
+      })
+    )
+    expect(denied.status).toBe(403)
+  })
+})
+
+describe("authorized event websocket", () => {
+  test("any authenticated principal may connect; events are filtered as they stream", async () => {
+    const port = await getFreePort()
+    const baseUrl = `http://127.0.0.1:${port}`
+    const { sixb, storage } = await createRuntime()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const server = new SixbServer({
+      sixb,
+      host: "127.0.0.1",
+      port,
+      quiet: true,
+      browser: createTestBrowserPolicy({ apiOrigin: baseUrl, atlasOrigin: baseUrl }),
+    })
+
+    await server.start()
+    try {
+      const wsUrl = `${baseUrl.replace("http://", "ws://")}/ws/events`
+
+      // No connection-level events grant: both principals connect, and the
+      // stream is filtered per-event by their grants during polling.
+      const runnerWs = new WebSocket(wsUrl, { headers: runner.headers })
+      expect(await nextWsMessage(runnerWs)).toEqual({ type: "connected", channel: "events" })
+      runnerWs.close()
+
+      const operatorWs = new WebSocket(wsUrl, { headers: operator.headers })
+      expect(await nextWsMessage(operatorWs)).toEqual({ type: "connected", channel: "events" })
+      operatorWs.close()
+    } finally {
+      await server.stop()
+    }
+  })
+})
+
+function nextWsMessage(ws: WebSocket): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    ws.addEventListener(
+      "message",
+      (event) => resolve(JSON.parse(String((event as MessageEvent).data))),
+      { once: true }
+    )
+    ws.addEventListener("error", () => reject(new Error("WebSocket errored")), { once: true })
+    ws.addEventListener("close", () => reject(new Error("WebSocket closed before a message")), {
+      once: true,
+    })
+  })
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise<number>((resolvePromise, reject) => {
+    const server = createServer() as ReturnType<typeof createServer> & {
+      on(event: string, listener: (error: Error) => void): void
+    }
+    server.on("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        reject(new Error("Could not resolve an open port"))
+        return
+      }
+
+      const { port } = address
+      server.close((error) => {
+        if (error) reject(error)
+        else resolvePromise(port)
+      })
+    })
+  })
+}

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -64,12 +64,12 @@ const contractOperator = defineRole("contract.operator", {
 
 const operationsRunner = defineRole("operations.runner", {
   grantedTo: [operations],
-  grants: [can.start(renewContract)],
+  grants: [can.run(renewContract)],
 })
 
 const adminOperator = defineRole("admin.operator", {
   grantedTo: [admins],
-  grants: [can.view(ontology.objects()), can.apply(actions()), can.start(workflows())],
+  grants: [can.view(ontology.objects()), can.apply(actions()), can.run(workflows())],
 })
 
 async function createRuntime(options: { readonly auth?: boolean } = {}) {
@@ -373,7 +373,33 @@ describe("authorized event and workflow routes", () => {
     expect(runnerBody.events.filter((event) => event.type === "object.upserted")).toEqual([])
   })
 
-  test("workflow runs require can.start", async () => {
+  test("workflow catalog narrows to runnable workflows and hides the rest as 404", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+
+    // The runner can run renew-contract, so it appears in the catalog.
+    const runnerList = await app.fetch(
+      new Request("http://localhost/api/workflows", { headers: runner.headers })
+    )
+    expect(((await runnerList.json()) as { id: string }[]).map((w) => w.id)).toEqual([
+      "renew-contract",
+    ])
+
+    // The operator holds no run grant, so the catalog is empty and the detail
+    // route hides the workflow as 404 (existence-hiding, never 403).
+    const operatorList = await app.fetch(
+      new Request("http://localhost/api/workflows", { headers: operator.headers })
+    )
+    expect(await operatorList.json()).toEqual([])
+
+    const hidden = await app.fetch(
+      new Request("http://localhost/api/workflows/renew-contract", { headers: operator.headers })
+    )
+    expect(hidden.status).toBe(404)
+  })
+
+  test("workflow runs require can.run", async () => {
     const { app, storage } = await createApp()
     const runner = await seedSession(storage, ["operations"], "usr_run")
     const operator = await seedSession(storage, ["commercial"], "usr_op")


### PR DESCRIPTION
## Review ask

This is a draft PR and I would really like another set of eyes on the direction here.

Apologies for the size of the change. I can break this up later if that is the right move, but at this point it feels more useful to get feedback on whether the overall authorization shape is on the right track before splitting it into smaller mechanical pieces.

The main questions I would like feedback on:

- Is `sixb.as(context)` returning a small scoped SDK surface the right core boundary?
- Are groups -> roles -> grants the right base model for v1?
- Is the grant vocabulary expressive enough without becoming too magical?
- Are the enforced surfaces the right first slice?
- Does the auth example make the intended DX clear enough?

## Summary

Adds the first framework-level authorization layer on top of the existing authentication system.

The current auth system gives us authenticated users, sessions, invitations, and group membership. This PR adds the first authorization kernel: declarative groups, roles, grants, per-request authorization context resolution, and a scoped runtime returned by `sixb.as(context)` that only exposes operations we can enforce end to end.

This is intentionally not a full policy/marking/object-instance authorization system yet. The goal here is the base layer that lets the framework answer: who can see which object types, who can apply which actions, who can run which workflows, and who can read events.

## Authorization model

### Layer 1: groups

Groups are named membership buckets. Auth strategies and invitations can place users into groups.

```ts
export const teamMembers = defineGroup("team-members")
export const securityAdmins = defineGroup("security-admins")
```

### Layer 2: roles

Roles are assigned to groups. A principal receives a role when one of their session group ids matches the role's `grantedTo` groups.

```ts
export const teamMemberAccess = defineRole("team-member.atlas-access", {
  grantedTo: [teamMembers],
  grants: [
    can.view(Note),
    can.apply(acknowledgeNote),
  ],
})
```

### Layer 3: grants

Grants are plain data. They are validated at startup, deduped by stable key, and resolved into fast per-request decision indexes.

Concrete grants:

```ts
can.view(Note)
can.apply(acknowledgeNote)
can.run(runAccessReview)
can.viewEvents()
```

Wildcard grants:

```ts
can.viewAllObjects()
can.applyAllActions()
can.runAllWorkflows()
can.viewEvents()
```

The auth example uses wildcard grants for the admin role:

```ts
export const securityAdminFullAccess = defineRole("security-admin.full-access", {
  grantedTo: [securityAdmins],
  grants: [
    can.viewAllObjects(),
    can.applyAllActions(),
    can.runAllWorkflows(),
    can.viewEvents(),
  ],
})
```

### Layer 4: authorization context

For each authenticated request, the server derives an authorization context once:

```ts
const authz = sixb.auth.contextFromSession(auth.session)
const scoped = sixb.as(authz)
```

The context stores:

- principal
- session id
- group ids
- matched role ids
- viewable object type ids
- applicable action ids
- runnable workflow ids
- wildcard grant booleans
- event-stream access boolean

Concrete `can.view(ObjectType)` grants are expanded to include subtypes during context resolution, so hot-path checks stay simple set lookups.

### Layer 5: scoped SDK

`sixb.as(context)` returns `ScopedSixb`, not another full `Sixb` implementation. This is meant to be a thin, allowlisted runtime surface over the same underlying core services.

The scoped surface currently exposes only operations with grant semantics that are enforced end to end:

```ts
scoped.list(...)
scoped.getObject(...)
scoped.objects(Note).list()
scoped.objects(Note).query().list()
scoped.requestAction(...)
scoped.runWorkflow(...)
scoped.readEvents(...)
```

It intentionally does not expose privileged surfaces like raw storage, auth runtime, writes, links, telemetry writes, providers, or registry mutation.

## Enforced surfaces in this PR

### Objects

- Broad object listings are narrowed to viewable object types.
- Explicit forbidden object type filters return `403`.
- Object identity reads hide forbidden objects as `404` to avoid existence leaks.
- Typed object sets (`sixb.as(ctx).objects(Type)`) enforce `can.view(Type)`.
- Object query, count, exists, and facets enforce view access for every object type touched by the query.
- Scoped object writes, links, telemetry writes, and link mutation fail closed because we do not have write/link grants yet.

### Ontology metadata

- `/api/object-types` only returns object types visible to the principal.
- `/api/object-types/:id` returns `404` for forbidden object types.
- Object type action metadata only includes actions that the principal can apply and, for object-bound actions, whose object type the principal can view.

This matters for Atlas because it prevents the UI from discovering hidden object types and avoids launching forbidden preview/count queries for those types.

### Actions

- `/api/actions` is narrowed to applicable actions.
- `/api/actions/:id` hides ungranted actions as `404`.
- Requesting an action requires `can.apply(action)`.
- Object-bound action requests also require `can.view(subjectObjectType)`.
- Action metadata follows the same rule: apply is not enough to discover an action bound to a hidden object type.

### Workflows

- Starting a workflow requires `can.run(workflow)` or `can.runAllWorkflows()`.
- Existing workflow metadata/history routes are not fully authorization-modeled yet. See out-of-scope section below.

### Events

- Reading `/api/events` requires `can.viewEvents()`.
- The event websocket requires `can.viewEvents()`.

Events are intentionally coarse for now because the stream can contain object payloads that bypass object-level read checks.

### Server request integration

The server now derives auth state once per request and exposes:

```ts
{ auth, authz, scoped }
```

Routes that have enforceable grant semantics use `scoped` rather than manually duplicating auth checks.

## Auth example

The auth example now works as a small authorization smoke test instead of only proving sign-in.

It defines:

- `Note`: visible to team members and admins
- `AdminNote`: visible to admins only
- `AccessRequest`: visible to admins only
- `acknowledge-note`: action team members can apply
- `resolve-access-request`: admin action
- `run-access-review`: admin workflow

It seeds one object of each type so Atlas is testable immediately after startup.

Expected behavior:

- team member sees only `Note`
- team member can apply `acknowledge-note`
- team member cannot see `AdminNote` or `AccessRequest`
- team member cannot apply admin actions, run admin workflows, or read events
- security admin can view all auth example objects, apply all actions, run all workflows, and read events through wildcard grants

## Generated client

OpenAPI/client generated artifacts were regenerated because several API routes now document `403` responses for authorization failures.

## What this version intentionally does not include

This PR does not implement every authorization case in the framework. The following are intentionally out of scope for this first layer:

- object instance policies / row-level object security
- property-level security, markings, or PII redaction
- `can.write(...)` or write grants
- link read/write grants
- telemetry read/write grants
- dataset grants
- sync grants
- connector grants
- pipeline grants
- projection grants
- rule grants
- webhook/webhook-run grants
- workflow run history visibility grants
- intervention review/submit authorization grants
- auth admin grants such as managing users, sessions, groups, or invitations
- a global `can.admin()` bypass

Some server routes for those resource families still behave as authenticated application surfaces rather than fully grant-scoped authorization surfaces. The scoped SDK fails closed for unsupported privileged operations, but full route coverage should be follow-up work with explicit grant semantics instead of implicit admin behavior.

## Why this shape

The goal is to keep the core SDK simple and safe:

- `Sixb` remains the privileged runtime for workers, syncs, server internals, setup, tests, and seed code.
- `sixb.as(context)` gives request handlers and app code a principal-scoped SDK.
- Enforcement lives in shared core services and leaf operations, not only in HTTP route wrappers.
- `ScopedSixb` is intentionally a small allowlist facade, not a second full `Sixb` implementation.
- Unsupported scoped operations fail closed until they have real grants.

This should let us add future grant families without changing the top-level programming model.

## Validation

Ran:

```bash
bun run generate:client
bun run typecheck
bun run build
bun run test
bun run check
git diff --check
```

Results:

- full typecheck passed
- full build passed
- full test suite passed: `1339 pass, 0 fail`
- Biome check passed
- generated client artifacts are up to date

## Follow-up recommendation

If the direction looks right, I would split follow-up work by grant family rather than trying to add every resource type here:

1. workflow run/intervention visibility and mutation grants
2. dataset/sync/pipeline/projection grants
3. write/link/telemetry grants
4. auth admin grants
5. object instance and property-level policy system

Again, apologies for the size of this one. I am opening it as draft because I mainly want feedback on whether the architecture and DX are right before polishing or splitting further.
