### PR TITLE
agents: add defineAgent builder, discovery, and registry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -333,6 +333,9 @@
     "packages/core": {
       "name": "@sixb/core",
       "version": "0.1.0",
+      "dependencies": {
+        "@ai-sdk/provider": "^3.0.10",
+      },
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "^5.7.0",
@@ -554,6 +557,8 @@
     },
   },
   "packages": {
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
@@ -1261,6 +1266,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,9 @@
     "test": "bun test",
     "prepack": "bun run build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@ai-sdk/provider": "^3.0.10"
+  },
   "devDependencies": {
     "@types/bun": "latest",
     "typescript": "^5.7.0"

--- a/packages/core/src/agents/builders.ts
+++ b/packages/core/src/agents/builders.ts
@@ -1,0 +1,33 @@
+import { AgentDefinitionError } from "./errors"
+import type { AgentDefinition, DefineAgentConfig } from "./types"
+import { assertNonEmpty } from "./validation"
+
+/**
+ * Define an agent: a conversational, looping actor auto-discovered from `agents/`.
+ *
+ * The returned definition is inert and can be exported from a project-level `agents/`
+ * module. Later slices turn it into a running, streaming agent; PR1 only loads and
+ * registers it (`sixb.agents`).
+ */
+export function defineAgent<const TId extends string>(
+  id: TId,
+  config: DefineAgentConfig
+): AgentDefinition<TId> {
+  assertNonEmpty(id, "id")
+  assertNonEmpty(config.name, "name")
+  assertNonEmpty(config.instructions, "instructions")
+
+  if (config.model === undefined || config.model === null) {
+    throw new AgentDefinitionError("[Sixb] Agent model is required.")
+  }
+
+  return {
+    kind: "agent",
+    id,
+    name: config.name,
+    model: config.model,
+    instructions: config.instructions,
+    ...(config.description !== undefined ? { description: config.description } : {}),
+    ...(config.loop !== undefined ? { loop: config.loop } : {}),
+  }
+}

--- a/packages/core/src/agents/errors.ts
+++ b/packages/core/src/agents/errors.ts
@@ -1,0 +1,7 @@
+/**
+ * Base error for the agents module. Specific subclasses extend this so callers
+ * can catch any agent-scoped failure with a single `instanceof AgentDefinitionError` check.
+ */
+export class AgentDefinitionError extends Error {
+  readonly name: string = "AgentDefinitionError"
+}

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,0 +1,5 @@
+export { defineAgent } from "./builders"
+export { AgentDefinitionError } from "./errors"
+export { AgentsRuntime } from "./runtime"
+export type { AgentDefinition, AgentLoopConfig, DefineAgentConfig } from "./types"
+export { isAgentDefinition } from "./validation"

--- a/packages/core/src/agents/runtime.ts
+++ b/packages/core/src/agents/runtime.ts
@@ -1,0 +1,28 @@
+import type { AgentDefinition } from "./types"
+
+/**
+ * Holds the agent definitions registered with a Sixb instance and exposes lookup.
+ *
+ * The PR1 surface is definition-only (`list` / `getById`). Runtime behaviour
+ * (starting a run, streaming) lands in later slices on this same `sixb.agents`
+ * namespace, mirroring `sixb.workflows` / `sixb.actions`.
+ *
+ * Duplicate ids are rejected by the `Sixb` constructor before this is built.
+ */
+export class AgentsRuntime {
+  private readonly agentsById: ReadonlyMap<string, AgentDefinition>
+
+  constructor(agents: readonly AgentDefinition[]) {
+    this.agentsById = new Map(agents.map((agent) => [agent.id, agent]))
+  }
+
+  /** All registered agent definitions. */
+  list(): readonly AgentDefinition[] {
+    return [...this.agentsById.values()]
+  }
+
+  /** Look up a registered agent definition by id. */
+  getById(agentId: string): AgentDefinition | null {
+    return this.agentsById.get(agentId) ?? null
+  }
+}

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -1,0 +1,44 @@
+import type { LanguageModelV3 } from "@ai-sdk/provider"
+
+/**
+ * Loop / stop controls for an agent run.
+ *
+ * Inert in PR1 — consumed by the agent worker in a later slice.
+ */
+export interface AgentLoopConfig {
+  readonly stopWhen?: {
+    readonly maxSteps?: number
+  }
+}
+
+/**
+ * Declarative config accepted by {@link defineAgent}.
+ *
+ * Every field is a static value in PR1. `instructions` is a plain string for now;
+ * widening it to `string | (ctx) => string` later is backwards-compatible.
+ */
+export interface DefineAgentConfig {
+  readonly name: string
+  readonly description?: string
+  readonly model: LanguageModelV3
+  readonly instructions: string
+  readonly loop?: AgentLoopConfig
+}
+
+/**
+ * Inert agent definition registered with Sixb.
+ *
+ * Definitions are safe to export from `agents/` modules. Later slices turn them into
+ * running, streaming agents; PR1 only loads and registers them. The `model` is an
+ * AI SDK v6 `LanguageModelV3` instance and is therefore not serialisable — the worker
+ * (later slice) resolves a definition from its own discovery rather than over the wire.
+ */
+export interface AgentDefinition<TId extends string = string> {
+  readonly kind: "agent"
+  readonly id: TId
+  readonly name: string
+  readonly description?: string
+  readonly model: LanguageModelV3
+  readonly instructions: string
+  readonly loop?: AgentLoopConfig
+}

--- a/packages/core/src/agents/validation.ts
+++ b/packages/core/src/agents/validation.ts
@@ -1,0 +1,22 @@
+import { AgentDefinitionError } from "./errors"
+import type { AgentDefinition } from "./types"
+
+export function assertNonEmpty(value: string, field: string): void {
+  if (!value.trim()) {
+    throw new AgentDefinitionError(`[Sixb] Agent ${field} must not be empty.`)
+  }
+}
+
+export function isAgentDefinition(value: unknown): value is AgentDefinition {
+  return (
+    isRecord(value) &&
+    value.kind === "agent" &&
+    typeof value.id === "string" &&
+    typeof value.name === "string" &&
+    typeof value.instructions === "string"
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/core/src/bootstrap/discovery.ts
+++ b/packages/core/src/bootstrap/discovery.ts
@@ -11,6 +11,8 @@ import { join, relative } from "node:path"
 import { pathToFileURL } from "node:url"
 import { isActionDefinition } from "../actions"
 import type { ActionDefinition } from "../actions/types"
+import type { AgentDefinition } from "../agents"
+import { isAgentDefinition } from "../agents"
 import { isConnectorDefinition } from "../connectors"
 import type { ConnectorDefinition } from "../connectors/types"
 import { isDatasetDefinition } from "../datasets"
@@ -344,6 +346,25 @@ export async function discoverWorkflows(
   return workflows
 }
 
+export async function discoverAgents(projectRoot: string): Promise<readonly AgentDefinition[]> {
+  const agentsDir = join(projectRoot, "agents")
+  const modulePaths = await listModuleFiles(agentsDir)
+  const exportedCandidates = await loadModuleExports({
+    modulePaths,
+    projectRoot,
+    kind: "agent",
+  })
+
+  const agents: AgentDefinition[] = []
+  for (const candidate of exportedCandidates) {
+    if (isAgentDefinition(candidate)) {
+      agents.push(candidate)
+    }
+  }
+
+  return agents
+}
+
 // ── Internal helpers ────────────────────────────────────────
 
 async function loadModuleExports(options: {
@@ -351,6 +372,7 @@ async function loadModuleExports(options: {
   projectRoot: string
   kind:
     | "action"
+    | "agent"
     | "ontology"
     | "dataset"
     | "function"

--- a/packages/core/src/bootstrap/index.ts
+++ b/packages/core/src/bootstrap/index.ts
@@ -1,5 +1,6 @@
 export {
   discoverActions,
+  discoverAgents,
   discoverConnectors,
   discoverDatasets,
   discoverFunctions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1220,6 +1220,11 @@ export type {
 } from "./functions"
 export { defineFunction } from "./functions"
 
+// ── Agents ──────────────────────────────────────────────────
+
+export type { AgentDefinition, AgentLoopConfig, DefineAgentConfig } from "./agents"
+export { AgentDefinitionError, AgentsRuntime, defineAgent, isAgentDefinition } from "./agents"
+
 // ── Scheduling ──────────────────────────────────────────────
 
 export { CronValidationError, createCronMatcher, nextCronOccurrence } from "./schedules"

--- a/packages/core/src/runtime/create.ts
+++ b/packages/core/src/runtime/create.ts
@@ -1,9 +1,11 @@
 import { resolve } from "node:path"
 import type { ActionDefinition } from "../actions"
+import type { AgentDefinition } from "../agents"
 import type { SixbAuthConfig } from "../auth"
 import type { BlobStorage } from "../blob-storage"
 import {
   discoverActions,
+  discoverAgents,
   discoverConnectors,
   discoverDatasets,
   discoverFunctions,
@@ -47,6 +49,8 @@ export interface CreateSixbOptions {
   sandboxes?: SandboxFactory
   ontologies?: readonly OntologySource[]
   actions?: readonly ActionDefinition[]
+  /** Agent definitions to register in addition to auto-discovered `agents/` exports. */
+  agents?: readonly AgentDefinition[]
   datasets?: readonly DatasetDefinition[]
   /** Connector definitions to register in addition to auto-discovered `connectors/` exports. */
   connectors?: readonly ConnectorDefinition[]
@@ -98,6 +102,7 @@ export async function createSixb(
     groups,
     roles,
     invitePolicies,
+    agents,
   ] = await Promise.all([
     options.actions ?? discoverActions(projectRoot),
     options.functions ?? discoverFunctions(projectRoot),
@@ -112,6 +117,7 @@ export async function createSixb(
     discoverGroups(projectRoot),
     discoverRoles(projectRoot),
     discoverInvitePolicies(projectRoot),
+    discoverAgents(projectRoot),
   ])
 
   // Explicit definitions come first so local setup can override ordering while
@@ -138,6 +144,7 @@ export async function createSixb(
     groups: [...(options.groups ?? []), ...groups],
     roles: [...(options.roles ?? []), ...roles],
     invitePolicies: [...(options.invitePolicies ?? []), ...invitePolicies],
+    agents: [...(options.agents ?? []), ...agents],
     auth: options.auth,
   })
 }

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -8,6 +8,8 @@
 
 import { ActionRegistry, ActionsRuntime } from "../actions"
 import type { ActionDefinition } from "../actions/types"
+import type { AgentDefinition } from "../agents"
+import { AgentsRuntime } from "../agents"
 import {
   AuthRuntime,
   AuthRuntimeError,
@@ -95,6 +97,7 @@ export interface SixbOptions<TOntologySources extends readonly OntologySource[]>
   projections?: readonly ProjectionDefinition[]
   rules?: readonly RuleDefinition[]
   workflows?: readonly WorkflowDefinition[]
+  agents?: readonly AgentDefinition[]
   groups?: readonly GroupDefinition[]
   roles?: readonly RoleDefinition[]
   invitePolicies?: readonly InvitePolicyDefinition[]
@@ -124,6 +127,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
   readonly actionRegistry: ActionRegistry
   readonly actions: ActionsRuntime
   readonly workflows: WorkflowsRuntime
+  readonly agents: AgentsRuntime
   readonly broker: Broker
   readonly events: EventsRuntime
   readonly storage: Storage
@@ -286,6 +290,16 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     }
     this.actions = new ActionsRuntime(this.runtimeContext)
     this.workflows = new WorkflowsRuntime(this.runtimeContext, workflows)
+
+    const agents = options.agents ?? []
+    const agentIds = new Set<string>()
+    for (const agent of agents) {
+      if (agentIds.has(agent.id)) {
+        throw new RuntimeError(`Duplicate agent id: ${agent.id}`)
+      }
+      agentIds.add(agent.id)
+    }
+    this.agents = new AgentsRuntime(agents)
 
     const { objectProjections, linkProjections, telemetryProjections } = categorizeProjections(
       options.projections ?? []

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -13,6 +13,7 @@ import type {
   InferActionParams,
   RequestActionResult,
 } from "../actions"
+import type { AgentsRuntime } from "../agents"
 import type { AuthRuntime } from "../auth"
 import type { AuthorizationContext } from "../authorization"
 import type { BlobStorage } from "../blob-storage"
@@ -638,6 +639,7 @@ export interface SixbInstance<_ extends readonly OntologySource[]> {
   readonly auth: AuthRuntime
   readonly actions: ActionsRuntime
   readonly workflows: WorkflowsRuntime
+  readonly agents: AgentsRuntime
 
   /** Create a principal-scoped runtime surface that enforces authorization grants. */
   as(context: AuthorizationContext): ScopedSixb<_>

--- a/packages/core/tests/agents.test.ts
+++ b/packages/core/tests/agents.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import type { LanguageModelV3 } from "@ai-sdk/provider"
+import {
+  AgentDefinitionError,
+  createSixb,
+  defineAgent,
+  defineObjectType,
+  isAgentDefinition,
+  prop,
+  RuntimeError,
+} from "../src"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const coreModuleUrl = pathToFileURL(resolve(import.meta.dir, "..", "src", "index.ts")).href
+const tempRoots = new Set<string>()
+
+// PR1 never reads the model, so a stub conforming to the type is enough.
+const model = {} as LanguageModelV3
+
+const Room = defineObjectType({
+  id: "Room",
+  name: "Room",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+afterEach(async () => {
+  for (const root of tempRoots) {
+    await rm(root, { recursive: true, force: true })
+  }
+  tempRoots.clear()
+})
+
+async function createTempProjectRoot(): Promise<string> {
+  const projectRoot = await mkdtemp(join(tmpdir(), "sixb-core-agents-"))
+  tempRoots.add(projectRoot)
+  return projectRoot
+}
+
+async function writeProjectFile(
+  projectRoot: string,
+  relativePath: string,
+  content: string
+): Promise<void> {
+  const absolutePath = join(projectRoot, relativePath)
+  await mkdir(dirname(absolutePath), { recursive: true })
+  await writeFile(absolutePath, content, "utf-8")
+}
+
+// Fixture modules run through Bun (transpiled, not type-checked), so an inline
+// stub model is fine — the runtime only requires it to be present.
+function agentModule(id: string, name = "Agent"): string {
+  return `import { defineAgent } from "${coreModuleUrl}"
+
+export const ${id} = defineAgent("${id}", {
+  name: "${name}",
+  model: { specificationVersion: "v3", provider: "test", modelId: "test" },
+  instructions: "You assist the user.",
+})
+`
+}
+
+describe("defineAgent", () => {
+  test("builds an inert agent definition", () => {
+    const agent = defineAgent("sales", {
+      name: "Sales Assistant",
+      model,
+      instructions: "Assist.",
+    })
+
+    expect(agent.kind).toBe("agent")
+    expect(agent.id).toBe("sales")
+    expect(agent.name).toBe("Sales Assistant")
+    expect(agent.instructions).toBe("Assist.")
+    expect(agent.description).toBeUndefined()
+    expect(agent.loop).toBeUndefined()
+  })
+
+  test("keeps description and loop when provided", () => {
+    const agent = defineAgent("sales", {
+      name: "Sales Assistant",
+      description: "Quotes and contacts.",
+      model,
+      instructions: "Assist.",
+      loop: { stopWhen: { maxSteps: 16 } },
+    })
+
+    expect(agent.description).toBe("Quotes and contacts.")
+    expect(agent.loop).toEqual({ stopWhen: { maxSteps: 16 } })
+  })
+
+  test("rejects empty id, name, and instructions", () => {
+    expect(() => defineAgent("", { name: "A", model, instructions: "x" })).toThrow(
+      AgentDefinitionError
+    )
+    expect(() => defineAgent("a", { name: "  ", model, instructions: "x" })).toThrow(
+      AgentDefinitionError
+    )
+    expect(() => defineAgent("a", { name: "A", model, instructions: " " })).toThrow(
+      AgentDefinitionError
+    )
+  })
+
+  test("rejects a missing model", () => {
+    expect(() =>
+      defineAgent("a", {
+        name: "A",
+        instructions: "x",
+        model: undefined as unknown as LanguageModelV3,
+      })
+    ).toThrow(AgentDefinitionError)
+  })
+})
+
+describe("isAgentDefinition", () => {
+  test("accepts a real agent definition", () => {
+    expect(isAgentDefinition(defineAgent("a", { name: "A", model, instructions: "x" }))).toBe(true)
+  })
+
+  test("rejects non-agents", () => {
+    expect(isAgentDefinition(null)).toBe(false)
+    expect(isAgentDefinition({ kind: "connector", id: "x" })).toBe(false)
+    // Right kind but missing required string fields.
+    expect(isAgentDefinition({ kind: "agent", id: "x" })).toBe(false)
+  })
+})
+
+describe("agent discovery + registry", () => {
+  test("returns no agents when agents/ is absent", async () => {
+    const projectRoot = await createTempProjectRoot()
+    const sixb = await createSixb({ projectRoot, ontologies: [Room], ...createTestRuntimeDeps() })
+
+    expect(sixb.agents.list()).toEqual([])
+    expect(sixb.agents.getById("sales")).toBeNull()
+  })
+
+  test("discovers agents from agents/ (incl. subfolders) and looks them up by id", async () => {
+    const projectRoot = await createTempProjectRoot()
+    await writeProjectFile(projectRoot, "agents/sales.ts", agentModule("sales", "Sales Assistant"))
+    await writeProjectFile(
+      projectRoot,
+      "agents/nested/support.ts",
+      agentModule("support", "Support")
+    )
+
+    const sixb = await createSixb({ projectRoot, ontologies: [Room], ...createTestRuntimeDeps() })
+
+    expect(
+      sixb.agents
+        .list()
+        .map((a) => a.id)
+        .sort()
+    ).toEqual(["sales", "support"])
+    expect(sixb.agents.getById("sales")?.name).toBe("Sales Assistant")
+    expect(sixb.agents.getById("unknown")).toBeNull()
+  })
+
+  test("ignores non-agent exports co-located in agents/", async () => {
+    const projectRoot = await createTempProjectRoot()
+    await writeProjectFile(projectRoot, "agents/sales.ts", agentModule("sales"))
+    await writeProjectFile(
+      projectRoot,
+      "agents/helpers.ts",
+      `export const helper = { hello: "world" }\n`
+    )
+
+    const sixb = await createSixb({ projectRoot, ontologies: [Room], ...createTestRuntimeDeps() })
+
+    expect(sixb.agents.list().map((a) => a.id)).toEqual(["sales"])
+  })
+
+  test("merges explicit agents with discovered ones", async () => {
+    const projectRoot = await createTempProjectRoot()
+    await writeProjectFile(projectRoot, "agents/sales.ts", agentModule("sales"))
+    const explicit = defineAgent("ops", { name: "Ops", model, instructions: "x" })
+
+    const sixb = await createSixb({
+      projectRoot,
+      ontologies: [Room],
+      agents: [explicit],
+      ...createTestRuntimeDeps(),
+    })
+
+    expect(
+      sixb.agents
+        .list()
+        .map((a) => a.id)
+        .sort()
+    ).toEqual(["ops", "sales"])
+  })
+
+  test("rejects duplicate agent ids", async () => {
+    const projectRoot = await createTempProjectRoot()
+    await writeProjectFile(projectRoot, "agents/sales.ts", agentModule("sales"))
+    const dup = defineAgent("sales", { name: "Dup", model, instructions: "x" })
+
+    await expect(
+      createSixb({ projectRoot, ontologies: [Room], agents: [dup], ...createTestRuntimeDeps() })
+    ).rejects.toThrow(RuntimeError)
+  })
+})


### PR DESCRIPTION
# Agents — `defineAgent` + discovery + registry

> First-class, **code-defined agent** primitive. This change ships the *definition* layer only — agents are discovered like `ontology/` and `actions/`, and looked up at runtime. No worker, routes, tokens, or persistence yet.

## ✨ What you can do

```ts
// agents/sales.ts — auto-discovered
export const sales = defineAgent("sales", {
  name: "Sales Assistant",
  description: "Works with quotes, contacts, and projects.",
  model: anthropic("claude-haiku-4-5"),
  instructions: "You assist the user…",
  loop: { stopWhen: { maxSteps: 16 } },
})
```

```ts
sixb.agents.list()            // all discovered agents
sixb.agents.getById("sales")  // lookup by id → AgentDefinition | null
```

## 📦 What's included

- **`defineAgent(id, config)`** → inert `AgentDefinition` (static config; `model` is an AI SDK v6 `LanguageModelV3`)
- **Auto-discovery** of `agents/` (non-breaking: no folder → `[]`), merged with explicit `createSixb({ agents })`
- **`sixb.agents`** registry (`list` / `getById`) — duplicate ids rejected at startup
- `isAgentDefinition` guard, public exports, and the `@ai-sdk/provider` dependency

## 🧭 Design decisions

| Topic | Choice |
|---|---|
| Model typing | AI SDK **v6** `LanguageModelV3` instance — light, type-only `@ai-sdk/provider` dep in core |
| Instructions | plain `string` for now (widening to `(ctx) => string` later is non-breaking) |
| Identity | **no service-account surface** — auto-created at spin-up by the service-account auth work later; grants stay operator-controlled |
| Lookup API | `sixb.agents` namespace, mirroring `sixb.workflows` / `sixb.actions` |

## 🚫 Out of scope (handled later)

Worker loop · `tools` · streaming · persistence · run token · UI.

## ✅ Verification

- [x] `typecheck` (whole monorepo)
- [x] `build`
- [x] `check` (Biome)
- [x] `generate:client` — no client drift
- [x] `bun test packages/core` — **838 pass / 0 fail** (incl. 11 new agent tests)

## 🗂️ Files

**New** — `packages/core/src/agents/` (`builders` · `types` · `runtime` · `validation` · `errors` · `index`) + `tests/agents.test.ts`
**Wired** — `bootstrap/discovery.ts`, `bootstrap/index.ts`, `runtime/create.ts`, `runtime/sixb.ts`, `runtime/types.ts`, `index.ts`, `package.json`
