### PR TITLE
server: gate adjacent reads by existing grants

### DIFF
--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -10550,6 +10550,23 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Response for status 404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         }
       }
@@ -11076,6 +11093,23 @@
           },
           "400": {
             "description": "Response for status 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Response for status 404",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3645,6 +3645,12 @@ export type ListObjectLinksErrors = {
   400: {
     error: string
   }
+  /**
+   * Response for status 404
+   */
+  404: {
+    error: string
+  }
 }
 
 export type ListObjectLinksError = ListObjectLinksErrors[keyof ListObjectLinksErrors]
@@ -3821,6 +3827,12 @@ export type GetTelemetryHistoryErrors = {
    * Response for status 400
    */
   400: {
+    error: string
+  }
+  /**
+   * Response for status 404
+   */
+  404: {
     error: string
   }
 }

--- a/packages/core/src/storage/rules/in-memory.ts
+++ b/packages/core/src/storage/rules/in-memory.ts
@@ -74,12 +74,18 @@ export class InMemoryRulesStorage implements RulesStorage {
   }
 
   async listActive(input: ListActiveRuleStatesInput): Promise<ListActiveRuleStatesResult> {
+    if (input.objectTypeIds?.length === 0) {
+      return { states: [], hasMore: false, total: 0 }
+    }
+
     const order = input.order ?? "desc"
     const offset = input.offset ?? 0
+    const objectTypeIds = input.objectTypeIds ? new Set(input.objectTypeIds) : null
     const states = [...this.active.values()]
       .filter((record) => record.projectId === input.projectId)
       .filter((record) => !input.ruleId || record.ruleId === input.ruleId)
       .filter((record) => !input.objectTypeId || record.subject.objectTypeId === input.objectTypeId)
+      .filter((record) => (objectTypeIds ? objectTypeIds.has(record.subject.objectTypeId) : true))
       .filter((record) => !input.primaryId || record.subject.primaryId === input.primaryId)
       .sort((left, right) => compareRuleStateRecords(left, right, order))
 

--- a/packages/core/src/storage/rules/types.ts
+++ b/packages/core/src/storage/rules/types.ts
@@ -15,6 +15,7 @@ export interface ListActiveRuleStatesInput {
   readonly projectId: string
   readonly ruleId?: string
   readonly objectTypeId?: string
+  readonly objectTypeIds?: readonly string[]
   readonly primaryId?: string
   readonly limit?: number
   readonly offset?: number

--- a/packages/core/tests/rules-storage.test.ts
+++ b/packages/core/tests/rules-storage.test.ts
@@ -201,6 +201,55 @@ describe("InMemoryRulesStorage", () => {
     })
   })
 
+  test("listActive filters by visible object type ids before pagination", async () => {
+    const storage = new InMemoryRulesStorage()
+    await storage.applyTriggered(
+      triggeredEvent({
+        triggeredAt: "2026-05-07T10:00:00.000Z",
+        cursor: "1",
+      })
+    )
+    await storage.applyTriggered(
+      triggeredEvent({
+        ruleId: "transaction.amount-positive",
+        subject: { ...defaultSubject, primaryId: "tx-2" },
+        triggeredAt: "2026-05-07T10:02:00.000Z",
+        cursor: "2",
+      })
+    )
+    await storage.applyTriggered(
+      triggeredEvent({
+        ruleId: "invoice.requires-approval",
+        subject: { kind: "object", objectTypeId: "invoice", primaryId: "inv-1" },
+        triggeredAt: "2026-05-07T10:04:00.000Z",
+        cursor: "3",
+      })
+    )
+
+    await expect(
+      storage.listActive({ projectId: "project-a", objectTypeIds: ["transaction"], limit: 1 })
+    ).resolves.toEqual({
+      states: [
+        {
+          projectId: "project-a",
+          ruleId: "transaction.amount-positive",
+          subject: { kind: "object", objectTypeId: "transaction", primaryId: "tx-2" },
+          triggeredAt: "2026-05-07T10:02:00.000Z",
+        },
+      ],
+      hasMore: true,
+      total: 2,
+    })
+
+    await expect(
+      storage.listActive({ projectId: "project-a", objectTypeIds: [] })
+    ).resolves.toEqual({
+      states: [],
+      hasMore: false,
+      total: 0,
+    })
+  })
+
   test("applyResolved removes active rule state", async () => {
     const storage = new InMemoryRulesStorage()
     await storage.applyTriggered(triggeredEvent())

--- a/packages/server/src/auth/scope.ts
+++ b/packages/server/src/auth/scope.ts
@@ -17,8 +17,7 @@ import type { AuthorizationContext, OntologySource, ScopedSixb } from "@sixb/cor
  *     Using the raw `sixb` on a path an authenticated principal can reach is a
  *     silent god-mode bypass — it will not fail to compile or to run.
  *   - Surfaces with no grant family yet (object/link/telemetry writes,
- *     projections, workflow run history, auth admin) stay
- *     authenticated-only by design and use the raw `sixb`
+ *     auth admin) stay authenticated-only by design and use the raw `sixb`
  *     deliberately, not by omission. Add such a route consciously, and lock it
  *     down when its grant family lands.
  *

--- a/packages/server/src/routes/datasets.ts
+++ b/packages/server/src/routes/datasets.ts
@@ -110,14 +110,15 @@ function buildDatasetReferenceIndex(
     }
   }
 
-  // Projection grants do not exist yet, so scoped callers do not get
-  // projection lineage ids through dataset metadata.
-  if (!scoped) {
-    for (const projection of [
-      ...sixb.getObjectProjections(),
-      ...sixb.getLinkProjections(),
-      ...sixb.getTelemetryProjections(),
-    ]) {
+  // Projections inherit dataset visibility: a scoped caller sees a
+  // projection's lineage only when it can view the projection's source
+  // dataset. Privileged callers (no scoped runtime) see them all.
+  for (const projection of [
+    ...sixb.getObjectProjections(),
+    ...sixb.getLinkProjections(),
+    ...sixb.getTelemetryProjections(),
+  ]) {
+    if (!scoped || scoped.getDatasetById(projection.datasetId)) {
       referencesFor(projection.datasetId).projectionIds.push(projection.id)
     }
   }

--- a/packages/server/src/routes/links.ts
+++ b/packages/server/src/routes/links.ts
@@ -1,5 +1,6 @@
-import type { OntologySource, Sixb } from "@sixb/core"
+import { isAllowed, type ObjectLinkRow, type OntologySource, type Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import { ErrorResponseSchema, SuccessResponseSchema } from "../schemas/common"
 import {
@@ -12,13 +13,27 @@ import {
 } from "../schemas/links"
 import { handleRouteError, toIsoString } from "../utils/http"
 
+function canViewLink(authz: ReturnType<typeof requestAuthState>["authz"], link: ObjectLinkRow) {
+  return (
+    isAllowed(authz, { kind: "object.view", objectTypeId: link.sourceTypeId }) &&
+    isAllowed(authz, { kind: "object.view", objectTypeId: link.targetTypeId })
+  )
+}
+
 export function registerLinkRoutes(app: Elysia, sixb: Sixb<readonly OntologySource[]>) {
   return app
     .get(
       "/api/objects/:objectTypeId/:objectId/links",
-      async ({ params, query, set }) => {
+      async (context) => {
+        const { params, query, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const parsedQuery = LinkQuerySchema.parse(query)
+          if (!isAllowed(authz, { kind: "object.view", objectTypeId: params.objectTypeId })) {
+            set.status = 404
+            return { error: "Object not found" }
+          }
+
           const links = await sixb.storage.objects.listLinks({
             projectId: sixb.id,
             objectTypeId: params.objectTypeId,
@@ -27,11 +42,13 @@ export function registerLinkRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
             direction: parsedQuery.direction,
           })
 
-          return links.map((link) => ({
-            ...link,
-            createdAt: toIsoString(link.createdAt),
-            updatedAt: toIsoString(link.updatedAt),
-          }))
+          return links
+            .filter((link) => canViewLink(authz, link))
+            .map((link) => ({
+              ...link,
+              createdAt: toIsoString(link.createdAt),
+              updatedAt: toIsoString(link.updatedAt),
+            }))
         } catch (error) {
           set.status = 400
           return { error: error instanceof Error ? error.message : String(error) }
@@ -40,7 +57,11 @@ export function registerLinkRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
       {
         params: LinkSourceParamsSchema,
         query: LinkQuerySchema,
-        response: { 200: ObjectLinkSchema.array(), 400: ErrorResponseSchema },
+        response: {
+          200: ObjectLinkSchema.array(),
+          400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+        },
         detail: {
           summary: "List object links",
           tags: ["Links"],

--- a/packages/server/src/routes/projections.ts
+++ b/packages/server/src/routes/projections.ts
@@ -1,5 +1,6 @@
-import type { OntologySource, Sixb } from "@sixb/core"
+import { isAllowed, type OntologySource, type ProjectionDefinition, type Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
   ProjectionListResponseSchema,
@@ -7,15 +8,29 @@ import {
   ProjectionResponseSchema,
 } from "../schemas/projections"
 
+function canViewProjection(
+  authz: ReturnType<typeof requestAuthState>["authz"],
+  projection: ProjectionDefinition
+) {
+  return isAllowed(authz, { kind: "dataset.view", datasetId: projection.datasetId })
+}
+
 export function registerProjectionRoutes(app: Elysia, sixb: Sixb<readonly OntologySource[]>) {
   return app
     .get(
       "/api/projections",
-      () => {
+      (context) => {
+        const { authz } = requestAuthState(context)
         return {
-          objectProjections: [...sixb.getObjectProjections()],
-          linkProjections: [...sixb.getLinkProjections()],
-          telemetryProjections: [...sixb.getTelemetryProjections()],
+          objectProjections: [...sixb.getObjectProjections()].filter((projection) =>
+            canViewProjection(authz, projection)
+          ),
+          linkProjections: [...sixb.getLinkProjections()].filter((projection) =>
+            canViewProjection(authz, projection)
+          ),
+          telemetryProjections: [...sixb.getTelemetryProjections()].filter((projection) =>
+            canViewProjection(authz, projection)
+          ),
         }
       },
       {
@@ -29,14 +44,16 @@ export function registerProjectionRoutes(app: Elysia, sixb: Sixb<readonly Ontolo
     )
     .get(
       "/api/projections/:projectionId",
-      ({ params, set }) => {
+      (context) => {
+        const { params, set } = context
+        const { authz } = requestAuthState(context)
         const all = [
           ...sixb.getObjectProjections(),
           ...sixb.getLinkProjections(),
           ...sixb.getTelemetryProjections(),
         ]
         const found = all.find((p) => p.id === params.projectionId)
-        if (!found) {
+        if (!found || !canViewProjection(authz, found)) {
           set.status = 404
           return { error: `Projection '${params.projectionId}' not found` }
         }

--- a/packages/server/src/routes/rules.ts
+++ b/packages/server/src/routes/rules.ts
@@ -1,11 +1,13 @@
 import {
   deriveRuleEventDependencies,
+  isAllowed,
   type OntologySource,
   type RuleDefinition,
   type RuleStateRecord,
   type Sixb,
 } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { ErrorResponseSchema } from "../schemas/common"
 import {
   RuleParamsSchema,
@@ -66,7 +68,9 @@ export function registerRuleRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
     )
     .get(
       "/api/rule-states",
-      async ({ query, set }) => {
+      async (context) => {
+        const { query, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const parsed = RuleStatesQuerySchema.parse(query)
           const storage = sixb.storage.rules
@@ -78,10 +82,24 @@ export function registerRuleRoutes(app: Elysia, sixb: Sixb<readonly OntologySour
             }
           }
 
+          const objectTypeIds = authz ? [...authz.grants["view:object"]] : undefined
+          if (
+            authz &&
+            parsed.objectTypeId &&
+            !isAllowed(authz, { kind: "object.view", objectTypeId: parsed.objectTypeId })
+          ) {
+            return {
+              states: [],
+              hasMore: false,
+              total: 0,
+            }
+          }
+
           const result = await storage.listActive({
             projectId: sixb.id,
             ruleId: parsed.ruleId,
             objectTypeId: parsed.objectTypeId,
+            objectTypeIds,
             primaryId: parsed.primaryId,
             limit: parseOptionalInt(parsed.limit),
             offset: parseOptionalInt(parsed.offset),

--- a/packages/server/src/routes/telemetry.ts
+++ b/packages/server/src/routes/telemetry.ts
@@ -1,5 +1,6 @@
-import type { OntologySource, Sixb } from "@sixb/core"
+import { isAllowed, type OntologySource, type Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
+import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
 import { ErrorResponseSchema, SuccessResponseSchema } from "../schemas/common"
 import {
@@ -52,9 +53,16 @@ export function registerTelemetryRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
     )
     .get(
       "/api/objects/:objectTypeId/:objectId/telemetry/:propertyId/history",
-      async ({ params, query, set }) => {
+      async (context) => {
+        const { params, query, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const parsedQuery = TelemetryHistoryQuerySchema.parse(query)
+          if (!isAllowed(authz, { kind: "object.view", objectTypeId: params.objectTypeId })) {
+            set.status = 404
+            return { error: "Object not found" }
+          }
+
           const history = await sixb.storage.timeseries.getHistory({
             projectId: sixb.id,
             objectTypeId: params.objectTypeId,
@@ -78,7 +86,11 @@ export function registerTelemetryRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
       {
         params: TelemetryParamsSchema,
         query: TelemetryHistoryQuerySchema,
-        response: { 200: TelemetryPointSchema.array(), 400: ErrorResponseSchema },
+        response: {
+          200: TelemetryPointSchema.array(),
+          400: ErrorResponseSchema,
+          404: ErrorResponseSchema,
+        },
         detail: {
           summary: "Get telemetry history",
           tags: ["Telemetry"],
@@ -88,7 +100,14 @@ export function registerTelemetryRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
     )
     .get(
       "/api/objects/:objectTypeId/:objectId/telemetry/:propertyId/latest",
-      async ({ params, set }) => {
+      async (context) => {
+        const { params, set } = context
+        const { authz } = requestAuthState(context)
+        if (!isAllowed(authz, { kind: "object.view", objectTypeId: params.objectTypeId })) {
+          set.status = 404
+          return { error: "Object not found" }
+        }
+
         const latest = await sixb.storage.timeseries.getLatest({
           projectId: sixb.id,
           objectTypeId: params.objectTypeId,

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -10,6 +10,7 @@ import {
   defineConnector,
   defineDataset,
   defineGroup,
+  defineLinkProjection,
   defineObjectType,
   definePipeline,
   definePipelineStep,
@@ -23,6 +24,7 @@ import {
   InMemoryLakeStorage,
   InMemoryQueues,
   InMemoryStorage,
+  link,
   type OntologySource,
   ontology,
   type PipelineDefinition,
@@ -37,20 +39,24 @@ import {
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
 
-const Contract = defineObjectType({
-  id: "contract",
-  name: "Contract",
-  properties: [prop("id", "string", { required: true, primary: true })],
-})
-
 const Invoice = defineObjectType({
   id: "invoice",
   name: "Invoice",
   properties: [prop("id", "string", { required: true, primary: true })],
 })
 
+const Contract = defineObjectType({
+  id: "contract",
+  name: "Contract",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("temperature", "double", { mode: "telemetry" }),
+  ],
+  links: [link("invoice", Invoice, { cardinality: "one" })],
+})
+
 const OrdersDataset = defineDataset("raw.erp.orders", {
-  schema: [col("id", "string")],
+  schema: [col("id", "string"), col("invoice_id", "string")],
 })
 
 const CustomersDataset = defineDataset("raw.crm.customers", {
@@ -89,13 +95,21 @@ const ordersPipeline: PipelineDefinition =
 const customersPipeline: PipelineDefinition =
   definePipeline("pipeline-customers").then(normalizeCustomersStep)
 
-// Projections have no grant family yet, so their dataset lineage is exposed
-// only to privileged (unauthenticated) callers and hidden from every scoped
-// principal. Registered here so the `projectionIds` assertions below are
-// load-bearing rather than vacuous.
-const ordersProjection = defineProjection("orders-rollup", Contract)
+const ordersContractProjection = defineProjection("orders-contracts", Contract)
   .fromDataset(OrdersDataset)
   .properties({ id: "id" })
+
+const customersInvoiceProjection = defineProjection("customers-invoices", Invoice)
+  .fromDataset(CustomersDataset)
+  .properties({ id: "id" })
+
+const ordersContractInvoiceProjection = defineLinkProjection(
+  "orders-contract-invoices",
+  Contract.l.invoice
+)
+  .fromDataset(OrdersDataset)
+  .sourceField("id")
+  .targetField("invoice_id")
 
 const sendContract = defineAction("send-contract")
   .on(Contract)
@@ -146,7 +160,11 @@ async function createRuntime(options: { readonly auth?: boolean } = {}) {
     datasets: [OrdersDataset, CustomersDataset],
     syncs: [ordersSync, customersSync],
     pipelines: [ordersPipeline, customersPipeline],
-    projections: [ordersProjection],
+    projections: [
+      ordersContractProjection,
+      customersInvoiceProjection,
+      ordersContractInvoiceProjection,
+    ],
     broker: new InMemoryBroker(),
     storage,
     lakeStorage: new InMemoryLakeStorage(),
@@ -161,6 +179,17 @@ async function createRuntime(options: { readonly auth?: boolean } = {}) {
 
   await sixb.upsertObject("contract", { id: "c1" })
   await sixb.upsertObject("invoice", { id: "i1" })
+  await sixb.upsertLink("contract", "c1", "invoice", {
+    targetTypeId: "invoice",
+    targetId: "i1",
+  })
+  await sixb.appendTelemetry("contract", [
+    {
+      id: "c1",
+      properties: { temperature: 72.5 },
+      at: new Date("2026-05-16T10:30:00.000Z"),
+    },
+  ])
 
   return { sixb, storage }
 }
@@ -212,6 +241,39 @@ async function seedSession(
       "content-type": "application/json",
     },
   }
+}
+
+async function seedRuleStates(storage: InMemoryStorage) {
+  await storage.rules.applyTriggered({
+    id: "evt_rule_contract",
+    cursor: "evt_rule_contract",
+    schemaVersion: 1,
+    projectId: "test-project",
+    type: "rule.triggered",
+    topic: "rules",
+    partitionKey: "contract-review:contract:c1",
+    payload: {
+      ruleId: "contract-review",
+      subject: { kind: "object", objectTypeId: "contract", primaryId: "c1" },
+      triggeredAt: "2026-05-16T10:35:00.000Z",
+    },
+    occurredAt: "2026-05-16T10:35:00.000Z",
+  })
+  await storage.rules.applyTriggered({
+    id: "evt_rule_invoice",
+    cursor: "evt_rule_invoice",
+    schemaVersion: 1,
+    projectId: "test-project",
+    type: "rule.triggered",
+    topic: "rules",
+    partitionKey: "invoice-review:invoice:i1",
+    payload: {
+      ruleId: "invoice-review",
+      subject: { kind: "object", objectTypeId: "invoice", primaryId: "i1" },
+      triggeredAt: "2026-05-16T10:40:00.000Z",
+    },
+    occurredAt: "2026-05-16T10:40:00.000Z",
+  })
 }
 
 describe("authorized object routes", () => {
@@ -388,7 +450,7 @@ describe("authorized object routes", () => {
         syncIds: [],
         sourcePipelineIds: [],
         targetPipelineIds: [],
-        projectionIds: [],
+        projectionIds: ["orders-contracts", "orders-contract-invoices"],
       })
     )
 
@@ -401,7 +463,7 @@ describe("authorized object routes", () => {
         syncIds: [],
         sourcePipelineIds: [],
         targetPipelineIds: [],
-        projectionIds: [],
+        projectionIds: ["orders-contracts", "orders-contract-invoices"],
       })
     )
 
@@ -451,6 +513,7 @@ describe("authorized object routes", () => {
         syncIds: ["sync-orders"],
         sourcePipelineIds: ["pipeline-orders"],
         targetPipelineIds: ["pipeline-orders"],
+        projectionIds: ["orders-contracts", "orders-contract-invoices"],
       })
     )
     expect(adminDatasetById.get("raw.crm.customers")).toEqual(
@@ -458,35 +521,175 @@ describe("authorized object routes", () => {
         syncIds: ["sync-customers"],
         sourcePipelineIds: ["pipeline-customers"],
         targetPipelineIds: ["pipeline-customers"],
+        projectionIds: ["customers-invoices"],
       })
     )
   })
+})
 
-  test("projection lineage is exposed to privileged callers but hidden from every scoped principal", async () => {
-    // The privileged (unauthenticated) catalog populates projectionIds, proving
-    // ordersProjection is registered against raw.erp.orders...
-    const { app: privilegedApp } = await createApp({ auth: false })
-    const privileged = await privilegedApp.fetch(
-      new Request("http://localhost/api/datasets/raw.erp.orders")
-    )
-    expect(privileged.status).toBe(200)
-    expect(await privileged.json()).toEqual(
-      expect.objectContaining({ projectionIds: ["orders-rollup"] })
-    )
-
-    // ...so the scoped operator's empty projectionIds is the guard at work, not
-    // an absent projection. (admins are scoped too, hence also empty.)
+describe("authorized adjacent read routes", () => {
+  test("link reads inherit source and target object visibility", async () => {
     const { app, storage } = await createApp()
     const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
     const admin = await seedSession(storage, ["admins"], "usr_admin")
 
-    for (const session of [operator, admin]) {
-      const detail = await app.fetch(
-        new Request("http://localhost/api/datasets/raw.erp.orders", { headers: session.headers })
-      )
-      expect(detail.status).toBe(200)
-      expect(await detail.json()).toEqual(expect.objectContaining({ projectionIds: [] }))
+    const operatorLinks = await app.fetch(
+      new Request("http://localhost/api/objects/contract/c1/links", {
+        headers: operator.headers,
+      })
+    )
+    expect(operatorLinks.status).toBe(200)
+    expect(await operatorLinks.json()).toEqual([])
+
+    const hiddenSource = await app.fetch(
+      new Request("http://localhost/api/objects/contract/c1/links", {
+        headers: runner.headers,
+      })
+    )
+    expect(hiddenSource.status).toBe(404)
+
+    const adminLinks = await app.fetch(
+      new Request("http://localhost/api/objects/contract/c1/links", {
+        headers: admin.headers,
+      })
+    )
+    expect(
+      ((await adminLinks.json()) as { targetTypeId: string }[]).map((link) => link.targetTypeId)
+    ).toEqual(["invoice"])
+  })
+
+  test("telemetry reads inherit object visibility", async () => {
+    const { app, storage } = await createApp()
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+
+    const history = await app.fetch(
+      new Request("http://localhost/api/objects/contract/c1/telemetry/temperature/history", {
+        headers: operator.headers,
+      })
+    )
+    expect(history.status).toBe(200)
+    expect(((await history.json()) as { value: number }[]).map((point) => point.value)).toEqual([
+      72.5,
+    ])
+
+    const latest = await app.fetch(
+      new Request("http://localhost/api/objects/contract/c1/telemetry/temperature/latest", {
+        headers: operator.headers,
+      })
+    )
+    expect(latest.status).toBe(200)
+    expect(await latest.json()).toEqual(expect.objectContaining({ value: 72.5 }))
+
+    const hiddenHistory = await app.fetch(
+      new Request("http://localhost/api/objects/contract/c1/telemetry/temperature/history", {
+        headers: runner.headers,
+      })
+    )
+    expect(hiddenHistory.status).toBe(404)
+
+    const hiddenLatest = await app.fetch(
+      new Request("http://localhost/api/objects/contract/c1/telemetry/temperature/latest", {
+        headers: runner.headers,
+      })
+    )
+    expect(hiddenLatest.status).toBe(404)
+  })
+
+  test("rule states narrow to viewable object types before pagination", async () => {
+    const { app, storage } = await createApp()
+    await seedRuleStates(storage)
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    const operatorStates = await app.fetch(
+      new Request("http://localhost/api/rule-states?limit=1", { headers: operator.headers })
+    )
+    expect(await operatorStates.json()).toEqual({
+      states: [
+        expect.objectContaining({
+          ruleId: "contract-review",
+          subject: { kind: "object", objectTypeId: "contract", primaryId: "c1" },
+        }),
+      ],
+      hasMore: false,
+      total: 1,
+    })
+
+    const hiddenFilter = await app.fetch(
+      new Request("http://localhost/api/rule-states?objectTypeId=invoice", {
+        headers: operator.headers,
+      })
+    )
+    expect(await hiddenFilter.json()).toEqual({ states: [], hasMore: false, total: 0 })
+
+    const runnerStates = await app.fetch(
+      new Request("http://localhost/api/rule-states", { headers: runner.headers })
+    )
+    expect(await runnerStates.json()).toEqual({ states: [], hasMore: false, total: 0 })
+
+    const adminStates = await app.fetch(
+      new Request("http://localhost/api/rule-states", { headers: admin.headers })
+    )
+    expect(
+      (
+        (await adminStates.json()) as { states: { subject: { objectTypeId: string } }[] }
+      ).states.map((state) => state.subject.objectTypeId)
+    ).toEqual(["invoice", "contract"])
+  })
+
+  test("projection reads inherit dataset visibility", async () => {
+    const { app, storage } = await createApp()
+    const operator = await seedSession(storage, ["commercial"], "usr_op")
+    const runner = await seedSession(storage, ["operations"], "usr_run")
+    const admin = await seedSession(storage, ["admins"], "usr_admin")
+
+    const operatorList = await app.fetch(
+      new Request("http://localhost/api/projections", { headers: operator.headers })
+    )
+    const operatorProjections = (await operatorList.json()) as {
+      objectProjections: { id: string }[]
+      linkProjections: { id: string }[]
     }
+    expect(operatorProjections.objectProjections.map((projection) => projection.id)).toEqual([
+      "orders-contracts",
+    ])
+    expect(operatorProjections.linkProjections.map((projection) => projection.id)).toEqual([
+      "orders-contract-invoices",
+    ])
+
+    const hiddenDetail = await app.fetch(
+      new Request("http://localhost/api/projections/customers-invoices", {
+        headers: operator.headers,
+      })
+    )
+    expect(hiddenDetail.status).toBe(404)
+
+    const runnerList = await app.fetch(
+      new Request("http://localhost/api/projections", { headers: runner.headers })
+    )
+    expect(await runnerList.json()).toEqual({
+      objectProjections: [],
+      linkProjections: [],
+      telemetryProjections: [],
+    })
+
+    const adminList = await app.fetch(
+      new Request("http://localhost/api/projections", { headers: admin.headers })
+    )
+    const adminProjections = (await adminList.json()) as {
+      objectProjections: { id: string }[]
+      linkProjections: { id: string }[]
+    }
+    expect(adminProjections.objectProjections.map((projection) => projection.id)).toEqual([
+      "orders-contracts",
+      "customers-invoices",
+    ])
+    expect(adminProjections.linkProjections.map((projection) => projection.id)).toEqual([
+      "orders-contract-invoices",
+    ])
   })
 })
 

--- a/storage/pg/src/pg-rules-storage.ts
+++ b/storage/pg/src/pg-rules-storage.ts
@@ -38,6 +38,10 @@ export class PgRulesStorage implements RulesStorage {
   }
 
   async listActive(input: ListActiveRuleStatesInput): Promise<ListActiveRuleStatesResult> {
+    if (input.objectTypeIds?.length === 0) {
+      return { states: [], hasMore: false, total: 0 }
+    }
+
     const whereClauses = ["project_id = $1"]
     const params: SqlParameter[] = [input.projectId]
     let index = 2
@@ -50,6 +54,12 @@ export class PgRulesStorage implements RulesStorage {
     if (input.objectTypeId) {
       whereClauses.push(`object_type_id = $${index++}`)
       params.push(input.objectTypeId)
+    }
+
+    if (input.objectTypeIds) {
+      const placeholders = input.objectTypeIds.map(() => `$${index++}`)
+      whereClauses.push(`object_type_id IN (${placeholders.join(", ")})`)
+      params.push(...input.objectTypeIds)
     }
 
     if (input.primaryId) {

--- a/storage/pg/tests/pg-rules-storage.e2e.ts
+++ b/storage/pg/tests/pg-rules-storage.e2e.ts
@@ -227,6 +227,58 @@ describe("PgRulesStorage", () => {
     })
   })
 
+  test("listActive filters by visible object type ids before pagination", async () => {
+    await storage.rules.applyTriggered(
+      triggeredEvent({
+        triggeredAt: "2026-05-07T10:00:00.000Z",
+        cursor: "1",
+      })
+    )
+    await storage.rules.applyTriggered(
+      triggeredEvent({
+        ruleId: "transaction.amount-positive",
+        subject: { ...defaultSubject, primaryId: "tx-2" },
+        triggeredAt: "2026-05-07T10:02:00.000Z",
+        cursor: "2",
+      })
+    )
+    await storage.rules.applyTriggered(
+      triggeredEvent({
+        ruleId: "invoice.requires-approval",
+        subject: { kind: "object", objectTypeId: "invoice", primaryId: "inv-1" },
+        triggeredAt: "2026-05-07T10:04:00.000Z",
+        cursor: "3",
+      })
+    )
+
+    await expect(
+      storage.rules.listActive({
+        projectId: "project-a",
+        objectTypeIds: ["transaction"],
+        limit: 1,
+      })
+    ).resolves.toEqual({
+      states: [
+        {
+          projectId: "project-a",
+          ruleId: "transaction.amount-positive",
+          subject: { kind: "object", objectTypeId: "transaction", primaryId: "tx-2" },
+          triggeredAt: "2026-05-07T10:02:00.000Z",
+        },
+      ],
+      hasMore: true,
+      total: 2,
+    })
+
+    await expect(
+      storage.rules.listActive({ projectId: "project-a", objectTypeIds: [] })
+    ).resolves.toEqual({
+      states: [],
+      hasMore: false,
+      total: 0,
+    })
+  })
+
   test("applyResolved removes active rule state", async () => {
     await storage.rules.applyTriggered(triggeredEvent())
     await storage.rules.applyResolved(resolvedEvent())

--- a/storage/sqlite/src/rules-storage.ts
+++ b/storage/sqlite/src/rules-storage.ts
@@ -70,6 +70,10 @@ export class SqliteRulesStorage implements RulesStorage {
   }
 
   async listActive(input: ListActiveRuleStatesInput): Promise<ListActiveRuleStatesResult> {
+    if (input.objectTypeIds?.length === 0) {
+      return { states: [], hasMore: false, total: 0 }
+    }
+
     const whereClauses = ["project_id = ?"]
     const args: (string | number)[] = [input.projectId]
 
@@ -81,6 +85,11 @@ export class SqliteRulesStorage implements RulesStorage {
     if (input.objectTypeId) {
       whereClauses.push("object_type_id = ?")
       args.push(input.objectTypeId)
+    }
+
+    if (input.objectTypeIds) {
+      whereClauses.push(`object_type_id IN (${input.objectTypeIds.map(() => "?").join(", ")})`)
+      args.push(...input.objectTypeIds)
     }
 
     if (input.primaryId) {

--- a/storage/sqlite/tests/sqlite-rules-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-rules-storage.test.ts
@@ -225,6 +225,54 @@ describe("SqliteRulesStorage", () => {
     })
   })
 
+  test("listActive filters by visible object type ids before pagination", async () => {
+    await storage.applyTriggered(
+      triggeredEvent({
+        triggeredAt: "2026-05-07T10:00:00.000Z",
+        cursor: "1",
+      })
+    )
+    await storage.applyTriggered(
+      triggeredEvent({
+        ruleId: "transaction.amount-positive",
+        subject: { ...defaultSubject, primaryId: "tx-2" },
+        triggeredAt: "2026-05-07T10:02:00.000Z",
+        cursor: "2",
+      })
+    )
+    await storage.applyTriggered(
+      triggeredEvent({
+        ruleId: "invoice.requires-approval",
+        subject: { kind: "object", objectTypeId: "invoice", primaryId: "inv-1" },
+        triggeredAt: "2026-05-07T10:04:00.000Z",
+        cursor: "3",
+      })
+    )
+
+    await expect(
+      storage.listActive({ projectId: "project-a", objectTypeIds: ["transaction"], limit: 1 })
+    ).resolves.toEqual({
+      states: [
+        {
+          projectId: "project-a",
+          ruleId: "transaction.amount-positive",
+          subject: { kind: "object", objectTypeId: "transaction", primaryId: "tx-2" },
+          triggeredAt: "2026-05-07T10:02:00.000Z",
+        },
+      ],
+      hasMore: true,
+      total: 2,
+    })
+
+    await expect(
+      storage.listActive({ projectId: "project-a", objectTypeIds: [] })
+    ).resolves.toEqual({
+      states: [],
+      hasMore: false,
+      total: 0,
+    })
+  })
+
   test("applyResolved removes active rule state", async () => {
     await storage.applyTriggered(triggeredEvent())
     await storage.applyResolved(resolvedEvent())


### PR DESCRIPTION
## Summary

This PR folds adjacent read surfaces into the grants that already own the underlying data. It is stacked on #94 (`dataset-sync-pipeline-grants`).

Object-adjacent reads now inherit object visibility:

```ts
can.view(Contract)

// visible for Contract readers
GET /api/objects/contract/c1/telemetry/temperature/latest
GET /api/objects/contract/c1/links
```

Rule states are filtered by visible object types before pagination:

```ts
await storage.listActive({
  projectId,
  objectTypeIds: [...authz.grants.objectTypes.view],
  limit,
  offset,
})
```

Projection reads now inherit dataset visibility:

```ts
can.view(OrdersDataset)

// visible when the backing dataset is visible
GET /api/projections/orders-contracts
GET /api/projections/orders-contract-invoices
```

Dataset metadata also returns `projectionIds` for projections backed by datasets the caller can view.

## Validation

```bash
bun test packages/server/tests/authorization-routes.test.ts
bun test packages/core/tests/rules-storage.test.ts
bun test storage/sqlite/tests/sqlite-rules-storage.test.ts
bun test packages/server/tests/authorization-routes.test.ts packages/core/tests/rules-storage.test.ts storage/sqlite/tests/sqlite-rules-storage.test.ts packages/server/tests/openapi-docs.test.ts
bun run generate:client
bun run typecheck
bun run check
bun run build
```

Postgres rule-storage e2e was added for the new filter, but it was not runnable locally because `DATABASE_URL` is not set.
