### PR TITLE
actions: support V2 action nodes in workflows

### DIFF
--- a/examples/acme-corp/workflows/invoice-reminder.ts
+++ b/examples/acme-corp/workflows/invoice-reminder.ts
@@ -141,7 +141,7 @@ export const invoiceReminderWorkflow = defineWorkflow("invoice-reminder-workflow
   .then(composeInvoiceReminder)
   .then(reviewInvoiceReminder)
   .then(sendReminder, ({ steps }) => ({
-    target: steps.composeInvoiceReminder.invoice,
+    subject: steps.composeInvoiceReminder.invoice,
     params: {
       approved: steps.reviewInvoiceReminder.approved,
       message: steps.reviewInvoiceReminder.message,

--- a/packages/atlas/src/features/workflows/components/nodes/WorkflowNodeRow.tsx
+++ b/packages/atlas/src/features/workflows/components/nodes/WorkflowNodeRow.tsx
@@ -55,7 +55,9 @@ function NodeMeta({ node }: { node: WorkflowNode }) {
   if (node.type === "action") {
     return (
       <p className="mt-0.5 truncate text-xs text-muted-foreground">
-        Sends an action request to {node.targetObjectTypeId}.
+        {node.objectTypeId === undefined
+          ? "Sends a global action request."
+          : `Sends an action request to ${node.objectTypeId}.`}
       </p>
     )
   }
@@ -73,12 +75,14 @@ function NodeMeta({ node }: { node: WorkflowNode }) {
 
 function NodeSummary({ node }: { node: WorkflowNode }) {
   if (node.type === "action") {
+    const isGlobal = node.objectTypeId === undefined
+
     return (
       <span className="hidden shrink-0 items-center gap-1.5 text-xs text-muted-foreground sm:inline-flex">
-        <span>targets</span>
+        <span>{isGlobal ? "scope" : "targets"}</span>
         <span className="inline-flex items-center gap-1 rounded-md bg-muted/60 px-2 py-0.5 font-medium text-foreground">
           <Box className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
-          {node.targetObjectTypeId}
+          {isGlobal ? "global" : node.objectTypeId}
         </span>
       </span>
     )

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -5155,7 +5155,7 @@
                                 "key": {
                                   "type": "string"
                                 },
-                                "targetObjectTypeId": {
+                                "objectTypeId": {
                                   "type": "string"
                                 },
                                 "params": {
@@ -5163,7 +5163,7 @@
                                   "additionalProperties": {}
                                 }
                               },
-                              "required": ["type", "id", "key", "targetObjectTypeId", "params"],
+                              "required": ["type", "id", "key", "params"],
                               "additionalProperties": false
                             },
                             {
@@ -5349,7 +5349,7 @@
                               "key": {
                                 "type": "string"
                               },
-                              "targetObjectTypeId": {
+                              "objectTypeId": {
                                 "type": "string"
                               },
                               "params": {
@@ -5357,7 +5357,7 @@
                                 "additionalProperties": {}
                               }
                             },
-                            "required": ["type", "id", "key", "targetObjectTypeId", "params"],
+                            "required": ["type", "id", "key", "params"],
                             "additionalProperties": false
                           },
                           {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1854,7 +1854,7 @@ export type ListWorkflowsResponses = {
           type: "action"
           id: string
           key: string
-          targetObjectTypeId: string
+          objectTypeId?: string
           params: {
             [key: string]: unknown
           }
@@ -1939,7 +1939,7 @@ export type GetWorkflowResponses = {
           type: "action"
           id: string
           key: string
-          targetObjectTypeId: string
+          objectTypeId?: string
           params: {
             [key: string]: unknown
           }

--- a/packages/core/src/workflows/builders.ts
+++ b/packages/core/src/workflows/builders.ts
@@ -1,5 +1,5 @@
-import type { ObjectActionDefinition } from "../actions"
-import { isActionDefinition, isObjectActionDefinition } from "../actions"
+import type { ActionDefinition } from "../actions"
+import { isActionDefinition } from "../actions"
 import type { SchemaOrRef } from "../ontology"
 import type { ScheduleDefinition } from "../schedules"
 import { isScheduleDefinition } from "../schedules"
@@ -121,53 +121,45 @@ function createWorkflowDraftBuilder(id: string, input: Record<string, SchemaOrRe
   let definition: WorkflowChainDefinition | null = null
 
   const appendNode = (
-    target: unknown,
+    nodeDefinition: unknown,
     mapper?: unknown,
     ...extraArgs: unknown[]
   ): WorkflowChainDefinition => {
     if (extraArgs.length > 0) {
-      throw invalidThenOverload(id)
+      throw new WorkflowDefinitionError(`Invalid workflow "${id}" .then(...) call.`)
     }
 
-    if (isStepDefinition(target)) {
+    if (isStepDefinition(nodeDefinition)) {
       if (mapper !== undefined && typeof mapper !== "function") {
-        throw invalidThenOverload(id)
+        throw new WorkflowDefinitionError(`Invalid workflow "${id}" .then(...) call.`)
       }
 
-      nodes.push(createStepNode(id, nodes, target, mapper))
+      nodes.push(createStepNode(id, nodes, nodeDefinition, mapper))
       definition ??= createWorkflowDefinition(id, input, triggers, nodes, appendNode)
       return definition
     }
 
-    if (isInterventionDefinition(target)) {
+    if (isInterventionDefinition(nodeDefinition)) {
       if (mapper !== undefined && typeof mapper !== "function") {
-        throw invalidThenOverload(id)
+        throw new WorkflowDefinitionError(`Invalid workflow "${id}" .then(...) call.`)
       }
 
-      nodes.push(createInterventionNode(id, nodes, target, mapper))
+      nodes.push(createInterventionNode(id, nodes, nodeDefinition, mapper))
       definition ??= createWorkflowDefinition(id, input, triggers, nodes, appendNode)
       return definition
     }
 
-    if (isActionDefinition(target)) {
-      if (!isObjectActionDefinition(target)) {
-        throw new WorkflowDefinitionError(
-          `Workflow "${id}" action node "${target.id}" must be object-scoped in V1.`
-        )
+    if (isActionDefinition(nodeDefinition)) {
+      if (mapper !== undefined && typeof mapper !== "function") {
+        throw new WorkflowDefinitionError(`Invalid workflow "${id}" .then(...) call.`)
       }
 
-      if (typeof mapper !== "function") {
-        throw new WorkflowDefinitionError(
-          `Workflow "${id}" action node "${target.id}" requires a mapper.`
-        )
-      }
-
-      nodes.push(createActionNode(id, nodes, target, mapper))
+      nodes.push(createActionNode(id, nodes, nodeDefinition, mapper))
       definition ??= createWorkflowDefinition(id, input, triggers, nodes, appendNode)
       return definition
     }
 
-    throw invalidThenOverload(id)
+    throw new WorkflowDefinitionError(`Invalid workflow "${id}" .then(...) call.`)
   }
 
   const draft = {
@@ -193,7 +185,11 @@ function createWorkflowDefinition(
   input: Record<string, SchemaOrRef>,
   triggers: readonly WorkflowTriggerDefinition[],
   nodes: readonly WorkflowNodeDefinition[],
-  then: (target: unknown, mapper?: unknown, ...extraArgs: unknown[]) => WorkflowChainDefinition
+  then: (
+    nodeDefinition: unknown,
+    mapper?: unknown,
+    ...extraArgs: unknown[]
+  ) => WorkflowChainDefinition
 ): WorkflowChainDefinition {
   return {
     kind: "workflow",
@@ -263,7 +259,7 @@ function createInterventionDefinition(input: {
 function createActionNode(
   workflowId: string,
   nodes: readonly WorkflowNodeDefinition[],
-  action: ObjectActionDefinition,
+  action: ActionDefinition,
   mapper: unknown
 ): WorkflowNodeDefinition {
   const key = deriveWorkflowNodeKey(action.id)
@@ -275,7 +271,7 @@ function createActionNode(
     id: action.id,
     key,
     action,
-    mapper,
+    ...(mapper !== undefined ? { mapper } : {}),
   }
 }
 
@@ -347,10 +343,4 @@ function uncapitalize(value: string): string {
 
 function capitalize(value: string): string {
   return value.length === 0 ? value : `${value[0].toUpperCase()}${value.slice(1)}`
-}
-
-function invalidThenOverload(workflowId: string): WorkflowDefinitionError {
-  return new WorkflowDefinitionError(
-    `Invalid workflow "${workflowId}" .then(...) overload. V1 supports then(step), then(step, mapper), then(intervention), then(intervention, mapper), and then(action, mapper).`
-  )
 }

--- a/packages/core/src/workflows/snapshot.ts
+++ b/packages/core/src/workflows/snapshot.ts
@@ -1,3 +1,4 @@
+import type { ActionSubject } from "../actions"
 import type { JsonValue } from "../json"
 import { isObjectRefSchema, type Schema, type SchemaOrRef, type ValueType } from "../ontology"
 import { WorkflowValidationError } from "./errors"
@@ -108,16 +109,18 @@ export function snapshotWorkflowInterventionDefaultResponse(params: {
 }
 
 export function snapshotWorkflowActionInput(params: {
-  readonly target: { readonly objectTypeId: string; readonly primaryId: string }
+  readonly subject?: ActionSubject
   readonly params: Readonly<Record<string, unknown>>
 }): WorkflowIOSnapshot {
-  return {
-    target: {
-      objectTypeId: params.target.objectTypeId,
-      primaryId: params.target.primaryId,
-    },
+  const snapshot: Record<string, JsonValue> = {
     params: snapshotJsonValue(params.params, "Workflow action params"),
   }
+
+  if (params.subject && params.subject.kind !== "none") {
+    snapshot.subject = snapshotJsonValue(params.subject, "Workflow action subject")
+  }
+
+  return snapshot
 }
 
 function snapshotWorkflowContractRecord(params: {

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -1,4 +1,9 @@
-import type { ActionParamsConfig, InferActionParams } from "../actions"
+import type {
+  ActionDefinition,
+  GlobalActionDefinition,
+  InferActionParams,
+  ObjectActionDefinition,
+} from "../actions"
 import type { JsonValue } from "../json"
 import type { InferSchemaOrRef, ObjectRef, SchemaOrRef } from "../ontology"
 import type { Sixb } from "../runtime/sixb"
@@ -278,28 +283,48 @@ export type InferInterventionResponse<TIntervention extends InterventionDefiniti
     ? NonNullable<TResponseValue>
     : never
 
-export interface WorkflowActionDefinition<
-  TId extends string = string,
-  TTargetId extends string = string,
-  TParams extends ActionParamsConfig = ActionParamsConfig,
-> {
-  readonly kind: "action"
-  readonly id: TId
-  readonly binding: { readonly kind: "object"; readonly objectType: { readonly id: TTargetId } }
-  readonly params: TParams
-}
+export type WorkflowActionDefinition = ActionDefinition
 
-export type WorkflowActionMapperResult<TAction extends WorkflowActionDefinition> = {
-  readonly target: ObjectRef<TAction["binding"]["objectType"]["id"]>
-  readonly params: InferActionParams<TAction["params"]>
-}
+export type WorkflowActionMapperResult<TAction extends WorkflowActionDefinition> =
+  TAction extends ObjectActionDefinition
+    ? {
+        readonly subject: ObjectRef<TAction["binding"]["objectType"]["id"]>
+        readonly params: InferActionParams<TAction["params"]>
+      }
+    : TAction extends GlobalActionDefinition
+      ? {
+          readonly subject?: never
+          readonly params: InferActionParams<TAction["params"]>
+        }
+      : never
 
 export type WorkflowActionMapper<
   TInput extends Record<string, unknown>,
   TSteps extends WorkflowStepOutputs,
   TAction extends WorkflowActionDefinition,
-  TResult extends WorkflowActionMapperResult<TAction> = WorkflowActionMapperResult<TAction>,
-> = (ctx: WorkflowMapperContext<TInput, TSteps>) => TResult
+> = (ctx: WorkflowMapperContext<TInput, TSteps>) => WorkflowActionMapperResult<TAction>
+
+type DirectObjectActionInput<TAction extends ObjectActionDefinition> =
+  "subject" extends keyof InferActionParams<TAction["params"]>
+    ? never
+    : Simplify<
+        {
+          readonly subject: ObjectRef<TAction["binding"]["objectType"]["id"]>
+        } & InferActionParams<TAction["params"]>
+      >
+
+type DirectActionDataflowGuard<
+  TCurrent extends Record<string, unknown>,
+  TAction extends WorkflowActionDefinition,
+> = TAction extends GlobalActionDefinition
+  ? TCurrent extends InferActionParams<TAction["params"]>
+    ? unknown
+    : never
+  : TAction extends ObjectActionDefinition
+    ? TCurrent extends DirectObjectActionInput<TAction>
+      ? unknown
+      : never
+    : never
 
 export interface WorkflowStepNodeDefinition<
   TStep extends StepDefinition = StepDefinition,
@@ -320,7 +345,7 @@ export interface WorkflowActionNodeDefinition<
   readonly id: TAction["id"]
   readonly key: DerivedWorkflowNodeKey<TAction["id"]>
   readonly action: TAction
-  readonly mapper: TMapper
+  readonly mapper?: TMapper
 }
 
 export interface WorkflowInterventionNodeDefinition<
@@ -444,12 +469,18 @@ export interface WorkflowChainDefinition<
     InferInterventionResponse<TIntervention>,
     AddInterventionOutput<TSteps, TIntervention>
   >
-  then<
-    const TAction extends WorkflowActionDefinition,
-    const TResult extends WorkflowActionMapperResult<TAction>,
-  >(
+  then<const TAction extends WorkflowActionDefinition>(
+    action: TAction & DirectActionDataflowGuard<TCurrent, TAction>
+  ): WorkflowChainDefinition<
+    TId,
+    TInput,
+    Append<TNodes, WorkflowActionNodeDefinition<TAction, undefined>>,
+    TCurrent,
+    TSteps
+  >
+  then<const TAction extends WorkflowActionDefinition>(
     action: TAction,
-    mapper: WorkflowActionMapper<InferSchemaOrRefRecord<TInput>, TSteps, TAction, TResult>
+    mapper: WorkflowActionMapper<InferSchemaOrRefRecord<TInput>, TSteps, TAction>
   ): WorkflowChainDefinition<
     TId,
     TInput,
@@ -457,7 +488,7 @@ export interface WorkflowChainDefinition<
       TNodes,
       WorkflowActionNodeDefinition<
         TAction,
-        WorkflowActionMapper<InferSchemaOrRefRecord<TInput>, TSteps, TAction, TResult>
+        WorkflowActionMapper<InferSchemaOrRefRecord<TInput>, TSteps, TAction>
       >
     >,
     TCurrent,
@@ -528,19 +559,25 @@ export interface WorkflowDraftBuilder<
     InferInterventionResponse<TIntervention>,
     AddInterventionOutput<TSteps, TIntervention>
   >
-  then<
-    const TAction extends WorkflowActionDefinition,
-    const TResult extends WorkflowActionMapperResult<TAction>,
-  >(
+  then<const TAction extends WorkflowActionDefinition>(
+    action: TAction & DirectActionDataflowGuard<TCurrent, TAction>
+  ): WorkflowChainDefinition<
+    TId,
+    TInput,
+    [WorkflowActionNodeDefinition<TAction, undefined>],
+    TCurrent,
+    TSteps
+  >
+  then<const TAction extends WorkflowActionDefinition>(
     action: TAction,
-    mapper: WorkflowActionMapper<InferSchemaOrRefRecord<TInput>, TSteps, TAction, TResult>
+    mapper: WorkflowActionMapper<InferSchemaOrRefRecord<TInput>, TSteps, TAction>
   ): WorkflowChainDefinition<
     TId,
     TInput,
     [
       WorkflowActionNodeDefinition<
         TAction,
-        WorkflowActionMapper<InferSchemaOrRefRecord<TInput>, TSteps, TAction, TResult>
+        WorkflowActionMapper<InferSchemaOrRefRecord<TInput>, TSteps, TAction>
       >,
     ],
     TCurrent,

--- a/packages/core/src/workflows/validation.ts
+++ b/packages/core/src/workflows/validation.ts
@@ -340,7 +340,7 @@ function validateActionNodeDefinition(
     )
   }
 
-  if (typeof node.mapper !== "function") {
+  if (node.mapper !== undefined && typeof node.mapper !== "function") {
     throw new WorkflowDefinitionError(
       `Workflow "${workflowId}" action node "${node.id}" mapper must be a function.`
     )

--- a/packages/core/tests/workflow-runtime-validation.test.ts
+++ b/packages/core/tests/workflow-runtime-validation.test.ts
@@ -343,7 +343,7 @@ describe("workflow runtime validation", () => {
       valueTypesById,
     })
     const actionInputSnapshot = snapshotWorkflowActionInput({
-      target: { objectTypeId: "Transaction", primaryId: "txn_123" },
+      subject: { kind: "object", objectTypeId: "Transaction", primaryId: "txn_123" },
       params: {
         reviewedAt,
         invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" },
@@ -388,7 +388,7 @@ describe("workflow runtime validation", () => {
       reviewedAt: "2026-05-08T10:00:00.000Z",
     })
     expect(actionInputSnapshot).toEqual({
-      target: { objectTypeId: "Transaction", primaryId: "txn_123" },
+      subject: { kind: "object", objectTypeId: "Transaction", primaryId: "txn_123" },
       params: {
         reviewedAt: "2026-05-08T10:00:00.000Z",
         invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" },
@@ -412,7 +412,7 @@ describe("workflow runtime validation", () => {
   test("rejects non-JSON workflow IO snapshots with path context", () => {
     expect(() =>
       snapshotWorkflowActionInput({
-        target: { objectTypeId: "Transaction", primaryId: "txn_123" },
+        subject: { kind: "object", objectTypeId: "Transaction", primaryId: "txn_123" },
         params: {
           callback: () => undefined,
         },
@@ -421,7 +421,7 @@ describe("workflow runtime validation", () => {
 
     expect(() =>
       snapshotWorkflowActionInput({
-        target: { objectTypeId: "Transaction", primaryId: "txn_123" },
+        subject: { kind: "object", objectTypeId: "Transaction", primaryId: "txn_123" },
         params: {
           callback: () => undefined,
         },

--- a/packages/core/tests/workflows.test.ts
+++ b/packages/core/tests/workflows.test.ts
@@ -247,7 +247,7 @@ describe("defineWorkflow", () => {
         confidence: 0.98,
       }))
       .then(attachInvoice, () => ({
-        target: { objectTypeId: "Transaction", primaryId: "transaction:1" },
+        subject: { objectTypeId: "Transaction", primaryId: "transaction:1" },
         params: {
           invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" },
         },
@@ -270,6 +270,23 @@ describe("defineWorkflow", () => {
     expect(typeof workflow.nodes[2].mapper).toBe("function")
   })
 
+  test("stores direct action nodes without a mapper", () => {
+    const workflow = runtimeDefineWorkflow("direct-action")
+      .input({
+        subject: ref(Transaction),
+        invoice: ref(Invoice),
+      })
+      .then(attachInvoice)
+
+    expect(workflow.nodes).toHaveLength(1)
+    expect(workflow.nodes[0]).toMatchObject({
+      type: "action",
+      id: "attach-invoice",
+      key: "attachInvoice",
+    })
+    expect(workflow.nodes[0]).not.toHaveProperty("mapper")
+  })
+
   test("stores intervention nodes in linear order", () => {
     const workflow = runtimeDefineWorkflow("review-then-attach")
       .input({
@@ -278,7 +295,7 @@ describe("defineWorkflow", () => {
       .then(findBestInvoice)
       .then(approveInvoiceMatch)
       .then(attachInvoice, () => ({
-        target: { objectTypeId: "Transaction", primaryId: "transaction:1" },
+        subject: { objectTypeId: "Transaction", primaryId: "transaction:1" },
         params: {
           invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" },
         },
@@ -383,8 +400,7 @@ describe("defineWorkflow", () => {
     })
     const then = draft.then
 
-    expect(() => then(attachInvoice)).toThrow(WorkflowDefinitionError)
-    expect(() => then(attachInvoice)).toThrow('action node "attach-invoice" requires a mapper')
+    expect(() => then(attachInvoice, "alias")).toThrow(WorkflowDefinitionError)
     expect(() => then(findBestInvoice, "alias")).toThrow(WorkflowDefinitionError)
     expect(() => then(findBestInvoice, () => ({}), "alias")).toThrow(WorkflowDefinitionError)
     expect(() => then(approveInvoiceMatch, "alias")).toThrow(WorkflowDefinitionError)
@@ -421,7 +437,7 @@ describe("Sixb workflow registration", () => {
       .when(daily)
       .then(findBestInvoice)
       .then(attachInvoice, ({ input, steps }) => ({
-        target: input.transaction,
+        subject: input.transaction,
         params: {
           invoice: steps.findBestInvoice.invoice,
         },
@@ -543,7 +559,7 @@ describe("Sixb workflow registration", () => {
       })
       .then(findBestInvoice)
       .then(attachInvoice, ({ input, steps }) => ({
-        target: input.transaction,
+        subject: input.transaction,
         params: {
           invoice: steps.findBestInvoice.invoice,
         },

--- a/packages/core/tests/workflows.types.ts
+++ b/packages/core/tests/workflows.types.ts
@@ -97,10 +97,59 @@ const persistReview = defineWorkflowStep("persist-review")
     invoice: input.invoice,
   }))
 
+const prepareCreateInvoice = defineWorkflowStep("prepare-create-invoice")
+  .input(workflowInput)
+  .output({
+    amount: "double",
+    transaction: ref(Transaction),
+    extraContext: "string",
+  })
+  .run(({ input }) => ({
+    amount: 250,
+    transaction: input.transaction,
+    extraContext: "available-to-later-steps",
+  }))
+
+const prepareAttachInvoice = defineWorkflowStep("prepare-attach-invoice")
+  .input({
+    transaction: ref(Transaction),
+    invoice: ref(Invoice),
+  })
+  .output({
+    subject: ref(Transaction),
+    invoice: ref(Invoice),
+    extraContext: "string",
+  })
+  .run(({ input }) => ({
+    subject: input.transaction,
+    invoice: input.invoice,
+    extraContext: "available-to-later-steps",
+  }))
+
+const prepareWrongSubject = defineWorkflowStep("prepare-wrong-subject")
+  .input({
+    invoice: ref(Invoice),
+  })
+  .output({
+    subject: ref(Invoice),
+    invoice: ref(Invoice),
+  })
+  .run(({ input }) => ({
+    subject: input.invoice,
+    invoice: input.invoice,
+  }))
+
 const attachInvoice = defineAction("attach-invoice")
   .on(Transaction)
   .params({
     invoice: param(ref(Invoice)),
+  })
+  .writeback(async () => {})
+
+const createInvoice = defineAction("create-invoice")
+  .params({
+    amount: param("double"),
+    transaction: param(ref(Transaction)),
   })
   .writeback(async () => {})
 
@@ -181,14 +230,23 @@ const workflow = defineWorkflow("reconcile-transaction")
     }
   })
   .then(attachInvoice, ({ input, steps }) => ({
-    target: input.transaction,
+    subject: input.transaction,
     params: {
       invoice: steps.reviewInvoiceMatch.invoice,
+    },
+  }))
+  .then(createInvoice, ({ input }) => ({
+    params: {
+      amount: 250,
+      transaction: input.transaction,
     },
   }))
   .then(persistReview, ({ steps }) => {
     // @ts-expect-error action nodes do not expose business output in steps
     steps.attachInvoice
+
+    // @ts-expect-error global action nodes do not expose business output in steps
+    steps.createInvoice
 
     return {
       invoice: steps.reviewInvoiceMatch.invoice,
@@ -221,14 +279,46 @@ defineWorkflow("direct-step-dataflow")
   .then(findBestInvoice)
   .then(reviewInvoiceMatch)
 
+defineWorkflow("action-direct-dataflow")
+  .input(workflowInput)
+  .then(prepareCreateInvoice)
+  .then(createInvoice)
+  .then(prepareAttachInvoice, ({ input }) => ({
+    transaction: input.transaction,
+    invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" } as const,
+  }))
+  .then(attachInvoice)
+
 // @ts-expect-error workflow input has no invoice for this direct first step
 defineWorkflow("direct-step-mismatch").input(workflowInput).then(persistReview)
 
 // @ts-expect-error workflow input has no invoice/confidence for this direct first intervention
 defineWorkflow("direct-intervention-mismatch").input(workflowInput).then(approveInvoiceMatch)
 
-// @ts-expect-error action mapper is mandatory
-defineWorkflow("missing-action-mapper").input(workflowInput).then(attachInvoice)
+defineWorkflow("action-direct-dataflow-missing-global-param")
+  .input(workflowInput)
+  .then(findBestInvoice)
+  // @ts-expect-error direct global action dataflow requires current output to contain required params
+  .then(createInvoice)
+
+defineWorkflow("action-direct-dataflow-missing-object-subject")
+  .input(workflowInput)
+  .then(reviewInvoiceMatch, ({ input }) => ({
+    transaction: input.transaction,
+    invoice: { objectTypeId: "Invoice", primaryId: "invoice:1" } as const,
+    confidence: 0.98,
+  }))
+  // @ts-expect-error direct object action dataflow requires a subject
+  .then(attachInvoice)
+
+defineWorkflow("action-direct-dataflow-wrong-object-subject")
+  .input(workflowInput)
+  .then(findBestInvoice)
+  .then(prepareWrongSubject, ({ steps }) => ({
+    invoice: steps.findBestInvoice.invoice,
+  }))
+  // @ts-expect-error direct object action subject must match the action binding type
+  .then(attachInvoice)
 
 // @ts-expect-error aliases are not supported in V1
 defineWorkflow("step-alias").input(workflowInput).then(findBestInvoice, "find")
@@ -241,9 +331,9 @@ defineWorkflow("step-mapper-alias")
 defineWorkflow("bad-action-target")
   .input(workflowInput)
   .then(findBestInvoice)
-  // @ts-expect-error action target must be a Transaction ref
+  // @ts-expect-error action subject must be a Transaction ref
   .then(attachInvoice, ({ steps }) => ({
-    target: steps.findBestInvoice.invoice,
+    subject: steps.findBestInvoice.invoice,
     params: {
       invoice: steps.findBestInvoice.invoice,
     },
@@ -254,9 +344,20 @@ defineWorkflow("bad-action-param")
   .then(findBestInvoice)
   // @ts-expect-error invoice param must be an Invoice ref
   .then(attachInvoice, ({ input }) => ({
-    target: input.transaction,
+    subject: input.transaction,
     params: {
       invoice: input.transaction,
+    },
+  }))
+
+defineWorkflow("bad-global-action-subject")
+  .input(workflowInput)
+  // @ts-expect-error global action mappers must not return subject
+  .then(createInvoice, ({ input }) => ({
+    subject: input.transaction,
+    params: {
+      amount: 250,
+      transaction: input.transaction,
     },
   }))
 

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -150,7 +150,9 @@ function serializeWorkflow(
           type: "action" as const,
           id: node.id,
           key: node.key,
-          targetObjectTypeId: node.action.binding.objectType.id,
+          ...(node.action.binding.kind === "object"
+            ? { objectTypeId: node.action.binding.objectType.id }
+            : {}),
           params: node.action.params,
         }
       }

--- a/packages/server/src/schemas/workflows.ts
+++ b/packages/server/src/schemas/workflows.ts
@@ -92,7 +92,7 @@ const WorkflowNodeSchema = z.union([
     type: z.literal("action"),
     id: z.string(),
     key: z.string(),
-    targetObjectTypeId: z.string(),
+    objectTypeId: z.string().optional(),
     params: z.record(z.unknown()),
   }),
   z.object({

--- a/packages/workflow-worker/src/nodes/action-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/action-node-executor.ts
@@ -1,15 +1,16 @@
-import type { ActionRunFailure, WorkflowActionNodeDefinition } from "@sixb/core"
-import { ActionRunFailedError, objectService, snapshotWorkflowActionInput } from "@sixb/core"
+import type { ActionRunFailure, ActionSubject, WorkflowActionNodeDefinition } from "@sixb/core"
+import {
+  ActionRunFailedError,
+  isObjectActionDefinition,
+  snapshotWorkflowActionInput,
+} from "@sixb/core"
 import { WorkflowWorkerError } from "../errors"
 import type { WorkflowNodeExecutor } from "../execution/node-executor"
 import { isRecord } from "../normalize"
 import { callWorkflowMapper } from "./mapper"
 
 interface ActionMapperResult {
-  readonly target: {
-    readonly objectTypeId: string
-    readonly primaryId: string
-  }
+  readonly subject?: ActionSubject
   readonly params: Readonly<Record<string, unknown>>
 }
 
@@ -17,20 +18,25 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
   type: "action",
 
   prepare({ node, context }) {
-    const rawMapperResult = callWorkflowMapper({
-      mapper: node.mapper,
-      workflowId: context.workflow.id,
-      nodeId: node.id,
-      workflowInput: context.state.workflowInput,
-      steps: context.state.steps,
-    })
+    const rawMapperResult =
+      node.mapper === undefined
+        ? context.state.current
+        : callWorkflowMapper({
+            mapper: node.mapper,
+            workflowId: context.workflow.id,
+            nodeId: node.id,
+            workflowInput: context.state.workflowInput,
+            steps: context.state.steps,
+          })
     const mapperResult = normalizeActionMapperResult({
       workflowId: context.workflow.id,
       nodeId: node.id,
+      action: node.action,
       value: rawMapperResult,
+      mode: node.mapper === undefined ? "direct" : "mapped",
     })
     const inputSnapshot = snapshotWorkflowActionInput({
-      target: mapperResult.target,
+      subject: mapperResult.subject,
       params: mapperResult.params,
     })
 
@@ -44,22 +50,20 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
     const mapperResult = normalizeActionMapperResult({
       workflowId: context.workflow.id,
       nodeId: node.id,
+      action: node.action,
       value: prepared.input,
+      mode: "mapped",
     })
     const actionRunId = `${context.job.id}:action:${nodeIndex}`
 
-    const run = await objectService.requestActionAndWait(
-      context.runtime,
-      mapperResult.target.objectTypeId,
-      mapperResult.target.primaryId,
-      node.action.id,
-      { ...mapperResult.params },
-      {
-        runId: actionRunId,
-        signal: context.signal,
-        onRequested: () => context.markSideEffectBoundaryPassed(),
-      }
-    )
+    const run = await context.runtime.sixb.actions.requestAndWait({
+      actionId: node.action.id,
+      subject: mapperResult.subject,
+      params: { ...mapperResult.params },
+      runId: actionRunId,
+      signal: context.signal,
+      onRequested: () => context.markSideEffectBoundaryPassed(),
+    })
     if (run.status !== "succeeded") {
       throw new ActionRunFailedError({
         runId: run.id,
@@ -70,7 +74,9 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
       })
     }
 
-    return {}
+    return {
+      outputSnapshot: { actionRunId },
+    }
   },
 }
 
@@ -87,20 +93,32 @@ function actionRunStatusFailure(
 function normalizeActionMapperResult(input: {
   readonly workflowId: string
   readonly nodeId: string
+  readonly action: WorkflowActionNodeDefinition["action"]
   readonly value: unknown
+  readonly mode: "direct" | "mapped"
 }): ActionMapperResult {
   if (!isRecord(input.value)) {
     throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must return an object.`
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' input must be an object.`
     )
   }
 
-  const { target, params } = input.value
-  if (!isObjectRef(target)) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must return a valid target object ref.`
-    )
+  const value = input.value
+
+  if (input.mode === "direct") {
+    return normalizeDirectActionInput({ ...input, value })
   }
+
+  return normalizeMappedActionInput({ ...input, value })
+}
+
+function normalizeMappedActionInput(input: {
+  readonly workflowId: string
+  readonly nodeId: string
+  readonly action: WorkflowActionNodeDefinition["action"]
+  readonly value: Readonly<Record<string, unknown>>
+}): ActionMapperResult {
+  const { subject, params } = input.value
 
   if (!isRecord(params)) {
     throw new WorkflowWorkerError(
@@ -108,10 +126,101 @@ function normalizeActionMapperResult(input: {
     )
   }
 
+  if (isObjectActionDefinition(input.action)) {
+    return {
+      subject: normalizeObjectActionSubject({
+        workflowId: input.workflowId,
+        nodeId: input.nodeId,
+        value: subject,
+      }),
+      params,
+    }
+  }
+
+  if (Object.hasOwn(input.value, "subject")) {
+    throw new WorkflowWorkerError(
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must not return subject for a global action.`
+    )
+  }
+
   return {
-    target,
     params,
   }
+}
+
+function normalizeDirectActionInput(input: {
+  readonly workflowId: string
+  readonly nodeId: string
+  readonly action: WorkflowActionNodeDefinition["action"]
+  readonly value: Readonly<Record<string, unknown>>
+}): ActionMapperResult {
+  if (isObjectActionDefinition(input.action)) {
+    if (!Object.hasOwn(input.value, "subject")) {
+      throw new WorkflowWorkerError(
+        `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' direct input must include subject for an object action.`
+      )
+    }
+
+    return {
+      subject: normalizeObjectActionSubject({
+        workflowId: input.workflowId,
+        nodeId: input.nodeId,
+        value: input.value.subject,
+      }),
+      params: pickActionParams(input.action, input.value),
+    }
+  }
+
+  if (Object.hasOwn(input.value, "subject")) {
+    throw new WorkflowWorkerError(
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' direct input must not include subject for a global action.`
+    )
+  }
+
+  return {
+    params: pickActionParams(input.action, input.value),
+  }
+}
+
+function pickActionParams(
+  action: WorkflowActionNodeDefinition["action"],
+  value: Readonly<Record<string, unknown>>
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {}
+  for (const paramId of Object.keys(action.params)) {
+    if (Object.hasOwn(value, paramId)) {
+      params[paramId] = value[paramId]
+    }
+  }
+  return params
+}
+
+function normalizeObjectActionSubject(input: {
+  readonly workflowId: string
+  readonly nodeId: string
+  readonly value: unknown
+}): ActionSubject {
+  if (isActionObjectSubject(input.value)) {
+    return input.value
+  }
+
+  if (!isObjectRef(input.value)) {
+    throw new WorkflowWorkerError(
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must return a valid subject object ref.`
+    )
+  }
+
+  return {
+    kind: "object",
+    objectTypeId: input.value.objectTypeId,
+    primaryId: input.value.primaryId,
+  }
+}
+
+function isActionObjectSubject(
+  value: unknown
+): value is Extract<ActionSubject, { kind: "object" }> {
+  return isRecord(value) && value.kind === "object" && isObjectRef(value)
 }
 
 function isObjectRef(value: unknown): value is { objectTypeId: string; primaryId: string } {

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   type ActionDefinition,
   type ActionRunStorage,
+  defineAction,
   defineIntervention,
   defineObjectType,
   defineWorkflow,
@@ -70,6 +71,38 @@ const reviewInvoiceMatch = defineWorkflowStep("review-invoice-match")
     invoice: input.invoice,
   }))
 
+const prepareAttachInvoiceAction = defineWorkflowStep("prepare-attach-invoice-action")
+  .input({
+    transaction: ref(Transaction),
+    invoice: ref(Invoice),
+    confidence: "double",
+  })
+  .output({
+    subject: ref(Transaction),
+    invoice: ref(Invoice),
+    confidence: "double",
+  })
+  .run(({ input }) => ({
+    subject: input.transaction,
+    invoice: input.invoice,
+    confidence: input.confidence,
+  }))
+
+const prepareInvoice = defineWorkflowStep("prepare-invoice")
+  .input({
+    transaction: ref(Transaction),
+  })
+  .output({
+    amount: "double",
+    transaction: ref(Transaction),
+    extraContext: "string",
+  })
+  .run(({ input }) => ({
+    amount: 250,
+    transaction: input.transaction,
+    extraContext: "ignored-by-action-request",
+  }))
+
 const reviewInvoiceDecision = defineIntervention("review-invoice-decision")
   .input({
     transaction: ref(Transaction),
@@ -133,20 +166,31 @@ const invalidOutputStep = defineWorkflowStep("invalid-output")
   }))
 
 let actionHandlerCalls = 0
-const attachInvoice: ActionDefinition = {
-  kind: "action",
-  id: "attach-invoice",
-  binding: { kind: "object", objectType: Transaction },
-  params: {
+const attachInvoice = defineAction("attach-invoice")
+  .on(Transaction)
+  .params({
     invoice: param(ref(Invoice)),
-  },
-  phases: {
-    validate: [],
-    writeback: () => {
-      actionHandlerCalls += 1
-    },
-  },
-}
+  })
+  .writeback(() => {
+    actionHandlerCalls += 1
+  })
+
+const createInvoice = defineAction("create-invoice")
+  .params({
+    invoice: param(ref(Invoice)),
+  })
+  .writeback(() => {
+    actionHandlerCalls += 1
+  })
+
+const createInvoiceFromTransaction = defineAction("create-invoice-from-transaction")
+  .params({
+    amount: param("double"),
+    transaction: param(ref(Transaction)),
+  })
+  .writeback(() => {
+    actionHandlerCalls += 1
+  })
 
 function createSixb(options: {
   readonly workflows?: readonly WorkflowDefinition[]
@@ -212,7 +256,8 @@ async function completeRequestedActions(
     readonly storage: { readonly actionRuns?: ActionRunStorage }
   },
   status: "succeeded" | "failed",
-  errorMessage = "action failed"
+  errorMessage = "action failed",
+  options: { readonly effectsErrorMessage?: string } = {}
 ): Promise<() => void> {
   const actionRuns = sixb.storage.actionRuns
   if (!actionRuns) {
@@ -238,6 +283,23 @@ async function completeRequestedActions(
             await actionRuns.start({
               projectId: sixb.id,
               id: event.payload.runId,
+            })
+          }
+
+          if (status === "succeeded" && options.effectsErrorMessage) {
+            await actionRuns.enterPhase({
+              projectId: sixb.id,
+              id: event.payload.runId,
+              phase: "effects",
+            })
+            await actionRuns.recordEffects({
+              projectId: sixb.id,
+              id: event.payload.runId,
+              status: "failed",
+              error: {
+                message: options.effectsErrorMessage,
+                phase: "effects",
+              },
             })
           }
 
@@ -839,7 +901,7 @@ describe("runWorkflowJob", () => {
       })
       .then(findBestInvoice)
       .then(attachInvoice, ({ input, steps }) => ({
-        target: input.transaction,
+        subject: input.transaction,
         params: {
           invoice: steps.findBestInvoice.invoice,
         },
@@ -875,6 +937,259 @@ describe("runWorkflowJob", () => {
         runId: "wfrun_action:action:1",
       })
       expect(result.nodes[1]?.status).toBe("succeeded")
+      expect(result.nodes[1]?.output).toEqual({
+        actionRunId: "wfrun_action:action:1",
+      })
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  test("runs global action nodes through the canonical action runtime", async () => {
+    actionHandlerCalls = 0
+    const workflow = defineWorkflow("create-invoice-workflow")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(createInvoice, ({ steps }) => ({
+        params: {
+          invoice: steps.findBestInvoice.invoice,
+        },
+      }))
+    const sixb = createSixb({ actions: [createInvoice], workflows: [workflow] })
+    const unsubscribe = await completeRequestedActions(sixb, "succeeded")
+
+    try {
+      const result = await runWorkflowJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "wfrun_global_action",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+
+      const events = await sixb.events.read({
+        types: ["action.requested"],
+      })
+      expect(actionHandlerCalls).toBe(0)
+      expect(events[0]?.payload).toMatchObject({
+        subject: { kind: "none" },
+        actionId: "create-invoice",
+        runId: "wfrun_global_action:action:1",
+      })
+      expect(result.nodes[1]?.status).toBe("succeeded")
+      expect(result.nodes[1]?.output).toEqual({
+        actionRunId: "wfrun_global_action:action:1",
+      })
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  test("runs global action nodes with direct dataflow", async () => {
+    actionHandlerCalls = 0
+    const workflow = defineWorkflow("create-invoice-direct-workflow")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(createInvoice)
+    const sixb = createSixb({ actions: [createInvoice], workflows: [workflow] })
+    const unsubscribe = await completeRequestedActions(sixb, "succeeded")
+
+    try {
+      const result = await runWorkflowJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "wfrun_global_action_direct",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+
+      const events = await sixb.events.read({
+        types: ["action.requested"],
+      })
+      expect(actionHandlerCalls).toBe(0)
+      expect(events[0]?.payload).toMatchObject({
+        subject: { kind: "none" },
+        params: {
+          invoice: { objectTypeId: "Invoice", primaryId: "inv_1" },
+        },
+        actionId: "create-invoice",
+        runId: "wfrun_global_action_direct:action:1",
+      })
+      const params = events[0]?.type === "action.requested" ? events[0].payload.params : {}
+      expect(params).not.toHaveProperty("transaction")
+      expect(params).not.toHaveProperty("confidence")
+      expect(result.nodes[1]?.input).toEqual({
+        params: {
+          invoice: { objectTypeId: "Invoice", primaryId: "inv_1" },
+        },
+      })
+      expect(result.nodes[1]?.status).toBe("succeeded")
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  test("picks declared params from direct global action dataflow", async () => {
+    actionHandlerCalls = 0
+    const workflow = defineWorkflow("create-invoice-from-transaction-workflow")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(prepareInvoice)
+      .then(createInvoiceFromTransaction)
+    const sixb = createSixb({
+      actions: [createInvoiceFromTransaction],
+      workflows: [workflow],
+    })
+    const unsubscribe = await completeRequestedActions(sixb, "succeeded")
+
+    try {
+      const result = await runWorkflowJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "wfrun_pick_global_action_params",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+
+      const events = await sixb.events.read({
+        types: ["action.requested"],
+      })
+      expect(events[0]?.payload).toMatchObject({
+        subject: { kind: "none" },
+        params: {
+          amount: 250,
+          transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+        },
+        actionId: "create-invoice-from-transaction",
+        runId: "wfrun_pick_global_action_params:action:1",
+      })
+      const params = events[0]?.type === "action.requested" ? events[0].payload.params : {}
+      expect(params).not.toHaveProperty("extraContext")
+      expect(result.nodes[1]?.input).toEqual({
+        params: {
+          amount: 250,
+          transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+        },
+      })
+      expect(result.nodes[1]?.status).toBe("succeeded")
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  test("runs object action nodes with direct dataflow", async () => {
+    actionHandlerCalls = 0
+    const workflow = defineWorkflow("attach-invoice-direct-workflow")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(prepareAttachInvoiceAction)
+      .then(attachInvoice)
+    const sixb = createSixb({ actions: [attachInvoice], workflows: [workflow] })
+    await sixb.upsertObject("Transaction", { id: "txn_1" })
+    const unsubscribe = await completeRequestedActions(sixb, "succeeded")
+
+    try {
+      const result = await runWorkflowJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "wfrun_object_action_direct",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+
+      const events = await sixb.events.read({
+        types: ["action.requested"],
+      })
+      expect(actionHandlerCalls).toBe(0)
+      expect(events[0]?.payload).toMatchObject({
+        subject: {
+          kind: "object",
+          objectTypeId: "Transaction",
+          primaryId: "txn_1",
+        },
+        params: {
+          invoice: { objectTypeId: "Invoice", primaryId: "inv_1" },
+        },
+        actionId: "attach-invoice",
+        runId: "wfrun_object_action_direct:action:2",
+      })
+      const params = events[0]?.type === "action.requested" ? events[0].payload.params : {}
+      expect(params).not.toHaveProperty("confidence")
+      expect(result.nodes[2]?.input).toEqual({
+        subject: {
+          kind: "object",
+          objectTypeId: "Transaction",
+          primaryId: "txn_1",
+        },
+        params: {
+          invoice: { objectTypeId: "Invoice", primaryId: "inv_1" },
+        },
+      })
+      expect(result.nodes[2]?.status).toBe("succeeded")
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  test("succeeds action nodes when only action effects fail", async () => {
+    const workflow = defineWorkflow("action-effects-fail-workflow")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(attachInvoice, ({ input, steps }) => ({
+        subject: input.transaction,
+        params: {
+          invoice: steps.findBestInvoice.invoice,
+        },
+      }))
+    const sixb = createSixb({ actions: [attachInvoice], workflows: [workflow] })
+    const unsubscribe = await completeRequestedActions(sixb, "succeeded", "action failed", {
+      effectsErrorMessage: "notification failed",
+    })
+
+    try {
+      const result = await runWorkflowJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "wfrun_action_effects_failed",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+      const actionRun = await sixb.storage.actionRuns!.getById({
+        projectId: sixb.id,
+        id: "wfrun_action_effects_failed:action:1",
+      })
+
+      expect(result.run.status).toBe("succeeded")
+      expect(result.nodes[1]?.status).toBe("succeeded")
+      expect(actionRun?.status).toBe("succeeded")
+      expect(actionRun?.effects).toMatchObject({
+        status: "failed",
+        error: { message: "notification failed", phase: "effects" },
+      })
     } finally {
       unsubscribe()
     }
@@ -956,7 +1271,7 @@ describe("runWorkflowJob", () => {
       })
       .then(findBestInvoice)
       .then(attachInvoice, ({ input, steps }) => ({
-        target: input.transaction,
+        subject: input.transaction,
         params: {
           invoice: steps.findBestInvoice.invoice,
         },
@@ -996,14 +1311,14 @@ describe("runWorkflowJob", () => {
     expect(nodes.nodes[1]?.error).toBe("attach failed")
   })
 
-  test("marks action node and workflow failed when the action worker rejects the target", async () => {
-    const workflow = defineWorkflow("missing-target-workflow")
+  test("marks action node and workflow failed when the action run fails after request", async () => {
+    const workflow = defineWorkflow("missing-subject-workflow")
       .input({
         transaction: ref(Transaction),
       })
       .then(findBestInvoice)
       .then(attachInvoice, ({ input, steps }) => ({
-        target: input.transaction,
+        subject: input.transaction,
         params: {
           invoice: steps.findBestInvoice.invoice,
         },


### PR DESCRIPTION
# PR Summary: Workflow Support For Actions V2

## What Changed

- Workflow action nodes now use the canonical Actions V2 runtime:

```ts
sixb.actions.requestAndWait(...)
```

- Workflows can call both global and object-scoped actions.
- Action node inputs now use `subject` instead of the old `target` vocabulary.
- Action nodes support direct dataflow:

```ts
defineWorkflow("create-invoice")
  .input({ transaction: ref(Transaction) })
  .then(prepareInvoice) // { amount, transaction, extraContext }
  .then(createInvoice) // picks declared action params only
```

```ts
defineWorkflow("attach-invoice")
  .input({ transaction: ref(Transaction) })
  .then(prepareAttach) // { subject, invoice, extraContext }
  .then(attachInvoice)
```

- Direct action dataflow only forwards declared params, so extra step output stays out of the action request and audit snapshot.
- Workflow API action nodes now expose a simple optional `objectTypeId`:

```ts
{
  type: "action",
  id: "create-invoice",
  objectTypeId?: string, // absent = global action
  params: { ... }
}
```

- Sentinel workflow node rendering was updated for global vs object action nodes.

## Tests

- Added type coverage for global/object action nodes and direct dataflow.
- Added runtime coverage for:
  - global action nodes
  - object action nodes
  - direct dataflow with extra fields ignored
  - action effects failing while the workflow still succeeds
- Updated workflow API/client snapshots.

## Verification

- `bun run typecheck`
- `bun run check`
- targeted workflow/action/storage tests
- `bun --filter @sixb/pg test:e2e`
