### PR TITLE
[codex] Add recursive ensureDir to SFTP connector

### DIFF
--- a/connectors/sftp/src/client.ts
+++ b/connectors/sftp/src/client.ts
@@ -1,0 +1,161 @@
+import { posix } from "node:path"
+import type { Callback, SFTPWrapper } from "ssh2"
+import type { SftpClient, SftpStats, SftpWriteData } from "./types"
+
+export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
+  return {
+    list(path) {
+      return callResult((callback) => sftpClient.readdir(path, callback))
+    },
+    stat(path) {
+      return callResult((callback) => sftpClient.stat(path, callback))
+    },
+    exists(path) {
+      return new Promise((resolve) => {
+        sftpClient.exists(path, (exists) => resolve(exists))
+      })
+    },
+    ensureDir(path) {
+      return ensureSftpDirectory(sftpClient, path)
+    },
+    read(path) {
+      return callResult((callback) => sftpClient.readFile(path, callback))
+    },
+    write(path, data) {
+      return callVoid((callback) => sftpClient.writeFile(path, toBuffer(data), callback))
+    },
+    rename(sourcePath, destinationPath) {
+      return callVoid((callback) => sftpClient.rename(sourcePath, destinationPath, callback))
+    },
+    delete(path) {
+      return callVoid((callback) => sftpClient.unlink(path, callback))
+    },
+    mkdir(path) {
+      return callVoid((callback) => sftpClient.mkdir(path, callback))
+    },
+    rmdir(path) {
+      return callVoid((callback) => sftpClient.rmdir(path, callback))
+    },
+  }
+}
+
+async function ensureSftpDirectory(sftpClient: SFTPWrapper, path: string): Promise<void> {
+  for (const directoryPath of directoryHierarchy(path)) {
+    const exists = await new Promise<boolean>((resolve) => {
+      sftpClient.exists(directoryPath, (value) => resolve(value))
+    })
+
+    if (exists) {
+      await assertRemoteDirectory(sftpClient, directoryPath)
+      continue
+    }
+
+    try {
+      await callVoid((callback) => sftpClient.mkdir(directoryPath, callback))
+    } catch (error) {
+      const stats = await statIfExists(sftpClient, directoryPath)
+
+      if (stats?.isDirectory()) {
+        continue
+      }
+
+      if (stats) {
+        throw new Error(
+          `[SixbSftp] Cannot ensure directory ${directoryPath} because it exists and is not a directory.`
+        )
+      }
+
+      throw error
+    }
+  }
+}
+
+function directoryHierarchy(path: string): string[] {
+  if (!path) {
+    throw new Error("[SixbSftp] directory path must not be empty.")
+  }
+
+  const normalizedPath = posix.normalize(path)
+
+  if (normalizedPath === "." || normalizedPath === "/") {
+    return []
+  }
+
+  const isAbsolute = normalizedPath.startsWith("/")
+  const parts = normalizedPath.split("/").filter(Boolean)
+  const hierarchy: string[] = []
+  let currentPath = isAbsolute ? "/" : ""
+
+  for (const part of parts) {
+    currentPath = currentPath === "/" ? `/${part}` : currentPath ? `${currentPath}/${part}` : part
+    hierarchy.push(currentPath)
+  }
+
+  return hierarchy
+}
+
+async function assertRemoteDirectory(sftpClient: SFTPWrapper, path: string): Promise<void> {
+  const stats = await statRemotePath(sftpClient, path)
+
+  if (!stats.isDirectory()) {
+    throw new Error(
+      `[SixbSftp] Cannot ensure directory ${path} because it exists and is not a directory.`
+    )
+  }
+}
+
+async function statIfExists(sftpClient: SFTPWrapper, path: string): Promise<SftpStats | null> {
+  const exists = await new Promise<boolean>((resolve) => {
+    sftpClient.exists(path, (value) => resolve(value))
+  })
+
+  if (!exists) {
+    return null
+  }
+
+  return statRemotePath(sftpClient, path)
+}
+
+function statRemotePath(sftpClient: SFTPWrapper, path: string): Promise<SftpStats> {
+  return callResult<SftpStats>((callback) => sftpClient.stat(path, callback))
+}
+
+function callVoid(method: (callback: Callback) => void): Promise<void> {
+  return new Promise((resolve, reject) => {
+    method((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}
+
+function callResult<T>(
+  method: (callback: (error: Error | undefined, result: T) => void) => void
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    method((error, result) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve(result)
+    })
+  })
+}
+
+function toBuffer(data: SftpWriteData): string | Buffer {
+  if (typeof data === "string" || Buffer.isBuffer(data)) {
+    return data
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data)
+  }
+
+  return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+}

--- a/connectors/sftp/src/sftp.ts
+++ b/connectors/sftp/src/sftp.ts
@@ -1,15 +1,14 @@
-import type { Callback, SFTPWrapper } from "ssh2"
+import type { SFTPWrapper } from "ssh2"
 import { Client } from "ssh2"
-import type { SftpClient, SftpConnection, SftpConnector, SftpWriteData } from "./types"
+import { createSftpClient } from "./client"
+import type { SftpClient, SftpConnection, SftpConnector } from "./types"
 
-const CONNECTION = Symbol("SixbSftpConnection")
-
-type InternalSftpClient = SftpClient & {
-  [CONNECTION]: {
-    client: Client
-    closed: boolean
-  }
+type ConnectionState = {
+  client: Client
+  closed: boolean
 }
+
+const connections = new WeakMap<SftpClient, ConnectionState>()
 
 /**
  * Create an SFTP connector backed by ssh2.
@@ -27,17 +26,29 @@ export function sftp(connection: SftpConnection): SftpConnector {
         throw new Error("[SixbSftp] Connection aborted before it started.")
       }
 
-      const client = new Client()
-      const sftpClient = await connectSftpClient(client, connection, context.signal)
-      return createSftpClient(client, sftpClient)
+      const sshClient = new Client()
+      const sftpSession = await connectSftpClient(sshClient, connection, context.signal)
+      const sftpClient = createSftpClient(sftpSession)
+      const state = {
+        client: sshClient,
+        closed: false,
+      }
+
+      sshClient.once("close", () => {
+        state.closed = true
+      })
+
+      connections.set(sftpClient, state)
+      return sftpClient
     },
     async disconnect(client) {
-      const state = (client as InternalSftpClient)[CONNECTION]
+      const state = connections.get(client)
       if (!state || state.closed) {
         return
       }
 
       await closeClient(state)
+      connections.delete(client)
     },
   }
 }
@@ -105,93 +116,7 @@ async function connectSftpClient(
   })
 }
 
-function createSftpClient(client: Client, sftpClient: SFTPWrapper): SftpClient {
-  const state = {
-    client,
-    closed: false,
-  }
-
-  client.once("close", () => {
-    state.closed = true
-  })
-
-  const wrappedClient: InternalSftpClient = {
-    [CONNECTION]: state,
-    list(path) {
-      return callResult((callback) => sftpClient.readdir(path, callback))
-    },
-    stat(path) {
-      return callResult((callback) => sftpClient.stat(path, callback))
-    },
-    exists(path) {
-      return new Promise((resolve) => {
-        sftpClient.exists(path, (exists) => resolve(exists))
-      })
-    },
-    read(path) {
-      return callResult((callback) => sftpClient.readFile(path, callback))
-    },
-    write(path, data) {
-      return callVoid((callback) => sftpClient.writeFile(path, toBuffer(data), callback))
-    },
-    rename(sourcePath, destinationPath) {
-      return callVoid((callback) => sftpClient.rename(sourcePath, destinationPath, callback))
-    },
-    delete(path) {
-      return callVoid((callback) => sftpClient.unlink(path, callback))
-    },
-    mkdir(path) {
-      return callVoid((callback) => sftpClient.mkdir(path, callback))
-    },
-    rmdir(path) {
-      return callVoid((callback) => sftpClient.rmdir(path, callback))
-    },
-  }
-
-  return wrappedClient
-}
-
-function callVoid(method: (callback: Callback) => void): Promise<void> {
-  return new Promise((resolve, reject) => {
-    method((error) => {
-      if (error) {
-        reject(error)
-        return
-      }
-
-      resolve()
-    })
-  })
-}
-
-function callResult<T>(
-  method: (callback: (error: Error | undefined, result: T) => void) => void
-): Promise<T> {
-  return new Promise((resolve, reject) => {
-    method((error, result) => {
-      if (error) {
-        reject(error)
-        return
-      }
-
-      resolve(result)
-    })
-  })
-}
-
-function toBuffer(data: SftpWriteData): string | Buffer {
-  if (typeof data === "string" || Buffer.isBuffer(data)) {
-    return data
-  }
-
-  if (data instanceof ArrayBuffer) {
-    return Buffer.from(data)
-  }
-
-  return Buffer.from(data.buffer, data.byteOffset, data.byteLength)
-}
-
-async function closeClient(state: InternalSftpClient[typeof CONNECTION]): Promise<void> {
+async function closeClient(state: ConnectionState): Promise<void> {
   await new Promise<void>((resolve) => {
     const finish = () => {
       cleanup()

--- a/connectors/sftp/src/types.ts
+++ b/connectors/sftp/src/types.ts
@@ -11,6 +11,7 @@ export interface SftpClient {
   list(path: string): Promise<readonly SftpListEntry[]>
   stat(path: string): Promise<SftpStats>
   exists(path: string): Promise<boolean>
+  ensureDir(path: string): Promise<void>
   read(path: string): Promise<Buffer>
   write(path: string, data: SftpWriteData): Promise<void>
   rename(sourcePath: string, destinationPath: string): Promise<void>

--- a/connectors/sftp/tests/sftp.test.ts
+++ b/connectors/sftp/tests/sftp.test.ts
@@ -102,6 +102,80 @@ describe("sftp connector", () => {
     }
   })
 
+  test("ensures deep directories", async () => {
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+
+    try {
+      await client.ensureDir("/files/archive/2026/06/reports")
+
+      const stats = await client.stat("/files/archive/2026/06/reports")
+      expect(stats.isDirectory()).toBe(true)
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
+  test("ensureDir is idempotent when directories already exist", async () => {
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+
+    try {
+      await client.ensureDir("/files/archive/2026")
+      await client.ensureDir("/files/archive/2026")
+
+      const stats = await client.stat("/files/archive/2026")
+      expect(stats.isDirectory()).toBe(true)
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
+  test("ensureDir fails when a parent segment is a file", async () => {
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+
+    try {
+      await client.write("/files/archive", "not a directory")
+
+      await expect(client.ensureDir("/files/archive/2026")).rejects.toThrow(
+        "exists and is not a directory"
+      )
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
   test("closes the ssh connection on disconnect", async () => {
     const adapter = sftp({
       host: server.host,


### PR DESCRIPTION
## Summary
- Add `ensureDir(path)` to the SFTP connector public client API.
- Implement recursive SFTP directory creation with clear failure when a path segment is not a directory.
- Split connected-client file operations into `client.ts`, keeping SSH lifecycle logic in `sftp.ts`.

## Validation
- `bun --filter @sixb/connector-sftp typecheck`
- `bun test connectors/sftp/tests/sftp.test.ts`
- `bun run check`
- `bun --filter @sixb/connector-sftp build`