### PR TITLE
app: fix custom app hot reload crash

### DIFF
--- a/packages/app/src/codegen.ts
+++ b/packages/app/src/codegen.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, writeFile } from "node:fs/promises"
+import { access, mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, relative, resolve } from "node:path"
 import { renderCustomAppRuntimeScript } from "./runtime"
 import type { PageRoute } from "./scanner"
@@ -34,7 +34,7 @@ ${entries}
 `
 
   const outPath = join(generatedDir, "routes.ts")
-  await writeFile(outPath, content, "utf-8")
+  await writeFileIfChanged(outPath, content)
   return outPath
 }
 
@@ -236,7 +236,7 @@ if (canRenderApp) {
 `
 
   const mainPath = join(generatedDir, "main.tsx")
-  await writeFile(mainPath, mainContent, "utf-8")
+  await writeFileIfChanged(mainPath, mainContent)
 
   // Generate index.html with only structural reset rules. Apps own visual
   // styling through app/globals.css.
@@ -270,9 +270,31 @@ if (canRenderApp) {
 `
 
   const htmlPath = join(generatedDir, "index.html")
-  await writeFile(htmlPath, htmlContent, "utf-8")
+  await writeFileIfChanged(htmlPath, htmlContent)
 
   return { htmlPath, mainPath }
+}
+
+async function writeFileIfChanged(path: string, content: string): Promise<void> {
+  try {
+    if ((await readFile(path, "utf-8")) === content) {
+      return
+    }
+  } catch (error) {
+    if (!isFileNotFoundError(error)) {
+      throw error
+    }
+  }
+
+  await writeFile(path, content, "utf-8")
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as Error & { readonly code?: unknown }).code === "ENOENT"
+  )
 }
 
 function relativeTo(from: string, to: string): string {

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -23,6 +23,14 @@ async function getFreePort(): Promise<number> {
       })
     })
   })
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms))
+}
+
+async function mtimes(paths: readonly string[]): Promise<readonly number[]> {
+  return await Promise.all(paths.map(async (path) => (await stat(path)).mtimeMs))
 }
 
 describe("createCustomApp.start", () => {
@@ -249,6 +257,28 @@ describe("createCustomApp.dev", () => {
     expect(manifest).toContain('{ path: "/", component: Page0 },')
     expect(manifest).toContain('{ path: "/devices/:id", component: Page1 },')
     expect(manifest).not.toContain("lazy(")
+  })
+
+  test("leaves generated entry files untouched when content is unchanged", async () => {
+    const generatedDir = join(tempRoot, ".sixb", "generated")
+    const routes = [
+      {
+        path: "/",
+        filePath: join(tempRoot, "app", "page.tsx"),
+        relativePath: "page.tsx",
+      },
+    ]
+
+    const manifestPath = await generateRouteManifest(routes, generatedDir)
+    const { htmlPath, mainPath } = await generateAppEntry(tempRoot, generatedDir)
+    const files = [manifestPath, mainPath, htmlPath]
+    const before = await mtimes(files)
+
+    await wait(25)
+    await generateRouteManifest(routes, generatedDir)
+    await generateAppEntry(tempRoot, generatedDir)
+
+    expect(await mtimes(files)).toEqual(before)
   })
 
   test("generated entry intercepts internal anchors conservatively", async () => {


### PR DESCRIPTION
## Summary

- Avoid rewriting generated custom app entry files when their content is unchanged.
- Prevent Bun dev HMR from treating every app save as a root-entry update cascade.
- Add a regression test that locks generated entry mtimes for unchanged output.

## Root cause

Custom app dev rebuilds regenerated `routes.ts`, `main.tsx`, and `index.html` on every `.ts`, `.tsx`, or `.css` save. Even when the generated content was identical, the file mtimes changed, so Bun's HTML bundle watcher saw artificial updates to root entry modules. Under repeated edits, that intermittently tripped Bun's browser runtime with `Failed to load bundled module './main.tsx'`.

## Validation

- `bun test packages/app/tests/createCustomApp.test.ts`
- `bun --filter @sixb/app typecheck`
- `bun --filter @sixb/app build`
- `bun run check`
- Reproduced the browser error with repeated custom app edits before the fix, then reran the same Chrome/CDP stress repro after the fix with no bundled-module errors.


closes #73 