### PR TITLE
cli: point bin at the committed source launcher

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "bin": {
-    "sixb": "./dist/index.js",
-    "create-sixb": "./dist/index.js"
+    "sixb": "./src/index.tsx",
+    "create-sixb": "./src/index.tsx"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The `sixb`/`create-sixb` bins pointed at `./dist/index.js`, which is never built in a source-vendored (submodule) install. Bun skips a bin whose target file is missing, so `bun install` created no `node_modules/.bin/sixb` and `sixb` was `command not found` (this also broke `sixb-deploy`'s "Install CLI shim" step).

```diff
   "bin": {
-    "sixb": "./dist/index.js",
-    "create-sixb": "./dist/index.js"
+    "sixb": "./src/index.tsx",
+    "create-sixb": "./src/index.tsx"
   },
```

The launcher already ships in the published tarball (it's in `files` and is the `bun` export condition), so this works for registry, git, and submodule installs alike.

**Safe for publish:** the CLI requires Bun at runtime regardless of the bin target — it uses `Bun.*` APIs, and even the built `dist/index.js` carries a `#!/usr/bin/env bun` shebang. So pointing the bin at source loses no compatibility; it just makes the bin resolve for unbuilt installs too. `main`/`types`/`exports` and the `prepack` build are unchanged.