### PR TITLE
server: gate run history with existing grants

### DIFF
--- a/packages/core/src/authorization/index.ts
+++ b/packages/core/src/authorization/index.ts
@@ -3,4 +3,5 @@ export { assertAuthorized, assertPrivileged, evaluate, isAllowed } from "./decis
 export { AuthorizationError } from "./errors"
 export { canViewEvent } from "./event-visibility"
 export { resolveAuthorizationContext, resolveRoleGrants } from "./resolve"
+export { canViewActionRun, canViewWorkflowIntervention, canViewWorkflowRun } from "./run-visibility"
 export type { AuthorizationContext, GrantIndex, ResolvedRole } from "./types"

--- a/packages/core/src/authorization/run-visibility.ts
+++ b/packages/core/src/authorization/run-visibility.ts
@@ -1,0 +1,44 @@
+import type { ActionRunRecord } from "../storage/action-runs"
+import type { WorkflowInterventionRecord } from "../storage/workflow-interventions"
+import type { WorkflowRunRecord } from "../storage/workflow-runs"
+import { isAllowed } from "./decision"
+import type { AuthorizationContext } from "./types"
+
+export function canViewActionRun(
+  authorization: AuthorizationContext | null | undefined,
+  run: Pick<ActionRunRecord, "actionId" | "subject">
+): boolean {
+  if (!authorization) {
+    return true
+  }
+
+  if (!isAllowed(authorization, { kind: "action.apply", actionId: run.actionId })) {
+    return false
+  }
+
+  return run.subject.kind !== "object"
+    ? true
+    : isAllowed(authorization, {
+        kind: "object.view",
+        objectTypeId: run.subject.objectTypeId,
+      })
+}
+
+export function canViewWorkflowRun(
+  authorization: AuthorizationContext | null | undefined,
+  run: Pick<WorkflowRunRecord, "workflowId">
+): boolean {
+  return (
+    !authorization || isAllowed(authorization, { kind: "workflow.run", workflowId: run.workflowId })
+  )
+}
+
+export function canViewWorkflowIntervention(
+  authorization: AuthorizationContext | null | undefined,
+  intervention: Pick<WorkflowInterventionRecord, "workflowId">
+): boolean {
+  return (
+    !authorization ||
+    isAllowed(authorization, { kind: "workflow.run", workflowId: intervention.workflowId })
+  )
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -456,7 +456,10 @@ export type {
 export {
   AuthorizationError,
   assertAuthorized,
+  canViewActionRun,
   canViewEvent,
+  canViewWorkflowIntervention,
+  canViewWorkflowRun,
   evaluate,
   isAllowed,
   resolveAuthorizationContext,

--- a/packages/core/src/storage/action-runs/in-memory.ts
+++ b/packages/core/src/storage/action-runs/in-memory.ts
@@ -346,14 +346,26 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
   }
 
   async list(input: ListActionRunsInput): Promise<ListActionRunsResult> {
+    if (input.actionIds?.length === 0) {
+      return { runs: [], hasMore: false, total: 0 }
+    }
+
     const order = input.order ?? "desc"
     const offset = input.offset ?? 0
     const limit = input.limit ?? this.rows.size
+    const actionIds = input.actionIds ? new Set(input.actionIds) : null
+    const objectTypeIds = input.objectTypeIds ? new Set(input.objectTypeIds) : null
     const statuses = input.statuses ? new Set(input.statuses) : null
 
     const filtered = [...this.rows.values()]
       .filter((record) => record.projectId === input.projectId)
       .filter((record) => (input.actionId ? record.actionId === input.actionId : true))
+      .filter((record) => (actionIds ? actionIds.has(record.actionId) : true))
+      .filter((record) =>
+        objectTypeIds
+          ? record.subject.kind !== "object" || objectTypeIds.has(record.subject.objectTypeId)
+          : true
+      )
       .filter((record) =>
         input.subject ? actionSubjectsEqual(record.subject, input.subject) : true
       )

--- a/packages/core/src/storage/action-runs/types.ts
+++ b/packages/core/src/storage/action-runs/types.ts
@@ -149,8 +149,10 @@ export type FinishActionRunInput =
 export interface ListActionRunsInput {
   readonly projectId: string
   readonly actionId?: string
+  readonly actionIds?: readonly string[]
   readonly subject?: ActionSubject
   readonly objectTypeId?: string
+  readonly objectTypeIds?: readonly string[]
   readonly primaryId?: string
   readonly statuses?: readonly ActionRunStatus[]
   readonly startedAfter?: Date

--- a/packages/core/src/storage/workflow-interventions/in-memory.ts
+++ b/packages/core/src/storage/workflow-interventions/in-memory.ts
@@ -112,7 +112,7 @@ export class InMemoryWorkflowInterventionStorage implements WorkflowIntervention
   }
 
   async list(input: ListWorkflowInterventionsInput): Promise<ListWorkflowInterventionsResult> {
-    if (hasEmptyStatuses(input)) {
+    if (hasEmptyStatuses(input) || input.workflowIds?.length === 0) {
       return {
         interventions: [],
         hasMore: false,
@@ -122,10 +122,12 @@ export class InMemoryWorkflowInterventionStorage implements WorkflowIntervention
 
     const order = input.order ?? "desc"
     const statuses = toStatusSet(input.statuses)
+    const workflowIds = input.workflowIds ? new Set(input.workflowIds) : null
     const filtered = [...this.interventions.values()]
       .filter((record) => record.projectId === input.projectId)
       .filter((record) => (statuses ? statuses.has(record.status) : true))
       .filter((record) => (input.workflowId ? record.workflowId === input.workflowId : true))
+      .filter((record) => (workflowIds ? workflowIds.has(record.workflowId) : true))
       .filter((record) =>
         input.workflowRunId ? record.workflowRunId === input.workflowRunId : true
       )

--- a/packages/core/src/storage/workflow-interventions/types.ts
+++ b/packages/core/src/storage/workflow-interventions/types.ts
@@ -71,6 +71,7 @@ export interface ListWorkflowInterventionsInput {
   readonly projectId: string
   readonly statuses?: readonly WorkflowInterventionStatus[]
   readonly workflowId?: string
+  readonly workflowIds?: readonly string[]
   readonly workflowRunId?: string
   readonly nodeRunId?: string
   readonly nodeId?: string

--- a/packages/core/src/storage/workflow-runs/in-memory.ts
+++ b/packages/core/src/storage/workflow-runs/in-memory.ts
@@ -184,7 +184,7 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
   }
 
   async list(input: ListWorkflowRunsInput): Promise<ListWorkflowRunsResult> {
-    if (hasEmptyStatuses(input)) {
+    if (hasEmptyStatuses(input) || input.workflowIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -194,9 +194,11 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
 
     const order = input.order ?? "desc"
     const statuses = toStatusSet(input.statuses)
+    const workflowIds = input.workflowIds ? new Set(input.workflowIds) : null
     const filtered = [...this.runs.values()]
       .filter((record) => record.projectId === input.projectId)
       .filter((record) => (input.workflowId ? record.workflowId === input.workflowId : true))
+      .filter((record) => (workflowIds ? workflowIds.has(record.workflowId) : true))
       .filter((record) =>
         matchesRunListDateFilters(record, {
           statuses,

--- a/packages/core/src/storage/workflow-runs/types.ts
+++ b/packages/core/src/storage/workflow-runs/types.ts
@@ -124,6 +124,7 @@ export type FinishWorkflowNodeRunInput =
 export interface ListWorkflowRunsInput {
   readonly projectId: string
   readonly workflowId?: string
+  readonly workflowIds?: readonly string[]
   readonly statuses?: readonly WorkflowRunStatus[]
   readonly startedAfter?: Date
   readonly startedBefore?: Date

--- a/packages/server/src/routes/action-runs.ts
+++ b/packages/server/src/routes/action-runs.ts
@@ -1,5 +1,6 @@
-import type { ActionRunRecord, OntologySource, Sixb } from "@sixb/core"
+import { type ActionRunRecord, canViewActionRun, type OntologySource, type Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import {
   ActionRunDetailSchema,
   ActionRunIdParamsSchema,
@@ -61,7 +62,9 @@ export function registerActionRunRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
   return app
     .get(
       "/api/action-runs",
-      async ({ query, set }) => {
+      async (context) => {
+        const { query, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const storage = sixb.storage.actionRuns
           if (!storage) {
@@ -70,16 +73,22 @@ export function registerActionRunRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
           }
 
           const parsed = ActionRunsQuerySchema.parse(query)
+          const limit = parseOptionalInt(parsed.limit)
+          const offset = parseOptionalInt(parsed.offset)
+          const actionIds = authz ? [...authz.grants.actions.apply] : undefined
+          const objectTypeIds = authz ? [...authz.grants.objectTypes.view] : undefined
           const result = await storage.list({
             projectId: sixb.id,
             actionId: parsed.actionId,
+            actionIds,
             objectTypeId: parsed.objectTypeId,
+            objectTypeIds,
             primaryId: parsed.primaryId,
             statuses: parsed.status ? [parsed.status] : undefined,
             startedAfter: parseDate(parsed.startedAfter),
             startedBefore: parseDate(parsed.startedBefore),
-            limit: parseOptionalInt(parsed.limit),
-            offset: parseOptionalInt(parsed.offset),
+            limit,
+            offset,
             order: parsed.order,
           })
 
@@ -104,7 +113,9 @@ export function registerActionRunRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
     )
     .get(
       "/api/action-runs/:runId",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const storage = sixb.storage.actionRuns
           if (!storage) {
@@ -113,7 +124,7 @@ export function registerActionRunRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
           }
 
           const run = await storage.getById({ projectId: sixb.id, id: params.runId })
-          if (!run) {
+          if (!run || !canViewActionRun(authz, run)) {
             set.status = 404
             return { error: "Action run not found" }
           }

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -1,13 +1,15 @@
-import type {
-  OntologySource,
-  Sixb,
-  WorkflowDefinition,
-  WorkflowInterventionNodeDefinition,
-  WorkflowInterventionRecord,
-  WorkflowNodeRunRecord,
-  WorkflowRunRecord,
+import {
+  canViewWorkflowIntervention,
+  canViewWorkflowRun,
+  type OntologySource,
+  type Sixb,
+  snapshotWorkflowInterventionResponse,
+  type WorkflowDefinition,
+  type WorkflowInterventionNodeDefinition,
+  type WorkflowInterventionRecord,
+  type WorkflowNodeRunRecord,
+  type WorkflowRunRecord,
 } from "@sixb/core"
-import { snapshotWorkflowInterventionResponse } from "@sixb/core"
 import type { Elysia } from "elysia"
 import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
@@ -336,17 +338,23 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/workflow-interventions",
-      async ({ query, set }) => {
+      async (context) => {
+        const { query, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const parsed = WorkflowInterventionsQuerySchema.parse(query)
+          const limit = parseOptionalInt(parsed.limit)
+          const offset = parseOptionalInt(parsed.offset)
           const storage = sixb.storage.workflowInterventions
           if (!storage) {
             return { interventions: [], hasMore: false, total: 0 }
           }
 
+          const workflowIds = authz ? [...authz.grants.workflows.run] : undefined
           const result = await storage.list({
             projectId: sixb.id,
             workflowId: parsed.workflowId,
+            workflowIds,
             workflowRunId: parsed.workflowRunId,
             nodeRunId: parsed.nodeRunId,
             nodeId: parsed.nodeId,
@@ -355,8 +363,8 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             statuses: parsed.status ? [parsed.status] : undefined,
             requestedAfter: parseDate(parsed.requestedAfter),
             requestedBefore: parseDate(parsed.requestedBefore),
-            limit: parseOptionalInt(parsed.limit),
-            offset: parseOptionalInt(parsed.offset),
+            limit,
+            offset,
             order: parsed.order,
           })
 
@@ -381,7 +389,9 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/workflow-interventions/:interventionId",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const storage = sixb.storage.workflowInterventions
           if (!storage) {
@@ -393,7 +403,7 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             projectId: sixb.id,
             id: params.interventionId,
           })
-          if (!intervention) {
+          if (!intervention || !canViewWorkflowIntervention(authz, intervention)) {
             set.status = 404
             return { error: "Workflow intervention not found" }
           }
@@ -615,22 +625,28 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/workflow-runs",
-      async ({ query, set }) => {
+      async (context) => {
+        const { query, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const parsed = WorkflowRunsQuerySchema.parse(query)
+          const limit = parseOptionalInt(parsed.limit)
+          const offset = parseOptionalInt(parsed.offset)
           const storage = sixb.storage.workflowRuns
           if (!storage) {
             return { runs: [], hasMore: false, total: 0 }
           }
 
+          const workflowIds = authz ? [...authz.grants.workflows.run] : undefined
           const result = await storage.list({
             projectId: sixb.id,
             workflowId: parsed.workflowId,
+            workflowIds,
             statuses: parsed.status ? [parsed.status] : undefined,
             startedAfter: parseDate(parsed.startedAfter),
             startedBefore: parseDate(parsed.startedBefore),
-            limit: parseOptionalInt(parsed.limit),
-            offset: parseOptionalInt(parsed.offset),
+            limit,
+            offset,
             order: parsed.order,
           })
 
@@ -655,7 +671,9 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/workflow-runs/:runId",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const storage = sixb.storage.workflowRuns
           if (!storage) {
@@ -664,7 +682,7 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
           }
 
           const run = await storage.getById({ projectId: sixb.id, id: params.runId })
-          if (!run) {
+          if (!run || !canViewWorkflowRun(authz, run)) {
             set.status = 404
             return { error: "Workflow run not found" }
           }

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -348,6 +348,52 @@ describe("authorized action routes", () => {
     )
     expect(denied.status).toBe(403)
   })
+
+  test("action run history inherits action and subject visibility", async () => {
+    const { app, storage } = await createApp()
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const request = await app.fetch(
+      new Request("http://localhost/api/actions/send-contract", {
+        method: "POST",
+        headers: operator.csrfHeaders,
+        body: JSON.stringify({
+          subject: { kind: "object", objectTypeId: "contract", primaryId: "c1" },
+        }),
+      })
+    )
+    const requested = (await request.json()) as { runId: string }
+    await storage.actionRuns.queue({
+      id: "act_hidden_invoice",
+      projectId: "test-project",
+      actionId: "send-contract",
+      subject: { kind: "object", objectTypeId: "invoice", primaryId: "i1" },
+      params: {},
+      idempotencyKey: "act_hidden_invoice",
+      queuedAt: new Date("2099-01-01T00:00:00.000Z"),
+    })
+
+    const visibleList = await app.fetch(
+      new Request("http://localhost/api/action-runs?limit=1", { headers: operator.headers })
+    )
+    expect(await visibleList.json()).toMatchObject({
+      runs: [expect.objectContaining({ id: requested.runId })],
+      hasMore: false,
+      total: 1,
+    })
+
+    const hiddenList = await app.fetch(
+      new Request("http://localhost/api/action-runs", { headers: runner.headers })
+    )
+    expect(await hiddenList.json()).toMatchObject({ runs: [], total: 0 })
+
+    const hiddenDetail = await app.fetch(
+      new Request(`http://localhost/api/action-runs/${requested.runId}`, {
+        headers: runner.headers,
+      })
+    )
+    expect(hiddenDetail.status).toBe(404)
+  })
 })
 
 describe("authorized event and workflow routes", () => {
@@ -424,6 +470,101 @@ describe("authorized event and workflow routes", () => {
       })
     )
     expect(denied.status).toBe(403)
+  })
+
+  test("workflow run history and interventions inherit workflow run visibility", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const request = await app.fetch(
+      new Request("http://localhost/api/workflows/renew-contract/runs", {
+        method: "POST",
+        headers: runner.csrfHeaders,
+        body: JSON.stringify({
+          input: { contract: { objectTypeId: "contract", primaryId: "c1" } },
+        }),
+      })
+    )
+    const requested = (await request.json()) as { runId: string }
+    await storage.workflowRuns.queue({
+      id: "wf_hidden",
+      projectId: "test-project",
+      workflowId: "hidden-workflow",
+      input: {},
+      queuedAt: new Date("2099-01-01T00:00:00.000Z"),
+    })
+    await storage.workflowInterventions.create({
+      id: "wi_1",
+      projectId: "test-project",
+      workflowId: "renew-contract",
+      workflowRunId: requested.runId,
+      nodeRunId: "node_1",
+      nodeIndex: 0,
+      nodeId: "approval",
+      nodeKey: "approval",
+      interventionId: "approval",
+      input: {},
+      defaultResponse: {},
+      requestedAt: new Date("2026-05-16T10:00:00.000Z"),
+    })
+    await storage.workflowInterventions.create({
+      id: "wi_hidden",
+      projectId: "test-project",
+      workflowId: "hidden-workflow",
+      workflowRunId: "wf_hidden",
+      nodeRunId: "node_hidden",
+      nodeIndex: 0,
+      nodeId: "approval",
+      nodeKey: "approval",
+      interventionId: "approval",
+      input: {},
+      defaultResponse: {},
+      requestedAt: new Date("2099-01-01T00:00:00.000Z"),
+    })
+
+    const runnerRuns = await app.fetch(
+      new Request("http://localhost/api/workflow-runs?limit=1", { headers: runner.headers })
+    )
+    expect(await runnerRuns.json()).toMatchObject({
+      runs: [expect.objectContaining({ id: requested.runId })],
+      hasMore: false,
+      total: 1,
+    })
+
+    const operatorRuns = await app.fetch(
+      new Request("http://localhost/api/workflow-runs", { headers: operator.headers })
+    )
+    expect(await operatorRuns.json()).toMatchObject({ runs: [], total: 0 })
+
+    const hiddenRun = await app.fetch(
+      new Request(`http://localhost/api/workflow-runs/${requested.runId}`, {
+        headers: operator.headers,
+      })
+    )
+    expect(hiddenRun.status).toBe(404)
+
+    const runnerInterventions = await app.fetch(
+      new Request("http://localhost/api/workflow-interventions?limit=1", {
+        headers: runner.headers,
+      })
+    )
+    expect(await runnerInterventions.json()).toMatchObject({
+      interventions: [expect.objectContaining({ id: "wi_1" })],
+      hasMore: false,
+      total: 1,
+    })
+
+    const operatorInterventions = await app.fetch(
+      new Request("http://localhost/api/workflow-interventions", { headers: operator.headers })
+    )
+    expect(await operatorInterventions.json()).toMatchObject({ interventions: [], total: 0 })
+
+    const hiddenIntervention = await app.fetch(
+      new Request("http://localhost/api/workflow-interventions/wi_1", {
+        headers: operator.headers,
+      })
+    )
+    expect(hiddenIntervention.status).toBe(404)
   })
 })
 

--- a/storage/pg/src/pg-action-run-storage.ts
+++ b/storage/pg/src/pg-action-run-storage.ts
@@ -392,7 +392,7 @@ export class PgActionRunStorage implements ActionRunStorage {
   }
 
   async list(input: ListActionRunsInput): Promise<ListActionRunsResult> {
-    if (input.statuses && input.statuses.length === 0) {
+    if ((input.statuses && input.statuses.length === 0) || input.actionIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -407,6 +407,26 @@ export class PgActionRunStorage implements ActionRunStorage {
     if (input.actionId) {
       whereClauses.push(`action_id = $${index++}`)
       params.push(input.actionId)
+    }
+
+    if (input.actionIds) {
+      const placeholders = input.actionIds.map(() => `$${index++}`)
+      whereClauses.push(`action_id IN (${placeholders.join(", ")})`)
+      params.push(...input.actionIds)
+    }
+
+    if (input.objectTypeIds) {
+      if (input.objectTypeIds.length === 0) {
+        whereClauses.push(`subject_kind <> $${index++}`)
+        params.push("object")
+      } else {
+        const subjectKindIndex = index++
+        const placeholders = input.objectTypeIds.map(() => `$${index++}`)
+        whereClauses.push(
+          `(subject_kind <> $${subjectKindIndex} OR object_type_id IN (${placeholders.join(", ")}))`
+        )
+        params.push("object", ...input.objectTypeIds)
+      }
     }
 
     if (input.objectTypeId) {

--- a/storage/pg/src/pg-workflow-intervention-storage.ts
+++ b/storage/pg/src/pg-workflow-intervention-storage.ts
@@ -136,7 +136,7 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
   }
 
   async list(input: ListWorkflowInterventionsInput): Promise<ListWorkflowInterventionsResult> {
-    if (input.statuses && input.statuses.length === 0) {
+    if ((input.statuses && input.statuses.length === 0) || input.workflowIds?.length === 0) {
       return {
         interventions: [],
         hasMore: false,
@@ -157,6 +157,12 @@ export class PgWorkflowInterventionStorage implements WorkflowInterventionStorag
     if (input.workflowId) {
       whereClauses.push(`workflow_id = $${index++}`)
       params.push(input.workflowId)
+    }
+
+    if (input.workflowIds) {
+      const placeholders = input.workflowIds.map(() => `$${index++}`)
+      whereClauses.push(`workflow_id IN (${placeholders.join(", ")})`)
+      params.push(...input.workflowIds)
     }
 
     if (input.workflowRunId) {

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -266,7 +266,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
   }
 
   async list(input: ListWorkflowRunsInput): Promise<ListWorkflowRunsResult> {
-    if (hasEmptyStatuses(input)) {
+    if (hasEmptyStatuses(input) || input.workflowIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -281,6 +281,12 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
     if (input.workflowId) {
       whereClauses.push(`workflow_id = $${index++}`)
       params.push(input.workflowId)
+    }
+
+    if (input.workflowIds) {
+      const placeholders = input.workflowIds.map(() => `$${index++}`)
+      whereClauses.push(`workflow_id IN (${placeholders.join(", ")})`)
+      params.push(...input.workflowIds)
     }
 
     index = appendRunListFilters(whereClauses, params, index, input)

--- a/storage/sqlite/src/action-run-storage.ts
+++ b/storage/sqlite/src/action-run-storage.ts
@@ -476,7 +476,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
   }
 
   async list(input: ListActionRunsInput): Promise<ListActionRunsResult> {
-    if (input.statuses && input.statuses.length === 0) {
+    if ((input.statuses && input.statuses.length === 0) || input.actionIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -490,6 +490,25 @@ export class SqliteActionRunStorage implements ActionRunStorage {
     if (input.actionId) {
       whereClauses.push("action_id = ?")
       args.push(input.actionId)
+    }
+
+    if (input.actionIds) {
+      whereClauses.push(`action_id IN (${input.actionIds.map(() => "?").join(", ")})`)
+      args.push(...input.actionIds)
+    }
+
+    if (input.objectTypeIds) {
+      if (input.objectTypeIds.length === 0) {
+        whereClauses.push("subject_kind <> ?")
+        args.push("object")
+      } else {
+        whereClauses.push(
+          `(subject_kind <> ? OR object_type_id IN (${input.objectTypeIds
+            .map(() => "?")
+            .join(", ")}))`
+        )
+        args.push("object", ...input.objectTypeIds)
+      }
     }
 
     if (input.objectTypeId) {

--- a/storage/sqlite/src/workflow-intervention-storage.ts
+++ b/storage/sqlite/src/workflow-intervention-storage.ts
@@ -187,7 +187,7 @@ export class SqliteWorkflowInterventionStorage implements WorkflowInterventionSt
   }
 
   async list(input: ListWorkflowInterventionsInput): Promise<ListWorkflowInterventionsResult> {
-    if (input.statuses && input.statuses.length === 0) {
+    if ((input.statuses && input.statuses.length === 0) || input.workflowIds?.length === 0) {
       return {
         interventions: [],
         hasMore: false,
@@ -206,6 +206,11 @@ export class SqliteWorkflowInterventionStorage implements WorkflowInterventionSt
     if (input.workflowId) {
       whereClauses.push("workflow_id = ?")
       args.push(input.workflowId)
+    }
+
+    if (input.workflowIds) {
+      whereClauses.push(`workflow_id IN (${input.workflowIds.map(() => "?").join(", ")})`)
+      args.push(...input.workflowIds)
     }
 
     if (input.workflowRunId) {

--- a/storage/sqlite/src/workflow-run-storage.ts
+++ b/storage/sqlite/src/workflow-run-storage.ts
@@ -308,7 +308,7 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
   }
 
   async list(input: ListWorkflowRunsInput): Promise<ListWorkflowRunsResult> {
-    if (hasEmptyStatuses(input)) {
+    if (hasEmptyStatuses(input) || input.workflowIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -322,6 +322,11 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
     if (input.workflowId) {
       whereClauses.push("workflow_id = ?")
       args.push(input.workflowId)
+    }
+
+    if (input.workflowIds) {
+      whereClauses.push(`workflow_id IN (${input.workflowIds.map(() => "?").join(", ")})`)
+      args.push(...input.workflowIds)
     }
 
     appendRunListFilters(whereClauses, args, input)


### PR DESCRIPTION
## Summary

This PR gates run-history reads with the grants we already have instead of adding new run-specific grants.

Action run visibility is inherited from the action and its object subject:

```ts
canViewActionRun =
  can.apply(action) &&
  (subject.kind !== "object" || can.view(subject.objectType))
```

Workflow run and workflow intervention visibility is inherited from the workflow run grant:

```ts
canViewWorkflowRun = can.run(workflow)
canViewWorkflowIntervention = can.run(workflow)
```

List routes now pass authorization-derived filters into storage before pagination. That keeps `limit`, `offset`, `hasMore`, and `total` scoped to visible rows instead of fetching a page and filtering afterward.

```ts
const actionIds = authz ? [...authz.grants.actions.apply] : undefined
const objectTypeIds = authz ? [...authz.grants.objectTypes.view] : undefined

await storage.list({
  projectId: sixb.id,
  actionId: parsed.actionId,
  actionIds,
  objectTypeId: parsed.objectTypeId,
  objectTypeIds,
  limit,
  offset,
})
```

Workflow history follows the same pattern:

```ts
const workflowIds = authz ? [...authz.grants.workflows.run] : undefined

await storage.list({
  projectId: sixb.id,
  workflowId: parsed.workflowId,
  workflowIds,
  limit,
  offset,
})
```

Detail routes still hide unauthorized run records as not found.

```ts
if (!run || !canViewWorkflowRun(authz, run)) {
  set.status = 404
  return { error: "Workflow run not found" }
}
```

## Storage changes

The run storage list inputs now accept plural authorization filters:

```ts
interface ListActionRunsInput {
  actionId?: string
  actionIds?: readonly string[]
  objectTypeId?: string
  objectTypeIds?: readonly string[]
}

interface ListWorkflowRunsInput {
  workflowId?: string
  workflowIds?: readonly string[]
}

interface ListWorkflowInterventionsInput {
  workflowId?: string
  workflowIds?: readonly string[]
}
```

In-memory, SQLite, and Postgres providers apply those filters before counting and paging.

## Validation

```bash
bun test packages/server/tests/authorization-routes.test.ts packages/core/tests/action-runs.test.ts packages/core/tests/workflow-runs.test.ts packages/core/tests/workflow-interventions.test.ts storage/sqlite/tests/sqlite-action-run-storage.test.ts storage/sqlite/tests/sqlite-workflow-run-storage.test.ts storage/sqlite/tests/sqlite-workflow-intervention-storage.test.ts
bun run check
bun run typecheck
```
