### PR TITLE
actions: expose link reads in action edit contexts

### DIFF
--- a/packages/action-worker/src/action-execution/context.ts
+++ b/packages/action-worker/src/action-execution/context.ts
@@ -22,6 +22,7 @@ type RuntimeReadObjectSet = {
   list(input?: ObjectSetListInput): Promise<unknown>
   byId(id: string): {
     get(): Promise<unknown>
+    listLinks(link?: unknown): Promise<unknown>
   }
 }
 
@@ -157,6 +158,11 @@ function createReadObjectSetAdapter<TObjectType extends ObjectTypeWithPropertyTo
       return {
         get() {
           return handle.get() as ReturnType<ReturnType<TypedReadObjectSet["byId"]>["get"]>
+        },
+        listLinks(link) {
+          return handle.listLinks(link) as ReturnType<
+            ReturnType<TypedReadObjectSet["byId"]>["listLinks"]
+          >
         },
       }
     },

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -11,6 +11,7 @@ import {
   InMemoryLakeStorage,
   InMemoryQueues,
   InMemoryStorage,
+  link,
   type ObjectRow,
   param,
   prop,
@@ -26,6 +27,7 @@ const Device = defineObjectType({
     prop("name", "string", { required: true }),
     prop("status", "string"),
   ],
+  links: [link("sensor", "Sensor", { cardinality: "one" })],
 })
 
 const Sensor = defineObjectType({
@@ -293,6 +295,77 @@ describe("runActionJob", () => {
 
     const created = await deviceObjects(sixb).get("device-1")
     expect(created?.properties.status).toBe("created")
+  })
+
+  test("exposes object link reads inside action edits", async () => {
+    const detachSensor = defineAction("detachSensor")
+      .on(Device)
+      .params({})
+      .edits(async ({ objects, read, subject }) => {
+        const links = await read.objects(Device).byId(subject.primaryId).listLinks(Device.l.sensor)
+        expect(links).toHaveLength(1)
+        expect(links[0]).toMatchObject({
+          linkId: "sensor",
+          targetTypeId: "Sensor",
+          targetId: "sensor-1",
+        })
+
+        objects(Device).byId(subject.primaryId).unlink(Device.l.sensor, {
+          objectTypeId: Sensor.id,
+          primaryId: links[0].targetId,
+        })
+        objects(Device).byId(subject.primaryId).update({ status: "detached" })
+      })
+
+    const sixb = createSixb([detachSensor], [Device, Sensor])
+    await sixb.upsertObject("Device", {
+      id: "device-1",
+      name: "Device 1",
+    })
+    await sixb.upsertObject("Sensor", {
+      id: "sensor-1",
+      name: "Sensor 1",
+    })
+    await (
+      sixb as unknown as {
+        objects(objectType: typeof Device): {
+          byId(id: string): {
+            link(
+              linkToken: typeof Device.l.sensor,
+              target: { objectTypeId: "Sensor"; primaryId: string }
+            ): Promise<void>
+          }
+        }
+      }
+    )
+      .objects(Device)
+      .byId("device-1")
+      .link(Device.l.sensor, { objectTypeId: "Sensor", primaryId: "sensor-1" })
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "detachSensor",
+      subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
+      params: {},
+    })
+
+    const result = await runActionJob({
+      runtime: createContext(sixb),
+      job: {
+        id: "act_1",
+        actionId: "detachSensor",
+      },
+    })
+
+    expect(result.status).toBe("succeeded")
+    const updated = await deviceObjects(sixb).get("device-1")
+    expect(updated?.properties.status).toBe("detached")
+    const linksAfter = await sixb.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "Device",
+      objectId: "device-1",
+      linkId: "sensor",
+    })
+    expect(linksAfter).toEqual([])
   })
 
   test("marks queued runs failed when the action definition is missing", async () => {

--- a/packages/core/src/actions/types/context.ts
+++ b/packages/core/src/actions/types/context.ts
@@ -68,6 +68,14 @@ export interface ActionReadObjectByIdHandle<
   TValueTypes extends readonly ValueType[],
 > {
   get(): Promise<TwinObject<TObjectType, TValueTypes> | null>
+  listLinks(link?: { readonly id: string }): Promise<
+    readonly {
+      readonly linkId: string
+      readonly targetTypeId: string
+      readonly targetId: string
+      readonly properties?: Readonly<Record<string, unknown>>
+    }[]
+  >
 }
 
 export interface ActionReadObjectSet<


### PR DESCRIPTION
## Summary
- expose `listLinks` on action edit read object handles to match the existing `sixb.objects(Type).byId(id)` DX
- pass link reads through the action-worker read facade
- add regression coverage for reading an existing link during `.edits(...)` before unlinking it

## Example
Actions that replace a cardinality-one link need to read the current link before recording the unlink/create edits. For example, assigning a task to a new person needs to remove the existing assignee link first:

```ts
const assignTask = defineAction("assignTask")
  .on(Task)
  .params({ assigneeId: param("string") })
  .edits(async ({ objects, read, params, subject }) => {
    const task = objects(Task).byId(subject.primaryId)
    const existing = await read
      .objects(Task)
      .byId(subject.primaryId)
      .listLinks(Task.l.assignee)

    for (const link of existing) {
      task.unlink(Task.l.assignee, {
        objectTypeId: Person.id,
        primaryId: link.targetId,
      })
    }

    task.link(Task.l.assignee, {
      objectTypeId: Person.id,
      primaryId: params.assigneeId,
    })
  })
```

Without link reads in the action read facade, this code has no way to preserve the existing object DX while safely replacing links inside `.edits(...)`.

## Checks
- `bun test packages/action-worker/tests/run-action-job.test.ts`
- `bun --filter @sixb/action-worker typecheck`
- `bun --filter @sixb/core typecheck`
- `bun run check`