### PR TITLE
feat(sync): expose blob storage facade to read handlers

### DIFF
--- a/docs/concepts/sync.md
+++ b/docs/concepts/sync.md
@@ -134,6 +134,50 @@ Better left to a [pipeline](./pipeline.md):
 - business calculations
 - turning raw rows into canonical rows
 
+## Sync files and blobs
+
+Datasets can include `fileRef` columns for blob-backed files. When a sync needs to ingest
+file bytes, use the blob facade on the read context.
+
+```ts
+import { col, defineDataset, defineSync } from "@sixb/core"
+import { fileSource } from "../connectors/file-source"
+
+export const rawFiles = defineDataset("raw.files", {
+  schema: [
+    col("id", "string"),
+    col("name", "string"),
+    col("relativePath", "string"),
+    col("fileRef", "fileRef", { nullable: true }),
+  ],
+})
+
+export const syncFiles = defineSync("sync-files")
+  .from(fileSource)
+  .read(async function* (client, context) {
+    for await (const file of client.walk("/documents")) {
+      const fileRef = await context.blobs.put({
+        body: await client.open(file.path),
+        fileName: file.name,
+        mediaType: file.mediaType,
+        logicalPath: file.relativePath,
+      })
+
+      yield {
+        id: file.id,
+        name: file.name,
+        relativePath: file.relativePath,
+        fileRef,
+      }
+    }
+  })
+  .intoDataset(rawFiles)
+```
+
+The connector reads the external source; `context.blobs` stores bytes in Sixb and returns the
+`fileRef` to write into the row. The sync worker validates returned `fileRef` values before
+committing, including existence, digest, and size.
+
 ## Convention
 
 Put sync definitions in `syncs/` and export them.
@@ -188,7 +232,7 @@ Good sync names usually start with the action and source entity:
 ## Extra details
 
 - `read(...)` receives `(client, context)`.
-- `context` includes `projectId`, `syncId`, and `signal`.
+- `context` includes `projectId`, `syncId`, `signal`, and `blobs`.
 - `read(...)` may return one row, an iterable, or an async iterable.
 - sync definitions are inert until a worker runs them.
 - `sixb dev` can co-host sync workers during local development.

--- a/packages/core/src/syncs/index.ts
+++ b/packages/core/src/syncs/index.ts
@@ -4,6 +4,7 @@ export type {
   BatchSyncConfig,
   BatchSyncDefinitionConfig,
   DatasetSyncTarget,
+  SyncBlobContext,
   SyncBuilder,
   SyncDefinition,
   SyncReadBuilder,

--- a/packages/core/src/syncs/types.ts
+++ b/packages/core/src/syncs/types.ts
@@ -1,3 +1,4 @@
+import type { BlobStorage } from "../blob-storage"
 import {
   type ConnectorAdapter,
   type ConnectorClient,
@@ -10,11 +11,15 @@ import type { ScheduleDefinition } from "../schedules"
 import type { RunTrigger } from "../triggers"
 import { isRunTrigger } from "../triggers"
 
+/** Blob operations available to sync read handlers. */
+export type SyncBlobContext = Pick<BlobStorage, "put" | "open" | "stat">
+
 /** Context passed to a sync read handler. */
 export type SyncReadContext<TCheckpoint = never> = {
   readonly projectId: string
   readonly syncId: string
   readonly signal: AbortSignal
+  readonly blobs: SyncBlobContext
 } & ([TCheckpoint] extends [never]
   ? { readonly checkpoint?: undefined }
   : {

--- a/packages/core/tests/syncs.test.ts
+++ b/packages/core/tests/syncs.test.ts
@@ -162,6 +162,7 @@ describe("defineSync", () => {
         projectId: "project-1",
         syncId: "sync-orders",
         signal: new AbortController().signal,
+        blobs: createTestRuntimeDeps().blobStorage,
         checkpoint: { cursor: "cursor-1" },
         setCheckpoint(next) {
           nextCheckpoint = next
@@ -193,6 +194,7 @@ describe("defineSync", () => {
         projectId: "project-1",
         syncId: "sync-orders",
         signal: new AbortController().signal,
+        blobs: createTestRuntimeDeps().blobStorage,
       }
     )
 

--- a/packages/core/tests/syncs.types.ts
+++ b/packages/core/tests/syncs.types.ts
@@ -1,4 +1,12 @@
-import { col, defineConnector, defineDataset, defineSync, type SyncDefinition } from "../src"
+import {
+  type BlobInfo,
+  col,
+  defineConnector,
+  defineDataset,
+  defineSync,
+  type FileRef,
+  type SyncDefinition,
+} from "../src"
 
 const erpDb = defineConnector("erpDb", {
   type: "sql",
@@ -22,6 +30,14 @@ const syncOrders = defineSync("sync-orders")
     const _projectId: string = context.projectId
     const _syncId: string = context.syncId
     const _signal: AbortSignal = context.signal
+    const _fileRef: FileRef = await context.blobs.put({
+      body: new Uint8Array([1, 2, 3]),
+      fileName: "orders.csv",
+      mediaType: "text/csv",
+      logicalPath: "erp/orders.csv",
+    })
+    const _blobInfo: BlobInfo | null = await context.blobs.stat(_fileRef.blobId)
+    const _stream: ReadableStream<Uint8Array> = await context.blobs.open(_fileRef.blobId)
 
     // @ts-expect-error connector client typing flows into sync read handlers
     db.nonexistent()
@@ -33,6 +49,9 @@ const syncOrders = defineSync("sync-orders")
 
     // @ts-expect-error sync read context should not expose the Sixb runtime
     context.sixb
+
+    // @ts-expect-error sync blob context exposes only put, stat, and open
+    context.blobs.delete(_fileRef.blobId)
 
     return [{ id: 1 }]
   })

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -164,6 +164,7 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
       projectId: runtime.id,
       syncId: sync.id,
       signal,
+      blobs: blobStorage,
       checkpoint: previousCheckpoint !== undefined ? cloneJsonValue(previousCheckpoint) : undefined,
       setCheckpoint(next: unknown) {
         assertJsonValue(next, `Sync '${sync.id}' checkpoint`)

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -9,6 +9,7 @@ import type {
   ConnectorDefinition,
   DatasetDefinition,
   DatasetRow,
+  FileRef,
   LakeStorage,
   LakeWriteSession,
   SyncDefinition,
@@ -669,6 +670,68 @@ describe("runSyncJob", () => {
       error: {
         message:
           "[SixbSyncWorker] Sync 'sync-docs' returned row 1 with dataset 'raw.docs' column 'attachment' referencing unknown blob 'blob_missing'.",
+      },
+    })
+  })
+
+  test("lets sync read handlers store blobs and return validated fileRefs", async () => {
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    const blobStorage = new InMemoryBlobStorage()
+    const body = new TextEncoder().encode("hello from a synced document")
+    let storedFileRef: FileRef | undefined
+
+    const sync = defineSync("sync-docs")
+      .from(erpDb)
+      .read(async (_client, context) => {
+        const fileRef = await context.blobs.put({
+          body,
+          fileName: "hello.txt",
+          mediaType: "text/plain",
+          logicalPath: "docs/hello.txt",
+        })
+        storedFileRef = fileRef
+
+        return [{ id: "doc_1", attachment: fileRef }]
+      })
+      .intoDataset(rawDocsDataset)
+
+    const runtime = createRuntime({
+      sync,
+      syncRunsStorage,
+      blobStorage,
+    })
+
+    const result = await runSyncJob({
+      runtime,
+      job: {
+        id: "run_blob_ingestion",
+        syncId: "sync-docs",
+      },
+    })
+
+    expect(result.rowsRead).toBe(1)
+    expect(storedFileRef).toBeDefined()
+
+    const fileRef = storedFileRef!
+    await expect(blobStorage.stat(fileRef.blobId)).resolves.toEqual({
+      blobId: fileRef.blobId,
+      digest: fileRef.digest,
+      sizeBytes: fileRef.sizeBytes,
+    })
+
+    const rows = await collectRows(runtime.lakeStorage.readRows({ datasetId: rawDocsDataset.id }))
+    expect(rows).toEqual([{ id: "doc_1", attachment: fileRef }])
+
+    const run = await syncRunsStorage.getById({
+      projectId: "project-1",
+      id: "run_blob_ingestion",
+    })
+    expect(run).toMatchObject({
+      status: "succeeded",
+      rowsRead: 1,
+      output: {
+        datasetId: "raw.docs",
+        versionId: result.version.versionId,
       },
     })
   })


### PR DESCRIPTION
## Summary

This PR lets sync read handlers store file bytes directly in Sixb blob storage through a
narrow `context.blobs` facade.

```txt
connector client -> sync read handler -> context.blobs.put(...)
                                      -> dataset row with fileRef
                                      -> sync worker validates fileRef
                                      -> lake commit
```

## What Changed

- Adds `SyncBlobContext` and exposes `context.blobs` in sync read handlers.
- Wires the sync worker to pass the configured blob storage into sync reads.
- Keeps the API intentionally narrow: `put`, `open`, and `stat`, with no full runtime access.
- Adds type coverage for the new DX and runtime coverage for blob-backed `fileRef` ingestion.
- Updates sync docs with a generic file-source example.

## Why

Syncs are the natural boundary for external file ingestion: the connector reads the source,
`context.blobs` stores bytes, and the sync yields rows containing validated `fileRef` values.

This keeps connectors focused on external systems while preserving the worker's existing blob
integrity checks before dataset commits.

## Validation

- `bun --filter @sixb/core typecheck`
- `bun --filter @sixb/sync-worker typecheck`
- `bun --filter @sixb/sync-worker test`
- `bun test packages/core/tests/syncs.test.ts packages/sync-worker/tests/run-sync-job.test.ts`
- `bun --filter @sixb/core build`
- `bun run check`