### PR TITLE
authz: add dataset sync and pipeline grants

### DIFF
--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -37,9 +37,9 @@ whole flow, not just sign-in:
   `security-admins`.
 - **Invite policy** — security admins can invite people into `team-members`
   (`security/invite-policies/default-invites.ts`).
-- **Roles** — `team-members` can view `Note` and apply `acknowledge-note`.
-  `security-admins` use wildcard grants: view all objects, apply all actions,
-  run all workflows, and view events
+- **Roles** — `team-members` can view `Note`, view the team-notes dataset,
+  and apply `acknowledge-note`. `security-admins` use wildcard grants: view all
+  objects, view all datasets, apply all actions, run all workflows, and view events
   (`security/roles/atlas-access.ts`).
 - **Seed data** — startup writes one `Note`, one `AdminNote`, and one
   `AccessRequest` (`seed.ts`).
@@ -48,10 +48,11 @@ So: sign in as `admin@example.com`, then use the admin UI in Atlas to invite a
 teammate. They receive their own sign-in link — printed to the terminal, or
 emailed if Resend is configured.
 
-In Atlas, the teammate's object list should only include `Note` objects and the
-`acknowledge-note` action. Requests for `AdminNote`, `AccessRequest`, admin
-actions, workflows, and events are denied by the scoped SDK that backs the
-server routes.
+In Atlas, the teammate's object list should only include `Note` objects, the
+dataset list should only include `auth.team_notes`, and the action list should
+only include `acknowledge-note`. Requests for `AdminNote`, `AccessRequest`,
+admin-only datasets, admin actions, workflows, and events are denied by the
+scoped SDK that backs the server routes.
 
 ## Use OIDC instead (Google Workspace)
 

--- a/examples/auth/datasets/auth-data.ts
+++ b/examples/auth/datasets/auth-data.ts
@@ -1,0 +1,9 @@
+import { col, defineDataset } from "@sixb/core"
+
+export const teamNotesDataset = defineDataset("auth.team_notes", {
+  schema: [col("id", "string"), col("title", "string"), col("ownerEmail", "string")],
+})
+
+export const adminAuditDataset = defineDataset("auth.admin_audit", {
+  schema: [col("id", "string"), col("actorEmail", "string"), col("event", "string")],
+})

--- a/examples/auth/security/roles/atlas-access.ts
+++ b/examples/auth/security/roles/atlas-access.ts
@@ -1,15 +1,21 @@
-import { actions, can, defineRole, ontology, workflows } from "@sixb/core"
+import { actions, can, datasets, defineRole, ontology, workflows } from "@sixb/core"
 import { acknowledgeNote } from "../../actions/acknowledge-note"
+import { teamNotesDataset } from "../../datasets/auth-data"
 import { Note } from "../../ontology/note"
 import { securityAdmins } from "../groups/security-admins"
 import { teamMembers } from "../groups/team-members"
 
 export const teamMemberAtlasAccess = defineRole("team-member.atlas-access", {
   grantedTo: [teamMembers],
-  grants: [can.view(Note), can.apply(acknowledgeNote)],
+  grants: [can.view(Note), can.view(teamNotesDataset), can.apply(acknowledgeNote)],
 })
 
 export const securityAdminFullAccess = defineRole("security-admin.full-access", {
   grantedTo: [securityAdmins],
-  grants: [can.view(ontology.objects()), can.apply(actions()), can.run(workflows())],
+  grants: [
+    can.view(ontology.objects()),
+    can.view(datasets()),
+    can.apply(actions()),
+    can.run(workflows()),
+  ],
 })

--- a/examples/auth/tests/atlas-authorization.test.ts
+++ b/examples/auth/tests/atlas-authorization.test.ts
@@ -11,6 +11,7 @@ import {
   resolveAuthorizationContext,
   type Sixb,
 } from "@sixb/core"
+import { adminAuditDataset, teamNotesDataset } from "../datasets/auth-data"
 import { seedAuthExampleObjects } from "../seed"
 
 async function createAuthExampleRuntime() {
@@ -57,6 +58,9 @@ describe("auth example Atlas authorization", () => {
     )
 
     expect(teamMember.listActions().map((action) => action.id)).toEqual(["acknowledge-note"])
+    expect(teamMember.listDatasets().map((dataset) => dataset.id)).toEqual([teamNotesDataset.id])
+    expect(teamMember.getDatasetById(teamNotesDataset.id)?.id).toBe(teamNotesDataset.id)
+    expect(teamMember.getDatasetById(adminAuditDataset.id)).toBeNull()
     await expect(
       teamMember.requestAction({
         actionId: "acknowledge-note",
@@ -93,6 +97,9 @@ describe("auth example Atlas authorization", () => {
         .map((action) => action.id)
         .sort()
     ).toEqual(["acknowledge-note", "resolve-access-request"])
+    expect(new Set(admin.listDatasets().map((dataset) => dataset.id))).toEqual(
+      new Set([teamNotesDataset.id, adminAuditDataset.id])
+    )
     await expect(
       admin.requestAction({
         actionId: "resolve-access-request",
@@ -111,5 +118,6 @@ describe("auth example Atlas authorization", () => {
 
     expect(await noGroups.list({})).toEqual({ objects: [], hasMore: false, total: 0 })
     expect(noGroups.listActions()).toEqual([])
+    expect(noGroups.listDatasets()).toEqual([])
   })
 })

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -3871,6 +3871,23 @@
               }
             }
           },
+          "403": {
+            "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
           "404": {
             "description": "Response for status 404",
             "content": {
@@ -5039,6 +5056,23 @@
           },
           "400": {
             "description": "Response for status 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Response for status 403",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1376,6 +1376,12 @@ export type RequestSyncRunErrors = {
     error: string
   }
   /**
+   * Response for status 403
+   */
+  403: {
+    error: string
+  }
+  /**
    * Response for status 404
    */
   404: {
@@ -1791,6 +1797,12 @@ export type RequestPipelineRunErrors = {
    * Response for status 400
    */
   400: {
+    error: string
+  }
+  /**
+   * Response for status 403
+   */
+  403: {
     error: string
   }
   /**

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -22,8 +22,11 @@ import type { AuthorizationContext, GrantIndex } from "./types"
 /** Something a principal may attempt, paired with the resource it targets. */
 export type AuthzRequest =
   | { readonly kind: "object.view"; readonly objectTypeId: string }
+  | { readonly kind: "dataset.view"; readonly datasetId: string }
   | { readonly kind: "action.apply"; readonly actionId: string }
   | { readonly kind: "workflow.run"; readonly workflowId: string }
+  | { readonly kind: "sync.run"; readonly syncId: string }
+  | { readonly kind: "pipeline.run"; readonly pipelineId: string }
   | { readonly kind: "object.query"; readonly touchedObjectTypeIds: readonly string[] }
 
 export interface AuthzDecision {
@@ -42,42 +45,65 @@ interface AuthorizedRuntime {
 // the single unit that both names a requirement and tests the grant index, so
 // the two can never drift.
 type Atom =
-  | { readonly capability: "view"; readonly id: string }
+  | { readonly capability: "view"; readonly target: "object" | "dataset"; readonly id: string }
   | { readonly capability: "apply"; readonly id: string }
-  | { readonly capability: "run"; readonly id: string }
+  | {
+      readonly capability: "run"
+      readonly target: "workflow" | "sync" | "pipeline"
+      readonly id: string
+    }
 
 function atomsFor(request: AuthzRequest): readonly Atom[] {
   switch (request.kind) {
     case "object.view":
-      return [{ capability: "view", id: request.objectTypeId }]
+      return [{ capability: "view", target: "object", id: request.objectTypeId }]
+    case "dataset.view":
+      return [{ capability: "view", target: "dataset", id: request.datasetId }]
     case "action.apply":
       return [{ capability: "apply", id: request.actionId }]
     case "workflow.run":
-      return [{ capability: "run", id: request.workflowId }]
+      return [{ capability: "run", target: "workflow", id: request.workflowId }]
+    case "sync.run":
+      return [{ capability: "run", target: "sync", id: request.syncId }]
+    case "pipeline.run":
+      return [{ capability: "run", target: "pipeline", id: request.pipelineId }]
     case "object.query":
-      return request.touchedObjectTypeIds.map((id) => ({ capability: "view", id }))
+      return request.touchedObjectTypeIds.map((id) => ({
+        capability: "view",
+        target: "object",
+        id,
+      }))
   }
 }
 
 function atomKey(atom: Atom): string {
   switch (atom.capability) {
     case "view":
-      return `view:object:${atom.id}`
+      return `view:${atom.target}:${atom.id}`
     case "apply":
       return `apply:action:${atom.id}`
     case "run":
-      return `run:workflow:${atom.id}`
+      return `run:${atom.target}:${atom.id}`
   }
 }
 
 function holds(grants: GrantIndex, atom: Atom): boolean {
   switch (atom.capability) {
     case "view":
-      return grants.objectTypes.view.has(atom.id)
+      return atom.target === "dataset"
+        ? grants.datasets.view.has(atom.id)
+        : grants.objectTypes.view.has(atom.id)
     case "apply":
       return grants.actions.apply.has(atom.id)
     case "run":
-      return grants.workflows.run.has(atom.id)
+      switch (atom.target) {
+        case "sync":
+          return grants.syncs.run.has(atom.id)
+        case "pipeline":
+          return grants.pipelines.run.has(atom.id)
+        case "workflow":
+          return grants.workflows.run.has(atom.id)
+      }
   }
 }
 
@@ -137,10 +163,16 @@ function deniedMessage(
   switch (request.kind) {
     case "object.view":
       return `[Sixb] Principal '${principalId}' is not allowed to view object type '${request.objectTypeId}'.`
+    case "dataset.view":
+      return `[Sixb] Principal '${principalId}' is not allowed to view dataset '${request.datasetId}'.`
     case "action.apply":
       return `[Sixb] Principal '${principalId}' is not allowed to apply action '${request.actionId}'.`
     case "workflow.run":
       return `[Sixb] Principal '${principalId}' is not allowed to run workflow '${request.workflowId}'.`
+    case "sync.run":
+      return `[Sixb] Principal '${principalId}' is not allowed to run sync '${request.syncId}'.`
+    case "pipeline.run":
+      return `[Sixb] Principal '${principalId}' is not allowed to run pipeline '${request.pipelineId}'.`
     case "object.query": {
       // Name the first touched type the principal cannot view.
       const blocked = request.touchedObjectTypeIds.find(

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -17,6 +17,7 @@
  */
 
 import { AuthorizationError } from "./errors"
+import type { GrantKind } from "./grant-kinds"
 import type { AuthorizationContext, GrantIndex } from "./types"
 
 /** Something a principal may attempt, paired with the resource it targets. */
@@ -41,70 +42,40 @@ interface AuthorizedRuntime {
   readonly authorization?: AuthorizationContext
 }
 
-// A request expands to one or more atomic (capability, id) checks. The atom is
+// A request expands to one or more atomic (grant kind, id) checks. The atom is
 // the single unit that both names a requirement and tests the grant index, so
-// the two can never drift.
-type Atom =
-  | { readonly capability: "view"; readonly target: "object" | "dataset"; readonly id: string }
-  | { readonly capability: "apply"; readonly id: string }
-  | {
-      readonly capability: "run"
-      readonly target: "workflow" | "sync" | "pipeline"
-      readonly id: string
-    }
+// the two can never drift. `kind` is the resolved-index key, so enforcement is
+// a direct lookup with no per-target dispatch.
+interface Atom {
+  readonly kind: GrantKind
+  readonly id: string
+}
 
 function atomsFor(request: AuthzRequest): readonly Atom[] {
   switch (request.kind) {
     case "object.view":
-      return [{ capability: "view", target: "object", id: request.objectTypeId }]
+      return [{ kind: "view:object", id: request.objectTypeId }]
     case "dataset.view":
-      return [{ capability: "view", target: "dataset", id: request.datasetId }]
+      return [{ kind: "view:dataset", id: request.datasetId }]
     case "action.apply":
-      return [{ capability: "apply", id: request.actionId }]
+      return [{ kind: "apply:action", id: request.actionId }]
     case "workflow.run":
-      return [{ capability: "run", target: "workflow", id: request.workflowId }]
+      return [{ kind: "run:workflow", id: request.workflowId }]
     case "sync.run":
-      return [{ capability: "run", target: "sync", id: request.syncId }]
+      return [{ kind: "run:sync", id: request.syncId }]
     case "pipeline.run":
-      return [{ capability: "run", target: "pipeline", id: request.pipelineId }]
+      return [{ kind: "run:pipeline", id: request.pipelineId }]
     case "object.query":
-      return request.touchedObjectTypeIds.map((id) => ({
-        capability: "view",
-        target: "object",
-        id,
-      }))
+      return request.touchedObjectTypeIds.map((id) => ({ kind: "view:object", id }))
   }
 }
 
 function atomKey(atom: Atom): string {
-  switch (atom.capability) {
-    case "view":
-      return `view:${atom.target}:${atom.id}`
-    case "apply":
-      return `apply:action:${atom.id}`
-    case "run":
-      return `run:${atom.target}:${atom.id}`
-  }
+  return `${atom.kind}:${atom.id}`
 }
 
 function holds(grants: GrantIndex, atom: Atom): boolean {
-  switch (atom.capability) {
-    case "view":
-      return atom.target === "dataset"
-        ? grants.datasets.view.has(atom.id)
-        : grants.objectTypes.view.has(atom.id)
-    case "apply":
-      return grants.actions.apply.has(atom.id)
-    case "run":
-      switch (atom.target) {
-        case "sync":
-          return grants.syncs.run.has(atom.id)
-        case "pipeline":
-          return grants.pipelines.run.has(atom.id)
-        case "workflow":
-          return grants.workflows.run.has(atom.id)
-      }
-  }
+  return grants[atom.kind].has(atom.id)
 }
 
 /** Resolve a request against a principal's grants. Never throws. */

--- a/packages/core/src/authorization/event-visibility.ts
+++ b/packages/core/src/authorization/event-visibility.ts
@@ -62,6 +62,10 @@ export function canViewEvent(
         kind: "object.view",
         objectTypeId: event.payload.subject.objectTypeId,
       })
+    // Run grant gates the operational stream. These payloads may also carry the
+    // produced datasetId/versionId; that target is already visible to a runner
+    // through the sync/pipeline catalog (`sync.target.dataset`), so surfacing it
+    // here discloses nothing new.
     case "syncs":
       return isAllowed(authorization, {
         kind: "sync.run",
@@ -78,6 +82,12 @@ export function canViewEvent(
       // they gain their own grants, add the checks here.
       return true
     case "datasets":
+      // dataset.view alone. The payload's `producer` (the sync/pipeline that
+      // produced the version, plus its runId) is intentionally visible to any
+      // dataset viewer as provenance — the same identity the versions API
+      // already serializes for that principal. This is distinct from the
+      // operational `references` in the dataset catalog (which syncs/pipelines
+      // are wired to a dataset), which stays gated on the run grants.
       return isAllowed(authorization, {
         kind: "dataset.view",
         datasetId: event.payload.datasetId,

--- a/packages/core/src/authorization/event-visibility.ts
+++ b/packages/core/src/authorization/event-visibility.ts
@@ -62,14 +62,26 @@ export function canViewEvent(
         kind: "object.view",
         objectTypeId: event.payload.subject.objectTypeId,
       })
-    case "schedules":
     case "syncs":
+      return isAllowed(authorization, {
+        kind: "sync.run",
+        syncId: event.payload.syncId,
+      })
     case "pipelines":
-    case "datasets":
-      // Infra topics with no object/action/workflow subject: no grant governs
-      // them yet, so they stay visible to any authorized reader. When they gain
-      // their own grants, add the checks here.
+      return isAllowed(authorization, {
+        kind: "pipeline.run",
+        pipelineId: event.payload.pipelineId,
+      })
+    case "schedules":
+      // Infra topics with no object/action/workflow/dataset subject: no grant
+      // governs them yet, so they stay visible to any authorized reader. When
+      // they gain their own grants, add the checks here.
       return true
+    case "datasets":
+      return isAllowed(authorization, {
+        kind: "dataset.view",
+        datasetId: event.payload.datasetId,
+      })
     default:
       // Fail closed: an unmodeled topic may carry a subject we don't yet gate.
       return false

--- a/packages/core/src/authorization/grant-kinds.ts
+++ b/packages/core/src/authorization/grant-kinds.ts
@@ -1,0 +1,105 @@
+/**
+ * Grant kinds: the single source of truth for the (capability, target) space.
+ *
+ * Every grant collapses to one `GrantKind` discriminant — the same
+ * `capability:target` string the decision engine uses as a grant key (e.g.
+ * `view:object`, `run:sync`). Resolution, validation, enforcement, and the
+ * resolved `GrantIndex` all key off it, so adding a grant family is a single
+ * entry in `GRANT_KINDS` plus the compile errors that forces at every consumer.
+ */
+
+import type { GrantDefinition } from "../security/types"
+
+export type GrantKind =
+  | "view:object"
+  | "view:dataset"
+  | "apply:action"
+  | "run:workflow"
+  | "run:sync"
+  | "run:pipeline"
+
+/** Registered id universes a grant kind ranges over, plus subtype expansion. */
+export interface GrantUniverse {
+  readonly objectTypeIds: ReadonlySet<string>
+  readonly datasetIds: ReadonlySet<string>
+  readonly actionIds: ReadonlySet<string>
+  readonly workflowIds: ReadonlySet<string>
+  readonly syncIds: ReadonlySet<string>
+  readonly pipelineIds: ReadonlySet<string>
+  readonly getSubTypes: (objectTypeId: string) => readonly string[]
+}
+
+/** The registered-id sets a grant kind validates against (no subtype hook). */
+export type GrantUniverseKey = Exclude<keyof GrantUniverse, "getSubTypes">
+
+interface GrantKindSpec {
+  /** Registered universe the grant's ids must belong to. */
+  readonly universeKey: GrantUniverseKey
+  /** Subject noun used in validation errors ("unknown <subject> '<id>'"). */
+  readonly subject: string
+  /** Actionable hint appended to the "unknown <subject>" error. */
+  readonly fix: string
+  /** Only object-type grants also expand to subtypes. */
+  readonly expandsSubtypes?: true
+}
+
+/**
+ * The exhaustive grant-kind table. A new grant family is one entry here; the
+ * `Record<GrantKind, …>` makes every omission a compile error.
+ */
+export const GRANT_KINDS: Record<GrantKind, GrantKindSpec> = {
+  "view:object": {
+    universeKey: "objectTypeIds",
+    subject: "object type",
+    fix: "Register it in 'ontology/' or pass it to createSixb({ ontologies }).",
+    expandsSubtypes: true,
+  },
+  "view:dataset": {
+    universeKey: "datasetIds",
+    subject: "dataset",
+    fix: "Add it to 'datasets/' or pass it to createSixb({ datasets }).",
+  },
+  "apply:action": {
+    universeKey: "actionIds",
+    subject: "action",
+    fix: "Add it to 'actions/' or pass it to createSixb({ actions }).",
+  },
+  "run:workflow": {
+    universeKey: "workflowIds",
+    subject: "workflow",
+    fix: "Add it to 'workflows/' or pass it to createSixb({ workflows }).",
+  },
+  "run:sync": {
+    universeKey: "syncIds",
+    subject: "sync",
+    fix: "Add it to 'syncs/' or pass it to createSixb({ syncs }).",
+  },
+  "run:pipeline": {
+    universeKey: "pipelineIds",
+    subject: "pipeline",
+    fix: "Add it to 'pipelines/' or pass it to createSixb({ pipelines }).",
+  },
+}
+
+export const GRANT_KIND_KEYS = Object.keys(GRANT_KINDS) as readonly GrantKind[]
+
+/** The grant kind a stored grant resolves to. */
+export function grantKindOf(grant: GrantDefinition): GrantKind {
+  switch (grant.capability) {
+    case "view":
+      return `view:${grant.target}`
+    case "apply":
+      return "apply:action"
+    case "run":
+      return `run:${grant.target}`
+  }
+}
+
+/** A fresh, mutable grant index with one empty id set per kind. */
+export function emptyGrantSets(): Record<GrantKind, Set<string>> {
+  const sets = {} as Record<GrantKind, Set<string>>
+  for (const kind of GRANT_KIND_KEYS) {
+    sets[kind] = new Set<string>()
+  }
+  return sets
+}

--- a/packages/core/src/authorization/index.ts
+++ b/packages/core/src/authorization/index.ts
@@ -2,6 +2,12 @@ export type { AuthzDecision, AuthzRequest } from "./decision"
 export { assertAuthorized, assertPrivileged, evaluate, isAllowed } from "./decision"
 export { AuthorizationError } from "./errors"
 export { canViewEvent } from "./event-visibility"
+export type { GrantKind, GrantUniverse } from "./grant-kinds"
 export { resolveAuthorizationContext, resolveRoleGrants } from "./resolve"
-export { canViewActionRun, canViewWorkflowIntervention, canViewWorkflowRun } from "./run-visibility"
+export {
+  canViewActionRun,
+  canViewPipelineRun,
+  canViewWorkflowIntervention,
+  canViewWorkflowRun,
+} from "./run-visibility"
 export type { AuthorizationContext, GrantIndex, ResolvedRole } from "./types"

--- a/packages/core/src/authorization/resolve.ts
+++ b/packages/core/src/authorization/resolve.ts
@@ -1,74 +1,38 @@
 import type { Principal } from "../auth/types"
 import type { RoleDefinition, Selection } from "../security"
+import {
+  emptyGrantSets,
+  GRANT_KIND_KEYS,
+  GRANT_KINDS,
+  type GrantUniverse,
+  grantKindOf,
+} from "./grant-kinds"
 import type { AuthorizationContext, GrantIndex, ResolvedRole } from "./types"
 
 /**
  * Expand a role's grants into concrete id sets once at startup.
  *
  * Broad grants (`ontology.objects().except(...)`) expand against the registered
- * universe; explicit object grants expand to subtypes. The result holds only
+ * universe; object-type grants also expand to subtypes. The result holds only
  * `Set`s, so per-request resolution and runtime checks stay simple `set.has`.
+ * The per-kind universe and subtype rules come from the `GRANT_KINDS` table, so
+ * this loop never enumerates targets by hand.
  */
-export function resolveRoleGrants(
-  role: RoleDefinition,
-  universe: {
-    readonly objectTypeIds: ReadonlySet<string>
-    readonly datasetIds: ReadonlySet<string>
-    readonly actionIds: ReadonlySet<string>
-    readonly workflowIds: ReadonlySet<string>
-    readonly syncIds: ReadonlySet<string>
-    readonly pipelineIds: ReadonlySet<string>
-    readonly getSubTypes: (objectTypeId: string) => readonly string[]
-  }
-): GrantIndex {
-  const viewObjects = new Set<string>()
-  const viewDatasets = new Set<string>()
-  const apply = new Set<string>()
-  const runWorkflows = new Set<string>()
-  const runSyncs = new Set<string>()
-  const runPipelines = new Set<string>()
+export function resolveRoleGrants(role: RoleDefinition, universe: GrantUniverse): GrantIndex {
+  const grants = emptyGrantSets()
 
   for (const grant of role.grants) {
-    switch (grant.capability) {
-      case "view":
-        if ((grant.target ?? "object") === "dataset") {
-          expandSelection(grant.selection, universe.datasetIds, viewDatasets)
-        } else {
-          expandSelection(
-            grant.selection,
-            universe.objectTypeIds,
-            viewObjects,
-            universe.getSubTypes
-          )
-        }
-        break
-      case "apply":
-        expandSelection(grant.selection, universe.actionIds, apply)
-        break
-      case "run":
-        switch (grant.target ?? "workflow") {
-          case "sync":
-            expandSelection(grant.selection, universe.syncIds, runSyncs)
-            break
-          case "pipeline":
-            expandSelection(grant.selection, universe.pipelineIds, runPipelines)
-            break
-          case "workflow":
-            expandSelection(grant.selection, universe.workflowIds, runWorkflows)
-            break
-        }
-        break
-    }
+    const kind = grantKindOf(grant)
+    const spec = GRANT_KINDS[kind]
+    expandSelection(
+      grant.selection,
+      universe[spec.universeKey],
+      grants[kind],
+      spec.expandsSubtypes ? universe.getSubTypes : undefined
+    )
   }
 
-  return {
-    objectTypes: { view: viewObjects },
-    datasets: { view: viewDatasets },
-    actions: { apply },
-    workflows: { run: runWorkflows },
-    syncs: { run: runSyncs },
-    pipelines: { run: runPipelines },
-  }
+  return grants
 }
 
 function expandSelection(
@@ -112,12 +76,7 @@ export function resolveAuthorizationContext(input: {
 }): AuthorizationContext {
   const memberGroupIds = new Set(input.groupIds)
   const roleIds: string[] = []
-  const viewObjects = new Set<string>()
-  const viewDatasets = new Set<string>()
-  const apply = new Set<string>()
-  const runWorkflows = new Set<string>()
-  const runSyncs = new Set<string>()
-  const runPipelines = new Set<string>()
+  const grants = emptyGrantSets()
 
   for (const role of input.roles) {
     if (!role.grantedToGroupIds.some((groupId) => memberGroupIds.has(groupId))) {
@@ -125,23 +84,10 @@ export function resolveAuthorizationContext(input: {
     }
 
     roleIds.push(role.id)
-    for (const id of role.grants.objectTypes.view) {
-      viewObjects.add(id)
-    }
-    for (const id of role.grants.datasets.view) {
-      viewDatasets.add(id)
-    }
-    for (const id of role.grants.actions.apply) {
-      apply.add(id)
-    }
-    for (const id of role.grants.workflows.run) {
-      runWorkflows.add(id)
-    }
-    for (const id of role.grants.syncs.run) {
-      runSyncs.add(id)
-    }
-    for (const id of role.grants.pipelines.run) {
-      runPipelines.add(id)
+    for (const kind of GRANT_KIND_KEYS) {
+      for (const id of role.grants[kind]) {
+        grants[kind].add(id)
+      }
     }
   }
 
@@ -150,13 +96,6 @@ export function resolveAuthorizationContext(input: {
     ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
     groupIds: input.groupIds,
     roleIds,
-    grants: {
-      objectTypes: { view: viewObjects },
-      datasets: { view: viewDatasets },
-      actions: { apply },
-      workflows: { run: runWorkflows },
-      syncs: { run: runSyncs },
-      pipelines: { run: runPipelines },
-    },
+    grants,
   }
 }

--- a/packages/core/src/authorization/resolve.ts
+++ b/packages/core/src/authorization/resolve.ts
@@ -1,5 +1,5 @@
 import type { Principal } from "../auth/types"
-import type { GrantCapability, RoleDefinition, Selection } from "../security"
+import type { RoleDefinition, Selection } from "../security"
 import type { AuthorizationContext, GrantIndex, ResolvedRole } from "./types"
 
 /**
@@ -13,37 +13,62 @@ export function resolveRoleGrants(
   role: RoleDefinition,
   universe: {
     readonly objectTypeIds: ReadonlySet<string>
+    readonly datasetIds: ReadonlySet<string>
     readonly actionIds: ReadonlySet<string>
     readonly workflowIds: ReadonlySet<string>
+    readonly syncIds: ReadonlySet<string>
+    readonly pipelineIds: ReadonlySet<string>
     readonly getSubTypes: (objectTypeId: string) => readonly string[]
   }
 ): GrantIndex {
-  const view = new Set<string>()
+  const viewObjects = new Set<string>()
+  const viewDatasets = new Set<string>()
   const apply = new Set<string>()
-  const run = new Set<string>()
-
-  // Capability -> the universe it ranges over, the set it expands into, and any
-  // subtype expansion. A Record keeps this exhaustive:
-  // adding a capability is a compile error until it is wired here.
-  const targets: Record<
-    GrantCapability,
-    {
-      readonly universe: ReadonlySet<string>
-      readonly into: Set<string>
-      readonly expand?: (id: string) => readonly string[]
-    }
-  > = {
-    view: { universe: universe.objectTypeIds, into: view, expand: universe.getSubTypes },
-    apply: { universe: universe.actionIds, into: apply },
-    run: { universe: universe.workflowIds, into: run },
-  }
+  const runWorkflows = new Set<string>()
+  const runSyncs = new Set<string>()
+  const runPipelines = new Set<string>()
 
   for (const grant of role.grants) {
-    const target = targets[grant.capability]
-    expandSelection(grant.selection, target.universe, target.into, target.expand)
+    switch (grant.capability) {
+      case "view":
+        if ((grant.target ?? "object") === "dataset") {
+          expandSelection(grant.selection, universe.datasetIds, viewDatasets)
+        } else {
+          expandSelection(
+            grant.selection,
+            universe.objectTypeIds,
+            viewObjects,
+            universe.getSubTypes
+          )
+        }
+        break
+      case "apply":
+        expandSelection(grant.selection, universe.actionIds, apply)
+        break
+      case "run":
+        switch (grant.target ?? "workflow") {
+          case "sync":
+            expandSelection(grant.selection, universe.syncIds, runSyncs)
+            break
+          case "pipeline":
+            expandSelection(grant.selection, universe.pipelineIds, runPipelines)
+            break
+          case "workflow":
+            expandSelection(grant.selection, universe.workflowIds, runWorkflows)
+            break
+        }
+        break
+    }
   }
 
-  return { objectTypes: { view }, actions: { apply }, workflows: { run } }
+  return {
+    objectTypes: { view: viewObjects },
+    datasets: { view: viewDatasets },
+    actions: { apply },
+    workflows: { run: runWorkflows },
+    syncs: { run: runSyncs },
+    pipelines: { run: runPipelines },
+  }
 }
 
 function expandSelection(
@@ -87,9 +112,12 @@ export function resolveAuthorizationContext(input: {
 }): AuthorizationContext {
   const memberGroupIds = new Set(input.groupIds)
   const roleIds: string[] = []
-  const view = new Set<string>()
+  const viewObjects = new Set<string>()
+  const viewDatasets = new Set<string>()
   const apply = new Set<string>()
-  const run = new Set<string>()
+  const runWorkflows = new Set<string>()
+  const runSyncs = new Set<string>()
+  const runPipelines = new Set<string>()
 
   for (const role of input.roles) {
     if (!role.grantedToGroupIds.some((groupId) => memberGroupIds.has(groupId))) {
@@ -98,13 +126,22 @@ export function resolveAuthorizationContext(input: {
 
     roleIds.push(role.id)
     for (const id of role.grants.objectTypes.view) {
-      view.add(id)
+      viewObjects.add(id)
+    }
+    for (const id of role.grants.datasets.view) {
+      viewDatasets.add(id)
     }
     for (const id of role.grants.actions.apply) {
       apply.add(id)
     }
     for (const id of role.grants.workflows.run) {
-      run.add(id)
+      runWorkflows.add(id)
+    }
+    for (const id of role.grants.syncs.run) {
+      runSyncs.add(id)
+    }
+    for (const id of role.grants.pipelines.run) {
+      runPipelines.add(id)
     }
   }
 
@@ -113,6 +150,13 @@ export function resolveAuthorizationContext(input: {
     ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
     groupIds: input.groupIds,
     roleIds,
-    grants: { objectTypes: { view }, actions: { apply }, workflows: { run } },
+    grants: {
+      objectTypes: { view: viewObjects },
+      datasets: { view: viewDatasets },
+      actions: { apply },
+      workflows: { run: runWorkflows },
+      syncs: { run: runSyncs },
+      pipelines: { run: runPipelines },
+    },
   }
 }

--- a/packages/core/src/authorization/run-visibility.ts
+++ b/packages/core/src/authorization/run-visibility.ts
@@ -1,4 +1,5 @@
 import type { ActionRunRecord } from "../storage/action-runs"
+import type { PipelineRunRecord } from "../storage/pipeline-runs"
 import type { WorkflowInterventionRecord } from "../storage/workflow-interventions"
 import type { WorkflowRunRecord } from "../storage/workflow-runs"
 import { isAllowed } from "./decision"
@@ -40,5 +41,14 @@ export function canViewWorkflowIntervention(
   return (
     !authorization ||
     isAllowed(authorization, { kind: "workflow.run", workflowId: intervention.workflowId })
+  )
+}
+
+export function canViewPipelineRun(
+  authorization: AuthorizationContext | null | undefined,
+  run: Pick<PipelineRunRecord, "pipelineId">
+): boolean {
+  return (
+    !authorization || isAllowed(authorization, { kind: "pipeline.run", pipelineId: run.pipelineId })
   )
 }

--- a/packages/core/src/authorization/types.ts
+++ b/packages/core/src/authorization/types.ts
@@ -8,21 +8,16 @@
  */
 
 import type { Principal } from "../auth/types"
+import type { GrantKind } from "./grant-kinds"
 
-export interface GrantIndex {
-  /** Object type ids viewable, expanded from grants (broad grants + subtypes). */
-  readonly objectTypes: { readonly view: ReadonlySet<string> }
-  /** Dataset ids viewable. */
-  readonly datasets: { readonly view: ReadonlySet<string> }
-  /** Action ids this principal may request. */
-  readonly actions: { readonly apply: ReadonlySet<string> }
-  /** Workflow ids this principal may run. */
-  readonly workflows: { readonly run: ReadonlySet<string> }
-  /** Sync ids this principal may run. */
-  readonly syncs: { readonly run: ReadonlySet<string> }
-  /** Pipeline ids this principal may run. */
-  readonly pipelines: { readonly run: ReadonlySet<string> }
-}
+/**
+ * Grants resolved to concrete id sets, keyed by grant kind (`view:object`,
+ * `run:sync`, …). Broad grants and object subtypes are already expanded, so
+ * enforcement is a single `grants[kind].has(id)` lookup. Keyed by `GrantKind`
+ * so a new grant family adds one key, not a new bucket every consumer must
+ * learn.
+ */
+export type GrantIndex = Readonly<Record<GrantKind, ReadonlySet<string>>>
 
 /** A role with its grants pre-expanded to concrete id sets at startup. */
 export interface ResolvedRole {

--- a/packages/core/src/authorization/types.ts
+++ b/packages/core/src/authorization/types.ts
@@ -12,10 +12,16 @@ import type { Principal } from "../auth/types"
 export interface GrantIndex {
   /** Object type ids viewable, expanded from grants (broad grants + subtypes). */
   readonly objectTypes: { readonly view: ReadonlySet<string> }
+  /** Dataset ids viewable. */
+  readonly datasets: { readonly view: ReadonlySet<string> }
   /** Action ids this principal may request. */
   readonly actions: { readonly apply: ReadonlySet<string> }
   /** Workflow ids this principal may run. */
   readonly workflows: { readonly run: ReadonlySet<string> }
+  /** Sync ids this principal may run. */
+  readonly syncs: { readonly run: ReadonlySet<string> }
+  /** Pipeline ids this principal may run. */
+  readonly pipelines: { readonly run: ReadonlySet<string> }
 }
 
 /** A role with its grants pre-expanded to concrete id sets at startup. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -481,11 +481,13 @@ export type {
   RegisteredSecurityDefinitions,
   RoleDefinition,
   RunGrant,
+  RunGrantTarget,
   Scope,
   ScopeTarget,
   SecurityRegistry,
   Selection,
   ViewGrant,
+  ViewGrantTarget,
 } from "./security"
 export {
   actions,
@@ -495,6 +497,7 @@ export {
   assertRoleDefinition,
   can,
   canInviteGroupIds,
+  datasets,
   defineGroup,
   defineInvitePolicy,
   defineRole,
@@ -503,8 +506,10 @@ export {
   isRoleDefinition,
   missingInviteGroupIds,
   ontology,
+  pipelines,
   resolveInvitePolicyScope,
   SecurityValidationError,
+  syncs,
   workflows,
 } from "./security"
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -451,6 +451,8 @@ export type {
   AuthzDecision,
   AuthzRequest,
   GrantIndex,
+  GrantKind,
+  GrantUniverse,
   ResolvedRole,
 } from "./authorization"
 export {
@@ -458,6 +460,7 @@ export {
   assertAuthorized,
   canViewActionRun,
   canViewEvent,
+  canViewPipelineRun,
   canViewWorkflowIntervention,
   canViewWorkflowRun,
   evaluate,

--- a/packages/core/src/objects/service/list-service.ts
+++ b/packages/core/src/objects/service/list-service.ts
@@ -71,7 +71,7 @@ function resolveAuthorizedTypeFilter(
   if (!expanded) {
     // Broad listings narrow to the visible universe rather than failing. The
     // set already contains every registered type when "all" was granted.
-    return [...runtime.authorization.grants.objectTypes.view]
+    return [...runtime.authorization.grants["view:object"]]
   }
 
   // Explicitly requested types must all be viewable.

--- a/packages/core/src/runtime/scoped.ts
+++ b/packages/core/src/runtime/scoped.ts
@@ -16,13 +16,16 @@ import {
   canViewEvent,
   isAllowed,
 } from "../authorization"
+import type { DatasetDefinition } from "../datasets"
 import type { EventsReadInput, StoredDomainEvent } from "../events"
 import { createObjectSet, objectService } from "../objects"
 import type { ListObjectsParams } from "../objects/service"
 import type { ValueType } from "../ontology"
 import { assertObjectTypeRegistered } from "../ontology"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
+import type { PipelineDefinition } from "../pipelines"
 import type { ObjectRow } from "../storage"
+import type { SyncDefinition } from "../syncs"
 import type {
   RequestWorkflowRunInput,
   WorkflowDefinition,
@@ -97,6 +100,12 @@ export interface ScopedSixb<TOntologySources extends readonly OntologySource[]> 
   /** Get an object by type id and primary id (server / dynamic contexts). */
   getObject(objectTypeId: string, primaryId: string): Promise<ObjectRow | null>
 
+  /** Dataset definitions the principal may view. */
+  listDatasets(): readonly DatasetDefinition[]
+
+  /** Look up a viewable dataset definition; null hides ungranted datasets. */
+  getDatasetById(datasetId: string): DatasetDefinition | null
+
   /** Action definitions the principal may apply. */
   listActions(): readonly ActionDefinition[]
 
@@ -115,13 +124,39 @@ export interface ScopedSixb<TOntologySources extends readonly OntologySource[]> 
   /** Look up a runnable workflow definition; null hides workflows the principal cannot run. */
   getWorkflowById(workflowId: string): WorkflowDefinition | null
 
+  /** Sync definitions the principal may run. */
+  listSyncs(): readonly SyncDefinition[]
+
+  /** Look up a runnable sync definition; null hides syncs the principal cannot run. */
+  getSyncById(syncId: string): SyncDefinition | null
+
+  /** Pipeline definitions the principal may run. */
+  listPipelines(): readonly PipelineDefinition[]
+
+  /** Look up a runnable pipeline definition; null hides pipelines the principal cannot run. */
+  getPipelineById(pipelineId: string): PipelineDefinition | null
+
   /** Read the domain events the principal is allowed to see (derived from grants). */
   readEvents(input?: EventsReadInput): Promise<readonly StoredDomainEvent[]>
 }
 
 export function createScopedSixb<TOntologySources extends readonly OntologySource[]>(
   runtime: SixbRuntimeContext & { readonly authorization: AuthorizationContext },
-  deps: { readonly workflows: WorkflowsRuntime }
+  deps: {
+    readonly datasets: {
+      readonly list: () => readonly DatasetDefinition[]
+      readonly getById: (datasetId: string) => DatasetDefinition | null
+    }
+    readonly syncs: {
+      readonly list: () => readonly SyncDefinition[]
+      readonly getById: (syncId: string) => SyncDefinition | null
+    }
+    readonly pipelines: {
+      readonly list: () => readonly PipelineDefinition[]
+      readonly getById: (pipelineId: string) => PipelineDefinition | null
+    }
+    readonly workflows: WorkflowsRuntime
+  }
 ): ScopedSixb<TOntologySources> {
   const canListAction = (action: ActionDefinition) =>
     isAllowed(runtime.authorization, { kind: "action.apply", actionId: action.id }) &&
@@ -155,6 +190,21 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
       })
     },
 
+    listDatasets: () =>
+      deps.datasets
+        .list()
+        .filter((dataset) =>
+          isAllowed(runtime.authorization, { kind: "dataset.view", datasetId: dataset.id })
+        ),
+
+    getDatasetById: (datasetId: string) => {
+      const dataset = deps.datasets.getById(datasetId)
+      return dataset &&
+        isAllowed(runtime.authorization, { kind: "dataset.view", datasetId: dataset.id })
+        ? dataset
+        : null
+    },
+
     listActions: () => runtime.actionRegistry.list().filter((action) => canListAction(action)),
 
     getActionById: (actionId: string) => {
@@ -180,6 +230,30 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
       const workflow = deps.workflows.getById(workflowId)
       return workflow && isAllowed(runtime.authorization, { kind: "workflow.run", workflowId })
         ? workflow
+        : null
+    },
+
+    listSyncs: () =>
+      deps.syncs
+        .list()
+        .filter((sync) => isAllowed(runtime.authorization, { kind: "sync.run", syncId: sync.id })),
+
+    getSyncById: (syncId: string) => {
+      const sync = deps.syncs.getById(syncId)
+      return sync && isAllowed(runtime.authorization, { kind: "sync.run", syncId }) ? sync : null
+    },
+
+    listPipelines: () =>
+      deps.pipelines
+        .list()
+        .filter((pipeline) =>
+          isAllowed(runtime.authorization, { kind: "pipeline.run", pipelineId: pipeline.id })
+        ),
+
+    getPipelineById: (pipelineId: string) => {
+      const pipeline = deps.pipelines.getById(pipelineId)
+      return pipeline && isAllowed(runtime.authorization, { kind: "pipeline.run", pipelineId })
+        ? pipeline
         : null
     },
 

--- a/packages/core/src/runtime/scoped.ts
+++ b/packages/core/src/runtime/scoped.ts
@@ -12,6 +12,7 @@ import type { ActionDefinition, RequestActionInput, RequestActionResult } from "
 import { requestAction as requestRuntimeAction } from "../actions/request"
 import {
   type AuthorizationContext,
+  type AuthzRequest,
   assertAuthorized,
   canViewEvent,
   isAllowed,
@@ -166,6 +167,38 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
         objectTypeId: action.binding.objectType.id,
       }))
 
+  // A scoped catalog narrows a definition source to what the principal may see.
+  // The run/view grant doubles as catalog visibility: a definition the principal
+  // cannot run/view is not worth surfacing, and hiding it also hides the
+  // (possibly ungranted) resources its shape references.
+  const scopedCatalog = <T extends { readonly id: string }>(
+    source: { list(): readonly T[]; getById(id: string): T | null },
+    toRequest: (id: string) => AuthzRequest
+  ) => {
+    const allowed = (id: string) => isAllowed(runtime.authorization, toRequest(id))
+    return {
+      list: () => source.list().filter((item) => allowed(item.id)),
+      getById: (id: string) => {
+        const item = source.getById(id)
+        return item && allowed(id) ? item : null
+      },
+    }
+  }
+
+  const datasets = scopedCatalog(deps.datasets, (datasetId) => ({
+    kind: "dataset.view",
+    datasetId,
+  }))
+  const syncs = scopedCatalog(deps.syncs, (syncId) => ({ kind: "sync.run", syncId }))
+  const pipelines = scopedCatalog(deps.pipelines, (pipelineId) => ({
+    kind: "pipeline.run",
+    pipelineId,
+  }))
+  const workflows = scopedCatalog(deps.workflows, (workflowId) => ({
+    kind: "workflow.run",
+    workflowId,
+  }))
+
   const scoped = {
     authorization: runtime.authorization,
 
@@ -190,20 +223,8 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
       })
     },
 
-    listDatasets: () =>
-      deps.datasets
-        .list()
-        .filter((dataset) =>
-          isAllowed(runtime.authorization, { kind: "dataset.view", datasetId: dataset.id })
-        ),
-
-    getDatasetById: (datasetId: string) => {
-      const dataset = deps.datasets.getById(datasetId)
-      return dataset &&
-        isAllowed(runtime.authorization, { kind: "dataset.view", datasetId: dataset.id })
-        ? dataset
-        : null
-    },
+    listDatasets: datasets.list,
+    getDatasetById: datasets.getById,
 
     listActions: () => runtime.actionRegistry.list().filter((action) => canListAction(action)),
 
@@ -216,46 +237,14 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
 
     runWorkflow: (input: RequestWorkflowRunInput) => deps.workflows.requestByIdAs(runtime, input),
 
-    // Run grant doubles as catalog visibility: a workflow you cannot run is not
-    // worth surfacing, and hiding it also hides the (possibly ungranted) object
-    // types and action params its node graph references.
-    listWorkflows: () =>
-      deps.workflows
-        .list()
-        .filter((workflow) =>
-          isAllowed(runtime.authorization, { kind: "workflow.run", workflowId: workflow.id })
-        ),
+    listWorkflows: workflows.list,
+    getWorkflowById: workflows.getById,
 
-    getWorkflowById: (workflowId: string) => {
-      const workflow = deps.workflows.getById(workflowId)
-      return workflow && isAllowed(runtime.authorization, { kind: "workflow.run", workflowId })
-        ? workflow
-        : null
-    },
+    listSyncs: syncs.list,
+    getSyncById: syncs.getById,
 
-    listSyncs: () =>
-      deps.syncs
-        .list()
-        .filter((sync) => isAllowed(runtime.authorization, { kind: "sync.run", syncId: sync.id })),
-
-    getSyncById: (syncId: string) => {
-      const sync = deps.syncs.getById(syncId)
-      return sync && isAllowed(runtime.authorization, { kind: "sync.run", syncId }) ? sync : null
-    },
-
-    listPipelines: () =>
-      deps.pipelines
-        .list()
-        .filter((pipeline) =>
-          isAllowed(runtime.authorization, { kind: "pipeline.run", pipelineId: pipeline.id })
-        ),
-
-    getPipelineById: (pipelineId: string) => {
-      const pipeline = deps.pipelines.getById(pipelineId)
-      return pipeline && isAllowed(runtime.authorization, { kind: "pipeline.run", pipelineId })
-        ? pipeline
-        : null
-    },
+    listPipelines: pipelines.list,
+    getPipelineById: pipelines.getById,
 
     // No standalone events grant: the stream is filtered to events whose
     // subject the principal may view/apply/run. `limit` applies before this

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -159,8 +159,11 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       roles: options.roles ?? [],
       invitePolicies: options.invitePolicies ?? [],
       objectTypeIds: new Set(this.ontology.getObjectTypesById().keys()),
+      datasetIds: new Set((options.datasets ?? []).map((dataset) => dataset.id)),
       actionIds: registeredActionIds,
       workflowIds: new Set((options.workflows ?? []).map((workflow) => workflow.id)),
+      syncIds: new Set((options.syncs ?? []).map((sync) => sync.id)),
+      pipelineIds: new Set((options.pipelines ?? []).map((pipeline) => pipeline.id)),
       getSubTypes: (objectTypeId) => this.ontology.getSubTypes(objectTypeId),
     })
     this.auth = new AuthRuntime({
@@ -484,7 +487,21 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
   as(context: AuthorizationContext): ScopedSixb<TOntologySources> {
     return createScopedSixb<TOntologySources>(
       { ...this.runtimeContext, authorization: context },
-      { workflows: this.workflows }
+      {
+        datasets: {
+          list: () => this.getDatasetDefinitions(),
+          getById: (datasetId) => this.getDatasetById(datasetId),
+        },
+        syncs: {
+          list: () => this.getSyncDefinitions(),
+          getById: (syncId) => this.getSyncById(syncId),
+        },
+        pipelines: {
+          list: () => this.getPipelineDefinitions(),
+          getById: (pipelineId) => this.getPipelineById(pipelineId),
+        },
+        workflows: this.workflows,
+      }
     )
   }
 

--- a/packages/core/src/security/grants.ts
+++ b/packages/core/src/security/grants.ts
@@ -8,7 +8,10 @@
  */
 
 import type { ActionDefinition } from "../actions/types"
+import type { DatasetDefinition } from "../datasets"
 import type { ObjectType } from "../ontology"
+import type { PipelineDefinition } from "../pipelines"
+import type { SyncDefinition } from "../syncs"
 import type { WorkflowDefinition } from "../workflows/types"
 import { SecurityValidationError } from "./errors"
 import { isScope, type Scope, scopeIdOf } from "./scopes"
@@ -37,16 +40,88 @@ function selectionFrom<TDefinition extends { readonly id?: unknown }>(
   return { all: false, ids }
 }
 
-function view(input: GrantInput<ObjectType, "object">): ViewGrant {
-  return { kind: "grant", capability: "view", selection: selectionFrom(input, "can.view") }
+function isDatasetDefinitionInput(value: unknown): value is DatasetDefinition {
+  return (
+    typeof value === "object" && value !== null && (value as DatasetDefinition).kind === "dataset"
+  )
+}
+
+function viewTargetFrom(
+  input: GrantInput<ObjectType | DatasetDefinition, "object" | "dataset">
+): "object" | "dataset" {
+  if (isScope(input)) {
+    if (input.target !== "object" && input.target !== "dataset") {
+      throw new SecurityValidationError("[Sixb] can.view scope target must be object or dataset.")
+    }
+    return input.target
+  }
+
+  const first = Array.isArray(input) ? input[0] : input
+  return isDatasetDefinitionInput(first) ? "dataset" : "object"
+}
+
+function view(input: GrantInput<ObjectType, "object">): ViewGrant<"object">
+function view(input: GrantInput<DatasetDefinition, "dataset">): ViewGrant<"dataset">
+function view(input: GrantInput<ObjectType | DatasetDefinition, "object" | "dataset">): ViewGrant {
+  return {
+    kind: "grant",
+    capability: "view",
+    target: viewTargetFrom(input),
+    selection: selectionFrom(input, "can.view"),
+  }
 }
 
 function apply(input: GrantInput<ActionDefinition, "action">): ApplyGrant {
   return { kind: "grant", capability: "apply", selection: selectionFrom(input, "can.apply") }
 }
 
-function run(input: GrantInput<WorkflowDefinition, "workflow">): RunGrant {
-  return { kind: "grant", capability: "run", selection: selectionFrom(input, "can.run") }
+function isSyncDefinitionInput(value: unknown): value is SyncDefinition {
+  return typeof value === "object" && value !== null && (value as SyncDefinition).kind === "sync"
+}
+
+function isPipelineDefinitionInput(value: unknown): value is PipelineDefinition {
+  return (
+    typeof value === "object" && value !== null && (value as PipelineDefinition).kind === "pipeline"
+  )
+}
+
+function runTargetFrom(
+  input: GrantInput<
+    WorkflowDefinition | SyncDefinition | PipelineDefinition,
+    "workflow" | "sync" | "pipeline"
+  >
+): "workflow" | "sync" | "pipeline" {
+  if (isScope(input)) {
+    if (input.target !== "workflow" && input.target !== "sync" && input.target !== "pipeline") {
+      throw new SecurityValidationError(
+        "[Sixb] can.run scope target must be workflow, sync, or pipeline."
+      )
+    }
+    return input.target
+  }
+
+  const first = Array.isArray(input) ? input[0] : input
+  if (isPipelineDefinitionInput(first)) {
+    return "pipeline"
+  }
+  return isSyncDefinitionInput(first) ? "sync" : "workflow"
+}
+
+function run(input: GrantInput<WorkflowDefinition, "workflow">): RunGrant<"workflow">
+function run(input: GrantInput<SyncDefinition, "sync">): RunGrant<"sync">
+function run(input: GrantInput<PipelineDefinition, "pipeline">): RunGrant<"pipeline">
+function run(
+  input: GrantInput<
+    WorkflowDefinition | SyncDefinition | PipelineDefinition,
+    "workflow" | "sync" | "pipeline"
+  >
+): RunGrant {
+  return {
+    kind: "grant",
+    capability: "run",
+    target: runTargetFrom(input),
+    selection: selectionFrom(input, "can.run"),
+  }
 }
 
 export const can = {

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -9,7 +9,7 @@ export {
   resolveInvitePolicyScope,
 } from "./invite-policies"
 export type { Scope, ScopeTarget } from "./scopes"
-export { actions, ontology, workflows } from "./scopes"
+export { actions, datasets, ontology, pipelines, syncs, workflows } from "./scopes"
 export type {
   ApplyGrant,
   GrantCapability,
@@ -19,9 +19,11 @@ export type {
   RegisteredSecurityDefinitions,
   RoleDefinition,
   RunGrant,
+  RunGrantTarget,
   SecurityRegistry,
   Selection,
   ViewGrant,
+  ViewGrantTarget,
 } from "./types"
 export {
   assertGrantDefinition,

--- a/packages/core/src/security/runtime.ts
+++ b/packages/core/src/security/runtime.ts
@@ -49,8 +49,11 @@ export function createRuntimeSecurityRegistry(input: {
   readonly roles?: readonly RoleDefinition[]
   readonly invitePolicies?: readonly InvitePolicyDefinition[]
   readonly objectTypeIds?: ReadonlySet<string>
+  readonly datasetIds?: ReadonlySet<string>
   readonly actionIds?: ReadonlySet<string>
   readonly workflowIds?: ReadonlySet<string>
+  readonly syncIds?: ReadonlySet<string>
+  readonly pipelineIds?: ReadonlySet<string>
   readonly getSubTypes?: (objectTypeId: string) => readonly string[]
 }): SecurityRegistry {
   const securityDefinitions = validateSecurityDefinitionsAtStartup({
@@ -58,14 +61,20 @@ export function createRuntimeSecurityRegistry(input: {
     roles: input.roles ?? [],
     invitePolicies: input.invitePolicies ?? [],
     objectTypeIds: input.objectTypeIds,
+    datasetIds: input.datasetIds,
     actionIds: input.actionIds,
     workflowIds: input.workflowIds,
+    syncIds: input.syncIds,
+    pipelineIds: input.pipelineIds,
   })
 
   const universe = {
     objectTypeIds: input.objectTypeIds ?? new Set<string>(),
+    datasetIds: input.datasetIds ?? new Set<string>(),
     actionIds: input.actionIds ?? new Set<string>(),
     workflowIds: input.workflowIds ?? new Set<string>(),
+    syncIds: input.syncIds ?? new Set<string>(),
+    pipelineIds: input.pipelineIds ?? new Set<string>(),
     getSubTypes: input.getSubTypes ?? (() => []),
   }
   const resolvedRoles = securityDefinitions.roles.map((role) => ({

--- a/packages/core/src/security/scopes.ts
+++ b/packages/core/src/security/scopes.ts
@@ -9,17 +9,23 @@
  */
 
 import type { ActionDefinition } from "../actions/types"
+import type { DatasetDefinition } from "../datasets"
 import type { ObjectType } from "../ontology"
+import type { PipelineDefinition } from "../pipelines"
+import type { SyncDefinition } from "../syncs"
 import type { WorkflowDefinition } from "../workflows/types"
 import { SecurityValidationError } from "./errors"
 
 /** Capability targets a scope can range over. */
-export type ScopeTarget = "object" | "action" | "workflow"
+export type ScopeTarget = "object" | "dataset" | "action" | "workflow" | "sync" | "pipeline"
 
 interface ScopeTargetInput {
   object: ObjectType
+  dataset: DatasetDefinition
   action: ActionDefinition
   workflow: WorkflowDefinition
+  sync: SyncDefinition
+  pipeline: PipelineDefinition
 }
 
 /**
@@ -70,6 +76,12 @@ export const ontology = {
   objects: (): Scope<"object"> => allScope("object"),
 }
 
+export const datasets = (): Scope<"dataset"> => allScope("dataset")
+
 export const actions = (): Scope<"action"> => allScope("action")
 
 export const workflows = (): Scope<"workflow"> => allScope("workflow")
+
+export const syncs = (): Scope<"sync"> => allScope("sync")
+
+export const pipelines = (): Scope<"pipeline"> => allScope("pipeline")

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -22,8 +22,7 @@ export type ViewGrantTarget = "object" | "dataset"
 export interface ViewGrant<TTarget extends ViewGrantTarget = ViewGrantTarget> {
   readonly kind: "grant"
   readonly capability: "view"
-  /** Missing target is treated as "object" for older hand-authored role data. */
-  readonly target?: TTarget
+  readonly target: TTarget
   readonly selection: Selection
 }
 
@@ -38,8 +37,7 @@ export type RunGrantTarget = "workflow" | "sync" | "pipeline"
 export interface RunGrant<TTarget extends RunGrantTarget = RunGrantTarget> {
   readonly kind: "grant"
   readonly capability: "run"
-  /** Missing target is treated as "workflow" for older hand-authored role data. */
-  readonly target?: TTarget
+  readonly target: TTarget
   readonly selection: Selection
 }
 

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -17,9 +17,13 @@ export type Selection =
   | { readonly all: true; readonly except: readonly string[] }
   | { readonly all: false; readonly ids: readonly string[] }
 
-export interface ViewGrant {
+export type ViewGrantTarget = "object" | "dataset"
+
+export interface ViewGrant<TTarget extends ViewGrantTarget = ViewGrantTarget> {
   readonly kind: "grant"
   readonly capability: "view"
+  /** Missing target is treated as "object" for older hand-authored role data. */
+  readonly target?: TTarget
   readonly selection: Selection
 }
 
@@ -29,9 +33,13 @@ export interface ApplyGrant {
   readonly selection: Selection
 }
 
-export interface RunGrant {
+export type RunGrantTarget = "workflow" | "sync" | "pipeline"
+
+export interface RunGrant<TTarget extends RunGrantTarget = RunGrantTarget> {
   readonly kind: "grant"
   readonly capability: "run"
+  /** Missing target is treated as "workflow" for older hand-authored role data. */
+  readonly target?: TTarget
   readonly selection: Selection
 }
 

--- a/packages/core/src/security/validation.ts
+++ b/packages/core/src/security/validation.ts
@@ -1,3 +1,4 @@
+import { GRANT_KINDS, type GrantUniverseKey, grantKindOf } from "../authorization/grant-kinds"
 import { SecurityValidationError } from "./errors"
 import type {
   GrantDefinition,
@@ -6,6 +7,9 @@ import type {
   RegisteredSecurityDefinitions,
   RoleDefinition,
 } from "./types"
+
+/** Registered id universes keyed as the grant-kind table expects them. */
+type RegisteredUniverses = Partial<Record<GrantUniverseKey, ReadonlySet<string>>>
 
 export type CreateSecurityError = (message: string) => Error
 
@@ -151,18 +155,12 @@ export function assertGrantDefinition(
     throw createError(`[Sixb] ${field} grant capability must be 'view', 'apply', or 'run'.`)
   }
 
-  if (
-    value.capability === "view" &&
-    value.target !== undefined &&
-    value.target !== "object" &&
-    value.target !== "dataset"
-  ) {
+  if (value.capability === "view" && value.target !== "object" && value.target !== "dataset") {
     throw createError(`[Sixb] ${field} view grant target must be 'object' or 'dataset'.`)
   }
 
   if (
     value.capability === "run" &&
-    value.target !== undefined &&
     value.target !== "workflow" &&
     value.target !== "sync" &&
     value.target !== "pipeline"
@@ -346,17 +344,10 @@ export function validateSecurityDefinitionsAtStartup(input: {
 function assertGrantReferences(
   roleId: string,
   grant: GrantDefinition,
-  registered: {
-    readonly objectTypeIds?: ReadonlySet<string>
-    readonly datasetIds?: ReadonlySet<string>
-    readonly actionIds?: ReadonlySet<string>
-    readonly workflowIds?: ReadonlySet<string>
-    readonly syncIds?: ReadonlySet<string>
-    readonly pipelineIds?: ReadonlySet<string>
-  }
+  registered: RegisteredUniverses
 ): void {
-  const target = grantReferenceTarget(grant, registered)
-  const universe = target.universe
+  const spec = GRANT_KINDS[grantKindOf(grant)]
+  const universe = registered[spec.universeKey]
 
   if (!universe) {
     return
@@ -370,66 +361,8 @@ function assertGrantReferences(
   for (const id of ids) {
     if (!universe.has(id)) {
       throw new SecurityValidationError(
-        `[Sixb] Role '${roleId}' grants ${grant.capability} on unknown ${target.subject} '${id}'. ${target.fix}`
+        `[Sixb] Role '${roleId}' grants ${grant.capability} on unknown ${spec.subject} '${id}'. ${spec.fix}`
       )
     }
-  }
-}
-
-function grantReferenceTarget(
-  grant: GrantDefinition,
-  registered: {
-    readonly objectTypeIds?: ReadonlySet<string>
-    readonly datasetIds?: ReadonlySet<string>
-    readonly actionIds?: ReadonlySet<string>
-    readonly workflowIds?: ReadonlySet<string>
-    readonly syncIds?: ReadonlySet<string>
-    readonly pipelineIds?: ReadonlySet<string>
-  }
-): {
-  readonly universe?: ReadonlySet<string>
-  readonly subject: string
-  readonly fix: string
-} {
-  switch (grant.capability) {
-    case "view":
-      return (grant.target ?? "object") === "dataset"
-        ? {
-            universe: registered.datasetIds,
-            subject: "dataset",
-            fix: "Add it to 'datasets/' or pass it to createSixb({ datasets }).",
-          }
-        : {
-            universe: registered.objectTypeIds,
-            subject: "object type",
-            fix: "Register it in 'ontology/' or pass it to createSixb({ ontologies }).",
-          }
-    case "apply":
-      return {
-        universe: registered.actionIds,
-        subject: "action",
-        fix: "Add it to 'actions/' or pass it to createSixb({ actions }).",
-      }
-    case "run":
-      switch (grant.target ?? "workflow") {
-        case "sync":
-          return {
-            universe: registered.syncIds,
-            subject: "sync",
-            fix: "Add it to 'syncs/' or pass it to createSixb({ syncs }).",
-          }
-        case "pipeline":
-          return {
-            universe: registered.pipelineIds,
-            subject: "pipeline",
-            fix: "Add it to 'pipelines/' or pass it to createSixb({ pipelines }).",
-          }
-        case "workflow":
-          return {
-            universe: registered.workflowIds,
-            subject: "workflow",
-            fix: "Add it to 'workflows/' or pass it to createSixb({ workflows }).",
-          }
-      }
   }
 }

--- a/packages/core/src/security/validation.ts
+++ b/packages/core/src/security/validation.ts
@@ -1,6 +1,5 @@
 import { SecurityValidationError } from "./errors"
 import type {
-  GrantCapability,
   GrantDefinition,
   GroupDefinition,
   InvitePolicyDefinition,
@@ -152,6 +151,25 @@ export function assertGrantDefinition(
     throw createError(`[Sixb] ${field} grant capability must be 'view', 'apply', or 'run'.`)
   }
 
+  if (
+    value.capability === "view" &&
+    value.target !== undefined &&
+    value.target !== "object" &&
+    value.target !== "dataset"
+  ) {
+    throw createError(`[Sixb] ${field} view grant target must be 'object' or 'dataset'.`)
+  }
+
+  if (
+    value.capability === "run" &&
+    value.target !== undefined &&
+    value.target !== "workflow" &&
+    value.target !== "sync" &&
+    value.target !== "pipeline"
+  ) {
+    throw createError(`[Sixb] ${field} run grant target must be 'workflow', 'sync', or 'pipeline'.`)
+  }
+
   assertSelection(value.selection, field, createError)
 }
 
@@ -215,10 +233,16 @@ export function validateSecurityDefinitionsAtStartup(input: {
   readonly roles?: readonly RoleDefinition[]
   /** Registered object type ids — when provided, view grants must reference them. */
   readonly objectTypeIds?: ReadonlySet<string>
+  /** Registered dataset ids — when provided, dataset view grants must reference them. */
+  readonly datasetIds?: ReadonlySet<string>
   /** Registered action ids — when provided, apply grants must reference them. */
   readonly actionIds?: ReadonlySet<string>
   /** Registered workflow ids — when provided, run grants must reference them. */
   readonly workflowIds?: ReadonlySet<string>
+  /** Registered sync ids — when provided, sync run grants must reference them. */
+  readonly syncIds?: ReadonlySet<string>
+  /** Registered pipeline ids — when provided, pipeline run grants must reference them. */
+  readonly pipelineIds?: ReadonlySet<string>
 }): RegisteredSecurityDefinitions {
   const groupsById = new Map<string, GroupDefinition>()
   const rolesById = new Map<string, RoleDefinition>()
@@ -319,38 +343,20 @@ export function validateSecurityDefinitionsAtStartup(input: {
   }
 }
 
-const GRANT_REFERENCE_HINTS: Record<
-  GrantDefinition["capability"],
-  { readonly subject: string; readonly fix: string }
-> = {
-  view: {
-    subject: "object type",
-    fix: "Register it in 'ontology/' or pass it to createSixb({ ontologies }).",
-  },
-  apply: { subject: "action", fix: "Add it to 'actions/' or pass it to createSixb({ actions })." },
-  run: {
-    subject: "workflow",
-    fix: "Add it to 'workflows/' or pass it to createSixb({ workflows }).",
-  },
-}
-
 function assertGrantReferences(
   roleId: string,
   grant: GrantDefinition,
   registered: {
     readonly objectTypeIds?: ReadonlySet<string>
+    readonly datasetIds?: ReadonlySet<string>
     readonly actionIds?: ReadonlySet<string>
     readonly workflowIds?: ReadonlySet<string>
+    readonly syncIds?: ReadonlySet<string>
+    readonly pipelineIds?: ReadonlySet<string>
   }
 ): void {
-  // Capability -> its registered id universe. A Record keeps this exhaustive:
-  // a new capability is a compile error until wired here.
-  const universeByCapability: Record<GrantCapability, ReadonlySet<string> | undefined> = {
-    view: registered.objectTypeIds,
-    apply: registered.actionIds,
-    run: registered.workflowIds,
-  }
-  const universe = universeByCapability[grant.capability]
+  const target = grantReferenceTarget(grant, registered)
+  const universe = target.universe
 
   if (!universe) {
     return
@@ -360,13 +366,70 @@ function assertGrantReferences(
   // to exclude. Either way every named id must be registered — an unknown id is
   // a typo that would silently widen or no-op the grant.
   const ids = grant.selection.all ? grant.selection.except : grant.selection.ids
-  const { subject, fix } = GRANT_REFERENCE_HINTS[grant.capability]
 
   for (const id of ids) {
     if (!universe.has(id)) {
       throw new SecurityValidationError(
-        `[Sixb] Role '${roleId}' grants ${grant.capability} on unknown ${subject} '${id}'. ${fix}`
+        `[Sixb] Role '${roleId}' grants ${grant.capability} on unknown ${target.subject} '${id}'. ${target.fix}`
       )
     }
+  }
+}
+
+function grantReferenceTarget(
+  grant: GrantDefinition,
+  registered: {
+    readonly objectTypeIds?: ReadonlySet<string>
+    readonly datasetIds?: ReadonlySet<string>
+    readonly actionIds?: ReadonlySet<string>
+    readonly workflowIds?: ReadonlySet<string>
+    readonly syncIds?: ReadonlySet<string>
+    readonly pipelineIds?: ReadonlySet<string>
+  }
+): {
+  readonly universe?: ReadonlySet<string>
+  readonly subject: string
+  readonly fix: string
+} {
+  switch (grant.capability) {
+    case "view":
+      return (grant.target ?? "object") === "dataset"
+        ? {
+            universe: registered.datasetIds,
+            subject: "dataset",
+            fix: "Add it to 'datasets/' or pass it to createSixb({ datasets }).",
+          }
+        : {
+            universe: registered.objectTypeIds,
+            subject: "object type",
+            fix: "Register it in 'ontology/' or pass it to createSixb({ ontologies }).",
+          }
+    case "apply":
+      return {
+        universe: registered.actionIds,
+        subject: "action",
+        fix: "Add it to 'actions/' or pass it to createSixb({ actions }).",
+      }
+    case "run":
+      switch (grant.target ?? "workflow") {
+        case "sync":
+          return {
+            universe: registered.syncIds,
+            subject: "sync",
+            fix: "Add it to 'syncs/' or pass it to createSixb({ syncs }).",
+          }
+        case "pipeline":
+          return {
+            universe: registered.pipelineIds,
+            subject: "pipeline",
+            fix: "Add it to 'pipelines/' or pass it to createSixb({ pipelines }).",
+          }
+        case "workflow":
+          return {
+            universe: registered.workflowIds,
+            subject: "workflow",
+            fix: "Add it to 'workflows/' or pass it to createSixb({ workflows }).",
+          }
+      }
   }
 }

--- a/packages/core/src/storage/pipeline-runs/in-memory.ts
+++ b/packages/core/src/storage/pipeline-runs/in-memory.ts
@@ -177,7 +177,7 @@ export class InMemoryPipelineRunStorage implements PipelineRunStorage {
   }
 
   async list(input: ListPipelineRunsInput): Promise<ListPipelineRunsResult> {
-    if (hasEmptyStatuses(input)) {
+    if (hasEmptyStatuses(input) || input.pipelineIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -187,9 +187,11 @@ export class InMemoryPipelineRunStorage implements PipelineRunStorage {
 
     const order = input.order ?? "desc"
     const statuses = toStatusSet(input.statuses)
+    const pipelineIds = input.pipelineIds ? new Set(input.pipelineIds) : null
     const filtered = [...this.runs.values()]
       .filter((record) => record.projectId === input.projectId)
       .filter((record) => (input.pipelineId ? record.pipelineId === input.pipelineId : true))
+      .filter((record) => (pipelineIds ? pipelineIds.has(record.pipelineId) : true))
       .filter((record) =>
         matchesRunListDateFilters(record, {
           statuses,

--- a/packages/core/src/storage/pipeline-runs/types.ts
+++ b/packages/core/src/storage/pipeline-runs/types.ts
@@ -92,6 +92,7 @@ export type FinishPipelineStepRunInput =
 export interface ListPipelineRunsInput {
   readonly projectId: string
   readonly pipelineId?: string
+  readonly pipelineIds?: readonly string[]
   readonly statuses?: readonly PipelineRunStatus[]
   readonly startedAfter?: Date
   readonly startedBefore?: Date

--- a/packages/core/src/storage/sync-runs/in-memory.ts
+++ b/packages/core/src/storage/sync-runs/in-memory.ts
@@ -1,5 +1,12 @@
 import { cloneJsonValue, type JsonValue } from "../../json"
-import { latestStartedAtByOwnerId } from "../run-listing"
+import {
+  compareStartedAt,
+  hasEmptyStatuses,
+  latestStartedAtByOwnerId,
+  matchesRunListDateFilters,
+  paginate,
+  toStatusSet,
+} from "../run-listing"
 import { SyncRunError } from "./errors"
 import type {
   FinishSyncRunInput,
@@ -27,19 +34,6 @@ function normalizeCheckpoint(checkpoint: JsonValue | undefined): JsonValue | und
 
 function normalizeError(error: SyncRunFailure | undefined): SyncRunFailure | undefined {
   return error ? structuredClone(error) : undefined
-}
-
-function compareRuns(a: SyncRunRecord, b: SyncRunRecord, order: "asc" | "desc"): number {
-  const delta = a.startedAt.getTime() - b.startedAt.getTime()
-  if (delta !== 0) {
-    return order === "asc" ? delta : -delta
-  }
-
-  if (a.id === b.id) {
-    return 0
-  }
-
-  return order === "asc" ? a.id.localeCompare(b.id) : b.id.localeCompare(a.id)
 }
 
 export class InMemorySyncRunStorage implements SyncRunStorage {
@@ -129,7 +123,7 @@ export class InMemorySyncRunStorage implements SyncRunStorage {
   }
 
   async list(input: ListSyncRunsInput): Promise<ListSyncRunsResult> {
-    if (input.syncIds && input.syncIds.length === 0) {
+    if (hasEmptyStatuses(input) || input.syncIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -138,27 +132,28 @@ export class InMemorySyncRunStorage implements SyncRunStorage {
     }
 
     const order = input.order ?? "desc"
-    const offset = input.offset ?? 0
-    const limit = input.limit ?? this.rows.size
+    const statuses = toStatusSet(input.statuses)
     const syncIds = input.syncIds ? new Set(input.syncIds) : null
-    const statuses = input.statuses ? new Set(input.statuses) : null
 
     const filtered = [...this.rows.values()]
       .filter((record) => record.projectId === input.projectId)
       .filter((record) => (input.syncId ? record.syncId === input.syncId : true))
       .filter((record) => (syncIds ? syncIds.has(record.syncId) : true))
       .filter((record) => (input.datasetId ? record.datasetId === input.datasetId : true))
-      .filter((record) => (statuses ? statuses.has(record.status) : true))
-      .filter((record) => (input.startedAfter ? record.startedAt >= input.startedAfter : true))
-      .filter((record) => (input.startedBefore ? record.startedAt <= input.startedBefore : true))
-      .sort((a, b) => compareRuns(a, b, order))
+      .filter((record) =>
+        matchesRunListDateFilters(record, {
+          statuses,
+          startedAfter: input.startedAfter,
+          startedBefore: input.startedBefore,
+        })
+      )
+      .sort((left, right) => compareStartedAt(left, right, order))
 
-    const total = filtered.length
-    const runs = filtered.slice(offset, offset + limit).map(cloneSyncRunRecord)
+    const { page, total, hasMore } = paginate(filtered, input)
 
     return {
-      runs,
-      hasMore: offset + runs.length < total,
+      runs: page.map(cloneSyncRunRecord),
+      hasMore,
       total,
     }
   }

--- a/packages/core/src/storage/sync-runs/in-memory.ts
+++ b/packages/core/src/storage/sync-runs/in-memory.ts
@@ -129,14 +129,24 @@ export class InMemorySyncRunStorage implements SyncRunStorage {
   }
 
   async list(input: ListSyncRunsInput): Promise<ListSyncRunsResult> {
+    if (input.syncIds && input.syncIds.length === 0) {
+      return {
+        runs: [],
+        hasMore: false,
+        total: 0,
+      }
+    }
+
     const order = input.order ?? "desc"
     const offset = input.offset ?? 0
     const limit = input.limit ?? this.rows.size
+    const syncIds = input.syncIds ? new Set(input.syncIds) : null
     const statuses = input.statuses ? new Set(input.statuses) : null
 
     const filtered = [...this.rows.values()]
       .filter((record) => record.projectId === input.projectId)
       .filter((record) => (input.syncId ? record.syncId === input.syncId : true))
+      .filter((record) => (syncIds ? syncIds.has(record.syncId) : true))
       .filter((record) => (input.datasetId ? record.datasetId === input.datasetId : true))
       .filter((record) => (statuses ? statuses.has(record.status) : true))
       .filter((record) => (input.startedAfter ? record.startedAt >= input.startedAfter : true))

--- a/packages/core/src/storage/sync-runs/types.ts
+++ b/packages/core/src/storage/sync-runs/types.ts
@@ -58,6 +58,7 @@ export type FinishSyncRunInput =
 export interface ListSyncRunsInput {
   readonly projectId: string
   readonly syncId?: string
+  readonly syncIds?: readonly string[]
   readonly datasetId?: string
   readonly statuses?: readonly SyncRunStatus[]
   readonly startedAfter?: Date

--- a/packages/core/tests/authorization-context.test.ts
+++ b/packages/core/tests/authorization-context.test.ts
@@ -156,49 +156,49 @@ describe("resolveAuthorizationContext", () => {
     expect(context.sessionId).toBe("ses_adam")
     expect(context.groupIds).toEqual(["commercial"])
     expect(context.roleIds).toEqual(["contract.operator"])
-    expect(context.grants.objectTypes.view).toEqual(new Set(["contract", "signed-contract"]))
-    expect(context.grants.datasets.view).toEqual(new Set())
-    expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
-    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts"]))
-    expect(context.grants.pipelines.run).toEqual(new Set(["pipeline-contracts"]))
+    expect(context.grants["view:object"]).toEqual(new Set(["contract", "signed-contract"]))
+    expect(context.grants["view:dataset"]).toEqual(new Set())
+    expect(context.grants["apply:action"]).toEqual(new Set(["send-contract"]))
+    expect(context.grants["run:sync"]).toEqual(new Set(["sync-contracts"]))
+    expect(context.grants["run:pipeline"]).toEqual(new Set(["pipeline-contracts"]))
   })
 
   test("unions grants across all matched roles", () => {
     const context = resolve(["commercial", "finance"], [contractOperator, invoiceViewer])
 
     expect(context.roleIds).toEqual(["contract.operator", "invoice.viewer"])
-    expect(context.grants.objectTypes.view).toEqual(
+    expect(context.grants["view:object"]).toEqual(
       new Set(["contract", "signed-contract", "invoice"])
     )
-    expect(context.grants.datasets.view).toEqual(new Set(["raw.invoices"]))
-    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts"]))
-    expect(context.grants.pipelines.run).toEqual(new Set(["pipeline-contracts"]))
+    expect(context.grants["view:dataset"]).toEqual(new Set(["raw.invoices"]))
+    expect(context.grants["run:sync"]).toEqual(new Set(["sync-contracts"]))
+    expect(context.grants["run:pipeline"]).toEqual(new Set(["pipeline-contracts"]))
   })
 
   test("principals without matching roles resolve to empty grants", () => {
     const context = resolve(["engineering"], [contractOperator, invoiceViewer, adminOperator])
 
     expect(context.roleIds).toEqual([])
-    expect(context.grants.objectTypes.view.size).toBe(0)
-    expect(context.grants.datasets.view.size).toBe(0)
-    expect(context.grants.actions.apply.size).toBe(0)
-    expect(context.grants.workflows.run.size).toBe(0)
-    expect(context.grants.syncs.run.size).toBe(0)
-    expect(context.grants.pipelines.run.size).toBe(0)
+    expect(context.grants["view:object"].size).toBe(0)
+    expect(context.grants["view:dataset"].size).toBe(0)
+    expect(context.grants["apply:action"].size).toBe(0)
+    expect(context.grants["run:workflow"].size).toBe(0)
+    expect(context.grants["run:sync"].size).toBe(0)
+    expect(context.grants["run:pipeline"].size).toBe(0)
   })
 
   test("expands broad grants to the registered universe", () => {
     const context = resolve(["admins"], [contractOperator, invoiceViewer, adminOperator])
 
     expect(context.roleIds).toEqual(["admin.operator"])
-    expect(context.grants.objectTypes.view).toEqual(
+    expect(context.grants["view:object"]).toEqual(
       new Set(["contract", "signed-contract", "invoice"])
     )
-    expect(context.grants.datasets.view).toEqual(new Set(["raw.contracts", "raw.invoices"]))
-    expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
-    expect(context.grants.workflows.run.size).toBe(0)
-    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts", "sync-invoices"]))
-    expect(context.grants.pipelines.run).toEqual(
+    expect(context.grants["view:dataset"]).toEqual(new Set(["raw.contracts", "raw.invoices"]))
+    expect(context.grants["apply:action"]).toEqual(new Set(["send-contract"]))
+    expect(context.grants["run:workflow"].size).toBe(0)
+    expect(context.grants["run:sync"]).toEqual(new Set(["sync-contracts", "sync-invoices"]))
+    expect(context.grants["run:pipeline"]).toEqual(
       new Set(["pipeline-contracts", "pipeline-invoices"])
     )
   })
@@ -211,8 +211,8 @@ describe("resolveAuthorizationContext", () => {
 
     const context = resolve(["admins"], [mostDatasets])
 
-    expect(context.grants.datasets.view).toEqual(new Set(["raw.contracts"]))
-    expect(context.grants.datasets.view.has("raw.invoices")).toBe(false)
+    expect(context.grants["view:dataset"]).toEqual(new Set(["raw.contracts"]))
+    expect(context.grants["view:dataset"].has("raw.invoices")).toBe(false)
   })
 
   test("except() excludes named syncs and keeps the rest of the sync universe", () => {
@@ -223,8 +223,8 @@ describe("resolveAuthorizationContext", () => {
 
     const context = resolve(["admins"], [mostSyncs])
 
-    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts"]))
-    expect(context.grants.syncs.run.has("sync-invoices")).toBe(false)
+    expect(context.grants["run:sync"]).toEqual(new Set(["sync-contracts"]))
+    expect(context.grants["run:sync"].has("sync-invoices")).toBe(false)
   })
 
   test("except() excludes named pipelines and keeps the rest of the pipeline universe", () => {
@@ -235,8 +235,8 @@ describe("resolveAuthorizationContext", () => {
 
     const context = resolve(["admins"], [mostPipelines])
 
-    expect(context.grants.pipelines.run).toEqual(new Set(["pipeline-contracts"]))
-    expect(context.grants.pipelines.run.has("pipeline-invoices")).toBe(false)
+    expect(context.grants["run:pipeline"]).toEqual(new Set(["pipeline-contracts"]))
+    expect(context.grants["run:pipeline"].has("pipeline-invoices")).toBe(false)
   })
 
   test("except() excludes the named types and keeps the rest of the universe", () => {
@@ -247,8 +247,8 @@ describe("resolveAuthorizationContext", () => {
 
     const context = resolve(["admins"], [mostObjects])
 
-    expect(context.grants.objectTypes.view).toEqual(new Set(["contract", "signed-contract"]))
-    expect(context.grants.objectTypes.view.has("invoice")).toBe(false)
+    expect(context.grants["view:object"]).toEqual(new Set(["contract", "signed-contract"]))
+    expect(context.grants["view:object"].has("invoice")).toBe(false)
   })
 
   test("except is per-grant: another role can re-grant an excluded type", () => {
@@ -263,7 +263,7 @@ describe("resolveAuthorizationContext", () => {
 
     const context = resolve(["admins", "finance"], [allButInvoice, invoiceOnly])
 
-    expect(context.grants.objectTypes.view).toEqual(
+    expect(context.grants["view:object"]).toEqual(
       new Set(["contract", "signed-contract", "invoice"])
     )
   })
@@ -342,11 +342,11 @@ describe("auth.createAuthorizationContext", () => {
     expect(context.sessionId).toBe(sessionId)
     expect(context.groupIds).toEqual(["commercial"])
     expect(context.roleIds).toEqual(["contract.operator"])
-    expect(context.grants.objectTypes.view).toEqual(new Set(["contract", "signed-contract"]))
-    expect(context.grants.datasets.view).toEqual(new Set())
-    expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
-    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts"]))
-    expect(context.grants.pipelines.run).toEqual(new Set(["pipeline-contracts"]))
+    expect(context.grants["view:object"]).toEqual(new Set(["contract", "signed-contract"]))
+    expect(context.grants["view:dataset"]).toEqual(new Set())
+    expect(context.grants["apply:action"]).toEqual(new Set(["send-contract"]))
+    expect(context.grants["run:sync"]).toEqual(new Set(["sync-contracts"]))
+    expect(context.grants["run:pipeline"]).toEqual(new Set(["pipeline-contracts"]))
   })
 
   test("rejects unauthenticated requests", async () => {

--- a/packages/core/tests/authorization-context.test.ts
+++ b/packages/core/tests/authorization-context.test.ts
@@ -2,17 +2,26 @@ import { describe, expect, test } from "bun:test"
 import {
   actions,
   can,
+  col,
   createSessionCredential,
+  datasets,
   defineAction,
+  defineConnector,
+  defineDataset,
   defineGroup,
   defineObjectType,
+  definePipeline,
+  definePipelineStep,
   defineRole,
+  defineSync,
   ontology,
+  pipelines,
   prop,
   type RoleDefinition,
   resolveAuthorizationContext,
   resolveRoleGrants,
   Sixb,
+  syncs,
   workflows,
 } from "../src"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
@@ -36,6 +45,44 @@ const Invoice = defineObjectType({
   properties: [prop("id", "string", { required: true, primary: true })],
 })
 
+const ContractsDataset = defineDataset("raw.contracts", {
+  schema: [col("id", "string")],
+})
+
+const InvoicesDataset = defineDataset("raw.invoices", {
+  schema: [col("id", "string")],
+})
+
+const sourceConnector = defineConnector("source", {
+  type: "test",
+  async connect() {
+    return {}
+  },
+})
+
+const syncContracts = defineSync("sync-contracts")
+  .from(sourceConnector)
+  .read(() => [])
+  .intoDataset(ContractsDataset)
+
+const syncInvoices = defineSync("sync-invoices")
+  .from(sourceConnector)
+  .read(() => [])
+  .intoDataset(InvoicesDataset)
+
+const contractsPipelineStep = definePipelineStep("pipeline-contracts-step")
+  .inputs({ contracts: ContractsDataset })
+  .output(ContractsDataset)
+  .run(async () => {})
+
+const invoicesPipelineStep = definePipelineStep("pipeline-invoices-step")
+  .inputs({ invoices: InvoicesDataset })
+  .output(InvoicesDataset)
+  .run(async () => {})
+
+const contractsPipeline = definePipeline("pipeline-contracts").then(contractsPipelineStep)
+const invoicesPipeline = definePipeline("pipeline-invoices").then(invoicesPipelineStep)
+
 const sendContract = defineAction("send-contract")
   .params({})
   .edits(() => {})
@@ -46,17 +93,29 @@ const admins = defineGroup("admins")
 
 const contractOperator = defineRole("contract.operator", {
   grantedTo: [commercial],
-  grants: [can.view(Contract), can.apply(sendContract)],
+  grants: [
+    can.view(Contract),
+    can.apply(sendContract),
+    can.run(syncContracts),
+    can.run(contractsPipeline),
+  ],
 })
 
 const invoiceViewer = defineRole("invoice.viewer", {
   grantedTo: [finance],
-  grants: [can.view(Invoice)],
+  grants: [can.view(Invoice), can.view(InvoicesDataset)],
 })
 
 const adminOperator = defineRole("admin.operator", {
   grantedTo: [admins],
-  grants: [can.view(ontology.objects()), can.apply(actions()), can.run(workflows())],
+  grants: [
+    can.view(ontology.objects()),
+    can.view(datasets()),
+    can.apply(actions()),
+    can.run(workflows()),
+    can.run(syncs()),
+    can.run(pipelines()),
+  ],
 })
 
 const principal = { type: "user", id: "adam" } as const
@@ -66,8 +125,11 @@ describe("resolveAuthorizationContext", () => {
   // here we expand by hand so the resolver can be exercised in isolation.
   const universe = {
     objectTypeIds: new Set(["contract", "signed-contract", "invoice"]),
+    datasetIds: new Set(["raw.contracts", "raw.invoices"]),
     actionIds: new Set(["send-contract"]),
     workflowIds: new Set<string>(),
+    syncIds: new Set(["sync-contracts", "sync-invoices"]),
+    pipelineIds: new Set(["pipeline-contracts", "pipeline-invoices"]),
     getSubTypes: (objectTypeId: string) => (objectTypeId === "contract" ? ["signed-contract"] : []),
   }
 
@@ -95,7 +157,10 @@ describe("resolveAuthorizationContext", () => {
     expect(context.groupIds).toEqual(["commercial"])
     expect(context.roleIds).toEqual(["contract.operator"])
     expect(context.grants.objectTypes.view).toEqual(new Set(["contract", "signed-contract"]))
+    expect(context.grants.datasets.view).toEqual(new Set())
     expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
+    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts"]))
+    expect(context.grants.pipelines.run).toEqual(new Set(["pipeline-contracts"]))
   })
 
   test("unions grants across all matched roles", () => {
@@ -105,6 +170,9 @@ describe("resolveAuthorizationContext", () => {
     expect(context.grants.objectTypes.view).toEqual(
       new Set(["contract", "signed-contract", "invoice"])
     )
+    expect(context.grants.datasets.view).toEqual(new Set(["raw.invoices"]))
+    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts"]))
+    expect(context.grants.pipelines.run).toEqual(new Set(["pipeline-contracts"]))
   })
 
   test("principals without matching roles resolve to empty grants", () => {
@@ -112,8 +180,11 @@ describe("resolveAuthorizationContext", () => {
 
     expect(context.roleIds).toEqual([])
     expect(context.grants.objectTypes.view.size).toBe(0)
+    expect(context.grants.datasets.view.size).toBe(0)
     expect(context.grants.actions.apply.size).toBe(0)
     expect(context.grants.workflows.run.size).toBe(0)
+    expect(context.grants.syncs.run.size).toBe(0)
+    expect(context.grants.pipelines.run.size).toBe(0)
   })
 
   test("expands broad grants to the registered universe", () => {
@@ -123,8 +194,49 @@ describe("resolveAuthorizationContext", () => {
     expect(context.grants.objectTypes.view).toEqual(
       new Set(["contract", "signed-contract", "invoice"])
     )
+    expect(context.grants.datasets.view).toEqual(new Set(["raw.contracts", "raw.invoices"]))
     expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
     expect(context.grants.workflows.run.size).toBe(0)
+    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts", "sync-invoices"]))
+    expect(context.grants.pipelines.run).toEqual(
+      new Set(["pipeline-contracts", "pipeline-invoices"])
+    )
+  })
+
+  test("except() excludes named datasets and keeps the rest of the dataset universe", () => {
+    const mostDatasets = defineRole("most.datasets", {
+      grantedTo: [admins],
+      grants: [can.view(datasets().except([InvoicesDataset]))],
+    })
+
+    const context = resolve(["admins"], [mostDatasets])
+
+    expect(context.grants.datasets.view).toEqual(new Set(["raw.contracts"]))
+    expect(context.grants.datasets.view.has("raw.invoices")).toBe(false)
+  })
+
+  test("except() excludes named syncs and keeps the rest of the sync universe", () => {
+    const mostSyncs = defineRole("most.syncs", {
+      grantedTo: [admins],
+      grants: [can.run(syncs().except([syncInvoices]))],
+    })
+
+    const context = resolve(["admins"], [mostSyncs])
+
+    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts"]))
+    expect(context.grants.syncs.run.has("sync-invoices")).toBe(false)
+  })
+
+  test("except() excludes named pipelines and keeps the rest of the pipeline universe", () => {
+    const mostPipelines = defineRole("most.pipelines", {
+      grantedTo: [admins],
+      grants: [can.run(pipelines().except([invoicesPipeline]))],
+    })
+
+    const context = resolve(["admins"], [mostPipelines])
+
+    expect(context.grants.pipelines.run).toEqual(new Set(["pipeline-contracts"]))
+    expect(context.grants.pipelines.run.has("pipeline-invoices")).toBe(false)
   })
 
   test("except() excludes the named types and keeps the rest of the universe", () => {
@@ -162,6 +274,9 @@ describe("auth.createAuthorizationContext", () => {
     const deps = createTestRuntimeDeps()
     const sixb = new Sixb({
       ontology: [Contract, SignedContract, Invoice],
+      datasets: [ContractsDataset, InvoicesDataset],
+      syncs: [syncContracts, syncInvoices],
+      pipelines: [contractsPipeline, invoicesPipeline],
       actions: [sendContract],
       groups: [commercial, finance],
       roles: [contractOperator, invoiceViewer],
@@ -228,7 +343,10 @@ describe("auth.createAuthorizationContext", () => {
     expect(context.groupIds).toEqual(["commercial"])
     expect(context.roleIds).toEqual(["contract.operator"])
     expect(context.grants.objectTypes.view).toEqual(new Set(["contract", "signed-contract"]))
+    expect(context.grants.datasets.view).toEqual(new Set())
     expect(context.grants.actions.apply).toEqual(new Set(["send-contract"]))
+    expect(context.grants.syncs.run).toEqual(new Set(["sync-contracts"]))
+    expect(context.grants.pipelines.run).toEqual(new Set(["pipeline-contracts"]))
   })
 
   test("rejects unauthenticated requests", async () => {

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -5,18 +5,24 @@ import {
   evaluate,
   isAllowed,
   type StoredActionRequestedEvent,
+  type StoredDatasetVersionCommittedEvent,
   type StoredLinkUpsertedEvent,
   type StoredObjectUpsertedEvent,
+  type StoredPipelineRunStartedEvent,
   type StoredRuleTriggeredEvent,
   type StoredScheduleTriggeredEvent,
+  type StoredSyncRunStartedEvent,
   type StoredTelemetryAppendedEvent,
   type StoredWorkflowRunStartedEvent,
 } from "../src"
 
 function context(grants: {
   view?: readonly string[]
+  datasets?: readonly string[]
   apply?: readonly string[]
   run?: readonly string[]
+  syncs?: readonly string[]
+  pipelines?: readonly string[]
 }): AuthorizationContext {
   return {
     principal: { type: "user", id: "u1" },
@@ -24,8 +30,11 @@ function context(grants: {
     roleIds: [],
     grants: {
       objectTypes: { view: new Set(grants.view ?? []) },
+      datasets: { view: new Set(grants.datasets ?? []) },
       actions: { apply: new Set(grants.apply ?? []) },
       workflows: { run: new Set(grants.run ?? []) },
+      syncs: { run: new Set(grants.syncs ?? []) },
+      pipelines: { run: new Set(grants.pipelines ?? []) },
     },
   }
 }
@@ -45,6 +54,21 @@ describe("evaluate", () => {
     })
   })
 
+  test("dataset.view checks dataset grants", () => {
+    expect(
+      evaluate(context({ datasets: ["raw.orders"] }), {
+        kind: "dataset.view",
+        datasetId: "raw.orders",
+      })
+    ).toEqual({ allowed: true, requirements: ["view:dataset:raw.orders"], missing: [] })
+
+    expect(evaluate(context({}), { kind: "dataset.view", datasetId: "raw.orders" })).toEqual({
+      allowed: false,
+      requirements: ["view:dataset:raw.orders"],
+      missing: ["view:dataset:raw.orders"],
+    })
+  })
+
   test("object.query requires every touched type and lists only the unviewable ones", () => {
     const decision = evaluate(context({ view: ["quote"] }), {
       kind: "object.query",
@@ -54,6 +78,33 @@ describe("evaluate", () => {
     expect(decision.allowed).toBe(false)
     expect(decision.requirements).toEqual(["view:object:quote", "view:object:contact"])
     expect(decision.missing).toEqual(["view:object:contact"])
+  })
+
+  test("sync.run checks sync grants", () => {
+    expect(
+      evaluate(context({ syncs: ["sync-orders"] }), { kind: "sync.run", syncId: "sync-orders" })
+    ).toEqual({ allowed: true, requirements: ["run:sync:sync-orders"], missing: [] })
+
+    expect(evaluate(context({}), { kind: "sync.run", syncId: "sync-orders" })).toEqual({
+      allowed: false,
+      requirements: ["run:sync:sync-orders"],
+      missing: ["run:sync:sync-orders"],
+    })
+  })
+
+  test("pipeline.run checks pipeline grants", () => {
+    expect(
+      evaluate(context({ pipelines: ["pipeline-orders"] }), {
+        kind: "pipeline.run",
+        pipelineId: "pipeline-orders",
+      })
+    ).toEqual({ allowed: true, requirements: ["run:pipeline:pipeline-orders"], missing: [] })
+
+    expect(evaluate(context({}), { kind: "pipeline.run", pipelineId: "pipeline-orders" })).toEqual({
+      allowed: false,
+      requirements: ["run:pipeline:pipeline-orders"],
+      missing: ["run:pipeline:pipeline-orders"],
+    })
   })
 
   test("a missing authorization context (privileged caller) allows everything", () => {
@@ -131,6 +182,34 @@ const workflowEvent: StoredWorkflowRunStartedEvent = {
   payload: { workflowId: "review", runId: "r1", startedAt: envelope.occurredAt },
 }
 
+const syncEvent: StoredSyncRunStartedEvent = {
+  ...envelope,
+  type: "sync.run.started",
+  topic: "syncs",
+  partitionKey: "sync-orders/run_1",
+  payload: { syncId: "sync-orders", runId: "run_1", startedAt: envelope.occurredAt },
+}
+
+const pipelineEvent: StoredPipelineRunStartedEvent = {
+  ...envelope,
+  type: "pipeline.run.started",
+  topic: "pipelines",
+  partitionKey: "pipeline-orders/run_1",
+  payload: { pipelineId: "pipeline-orders", runId: "run_1", startedAt: envelope.occurredAt },
+}
+
+const datasetEvent: StoredDatasetVersionCommittedEvent = {
+  ...envelope,
+  type: "dataset.version.committed",
+  topic: "datasets",
+  partitionKey: "raw.orders",
+  payload: {
+    datasetId: "raw.orders",
+    versionId: "v1",
+    producer: { kind: "sync", id: "erp-orders", runId: "run_1" },
+  },
+}
+
 const ruleEvent: StoredRuleTriggeredEvent = {
   ...envelope,
   type: "rule.triggered",
@@ -183,6 +262,21 @@ describe("canViewEvent", () => {
   test("workflow events require running the workflow", () => {
     expect(canViewEvent(context({ run: ["review"] }), workflowEvent)).toBe(true)
     expect(canViewEvent(context({}), workflowEvent)).toBe(false)
+  })
+
+  test("sync events require running the sync", () => {
+    expect(canViewEvent(context({ syncs: ["sync-orders"] }), syncEvent)).toBe(true)
+    expect(canViewEvent(context({}), syncEvent)).toBe(false)
+  })
+
+  test("pipeline events require running the pipeline", () => {
+    expect(canViewEvent(context({ pipelines: ["pipeline-orders"] }), pipelineEvent)).toBe(true)
+    expect(canViewEvent(context({}), pipelineEvent)).toBe(false)
+  })
+
+  test("dataset events require viewing the dataset", () => {
+    expect(canViewEvent(context({ datasets: ["raw.orders"] }), datasetEvent)).toBe(true)
+    expect(canViewEvent(context({}), datasetEvent)).toBe(false)
   })
 
   test("rule events require viewing the object the rule fired on", () => {

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -29,12 +29,12 @@ function context(grants: {
     groupIds: [],
     roleIds: [],
     grants: {
-      objectTypes: { view: new Set(grants.view ?? []) },
-      datasets: { view: new Set(grants.datasets ?? []) },
-      actions: { apply: new Set(grants.apply ?? []) },
-      workflows: { run: new Set(grants.run ?? []) },
-      syncs: { run: new Set(grants.syncs ?? []) },
-      pipelines: { run: new Set(grants.pipelines ?? []) },
+      "view:object": new Set(grants.view ?? []),
+      "view:dataset": new Set(grants.datasets ?? []),
+      "apply:action": new Set(grants.apply ?? []),
+      "run:workflow": new Set(grants.run ?? []),
+      "run:sync": new Set(grants.syncs ?? []),
+      "run:pipeline": new Set(grants.pipelines ?? []),
     },
   }
 }
@@ -277,6 +277,16 @@ describe("canViewEvent", () => {
   test("dataset events require viewing the dataset", () => {
     expect(canViewEvent(context({ datasets: ["raw.orders"] }), datasetEvent)).toBe(true)
     expect(canViewEvent(context({}), datasetEvent)).toBe(false)
+  })
+
+  test("dataset version provenance is visible to a dataset viewer who cannot run the producer", () => {
+    // datasetEvent.payload.producer is sync 'erp-orders'. A principal who can
+    // view the dataset but cannot run that sync still sees the event (and its
+    // producer): provenance is intentionally exposed to dataset viewers,
+    // matching the versions API. It is NOT gated on running the producer.
+    const datasetViewerOnly = context({ datasets: ["raw.orders"] })
+    expect(canViewEvent(datasetViewerOnly, datasetEvent)).toBe(true)
+    expect(isAllowed(datasetViewerOnly, { kind: "sync.run", syncId: "erp-orders" })).toBe(false)
   })
 
   test("rule events require viewing the object the rule fired on", () => {

--- a/packages/core/tests/pipeline-runs.test.ts
+++ b/packages/core/tests/pipeline-runs.test.ts
@@ -97,6 +97,13 @@ describe("InMemoryPipelineRunStorage", () => {
     expect(page.hasMore).toBe(false)
     expect(page.runs.map((run) => run.id)).toEqual(["run-2"])
 
+    const selectedPipelines = await storage.list({
+      projectId: "my-app",
+      pipelineIds: ["orders"],
+    })
+    expect(selectedPipelines.total).toBe(1)
+    expect(selectedPipelines.runs.map((run) => run.id)).toEqual(["run-3"])
+
     const empty = await storage.list({
       projectId: "my-app",
       statuses: [],

--- a/packages/core/tests/pipeline-runs.test.ts
+++ b/packages/core/tests/pipeline-runs.test.ts
@@ -104,6 +104,10 @@ describe("InMemoryPipelineRunStorage", () => {
     expect(selectedPipelines.total).toBe(1)
     expect(selectedPipelines.runs.map((run) => run.id)).toEqual(["run-3"])
 
+    // An empty allowlist must deny all — never fall through to an unfiltered list.
+    const noneAllowed = await storage.list({ projectId: "my-app", pipelineIds: [] })
+    expect(noneAllowed).toEqual({ runs: [], hasMore: false, total: 0 })
+
     const empty = await storage.list({
       projectId: "my-app",
       statuses: [],

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -3,13 +3,20 @@ import {
   type ActionDefinition,
   AuthorizationError,
   can,
+  col,
   defineAction,
+  defineConnector,
+  defineDataset,
   defineGroup,
   defineObjectType,
+  definePipeline,
+  definePipelineStep,
   defineRole,
+  defineSync,
   defineWorkflow,
   defineWorkflowStep,
   link,
+  type PipelineDefinition,
   prop,
   ref,
   resolveAuthorizationContext,
@@ -38,6 +45,46 @@ const Invoice = defineObjectType({
   properties: [prop("id", "string", { required: true, primary: true })],
   links: [link("contract", Contract)],
 })
+
+const ContractsDataset = defineDataset("raw.contracts", {
+  schema: [col("id", "string")],
+})
+
+const InvoicesDataset = defineDataset("raw.invoices", {
+  schema: [col("id", "string")],
+})
+
+const sourceConnector = defineConnector("source", {
+  type: "test",
+  async connect() {
+    return {}
+  },
+})
+
+const syncContracts = defineSync("sync-contracts")
+  .from(sourceConnector)
+  .read(() => [])
+  .intoDataset(ContractsDataset)
+
+const syncInvoices = defineSync("sync-invoices")
+  .from(sourceConnector)
+  .read(() => [])
+  .intoDataset(InvoicesDataset)
+
+const contractPipelineStep = definePipelineStep("contract-pipeline-step")
+  .inputs({ contracts: ContractsDataset })
+  .output(ContractsDataset)
+  .run(async () => {})
+
+const invoicePipelineStep = definePipelineStep("invoice-pipeline-step")
+  .inputs({ invoices: InvoicesDataset })
+  .output(InvoicesDataset)
+  .run(async () => {})
+
+const contractPipeline: PipelineDefinition =
+  definePipeline("contract-pipeline").then(contractPipelineStep)
+const invoicePipeline: PipelineDefinition =
+  definePipeline("invoice-pipeline").then(invoicePipelineStep)
 
 // Widened to the base type, like renewContract below: keeps the registered
 // actions array out of the deep Sixb<tuple> instantiation (TS2589).
@@ -69,7 +116,7 @@ const operations = defineGroup("operations")
 
 const contractOperator = defineRole("contract.operator", {
   grantedTo: [commercial],
-  grants: [can.view(Contract), can.apply(sendContract)],
+  grants: [can.view(Contract), can.view(ContractsDataset), can.apply(sendContract)],
 })
 
 const invoiceViewer = defineRole("invoice.viewer", {
@@ -85,7 +132,7 @@ const contractSender = defineRole("contract.sender", {
 
 const operationsRunner = defineRole("operations.runner", {
   grantedTo: [operations],
-  grants: [can.run(renewContract)],
+  grants: [can.run(renewContract), can.run(syncContracts), can.run(contractPipeline)],
 })
 
 const principal = { type: "user", id: "adam" } as const
@@ -96,7 +143,10 @@ const principal = { type: "user", id: "adam" } as const
 function createRuntime() {
   return new Sixb<readonly [typeof Contract, typeof SignedContract, typeof Invoice]>({
     ontology: [Contract, SignedContract, Invoice],
+    datasets: [ContractsDataset, InvoicesDataset],
     actions: [sendContract, archiveInvoice],
+    syncs: [syncContracts, syncInvoices],
+    pipelines: [contractPipeline, invoicePipeline],
     workflows: [renewContract],
     groups: [commercial, finance, ops, operations],
     roles: [contractOperator, invoiceViewer, contractSender, operationsRunner],
@@ -217,6 +267,18 @@ describe("sixb.as() actions", () => {
 })
 
 describe("sixb.as() operational access", () => {
+  test("dataset catalog narrows to viewable datasets", () => {
+    const sixb = createRuntime()
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+
+    expect(operator.listDatasets().map((dataset) => dataset.id)).toEqual(["raw.contracts"])
+    expect(operator.getDatasetById("raw.contracts")?.id).toBe("raw.contracts")
+    expect(operator.getDatasetById("raw.invoices")).toBeNull()
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    expect(runner.listDatasets()).toEqual([])
+  })
+
   test("workflow runs require can.run", async () => {
     const sixb = createRuntime()
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
@@ -293,6 +355,32 @@ describe("sixb.as() operational access", () => {
     expect(operator.listWorkflows()).toEqual([])
     expect(operator.getWorkflowById("renew-contract")).toBeNull()
   })
+
+  test("sync catalog narrows to runnable syncs", () => {
+    const sixb = createRuntime()
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    expect(runner.listSyncs().map((sync) => sync.id)).toEqual(["sync-contracts"])
+    expect(runner.getSyncById("sync-contracts")?.id).toBe("sync-contracts")
+    expect(runner.getSyncById("sync-invoices")).toBeNull()
+
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    expect(operator.listSyncs()).toEqual([])
+    expect(operator.getSyncById("sync-contracts")).toBeNull()
+  })
+
+  test("pipeline catalog narrows to runnable pipelines", () => {
+    const sixb = createRuntime()
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    expect(runner.listPipelines().map((pipeline) => pipeline.id)).toEqual(["contract-pipeline"])
+    expect(runner.getPipelineById("contract-pipeline")?.id).toBe("contract-pipeline")
+    expect(runner.getPipelineById("invoice-pipeline")).toBeNull()
+
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    expect(operator.listPipelines()).toEqual([])
+    expect(operator.getPipelineById("contract-pipeline")).toBeNull()
+  })
 })
 
 describe("sixb.as() fails closed on ungranted surfaces", () => {
@@ -350,11 +438,17 @@ describe("ScopedSixb surface", () => {
     expect(Object.keys(scoped).sort()).toEqual(
       [
         "authorization",
+        "getDatasetById",
         "getActionById",
         "getObject",
+        "getPipelineById",
+        "getSyncById",
         "getWorkflowById",
         "list",
         "listActions",
+        "listDatasets",
+        "listPipelines",
+        "listSyncs",
         "listWorkflows",
         "objects",
         "readEvents",

--- a/packages/core/tests/security-definitions.test.ts
+++ b/packages/core/tests/security-definitions.test.ts
@@ -7,20 +7,32 @@ import {
   type ActionDefinition,
   can,
   canInviteGroupIds,
+  col,
   createSixb,
+  type DatasetDefinition,
+  datasets,
   defineAction,
+  defineConnector,
+  defineDataset,
   defineGroup,
   defineInvitePolicy,
   defineObjectType,
+  definePipeline,
+  definePipelineStep,
   defineRole,
+  defineSync,
   type GroupDefinition,
   type InvitePolicyDefinition,
   ontology,
+  type PipelineDefinition,
+  pipelines,
   prop,
   type RoleDefinition,
   resolveInvitePolicyScope,
   SecurityValidationError,
   Sixb,
+  type SyncDefinition,
+  syncs,
 } from "../src"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
@@ -32,6 +44,29 @@ const Account = defineObjectType({
   name: "Account",
   properties: [prop("id", "string", { required: true, primary: true })],
 })
+
+const AccountSnapshot = defineDataset("account.snapshot", {
+  schema: [col("id", "string")],
+})
+
+const sourceConnector = defineConnector("source", {
+  type: "test",
+  async connect() {
+    return {}
+  },
+})
+
+const syncAccounts = defineSync("sync-accounts")
+  .from(sourceConnector)
+  .read(() => [])
+  .intoDataset(AccountSnapshot)
+
+const normalizeAccountsStep = definePipelineStep("normalize-accounts")
+  .inputs({ snapshot: AccountSnapshot })
+  .output(AccountSnapshot)
+  .run(async () => {})
+
+const normalizeAccountsPipeline = definePipeline("normalize-accounts").then(normalizeAccountsStep)
 
 afterEach(async () => {
   for (const root of tempRoots) {
@@ -282,7 +317,12 @@ describe("role definitions", () => {
       label: "Contract operator",
       grantedToGroupIds: ["commercial", "finance"],
       grants: [
-        { kind: "grant", capability: "view", selection: { all: false, ids: ["account"] } },
+        {
+          kind: "grant",
+          capability: "view",
+          target: "object",
+          selection: { all: false, ids: ["account"] },
+        },
         { kind: "grant", capability: "apply", selection: { all: false, ids: ["reboot"] } },
       ],
     })
@@ -292,7 +332,53 @@ describe("role definitions", () => {
     expect(can.view([Account, Account])).toEqual({
       kind: "grant",
       capability: "view",
+      target: "object",
       selection: { all: false, ids: ["account"] },
+    })
+  })
+
+  test("can.view supports dataset definitions and scopes", () => {
+    expect(can.view(AccountSnapshot)).toEqual({
+      kind: "grant",
+      capability: "view",
+      target: "dataset",
+      selection: { all: false, ids: ["account.snapshot"] },
+    })
+    expect(can.view(datasets()).selection).toEqual({ all: true, except: [] })
+    expect(can.view(datasets().except([AccountSnapshot]))).toEqual({
+      kind: "grant",
+      capability: "view",
+      target: "dataset",
+      selection: { all: true, except: ["account.snapshot"] },
+    })
+  })
+
+  test("can.run supports sync and pipeline definitions and scopes", () => {
+    expect(can.run(syncAccounts)).toEqual({
+      kind: "grant",
+      capability: "run",
+      target: "sync",
+      selection: { all: false, ids: ["sync-accounts"] },
+    })
+    expect(can.run(syncs()).selection).toEqual({ all: true, except: [] })
+    expect(can.run(syncs().except([syncAccounts]))).toEqual({
+      kind: "grant",
+      capability: "run",
+      target: "sync",
+      selection: { all: true, except: ["sync-accounts"] },
+    })
+    expect(can.run(normalizeAccountsPipeline)).toEqual({
+      kind: "grant",
+      capability: "run",
+      target: "pipeline",
+      selection: { all: false, ids: ["normalize-accounts"] },
+    })
+    expect(can.run(pipelines()).selection).toEqual({ all: true, except: [] })
+    expect(can.run(pipelines().except([normalizeAccountsPipeline]))).toEqual({
+      kind: "grant",
+      capability: "run",
+      target: "pipeline",
+      selection: { all: true, except: ["normalize-accounts"] },
     })
   })
 
@@ -358,6 +444,26 @@ describe("role definitions", () => {
     )
   })
 
+  test("runtime registration rejects view grants on unknown datasets", () => {
+    const role: RoleDefinition = {
+      kind: "role",
+      id: "dataset.viewer",
+      grantedToGroupIds: ["commercial"],
+      grants: [
+        {
+          kind: "grant",
+          capability: "view",
+          target: "dataset",
+          selection: { all: false, ids: ["missing"] },
+        },
+      ],
+    }
+
+    expect(() => createRuntime({ groups: [commercial], roles: [role] })).toThrow(
+      "unknown dataset 'missing'"
+    )
+  })
+
   test("runtime registration rejects apply grants on unknown actions", () => {
     const role: RoleDefinition = {
       kind: "role",
@@ -368,6 +474,46 @@ describe("role definitions", () => {
 
     expect(() => createRuntime({ groups: [commercial], roles: [role] })).toThrow(
       "unknown action 'missing'"
+    )
+  })
+
+  test("runtime registration rejects run grants on unknown syncs", () => {
+    const role: RoleDefinition = {
+      kind: "role",
+      id: "sync.runner",
+      grantedToGroupIds: ["commercial"],
+      grants: [
+        {
+          kind: "grant",
+          capability: "run",
+          target: "sync",
+          selection: { all: false, ids: ["missing"] },
+        },
+      ],
+    }
+
+    expect(() => createRuntime({ groups: [commercial], roles: [role] })).toThrow(
+      "unknown sync 'missing'"
+    )
+  })
+
+  test("runtime registration rejects run grants on unknown pipelines", () => {
+    const role: RoleDefinition = {
+      kind: "role",
+      id: "pipeline.runner",
+      grantedToGroupIds: ["commercial"],
+      grants: [
+        {
+          kind: "grant",
+          capability: "run",
+          target: "pipeline",
+          selection: { all: false, ids: ["missing"] },
+        },
+      ],
+    }
+
+    expect(() => createRuntime({ groups: [commercial], roles: [role] })).toThrow(
+      "unknown pipeline 'missing'"
     )
   })
 
@@ -449,7 +595,12 @@ export const contractOperator = defineRole("contract.operator", {
       id: "contract.operator",
       grantedToGroupIds: ["commercial"],
       grants: [
-        { kind: "grant", capability: "view", selection: { all: false, ids: ["account"] } },
+        {
+          kind: "grant",
+          capability: "view",
+          target: "object",
+          selection: { all: false, ids: ["account"] },
+        },
         { kind: "grant", capability: "apply", selection: { all: false, ids: ["reboot"] } },
       ],
     })
@@ -468,6 +619,9 @@ function createRuntime(
     roles?: readonly RoleDefinition[]
     invitePolicies?: readonly InvitePolicyDefinition[]
     actions?: readonly ActionDefinition[]
+    datasets?: readonly DatasetDefinition[]
+    syncs?: readonly SyncDefinition[]
+    pipelines?: readonly PipelineDefinition[]
   } = {}
 ): Sixb<readonly [typeof Account]> {
   return new Sixb<readonly [typeof Account]>({

--- a/packages/core/tests/security-definitions.test.ts
+++ b/packages/core/tests/security-definitions.test.ts
@@ -436,7 +436,14 @@ describe("role definitions", () => {
       kind: "role",
       id: "contract.operator",
       grantedToGroupIds: ["commercial"],
-      grants: [{ kind: "grant", capability: "view", selection: { all: false, ids: ["missing"] } }],
+      grants: [
+        {
+          kind: "grant",
+          capability: "view",
+          target: "object",
+          selection: { all: false, ids: ["missing"] },
+        },
+      ],
     }
 
     expect(() => createRuntime({ groups: [commercial], roles: [role] })).toThrow(

--- a/packages/core/tests/sync-runs.test.ts
+++ b/packages/core/tests/sync-runs.test.ts
@@ -174,6 +174,10 @@ describe("InMemorySyncRunStorage", () => {
     expect(selectedSyncs.runs.map((run) => run.id)).toEqual(["run-3"])
     expect(selectedSyncs.total).toBe(1)
 
+    // An empty allowlist must deny all — never fall through to an unfiltered list.
+    const noneAllowed = await storage.list({ projectId: "my-app", syncIds: [] })
+    expect(noneAllowed).toEqual({ runs: [], hasMore: false, total: 0 })
+
     const failed = await storage.getById({
       projectId: "my-app",
       id: "run-1",

--- a/packages/core/tests/sync-runs.test.ts
+++ b/packages/core/tests/sync-runs.test.ts
@@ -166,6 +166,14 @@ describe("InMemorySyncRunStorage", () => {
     expect(page.hasMore).toBe(false)
     expect(page.runs.map((run) => run.id)).toEqual(["run-2"])
 
+    const selectedSyncs = await storage.list({
+      projectId: "my-app",
+      syncIds: ["sync-customers"],
+    })
+
+    expect(selectedSyncs.runs.map((run) => run.id)).toEqual(["run-3"])
+    expect(selectedSyncs.total).toBe(1)
+
     const failed = await storage.getById({
       projectId: "my-app",
       id: "run-1",

--- a/packages/server/src/auth/scope.ts
+++ b/packages/server/src/auth/scope.ts
@@ -17,8 +17,8 @@ import type { AuthorizationContext, OntologySource, ScopedSixb } from "@sixb/cor
  *     Using the raw `sixb` on a path an authenticated principal can reach is a
  *     silent god-mode bypass — it will not fail to compile or to run.
  *   - Surfaces with no grant family yet (object/link/telemetry writes,
- *     datasets, syncs, pipelines, projections, workflow run history, auth
- *     admin) stay authenticated-only by design and use the raw `sixb`
+ *     projections, workflow run history, auth admin) stay
+ *     authenticated-only by design and use the raw `sixb`
  *     deliberately, not by omission. Add such a route consciously, and lock it
  *     down when its grant family lands.
  *

--- a/packages/server/src/routes/action-runs.ts
+++ b/packages/server/src/routes/action-runs.ts
@@ -75,8 +75,8 @@ export function registerActionRunRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
           const parsed = ActionRunsQuerySchema.parse(query)
           const limit = parseOptionalInt(parsed.limit)
           const offset = parseOptionalInt(parsed.offset)
-          const actionIds = authz ? [...authz.grants.actions.apply] : undefined
-          const objectTypeIds = authz ? [...authz.grants.objectTypes.view] : undefined
+          const actionIds = authz ? [...authz.grants["apply:action"]] : undefined
+          const objectTypeIds = authz ? [...authz.grants["view:object"]] : undefined
           const result = await storage.list({
             projectId: sixb.id,
             actionId: parsed.actionId,

--- a/packages/server/src/routes/datasets.ts
+++ b/packages/server/src/routes/datasets.ts
@@ -7,6 +7,7 @@ import type {
   Sixb,
 } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
   DatasetCatalogItemSchema,
@@ -75,7 +76,8 @@ const EMPTY_DATASET_REFERENCES: DatasetReferences = {
  * syncs, pipelines, and projections once per dataset.
  */
 function buildDatasetReferenceIndex(
-  sixb: Sixb<readonly OntologySource[]>
+  sixb: Sixb<readonly OntologySource[]>,
+  scoped: ReturnType<typeof requestAuthState>["scoped"] = null
 ): Map<string, DatasetReferences> {
   const index = new Map<string, DatasetReferences>()
   const referencesFor = (datasetId: string): DatasetReferences => {
@@ -87,11 +89,11 @@ function buildDatasetReferenceIndex(
     return references
   }
 
-  for (const sync of sixb.getSyncDefinitions()) {
+  for (const sync of scoped ? scoped.listSyncs() : sixb.getSyncDefinitions()) {
     referencesFor(sync.target.dataset.id).syncIds.push(sync.id)
   }
 
-  for (const pipeline of sixb.getPipelineDefinitions()) {
+  for (const pipeline of scoped ? scoped.listPipelines() : sixb.getPipelineDefinitions()) {
     const sourceDatasetIds = new Set<string>()
     const targetDatasetIds = new Set<string>()
     for (const node of pipeline.graph.nodes) {
@@ -108,12 +110,16 @@ function buildDatasetReferenceIndex(
     }
   }
 
-  for (const projection of [
-    ...sixb.getObjectProjections(),
-    ...sixb.getLinkProjections(),
-    ...sixb.getTelemetryProjections(),
-  ]) {
-    referencesFor(projection.datasetId).projectionIds.push(projection.id)
+  // Projection grants do not exist yet, so scoped callers do not get
+  // projection lineage ids through dataset metadata.
+  if (!scoped) {
+    for (const projection of [
+      ...sixb.getObjectProjections(),
+      ...sixb.getLinkProjections(),
+      ...sixb.getTelemetryProjections(),
+    ]) {
+      referencesFor(projection.datasetId).projectionIds.push(projection.id)
+    }
   }
 
   return index
@@ -145,9 +151,12 @@ function serializeDatasetCatalogItem(
   })
 }
 
-async function serializeDatasetCatalogItems(sixb: Sixb<readonly OntologySource[]>) {
-  const definitions = sixb.getDatasetDefinitions()
-  const references = buildDatasetReferenceIndex(sixb)
+async function serializeDatasetCatalogItems(
+  sixb: Sixb<readonly OntologySource[]>,
+  definitions: readonly DatasetDefinition[],
+  scoped: ReturnType<typeof requestAuthState>["scoped"] = null
+) {
+  const references = buildDatasetReferenceIndex(sixb, scoped)
   const states = await sixb.lakeStorage.listDatasetCatalogState(definitions.map((d) => d.id))
   const stateByDatasetId = new Map(states.map((state) => [state.datasetId, state]))
 
@@ -160,8 +169,12 @@ async function serializeDatasetCatalogItems(sixb: Sixb<readonly OntologySource[]
   )
 }
 
-function requireDataset(sixb: Sixb<readonly OntologySource[]>, datasetId: string) {
-  const dataset = sixb.getDatasetById(datasetId)
+function requireDataset(
+  sixb: Sixb<readonly OntologySource[]>,
+  scoped: ReturnType<typeof requestAuthState>["scoped"],
+  datasetId: string
+) {
+  const dataset = scoped ? scoped.getDatasetById(datasetId) : sixb.getDatasetById(datasetId)
   if (!dataset) {
     throw new Error("Dataset not found")
   }
@@ -206,9 +219,12 @@ export function registerDatasetRoutes(app: Elysia, sixb: Sixb<readonly OntologyS
   return app
     .get(
       "/api/datasets",
-      async ({ set }) => {
+      async (context) => {
+        const { set } = context
+        const { scoped } = requestAuthState(context)
         try {
-          return await serializeDatasetCatalogItems(sixb)
+          const definitions = scoped ? scoped.listDatasets() : sixb.getDatasetDefinitions()
+          return await serializeDatasetCatalogItems(sixb, definitions, scoped)
         } catch (error) {
           set.status = 400
           return { error: error instanceof Error ? error.message : String(error) }
@@ -225,11 +241,13 @@ export function registerDatasetRoutes(app: Elysia, sixb: Sixb<readonly OntologyS
     )
     .get(
       "/api/datasets/:datasetId",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
         try {
-          const dataset = requireDataset(sixb, params.datasetId)
+          const dataset = requireDataset(sixb, scoped, params.datasetId)
           const [state] = await sixb.lakeStorage.listDatasetCatalogState([dataset.id])
-          const references = buildDatasetReferenceIndex(sixb).get(dataset.id)
+          const references = buildDatasetReferenceIndex(sixb, scoped).get(dataset.id)
           return serializeDatasetCatalogItem(dataset, state, references ?? EMPTY_DATASET_REFERENCES)
         } catch (error) {
           return handleRouteError(error, set)
@@ -251,9 +269,11 @@ export function registerDatasetRoutes(app: Elysia, sixb: Sixb<readonly OntologyS
     )
     .get(
       "/api/datasets/:datasetId/versions",
-      async ({ params, query, set }) => {
+      async (context) => {
+        const { params, query, set } = context
+        const { scoped } = requestAuthState(context)
         try {
-          requireDataset(sixb, params.datasetId)
+          requireDataset(sixb, scoped, params.datasetId)
           const parsed = DatasetVersionsQuerySchema.parse(query)
           const limit = parseLimit(parsed.limit, DEFAULT_VERSION_LIMIT, MAX_VERSION_LIMIT)
           const versions = await sixb.lakeStorage.listVersions(params.datasetId, limit)
@@ -283,9 +303,11 @@ export function registerDatasetRoutes(app: Elysia, sixb: Sixb<readonly OntologyS
     )
     .get(
       "/api/datasets/:datasetId/versions/:versionId",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
         try {
-          requireDataset(sixb, params.datasetId)
+          requireDataset(sixb, scoped, params.datasetId)
           const version = await sixb.lakeStorage.getVersion(params.datasetId, params.versionId)
           if (!version) {
             set.status = 404
@@ -313,9 +335,11 @@ export function registerDatasetRoutes(app: Elysia, sixb: Sixb<readonly OntologyS
     )
     .get(
       "/api/datasets/:datasetId/rows",
-      async ({ params, query, set }) => {
+      async (context) => {
+        const { params, query, set } = context
+        const { scoped } = requestAuthState(context)
         try {
-          requireDataset(sixb, params.datasetId)
+          requireDataset(sixb, scoped, params.datasetId)
           const parsed = DatasetRowsQuerySchema.parse(query)
           const limit = parseLimit(parsed.limit, DEFAULT_ROW_LIMIT, MAX_ROW_LIMIT)
           const offset = parseOffset(parsed.offset)

--- a/packages/server/src/routes/pipelines.ts
+++ b/packages/server/src/routes/pipelines.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import {
   assertAuthorized,
+  canViewPipelineRun,
   type OntologySource,
   type PipelineDefinition,
   type PipelineRunRecord,
@@ -187,7 +188,7 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
       "/api/pipeline-runs",
       async (context) => {
         const { query, set } = context
-        const { scoped } = requestAuthState(context)
+        const { authz } = requestAuthState(context)
         try {
           const parsed = PipelineRunsQuerySchema.parse(query)
           const storage = sixb.storage.pipelineRuns
@@ -199,18 +200,11 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             }
           }
 
-          if (scoped && parsed.pipelineId && !scoped.getPipelineById(parsed.pipelineId)) {
-            return {
-              runs: [],
-              hasMore: false,
-              total: 0,
-            }
-          }
-
-          const pipelineIds =
-            scoped && !parsed.pipelineId
-              ? scoped.listPipelines().map((pipeline) => pipeline.id)
-              : undefined
+          // Scope to runnable pipelines the same way workflow run history does:
+          // pass the grant allowlist alongside any explicit pipelineId and let
+          // storage AND them. An ungranted pipelineId yields an empty
+          // intersection, and an empty allowlist short-circuits to no rows.
+          const pipelineIds = authz ? [...authz.grants["run:pipeline"]] : undefined
           const result = await storage.list({
             projectId: sixb.id,
             pipelineId: parsed.pipelineId,
@@ -246,7 +240,7 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
       "/api/pipeline-runs/:runId",
       async (context) => {
         const { params, set } = context
-        const { scoped } = requestAuthState(context)
+        const { authz } = requestAuthState(context)
         try {
           const storage = sixb.storage.pipelineRuns
           if (!storage) {
@@ -258,12 +252,9 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             projectId: sixb.id,
             id: params.runId,
           })
-          if (!run) {
-            set.status = 404
-            return { error: "Pipeline run not found" }
-          }
-
-          if (scoped && !scoped.getPipelineById(run.pipelineId)) {
+          // A run the principal cannot run is hidden as 404, never surfaced as a
+          // distinct 403, mirroring the catalog and run-history routes.
+          if (!run || !canViewPipelineRun(authz, run)) {
             set.status = 404
             return { error: "Pipeline run not found" }
           }

--- a/packages/server/src/routes/pipelines.ts
+++ b/packages/server/src/routes/pipelines.ts
@@ -1,13 +1,15 @@
 import { randomUUID } from "node:crypto"
-import type {
-  OntologySource,
-  PipelineDefinition,
-  PipelineRunRecord,
-  PipelineStepExecutor,
-  PipelineStepRunRecord,
-  Sixb,
+import {
+  assertAuthorized,
+  type OntologySource,
+  type PipelineDefinition,
+  type PipelineRunRecord,
+  type PipelineStepExecutor,
+  type PipelineStepRunRecord,
+  type Sixb,
 } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
@@ -135,8 +137,9 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
   return app
     .get(
       "/api/pipelines",
-      async () => {
-        const pipelines = sixb.getPipelineDefinitions()
+      async (context) => {
+        const { scoped } = requestAuthState(context)
+        const pipelines = scoped ? scoped.listPipelines() : sixb.getPipelineDefinitions()
         const latestRuns = await getLatestPipelineRuns(
           sixb,
           pipelines.map((pipeline) => pipeline.id)
@@ -157,8 +160,12 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/pipelines/:pipelineId",
-      async ({ params, set }) => {
-        const pipeline = sixb.getPipelineById(params.pipelineId)
+      async (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
+        const pipeline = scoped
+          ? scoped.getPipelineById(params.pipelineId)
+          : sixb.getPipelineById(params.pipelineId)
         if (!pipeline) {
           set.status = 404
           return { error: "Pipeline not found" }
@@ -178,7 +185,9 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/pipeline-runs",
-      async ({ query, set }) => {
+      async (context) => {
+        const { query, set } = context
+        const { scoped } = requestAuthState(context)
         try {
           const parsed = PipelineRunsQuerySchema.parse(query)
           const storage = sixb.storage.pipelineRuns
@@ -190,9 +199,22 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             }
           }
 
+          if (scoped && parsed.pipelineId && !scoped.getPipelineById(parsed.pipelineId)) {
+            return {
+              runs: [],
+              hasMore: false,
+              total: 0,
+            }
+          }
+
+          const pipelineIds =
+            scoped && !parsed.pipelineId
+              ? scoped.listPipelines().map((pipeline) => pipeline.id)
+              : undefined
           const result = await storage.list({
             projectId: sixb.id,
             pipelineId: parsed.pipelineId,
+            pipelineIds,
             statuses: parsed.status ? [parsed.status] : undefined,
             startedAfter: parseDate(parsed.startedAfter),
             startedBefore: parseDate(parsed.startedBefore),
@@ -222,7 +244,9 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .get(
       "/api/pipeline-runs/:runId",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
         try {
           const storage = sixb.storage.pipelineRuns
           if (!storage) {
@@ -235,6 +259,11 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             id: params.runId,
           })
           if (!run) {
+            set.status = 404
+            return { error: "Pipeline run not found" }
+          }
+
+          if (scoped && !scoped.getPipelineById(run.pipelineId)) {
             set.status = 404
             return { error: "Pipeline run not found" }
           }
@@ -269,7 +298,9 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
     )
     .post(
       "/api/pipelines/:pipelineId/runs",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const pipeline = sixb.getPipelineById(params.pipelineId)
           if (!pipeline) {
@@ -281,6 +312,11 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             set.status = 400
             return { error: "Pipeline run storage is not configured" }
           }
+
+          assertAuthorized(
+            { authorization: authz ?? undefined },
+            { kind: "pipeline.run", pipelineId: pipeline.id }
+          )
 
           const runId = `run_${randomUUID()}`
           const queuedAt = new Date().toISOString()
@@ -313,6 +349,7 @@ export function registerPipelineRoutes(app: Elysia, sixb: Sixb<readonly Ontology
         response: {
           202: RequestPipelineRunResponseSchema,
           400: ErrorResponseSchema,
+          403: ErrorResponseSchema,
           404: ErrorResponseSchema,
         },
         detail: {

--- a/packages/server/src/routes/syncs.ts
+++ b/packages/server/src/routes/syncs.ts
@@ -1,6 +1,13 @@
 import { randomUUID } from "node:crypto"
-import type { OntologySource, Sixb, SyncDefinition, SyncRunRecord } from "@sixb/core"
+import {
+  assertAuthorized,
+  type OntologySource,
+  type Sixb,
+  type SyncDefinition,
+  type SyncRunRecord,
+} from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
@@ -92,8 +99,9 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
   return app
     .get(
       "/api/syncs",
-      async () => {
-        const syncs = sixb.getSyncDefinitions()
+      async (context) => {
+        const { scoped } = requestAuthState(context)
+        const syncs = scoped ? scoped.listSyncs() : sixb.getSyncDefinitions()
         const latestRuns = await getLatestSyncRuns(
           sixb,
           syncs.map((sync) => sync.id)
@@ -112,8 +120,10 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
     )
     .get(
       "/api/syncs/:syncId",
-      async ({ params, set }) => {
-        const sync = sixb.getSyncById(params.syncId)
+      async (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
+        const sync = scoped ? scoped.getSyncById(params.syncId) : sixb.getSyncById(params.syncId)
         if (!sync) {
           set.status = 404
           return { error: "Sync not found" }
@@ -133,7 +143,9 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
     )
     .get(
       "/api/sync-runs",
-      async ({ query, set }) => {
+      async (context) => {
+        const { query, set } = context
+        const { scoped } = requestAuthState(context)
         try {
           const parsed = SyncRunsQuerySchema.parse(query)
           const storage = sixb.storage.syncRuns
@@ -145,9 +157,20 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
             }
           }
 
+          if (scoped && parsed.syncId && !scoped.getSyncById(parsed.syncId)) {
+            return {
+              runs: [],
+              hasMore: false,
+              total: 0,
+            }
+          }
+
+          const syncIds =
+            scoped && !parsed.syncId ? scoped.listSyncs().map((sync) => sync.id) : undefined
           const result = await storage.list({
             projectId: sixb.id,
             syncId: parsed.syncId,
+            syncIds,
             datasetId: parsed.datasetId,
             statuses: parsed.status ? [parsed.status] : undefined,
             startedAfter: parseDate(parsed.startedAfter),
@@ -178,7 +201,9 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
     )
     .post(
       "/api/syncs/:syncId/runs",
-      async ({ params, body, set }) => {
+      async (context) => {
+        const { params, body, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const sync = sixb.getSyncById(params.syncId)
           if (!sync) {
@@ -190,6 +215,11 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
             set.status = 400
             return { error: "Sync run storage is not configured" }
           }
+
+          assertAuthorized(
+            { authorization: authz ?? undefined },
+            { kind: "sync.run", syncId: sync.id }
+          )
 
           const parsedBody = RequestSyncRunBodySchema.parse(body)
           const runId = `run_${randomUUID()}`
@@ -226,6 +256,7 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
         response: {
           202: RequestSyncRunResponseSchema,
           400: ErrorResponseSchema,
+          403: ErrorResponseSchema,
           404: ErrorResponseSchema,
         },
         detail: {

--- a/packages/server/src/routes/syncs.ts
+++ b/packages/server/src/routes/syncs.ts
@@ -145,7 +145,7 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
       "/api/sync-runs",
       async (context) => {
         const { query, set } = context
-        const { scoped } = requestAuthState(context)
+        const { authz } = requestAuthState(context)
         try {
           const parsed = SyncRunsQuerySchema.parse(query)
           const storage = sixb.storage.syncRuns
@@ -157,16 +157,11 @@ export function registerSyncRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
             }
           }
 
-          if (scoped && parsed.syncId && !scoped.getSyncById(parsed.syncId)) {
-            return {
-              runs: [],
-              hasMore: false,
-              total: 0,
-            }
-          }
-
-          const syncIds =
-            scoped && !parsed.syncId ? scoped.listSyncs().map((sync) => sync.id) : undefined
+          // Scope to runnable syncs the same way workflow run history does: pass
+          // the grant allowlist alongside any explicit syncId and let storage AND
+          // them. An ungranted syncId yields an empty intersection (no rows), and
+          // an empty allowlist short-circuits to no rows.
+          const syncIds = authz ? [...authz.grants["run:sync"]] : undefined
           const result = await storage.list({
             projectId: sixb.id,
             syncId: parsed.syncId,

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -350,7 +350,7 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             return { interventions: [], hasMore: false, total: 0 }
           }
 
-          const workflowIds = authz ? [...authz.grants.workflows.run] : undefined
+          const workflowIds = authz ? [...authz.grants["run:workflow"]] : undefined
           const result = await storage.list({
             projectId: sixb.id,
             workflowId: parsed.workflowId,
@@ -637,7 +637,7 @@ export function registerWorkflowRoutes(app: Elysia, sixb: Sixb<readonly Ontology
             return { runs: [], hasMore: false, total: 0 }
           }
 
-          const workflowIds = authz ? [...authz.grants.workflows.run] : undefined
+          const workflowIds = authz ? [...authz.grants["run:workflow"]] : undefined
           const result = await storage.list({
             projectId: sixb.id,
             workflowId: parsed.workflowId,

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -3,11 +3,18 @@ import { createServer } from "node:net"
 import {
   actions,
   can,
+  col,
   createSessionCredential,
+  datasets,
   defineAction,
+  defineConnector,
+  defineDataset,
   defineGroup,
   defineObjectType,
+  definePipeline,
+  definePipelineStep,
   defineRole,
+  defineSync,
   defineWorkflow,
   defineWorkflowStep,
   InMemoryBlobStorage,
@@ -17,9 +24,12 @@ import {
   InMemoryStorage,
   type OntologySource,
   ontology,
+  type PipelineDefinition,
+  pipelines,
   prop,
   ref,
   Sixb,
+  syncs,
   type WorkflowDefinition,
   workflows,
 } from "@sixb/core"
@@ -37,6 +47,46 @@ const Invoice = defineObjectType({
   name: "Invoice",
   properties: [prop("id", "string", { required: true, primary: true })],
 })
+
+const OrdersDataset = defineDataset("raw.erp.orders", {
+  schema: [col("id", "string")],
+})
+
+const CustomersDataset = defineDataset("raw.crm.customers", {
+  schema: [col("id", "string")],
+})
+
+const sourceConnector = defineConnector("source", {
+  type: "test",
+  async connect() {
+    return {}
+  },
+})
+
+const ordersSync = defineSync("sync-orders")
+  .from(sourceConnector)
+  .read(() => [])
+  .intoDataset(OrdersDataset)
+
+const customersSync = defineSync("sync-customers")
+  .from(sourceConnector)
+  .read(() => [])
+  .intoDataset(CustomersDataset)
+
+const normalizeOrdersStep = definePipelineStep("normalize-orders")
+  .inputs({ orders: OrdersDataset })
+  .output(OrdersDataset)
+  .run(async () => {})
+
+const normalizeCustomersStep = definePipelineStep("normalize-customers")
+  .inputs({ customers: CustomersDataset })
+  .output(CustomersDataset)
+  .run(async () => {})
+
+const ordersPipeline: PipelineDefinition =
+  definePipeline("pipeline-orders").then(normalizeOrdersStep)
+const customersPipeline: PipelineDefinition =
+  definePipeline("pipeline-customers").then(normalizeCustomersStep)
 
 const sendContract = defineAction("send-contract")
   .on(Contract)
@@ -59,17 +109,24 @@ const admins = defineGroup("admins")
 
 const contractOperator = defineRole("contract.operator", {
   grantedTo: [commercial],
-  grants: [can.view(Contract), can.apply(sendContract)],
+  grants: [can.view(Contract), can.view(OrdersDataset), can.apply(sendContract)],
 })
 
 const operationsRunner = defineRole("operations.runner", {
   grantedTo: [operations],
-  grants: [can.run(renewContract)],
+  grants: [can.run(renewContract), can.run(ordersSync), can.run(ordersPipeline)],
 })
 
 const adminOperator = defineRole("admin.operator", {
   grantedTo: [admins],
-  grants: [can.view(ontology.objects()), can.apply(actions()), can.run(workflows())],
+  grants: [
+    can.view(ontology.objects()),
+    can.view(datasets()),
+    can.apply(actions()),
+    can.run(workflows()),
+    can.run(syncs()),
+    can.run(pipelines()),
+  ],
 })
 
 async function createRuntime(options: { readonly auth?: boolean } = {}) {
@@ -77,6 +134,9 @@ async function createRuntime(options: { readonly auth?: boolean } = {}) {
   const sixb = new Sixb<readonly OntologySource[]>({
     id: "test-project",
     ontology: [Contract, Invoice],
+    datasets: [OrdersDataset, CustomersDataset],
+    syncs: [ordersSync, customersSync],
+    pipelines: [ordersPipeline, customersPipeline],
     broker: new InMemoryBroker(),
     storage,
     lakeStorage: new InMemoryLakeStorage(),
@@ -295,6 +355,102 @@ describe("authorized object routes", () => {
       new Set(["contract", "invoice"])
     )
   })
+
+  test("dataset routes narrow to viewable datasets and hide forbidden identities", async () => {
+    const { app, storage } = await createApp()
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    const operatorList = await app.fetch(
+      new Request("http://localhost/api/datasets", { headers: operator.headers })
+    )
+    const operatorDatasets = (await operatorList.json()) as {
+      id: string
+      syncIds: string[]
+      sourcePipelineIds: string[]
+      targetPipelineIds: string[]
+      projectionIds: string[]
+    }[]
+    expect(operatorDatasets.map((dataset) => dataset.id)).toEqual(["raw.erp.orders"])
+    expect(operatorDatasets[0]).toEqual(
+      expect.objectContaining({
+        syncIds: [],
+        sourcePipelineIds: [],
+        targetPipelineIds: [],
+        projectionIds: [],
+      })
+    )
+
+    const operatorDetail = await app.fetch(
+      new Request("http://localhost/api/datasets/raw.erp.orders", { headers: operator.headers })
+    )
+    expect(operatorDetail.status).toBe(200)
+    expect(await operatorDetail.json()).toEqual(
+      expect.objectContaining({
+        syncIds: [],
+        sourcePipelineIds: [],
+        targetPipelineIds: [],
+        projectionIds: [],
+      })
+    )
+
+    const hiddenList = await app.fetch(
+      new Request("http://localhost/api/datasets", { headers: runner.headers })
+    )
+    expect(await hiddenList.json()).toEqual([])
+
+    const hiddenDetail = await app.fetch(
+      new Request("http://localhost/api/datasets/raw.crm.customers", {
+        headers: operator.headers,
+      })
+    )
+    expect(hiddenDetail.status).toBe(404)
+
+    const hiddenVersions = await app.fetch(
+      new Request("http://localhost/api/datasets/raw.crm.customers/versions", {
+        headers: operator.headers,
+      })
+    )
+    expect(hiddenVersions.status).toBe(404)
+
+    const hiddenRows = await app.fetch(
+      new Request("http://localhost/api/datasets/raw.crm.customers/rows", {
+        headers: operator.headers,
+      })
+    )
+    expect(hiddenRows.status).toBe(404)
+
+    const adminList = await app.fetch(
+      new Request("http://localhost/api/datasets", { headers: admin.headers })
+    )
+    const adminDatasets = (await adminList.json()) as {
+      id: string
+      syncIds: string[]
+      sourcePipelineIds: string[]
+      targetPipelineIds: string[]
+      projectionIds: string[]
+    }[]
+    expect(adminDatasets.map((dataset) => dataset.id)).toEqual([
+      "raw.erp.orders",
+      "raw.crm.customers",
+    ])
+    const adminDatasetById = new Map(adminDatasets.map((dataset) => [dataset.id, dataset]))
+    expect(adminDatasetById.get("raw.erp.orders")).toEqual(
+      expect.objectContaining({
+        syncIds: ["sync-orders"],
+        sourcePipelineIds: ["pipeline-orders"],
+        targetPipelineIds: ["pipeline-orders"],
+      })
+    )
+    expect(adminDatasetById.get("raw.crm.customers")).toEqual(
+      expect.objectContaining({
+        syncIds: ["sync-customers"],
+        sourcePipelineIds: ["pipeline-customers"],
+        targetPipelineIds: ["pipeline-customers"],
+      })
+    )
+  })
 })
 
 describe("authorized action routes", () => {
@@ -393,6 +549,232 @@ describe("authorized action routes", () => {
       })
     )
     expect(hiddenDetail.status).toBe(404)
+  })
+})
+
+describe("authorized sync routes", () => {
+  test("sync catalog narrows to runnable syncs and hides the rest as 404", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    const runnerList = await app.fetch(
+      new Request("http://localhost/api/syncs", { headers: runner.headers })
+    )
+    expect(((await runnerList.json()) as { id: string }[]).map((sync) => sync.id)).toEqual([
+      "sync-orders",
+    ])
+
+    const operatorList = await app.fetch(
+      new Request("http://localhost/api/syncs", { headers: operator.headers })
+    )
+    expect(await operatorList.json()).toEqual([])
+
+    const hidden = await app.fetch(
+      new Request("http://localhost/api/syncs/sync-orders", { headers: operator.headers })
+    )
+    expect(hidden.status).toBe(404)
+
+    const adminList = await app.fetch(
+      new Request("http://localhost/api/syncs", { headers: admin.headers })
+    )
+    expect(((await adminList.json()) as { id: string }[]).map((sync) => sync.id)).toEqual([
+      "sync-orders",
+      "sync-customers",
+    ])
+  })
+
+  test("sync run requests require can.run", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+
+    const allowed = await app.fetch(
+      new Request("http://localhost/api/syncs/sync-orders/runs", {
+        method: "POST",
+        headers: runner.csrfHeaders,
+        body: JSON.stringify({ commitMessage: "manual run" }),
+      })
+    )
+    expect(allowed.status).toBe(202)
+
+    const denied = await app.fetch(
+      new Request("http://localhost/api/syncs/sync-orders/runs", {
+        method: "POST",
+        headers: operator.csrfHeaders,
+        body: JSON.stringify({ commitMessage: "manual run" }),
+      })
+    )
+    expect(denied.status).toBe(403)
+  })
+
+  test("sync run history narrows to runnable syncs", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    await storage.syncRuns!.start({
+      id: "run-orders",
+      projectId: "test-project",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "snapshot",
+      startedAt: new Date("2026-05-16T12:00:00.000Z"),
+    })
+    await storage.syncRuns!.start({
+      id: "run-customers",
+      projectId: "test-project",
+      syncId: "sync-customers",
+      datasetId: "raw.crm.customers",
+      mode: "snapshot",
+      startedAt: new Date("2026-05-16T13:00:00.000Z"),
+    })
+
+    const runnerRuns = await app.fetch(
+      new Request("http://localhost/api/sync-runs", { headers: runner.headers })
+    )
+    expect(((await runnerRuns.json()) as { runs: { syncId: string }[] }).runs).toEqual([
+      expect.objectContaining({ syncId: "sync-orders" }),
+    ])
+
+    const hiddenRuns = await app.fetch(
+      new Request("http://localhost/api/sync-runs?syncId=sync-customers", {
+        headers: runner.headers,
+      })
+    )
+    expect(await hiddenRuns.json()).toEqual({ runs: [], hasMore: false, total: 0 })
+
+    const operatorRuns = await app.fetch(
+      new Request("http://localhost/api/sync-runs", { headers: operator.headers })
+    )
+    expect(await operatorRuns.json()).toEqual({ runs: [], hasMore: false, total: 0 })
+
+    const adminRuns = await app.fetch(
+      new Request("http://localhost/api/sync-runs", { headers: admin.headers })
+    )
+    expect(
+      ((await adminRuns.json()) as { runs: { syncId: string }[] }).runs.map((run) => run.syncId)
+    ).toEqual(["sync-customers", "sync-orders"])
+  })
+})
+
+describe("authorized pipeline routes", () => {
+  test("pipeline catalog narrows to runnable pipelines and hides the rest as 404", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    const runnerList = await app.fetch(
+      new Request("http://localhost/api/pipelines", { headers: runner.headers })
+    )
+    expect(((await runnerList.json()) as { id: string }[]).map((pipeline) => pipeline.id)).toEqual([
+      "pipeline-orders",
+    ])
+
+    const operatorList = await app.fetch(
+      new Request("http://localhost/api/pipelines", { headers: operator.headers })
+    )
+    expect(await operatorList.json()).toEqual([])
+
+    const hidden = await app.fetch(
+      new Request("http://localhost/api/pipelines/pipeline-orders", { headers: operator.headers })
+    )
+    expect(hidden.status).toBe(404)
+
+    const adminList = await app.fetch(
+      new Request("http://localhost/api/pipelines", { headers: admin.headers })
+    )
+    expect(((await adminList.json()) as { id: string }[]).map((pipeline) => pipeline.id)).toEqual([
+      "pipeline-orders",
+      "pipeline-customers",
+    ])
+  })
+
+  test("pipeline run requests require can.run", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+
+    const allowed = await app.fetch(
+      new Request("http://localhost/api/pipelines/pipeline-orders/runs", {
+        method: "POST",
+        headers: runner.csrfHeaders,
+        body: JSON.stringify({}),
+      })
+    )
+    expect(allowed.status).toBe(202)
+
+    const denied = await app.fetch(
+      new Request("http://localhost/api/pipelines/pipeline-orders/runs", {
+        method: "POST",
+        headers: operator.csrfHeaders,
+        body: JSON.stringify({}),
+      })
+    )
+    expect(denied.status).toBe(403)
+  })
+
+  test("pipeline run history narrows to runnable pipelines", async () => {
+    const { app, storage } = await createApp()
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    await storage.pipelineRuns!.start({
+      id: "run-orders",
+      projectId: "test-project",
+      pipelineId: "pipeline-orders",
+      startedAt: new Date("2026-05-16T12:00:00.000Z"),
+    })
+    await storage.pipelineRuns!.start({
+      id: "run-customers",
+      projectId: "test-project",
+      pipelineId: "pipeline-customers",
+      startedAt: new Date("2026-05-16T13:00:00.000Z"),
+    })
+
+    const runnerRuns = await app.fetch(
+      new Request("http://localhost/api/pipeline-runs", { headers: runner.headers })
+    )
+    expect(((await runnerRuns.json()) as { runs: { pipelineId: string }[] }).runs).toEqual([
+      expect.objectContaining({ pipelineId: "pipeline-orders" }),
+    ])
+
+    const hiddenRuns = await app.fetch(
+      new Request("http://localhost/api/pipeline-runs?pipelineId=pipeline-customers", {
+        headers: runner.headers,
+      })
+    )
+    expect(await hiddenRuns.json()).toEqual({ runs: [], hasMore: false, total: 0 })
+
+    const hiddenDetail = await app.fetch(
+      new Request("http://localhost/api/pipeline-runs/run-customers", {
+        headers: runner.headers,
+      })
+    )
+    expect(hiddenDetail.status).toBe(404)
+
+    const allowedDetail = await app.fetch(
+      new Request("http://localhost/api/pipeline-runs/run-orders", { headers: runner.headers })
+    )
+    expect(allowedDetail.status).toBe(200)
+
+    const operatorRuns = await app.fetch(
+      new Request("http://localhost/api/pipeline-runs", { headers: operator.headers })
+    )
+    expect(await operatorRuns.json()).toEqual({ runs: [], hasMore: false, total: 0 })
+
+    const adminRuns = await app.fetch(
+      new Request("http://localhost/api/pipeline-runs", { headers: admin.headers })
+    )
+    expect(
+      ((await adminRuns.json()) as { runs: { pipelineId: string }[] }).runs.map(
+        (run) => run.pipelineId
+      )
+    ).toEqual(["pipeline-customers", "pipeline-orders"])
   })
 })
 

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -13,6 +13,7 @@ import {
   defineObjectType,
   definePipeline,
   definePipelineStep,
+  defineProjection,
   defineRole,
   defineSync,
   defineWorkflow,
@@ -88,6 +89,14 @@ const ordersPipeline: PipelineDefinition =
 const customersPipeline: PipelineDefinition =
   definePipeline("pipeline-customers").then(normalizeCustomersStep)
 
+// Projections have no grant family yet, so their dataset lineage is exposed
+// only to privileged (unauthenticated) callers and hidden from every scoped
+// principal. Registered here so the `projectionIds` assertions below are
+// load-bearing rather than vacuous.
+const ordersProjection = defineProjection("orders-rollup", Contract)
+  .fromDataset(OrdersDataset)
+  .properties({ id: "id" })
+
 const sendContract = defineAction("send-contract")
   .on(Contract)
   .params({})
@@ -137,6 +146,7 @@ async function createRuntime(options: { readonly auth?: boolean } = {}) {
     datasets: [OrdersDataset, CustomersDataset],
     syncs: [ordersSync, customersSync],
     pipelines: [ordersPipeline, customersPipeline],
+    projections: [ordersProjection],
     broker: new InMemoryBroker(),
     storage,
     lakeStorage: new InMemoryLakeStorage(),
@@ -285,7 +295,7 @@ describe("authorized object routes", () => {
     const response = await app.fetch(
       new Request("http://localhost/api/objects", { headers: session.headers })
     )
-    const body = (await response.json()) as { objects: unknown[]; total: number }
+    const body = (await response.json()) as { objects: unknown[]; hasMore: boolean; total: number }
 
     expect(response.status).toBe(200)
     expect(body).toEqual({ objects: [], hasMore: false, total: 0 })
@@ -450,6 +460,33 @@ describe("authorized object routes", () => {
         targetPipelineIds: ["pipeline-customers"],
       })
     )
+  })
+
+  test("projection lineage is exposed to privileged callers but hidden from every scoped principal", async () => {
+    // The privileged (unauthenticated) catalog populates projectionIds, proving
+    // ordersProjection is registered against raw.erp.orders...
+    const { app: privilegedApp } = await createApp({ auth: false })
+    const privileged = await privilegedApp.fetch(
+      new Request("http://localhost/api/datasets/raw.erp.orders")
+    )
+    expect(privileged.status).toBe(200)
+    expect(await privileged.json()).toEqual(
+      expect.objectContaining({ projectionIds: ["orders-rollup"] })
+    )
+
+    // ...so the scoped operator's empty projectionIds is the guard at work, not
+    // an absent projection. (admins are scoped too, hence also empty.)
+    const { app, storage } = await createApp()
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    for (const session of [operator, admin]) {
+      const detail = await app.fetch(
+        new Request("http://localhost/api/datasets/raw.erp.orders", { headers: session.headers })
+      )
+      expect(detail.status).toBe(200)
+      expect(await detail.json()).toEqual(expect.objectContaining({ projectionIds: [] }))
+    }
   })
 })
 

--- a/storage/pg/src/pg-pipeline-run-storage.ts
+++ b/storage/pg/src/pg-pipeline-run-storage.ts
@@ -240,7 +240,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
   }
 
   async list(input: ListPipelineRunsInput): Promise<ListPipelineRunsResult> {
-    if (hasEmptyStatuses(input)) {
+    if (hasEmptyStatuses(input) || input.pipelineIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -255,6 +255,12 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
     if (input.pipelineId) {
       whereClauses.push(`pipeline_id = $${index++}`)
       params.push(input.pipelineId)
+    }
+
+    if (input.pipelineIds) {
+      const placeholders = input.pipelineIds.map(() => `$${index++}`).join(", ")
+      whereClauses.push(`pipeline_id IN (${placeholders})`)
+      params.push(...input.pipelineIds)
     }
 
     index = appendRunListFilters(whereClauses, params, index, input)

--- a/storage/pg/src/pg-sync-run-storage.ts
+++ b/storage/pg/src/pg-sync-run-storage.ts
@@ -120,6 +120,14 @@ export class PgSyncRunStorage implements SyncRunStorage {
   }
 
   async list(input: ListSyncRunsInput): Promise<ListSyncRunsResult> {
+    if (input.syncIds && input.syncIds.length === 0) {
+      return {
+        runs: [],
+        hasMore: false,
+        total: 0,
+      }
+    }
+
     if (input.statuses && input.statuses.length === 0) {
       return {
         runs: [],
@@ -135,6 +143,12 @@ export class PgSyncRunStorage implements SyncRunStorage {
     if (input.syncId) {
       whereClauses.push(`sync_id = $${index++}`)
       params.push(input.syncId)
+    }
+
+    if (input.syncIds) {
+      const placeholders = input.syncIds.map(() => `$${index++}`)
+      whereClauses.push(`sync_id IN (${placeholders.join(", ")})`)
+      params.push(...input.syncIds)
     }
 
     if (input.datasetId) {

--- a/storage/pg/src/pg-sync-run-storage.ts
+++ b/storage/pg/src/pg-sync-run-storage.ts
@@ -13,6 +13,7 @@ import type {
 import { SyncRunError } from "@sixb/core"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import type { SqlParameter } from "./pg-client"
+import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
 import { isUniqueViolation } from "./storage-errors"
 import { type PgStoreClient, runPgTransaction } from "./transactions"
 
@@ -120,15 +121,7 @@ export class PgSyncRunStorage implements SyncRunStorage {
   }
 
   async list(input: ListSyncRunsInput): Promise<ListSyncRunsResult> {
-    if (input.syncIds && input.syncIds.length === 0) {
-      return {
-        runs: [],
-        hasMore: false,
-        total: 0,
-      }
-    }
-
-    if (input.statuses && input.statuses.length === 0) {
+    if (hasEmptyStatuses(input) || input.syncIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -156,53 +149,23 @@ export class PgSyncRunStorage implements SyncRunStorage {
       params.push(input.datasetId)
     }
 
-    if (input.statuses) {
-      const placeholders = input.statuses.map(() => `$${index++}`)
-      whereClauses.push(`status IN (${placeholders.join(", ")})`)
-      params.push(...input.statuses)
-    }
+    index = appendRunListFilters(whereClauses, params, index, input)
 
-    if (input.startedAfter) {
-      whereClauses.push(`started_at >= $${index++}`)
-      params.push(input.startedAfter)
-    }
-
-    if (input.startedBefore) {
-      whereClauses.push(`started_at <= $${index++}`)
-      params.push(input.startedBefore)
-    }
-
-    const where = `WHERE ${whereClauses.join(" AND ")}`
-    const order = input.order === "asc" ? "ASC" : "DESC"
-    const offset = input.offset ?? 0
-
-    const [totalRow] = await this.sql.unsafe<{ count: string | number }[]>(
-      `SELECT COUNT(*)::bigint AS count FROM sync_runs ${where}`,
-      params
-    )
-
-    const queryParams = [...params]
-    let query = `
-      SELECT *, checkpoint IS NOT NULL AS checkpoint_present FROM sync_runs
-      ${where}
-      ORDER BY started_at ${order}, id ${order}
-    `
-
-    if (input.limit !== undefined) {
-      query += ` LIMIT $${index++} OFFSET $${index++}`
-      queryParams.push(input.limit, offset)
-    } else if (offset > 0) {
-      query += ` OFFSET $${index++}`
-      queryParams.push(offset)
-    }
-
-    const rows = await this.sql.unsafe<DatabaseRow[]>(query, queryParams)
-    const total = Number(totalRow?.count ?? 0)
-    const runs = rows.map(rowToSyncRunRecord)
+    const { rows, total, hasMore } = await queryRunList<DatabaseRow>({
+      sql: this.sql,
+      tableName: "sync_runs",
+      selectList: "*, checkpoint IS NOT NULL AS checkpoint_present",
+      whereClauses,
+      params,
+      nextIndex: index,
+      order: input.order,
+      limit: input.limit,
+      offset: input.offset,
+    })
 
     return {
-      runs,
-      hasMore: offset + runs.length < total,
+      runs: rows.map(rowToSyncRunRecord),
+      hasMore,
       total,
     }
   }

--- a/storage/pg/src/run-list-query.ts
+++ b/storage/pg/src/run-list-query.ts
@@ -3,9 +3,13 @@ import type { SQLClient, SqlParameter } from "./pg-client"
 type PgRunListTable =
   | "pipeline_runs"
   | "pipeline_step_runs"
+  | "sync_runs"
   | "webhook_runs"
   | "workflow_runs"
   | "workflow_node_runs"
+
+/** Column projection — `sync_runs` needs the derived `checkpoint_present` flag. */
+type PgRunListSelectList = "*" | "*, checkpoint IS NOT NULL AS checkpoint_present"
 
 export function hasEmptyStatuses(input: { readonly statuses?: readonly unknown[] }): boolean {
   return input.statuses !== undefined && input.statuses.length === 0
@@ -55,6 +59,7 @@ export async function queryRunList<TRow>(input: {
   readonly order?: "asc" | "desc"
   readonly limit?: number
   readonly offset?: number
+  readonly selectList?: PgRunListSelectList
 }): Promise<{ readonly rows: readonly TRow[]; readonly total: number; readonly hasMore: boolean }> {
   const where = `WHERE ${input.whereClauses.join(" AND ")}`
   const order = input.order === "asc" ? "ASC" : "DESC"
@@ -67,7 +72,7 @@ export async function queryRunList<TRow>(input: {
 
   const queryParams = [...input.params] as SqlParameter[]
   let query = `
-    SELECT * FROM ${input.tableName}
+    SELECT ${input.selectList ?? "*"} FROM ${input.tableName}
     ${where}
     ORDER BY started_at ${order}, id ${order}
   `

--- a/storage/pg/tests/pg-pipeline-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-pipeline-run-storage.e2e.ts
@@ -102,6 +102,13 @@ describe("PgPipelineRunStorage", () => {
     expect(page.hasMore).toBe(false)
     expect(page.runs.map((run) => run.id)).toEqual(["run-2"])
 
+    const selectedPipelines = await storage.pipelineRuns.list({
+      projectId: "my-app",
+      pipelineIds: ["orders"],
+    })
+    expect(selectedPipelines.total).toBe(1)
+    expect(selectedPipelines.runs.map((run) => run.id)).toEqual(["run-3"])
+
     const empty = await storage.pipelineRuns.list({
       projectId: "my-app",
       statuses: [],

--- a/storage/pg/tests/pg-pipeline-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-pipeline-run-storage.e2e.ts
@@ -109,6 +109,10 @@ describe("PgPipelineRunStorage", () => {
     expect(selectedPipelines.total).toBe(1)
     expect(selectedPipelines.runs.map((run) => run.id)).toEqual(["run-3"])
 
+    // An empty allowlist must deny all — never fall through to an unfiltered list.
+    const noneAllowed = await storage.pipelineRuns.list({ projectId: "my-app", pipelineIds: [] })
+    expect(noneAllowed).toEqual({ runs: [], hasMore: false, total: 0 })
+
     const empty = await storage.pipelineRuns.list({
       projectId: "my-app",
       statuses: [],

--- a/storage/pg/tests/pg-sync-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-sync-run-storage.e2e.ts
@@ -131,6 +131,10 @@ describe("PgSyncRunStorage", () => {
     expect(selectedSyncs.total).toBe(1)
     expect(selectedSyncs.runs.map((run) => run.id)).toEqual(["run-3"])
 
+    // An empty allowlist must deny all — never fall through to an unfiltered list.
+    const noneAllowed = await storage.syncRuns.list({ projectId: "my-app", syncIds: [] })
+    expect(noneAllowed).toEqual({ runs: [], hasMore: false, total: 0 })
+
     const failed = await storage.syncRuns.getById({
       projectId: "my-app",
       id: "run-1",

--- a/storage/pg/tests/pg-sync-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-sync-run-storage.e2e.ts
@@ -124,6 +124,13 @@ describe("PgSyncRunStorage", () => {
     expect(page.hasMore).toBe(true)
     expect(page.runs.map((run) => run.id)).toEqual(["run-3"])
 
+    const selectedSyncs = await storage.syncRuns.list({
+      projectId: "my-app",
+      syncIds: ["sync-customers"],
+    })
+    expect(selectedSyncs.total).toBe(1)
+    expect(selectedSyncs.runs.map((run) => run.id)).toEqual(["run-3"])
+
     const failed = await storage.syncRuns.getById({
       projectId: "my-app",
       id: "run-1",

--- a/storage/sqlite/src/pipeline-run-storage.ts
+++ b/storage/sqlite/src/pipeline-run-storage.ts
@@ -288,7 +288,7 @@ export class SqlitePipelineRunStorage implements PipelineRunStorage {
   }
 
   async list(input: ListPipelineRunsInput): Promise<ListPipelineRunsResult> {
-    if (hasEmptyStatuses(input)) {
+    if (hasEmptyStatuses(input) || input.pipelineIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -302,6 +302,11 @@ export class SqlitePipelineRunStorage implements PipelineRunStorage {
     if (input.pipelineId) {
       whereClauses.push("pipeline_id = ?")
       args.push(input.pipelineId)
+    }
+
+    if (input.pipelineIds) {
+      whereClauses.push(`pipeline_id IN (${input.pipelineIds.map(() => "?").join(", ")})`)
+      args.push(...input.pipelineIds)
     }
 
     appendRunListFilters(whereClauses, args, input)

--- a/storage/sqlite/src/run-list-query.ts
+++ b/storage/sqlite/src/run-list-query.ts
@@ -5,6 +5,7 @@ export type SqliteValue = string | number | null
 type SqliteRunListTable =
   | "pipeline_runs"
   | "pipeline_step_runs"
+  | "sync_runs"
   | "webhook_runs"
   | "workflow_runs"
   | "workflow_node_runs"

--- a/storage/sqlite/src/sync-run-storage.ts
+++ b/storage/sqlite/src/sync-run-storage.ts
@@ -155,6 +155,14 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
   }
 
   async list(input: ListSyncRunsInput): Promise<ListSyncRunsResult> {
+    if (input.syncIds && input.syncIds.length === 0) {
+      return {
+        runs: [],
+        hasMore: false,
+        total: 0,
+      }
+    }
+
     if (input.statuses && input.statuses.length === 0) {
       return {
         runs: [],
@@ -169,6 +177,11 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
     if (input.syncId) {
       whereClauses.push("sync_id = ?")
       args.push(input.syncId)
+    }
+
+    if (input.syncIds) {
+      whereClauses.push(`sync_id IN (${input.syncIds.map(() => "?").join(", ")})`)
+      args.push(...input.syncIds)
     }
 
     if (input.datasetId) {

--- a/storage/sqlite/src/sync-run-storage.ts
+++ b/storage/sqlite/src/sync-run-storage.ts
@@ -15,6 +15,12 @@ import { SyncRunError } from "@sixb/core"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import { installFreshSqliteSchema } from "./migrations"
 import {
+  appendRunListFilters,
+  hasEmptyStatuses,
+  queryRunList,
+  type SqliteValue,
+} from "./run-list-query"
+import {
   closeSqliteStoreConnection,
   openSqliteStoreConnection,
   type SqliteStoreConnection,
@@ -155,15 +161,7 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
   }
 
   async list(input: ListSyncRunsInput): Promise<ListSyncRunsResult> {
-    if (input.syncIds && input.syncIds.length === 0) {
-      return {
-        runs: [],
-        hasMore: false,
-        total: 0,
-      }
-    }
-
-    if (input.statuses && input.statuses.length === 0) {
+    if (hasEmptyStatuses(input) || input.syncIds?.length === 0) {
       return {
         runs: [],
         hasMore: false,
@@ -172,7 +170,7 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
     }
 
     const whereClauses = ["project_id = ?"]
-    const args: (string | number)[] = [input.projectId]
+    const args: SqliteValue[] = [input.projectId]
 
     if (input.syncId) {
       whereClauses.push("sync_id = ?")
@@ -189,52 +187,22 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
       args.push(input.datasetId)
     }
 
-    if (input.statuses) {
-      whereClauses.push(`status IN (${input.statuses.map(() => "?").join(", ")})`)
-      args.push(...input.statuses)
-    }
+    appendRunListFilters(whereClauses, args, input)
 
-    if (input.startedAfter) {
-      whereClauses.push("started_at >= ?")
-      args.push(input.startedAfter.toISOString())
-    }
-
-    if (input.startedBefore) {
-      whereClauses.push("started_at <= ?")
-      args.push(input.startedBefore.toISOString())
-    }
-
-    const where = `WHERE ${whereClauses.join(" AND ")}`
-    const order = input.order === "asc" ? "ASC" : "DESC"
-    const offset = input.offset ?? 0
-    const limit = input.limit
-
-    const totalRow = this.db
-      .query(`SELECT COUNT(*) AS count FROM sync_runs ${where}`)
-      .get(...args) as { count: number }
-
-    let query = `
-      SELECT * FROM sync_runs
-      ${where}
-      ORDER BY started_at ${order}, id ${order}
-    `
-    const queryArgs = [...args]
-
-    if (limit !== undefined) {
-      query += " LIMIT ? OFFSET ?"
-      queryArgs.push(limit, offset)
-    } else if (offset > 0) {
-      query += " LIMIT -1 OFFSET ?"
-      queryArgs.push(offset)
-    }
-
-    const rows = this.db.query(query).all(...queryArgs) as DatabaseRow[]
-    const runs = rows.map(rowToSyncRunRecord)
+    const { rows, total, hasMore } = queryRunList<DatabaseRow>({
+      db: this.db,
+      tableName: "sync_runs",
+      whereClauses,
+      args,
+      order: input.order,
+      limit: input.limit,
+      offset: input.offset,
+    })
 
     return {
-      runs,
-      hasMore: offset + runs.length < totalRow.count,
-      total: totalRow.count,
+      runs: rows.map(rowToSyncRunRecord),
+      hasMore,
+      total,
     }
   }
 

--- a/storage/sqlite/tests/sqlite-pipeline-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-pipeline-run-storage.test.ts
@@ -106,6 +106,10 @@ describe("SqlitePipelineRunStorage", () => {
     expect(selectedPipelines.total).toBe(1)
     expect(selectedPipelines.runs.map((run) => run.id)).toEqual(["run-3"])
 
+    // An empty allowlist must deny all — never fall through to an unfiltered list.
+    const noneAllowed = await storage.list({ projectId: "my-app", pipelineIds: [] })
+    expect(noneAllowed).toEqual({ runs: [], hasMore: false, total: 0 })
+
     const empty = await storage.list({
       projectId: "my-app",
       statuses: [],

--- a/storage/sqlite/tests/sqlite-pipeline-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-pipeline-run-storage.test.ts
@@ -99,6 +99,13 @@ describe("SqlitePipelineRunStorage", () => {
     expect(page.hasMore).toBe(false)
     expect(page.runs.map((run) => run.id)).toEqual(["run-2"])
 
+    const selectedPipelines = await storage.list({
+      projectId: "my-app",
+      pipelineIds: ["orders"],
+    })
+    expect(selectedPipelines.total).toBe(1)
+    expect(selectedPipelines.runs.map((run) => run.id)).toEqual(["run-3"])
+
     const empty = await storage.list({
       projectId: "my-app",
       statuses: [],

--- a/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
@@ -129,6 +129,10 @@ describe("SqliteSyncRunStorage", () => {
     expect(selectedSyncs.total).toBe(1)
     expect(selectedSyncs.runs.map((run) => run.id)).toEqual(["run-3"])
 
+    // An empty allowlist must deny all — never fall through to an unfiltered list.
+    const noneAllowed = await storage.list({ projectId: "my-app", syncIds: [] })
+    expect(noneAllowed).toEqual({ runs: [], hasMore: false, total: 0 })
+
     const failed = await storage.getById({
       projectId: "my-app",
       id: "run-1",

--- a/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
@@ -122,6 +122,13 @@ describe("SqliteSyncRunStorage", () => {
     expect(page.hasMore).toBe(true)
     expect(page.runs.map((run) => run.id)).toEqual(["run-3"])
 
+    const selectedSyncs = await storage.list({
+      projectId: "my-app",
+      syncIds: ["sync-customers"],
+    })
+    expect(selectedSyncs.total).toBe(1)
+    expect(selectedSyncs.runs.map((run) => run.id)).toEqual(["run-3"])
+
     const failed = await storage.getById({
       projectId: "my-app",
       id: "run-1",


### PR DESCRIPTION
## Summary
Adds dataset visibility grants so roles can expose datasets separately from object types.

```ts
grants: [
  can.view(OrdersDataset),
  can.view(datasets().except([InternalDataset])),
]
```

Adds sync and pipeline run grants. The run grant doubles as catalog and run-history visibility for those operational surfaces.

```ts
grants: [
  can.run(ordersSync),
  can.run(pipelines().except([backfillPipeline])),
]
```

Routes filter with the scoped runtime before touching paginated storage, so run history stays correctly paged and avoids fetch-all filtering.

```ts
const syncIds = scoped && !parsed.syncId
  ? scoped.listSyncs().map((sync) => sync.id)
  : undefined

await storage.list({
  projectId: sixb.id,
  syncId: parsed.syncId,
  syncIds,
  limit,
  offset,
})
```

Dataset metadata now scopes operational lineage too: dataset viewers only see sync or pipeline references they can run, and projection references stay hidden until projection grants exist.

```ts
for (const sync of scoped ? scoped.listSyncs() : sixb.getSyncDefinitions()) {
  referencesFor(sync.target.dataset.id).syncIds.push(sync.id)
}
```

## Validation
- `bun run generate:client`
- `bun run typecheck`
- `bun run build`
- `bun run test`
- `bun run check`
