### PR TITLE
atlas: add object query builder

### DIFF
--- a/packages/atlas/src/components/objects/ObjectFilterPopover.tsx
+++ b/packages/atlas/src/components/objects/ObjectFilterPopover.tsx
@@ -1,0 +1,315 @@
+import type { ObjectQueryFacetResult } from "@sixb/client"
+import {
+  Button,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import { Check, Plus } from "lucide-react"
+import { useEffect, useState } from "react"
+import { formatCount, formatValue } from "../../lib/formatValue"
+import {
+  arrayItemSchema,
+  createFilterId,
+  enumValues,
+  filterHasValue,
+  getOperatorsForProperty,
+  getPropertyLabel,
+  getQuickFilterValues,
+  isBooleanSchema,
+  isDateSchema,
+  isNumberSchema,
+  operatorLabels,
+  operatorRequiresValue,
+  parseValueForSchema,
+  type QueryFilter,
+  type QueryFilterOperator,
+  type QueryProperty,
+  schemaType,
+} from "../../lib/objects/objectQuery"
+
+export function ObjectFilterPopover({
+  properties,
+  filters,
+  facetResults,
+  label = "Filter",
+  prominent = false,
+  onAddFilter,
+}: {
+  properties: QueryProperty[]
+  filters: QueryFilter[]
+  facetResults: ObjectQueryFacetResult[]
+  label?: string
+  prominent?: boolean
+  onAddFilter: (filter: QueryFilter) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [propertyId, setPropertyId] = useState(properties[0]?.id ?? "")
+  const selectedProperty = properties.find((property) => property.id === propertyId)
+  const operatorOptions = selectedProperty ? getOperatorsForProperty(selectedProperty) : []
+  const [operator, setOperator] = useState<QueryFilterOperator>(operatorOptions[0] ?? "eq")
+  const [rawValue, setRawValue] = useState("")
+
+  useEffect(() => {
+    if (properties.length === 0) {
+      setPropertyId("")
+      return
+    }
+    if (!properties.some((property) => property.id === propertyId)) {
+      const nextProperty = properties[0]
+      setPropertyId(nextProperty.id)
+      setOperator(getOperatorsForProperty(nextProperty)[0] ?? "eq")
+      setRawValue("")
+    }
+  }, [properties, propertyId])
+
+  useEffect(() => {
+    if (operatorOptions.length === 0) return
+    if (!operatorOptions.includes(operator)) {
+      setOperator(operatorOptions[0])
+      setRawValue("")
+    }
+  }, [operator, operatorOptions])
+
+  const requiresValue = operatorRequiresValue(operator)
+  const valueSchema =
+    selectedProperty && operator === "contains" && schemaType(selectedProperty.schema) === "array"
+      ? arrayItemSchema(selectedProperty.schema)
+      : selectedProperty?.schema
+  const parsedValue = requiresValue
+    ? parseValueForSchema(valueSchema, rawValue)
+    : ({ ok: true, value: undefined } as const)
+  const quickValues = selectedProperty
+    ? getQuickFilterValues(selectedProperty, valueSchema, facetResults).filter(
+        (option) => !filterHasValue(filters, selectedProperty.id, option.value)
+      )
+    : []
+  const quickValuesOnly = Boolean(
+    valueSchema &&
+      (enumValues(valueSchema) || isBooleanSchema(valueSchema)) &&
+      quickValues.length > 0
+  )
+  const canAdd = Boolean(
+    selectedProperty && (!requiresValue || (rawValue.trim().length > 0 && parsedValue.ok))
+  )
+
+  const addFilter = (input?: { value: unknown }) => {
+    if (!selectedProperty) return
+    const resolvedValue = input ? input.value : parsedValue.ok ? parsedValue.value : undefined
+    if (operatorRequiresValue(operator) && !input && !canAdd) return
+    if (operatorRequiresValue(operator) && !input && !parsedValue.ok) return
+    onAddFilter({
+      id: createFilterId(),
+      propertyId: selectedProperty.id,
+      operator,
+      ...(operatorRequiresValue(operator) ? { value: resolvedValue } : {}),
+    })
+    setRawValue("")
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant={prominent ? "default" : "outline"}
+          size="sm"
+          className="h-10 rounded-xl"
+          disabled={properties.length === 0}
+        >
+          <Plus />
+          {label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 space-y-3">
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">Create filter</p>
+          <p className="text-xs text-muted-foreground">Choose a field, condition, and value.</p>
+        </div>
+
+        <div className="grid gap-2">
+          <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Field
+          </p>
+          <div className="max-h-44 space-y-1 overflow-y-auto rounded-lg bg-muted/45 p-1">
+            {properties.map((property) => {
+              const selected = property.id === propertyId
+              return (
+                <button
+                  key={property.id}
+                  type="button"
+                  className={cn(
+                    "flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
+                    selected
+                      ? "bg-foreground text-background shadow-sm"
+                      : "text-muted-foreground hover:bg-background/70 hover:text-foreground"
+                  )}
+                  onClick={() => {
+                    setPropertyId(property.id)
+                    setOperator(getOperatorsForProperty(property)[0] ?? "eq")
+                    setRawValue("")
+                  }}
+                >
+                  <span className="min-w-0 truncate">{getPropertyLabel(property)}</span>
+                  <span className="flex shrink-0 items-center gap-2">
+                    <span
+                      className={cn(
+                        "font-mono text-[10px]",
+                        selected ? "text-background/70" : "text-muted-foreground"
+                      )}
+                    >
+                      {property.id}
+                    </span>
+                    {selected ? <Check className="size-3.5" /> : null}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+
+          <p className="mt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Condition
+          </p>
+          <Select
+            value={operator}
+            onValueChange={(value) => {
+              setOperator(value as QueryFilterOperator)
+              setRawValue("")
+            }}
+          >
+            <SelectTrigger size="sm" aria-label="Filter operator">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {operatorOptions.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {operatorLabels[option]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {requiresValue ? (
+            <>
+              <p className="mt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Value
+              </p>
+              {quickValues.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {quickValues.map((option) => (
+                    <button
+                      key={String(option.value)}
+                      type="button"
+                      className="inline-flex h-8 items-center gap-1.5 rounded-full bg-muted px-3 text-sm text-foreground transition-colors hover:bg-foreground hover:text-background"
+                      onClick={() => addFilter({ value: option.value })}
+                    >
+                      <span>{option.label}</span>
+                      {typeof option.count === "number" ? (
+                        <span className="tabular-nums opacity-65">{formatCount(option.count)}</span>
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+              {!quickValuesOnly ? (
+                <FilterValueInput
+                  schema={valueSchema}
+                  value={rawValue}
+                  onValueChange={setRawValue}
+                  onSubmit={() => addFilter()}
+                />
+              ) : null}
+            </>
+          ) : (
+            <div className="mt-1 rounded-lg bg-muted/60 px-3 py-2 text-xs text-muted-foreground">
+              This operator does not need a value.
+            </div>
+          )}
+
+          {requiresValue && !parsedValue.ok && rawValue.trim().length > 0 ? (
+            <p className="text-xs text-destructive">{parsedValue.error}</p>
+          ) : null}
+        </div>
+
+        {!quickValuesOnly ? (
+          <Button
+            type="button"
+            size="sm"
+            className="w-full"
+            disabled={!canAdd}
+            onClick={() => addFilter()}
+          >
+            Apply filter
+          </Button>
+        ) : (
+          <p className="text-center text-xs text-muted-foreground">Choose a value to apply.</p>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function FilterValueInput({
+  schema,
+  value,
+  onValueChange,
+  onSubmit,
+}: {
+  schema: unknown
+  value: string
+  onValueChange: (value: string) => void
+  onSubmit: () => void
+}) {
+  const values = enumValues(schema)
+  if (values) {
+    return (
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger size="sm" aria-label="Filter value">
+          <SelectValue placeholder="Value" />
+        </SelectTrigger>
+        <SelectContent>
+          {values.map((option) => (
+            <SelectItem key={String(option)} value={String(option)}>
+              {formatValue(option)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  if (isBooleanSchema(schema)) {
+    return (
+      <Select value={value} onValueChange={onValueChange}>
+        <SelectTrigger size="sm" aria-label="Filter value">
+          <SelectValue placeholder="Value" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="true">True</SelectItem>
+          <SelectItem value="false">False</SelectItem>
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  return (
+    <Input
+      type={isNumberSchema(schema) ? "number" : "text"}
+      value={value}
+      autoFocus
+      onChange={(event) => onValueChange(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") onSubmit()
+      }}
+      placeholder={isDateSchema(schema) ? "2026-12-31" : "Value"}
+    />
+  )
+}

--- a/packages/atlas/src/components/objects/ObjectQueryBar.tsx
+++ b/packages/atlas/src/components/objects/ObjectQueryBar.tsx
@@ -1,0 +1,318 @@
+import type { ObjectQueryFacetResult } from "@sixb/client"
+import { Alert, AlertDescription, Badge, Button, Input } from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import { AlertCircle, Search, X } from "lucide-react"
+import { formatCount, formatValue } from "../../lib/formatValue"
+import { humanizeIdentifier } from "../../lib/labels"
+import {
+  type AtlasObjectType,
+  createFilterId,
+  describeFilter,
+  filterHasValue,
+  getObjectQueryError,
+  getPropertyLabel,
+  type QueryFilter,
+  type QueryMatchMode,
+  type QueryProperty,
+} from "../../lib/objects/objectQuery"
+import { ObjectFilterPopover } from "./ObjectFilterPopover"
+
+export function ObjectQueryBar({
+  objectType,
+  searchQuery,
+  textSearchEnabled,
+  filters,
+  matchMode,
+  filterableProperties,
+  propertiesById,
+  facetResults,
+  facetsLoading,
+  queryError,
+  onSearchQueryChange,
+  onAddFilter,
+  onRemoveFilter,
+  onClear,
+  onMatchModeChange,
+}: {
+  objectType: AtlasObjectType
+  searchQuery: string
+  textSearchEnabled: boolean
+  filters: QueryFilter[]
+  matchMode: QueryMatchMode
+  filterableProperties: QueryProperty[]
+  propertiesById: ReadonlyMap<string, QueryProperty>
+  facetResults: ObjectQueryFacetResult[]
+  facetsLoading: boolean
+  queryError: unknown
+  onSearchQueryChange: (value: string) => void
+  onAddFilter: (filter: QueryFilter) => void
+  onRemoveFilter: (filterId: string) => void
+  onClear: () => void
+  onMatchModeChange: (mode: QueryMatchMode) => void
+}) {
+  const active = searchQuery.trim().length > 0 || filters.length > 0
+  const objectTypeLabel = humanizeIdentifier(objectType.name || objectType.id)
+  const addFilterLabel = textSearchEnabled || active ? "Filter" : `Filter ${objectTypeLabel}`
+
+  return (
+    <div className="mt-3 space-y-3">
+      {textSearchEnabled ? (
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <div className="relative min-w-0 flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="text"
+              value={searchQuery}
+              onChange={(event) => onSearchQueryChange(event.target.value)}
+              placeholder={`Search ${objectTypeLabel}...`}
+              className="h-10 rounded-xl bg-card pl-9 shadow-none"
+            />
+          </div>
+          <QueryToolbarActions
+            active={active}
+            filters={filters}
+            facetResults={facetResults}
+            filterLabel={addFilterLabel}
+            filterableProperties={filterableProperties}
+            onAddFilter={onAddFilter}
+            onClear={onClear}
+          />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2 rounded-xl bg-muted/35 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0 space-y-0.5">
+            <p className="text-sm font-medium text-foreground">Filter {objectTypeLabel}</p>
+            <p className="text-xs text-muted-foreground">
+              Text search is not configured for this type. Use fields to narrow the set.
+            </p>
+          </div>
+          <QueryToolbarActions
+            active={active}
+            filters={filters}
+            facetResults={facetResults}
+            filterLabel={addFilterLabel}
+            filterableProperties={filterableProperties}
+            prominent={!active}
+            onAddFilter={onAddFilter}
+            onClear={onClear}
+          />
+        </div>
+      )}
+
+      {filters.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="mr-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Where
+          </span>
+          {filters.length > 1 ? (
+            <div className="mr-1 inline-flex h-7 rounded-full bg-muted p-0.5 text-[11px]">
+              <button
+                type="button"
+                className={cn(
+                  "rounded-full px-2 transition-colors",
+                  matchMode === "all"
+                    ? "bg-foreground text-background"
+                    : "bg-background text-muted-foreground hover:bg-muted"
+                )}
+                onClick={() => onMatchModeChange("all")}
+              >
+                Match all
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  "rounded-full px-2 transition-colors",
+                  matchMode === "any"
+                    ? "bg-foreground text-background"
+                    : "bg-background text-muted-foreground hover:bg-muted"
+                )}
+                onClick={() => onMatchModeChange("any")}
+              >
+                Match any
+              </button>
+            </div>
+          ) : null}
+
+          {filters.map((filter) => (
+            <Badge key={filter.id} variant="secondary" className="gap-1 rounded-full px-2.5 py-1">
+              <span>{describeFilter(filter, propertiesById)}</span>
+              <button
+                type="button"
+                aria-label={`Remove ${describeFilter(filter, propertiesById)}`}
+                className="rounded-full text-muted-foreground hover:text-foreground"
+                onClick={() => onRemoveFilter(filter.id)}
+              >
+                <X className="size-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+
+      <FacetSuggestions
+        filters={filters}
+        propertiesById={propertiesById}
+        facetResults={facetResults}
+        loading={facetsLoading}
+        onAddFilter={onAddFilter}
+      />
+
+      <ObjectQueryErrorAlert error={queryError} />
+    </div>
+  )
+}
+
+function QueryToolbarActions({
+  active,
+  filters,
+  facetResults,
+  filterLabel,
+  filterableProperties,
+  prominent = false,
+  onAddFilter,
+  onClear,
+}: {
+  active: boolean
+  filters: QueryFilter[]
+  facetResults: ObjectQueryFacetResult[]
+  filterLabel: string
+  filterableProperties: QueryProperty[]
+  prominent?: boolean
+  onAddFilter: (filter: QueryFilter) => void
+  onClear: () => void
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      <ObjectFilterPopover
+        properties={filterableProperties}
+        filters={filters}
+        facetResults={facetResults}
+        label={filterLabel}
+        prominent={prominent}
+        onAddFilter={onAddFilter}
+      />
+      {active ? (
+        <Button type="button" variant="ghost" size="sm" className="h-10 px-2.5" onClick={onClear}>
+          <X />
+          Clear
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+function FacetSuggestions({
+  filters,
+  propertiesById,
+  facetResults,
+  loading,
+  onAddFilter,
+}: {
+  filters: QueryFilter[]
+  propertiesById: ReadonlyMap<string, QueryProperty>
+  facetResults: ObjectQueryFacetResult[]
+  loading: boolean
+  onAddFilter: (filter: QueryFilter) => void
+}) {
+  const suggestions = facetResults
+    .flatMap((facet) => {
+      const property = propertiesById.get(facet.propertyId)
+      if (!property) return []
+      return facet.buckets
+        .filter((bucket) => !filterHasValue(filters, property.id, bucket.value))
+        .slice(0, 4)
+        .map((bucket) => ({ property, bucket }))
+    })
+    .slice(0, 8)
+
+  if (loading && suggestions.length === 0) {
+    return <p className="px-1 text-xs text-muted-foreground">Loading facet suggestions...</p>
+  }
+
+  if (suggestions.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 pt-1">
+      <span className="mr-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        Try
+      </span>
+      {suggestions.map(({ property, bucket }) => {
+        return (
+          <button
+            key={`${property.id}:${formatValue(bucket.value)}`}
+            type="button"
+            className={cn(
+              "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-xs shadow-xs transition-colors",
+              "border-border bg-card text-foreground hover:border-muted-foreground/40 hover:bg-muted",
+              "dark:bg-muted/45 dark:hover:bg-muted"
+            )}
+            onClick={() =>
+              onAddFilter({
+                id: createFilterId(),
+                propertyId: property.id,
+                operator: "eq",
+                value: bucket.value,
+              })
+            }
+          >
+            <span>
+              {getPropertyLabel(property)}: {formatValue(bucket.value)}
+            </span>
+            <span className="tabular-nums text-muted-foreground">{formatCount(bucket.count)}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function ObjectQueryErrorAlert({ error }: { error: unknown }) {
+  if (!error) return null
+  const queryError = getObjectQueryError(error)
+  const [firstIssue] = queryError.issues
+
+  return (
+    <Alert variant="destructive" className="mt-2">
+      <AlertCircle />
+      <AlertDescription>
+        <p>{queryError.message}</p>
+        {firstIssue ? (
+          <p className="font-mono text-[11px]">
+            {firstIssue.path}: {firstIssue.message}
+          </p>
+        ) : null}
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+export function ObjectsQueryPagination({
+  loadedCount,
+  total,
+  hasMore,
+  loadingMore,
+  onLoadMore,
+}: {
+  loadedCount: number
+  total: number
+  hasMore: boolean
+  loadingMore: boolean
+  onLoadMore: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-3 border-t border-border pt-3 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-xs tabular-nums text-muted-foreground">
+        Showing {formatCount(loadedCount)} of {formatCount(total)}
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={!hasMore || loadingMore}
+        onClick={onLoadMore}
+      >
+        {loadingMore ? "Loading..." : hasMore ? "Load more" : "All results loaded"}
+      </Button>
+    </div>
+  )
+}

--- a/packages/atlas/src/index.css
+++ b/packages/atlas/src/index.css
@@ -19,7 +19,7 @@ html,
 body {
   height: 100%;
   overflow: hidden;
-  overscroll-behavior: none;
+  overscroll-behavior-y: none;
   background-color: var(--background);
 }
 
@@ -31,12 +31,14 @@ body {
   height: 100%;
 }
 
-button, a {
+button,
+a {
   transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease,
     transform 0.15s ease;
 }
 
-button:focus-visible, a:focus-visible {
+button:focus-visible,
+a:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 2px;
 }

--- a/packages/atlas/src/lib/formatValue.ts
+++ b/packages/atlas/src/lib/formatValue.ts
@@ -28,3 +28,7 @@ export function formatValue(value: unknown, depth = 0): string {
 
   return String(value)
 }
+
+export function formatCount(value: number): string {
+  return value.toLocaleString()
+}

--- a/packages/atlas/src/lib/objects/objectQuery.ts
+++ b/packages/atlas/src/lib/objects/objectQuery.ts
@@ -1,0 +1,380 @@
+import {
+  facetObjects,
+  type ListObjectTypesResponse,
+  type ObjectQuery,
+  type ObjectQueryFacetResult,
+  type ObjectQueryIssue,
+  type ObjectQueryPlanSummary,
+  type ObjectQueryPredicate,
+  type ObjectSummary,
+  queryObjects,
+  toObjectSummary,
+} from "@sixb/client"
+import { formatValue } from "../formatValue"
+import { humanizeIdentifier } from "../labels"
+
+export type AtlasObjectType = ListObjectTypesResponse[number]
+type QueryMetadata = NonNullable<AtlasObjectType["properties"][number]["query"]>
+export type QueryProperty = AtlasObjectType["properties"][number] & { query?: QueryMetadata }
+
+export type QueryFilterOperator =
+  | "eq"
+  | "neq"
+  | "lt"
+  | "lte"
+  | "gt"
+  | "gte"
+  | "contains"
+  | "exists"
+  | "missing"
+
+export type QueryMatchMode = "all" | "any"
+
+export interface QueryFilter {
+  id: string
+  propertyId: string
+  operator: QueryFilterOperator
+  value?: unknown
+}
+
+export interface QuerySort {
+  propertyId: string
+  direction: "asc" | "desc"
+}
+
+export interface AtlasObjectQueryPage {
+  objects: ObjectSummary[]
+  hasMore: boolean
+  nextPageToken?: string
+  total?: number
+  plan: ObjectQueryPlanSummary
+}
+
+export interface QuickFilterValue {
+  value: unknown
+  label: string
+  count?: number
+}
+
+export const operatorLabels: Record<QueryFilterOperator, string> = {
+  eq: "is",
+  neq: "is not",
+  lt: "<",
+  lte: "<=",
+  gt: ">",
+  gte: ">=",
+  contains: "contains",
+  exists: "exists",
+  missing: "is missing",
+}
+
+export class AtlasObjectQueryError extends Error {
+  readonly issues: readonly ObjectQueryIssue[]
+
+  constructor(message: string, issues: readonly ObjectQueryIssue[] = []) {
+    super(message)
+    this.name = "AtlasObjectQueryError"
+    this.issues = issues
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+export function createFilterId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `filter-${Date.now()}-${Math.random()}`
+}
+
+export function getPropertyLabel(property: Pick<QueryProperty, "id" | "name">): string {
+  return humanizeIdentifier(property.name || property.id)
+}
+
+export function isFilterableProperty(property: QueryProperty): boolean {
+  return (
+    property.primary === true ||
+    (property.query?.searchable === true && property.query.filterable === true)
+  )
+}
+
+export function isSortableProperty(property: QueryProperty): boolean {
+  return property.query?.searchable === true && property.query.sortable === true
+}
+
+export function isFacetProperty(property: QueryProperty): boolean {
+  return property.query?.searchable === true && property.query.facet === true
+}
+
+export function schemaType(schema: unknown): string | undefined {
+  if (typeof schema === "string") return schema
+  if (isRecord(schema) && typeof schema.type === "string") return schema.type
+  return undefined
+}
+
+export function enumValues(schema: unknown): readonly (string | number)[] | undefined {
+  if (!isRecord(schema) || schema.type !== "enum" || !Array.isArray(schema.values)) return undefined
+  const values = schema.values.filter(
+    (value): value is string | number => typeof value === "string" || typeof value === "number"
+  )
+  return values.length === schema.values.length ? values : undefined
+}
+
+export function arrayItemSchema(schema: unknown): unknown {
+  return isRecord(schema) && schema.type === "array" ? schema.items : undefined
+}
+
+export function isNumberSchema(schema: unknown): boolean {
+  const type = schemaType(schema)
+  return type === "integer" || type === "double" || type === "decimal" || type === "number"
+}
+
+export function isBooleanSchema(schema: unknown): boolean {
+  return schemaType(schema) === "boolean"
+}
+
+export function isDateSchema(schema: unknown): boolean {
+  const type = schemaType(schema)
+  return type === "date" || type === "timestamp"
+}
+
+function isExactSchema(schema: unknown): boolean {
+  const type = schemaType(schema)
+  if (type === "enum") return true
+  if (typeof schema === "string") return schema !== "fileRef"
+  return false
+}
+
+function isSortableSchema(schema: unknown): boolean {
+  const type = schemaType(schema)
+  return (
+    type === "string" ||
+    type === "uuid" ||
+    type === "integer" ||
+    type === "double" ||
+    type === "decimal" ||
+    type === "date" ||
+    type === "timestamp" ||
+    type === "enum"
+  )
+}
+
+function isContainsSchema(schema: unknown): boolean {
+  const type = schemaType(schema)
+  return type === "string" || type === "uuid" || type === "array" || type === "map"
+}
+
+export function getOperatorsForProperty(property: QueryProperty): QueryFilterOperator[] {
+  if (property.primary === true && property.query?.filterable !== true) return ["eq"]
+
+  const operators: QueryFilterOperator[] = []
+  if (isExactSchema(property.schema)) operators.push("eq", "neq")
+  if (isSortableSchema(property.schema)) operators.push("lt", "lte", "gt", "gte")
+  if (isContainsSchema(property.schema)) operators.push("contains")
+  if (isExactSchema(property.schema)) operators.push("exists", "missing")
+  return operators
+}
+
+export function operatorRequiresValue(operator: QueryFilterOperator): boolean {
+  return operator !== "exists" && operator !== "missing"
+}
+
+export function parseValueForSchema(
+  schema: unknown,
+  rawValue: string
+): { ok: true; value: unknown } | { ok: false; error: string } {
+  const trimmed = rawValue.trim()
+  if (trimmed === "null") return { ok: true, value: null }
+
+  const values = enumValues(schema)
+  if (values) {
+    const selected = values.find((value) => String(value) === trimmed)
+    if (selected !== undefined) return { ok: true, value: selected }
+    return { ok: false, error: "Choose one of the allowed values." }
+  }
+
+  if (isBooleanSchema(schema)) {
+    if (trimmed === "true") return { ok: true, value: true }
+    if (trimmed === "false") return { ok: true, value: false }
+    return { ok: false, error: "Use true or false." }
+  }
+
+  if (isNumberSchema(schema)) {
+    const parsed = Number(trimmed)
+    if (Number.isFinite(parsed)) return { ok: true, value: parsed }
+    return { ok: false, error: "Use a numeric value." }
+  }
+
+  if (isRecord(schema) && schema.type === "array") {
+    return parseValueForSchema(arrayItemSchema(schema), rawValue)
+  }
+
+  return { ok: true, value: rawValue }
+}
+
+function filterToPredicate(filter: QueryFilter): ObjectQueryPredicate {
+  if (filter.operator === "exists" || filter.operator === "missing") {
+    return {
+      op: "exists",
+      propertyId: filter.propertyId,
+      value: filter.operator === "exists",
+    }
+  }
+
+  if (filter.operator === "contains") {
+    return { op: "contains", propertyId: filter.propertyId, value: filter.value }
+  }
+
+  return {
+    op: filter.operator,
+    propertyId: filter.propertyId,
+    value: filter.value,
+  }
+}
+
+export function buildObjectQuery(input: {
+  objectTypeId: string
+  text: string
+  textSearchEnabled: boolean
+  filters: readonly QueryFilter[]
+  matchMode: QueryMatchMode
+  sort: QuerySort | null
+}): ObjectQuery {
+  let query: ObjectQuery = { kind: "start", objectTypeId: input.objectTypeId }
+  const text = input.text.trim()
+
+  if (text && input.textSearchEnabled) {
+    query = { kind: "text", input: query, query: text }
+  }
+
+  if (input.filters.length > 0) {
+    const predicates = input.filters.map(filterToPredicate)
+    const predicate: ObjectQueryPredicate =
+      predicates.length === 1
+        ? predicates[0]
+        : { op: input.matchMode === "all" ? "and" : "or", items: predicates }
+    query = { kind: "filter", input: query, predicate }
+  }
+
+  if (input.sort) {
+    query = {
+      kind: "sort",
+      input: query,
+      fields: [
+        {
+          kind: "property",
+          propertyId: input.sort.propertyId,
+          direction: input.sort.direction,
+        },
+      ],
+    }
+  }
+
+  return query
+}
+
+export function getObjectQueryError(error: unknown): AtlasObjectQueryError {
+  if (error instanceof AtlasObjectQueryError) return error
+  if (isRecord(error) && typeof error.error === "string") {
+    const issues = Array.isArray(error.issues) ? (error.issues as ObjectQueryIssue[]) : []
+    return new AtlasObjectQueryError(error.error, issues)
+  }
+  if (error instanceof Error) return new AtlasObjectQueryError(error.message)
+  return new AtlasObjectQueryError("Object query failed")
+}
+
+export async function executeAtlasObjectQuery(
+  query: ObjectQuery,
+  objectType: AtlasObjectType
+): Promise<AtlasObjectQueryPage> {
+  const { data, error } = await queryObjects({
+    body: { query, includeTotal: true },
+    responseStyle: "fields",
+    throwOnError: false,
+  })
+  if (error || !data) throw getObjectQueryError(error)
+
+  return {
+    objects: data.objects.map((object) => toObjectSummary(object, objectType)),
+    hasMore: data.hasMore,
+    nextPageToken: data.nextPageToken,
+    total: data.total,
+    plan: data.plan,
+  }
+}
+
+export async function executeAtlasObjectFacets(
+  query: ObjectQuery,
+  facets: readonly { propertyId: string; limit: number }[]
+): Promise<ObjectQueryFacetResult[]> {
+  const { data, error } = await facetObjects({
+    body: { query, facets: [...facets] },
+    responseStyle: "fields",
+    throwOnError: false,
+  })
+  if (error || !data) throw getObjectQueryError(error)
+  return data.facets
+}
+
+export function describeFilter(
+  filter: QueryFilter,
+  properties: ReadonlyMap<string, QueryProperty>
+): string {
+  const property = properties.get(filter.propertyId)
+  const propertyLabel = property ? getPropertyLabel(property) : filter.propertyId
+  const operatorLabel = operatorLabels[filter.operator]
+  if (!operatorRequiresValue(filter.operator)) return `${propertyLabel} ${operatorLabel}`
+  return `${propertyLabel} ${operatorLabel} ${formatValue(filter.value)}`
+}
+
+export function getQuickFilterValues(
+  property: QueryProperty,
+  schema: unknown,
+  facetResults: readonly ObjectQueryFacetResult[]
+): QuickFilterValue[] {
+  const buckets = facetResults.find((facet) => facet.propertyId === property.id)?.buckets ?? []
+  const countForValue = (value: unknown) =>
+    buckets.find((bucket) => Object.is(bucket.value, value))?.count
+
+  const values = enumValues(schema)
+  if (values) {
+    return values.map((value) => ({
+      value,
+      label: formatValue(value),
+      count: countForValue(value),
+    }))
+  }
+
+  if (isBooleanSchema(schema)) {
+    return [true, false].map((value) => ({
+      value,
+      label: value ? "True" : "False",
+      count: countForValue(value),
+    }))
+  }
+
+  return buckets
+    .filter(
+      (bucket) =>
+        bucket.value === null ||
+        typeof bucket.value === "string" ||
+        typeof bucket.value === "number" ||
+        typeof bucket.value === "boolean"
+    )
+    .slice(0, 8)
+    .map((bucket) => ({
+      value: bucket.value,
+      label: formatValue(bucket.value),
+      count: bucket.count,
+    }))
+}
+
+export function filterHasValue(
+  filters: readonly QueryFilter[],
+  propertyId: string,
+  value: unknown
+): boolean {
+  return filters.some(
+    (filter) =>
+      filter.propertyId === propertyId && filter.operator === "eq" && Object.is(filter.value, value)
+  )
+}

--- a/packages/atlas/src/pages/ObjectsWorkbench.tsx
+++ b/packages/atlas/src/pages/ObjectsWorkbench.tsx
@@ -1,5 +1,4 @@
-import type { ObjectDetail, ObjectSummary } from "@sixb/client"
-import { getObjectOptions } from "@sixb/client/hooks"
+import type { ObjectSummary } from "@sixb/client"
 import {
   Button,
   Card,
@@ -22,12 +21,28 @@ import {
   TableRow,
 } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
-import { useQueries } from "@tanstack/react-query"
-import { Box, ChevronLeft, ChevronRight, Search } from "lucide-react"
-import { type ReactNode, useMemo, useState } from "react"
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import { Box, ChevronRight, Search } from "lucide-react"
+import { type ReactNode, useDeferredValue, useEffect, useMemo, useState } from "react"
 import { LetterAvatar, LoadingState } from "../components/common"
 import { ObjectIcon } from "../components/ObjectIcon"
+import { ObjectQueryBar, ObjectsQueryPagination } from "../components/objects/ObjectQueryBar"
+import { formatCount } from "../lib/formatValue"
 import { formatLocation, humanizeIdentifier } from "../lib/labels"
+import {
+  type AtlasObjectType,
+  buildObjectQuery,
+  executeAtlasObjectFacets,
+  executeAtlasObjectQuery,
+  getPropertyLabel,
+  isFacetProperty,
+  isFilterableProperty,
+  isSortableProperty,
+  type QueryFilter,
+  type QueryMatchMode,
+  type QueryProperty,
+  type QuerySort,
+} from "../lib/objects/objectQuery"
 import type { TelemetryUpdate } from "../lib/telemetryEvents"
 import { formatRelativeTime } from "../lib/time"
 import {
@@ -45,23 +60,19 @@ export interface ObjectTypePreviewSection {
 
 interface ObjectsWorkbenchProps {
   projectName: string
-  objects: ObjectSummary[]
-  objectsTotal: number
-  objectsHasMore: boolean
-  objectOffset: number
   objectPageSize: number
   allObjectsTotal: number
   objectTypeCounts: ReadonlyMap<string, number>
   overviewSections: ObjectTypePreviewSection[]
   overviewLoading: boolean
-  loading: boolean
+  objectTypesLoading?: boolean
   sortBy: ObjectSortPreference
   classFilter?: string | null
+  selectedObjectType?: AtlasObjectType | null
   selectedObjectId?: string | null
   latestProjectUpdates: TelemetryUpdate[]
   onSortByChange: (sortBy: ObjectSortPreference) => void
-  onClassFilterChange: (objectTypeId: string | null, offset?: number) => void
-  onObjectOffsetChange: (offset: number) => void
+  onClassFilterChange: (objectTypeId: string | null) => void
   onSelectObject: (id: string) => void
 }
 
@@ -80,10 +91,6 @@ function formatCompactValue(value: number | string | boolean): string {
   return value
 }
 
-function formatCount(value: number): string {
-  return value.toLocaleString()
-}
-
 function formatLoadedCount(loaded: number, total: number | undefined): string {
   if (typeof total === "number" && total !== loaded) {
     return `${formatCount(loaded)} of ${formatCount(total)}`
@@ -91,13 +98,8 @@ function formatLoadedCount(loaded: number, total: number | undefined): string {
   return formatCount(total ?? loaded)
 }
 
-function objectMatchesQuery(
-  candidate: ObjectSummary,
-  query: string,
-  details: ReadonlyMap<string, ObjectDetail>
-): boolean {
-  const detail = details.get(candidate.id)
-  const location = formatLocation(detail?.location).toLowerCase()
+function objectMatchesQuery(candidate: ObjectSummary, query: string): boolean {
+  const location = formatLocation(candidate.location).toLowerCase()
   const name = (candidate.name || "").toLowerCase()
   const className = humanizeIdentifier(candidate.class).toLowerCase()
   return (
@@ -111,52 +113,124 @@ function objectMatchesQuery(
 
 export function ObjectsWorkbench({
   projectName,
-  objects,
-  objectsTotal,
-  objectsHasMore,
-  objectOffset,
   objectPageSize,
   allObjectsTotal,
   objectTypeCounts,
   overviewSections,
   overviewLoading,
-  loading,
+  objectTypesLoading = false,
   sortBy,
   classFilter,
+  selectedObjectType,
   selectedObjectId,
   latestProjectUpdates,
   onSortByChange,
   onClassFilterChange,
-  onObjectOffsetChange,
   onSelectObject,
 }: ObjectsWorkbenchProps) {
   const [searchQuery, setSearchQuery] = useState("")
+  const deferredSearchQuery = useDeferredValue(searchQuery)
+  const [queryFilters, setQueryFilters] = useState<QueryFilter[]>([])
+  const [queryMatchMode, setQueryMatchMode] = useState<QueryMatchMode>("all")
+  const [querySort, setQuerySort] = useState<QuerySort | null>(null)
   const [viewStyle, setViewStyle] = useState<ViewStyle>(getObjectViewStyle)
   const selectedTypeMode = classFilter != null
 
-  const displayObjects = useMemo(
-    () => (selectedTypeMode ? objects : overviewSections.flatMap((section) => section.objects)),
-    [objects, overviewSections, selectedTypeMode]
-  )
+  useEffect(() => {
+    if (classFilter === undefined) return
+    setSearchQuery("")
+    setQueryFilters([])
+    setQueryMatchMode("all")
+    setQuerySort(null)
+  }, [classFilter])
 
-  const detailQueries = useQueries({
-    queries: displayObjects.map((object) => ({
-      ...getObjectOptions({
-        path: { projectName, objectId: object.id },
-      }),
-      enabled: !!projectName,
-      retry: false,
-    })),
+  const queryMode = selectedTypeMode && !!selectedObjectType
+  const queryProperties = useMemo(
+    () => (selectedObjectType?.properties ?? []) as QueryProperty[],
+    [selectedObjectType]
+  )
+  const queryPropertiesById = useMemo(
+    () => new Map(queryProperties.map((property) => [property.id, property])),
+    [queryProperties]
+  )
+  const filterableProperties = useMemo(
+    () => queryProperties.filter(isFilterableProperty),
+    [queryProperties]
+  )
+  const sortableProperties = useMemo(
+    () => queryProperties.filter(isSortableProperty),
+    [queryProperties]
+  )
+  const facetProperties = useMemo(() => queryProperties.filter(isFacetProperty), [queryProperties])
+  const textSearchEnabled = Boolean(selectedObjectType?.search?.defaultText?.length)
+
+  const objectQuery = useMemo(() => {
+    if (!queryMode || !classFilter) return null
+    return buildObjectQuery({
+      objectTypeId: classFilter,
+      text: deferredSearchQuery,
+      textSearchEnabled,
+      filters: queryFilters,
+      matchMode: queryMatchMode,
+      sort: querySort,
+    })
+  }, [
+    classFilter,
+    deferredSearchQuery,
+    queryFilters,
+    queryMatchMode,
+    queryMode,
+    querySort,
+    textSearchEnabled,
+  ])
+
+  const facetQuery = useMemo(() => {
+    if (!queryMode || !classFilter) return null
+    return buildObjectQuery({
+      objectTypeId: classFilter,
+      text: deferredSearchQuery,
+      textSearchEnabled,
+      filters: queryFilters,
+      matchMode: queryMatchMode,
+      sort: null,
+    })
+  }, [classFilter, deferredSearchQuery, queryFilters, queryMatchMode, queryMode, textSearchEnabled])
+
+  const queriedObjects = useInfiniteQuery({
+    queryKey: ["atlas", "objects", "query", objectQuery, objectPageSize],
+    enabled: queryMode && !!objectQuery && !!selectedObjectType,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      executeAtlasObjectQuery(
+        {
+          kind: "page",
+          input: objectQuery!,
+          pageSize: objectPageSize,
+          pageToken: pageParam,
+        },
+        selectedObjectType!
+      ),
+    getNextPageParam: (lastPage) => lastPage.nextPageToken,
+    retry: false,
   })
 
-  const detailById = useMemo(() => {
-    const detailMap = new Map<string, ObjectDetail>()
-    for (let i = 0; i < displayObjects.length; i += 1) {
-      const detail = detailQueries[i]?.data as ObjectDetail | undefined
-      if (detail) detailMap.set(displayObjects[i].id, detail)
-    }
-    return detailMap
-  }, [displayObjects, detailQueries])
+  const facetRequests = useMemo(
+    () => facetProperties.slice(0, 4).map((property) => ({ propertyId: property.id, limit: 8 })),
+    [facetProperties]
+  )
+
+  const facetsQuery = useQuery({
+    queryKey: ["atlas", "objects", "facets", facetQuery, facetRequests],
+    enabled: queryMode && !!facetQuery && facetRequests.length > 0,
+    queryFn: () => executeAtlasObjectFacets(facetQuery!, facetRequests),
+    retry: false,
+  })
+
+  const queryObjectsPage = useMemo(
+    () => queriedObjects.data?.pages.flatMap((page) => page.objects) ?? [],
+    [queriedObjects.data]
+  )
+  const queryTotal = queriedObjects.data?.pages[0]?.total ?? queryObjectsPage.length
 
   const updatesByObject = useMemo(() => {
     const grouped = new Map<string, TelemetryUpdate[]>()
@@ -181,10 +255,13 @@ export function ObjectsWorkbench({
   )
 
   const filteredObjects = useMemo(() => {
+    if (queryMode) return queryObjectsPage
+    if (selectedTypeMode) return []
     const query = searchQuery.trim().toLowerCase()
-    if (!query) return objects
-    return objects.filter((candidate) => objectMatchesQuery(candidate, query, detailById))
-  }, [objects, searchQuery, detailById])
+    const overviewObjects = overviewSections.flatMap((section) => section.objects)
+    if (!query) return overviewObjects
+    return overviewObjects.filter((candidate) => objectMatchesQuery(candidate, query))
+  }, [overviewSections, queryMode, queryObjectsPage, selectedTypeMode, searchQuery])
 
   const filteredOverviewSections = useMemo(() => {
     const query = searchQuery.trim().toLowerCase()
@@ -193,9 +270,7 @@ export function ObjectsWorkbench({
     return overviewSections
       .map((section) => ({
         ...section,
-        objects: section.objects.filter((candidate) =>
-          objectMatchesQuery(candidate, query, detailById)
-        ),
+        objects: section.objects.filter((candidate) => objectMatchesQuery(candidate, query)),
       }))
       .filter(
         (section) =>
@@ -203,7 +278,7 @@ export function ObjectsWorkbench({
           humanizeIdentifier(section.objectTypeId).toLowerCase().includes(query) ||
           section.objectTypeId.toLowerCase().includes(query)
       )
-  }, [overviewSections, searchQuery, detailById])
+  }, [overviewSections, searchQuery])
 
   const groups = useMemo(() => {
     const grouped = new Map<string, ObjectSummary[]>()
@@ -222,21 +297,29 @@ export function ObjectsWorkbench({
     onSelectObject(objectId)
   }
 
-  const searching = searchQuery.trim().length > 0
+  const searching = queryMode
+    ? searchQuery.trim().length > 0 || queryFilters.length > 0
+    : searchQuery.trim().length > 0
   const visibleObjectCount = selectedTypeMode
     ? filteredObjects.length
     : filteredOverviewSections.reduce((total, section) => total + section.objects.length, 0)
-  const headerCount = searching
-    ? visibleObjectCount
-    : selectedTypeMode
-      ? objectsTotal
-      : allObjectsTotal
-  const pageLoading = selectedTypeMode ? loading : overviewLoading
-  const showPagination =
-    selectedTypeMode && !loading && (objectsTotal > objectPageSize || objectOffset > 0)
+  const headerCount = queryMode
+    ? queryTotal
+    : searching
+      ? visibleObjectCount
+      : selectedTypeMode
+        ? 0
+        : allObjectsTotal
+  const pageLoading = queryMode
+    ? queriedObjects.isLoading
+    : selectedTypeMode && !selectedObjectType
+      ? objectTypesLoading
+      : overviewLoading
   const hasResults = selectedTypeMode
     ? filteredObjects.length > 0
     : filteredOverviewSections.some((section) => section.objects.length > 0)
+  const queryError = queriedObjects.error ?? facetsQuery.error
+  const querySortValue = querySort ? `${querySort.propertyId}:${querySort.direction}` : "default"
 
   return (
     <div className="mx-auto w-full max-w-5xl">
@@ -245,22 +328,58 @@ export function ObjectsWorkbench({
         count={headerCount}
         actions={
           <div className="flex items-center gap-2">
-            <Select
-              value={sortBy}
-              onValueChange={(value) => {
-                if (value === "primaryId" || value === "updatedAt") {
-                  onSortByChange(value)
-                }
-              }}
-            >
-              <SelectTrigger size="sm" className="h-8 w-28 text-xs" aria-label="Sort objects">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent align="end">
-                <SelectItem value="primaryId">Primary ID</SelectItem>
-                <SelectItem value="updatedAt">Updated at</SelectItem>
-              </SelectContent>
-            </Select>
+            {queryMode ? (
+              <Select
+                value={querySortValue}
+                disabled={sortableProperties.length === 0}
+                onValueChange={(value) => {
+                  if (value === "default") {
+                    setQuerySort(null)
+                    return
+                  }
+
+                  const separator = value.lastIndexOf(":")
+                  const direction = value.slice(separator + 1)
+                  if (separator > 0 && (direction === "asc" || direction === "desc")) {
+                    setQuerySort({ propertyId: value.slice(0, separator), direction })
+                  }
+                }}
+              >
+                <SelectTrigger size="sm" className="h-8 w-36 text-xs" aria-label="Sort objects">
+                  <SelectValue placeholder="Sort" />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  <SelectItem value="default">Default order</SelectItem>
+                  {sortableProperties.map((property) => (
+                    <SelectItem key={`${property.id}:asc`} value={`${property.id}:asc`}>
+                      {getPropertyLabel(property)} asc
+                    </SelectItem>
+                  ))}
+                  {sortableProperties.map((property) => (
+                    <SelectItem key={`${property.id}:desc`} value={`${property.id}:desc`}>
+                      {getPropertyLabel(property)} desc
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <Select
+                value={sortBy}
+                onValueChange={(value) => {
+                  if (value === "primaryId" || value === "updatedAt") {
+                    onSortByChange(value)
+                  }
+                }}
+              >
+                <SelectTrigger size="sm" className="h-8 w-28 text-xs" aria-label="Sort objects">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  <SelectItem value="primaryId">Primary ID</SelectItem>
+                  <SelectItem value="updatedAt">Updated at</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
             {selectedTypeMode ? (
               <CollectionViewToggle
                 value={viewStyle}
@@ -295,16 +414,41 @@ export function ObjectsWorkbench({
         </div>
       ) : null}
 
-      <div className="relative mt-3">
-        <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          type="text"
-          value={searchQuery}
-          onChange={(event) => setSearchQuery(event.target.value)}
-          placeholder="Search objects, location, or class..."
-          className="pl-9"
+      {queryMode && selectedObjectType ? (
+        <ObjectQueryBar
+          objectType={selectedObjectType}
+          searchQuery={searchQuery}
+          textSearchEnabled={textSearchEnabled}
+          filters={queryFilters}
+          matchMode={queryMatchMode}
+          filterableProperties={filterableProperties}
+          propertiesById={queryPropertiesById}
+          facetResults={facetsQuery.data ?? []}
+          facetsLoading={facetsQuery.isLoading}
+          queryError={queryError}
+          onSearchQueryChange={setSearchQuery}
+          onAddFilter={(filter) => setQueryFilters((current) => [...current, filter])}
+          onRemoveFilter={(filterId) =>
+            setQueryFilters((current) => current.filter((filter) => filter.id !== filterId))
+          }
+          onClear={() => {
+            setSearchQuery("")
+            setQueryFilters([])
+          }}
+          onMatchModeChange={setQueryMatchMode}
         />
-      </div>
+      ) : (
+        <div className="relative mt-3">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="text"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search objects, location, or class..."
+            className="pl-9"
+          />
+        </div>
+      )}
 
       <div className="mt-4 space-y-4">
         {pageLoading ? (
@@ -315,7 +459,11 @@ export function ObjectsWorkbench({
           <EmptyState
             icon={<Box className="size-12 stroke-1" />}
             title="No matching objects"
-            description="Try a broader search query."
+            description={
+              queryMode
+                ? "Try removing filters or broadening the search."
+                : "Try a broader search query."
+            }
           />
         ) : !selectedTypeMode ? (
           <div className="space-y-6">
@@ -349,7 +497,6 @@ export function ObjectsWorkbench({
         ) : viewStyle === "table" ? (
           <TableView
             objects={filteredObjects}
-            detailById={detailById}
             updatesByObject={updatesByObject}
             selectedObjectId={selectedObjectId ?? null}
             onSelectObject={handleSelectObject}
@@ -363,11 +510,13 @@ export function ObjectsWorkbench({
                 objects={items}
                 count={formatLoadedCount(
                   items.length,
-                  searching
-                    ? undefined
-                    : className === classFilter
-                      ? objectsTotal
-                      : objectTypeCounts.get(className)
+                  queryMode
+                    ? queryTotal
+                    : searching
+                      ? undefined
+                      : className === classFilter
+                        ? queryTotal
+                        : objectTypeCounts.get(className)
                 )}
                 selectedObjectId={selectedObjectId}
                 onSelectObject={handleSelectObject}
@@ -375,16 +524,13 @@ export function ObjectsWorkbench({
             ))}
           </div>
         )}
-        {showPagination ? (
-          <ObjectsPagination
-            offset={objectOffset}
-            pageSize={objectPageSize}
-            total={objectsTotal}
-            loadedCount={objects.length}
-            visibleCount={filteredObjects.length}
-            hasMore={objectsHasMore}
-            searching={searching}
-            onOffsetChange={onObjectOffsetChange}
+        {queryMode && hasResults ? (
+          <ObjectsQueryPagination
+            loadedCount={queryObjectsPage.length}
+            total={queryTotal}
+            hasMore={queriedObjects.hasNextPage}
+            loadingMore={queriedObjects.isFetchingNextPage}
+            onLoadMore={() => queriedObjects.fetchNextPage()}
           />
         ) : null}
       </div>
@@ -430,62 +576,6 @@ function ObjectCardSection({
         ))}
       </CollectionCardGrid>
     </section>
-  )
-}
-
-function ObjectsPagination({
-  offset,
-  pageSize,
-  total,
-  loadedCount,
-  visibleCount,
-  hasMore,
-  searching,
-  onOffsetChange,
-}: {
-  offset: number
-  pageSize: number
-  total: number
-  loadedCount: number
-  visibleCount: number
-  hasMore: boolean
-  searching: boolean
-  onOffsetChange: (offset: number) => void
-}) {
-  const rangeStart = loadedCount > 0 ? offset + 1 : 0
-  const rangeEnd = loadedCount > 0 ? offset + loadedCount : 0
-  const canGoBack = offset > 0
-  const canGoForward = hasMore
-
-  return (
-    <div className="flex flex-col gap-3 border-t border-border pt-3 sm:flex-row sm:items-center sm:justify-between">
-      <p className="text-xs tabular-nums text-muted-foreground">
-        Showing {formatCount(rangeStart)}-{formatCount(rangeEnd)} of {formatCount(total)}
-        {searching ? ` · ${formatCount(visibleCount)} matching this page` : ""}
-      </p>
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={!canGoBack}
-          onClick={() => onOffsetChange(Math.max(0, offset - pageSize))}
-        >
-          <ChevronLeft />
-          Previous
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={!canGoForward}
-          onClick={() => onOffsetChange(offset + pageSize)}
-        >
-          Next
-          <ChevronRight />
-        </Button>
-      </div>
-    </div>
   )
 }
 
@@ -542,13 +632,11 @@ function ObjectCardItem({
 
 function TableView({
   objects,
-  detailById,
   updatesByObject,
   selectedObjectId,
   onSelectObject,
 }: {
   objects: ObjectSummary[]
-  detailById: Map<string, ObjectDetail>
   updatesByObject: Map<string, TelemetryUpdate[]>
   selectedObjectId: string | null
   onSelectObject: (id: string) => void
@@ -568,8 +656,7 @@ function TableView({
         <TableBody>
           {objects.map((object) => {
             const updates = updatesByObject.get(object.id) ?? []
-            const detail = detailById.get(object.id)
-            const location = formatLocation(detail?.location)
+            const location = formatLocation(object.location)
             const keySignal = updates[0]
             const isActive = selectedObjectId === object.id
 

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -48,14 +48,6 @@ const emptyObjectList: ObjectSummary[] = []
 const OBJECT_PAGE_SIZE = 300
 const OBJECT_TYPE_PREVIEW_LIMIT = 12
 
-function parseObjectOffset(value: string | null): number {
-  if (!value) return 0
-
-  const parsed = Number.parseInt(value, 10)
-  if (!Number.isFinite(parsed) || parsed < 0) return 0
-  return parsed
-}
-
 export function ProjectWorkspace() {
   const navigate = useNavigate()
   const location = useLocation()
@@ -68,29 +60,9 @@ export function ProjectWorkspace() {
   const [objectSortBy, setObjectSortBy] = useState<ObjectSortPreference>(getObjectSortPreference)
   const [searchParams, setSearchParams] = useSearchParams()
   const classFilter = searchParams.get("class") || null
-  const objectOffset = parseObjectOffset(searchParams.get("offset"))
-
-  const setObjectOffset = useCallback(
-    (nextOffset: number, options?: { replace?: boolean }) => {
-      const offset = Math.max(0, Math.trunc(nextOffset))
-      setSearchParams(
-        (prev) => {
-          const params = new URLSearchParams(prev)
-          if (offset > 0) {
-            params.set("offset", String(offset))
-          } else {
-            params.delete("offset")
-          }
-          return params
-        },
-        { replace: options?.replace ?? false }
-      )
-    },
-    [setSearchParams]
-  )
 
   const setClassFilter = useCallback(
-    (next: string | null, options?: { offset?: number; replace?: boolean }) => {
+    (next: string | null, options?: { replace?: boolean }) => {
       setSearchParams(
         (prev) => {
           const params = new URLSearchParams(prev)
@@ -99,12 +71,7 @@ export function ProjectWorkspace() {
           } else {
             params.delete("class")
           }
-          const offset = Math.max(0, Math.trunc(options?.offset ?? 0))
-          if (offset > 0) {
-            params.set("offset", String(offset))
-          } else {
-            params.delete("offset")
-          }
+          params.delete("offset")
           return params
         },
         { replace: options?.replace ?? true }
@@ -128,22 +95,6 @@ export function ProjectWorkspace() {
     setLatestUpdates({})
   }, [resolvedProjectName])
 
-  const objectsQuery = useQuery({
-    ...listObjectsPageOptions({
-      query: {
-        objectTypeId: classFilter ?? undefined,
-        limit: String(OBJECT_PAGE_SIZE),
-        offset: objectOffset > 0 ? String(objectOffset) : undefined,
-        orderBy: objectSortBy,
-        order: objectSortBy === "primaryId" ? "asc" : "desc",
-      },
-    }),
-    enabled: !!projectInfo && !!classFilter,
-  })
-  const objectsPage = objectsQuery.data
-  const objects = objectsPage?.objects ?? emptyObjectList
-  const { isLoading: objectsLoading } = objectsQuery
-
   const { data: objectTypes = [], isLoading: objectTypesLoading } = useQuery({
     ...listObjectTypesOptions(),
     enabled: !!projectInfo,
@@ -156,18 +107,10 @@ export function ProjectWorkspace() {
     }
   }, [classFilter, objectTypes, setClassFilter])
 
-  useEffect(() => {
-    const total = objectsPage?.total
-    if (typeof total !== "number" || objectOffset === 0) return
-    if (total === 0) {
-      setObjectOffset(0, { replace: true })
-      return
-    }
-    if (objectOffset < total) return
-
-    const lastOffset = Math.floor((total - 1) / OBJECT_PAGE_SIZE) * OBJECT_PAGE_SIZE
-    setObjectOffset(lastOffset, { replace: true })
-  }, [objectOffset, objectsPage?.total, setObjectOffset])
+  const selectedObjectType = useMemo(
+    () => objectTypes.find((objectType) => objectType.id === classFilter) ?? null,
+    [classFilter, objectTypes]
+  )
 
   const globalObjectCountQuery = useQuery({
     ...objectCountOptions(),
@@ -331,11 +274,11 @@ export function ProjectWorkspace() {
   const objectLookup = useMemo(
     () =>
       Object.fromEntries(
-        [...objects, ...objectTypePreviewSections.flatMap((section) => section.objects)].map(
-          (object) => [object.id, object]
-        )
+        objectTypePreviewSections
+          .flatMap((section) => section.objects)
+          .map((object) => [object.id, object])
       ),
-    [objects, objectTypePreviewSections]
+    [objectTypePreviewSections]
   )
 
   const toProjectPath = (suffix: string) => `/${suffix}`
@@ -343,7 +286,6 @@ export function ProjectWorkspace() {
   const handleObjectSortByChange = (sortBy: ObjectSortPreference) => {
     setObjectSortBy(sortBy)
     setObjectSortPreference(sortBy)
-    setObjectOffset(0, { replace: true })
   }
 
   if (projectLoading) {
@@ -395,25 +337,19 @@ export function ProjectWorkspace() {
               element={
                 <ObjectsWorkbench
                   projectName={resolvedProjectName}
-                  objects={objects}
-                  objectsTotal={objectsPage?.total ?? objects.length}
-                  objectsHasMore={objectsPage?.hasMore ?? false}
-                  objectOffset={objectOffset}
                   objectPageSize={OBJECT_PAGE_SIZE}
                   allObjectsTotal={allObjectsTotal}
                   objectTypeCounts={objectTypeCounts}
                   overviewSections={objectTypePreviewSections}
                   overviewLoading={overviewLoading}
-                  loading={objectsLoading}
+                  objectTypesLoading={objectTypesLoading}
                   sortBy={objectSortBy}
                   classFilter={classFilter}
+                  selectedObjectType={selectedObjectType}
                   selectedObjectId={selectedObjectIdForSidebar}
                   latestProjectUpdates={latestProjectUpdates}
                   onSortByChange={handleObjectSortByChange}
-                  onClassFilterChange={(objectTypeId, offset) =>
-                    setClassFilter(objectTypeId, { offset })
-                  }
-                  onObjectOffsetChange={setObjectOffset}
+                  onClassFilterChange={setClassFilter}
                   onSelectObject={(objectId) => navigate(toProjectPath(objectId))}
                 />
               }

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -8149,11 +8149,78 @@
                             "semanticType": {
                               "type": "string"
                             },
-                            "schema": {}
+                            "schema": {},
+                            "query": {
+                              "type": "object",
+                              "properties": {
+                                "searchable": {
+                                  "type": "boolean"
+                                },
+                                "filterable": {
+                                  "type": "boolean"
+                                },
+                                "sortable": {
+                                  "type": "boolean"
+                                },
+                                "text": {
+                                  "type": "boolean"
+                                },
+                                "exact": {
+                                  "type": "boolean"
+                                },
+                                "facet": {
+                                  "type": "boolean"
+                                },
+                                "vector": {
+                                  "type": "boolean"
+                                },
+                                "weight": {
+                                  "type": "number"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
                           },
                           "required": ["id", "name"],
                           "additionalProperties": false
                         }
+                      },
+                      "search": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "defaultText": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "exact": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "vector": {
+                            "type": "object",
+                            "properties": {
+                              "property": {
+                                "type": "string"
+                              },
+                              "source": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": ["property", "source"],
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
                       },
                       "links": {
                         "type": "array",
@@ -8216,7 +8283,37 @@
                                   "semanticType": {
                                     "type": "string"
                                   },
-                                  "schema": {}
+                                  "schema": {},
+                                  "query": {
+                                    "type": "object",
+                                    "properties": {
+                                      "searchable": {
+                                        "type": "boolean"
+                                      },
+                                      "filterable": {
+                                        "type": "boolean"
+                                      },
+                                      "sortable": {
+                                        "type": "boolean"
+                                      },
+                                      "text": {
+                                        "type": "boolean"
+                                      },
+                                      "exact": {
+                                        "type": "boolean"
+                                      },
+                                      "facet": {
+                                        "type": "boolean"
+                                      },
+                                      "vector": {
+                                        "type": "boolean"
+                                      },
+                                      "weight": {
+                                        "type": "number"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
                                 },
                                 "required": ["id", "name"],
                                 "additionalProperties": false
@@ -8355,11 +8452,78 @@
                           "semanticType": {
                             "type": "string"
                           },
-                          "schema": {}
+                          "schema": {},
+                          "query": {
+                            "type": "object",
+                            "properties": {
+                              "searchable": {
+                                "type": "boolean"
+                              },
+                              "filterable": {
+                                "type": "boolean"
+                              },
+                              "sortable": {
+                                "type": "boolean"
+                              },
+                              "text": {
+                                "type": "boolean"
+                              },
+                              "exact": {
+                                "type": "boolean"
+                              },
+                              "facet": {
+                                "type": "boolean"
+                              },
+                              "vector": {
+                                "type": "boolean"
+                              },
+                              "weight": {
+                                "type": "number"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
                         },
                         "required": ["id", "name"],
                         "additionalProperties": false
                       }
+                    },
+                    "search": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "defaultText": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "exact": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "vector": {
+                          "type": "object",
+                          "properties": {
+                            "property": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": ["property", "source"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
                     },
                     "links": {
                       "type": "array",
@@ -8422,7 +8586,37 @@
                                 "semanticType": {
                                   "type": "string"
                                 },
-                                "schema": {}
+                                "schema": {},
+                                "query": {
+                                  "type": "object",
+                                  "properties": {
+                                    "searchable": {
+                                      "type": "boolean"
+                                    },
+                                    "filterable": {
+                                      "type": "boolean"
+                                    },
+                                    "sortable": {
+                                      "type": "boolean"
+                                    },
+                                    "text": {
+                                      "type": "boolean"
+                                    },
+                                    "exact": {
+                                      "type": "boolean"
+                                    },
+                                    "facet": {
+                                      "type": "boolean"
+                                    },
+                                    "vector": {
+                                      "type": "boolean"
+                                    },
+                                    "weight": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
                               },
                               "required": ["id", "name"],
                               "additionalProperties": false

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2802,7 +2802,26 @@ export type ListObjectTypesResponses = {
       primary?: boolean
       semanticType?: string
       schema?: unknown
+      query?: {
+        searchable?: boolean
+        filterable?: boolean
+        sortable?: boolean
+        text?: boolean
+        exact?: boolean
+        facet?: boolean
+        vector?: boolean
+        weight?: number
+      }
     }>
+    search?: {
+      title?: string
+      defaultText?: Array<string>
+      exact?: Array<string>
+      vector?: {
+        property: string
+        source: Array<string>
+      }
+    }
     links: Array<{
       id: string
       name: string
@@ -2819,6 +2838,16 @@ export type ListObjectTypesResponses = {
         primary?: boolean
         semanticType?: string
         schema?: unknown
+        query?: {
+          searchable?: boolean
+          filterable?: boolean
+          sortable?: boolean
+          text?: boolean
+          exact?: boolean
+          facet?: boolean
+          vector?: boolean
+          weight?: number
+        }
       }>
     }>
     actions: Array<{
@@ -2879,7 +2908,26 @@ export type GetObjectTypeResponses = {
       primary?: boolean
       semanticType?: string
       schema?: unknown
+      query?: {
+        searchable?: boolean
+        filterable?: boolean
+        sortable?: boolean
+        text?: boolean
+        exact?: boolean
+        facet?: boolean
+        vector?: boolean
+        weight?: number
+      }
     }>
+    search?: {
+      title?: string
+      defaultText?: Array<string>
+      exact?: Array<string>
+      vector?: {
+        property: string
+        source: Array<string>
+      }
+    }
     links: Array<{
       id: string
       name: string
@@ -2896,6 +2944,16 @@ export type GetObjectTypeResponses = {
         primary?: boolean
         semanticType?: string
         schema?: unknown
+        query?: {
+          searchable?: boolean
+          filterable?: boolean
+          sortable?: boolean
+          text?: boolean
+          exact?: boolean
+          facet?: boolean
+          vector?: boolean
+          weight?: number
+        }
       }>
     }>
     actions: Array<{

--- a/packages/server/src/routes/ontology.ts
+++ b/packages/server/src/routes/ontology.ts
@@ -3,6 +3,42 @@ import type { Elysia } from "elysia"
 import { ErrorResponseSchema } from "../schemas/common"
 import { ObjectTypeParamsSchema, ObjectTypeSchema } from "../schemas/ontology"
 
+function serializeProperty(
+  property: ReturnType<
+    Sixb<readonly OntologySource[]>["listObjectTypes"]
+  >[number]["properties"][number]
+) {
+  return {
+    id: property.id,
+    name: property.name,
+    description: property.description,
+    mode: property.mode,
+    required: property.required,
+    nullable: property.nullable,
+    primary: property.primary,
+    semanticType: property.semanticType,
+    schema: property.schema,
+    query: property.query ? { ...property.query } : undefined,
+  }
+}
+
+function serializeSearch(
+  search: ReturnType<Sixb<readonly OntologySource[]>["listObjectTypes"]>[number]["search"]
+) {
+  if (!search) return undefined
+  return {
+    title: search.title,
+    defaultText: search.defaultText ? [...search.defaultText] : undefined,
+    exact: search.exact ? [...search.exact] : undefined,
+    vector: search.vector
+      ? {
+          property: search.vector.property,
+          source: [...search.vector.source],
+        }
+      : undefined,
+  }
+}
+
 function serializeObjectType(
   sixb: Sixb<readonly OntologySource[]>,
   objectType: ReturnType<Sixb<readonly OntologySource[]>["listObjectTypes"]>[number]
@@ -12,15 +48,18 @@ function serializeObjectType(
     name: objectType.name,
     description: objectType.description,
     extends: objectType.extends,
-    implements: objectType.implements,
-    properties: objectType.properties,
+    implements: objectType.implements ? [...objectType.implements] : undefined,
+    properties: objectType.properties.map(serializeProperty),
+    search: serializeSearch(objectType.search),
     links: objectType.links.map((link) => ({
       id: link.id,
       name: link.name,
       description: link.description,
-      targetObjectTypeId: link.targetObjectTypeId,
+      targetObjectTypeId: Array.isArray(link.targetObjectTypeId)
+        ? [...link.targetObjectTypeId]
+        : link.targetObjectTypeId,
       cardinality: link.cardinality,
-      properties: link.properties,
+      properties: link.properties?.map(serializeProperty),
     })),
     actions: sixb.getActionsForType(objectType).map((action) => ({
       id: action.id,

--- a/packages/server/src/schemas/ontology.ts
+++ b/packages/server/src/schemas/ontology.ts
@@ -12,6 +12,18 @@ export const PropertyDefinitionSchema = z.object({
   primary: z.boolean().optional(),
   semanticType: z.string().optional(),
   schema: z.unknown(),
+  query: z
+    .object({
+      searchable: z.boolean().optional(),
+      filterable: z.boolean().optional(),
+      sortable: z.boolean().optional(),
+      text: z.boolean().optional(),
+      exact: z.boolean().optional(),
+      facet: z.boolean().optional(),
+      vector: z.boolean().optional(),
+      weight: z.number().optional(),
+    })
+    .optional(),
 })
 
 export const LinkDefinitionSchema = z.object({
@@ -46,6 +58,19 @@ export const ObjectTypeSchema = z.object({
   extends: z.string().optional(),
   implements: z.array(z.string()).optional(),
   properties: z.array(PropertyDefinitionSchema),
+  search: z
+    .object({
+      title: z.string().optional(),
+      defaultText: z.array(z.string()).optional(),
+      exact: z.array(z.string()).optional(),
+      vector: z
+        .object({
+          property: z.string(),
+          source: z.array(z.string()),
+        })
+        .optional(),
+    })
+    .optional(),
   links: z.array(LinkDefinitionSchema),
   actions: z.array(ActionSchema),
 })


### PR DESCRIPTION
## Summary
- expose ontology query/search metadata through object type responses and regenerated client types
- add a server-backed Atlas query builder for selected object types with text search, filters, match-all/match-any, sort, facets, and load-more pagination
- split object query UI/model into focused Atlas components and helpers, and remove extra per-object detail queries from the workbench

## Validation
- bun run generate:client
- bun test packages/server/tests/openapi-docs.test.ts
- bun run check
- bun run typecheck
- bun run build && bun run test

## Screenshots

<img width="1122" height="670" alt="Screenshot 2026-06-16 at 10 50 18 PM" src="https://github.com/user-attachments/assets/2d34ff45-73bc-4ab2-ba0a-e5f2a60b39d1" />
<img width="699" height="272" alt="Screenshot 2026-06-16 at 10 50 24 PM" src="https://github.com/user-attachments/assets/d6f4c2d4-5d98-41fe-bf59-ba2d0a0abb7e" />
<img width="1080" height="150" alt="Screenshot 2026-06-16 at 10 50 46 PM" src="https://github.com/user-attachments/assets/91f8b86d-2b8a-4b0d-b1e1-6dd2c4707fe9" />
