### PR TITLE
workers: idle instead of exiting when a type has no definitions

### DIFF
--- a/packages/action-worker/src/worker.ts
+++ b/packages/action-worker/src/worker.ts
@@ -34,9 +34,10 @@ export interface ActionWorkerOptions {
 export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
   private readonly context: ActionWorkerContext | null
   private readonly sixb: ActionWorkerSixb
-  private readonly idleWithoutDefinitions: boolean
 
   constructor(sixb: ActionWorkerSixb, options: ActionWorkerOptions = {}) {
+    const idle = sixb.getActionDefinitions().length === 0
+
     super({
       projectId: sixb.id,
       queue: sixb.queues.actions,
@@ -44,31 +45,15 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
       claimLimit: 1,
       leaseMs: options.leaseMs,
       idlePollMs: options.idlePollMs,
+      idle,
     })
 
-    const actions = sixb.getActionDefinitions()
-    if (actions.length === 0) {
+    if (idle) {
       console.log("[SixbActionWorker] No action definitions registered; worker will idle.")
     }
 
-    this.context = actions.length > 0 ? buildActionContext(sixb) : null
+    this.context = idle ? null : buildActionContext(sixb)
     this.sixb = sixb
-    this.idleWithoutDefinitions = actions.length === 0
-  }
-
-  protected override async run(signal: AbortSignal): Promise<void> {
-    if (!this.idleWithoutDefinitions) {
-      await super.run(signal)
-      return
-    }
-
-    await new Promise<void>((resolve) => {
-      if (signal.aborted) {
-        resolve()
-        return
-      }
-      signal.addEventListener("abort", () => resolve(), { once: true })
-    })
   }
 
   protected async execute(

--- a/packages/cli/tests/fixtures/worker-missing-run-storage/sixb.config.ts
+++ b/packages/cli/tests/fixtures/worker-missing-run-storage/sixb.config.ts
@@ -1,11 +1,9 @@
 import { appendFileSync } from "node:fs"
 import {
   col,
-  type DatasetDefinition,
   defineConnector,
   defineDataset,
   defineObjectType,
-  defineSchedule,
   defineSync,
   InMemoryBlobStorage,
   InMemoryBroker,
@@ -14,15 +12,19 @@ import {
   InMemoryStorage,
   prop,
   type Queues,
-  type RuleDefinition,
   Sixb,
-  type StorageMigrator,
+  type Storage,
 } from "@sixb/core"
+
+// A registered sync makes the sync worker run for real (it does not idle), but
+// the storage below omits `syncRuns`, so the worker throws during construction.
+// This exercises the "startup fails after loading the runtime" provider-cleanup
+// path without relying on the (now removed) no-definitions crash.
 
 const Transaction = defineObjectType({
   id: "Transaction",
   name: "Transaction",
-  properties: [prop("id", "string", { required: true, primary: true }), prop("status", "string")],
+  properties: [prop("id", "string", { required: true, primary: true })],
 })
 
 const erpDb = defineConnector("erpDb", {
@@ -41,33 +43,13 @@ const ordersSync = defineSync("sync-orders")
   .read(() => [])
   .intoDataset(rawOrders)
 
-const daily = defineSchedule("prod-roles-daily").cron("0 2 * * *")
-
-const postedRule: RuleDefinition = {
-  kind: "rule",
-  id: "transaction.posted",
-  subject: { kind: "object", objectTypeId: "Transaction" },
-  predicate: { kind: "property", propertyId: "status", op: "eq", value: "posted" },
-}
-
 function logFixtureEvent(entry: Record<string, unknown>): void {
   const logPath = process.env.SIXB_CLI_TEST_LOG
   if (!logPath) return
   appendFileSync(logPath, `${JSON.stringify(entry)}\n`, "utf-8")
 }
 
-// Logs every lake definition probe so tests can assert role startup never opens
-// the lake catalog (the thundering-herd regression this slice removes).
 class TrackingLakeStorage extends InMemoryLakeStorage {
-  override async assertDatasetDefinitionsCompatible(
-    definitions: readonly DatasetDefinition[]
-  ): Promise<void> {
-    for (const definition of definitions) {
-      logFixtureEvent({ type: "lake:assert", datasetId: definition.id })
-    }
-    return super.assertDatasetDefinitionsCompatible(definitions)
-  }
-
   async close(): Promise<void> {
     logFixtureEvent({ type: "lake-storage:close" })
   }
@@ -99,41 +81,18 @@ class SharedQueues implements Queues {
   }
 }
 
-function loggingStorage() {
-  const migrator: StorageMigrator = {
-    adapterId: "FixtureStorage",
-    latestVersion: 1,
-    async plan() {
-      throw new Error("plan should not run")
-    },
-    async migrate() {
-      logFixtureEvent({ type: "storage:migrate" })
-      return {
-        adapterId: "FixtureStorage",
-        latestVersion: 1,
-        status: "migrated",
-        applied: ["001-fixture"],
-        skipped: [],
-      }
-    },
-  }
-
-  return Object.assign(new InMemoryStorage(), { migrators: [migrator] })
-}
+// Drop the sync-run store so the sync worker fails its storage requirement.
+const storage = Object.assign(new InMemoryStorage(), { syncRuns: undefined }) as unknown as Storage
 
 export const sixb = new Sixb({
-  id: "cli-prod-roles",
-  // Explicit disabled auth lets `sixb api` boot in production mode for tests.
-  auth: { id: "disabled", kind: "disabled", allowDisabledInProduction: true },
+  id: "cli-worker-missing-run-storage",
   ontology: [Transaction],
   connectors: [erpDb],
   broker: new InMemoryBroker(),
-  storage: loggingStorage(),
+  storage,
   lakeStorage: new TrackingLakeStorage(),
   blobStorage: new InMemoryBlobStorage(),
   queues: new SharedQueues(),
   datasets: [rawOrders],
   syncs: [ordersSync],
-  schedules: [daily],
-  rules: [postedRule],
 })

--- a/packages/cli/tests/worker-group.test.ts
+++ b/packages/cli/tests/worker-group.test.ts
@@ -69,12 +69,12 @@ describe("sixb worker-group", () => {
   })
 
   test("stops workers and providers when a worker fails to start", async () => {
-    // The prod-roles fixture has no projection definitions, so the projection
+    // The fixture registers a sync but omits storage.syncRuns, so the sync
     // worker throws on start; the group must still close providers and exit.
-    const result = await runOnce(["worker-group", "projection"], "prod-roles")
+    const result = await runOnce(["worker-group", "sync"], "worker-missing-run-storage")
 
     expect(result.exitCode).toBe(1)
-    expect(result.stdout).toContain("No projection definitions are registered")
+    expect(result.stdout).toContain("storage.syncRuns")
     expect(result.logEntries).toContainEqual({ type: "queues:close" })
     expect(result.logEntries).toContainEqual({ type: "lake-storage:close" })
   })

--- a/packages/cli/tests/worker.test.ts
+++ b/packages/cli/tests/worker.test.ts
@@ -130,10 +130,12 @@ describe("sixb worker", () => {
 
   test("closes runtime providers when startup fails after loading the runtime", async () => {
     const logPath = await tempLogPath()
-    const result = runWorkerFixture("prod-roles", ["projection"], { logPath })
+    // The fixture registers a sync but omits storage.syncRuns, so the worker
+    // throws during construction — a real post-load startup failure.
+    const result = runWorkerFixture("worker-missing-run-storage", ["sync"], { logPath })
 
     expect(result.exitCode).toBe(1)
-    expect(result.stdout).toContain("No projection definitions are registered")
+    expect(result.stdout).toContain("storage.syncRuns")
     expect(result.stderr).toBe("")
 
     const logEntries = await readLogEntries(logPath)

--- a/packages/core/src/workers/queue-worker.ts
+++ b/packages/core/src/workers/queue-worker.ts
@@ -9,6 +9,13 @@ export interface QueueWorkerConfig<TJob extends QueueJob> {
   readonly leaseMs?: number
   readonly claimLimit?: number
   readonly idlePollMs?: number
+  /**
+   * When true, the worker stays alive but never claims jobs — it simply waits
+   * for shutdown. Used when a worker has no definitions to run: idling keeps the
+   * process healthy under a supervisor instead of exiting non-zero and being
+   * restarted forever.
+   */
+  readonly idle?: boolean
 }
 
 export interface QueueWorkerFailureDecision {
@@ -32,10 +39,16 @@ export abstract class QueueWorker<TJob extends QueueJob> extends Worker {
       leaseMs: config.leaseMs ?? DEFAULT_LEASE_MS,
       claimLimit: config.claimLimit ?? DEFAULT_CLAIM_LIMIT,
       idlePollMs: config.idlePollMs ?? DEFAULT_IDLE_POLL_MS,
+      idle: config.idle ?? false,
     }
   }
 
   protected async run(signal: AbortSignal): Promise<void> {
+    if (this.config.idle) {
+      await waitForAbort(signal)
+      return
+    }
+
     while (!signal.aborted) {
       const claimed = await this.claimOrIdle(signal)
       for (const claimedJob of claimed) {
@@ -145,6 +158,16 @@ function toQueueJobError(error: unknown): QueueJobError {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError"
+}
+
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    signal.addEventListener("abort", () => resolve(), { once: true })
+  })
 }
 
 async function sleep(ms: number, signal: AbortSignal): Promise<void> {

--- a/packages/core/tests/queue-worker.test.ts
+++ b/packages/core/tests/queue-worker.test.ts
@@ -50,6 +50,39 @@ describe("QueueWorker", () => {
     expect(claimed).toHaveLength(0)
   })
 
+  test("idle workers never claim jobs and stop cleanly", async () => {
+    const queues = new InMemoryQueues()
+    let executeCalls = 0
+
+    class IdleWorker extends QueueWorker<SyncRunRequestedQueueJob> {
+      protected async execute(): Promise<void> {
+        executeCalls += 1
+      }
+    }
+
+    const worker = new IdleWorker({
+      projectId: PROJECT_ID,
+      queue: queues.syncRuns,
+      workerId: "w",
+      idlePollMs: 10,
+      idle: true,
+    })
+
+    await queues.syncRuns.enqueue({
+      projectId: PROJECT_ID,
+      jobs: [{ type: "sync.run.requested", payload: { syncId: "s" } }],
+    })
+
+    await worker.start()
+    await Bun.sleep(50)
+    await worker.stop()
+
+    expect(executeCalls).toBe(0)
+    // The job is left untouched for a non-idle worker to claim later.
+    const claimed = await queues.syncRuns.claim({ projectId: PROJECT_ID, workerId: "observer" })
+    expect(claimed).toHaveLength(1)
+  })
+
   test("default policy fails jobs on execution errors", async () => {
     const queues = new InMemoryQueues()
 

--- a/packages/pipeline-worker/src/worker.ts
+++ b/packages/pipeline-worker/src/worker.ts
@@ -16,12 +16,25 @@ import { runPipelineJob } from "./run-pipeline-job"
 import type { PipelineJob, PipelineWorkerContext, PipelineWorkerSixb } from "./types"
 
 export class PipelineWorker extends QueueWorker<PipelineRunRequestedQueueJob> {
-  private readonly context: PipelineWorkerContext
+  private readonly context: PipelineWorkerContext | null
   private readonly sixb: PipelineWorkerSixb
 
   constructor(sixb: PipelineWorkerSixb) {
-    if (sixb.getPipelineDefinitions().length === 0) {
-      throw new Error("[SixbPipelineWorker] No pipeline definitions are registered.")
+    const idle = sixb.getPipelineDefinitions().length === 0
+
+    super({
+      projectId: sixb.id,
+      queue: sixb.queues.pipelines,
+      workerId: `pipeline-worker-${sixb.id}`,
+      idle,
+    })
+
+    this.sixb = sixb
+
+    if (idle) {
+      console.log("[SixbPipelineWorker] No pipeline definitions are registered; worker will idle.")
+      this.context = null
+      return
     }
 
     const pipelineRunsStorage = sixb.storage.pipelineRuns
@@ -29,20 +42,14 @@ export class PipelineWorker extends QueueWorker<PipelineRunRequestedQueueJob> {
       throw new Error("[SixbPipelineWorker] Pipeline workers require storage.pipelineRuns support.")
     }
 
-    super({
-      projectId: sixb.id,
-      queue: sixb.queues.pipelines,
-      workerId: `pipeline-worker-${sixb.id}`,
-    })
-
     this.context = buildPipelineContext(sixb, pipelineRunsStorage)
-    this.sixb = sixb
   }
 
   protected async execute(
     claimed: ClaimedQueueJob<PipelineRunRequestedQueueJob>,
     signal: AbortSignal
   ): Promise<void> {
+    const context = this.requireContext()
     const { job } = claimed
     const pipelineJob: PipelineJob = {
       id: job.payload.runId ?? `${job.id}:attempt:${job.attempt}`,
@@ -50,7 +57,7 @@ export class PipelineWorker extends QueueWorker<PipelineRunRequestedQueueJob> {
     }
 
     const result = await runPipelineJob({
-      runtime: this.context,
+      runtime: context,
       job: pipelineJob,
       signal,
       onRunStarted: (run) => emitPipelineRunStarted(this.sixb.events, run),
@@ -95,7 +102,7 @@ export class PipelineWorker extends QueueWorker<PipelineRunRequestedQueueJob> {
       pipelineId: job.payload.pipelineId,
     }
 
-    if (!(await hasCommittedStep(this.context, pipelineJob.id))) {
+    if (!(await hasCommittedStep(this.requireContext(), pipelineJob.id))) {
       return { kind: "retry" }
     }
 
@@ -107,6 +114,13 @@ export class PipelineWorker extends QueueWorker<PipelineRunRequestedQueueJob> {
     })
 
     return { kind: "fail" }
+  }
+
+  private requireContext(): PipelineWorkerContext {
+    if (!this.context) {
+      throw new Error("[SixbPipelineWorker] No pipeline definitions are registered.")
+    }
+    return this.context
   }
 }
 

--- a/packages/pipeline-worker/tests/worker.test.ts
+++ b/packages/pipeline-worker/tests/worker.test.ts
@@ -78,7 +78,7 @@ async function seedDatasetVersion(
 }
 
 describe("PipelineWorker", () => {
-  test("requires registered pipelines and pipeline run storage", () => {
+  test("idles instead of crashing without pipeline definitions", async () => {
     const emptySixb = new Sixb({
       id: "pipeline-worker-tests",
       ontology: [Room],
@@ -89,8 +89,13 @@ describe("PipelineWorker", () => {
       queues: new InMemoryQueues(),
       datasets: [rawCustomersDataset],
     })
-    expect(() => new PipelineWorker(emptySixb)).toThrow("No pipeline definitions")
 
+    const worker = new PipelineWorker(emptySixb)
+    await worker.start()
+    await worker.stop()
+  })
+
+  test("requires pipeline run storage when pipelines are registered", () => {
     const cleanStep = definePipelineStep("clean-customers")
       .inputs({ rawCustomers: rawCustomersDataset })
       .output(customersDataset)

--- a/packages/projection-worker/src/worker.ts
+++ b/packages/projection-worker/src/worker.ts
@@ -8,24 +8,31 @@ import { runProjectionJob } from "./run-projection-job"
 import type { ProjectionWorkerContext, ProjectionWorkerSixb } from "./types"
 
 export class ProjectionWorker extends QueueWorker<ProjectionRunRequestedQueueJob> {
-  private readonly context: ProjectionWorkerContext
+  private readonly context: ProjectionWorkerContext | null
 
   constructor(sixb: ProjectionWorkerSixb) {
     const projectionCount = sixb.getObjectProjections().length + sixb.getLinkProjections().length
-    if (projectionCount === 0) {
-      throw new Error("[SixbProjectionWorker] No projection definitions are registered.")
+    const idle = projectionCount === 0
+
+    super({
+      projectId: sixb.projectId,
+      queue: sixb.queues.projections,
+      workerId: `projection-worker-${sixb.id}`,
+      idle,
+    })
+
+    if (idle) {
+      console.log(
+        "[SixbProjectionWorker] No projection definitions are registered; worker will idle."
+      )
+      this.context = null
+      return
     }
 
     const projectionRunsStorage = sixb.storage.projectionRuns
     if (!projectionRunsStorage) {
       throw new Error("[SixbProjectionWorker] Projection workers require storage.projectionRuns.")
     }
-
-    super({
-      projectId: sixb.projectId,
-      queue: sixb.queues.projections,
-      workerId: `projection-worker-${sixb.id}`,
-    })
 
     this.context = buildProjectionContext(sixb, projectionRunsStorage)
   }
@@ -34,9 +41,10 @@ export class ProjectionWorker extends QueueWorker<ProjectionRunRequestedQueueJob
     claimed: ClaimedQueueJob<ProjectionRunRequestedQueueJob>,
     signal: AbortSignal
   ): Promise<void> {
+    const context = this.requireContext()
     const { job } = claimed
     await runProjectionJob({
-      runtime: this.context,
+      runtime: context,
       job: {
         id: `${job.id}:attempt:${job.attempt}`,
         projectionId: job.payload.projectionId,
@@ -47,6 +55,13 @@ export class ProjectionWorker extends QueueWorker<ProjectionRunRequestedQueueJob
       },
       signal,
     })
+  }
+
+  private requireContext(): ProjectionWorkerContext {
+    if (!this.context) {
+      throw new Error("[SixbProjectionWorker] No projection definitions are registered.")
+    }
+    return this.context
   }
 }
 

--- a/packages/projection-worker/tests/worker.test.ts
+++ b/packages/projection-worker/tests/worker.test.ts
@@ -196,11 +196,13 @@ describe("ProjectionWorker", () => {
     }
   })
 
-  test("requires registered projections and projection run storage", () => {
-    expect(() => new ProjectionWorker(createSixb({ datasets: [roomsDataset] }))).toThrow(
-      "No projection definitions"
-    )
+  test("idles instead of crashing without projection definitions", async () => {
+    const worker = new ProjectionWorker(createSixb({ datasets: [roomsDataset] }))
+    await worker.start()
+    await worker.stop()
+  })
 
+  test("requires projection run storage when projections are registered", () => {
     const sixb = createSixb({
       datasets: [roomsDataset],
       projections: [roomProjection],

--- a/packages/sync-worker/src/worker.ts
+++ b/packages/sync-worker/src/worker.ts
@@ -34,21 +34,24 @@ export interface SyncWorkerSixb {
 }
 
 export class SyncWorker extends QueueWorker<SyncRunRequestedQueueJob> {
-  private readonly context: SyncWorkerContext
+  private readonly context: SyncWorkerContext | null
   private readonly sixb: SyncWorkerSixb
 
   constructor(sixb: SyncWorkerSixb) {
-    if (sixb.getSyncDefinitions().length === 0) {
-      throw new Error("[SixbSyncWorker] No sync definitions are registered.")
-    }
+    const idle = sixb.getSyncDefinitions().length === 0
 
     super({
       projectId: sixb.id,
       queue: sixb.queues.syncRuns,
       workerId: `sync-worker-${sixb.id}`,
+      idle,
     })
 
-    this.context = buildSyncContext(sixb)
+    if (idle) {
+      console.log("[SixbSyncWorker] No sync definitions are registered; worker will idle.")
+    }
+
+    this.context = idle ? null : buildSyncContext(sixb)
     this.sixb = sixb
   }
 
@@ -56,6 +59,7 @@ export class SyncWorker extends QueueWorker<SyncRunRequestedQueueJob> {
     claimed: ClaimedQueueJob<SyncRunRequestedQueueJob>,
     signal: AbortSignal
   ): Promise<void> {
+    const context = this.requireContext()
     const { job } = claimed
     const syncJob: SyncJob = {
       id: job.payload.runId ?? `${job.id}:attempt:${job.attempt}`,
@@ -65,13 +69,20 @@ export class SyncWorker extends QueueWorker<SyncRunRequestedQueueJob> {
     }
 
     const result = await runSyncJob({
-      runtime: this.context,
+      runtime: context,
       job: syncJob,
       signal,
       onRunStarted: (run) => emitSyncRunStarted(this.sixb, run),
     })
 
     await emitSyncSucceededEvents(this.sixb, syncJob, result)
+  }
+
+  private requireContext(): SyncWorkerContext {
+    if (!this.context) {
+      throw new Error("[SixbSyncWorker] No sync definitions are registered.")
+    }
+    return this.context
   }
 
   protected override async onExecutionError(

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -72,6 +72,23 @@ function createSixbForSync(sync: SyncDefinition) {
 }
 
 describe("SyncWorker", () => {
+  test("idles instead of crashing without sync definitions", async () => {
+    const emptySixb = new Sixb({
+      id: "sync-worker-tests",
+      ontology: [Room],
+      connectors: [erpDb],
+      broker: new InMemoryBroker(),
+      storage: new InMemoryStorage(),
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: new InMemoryBlobStorage(),
+      queues: new InMemoryQueues(),
+    })
+
+    const worker = new SyncWorker(emptySixb)
+    await worker.start()
+    await worker.stop()
+  })
+
   test("processes queued sync jobs end-to-end", async () => {
     const rawOrdersDataset = makeDataset("raw.erp.orders")
     const sync = defineSync("sync-orders")

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -16,12 +16,25 @@ import type {
 } from "./types"
 
 export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
-  private readonly context: WorkflowWorkerContext
+  private readonly context: WorkflowWorkerContext | null
   private readonly observer: WorkflowRunObserver
 
   constructor(sixb: WorkflowWorkerSixb) {
-    if (sixb.workflows.list().length === 0) {
-      throw new Error("[SixbWorkflowWorker] No workflow definitions are registered.")
+    const idle = sixb.workflows.list().length === 0
+
+    super({
+      projectId: sixb.projectId,
+      queue: sixb.queues.workflows,
+      workerId: `workflow-worker-${sixb.id}`,
+      idle,
+    })
+
+    this.observer = new EventsRuntimeWorkflowRunObserver(sixb.events)
+
+    if (idle) {
+      console.log("[SixbWorkflowWorker] No workflow definitions are registered; worker will idle.")
+      this.context = null
+      return
     }
 
     const workflowRuns = sixb.storage.workflowRuns
@@ -35,23 +48,17 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
       )
     }
 
-    super({
-      projectId: sixb.projectId,
-      queue: sixb.queues.workflows,
-      workerId: `workflow-worker-${sixb.id}`,
-    })
-
     this.context = buildWorkflowContext(sixb, workflowRuns)
-    this.observer = new EventsRuntimeWorkflowRunObserver(sixb.events)
   }
 
   protected async execute(
     claimed: ClaimedQueueJob<WorkflowQueueJob>,
     signal: AbortSignal
   ): Promise<void> {
+    const context = this.requireContext()
     if (claimed.job.type === "workflow.run.resume.requested") {
       await runWorkflowResumeJob({
-        runtime: this.context,
+        runtime: context,
         job: workflowResumeJobFromClaimed(claimed),
         signal,
         observer: this.observer,
@@ -62,11 +69,18 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
     const workflowJob = workflowJobFromClaimed(claimed)
 
     await runWorkflowJob({
-      runtime: this.context,
+      runtime: context,
       job: workflowJob,
       signal,
       observer: this.observer,
     })
+  }
+
+  private requireContext(): WorkflowWorkerContext {
+    if (!this.context) {
+      throw new Error("[SixbWorkflowWorker] No workflow definitions are registered.")
+    }
+    return this.context
   }
 
   protected override async onExecutionError(

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -124,9 +124,13 @@ async function waitFor<T>(
 }
 
 describe("WorkflowWorker", () => {
-  test("requires registered workflows and workflow storage", () => {
-    expect(() => new WorkflowWorker(createSixb({}))).toThrow("No workflow definitions")
+  test("idles instead of crashing without workflow definitions", async () => {
+    const worker = new WorkflowWorker(createSixb({}))
+    await worker.start()
+    await worker.stop()
+  })
 
+  test("requires workflow storage when workflows are registered", () => {
     const workflow = defineWorkflow("reconcile-transaction")
       .input({
         transaction: ref(Transaction),


### PR DESCRIPTION
A dedicated worker process (`sixb worker <type>`) started for a type with **no** registered definitions threw in its constructor → the process exited non-zero → the supervisor restarted it forever (we saw 94 restarts).

```
[SixbSyncWorker] No sync definitions are registered.   → exit 1 → restart loop
```

Now an empty worker **idles** (waits for shutdown) instead of crashing — matching what `action-worker` already did.

### Change
- `QueueWorker` gains an `idle` flag; when set, `run()` waits for the abort signal instead of polling the queue (single source of truth).
- `sync` / `pipeline` / `projection` / `workflow` workers compute `idle = definitions.length === 0`, log once, and idle instead of throwing. `action-worker` is refactored to use the shared flag (drops its hand-rolled `run()` override).
- Run-storage requirement checks (`storage.syncRuns`, etc.) now fire only when definitions exist — an empty worker no longer needs run storage to idle.

| Worker | empty before | empty after |
|---|---|---|
| sync / pipeline / projection / workflow | throw → exit 1 | idle |
| action | idle (already) | idle (shared flag) |

The cohosted path (`sixb dev`) already guarded each worker, so only dedicated worker processes were affected.

### Tests
- Per-worker "idles without definitions" unit tests + a base `QueueWorker` idle test.
- The CLI provider-cleanup tests asserted the old crash; since "no definitions" is no longer a failure (and would hang `spawnSync` on an idling worker), they were repointed to a genuine post-load failure via a new `worker-missing-run-storage` fixture (registers a sync but omits `storage.syncRuns`).

Note: `rules-worker` still throws on empty but is unaffected — it's not a dedicated worker type and is guarded by the runtime.