### PR TITLE
ducklake: stage write rows in batches outside the DuckDB queue

### DIFF
--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -93,9 +93,16 @@ const report = await lakeStorage.runMaintenance({
 
 Reads, writes, SQL previews, and SQL transforms use the same DuckDB runtime and
 the same DuckLake PostgreSQL metadata pool. Work is serialized inside one
-`DuckLakeStorage` instance, so a large write can make later reads wait. A large
-streaming read can also make a later write wait until the stream is consumed or
-closed.
+`DuckLakeStorage` instance, so a queued DuckDB operation makes later operations
+wait. Only actual DuckDB work holds the runtime: batch appends, commits, SQL
+transforms, and metadata reads. A large streaming read can also make a later
+write wait until the stream is consumed or closed.
+
+A write does not hold the runtime while its source iterable is producing rows.
+`writeRows(...)` validates and stages rows in bounded in-memory batches, then
+takes a queue slot only to flush each batch into the staging table. Slow external
+reads (pagination, APIs, SFTP, retries) run outside the queue, so other reads and
+write batches can interleave between a write's batches.
 
 ```txt
 same provider instance:

--- a/storage/ducklake/src/internal/ducklake-write-session.ts
+++ b/storage/ducklake/src/internal/ducklake-write-session.ts
@@ -21,6 +21,11 @@ export interface DuckLakeCommitWriteInput {
 
 type DuckLakeCommitWrite = (options: DuckLakeCommitWriteInput) => Promise<DatasetVersion>
 
+// Rows are staged in bounded in-memory batches so a slow source iterable never
+// holds the DuckDB runtime queue. Only the per-batch appender flush takes a
+// queue slot. 1000 keeps memory bounded while amortizing appender open/close.
+const WRITE_ROW_BATCH_SIZE = 1000
+
 interface CreateDuckLakeWriteSessionInput {
   readonly commitWrite: DuckLakeCommitWrite
   readonly runtime: DuckDbRuntime
@@ -66,17 +71,42 @@ class DuckLakeWriteSession implements LakeWriteSession {
   async writeRows(rows: Iterable<DatasetRow> | AsyncIterable<DatasetRow>): Promise<void> {
     this.assertOpen()
 
-    await this.runtime.withAppender(this.stagingTableName, async (appender) => {
-      for await (const row of rows) {
-        const validationError = getDatasetRowValidationError(row, this.input.dataset)
-        if (validationError) {
-          throw new LakeStorageError(`[SixbDuckLake] ${validationError}`)
-        }
+    // Drain and validate the source OUTSIDE the DuckDB queue so slow external
+    // reads (pagination, APIs, SFTP, retries) never hold a runtime slot. Only
+    // appendBatchToStagingTable below briefly enters the queue.
+    let batch: DatasetRow[] = []
+    for await (const row of rows) {
+      const validationError = getDatasetRowValidationError(row, this.input.dataset)
+      if (validationError) {
+        throw new LakeStorageError(`[SixbDuckLake] ${validationError}`)
+      }
 
+      // Snapshot the validated row. Callers may reuse and mutate one row object
+      // between yields, so the batch must not retain a live reference.
+      batch.push(structuredClone(row))
+
+      if (batch.length >= WRITE_ROW_BATCH_SIZE) {
+        await this.appendBatchToStagingTable(batch)
+        batch = []
+      }
+    }
+
+    if (batch.length > 0) {
+      await this.appendBatchToStagingTable(batch)
+    }
+  }
+
+  private async appendBatchToStagingTable(batch: readonly DatasetRow[]): Promise<void> {
+    // Synchronous callback: no awaits inside the queue slot. The appender
+    // buffers and flushes the whole batch into the staging temp table on close.
+    await this.runtime.withAppender(this.stagingTableName, (appender) => {
+      for (const row of batch) {
         appendDatasetRow(appender, this.input.dataset.schema, row)
-        this.rowsWritten += 1
       }
     })
+    // Count only rows actually appended -- commit asserts rowsWritten ===
+    // sourceRowCount in the write coordinator.
+    this.rowsWritten += batch.length
   }
 
   async commit(input?: CommitDatasetWriteInput): Promise<DatasetVersion> {

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -313,6 +313,44 @@ describe("DuckLakeStorage writes and latest reads", () => {
     ])
   })
 
+  test("frees the DuckDB queue for reads while a slow source is mid-write", async () => {
+    let releaseSource: () => void = () => {}
+    const sourceGate = new Promise<void>((resolve) => {
+      releaseSource = resolve
+    })
+    let firstRowYielded: () => void = () => {}
+    const firstRow = new Promise<void>((resolve) => {
+      firstRowYielded = resolve
+    })
+
+    async function* slowOrders(): AsyncIterable<DatasetRow> {
+      yield { orderId: "ord_1", customerName: "Ada", orderCount: 1 }
+      firstRowYielded()
+      // Simulate an external wait (API/pagination/SFTP) mid-stream.
+      await sourceGate
+    }
+
+    const write = await storage.beginWrite({ dataset: ordersDataset, mode: "snapshot" })
+    const writePromise = write.writeRows(slowOrders())
+
+    await firstRow
+
+    // The source is now parked on sourceGate. If writeRows held the appender's
+    // queue slot across the external wait this read would deadlock and time
+    // out; with batched staging the queue is free between batches.
+    const datasets = await storage.listDatasets()
+    expect(datasets.map((dataset) => dataset.id)).toContain(ordersDataset.id)
+
+    releaseSource()
+    await writePromise
+    const version = await write.commit()
+
+    expect(version.rowCount).toBe(1)
+    expect(await collectRows(storage.readRows({ datasetId: ordersDataset.id }))).toEqual([
+      { orderId: "ord_1", customerName: "Ada", orderCount: "1", metadata: null },
+    ])
+  })
+
   test("evolves a dataset by appending a nullable column and writes new-format rows", async () => {
     const initialDataset = defineDataset("raw.erp.schema_evolution", {
       schema: [col("invoiceId", "string"), col("total", "int64")],


### PR DESCRIPTION
## Problem

`DuckLakeWriteSession.writeRows(...)` drained the source iterable *inside* `runtime.withAppender(...)`. Because the appender runs through the runtime's single serialized operation queue, any `await` the source performed between yields held the only DuckDB queue slot for its full duration.

For a sync whose `read(...)` is an async generator doing network work (pagination, APIs, SFTP, retries), that meant every external round-trip blocked all other operations on the provider — reads, metadata lookups, and other write batches — for the entire wait. In `sixb dev` this serializes a slow sync against all lake reads.

## Change

Drain and validate the source **outside** the queue into bounded in-memory batches, then take a queue slot only to flush each batch into the staging temp table.

```ts
let batch: DatasetRow[] = []
for await (const row of rows) {
  // validate(row)
  batch.push(structuredClone(row))
  if (batch.length >= WRITE_ROW_BATCH_SIZE) {
    await this.appendBatchToStagingTable(batch) // brief queue slot, sync callback
    batch = []
  }
}
if (batch.length > 0) await this.appendBatchToStagingTable(batch)
```

- External source iteration no longer holds the runtime; only DuckDB work (batch appends, commits, SQL transforms, metadata reads) does.
- Memory is bounded at `WRITE_ROW_BATCH_SIZE` (1000) rows; the DuckDB queue is released between batches so reads and other writes interleave.
- Rows are deep-cloned on buffer, preserving the existing contract that a source may reuse and mutate one row object between yields.
- `rowsWritten` counts only rows actually flushed, keeping the commit-time `rowsWritten === sourceRowCount` assertion intact.

The durable commit path (one DuckLake snapshot under the exclusive attached runtime) is unchanged.

## Tests

Added a regression test: a slow source parks mid-stream while `listDatasets()` runs concurrently and must resolve. It deadlocks (10s timeout) against the old code and passes with the change.

| Check | Result |
|---|---|
| `ducklake-writes.e2e.ts` | 18 pass |
| New test vs. pre-change code | fails (deadlock timeout) |
| Local e2e suite | 94 pass |
| Fast unit tests | 43 pass |
| typecheck | pass |
| biome check | clean |

## Scope

No public API change — `defineSync`, `.read`, `mode`, and `intoDataset` are untouched. No commit-path change, no batch-size option, no separate read/write runtimes.