### PR TITLE
auth: provision every bootstrap user and reconcile their groups

### DIFF
--- a/auth/magic-link/src/strategy.ts
+++ b/auth/magic-link/src/strategy.ts
@@ -194,14 +194,13 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
       throw new MagicLinkError("Magic link is invalid or expired.")
     }
 
-    const existingUser = await input.authStorage.users.getByEmail({
-      projectId: input.projectId,
-      email: magicLink.email,
-    })
-    const canBootstrap =
-      !existingUser &&
-      this.bootstrapUsers.has(magicLink.email) &&
-      (await hasNoActiveUsers(input.authStorage, input.projectId))
+    // Every email in the configured bootstrap allowlist may self-provision
+    // without an invitation — at any time, not only as the first user. The
+    // allowlist itself is the trust boundary. Applied on every sign-in (not just
+    // creation), so the configured bootstrap groups stay reconciled for existing
+    // bootstrap users; user creation itself is still gated by storage, which only
+    // creates when no user exists for the email.
+    const canBootstrap = this.bootstrapUsers.has(magicLink.email)
 
     const signIn = await input.authStorage.completeMagicLinkSignIn({
       projectId: input.projectId,
@@ -210,7 +209,7 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
       completedAt: now,
       newUserId: `usr_${randomUUID()}`,
       allowUserCreationWithoutInvitation: canBootstrap,
-      requireNoActiveUsersForUserCreation: canBootstrap,
+      requireNoActiveUsersForUserCreation: false,
       manualGroupIds: canBootstrap ? this.bootstrapGroupIds : [],
       session: {
         ...input.session,
@@ -249,10 +248,7 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
       return true
     }
 
-    return (
-      this.bootstrapUsers.has(input.email) &&
-      (await hasNoActiveUsers(input.storage, input.projectId))
-    )
+    return this.bootstrapUsers.has(input.email)
   }
 
   private createCallbackUrl(input: {
@@ -271,16 +267,6 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
     const domain = emailDomain(email)
     return domain ? this.allowedDomains.has(domain) : false
   }
-}
-
-async function hasNoActiveUsers(storage: AuthStorage, projectId: string): Promise<boolean> {
-  const page = await storage.users.list({
-    projectId,
-    statuses: ["active"],
-    limit: 1,
-  })
-
-  return page.total === 0
 }
 
 function normalizeStrategyId(value: string | undefined): string {

--- a/auth/magic-link/tests/magic-link.test.ts
+++ b/auth/magic-link/tests/magic-link.test.ts
@@ -257,7 +257,7 @@ describe("magicLink", () => {
     expect(messages).toHaveLength(1)
   })
 
-  test("allows bootstrap requests only while no active users exist", async () => {
+  test("allows bootstrap requests even after active users exist", async () => {
     const storage = new InMemoryAuthStorage()
     const { messages, sendMagicLink } = createSender()
     const strategy = magicLink({
@@ -270,6 +270,8 @@ describe("magicLink", () => {
       requestMagicLink({ storage, strategy, email: "founder@acme.com" })
     ).resolves.toEqual({ status: "sent" })
 
+    // Another user now exists; a listed bootstrap user must still be able to
+    // request a magic link (the allowlist is the trust boundary, not "first user only").
     await storage.users.create({
       id: "usr_existing",
       projectId,
@@ -282,9 +284,9 @@ describe("magicLink", () => {
         email: "founder@acme.com",
         now: at("2026-05-16T10:02:00.000Z"),
       })
-    ).resolves.toEqual({ status: "skipped" })
+    ).resolves.toEqual({ status: "sent" })
 
-    expect(messages).toHaveLength(1)
+    expect(messages).toHaveLength(2)
   })
 
   test("completes bootstrap magic-link sign-in and applies bootstrap groups", async () => {
@@ -315,6 +317,63 @@ describe("magicLink", () => {
     await expect(
       storage.groupMemberships.listForUser({ projectId, userId: result.user.id })
     ).resolves.toMatchObject([{ groupId: "security-admins", source: "manual" }])
+  })
+
+  test("reconciles bootstrap groups for an existing user on later sign-in", async () => {
+    const storage = new InMemoryAuthStorage()
+
+    const first = createSender()
+    const strategyV1 = magicLink({
+      allowedDomains: ["acme.com"],
+      bootstrapUsers: ["founder@acme.com"],
+      bootstrapGroups: ["security-admins"],
+      sendMagicLink: first.sendMagicLink,
+    })
+    await requestMagicLink({ storage, strategy: strategyV1, email: "founder@acme.com" })
+    const firstLink = linkFromLatestMessage(first.messages)
+    const created = await strategyV1.completeMagicLinkSignIn({
+      projectId,
+      authStorage: storage,
+      magicLinkId: firstLink.searchParams.get("magicLinkId") ?? "",
+      token: firstLink.searchParams.get("token") ?? "",
+      session: sessionInput("ses_1"),
+      now: at("2026-05-16T10:05:00.000Z"),
+    })
+    await expect(
+      storage.groupMemberships.listForUser({ projectId, userId: created.user.id })
+    ).resolves.toMatchObject([{ groupId: "security-admins", source: "manual" }])
+
+    // A newly-added bootstrap group must reach the already-existing bootstrap user
+    // on their next sign-in, not only at first creation.
+    const second = createSender()
+    const strategyV2 = magicLink({
+      allowedDomains: ["acme.com"],
+      bootstrapUsers: ["founder@acme.com"],
+      bootstrapGroups: ["security-admins", "billing-admins"],
+      sendMagicLink: second.sendMagicLink,
+    })
+    await requestMagicLink({
+      storage,
+      strategy: strategyV2,
+      email: "founder@acme.com",
+      now: at("2026-05-17T10:00:00.000Z"),
+    })
+    const secondLink = linkFromLatestMessage(second.messages)
+    const reSignIn = await strategyV2.completeMagicLinkSignIn({
+      projectId,
+      authStorage: storage,
+      magicLinkId: secondLink.searchParams.get("magicLinkId") ?? "",
+      token: secondLink.searchParams.get("token") ?? "",
+      session: sessionInput("ses_2"),
+      now: at("2026-05-17T10:05:00.000Z"),
+    })
+
+    expect(reSignIn.user.id).toBe(created.user.id)
+    const groupIds = (
+      await storage.groupMemberships.listForUser({ projectId, userId: reSignIn.user.id })
+    ).map((membership) => membership.groupId)
+    expect(groupIds).toContain("security-admins")
+    expect(groupIds).toContain("billing-admins")
   })
 
   test("invalidates the previous active magic link when requesting a new one", async () => {

--- a/auth/oidc/src/strategy.ts
+++ b/auth/oidc/src/strategy.ts
@@ -186,10 +186,10 @@ class OidcAuthStrategyImpl implements OidcAuthStrategy {
         throw new OidcAuthError("OIDC email domain is not allowed.")
       }
 
-      const canBootstrap =
-        profile.emailVerified &&
-        this.bootstrapUsers.has(email) &&
-        (await hasNoActiveUsers(input.authStorage, input.projectId))
+      // Every verified email in the configured bootstrap allowlist may
+      // self-provision without an invitation — at any time, not only as the
+      // first user. The allowlist itself is the trust boundary.
+      const canBootstrap = profile.emailVerified && this.bootstrapUsers.has(email)
       const signIn = await input.authStorage.completeOidcSignIn({
         projectId: input.projectId,
         oidcAuthorizationAttemptId: attempt.id,
@@ -203,7 +203,7 @@ class OidcAuthStrategyImpl implements OidcAuthStrategy {
         claims: profile.claims,
         autoLinkByVerifiedEmail: profile.emailVerified,
         allowUserCreationWithoutInvitation: canBootstrap,
-        requireNoActiveUsersForUserCreation: canBootstrap,
+        requireNoActiveUsersForUserCreation: false,
         manualGroupIds: canBootstrap ? this.bootstrapGroupIds : [],
         newUserId: `usr_${randomUUID()}`,
         session: {
@@ -324,16 +324,6 @@ class OidcAuthStrategyImpl implements OidcAuthStrategy {
   }): Promise<void> {
     await input.authStorage.oidcAuthorizationAttempts.consume(input).catch(() => undefined)
   }
-}
-
-async function hasNoActiveUsers(storage: AuthStorage, projectId: string): Promise<boolean> {
-  const page = await storage.users.list({
-    projectId,
-    statuses: ["active"],
-    limit: 1,
-  })
-
-  return page.total === 0
 }
 
 function normalizeStrategyId(value: string | undefined): string {

--- a/auth/oidc/tests/oidc.test.ts
+++ b/auth/oidc/tests/oidc.test.ts
@@ -79,6 +79,7 @@ async function startSignIn(input: {
   readonly authStorage: InMemoryAuthStorage
   readonly client: FakeOidcClient
   readonly bootstrapUsers?: readonly string[]
+  readonly bootstrapGroups?: readonly string[]
   readonly returnTo?: string
 }) {
   const strategy = oidc({
@@ -88,7 +89,7 @@ async function startSignIn(input: {
     clientSecret: "client-secret",
     allowedDomains: ["acme.com"],
     bootstrapUsers: input.bootstrapUsers,
-    bootstrapGroups: ["security-admins"],
+    bootstrapGroups: input.bootstrapGroups ?? ["security-admins"],
     clientAdapter: input.client,
   })
   const start = await strategy.startOidcSignIn({
@@ -175,7 +176,7 @@ describe("oidc auth strategy", () => {
     expect(result.groupMemberships).toMatchObject([{ groupId: "commercial" }])
   })
 
-  test("allows first-user bootstrap and then closes bootstrap creation", async () => {
+  test("provisions every bootstrap user, not just the first", async () => {
     const authStorage = new InMemoryAuthStorage()
     const client = new FakeOidcClient()
     client.tokenClaims = {
@@ -191,7 +192,7 @@ describe("oidc auth strategy", () => {
     const { strategy, redirectTo } = await startSignIn({
       authStorage,
       client,
-      bootstrapUsers: ["founder@acme.com"],
+      bootstrapUsers: ["founder@acme.com", "second@acme.com"],
     })
 
     const result = await strategy.completeOidcSignIn({
@@ -210,6 +211,8 @@ describe("oidc auth strategy", () => {
       { groupId: "security-admins", source: "manual" },
     ])
 
+    // A second listed bootstrap user must still self-provision even though an
+    // active user now exists.
     const secondClient = new FakeOidcClient()
     secondClient.tokenClaims = {
       sub: "00u-second",
@@ -224,21 +227,130 @@ describe("oidc auth strategy", () => {
     const second = await startSignIn({
       authStorage,
       client: secondClient,
-      bootstrapUsers: ["second@acme.com"],
+      bootstrapUsers: ["founder@acme.com", "second@acme.com"],
+    })
+
+    const secondResult = await second.strategy.completeOidcSignIn({
+      projectId,
+      authStorage,
+      requestUrl: `http://localhost/auth/callback?code=code&state=${second.redirectTo.searchParams.get(
+        "state"
+      )}`,
+      requestOrigin: "http://localhost",
+      session: sessionInput("ses_second"),
+      now: new Date("2026-05-17T10:02:00.000Z"),
+    })
+
+    expect(secondResult.user.email).toBe("second@acme.com")
+    expect(secondResult.groupMemberships).toMatchObject([
+      { groupId: "security-admins", source: "manual" },
+    ])
+  })
+
+  test("does not bootstrap an allowed-domain email absent from the bootstrap list", async () => {
+    const authStorage = new InMemoryAuthStorage()
+    const founderClient = new FakeOidcClient()
+    founderClient.tokenClaims = {
+      sub: "00u-founder",
+      email: "founder@acme.com",
+      email_verified: true,
+    }
+    founderClient.userInfo = founderClient.tokenClaims
+    const founder = await startSignIn({
+      authStorage,
+      client: founderClient,
+      bootstrapUsers: ["founder@acme.com"],
+    })
+    await founder.strategy.completeOidcSignIn({
+      projectId,
+      authStorage,
+      requestUrl: `http://localhost/auth/callback?code=code&state=${founder.redirectTo.searchParams.get(
+        "state"
+      )}`,
+      requestOrigin: "http://localhost",
+      session: sessionInput("ses_founder"),
+      now: new Date("2026-05-17T10:00:00.000Z"),
+    })
+
+    // Same allowed domain, but not on the bootstrap allowlist → needs an invite.
+    const strangerClient = new FakeOidcClient()
+    strangerClient.tokenClaims = {
+      sub: "00u-stranger",
+      email: "stranger@acme.com",
+      email_verified: true,
+    }
+    strangerClient.userInfo = strangerClient.tokenClaims
+    const stranger = await startSignIn({
+      authStorage,
+      client: strangerClient,
+      bootstrapUsers: ["founder@acme.com"],
     })
 
     await expect(
-      second.strategy.completeOidcSignIn({
+      stranger.strategy.completeOidcSignIn({
         projectId,
         authStorage,
-        requestUrl: `http://localhost/auth/callback?code=code&state=${second.redirectTo.searchParams.get(
+        requestUrl: `http://localhost/auth/callback?code=code&state=${stranger.redirectTo.searchParams.get(
           "state"
         )}`,
         requestOrigin: "http://localhost",
-        session: sessionInput("ses_second"),
+        session: sessionInput("ses_stranger"),
         now: new Date("2026-05-17T10:02:00.000Z"),
       })
     ).rejects.toBeInstanceOf(Error)
+  })
+
+  test("reconciles bootstrap groups for an existing user on later sign-in", async () => {
+    const authStorage = new InMemoryAuthStorage()
+    const client = new FakeOidcClient()
+    client.tokenClaims = { sub: "00u-founder", email: "founder@acme.com", email_verified: true }
+    client.userInfo = client.tokenClaims
+
+    const first = await startSignIn({
+      authStorage,
+      client,
+      bootstrapUsers: ["founder@acme.com"],
+      bootstrapGroups: ["security-admins"],
+    })
+    const created = await first.strategy.completeOidcSignIn({
+      projectId,
+      authStorage,
+      requestUrl: `http://localhost/auth/callback?code=code&state=${first.redirectTo.searchParams.get(
+        "state"
+      )}`,
+      requestOrigin: "http://localhost",
+      session: sessionInput("ses_founder"),
+      now: new Date("2026-05-17T10:00:00.000Z"),
+    })
+    expect(created.groupMemberships).toMatchObject([
+      { groupId: "security-admins", source: "manual" },
+    ])
+
+    // A newly-added bootstrap group must reach the already-existing bootstrap user
+    // on their next sign-in, not only at first creation.
+    const second = await startSignIn({
+      authStorage,
+      client,
+      bootstrapUsers: ["founder@acme.com"],
+      bootstrapGroups: ["security-admins", "billing-admins"],
+    })
+    const reSignIn = await second.strategy.completeOidcSignIn({
+      projectId,
+      authStorage,
+      requestUrl: `http://localhost/auth/callback?code=code&state=${second.redirectTo.searchParams.get(
+        "state"
+      )}`,
+      requestOrigin: "http://localhost",
+      session: sessionInput("ses_founder_2"),
+      now: new Date("2026-05-17T10:05:00.000Z"),
+    })
+
+    expect(reSignIn.user.id).toBe(created.user.id)
+    const groupIds = (
+      await authStorage.groupMemberships.listForUser({ projectId, userId: reSignIn.user.id })
+    ).map((membership) => membership.groupId)
+    expect(groupIds).toContain("security-admins")
+    expect(groupIds).toContain("billing-admins")
   })
 
   test("rejects disallowed domains and consumes the attempt after state validation", async () => {


### PR DESCRIPTION
Two related `bootstrapUsers` fixes.

### Provision every listed bootstrap user, not just the first
Bootstrap creation was gated on `hasNoActiveUsers`, so only the first listed user to sign in was created — every other `bootstrapUsers` entry was locked out and needed an invite once any user existed. A configured **list** of emails should all be provisionable.

```diff
- const canBootstrap = emailVerified && bootstrapUsers.has(email) && (await hasNoActiveUsers(...))
+ const canBootstrap = emailVerified && bootstrapUsers.has(email)
// requireNoActiveUsersForUserCreation: false
```

The allowlist (+ verified email + allowed domain) is the trust boundary; the no-active-users gate only added a confusing lockout. Applied to both oidc and magic-link (including magic-link's request-eligibility check). User creation itself is still gated by storage, which only creates when no user exists for the email.

### Reconcile bootstrap groups on every sign-in
Groups were applied only at first creation, so editing `bootstrapGroups` later never reached an existing user. Now bootstrap users get their configured groups reconciled (additive) on each sign-in — oidc already did this as a side effect of the change above; magic-link needed its `!existingUser` guard dropped to match.

Semantics note: this is **additive** — removing a group from `bootstrapGroups` does not de-provision it (manual memberships are shared with admin-assigned groups; auto-removal is deferred to in-app group management).

### Tests
- oidc: a second listed bootstrap user provisions after the first exists; an allowed-domain email *not* on the list still needs an invite.
- magic-link: bootstrap requests succeed after other users exist.
- both: a newly-added `bootstrapGroup` reaches an existing bootstrap user on next sign-in.

Storage behavior is unchanged (the `requireNoActiveUsersForUserCreation` capability still exists; the strategies just stop requiring it) — verified by the unchanged sqlite auth-storage suite.