### PR TITLE
projections: add telemetry projections

### DIFF
--- a/docs/concepts/projection.md
+++ b/docs/concepts/projection.md
@@ -1,6 +1,6 @@
 # Projection
 
-A projection turns dataset rows into ontology objects and links.
+A projection turns dataset rows into ontology objects, links, and telemetry points.
 
 Use projections after syncs and pipelines have produced clean table data. Projections are the
 step that makes that data show up as typed app objects.
@@ -14,6 +14,7 @@ A projection connects those two worlds:
 - map dataset columns to object properties
 - create or update objects from rows
 - create links from foreign key columns
+- append timestamped readings to telemetry properties
 - keep app state in sync with committed dataset versions
 
 In a typical app, syncs and pipelines prepare clean datasets before projections create objects and
@@ -99,6 +100,49 @@ export const projectMembersProjection = defineLinkProjection("project-members", 
 
 Each row creates one link from a `Project` to an `Employee`.
 
+## Project telemetry points
+
+A telemetry projection records timestamped readings onto a telemetry-mode property. Use it
+when a dataset has one row per measurement: a value, the object it belongs to, and when it
+was recorded.
+
+First mark the property as telemetry in the ontology:
+
+```ts
+prop("progress", "integer", { mode: "telemetry" })
+```
+
+Then map a dataset of readings onto it:
+
+```ts
+import { defineTelemetryProjection } from "@sixb/core"
+import { projectProgressDataset } from "../datasets/projects"
+import { Project } from "../ontology/project"
+
+export const projectProgressProjection = defineTelemetryProjection(
+  "project-progress",
+  Project.p.progress
+)
+  .fromDataset(projectProgressDataset)
+  .points({
+    objectId: "project_id",
+    at: "recorded_at",
+    value: "progress_pct",
+  })
+```
+
+Each row appends one point to the `progress` series of the `Project` named by `project_id`.
+
+| Mapping key | Meaning |
+| --- | --- |
+| `objectId` | Dataset column holding the target object's primary id |
+| `at` | Timestamp column for the reading |
+| `value` | Column holding the reading |
+| `unit` | Optional column holding the reading's unit (required for properties that carry a unit) |
+
+The most recent reading also materializes onto the object, so the property always reflects
+the latest value while the full history stays queryable.
+
 ## Projection vs pipeline
 
 Pipelines and projections solve different problems.
@@ -108,6 +152,7 @@ Pipelines and projections solve different problems.
 | Clean, filter, join, or reshape rows | Pipeline |
 | Create app objects from rows | Projection |
 | Create object relationships from foreign keys | Projection |
+| Record timestamped readings on a property | Projection |
 | Keep data as tables | Dataset or pipeline |
 
 A good rule: pipelines make better rows; projections make objects.
@@ -184,5 +229,8 @@ sixb worker projection
 - projection execution is triggered by committed dataset versions.
 - projections are set-only in V1: missing rows do not delete existing objects or links.
 - link projections require string source and target fields.
+- telemetry projections target a telemetry-mode property; the `at` column must be a string, date, or timestamp.
+- `at` values without a time zone (no trailing `Z` or numeric offset) are read as UTC.
+- a telemetry point's identity is its object, property, and time: re-projecting the same instant updates the value instead of adding a duplicate.
 
 The important first step is to decide which clean table should become which object type.

--- a/examples/acme-corp/datasets/erp.ts
+++ b/examples/acme-corp/datasets/erp.ts
@@ -56,6 +56,12 @@ export const erpProjectMembersDataset = defineDataset("erp.project_members", {
   schema: [col("project_id", "string"), col("employee_id", "string")],
 })
 
+export const erpProjectProgressDataset = defineDataset("erp.project_progress", {
+  // recorded_at is a string column carrying zone-less local timestamps; the
+  // telemetry projection normalizes them to UTC instants when it materializes.
+  schema: [col("project_id", "string"), col("recorded_at", "string"), col("progress_pct", "int64")],
+})
+
 export const erpDocumentsDataset = defineDataset("erp.documents", {
   schema: [
     col("id", "string"),

--- a/examples/acme-corp/lib/acme-erp.ts
+++ b/examples/acme-corp/lib/acme-erp.ts
@@ -41,6 +41,12 @@ export interface ErpProjectMemberRow {
   readonly employee_id: string
 }
 
+export interface ErpProjectProgressRow {
+  readonly project_id: string
+  readonly recorded_at: string
+  readonly progress_pct: number
+}
+
 export interface ErpDocumentRow {
   readonly id: string
   readonly title: string
@@ -80,6 +86,7 @@ export interface AcmeErpClient {
   listCustomers(): Promise<readonly ErpCustomerRow[]>
   listProjects(): Promise<readonly ErpProjectRow[]>
   listProjectMembers(): Promise<readonly ErpProjectMemberRow[]>
+  listProjectProgress(): Promise<readonly ErpProjectProgressRow[]>
   listDocuments(): Promise<readonly ErpDocumentRow[]>
   listInvoices(): Promise<readonly ErpInvoiceRow[]>
   listTasks(): Promise<readonly ErpTaskRow[]>
@@ -247,6 +254,33 @@ const projectMembers = [
   { project_id: "proj-healthfirst-portal", employee_id: "emp-bob" },
   { project_id: "proj-healthfirst-portal", employee_id: "emp-francois" },
 ] satisfies readonly ErpProjectMemberRow[]
+
+// Progress snapshots arrive from the ERP as zone-less local timestamps (no "Z"
+// and no numeric offset), and some carry single-digit (non-zero-padded) hours
+// like "9:30:00" exactly as the source system emits them. The telemetry
+// projection normalizes every form to UTC so a reading materializes at the same
+// absolute instant on any worker host.
+const projectProgress = [
+  { project_id: "proj-techstart-platform", recorded_at: "2024-02-29 17:00:00", progress_pct: 15 },
+  { project_id: "proj-techstart-platform", recorded_at: "2024-05-31 9:30:00", progress_pct: 38 },
+  { project_id: "proj-techstart-platform", recorded_at: "2024-08-30 17:15:00", progress_pct: 60 },
+  { project_id: "proj-techstart-platform", recorded_at: "2024-10-31 8:00:00", progress_pct: 72 },
+  { project_id: "proj-greenenergy-dashboard", recorded_at: "2024-03-29 9:00:00", progress_pct: 12 },
+  {
+    project_id: "proj-greenenergy-dashboard",
+    recorded_at: "2024-05-31 14:00:00",
+    progress_pct: 34,
+  },
+  {
+    project_id: "proj-greenenergy-dashboard",
+    recorded_at: "2024-07-31 17:30:00",
+    progress_pct: 55,
+  },
+  { project_id: "proj-eduplatform-redesign", recorded_at: "2024-06-14 9:30:00", progress_pct: 5 },
+  { project_id: "proj-healthfirst-portal", recorded_at: "2023-08-31 17:00:00", progress_pct: 30 },
+  { project_id: "proj-healthfirst-portal", recorded_at: "2023-11-30 17:00:00", progress_pct: 65 },
+  { project_id: "proj-healthfirst-portal", recorded_at: "2024-01-31 18:00:00", progress_pct: 100 },
+] satisfies readonly ErpProjectProgressRow[]
 
 const documents = [
   {
@@ -438,6 +472,9 @@ export function createAcmeErpClient(): AcmeErpClient {
     },
     async listProjectMembers() {
       return cloneRows(projectMembers)
+    },
+    async listProjectProgress() {
+      return cloneRows(projectProgress)
     },
     async listDocuments() {
       return cloneRows(documents)

--- a/examples/acme-corp/projections/project-progress-projection.ts
+++ b/examples/acme-corp/projections/project-progress-projection.ts
@@ -1,0 +1,14 @@
+import { defineTelemetryProjection } from "@sixb/core"
+import { erpProjectProgressDataset } from "../datasets/erp"
+import { Project } from "../ontology/project"
+
+export const projectProgressProjection = defineTelemetryProjection(
+  "project-progress",
+  Project.p.progress
+)
+  .fromDataset(erpProjectProgressDataset)
+  .points({
+    objectId: "project_id",
+    at: "recorded_at",
+    value: "progress_pct",
+  })

--- a/examples/acme-corp/syncs/erp.ts
+++ b/examples/acme-corp/syncs/erp.ts
@@ -7,6 +7,7 @@ import {
   erpEmployeesDataset,
   erpInvoicesDataset,
   erpProjectMembersDataset,
+  erpProjectProgressDataset,
   erpProjectsDataset,
   erpTasksDataset,
 } from "../datasets/erp"
@@ -59,3 +60,9 @@ export const syncErpTasks = defineSync("sync-erp-tasks")
   .from(acmeErpConnector)
   .read((client) => client.listTasks())
   .intoDataset(erpTasksDataset)
+
+export const syncErpProjectProgress = defineSync("sync-erp-project-progress")
+  .when(syncFinished(syncErpTasks.id))
+  .from(acmeErpConnector)
+  .read((client) => client.listProjectProgress())
+  .intoDataset(erpProjectProgressDataset)

--- a/examples/acme-corp/tests/project-progress-projection.test.ts
+++ b/examples/acme-corp/tests/project-progress-projection.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Wiring check for the telemetry projection added to the acme-corp example:
+ * the runtime discovers `project-progress`, startup validation accepts it, and
+ * the definition maps the ERP progress columns onto `Project.progress`.
+ */
+import { describe, expect, test } from "bun:test"
+import {
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  InMemoryStorage,
+  Sixb,
+} from "@sixb/core"
+import { erpProjectProgressDataset } from "../datasets/erp"
+import { Customer } from "../ontology/customer"
+import { Department } from "../ontology/department"
+import { Employee } from "../ontology/employee"
+import { Project } from "../ontology/project"
+import { projectProgressProjection } from "../projections/project-progress-projection"
+
+function createRuntime() {
+  return new Sixb({
+    id: "acme-project-progress-test",
+    ontology: [Project, Customer, Employee, Department],
+    broker: new InMemoryBroker(),
+    storage: new InMemoryStorage(),
+    lakeStorage: new InMemoryLakeStorage(),
+    blobStorage: new InMemoryBlobStorage(),
+    queues: new InMemoryQueues(),
+    datasets: [erpProjectProgressDataset],
+    projections: [projectProgressProjection],
+  })
+}
+
+describe("project-progress telemetry projection", () => {
+  test("startup validation accepts the projection and registers it", () => {
+    const sixb = createRuntime()
+
+    const telemetryProjections = sixb.getTelemetryProjections()
+    expect(telemetryProjections.map((projection) => projection.id)).toContain("project-progress")
+    expect(sixb.getProjectionById("project-progress")).not.toBeNull()
+  })
+
+  test("maps the ERP progress columns onto Project.progress", () => {
+    expect(projectProgressProjection).toMatchObject({
+      _tag: "TelemetryProjectionDefinition",
+      id: "project-progress",
+      objectTypeId: "Project",
+      propertyId: "progress",
+      datasetId: "erp.project_progress",
+      objectIdField: "project_id",
+      atField: "recorded_at",
+      valueField: "progress_pct",
+    })
+    // progress is unitless, so the mapping must not carry a unit field.
+    expect(projectProgressProjection).not.toHaveProperty("unitField")
+  })
+})

--- a/packages/atlas/src/pages/ObjectTypeDetail.tsx
+++ b/packages/atlas/src/pages/ObjectTypeDetail.tsx
@@ -80,16 +80,18 @@ export function ObjectTypeDetail() {
   }, [objectType, allTypes])
 
   const typeProjections = useMemo(() => {
-    if (!projections || !typeId) return { object: [], link: [] }
+    if (!projections || !typeId) return { object: [], link: [], telemetry: [] }
     return {
       object: projections.objectProjections.filter((p) => p.objectTypeId === typeId),
       link: projections.linkProjections.filter(
         (p) => p.sourceObjectTypeId === typeId || p.targetObjectTypeId === typeId
       ),
+      telemetry: projections.telemetryProjections.filter((p) => p.objectTypeId === typeId),
     }
   }, [projections, typeId])
 
-  const projectionCount = typeProjections.object.length + typeProjections.link.length
+  const projectionCount =
+    typeProjections.object.length + typeProjections.link.length + typeProjections.telemetry.length
   const resolvedTab: TabValue =
     activeTab === "projections" && projectionCount === 0 ? DEFAULT_TAB : activeTab
 
@@ -400,6 +402,32 @@ export function ObjectTypeDetail() {
                 </div>
               </section>
             ) : null}
+
+            {typeProjections.telemetry.length > 0 ? (
+              <section className="space-y-2">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  Telemetry projections
+                </h3>
+                <div className="space-y-3">
+                  {typeProjections.telemetry.map((proj) => (
+                    <Card key={proj.id} className="space-y-4 p-4">
+                      <ProjectionHeader id={proj.id} datasetId={proj.datasetId} />
+                      <div className="space-y-1.5">
+                        <SectionLabel>Point mapping</SectionLabel>
+                        <dl className="grid grid-cols-[max-content_max-content_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1 font-mono text-xs">
+                          <TelemetryMappingRow label={proj.propertyId} column={proj.valueField} />
+                          <TelemetryMappingRow label="at" column={proj.atField} />
+                          <TelemetryMappingRow label="object" column={proj.objectIdField} />
+                          {proj.unitField ? (
+                            <TelemetryMappingRow label="unit" column={proj.unitField} />
+                          ) : null}
+                        </dl>
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              </section>
+            ) : null}
           </TabsContent>
         ) : null}
       </Tabs>
@@ -521,6 +549,18 @@ function SectionLabel({ children }: { children: ReactNode }) {
     <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
       {children}
     </p>
+  )
+}
+
+function TelemetryMappingRow({ label, column }: { label: string; column: string }) {
+  return (
+    <Fragment>
+      <dt className="text-foreground">{label}</dt>
+      <span aria-hidden="true" className="text-muted-foreground/40">
+        ←
+      </span>
+      <dd className="truncate text-muted-foreground">{column}</dd>
+    </Fragment>
   )
 }
 

--- a/packages/cli/src/lib/loadSixb.ts
+++ b/packages/cli/src/lib/loadSixb.ts
@@ -16,6 +16,7 @@ import type {
   ScheduleDefinition,
   SixbRuntimeContext,
   SyncDefinition,
+  TelemetryProjectionDefinition,
   WorkflowsRuntime,
 } from "@sixb/core"
 
@@ -33,6 +34,7 @@ export interface LoadedSixb extends SixbRuntimeContext {
   readonly workflows: WorkflowsRuntime
   getObjectProjections(): readonly ObjectProjectionDefinition[]
   getLinkProjections(): readonly LinkProjectionDefinition[]
+  getTelemetryProjections(): readonly TelemetryProjectionDefinition[]
   getDatasetDefinitions(): readonly DatasetDefinition[]
   getRuleDefinitions(): readonly RuleDefinition[]
   getDatasetById(datasetId: string): DatasetDefinition | null
@@ -87,6 +89,8 @@ function isSixbInstance(value: unknown): value is LoadedSixb {
     typeof (value as { workflows?: { getById?: unknown } }).workflows?.getById === "function" &&
     typeof (value as { getObjectProjections?: unknown }).getObjectProjections === "function" &&
     typeof (value as { getLinkProjections?: unknown }).getLinkProjections === "function" &&
+    typeof (value as { getTelemetryProjections?: unknown }).getTelemetryProjections ===
+      "function" &&
     typeof (value as { getDatasetDefinitions?: unknown }).getDatasetDefinitions === "function" &&
     typeof (value as { getRuleDefinitions?: unknown }).getRuleDefinitions === "function" &&
     typeof (value as { getDatasetById?: unknown }).getDatasetById === "function" &&

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -121,7 +121,11 @@ export async function startOrchestratorRuntime(
   const { routes, diagnostics } = compileRoutesWithDiagnostics({
     syncs: sixb.getSyncDefinitions(),
     pipelines: sixb.getPipelineDefinitions(),
-    projections: [...sixb.getObjectProjections(), ...sixb.getLinkProjections()],
+    projections: [
+      ...sixb.getObjectProjections(),
+      ...sixb.getLinkProjections(),
+      ...sixb.getTelemetryProjections(),
+    ],
     workflows: sixb.workflows.list(),
   })
   const warnings = diagnostics.map(formatRouteDiagnosticWarning)
@@ -217,7 +221,10 @@ export async function startSixbRuntime(
         await actionWorker.start()
       }
 
-      const projectionCount = sixb.getObjectProjections().length + sixb.getLinkProjections().length
+      const projectionCount =
+        sixb.getObjectProjections().length +
+        sixb.getLinkProjections().length +
+        sixb.getTelemetryProjections().length
       if (projectionCount > 0) {
         projectionWorker = new ProjectionWorker(sixb)
         await projectionWorker.start()

--- a/packages/cli/src/lib/worker-registry.ts
+++ b/packages/cli/src/lib/worker-registry.ts
@@ -62,7 +62,12 @@ export function resolveRegisteredWorkerTypes(sixb: LoadedSixb): readonly string[
     workerTypes.push("pipeline")
   }
 
-  if (sixb.getObjectProjections().length + sixb.getLinkProjections().length > 0) {
+  if (
+    sixb.getObjectProjections().length +
+      sixb.getLinkProjections().length +
+      sixb.getTelemetryProjections().length >
+    0
+  ) {
     workerTypes.push("projection")
   }
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -42,12 +42,12 @@ const { data: objects } = await listObjects({
 
 // Get a single object
 const { data: object } = await getObject({
-  path: { objectTypeId: "thermostat", objectKey: "living-room" },
+  path: { objectTypeId: "thermostat", objectId: "living-room" },
 })
 
 // Fetch telemetry history
 const { data: history } = await getTelemetryHistory({
-  path: { objectTypeId: "thermostat", objectKey: "living-room", propertyId: "temperature" },
+  path: { objectTypeId: "thermostat", objectId: "living-room", propertyId: "temperature" },
   query: { from: "2025-01-01T00:00:00Z", to: "2025-01-02T00:00:00Z", order: "asc" },
 })
 
@@ -77,6 +77,8 @@ import {
   listObjectsOptions,
   getObjectOptions,
   getTelemetryHistoryOptions,
+  telemetryHistoryQueryOptions,
+  useTelemetryHistoryQuery,
 } from "@sixb/client/hooks"
 
 // List objects with automatic caching and refetching
@@ -94,6 +96,22 @@ const { data: history } = useQuery(
     query: { range: "5m" },
   })
 )
+
+// Typed telemetry history with ontology tokens
+const { data: temperatureHistory } = useTelemetryHistoryQuery({
+  objectType: Thermostat,
+  objectId: "living-room",
+  property: Thermostat.p.temperature,
+  from: new Date("2025-01-01T00:00:00Z"),
+  to: new Date("2025-01-02T00:00:00Z"),
+})
+
+// The same token-based shape is available as a query options factory.
+const temperatureHistoryOptions = telemetryHistoryQueryOptions({
+  objectType: Thermostat,
+  objectId: "living-room",
+  property: Thermostat.p.temperature,
+})
 ```
 
 ### Domain events
@@ -128,5 +146,5 @@ The models module provides normalized types and adapter functions that transform
 | Entry point | What it provides |
 |---|---|
 | `@sixb/client` | `client`, all generated SDK functions (`listObjects`, `getObject`, `upsertObject`, `requestAction`, `getActionRun`, `getTelemetryHistory`, etc.), all generated types, and UI model types/adapters |
-| `@sixb/client/hooks` | TanStack Query `queryOptions` factories (`listObjectsOptions`, `getObjectOptions`, `getTelemetryHistoryOptions`, `listRelationshipsOptions`) and `useSixbEvents` |
+| `@sixb/client/hooks` | TanStack Query `queryOptions` factories (`listObjectsOptions`, `getObjectOptions`, `getTelemetryHistoryOptions`, `telemetryHistoryQueryOptions`, `listRelationshipsOptions`), typed hooks (`useTelemetryHistoryQuery`, object query hooks), and `useSixbEvents` |
 | `@sixb/client/models` | UI model types (`ObjectSummary`, `ObjectDetail`, `TelemetryHistory`, `RelationshipEdge`, etc.) and adapters (`toObjectSummary`, `toObjectDetail`, `toTelemetryHistoryWithRange`, `executeAction`) |

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -11513,9 +11513,56 @@
                         ],
                         "additionalProperties": false
                       }
+                    },
+                    "telemetryProjections": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "_tag": {
+                            "type": "string",
+                            "enum": ["TelemetryProjectionDefinition"]
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "objectTypeId": {
+                            "type": "string"
+                          },
+                          "propertyId": {
+                            "type": "string"
+                          },
+                          "datasetId": {
+                            "type": "string"
+                          },
+                          "objectIdField": {
+                            "type": "string"
+                          },
+                          "atField": {
+                            "type": "string"
+                          },
+                          "valueField": {
+                            "type": "string"
+                          },
+                          "unitField": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "_tag",
+                          "id",
+                          "objectTypeId",
+                          "propertyId",
+                          "datasetId",
+                          "objectIdField",
+                          "atField",
+                          "valueField"
+                        ],
+                        "additionalProperties": false
+                      }
                     }
                   },
-                  "required": ["objectProjections", "linkProjections"],
+                  "required": ["objectProjections", "linkProjections", "telemetryProjections"],
                   "additionalProperties": false
                 }
               }
@@ -11640,6 +11687,50 @@
                         "datasetId",
                         "sourceField",
                         "targetField"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "_tag": {
+                          "type": "string",
+                          "enum": ["TelemetryProjectionDefinition"]
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "objectTypeId": {
+                          "type": "string"
+                        },
+                        "propertyId": {
+                          "type": "string"
+                        },
+                        "datasetId": {
+                          "type": "string"
+                        },
+                        "objectIdField": {
+                          "type": "string"
+                        },
+                        "atField": {
+                          "type": "string"
+                        },
+                        "valueField": {
+                          "type": "string"
+                        },
+                        "unitField": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "_tag",
+                        "id",
+                        "objectTypeId",
+                        "propertyId",
+                        "datasetId",
+                        "objectIdField",
+                        "atField",
+                        "valueField"
                       ],
                       "additionalProperties": false
                     }

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4051,6 +4051,17 @@ export type ListProjectionsResponses = {
       sourceField: string
       targetField: string
     }>
+    telemetryProjections: Array<{
+      _tag: "TelemetryProjectionDefinition"
+      id: string
+      objectTypeId: string
+      propertyId: string
+      datasetId: string
+      objectIdField: string
+      atField: string
+      valueField: string
+      unitField?: string
+    }>
   }
 }
 
@@ -4107,6 +4118,17 @@ export type GetProjectionResponses = {
         datasetId: string
         sourceField: string
         targetField: string
+      }
+    | {
+        _tag: "TelemetryProjectionDefinition"
+        id: string
+        objectTypeId: string
+        propertyId: string
+        datasetId: string
+        objectIdField: string
+        atField: string
+        valueField: string
+        unitField?: string
       }
 }
 

--- a/packages/client/src/query-hooks.ts
+++ b/packages/client/src/query-hooks.ts
@@ -6,6 +6,7 @@
  * query IR, so identical queries share cache entries — inline builders are
  * safe to construct on every render.
  */
+import type { InferPropertyValue, Property, TelemetryPropertyToken } from "@sixb/core"
 import type {
   ListResult,
   ListResultWithoutTotal,
@@ -13,6 +14,7 @@ import type {
   ObjectQueryExecutor,
   ObjectQueryFacetResult,
   ObjectQueryListOptions,
+  ObjectTypeWithPropertyTokens,
 } from "@sixb/core/query"
 import {
   infiniteQueryOptions,
@@ -23,12 +25,35 @@ import {
 } from "@tanstack/react-query"
 import { createContext, createElement, type ReactNode, useContext, useMemo } from "react"
 import type { Client } from "./generated/client"
+import { getTelemetryHistory, type Options } from "./generated/sdk.gen"
+import type { GetTelemetryHistoryData } from "./generated/types.gen"
 import { createHttpQueryExecutor } from "./query"
 
 const objectQueryBaseKey = ["sixb", "objects"] as const
 
 function objectQueryKey(scope: string, ir: ObjectQuery, extra?: unknown) {
   return [...objectQueryBaseKey, scope, ir, extra ?? null] as const
+}
+
+const telemetryHistoryBaseKey = ["sixb", "telemetry", "history"] as const
+
+function toTelemetryHistoryDate(value: Date | string | undefined): string | undefined {
+  return value instanceof Date ? value.toISOString() : value
+}
+
+function toTelemetryHistoryLimit(value: number | string | undefined): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(1, Math.trunc(value)).toString()
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10)
+    if (Number.isFinite(parsed)) {
+      return Math.max(1, parsed).toString()
+    }
+  }
+
+  return undefined
 }
 
 // Options factories accept anything query-shaped, so they work with builders
@@ -166,6 +191,126 @@ type QueryHookExtras = {
   retry?: boolean | number
 }
 
+export type TelemetryHistoryValue<
+  TProperty extends { readonly property: Pick<Property, "schema" | "nullable"> },
+> = InferPropertyValue<TProperty["property"]>
+
+export interface TelemetryHistoryPoint<TValue> {
+  readonly projectId: string
+  readonly objectTypeId: string
+  readonly objectId: string
+  readonly propertyId: string
+  readonly value: TValue
+  readonly unit?: string
+  readonly at: string
+}
+
+export type TelemetryHistoryPoints<
+  TProperty extends { readonly property: Pick<Property, "schema" | "nullable"> },
+> = readonly TelemetryHistoryPoint<TelemetryHistoryValue<TProperty>>[]
+
+export interface TelemetryHistoryQueryOptions<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TProperty extends TelemetryPropertyToken<TObjectType> = TelemetryPropertyToken<TObjectType>,
+> extends Omit<Options<GetTelemetryHistoryData>, "path" | "query"> {
+  readonly objectType: TObjectType
+  readonly objectId: string
+  readonly property: TProperty & TelemetryPropertyToken<NoInfer<TObjectType>>
+  readonly from?: Date | string
+  readonly to?: Date | string
+  readonly limit?: number | string
+  readonly order?: "asc" | "desc"
+}
+
+export type TelemetryHistoryHookOptions<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TProperty extends TelemetryPropertyToken<TObjectType> = TelemetryPropertyToken<TObjectType>,
+> = TelemetryHistoryQueryOptions<TObjectType, TProperty> & QueryHookExtras
+
+function telemetryHistoryPath<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TProperty extends TelemetryPropertyToken<TObjectType>,
+>(options: TelemetryHistoryQueryOptions<TObjectType, TProperty>) {
+  return {
+    objectTypeId: options.objectType.id,
+    objectId: options.objectId,
+    propertyId: options.property.id,
+  }
+}
+
+function telemetryHistoryQuery<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TProperty extends TelemetryPropertyToken<TObjectType>,
+>(options: TelemetryHistoryQueryOptions<TObjectType, TProperty>) {
+  return {
+    from: toTelemetryHistoryDate(options.from),
+    to: toTelemetryHistoryDate(options.to),
+    limit: toTelemetryHistoryLimit(options.limit),
+    order: options.order ?? "asc",
+  }
+}
+
+export function telemetryHistoryQueryKey<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TProperty extends TelemetryPropertyToken<TObjectType>,
+>(options: TelemetryHistoryQueryOptions<TObjectType, TProperty>) {
+  return [
+    ...telemetryHistoryBaseKey,
+    telemetryHistoryPath(options),
+    telemetryHistoryQuery(options),
+  ] as const
+}
+
+async function fetchTelemetryHistory<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TProperty extends TelemetryPropertyToken<TObjectType>,
+>(
+  options: TelemetryHistoryQueryOptions<TObjectType, TProperty>,
+  signal?: AbortSignal
+): Promise<TelemetryHistoryPoints<TProperty>> {
+  const path = telemetryHistoryPath(options)
+  const query = telemetryHistoryQuery(options)
+  const {
+    objectType: _objectType,
+    objectId: _objectId,
+    property: _property,
+    from: _from,
+    to: _to,
+    limit: _limit,
+    order: _order,
+    ...rest
+  } = options
+
+  const { data } = await getTelemetryHistory({
+    ...rest,
+    path,
+    query,
+    signal,
+    responseStyle: "fields",
+    throwOnError: true,
+  })
+
+  return data.map((point) => ({
+    projectId: point.projectId,
+    objectTypeId: point.objectTypeId,
+    objectId: point.objectId,
+    propertyId: point.propertyId,
+    value: point.value as TelemetryHistoryValue<TProperty>,
+    unit: point.unit,
+    at: point.at,
+  }))
+}
+
+export function telemetryHistoryQueryOptions<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TProperty extends TelemetryPropertyToken<TObjectType>,
+>(options: TelemetryHistoryQueryOptions<TObjectType, TProperty>) {
+  return queryOptions({
+    queryKey: telemetryHistoryQueryKey(options),
+    queryFn: ({ signal }) => fetchTelemetryHistory(options, signal),
+  })
+}
+
 /**
  * Executor bound to the nearest `SixbProvider` client, or the global client.
  * Hooks run the query IR through this, so the binding a query was built with
@@ -174,6 +319,40 @@ type QueryHookExtras = {
 function useClientQueryExecutor(): ObjectQueryExecutor {
   const client = useContext(SixbClientContext)
   return useMemo(() => createHttpQueryExecutor(client), [client])
+}
+
+export function useTelemetryHistoryQuery<
+  TObjectType extends ObjectTypeWithPropertyTokens,
+  TProperty extends TelemetryPropertyToken<TObjectType>,
+>(
+  options: TelemetryHistoryHookOptions<TObjectType, TProperty>
+): UseQueryResult<TelemetryHistoryPoints<TProperty>, Error> {
+  const client = useContext(SixbClientContext)
+  const {
+    enabled,
+    staleTime,
+    gcTime,
+    refetchInterval,
+    refetchOnWindowFocus,
+    retry,
+    ...historyOptions
+  } = options
+
+  const historyInput: TelemetryHistoryQueryOptions<TObjectType, TProperty> = {
+    ...historyOptions,
+    client: historyOptions.client ?? client,
+  }
+
+  return useQuery({
+    queryKey: telemetryHistoryQueryKey(historyInput),
+    queryFn: ({ signal }) => fetchTelemetryHistory(historyInput, signal),
+    enabled,
+    staleTime,
+    gcTime,
+    refetchInterval,
+    refetchOnWindowFocus,
+    retry,
+  })
 }
 
 export function useObjectsQuery<TBuilt extends { readonly ir: ObjectQuery }>(

--- a/packages/client/src/query-hooks.ts
+++ b/packages/client/src/query-hooks.ts
@@ -344,8 +344,7 @@ export function useTelemetryHistoryQuery<
   }
 
   return useQuery({
-    queryKey: telemetryHistoryQueryKey(historyInput),
-    queryFn: ({ signal }) => fetchTelemetryHistory(historyInput, signal),
+    ...telemetryHistoryQueryOptions(historyInput),
     enabled,
     staleTime,
     gcTime,

--- a/packages/client/tests/hooks.test.ts
+++ b/packages/client/tests/hooks.test.ts
@@ -1,5 +1,22 @@
 import { describe, expect, test } from "bun:test"
-import { type ListObjectSummariesPage, listObjectsInfiniteOptions } from "../src/hooks"
+import { defineObjectType, prop } from "@sixb/core"
+import { createClient, createConfig } from "../src/generated/client"
+import {
+  type ListObjectSummariesPage,
+  listObjectsInfiniteOptions,
+  type TelemetryHistoryPoint,
+  telemetryHistoryQueryOptions,
+} from "../src/hooks"
+
+const SocialMetricSeries = defineObjectType({
+  id: "SocialMetricSeries",
+  name: "Social Metric Series",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string"),
+    prop("value", "double", { mode: "telemetry" }),
+  ],
+})
 
 function objectPage(count: number, hasMore: boolean): ListObjectSummariesPage {
   return {
@@ -47,5 +64,78 @@ describe("listObjectsInfiniteOptions", () => {
     expect(
       options.getNextPageParam?.(objectPage(20, false), [objectPage(20, false)], "100", ["100"])
     ).toBeUndefined()
+  })
+})
+
+function createTelemetryTestClient() {
+  const requests: Request[] = []
+  const client = createClient(
+    createConfig({
+      baseUrl: "http://sixb.test",
+      fetch: (async (request: Request) => {
+        requests.push(request)
+        return Response.json([
+          {
+            projectId: "default",
+            objectTypeId: "SocialMetricSeries",
+            objectId: "engagement-series",
+            propertyId: "value",
+            value: 42.5,
+            unit: "count",
+            at: "2026-01-02T00:00:00.000Z",
+          },
+        ])
+      }) as unknown as typeof fetch,
+    })
+  )
+
+  return { client, requests }
+}
+
+describe("telemetryHistoryQueryOptions", () => {
+  test("maps ontology tokens to the telemetry history route", async () => {
+    const { client, requests } = createTelemetryTestClient()
+    const options = telemetryHistoryQueryOptions({
+      client,
+      objectType: SocialMetricSeries,
+      objectId: "engagement-series",
+      property: SocialMetricSeries.p.value,
+      from: new Date("2026-01-01T00:00:00.000Z"),
+      to: "2026-01-03T00:00:00.000Z",
+      limit: 25,
+    })
+
+    expect(options.queryKey as unknown).toEqual([
+      "sixb",
+      "telemetry",
+      "history",
+      {
+        objectTypeId: "SocialMetricSeries",
+        objectId: "engagement-series",
+        propertyId: "value",
+      },
+      {
+        from: "2026-01-01T00:00:00.000Z",
+        to: "2026-01-03T00:00:00.000Z",
+        limit: "25",
+        order: "asc",
+      },
+    ])
+
+    const queryFn = options.queryFn as unknown as (context: {
+      signal?: AbortSignal
+    }) => Promise<readonly TelemetryHistoryPoint<number>[]>
+    const history = await queryFn({})
+
+    const requestUrl = new URL(requests[0]?.url ?? "")
+    expect(requestUrl.pathname).toBe(
+      "/api/objects/SocialMetricSeries/engagement-series/telemetry/value/history"
+    )
+    expect(requestUrl.searchParams.get("from")).toBe("2026-01-01T00:00:00.000Z")
+    expect(requestUrl.searchParams.get("to")).toBe("2026-01-03T00:00:00.000Z")
+    expect(requestUrl.searchParams.get("limit")).toBe("25")
+    expect(requestUrl.searchParams.get("order")).toBe("asc")
+    expect(history[0]?.value).toBe(42.5)
+    expect(history[0]?.at).toBe("2026-01-02T00:00:00.000Z")
   })
 })

--- a/packages/client/tests/hooks.types.ts
+++ b/packages/client/tests/hooks.types.ts
@@ -1,0 +1,69 @@
+import { defineObjectType, prop } from "@sixb/core"
+import {
+  type TelemetryHistoryPoint,
+  type TelemetryHistoryPoints,
+  telemetryHistoryQueryOptions,
+} from "../src/hooks"
+
+/**
+ * Compile-time contract tests for token-based telemetry history hooks.
+ *
+ * This file is intentionally type-only (no runtime `bun:test` cases).
+ */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+type Expect<T extends true> = T
+
+const MetricSeries = defineObjectType({
+  id: "MetricSeries",
+  name: "Metric Series",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string"),
+    prop("value", "double", { mode: "telemetry" }),
+    prop("online", "boolean", { mode: "telemetry" }),
+  ],
+})
+
+const OtherMetricSeries = defineObjectType({
+  id: "OtherMetricSeries",
+  name: "Other Metric Series",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("value", "double", { mode: "telemetry" }),
+  ],
+})
+
+const _numberHistory = telemetryHistoryQueryOptions({
+  objectType: MetricSeries,
+  objectId: "series-1",
+  property: MetricSeries.p.value,
+})
+
+type _NumberHistory = Expect<
+  Equal<
+    TelemetryHistoryPoints<typeof MetricSeries.p.value>,
+    readonly TelemetryHistoryPoint<number>[]
+  >
+>
+
+type _BooleanHistory = Expect<
+  Equal<
+    TelemetryHistoryPoints<typeof MetricSeries.p.online>,
+    readonly TelemetryHistoryPoint<boolean>[]
+  >
+>
+
+telemetryHistoryQueryOptions({
+  objectType: MetricSeries,
+  objectId: "series-1",
+  // @ts-expect-error static properties cannot be used as telemetry history properties
+  property: MetricSeries.p.name,
+})
+
+telemetryHistoryQueryOptions({
+  objectType: MetricSeries,
+  objectId: "series-1",
+  // @ts-expect-error telemetry property tokens must belong to the selected object type
+  property: OtherMetricSeries.p.value,
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -735,6 +735,7 @@ export {
   normalizeActionRunCommitDiff,
   ObjectStorageError,
   PipelineRunError,
+  PROJECTION_COUNTER_KEYS,
   ProjectionRunError,
   planMigrationSet,
   runMigrationSet,
@@ -745,6 +746,7 @@ export {
   WebhookRunError,
   WorkflowInterventionError,
   WorkflowRunError,
+  zeroProjectionRunCounters,
 } from "./storage"
 
 // ── Blob Storage ───────────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1149,13 +1149,18 @@ export type {
   LinkProjectionDefinition,
   ObjectProjectionDefinition,
   ProjectionDefinition,
+  TelemetryProjectionDefinition,
 } from "./projections"
 
 export {
   defineLinkProjection,
   defineProjection,
+  defineTelemetryProjection,
   fromForeignKey,
   isLinkProjectionDefinition,
   isObjectProjectionDefinition,
   isProjectionDefinition,
+  isTelemetryProjectionDefinition,
+  projectionKindOf,
+  validateTelemetryProjectionFieldMapping,
 } from "./projections"

--- a/packages/core/src/objects/telemetry/append-batch.ts
+++ b/packages/core/src/objects/telemetry/append-batch.ts
@@ -13,9 +13,21 @@ import type { ResolvedObjectContext } from "../context"
 import { requireObject } from "../helpers"
 import { writeTelemetryBatch } from "./write-batch"
 
-/** Type guard for telemetry values that carry an explicit unit. */
+/**
+ * Type guard for telemetry values that carry an explicit unit.
+ *
+ * Matches only the exact `{ value, unit }` wrapper (a string `unit` and no other
+ * keys) so a legitimate JSON/object telemetry value is not silently
+ * reinterpreted as value+unit. A fully explicit batch contract (passing units
+ * out-of-band like the single-property appender) is tracked as a follow-up;
+ * this narrows the heuristic without changing the public batch API.
+ */
 function isUnitBearingValue(raw: unknown): raw is { value: unknown; unit: string } {
-  return raw !== null && typeof raw === "object" && "value" in raw && "unit" in raw
+  if (raw === null || typeof raw !== "object") {
+    return false
+  }
+  const record = raw as Record<string, unknown>
+  return "value" in record && typeof record.unit === "string" && Object.keys(record).length === 2
 }
 
 export async function appendTelemetryBatch(

--- a/packages/core/src/objects/telemetry/write-batch.ts
+++ b/packages/core/src/objects/telemetry/write-batch.ts
@@ -18,6 +18,50 @@ export async function writeTelemetryBatch(
     (e): e is StoredTelemetryAppendedEvent => e.type === "telemetry.appended"
   )
   await storage.timeseries.applyTelemetryAppendedBatch(telemetryEvents)
-  await storage.objects.applyTelemetryAppendedBatch(telemetryEvents)
+  await storage.objects.applyTelemetryAppendedBatch(
+    await latestTelemetryEventsForObjectMaterialization(ctx, telemetryEvents)
+  )
   return telemetryEvents
+}
+
+async function latestTelemetryEventsForObjectMaterialization(
+  ctx: Pick<ResolvedObjectContext, "storage">,
+  events: readonly StoredTelemetryAppendedEvent[]
+): Promise<readonly StoredTelemetryAppendedEvent[]> {
+  const latestEventIds = new Set<string>()
+  const groups = new Map<string, StoredTelemetryAppendedEvent>()
+
+  for (const event of events) {
+    groups.set(telemetryPropertyKey(event), event)
+  }
+
+  // The per-group lookups are independent; run them concurrently so a batch
+  // touching many (object, property) groups pays one round-trip of latency
+  // rather than one per group.
+  const latestPoints = await Promise.all(
+    [...groups.values()].map((event) =>
+      ctx.storage.timeseries.getLatest({
+        projectId: event.projectId,
+        objectTypeId: event.payload.objectTypeId,
+        objectId: event.payload.objectId,
+        propertyId: event.payload.propertyId,
+      })
+    )
+  )
+  for (const latest of latestPoints) {
+    if (latest?.sourceEventId) {
+      latestEventIds.add(latest.sourceEventId)
+    }
+  }
+
+  return events.filter((event) => latestEventIds.has(event.id))
+}
+
+function telemetryPropertyKey(event: StoredTelemetryAppendedEvent): string {
+  return [
+    event.projectId,
+    event.payload.objectTypeId,
+    event.payload.objectId,
+    event.payload.propertyId,
+  ].join("\0")
 }

--- a/packages/core/src/projections/builders.ts
+++ b/packages/core/src/projections/builders.ts
@@ -11,13 +11,14 @@ import type {
   DatasetDefinition,
 } from "../datasets"
 import type { LinkToken, PropertyToken } from "../ontology/tokens"
-import type { ObjectLink, ObjectType, Schema } from "../ontology/types"
+import type { ObjectLink, ObjectType, Property, Schema } from "../ontology/types"
 import { ProjectionValidationError } from "./errors"
 import type {
   ForeignKeyDescriptor,
   LinkProjectionDefinition,
   ObjectProjectionDefinition,
   ProjectionDefinition,
+  TelemetryProjectionDefinition,
 } from "./types"
 import {
   validateAndLowerLinkMapping,
@@ -137,6 +138,18 @@ type StringDatasetColumnNameOf<TDataset extends DatasetDefinition> =
           : never
       }[DatasetColumnNameOf<TDataset>]
 
+type DateLikeDatasetColumnNameOf<TDataset extends DatasetDefinition> =
+  string extends DatasetColumnNameOf<TDataset>
+    ? string
+    : {
+        [TColumnName in DatasetColumnNameOf<TDataset>]: DatasetColumnTypeOf<
+          TDataset,
+          TColumnName
+        > extends "string" | "date" | "timestamp"
+          ? TColumnName
+          : never
+      }[DatasetColumnNameOf<TDataset>]
+
 type ProjectionMappingFor<TObjectType extends ObjectType, TDataset extends DatasetDefinition> = {
   readonly [TPropertyId in PropertyIdOf<TObjectType>]?: DatasetColumnNameCompatibleWithSchema<
     TDataset,
@@ -146,6 +159,29 @@ type ProjectionMappingFor<TObjectType extends ObjectType, TDataset extends Datas
 
 type ExactProjectionMapping<TObjectType extends ObjectType, TMapping> = TMapping & {
   readonly [TKey in Exclude<keyof TMapping, PropertyIdOf<TObjectType>>]: never
+}
+
+type TelemetryPropertyToken<TObjectTypeId extends string = string> = PropertyToken<
+  TObjectTypeId,
+  string,
+  Property & { readonly mode: "telemetry" }
+>
+
+type TelemetryProjectionPointMapping<
+  TPropertyToken extends TelemetryPropertyToken,
+  TDataset extends DatasetDefinition,
+> = {
+  readonly objectId: StringDatasetColumnNameOf<TDataset>
+  readonly at: DateLikeDatasetColumnNameOf<TDataset>
+  readonly value: DatasetColumnNameCompatibleWithSchema<
+    TDataset,
+    TPropertyToken["property"]["schema"]
+  >
+  readonly unit?: StringDatasetColumnNameOf<TDataset>
+}
+
+type ExactTelemetryProjectionPointMapping<TMapping> = TMapping & {
+  readonly [TKey in Exclude<keyof TMapping, "objectId" | "at" | "value" | "unit">]: never
 }
 
 type ForeignKeyFromSourceProperty = Omit<
@@ -327,6 +363,126 @@ export function defineProjection<const TObjectType extends ObjectType>(
   }
 }
 
+// ── defineTelemetryProjection ────────────────────────────────
+
+interface TelemetryProjectionSourceBuilder<TPropertyToken extends TelemetryPropertyToken> {
+  fromDataset<const TDataset extends DatasetDefinition>(
+    dataset: TDataset
+  ): TelemetryProjectionMappingBuilder<TPropertyToken, TDataset>
+}
+
+interface TelemetryProjectionMappingBuilder<
+  TPropertyToken extends TelemetryPropertyToken,
+  TDataset extends DatasetDefinition,
+> {
+  points<const TMapping extends TelemetryProjectionPointMapping<TPropertyToken, TDataset>>(
+    mapping: ExactTelemetryProjectionPointMapping<TMapping>
+  ): TelemetryProjectionDefinition
+}
+
+/**
+ * Fluent builder for {@link TelemetryProjectionDefinition}.
+ *
+ * ```ts
+ * defineTelemetryProjection("room-temperatures", Room.p.temperature)
+ *   .fromDataset(roomReadingsDataset)
+ *   .points({
+ *     objectId: "room_id",
+ *     at: "observed_at",
+ *     value: "temperature",
+ *     unit: "unit",
+ *   })
+ * ```
+ */
+export function defineTelemetryProjection<const TPropertyToken extends TelemetryPropertyToken>(
+  id: string,
+  propertyToken: TPropertyToken
+): TelemetryProjectionSourceBuilder<TPropertyToken> {
+  assertNonEmpty(id, "id")
+  validateTelemetryProjectionProperty(propertyToken)
+
+  return {
+    fromDataset<const TDataset extends DatasetDefinition>(
+      dataset: TDataset
+    ): TelemetryProjectionMappingBuilder<TPropertyToken, TDataset> {
+      assertProjectionDataset(dataset)
+      const datasetId = dataset.id
+
+      return {
+        points<const TMapping extends TelemetryProjectionPointMapping<TPropertyToken, TDataset>>(
+          mapping: ExactTelemetryProjectionPointMapping<TMapping>
+        ): TelemetryProjectionDefinition {
+          const pointMapping = lowerTelemetryPointMapping(mapping)
+          return {
+            _tag: "TelemetryProjectionDefinition",
+            id,
+            objectTypeId: propertyToken.objectTypeId,
+            propertyId: propertyToken.id,
+            datasetId,
+            objectIdField: pointMapping.objectId,
+            atField: pointMapping.at,
+            valueField: pointMapping.value,
+            ...(pointMapping.unit !== undefined ? { unitField: pointMapping.unit } : {}),
+          }
+        },
+      }
+    },
+  }
+}
+
+function validateTelemetryProjectionProperty(propertyToken: PropertyToken): void {
+  if (propertyToken.property.mode !== "telemetry") {
+    throw new ProjectionValidationError(
+      `Projection property '${propertyToken.objectTypeId}.${propertyToken.id}' must be telemetry-enabled.`
+    )
+  }
+}
+
+function lowerTelemetryPointMapping(mapping: {
+  readonly objectId?: string
+  readonly at?: string
+  readonly value?: string
+  readonly unit?: string
+}): {
+  readonly objectId: string
+  readonly at: string
+  readonly value: string
+  readonly unit?: string
+} {
+  const allowedKeys = new Set(["objectId", "at", "value", "unit"])
+  for (const key of Object.keys(mapping)) {
+    if (!allowedKeys.has(key)) {
+      throw new ProjectionValidationError(
+        `Telemetry projection point mapping contains unknown key '${key}'.`
+      )
+    }
+  }
+
+  if (mapping.objectId === undefined) {
+    throw new ProjectionValidationError("Telemetry projection point mapping requires objectId.")
+  }
+  if (mapping.at === undefined) {
+    throw new ProjectionValidationError("Telemetry projection point mapping requires at.")
+  }
+  if (mapping.value === undefined) {
+    throw new ProjectionValidationError("Telemetry projection point mapping requires value.")
+  }
+
+  assertNonEmpty(mapping.objectId, "objectId field")
+  assertNonEmpty(mapping.at, "at field")
+  assertNonEmpty(mapping.value, "value field")
+  if (mapping.unit !== undefined) {
+    assertNonEmpty(mapping.unit, "unit field")
+  }
+
+  return {
+    objectId: mapping.objectId,
+    at: mapping.at,
+    value: mapping.value,
+    ...(mapping.unit !== undefined ? { unit: mapping.unit } : {}),
+  }
+}
+
 // ── fromForeignKey ───────────────────────────────────────────
 
 /**
@@ -504,9 +660,40 @@ export function isLinkProjectionDefinition(value: unknown): value is LinkProject
   )
 }
 
+/** Runtime type guard for {@link TelemetryProjectionDefinition}. */
+export function isTelemetryProjectionDefinition(
+  value: unknown
+): value is TelemetryProjectionDefinition {
+  if (!isRecord(value)) return false
+  return (
+    value._tag === "TelemetryProjectionDefinition" &&
+    typeof value.id === "string" &&
+    typeof value.objectTypeId === "string" &&
+    typeof value.propertyId === "string" &&
+    typeof value.datasetId === "string" &&
+    typeof value.objectIdField === "string" &&
+    typeof value.atField === "string" &&
+    typeof value.valueField === "string" &&
+    (value.unitField === undefined || typeof value.unitField === "string")
+  )
+}
+
 /** Runtime type guard for any {@link ProjectionDefinition}. */
 export function isProjectionDefinition(value: unknown): value is ProjectionDefinition {
-  return isObjectProjectionDefinition(value) || isLinkProjectionDefinition(value)
+  return (
+    isObjectProjectionDefinition(value) ||
+    isLinkProjectionDefinition(value) ||
+    isTelemetryProjectionDefinition(value)
+  )
+}
+
+/** Returns the queue/runtime kind for a projection definition. */
+export function projectionKindOf(
+  projection: ProjectionDefinition
+): "object" | "link" | "telemetry" {
+  if (projection._tag === "ObjectProjectionDefinition") return "object"
+  if (projection._tag === "LinkProjectionDefinition") return "link"
+  return "telemetry"
 }
 
 // ── Categorization ──────────────────────────────────────────
@@ -515,15 +702,19 @@ export function isProjectionDefinition(value: unknown): value is ProjectionDefin
 export function categorizeProjections(projections: readonly ProjectionDefinition[]): {
   objectProjections: ObjectProjectionDefinition[]
   linkProjections: LinkProjectionDefinition[]
+  telemetryProjections: TelemetryProjectionDefinition[]
 } {
   const objectProjections: ObjectProjectionDefinition[] = []
   const linkProjections: LinkProjectionDefinition[] = []
+  const telemetryProjections: TelemetryProjectionDefinition[] = []
   for (const projection of projections) {
     if (isObjectProjectionDefinition(projection)) {
       objectProjections.push(projection)
     } else if (isLinkProjectionDefinition(projection)) {
       linkProjections.push(projection)
+    } else if (isTelemetryProjectionDefinition(projection)) {
+      telemetryProjections.push(projection)
     }
   }
-  return { objectProjections, linkProjections }
+  return { objectProjections, linkProjections, telemetryProjections }
 }

--- a/packages/core/src/projections/index.ts
+++ b/packages/core/src/projections/index.ts
@@ -3,10 +3,13 @@ export {
   categorizeProjections,
   defineLinkProjection,
   defineProjection,
+  defineTelemetryProjection,
   fromForeignKey,
   isLinkProjectionDefinition,
   isObjectProjectionDefinition,
   isProjectionDefinition,
+  isTelemetryProjectionDefinition,
+  projectionKindOf,
 } from "./builders"
 // ── Errors ──────────────────────────────────────────────────
 export { ProjectionValidationError } from "./errors"
@@ -16,6 +19,10 @@ export type {
   LinkProjectionDefinition,
   ObjectProjectionDefinition,
   ProjectionDefinition,
+  TelemetryProjectionDefinition,
 } from "./types"
 // ── Validation ───────────────────────────────────────────────
-export { validateProjectionsAtStartup } from "./validation"
+export {
+  validateProjectionsAtStartup,
+  validateTelemetryProjectionFieldMapping,
+} from "./validation"

--- a/packages/core/src/projections/types.ts
+++ b/packages/core/src/projections/types.ts
@@ -64,5 +64,32 @@ export interface LinkProjectionDefinition {
   readonly targetField: string
 }
 
+/**
+ * Lowered, serializable definition for projecting dataset rows into telemetry history.
+ *
+ * Each row in the dataset becomes one telemetry point for a single object type property.
+ * The target object type and property are fixed by the telemetry property token used by
+ * the builder; the point mapping selects the dataset columns for object id, timestamp,
+ * value, and optional unit.
+ */
+export interface TelemetryProjectionDefinition {
+  readonly _tag: "TelemetryProjectionDefinition"
+  readonly id: string
+  readonly objectTypeId: string
+  readonly propertyId: string
+  readonly datasetId: string
+  /** Dataset column holding the target object's primary id. */
+  readonly objectIdField: string
+  /** Dataset column holding the telemetry observation timestamp. */
+  readonly atField: string
+  /** Dataset column holding the telemetry value. */
+  readonly valueField: string
+  /** Dataset column holding the telemetry unit, when the property requires one. */
+  readonly unitField?: string
+}
+
 /** Union of all projection definition types. */
-export type ProjectionDefinition = ObjectProjectionDefinition | LinkProjectionDefinition
+export type ProjectionDefinition =
+  | ObjectProjectionDefinition
+  | LinkProjectionDefinition
+  | TelemetryProjectionDefinition

--- a/packages/core/src/projections/validation.ts
+++ b/packages/core/src/projections/validation.ts
@@ -214,7 +214,7 @@ export function validateTelemetryProjectionFieldMapping(
     if (!datasetColumnNames.has(columnName)) {
       throw new ProjectionValidationError(
         `${prefix}: ${fieldRole} field "${columnName}" references unknown dataset column ` +
-          `"${columnName}" on dataset "${projection.datasetId}"`
+          `on dataset "${projection.datasetId}"`
       )
     }
   }
@@ -328,7 +328,7 @@ export function validateProjectionsAtStartup(
       }
       if (sourceField && !datasetColumnNames.has(sourceField)) {
         throw new ProjectionValidationError(
-          `${prefix}: FK link "${linkId}" source field "${sourceField}" references unknown dataset column "${sourceField}" on dataset "${projection.datasetId}"`
+          `${prefix}: FK link "${linkId}" source field "${sourceField}" references unknown dataset column on dataset "${projection.datasetId}"`
         )
       }
       if (!objectTypesById.has(fk.targetObjectTypeId)) {
@@ -375,13 +375,13 @@ export function validateProjectionsAtStartup(
     if (!datasetColumnNames.has(projection.sourceField)) {
       throw new ProjectionValidationError(
         `${prefix}: source field "${projection.sourceField}" references unknown dataset column ` +
-          `"${projection.sourceField}" on dataset "${projection.datasetId}"`
+          `on dataset "${projection.datasetId}"`
       )
     }
     if (!datasetColumnNames.has(projection.targetField)) {
       throw new ProjectionValidationError(
         `${prefix}: target field "${projection.targetField}" references unknown dataset column ` +
-          `"${projection.targetField}" on dataset "${projection.datasetId}"`
+          `on dataset "${projection.datasetId}"`
       )
     }
     if (!primaryByTypeId.has(projection.sourceObjectTypeId)) {

--- a/packages/core/src/projections/validation.ts
+++ b/packages/core/src/projections/validation.ts
@@ -7,12 +7,13 @@
 
 import type { DatasetDefinition } from "../datasets"
 import type { OntologyRegistry } from "../ontology"
-import type { ObjectType } from "../ontology/types"
+import type { ObjectType, Property } from "../ontology/types"
 import { ProjectionValidationError } from "./errors"
 import type {
   ForeignKeyDescriptor,
   LinkProjectionDefinition,
   ObjectProjectionDefinition,
+  TelemetryProjectionDefinition,
 } from "./types"
 
 /**
@@ -176,6 +177,52 @@ export function validateLinkProjectionTarget(linkToken: {
 }
 
 /**
+ * Validates a telemetry projection's field mapping against its dataset columns
+ * and object type: the telemetry property exists and is telemetry-enabled, and
+ * every mapped field (objectId/at/value/unit) resolves to a real dataset column.
+ *
+ * Owned here so startup validation and the projection worker's pre-execution
+ * check share one implementation and cannot drift; the worker layers
+ * dataset-version column type compatibility on top of these rules. Returns the
+ * resolved telemetry property for callers that need its schema.
+ */
+export function validateTelemetryProjectionFieldMapping(
+  projection: TelemetryProjectionDefinition,
+  objectType: { readonly id: string; readonly properties: readonly Property[] },
+  datasetColumnNames: ReadonlySet<string>,
+  prefix: string
+): Property {
+  const property = objectType.properties.find((candidate) => candidate.id === projection.propertyId)
+  if (!property) {
+    throw new ProjectionValidationError(
+      `${prefix}: unknown property "${projection.propertyId}" on type "${projection.objectTypeId}"`
+    )
+  }
+  if (property.mode !== "telemetry") {
+    throw new ProjectionValidationError(
+      `${prefix}: property "${projection.propertyId}" on type "${projection.objectTypeId}" must be telemetry-enabled`
+    )
+  }
+
+  const mappedFields = [
+    ["objectId", projection.objectIdField],
+    ["at", projection.atField],
+    ["value", projection.valueField],
+    ...(projection.unitField !== undefined ? ([["unit", projection.unitField]] as const) : []),
+  ] as const
+  for (const [fieldRole, columnName] of mappedFields) {
+    if (!datasetColumnNames.has(columnName)) {
+      throw new ProjectionValidationError(
+        `${prefix}: ${fieldRole} field "${columnName}" references unknown dataset column ` +
+          `"${columnName}" on dataset "${projection.datasetId}"`
+      )
+    }
+  }
+
+  return property
+}
+
+/**
  * Validates all registered projections against the ontology at startup.
  *
  * For object projections:
@@ -193,10 +240,17 @@ export function validateLinkProjectionTarget(linkToken: {
  * 3. The link exists on the source type.
  * 4. Source and target fields exist in the referenced dataset.
  * 5. Both source and target types have primary properties.
+ *
+ * For telemetry projections:
+ * 1. `datasetId` exists in the dataset registry.
+ * 2. `objectTypeId` exists in the type registry.
+ * 3. `propertyId` exists on the object type and is telemetry-enabled.
+ * 4. Point mapping fields exist in the referenced dataset.
  */
 export function validateProjectionsAtStartup(
   objectProjections: readonly ObjectProjectionDefinition[],
   linkProjections: readonly LinkProjectionDefinition[],
+  telemetryProjections: readonly TelemetryProjectionDefinition[],
   ontology: OntologyRegistry,
   datasetsById: ReadonlyMap<string, DatasetDefinition>
 ): void {
@@ -340,5 +394,26 @@ export function validateProjectionsAtStartup(
         `${prefix}: target type "${projection.targetObjectTypeId}" has no primary property`
       )
     }
+  }
+
+  for (const projection of telemetryProjections) {
+    const prefix = `Projection "${projection.id}"`
+    const dataset = datasetsById.get(projection.datasetId)
+    if (!dataset) {
+      throw new ProjectionValidationError(
+        `${prefix}: unknown dataset "${projection.datasetId}". ` +
+          `Add it to 'datasets' in createSixb() or export it from 'datasets/'.`
+      )
+    }
+
+    const objectType = objectTypesById.get(projection.objectTypeId)
+    if (!objectType) {
+      throw new ProjectionValidationError(
+        `${prefix}: unknown object type "${projection.objectTypeId}"`
+      )
+    }
+
+    const datasetColumnNames = new Set(dataset.schema.columns.map((column) => column.name))
+    validateTelemetryProjectionFieldMapping(projection, objectType, datasetColumnNames, prefix)
   }
 }

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -122,7 +122,7 @@ export interface ProjectionRunRequestedQueueJob
     "projection.run.requested",
     {
       readonly projectionId: string
-      readonly projectionKind: "object" | "link"
+      readonly projectionKind: "object" | "link" | "telemetry"
       readonly datasetId: string
       readonly versionId: string
     }

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -40,6 +40,7 @@ import type {
   LinkProjectionDefinition,
   ObjectProjectionDefinition,
   ProjectionDefinition,
+  TelemetryProjectionDefinition,
 } from "../projections/types"
 import { validateProjectionsAtStartup } from "../projections/validation"
 import type { Queues } from "../queues"
@@ -115,6 +116,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
   private readonly runtimeContext: SixbRuntimeContext
   private readonly objectProjections: readonly ObjectProjectionDefinition[]
   private readonly linkProjections: readonly LinkProjectionDefinition[]
+  private readonly telemetryProjections: readonly TelemetryProjectionDefinition[]
   private readonly projectionsById = new Map<string, ProjectionDefinition>()
   readonly ontology: OntologyRegistry
   readonly actionRegistry: ActionRegistry
@@ -277,10 +279,13 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     this.actions = new ActionsRuntime(this.runtimeContext)
     this.workflows = new WorkflowsRuntime(this.runtimeContext, workflows)
 
-    const { objectProjections, linkProjections } = categorizeProjections(options.projections ?? [])
+    const { objectProjections, linkProjections, telemetryProjections } = categorizeProjections(
+      options.projections ?? []
+    )
     this.objectProjections = objectProjections
     this.linkProjections = linkProjections
-    for (const projection of [...objectProjections, ...linkProjections]) {
+    this.telemetryProjections = telemetryProjections
+    for (const projection of [...objectProjections, ...linkProjections, ...telemetryProjections]) {
       if (this.projectionsById.has(projection.id)) {
         throw new RuntimeError(`Duplicate projection id: ${projection.id}`)
       }
@@ -289,6 +294,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     validateProjectionsAtStartup(
       objectProjections,
       linkProjections,
+      telemetryProjections,
       this.ontology,
       this.datasetsById
     )
@@ -553,6 +559,10 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
 
   getLinkProjections(): readonly LinkProjectionDefinition[] {
     return this.linkProjections
+  }
+
+  getTelemetryProjections(): readonly TelemetryProjectionDefinition[] {
+    return this.telemetryProjections
   }
 
   getProjectionById(projectionId: string): ProjectionDefinition | null {

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -49,6 +49,7 @@ import type {
   LinkProjectionDefinition,
   ObjectProjectionDefinition,
   ProjectionDefinition,
+  TelemetryProjectionDefinition,
 } from "../projections/types"
 import type { Queues } from "../queues"
 import type { RuleDefinition } from "../rules"
@@ -813,7 +814,10 @@ export interface SixbInstance<_ extends readonly OntologySource[]> {
   /** All registered link projection definitions. */
   getLinkProjections(): readonly LinkProjectionDefinition[]
 
-  /** Lookup a registered object or link projection by id. */
+  /** All registered telemetry projection definitions. */
+  getTelemetryProjections(): readonly TelemetryProjectionDefinition[]
+
+  /** Lookup a registered projection by id. */
   getProjectionById(projectionId: string): ProjectionDefinition | null
 }
 

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -169,7 +169,12 @@ export type {
   StartProjectionRunInput,
   UpdateProjectionRunInput,
 } from "./projection-runs"
-export { InMemoryProjectionRunStorage, ProjectionRunError } from "./projection-runs"
+export {
+  InMemoryProjectionRunStorage,
+  PROJECTION_COUNTER_KEYS,
+  ProjectionRunError,
+  zeroProjectionRunCounters,
+} from "./projection-runs"
 export type {
   ListActiveRuleStatesInput,
   ListActiveRuleStatesResult,

--- a/packages/core/src/storage/projection-runs/in-memory.ts
+++ b/packages/core/src/storage/projection-runs/in-memory.ts
@@ -17,6 +17,9 @@ const counterKeys: readonly CounterKey[] = [
   "rowsSkipped",
   "objectsUpserted",
   "linksUpserted",
+  "telemetryPointsAppended",
+  "telemetryPointsSkipped",
+  "telemetryRowsFailed",
 ]
 
 function projectionRunKey(projectId: string, id: string): string {
@@ -80,6 +83,9 @@ function applyCounters(
     rowsSkipped: input.rowsSkipped ?? record.rowsSkipped,
     objectsUpserted: input.objectsUpserted ?? record.objectsUpserted,
     linksUpserted: input.linksUpserted ?? record.linksUpserted,
+    telemetryPointsAppended: input.telemetryPointsAppended ?? record.telemetryPointsAppended,
+    telemetryPointsSkipped: input.telemetryPointsSkipped ?? record.telemetryPointsSkipped,
+    telemetryRowsFailed: input.telemetryRowsFailed ?? record.telemetryRowsFailed,
   }
 }
 
@@ -124,6 +130,9 @@ export class InMemoryProjectionRunStorage implements ProjectionRunStorage {
       rowsSkipped: 0,
       objectsUpserted: 0,
       linksUpserted: 0,
+      telemetryPointsAppended: 0,
+      telemetryPointsSkipped: 0,
+      telemetryRowsFailed: 0,
     }
 
     this.rows.set(key, structuredClone(record))

--- a/packages/core/src/storage/projection-runs/in-memory.ts
+++ b/packages/core/src/storage/projection-runs/in-memory.ts
@@ -1,26 +1,16 @@
 import { ProjectionRunError } from "./errors"
-import type {
-  FinishProjectionRunInput,
-  ListProjectionRunsInput,
-  ListProjectionRunsResult,
-  ProjectionRunCounters,
-  ProjectionRunRecord,
-  ProjectionRunStorage,
-  StartProjectionRunInput,
-  UpdateProjectionRunInput,
+import {
+  type FinishProjectionRunInput,
+  type ListProjectionRunsInput,
+  type ListProjectionRunsResult,
+  PROJECTION_COUNTER_KEYS,
+  type ProjectionRunCounters,
+  type ProjectionRunRecord,
+  type ProjectionRunStorage,
+  type StartProjectionRunInput,
+  type UpdateProjectionRunInput,
+  zeroProjectionRunCounters,
 } from "./types"
-
-type CounterKey = keyof ProjectionRunCounters
-
-const counterKeys: readonly CounterKey[] = [
-  "rowsProcessed",
-  "rowsSkipped",
-  "objectsUpserted",
-  "linksUpserted",
-  "telemetryPointsAppended",
-  "telemetryPointsSkipped",
-  "telemetryRowsFailed",
-]
 
 function projectionRunKey(projectId: string, id: string): string {
   return `${projectId}:${id}`
@@ -73,20 +63,13 @@ function applyCounters(
   record: ProjectionRunRecord,
   input: Partial<ProjectionRunCounters>
 ): ProjectionRunRecord {
-  for (const key of counterKeys) {
+  const merged = {} as Record<keyof ProjectionRunCounters, number>
+  for (const key of PROJECTION_COUNTER_KEYS) {
     assertOptionalCounter(input[key], key)
+    merged[key] = input[key] ?? record[key]
   }
 
-  return {
-    ...record,
-    rowsProcessed: input.rowsProcessed ?? record.rowsProcessed,
-    rowsSkipped: input.rowsSkipped ?? record.rowsSkipped,
-    objectsUpserted: input.objectsUpserted ?? record.objectsUpserted,
-    linksUpserted: input.linksUpserted ?? record.linksUpserted,
-    telemetryPointsAppended: input.telemetryPointsAppended ?? record.telemetryPointsAppended,
-    telemetryPointsSkipped: input.telemetryPointsSkipped ?? record.telemetryPointsSkipped,
-    telemetryRowsFailed: input.telemetryRowsFailed ?? record.telemetryRowsFailed,
-  }
+  return { ...record, ...merged }
 }
 
 export class InMemoryProjectionRunStorage implements ProjectionRunStorage {
@@ -126,13 +109,7 @@ export class InMemoryProjectionRunStorage implements ProjectionRunStorage {
       datasetVersionId: input.datasetVersionId,
       status: "running",
       startedAt: new Date(input.startedAt ?? new Date()),
-      rowsProcessed: 0,
-      rowsSkipped: 0,
-      objectsUpserted: 0,
-      linksUpserted: 0,
-      telemetryPointsAppended: 0,
-      telemetryPointsSkipped: 0,
-      telemetryRowsFailed: 0,
+      ...zeroProjectionRunCounters(),
     }
 
     this.rows.set(key, structuredClone(record))

--- a/packages/core/src/storage/projection-runs/index.ts
+++ b/packages/core/src/storage/projection-runs/index.ts
@@ -12,3 +12,4 @@ export type {
   StartProjectionRunInput,
   UpdateProjectionRunInput,
 } from "./types"
+export { PROJECTION_COUNTER_KEYS, zeroProjectionRunCounters } from "./types"

--- a/packages/core/src/storage/projection-runs/types.ts
+++ b/packages/core/src/storage/projection-runs/types.ts
@@ -1,4 +1,4 @@
-export type ProjectionKind = "object" | "link"
+export type ProjectionKind = "object" | "link" | "telemetry"
 export type ProjectionRunStatus = "running" | "succeeded" | "failed" | "cancelled"
 
 export interface ProjectionRunCounters {
@@ -6,6 +6,9 @@ export interface ProjectionRunCounters {
   readonly rowsSkipped: number
   readonly objectsUpserted: number
   readonly linksUpserted: number
+  readonly telemetryPointsAppended: number
+  readonly telemetryPointsSkipped: number
+  readonly telemetryRowsFailed: number
 }
 
 export interface ProjectionRunRecord extends ProjectionRunCounters {

--- a/packages/core/src/storage/projection-runs/types.ts
+++ b/packages/core/src/storage/projection-runs/types.ts
@@ -4,11 +4,43 @@ export type ProjectionRunStatus = "running" | "succeeded" | "failed" | "cancelle
 export interface ProjectionRunCounters {
   readonly rowsProcessed: number
   readonly rowsSkipped: number
+  // objectsUpserted, linksUpserted, and telemetryPointsAppended count
+  // materialization operations *attempted* during the run, not distinct
+  // surviving rows. Operations collapse under last-write-wins upserts (e.g. two
+  // rows for the same (object, property, at) telemetry point, or the same
+  // object/link key), so these counters can exceed the number of stored rows.
   readonly objectsUpserted: number
   readonly linksUpserted: number
   readonly telemetryPointsAppended: number
   readonly telemetryPointsSkipped: number
   readonly telemetryRowsFailed: number
+}
+
+// Single source of truth for the counter field names. The Record type forces
+// this map to list every ProjectionRunCounters key — omitting one is a compile
+// error — so zeroing, merging, and snapshotting can iterate the keys instead of
+// re-listing the fields by hand (and silently dropping one).
+const counterKeyFlags: Record<keyof ProjectionRunCounters, true> = {
+  rowsProcessed: true,
+  rowsSkipped: true,
+  objectsUpserted: true,
+  linksUpserted: true,
+  telemetryPointsAppended: true,
+  telemetryPointsSkipped: true,
+  telemetryRowsFailed: true,
+}
+
+export const PROJECTION_COUNTER_KEYS = Object.keys(
+  counterKeyFlags
+) as readonly (keyof ProjectionRunCounters)[]
+
+/** Builds a fresh counter record with every field zeroed. */
+export function zeroProjectionRunCounters(): ProjectionRunCounters {
+  const counters = {} as Record<keyof ProjectionRunCounters, number>
+  for (const key of PROJECTION_COUNTER_KEYS) {
+    counters[key] = 0
+  }
+  return counters
 }
 
 export interface ProjectionRunRecord extends ProjectionRunCounters {

--- a/packages/core/src/storage/timeseries/store.ts
+++ b/packages/core/src/storage/timeseries/store.ts
@@ -11,13 +11,14 @@ function pointKey(
 }
 
 export class InMemoryTimeseriesStorage implements TimeseriesStorage {
-  private readonly pointsByKey = new Map<string, TimeseriesPoint[]>()
-  private readonly appliedEventIds = new Set<string>()
+  // A telemetry point is uniquely identified by (series, at): one value per
+  // instant per series. Re-applying the same instant is a last-write-wins
+  // upsert, which makes telemetry writes idempotent under replay for free.
+  private readonly pointsByKey = new Map<string, Map<number, TimeseriesPoint>>()
 
   snapshot(): InMemoryTimeseriesStorageSnapshot {
     return {
       pointsByKey: structuredClone(this.pointsByKey),
-      appliedEventIds: new Set(this.appliedEventIds),
     }
   }
 
@@ -26,38 +27,28 @@ export class InMemoryTimeseriesStorage implements TimeseriesStorage {
     for (const [key, points] of structuredClone(snapshot.pointsByKey)) {
       this.pointsByKey.set(key, points)
     }
-
-    this.appliedEventIds.clear()
-    for (const eventId of snapshot.appliedEventIds) {
-      this.appliedEventIds.add(eventId)
-    }
   }
 
   async applyTelemetryAppended(event: StoredTelemetryAppendedEvent): Promise<void> {
-    if (this.appliedEventIds.has(event.id)) {
-      return
-    }
-
     const key = pointKey(
       event.projectId,
       event.payload.objectTypeId,
       event.payload.objectId,
       event.payload.propertyId
     )
-
-    const points = this.pointsByKey.get(key) ?? []
-    points.push({
+    const at = new Date(event.payload.at)
+    const series = this.pointsByKey.get(key) ?? new Map<number, TimeseriesPoint>()
+    series.set(at.getTime(), {
       projectId: event.projectId,
       objectTypeId: event.payload.objectTypeId,
       objectId: event.payload.objectId,
       propertyId: event.payload.propertyId,
       value: event.payload.value,
       unit: event.payload.unit,
-      at: new Date(event.payload.at),
+      at,
       sourceEventId: event.id,
     })
-    this.pointsByKey.set(key, points)
-    this.appliedEventIds.add(event.id)
+    this.pointsByKey.set(key, series)
   }
 
   async applyTelemetryAppendedBatch(
@@ -80,12 +71,10 @@ export class InMemoryTimeseriesStorage implements TimeseriesStorage {
   }): Promise<readonly TimeseriesPoint[]> {
     const key = pointKey(params.projectId, params.objectTypeId, params.objectId, params.propertyId)
     const { from, to } = params
-    let points =
-      from || to
-        ? (this.pointsByKey.get(key) ?? []).filter(
-            (point) => (!from || point.at >= from) && (!to || point.at <= to)
-          )
-        : [...(this.pointsByKey.get(key) ?? [])]
+    let points = [...(this.pointsByKey.get(key)?.values() ?? [])]
+    if (from || to) {
+      points = points.filter((point) => (!from || point.at >= from) && (!to || point.at <= to))
+    }
 
     points.sort((a, b) => a.at.getTime() - b.at.getTime())
     if (params.order === "desc") {
@@ -105,17 +94,17 @@ export class InMemoryTimeseriesStorage implements TimeseriesStorage {
     objectId: string
     propertyId: string
   }): Promise<TimeseriesPoint | null> {
-    const key = pointKey(params.projectId, params.objectTypeId, params.objectId, params.propertyId)
-    const points = this.pointsByKey.get(key)
-    if (!points || points.length === 0) {
+    const series = this.pointsByKey.get(
+      pointKey(params.projectId, params.objectTypeId, params.objectId, params.propertyId)
+    )
+    if (!series || series.size === 0) {
       return null
     }
 
-    let latest = points[0]
-    for (let index = 1; index < points.length; index += 1) {
-      const candidate = points[index]
-      if (candidate.at > latest.at) {
-        latest = candidate
+    let latest: TimeseriesPoint | null = null
+    for (const point of series.values()) {
+      if (!latest || point.at.getTime() > latest.at.getTime()) {
+        latest = point
       }
     }
     return latest
@@ -123,6 +112,5 @@ export class InMemoryTimeseriesStorage implements TimeseriesStorage {
 }
 
 export interface InMemoryTimeseriesStorageSnapshot {
-  readonly pointsByKey: Map<string, TimeseriesPoint[]>
-  readonly appliedEventIds: Set<string>
+  readonly pointsByKey: Map<string, Map<number, TimeseriesPoint>>
 }

--- a/packages/core/tests/create-sixb.test.ts
+++ b/packages/core/tests/create-sixb.test.ts
@@ -13,6 +13,7 @@ import {
   defineProjection,
   defineSchedule,
   defineSync,
+  defineTelemetryProjection,
   defineValueType,
   defineWorkflow,
   defineWorkflowStep,
@@ -899,6 +900,75 @@ export const roomProjection = defineProjection("room-proj", Room)
     expect(sixb.getObjectProjections()[0].objectTypeId).toBe("Room")
     expect(sixb.getObjectProjections()[0].datasetId).toBe("canonical.rooms")
     expect(sixb.getLinkProjections()).toHaveLength(0)
+    expect(sixb.getTelemetryProjections()).toHaveLength(0)
+  })
+
+  test("discovers telemetry projections from projections/ directory", async () => {
+    const projectRoot = await createTempProjectRoot()
+
+    await writeProjectFile(
+      projectRoot,
+      "ontology/room.ts",
+      `import { defineObjectType, prop } from "${coreModuleUrl}"
+
+export const Room = defineObjectType({
+  id: "Room",
+  name: "Room",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("temperature", "double", { mode: "telemetry" }),
+  ],
+})
+`
+    )
+
+    await writeProjectFile(
+      projectRoot,
+      "datasets/room-readings.ts",
+      `import { col, defineDataset } from "${coreModuleUrl}"
+
+export const roomReadingsDataset = defineDataset("canonical.room-readings", {
+  schema: [
+    col("room_id", "string"),
+    col("observed_at", "timestamp"),
+    col("temperature", "float64"),
+  ],
+})
+`
+    )
+
+    await writeProjectFile(
+      projectRoot,
+      "projections/room-temperatures.ts",
+      `import { defineTelemetryProjection } from "${coreModuleUrl}"
+import { roomReadingsDataset } from "../datasets/room-readings"
+import { Room } from "../ontology/room"
+
+export const roomTemperatureProjection = defineTelemetryProjection(
+  "room-temperatures",
+  Room.p.temperature
+)
+  .fromDataset(roomReadingsDataset)
+  .points({
+    objectId: "room_id",
+    at: "observed_at",
+    value: "temperature",
+  })
+`
+    )
+
+    const sixb = await createSixb({
+      projectRoot,
+      ...createTestRuntimeDeps(),
+    })
+
+    expect(sixb.getObjectProjections()).toHaveLength(0)
+    expect(sixb.getLinkProjections()).toHaveLength(0)
+    expect(sixb.getTelemetryProjections()).toHaveLength(1)
+    expect(sixb.getTelemetryProjections()[0].id).toBe("room-temperatures")
+    expect(sixb.getTelemetryProjections()[0].objectTypeId).toBe("Room")
+    expect(sixb.getTelemetryProjections()[0].propertyId).toBe("temperature")
+    expect(sixb.getTelemetryProjections()[0].datasetId).toBe("canonical.room-readings")
   })
 
   test("uses explicit projections when provided", async () => {
@@ -924,6 +994,43 @@ export const roomProjection = defineProjection("room-proj", Room)
 
     expect(sixb.getObjectProjections()).toHaveLength(1)
     expect(sixb.getObjectProjections()[0].id).toBe("room-proj")
+  })
+
+  test("uses explicit telemetry projections when provided", async () => {
+    const projectRoot = await createTempProjectRoot()
+
+    const Room = defineObjectType({
+      id: "Room",
+      name: "Room",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("temperature", "double", { mode: "telemetry" }),
+      ],
+    })
+    const roomReadingsDataset = defineDataset("canonical.room-readings", {
+      schema: [
+        col("room_id", "string"),
+        col("observed_at", "timestamp"),
+        col("temperature", "float64"),
+      ],
+    })
+
+    const telemetryProjection = defineTelemetryProjection("room-temperatures", Room.p.temperature)
+      .fromDataset(roomReadingsDataset)
+      .points({ objectId: "room_id", at: "observed_at", value: "temperature" })
+
+    const sixb = await createSixb({
+      projectRoot,
+      ontologies: [Room],
+      datasets: [roomReadingsDataset],
+      projections: [telemetryProjection],
+      ...createTestRuntimeDeps(),
+    })
+
+    expect(sixb.getObjectProjections()).toHaveLength(0)
+    expect(sixb.getLinkProjections()).toHaveLength(0)
+    expect(sixb.getTelemetryProjections()).toEqual([telemetryProjection])
+    expect(sixb.getProjectionById("room-temperatures")).toBe(telemetryProjection)
   })
 
   test("looks up object and link projections by id", async () => {
@@ -1070,6 +1177,144 @@ export const roomProjection = defineProjection("room-proj", Room)
     ).rejects.toThrow('unknown dataset column "missing_column"')
   })
 
+  test("validates telemetry projection referencing unknown dataset", async () => {
+    const projectRoot = await createTempProjectRoot()
+
+    const Room = defineObjectType({
+      id: "Room",
+      name: "Room",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("temperature", "double", { mode: "telemetry" }),
+      ],
+    })
+    const roomReadingsDataset = defineDataset("canonical.room-readings", {
+      schema: [
+        col("room_id", "string"),
+        col("observed_at", "timestamp"),
+        col("temperature", "float64"),
+      ],
+    })
+    const telemetryProjection = defineTelemetryProjection("room-temperatures", Room.p.temperature)
+      .fromDataset(roomReadingsDataset)
+      .points({ objectId: "room_id", at: "observed_at", value: "temperature" })
+
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        projections: [telemetryProjection],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toBeInstanceOf(ProjectionValidationError)
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        projections: [telemetryProjection],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toThrow('unknown dataset "canonical.room-readings"')
+  })
+
+  test("validates telemetry projection referencing unknown dataset column", async () => {
+    const projectRoot = await createTempProjectRoot()
+
+    const Room = defineObjectType({
+      id: "Room",
+      name: "Room",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("temperature", "double", { mode: "telemetry" }),
+      ],
+    })
+    const roomReadingsDataset = defineDataset("canonical.room-readings", {
+      schema: [
+        col("room_id", "string"),
+        col("observed_at", "timestamp"),
+        col("temperature", "float64"),
+      ],
+    })
+    const telemetryProjection = {
+      _tag: "TelemetryProjectionDefinition" as const,
+      id: "room-temperatures",
+      objectTypeId: "Room",
+      propertyId: "temperature",
+      datasetId: "canonical.room-readings",
+      objectIdField: "room_id",
+      atField: "missing_observed_at",
+      valueField: "temperature",
+    }
+
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        datasets: [roomReadingsDataset],
+        projections: [telemetryProjection],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toBeInstanceOf(ProjectionValidationError)
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        datasets: [roomReadingsDataset],
+        projections: [telemetryProjection],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toThrow('at field "missing_observed_at" references unknown dataset column')
+  })
+
+  test("validates telemetry projection targeting a telemetry property", async () => {
+    const projectRoot = await createTempProjectRoot()
+
+    const Room = defineObjectType({
+      id: "Room",
+      name: "Room",
+      properties: [
+        prop("id", "string", { required: true, primary: true }),
+        prop("temperature", "double"),
+      ],
+    })
+    const roomReadingsDataset = defineDataset("canonical.room-readings", {
+      schema: [
+        col("room_id", "string"),
+        col("observed_at", "timestamp"),
+        col("temperature", "float64"),
+      ],
+    })
+    const telemetryProjection = {
+      _tag: "TelemetryProjectionDefinition" as const,
+      id: "room-temperatures",
+      objectTypeId: "Room",
+      propertyId: "temperature",
+      datasetId: "canonical.room-readings",
+      objectIdField: "room_id",
+      atField: "observed_at",
+      valueField: "temperature",
+    }
+
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        datasets: [roomReadingsDataset],
+        projections: [telemetryProjection],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toBeInstanceOf(ProjectionValidationError)
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        datasets: [roomReadingsDataset],
+        projections: [telemetryProjection],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toThrow('property "temperature" on type "Room" must be telemetry-enabled')
+  })
+
   test("treats missing projections folder as empty", async () => {
     const projectRoot = await createTempProjectRoot()
 
@@ -1093,6 +1338,7 @@ export const Room = defineObjectType({
 
     expect(sixb.getObjectProjections()).toEqual([])
     expect(sixb.getLinkProjections()).toEqual([])
+    expect(sixb.getTelemetryProjections()).toEqual([])
   })
 
   test("validates projection referencing unknown type", async () => {

--- a/packages/core/tests/in-memory-providers.test.ts
+++ b/packages/core/tests/in-memory-providers.test.ts
@@ -583,6 +583,39 @@ describe("InMemoryTimeseriesStorage", () => {
     expect(latest?.value).toBe(22)
   })
 
+  test("upserts on equal timestamps: one point per instant, last value wins", async () => {
+    const storage = new InMemoryTimeseriesStorage()
+    const at = new Date("2026-01-01T10:00:00Z")
+
+    // A telemetry point is identified by (series, at), so two appends at the
+    // same instant collapse to a single point with the last-written value.
+    await storage.applyTelemetryAppended({
+      ...makeTelemetryEvent("p1", "Room", "r1", "temp", 22, at),
+      id: "evt-1",
+    })
+    await storage.applyTelemetryAppended({
+      ...makeTelemetryEvent("p1", "Room", "r1", "temp", 20, at),
+      id: "evt-2",
+    })
+
+    const history = await storage.getHistory({
+      projectId: "p1",
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temp",
+    })
+    expect(history).toHaveLength(1)
+    expect(history[0]?.value).toBe(20)
+
+    const latest = await storage.getLatest({
+      projectId: "p1",
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temp",
+    })
+    expect(latest?.value).toBe(20)
+  })
+
   test("getHistory returns points in order", async () => {
     const storage = new InMemoryTimeseriesStorage()
     const t1 = new Date("2026-01-01T10:00:00Z")

--- a/packages/core/tests/projection-runs.test.ts
+++ b/packages/core/tests/projection-runs.test.ts
@@ -31,6 +31,9 @@ describe("InMemoryProjectionRunStorage", () => {
       rowsSkipped: 0,
       objectsUpserted: 0,
       linksUpserted: 0,
+      telemetryPointsAppended: 0,
+      telemetryPointsSkipped: 0,
+      telemetryRowsFailed: 0,
     })
 
     const updated = await storage.update({
@@ -39,6 +42,8 @@ describe("InMemoryProjectionRunStorage", () => {
       rowsProcessed: 10,
       rowsSkipped: 2,
       objectsUpserted: 8,
+      telemetryPointsAppended: 3,
+      telemetryPointsSkipped: 1,
     })
 
     expect(updated).toMatchObject({
@@ -46,6 +51,9 @@ describe("InMemoryProjectionRunStorage", () => {
       rowsSkipped: 2,
       objectsUpserted: 8,
       linksUpserted: 0,
+      telemetryPointsAppended: 3,
+      telemetryPointsSkipped: 1,
+      telemetryRowsFailed: 0,
       status: "running",
     })
 
@@ -56,6 +64,8 @@ describe("InMemoryProjectionRunStorage", () => {
       finishedAt,
       rowsProcessed: 12,
       objectsUpserted: 10,
+      telemetryPointsAppended: 4,
+      telemetryRowsFailed: 1,
     })
 
     const stored = await storage.getById({ projectId: "my-app", id: "projrun_1" })
@@ -66,6 +76,9 @@ describe("InMemoryProjectionRunStorage", () => {
       rowsSkipped: 2,
       objectsUpserted: 10,
       linksUpserted: 0,
+      telemetryPointsAppended: 4,
+      telemetryPointsSkipped: 1,
+      telemetryRowsFailed: 1,
       errorMessage: undefined,
     })
     expect(stored?.startedAt.toISOString()).toBe(startedAt.toISOString())
@@ -223,7 +236,7 @@ describe("InMemoryProjectionRunStorage", () => {
         id: "run-1",
         projectId: "my-app",
         status: "succeeded",
-        objectsUpserted: 1.5,
+        telemetryRowsFailed: 1.5,
       })
     ).rejects.toBeInstanceOf(ProjectionRunError)
   })

--- a/packages/core/tests/projection.test.ts
+++ b/packages/core/tests/projection.test.ts
@@ -5,14 +5,17 @@ import {
   defineLinkProjection,
   defineObjectType,
   defineProjection,
+  defineTelemetryProjection,
   fromForeignKey,
   isLinkProjectionDefinition,
   isObjectProjectionDefinition,
   isProjectionDefinition,
+  isTelemetryProjectionDefinition,
   link,
   ProjectionValidationError,
   prop,
 } from "../src"
+import { categorizeProjections } from "../src/projections"
 
 // ── Test fixtures ────────────────────────────────────────────
 
@@ -30,6 +33,7 @@ const Room = defineObjectType({
     prop("name", "string"),
     prop("buildingRef", "string"),
     prop("sensorRef", "string"),
+    prop("temperature", "double", { mode: "telemetry" }),
   ],
   links: [
     link("inBuilding", Building, { cardinality: "one" }),
@@ -52,6 +56,15 @@ const genericDataset = defineDataset("ds", {
 
 const roomSensorsDataset = defineDataset("join.room-sensors", {
   schema: [col("room_id", "string"), col("sensor_id", "string")],
+})
+
+const roomReadingsDataset = defineDataset("canonical.room-readings", {
+  schema: [
+    col("room_id", "string"),
+    col("observed_at", "timestamp"),
+    col("temperature", "float64"),
+    col("unit", "string"),
+  ],
 })
 
 const TypeWithPolymorphicLink = defineObjectType({
@@ -448,6 +461,107 @@ describe("defineLinkProjection", () => {
   })
 })
 
+// ── defineTelemetryProjection ────────────────────────────────
+
+describe("defineTelemetryProjection", () => {
+  test("builds correct TelemetryProjectionDefinition", () => {
+    const result = defineTelemetryProjection("room-temperatures", Room.p.temperature)
+      .fromDataset(roomReadingsDataset)
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        value: "temperature",
+      })
+
+    expect(result._tag).toBe("TelemetryProjectionDefinition")
+    expect(result.id).toBe("room-temperatures")
+    expect(result.objectTypeId).toBe("room")
+    expect(result.propertyId).toBe("temperature")
+    expect(result.datasetId).toBe("canonical.room-readings")
+    expect(result.objectIdField).toBe("room_id")
+    expect(result.atField).toBe("observed_at")
+    expect(result.valueField).toBe("temperature")
+    expect(result.unitField).toBeUndefined()
+  })
+
+  test("builds definition with optional unit field", () => {
+    const result = defineTelemetryProjection("room-temperatures", Room.p.temperature)
+      .fromDataset(roomReadingsDataset)
+      .points({
+        objectId: "room_id",
+        at: "observed_at",
+        value: "temperature",
+        unit: "unit",
+      })
+
+    expect(result.unitField).toBe("unit")
+  })
+
+  test("rejects static property token", () => {
+    expect(() => defineTelemetryProjection("room-names", Room.p.name as never)).toThrow(
+      ProjectionValidationError
+    )
+    expect(() => defineTelemetryProjection("room-names", Room.p.name as never)).toThrow(
+      "must be telemetry-enabled"
+    )
+  })
+
+  test("rejects empty id", () => {
+    expect(() => defineTelemetryProjection("  ", Room.p.temperature)).toThrow(
+      ProjectionValidationError
+    )
+    expect(() => defineTelemetryProjection("  ", Room.p.temperature)).toThrow(
+      "Projection id must not be empty"
+    )
+  })
+
+  test("rejects empty dataset id", () => {
+    const invalidDataset = { kind: "dataset", id: "  ", schema: { columns: [] } } as never
+    expect(() =>
+      defineTelemetryProjection("tp", Room.p.temperature).fromDataset(invalidDataset)
+    ).toThrow(ProjectionValidationError)
+    expect(() =>
+      defineTelemetryProjection("tp", Room.p.temperature).fromDataset(invalidDataset)
+    ).toThrow("Projection dataset id must not be empty")
+  })
+
+  test("rejects missing required point mapping fields", () => {
+    expect(() =>
+      defineTelemetryProjection("tp", Room.p.temperature)
+        .fromDataset(roomReadingsDataset)
+        .points({ objectId: "room_id", value: "temperature" } as never)
+    ).toThrow(ProjectionValidationError)
+    expect(() =>
+      defineTelemetryProjection("tp", Room.p.temperature)
+        .fromDataset(roomReadingsDataset)
+        .points({ objectId: "room_id", value: "temperature" } as never)
+    ).toThrow("requires at")
+  })
+
+  test("rejects unknown point mapping keys", () => {
+    expect(() =>
+      defineTelemetryProjection("tp", Room.p.temperature)
+        .fromDataset(roomReadingsDataset)
+        .points({
+          objectId: "room_id",
+          at: "observed_at",
+          value: "temperature",
+          extra: "room_id",
+        } as never)
+    ).toThrow(ProjectionValidationError)
+    expect(() =>
+      defineTelemetryProjection("tp", Room.p.temperature)
+        .fromDataset(roomReadingsDataset)
+        .points({
+          objectId: "room_id",
+          at: "observed_at",
+          value: "temperature",
+          extra: "room_id",
+        } as never)
+    ).toThrow("unknown key 'extra'")
+  })
+})
+
 // ── Type guards ──────────────────────────────────────────────
 
 describe("type guards", () => {
@@ -459,6 +573,10 @@ describe("type guards", () => {
     .fromDataset(genericDataset)
     .sourceField("a")
     .targetField("b")
+
+  const telemetryDef = defineTelemetryProjection("tp", Room.p.temperature)
+    .fromDataset(roomReadingsDataset)
+    .points({ objectId: "room_id", at: "observed_at", value: "temperature" })
 
   test("isObjectProjectionDefinition — positive", () => {
     expect(isObjectProjectionDefinition(objectDef)).toBe(true)
@@ -480,10 +598,29 @@ describe("type guards", () => {
     expect(isLinkProjectionDefinition({ _tag: "LinkProjectionDefinition" })).toBe(false)
   })
 
+  test("isTelemetryProjectionDefinition — positive", () => {
+    expect(isTelemetryProjectionDefinition(telemetryDef)).toBe(true)
+  })
+
+  test("isTelemetryProjectionDefinition — negative", () => {
+    expect(isTelemetryProjectionDefinition(objectDef)).toBe(false)
+    expect(isTelemetryProjectionDefinition(linkDef)).toBe(false)
+    expect(isTelemetryProjectionDefinition({ _tag: "TelemetryProjectionDefinition" })).toBe(false)
+  })
+
   test("isProjectionDefinition", () => {
     expect(isProjectionDefinition(objectDef)).toBe(true)
     expect(isProjectionDefinition(linkDef)).toBe(true)
+    expect(isProjectionDefinition(telemetryDef)).toBe(true)
     expect(isProjectionDefinition({})).toBe(false)
     expect(isProjectionDefinition("string")).toBe(false)
+  })
+
+  test("categorizeProjections groups telemetry definitions separately", () => {
+    const categorized = categorizeProjections([objectDef, linkDef, telemetryDef])
+
+    expect(categorized.objectProjections).toEqual([objectDef])
+    expect(categorized.linkProjections).toEqual([linkDef])
+    expect(categorized.telemetryProjections).toEqual([telemetryDef])
   })
 })

--- a/packages/core/tests/projection.types.ts
+++ b/packages/core/tests/projection.types.ts
@@ -4,6 +4,7 @@ import {
   defineLinkProjection,
   defineObjectType,
   defineProjection,
+  defineTelemetryProjection,
   defineValueType,
   fromForeignKey,
   link,
@@ -44,6 +45,7 @@ const _Room = defineObjectType({
     prop("area", "double"),
     prop("openedOn", "date"),
     prop("lastSeenAt", "timestamp"),
+    prop("currentTemperature", "double", { mode: "telemetry" }),
     prop("mode", stringEnum(["occupied", "vacant"])),
     prop("metadata", {
       type: "object",
@@ -67,11 +69,13 @@ const roomDataset = defineDataset("canonical.rooms", {
     col("col_ref", "string"),
     col("col_room_number", "int64"),
     col("col_area", "float64"),
+    col("col_temperature", "float64"),
     col("col_opened_on", "date"),
     col("col_last_seen_at", "timestamp"),
     col("col_mode", "string"),
     col("col_metadata", "json"),
     col("col_reading", "decimal"),
+    col("col_unit", "string"),
   ],
 })
 
@@ -215,3 +219,56 @@ defineLinkProjection("test", _Room.l.hasSensors)
   .fromDataset(roomSensorsDataset)
   // @ts-expect-error — link projection fields must be string columns
   .sourceField("weight")
+
+// 14. defineTelemetryProjection with valid telemetry property and point mapping
+const telemetryProjection = defineTelemetryProjection("test", _Room.p.currentTemperature)
+  .fromDataset(roomDataset)
+  .points({
+    objectId: "col_id",
+    at: "col_last_seen_at",
+    value: "col_temperature",
+  })
+type _telemetryProjTag = Expect<
+  Equal<typeof telemetryProjection._tag, "TelemetryProjectionDefinition">
+>
+
+defineTelemetryProjection("test", _Room.p.currentTemperature).fromDataset(roomDataset).points({
+  objectId: "col_id",
+  at: "col_last_seen_at",
+  value: "col_temperature",
+  unit: "col_unit",
+})
+
+// @ts-expect-error — telemetry projections require telemetry property tokens
+defineTelemetryProjection("test", _Room.p.name)
+
+defineTelemetryProjection("test", _Room.p.currentTemperature)
+  .fromDataset(roomDataset)
+  // @ts-expect-error — objectId must be a string dataset column
+  .points({ objectId: "col_room_number", at: "col_last_seen_at", value: "col_temperature" })
+
+defineTelemetryProjection("test", _Room.p.currentTemperature)
+  .fromDataset(roomDataset)
+  // @ts-expect-error — at must be a string, date, or timestamp dataset column
+  .points({ objectId: "col_id", at: "col_area", value: "col_temperature" })
+
+defineTelemetryProjection("test", _Room.p.currentTemperature)
+  .fromDataset(roomDataset)
+  // @ts-expect-error — value column must be compatible with the telemetry property schema
+  .points({ objectId: "col_id", at: "col_last_seen_at", value: "col_name" })
+
+defineTelemetryProjection("test", _Room.p.currentTemperature).fromDataset(roomDataset).points({
+  objectId: "col_id",
+  at: "col_last_seen_at",
+  value: "col_temperature",
+  // @ts-expect-error — unit must be a string dataset column
+  unit: "col_room_number",
+})
+
+defineTelemetryProjection("test", _Room.p.currentTemperature).fromDataset(roomDataset).points({
+  objectId: "col_id",
+  at: "col_last_seen_at",
+  value: "col_temperature",
+  // @ts-expect-error — point mappings only accept objectId, at, value, and unit
+  extra: "col_id",
+})

--- a/packages/core/tests/sixb-runtime.test.ts
+++ b/packages/core/tests/sixb-runtime.test.ts
@@ -736,6 +736,50 @@ describe("Sixb runtime", () => {
     expect(events).toHaveLength(2)
   })
 
+  test("late-arriving telemetry does not replace the object latest value", async () => {
+    const runtimeDeps = createTestRuntimeDeps()
+    const sixb = new Sixb({
+      id: "late-telemetry-test",
+      ontology: [Room],
+      ...runtimeDeps,
+    })
+
+    await sixb.objects(Room).upsert({
+      properties: { id: "room:101", externalId: "RM-101", name: "Conference 101" },
+    })
+
+    await sixb.objects(Room).appendTelemetryBatch([
+      {
+        id: "room:101",
+        properties: { currentTemperature: { value: 23, unit: "degreeCelsius" } },
+        at: new Date("2026-03-02T12:00:00.000Z"),
+      },
+    ])
+
+    await sixb.objects(Room).appendTelemetryBatch([
+      {
+        id: "room:101",
+        properties: { currentTemperature: { value: 21, unit: "degreeCelsius" } },
+        at: new Date("2026-03-01T12:00:00.000Z"),
+      },
+    ])
+
+    const room = await runtimeDeps.storage.objects.getByPrimaryId({
+      projectId: "late-telemetry-test",
+      objectTypeId: "Room",
+      primaryId: "room:101",
+    })
+    expect(room?.properties.currentTemperature).toBe(23)
+
+    const history = await runtimeDeps.storage.timeseries.getHistory({
+      projectId: "late-telemetry-test",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      propertyId: "currentTemperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([21, 23])
+  })
+
   test("appendTelemetryBatch validates all inputs before writing", async () => {
     const sixb = new Sixb({
       id: "batch-validate-test",

--- a/packages/orchestrator/src/compile-routes.ts
+++ b/packages/orchestrator/src/compile-routes.ts
@@ -1,4 +1,4 @@
-import type { DomainEvent, ProjectionDefinition, RunTrigger } from "@sixb/core"
+import { type DomainEvent, projectionKindOf, type RunTrigger } from "@sixb/core"
 import type {
   CompileRoutesDiagnostic,
   CompileRoutesParams,
@@ -152,10 +152,6 @@ function addDatasetVersionCommittedRouteJob(
     },
     job
   )
-}
-
-function projectionKindOf(projection: ProjectionDefinition): "object" | "link" {
-  return projection._tag === "ObjectProjectionDefinition" ? "object" : "link"
 }
 
 function triggerToRoute(trigger: NonScheduleRunTrigger): {

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -2,20 +2,27 @@ import type {
   DatasetVersionCommittedEvent,
   DomainEvent,
   EventsRuntime,
+  LinkProjectionDefinition,
   NewQueueJob,
+  ObjectProjectionDefinition,
   PipelineDefinition,
   PipelineRunFinishedEvent,
   PipelineRunRequestedQueueJob,
-  ProjectionDefinition,
   ProjectionRunRequestedQueueJob,
   Queues,
   ScheduleTriggeredEvent,
   SyncDefinition,
   SyncRunFinishedEvent,
   SyncRunRequestedQueueJob,
+  TelemetryProjectionDefinition,
   WorkflowDefinition,
   WorkflowRunRequestedQueueJob,
 } from "@sixb/core"
+
+export type RoutableProjectionDefinition =
+  | ObjectProjectionDefinition
+  | LinkProjectionDefinition
+  | TelemetryProjectionDefinition
 
 type ScheduleTriggeredRouteKey =
   `${ScheduleTriggeredEvent["type"]}:${ScheduleTriggeredEvent["payload"]["scheduleId"]}`
@@ -58,7 +65,7 @@ export type OrchestratorRoutes = ReadonlyMap<OrchestratorRouteKey, OrchestratorR
 export interface CompileRoutesParams {
   readonly syncs: readonly SyncDefinition[]
   readonly pipelines: readonly PipelineDefinition[]
-  readonly projections?: readonly ProjectionDefinition[]
+  readonly projections?: readonly RoutableProjectionDefinition[]
   readonly workflows?: readonly WorkflowDefinition[]
 }
 

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -2,27 +2,22 @@ import type {
   DatasetVersionCommittedEvent,
   DomainEvent,
   EventsRuntime,
-  LinkProjectionDefinition,
   NewQueueJob,
-  ObjectProjectionDefinition,
   PipelineDefinition,
   PipelineRunFinishedEvent,
   PipelineRunRequestedQueueJob,
+  ProjectionDefinition,
   ProjectionRunRequestedQueueJob,
   Queues,
   ScheduleTriggeredEvent,
   SyncDefinition,
   SyncRunFinishedEvent,
   SyncRunRequestedQueueJob,
-  TelemetryProjectionDefinition,
   WorkflowDefinition,
   WorkflowRunRequestedQueueJob,
 } from "@sixb/core"
 
-export type RoutableProjectionDefinition =
-  | ObjectProjectionDefinition
-  | LinkProjectionDefinition
-  | TelemetryProjectionDefinition
+export type RoutableProjectionDefinition = ProjectionDefinition
 
 type ScheduleTriggeredRouteKey =
   `${ScheduleTriggeredEvent["type"]}:${ScheduleTriggeredEvent["payload"]["scheduleId"]}`

--- a/packages/orchestrator/tests/compile-routes.test.ts
+++ b/packages/orchestrator/tests/compile-routes.test.ts
@@ -12,6 +12,7 @@ import {
   defineProjection,
   defineSchedule,
   defineSync,
+  defineTelemetryProjection,
   defineWorkflow,
   defineWorkflowStep,
   link,
@@ -42,7 +43,10 @@ const Sensor = defineObjectType({
 const Room = defineObjectType({
   id: "room",
   name: "Room",
-  properties: [prop("id", "string", { required: true, primary: true })],
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("temperature", "double", { mode: "telemetry" }),
+  ],
   links: [link("hasSensors", Sensor, { cardinality: "many" })],
 })
 
@@ -55,6 +59,16 @@ function makeDataset(id: string) {
 function makeJoinDataset(id: string) {
   return defineDataset(id, {
     schema: [col("room_id", "string"), col("sensor_id", "string")],
+  })
+}
+
+function makeTelemetryDataset(id: string) {
+  return defineDataset(id, {
+    schema: [
+      col("room_id", "string"),
+      col("observed_at", "timestamp"),
+      col("temperature", "float64"),
+    ],
   })
 }
 
@@ -126,6 +140,12 @@ function makeLinkProjection(id: string, datasetId: string) {
     .fromDataset(makeJoinDataset(datasetId))
     .sourceField("room_id")
     .targetField("sensor_id")
+}
+
+function makeTelemetryProjection(id: string, datasetId: string) {
+  return defineTelemetryProjection(id, Room.p.temperature)
+    .fromDataset(makeTelemetryDataset(datasetId))
+    .points({ objectId: "room_id", at: "observed_at", value: "temperature" })
 }
 
 function getJobs(routes: OrchestratorRoutes, key: OrchestratorRouteKey) {
@@ -441,6 +461,29 @@ describe("compileRoutes", () => {
           projectionId: "room-sensors",
           projectionKind: "link",
           datasetId: "join.room-sensors",
+        },
+      },
+    })
+  })
+
+  test("one telemetry projection produces one projection route", () => {
+    const routes = compileRoutes({
+      syncs: [],
+      pipelines: [],
+      projections: [makeTelemetryProjection("room-temperature", "canonical.room-readings")],
+    })
+
+    expect(routes.size).toBe(1)
+    const jobs = getJobs(routes, "dataset.version.committed:canonical.room-readings")
+    expect(jobs).toHaveLength(1)
+    expect(jobs![0]).toEqual({
+      queue: "projections",
+      job: {
+        type: "projection.run.requested",
+        payload: {
+          projectionId: "room-temperature",
+          projectionKind: "telemetry",
+          datasetId: "canonical.room-readings",
         },
       },
     })

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -10,6 +10,7 @@ import {
 import { ProjectionWorkerError } from "./errors"
 import { resolveProjectionSchema } from "./projection-schema"
 import { normalizeProjectedValue } from "./projection-value-coercion"
+import { isPlainObject } from "./utils"
 
 export interface ObjectProjectionPlan {
   readonly projection: ObjectProjectionDefinition
@@ -201,13 +202,4 @@ function collectForeignKeyValues(
   }
 
   return values
-}
-
-function isPlainObject(value: unknown): value is DatasetRow {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false
-  }
-
-  const prototype = Object.getPrototypeOf(value)
-  return prototype === Object.prototype || prototype === null
 }

--- a/packages/projection-worker/src/run-link-projection.ts
+++ b/packages/projection-worker/src/run-link-projection.ts
@@ -6,18 +6,13 @@ import {
   ObjectNotFoundError,
   objectService,
 } from "@sixb/core"
+import { type FlushContext, runStreamingProjection } from "./run-streaming-projection"
 import type {
   ProjectionExecutionResult,
   ProjectionProgressReporter,
   ProjectionWorkerContext,
 } from "./types"
-import {
-  createZeroCounters,
-  errorMessage,
-  isBlank,
-  snapshotCounters,
-  throwIfAborted,
-} from "./utils"
+import { errorMessage, isBlank } from "./utils"
 
 interface RunLinkProjectionInput {
   readonly runtime: ProjectionWorkerContext
@@ -48,92 +43,73 @@ export async function runLinkProjection(
   input: RunLinkProjectionInput
 ): Promise<ProjectionExecutionResult> {
   const { runtime, projection, dataset, versionId, signal, batchSize, onProgress } = input
-  const counters = createZeroCounters()
+  const readColumns = linkProjectionReadColumns(projection)
   const seenPairs = new Set<string>()
-  const batch: CollectedLinkRow[] = []
-  let firstErrorMessage: string | undefined
 
-  const rememberError = (message: string): void => {
-    firstErrorMessage ??= message
-  }
+  return runStreamingProjection<CollectedLinkRow>({
+    runtime,
+    signal,
+    batchSize,
+    onProgress,
+    spec: {
+      datasetId: projection.datasetId,
+      versionId,
+      readColumns,
+      projectRow(row) {
+        const validationError = getDatasetRowValidationError(row, dataset, { columns: readColumns })
+        if (validationError) {
+          return { status: "fail", errorMessage: validationError }
+        }
 
-  const flushBatch = async (): Promise<void> => {
-    if (batch.length === 0) {
-      return
-    }
+        const linkRow = collectLinkRow(projection, row)
+        if (!linkRow) {
+          return { status: "skip" }
+        }
 
-    const rows = batch.splice(0, batch.length)
-    const linkItems: LinkItem[] = rows.map((row) => ({
-      objectTypeId: projection.sourceObjectTypeId,
-      sourceId: row.sourceId,
-      linkId: projection.linkId,
-      target: {
-        targetTypeId: projection.targetObjectTypeId,
-        targetId: row.targetId,
+        const pairKey = `${linkRow.sourceId}\0${linkRow.targetId}`
+        if (seenPairs.has(pairKey)) {
+          return { status: "skip" }
+        }
+        seenPairs.add(pairKey)
+
+        return { status: "item", item: linkRow }
       },
-    }))
+      flushBatch: (rows, ctx) => flushLinkBatch({ runtime, projection, rows, ctx }),
+    },
+  })
+}
 
-    const linkResults = await objectService.upsertLinkBatch(runtime, linkItems)
-    for (let index = 0; index < linkResults.length; index += 1) {
-      const result = linkResults[index]
-      if (result?.ok) {
-        counters.linksUpserted += 1
-        continue
-      }
+async function flushLinkBatch(input: {
+  readonly runtime: ProjectionWorkerContext
+  readonly projection: LinkProjectionDefinition
+  readonly rows: readonly CollectedLinkRow[]
+  readonly ctx: FlushContext
+}): Promise<void> {
+  const { runtime, projection, rows, ctx } = input
+  const { counters, rememberError } = ctx
 
-      counters.rowsSkipped += 1
-      if (!(result?.error instanceof ObjectNotFoundError)) {
-        rememberError(errorMessage(result?.error))
-      }
-    }
+  const linkItems: LinkItem[] = rows.map((row) => ({
+    objectTypeId: projection.sourceObjectTypeId,
+    sourceId: row.sourceId,
+    linkId: projection.linkId,
+    target: {
+      targetTypeId: projection.targetObjectTypeId,
+      targetId: row.targetId,
+    },
+  }))
 
-    await onProgress?.(snapshotCounters(counters))
-  }
-
-  for await (const row of runtime.lakeStorage.readRows({
-    datasetId: projection.datasetId,
-    versionId,
-    columns: linkProjectionReadColumns(projection),
-  })) {
-    throwIfAborted(signal)
-    counters.rowsProcessed += 1
-
-    const validationError = getDatasetRowValidationError(row, dataset, {
-      columns: linkProjectionReadColumns(projection),
-    })
-    if (validationError) {
-      counters.rowsSkipped += 1
-      rememberError(validationError)
+  const linkResults = await objectService.upsertLinkBatch(runtime, linkItems)
+  for (let index = 0; index < linkResults.length; index += 1) {
+    const result = linkResults[index]
+    if (result?.ok) {
+      counters.linksUpserted += 1
       continue
     }
 
-    const linkRow = collectLinkRow(projection, row)
-    if (!linkRow) {
-      counters.rowsSkipped += 1
-      continue
+    counters.rowsSkipped += 1
+    if (!(result?.error instanceof ObjectNotFoundError)) {
+      rememberError(errorMessage(result?.error))
     }
-
-    const pairKey = `${linkRow.sourceId}\0${linkRow.targetId}`
-    if (seenPairs.has(pairKey)) {
-      counters.rowsSkipped += 1
-      continue
-    }
-    seenPairs.add(pairKey)
-
-    batch.push(linkRow)
-    if (batch.length >= batchSize) {
-      await flushBatch()
-    }
-  }
-
-  throwIfAborted(signal)
-  await flushBatch()
-  throwIfAborted(signal)
-  await onProgress?.(snapshotCounters(counters))
-
-  return {
-    ...snapshotCounters(counters),
-    firstErrorMessage,
   }
 }
 

--- a/packages/projection-worker/src/run-object-projection.ts
+++ b/packages/projection-worker/src/run-object-projection.ts
@@ -9,18 +9,13 @@ import {
   type ProjectedObjectRow,
   projectObjectRow,
 } from "./object-projection-plan"
+import { type FlushContext, runStreamingProjection } from "./run-streaming-projection"
 import type {
   ProjectionExecutionResult,
   ProjectionProgressReporter,
   ProjectionWorkerContext,
 } from "./types"
-import {
-  createZeroCounters,
-  errorMessage,
-  isBlank,
-  snapshotCounters,
-  throwIfAborted,
-} from "./utils"
+import { errorMessage, isBlank } from "./utils"
 
 interface RunObjectProjectionInput {
   readonly runtime: ProjectionWorkerContext
@@ -46,7 +41,6 @@ export async function runObjectProjection(
   input: RunObjectProjectionInput
 ): Promise<ProjectionExecutionResult> {
   const { runtime, projection, dataset, versionId, signal, batchSize, onProgress } = input
-  const counters = createZeroCounters()
   const primaryPropertyId = runtime.ontology.getPrimaryPropertyId(projection.objectTypeId)
   const projectionPlan = buildObjectProjectionPlan({
     ontology: runtime.ontology,
@@ -54,87 +48,69 @@ export async function runObjectProjection(
     dataset,
     primaryPropertyId,
   })
-  const batch: ProjectedObjectRow[] = []
-  let firstErrorMessage: string | undefined
 
-  const rememberError = (message: string): void => {
-    firstErrorMessage ??= message
-  }
+  return runStreamingProjection<ProjectedObjectRow>({
+    runtime,
+    signal,
+    batchSize,
+    onProgress,
+    spec: {
+      datasetId: projection.datasetId,
+      versionId,
+      readColumns: objectProjectionReadColumns(projection),
+      projectRow(row) {
+        const projected = projectObjectRow(projectionPlan, row)
+        if (!projected.ok) {
+          return { status: "fail", errorMessage: projected.errorMessage }
+        }
+        if (isBlank(projected.row.primaryValue)) {
+          return { status: "skip" }
+        }
+        return { status: "item", item: projected.row }
+      },
+      flushBatch: (rows, ctx) => flushObjectBatch({ runtime, projection, rows, ctx }),
+    },
+  })
+}
 
-  const flushBatch = async (): Promise<void> => {
-    if (batch.length === 0) {
-      return
+async function flushObjectBatch(input: {
+  readonly runtime: ProjectionWorkerContext
+  readonly projection: ObjectProjectionDefinition
+  readonly rows: readonly ProjectedObjectRow[]
+  readonly ctx: FlushContext
+}): Promise<void> {
+  const { runtime, projection, rows, ctx } = input
+  const { counters, rememberError } = ctx
+
+  const batchResults = await objectService.upsertObjectBatch(
+    runtime,
+    projection.objectTypeId,
+    rows.map((row) => ({ properties: row.properties }))
+  )
+
+  const succeededRows: ProjectedObjectRow[] = []
+  for (let index = 0; index < rows.length; index += 1) {
+    const result = batchResults[index]
+    const row = rows[index]!
+    if (result?.ok) {
+      counters.objectsUpserted += 1
+      succeededRows.push(row)
+      continue
     }
 
-    const rows = batch.splice(0, batch.length)
-    const batchResults = await objectService.upsertObjectBatch(
-      runtime,
-      projection.objectTypeId,
-      rows.map((row) => ({ properties: row.properties }))
+    counters.rowsSkipped += 1
+    rememberError(
+      `Failed to upsert object '${String(row.primaryValue)}': ${errorMessage(result?.error)}`
     )
-
-    const succeededRows: ProjectedObjectRow[] = []
-    for (let index = 0; index < rows.length; index += 1) {
-      const result = batchResults[index]
-      const row = rows[index]!
-      if (result?.ok) {
-        counters.objectsUpserted += 1
-        succeededRows.push(row)
-        continue
-      }
-
-      counters.rowsSkipped += 1
-      rememberError(
-        `Failed to upsert object '${String(row.primaryValue)}': ${errorMessage(result?.error)}`
-      )
-    }
-
-    await upsertForeignKeyLinks({
-      runtime,
-      projection,
-      rows: succeededRows,
-      counters,
-      rememberError,
-    })
-
-    await onProgress?.(snapshotCounters(counters))
   }
 
-  for await (const row of runtime.lakeStorage.readRows({
-    datasetId: projection.datasetId,
-    versionId,
-    columns: objectProjectionReadColumns(projection),
-  })) {
-    throwIfAborted(signal)
-    counters.rowsProcessed += 1
-
-    const projected = projectObjectRow(projectionPlan, row)
-    if (!projected.ok) {
-      counters.rowsSkipped += 1
-      rememberError(projected.errorMessage)
-      continue
-    }
-
-    if (isBlank(projected.row.primaryValue)) {
-      counters.rowsSkipped += 1
-      continue
-    }
-
-    batch.push(projected.row)
-    if (batch.length >= batchSize) {
-      await flushBatch()
-    }
-  }
-
-  throwIfAborted(signal)
-  await flushBatch()
-  throwIfAborted(signal)
-  await onProgress?.(snapshotCounters(counters))
-
-  return {
-    ...snapshotCounters(counters),
-    firstErrorMessage,
-  }
+  await upsertForeignKeyLinks({
+    runtime,
+    projection,
+    rows: succeededRows,
+    counters,
+    rememberError,
+  })
 }
 
 function objectProjectionReadColumns(projection: ObjectProjectionDefinition): readonly string[] {

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -5,13 +5,14 @@ import type {
   ProjectionRunCounters,
   ProjectionRunRecord,
 } from "@sixb/core"
+import { projectionKindOf } from "@sixb/core"
 import { ProjectionWorkerError } from "./errors"
 import { runLinkProjection } from "./run-link-projection"
 import { runObjectProjection } from "./run-object-projection"
+import { runTelemetryProjection } from "./run-telemetry-projection"
 import {
   assertDatasetVersionMatchesDefinition,
   assertProjectionCompatibleWithDataset,
-  projectionKindOf,
 } from "./schema-validation"
 import type {
   ProjectionExecutionResult,
@@ -33,6 +34,9 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
     rowsSkipped: 0,
     objectsUpserted: 0,
     linksUpserted: 0,
+    telemetryPointsAppended: 0,
+    telemetryPointsSkipped: 0,
+    telemetryRowsFailed: 0,
   }
   let started = false
   let finished = false
@@ -119,6 +123,9 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
       rowsSkipped: counters.rowsSkipped,
       objectsUpserted: counters.objectsUpserted,
       linksUpserted: counters.linksUpserted,
+      telemetryPointsAppended: counters.telemetryPointsAppended,
+      telemetryPointsSkipped: counters.telemetryPointsSkipped,
+      telemetryRowsFailed: counters.telemetryRowsFailed,
       run,
     }
   } catch (error) {
@@ -159,7 +166,19 @@ async function executeProjection(input: {
     })
   }
 
-  return runLinkProjection({
+  if (projection._tag === "LinkProjectionDefinition") {
+    return runLinkProjection({
+      runtime,
+      projection,
+      dataset,
+      versionId: job.versionId,
+      signal,
+      batchSize,
+      onProgress,
+    })
+  }
+
+  return runTelemetryProjection({
     runtime,
     projection,
     dataset,
@@ -294,7 +313,11 @@ async function finishAfterError(input: {
 }
 
 function hasMaterialized(counters: ProjectionRunCounters): boolean {
-  return counters.objectsUpserted > 0 || counters.linksUpserted > 0
+  return (
+    counters.objectsUpserted > 0 ||
+    counters.linksUpserted > 0 ||
+    counters.telemetryPointsAppended > 0
+  )
 }
 
 function copyCounters(
@@ -303,6 +326,9 @@ function copyCounters(
     rowsSkipped: number
     objectsUpserted: number
     linksUpserted: number
+    telemetryPointsAppended: number
+    telemetryPointsSkipped: number
+    telemetryRowsFailed: number
   },
   source: ProjectionRunCounters
 ): void {
@@ -310,6 +336,9 @@ function copyCounters(
   target.rowsSkipped = source.rowsSkipped
   target.objectsUpserted = source.objectsUpserted
   target.linksUpserted = source.linksUpserted
+  target.telemetryPointsAppended = source.telemetryPointsAppended
+  target.telemetryPointsSkipped = source.telemetryPointsSkipped
+  target.telemetryRowsFailed = source.telemetryRowsFailed
 }
 
 function isAbortError(error: unknown): boolean {
@@ -323,7 +352,7 @@ function createBookkeepingError(input: {
   readonly cause: unknown
 }): Error {
   return new ProjectionWorkerError(
-    `[SixbProjectionWorker] Projection '${input.projectionId}' materialized dataset version '${input.datasetVersionId}', but failed to finalize projection run '${input.runId}'. The materialized object/link state may need repair.`,
+    `[SixbProjectionWorker] Projection '${input.projectionId}' materialized dataset version '${input.datasetVersionId}', but failed to finalize projection run '${input.runId}'. The materialized projection state may need repair.`,
     { cause: input.cause }
   )
 }

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -5,7 +5,7 @@ import type {
   ProjectionRunCounters,
   ProjectionRunRecord,
 } from "@sixb/core"
-import { projectionKindOf } from "@sixb/core"
+import { PROJECTION_COUNTER_KEYS, projectionKindOf } from "@sixb/core"
 import { ProjectionWorkerError } from "./errors"
 import { runLinkProjection } from "./run-link-projection"
 import { runObjectProjection } from "./run-object-projection"
@@ -20,7 +20,13 @@ import type {
   ProjectionJobResult,
   RunProjectionJobInput,
 } from "./types"
-import { createAbortError, errorMessage, throwIfAborted } from "./utils"
+import {
+  createAbortError,
+  createZeroCounters,
+  errorMessage,
+  snapshotCounters,
+  throwIfAborted,
+} from "./utils"
 
 const DEFAULT_BATCH_SIZE = 500
 
@@ -29,15 +35,7 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
   const signal = input.signal ?? new AbortController().signal
   const batchSize = input.batchSize ?? DEFAULT_BATCH_SIZE
   const projectId = runtime.projectId
-  const counters = {
-    rowsProcessed: 0,
-    rowsSkipped: 0,
-    objectsUpserted: 0,
-    linksUpserted: 0,
-    telemetryPointsAppended: 0,
-    telemetryPointsSkipped: 0,
-    telemetryRowsFailed: 0,
-  }
+  const counters = createZeroCounters()
   let started = false
   let finished = false
   let runFinishAttempted = false
@@ -84,7 +82,9 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
       },
     })
 
-    copyCounters(counters, execution)
+    for (const key of PROJECTION_COUNTER_KEYS) {
+      counters[key] = execution[key]
+    }
     materialized = hasMaterialized(counters)
 
     if (execution.firstErrorMessage) {
@@ -119,13 +119,7 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
       projectionKind: job.projectionKind,
       datasetId: job.datasetId,
       datasetVersionId: job.versionId,
-      rowsProcessed: counters.rowsProcessed,
-      rowsSkipped: counters.rowsSkipped,
-      objectsUpserted: counters.objectsUpserted,
-      linksUpserted: counters.linksUpserted,
-      telemetryPointsAppended: counters.telemetryPointsAppended,
-      telemetryPointsSkipped: counters.telemetryPointsSkipped,
-      telemetryRowsFailed: counters.telemetryRowsFailed,
+      ...snapshotCounters(counters),
       run,
     }
   } catch (error) {
@@ -318,27 +312,6 @@ function hasMaterialized(counters: ProjectionRunCounters): boolean {
     counters.linksUpserted > 0 ||
     counters.telemetryPointsAppended > 0
   )
-}
-
-function copyCounters(
-  target: {
-    rowsProcessed: number
-    rowsSkipped: number
-    objectsUpserted: number
-    linksUpserted: number
-    telemetryPointsAppended: number
-    telemetryPointsSkipped: number
-    telemetryRowsFailed: number
-  },
-  source: ProjectionRunCounters
-): void {
-  target.rowsProcessed = source.rowsProcessed
-  target.rowsSkipped = source.rowsSkipped
-  target.objectsUpserted = source.objectsUpserted
-  target.linksUpserted = source.linksUpserted
-  target.telemetryPointsAppended = source.telemetryPointsAppended
-  target.telemetryPointsSkipped = source.telemetryPointsSkipped
-  target.telemetryRowsFailed = source.telemetryRowsFailed
 }
 
 function isAbortError(error: unknown): boolean {

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -172,15 +172,21 @@ async function executeProjection(input: {
     })
   }
 
-  return runTelemetryProjection({
-    runtime,
-    projection,
-    dataset,
-    versionId: job.versionId,
-    signal,
-    batchSize,
-    onProgress,
-  })
+  if (projection._tag === "TelemetryProjectionDefinition") {
+    return runTelemetryProjection({
+      runtime,
+      projection,
+      dataset,
+      versionId: job.versionId,
+      signal,
+      batchSize,
+      onProgress,
+    })
+  }
+
+  throw new ProjectionWorkerError(
+    `[SixbProjectionWorker] Unsupported projection kind '${(projection as { _tag: string })._tag}'.`
+  )
 }
 
 function requireProjection(

--- a/packages/projection-worker/src/run-streaming-projection.ts
+++ b/packages/projection-worker/src/run-streaming-projection.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared streaming-batch driver for projection runners.
+ *
+ * Object, link, and telemetry projections all stream dataset rows, project each
+ * into a batch item, and flush in batches. The control flow — counter init,
+ * abort checks, the batchSize-triggered flush, the end-of-stream flush, and
+ * progress reporting — is identical across kinds; only how a row projects, what
+ * a flush writes, and which columns to read differ. Each runner supplies those
+ * via {@link StreamingProjectionSpec}; everything else lives here once.
+ */
+import type { DatasetRow } from "@sixb/core"
+import type {
+  ProjectionExecutionResult,
+  ProjectionProgressReporter,
+  ProjectionWorkerContext,
+} from "./types"
+import {
+  createZeroCounters,
+  type MutableProjectionCounters,
+  snapshotCounters,
+  throwIfAborted,
+} from "./utils"
+
+/** Outcome of projecting one dataset row: queue an item, skip cleanly, or fail. */
+export type RowProjection<TItem> =
+  | { readonly status: "item"; readonly item: TItem }
+  | { readonly status: "skip" }
+  | { readonly status: "fail"; readonly errorMessage: string }
+
+export interface FlushContext {
+  readonly counters: MutableProjectionCounters
+  readonly rememberError: (message: string) => void
+}
+
+export interface StreamingProjectionSpec<TItem> {
+  readonly datasetId: string
+  readonly versionId: string
+  readonly readColumns: readonly string[]
+  /** Projects a raw dataset row into a batch item. May capture a plan, dedup set, etc. */
+  projectRow(row: DatasetRow): RowProjection<TItem>
+  /** Writes a full batch and bumps the kind-specific success counters. */
+  flushBatch(items: readonly TItem[], ctx: FlushContext): Promise<void>
+  /** Optional secondary counter for a clean (blank) skip; rowsSkipped is always bumped by the driver. */
+  onSkip?(counters: MutableProjectionCounters): void
+  /** Optional secondary counter for a row-level projection failure; rowsSkipped is always bumped. */
+  onFail?(counters: MutableProjectionCounters): void
+}
+
+export async function runStreamingProjection<TItem>(input: {
+  readonly runtime: ProjectionWorkerContext
+  readonly signal: AbortSignal
+  readonly batchSize: number
+  readonly onProgress?: ProjectionProgressReporter
+  readonly spec: StreamingProjectionSpec<TItem>
+}): Promise<ProjectionExecutionResult> {
+  const { runtime, signal, batchSize, onProgress, spec } = input
+  const counters = createZeroCounters()
+  const batch: TItem[] = []
+  let firstErrorMessage: string | undefined
+
+  const rememberError = (message: string): void => {
+    firstErrorMessage ??= message
+  }
+
+  const flush = async (): Promise<void> => {
+    if (batch.length === 0) {
+      return
+    }
+    await spec.flushBatch(batch.splice(0, batch.length), { counters, rememberError })
+    await onProgress?.(snapshotCounters(counters))
+  }
+
+  for await (const row of runtime.lakeStorage.readRows({
+    datasetId: spec.datasetId,
+    versionId: spec.versionId,
+    columns: spec.readColumns,
+  })) {
+    throwIfAborted(signal)
+    counters.rowsProcessed += 1
+
+    const projected = spec.projectRow(row)
+    if (projected.status === "fail") {
+      counters.rowsSkipped += 1
+      spec.onFail?.(counters)
+      rememberError(projected.errorMessage)
+      continue
+    }
+    if (projected.status === "skip") {
+      counters.rowsSkipped += 1
+      spec.onSkip?.(counters)
+      continue
+    }
+
+    batch.push(projected.item)
+    if (batch.length >= batchSize) {
+      await flush()
+    }
+  }
+
+  throwIfAborted(signal)
+  await flush()
+  throwIfAborted(signal)
+  await onProgress?.(snapshotCounters(counters))
+
+  return {
+    ...snapshotCounters(counters),
+    firstErrorMessage,
+  }
+}

--- a/packages/projection-worker/src/run-telemetry-projection.ts
+++ b/packages/projection-worker/src/run-telemetry-projection.ts
@@ -1,7 +1,6 @@
 import {
   type DatasetColumnDefinition,
   type DatasetDefinition,
-  type DatasetRow,
   getDatasetRowValidationError,
   ObjectNotFoundError,
   OntologyValidationError,
@@ -18,7 +17,7 @@ import type {
   ProjectionProgressReporter,
   ProjectionWorkerContext,
 } from "./types"
-import { errorMessage, isBlank } from "./utils"
+import { errorMessage, isBlank, isPlainObject } from "./utils"
 
 interface RunTelemetryProjectionInput {
   readonly runtime: ProjectionWorkerContext
@@ -350,13 +349,4 @@ function wallClockMatchesComponents(wallClock: number, components: TimestampComp
 
 function isRecoverableTelemetryRowError(error: unknown): boolean {
   return error instanceof ObjectNotFoundError || error instanceof OntologyValidationError
-}
-
-function isPlainObject(value: unknown): value is DatasetRow {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false
-  }
-
-  const prototype = Object.getPrototypeOf(value)
-  return prototype === Object.prototype || prototype === null
 }

--- a/packages/projection-worker/src/run-telemetry-projection.ts
+++ b/packages/projection-worker/src/run-telemetry-projection.ts
@@ -1,0 +1,331 @@
+import {
+  type DatasetColumnDefinition,
+  type DatasetDefinition,
+  type DatasetRow,
+  getDatasetRowValidationError,
+  ObjectNotFoundError,
+  OntologyValidationError,
+  objectService,
+  type Schema,
+  type TelemetryProjectionDefinition,
+} from "@sixb/core"
+import { ProjectionWorkerError } from "./errors"
+import { resolveProjectionSchema } from "./projection-schema"
+import { normalizeProjectedValue } from "./projection-value-coercion"
+import type {
+  ProjectionExecutionResult,
+  ProjectionProgressReporter,
+  ProjectionWorkerContext,
+} from "./types"
+import {
+  createZeroCounters,
+  errorMessage,
+  isBlank,
+  snapshotCounters,
+  throwIfAborted,
+} from "./utils"
+
+interface RunTelemetryProjectionInput {
+  readonly runtime: ProjectionWorkerContext
+  readonly projection: TelemetryProjectionDefinition
+  readonly dataset: DatasetDefinition
+  readonly versionId: string
+  readonly signal: AbortSignal
+  readonly batchSize: number
+  readonly onProgress?: ProjectionProgressReporter
+}
+
+interface TelemetryProjectionPlan {
+  readonly projection: TelemetryProjectionDefinition
+  readonly dataset: DatasetDefinition
+  readonly valueColumnType: DatasetColumnDefinition["type"]
+  readonly valueSchema: Schema
+  readonly readColumns: readonly string[]
+}
+
+interface ProjectedTelemetryItem {
+  readonly id: string
+  readonly properties: Record<string, unknown>
+  readonly at: Date
+}
+
+type ProjectTelemetryRowResult =
+  | { readonly ok: true; readonly item: ProjectedTelemetryItem | null }
+  | { readonly ok: false; readonly errorMessage: string }
+
+/**
+ * Telemetry projections append points keyed by (object, property, at); the
+ * timeseries store upserts on that identity, so replays are idempotent without
+ * any worker-side dedup ledger. This mirrors the object/link projections:
+ * read rows, project each, append in batches.
+ */
+export async function runTelemetryProjection(
+  input: RunTelemetryProjectionInput
+): Promise<ProjectionExecutionResult> {
+  const { runtime, projection, dataset, versionId, signal, batchSize, onProgress } = input
+  const counters = createZeroCounters()
+  const projectionPlan = buildTelemetryProjectionPlan({ runtime, projection, dataset })
+  const batch: ProjectedTelemetryItem[] = []
+  let firstErrorMessage: string | undefined
+
+  const rememberError = (message: string): void => {
+    firstErrorMessage ??= message
+  }
+
+  const appendItems = async (items: readonly ProjectedTelemetryItem[]): Promise<void> => {
+    await objectService.appendTelemetry(runtime, projection.objectTypeId, items)
+  }
+
+  const appendSingleItem = async (item: ProjectedTelemetryItem): Promise<void> => {
+    try {
+      await appendItems([item])
+      counters.telemetryPointsAppended += 1
+      await onProgress?.(snapshotCounters(counters))
+    } catch (error) {
+      if (error instanceof ObjectNotFoundError) {
+        // A reading for an object that does not exist yet is a benign, retryable
+        // skip (matching object/link projections); a later run after the object
+        // is created appends the point.
+        counters.rowsSkipped += 1
+        counters.telemetryPointsSkipped += 1
+        return
+      }
+      if (!isRecoverableTelemetryRowError(error)) {
+        throw error
+      }
+      counters.rowsSkipped += 1
+      counters.telemetryRowsFailed += 1
+      rememberError(errorMessage(error))
+    }
+  }
+
+  const flushBatch = async (): Promise<void> => {
+    if (batch.length === 0) {
+      return
+    }
+    const items = batch.splice(0, batch.length)
+    try {
+      await appendItems(items)
+      counters.telemetryPointsAppended += items.length
+      await onProgress?.(snapshotCounters(counters))
+    } catch (error) {
+      if (!isRecoverableTelemetryRowError(error)) {
+        throw error
+      }
+      // Isolate the failing row: re-apply individually so the good rows still land.
+      for (const item of items) {
+        await appendSingleItem(item)
+      }
+    }
+  }
+
+  for await (const row of runtime.lakeStorage.readRows({
+    datasetId: projection.datasetId,
+    versionId,
+    columns: projectionPlan.readColumns,
+  })) {
+    throwIfAborted(signal)
+    counters.rowsProcessed += 1
+
+    const projected = projectTelemetryRow(projectionPlan, row)
+    if (!projected.ok) {
+      counters.rowsSkipped += 1
+      counters.telemetryRowsFailed += 1
+      rememberError(projected.errorMessage)
+      continue
+    }
+    if (!projected.item) {
+      counters.rowsSkipped += 1
+      counters.telemetryPointsSkipped += 1
+      continue
+    }
+
+    batch.push(projected.item)
+    if (batch.length >= batchSize) {
+      await flushBatch()
+    }
+  }
+
+  throwIfAborted(signal)
+  await flushBatch()
+  throwIfAborted(signal)
+  await onProgress?.(snapshotCounters(counters))
+
+  return {
+    ...snapshotCounters(counters),
+    firstErrorMessage,
+  }
+}
+
+function buildTelemetryProjectionPlan(input: {
+  readonly runtime: ProjectionWorkerContext
+  readonly projection: TelemetryProjectionDefinition
+  readonly dataset: DatasetDefinition
+}): TelemetryProjectionPlan {
+  const { runtime, projection, dataset } = input
+  const objectType = runtime.ontology.getObjectTypeById(projection.objectTypeId)
+  const property = objectType?.properties.find(
+    (candidate) => candidate.id === projection.propertyId
+  )
+  const valueColumn = dataset.schema.columns.find((column) => column.name === projection.valueField)
+
+  if (!objectType || !property || !valueColumn) {
+    throw new ProjectionWorkerError(
+      `[SixbProjectionWorker] Telemetry projection '${projection.id}' was not validated before execution.`
+    )
+  }
+
+  return {
+    projection,
+    dataset,
+    valueColumnType: valueColumn.type,
+    valueSchema: resolveProjectionSchema(property.schema, runtime.ontology.getValueTypesById()),
+    readColumns: telemetryProjectionReadColumns(projection),
+  }
+}
+
+function telemetryProjectionReadColumns(
+  projection: TelemetryProjectionDefinition
+): readonly string[] {
+  return [
+    ...new Set([
+      projection.objectIdField,
+      projection.atField,
+      projection.valueField,
+      ...(projection.unitField !== undefined ? [projection.unitField] : []),
+    ]),
+  ]
+}
+
+function projectTelemetryRow(
+  plan: TelemetryProjectionPlan,
+  row: unknown
+): ProjectTelemetryRowResult {
+  const { projection, dataset } = plan
+  const rowValidationError = getDatasetRowValidationError(row, dataset, {
+    columns: plan.readColumns,
+  })
+  if (rowValidationError) {
+    return { ok: false, errorMessage: rowValidationError }
+  }
+
+  if (!isPlainObject(row)) {
+    return {
+      ok: false,
+      errorMessage: `Dataset '${dataset.id}' rows must be plain objects.`,
+    }
+  }
+
+  const objectId = row[projection.objectIdField]
+  const at = row[projection.atField]
+  const value = row[projection.valueField]
+  if (isBlank(objectId) || isBlank(at) || isBlank(value)) {
+    return { ok: true, item: null }
+  }
+
+  const parsedAt = parseTelemetryTimestamp(at)
+  if (!parsedAt) {
+    return {
+      ok: false,
+      errorMessage: `[SixbProjectionWorker] Telemetry projection '${projection.id}' at field '${projection.atField}' has invalid timestamp value '${String(at)}'.`,
+    }
+  }
+
+  const normalized = normalizeProjectedValue({
+    columnType: plan.valueColumnType,
+    schema: plan.valueSchema,
+    value,
+  })
+  if (!normalized.ok) {
+    return {
+      ok: false,
+      errorMessage: `[SixbProjectionWorker] Telemetry projection '${projection.id}' value from dataset column '${projection.valueField}' (${plan.valueColumnType}) ${normalized.errorMessage}.`,
+    }
+  }
+
+  const properties: Record<string, unknown> = {}
+  const unit = projection.unitField === undefined ? undefined : row[projection.unitField]
+  properties[projection.propertyId] = isBlank(unit)
+    ? normalized.value
+    : { value: normalized.value, unit }
+
+  return {
+    ok: true,
+    item: {
+      id: String(objectId),
+      properties,
+      at: parsedAt,
+    },
+  }
+}
+
+// A trailing "Z" or a numeric ±HH:MM / ±HHMM offset names the zone, so the
+// instant is unambiguous and the engine can resolve it as-is.
+const TIMESTAMP_WITH_EXPLICIT_ZONE = /(?:[zZ]|[+-]\d{2}:?\d{2})$/
+
+// Zone-less calendar date or datetime, tolerating non-zero-padded month / day /
+// hour fields. Capture groups: year, month, day, hour, minute, second, fraction.
+const ZONE_LESS_TIMESTAMP =
+  /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?)?$/
+
+// Parse a telemetry `at` value to an absolute instant. Zone-less inputs are
+// interpreted as UTC by building the instant from explicit components via
+// Date.UTC, so a row materializes at the same instant regardless of the worker
+// process timezone. We never hand a zone-less string to new Date(), which would
+// silently fall back to local-time parsing for any non-ISO (e.g. non-padded)
+// form and break the (series, at) idempotency invariant across worker hosts.
+export function parseTelemetryTimestamp(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value
+  }
+  if (typeof value !== "string") {
+    return null
+  }
+  const trimmed = value.trim()
+
+  if (TIMESTAMP_WITH_EXPLICIT_ZONE.test(trimmed)) {
+    const date = new Date(trimmed)
+    return Number.isNaN(date.getTime()) ? null : date
+  }
+
+  const match = ZONE_LESS_TIMESTAMP.exec(trimmed)
+  if (match === null) {
+    return null
+  }
+  const [, year, month, day, hour, minute, second, fraction] = match
+  const milliseconds = fraction === undefined ? 0 : Math.trunc(Number(`0.${fraction}`) * 1000)
+  const date = new Date(
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      hour === undefined ? 0 : Number(hour),
+      minute === undefined ? 0 : Number(minute),
+      second === undefined ? 0 : Number(second),
+      milliseconds
+    )
+  )
+  // Reject calendar rollover (e.g. "2026-13-01" → 2027) so an out-of-range
+  // timestamp is flagged as invalid rather than silently shifted.
+  if (
+    date.getUTCFullYear() !== Number(year) ||
+    date.getUTCMonth() !== Number(month) - 1 ||
+    date.getUTCDate() !== Number(day)
+  ) {
+    return null
+  }
+  return date
+}
+
+function isRecoverableTelemetryRowError(error: unknown): boolean {
+  return error instanceof ObjectNotFoundError || error instanceof OntologyValidationError
+}
+
+function isPlainObject(value: unknown): value is DatasetRow {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}

--- a/packages/projection-worker/src/run-telemetry-projection.ts
+++ b/packages/projection-worker/src/run-telemetry-projection.ts
@@ -12,18 +12,13 @@ import {
 import { ProjectionWorkerError } from "./errors"
 import { resolveProjectionSchema } from "./projection-schema"
 import { normalizeProjectedValue } from "./projection-value-coercion"
+import { type FlushContext, runStreamingProjection } from "./run-streaming-projection"
 import type {
   ProjectionExecutionResult,
   ProjectionProgressReporter,
   ProjectionWorkerContext,
 } from "./types"
-import {
-  createZeroCounters,
-  errorMessage,
-  isBlank,
-  snapshotCounters,
-  throwIfAborted,
-} from "./utils"
+import { errorMessage, isBlank } from "./utils"
 
 interface RunTelemetryProjectionInput {
   readonly runtime: ProjectionWorkerContext
@@ -57,103 +52,97 @@ type ProjectTelemetryRowResult =
  * Telemetry projections append points keyed by (object, property, at); the
  * timeseries store upserts on that identity, so replays are idempotent without
  * any worker-side dedup ledger. This mirrors the object/link projections:
- * read rows, project each, append in batches.
+ * read rows, project each, append in batches — sharing the streaming-batch
+ * driver and contributing only the telemetry-specific row projection and flush.
  */
 export async function runTelemetryProjection(
   input: RunTelemetryProjectionInput
 ): Promise<ProjectionExecutionResult> {
   const { runtime, projection, dataset, versionId, signal, batchSize, onProgress } = input
-  const counters = createZeroCounters()
   const projectionPlan = buildTelemetryProjectionPlan({ runtime, projection, dataset })
-  const batch: ProjectedTelemetryItem[] = []
-  let firstErrorMessage: string | undefined
 
-  const rememberError = (message: string): void => {
-    firstErrorMessage ??= message
-  }
-
-  const appendItems = async (items: readonly ProjectedTelemetryItem[]): Promise<void> => {
-    await objectService.appendTelemetry(runtime, projection.objectTypeId, items)
-  }
-
-  const appendSingleItem = async (item: ProjectedTelemetryItem): Promise<void> => {
-    try {
-      await appendItems([item])
-      counters.telemetryPointsAppended += 1
-      await onProgress?.(snapshotCounters(counters))
-    } catch (error) {
-      if (error instanceof ObjectNotFoundError) {
-        // A reading for an object that does not exist yet is a benign, retryable
-        // skip (matching object/link projections); a later run after the object
-        // is created appends the point.
-        counters.rowsSkipped += 1
+  return runStreamingProjection<ProjectedTelemetryItem>({
+    runtime,
+    signal,
+    batchSize,
+    onProgress,
+    spec: {
+      datasetId: projection.datasetId,
+      versionId,
+      readColumns: projectionPlan.readColumns,
+      projectRow(row) {
+        const projected = projectTelemetryRow(projectionPlan, row)
+        if (!projected.ok) {
+          return { status: "fail", errorMessage: projected.errorMessage }
+        }
+        if (!projected.item) {
+          return { status: "skip" }
+        }
+        return { status: "item", item: projected.item }
+      },
+      // A blank reading is a clean skip; an invalid projection is a row failure.
+      onSkip: (counters) => {
         counters.telemetryPointsSkipped += 1
-        return
-      }
-      if (!isRecoverableTelemetryRowError(error)) {
-        throw error
-      }
-      counters.rowsSkipped += 1
-      counters.telemetryRowsFailed += 1
-      rememberError(errorMessage(error))
+      },
+      onFail: (counters) => {
+        counters.telemetryRowsFailed += 1
+      },
+      flushBatch: (items, ctx) => appendTelemetryItems({ runtime, projection, items, ctx }),
+    },
+  })
+}
+
+async function appendTelemetryItems(input: {
+  readonly runtime: ProjectionWorkerContext
+  readonly projection: TelemetryProjectionDefinition
+  readonly items: readonly ProjectedTelemetryItem[]
+  readonly ctx: FlushContext
+}): Promise<void> {
+  const { runtime, projection, items, ctx } = input
+  const { counters, rememberError } = ctx
+
+  const appendItems = (batch: readonly ProjectedTelemetryItem[]): Promise<void> =>
+    objectService.appendTelemetry(runtime, projection.objectTypeId, batch)
+
+  try {
+    await appendItems(items)
+    counters.telemetryPointsAppended += items.length
+  } catch (error) {
+    if (!isRecoverableTelemetryRowError(error)) {
+      throw error
+    }
+    // Isolate the failing row: re-apply individually so the good rows still land.
+    for (const item of items) {
+      await appendSingleTelemetryItem({ appendItems, item, counters, rememberError })
     }
   }
+}
 
-  const flushBatch = async (): Promise<void> => {
-    if (batch.length === 0) {
-      return
-    }
-    const items = batch.splice(0, batch.length)
-    try {
-      await appendItems(items)
-      counters.telemetryPointsAppended += items.length
-      await onProgress?.(snapshotCounters(counters))
-    } catch (error) {
-      if (!isRecoverableTelemetryRowError(error)) {
-        throw error
-      }
-      // Isolate the failing row: re-apply individually so the good rows still land.
-      for (const item of items) {
-        await appendSingleItem(item)
-      }
-    }
-  }
-
-  for await (const row of runtime.lakeStorage.readRows({
-    datasetId: projection.datasetId,
-    versionId,
-    columns: projectionPlan.readColumns,
-  })) {
-    throwIfAborted(signal)
-    counters.rowsProcessed += 1
-
-    const projected = projectTelemetryRow(projectionPlan, row)
-    if (!projected.ok) {
-      counters.rowsSkipped += 1
-      counters.telemetryRowsFailed += 1
-      rememberError(projected.errorMessage)
-      continue
-    }
-    if (!projected.item) {
+async function appendSingleTelemetryItem(input: {
+  readonly appendItems: (batch: readonly ProjectedTelemetryItem[]) => Promise<void>
+  readonly item: ProjectedTelemetryItem
+  readonly counters: FlushContext["counters"]
+  readonly rememberError: FlushContext["rememberError"]
+}): Promise<void> {
+  const { appendItems, item, counters, rememberError } = input
+  try {
+    await appendItems([item])
+    counters.telemetryPointsAppended += 1
+  } catch (error) {
+    if (error instanceof ObjectNotFoundError) {
+      // A reading for an object that does not exist yet is a benign, retryable
+      // skip (matching object/link projections); a later run after the object
+      // is created appends the point.
       counters.rowsSkipped += 1
       counters.telemetryPointsSkipped += 1
-      continue
+      return
     }
-
-    batch.push(projected.item)
-    if (batch.length >= batchSize) {
-      await flushBatch()
+    if (!isRecoverableTelemetryRowError(error)) {
+      throw error
     }
-  }
-
-  throwIfAborted(signal)
-  await flushBatch()
-  throwIfAborted(signal)
-  await onProgress?.(snapshotCounters(counters))
-
-  return {
-    ...snapshotCounters(counters),
-    firstErrorMessage,
+    counters.rowsSkipped += 1
+    counters.telemetryRowsFailed += 1
+    rememberError(errorMessage(error))
   }
 }
 

--- a/packages/projection-worker/src/run-telemetry-projection.ts
+++ b/packages/projection-worker/src/run-telemetry-projection.ts
@@ -248,21 +248,30 @@ function projectTelemetryRow(
   }
 }
 
-// A trailing "Z" or a numeric ±HH:MM / ±HHMM offset names the zone, so the
-// instant is unambiguous and the engine can resolve it as-is.
-const TIMESTAMP_WITH_EXPLICIT_ZONE = /(?:[zZ]|[+-]\d{2}:?\d{2})$/
+// Calendar date or datetime with an optional zone designator. Tolerates
+// non-zero-padded month / day / hour fields. A trailing "Z" or a numeric
+// ±HH:MM / ±HHMM offset names the zone; its absence means UTC. Capture groups:
+// year, month, day, hour, minute, second, fraction, zone.
+const TELEMETRY_TIMESTAMP =
+  /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?)?([zZ]|[+-]\d{2}:?\d{2})?$/
 
-// Zone-less calendar date or datetime, tolerating non-zero-padded month / day /
-// hour fields. Capture groups: year, month, day, hour, minute, second, fraction.
-const ZONE_LESS_TIMESTAMP =
-  /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[ T](\d{1,2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?)?$/
+interface TimestampComponents {
+  readonly year: number
+  readonly month: number
+  readonly day: number
+  readonly hour: number
+  readonly minute: number
+  readonly second: number
+  readonly milliseconds: number
+}
 
-// Parse a telemetry `at` value to an absolute instant. Zone-less inputs are
-// interpreted as UTC by building the instant from explicit components via
-// Date.UTC, so a row materializes at the same instant regardless of the worker
-// process timezone. We never hand a zone-less string to new Date(), which would
-// silently fall back to local-time parsing for any non-ISO (e.g. non-padded)
-// form and break the (series, at) idempotency invariant across worker hosts.
+// Parse a telemetry `at` value to an absolute instant from explicit calendar
+// components, never via new Date(string) — which would fall back to local-time
+// parsing for non-ISO forms and silently roll over out-of-range fields. The
+// written wall-clock fields are validated as a real calendar date/time
+// (timezone-independent) before the named offset is applied, so a row
+// materializes at the same instant regardless of the worker process timezone
+// and an invalid timestamp is rejected rather than shifted.
 export function parseTelemetryTimestamp(value: unknown): Date | null {
   if (value instanceof Date) {
     return Number.isNaN(value.getTime()) ? null : value
@@ -270,40 +279,73 @@ export function parseTelemetryTimestamp(value: unknown): Date | null {
   if (typeof value !== "string") {
     return null
   }
-  const trimmed = value.trim()
 
-  if (TIMESTAMP_WITH_EXPLICIT_ZONE.test(trimmed)) {
-    const date = new Date(trimmed)
-    return Number.isNaN(date.getTime()) ? null : date
-  }
-
-  const match = ZONE_LESS_TIMESTAMP.exec(trimmed)
+  const match = TELEMETRY_TIMESTAMP.exec(value.trim())
   if (match === null) {
     return null
   }
-  const [, year, month, day, hour, minute, second, fraction] = match
-  const milliseconds = fraction === undefined ? 0 : Math.trunc(Number(`0.${fraction}`) * 1000)
-  const date = new Date(
-    Date.UTC(
-      Number(year),
-      Number(month) - 1,
-      Number(day),
-      hour === undefined ? 0 : Number(hour),
-      minute === undefined ? 0 : Number(minute),
-      second === undefined ? 0 : Number(second),
-      milliseconds
-    )
-  )
-  // Reject calendar rollover (e.g. "2026-13-01" → 2027) so an out-of-range
-  // timestamp is flagged as invalid rather than silently shifted.
-  if (
-    date.getUTCFullYear() !== Number(year) ||
-    date.getUTCMonth() !== Number(month) - 1 ||
-    date.getUTCDate() !== Number(day)
-  ) {
+  const [, year, month, day, hour, minute, second, fraction, zone] = match
+
+  const offsetMinutes = parseZoneOffsetMinutes(zone)
+  if (offsetMinutes === null) {
     return null
   }
-  return date
+
+  const components: TimestampComponents = {
+    year: Number(year),
+    month: Number(month),
+    day: Number(day),
+    hour: hour === undefined ? 0 : Number(hour),
+    minute: minute === undefined ? 0 : Number(minute),
+    second: second === undefined ? 0 : Number(second),
+    milliseconds: fraction === undefined ? 0 : Math.trunc(Number(`0.${fraction}`) * 1000),
+  }
+
+  // Build the wall-clock instant as if UTC, then re-read every field to reject
+  // any that rolled over (e.g. "2026-02-29", "...09:99", "...24:00"). Calendar
+  // validity is timezone-independent, so this guards both zone-less and zoned
+  // inputs; only after it round-trips do we shift by the offset.
+  const wallClock = Date.UTC(
+    components.year,
+    components.month - 1,
+    components.day,
+    components.hour,
+    components.minute,
+    components.second,
+    components.milliseconds
+  )
+  if (!wallClockMatchesComponents(wallClock, components)) {
+    return null
+  }
+
+  return new Date(wallClock - offsetMinutes * 60_000)
+}
+
+// Returns the offset in minutes to subtract from the wall-clock UTC instant, or
+// null if the offset is out of range. Zone-less and "Z" inputs are UTC (0).
+function parseZoneOffsetMinutes(zone: string | undefined): number | null {
+  if (zone === undefined || zone === "Z" || zone === "z") {
+    return 0
+  }
+  const digits = zone.slice(1).replace(":", "")
+  const hours = Number(digits.slice(0, 2))
+  const minutes = Number(digits.slice(2, 4))
+  if (hours > 23 || minutes > 59) {
+    return null
+  }
+  return (zone[0] === "-" ? -1 : 1) * (hours * 60 + minutes)
+}
+
+function wallClockMatchesComponents(wallClock: number, components: TimestampComponents): boolean {
+  const date = new Date(wallClock)
+  return (
+    date.getUTCFullYear() === components.year &&
+    date.getUTCMonth() === components.month - 1 &&
+    date.getUTCDate() === components.day &&
+    date.getUTCHours() === components.hour &&
+    date.getUTCMinutes() === components.minute &&
+    date.getUTCSeconds() === components.second
+  )
 }
 
 function isRecoverableTelemetryRowError(error: unknown): boolean {

--- a/packages/projection-worker/src/schema-validation.ts
+++ b/packages/projection-worker/src/schema-validation.ts
@@ -10,14 +10,11 @@ import type {
   Schema,
   ValueType,
 } from "@sixb/core"
+import { validateTelemetryProjectionFieldMapping } from "@sixb/core"
 import { ProjectionWorkerError } from "./errors"
 import { isIntegerEnumSchema, resolveProjectionSchema } from "./projection-schema"
 
 type DatasetColumnsByName = Map<string, DatasetColumnDefinition>
-
-export function projectionKindOf(projection: ProjectionDefinition): "object" | "link" {
-  return projection._tag === "ObjectProjectionDefinition" ? "object" : "link"
-}
 
 export function assertDatasetVersionMatchesDefinition(input: {
   readonly dataset: DatasetDefinition
@@ -156,6 +153,78 @@ export function assertProjectionCompatibleWithDataset(input: {
     return
   }
 
+  if (projection._tag === "TelemetryProjectionDefinition") {
+    const objectType = requireObjectType(
+      ontology,
+      projection.objectTypeId,
+      projection.id,
+      "object type"
+    )
+    // Existence + telemetry-mode + field-mapping rules are owned by core so the
+    // startup and worker checks share one implementation and cannot drift. The
+    // worker then layers dataset-version column type compatibility on top.
+    const datasetColumnNames = new Set(dataset.schema.columns.map((column) => column.name))
+    const property = validateTelemetryProjectionFieldMapping(
+      projection,
+      objectType,
+      datasetColumnNames,
+      `Projection "${projection.id}"`
+    )
+
+    const objectIdColumn = requireColumn(
+      columnsByName,
+      dataset.id,
+      projection.objectIdField,
+      projection.id
+    )
+    if (objectIdColumn.type !== "string") {
+      throw new ProjectionWorkerError(
+        `[SixbProjectionWorker] Telemetry projection '${projection.id}' objectId field '${projection.objectIdField}' must be a string dataset column.`
+      )
+    }
+
+    const atColumn = requireColumn(columnsByName, dataset.id, projection.atField, projection.id)
+    if (!isDateLikeColumnType(atColumn.type)) {
+      throw new ProjectionWorkerError(
+        `[SixbProjectionWorker] Telemetry projection '${projection.id}' at field '${projection.atField}' must be a string, date, or timestamp dataset column.`
+      )
+    }
+
+    const valueColumn = requireColumn(
+      columnsByName,
+      dataset.id,
+      projection.valueField,
+      projection.id
+    )
+    if (
+      !isDatasetColumnCompatibleWithSchema(
+        valueColumn.type,
+        property.schema,
+        ontology.getValueTypesById()
+      )
+    ) {
+      throw new ProjectionWorkerError(
+        `[SixbProjectionWorker] Telemetry projection '${projection.id}' maps dataset column '${valueColumn.name}' (${valueColumn.type}) to incompatible property '${projection.propertyId}'.`
+      )
+    }
+
+    if (projection.unitField !== undefined) {
+      const unitColumn = requireColumn(
+        columnsByName,
+        dataset.id,
+        projection.unitField,
+        projection.id
+      )
+      if (unitColumn.type !== "string") {
+        throw new ProjectionWorkerError(
+          `[SixbProjectionWorker] Telemetry projection '${projection.id}' unit field '${projection.unitField}' must be a string dataset column.`
+        )
+      }
+    }
+
+    return
+  }
+
   const sourceObjectType = requireObjectType(
     ontology,
     projection.sourceObjectTypeId,
@@ -268,6 +337,10 @@ function requireColumn(
     )
   }
   return column
+}
+
+function isDateLikeColumnType(type: DatasetColumnDefinition["type"]): boolean {
+  return type === "string" || type === "date" || type === "timestamp"
 }
 
 function isDatasetColumnCompatibleWithSchema(

--- a/packages/projection-worker/src/schema-validation.ts
+++ b/packages/projection-worker/src/schema-validation.ts
@@ -168,7 +168,7 @@ export function assertProjectionCompatibleWithDataset(input: {
       projection,
       objectType,
       datasetColumnNames,
-      `Projection "${projection.id}"`
+      `[SixbProjectionWorker] Projection "${projection.id}"`
     )
 
     const objectIdColumn = requireColumn(

--- a/packages/projection-worker/src/types.ts
+++ b/packages/projection-worker/src/types.ts
@@ -8,6 +8,7 @@ import type {
   ProjectionRunRecord,
   ProjectionRunStorage,
   SixbRuntimeContext,
+  TelemetryProjectionDefinition,
 } from "@sixb/core"
 
 export interface ProjectionWorkerContext extends SixbRuntimeContext {
@@ -20,6 +21,7 @@ export interface ProjectionWorkerSixb extends SixbRuntimeContext {
   readonly id: string
   getObjectProjections(): readonly ObjectProjectionDefinition[]
   getLinkProjections(): readonly LinkProjectionDefinition[]
+  getTelemetryProjections(): readonly TelemetryProjectionDefinition[]
   getDatasetById(datasetId: string): DatasetDefinition | null
   getProjectionById(projectionId: string): ProjectionDefinition | null
 }

--- a/packages/projection-worker/src/utils.ts
+++ b/packages/projection-worker/src/utils.ts
@@ -1,37 +1,17 @@
-import type { ProjectionRunCounters } from "@sixb/core"
+import { type ProjectionRunCounters, zeroProjectionRunCounters } from "@sixb/core"
 
+// A writable view of the canonical counter shape, derived so the field set
+// stays in lockstep with ProjectionRunCounters.
 export type MutableProjectionCounters = {
-  rowsProcessed: number
-  rowsSkipped: number
-  objectsUpserted: number
-  linksUpserted: number
-  telemetryPointsAppended: number
-  telemetryPointsSkipped: number
-  telemetryRowsFailed: number
+  -readonly [K in keyof ProjectionRunCounters]: ProjectionRunCounters[K]
 }
 
 export function createZeroCounters(): MutableProjectionCounters {
-  return {
-    rowsProcessed: 0,
-    rowsSkipped: 0,
-    objectsUpserted: 0,
-    linksUpserted: 0,
-    telemetryPointsAppended: 0,
-    telemetryPointsSkipped: 0,
-    telemetryRowsFailed: 0,
-  }
+  return { ...zeroProjectionRunCounters() }
 }
 
 export function snapshotCounters(counters: MutableProjectionCounters): ProjectionRunCounters {
-  return {
-    rowsProcessed: counters.rowsProcessed,
-    rowsSkipped: counters.rowsSkipped,
-    objectsUpserted: counters.objectsUpserted,
-    linksUpserted: counters.linksUpserted,
-    telemetryPointsAppended: counters.telemetryPointsAppended,
-    telemetryPointsSkipped: counters.telemetryPointsSkipped,
-    telemetryRowsFailed: counters.telemetryRowsFailed,
-  }
+  return { ...counters }
 }
 
 export function isBlank(value: unknown): boolean {

--- a/packages/projection-worker/src/utils.ts
+++ b/packages/projection-worker/src/utils.ts
@@ -1,4 +1,4 @@
-import { type ProjectionRunCounters, zeroProjectionRunCounters } from "@sixb/core"
+import { type DatasetRow, type ProjectionRunCounters, zeroProjectionRunCounters } from "@sixb/core"
 
 // A writable view of the canonical counter shape, derived so the field set
 // stays in lockstep with ProjectionRunCounters.
@@ -32,4 +32,15 @@ export function throwIfAborted(signal: AbortSignal): void {
   if (signal.aborted) {
     throw createAbortError()
   }
+}
+
+// Narrows a raw value to a plain-object dataset row, rejecting class instances
+// and arrays. Shared by the object and telemetry row projectors.
+export function isPlainObject(value: unknown): value is DatasetRow {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }

--- a/packages/projection-worker/src/utils.ts
+++ b/packages/projection-worker/src/utils.ts
@@ -5,6 +5,9 @@ export type MutableProjectionCounters = {
   rowsSkipped: number
   objectsUpserted: number
   linksUpserted: number
+  telemetryPointsAppended: number
+  telemetryPointsSkipped: number
+  telemetryRowsFailed: number
 }
 
 export function createZeroCounters(): MutableProjectionCounters {
@@ -13,6 +16,9 @@ export function createZeroCounters(): MutableProjectionCounters {
     rowsSkipped: 0,
     objectsUpserted: 0,
     linksUpserted: 0,
+    telemetryPointsAppended: 0,
+    telemetryPointsSkipped: 0,
+    telemetryRowsFailed: 0,
   }
 }
 
@@ -22,6 +28,9 @@ export function snapshotCounters(counters: MutableProjectionCounters): Projectio
     rowsSkipped: counters.rowsSkipped,
     objectsUpserted: counters.objectsUpserted,
     linksUpserted: counters.linksUpserted,
+    telemetryPointsAppended: counters.telemetryPointsAppended,
+    telemetryPointsSkipped: counters.telemetryPointsSkipped,
+    telemetryRowsFailed: counters.telemetryRowsFailed,
   }
 }
 

--- a/packages/projection-worker/src/worker.ts
+++ b/packages/projection-worker/src/worker.ts
@@ -11,7 +11,10 @@ export class ProjectionWorker extends QueueWorker<ProjectionRunRequestedQueueJob
   private readonly context: ProjectionWorkerContext
 
   constructor(sixb: ProjectionWorkerSixb) {
-    const projectionCount = sixb.getObjectProjections().length + sixb.getLinkProjections().length
+    const projectionCount =
+      sixb.getObjectProjections().length +
+      sixb.getLinkProjections().length +
+      sixb.getTelemetryProjections().length
     if (projectionCount === 0) {
       throw new Error("[SixbProjectionWorker] No projection definitions are registered.")
     }

--- a/packages/projection-worker/tests/parse-telemetry-timestamp.test.ts
+++ b/packages/projection-worker/tests/parse-telemetry-timestamp.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { parseTelemetryTimestamp } from "../src/run-telemetry-projection"
+
+// Each case asserts the absolute instant (UTC ISO) the parser must produce. The
+// suite runs under a deliberately non-UTC TZ so that any regression back to
+// local-time parsing of zone-less strings is caught regardless of the ambient
+// timezone the test happens to run in.
+const ORIGINAL_TZ = process.env.TZ
+
+const utcCases: ReadonlyArray<readonly [label: string, input: unknown, expected: string]> = [
+  ["padded ISO datetime", "2026-06-01T12:00:00", "2026-06-01T12:00:00.000Z"],
+  ["padded space datetime", "2026-06-01 12:00:00", "2026-06-01T12:00:00.000Z"],
+  // The regression: non-zero-padded zone-less forms previously fell through to
+  // new Date() and were parsed in the worker's local timezone.
+  ["non-padded space datetime", "2026-6-1 12:00:00", "2026-06-01T12:00:00.000Z"],
+  ["non-padded, no seconds", "2026-06-01 9:30", "2026-06-01T09:30:00.000Z"],
+  ["fractional seconds", "2026-06-01 12:00:00.5", "2026-06-01T12:00:00.500Z"],
+  ["date-only padded", "2026-06-01", "2026-06-01T00:00:00.000Z"],
+  ["date-only non-padded", "2026-6-1", "2026-06-01T00:00:00.000Z"],
+  ["surrounding whitespace", "  2026-06-01 12:00:00  ", "2026-06-01T12:00:00.000Z"],
+]
+
+const zonedCases: ReadonlyArray<readonly [label: string, input: string, expected: string]> = [
+  ["explicit Z", "2026-06-01T12:00:00.000Z", "2026-06-01T12:00:00.000Z"],
+  ["explicit offset -05:00", "2026-06-01T12:00:00-05:00", "2026-06-01T17:00:00.000Z"],
+  ["explicit offset +0530", "2026-06-01T12:00:00+0530", "2026-06-01T06:30:00.000Z"],
+]
+
+const rejectedCases: ReadonlyArray<readonly [label: string, input: unknown]> = [
+  ["calendar rollover", "2026-13-01 00:00:00"],
+  ["slash format", "06/01/2026"],
+  ["free-text date", "June 1, 2026"],
+  ["non-string, non-Date", 1717243200],
+  ["null", null],
+  ["empty string", ""],
+  ["invalid Date instance", new Date("nope")],
+]
+
+describe("parseTelemetryTimestamp", () => {
+  beforeAll(() => {
+    process.env.TZ = "America/New_York"
+  })
+  afterAll(() => {
+    if (ORIGINAL_TZ === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = ORIGINAL_TZ
+    }
+  })
+
+  test.each(utcCases)("interprets zone-less %s as UTC", (_label, input, expected) => {
+    expect(parseTelemetryTimestamp(input)?.toISOString()).toBe(expected)
+  })
+
+  test.each(zonedCases)("honors the explicit zone of %s", (_label, input, expected) => {
+    expect(parseTelemetryTimestamp(input)?.toISOString()).toBe(expected)
+  })
+
+  test.each(rejectedCases)("rejects %s as null", (_label, input) => {
+    expect(parseTelemetryTimestamp(input)).toBeNull()
+  })
+
+  test("passes a valid Date instance through unchanged", () => {
+    const instant = new Date("2026-06-01T12:00:00.000Z")
+    expect(parseTelemetryTimestamp(instant)).toBe(instant)
+  })
+})

--- a/packages/projection-worker/tests/parse-telemetry-timestamp.test.ts
+++ b/packages/projection-worker/tests/parse-telemetry-timestamp.test.ts
@@ -24,10 +24,25 @@ const zonedCases: ReadonlyArray<readonly [label: string, input: string, expected
   ["explicit Z", "2026-06-01T12:00:00.000Z", "2026-06-01T12:00:00.000Z"],
   ["explicit offset -05:00", "2026-06-01T12:00:00-05:00", "2026-06-01T17:00:00.000Z"],
   ["explicit offset +0530", "2026-06-01T12:00:00+0530", "2026-06-01T06:30:00.000Z"],
+  // The component-based parser still resolves zoned forms it does not hand to
+  // new Date(): space separator with Z, non-padded fields, and date-only Z.
+  ["space separator with Z", "2026-06-01 12:00:00Z", "2026-06-01T12:00:00.000Z"],
+  ["non-padded with offset", "2026-6-1 9:00:00+02:00", "2026-06-01T07:00:00.000Z"],
+  ["date-only Z", "2026-06-01Z", "2026-06-01T00:00:00.000Z"],
 ]
 
 const rejectedCases: ReadonlyArray<readonly [label: string, input: unknown]> = [
   ["calendar rollover", "2026-13-01 00:00:00"],
+  // B1: out-of-range calendar dates must be rejected on the zoned path too, not
+  // silently rolled forward by new Date() (Feb 29 of a non-leap year, Apr 31).
+  ["zoned non-leap Feb 29", "2026-02-29T00:00:00Z"],
+  ["zoned April 31 with offset", "2026-04-31T00:00:00-05:00"],
+  ["zone-less non-leap Feb 29", "2026-02-29 00:00:00"],
+  // B2: out-of-range time fields must be rejected, not rolled within the day.
+  ["minute out of range", "2024-05-31 09:99"],
+  ["second out of range", "2024-05-31 09:30:99"],
+  ["hour out of range", "2026-06-01T24:00:00"],
+  ["offset hour out of range", "2026-06-01T12:00:00+25:00"],
   ["slash format", "06/01/2026"],
   ["free-text date", "June 1, 2026"],
   ["non-string, non-Date", 1717243200],

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -49,6 +49,7 @@ const Room = defineObjectType({
     prop("name", "string"),
     prop("buildingRef", "string"),
     prop("temperature", "double", { mode: "telemetry" }),
+    prop("targetTemperature", "double", { mode: "telemetry", semanticType: "Temperature" }),
   ],
   links: [
     link("inBuilding", Building, { cardinality: "one" }),
@@ -112,6 +113,19 @@ const roomTemperatureProjection = defineTelemetryProjection(
 )
   .fromDataset(roomReadingsDataset)
   .points({ objectId: "room_id", at: "observed_at", value: "temperature" })
+
+const roomTargetsDataset = defineDataset("canonical.room-targets", {
+  schema: [
+    col("room_id", "string"),
+    col("observed_at", "timestamp"),
+    col("target", "float64"),
+    col("target_unit", "string", { nullable: true }),
+  ],
+})
+
+const roomTargetProjection = defineTelemetryProjection("room-target-proj", Room.p.targetTemperature)
+  .fromDataset(roomTargetsDataset)
+  .points({ objectId: "room_id", at: "observed_at", value: "target", unit: "target_unit" })
 
 class RecordingLakeStorage implements LakeStorage {
   readonly standard: LakeStorage["standard"]
@@ -1636,6 +1650,176 @@ describe("runProjectionJob", () => {
       expect(error).toHaveProperty("cause", finishCause)
       expect(errorMessage(error)).toContain("may need repair")
     }
+  })
+
+  test("telemetry projections carry units in history and materialize the latest value", async () => {
+    const deps = createDeps()
+    const lakeStorage = new RecordingLakeStorage(deps.lakeStorage)
+    const sixb = createSixb(
+      {
+        datasets: [roomTargetsDataset],
+        projections: [roomTargetProjection],
+      },
+      { ...deps, lakeStorage }
+    )
+
+    await sixb.objects(Room).upsert({ properties: { id: "r1", name: "Kitchen" } })
+    const version = await commitDatasetVersion(lakeStorage, roomTargetsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        target: 21,
+        target_unit: "degreeCelsius",
+      },
+      {
+        room_id: "r1",
+        observed_at: "2026-06-02T12:00:00.000Z",
+        target: 22,
+        target_unit: "degreeCelsius",
+      },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-target",
+        projectionId: "room-target-proj",
+        projectionKind: "telemetry",
+        datasetId: roomTargetsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.telemetryPointsAppended).toBe(2)
+    expect(result.telemetryRowsFailed).toBe(0)
+    expect(result.run.status).toBe("succeeded")
+
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "targetTemperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([21, 22])
+    expect(history.map((point) => point.unit)).toEqual(["degreeCelsius", "degreeCelsius"])
+
+    // The mapped unit column must be read, and the object materializes the latest raw value.
+    expect(lakeStorage.readInputs[0]?.columns).toContain("target_unit")
+    const room = await deps.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      primaryId: "r1",
+    })
+    expect(room?.properties.targetTemperature).toBe(22)
+  })
+
+  test("isolates an invalid-unit telemetry row, failing the run while keeping good points", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomTargetsDataset],
+        projections: [roomTargetProjection],
+      },
+      deps
+    )
+
+    await sixb.objects(Room).upsert({ properties: { id: "r1", name: "Kitchen" } })
+    const version = await commitDatasetVersion(deps.lakeStorage, roomTargetsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        target: 21,
+        target_unit: "degreeCelsius",
+      },
+      {
+        room_id: "r1",
+        observed_at: "2026-06-02T12:00:00.000Z",
+        target: 22,
+        target_unit: "bananas", // not a Temperature unit -> OntologyValidationError at append time
+      },
+    ])
+
+    await expect(
+      runProjectionJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "projrun-target-bad-unit",
+          projectionId: "room-target-proj",
+          projectionKind: "telemetry",
+          datasetId: roomTargetsDataset.id,
+          versionId: version.versionId,
+        },
+      })
+    ).rejects.toBeInstanceOf(ProjectionWorkerError)
+
+    const run = await deps.storage.projectionRuns.getById({
+      projectId: sixb.id,
+      id: "projrun-target-bad-unit",
+    })
+    expect(run?.status).toBe("failed")
+    expect(run?.rowsProcessed).toBe(2)
+    expect(run?.telemetryPointsAppended).toBe(1)
+    expect(run?.telemetryRowsFailed).toBe(1)
+    expect(run?.errorMessage).toContain("Invalid unit")
+
+    // The good reading from the same batch still landed via per-row isolation.
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "targetTemperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([21])
+  })
+
+  test("fails before reading rows when a telemetry at field is not date-like", async () => {
+    const deps = createDeps()
+    const invalidAtProjection = {
+      _tag: "TelemetryProjectionDefinition",
+      id: "room-invalid-at-proj",
+      objectTypeId: "Room",
+      propertyId: "temperature",
+      datasetId: roomReadingsDataset.id,
+      objectIdField: "room_id",
+      atField: "temperature", // float64 column, not date-like
+      valueField: "temperature",
+    } satisfies ProjectionDefinition
+    const sixb = createSixb(
+      {
+        datasets: [roomReadingsDataset],
+        projections: [invalidAtProjection],
+      },
+      deps
+    )
+    const version = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: null,
+      },
+    ])
+
+    await expect(
+      runProjectionJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "projrun-invalid-at",
+          projectionId: "room-invalid-at-proj",
+          projectionKind: "telemetry",
+          datasetId: roomReadingsDataset.id,
+          versionId: version.versionId,
+        },
+      })
+    ).rejects.toThrow("must be a string, date, or timestamp")
+
+    const run = await deps.storage.projectionRuns.getById({
+      projectId: sixb.id,
+      id: "projrun-invalid-at",
+    })
+    expect(run?.status).toBe("failed")
+    expect(run?.rowsProcessed).toBe(0)
   })
 })
 

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -8,6 +8,7 @@ import {
   defineLinkProjection,
   defineObjectType,
   defineProjection,
+  defineTelemetryProjection,
   defineValueType,
   fromForeignKey,
   InMemoryBlobStorage,
@@ -47,6 +48,7 @@ const Room = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string"),
     prop("buildingRef", "string"),
+    prop("temperature", "double", { mode: "telemetry" }),
   ],
   links: [
     link("inBuilding", Building, { cardinality: "one" }),
@@ -64,6 +66,16 @@ const roomsDataset = defineDataset("canonical.rooms", {
 
 const roomSensorsDataset = defineDataset("canonical.room-sensors", {
   schema: [col("room_id", "string"), col("sensor_id", "string")],
+})
+
+const roomReadingsDataset = defineDataset("canonical.room-readings", {
+  schema: [
+    col("room_id", "string"),
+    col("observed_at", "timestamp"),
+    col("temperature", "float64"),
+    col("sync_row_id", "string"),
+    col("unused", "string", { nullable: true }),
+  ],
 })
 
 const roomProjection = defineProjection("room-proj", Room)
@@ -93,6 +105,13 @@ const roomSensorProjection = defineLinkProjection("room-sensor-proj", Room.l.has
   .fromDataset(roomSensorsDataset)
   .sourceField("room_id")
   .targetField("sensor_id")
+
+const roomTemperatureProjection = defineTelemetryProjection(
+  "room-temperature-proj",
+  Room.p.temperature
+)
+  .fromDataset(roomReadingsDataset)
+  .points({ objectId: "room_id", at: "observed_at", value: "temperature" })
 
 class RecordingLakeStorage implements LakeStorage {
   readonly standard: LakeStorage["standard"]
@@ -301,6 +320,455 @@ describe("runProjectionJob", () => {
       primaryId: "r1",
     })
     expect(room?.properties.name).toBe("Kitchen")
+  })
+
+  test("materializes a telemetry projection from the exact dataset version", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset, roomReadingsDataset],
+        projections: [roomProjection, roomTemperatureProjection],
+      },
+      deps
+    )
+
+    await sixb.objects(Room).upsert({
+      properties: { id: "r1", name: "Kitchen" },
+    })
+    const version1 = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: "ignored",
+      },
+    ])
+    await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-02T12:00:00.000Z",
+        temperature: 72,
+        sync_row_id: "reading-2",
+        unused: "ignored",
+      },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-telemetry-1",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: "canonical.room-readings",
+        versionId: version1.versionId,
+      },
+    })
+
+    expect(result.rowsProcessed).toBe(1)
+    expect(result.telemetryPointsAppended).toBe(1)
+    expect(result.telemetryPointsSkipped).toBe(0)
+    expect(result.telemetryRowsFailed).toBe(0)
+    expect(result.objectsUpserted).toBe(0)
+    expect(result.linksUpserted).toBe(0)
+    expect(result.run.status).toBe("succeeded")
+
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([70.5])
+    expect(history[0]?.at.toISOString()).toBe("2026-06-01T12:00:00.000Z")
+
+    const room = await deps.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      primaryId: "r1",
+    })
+    expect(room?.properties.temperature).toBe(70.5)
+  })
+
+  test("telemetry projections read only mapped dataset columns", async () => {
+    const deps = createDeps()
+    const lakeStorage = new RecordingLakeStorage(deps.lakeStorage)
+    const sixb = createSixb(
+      {
+        datasets: [roomReadingsDataset],
+        projections: [roomTemperatureProjection],
+      },
+      { ...deps, lakeStorage }
+    )
+    await sixb.objects(Room).upsert({
+      properties: { id: "r1", name: "Kitchen" },
+    })
+    const version = await commitDatasetVersion(lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: "ignored",
+      },
+    ])
+
+    await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-column-pruning-telemetry",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(lakeStorage.readInputs).toHaveLength(1)
+    expect(lakeStorage.readInputs[0]?.columns).toEqual(["room_id", "observed_at", "temperature"])
+  })
+
+  test("telemetry projections materialize object latest by telemetry timestamp", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomReadingsDataset],
+        projections: [roomTemperatureProjection],
+      },
+      deps
+    )
+    await sixb.objects(Room).upsert({
+      properties: { id: "r1", name: "Kitchen" },
+    })
+    const version = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-02T12:00:00.000Z",
+        temperature: 72,
+        sync_row_id: "reading-2",
+        unused: "ignored",
+      },
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: "ignored",
+      },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-telemetry-late",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.telemetryPointsAppended).toBe(2)
+    expect(result.telemetryPointsSkipped).toBe(0)
+    expect(result.telemetryRowsFailed).toBe(0)
+
+    const room = await deps.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      primaryId: "r1",
+    })
+    expect(room?.properties.temperature).toBe(72)
+
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([70.5, 72])
+  })
+
+  test("telemetry projections replay idempotently via the (series, at) upsert", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomReadingsDataset],
+        projections: [roomTemperatureProjection],
+      },
+      deps
+    )
+    await sixb.objects(Room).upsert({
+      properties: { id: "r1", name: "Kitchen" },
+    })
+    const version = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: "ignored",
+      },
+    ])
+
+    const first = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-telemetry-first",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    const replay = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-telemetry-replay",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(first.telemetryPointsAppended).toBe(1)
+    expect(replay.run.status).toBe("succeeded")
+    expect(replay.telemetryPointsAppended).toBe(1)
+    expect(replay.telemetryRowsFailed).toBe(0)
+
+    // The store upserts on (series, at), so replaying leaves a single point.
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([70.5])
+  })
+
+  test("telemetry projections overwrite a prior value at the same instant (last-write-wins)", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomReadingsDataset],
+        projections: [roomTemperatureProjection],
+      },
+      deps
+    )
+    await sixb.objects(Room).upsert({
+      properties: { id: "r1", name: "Kitchen" },
+    })
+    const version1 = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: "ignored",
+      },
+    ])
+    const version2 = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 71,
+        sync_row_id: "reading-1",
+        unused: "ignored",
+      },
+    ])
+
+    await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-telemetry-v1",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version1.versionId,
+      },
+    })
+    const second = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-telemetry-v2",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version2.versionId,
+      },
+    })
+
+    // Same (object, property, instant): the newer value overwrites.
+    expect(second.run.status).toBe("succeeded")
+
+    const room = await deps.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      primaryId: "r1",
+    })
+    expect(room?.properties.temperature).toBe(71)
+
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([71])
+  })
+
+  test("telemetry projections skip readings for missing objects and keep the run successful", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomReadingsDataset],
+        projections: [roomTemperatureProjection],
+      },
+      deps
+    )
+    await sixb.objects(Room).upsert({
+      properties: { id: "r1", name: "Kitchen" },
+    })
+    const version = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: null,
+      },
+      {
+        room_id: "missing-room",
+        observed_at: "2026-06-01T12:05:00.000Z",
+        temperature: 71,
+        sync_row_id: "reading-2",
+        unused: null,
+      },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      batchSize: 10,
+      job: {
+        id: "projrun-telemetry-partial-failure",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    // A reading for an object that does not exist yet is a benign, retryable
+    // skip (matching object/link projections), not a whole-run failure.
+    expect(result.run.status).toBe("succeeded")
+    expect(result.rowsProcessed).toBe(2)
+    expect(result.rowsSkipped).toBe(1)
+    expect(result.telemetryPointsAppended).toBe(1)
+    expect(result.telemetryPointsSkipped).toBe(1)
+    expect(result.telemetryRowsFailed).toBe(0)
+
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([70.5])
+  })
+
+  test("telemetry projections parse zone-less timestamps as UTC", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomReadingsDataset],
+        projections: [roomTemperatureProjection],
+      },
+      deps
+    )
+    await sixb.objects(Room).upsert({ properties: { id: "r1", name: "Kitchen" } })
+    const version = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01 12:00:00",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: null,
+      },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-telemetry-zoneless",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.run.status).toBe("succeeded")
+    expect(result.telemetryPointsAppended).toBe(1)
+
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temperature",
+    })
+    expect(history.map((point) => point.at.toISOString())).toEqual(["2026-06-01T12:00:00.000Z"])
+  })
+
+  test("telemetry projections upsert rows that share an instant within one version (last-write-wins)", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomReadingsDataset],
+        projections: [roomTemperatureProjection],
+      },
+      deps
+    )
+    await sixb.objects(Room).upsert({ properties: { id: "r1", name: "Kitchen" } })
+    const version = await commitDatasetVersion(deps.lakeStorage, roomReadingsDataset, [
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 70.5,
+        sync_row_id: "reading-1",
+        unused: null,
+      },
+      {
+        room_id: "r1",
+        observed_at: "2026-06-01T12:00:00.000Z",
+        temperature: 71,
+        sync_row_id: "reading-2",
+        unused: null,
+      },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-telemetry-inbatch",
+        projectionId: "room-temperature-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    // Both rows share (object, property, instant); the upsert keeps the last.
+    expect(result.run.status).toBe("succeeded")
+    expect(result.telemetryRowsFailed).toBe(0)
+
+    const history = await deps.storage.timeseries.getHistory({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      propertyId: "temperature",
+    })
+    expect(history.map((point) => point.value)).toEqual([71])
   })
 
   test("object projections read only mapped dataset columns", async () => {

--- a/packages/projection-worker/tests/worker.test.ts
+++ b/packages/projection-worker/tests/worker.test.ts
@@ -220,6 +220,7 @@ describe("ProjectionWorker", () => {
       queues: sixb.queues,
       getObjectProjections: () => sixb.getObjectProjections(),
       getLinkProjections: () => sixb.getLinkProjections(),
+      getTelemetryProjections: () => sixb.getTelemetryProjections(),
       getDatasetById: (datasetId: string) => sixb.getDatasetById(datasetId),
       getProjectionById: (projectionId: string) => sixb.getProjectionById(projectionId),
     }

--- a/packages/server/src/routes/datasets.ts
+++ b/packages/server/src/routes/datasets.ts
@@ -108,7 +108,11 @@ function buildDatasetReferenceIndex(
     }
   }
 
-  for (const projection of [...sixb.getObjectProjections(), ...sixb.getLinkProjections()]) {
+  for (const projection of [
+    ...sixb.getObjectProjections(),
+    ...sixb.getLinkProjections(),
+    ...sixb.getTelemetryProjections(),
+  ]) {
     referencesFor(projection.datasetId).projectionIds.push(projection.id)
   }
 

--- a/packages/server/src/routes/projections.ts
+++ b/packages/server/src/routes/projections.ts
@@ -1,9 +1,4 @@
-import type {
-  OntologySource,
-  ProjectionDefinition,
-  Sixb,
-  TelemetryProjectionDefinition,
-} from "@sixb/core"
+import type { OntologySource, Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
@@ -20,7 +15,7 @@ export function registerProjectionRoutes(app: Elysia, sixb: Sixb<readonly Ontolo
         return {
           objectProjections: [...sixb.getObjectProjections()],
           linkProjections: [...sixb.getLinkProjections()],
-          telemetryProjections: sixb.getTelemetryProjections().map(serializeTelemetryProjection),
+          telemetryProjections: [...sixb.getTelemetryProjections()],
         }
       },
       {
@@ -45,7 +40,7 @@ export function registerProjectionRoutes(app: Elysia, sixb: Sixb<readonly Ontolo
           set.status = 404
           return { error: `Projection '${params.projectionId}' not found` }
         }
-        return serializeProjection(found)
+        return found
       },
       {
         params: ProjectionParamsSchema,
@@ -57,26 +52,4 @@ export function registerProjectionRoutes(app: Elysia, sixb: Sixb<readonly Ontolo
         },
       }
     )
-}
-
-function serializeProjection(projection: ProjectionDefinition) {
-  if (projection._tag !== "TelemetryProjectionDefinition") {
-    return projection
-  }
-
-  return serializeTelemetryProjection(projection)
-}
-
-function serializeTelemetryProjection(projection: TelemetryProjectionDefinition) {
-  return {
-    _tag: projection._tag,
-    id: projection.id,
-    objectTypeId: projection.objectTypeId,
-    propertyId: projection.propertyId,
-    datasetId: projection.datasetId,
-    objectIdField: projection.objectIdField,
-    atField: projection.atField,
-    valueField: projection.valueField,
-    ...(projection.unitField !== undefined ? { unitField: projection.unitField } : {}),
-  }
 }

--- a/packages/server/src/routes/projections.ts
+++ b/packages/server/src/routes/projections.ts
@@ -1,4 +1,9 @@
-import type { OntologySource, Sixb } from "@sixb/core"
+import type {
+  OntologySource,
+  ProjectionDefinition,
+  Sixb,
+  TelemetryProjectionDefinition,
+} from "@sixb/core"
 import type { Elysia } from "elysia"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
@@ -15,6 +20,7 @@ export function registerProjectionRoutes(app: Elysia, sixb: Sixb<readonly Ontolo
         return {
           objectProjections: [...sixb.getObjectProjections()],
           linkProjections: [...sixb.getLinkProjections()],
+          telemetryProjections: sixb.getTelemetryProjections().map(serializeTelemetryProjection),
         }
       },
       {
@@ -29,13 +35,17 @@ export function registerProjectionRoutes(app: Elysia, sixb: Sixb<readonly Ontolo
     .get(
       "/api/projections/:projectionId",
       ({ params, set }) => {
-        const all = [...sixb.getObjectProjections(), ...sixb.getLinkProjections()]
+        const all = [
+          ...sixb.getObjectProjections(),
+          ...sixb.getLinkProjections(),
+          ...sixb.getTelemetryProjections(),
+        ]
         const found = all.find((p) => p.id === params.projectionId)
         if (!found) {
           set.status = 404
           return { error: `Projection '${params.projectionId}' not found` }
         }
-        return found
+        return serializeProjection(found)
       },
       {
         params: ProjectionParamsSchema,
@@ -47,4 +57,26 @@ export function registerProjectionRoutes(app: Elysia, sixb: Sixb<readonly Ontolo
         },
       }
     )
+}
+
+function serializeProjection(projection: ProjectionDefinition) {
+  if (projection._tag !== "TelemetryProjectionDefinition") {
+    return projection
+  }
+
+  return serializeTelemetryProjection(projection)
+}
+
+function serializeTelemetryProjection(projection: TelemetryProjectionDefinition) {
+  return {
+    _tag: projection._tag,
+    id: projection.id,
+    objectTypeId: projection.objectTypeId,
+    propertyId: projection.propertyId,
+    datasetId: projection.datasetId,
+    objectIdField: projection.objectIdField,
+    atField: projection.atField,
+    valueField: projection.valueField,
+    ...(projection.unitField !== undefined ? { unitField: projection.unitField } : {}),
+  }
 }

--- a/packages/server/src/schemas/projections.ts
+++ b/packages/server/src/schemas/projections.ts
@@ -27,13 +27,30 @@ export const LinkProjectionSchema = z.object({
   targetField: z.string(),
 })
 
+export const TelemetryProjectionSchema = z.object({
+  _tag: z.literal("TelemetryProjectionDefinition"),
+  id: z.string(),
+  objectTypeId: z.string(),
+  propertyId: z.string(),
+  datasetId: z.string(),
+  objectIdField: z.string(),
+  atField: z.string(),
+  valueField: z.string(),
+  unitField: z.string().optional(),
+})
+
 export const ProjectionListResponseSchema = z.object({
   objectProjections: z.array(ObjectProjectionSchema),
   linkProjections: z.array(LinkProjectionSchema),
+  telemetryProjections: z.array(TelemetryProjectionSchema),
 })
 
 export const ProjectionParamsSchema = z.object({
   projectionId: z.string().min(1),
 })
 
-export const ProjectionResponseSchema = z.union([ObjectProjectionSchema, LinkProjectionSchema])
+export const ProjectionResponseSchema = z.union([
+  ObjectProjectionSchema,
+  LinkProjectionSchema,
+  TelemetryProjectionSchema,
+])

--- a/packages/server/tests/datasets-routes.test.ts
+++ b/packages/server/tests/datasets-routes.test.ts
@@ -60,6 +60,7 @@ function createSixbStub(
     getPipelineDefinitions: () => [],
     getObjectProjections: () => [],
     getLinkProjections: () => [],
+    getTelemetryProjections: () => [],
   } as unknown as Sixb<readonly OntologySource[]>
 }
 

--- a/storage/pg/src/migrations/001-initial-schema.sql
+++ b/storage/pg/src/migrations/001-initial-schema.sql
@@ -47,13 +47,13 @@ CREATE TABLE IF NOT EXISTS timeseries (
   unit TEXT,
   at TIMESTAMPTZ NOT NULL,
   source_event_id TEXT NOT NULL,
-  PRIMARY KEY (project_id, object_type_id, object_id, property_id, at, source_event_id)
+  -- A telemetry point's identity is (series, at): one value per instant per
+  -- series. Appends upsert on this key, so no separate idempotency ledger is
+  -- needed. This primary-key index also serves point lookups and latest-value
+  -- reads (equality on the series prefix + range/backward scan on `at`), so no
+  -- additional timeseries indexes are required.
+  PRIMARY KEY (project_id, object_type_id, object_id, property_id, at)
 );
-
-CREATE INDEX IF NOT EXISTS idx_timeseries_lookup
-  ON timeseries (project_id, object_type_id, object_id, property_id, at);
-CREATE INDEX IF NOT EXISTS idx_timeseries_latest
-  ON timeseries (project_id, object_type_id, object_id, property_id, at DESC);
 
 CREATE TABLE IF NOT EXISTS sync_runs (
   project_id TEXT NOT NULL,
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS projection_runs (
   project_id TEXT NOT NULL,
   id TEXT NOT NULL,
   projection_id TEXT NOT NULL,
-  projection_kind TEXT NOT NULL CHECK (projection_kind IN ('object', 'link')),
+  projection_kind TEXT NOT NULL CHECK (projection_kind IN ('object', 'link', 'telemetry')),
   dataset_id TEXT NOT NULL,
   dataset_version_id TEXT NOT NULL,
   status TEXT NOT NULL CHECK (status IN ('running', 'succeeded', 'failed', 'cancelled')),
@@ -137,6 +137,9 @@ CREATE TABLE IF NOT EXISTS projection_runs (
   rows_skipped INTEGER NOT NULL DEFAULT 0 CHECK (rows_skipped >= 0),
   objects_upserted INTEGER NOT NULL DEFAULT 0 CHECK (objects_upserted >= 0),
   links_upserted INTEGER NOT NULL DEFAULT 0 CHECK (links_upserted >= 0),
+  telemetry_points_appended INTEGER NOT NULL DEFAULT 0 CHECK (telemetry_points_appended >= 0),
+  telemetry_points_skipped INTEGER NOT NULL DEFAULT 0 CHECK (telemetry_points_skipped >= 0),
+  telemetry_rows_failed INTEGER NOT NULL DEFAULT 0 CHECK (telemetry_rows_failed >= 0),
   error_message TEXT,
   PRIMARY KEY (project_id, id)
 );
@@ -322,12 +325,10 @@ CREATE TABLE IF NOT EXISTS rule_states (
 CREATE INDEX IF NOT EXISTS idx_rule_states_project_rule
   ON rule_states (project_id, rule_id);
 
--- Object and timeseries projections can both apply the same telemetry event.
+-- Object materialization dedupes re-applied events (object.upserted and
+-- telemetry.appended) by id. Timeseries needs no equivalent ledger: its
+-- (series, at) upsert is idempotent on its own.
 CREATE TABLE IF NOT EXISTS applied_events_objects (
-  event_id TEXT PRIMARY KEY
-);
-
-CREATE TABLE IF NOT EXISTS applied_events_timeseries (
   event_id TEXT PRIMARY KEY
 );
 

--- a/storage/pg/src/pg-projection-run-storage.ts
+++ b/storage/pg/src/pg-projection-run-storage.ts
@@ -22,6 +22,9 @@ const counterKeys: readonly CounterKey[] = [
   "rowsSkipped",
   "objectsUpserted",
   "linksUpserted",
+  "telemetryPointsAppended",
+  "telemetryPointsSkipped",
+  "telemetryRowsFailed",
 ]
 
 export class PgProjectionRunStorage implements ProjectionRunStorage {
@@ -48,7 +51,10 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
           rows_processed,
           rows_skipped,
           objects_upserted,
-          links_upserted
+          links_upserted,
+          telemetry_points_appended,
+          telemetry_points_skipped,
+          telemetry_rows_failed
         ) VALUES (
           ${input.projectId},
           ${input.id},
@@ -58,6 +64,9 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
           ${input.datasetVersionId},
           ${"running"},
           ${input.startedAt ?? new Date()},
+          ${0},
+          ${0},
+          ${0},
           ${0},
           ${0},
           ${0},
@@ -89,7 +98,10 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
           rows_processed = ${counters.rowsProcessed},
           rows_skipped = ${counters.rowsSkipped},
           objects_upserted = ${counters.objectsUpserted},
-          links_upserted = ${counters.linksUpserted}
+          links_upserted = ${counters.linksUpserted},
+          telemetry_points_appended = ${counters.telemetryPointsAppended},
+          telemetry_points_skipped = ${counters.telemetryPointsSkipped},
+          telemetry_rows_failed = ${counters.telemetryRowsFailed}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
       `
@@ -112,6 +124,9 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
           rows_skipped = ${counters.rowsSkipped},
           objects_upserted = ${counters.objectsUpserted},
           links_upserted = ${counters.linksUpserted},
+          telemetry_points_appended = ${counters.telemetryPointsAppended},
+          telemetry_points_skipped = ${counters.telemetryPointsSkipped},
+          telemetry_rows_failed = ${counters.telemetryRowsFailed},
           error_message = ${input.status === "succeeded" ? null : (input.errorMessage ?? null)}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
@@ -257,6 +272,9 @@ function mergeCounters(
     rowsSkipped: input.rowsSkipped ?? existing.rowsSkipped,
     objectsUpserted: input.objectsUpserted ?? existing.objectsUpserted,
     linksUpserted: input.linksUpserted ?? existing.linksUpserted,
+    telemetryPointsAppended: input.telemetryPointsAppended ?? existing.telemetryPointsAppended,
+    telemetryPointsSkipped: input.telemetryPointsSkipped ?? existing.telemetryPointsSkipped,
+    telemetryRowsFailed: input.telemetryRowsFailed ?? existing.telemetryRowsFailed,
   }
 }
 
@@ -266,6 +284,9 @@ function rowToCounters(row: DatabaseRow): ProjectionRunCounters {
     rowsSkipped: Number(row.rows_skipped),
     objectsUpserted: Number(row.objects_upserted),
     linksUpserted: Number(row.links_upserted),
+    telemetryPointsAppended: Number(row.telemetry_points_appended),
+    telemetryPointsSkipped: Number(row.telemetry_points_skipped),
+    telemetryRowsFailed: Number(row.telemetry_rows_failed),
   }
 }
 
@@ -325,5 +346,8 @@ interface DatabaseRow {
   rows_skipped: number | string
   objects_upserted: number | string
   links_upserted: number | string
+  telemetry_points_appended: number | string
+  telemetry_points_skipped: number | string
+  telemetry_rows_failed: number | string
   error_message: string | null
 }

--- a/storage/pg/src/pg-projection-run-storage.ts
+++ b/storage/pg/src/pg-projection-run-storage.ts
@@ -10,22 +10,10 @@ import type {
   StartProjectionRunInput,
   UpdateProjectionRunInput,
 } from "@sixb/core"
-import { ProjectionRunError } from "@sixb/core"
+import { PROJECTION_COUNTER_KEYS, ProjectionRunError } from "@sixb/core"
 import type { SQLClient, SqlParameter } from "./pg-client"
 import { isUniqueViolation } from "./storage-errors"
 import { type PgStoreClient, runPgTransaction } from "./transactions"
-
-type CounterKey = keyof ProjectionRunCounters
-
-const counterKeys: readonly CounterKey[] = [
-  "rowsProcessed",
-  "rowsSkipped",
-  "objectsUpserted",
-  "linksUpserted",
-  "telemetryPointsAppended",
-  "telemetryPointsSkipped",
-  "telemetryRowsFailed",
-]
 
 export class PgProjectionRunStorage implements ProjectionRunStorage {
   constructor(private readonly sql: PgStoreClient) {}
@@ -263,19 +251,12 @@ function mergeCounters(
   existing: ProjectionRunCounters,
   input: Partial<ProjectionRunCounters>
 ): ProjectionRunCounters {
-  for (const key of counterKeys) {
+  const merged = {} as Record<keyof ProjectionRunCounters, number>
+  for (const key of PROJECTION_COUNTER_KEYS) {
     assertOptionalCounter(input[key], key)
+    merged[key] = input[key] ?? existing[key]
   }
-
-  return {
-    rowsProcessed: input.rowsProcessed ?? existing.rowsProcessed,
-    rowsSkipped: input.rowsSkipped ?? existing.rowsSkipped,
-    objectsUpserted: input.objectsUpserted ?? existing.objectsUpserted,
-    linksUpserted: input.linksUpserted ?? existing.linksUpserted,
-    telemetryPointsAppended: input.telemetryPointsAppended ?? existing.telemetryPointsAppended,
-    telemetryPointsSkipped: input.telemetryPointsSkipped ?? existing.telemetryPointsSkipped,
-    telemetryRowsFailed: input.telemetryRowsFailed ?? existing.telemetryRowsFailed,
-  }
+  return merged
 }
 
 function rowToCounters(row: DatabaseRow): ProjectionRunCounters {

--- a/storage/pg/src/pg-timeseries-storage.ts
+++ b/storage/pg/src/pg-timeseries-storage.ts
@@ -97,7 +97,7 @@ export class PgTimeseriesStorage implements TimeseriesStorage {
         AND object_type_id = ${params.objectTypeId}
         AND object_id = ${params.objectId}
         AND property_id = ${params.propertyId}
-      ORDER BY at DESC, source_event_id DESC
+      ORDER BY at DESC
       LIMIT 1
     `
 

--- a/storage/pg/src/pg-timeseries-storage.ts
+++ b/storage/pg/src/pg-timeseries-storage.ts
@@ -13,34 +13,7 @@ export class PgTimeseriesStorage implements TimeseriesStorage {
   constructor(private readonly sql: PgStoreClient) {}
 
   async applyTelemetryAppended(event: StoredTelemetryAppendedEvent): Promise<void> {
-    await runPgTransaction(this.sql, async (tx) => {
-      // Idempotence check inside transaction to prevent race conditions
-      const [applied] = await tx`
-        SELECT 1 FROM applied_events_timeseries WHERE event_id = ${event.id}
-      `
-      if (applied) return
-
-      await tx`
-        INSERT INTO timeseries (
-          project_id, object_type_id, object_id, property_id,
-          value, unit, at, source_event_id
-        ) VALUES (
-          ${event.projectId}, ${event.payload.objectTypeId}, ${event.payload.objectId},
-          ${event.payload.propertyId},
-          ${JSON.stringify(event.payload.value)}::text::jsonb,
-          ${event.payload.unit ?? null}, ${event.payload.at}::timestamptz,
-          ${event.id}
-        )
-        ON CONFLICT (project_id, object_type_id, object_id, property_id, at, source_event_id)
-        DO NOTHING
-      `
-
-      await tx`
-        INSERT INTO applied_events_timeseries (event_id)
-        VALUES (${event.id})
-        ON CONFLICT DO NOTHING
-      `
-    })
+    await this.upsertPoint(this.sql, event)
   }
 
   async applyTelemetryAppendedBatch(
@@ -48,39 +21,36 @@ export class PgTimeseriesStorage implements TimeseriesStorage {
   ): Promise<void> {
     if (events.length === 0) return
     await runPgTransaction(this.sql, async (tx) => {
-      // Batch idempotence check: single query instead of N individual SELECTs
-      const allEventIds = events.map((e) => e.id)
-      const appliedRows = await tx<{ event_id: string }[]>`
-        SELECT event_id FROM applied_events_timeseries
-        WHERE event_id IN ${this.sql(allEventIds)}
-      `
-      const appliedSet = new Set(appliedRows.map((r) => r.event_id))
-
       for (const event of events) {
-        if (appliedSet.has(event.id)) continue
-
-        await tx`
-          INSERT INTO timeseries (
-            project_id, object_type_id, object_id, property_id,
-            value, unit, at, source_event_id
-          ) VALUES (
-            ${event.projectId}, ${event.payload.objectTypeId}, ${event.payload.objectId},
-            ${event.payload.propertyId},
-            ${JSON.stringify(event.payload.value)}::text::jsonb,
-            ${event.payload.unit ?? null}, ${event.payload.at}::timestamptz,
-            ${event.id}
-          )
-          ON CONFLICT (project_id, object_type_id, object_id, property_id, at, source_event_id)
-          DO NOTHING
-        `
-
-        await tx`
-          INSERT INTO applied_events_timeseries (event_id)
-          VALUES (${event.id})
-          ON CONFLICT DO NOTHING
-        `
+        await this.upsertPoint(tx, event)
       }
     })
+  }
+
+  // A telemetry point is uniquely identified by (series, at). Re-applying the
+  // same instant is a last-write-wins upsert, so telemetry writes are idempotent
+  // under replay without a separate dedup ledger.
+  private async upsertPoint(
+    sql: PgStoreClient,
+    event: StoredTelemetryAppendedEvent
+  ): Promise<void> {
+    await sql`
+      INSERT INTO timeseries (
+        project_id, object_type_id, object_id, property_id,
+        value, unit, at, source_event_id
+      ) VALUES (
+        ${event.projectId}, ${event.payload.objectTypeId}, ${event.payload.objectId},
+        ${event.payload.propertyId},
+        ${JSON.stringify(event.payload.value)}::text::jsonb,
+        ${event.payload.unit ?? null}, ${event.payload.at}::timestamptz,
+        ${event.id}
+      )
+      ON CONFLICT (project_id, object_type_id, object_id, property_id, at)
+      DO UPDATE SET
+        value = EXCLUDED.value,
+        unit = EXCLUDED.unit,
+        source_event_id = EXCLUDED.source_event_id
+    `
   }
 
   async getHistory(params: {

--- a/storage/pg/tests/pg-projection-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-projection-run-storage.e2e.ts
@@ -31,6 +31,8 @@ describe("PgProjectionRunStorage", () => {
       projectId: "my-app",
       rowsProcessed: 10,
       objectsUpserted: 8,
+      telemetryPointsAppended: 3,
+      telemetryPointsSkipped: 1,
     })
 
     const finished = await storage.projectionRuns.finish({
@@ -54,6 +56,9 @@ describe("PgProjectionRunStorage", () => {
       rowsSkipped: 0,
       objectsUpserted: 10,
       linksUpserted: 0,
+      telemetryPointsAppended: 3,
+      telemetryPointsSkipped: 1,
+      telemetryRowsFailed: 0,
     })
     expect(finished.startedAt.toISOString()).toBe("2026-04-06T15:00:00.000Z")
     expect(finished.finishedAt?.toISOString()).toBe("2026-04-06T15:00:01.280Z")
@@ -177,7 +182,7 @@ describe("PgProjectionRunStorage", () => {
       storage.projectionRuns.update({
         id: "run-2",
         projectId: "my-app",
-        rowsProcessed: -1,
+        telemetryRowsFailed: -1,
       })
     ).rejects.toBeInstanceOf(ProjectionRunError)
   })

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -73,6 +73,9 @@ describe("Postgres storage migrations", () => {
       expect(syncRun?.checkpoint).toEqual({ cursor: "legacy" })
       expect(projectionRun?.status).toBe("succeeded")
       expect(projectionRun?.objectsUpserted).toBe(4)
+      expect(projectionRun?.telemetryPointsAppended).toBe(0)
+      expect(projectionRun?.telemetryPointsSkipped).toBe(0)
+      expect(projectionRun?.telemetryRowsFailed).toBe(0)
       expect(workflowRun?.status).toBe("succeeded")
       expect(workflowRun?.input).toEqual({ transactionId: "txn-1" })
       expect(webhookRun).toMatchObject({

--- a/storage/pg/tests/pg-timeseries-storage.e2e.ts
+++ b/storage/pg/tests/pg-timeseries-storage.e2e.ts
@@ -90,6 +90,50 @@ describe("PgTimeseriesStorage", () => {
     expect(history).toHaveLength(1)
   })
 
+  test("overwrites an existing point at the same instant (last-write-wins)", async () => {
+    const at = new Date().toISOString()
+    const first = createTelemetryEvent(
+      "project-a",
+      "Room",
+      "room:101",
+      "temperature",
+      22.5,
+      at,
+      "1"
+    )
+    const second = createTelemetryEvent(
+      "project-a",
+      "Room",
+      "room:101",
+      "temperature",
+      23.5,
+      at,
+      "2"
+    )
+
+    await storage.timeseries.applyTelemetryAppended(first)
+    await storage.timeseries.applyTelemetryAppended(second)
+
+    // (series, at) is the point's identity: two events at the same instant
+    // collapse to one row, and the most recent write wins.
+    const history = await storage.timeseries.getHistory({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      propertyId: "temperature",
+    })
+    expect(history).toHaveLength(1)
+    expect(history[0]?.value).toBe(23.5)
+
+    const latest = await storage.timeseries.getLatest({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      propertyId: "temperature",
+    })
+    expect(latest?.value).toBe(23.5)
+  })
+
   test("getHistory returns chronological data", async () => {
     const baseTime = new Date("2024-01-01T00:00:00Z")
 

--- a/storage/sqlite/src/migrations/001-initial-schema.sql
+++ b/storage/sqlite/src/migrations/001-initial-schema.sql
@@ -45,13 +45,13 @@ CREATE TABLE IF NOT EXISTS timeseries (
   unit TEXT,
   at TEXT NOT NULL,
   source_event_id TEXT NOT NULL,
-  PRIMARY KEY (project_id, object_type_id, object_id, property_id, at, source_event_id)
+  -- A telemetry point's identity is (series, at): one value per instant per
+  -- series. Appends upsert on this key (ON CONFLICT targets these columns), so
+  -- no separate idempotency ledger is needed. This primary-key index also serves
+  -- point lookups and latest-value reads (equality on the series prefix +
+  -- range/backward scan on `at`), so no additional timeseries indexes.
+  PRIMARY KEY (project_id, object_type_id, object_id, property_id, at)
 );
-
-CREATE INDEX IF NOT EXISTS idx_timeseries_lookup
-  ON timeseries(project_id, object_type_id, object_id, property_id, at);
-CREATE INDEX IF NOT EXISTS idx_timeseries_latest
-  ON timeseries(project_id, object_type_id, object_id, property_id, at DESC);
 
 CREATE TABLE IF NOT EXISTS sync_runs (
   project_id TEXT NOT NULL,
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS projection_runs (
   project_id TEXT NOT NULL,
   id TEXT NOT NULL,
   projection_id TEXT NOT NULL,
-  projection_kind TEXT NOT NULL CHECK (projection_kind IN ('object', 'link')),
+  projection_kind TEXT NOT NULL CHECK (projection_kind IN ('object', 'link', 'telemetry')),
   dataset_id TEXT NOT NULL,
   dataset_version_id TEXT NOT NULL,
   status TEXT NOT NULL CHECK (status IN ('running', 'succeeded', 'failed', 'cancelled')),
@@ -95,6 +95,9 @@ CREATE TABLE IF NOT EXISTS projection_runs (
   rows_skipped INTEGER NOT NULL DEFAULT 0 CHECK (rows_skipped >= 0),
   objects_upserted INTEGER NOT NULL DEFAULT 0 CHECK (objects_upserted >= 0),
   links_upserted INTEGER NOT NULL DEFAULT 0 CHECK (links_upserted >= 0),
+  telemetry_points_appended INTEGER NOT NULL DEFAULT 0 CHECK (telemetry_points_appended >= 0),
+  telemetry_points_skipped INTEGER NOT NULL DEFAULT 0 CHECK (telemetry_points_skipped >= 0),
+  telemetry_rows_failed INTEGER NOT NULL DEFAULT 0 CHECK (telemetry_rows_failed >= 0),
   error_message TEXT,
   PRIMARY KEY (project_id, id)
 );
@@ -320,12 +323,10 @@ CREATE TABLE IF NOT EXISTS rule_states (
 CREATE INDEX IF NOT EXISTS idx_rule_states_project_rule
   ON rule_states(project_id, rule_id);
 
--- Object and timeseries projections can both apply the same telemetry event.
+-- Object materialization dedupes re-applied events (object.upserted and
+-- telemetry.appended) by id. Timeseries needs no equivalent ledger: its
+-- (series, at) upsert is idempotent on its own.
 CREATE TABLE IF NOT EXISTS applied_events_objects (
-  event_id TEXT PRIMARY KEY
-);
-
-CREATE TABLE IF NOT EXISTS applied_events_timeseries (
   event_id TEXT PRIMARY KEY
 );
 

--- a/storage/sqlite/src/projection-run-storage.ts
+++ b/storage/sqlite/src/projection-run-storage.ts
@@ -38,6 +38,9 @@ const counterKeys: readonly CounterKey[] = [
   "rowsSkipped",
   "objectsUpserted",
   "linksUpserted",
+  "telemetryPointsAppended",
+  "telemetryPointsSkipped",
+  "telemetryRowsFailed",
 ]
 
 export class SqliteProjectionRunStorage implements ProjectionRunStorage {
@@ -78,8 +81,11 @@ export class SqliteProjectionRunStorage implements ProjectionRunStorage {
             rows_processed,
             rows_skipped,
             objects_upserted,
-            links_upserted
-          ) VALUES (?, ?, ?, ?, ?, ?, 'running', ?, 0, 0, 0, 0)
+            links_upserted,
+            telemetry_points_appended,
+            telemetry_points_skipped,
+            telemetry_rows_failed
+          ) VALUES (?, ?, ?, ?, ?, ?, 'running', ?, 0, 0, 0, 0, 0, 0, 0)
         `
         )
         .run(
@@ -124,7 +130,10 @@ export class SqliteProjectionRunStorage implements ProjectionRunStorage {
             rows_processed = ?,
             rows_skipped = ?,
             objects_upserted = ?,
-            links_upserted = ?
+            links_upserted = ?,
+            telemetry_points_appended = ?,
+            telemetry_points_skipped = ?,
+            telemetry_rows_failed = ?
           WHERE project_id = ? AND id = ?
         `
         )
@@ -133,6 +142,9 @@ export class SqliteProjectionRunStorage implements ProjectionRunStorage {
           counters.rowsSkipped,
           counters.objectsUpserted,
           counters.linksUpserted,
+          counters.telemetryPointsAppended,
+          counters.telemetryPointsSkipped,
+          counters.telemetryRowsFailed,
           input.projectId,
           input.id
         )
@@ -157,6 +169,9 @@ export class SqliteProjectionRunStorage implements ProjectionRunStorage {
             rows_skipped = ?,
             objects_upserted = ?,
             links_upserted = ?,
+            telemetry_points_appended = ?,
+            telemetry_points_skipped = ?,
+            telemetry_rows_failed = ?,
             error_message = ?
           WHERE project_id = ? AND id = ?
         `
@@ -168,6 +183,9 @@ export class SqliteProjectionRunStorage implements ProjectionRunStorage {
           counters.rowsSkipped,
           counters.objectsUpserted,
           counters.linksUpserted,
+          counters.telemetryPointsAppended,
+          counters.telemetryPointsSkipped,
+          counters.telemetryRowsFailed,
           input.status === "succeeded" ? null : (input.errorMessage ?? null),
           input.projectId,
           input.id
@@ -316,6 +334,9 @@ function mergeCounters(
     rowsSkipped: input.rowsSkipped ?? existing.rowsSkipped,
     objectsUpserted: input.objectsUpserted ?? existing.objectsUpserted,
     linksUpserted: input.linksUpserted ?? existing.linksUpserted,
+    telemetryPointsAppended: input.telemetryPointsAppended ?? existing.telemetryPointsAppended,
+    telemetryPointsSkipped: input.telemetryPointsSkipped ?? existing.telemetryPointsSkipped,
+    telemetryRowsFailed: input.telemetryRowsFailed ?? existing.telemetryRowsFailed,
   }
 }
 
@@ -325,6 +346,9 @@ function rowToCounters(row: DatabaseRow): ProjectionRunCounters {
     rowsSkipped: row.rows_skipped,
     objectsUpserted: row.objects_upserted,
     linksUpserted: row.links_upserted,
+    telemetryPointsAppended: row.telemetry_points_appended,
+    telemetryPointsSkipped: row.telemetry_points_skipped,
+    telemetryRowsFailed: row.telemetry_rows_failed,
   }
 }
 
@@ -343,6 +367,9 @@ function rowToProjectionRunRecord(row: DatabaseRow): ProjectionRunRecord {
     rowsSkipped: row.rows_skipped,
     objectsUpserted: row.objects_upserted,
     linksUpserted: row.links_upserted,
+    telemetryPointsAppended: row.telemetry_points_appended,
+    telemetryPointsSkipped: row.telemetry_points_skipped,
+    telemetryRowsFailed: row.telemetry_rows_failed,
     errorMessage: row.error_message ?? undefined,
   }
 }
@@ -365,5 +392,8 @@ interface DatabaseRow {
   rows_skipped: number
   objects_upserted: number
   links_upserted: number
+  telemetry_points_appended: number
+  telemetry_points_skipped: number
+  telemetry_rows_failed: number
   error_message: string | null
 }

--- a/storage/sqlite/src/projection-run-storage.ts
+++ b/storage/sqlite/src/projection-run-storage.ts
@@ -11,7 +11,7 @@ import type {
   StartProjectionRunInput,
   UpdateProjectionRunInput,
 } from "@sixb/core"
-import { ProjectionRunError } from "@sixb/core"
+import { PROJECTION_COUNTER_KEYS, ProjectionRunError } from "@sixb/core"
 import { installFreshSqliteSchema } from "./migrations"
 import {
   closeSqliteStoreConnection,
@@ -30,18 +30,6 @@ export interface SqliteProjectionRunStorageOptions {
   /** Internal shared connection used by bundled SqliteStorage. */
   connection?: SqliteStoreConnection
 }
-
-type CounterKey = keyof ProjectionRunCounters
-
-const counterKeys: readonly CounterKey[] = [
-  "rowsProcessed",
-  "rowsSkipped",
-  "objectsUpserted",
-  "linksUpserted",
-  "telemetryPointsAppended",
-  "telemetryPointsSkipped",
-  "telemetryRowsFailed",
-]
 
 export class SqliteProjectionRunStorage implements ProjectionRunStorage {
   private readonly connection: SqliteStoreConnection
@@ -325,19 +313,12 @@ function mergeCounters(
   existing: ProjectionRunCounters,
   input: Partial<ProjectionRunCounters>
 ): ProjectionRunCounters {
-  for (const key of counterKeys) {
+  const merged = {} as Record<keyof ProjectionRunCounters, number>
+  for (const key of PROJECTION_COUNTER_KEYS) {
     assertOptionalProjectionRunCounter(input[key], key)
+    merged[key] = input[key] ?? existing[key]
   }
-
-  return {
-    rowsProcessed: input.rowsProcessed ?? existing.rowsProcessed,
-    rowsSkipped: input.rowsSkipped ?? existing.rowsSkipped,
-    objectsUpserted: input.objectsUpserted ?? existing.objectsUpserted,
-    linksUpserted: input.linksUpserted ?? existing.linksUpserted,
-    telemetryPointsAppended: input.telemetryPointsAppended ?? existing.telemetryPointsAppended,
-    telemetryPointsSkipped: input.telemetryPointsSkipped ?? existing.telemetryPointsSkipped,
-    telemetryRowsFailed: input.telemetryRowsFailed ?? existing.telemetryRowsFailed,
-  }
+  return merged
 }
 
 function rowToCounters(row: DatabaseRow): ProjectionRunCounters {

--- a/storage/sqlite/src/timeseries-storage.ts
+++ b/storage/sqlite/src/timeseries-storage.ts
@@ -151,7 +151,7 @@ export class SqliteTimeseriesStorage implements TimeseriesStorage {
         `
         SELECT * FROM timeseries
         WHERE project_id = ? AND object_type_id = ? AND object_id = ? AND property_id = ?
-        ORDER BY at DESC, source_event_id DESC
+        ORDER BY at DESC
         LIMIT 1
       `
       )

--- a/storage/sqlite/src/timeseries-storage.ts
+++ b/storage/sqlite/src/timeseries-storage.ts
@@ -14,6 +14,36 @@ export interface SqliteTimeseriesStorageOptions {
   connection?: SqliteStoreConnection
 }
 
+// A telemetry point is uniquely identified by (series, at). Re-applying the
+// same instant is a last-write-wins upsert, so telemetry writes are idempotent
+// under replay without a separate dedup ledger.
+const UPSERT_POINT_SQL = `
+  INSERT INTO timeseries (
+    project_id, object_type_id, object_id, property_id,
+    value, unit, at, source_event_id
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT (project_id, object_type_id, object_id, property_id, at)
+  DO UPDATE SET
+    value = excluded.value,
+    unit = excluded.unit,
+    source_event_id = excluded.source_event_id
+`
+
+function pointParams(
+  event: StoredTelemetryAppendedEvent
+): [string, string, string, string, string, string | null, string, string] {
+  return [
+    event.projectId,
+    event.payload.objectTypeId,
+    event.payload.objectId,
+    event.payload.propertyId,
+    JSON.stringify(event.payload.value),
+    event.payload.unit ?? null,
+    event.payload.at,
+    event.id,
+  ]
+}
+
 /**
  * SQLite-based TimeseriesStorage implementation.
  *
@@ -33,36 +63,7 @@ export class SqliteTimeseriesStorage implements TimeseriesStorage {
   }
 
   async applyTelemetryAppended(event: StoredTelemetryAppendedEvent): Promise<void> {
-    // Check idempotency
-    const applied = this.db
-      .query("SELECT 1 FROM applied_events_timeseries WHERE event_id = ?")
-      .get(event.id)
-
-    if (applied) return
-
-    this.db
-      .query(
-        `
-        INSERT INTO timeseries (
-          project_id, object_type_id, object_id, property_id,
-          value, unit, at, source_event_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `
-      )
-      .run(
-        event.projectId,
-        event.payload.objectTypeId,
-        event.payload.objectId,
-        event.payload.propertyId,
-        JSON.stringify(event.payload.value),
-        event.payload.unit ?? null,
-        event.payload.at,
-        event.id
-      )
-
-    this.db
-      .query("INSERT OR IGNORE INTO applied_events_timeseries (event_id) VALUES (?)")
-      .run(event.id)
+    this.db.query(UPSERT_POINT_SQL).run(...pointParams(event))
   }
 
   async applyTelemetryAppendedBatch(
@@ -71,33 +72,9 @@ export class SqliteTimeseriesStorage implements TimeseriesStorage {
     if (events.length === 0) return
 
     this.db.transaction(() => {
-      const checkApplied = this.db.query(
-        "SELECT 1 FROM applied_events_timeseries WHERE event_id = ?"
-      )
-      const insertPoint = this.db.query(`
-        INSERT INTO timeseries (
-          project_id, object_type_id, object_id, property_id,
-          value, unit, at, source_event_id
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `)
-      const markApplied = this.db.query(
-        "INSERT OR IGNORE INTO applied_events_timeseries (event_id) VALUES (?)"
-      )
-
+      const upsert = this.db.query(UPSERT_POINT_SQL)
       for (const event of events) {
-        if (checkApplied.get(event.id)) continue
-
-        insertPoint.run(
-          event.projectId,
-          event.payload.objectTypeId,
-          event.payload.objectId,
-          event.payload.propertyId,
-          JSON.stringify(event.payload.value),
-          event.payload.unit ?? null,
-          event.payload.at,
-          event.id
-        )
-        markApplied.run(event.id)
+        upsert.run(...pointParams(event))
       }
     })()
   }

--- a/storage/sqlite/src/timeseries-storage.ts
+++ b/storage/sqlite/src/timeseries-storage.ts
@@ -39,9 +39,27 @@ function pointParams(
     event.payload.propertyId,
     JSON.stringify(event.payload.value),
     event.payload.unit ?? null,
-    event.payload.at,
+    assertCanonicalUtcAt(event.payload.at),
     event.id,
   ]
+}
+
+// `at` is stored and compared as TEXT, so SQLite's lexicographic ordering and
+// range scans match chronological order — and the (series, at) identity stays
+// well-defined — only when every value is the canonical UTC ISO-8601 form that
+// appendTelemetryBatch produces via Date.toISOString(). Enforce that invariant
+// here so a writer that bypasses the normalization fails loudly instead of
+// silently corrupting history queries. (pg needs no equivalent: TIMESTAMPTZ
+// compares by instant regardless of textual form.)
+function assertCanonicalUtcAt(at: string): string {
+  const instant = new Date(at)
+  if (Number.isNaN(instant.getTime()) || instant.toISOString() !== at) {
+    throw new Error(
+      `[SixbSqlite] Telemetry 'at' must be a canonical UTC ISO-8601 timestamp ` +
+        `(e.g. "2026-06-21T10:00:00.000Z"), received "${at}".`
+    )
+  }
+  return at
 }
 
 /**

--- a/storage/sqlite/tests/sqlite-projection-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-projection-run-storage.test.ts
@@ -29,6 +29,8 @@ describe("SqliteProjectionRunStorage", () => {
       projectId: "my-app",
       rowsProcessed: 10,
       objectsUpserted: 8,
+      telemetryPointsAppended: 3,
+      telemetryPointsSkipped: 1,
     })
 
     const finished = await storage.finish({
@@ -52,6 +54,9 @@ describe("SqliteProjectionRunStorage", () => {
       rowsSkipped: 0,
       objectsUpserted: 10,
       linksUpserted: 0,
+      telemetryPointsAppended: 3,
+      telemetryPointsSkipped: 1,
+      telemetryRowsFailed: 0,
     })
     expect(finished.startedAt.toISOString()).toBe("2026-04-06T15:00:00.000Z")
     expect(finished.finishedAt?.toISOString()).toBe("2026-04-06T15:00:01.280Z")
@@ -175,7 +180,7 @@ describe("SqliteProjectionRunStorage", () => {
       storage.update({
         id: "run-2",
         projectId: "my-app",
-        rowsProcessed: -1,
+        telemetryRowsFailed: -1,
       })
     ).rejects.toBeInstanceOf(ProjectionRunError)
   })

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -8,6 +8,7 @@ import { SqliteStorage } from "../src"
 import {
   migrateSqliteStorage,
   SQLITE_STORAGE_ADAPTER_ID,
+  sqliteStorageMigrations,
   sqliteStoragePath,
 } from "../src/migrations"
 
@@ -138,6 +139,9 @@ describe("SQLite storage migrations", () => {
     expect(syncRun?.checkpoint).toEqual({ cursor: "legacy" })
     expect(projectionRun?.status).toBe("succeeded")
     expect(projectionRun?.objectsUpserted).toBe(4)
+    expect(projectionRun?.telemetryPointsAppended).toBe(0)
+    expect(projectionRun?.telemetryPointsSkipped).toBe(0)
+    expect(projectionRun?.telemetryRowsFailed).toBe(0)
     expect(workflowRun?.status).toBe("succeeded")
     expect(workflowRun?.input).toEqual({ transactionId: "txn-1" })
     expect(webhookRun).toMatchObject({
@@ -165,6 +169,29 @@ describe("SQLite storage migrations", () => {
     await expect(migrateStorage(storage)).rejects.toThrow("dirty migration state")
 
     closeStorage(storage)
+  })
+
+  test("the timeseries primary key enforces the (series, at) natural key", () => {
+    const db = new Database(":memory:")
+    try {
+      sqliteStorageMigrations.steps[0]?.up(db)
+
+      const insert = db.query(`
+        INSERT INTO timeseries (
+          project_id, object_type_id, object_id, property_id,
+          value, unit, at, source_event_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      insert.run("p", "Room", "r1", "temp", "70.5", null, "2026-06-01T12:00:00.000Z", "evt-1")
+
+      // A second row at the same (series, at) is rejected by the natural-key
+      // PRIMARY KEY, even with a different source_event_id — appends must upsert.
+      expect(() =>
+        insert.run("p", "Room", "r1", "temp", "71", null, "2026-06-01T12:00:00.000Z", "evt-2")
+      ).toThrow()
+    } finally {
+      db.close()
+    }
   })
 })
 

--- a/storage/sqlite/tests/sqlite-timeseries-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-timeseries-storage.test.ts
@@ -90,6 +90,81 @@ describe("SqliteTimeseriesStorage", () => {
     expect(history).toHaveLength(1)
   })
 
+  test("overwrites the point at the same instant (last write wins)", async () => {
+    const at = new Date("2024-01-01T00:00:00.000Z").toISOString()
+    await storage.applyTelemetryAppended(
+      createTelemetryEvent("project-a", "Room", "room:101", "temperature", 22.5, at, "1")
+    )
+    await storage.applyTelemetryAppended(
+      createTelemetryEvent("project-a", "Room", "room:101", "temperature", 23.5, at, "2")
+    )
+
+    const history = await storage.getHistory({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      propertyId: "temperature",
+    })
+    expect(history).toHaveLength(1)
+    expect(history[0]?.value).toBe(23.5)
+
+    const latest = await storage.getLatest({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      propertyId: "temperature",
+    })
+    expect(latest?.value).toBe(23.5)
+    expect(latest?.sourceEventId).toBe("event-2")
+  })
+
+  test("applyTelemetryAppendedBatch upserts same-instant points within one batch", async () => {
+    const at = new Date("2024-01-01T00:00:00.000Z").toISOString()
+    await storage.applyTelemetryAppendedBatch([
+      createTelemetryEvent("project-a", "Room", "room:101", "temperature", 22.5, at, "1"),
+      createTelemetryEvent("project-a", "Room", "room:101", "temperature", 23.5, at, "2"),
+    ])
+
+    const history = await storage.getHistory({
+      projectId: "project-a",
+      objectTypeId: "Room",
+      objectId: "room:101",
+      propertyId: "temperature",
+    })
+    expect(history).toHaveLength(1)
+    expect(history[0]?.value).toBe(23.5)
+  })
+
+  test("rejects a non-canonical 'at' timestamp", async () => {
+    await expect(
+      storage.applyTelemetryAppended(
+        createTelemetryEvent(
+          "project-a",
+          "Room",
+          "room:101",
+          "temperature",
+          1,
+          "2024-01-01T00:00:00+05:00", // zone offset, not canonical UTC
+          "1"
+        )
+      )
+    ).rejects.toThrow("[SixbSqlite]")
+
+    await expect(
+      storage.applyTelemetryAppended(
+        createTelemetryEvent(
+          "project-a",
+          "Room",
+          "room:101",
+          "temperature",
+          1,
+          "2024-01-01 00:00:00", // zone-less
+          "2"
+        )
+      )
+    ).rejects.toThrow("canonical UTC ISO-8601")
+  })
+
   test("getHistory returns chronological data", async () => {
     const baseTime = new Date("2024-01-01T00:00:00Z")
 


### PR DESCRIPTION
Adds telemetry projections, so timestamped dataset rows can materialize onto telemetry-mode object properties — alongside the existing object and link projections.

## Usage

Mark the property as telemetry in the ontology, then map a dataset of readings onto it:

```ts
export const projectProgressProjection = defineTelemetryProjection(
  "project-progress",
  Project.p.progress
)
  .fromDataset(projectProgressDataset)
  .points({
    objectId: "project_id",
    at: "recorded_at",
    value: "progress_pct",
  })
```

Each row appends one point to the property's series. The latest reading also materializes onto the object, and the full history is queryable through `useTelemetryHistoryQuery`.

## What's included

| Area | Change |
| --- | --- |
| core | `defineTelemetryProjection`, startup validation, projection-run telemetry counters |
| storage | `(series, at)` natural-key timeseries identity, folded into the initial migration |
| projection-worker | telemetry runner; zone-less `at` timestamps parsed as UTC |
| server / client | telemetry projections in the projections API; `useTelemetryHistoryQuery` hook |
| atlas | telemetry projections listed on the object type page |
| examples / docs | acme-corp `project-progress` example and projection concept docs |

## Notes

- A telemetry point's identity is `(object, property, time)`: re-projecting the same instant upserts instead of duplicating, so runs stay idempotent without a separate ledger.
- The telemetry schema lives in `001-initial-schema` rather than a follow-up migration — pre-release, with no existing telemetry data to migrate.

## Verification

- `bun run typecheck`, `bun run check`, and `bun run generate:client` are clean
- targeted tests across core, projection-worker, storage (sqlite), and the acme-corp example pass locally; the pg storage e2e suite runs in CI
