### PR TITLE
core: honor Date/timestamp values in upsert and action params

### DIFF
--- a/packages/action-worker/src/action-execution/context.ts
+++ b/packages/action-worker/src/action-execution/context.ts
@@ -11,7 +11,11 @@ import type {
   ObjectTypeWithPropertyTokens,
   ValueType,
 } from "@sixb/core"
-import { isObjectActionDefinition, ObjectNotFoundError } from "@sixb/core"
+import {
+  coerceActionParamsToTyped,
+  isObjectActionDefinition,
+  ObjectNotFoundError,
+} from "@sixb/core"
 import { ActionWorkerError } from "../errors"
 import type { RunActionJobInput } from "../types"
 import type { LoadedObjectTarget } from "./types"
@@ -61,6 +65,7 @@ function toActionTargetObject(
 
 export function createBasePhaseContext(input: {
   readonly runtime: RunActionJobInput["runtime"]
+  readonly action: ActionDefinition
   readonly run: ActionRunRecord
   readonly signal: AbortSignal
 }) {
@@ -70,7 +75,13 @@ export function createBasePhaseContext(input: {
       startedAt: input.run.startedAt ?? input.run.queuedAt,
       idempotencyKey: input.run.idempotencyKey,
     },
-    params: input.run.params,
+    // Params are stored as JSON (date/timestamp -> ISO string); handler types
+    // promise `Date`, so re-hydrate them before the handler sees them.
+    params: coerceActionParamsToTyped(
+      input.action.params,
+      input.run.params,
+      input.runtime.sixb.getValueTypesById()
+    ),
     subject: input.run.subject,
     signal: input.signal,
   }

--- a/packages/action-worker/src/action-execution/phases.ts
+++ b/packages/action-worker/src/action-execution/phases.ts
@@ -16,7 +16,7 @@ export async function executeActionPhases(
   const { runtime, action, signal } = input
   let run = input.run
   const objectTarget = await loadObjectTarget({ runtime, action, run })
-  const phaseContext = createBasePhaseContext({ runtime, run, signal })
+  const phaseContext = createBasePhaseContext({ runtime, action, run, signal })
 
   if (!run.writeback && !run.commit) {
     run = await runtime.actionRunsStorage.enterPhase({

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -121,6 +121,44 @@ describe("ActionWorker", () => {
     ).toThrow(ActionWorkerError)
   })
 
+  test("date/timestamp params arrive as Date objects in handlers", async () => {
+    const observed: { dueDate: unknown; day: unknown }[] = []
+    const setDue = defineAction("setDue")
+      .on(Device)
+      .params({ dueDate: param("timestamp"), day: param("date") })
+      .writeback((ctx) => {
+        observed.push({ dueDate: ctx.params.dueDate, day: ctx.params.day })
+        // Typed as Date, so this must not throw at runtime.
+        return { iso: ctx.params.dueDate.toISOString() }
+      })
+
+    const sixb = createSixb([setDue])
+    const worker = new ActionWorker(sixb)
+    await sixb.upsertObject("Device", { id: "device-1", name: "Device 1" })
+
+    await worker.start()
+    const { runId } = await deviceObjects(sixb).requestAction({
+      id: "device-1",
+      actionId: "setDue",
+      params: {
+        dueDate: new Date("2026-06-20T12:34:56.000Z"),
+        day: new Date("2026-06-20T12:34:56.000Z"),
+      },
+    })
+
+    const run = await waitFor(
+      () => sixb.storage.actionRuns!.getById({ projectId: sixb.id, id: runId }),
+      (value) => value?.status === "succeeded" || value?.status === "failed"
+    )
+    expect(run?.status).toBe("succeeded")
+    const seen = observed[0]
+    expect(seen?.dueDate).toBeInstanceOf(Date)
+    expect(seen?.day).toBeInstanceOf(Date)
+    expect((seen?.dueDate as Date).toISOString()).toBe("2026-06-20T12:34:56.000Z")
+
+    await worker.stop()
+  })
+
   test("claims requested action runs and emits action.completed", async () => {
     const setStatus = defineAction("setStatus")
       .on(Device)

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -64,6 +64,7 @@ export type {
   ObjectActionPhaseBuilder,
 } from "./types"
 export {
+  coerceActionParamsToTyped,
   isActionDefinition,
   isGlobalActionDefinition,
   isObjectActionDefinition,

--- a/packages/core/src/actions/validation.ts
+++ b/packages/core/src/actions/validation.ts
@@ -3,7 +3,7 @@ import { type SchemaOrRef, type ValueType, validateSchemaOrRefValue } from "../o
 import { OntologyValidationError } from "../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
 import type { Schema } from "../ontology/types"
-import { normalizeSchemaValue } from "../ontology/validation"
+import { coerceSchemaValueToTyped, normalizeSchemaValue } from "../ontology/validation"
 import type { ActionRunParams } from "../storage/action-runs"
 import { ActionDefinitionError } from "./errors"
 import type {
@@ -91,6 +91,34 @@ export function normalizeActionParams(
   }
 
   return normalized
+}
+
+/**
+ * Re-hydrate stored action params for the handler-facing surface. Params are
+ * normalized to JSON (e.g. `date`/`timestamp` -> ISO string) for storage; action
+ * handler types promise `Date` for those, so this converts them back before the
+ * handler runs. `objectRef` params pass through unchanged.
+ */
+export function coerceActionParamsToTyped(
+  paramsConfig: ActionParamsConfig,
+  params: Record<string, unknown>,
+  valueTypesById: ReadonlyMap<string, ValueType>
+): Record<string, unknown> {
+  const coerced: Record<string, unknown> = { ...params }
+
+  for (const [paramId, paramDef] of Object.entries(paramsConfig)) {
+    const value = params[paramId]
+    if (value === undefined) continue
+
+    const schema = paramDef.schema
+    if (typeof schema === "object" && schema !== null && schema.type === "objectRef") {
+      continue
+    }
+
+    coerced[paramId] = coerceSchemaValueToTyped(schema as Schema, value, valueTypesById)
+  }
+
+  return coerced
 }
 
 export function validateActionSubject(action: ActionDefinition, subject: ActionSubject): void {

--- a/packages/core/src/edits/properties.ts
+++ b/packages/core/src/edits/properties.ts
@@ -1,10 +1,9 @@
-import type { JsonValue } from "../json"
 import type { ObjectLink, Property, ValueType } from "../ontology"
 import { OntologyValidationError } from "../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
 import {
   assertKnownProperties,
-  normalizeSchemaValue,
+  normalizeObjectProperties,
   validateObjectProperties,
   validatePropertyValue,
 } from "../ontology/validation"
@@ -21,7 +20,7 @@ export function normalizeObjectEditProperties(params: {
   assertKnownProperties(objectType, properties)
   assertNoTelemetryProperties(objectType.properties, properties, path)
   validateObjectProperties(objectType, properties, valueTypesById)
-  return normalizeProperties(objectType.properties, properties, valueTypesById, path)
+  return normalizeObjectProperties(objectType.properties, properties, valueTypesById, path)
 }
 
 export function normalizeLinkEditProperties(params: {
@@ -62,7 +61,7 @@ export function normalizeLinkEditProperties(params: {
     )
   }
 
-  return normalizeProperties(
+  return normalizeObjectProperties(
     linkProperties,
     properties,
     valueTypesById,
@@ -90,38 +89,6 @@ export function assertPrimaryPropertyNotUpdated(
       `[Sixb] EditBatch cannot update primary property '${objectType.id}.${primaryProperty.id}'.`
     )
   }
-}
-
-function normalizeProperties(
-  definitions: readonly Property[],
-  properties: Readonly<Record<string, unknown>>,
-  valueTypesById: ReadonlyMap<string, ValueType>,
-  path: string
-): EditObjectProperties {
-  const normalized: Record<string, JsonValue> = {}
-  for (const [propertyId, value] of Object.entries(properties)) {
-    const property = definitions.find((candidate) => candidate.id === propertyId)
-    if (!property) continue
-    normalized[propertyId] = normalizePropertyValue(
-      property,
-      value,
-      `${path}.${propertyId}`,
-      valueTypesById
-    )
-  }
-  return normalized
-}
-
-function normalizePropertyValue(
-  property: Property,
-  value: unknown,
-  path: string,
-  valueTypesById: ReadonlyMap<string, ValueType>
-): JsonValue {
-  if (value === null) {
-    return null
-  }
-  return normalizeSchemaValue(property.schema, value, path, valueTypesById)
 }
 
 function assertNoTelemetryProperties(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -156,6 +156,7 @@ export {
   ActionEditCommitError,
   ActionRegistry,
   ActionsRuntime,
+  coerceActionParamsToTyped,
   commitActionEditBatch,
   defineAction,
   isActionDefinition,

--- a/packages/core/src/objects/object/upsert.ts
+++ b/packages/core/src/objects/object/upsert.ts
@@ -5,6 +5,7 @@
 import {
   assertKnownProperties,
   assertRequiredProperties,
+  normalizeObjectProperties,
   validateObjectProperties,
 } from "../../ontology/validation"
 import type { ObjectRow } from "../../storage"
@@ -21,6 +22,16 @@ export async function upsertObject(
   assertKnownProperties(objectType, properties)
   validateObjectProperties(objectType, properties, ontology.getValueTypesById())
 
+  // Normalize to JSON-safe values (e.g. Date -> ISO string) before the value
+  // reaches the event store, which only accepts JSON. The typed surface accepts
+  // `Date | string`; without this a `Date` would be rejected at append time.
+  const normalizedProperties = normalizeObjectProperties(
+    objectType.properties,
+    properties,
+    ontology.getValueTypesById(),
+    objectType.id
+  )
+
   const existing = await storage.objects.getByPrimaryId({
     projectId,
     objectTypeId: objectType.id,
@@ -29,7 +40,7 @@ export async function upsertObject(
 
   const mergedProperties = {
     ...(existing?.properties ?? {}),
-    ...properties,
+    ...normalizedProperties,
   }
   assertRequiredProperties(objectType, mergedProperties)
 
@@ -40,7 +51,7 @@ export async function upsertObject(
         payload: {
           objectTypeId: objectType.id,
           primaryId,
-          properties,
+          properties: normalizedProperties,
         },
       },
     ],

--- a/packages/core/src/ontology/validation/batch.ts
+++ b/packages/core/src/ontology/validation/batch.ts
@@ -3,6 +3,7 @@ import type { ObjectLink, ValueType } from ".."
 import { OntologyValidationError } from "../errors"
 import type { ObjectTypeWithPropertyTokens } from "../tokens"
 import { assertLinkTargetType, validateLinkProperties } from "./links"
+import { normalizeObjectProperties } from "./normalize"
 import {
   assertKnownProperties,
   assertRequiredProperties,
@@ -53,11 +54,23 @@ export function validateObjectBatch(
         )
       }
 
+      // Normalize to JSON-safe values (e.g. Date -> ISO string) so the batch
+      // emits the same serializable shape as the single-item upsert path.
+      const normalizedProperties = normalizeObjectProperties(
+        objectType.properties,
+        properties,
+        valueTypesById,
+        objectType.id
+      )
+
       const existing = existingMap.get(`${objectType.id}:${String(primaryId)}`)
-      const mergedProperties = { ...(existing?.properties ?? {}), ...properties }
+      const mergedProperties = { ...(existing?.properties ?? {}), ...normalizedProperties }
       assertRequiredProperties(objectType, mergedProperties)
 
-      valid.push({ index: i, item: { primaryId: String(primaryId), properties } })
+      valid.push({
+        index: i,
+        item: { primaryId: String(primaryId), properties: normalizedProperties },
+      })
     } catch (e) {
       errors.push({ index: i, error: toError(e) })
     }

--- a/packages/core/src/ontology/validation/index.ts
+++ b/packages/core/src/ontology/validation/index.ts
@@ -1,7 +1,11 @@
 export type { BatchValidationResult } from "./batch"
 export { validateLinkBatch, validateObjectBatch } from "./batch"
 export { assertLinkTargetType, assertTargetTypeCompatible, validateLinkProperties } from "./links"
-export { normalizeSchemaValue } from "./normalize"
+export {
+  coerceSchemaValueToTyped,
+  normalizeObjectProperties,
+  normalizeSchemaValue,
+} from "./normalize"
 
 export {
   assertKnownProperties,

--- a/packages/core/src/ontology/validation/normalize.ts
+++ b/packages/core/src/ontology/validation/normalize.ts
@@ -1,7 +1,33 @@
 import { assertJsonValue, cloneJsonValue, type JsonValue } from "../../json"
-import type { ObjectFieldSchema, Schema, ValueType } from ".."
+import type { ObjectFieldSchema, Property, Schema, ValueType } from ".."
 import { OntologyValidationError } from "../errors"
 import { resolveValueTypeSchema } from "./schema"
+
+/**
+ * Normalize a property bag to JSON-safe values using each property's schema —
+ * notably converting `Date` to an ISO string for `date`/`timestamp` props.
+ * Unknown properties are skipped; `null` passes through unchanged.
+ *
+ * Shared by the object upsert and edit paths so both emit the same serializable
+ * shape; the typed surface accepts `Date | string`, the wire stores strings.
+ */
+export function normalizeObjectProperties(
+  definitions: readonly Property[],
+  properties: Readonly<Record<string, unknown>>,
+  valueTypesById: ReadonlyMap<string, ValueType>,
+  path: string
+): Record<string, JsonValue> {
+  const normalized: Record<string, JsonValue> = {}
+  for (const [propertyId, value] of Object.entries(properties)) {
+    const property = definitions.find((candidate) => candidate.id === propertyId)
+    if (!property) continue
+    normalized[propertyId] =
+      value === null
+        ? null
+        : normalizeSchemaValue(property.schema, value, `${path}.${propertyId}`, valueTypesById)
+  }
+  return normalized
+}
 
 export function normalizeSchemaValue(
   schema: Schema,
@@ -106,4 +132,69 @@ function normalizeDateLike(value: unknown, path: string): Date {
     throw new OntologyValidationError(`[Sixb] Property ${path} must be a valid date`)
   }
   return date
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Inverse of `normalizeSchemaValue` for the handler-facing surface: re-hydrate
+ * `date`/`timestamp` values from their stored ISO string back into a `Date`, so
+ * a handler receives the `Date` its types promise. Other scalars pass through;
+ * arrays, maps, objects, and value-type refs recurse. The input is assumed to be
+ * already validated/normalized JSON, so this is permissive and never throws.
+ */
+export function coerceSchemaValueToTyped(
+  schema: Schema,
+  value: unknown,
+  valueTypesById: ReadonlyMap<string, ValueType>
+): unknown {
+  if (value === null || value === undefined) {
+    return value
+  }
+
+  if (typeof schema === "string") {
+    if (schema === "date" || schema === "timestamp") {
+      return value instanceof Date ? value : new Date(String(value))
+    }
+    return value
+  }
+
+  if (schema.type === "valueTypeRef") {
+    return coerceSchemaValueToTyped(
+      resolveValueTypeSchema(schema, valueTypesById, ""),
+      value,
+      valueTypesById
+    )
+  }
+
+  if (schema.type === "enum") {
+    return value
+  }
+
+  if (schema.type === "array") {
+    if (!Array.isArray(value)) return value
+    return (value as readonly unknown[]).map((entry) =>
+      coerceSchemaValueToTyped(schema.items, entry, valueTypesById)
+    )
+  }
+
+  if (schema.type === "map") {
+    if (!isPlainRecord(value)) return value
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        coerceSchemaValueToTyped(schema.valueSchema, entry, valueTypesById),
+      ])
+    )
+  }
+
+  if (!isPlainRecord(value)) return value
+  const output: Record<string, unknown> = { ...value }
+  for (const [fieldId, field] of Object.entries(schema.properties)) {
+    if (value[fieldId] === undefined) continue
+    output[fieldId] = coerceSchemaValueToTyped(field.schema, value[fieldId], valueTypesById)
+  }
+  return output
 }

--- a/packages/core/tests/date-normalization.test.ts
+++ b/packages/core/tests/date-normalization.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { defineObjectType, prop, Sixb } from "../src"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+// Regression: the typed surface accepts `Date | string` for date/timestamp
+// props, so passing a `Date` typechecks. The upsert path must serialize it to an
+// ISO string before the value reaches the event store (which only stores JSON);
+// otherwise `events.append` rejects the Date.
+
+const Task = defineObjectType({
+  id: "task",
+  name: "Task",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("createdAt", "timestamp"),
+    prop("due", "date"),
+  ],
+})
+
+describe("date/timestamp normalization on upsert", () => {
+  test("single upsert serializes Date props to ISO strings", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({ ontology: [Task], ...deps })
+
+    const at = new Date("2026-06-20T12:34:56.000Z")
+    const row = await sixb.objects(Task).upsert({
+      properties: { id: "t1", createdAt: at, due: at },
+    })
+
+    expect(row.properties.createdAt).toBe("2026-06-20T12:34:56.000Z")
+    expect(row.properties.due).toBe("2026-06-20")
+
+    const stored = await deps.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: "task",
+      primaryId: "t1",
+    })
+    expect(stored?.properties.createdAt).toBe("2026-06-20T12:34:56.000Z")
+    expect(stored?.properties.due).toBe("2026-06-20")
+  })
+
+  test("ISO string input is preserved", async () => {
+    const sixb = new Sixb({ ontology: [Task], ...createTestRuntimeDeps() })
+
+    const row = await sixb.objects(Task).upsert({
+      properties: { id: "t2", createdAt: "2026-01-02T03:04:05.000Z" },
+    })
+
+    expect(row.properties.createdAt).toBe("2026-01-02T03:04:05.000Z")
+  })
+
+  test("batch upsert serializes Date props to ISO strings", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({ ontology: [Task], ...deps })
+
+    const at = new Date("2026-06-20T12:34:56.000Z")
+    const results = await sixb.upsertObjectBatch("task", [
+      { properties: { id: "b1", createdAt: at } },
+      { properties: { id: "b2", createdAt: at } },
+    ])
+
+    expect(results.every((r) => r.ok)).toBe(true)
+    if (results[0].ok)
+      expect(results[0].value.properties.createdAt).toBe("2026-06-20T12:34:56.000Z")
+
+    const stored = await deps.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: "task",
+      primaryId: "b2",
+    })
+    expect(stored?.properties.createdAt).toBe("2026-06-20T12:34:56.000Z")
+  })
+})


### PR DESCRIPTION
Two bugs with the same root cause: the typed surface promises a richer type than the wire carries for `date`/`timestamp`.

### upsert accepted a `Date` the event store then rejected
`date`/`timestamp` props infer `Date | string`, so passing a `Date` typechecks — but the upsert path validated without normalizing and put the raw `Date` into the `object.upserted` event, which the JSON event store rejected:
```
EventsError: object.upserted ... properties.createdAt is a Date
```
Fixed by normalizing `Date → ISO` in the single + batch upsert paths, reusing the same normalizer the edits path already used (extracted to `normalizeObjectProperties`).

### action date/timestamp params arrived as strings, not `Date`
Action params type `date`/`timestamp` as `Date`, but params are normalized to ISO strings for storage, so handlers received a string:
```ts
.writeback(({ params }) => params.dueDate.toISOString()) // typechecks
// TypeError: params.dueDate.toISOString is not a function
```
Fixed by re-hydrating `date`/`timestamp` params back to `Date` (recursively, via `coerceSchemaValueToTyped`) before the handler runs, so the runtime matches the typed surface.

Net: input stays ergonomic (`new Date()` works), storage stays JSON, and handlers receive the `Date` their types promise.

### Tests
- `date-normalization.test.ts`: single + batch upsert serialize `Date` props to ISO; ISO-string input preserved.
- action-worker: a `timestamp`/`date` param arrives as a real `Date` and `.toISOString()` works.

No server routes, schemas, or client contracts change, so no `generate:client`.