### PR TITLE
actions: run trail, request UI

### DIFF
--- a/examples/acme-corp/actions/createDraftInvoice.ts
+++ b/examples/acme-corp/actions/createDraftInvoice.ts
@@ -1,0 +1,34 @@
+import { defineAction, optional, param, ref } from "@sixb/core"
+import { stringEnum } from "@sixb/core/ontology"
+import { Customer } from "../ontology/customer"
+import { Invoice } from "../ontology/invoice"
+import { Project } from "../ontology/project"
+
+export const createDraftInvoice = defineAction("createDraftInvoice", {
+  description: "Create a draft invoice and attach it to a customer and project.",
+})
+  .params({
+    id: param("string"),
+    number: param("string"),
+    amount: param("double"),
+    currency: optional(param(stringEnum(["EUR", "USD", "GBP"]))),
+    customer: param(ref(Customer), { description: "Customer to bill." }),
+    project: param(ref(Project), { description: "Project the invoice belongs to." }),
+  })
+  .edits(({ objects, params, run }) => {
+    const invoice = objects(Invoice).create({
+      id: params.id,
+      number: params.number,
+      amount: params.amount,
+      currency: params.currency ?? "EUR",
+      status: "draft",
+      paymentInfo: {
+        method: "pending",
+        reference: `draft:${params.id}`,
+        recordedAt: run.startedAt.toISOString(),
+      },
+    })
+
+    invoice.link(Invoice.l.customer, objects(Customer).byId(params.customer.primaryId))
+    invoice.link(Invoice.l.project, objects(Project).byId(params.project.primaryId))
+  })

--- a/examples/acme-corp/actions/deleteInvoice.ts
+++ b/examples/acme-corp/actions/deleteInvoice.ts
@@ -1,0 +1,11 @@
+import { defineAction } from "@sixb/core"
+import { Invoice } from "../ontology/invoice"
+
+export const deleteInvoice = defineAction("deleteInvoice", {
+  description: "Delete this invoice and its incident links.",
+})
+  .on(Invoice)
+  .params({})
+  .edits(({ objects, subject }) => {
+    objects(Invoice).byId(subject.primaryId).delete()
+  })

--- a/examples/acme-corp/actions/markPaid.ts
+++ b/examples/acme-corp/actions/markPaid.ts
@@ -1,13 +1,23 @@
-import { defineAction } from "@sixb/core"
+import { defineAction, optional, param } from "@sixb/core"
 import { Invoice } from "../ontology/invoice"
 
 export const markPaid = defineAction("markPaid", {
   description: "Mark this invoice as paid.",
 })
   .on(Invoice)
-  .params({})
-  .edits(({ objects, subject }) => {
-    objects(Invoice).byId(subject.primaryId).update({
-      status: "paid",
-    })
+  .params({
+    paymentMethod: optional(param("string")),
+    paymentReference: optional(param("string")),
+  })
+  .edits(({ objects, params, run, subject }) => {
+    objects(Invoice)
+      .byId(subject.primaryId)
+      .update({
+        status: "paid",
+        paymentInfo: {
+          method: params.paymentMethod ?? "manual",
+          reference: params.paymentReference ?? `manual:${subject.primaryId}`,
+          recordedAt: run.startedAt.toISOString(),
+        },
+      })
   })

--- a/examples/acme-corp/ontology/invoice.ts
+++ b/examples/acme-corp/ontology/invoice.ts
@@ -36,6 +36,14 @@ export const Invoice = defineObjectType({
     prop("reminderReviewRequestedAt", "timestamp"),
     prop("reminderReviewedAt", "timestamp"),
     prop("reminderReviewerNote", "string"),
+    prop("paymentInfo", {
+      type: "object",
+      properties: {
+        method: { schema: "string", required: true },
+        reference: { schema: "string", required: true },
+        recordedAt: { schema: "timestamp", required: true },
+      },
+    }),
   ],
   search: {
     title: "number",

--- a/packages/action-worker/src/action-execution/context.ts
+++ b/packages/action-worker/src/action-execution/context.ts
@@ -1,15 +1,11 @@
 import type {
   ActionDefinition,
   ActionObjectSubject,
-  ActionReadFacade,
-  ActionReadObjectSet,
   ActionRunRecord,
   ActionRuntimeFacade,
   ActionSubject,
   ActionTargetObject,
-  ObjectSetListInput,
   ObjectTypeWithPropertyTokens,
-  ValueType,
 } from "@sixb/core"
 import {
   coerceActionParamsToTyped,
@@ -19,16 +15,6 @@ import {
 import { ActionWorkerError } from "../errors"
 import type { RunActionJobInput } from "../types"
 import type { LoadedObjectTarget } from "./types"
-
-type RuntimeReadObjectSet = {
-  get(id: string): Promise<unknown>
-  query(): unknown
-  list(input?: ObjectSetListInput): Promise<unknown>
-  byId(id: string): {
-    get(): Promise<unknown>
-    listLinks(link?: unknown): Promise<unknown>
-  }
-}
 
 export function toActionRuntimeFacade(runtime: RunActionJobInput["runtime"]): ActionRuntimeFacade {
   return {
@@ -129,54 +115,6 @@ export async function loadObjectTarget(input: {
   return {
     subjectObjectType,
     snapshot: toActionTargetObject(targetRow, input.action.binding.objectType.id),
-  }
-}
-
-export function createReadFacade(sixb: RunActionJobInput["runtime"]["sixb"]): ActionReadFacade {
-  const facade = {
-    objects<const TObjectType extends ObjectTypeWithPropertyTokens>(objectType: TObjectType) {
-      return createReadObjectSetAdapter<TObjectType>(
-        sixb.objects(objectType) as RuntimeReadObjectSet
-      )
-    },
-  }
-  // The worker only knows the widened ontology; action validation already checked the
-  // object type, so the read facade can restore the narrow type chosen by the handler.
-  return facade as ActionReadFacade
-}
-
-function createReadObjectSetAdapter<TObjectType extends ObjectTypeWithPropertyTokens>(
-  objectSet: RuntimeReadObjectSet
-): ActionReadObjectSet<TObjectType, readonly ValueType[], ObjectTypeWithPropertyTokens> {
-  type TypedReadObjectSet = ActionReadObjectSet<
-    TObjectType,
-    readonly ValueType[],
-    ObjectTypeWithPropertyTokens
-  >
-
-  return {
-    get(id) {
-      return objectSet.get(id) as ReturnType<TypedReadObjectSet["get"]>
-    },
-    query() {
-      return objectSet.query() as ReturnType<TypedReadObjectSet["query"]>
-    },
-    list(input) {
-      return objectSet.list(input) as ReturnType<TypedReadObjectSet["list"]>
-    },
-    byId(id) {
-      const handle = objectSet.byId(id)
-      return {
-        get() {
-          return handle.get() as ReturnType<ReturnType<TypedReadObjectSet["byId"]>["get"]>
-        },
-        listLinks(link) {
-          return handle.listLinks(link) as ReturnType<
-            ReturnType<TypedReadObjectSet["byId"]>["listLinks"]
-          >
-        },
-      }
-    },
   }
 }
 

--- a/packages/action-worker/src/action-execution/edits-commit.ts
+++ b/packages/action-worker/src/action-execution/edits-commit.ts
@@ -1,8 +1,13 @@
-import type { ActionEditCommitResult, ActionRunRecord, JsonValue } from "@sixb/core"
-import { commitActionEditBatch, isObjectActionDefinition } from "@sixb/core"
+import type {
+  ActionEditCommitResult,
+  ActionReadObjectSetSource,
+  ActionRunRecord,
+  JsonValue,
+} from "@sixb/core"
+import { commitActionEditBatch, createActionReadFacade, isObjectActionDefinition } from "@sixb/core"
 import { recordEdits } from "@sixb/core/actions/worker"
 import { emitLocalCommitEvents } from "./commit-events"
-import { type BasePhaseContext, createReadFacade, requireObjectSubject } from "./context"
+import { type BasePhaseContext, requireObjectSubject } from "./context"
 import type {
   LoadedObjectTarget,
   PhaseExecutionBase,
@@ -51,7 +56,9 @@ export async function runEditsAndCommitPhase(
       const baseContext = {
         ...input.baseContext,
         objects,
-        read: createReadFacade(input.runtime.sixb),
+        read: createActionReadFacade(
+          (objectType) => input.runtime.sixb.objects(objectType) as ActionReadObjectSetSource
+        ),
         writeback: input.writeback,
       }
 

--- a/packages/action-worker/src/action-execution/phases.ts
+++ b/packages/action-worker/src/action-execution/phases.ts
@@ -1,10 +1,10 @@
 import type { ActionRunRecord } from "@sixb/core"
+import { isObjectActionDefinition, runActionValidators } from "@sixb/core"
 import { throwIfAborted } from "../normalize"
 import { createBasePhaseContext, loadObjectTarget } from "./context"
 import { runEditsAndCommitPhase } from "./edits-commit"
 import { runEffectsPhase } from "./effects"
 import type { PhaseExecutionBase, UpdateActiveRun } from "./types"
-import { runValidators } from "./validation"
 import { runWritebackPhase } from "./writeback"
 
 export async function executeActionPhases(
@@ -25,7 +25,12 @@ export async function executeActionPhases(
       phase: "validation",
     })
     input.updateActiveRun(run)
-    await runValidators({ action, run, baseContext: phaseContext, objectTarget })
+    await runActionValidators({
+      action,
+      subject: run.subject,
+      baseContext: phaseContext,
+      target: isObjectActionDefinition(action) ? objectTarget?.snapshot : undefined,
+    })
   }
 
   throwIfAborted(signal)

--- a/packages/atlas/src/components/ActionButton.tsx
+++ b/packages/atlas/src/components/ActionButton.tsx
@@ -20,6 +20,7 @@ import {
 import { cn } from "@sixb/ui/lib/utils"
 import { Loader2 } from "lucide-react"
 import { useState } from "react"
+import { useNavigate } from "react-router-dom"
 
 type ActionParams = Record<string, string | number | boolean>
 
@@ -155,6 +156,7 @@ export function ActionButton({
   size = "compact",
   requireConfirm,
 }: ActionButtonProps) {
+  const navigate = useNavigate()
   const [isExecuting, setIsExecuting] = useState(false)
   const [showParams, setShowParams] = useState(false)
   const [result, setResult] = useState<{ success: boolean; message?: string } | null>(null)
@@ -177,7 +179,10 @@ export function ActionButton({
         body: { params },
       })
 
-      if (response.data?.success) {
+      if (response.data?.success && response.data.runId) {
+        setResult({ success: true })
+        navigate(`/actions/runs/${response.data.runId}`)
+      } else if (response.data?.success) {
         setResult({ success: true })
         setTimeout(() => setResult(null), 2000)
       } else {

--- a/packages/atlas/src/components/StructuredValue.tsx
+++ b/packages/atlas/src/components/StructuredValue.tsx
@@ -2,7 +2,7 @@ import { cn } from "@sixb/ui/lib/utils"
 import { Box, Braces, Brackets, Check, Copy, Hash, Minus, Type } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 
-export function RunIOShape({
+export function StructuredValue({
   value,
   emptyLabel = "No data",
 }: {
@@ -66,7 +66,7 @@ function RunValue({ label, value }: { label?: string; value: unknown }) {
         </div>
         {value.length > 0 ? (
           <div className="border-l border-border pl-3">
-            <RunIOShape value={value} />
+            <StructuredValue value={value} />
           </div>
         ) : null}
       </div>
@@ -83,7 +83,7 @@ function RunValue({ label, value }: { label?: string; value: unknown }) {
         </div>
         {entries.length > 0 ? (
           <div className="border-l border-border pl-3">
-            <RunIOShape value={value} />
+            <StructuredValue value={value} />
           </div>
         ) : null}
       </div>

--- a/packages/atlas/src/components/common.tsx
+++ b/packages/atlas/src/components/common.tsx
@@ -1,8 +1,9 @@
 import { Button, Card, CardContent, EmptyState } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { AlertCircle, ChevronLeft, Loader2 } from "lucide-react"
-import type { ReactNode } from "react"
+import { type ReactNode, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
+import { StructuredValue } from "./StructuredValue"
 
 type AvatarSize = "xs" | "sm" | "md" | "lg"
 
@@ -158,16 +159,60 @@ export function KeyValue({ label, value, to }: { label: string; value: string; t
   )
 }
 
-export function JsonPreview({ label, value }: { label?: string; value: unknown }) {
-  const rendered = JSON.stringify(value ?? null, null, 2)
+type DataPanelMode = "structured" | "raw"
+
+export function DataPanel({
+  label,
+  value,
+  emptyLabel = "Not recorded",
+}: {
+  label?: string
+  value: unknown
+  emptyLabel?: string
+}) {
+  const [mode, setMode] = useState<DataPanelMode>("structured")
+  const isEmpty = value === null || value === undefined
+
   return (
     <div className="min-w-0 space-y-2">
-      {label ? (
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
-      ) : null}
-      <pre className="max-h-72 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground scrollbar-auto-hide">
-        {rendered}
-      </pre>
+      <div className="flex items-center justify-between gap-2">
+        {label ? (
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {label}
+          </p>
+        ) : (
+          <span />
+        )}
+        {isEmpty ? null : (
+          <div className="inline-flex rounded-md bg-muted p-0.5">
+            {(["structured", "raw"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setMode(option)}
+                aria-pressed={mode === option}
+                className={cn(
+                  "rounded-[5px] px-2 py-0.5 text-[11px] font-medium capitalize transition-colors",
+                  mode === option
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      {isEmpty ? (
+        <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+      ) : mode === "structured" ? (
+        <StructuredValue value={value} emptyLabel={emptyLabel} />
+      ) : (
+        <pre className="max-h-72 overflow-auto text-xs leading-relaxed text-muted-foreground scrollbar-auto-hide">
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      )}
     </div>
   )
 }

--- a/packages/atlas/src/components/layout/AppLayout.tsx
+++ b/packages/atlas/src/components/layout/AppLayout.tsx
@@ -43,6 +43,7 @@ export function AppLayout() {
       syncCount={sidebarData?.syncCount}
       pipelineCount={sidebarData?.pipelineCount}
       workflowCount={sidebarData?.workflowCount}
+      actionCount={sidebarData?.actionCount}
       ruleCount={sidebarData?.ruleCount}
       ontologyCount={sidebarData?.ontologyCount}
     />

--- a/packages/atlas/src/components/layout/Sidebar.tsx
+++ b/packages/atlas/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from "@sixb/ui/components"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import {
+  Bolt,
   Box,
   Cable,
   Database,
@@ -36,6 +37,7 @@ export type ViewMode =
   | "syncs"
   | "pipelines"
   | "workflows"
+  | "actions"
   | "rules"
   | "ontology"
   | "settings"
@@ -52,6 +54,7 @@ const projectNavItems: NavItem[] = [
   { id: "syncs", label: "Syncs", Icon: RefreshCw },
   { id: "pipelines", label: "Pipelines", Icon: Workflow },
   { id: "workflows", label: "Workflows", Icon: GitBranch },
+  { id: "actions", label: "Actions", Icon: Bolt },
   { id: "ontology", label: "Ontology", Icon: LayoutGrid },
   { id: "home", label: "Objects", Icon: Box },
   { id: "rules", label: "Rules", Icon: ListChecks },
@@ -71,6 +74,7 @@ interface SidebarProps {
   syncCount?: number
   pipelineCount?: number
   workflowCount?: number
+  actionCount?: number
   ruleCount?: number
   ontologyCount?: number
   objectCount?: number
@@ -85,6 +89,7 @@ export function Sidebar({
   syncCount,
   pipelineCount,
   workflowCount,
+  actionCount,
   ruleCount,
   ontologyCount,
   objectCount,
@@ -96,6 +101,7 @@ export function Sidebar({
     if (id === "syncs") return syncCount
     if (id === "pipelines") return pipelineCount
     if (id === "workflows") return workflowCount
+    if (id === "actions") return actionCount
     if (id === "rules") return ruleCount
     if (id === "ontology") return ontologyCount
     return undefined

--- a/packages/atlas/src/components/layout/sidebarData.ts
+++ b/packages/atlas/src/components/layout/sidebarData.ts
@@ -7,6 +7,7 @@ export interface ProjectSidebarData {
   syncCount: number
   pipelineCount: number
   workflowCount: number
+  actionCount: number
   ruleCount: number
   ontologyCount: number
 }

--- a/packages/atlas/src/components/layout/viewMode.ts
+++ b/packages/atlas/src/components/layout/viewMode.ts
@@ -7,6 +7,7 @@ export const KNOWN_VIEWS = new Set([
   "syncs",
   "pipelines",
   "workflows",
+  "actions",
   "runs",
   "rules",
   "ontology",
@@ -18,6 +19,7 @@ export function getViewModeFromPath(pathname: string): ViewMode {
   const segments = pathname.split("/").filter(Boolean)
   const view = segments[0]
   if (view === "runs") return "workflows"
+  if (view === "actions" && segments[1] === "runs") return "actions"
   if (view && KNOWN_VIEWS.has(view)) return view as ViewMode
   return "home"
 }

--- a/packages/atlas/src/features/workflows/components/nodes/RunNodeRow.tsx
+++ b/packages/atlas/src/features/workflows/components/nodes/RunNodeRow.tsx
@@ -2,8 +2,8 @@ import { Badge, Card, CardContent } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { ChevronRight, UserCheck, Workflow, Zap } from "lucide-react"
 import { useState } from "react"
+import { StructuredValue } from "../../../../components/StructuredValue"
 import { formatNodeDuration, formatRelativeTime, type WorkflowRunNode } from "../../utils/workflows"
-import { RunIOShape } from "../runs/RunIOShape"
 import { NodeStatusBadge } from "../runs/StatusBadge"
 import { WorkflowInterventionPanel } from "./WorkflowInterventionPanel"
 
@@ -88,7 +88,7 @@ function JsonPanel({ label, value }: { label: string; value: unknown }) {
       <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
         {label}
       </p>
-      <RunIOShape value={value} />
+      <StructuredValue value={value} />
     </div>
   )
 }

--- a/packages/atlas/src/lib/actions/params.ts
+++ b/packages/atlas/src/lib/actions/params.ts
@@ -1,0 +1,125 @@
+import type { ListActionsResponse } from "@sixb/client"
+
+type ActionCatalogItem = ListActionsResponse[number]
+type ActionParam = ActionCatalogItem["params"][number]
+
+export type ActionRequestPayload = {
+  path: { actionId: string }
+  body: {
+    subject?: { kind: "none" } | { kind: "object"; objectTypeId: string; primaryId: string }
+    params?: Record<string, unknown>
+    runId?: string
+  }
+}
+
+export type ActionParamInputDescriptor =
+  | { kind: "text" }
+  | { kind: "number"; integer?: boolean }
+  | { kind: "boolean" }
+  | { kind: "json" }
+  | { kind: "enum"; values: readonly unknown[]; valueType: "string" | "integer" }
+  | { kind: "objectRef"; objectTypeId: string }
+
+export function buildActionParams(action: ActionCatalogItem, values: Record<string, string>) {
+  const params: Record<string, unknown> = {}
+  const errors: Record<string, string> = {}
+
+  for (const param of action.params) {
+    const rawValue = values[param.id]?.trim() ?? ""
+    if (!rawValue) {
+      if (param.required) {
+        errors[param.id] = "Required."
+      }
+      continue
+    }
+
+    try {
+      params[param.id] = parseActionParamValue(param, rawValue)
+    } catch (error) {
+      errors[param.id] = error instanceof Error ? error.message : "Invalid value."
+    }
+  }
+
+  return { params, errors }
+}
+
+export function describeActionParamInput(schema: unknown): ActionParamInputDescriptor {
+  const resolved = resolveSchemaForForm(schema)
+
+  if (resolved === "integer") {
+    return { kind: "number", integer: true }
+  }
+  if (resolved === "double" || resolved === "decimal") {
+    return { kind: "number" }
+  }
+  if (resolved === "boolean") {
+    return { kind: "boolean" }
+  }
+  if (isRecord(resolved)) {
+    if (resolved.type === "objectRef" && typeof resolved.objectTypeId === "string") {
+      return { kind: "objectRef", objectTypeId: resolved.objectTypeId }
+    }
+    if (resolved.type === "enum" && Array.isArray(resolved.values)) {
+      return {
+        kind: "enum",
+        values: resolved.values,
+        valueType: resolved.valueType === "integer" ? "integer" : "string",
+      }
+    }
+    if (resolved.type === "valueTypeRef") {
+      return { kind: "json" }
+    }
+    return { kind: "json" }
+  }
+  return { kind: "text" }
+}
+
+function parseActionParamValue(param: ActionParam, rawValue: string): unknown {
+  const input = describeActionParamInput(param.schema)
+  switch (input.kind) {
+    case "number": {
+      const value = Number(rawValue)
+      if (!Number.isFinite(value)) {
+        throw new Error("Expected a number.")
+      }
+      if (input.integer && !Number.isInteger(value)) {
+        throw new Error("Expected an integer.")
+      }
+      return value
+    }
+    case "boolean":
+      return rawValue === "true"
+    case "json":
+      return JSON.parse(rawValue)
+    case "enum":
+      return input.valueType === "integer"
+        ? parseIntegerEnumValue(rawValue, input.values)
+        : rawValue
+    case "objectRef":
+      return { objectTypeId: input.objectTypeId, primaryId: rawValue }
+    case "text":
+      return rawValue
+  }
+}
+
+function parseIntegerEnumValue(rawValue: string, values: readonly unknown[]): number {
+  const value = Number(rawValue)
+  if (!Number.isInteger(value)) {
+    throw new Error("Expected an integer enum value.")
+  }
+  if (!values.includes(value)) {
+    throw new Error("Unknown enum value.")
+  }
+  return value
+}
+
+function resolveSchemaForForm(schema: unknown): unknown {
+  if (!isRecord(schema) || schema.type !== "valueTypeRef") {
+    return schema
+  }
+  return schema._resolved ?? schema
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/atlas/src/pages/ActionRunDetailPage.tsx
+++ b/packages/atlas/src/pages/ActionRunDetailPage.tsx
@@ -2,7 +2,7 @@ import { getActionRunOptions } from "@sixb/client/hooks"
 import { Card, CardContent } from "@sixb/ui/components"
 import { useQuery } from "@tanstack/react-query"
 import { Navigate, useParams } from "react-router-dom"
-import { ErrorPage, JsonPreview, LoadingPage, PageFrame } from "../components/common"
+import { DataPanel, ErrorPage, LoadingPage, PageFrame } from "../components/common"
 import {
   ActionRunDiffSummary,
   ActionRunMetaGrid,
@@ -51,34 +51,34 @@ export function ActionRunDetailPage() {
       <ActionRunMetaGrid run={run} />
 
       {run.error ? (
-        <Card>
-          <CardContent className="p-4">
+        <Card className="p-0">
+          <CardContent className="p-5">
             <div className="mb-3 flex items-center gap-2">
               <ActionRunStatusBadge status={run.status} />
               <span className="text-sm font-medium text-foreground">Failure</span>
             </div>
-            <JsonPreview value={run.error} />
+            <DataPanel value={run.error} />
           </CardContent>
         </Card>
       ) : null}
 
       <div className="grid gap-4 lg:grid-cols-2">
-        <Card>
-          <CardContent className="p-4">
-            <JsonPreview label="Params" value={run.params} />
+        <Card className="p-0">
+          <CardContent className="p-5">
+            <DataPanel label="Params" value={run.params} />
           </CardContent>
         </Card>
 
-        <Card>
-          <CardContent className="p-4">
-            <JsonPreview label="Writeback" value={run.writeback ?? null} />
+        <Card className="p-0">
+          <CardContent className="p-5">
+            <DataPanel label="Writeback" value={run.writeback ?? null} emptyLabel="No writeback" />
           </CardContent>
         </Card>
       </div>
 
-      <Card>
-        <CardContent className="space-y-3 p-4">
-          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+      <Card className="p-0">
+        <CardContent className="space-y-3 p-5">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
             Local commit
           </p>
           {run.commit ? (
@@ -89,9 +89,9 @@ export function ActionRunDetailPage() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardContent className="p-4">
-          <JsonPreview label="Effects" value={run.effects ?? null} />
+      <Card className="p-0">
+        <CardContent className="p-5">
+          <DataPanel label="Effects" value={run.effects ?? null} emptyLabel="No effects" />
         </CardContent>
       </Card>
     </PageFrame>

--- a/packages/atlas/src/pages/ActionRunDetailPage.tsx
+++ b/packages/atlas/src/pages/ActionRunDetailPage.tsx
@@ -1,0 +1,99 @@
+import { getActionRunOptions } from "@sixb/client/hooks"
+import { Card, CardContent } from "@sixb/ui/components"
+import { useQuery } from "@tanstack/react-query"
+import { Navigate, useParams } from "react-router-dom"
+import { ErrorPage, JsonPreview, LoadingPage, PageFrame } from "../components/common"
+import {
+  ActionRunDiffSummary,
+  ActionRunMetaGrid,
+  ActionRunStatusBadge,
+  formatSubject,
+} from "./ActionsPage"
+
+export function ActionRunDetailPage() {
+  const { runId = "" } = useParams()
+  const runQuery = useQuery({
+    ...getActionRunOptions({ path: { runId } }),
+    enabled: runId.length > 0,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      return status === "queued" || status === "running" ? 2000 : false
+    },
+  })
+
+  if (!runId) {
+    return <Navigate to="/actions?tab=runs" replace />
+  }
+
+  if (runQuery.isLoading) {
+    return <LoadingPage label="Loading action run..." />
+  }
+
+  if (runQuery.isError || !runQuery.data) {
+    return <ErrorPage title="Action run unavailable" description="Could not load action run." />
+  }
+
+  const run = runQuery.data
+
+  return (
+    <PageFrame
+      eyebrow="Action run"
+      title={run.id}
+      description={
+        <span>
+          <span className="font-mono">{run.actionId}</span> on{" "}
+          <span className="font-mono">{formatSubject(run.subject)}</span>
+        </span>
+      }
+      backTo="/actions?tab=runs"
+      backLabel="Back to action runs"
+    >
+      <ActionRunMetaGrid run={run} />
+
+      {run.error ? (
+        <Card>
+          <CardContent className="p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <ActionRunStatusBadge status={run.status} />
+              <span className="text-sm font-medium text-foreground">Failure</span>
+            </div>
+            <JsonPreview value={run.error} />
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardContent className="p-4">
+            <JsonPreview label="Params" value={run.params} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-4">
+            <JsonPreview label="Writeback" value={run.writeback ?? null} />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Local commit
+          </p>
+          {run.commit ? (
+            <ActionRunDiffSummary diff={run.commit.diff} />
+          ) : (
+            <p className="text-sm text-muted-foreground">No local commit recorded.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-4">
+          <JsonPreview label="Effects" value={run.effects ?? null} />
+        </CardContent>
+      </Card>
+    </PageFrame>
+  )
+}

--- a/packages/atlas/src/pages/ActionsPage.tsx
+++ b/packages/atlas/src/pages/ActionsPage.tsx
@@ -1,0 +1,697 @@
+import type {
+  GetActionRunResponse,
+  ListActionRunsResponse,
+  ListActionsResponse,
+} from "@sixb/client"
+import {
+  getActionRunQueryKey,
+  listActionRunsOptions,
+  listActionRunsQueryKey,
+  listActionsOptions,
+  listActionsQueryKey,
+  listObjectsOptions,
+  requestActionMutation,
+} from "@sixb/client/hooks"
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  EmptyState,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Textarea,
+} from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { AlertCircle, CheckCircle2, Loader2, Play, SquareActivity } from "lucide-react"
+import { type FormEvent, useState } from "react"
+import { Link, useNavigate, useSearchParams } from "react-router-dom"
+import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
+import { formatDate, formatRelativeTime } from "../features/workflows/utils/workflows"
+import {
+  type ActionRequestPayload,
+  buildActionParams,
+  describeActionParamInput,
+} from "../lib/actions/params"
+
+type ActionCatalogItem = ListActionsResponse[number]
+type ActionRunSummary = ListActionRunsResponse["runs"][number]
+type ActionRunStatus = ActionRunSummary["status"]
+type ActionCommitDiff = NonNullable<GetActionRunResponse["commit"]>["diff"]
+
+type ActionsPageTab = "actions" | "runs"
+
+const actionRunStatusLabels: Record<ActionRunStatus, string> = {
+  queued: "Queued",
+  running: "Running",
+  succeeded: "Succeeded",
+  failed: "Failed",
+  cancelled: "Cancelled",
+}
+
+const actionRunStatusClasses: Record<ActionRunStatus, string> = {
+  queued:
+    "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900 dark:bg-sky-950 dark:text-sky-300",
+  running:
+    "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300",
+  succeeded:
+    "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300",
+  failed:
+    "border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300",
+  cancelled:
+    "border-zinc-200 bg-zinc-50 text-zinc-700 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300",
+}
+
+export function ActionsPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTab: ActionsPageTab = searchParams.get("tab") === "runs" ? "runs" : "actions"
+
+  const handleTabChange = (value: string) => {
+    const nextTab: ActionsPageTab = value === "runs" ? "runs" : "actions"
+    setSearchParams((previous) => {
+      const params = new URLSearchParams(previous)
+      params.set("tab", nextTab)
+      return params
+    })
+  }
+
+  return (
+    <PageFrame
+      eyebrow="Atlas"
+      title="Actions"
+      description="Request ontology actions and inspect their durable execution history."
+    >
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="gap-4">
+        <TabsList variant="line" className="border-b border-border">
+          <TabsTrigger value="actions">Actions</TabsTrigger>
+          <TabsTrigger value="runs">Runs</TabsTrigger>
+        </TabsList>
+        <TabsContent value="actions" className="mt-0">
+          <ActionDefinitionsTab />
+        </TabsContent>
+        <TabsContent value="runs" className="mt-0">
+          <ActionRunHistoryTab />
+        </TabsContent>
+      </Tabs>
+    </PageFrame>
+  )
+}
+
+function ActionDefinitionsTab() {
+  const actionsQuery = useQuery(listActionsOptions())
+  const actions = actionsQuery.data ?? []
+
+  if (actionsQuery.isLoading) {
+    return <LoadingPage label="Loading actions..." />
+  }
+
+  if (actionsQuery.isError) {
+    return <ErrorPage title="Actions unavailable" description="Could not load action metadata." />
+  }
+
+  return (
+    <section className="space-y-3">
+      {actions.length === 0 ? (
+        <Card>
+          <EmptyState
+            icon={<SquareActivity className="size-12 stroke-1" />}
+            title="No actions registered"
+            description="Define actions to request ontology mutations from Atlas."
+          />
+        </Card>
+      ) : (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {actions.map((action) => (
+            <ActionDefinitionCard key={action.id} action={action} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ActionDefinitionCard({ action }: { action: ActionCatalogItem }) {
+  const paramCount = action.params.length
+
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="flex h-full flex-col gap-4 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <h3 className="truncate font-medium text-foreground">{action.id}</h3>
+            <p className="text-sm text-muted-foreground">
+              {action.objectTypeId ? `Object action on ${action.objectTypeId}` : "Global action"} ·{" "}
+              {paramCount} {paramCount === 1 ? "param" : "params"}
+            </p>
+          </div>
+          <ActionRequestDialog action={action} />
+        </div>
+
+        {action.description ? (
+          <p className="line-clamp-2 text-sm text-muted-foreground">{action.description}</p>
+        ) : null}
+
+        <div className="mt-auto flex flex-wrap gap-2">
+          <PhaseBadge active={action.phases.writeback}>writeback</PhaseBadge>
+          <PhaseBadge active={action.phases.edits}>edits</PhaseBadge>
+          <PhaseBadge active={action.phases.effects}>effects</PhaseBadge>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function PhaseBadge({ active, children }: { active: boolean; children: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "rounded-md font-mono text-[10px]",
+        active ? "border-border bg-muted text-foreground" : "text-muted-foreground opacity-60"
+      )}
+    >
+      {children}
+    </Badge>
+  )
+}
+
+function ActionRunHistoryTab() {
+  const runsQuery = useQuery({
+    ...listActionRunsOptions({ query: { limit: "50", order: "desc" } }),
+    refetchInterval: (query) =>
+      query.state.data?.runs.some((run) => run.status === "queued" || run.status === "running")
+        ? 2000
+        : false,
+  })
+  const runs = runsQuery.data?.runs ?? []
+
+  if (runsQuery.isLoading) {
+    return <LoadingPage label="Loading action runs..." />
+  }
+
+  if (runsQuery.isError) {
+    return (
+      <ErrorPage title="Action runs unavailable" description="Could not load action run history." />
+    )
+  }
+
+  if (runs.length === 0) {
+    return (
+      <Card>
+        <EmptyState
+          icon={<SquareActivity className="size-12 stroke-1" />}
+          title="No action runs"
+          description="Requested actions will appear here."
+        />
+      </Card>
+    )
+  }
+
+  return <ActionRunTable runs={runs} />
+}
+
+export function ActionRunTable({ runs }: { runs: readonly ActionRunSummary[] }) {
+  return (
+    <Card className="overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Run</TableHead>
+            <TableHead>Action</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="hidden md:table-cell">Subject</TableHead>
+            <TableHead className="hidden text-right sm:table-cell">Queued</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {runs.map((run) => (
+            <TableRow key={run.id}>
+              <TableCell className="font-mono text-xs">
+                <Link to={`/actions/runs/${run.id}`} className="underline-offset-4 hover:underline">
+                  {run.id}
+                </Link>
+              </TableCell>
+              <TableCell className="font-mono text-xs text-muted-foreground">
+                {run.actionId}
+              </TableCell>
+              <TableCell>
+                <ActionRunStatusBadge status={run.status} />
+              </TableCell>
+              <TableCell className="hidden font-mono text-xs text-muted-foreground md:table-cell">
+                {formatSubject(run.subject)}
+              </TableCell>
+              <TableCell className="hidden text-right text-xs text-muted-foreground sm:table-cell">
+                {formatRelativeTime(run.queuedAt)}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
+  )
+}
+
+export function ActionRunStatusBadge({ status }: { status: ActionRunStatus }) {
+  return (
+    <Badge variant="outline" className={cn("gap-1.5 rounded-md", actionRunStatusClasses[status])}>
+      {status === "succeeded" ? <CheckCircle2 className="h-3 w-3" /> : null}
+      {status === "running" ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+      {actionRunStatusLabels[status]}
+    </Badge>
+  )
+}
+
+function ActionRequestDialog({
+  action,
+  subject,
+}: {
+  action: ActionCatalogItem
+  subject?: { kind: "object"; objectTypeId: string; primaryId: string }
+}) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [subjectPrimaryId, setSubjectPrimaryId] = useState(subject?.primaryId ?? "")
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+  const requestAction = useMutation({
+    ...requestActionMutation(),
+    onSuccess: async (response) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: listActionsQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: listActionRunsQueryKey() }),
+        queryClient.invalidateQueries({
+          queryKey: getActionRunQueryKey({ path: { runId: response.runId } }),
+        }),
+      ])
+      setOpen(false)
+      navigate(`/actions/runs/${response.runId}`)
+    },
+  })
+
+  const apiErrorMessage = errorToMessage(requestAction.error)
+  const defaultSubject =
+    subject ??
+    (action.objectTypeId && subjectPrimaryId
+      ? { kind: "object" as const, objectTypeId: action.objectTypeId, primaryId: subjectPrimaryId }
+      : undefined)
+
+  function handleSubjectPrimaryIdChange(value: string) {
+    setSubjectPrimaryId(value)
+    setFieldErrors(({ __subject: _subject, ...rest }) => rest)
+    requestAction.reset()
+  }
+
+  function handleParamChange(paramId: string, value: string) {
+    setValues((current) => ({ ...current, [paramId]: value }))
+    setFieldErrors(({ [paramId]: _param, ...rest }) => rest)
+    requestAction.reset()
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen)
+    setValues({})
+    setFieldErrors({})
+    requestAction.reset()
+    setSubjectPrimaryId(subject?.primaryId ?? "")
+  }
+
+  function buildRequestPayload(options: { updateErrors: boolean }): ActionRequestPayload | null {
+    const paramsResult = buildActionParams(action, values)
+    const errors = { ...paramsResult.errors }
+    if (action.objectTypeId && !defaultSubject) {
+      errors.__subject = "Target object id is required."
+    }
+    if (options.updateErrors) {
+      setFieldErrors(errors)
+    }
+    if (Object.keys(errors).length > 0) {
+      return null
+    }
+    return {
+      path: { actionId: action.id },
+      body: {
+        ...(defaultSubject ? { subject: defaultSubject } : {}),
+        params: paramsResult.params,
+      },
+    }
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    requestAction.reset()
+    const payload = buildRequestPayload({ updateErrors: true })
+    if (!payload) return
+    requestAction.mutate(payload)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button type="button" size="sm">
+          <Play className="h-4 w-4" />
+          Request
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[min(48rem,calc(100vh-2rem))] sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Request action</DialogTitle>
+          <DialogDescription>
+            <span className="font-mono">{action.id}</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <section className="max-h-[min(33rem,calc(100vh-17rem))] space-y-4 overflow-y-auto pr-1">
+            {action.objectTypeId ? (
+              <div className="space-y-1.5">
+                <Label htmlFor={`action-${action.id}-subject`} className="text-xs">
+                  Target {action.objectTypeId} id
+                </Label>
+                <Input
+                  id={`action-${action.id}-subject`}
+                  value={subjectPrimaryId}
+                  onChange={(event) => handleSubjectPrimaryIdChange(event.target.value)}
+                  disabled={Boolean(subject)}
+                  required
+                />
+                {fieldErrors.__subject ? (
+                  <p className="text-xs text-destructive">{fieldErrors.__subject}</p>
+                ) : null}
+              </div>
+            ) : null}
+
+            <ActionParamFields
+              action={action}
+              values={values}
+              errors={fieldErrors}
+              onChange={handleParamChange}
+            />
+          </section>
+
+          {apiErrorMessage ? (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Action request failed</AlertTitle>
+              <AlertDescription>{apiErrorMessage}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={requestAction.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={requestAction.isPending}>
+              {requestAction.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              Request action
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ActionParamFields({
+  action,
+  values,
+  errors,
+  onChange,
+}: {
+  action: ActionCatalogItem
+  values: Record<string, string>
+  errors: Record<string, string>
+  onChange: (paramId: string, value: string) => void
+}) {
+  if (action.params.length === 0) {
+    return <p className="text-sm text-muted-foreground">This action does not require params.</p>
+  }
+
+  return (
+    <div className="space-y-3">
+      {action.params.map((param) => {
+        const input = describeActionParamInput(param.schema)
+        const value = values[param.id] ?? ""
+        const fieldId = `action-${action.id}-${param.id}`
+
+        return (
+          <div key={param.id} className="space-y-1.5">
+            <div className="flex items-center gap-1.5">
+              <Label htmlFor={fieldId} className="text-xs">
+                {param.id}
+              </Label>
+              {param.required ? (
+                <Badge variant="outline" className="h-4 px-1 py-0 text-[8px] uppercase">
+                  Required
+                </Badge>
+              ) : null}
+            </div>
+            {param.description ? (
+              <p className="text-[11px] text-muted-foreground">{param.description}</p>
+            ) : null}
+
+            {input.kind === "objectRef" ? (
+              <ObjectRefField
+                objectTypeId={input.objectTypeId}
+                value={value}
+                onChange={(next) => onChange(param.id, next)}
+                fieldId={fieldId}
+              />
+            ) : input.kind === "enum" ? (
+              <Select value={value} onValueChange={(next) => onChange(param.id, next)}>
+                <SelectTrigger id={fieldId} className="w-full">
+                  <SelectValue placeholder="Select..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {input.values.map((option) => (
+                    <SelectItem key={String(option)} value={String(option)}>
+                      {String(option)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : input.kind === "boolean" ? (
+              <Select value={value} onValueChange={(next) => onChange(param.id, next)}>
+                <SelectTrigger id={fieldId} className="w-full">
+                  <SelectValue placeholder="Select..." />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="true">true</SelectItem>
+                  <SelectItem value="false">false</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : input.kind === "json" ? (
+              <Textarea
+                id={fieldId}
+                value={value}
+                onChange={(event) => onChange(param.id, event.target.value)}
+                required={param.required}
+                placeholder='{"objectTypeId":"Customer","primaryId":"cus_1"}'
+                className="min-h-24 font-mono text-xs"
+              />
+            ) : (
+              <Input
+                id={fieldId}
+                type={input.kind === "number" ? "number" : "text"}
+                value={value}
+                onChange={(event) => onChange(param.id, event.target.value)}
+                required={param.required}
+              />
+            )}
+
+            {errors[param.id] ? (
+              <p className="text-xs text-destructive">{errors[param.id]}</p>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function ObjectRefField({
+  objectTypeId,
+  value,
+  onChange,
+  fieldId,
+}: {
+  objectTypeId: string
+  value: string
+  onChange: (value: string) => void
+  fieldId: string
+}) {
+  const objectsQuery = useQuery(
+    listObjectsOptions({
+      query: { objectTypeId, limit: "100", orderBy: "primaryId", order: "asc" },
+    })
+  )
+  const objects = objectsQuery.data ?? []
+
+  if (objectsQuery.isError) {
+    return (
+      <Input
+        id={fieldId}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={`${objectTypeId} id`}
+      />
+    )
+  }
+
+  const isEmpty = !objectsQuery.isLoading && objects.length === 0
+
+  return (
+    <Select value={value} onValueChange={onChange} disabled={objectsQuery.isLoading || isEmpty}>
+      <SelectTrigger id={fieldId} className="w-full">
+        <SelectValue
+          placeholder={
+            objectsQuery.isLoading
+              ? "Loading..."
+              : isEmpty
+                ? `No ${objectTypeId} found`
+                : `Select ${objectTypeId}...`
+          }
+        />
+      </SelectTrigger>
+      <SelectContent>
+        {objects.map((object) => (
+          <SelectItem key={object.primaryId} value={object.primaryId}>
+            {objectRefLabel(object)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function objectRefLabel(object: { name: string; primaryId: string }): string {
+  return object.name && object.name !== object.primaryId
+    ? `${object.name} · ${object.primaryId}`
+    : object.primaryId
+}
+
+export function ActionRunDiffSummary({ diff }: { diff: ActionCommitDiff }) {
+  const objectCount = diff.objects.length
+  const linkCount = diff.links.length
+
+  return (
+    <div className="space-y-3">
+      <div className="text-sm text-muted-foreground">
+        {objectCount} object {objectCount === 1 ? "change" : "changes"} · {linkCount} link{" "}
+        {linkCount === 1 ? "change" : "changes"}
+      </div>
+      {diff.objects.map((object) => (
+        <div
+          key={`${object.objectTypeId}:${object.primaryId}:${object.operation}`}
+          className="rounded-md border border-border p-3"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline" className="rounded-md font-mono text-[10px]">
+              object.{object.operation}
+            </Badge>
+            <span className="font-mono text-xs text-muted-foreground">
+              {object.objectTypeId}:{object.primaryId}
+            </span>
+          </div>
+          {object.changedProperties.length > 0 ? (
+            <p className="mt-2 font-mono text-xs text-muted-foreground">
+              {object.changedProperties.join(", ")}
+            </p>
+          ) : null}
+        </div>
+      ))}
+      {diff.links.map((link) => (
+        <div
+          key={`${link.source.objectTypeId}:${link.source.primaryId}:${link.linkId}:${link.target.objectTypeId}:${link.target.primaryId}:${link.operation}`}
+          className="rounded-md border border-border p-3"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline" className="rounded-md font-mono text-[10px]">
+              link.{link.operation}
+            </Badge>
+            <span className="font-mono text-xs text-muted-foreground">
+              {link.source.objectTypeId}:{link.source.primaryId}.{link.linkId} -&gt;{" "}
+              {link.target.objectTypeId}:{link.target.primaryId}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ActionRunMetaGrid({ run }: { run: ActionRunSummary }) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <Metric label="Status" value={<ActionRunStatusBadge status={run.status} />} />
+      <Metric label="Phase" value={run.phase ?? "Not started"} />
+      <Metric label="Queued" value={formatDate(run.queuedAt)} />
+      <Metric label="Subject" value={formatSubject(run.subject)} mono />
+    </div>
+  )
+}
+
+function Metric({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
+  return (
+    <Card>
+      <CardContent className="space-y-1 p-4">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+        <div className={cn("break-words text-sm text-foreground", mono && "font-mono text-xs")}>
+          {value}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function formatSubject(subject: ActionRunSummary["subject"]): string {
+  if (subject.kind === "none") {
+    return "global"
+  }
+  return `${subject.objectTypeId}:${subject.primaryId}`
+}
+
+function errorToMessage(error: unknown): string | null {
+  if (!error) return null
+  if (isRecord(error) && typeof error.error === "string") return error.error
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  return "Could not request action."
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export { ActionRequestDialog, formatSubject }

--- a/packages/atlas/src/pages/ActionsPage.tsx
+++ b/packages/atlas/src/pages/ActionsPage.tsx
@@ -49,8 +49,8 @@ import {
 } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { AlertCircle, CheckCircle2, Loader2, Play, SquareActivity } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { AlertCircle, ArrowRight, CheckCircle2, Loader2, Play, SquareActivity } from "lucide-react"
+import { type SyntheticEvent, useState } from "react"
 import { Link, useNavigate, useSearchParams } from "react-router-dom"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
 import { formatDate, formatRelativeTime } from "../features/workflows/utils/workflows"
@@ -160,8 +160,8 @@ function ActionDefinitionCard({ action }: { action: ActionCatalogItem }) {
   const paramCount = action.params.length
 
   return (
-    <Card className="overflow-hidden">
-      <CardContent className="flex h-full flex-col gap-4 p-4">
+    <Card className="overflow-hidden p-0">
+      <CardContent className="flex h-full flex-col gap-3 p-5">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 space-y-1">
             <h3 className="truncate font-medium text-foreground">{action.id}</h3>
@@ -238,7 +238,7 @@ function ActionRunHistoryTab() {
 
 export function ActionRunTable({ runs }: { runs: readonly ActionRunSummary[] }) {
   return (
-    <Card className="overflow-hidden">
+    <Card className="overflow-hidden p-0">
       <Table>
         <TableHeader>
           <TableRow>
@@ -363,7 +363,7 @@ function ActionRequestDialog({
     }
   }
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  function handleSubmit(event: SyntheticEvent<HTMLFormElement>) {
     event.preventDefault()
     requestAction.reset()
     const payload = buildRequestPayload({ updateErrors: true })
@@ -601,52 +601,118 @@ function objectRefLabel(object: { name: string; primaryId: string }): string {
     : object.primaryId
 }
 
+type DiffOperation = ActionCommitDiff["objects"][number]["operation"]
+
+const diffOperationClasses: Record<DiffOperation, string> = {
+  create:
+    "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300",
+  update:
+    "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300",
+  delete:
+    "border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300",
+}
+
+function DiffOperationBadge({ operation }: { operation: DiffOperation }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn("rounded-md font-mono text-[10px]", diffOperationClasses[operation])}
+    >
+      {operation}
+    </Badge>
+  )
+}
+
+function DiffGroup({
+  label,
+  count,
+  children,
+}: {
+  label: string
+  count: number
+  children: React.ReactNode
+}) {
+  return (
+    <section className="space-y-2.5">
+      <div className="flex items-baseline gap-2">
+        <h4 className="text-sm font-medium text-foreground">{label}</h4>
+        <span className="text-xs tabular-nums text-muted-foreground">{count}</span>
+      </div>
+      <div className="space-y-3">{children}</div>
+    </section>
+  )
+}
+
+function ObjectRef({ objectTypeId, primaryId }: { objectTypeId: string; primaryId: string }) {
+  return (
+    <span className="font-mono text-sm">
+      <span className="text-muted-foreground">{objectTypeId}:</span>
+      <span className="text-foreground">{primaryId}</span>
+    </span>
+  )
+}
+
 export function ActionRunDiffSummary({ diff }: { diff: ActionCommitDiff }) {
   const objectCount = diff.objects.length
   const linkCount = diff.links.length
 
+  if (objectCount === 0 && linkCount === 0) {
+    return <p className="text-sm text-muted-foreground">No changes recorded.</p>
+  }
+
   return (
-    <div className="space-y-3">
-      <div className="text-sm text-muted-foreground">
-        {objectCount} object {objectCount === 1 ? "change" : "changes"} · {linkCount} link{" "}
-        {linkCount === 1 ? "change" : "changes"}
-      </div>
-      {diff.objects.map((object) => (
-        <div
-          key={`${object.objectTypeId}:${object.primaryId}:${object.operation}`}
-          className="rounded-md border border-border p-3"
-        >
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="outline" className="rounded-md font-mono text-[10px]">
-              object.{object.operation}
-            </Badge>
-            <span className="font-mono text-xs text-muted-foreground">
-              {object.objectTypeId}:{object.primaryId}
-            </span>
-          </div>
-          {object.changedProperties.length > 0 ? (
-            <p className="mt-2 font-mono text-xs text-muted-foreground">
-              {object.changedProperties.join(", ")}
-            </p>
-          ) : null}
-        </div>
-      ))}
-      {diff.links.map((link) => (
-        <div
-          key={`${link.source.objectTypeId}:${link.source.primaryId}:${link.linkId}:${link.target.objectTypeId}:${link.target.primaryId}:${link.operation}`}
-          className="rounded-md border border-border p-3"
-        >
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="outline" className="rounded-md font-mono text-[10px]">
-              link.{link.operation}
-            </Badge>
-            <span className="font-mono text-xs text-muted-foreground">
-              {link.source.objectTypeId}:{link.source.primaryId}.{link.linkId} -&gt;{" "}
-              {link.target.objectTypeId}:{link.target.primaryId}
-            </span>
-          </div>
-        </div>
-      ))}
+    <div className="space-y-5">
+      {objectCount > 0 ? (
+        <DiffGroup label="Objects" count={objectCount}>
+          {diff.objects.map((object) => (
+            <div
+              key={`${object.objectTypeId}:${object.primaryId}:${object.operation}`}
+              className="space-y-2"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <DiffOperationBadge operation={object.operation} />
+                <ObjectRef objectTypeId={object.objectTypeId} primaryId={object.primaryId} />
+              </div>
+              {object.changedProperties.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {object.changedProperties.map((prop) => (
+                    <span
+                      key={prop}
+                      className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+                    >
+                      {prop}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </DiffGroup>
+      ) : null}
+
+      {linkCount > 0 ? (
+        <DiffGroup label="Links" count={linkCount}>
+          {diff.links.map((link) => (
+            <div
+              key={`${link.source.objectTypeId}:${link.source.primaryId}:${link.linkId}:${link.target.objectTypeId}:${link.target.primaryId}:${link.operation}`}
+              className="flex flex-wrap items-center gap-2"
+            >
+              <DiffOperationBadge operation={link.operation} />
+              <span className="font-mono text-sm">
+                <span className="text-foreground">
+                  {link.source.objectTypeId}:{link.source.primaryId}
+                </span>
+                <span className="text-muted-foreground">.{link.linkId}</span>
+              </span>
+              <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <ObjectRef
+                objectTypeId={link.target.objectTypeId}
+                primaryId={link.target.primaryId}
+              />
+            </div>
+          ))}
+        </DiffGroup>
+      ) : null}
     </div>
   )
 }
@@ -664,8 +730,8 @@ export function ActionRunMetaGrid({ run }: { run: ActionRunSummary }) {
 
 function Metric({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
   return (
-    <Card>
-      <CardContent className="space-y-1 p-4">
+    <Card className="p-0">
+      <CardContent className="space-y-1.5 p-4">
         <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
         <div className={cn("break-words text-sm text-foreground", mono && "font-mono text-xs")}>
           {value}

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -1,6 +1,7 @@
 import type { ObjectSummary } from "@sixb/client"
 import {
   getProjectInfoOptions,
+  listActionsOptions,
   listConnectorsOptions,
   listDatasetsOptions,
   listObjectsPageOptions,
@@ -36,6 +37,8 @@ import {
   type ObjectSortPreference,
   setObjectSortPreference,
 } from "../lib/userPreferences"
+import { ActionRunDetailPage } from "./ActionRunDetailPage"
+import { ActionsPage } from "./ActionsPage"
 import { ConnectorDetailPage, ConnectorsPage } from "./ConnectorsPage"
 import { DatasetDetailPage, DatasetsPage } from "./DatasetsPage"
 import { ObjectDetailPage } from "./ObjectDetailPage"
@@ -219,6 +222,11 @@ export function ProjectWorkspace() {
     enabled: !!projectInfo,
   })
 
+  const { data: actions = [] } = useQuery({
+    ...listActionsOptions(),
+    enabled: !!projectInfo,
+  })
+
   const { data: rules = [] } = useQuery({
     ...listRulesOptions(),
     enabled: !!projectInfo,
@@ -257,6 +265,7 @@ export function ProjectWorkspace() {
       syncCount: syncs.length,
       pipelineCount: pipelines.length,
       workflowCount: workflows.length,
+      actionCount: actions.length,
       ruleCount: rules.length,
       ontologyCount: objectTypes.length,
     })
@@ -268,6 +277,7 @@ export function ProjectWorkspace() {
     syncs.length,
     pipelines.length,
     workflows.length,
+    actions.length,
     rules.length,
     objectTypes.length,
     setSidebarData,
@@ -381,6 +391,8 @@ export function ProjectWorkspace() {
             <Route path="syncs" element={<SyncsPage />} />
             <Route path="syncs/:syncId" element={<SyncDetailPage />} />
             <Route path="pipelines" element={<PipelinesPage />} />
+            <Route path="actions" element={<ActionsPage />} />
+            <Route path="actions/runs/:runId" element={<ActionRunDetailPage />} />
             <Route path="rules" element={<RulesPage />} />
             <Route path="rules/:ruleId" element={<RuleDetailPage />} />
             <Route path="settings" element={<Navigate to="/settings/invitations" replace />} />

--- a/packages/atlas/src/pages/RunDetailPage.tsx
+++ b/packages/atlas/src/pages/RunDetailPage.tsx
@@ -6,8 +6,8 @@ import type { ReactNode } from "react"
 import { useEffect, useState } from "react"
 import { Link, Navigate, useParams } from "react-router-dom"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
+import { StructuredValue } from "../components/StructuredValue"
 import { RunNodeRow } from "../features/workflows/components/nodes/RunNodeRow"
-import { RunIOShape } from "../features/workflows/components/runs/RunIOShape"
 import { RunProgress } from "../features/workflows/components/runs/RunProgress"
 import { StatusBadge } from "../features/workflows/components/runs/StatusBadge"
 import {
@@ -249,7 +249,7 @@ function RunInputCard({ value }: { value: unknown }) {
           </div>
         </div>
         <div className="border-t border-border/60 bg-muted/20 p-4">
-          <RunIOShape value={value} />
+          <StructuredValue value={value} />
         </div>
       </CardContent>
     </Card>

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -9446,39 +9446,9 @@
                         },
                         "required": ["validate", "writeback", "edits", "effects"],
                         "additionalProperties": false
-                      },
-                      "preview": {
-                        "anyOf": [
-                          {
-                            "type": "object",
-                            "properties": {
-                              "supported": {
-                                "type": "boolean",
-                                "enum": [true]
-                              }
-                            },
-                            "required": ["supported"],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "supported": {
-                                "type": "boolean",
-                                "enum": [false]
-                              },
-                              "reason": {
-                                "type": "string",
-                                "enum": ["no_edits", "writeback_required"]
-                              }
-                            },
-                            "required": ["supported", "reason"],
-                            "additionalProperties": false
-                          }
-                        ]
                       }
                     },
-                    "required": ["id", "name", "params", "phases", "preview"],
+                    "required": ["id", "name", "params", "phases"],
                     "additionalProperties": false
                   }
                 }
@@ -9568,39 +9538,9 @@
                       },
                       "required": ["validate", "writeback", "edits", "effects"],
                       "additionalProperties": false
-                    },
-                    "preview": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "supported": {
-                              "type": "boolean",
-                              "enum": [true]
-                            }
-                          },
-                          "required": ["supported"],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "supported": {
-                              "type": "boolean",
-                              "enum": [false]
-                            },
-                            "reason": {
-                              "type": "string",
-                              "enum": ["no_edits", "writeback_required"]
-                            }
-                          },
-                          "required": ["supported", "reason"],
-                          "additionalProperties": false
-                        }
-                      ]
                     }
                   },
-                  "required": ["id", "name", "params", "phases", "preview"],
+                  "required": ["id", "name", "params", "phases"],
                   "additionalProperties": false
                 }
               }

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3285,14 +3285,6 @@ export type ListActionsResponses = {
       edits: boolean
       effects: boolean
     }
-    preview:
-      | {
-          supported: true
-        }
-      | {
-          supported: false
-          reason: "no_edits" | "writeback_required"
-        }
   }>
 }
 
@@ -3341,14 +3333,6 @@ export type GetActionResponses = {
       edits: boolean
       effects: boolean
     }
-    preview:
-      | {
-          supported: true
-        }
-      | {
-          supported: false
-          reason: "no_edits" | "writeback_required"
-        }
   }
 }
 

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -7,6 +7,8 @@ export type {
 } from "./commit-edit-batch"
 export { commitActionEditBatch } from "./commit-edit-batch"
 export { ActionDefinitionError, ActionEditCommitError } from "./errors"
+export type { ActionReadObjectSetSource } from "./read-facade"
+export { createActionReadFacade } from "./read-facade"
 export { ActionRegistry } from "./registry"
 export type {
   RequestActionAndWaitInput,
@@ -69,3 +71,4 @@ export {
   isGlobalActionDefinition,
   isObjectActionDefinition,
 } from "./validation"
+export { runActionValidators } from "./validators"

--- a/packages/core/src/actions/read-facade.ts
+++ b/packages/core/src/actions/read-facade.ts
@@ -1,0 +1,63 @@
+import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
+import type { ValueType } from "../ontology/types"
+import type { ObjectSetListInput } from "../runtime/types"
+import type { ActionReadFacade, ActionReadObjectSet } from "./types"
+
+export type ActionReadObjectSetSource = {
+  get(id: string): Promise<unknown>
+  query(): unknown
+  list(input?: ObjectSetListInput): Promise<unknown>
+  byId(id: string): {
+    get(): Promise<unknown>
+    listLinks(link?: unknown): Promise<unknown>
+  }
+}
+
+export function createActionReadFacade(
+  createObjectSet: <const TObjectType extends ObjectTypeWithPropertyTokens>(
+    objectType: TObjectType
+  ) => ActionReadObjectSetSource
+): ActionReadFacade {
+  const facade = {
+    objects<const TObjectType extends ObjectTypeWithPropertyTokens>(objectType: TObjectType) {
+      return createActionReadObjectSetAdapter<TObjectType>(createObjectSet(objectType))
+    },
+  }
+
+  return facade as ActionReadFacade
+}
+
+function createActionReadObjectSetAdapter<TObjectType extends ObjectTypeWithPropertyTokens>(
+  objectSet: ActionReadObjectSetSource
+): ActionReadObjectSet<TObjectType, readonly ValueType[], ObjectTypeWithPropertyTokens> {
+  type TypedReadObjectSet = ActionReadObjectSet<
+    TObjectType,
+    readonly ValueType[],
+    ObjectTypeWithPropertyTokens
+  >
+
+  return {
+    get(id) {
+      return objectSet.get(id) as ReturnType<TypedReadObjectSet["get"]>
+    },
+    query() {
+      return objectSet.query() as ReturnType<TypedReadObjectSet["query"]>
+    },
+    list(input) {
+      return objectSet.list(input) as ReturnType<TypedReadObjectSet["list"]>
+    },
+    byId(id) {
+      const handle = objectSet.byId(id)
+      return {
+        get() {
+          return handle.get() as ReturnType<ReturnType<TypedReadObjectSet["byId"]>["get"]>
+        },
+        listLinks(link) {
+          return handle.listLinks(link) as ReturnType<
+            ReturnType<TypedReadObjectSet["byId"]>["listLinks"]
+          >
+        },
+      }
+    },
+  }
+}

--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -1,7 +1,4 @@
-import { randomUUID } from "node:crypto"
-import type { SecurityContext } from "../auth"
 import { assertAuthorized } from "../authorization"
-import type { EventActor } from "../events"
 import { ActionRunTimeoutError } from "../objects/action/errors"
 import { OntologyValidationError } from "../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
@@ -15,6 +12,7 @@ import {
   actionSubjectsEqual,
   isTerminalActionRun,
 } from "../storage"
+import { createActionRunId, createActionRunIdempotencyKey } from "./run-id"
 import type { ActionDefinition, ActionSubject } from "./types"
 import {
   isObjectActionDefinition,
@@ -33,7 +31,6 @@ export interface RequestActionResult {
 export interface RequestActionOptions {
   readonly runId?: string
   readonly signal?: AbortSignal
-  readonly securityContext?: SecurityContext
 }
 
 export interface RequestActionAndWaitOptions extends RequestActionOptions {
@@ -47,7 +44,6 @@ export interface RequestActionInput {
   readonly params?: Record<string, unknown>
   readonly runId?: string
   readonly signal?: AbortSignal
-  readonly securityContext?: SecurityContext
 }
 
 export interface RequestActionAndWaitInput extends RequestActionInput {
@@ -63,17 +59,6 @@ export interface WaitForActionRunInput {
 
 const DEFAULT_ACTION_WAIT_TIMEOUT_MS = 60_000
 const DEFAULT_ACTION_WAIT_POLL_MS = 1_000
-
-function createActionRunId(runId: string | undefined): string {
-  if (runId !== undefined) {
-    if (!runId.trim()) {
-      throw new OntologyValidationError("[Sixb] Action run id must not be empty")
-    }
-    return runId
-  }
-
-  return `act_${randomUUID()}`
-}
 
 function clearTimer(timer: ReturnType<typeof setTimeout> | undefined): void {
   if (timer) {
@@ -134,7 +119,6 @@ export async function requestAction(
         subject,
         params: actionParams,
         idempotencyKey: existing.idempotencyKey,
-        securityContext: existing.securityContext,
         queuedAt,
       })
       return enqueueActionRunJob(runtime, {
@@ -145,7 +129,6 @@ export async function requestAction(
         runId,
         queuedAt,
         created: false,
-        securityContext: input.securityContext,
       })
     }
     return {
@@ -165,7 +148,6 @@ export async function requestAction(
     subject,
     params: actionParams,
     idempotencyKey,
-    securityContext: input.securityContext,
     queuedAt,
   })
 
@@ -177,7 +159,6 @@ export async function requestAction(
     runId,
     queuedAt,
     created: true,
-    securityContext: input.securityContext,
   })
 }
 
@@ -191,7 +172,6 @@ async function enqueueActionRunJob(
     readonly runId: string
     readonly queuedAt: Date
     readonly created: boolean
-    readonly securityContext?: SecurityContext
   }
 ): Promise<RequestActionResult> {
   let jobId: string | undefined
@@ -222,8 +202,6 @@ async function enqueueActionRunJob(
 
   try {
     await runtime.events.append({
-      actor: params.securityContext ? toEventActor(params.securityContext) : undefined,
-      correlationId: params.securityContext?.correlationId,
       events: [
         {
           type: "action.requested",
@@ -376,10 +354,6 @@ function requireActionRunStorage(runtime: SixbRuntimeContext): ActionRunStorage 
   return actionRuns
 }
 
-function createActionRunIdempotencyKey(projectId: string, runId: string): string {
-  return `action:${projectId}:${runId}`
-}
-
 function assertExistingRunMatchesRequest(
   existing: ActionRunRecord,
   request: {
@@ -419,11 +393,4 @@ function toActionRunFailure(
     message: String(error),
     phase,
   }
-}
-
-function toEventActor(securityContext: SecurityContext): EventActor {
-  if (securityContext.principal.type === "serviceAccount") {
-    return { type: "service", id: securityContext.principal.id }
-  }
-  return securityContext.principal
 }

--- a/packages/core/src/actions/run-id.ts
+++ b/packages/core/src/actions/run-id.ts
@@ -1,0 +1,17 @@
+import { randomUUID } from "node:crypto"
+import { OntologyValidationError } from "../ontology/errors"
+
+export function createActionRunId(runId: string | undefined): string {
+  if (runId !== undefined) {
+    if (!runId.trim()) {
+      throw new OntologyValidationError("[Sixb] Action run id must not be empty")
+    }
+    return runId
+  }
+
+  return `act_${randomUUID()}`
+}
+
+export function createActionRunIdempotencyKey(projectId: string, runId: string): string {
+  return `action:${projectId}:${runId}`
+}

--- a/packages/core/src/actions/validators.ts
+++ b/packages/core/src/actions/validators.ts
@@ -1,13 +1,14 @@
-import type { ActionDefinition, ActionRunRecord } from "@sixb/core"
-import { ActionValidationError, isObjectActionDefinition } from "@sixb/core"
-import { type BasePhaseContext, requireObjectTarget } from "./context"
-import type { LoadedObjectTarget, RuntimePhaseHandler } from "./types"
+import { ActionValidationError } from "../objects/action/errors"
+import type { ActionDefinition, ActionSubject, ActionTargetObject } from "./types"
+import { isObjectActionDefinition } from "./validation"
 
-export async function runValidators(input: {
+type RuntimePhaseHandler = (ctx: unknown) => unknown | Promise<unknown>
+
+export async function runActionValidators<TBaseContext extends object>(input: {
   readonly action: ActionDefinition
-  readonly run: ActionRunRecord
-  readonly baseContext: BasePhaseContext
-  readonly objectTarget: LoadedObjectTarget | null
+  readonly subject: ActionSubject
+  readonly baseContext: TBaseContext
+  readonly target?: ActionTargetObject | null
 }): Promise<void> {
   const validators = input.action.phases.validate as readonly RuntimePhaseHandler[]
   if (validators.length === 0) {
@@ -20,23 +21,26 @@ export async function runValidators(input: {
       if (isValidatorErrorResult(result)) {
         throw new ActionValidationError(result.error, {
           actionId: input.action.id,
-          subject: input.run.subject,
+          subject: input.subject,
         })
       }
     }
     return
   }
 
-  const target = requireObjectTarget(input.objectTarget, input.action.id)
+  if (!input.target) {
+    throw new Error(`[Sixb] Action '${input.action.id}' requires an object target.`)
+  }
+
   for (const validator of validators) {
     const result = await validator({
       ...input.baseContext,
-      target: target.snapshot,
+      target: input.target,
     })
     if (isValidatorErrorResult(result)) {
       throw new ActionValidationError(result.error, {
         actionId: input.action.id,
-        subject: input.run.subject,
+        subject: input.subject,
       })
     }
   }

--- a/packages/core/src/edits/index.ts
+++ b/packages/core/src/edits/index.ts
@@ -25,6 +25,7 @@ export type {
   TypedEditObjectRef,
 } from "./types"
 export type {
+  EditBatchLoadedState,
   EditBatchLoadRequests,
   EditCommitPlan,
   EditLinkDeletePlan,
@@ -37,6 +38,7 @@ export type {
 export {
   collectEditBatchLoadRequests,
   deriveEditCommitDiff,
+  loadEditBatchState,
   planEditBatch,
   planEditBatchFromLoadedState,
   validateEditBatch,

--- a/packages/core/src/edits/validation.ts
+++ b/packages/core/src/edits/validation.ts
@@ -1,4 +1,4 @@
-import type { JsonValue } from "../json"
+import { compareStrings, type JsonValue, jsonValuesEqual } from "../json"
 import type { ObjectLink, ValueType } from "../ontology"
 import type { OntologyRegistry } from "../ontology/registry"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
@@ -35,7 +35,10 @@ export interface ValidateEditBatchInput {
     "resolveObjectType" | "getPrimaryPropertyId" | "getValueTypesById" | "isValidLinkTarget"
   >
   readonly storage: {
-    readonly objects: Pick<ObjectStorage, "getByPrimaryIdBatch" | "listLinks" | "listLinksBatch">
+    readonly objects: Pick<
+      ObjectStorage,
+      "getByPrimaryIdBatch" | "listLinksBatch" | "listIncidentLinksBatch"
+    >
   }
   readonly batch: EditBatchInput
 }
@@ -49,6 +52,11 @@ export interface EditBatchLoadRequests {
   readonly objects: readonly { objectTypeId: string; primaryId: string }[]
   readonly sourceLinks: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   readonly incidentLinks: readonly { objectTypeId: string; objectId: string }[]
+}
+
+export interface EditBatchLoadedState {
+  readonly existingObjects: Map<string, ObjectRow>
+  readonly existingLinks: Map<string, ObjectLinkRow[]>
 }
 
 export interface EditObjectUpsertPlan {
@@ -164,15 +172,40 @@ export async function deriveEditCommitDiff(input: ValidateEditBatchInput): Promi
 
 export async function planEditBatch(input: ValidateEditBatchInput): Promise<EditCommitPlan> {
   const batch = normalizeEditBatchWithOntology(normalizeEditBatch(input.batch), input)
-  const existingObjects = await loadExistingObjects(input, batch.operations)
-  const existingLinks = await loadExistingLinks(input, batch.operations)
+  const loadedState = await loadEditBatchState({ ...input, batch })
 
   return planEditBatchFromLoadedState({
     ...input,
     batch,
-    existingObjects,
-    existingLinks,
+    ...loadedState,
   })
+}
+
+export async function loadEditBatchState(
+  input: ValidateEditBatchInput
+): Promise<EditBatchLoadedState> {
+  const requests = collectEditBatchLoadRequests(input.batch)
+  const existingObjects = await input.storage.objects.getByPrimaryIdBatch({
+    projectId: input.projectId,
+    items: requests.objects,
+  })
+  const existingLinks = await input.storage.objects.listLinksBatch({
+    projectId: input.projectId,
+    items: requests.sourceLinks,
+  })
+
+  // `listLinksBatch` only returns outgoing links (by source+linkId); a delete cascades to links in
+  // both directions, so load those in one batched read — fewer round trips keep the serializable
+  // commit transaction's lock hold short. Bucket key is arbitrary: `seedLinkIndex` re-keys by link.
+  const incidentLinks = await input.storage.objects.listIncidentLinksBatch({
+    projectId: input.projectId,
+    items: requests.incidentLinks,
+  })
+  if (incidentLinks.length > 0) {
+    existingLinks.set("incident", [...incidentLinks])
+  }
+
+  return { existingObjects, existingLinks }
 }
 
 export function collectEditBatchLoadRequests(batchInput: EditBatchInput): EditBatchLoadRequests {
@@ -342,53 +375,6 @@ function normalizeOperationWithOntology(
       return operation
     }
   }
-}
-
-async function loadExistingObjects(
-  input: ValidateEditBatchInput,
-  operations: readonly EditOperation[]
-): Promise<Map<string, ObjectRow>> {
-  const items = collectEditBatchLoadRequests({ version: 1, operations }).objects
-
-  return input.storage.objects.getByPrimaryIdBatch({
-    projectId: input.projectId,
-    items,
-  })
-}
-
-async function loadExistingLinks(
-  input: ValidateEditBatchInput,
-  operations: readonly EditOperation[]
-): Promise<Map<string, ObjectLinkRow[]>> {
-  const requests = collectEditBatchLoadRequests({ version: 1, operations })
-  const result = await input.storage.objects.listLinksBatch({
-    projectId: input.projectId,
-    items: requests.sourceLinks,
-  })
-
-  // Incident links (links touching an object being deleted, in either direction) cannot be
-  // expressed through `listLinksBatch`, which keys on a specific linkId. Issue the per-object
-  // lookups concurrently rather than awaiting them one at a time so the read phase does not grow
-  // linearly with the number of deleted objects — important because planning runs inside the
-  // serializable commit transaction.
-  const incidentResults = await Promise.all(
-    requests.incidentLinks.map(async (incident) => ({
-      incident,
-      rows: await input.storage.objects.listLinks({
-        projectId: input.projectId,
-        objectTypeId: incident.objectTypeId,
-        objectId: incident.objectId,
-        direction: "both",
-      }),
-    }))
-  )
-  for (const { incident, rows } of incidentResults) {
-    if (rows.length > 0) {
-      result.set(`incident:${incident.objectTypeId}:${incident.objectId}`, [...rows])
-    }
-  }
-
-  return result
 }
 
 function analyzeEditBatch(input: EditAnalysisInput): EditCommitPlan {
@@ -914,20 +900,6 @@ function linkKey(
   ])
 }
 
-function jsonValuesEqual(left: unknown, right: unknown): boolean {
-  return stableJsonStringify(left) === stableJsonStringify(right)
-}
-
-function stableJsonStringify(value: unknown): string {
-  if (value === undefined) return "undefined"
-  if (value === null || typeof value !== "object") return JSON.stringify(value)
-  if (Array.isArray(value)) return `[${value.map(stableJsonStringify).join(",")}]`
-  return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([left], [right]) => compareStrings(left, right))
-    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
-    .join(",")}}`
-}
-
 function compareObjectDiffs(
   left: EditCommitDiff["objects"][number],
   right: EditCommitDiff["objects"][number]
@@ -951,12 +923,6 @@ function compareLinkDiffs(
     compareStrings(left.target.primaryId, right.target.primaryId) ||
     compareStrings(left.operation, right.operation)
   )
-}
-
-function compareStrings(left: string, right: string): number {
-  if (left < right) return -1
-  if (left > right) return 1
-  return 0
 }
 
 function buildObjectPlan(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export {
 export type {
   EditBatch,
   EditBatchInput,
+  EditBatchLoadedState,
   EditBatchLoadRequests,
   EditBatchProducer,
   EditBatchVersion,
@@ -87,6 +88,7 @@ export {
   collectEditBatchLoadRequests,
   deriveEditCommitDiff,
   EditBatchError,
+  loadEditBatchState,
   normalizeEditBatch,
   normalizeEditOperationInput,
   planEditBatch,
@@ -112,6 +114,7 @@ export type {
   ActionReadFacade,
   ActionReadObjectByIdHandle,
   ActionReadObjectSet,
+  ActionReadObjectSetSource,
   ActionRunPhaseInfo,
   ActionRuntimeFacade,
   ActionSubject,
@@ -158,6 +161,7 @@ export {
   ActionsRuntime,
   coerceActionParamsToTyped,
   commitActionEditBatch,
+  createActionReadFacade,
   defineAction,
   isActionDefinition,
   isGlobalActionDefinition,
@@ -166,6 +170,7 @@ export {
   param,
   requestAction,
   requestActionAndWait,
+  runActionValidators,
   waitForActionRun,
 } from "./actions"
 export {
@@ -209,8 +214,11 @@ export type { JsonValue } from "./json"
 export {
   assertJsonValue,
   cloneJsonValue,
+  compareStrings,
   getInvalidJsonValueReason,
   isJsonValue,
+  jsonValuesEqual,
+  stableJsonStringify,
 } from "./json"
 
 // ── Quantitative Types (units) ──────────────────────────────

--- a/packages/core/src/json.ts
+++ b/packages/core/src/json.ts
@@ -19,6 +19,26 @@ export function cloneJsonValue(value: JsonValue): JsonValue {
   return JSON.parse(JSON.stringify(value)) as JsonValue
 }
 
+export function jsonValuesEqual(left: unknown, right: unknown): boolean {
+  return stableJsonStringify(left) === stableJsonStringify(right)
+}
+
+export function stableJsonStringify(value: unknown): string {
+  if (value === undefined) return "undefined"
+  if (value === null || typeof value !== "object") return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableJsonStringify).join(",")}]`
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
+    .join(",")}}`
+}
+
+export function compareStrings(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
 export function getInvalidJsonValueReason(
   value: unknown,
   label = "value",

--- a/packages/core/src/objects/action/request.ts
+++ b/packages/core/src/objects/action/request.ts
@@ -35,7 +35,6 @@ export async function requestAction(
     params: params.params,
     runId: params.options?.runId,
     signal: params.options?.signal,
-    securityContext: params.options?.securityContext,
   })
 }
 
@@ -59,7 +58,6 @@ export async function requestActionAndWait(
     runId: params.options?.runId,
     timeoutMs: params.options?.timeoutMs,
     signal: params.options?.signal,
-    securityContext: params.options?.securityContext,
     onRequested: params.options?.onRequested,
   })
 }

--- a/packages/core/src/storage/action-runs/idempotency.ts
+++ b/packages/core/src/storage/action-runs/idempotency.ts
@@ -1,4 +1,5 @@
 import type { ActionSubject } from "../../actions"
+import { compareStrings, stableJsonStringify } from "../../json"
 import { ActionRunError } from "./errors"
 import type {
   ActionRunCommitDiff,
@@ -199,25 +200,6 @@ export function isTerminalActionRun(record: Pick<ActionRunRecord, "status">): bo
   return (
     record.status === "succeeded" || record.status === "failed" || record.status === "cancelled"
   )
-}
-
-function stableJsonStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value)
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableJsonStringify).join(",")}]`
-  }
-  return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([left], [right]) => compareStrings(left, right))
-    .map(([key, entry]) => `${JSON.stringify(key)}:${stableJsonStringify(entry)}`)
-    .join(",")}}`
-}
-
-function compareStrings(left: string, right: string): number {
-  if (left < right) return -1
-  if (left > right) return 1
-  return 0
 }
 
 function assertUniqueActionRunCommitDiff(diff: ActionRunCommitDiff): void {

--- a/packages/core/src/storage/action-runs/in-memory.ts
+++ b/packages/core/src/storage/action-runs/in-memory.ts
@@ -138,7 +138,6 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
       queuedAt: new Date(input.queuedAt ?? new Date()),
       params: normalizeParams(input.params),
       idempotencyKey: input.idempotencyKey,
-      securityContext: input.securityContext ? structuredClone(input.securityContext) : undefined,
     }
 
     if (existing) {
@@ -153,7 +152,6 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
         writeback: undefined,
         commit: undefined,
         effects: undefined,
-        securityContext: record.securityContext,
       }
       this.rows.set(key, structuredClone(next))
       return cloneActionRunRecord(next)

--- a/packages/core/src/storage/action-runs/types.ts
+++ b/packages/core/src/storage/action-runs/types.ts
@@ -1,5 +1,4 @@
 import type { ActionSubject } from "../../actions"
-import type { SecurityContext } from "../../auth"
 import type { EditCommitDiff, EditLinkDiff, EditObjectDiff, EditObjectRef } from "../../edits/types"
 import type { JsonValue } from "../../json"
 
@@ -60,7 +59,6 @@ export interface ActionRunRecord {
   readonly finishedAt?: Date
   readonly params: ActionRunParams
   readonly idempotencyKey: string
-  readonly securityContext?: SecurityContext
   readonly writeback?: ActionRunWritebackRecord
   readonly commit?: ActionRunCommitRecord
   readonly effects?: ActionRunEffectsRecord
@@ -74,7 +72,6 @@ export interface QueueActionRunInput {
   readonly subject: ActionSubject
   readonly params: ActionRunParams
   readonly idempotencyKey: string
-  readonly securityContext?: SecurityContext
   readonly queuedAt?: Date
 }
 

--- a/packages/core/src/storage/objects/in-memory.ts
+++ b/packages/core/src/storage/objects/in-memory.ts
@@ -642,6 +642,25 @@ export class InMemoryObjectStorage implements ObjectStorage {
     return result
   }
 
+  async listIncidentLinksBatch(params: {
+    projectId: string
+    items: readonly { objectTypeId: string; objectId: string }[]
+  }): Promise<readonly ObjectLinkRow[]> {
+    const deduped = new Map<string, ObjectLinkRow>()
+    for (const item of params.items) {
+      const rows = await this.listLinks({
+        projectId: params.projectId,
+        objectTypeId: item.objectTypeId,
+        objectId: item.objectId,
+        direction: "both",
+      })
+      for (const row of rows) {
+        deduped.set(fullLinkRowKey(row), row)
+      }
+    }
+    return [...deduped.values()]
+  }
+
   async list(params: {
     projectId: string
     objectTypeId?: string | readonly string[]

--- a/packages/core/src/storage/objects/types.ts
+++ b/packages/core/src/storage/objects/types.ts
@@ -199,6 +199,17 @@ export interface ObjectStorage {
     items: readonly { objectTypeId: string; objectId: string; linkId: string }[]
   }): Promise<Map<string, ObjectLinkRow[]>>
 
+  /**
+   * Batch fetch every link incident to any of the given objects, in BOTH directions (the object as
+   * link source or target). Returns a flat, de-duplicated list: a physical link incident to two
+   * listed objects appears once. Used to load cascade-delete state for `object.delete` operations,
+   * which {@link listLinksBatch} cannot express because it keys on a specific linkId.
+   */
+  listIncidentLinksBatch(params: {
+    projectId: string
+    items: readonly { objectTypeId: string; objectId: string }[]
+  }): Promise<readonly ObjectLinkRow[]>
+
   list(params: {
     projectId: string
     objectTypeId?: string | readonly string[]

--- a/packages/server/src/routes/actions.ts
+++ b/packages/server/src/routes/actions.ts
@@ -33,28 +33,7 @@ function serializeAction(
       edits: action.phases.edits !== undefined,
       effects: action.phases.effects !== undefined,
     },
-    preview: getActionPreview(action),
   })
-}
-
-function getActionPreview(
-  action: ActionDefinition
-): ReturnType<typeof ActionCatalogItemSchema.parse>["preview"] {
-  if (!action.phases.edits) {
-    return {
-      supported: false,
-      reason: "no_edits",
-    }
-  }
-
-  if (action.phases.writeback) {
-    return {
-      supported: false,
-      reason: "writeback_required",
-    }
-  }
-
-  return { supported: true }
 }
 
 export function registerActionRoutes(app: Elysia, sixb: Sixb<readonly OntologySource[]>) {

--- a/packages/server/src/schemas/actions.ts
+++ b/packages/server/src/schemas/actions.ts
@@ -33,16 +33,6 @@ export const RequestActionResponseSchema = z.object({
   created: z.boolean(),
 })
 
-export const ActionPreviewSchema = z.discriminatedUnion("supported", [
-  z.object({
-    supported: z.literal(true),
-  }),
-  z.object({
-    supported: z.literal(false),
-    reason: z.enum(["no_edits", "writeback_required"]),
-  }),
-])
-
 export const ActionCatalogItemSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -55,7 +45,6 @@ export const ActionCatalogItemSchema = z.object({
     edits: z.boolean(),
     effects: z.boolean(),
   }),
-  preview: ActionPreviewSchema,
 })
 
 export const ActionRunStatusSchema = z.enum([

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -510,11 +510,6 @@ describe("SixbServer HTTP contract", () => {
       params: { label: "Fan 1 audited" },
       idempotencyKey: "action:contract-project:act_audit_previous",
       queuedAt: new Date("2026-02-18T09:12:00.000Z"),
-      securityContext: {
-        principal: { type: "user", id: "usr_contract" },
-        projectId: "contract-project",
-        correlationId: "corr_contract",
-      },
     })
     await sixb.storage.actionRuns!.start({
       id: "act_audit_previous",
@@ -1177,10 +1172,6 @@ describe("SixbServer HTTP contract", () => {
             edits: false,
             effects: false,
           },
-          preview: {
-            supported: false,
-            reason: "no_edits",
-          },
         },
         {
           id: "renameDevice",
@@ -1199,9 +1190,6 @@ describe("SixbServer HTTP contract", () => {
             writeback: false,
             edits: true,
             effects: false,
-          },
-          preview: {
-            supported: true,
           },
         },
         {
@@ -1222,10 +1210,6 @@ describe("SixbServer HTTP contract", () => {
             edits: true,
             effects: true,
           },
-          preview: {
-            supported: false,
-            reason: "writeback_required",
-          },
         },
         {
           id: "createMaintenanceRun",
@@ -1243,10 +1227,6 @@ describe("SixbServer HTTP contract", () => {
             writeback: true,
             edits: false,
             effects: false,
-          },
-          preview: {
-            supported: false,
-            reason: "no_edits",
           },
         },
       ])
@@ -1269,10 +1249,6 @@ describe("SixbServer HTTP contract", () => {
           writeback: true,
           edits: false,
           effects: false,
-        },
-        preview: {
-          supported: false,
-          reason: "no_edits",
         },
       })
 

--- a/storage/pg/src/migrations/001-initial-schema.sql
+++ b/storage/pg/src/migrations/001-initial-schema.sql
@@ -356,7 +356,6 @@ CREATE TABLE IF NOT EXISTS action_runs (
   finished_at TIMESTAMPTZ,
   params JSONB NOT NULL,
   idempotency_key TEXT NOT NULL,
-  security_context JSONB,
   writeback_status TEXT CHECK (writeback_status IS NULL OR writeback_status IN ('succeeded', 'failed')),
   writeback_completed_at TIMESTAMPTZ,
   writeback_result JSONB,

--- a/storage/pg/src/pg-action-run-storage.ts
+++ b/storage/pg/src/pg-action-run-storage.ts
@@ -22,7 +22,6 @@ import type {
   RecordActionCommitInput,
   RecordActionEffectsInput,
   RecordActionWritebackInput,
-  SecurityContext,
   StartActionRunInput,
 } from "@sixb/core"
 import {
@@ -60,7 +59,6 @@ export class PgActionRunStorage implements ActionRunStorage {
           finished_at,
           params,
           idempotency_key,
-          security_context,
           writeback_status,
           writeback_completed_at,
           writeback_result,
@@ -89,7 +87,6 @@ export class PgActionRunStorage implements ActionRunStorage {
           ${null},
           ${JSON.stringify(input.params)}::text::jsonb,
           ${input.idempotencyKey},
-          ${serializeSecurityContext(input.securityContext)}::text::jsonb,
           ${null},
           ${null},
           ${null},
@@ -143,7 +140,6 @@ export class PgActionRunStorage implements ActionRunStorage {
           queued_at = ${input.queuedAt ?? new Date()},
           started_at = ${null},
           finished_at = ${null},
-          security_context = ${serializeSecurityContext(input.securityContext)}::text::jsonb,
           writeback_status = ${null},
           writeback_completed_at = ${null},
           writeback_result = ${null},
@@ -616,19 +612,6 @@ export class PgActionRunStorage implements ActionRunStorage {
   }
 }
 
-function serializeSecurityContext(securityContext: SecurityContext | undefined): string | null {
-  return securityContext ? JSON.stringify(securityContext) : null
-}
-
-function normalizeSecurityContext(
-  value: SecurityContext | string | null
-): SecurityContext | undefined {
-  if (!value) {
-    return undefined
-  }
-  return typeof value === "string" ? (JSON.parse(value) as SecurityContext) : value
-}
-
 function toActionRunFailure(row: DatabaseRow): ActionRunFailure | undefined {
   return toFailure(row.error_name, row.error_message, row.error_phase)
 }
@@ -750,7 +733,6 @@ function rowToActionRunRecord(row: DatabaseRow, commit?: ActionRunCommitRecord):
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     params: row.params,
     idempotencyKey: row.idempotency_key,
-    securityContext: normalizeSecurityContext(row.security_context),
     writeback: toActionRunWritebackRecord(row),
     commit,
     effects: toActionRunEffectsRecord(row),
@@ -827,7 +809,6 @@ interface DatabaseRow {
   finished_at: Date | string | null
   params: ActionRunParams
   idempotency_key: string
-  security_context: SecurityContext | string | null
   writeback_status: ActionRunWritebackRecord["status"] | null
   writeback_completed_at: Date | string | null
   writeback_result: JsonValue | null

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -655,6 +655,46 @@ export class PgObjectStorage implements ObjectStorage {
     return result
   }
 
+  async listIncidentLinksBatch(params: {
+    projectId: string
+    items: readonly { objectTypeId: string; objectId: string }[]
+  }): Promise<readonly ObjectLinkRow[]> {
+    if (params.items.length === 0) return []
+    const tuples = params.items.map((item) => [item.objectTypeId, item.objectId])
+
+    // Cover both link directions with two index-friendly equality joins (source-side, then
+    // target-side) rather than a single OR-join, which would defeat index usage. This is a constant
+    // number of round trips regardless of how many objects are deleted — issued sequentially because
+    // these reads run on the serializable commit transaction's single connection. A link incident to
+    // two listed objects matches both halves and is de-duplicated below.
+    const sourceRows = await valuesJoin<LinkDatabaseRow>(
+      this.sql,
+      "SELECT l.* FROM links l",
+      ["source_type_id", "source_id"],
+      tuples,
+      "WHERE l.project_id = $1",
+      [params.projectId]
+    )
+    const targetRows = await valuesJoin<LinkDatabaseRow>(
+      this.sql,
+      "SELECT l.* FROM links l",
+      ["target_type_id", "target_id"],
+      tuples,
+      "WHERE l.project_id = $1",
+      [params.projectId]
+    )
+
+    const deduped = new Map<string, ObjectLinkRow>()
+    for (const row of [...sourceRows, ...targetRows]) {
+      const link = rowToLink(row)
+      deduped.set(
+        `${link.sourceTypeId}:${link.sourceId}:${link.linkId}:${link.targetTypeId}:${link.targetId}`,
+        link
+      )
+    }
+    return [...deduped.values()]
+  }
+
   async applyEditCommitPlan(input: {
     projectId: string
     plan: EditCommitPlan

--- a/storage/pg/tests/pg-object-storage.e2e.ts
+++ b/storage/pg/tests/pg-object-storage.e2e.ts
@@ -725,4 +725,39 @@ describe("PgObjectStorage", () => {
     expect(result.get("Room:r1:hasSensors")).toHaveLength(1)
     expect(result.has("Room:r1:noLinks")).toBe(false)
   })
+
+  test("listIncidentLinksBatch — both directions, de-duplicated", async () => {
+    await storage.objects.applyObjectUpserted(createObjectEvent("p1", "Room", "r1", {}, "1"))
+    await storage.objects.applyObjectUpserted(createObjectEvent("p1", "Room", "r2", {}, "2"))
+    await storage.objects.applyObjectUpserted(createObjectEvent("p1", "Sensor", "s1", {}, "3"))
+    await storage.objects.applyObjectUpserted(createObjectEvent("p1", "Sensor", "s2", {}, "4"))
+
+    // r1 as source
+    await storage.objects.applyLinkUpserted(
+      createLinkUpsertedEvent("p1", "Room", "r1", "hasSensors", "Sensor", "s1", "5")
+    )
+    // r1 as target
+    await storage.objects.applyLinkUpserted(
+      createLinkUpsertedEvent("p1", "Sensor", "s2", "installedIn", "Room", "r1", "6")
+    )
+    // incident to both listed objects (r1 source, r2 target)
+    await storage.objects.applyLinkUpserted(
+      createLinkUpsertedEvent("p1", "Room", "r1", "relatedTo", "Room", "r2", "7")
+    )
+
+    const links = await storage.objects.listIncidentLinksBatch({
+      projectId: "p1",
+      items: [
+        { objectTypeId: "Room", objectId: "r1" },
+        { objectTypeId: "Room", objectId: "r2" },
+      ],
+    })
+
+    // hasSensors + installedIn + relatedTo. relatedTo is incident to both r1 and r2 but appears once.
+    expect(links).toHaveLength(3)
+    expect(links.filter((link) => link.linkId === "relatedTo")).toHaveLength(1)
+
+    const empty = await storage.objects.listIncidentLinksBatch({ projectId: "p1", items: [] })
+    expect(empty).toHaveLength(0)
+  })
 })

--- a/storage/sqlite/src/action-run-storage.ts
+++ b/storage/sqlite/src/action-run-storage.ts
@@ -23,7 +23,6 @@ import type {
   RecordActionCommitInput,
   RecordActionEffectsInput,
   RecordActionWritebackInput,
-  SecurityContext,
   StartActionRunInput,
 } from "@sixb/core"
 import {
@@ -85,7 +84,6 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             finished_at,
             params,
             idempotency_key,
-            security_context,
             writeback_status,
             writeback_completed_at,
             writeback_result,
@@ -101,7 +99,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             error_message,
             error_phase
           ) VALUES (
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?,
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?,
             NULL, NULL, NULL, NULL, NULL, NULL,
             NULL, NULL, NULL, NULL, NULL,
             NULL, NULL, NULL
@@ -119,8 +117,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
           "request",
           queuedAt.toISOString(),
           JSON.stringify(input.params),
-          input.idempotencyKey,
-          serializeSecurityContext(input.securityContext)
+          input.idempotencyKey
         )
     } catch (error) {
       if (isUniqueConstraintError(error)) {
@@ -168,7 +165,6 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             queued_at = ?,
             started_at = NULL,
             finished_at = NULL,
-            security_context = ?,
             writeback_status = NULL,
             writeback_completed_at = NULL,
             writeback_result = NULL,
@@ -186,14 +182,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
           WHERE project_id = ? AND id = ?
         `
         )
-        .run(
-          "queued",
-          "request",
-          queuedAt.toISOString(),
-          serializeSecurityContext(input.securityContext),
-          input.projectId,
-          input.id
-        )
+        .run("queued", "request", queuedAt.toISOString(), input.projectId, input.id)
 
       this.deleteCommitRows(input.projectId, input.id)
 
@@ -697,14 +686,6 @@ function serializeJsonValue(value: JsonValue): string {
   return JSON.stringify(value)
 }
 
-function serializeSecurityContext(securityContext: SecurityContext | undefined): string | null {
-  return securityContext ? JSON.stringify(securityContext) : null
-}
-
-function parseSecurityContext(value: string | null): SecurityContext | undefined {
-  return value ? (JSON.parse(value) as SecurityContext) : undefined
-}
-
 function toActionRunFailure(row: DatabaseRow): ActionRunFailure | undefined {
   return toFailure(row.error_name, row.error_message, row.error_phase)
 }
@@ -827,7 +808,6 @@ function rowToActionRunRecord(row: DatabaseRow, commit?: ActionRunCommitRecord):
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     params: JSON.parse(row.params) as ActionRunParams,
     idempotencyKey: row.idempotency_key,
-    securityContext: parseSecurityContext(row.security_context),
     writeback: toActionRunWritebackRecord(row),
     commit,
     effects: toActionRunEffectsRecord(row),
@@ -908,7 +888,6 @@ interface DatabaseRow {
   finished_at: string | null
   params: string
   idempotency_key: string
-  security_context: string | null
   writeback_status: ActionRunWritebackRecord["status"] | null
   writeback_completed_at: string | null
   writeback_result: string | null

--- a/storage/sqlite/src/migrations/001-initial-schema.sql
+++ b/storage/sqlite/src/migrations/001-initial-schema.sql
@@ -354,7 +354,6 @@ CREATE TABLE IF NOT EXISTS action_runs (
   finished_at TEXT,
   params TEXT NOT NULL,
   idempotency_key TEXT NOT NULL,
-  security_context TEXT,
   writeback_status TEXT CHECK (writeback_status IS NULL OR writeback_status IN ('succeeded', 'failed')),
   writeback_completed_at TEXT,
   writeback_result TEXT,

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -775,6 +775,28 @@ export class SqliteObjectStorage implements ObjectStorage {
     return result
   }
 
+  async listIncidentLinksBatch(params: {
+    projectId: string
+    items: readonly { objectTypeId: string; objectId: string }[]
+  }): Promise<readonly ObjectLinkRow[]> {
+    const deduped = new Map<string, ObjectLinkRow>()
+    for (const item of params.items) {
+      const rows = await this.listLinks({
+        projectId: params.projectId,
+        objectTypeId: item.objectTypeId,
+        objectId: item.objectId,
+        direction: "both",
+      })
+      for (const row of rows) {
+        deduped.set(
+          `${row.sourceTypeId}:${row.sourceId}:${row.linkId}:${row.targetTypeId}:${row.targetId}`,
+          row
+        )
+      }
+    }
+    return [...deduped.values()]
+  }
+
   async list(params: {
     projectId: string
     objectTypeId?: string | readonly string[]

--- a/storage/sqlite/tests/sqlite-object-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-object-storage.test.ts
@@ -1359,4 +1359,35 @@ describe("SqliteObjectStorage", () => {
     expect(result.get("Room:r1:hasSensors")).toHaveLength(1)
     expect(result.has("Room:r1:noLinks")).toBe(false)
   })
+
+  test("listIncidentLinksBatch — both directions, de-duplicated", async () => {
+    await storage.applyObjectUpserted(createObjectEvent("p1", "Room", "r1", {}, "1"))
+    await storage.applyObjectUpserted(createObjectEvent("p1", "Room", "r2", {}, "2"))
+    await storage.applyObjectUpserted(createObjectEvent("p1", "Sensor", "s1", {}, "3"))
+    await storage.applyObjectUpserted(createObjectEvent("p1", "Sensor", "s2", {}, "4"))
+
+    await storage.applyLinkUpsertedBatch([
+      // r1 as source
+      createLinkUpsertedEvent("p1", "Room", "r1", "hasSensors", "Sensor", "s1", "5"),
+      // r1 as target
+      createLinkUpsertedEvent("p1", "Sensor", "s2", "installedIn", "Room", "r1", "6"),
+      // incident to both listed objects (r1 source, r2 target)
+      createLinkUpsertedEvent("p1", "Room", "r1", "relatedTo", "Room", "r2", "7"),
+    ])
+
+    const links = await storage.listIncidentLinksBatch({
+      projectId: "p1",
+      items: [
+        { objectTypeId: "Room", objectId: "r1" },
+        { objectTypeId: "Room", objectId: "r2" },
+      ],
+    })
+
+    // hasSensors + installedIn + relatedTo. relatedTo is incident to both r1 and r2 but appears once.
+    expect(links).toHaveLength(3)
+    expect(links.filter((link) => link.linkId === "relatedTo")).toHaveLength(1)
+
+    const empty = await storage.listIncidentLinksBatch({ projectId: "p1", items: [] })
+    expect(empty).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
# Actions — Atlas Run/Request UI, Object-Ref Params & Edit Cleanups

> Builds the Atlas UI on top of the action-run API (already in `main`), drops the unused
> forward-looking edit preview, and tidies the action edit path. UI + cleanups — no new API surface.

---

## ✨ What this PR does

### 🖥️ Atlas UI (new)
- **Actions** page: catalog of registered actions + a **request dialog** with typed param inputs.
- **Run detail** page: status, phase, the **recorded commit diff**, writeback & effects (polls while running).
- Sidebar entry + route wiring; "Request" button navigates to the new run.
- _Consumes the existing `GET /api/action-runs[/:runId]` API — this PR adds no endpoints._

### 🔌 Object-ref params + selector
- Action params can be an object **`ref(Type)`** (value `{ objectTypeId, primaryId }`), validated by core.
- Atlas renders a **`listObjects`-backed selector** for ref params instead of a raw id field.
- Acme `createDraftInvoice` uses `ref(Customer)` / `ref(Project)`.

### 🧹 Removals
- **Forward-looking preview/diff** dropped from the action surface (`POST /api/actions/:id/preview`,
  its schemas, the catalog `preview` flag, client regen). A diff belongs to a *proposal* flow
  (review before commit), not to directly triggering a trusted action.
- **MVP `security_context`** column removed from `action_runs` (pg + sqlite migrations + storage).

### ⚙️ Edit-path internals
- A deleted object's incident links (**both directions**) load via one batched
  **`listIncidentLinksBatch`** read instead of one query per object — a constant number of round
  trips inside the serializable commit transaction (shorter lock hold).
- Extracted shared pieces into core: action **read-facade**, **run-id/idempotency**, **validators**.

### 🧪 Example (Acme)
- `createDraftInvoice` (ref params), `deleteInvoice`, `markPaid`, and an `Invoice.paymentInfo` object prop.

---

## 🧭 Decisions
- **No diff on trigger.** Action gating stays simple — **authorization** (who) + **validation**
  (preconditions), never a blocking approval. The *recorded* commit diff on the run trail is the real "after".
- **One human-in-the-loop primitive.** Approval lives in workflow interventions; actions stay pure,
  immediate, transactional. They compose rather than duplicate.

---

## ✅ Verification
- `bun run typecheck` — clean repo-wide.
- Suites pass: core (actions, edits), server (httpContract), sqlite (object-storage), action-worker (run-action-job).
- `bun run generate:client` — client regenerated; diff scoped to the preview removal.
- Biome clean. Postgres e2e runs in the CI e2e matrix.

---

## 🔗 Context
Sits on top of the action-run trail API and V2 workflow action nodes that already landed in `main`
(rebased). This PR is the Atlas-facing half plus edit-path cleanups.