### PR TITLE
atlas: add telemetry range controls

### DIFF
--- a/examples/acme-corp/lib/acme-erp.ts
+++ b/examples/acme-corp/lib/acme-erp.ts
@@ -255,32 +255,104 @@ const projectMembers = [
   { project_id: "proj-healthfirst-portal", employee_id: "emp-francois" },
 ] satisfies readonly ErpProjectMemberRow[]
 
+const minuteMs = 60_000
+const hourMs = 60 * minuteMs
+const dayMs = 24 * hourMs
+
+function padDatePart(value: number): string {
+  return String(value).padStart(2, "0")
+}
+
+function recentDatePart(daysAgo: number): string {
+  const date = new Date(Date.now() - daysAgo * dayMs)
+  return [
+    date.getUTCFullYear(),
+    padDatePart(date.getUTCMonth() + 1),
+    padDatePart(date.getUTCDate()),
+  ].join("-")
+}
+
+function recentTimestamp(offsetMs: number): string {
+  const date = new Date(Date.now() - offsetMs)
+  const datePart = [
+    date.getUTCFullYear(),
+    padDatePart(date.getUTCMonth() + 1),
+    padDatePart(date.getUTCDate()),
+  ].join("-")
+  return `${datePart} ${padDatePart(date.getUTCHours())}:${padDatePart(
+    date.getUTCMinutes()
+  )}:${padDatePart(date.getUTCSeconds())}`
+}
+
 // Progress snapshots arrive from the ERP as zone-less local timestamps (no "Z"
 // and no numeric offset), and some carry single-digit (non-zero-padded) hours
 // like "9:30:00" exactly as the source system emits them. The telemetry
 // projection normalizes every form to UTC so a reading materializes at the same
 // absolute instant on any worker host.
-const projectProgress = [
-  { project_id: "proj-techstart-platform", recorded_at: "2024-02-29 17:00:00", progress_pct: 15 },
-  { project_id: "proj-techstart-platform", recorded_at: "2024-05-31 9:30:00", progress_pct: 38 },
-  { project_id: "proj-techstart-platform", recorded_at: "2024-08-30 17:15:00", progress_pct: 60 },
-  { project_id: "proj-techstart-platform", recorded_at: "2024-10-31 8:00:00", progress_pct: 72 },
-  { project_id: "proj-greenenergy-dashboard", recorded_at: "2024-03-29 9:00:00", progress_pct: 12 },
-  {
-    project_id: "proj-greenenergy-dashboard",
-    recorded_at: "2024-05-31 14:00:00",
-    progress_pct: 34,
-  },
-  {
-    project_id: "proj-greenenergy-dashboard",
-    recorded_at: "2024-07-31 17:30:00",
-    progress_pct: 55,
-  },
-  { project_id: "proj-eduplatform-redesign", recorded_at: "2024-06-14 9:30:00", progress_pct: 5 },
-  { project_id: "proj-healthfirst-portal", recorded_at: "2023-08-31 17:00:00", progress_pct: 30 },
-  { project_id: "proj-healthfirst-portal", recorded_at: "2023-11-30 17:00:00", progress_pct: 65 },
-  { project_id: "proj-healthfirst-portal", recorded_at: "2024-01-31 18:00:00", progress_pct: 100 },
-] satisfies readonly ErpProjectProgressRow[]
+function createRecentProjectProgress(): readonly ErpProjectProgressRow[] {
+  return [
+    {
+      project_id: "proj-techstart-platform",
+      recorded_at: `${recentDatePart(6)} 17:00:00`,
+      progress_pct: 15,
+    },
+    {
+      project_id: "proj-techstart-platform",
+      recorded_at: `${recentDatePart(4)} 9:30:00`,
+      progress_pct: 38,
+    },
+    {
+      project_id: "proj-techstart-platform",
+      recorded_at: `${recentDatePart(2)} 17:15:00`,
+      progress_pct: 60,
+    },
+    {
+      project_id: "proj-techstart-platform",
+      recorded_at: recentTimestamp(35 * minuteMs),
+      progress_pct: 72,
+    },
+    {
+      project_id: "proj-greenenergy-dashboard",
+      recorded_at: `${recentDatePart(5)} 9:00:00`,
+      progress_pct: 12,
+    },
+    {
+      project_id: "proj-greenenergy-dashboard",
+      recorded_at: `${recentDatePart(2)} 14:00:00`,
+      progress_pct: 34,
+    },
+    {
+      project_id: "proj-greenenergy-dashboard",
+      recorded_at: recentTimestamp(45 * minuteMs),
+      progress_pct: 55,
+    },
+    {
+      project_id: "proj-eduplatform-redesign",
+      recorded_at: `${recentDatePart(1)} 9:30:00`,
+      progress_pct: 5,
+    },
+    {
+      project_id: "proj-healthfirst-portal",
+      recorded_at: `${recentDatePart(6)} 17:00:00`,
+      progress_pct: 30,
+    },
+    {
+      project_id: "proj-healthfirst-portal",
+      recorded_at: `${recentDatePart(3)} 17:00:00`,
+      progress_pct: 65,
+    },
+    {
+      project_id: "proj-healthfirst-portal",
+      recorded_at: recentTimestamp(50 * minuteMs),
+      progress_pct: 90,
+    },
+    {
+      project_id: "proj-healthfirst-portal",
+      recorded_at: recentTimestamp(3 * minuteMs),
+      progress_pct: 100,
+    },
+  ]
+}
 
 const documents = [
   {
@@ -452,7 +524,7 @@ const tasks = [
   },
 ] satisfies readonly ErpTaskRow[]
 
-function cloneRows<T extends Record<string, unknown>>(rows: readonly T[]): T[] {
+function cloneRows<T extends object>(rows: readonly T[]): T[] {
   return rows.map((row) => ({ ...row }))
 }
 
@@ -474,7 +546,7 @@ export function createAcmeErpClient(): AcmeErpClient {
       return cloneRows(projectMembers)
     },
     async listProjectProgress() {
-      return cloneRows(projectProgress)
+      return cloneRows(createRecentProjectProgress())
     },
     async listDocuments() {
       return cloneRows(documents)

--- a/packages/atlas/src/components/TelemetryChart.tsx
+++ b/packages/atlas/src/components/TelemetryChart.tsx
@@ -1,5 +1,5 @@
 import type { TelemetryHistory } from "@sixb/client"
-import { getTelemetryHistoryOptions } from "@sixb/client/hooks"
+import { type GetTelemetryHistoryOptions, getTelemetryHistoryOptions } from "@sixb/client/hooks"
 import { Button, Card } from "@sixb/ui/components"
 import { useQuery } from "@tanstack/react-query"
 import { X } from "lucide-react"
@@ -14,13 +14,19 @@ import {
   XAxis,
   YAxis,
 } from "recharts/lib/index.js"
-import type { TelemetryUpdate } from "../lib/telemetryEvents"
+import { objectIdAliases, type TelemetryUpdate } from "../lib/telemetryEvents"
+import { getHistoryBounds, isSampleInBounds } from "../lib/telemetryHistory"
 import { TelemetryValue } from "./TelemetryValue"
 
 interface TelemetryChartProps {
   objectId: string
   propertyId: string
   projectName: string
+  propertyLabel: string
+  rangeLabel: string
+  historyQuery: GetTelemetryHistoryOptions["query"]
+  historyEnabled?: boolean
+  objectDisplayName?: string
   unit?: string
   latestUpdate?: TelemetryUpdate | null
   onClose: () => void
@@ -63,6 +69,23 @@ function formatTooltip(value: number, unit?: string): string {
   return value.toFixed(2)
 }
 
+function formatChartTickTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  })
+}
+
+function formatChartTooltipTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  })
+}
+
 function getTimestampMs(timestamp: string): number {
   const value = new Date(timestamp).getTime()
   return Number.isFinite(value) ? value : 0
@@ -103,16 +126,20 @@ function createChartTicks(points: ChartPoint[]): string[] {
   return Array.from(new Set(ticks))
 }
 
-const rangeWindowMs = 5 * 60 * 1000
-
 export function TelemetryChart({
   objectId,
   propertyId,
   projectName,
+  propertyLabel,
+  rangeLabel,
+  historyQuery,
+  historyEnabled = true,
+  objectDisplayName,
   unit,
   latestUpdate,
   onClose,
 }: TelemetryChartProps) {
+  const objectAliases = useMemo(() => new Set(objectIdAliases(objectId)), [objectId])
   const {
     data: history,
     isLoading: loading,
@@ -120,8 +147,9 @@ export function TelemetryChart({
   } = useQuery({
     ...getTelemetryHistoryOptions({
       path: { projectName, objectId, propertyId },
-      query: { range: "5m" },
+      query: historyQuery,
     }),
+    enabled: historyEnabled,
   })
   const error = queryError ? String(queryError) : null
   const [liveHistory, setLiveHistory] = useState<TelemetryHistory | null>(
@@ -129,6 +157,11 @@ export function TelemetryChart({
   )
 
   useEffect(() => {
+    if (!historyEnabled) {
+      setLiveHistory(null)
+      return
+    }
+
     if (!history) {
       setLiveHistory(null)
       return
@@ -141,48 +174,50 @@ export function TelemetryChart({
         return historyData
 
       const historyEnd = new Date(historyData.range.end).getTime()
+      const bounds = getHistoryBounds(historyQuery)
       const appended = prev.data.filter(
-        (sample: { timestamp: string }) => new Date(sample.timestamp).getTime() > historyEnd
+        (sample: { timestamp: string }) =>
+          new Date(sample.timestamp).getTime() > historyEnd && isSampleInBounds(sample, bounds)
       )
 
       if (appended.length === 0) return historyData
 
-      const cutoff = Date.now() - rangeWindowMs
       const mergedData = [...historyData.data, ...appended].filter(
-        (sample: { timestamp: string }) => new Date(sample.timestamp).getTime() >= cutoff
+        (sample: { timestamp: string }) => isSampleInBounds(sample, bounds)
       )
 
       return {
         ...historyData,
         range: {
-          start: new Date(cutoff).toISOString(),
+          start: new Date(bounds.startMs).toISOString(),
           end: appended[appended.length - 1]?.timestamp ?? historyData.range.end,
         },
         data: mergedData,
       }
     })
-  }, [history])
+  }, [history, historyEnabled, historyQuery])
 
   useEffect(() => {
+    if (!historyEnabled) return
     if (!latestUpdate) return
     if (latestUpdate.projectName !== projectName) return
-    if (latestUpdate.objectId !== objectId || latestUpdate.propertyId !== propertyId) return
+    if (!objectAliases.has(latestUpdate.objectId) || latestUpdate.propertyId !== propertyId) return
 
     setLiveHistory((prev: TelemetryHistory | null) => {
-      const cutoff = Date.now() - rangeWindowMs
-
       const nextSample = {
         value: latestUpdate.value,
         timestamp: latestUpdate.timestamp,
         quality: latestUpdate.quality,
       }
+      const bounds = getHistoryBounds(historyQuery)
+      if (!isSampleInBounds(nextSample, bounds)) return prev
 
       if (!prev) {
         return {
           objectId,
           propertyId,
           range: {
-            start: new Date(cutoff).toISOString(),
+            start: new Date(bounds.startMs).toISOString(),
             end: latestUpdate.timestamp,
           },
           data: [nextSample],
@@ -196,20 +231,20 @@ export function TelemetryChart({
         ? [...prev.data.slice(0, -1), nextSample]
         : [...prev.data, nextSample]
 
-      const trimmedData = nextData.filter(
-        (sample: { timestamp: string }) => new Date(sample.timestamp).getTime() >= cutoff
+      const trimmedData = nextData.filter((sample: { timestamp: string }) =>
+        isSampleInBounds(sample, bounds)
       )
 
       return {
         ...prev,
         range: {
-          start: new Date(cutoff).toISOString(),
+          start: new Date(bounds.startMs).toISOString(),
           end: latestUpdate.timestamp,
         },
         data: trimmedData,
       }
     })
-  }, [objectId, propertyId, latestUpdate, projectName])
+  }, [objectId, propertyId, latestUpdate, projectName, objectAliases, historyQuery, historyEnabled])
 
   const chartData = useMemo(() => {
     return sortAndDedupeChartData(
@@ -229,9 +264,11 @@ export function TelemetryChart({
       <div className="flex flex-col gap-3 border-b border-border px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6 sm:py-5">
         <div className="min-w-0">
           <h3 className="break-all text-[14px] font-semibold tracking-tight text-foreground sm:text-[15px] sm:break-normal">
-            {objectId} / {propertyId}
+            {propertyLabel}
           </h3>
-          <p className="mt-0.5 text-[11px] text-muted-foreground">Last 5 minutes</p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            {objectDisplayName ? `${objectDisplayName} / ${rangeLabel}` : rangeLabel}
+          </p>
         </div>
         <div className="flex items-center justify-between gap-3 sm:justify-end sm:gap-6">
           {latestValue && (
@@ -294,13 +331,8 @@ export function TelemetryChart({
                 <XAxis
                   dataKey="timestamp"
                   ticks={xTicks}
-                  tickFormatter={(value: string) =>
-                    new Date(value).toLocaleTimeString([], {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                      hour12: false,
-                    })
-                  }
+                  padding={{ left: 16, right: 36 }}
+                  tickFormatter={(value: string) => formatChartTickTime(value)}
                   tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
                   tickLine={false}
                   axisLine={{ stroke: "var(--border)" }}
@@ -324,15 +356,8 @@ export function TelemetryChart({
                     boxShadow: "0 6px 16px -4px rgb(0 0 0 / 0.3)",
                     color: "var(--foreground)",
                   }}
-                  formatter={(value: number) => [formatTooltip(value, unit), propertyId]}
-                  labelFormatter={(label) =>
-                    new Date(label).toLocaleTimeString([], {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                      second: "2-digit",
-                      hour12: false,
-                    })
-                  }
+                  formatter={(value: number) => [formatTooltip(value, unit), propertyLabel]}
+                  labelFormatter={(label: string) => formatChartTooltipTime(label)}
                   labelStyle={{ color: "var(--muted-foreground)", marginBottom: "4px" }}
                 />
                 <Line

--- a/packages/atlas/src/components/telemetry/TelemetryGrid.tsx
+++ b/packages/atlas/src/components/telemetry/TelemetryGrid.tsx
@@ -14,6 +14,7 @@ interface TelemetryGridProps {
     { value: number | string | boolean; quality?: "good" | "bad" | "uncertain" }
   >
   compact?: boolean
+  hideSingleGroupHeader?: boolean
 }
 
 interface GroupedTelemetry {
@@ -29,6 +30,7 @@ export function TelemetryGrid({
   onSelectProperty,
   latestUpdates = {},
   compact = false,
+  hideSingleGroupHeader = false,
 }: TelemetryGridProps) {
   const grouped = useMemo(() => {
     const result: GroupedTelemetry = {
@@ -51,6 +53,9 @@ export function TelemetryGrid({
     return result
   }, [telemetry])
 
+  const nonEmptyGroupCount = Object.values(grouped).filter((items) => items.length > 0).length
+  const showGroupHeaders = !hideSingleGroupHeader || nonEmptyGroupCount > 1
+
   const renderSection = (
     title: string,
     items: [string, TelemetryProperty][],
@@ -59,15 +64,17 @@ export function TelemetryGrid({
     if (items.length === 0) return null
 
     return (
-      <div className="space-y-3">
-        <div className="flex items-center gap-2">
-          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-            {title}
-          </h3>
-          <Badge variant="secondary" className={cn("text-[10px] font-medium", colorClass)}>
-            {items.length}
-          </Badge>
-        </div>
+      <div className={cn(showGroupHeaders && "space-y-3")}>
+        {showGroupHeaders ? (
+          <div className="flex items-center gap-2">
+            <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              {title}
+            </h3>
+            <Badge variant="secondary" className={cn("text-[10px] font-medium", colorClass)}>
+              {items.length}
+            </Badge>
+          </div>
+        ) : null}
         <div
           className={cn(
             "grid gap-3",

--- a/packages/atlas/src/lib/telemetryEvents.ts
+++ b/packages/atlas/src/lib/telemetryEvents.ts
@@ -1,4 +1,4 @@
-import type { SixbEventOfType } from "@sixb/client"
+import { decodeObjectId, encodeObjectId, type SixbEventOfType } from "@sixb/client"
 
 export interface TelemetryUpdate {
   readonly type: "telemetryUpdate"
@@ -28,6 +28,21 @@ export function telemetryUpdateFromEvent(
     quality: "good",
     unit: event.payload.unit,
   }
+}
+
+export function objectIdAliases(objectId: string): readonly string[] {
+  const parsed = decodeObjectId(objectId)
+  if (!parsed) return [objectId]
+
+  return [objectId, parsed.primaryId, encodeObjectId(parsed.objectTypeId, parsed.primaryId)]
+}
+
+export function telemetryUpdateKey(
+  projectId: string,
+  objectId: string,
+  propertyId: string
+): string {
+  return `${projectId}:${objectId}:${propertyId}`
 }
 
 function normalizeTelemetryValue(value: unknown): number | string | boolean {

--- a/packages/atlas/src/lib/telemetryHistory.ts
+++ b/packages/atlas/src/lib/telemetryHistory.ts
@@ -1,0 +1,56 @@
+import type { GetTelemetryHistoryOptions } from "@sixb/client/hooks"
+
+export interface TelemetryHistoryBounds {
+  startMs: number
+  endMs: number
+}
+
+function parseDurationMs(input: string | undefined): number | null {
+  if (!input) return null
+
+  const match = /^(\d+)(ms|s|m|h|d)$/.exec(input.trim())
+  if (!match) return null
+
+  const value = Number.parseInt(match[1], 10)
+  const unit = match[2]
+
+  if (unit === "ms") return value
+  if (unit === "s") return value * 1000
+  if (unit === "m") return value * 60_000
+  if (unit === "h") return value * 3_600_000
+  if (unit === "d") return value * 86_400_000
+  return null
+}
+
+function getDateMs(value: Date | string | undefined): number | null {
+  if (value === undefined) return null
+
+  const date = typeof value === "string" ? new Date(value) : value
+  const timestamp = date.getTime()
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+function getTimestampMs(timestamp: string): number {
+  const value = new Date(timestamp).getTime()
+  return Number.isFinite(value) ? value : 0
+}
+
+export function getHistoryBounds(
+  query: GetTelemetryHistoryOptions["query"] | undefined,
+  nowMs = Date.now()
+): TelemetryHistoryBounds {
+  const endMs = getDateMs(query?.to) ?? nowMs
+  const duration = parseDurationMs(query?.range)
+  return {
+    startMs: getDateMs(query?.from) ?? endMs - (duration ?? 7 * 86_400_000),
+    endMs,
+  }
+}
+
+export function isSampleInBounds(
+  sample: { timestamp: string },
+  bounds: TelemetryHistoryBounds
+): boolean {
+  const timestampMs = getTimestampMs(sample.timestamp)
+  return timestampMs >= bounds.startMs && timestampMs <= bounds.endMs
+}

--- a/packages/atlas/src/pages/ObjectDetailPage.tsx
+++ b/packages/atlas/src/pages/ObjectDetailPage.tsx
@@ -7,14 +7,26 @@ import type {
 } from "@sixb/client"
 import { decodeObjectId, encodeObjectId } from "@sixb/client"
 import {
+  type GetTelemetryHistoryOptions,
   getObjectOptions,
   getTelemetryHistoryOptions,
   listRelationshipsOptions,
 } from "@sixb/client/hooks"
-import { Badge, Button, Card, EmptyState } from "@sixb/ui/components"
+import {
+  Badge,
+  Button,
+  Calendar,
+  Card,
+  EmptyState,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { useQuery } from "@tanstack/react-query"
-import { Box } from "lucide-react"
+import { Box, CalendarIcon } from "lucide-react"
 import { Fragment, useEffect, useMemo, useState } from "react"
 import { Link, useNavigate, useParams } from "react-router-dom"
 import { ActionButton } from "../components/ActionButton"
@@ -25,7 +37,8 @@ import { TelemetryGrid } from "../components/telemetry"
 import { UsageBar } from "../components/UsageBar"
 import { formatValue } from "../lib/formatValue"
 import { humanizeIdentifier } from "../lib/labels"
-import type { TelemetryUpdate } from "../lib/telemetryEvents"
+import { objectIdAliases, type TelemetryUpdate, telemetryUpdateKey } from "../lib/telemetryEvents"
+import { getHistoryBounds, isSampleInBounds } from "../lib/telemetryHistory"
 import { formatRelativeTime } from "../lib/time"
 
 interface ObjectDetailPageProps {
@@ -33,6 +46,18 @@ interface ObjectDetailPageProps {
   latestUpdates: Record<string, TelemetryUpdate>
   objectLookup: Record<string, ObjectSummary>
 }
+
+const telemetryRanges = [
+  { value: "5m", label: "5m" },
+  { value: "1h", label: "1h" },
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7d" },
+  { value: "custom", label: "Custom" },
+] as const
+
+type TelemetryRangeValue = (typeof telemetryRanges)[number]["value"]
+
+const defaultTelemetryRange: TelemetryRangeValue = "7d"
 
 function formatHistoryValue(value: string | number | boolean): string {
   if (typeof value === "boolean") return value ? "True" : "False"
@@ -44,6 +69,104 @@ function qualityDotClass(quality?: "good" | "uncertain" | "bad"): string {
   if (quality === "uncertain") return "bg-amber-500"
   if (quality === "bad") return "bg-red-500"
   return "bg-muted-foreground/40"
+}
+
+function telemetryPropertyLabel(
+  propertyId: string,
+  property?: (TelemetryProperty & { name?: string }) | undefined
+): string {
+  const explicitName =
+    typeof property?.name === "string" && property.name.length > 0 ? property.name : null
+  return humanizeIdentifier(explicitName ?? propertyId)
+}
+
+function isoTimestamp(date: Date): string {
+  return date.toISOString()
+}
+
+function parseTimestamp(value: string): Date | null {
+  if (!value) return null
+
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function timestampIso(value: string): string | undefined {
+  return parseTimestamp(value)?.toISOString()
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0)
+}
+
+function endOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999)
+}
+
+function dateBoundaryIso(day: Date, boundary: "start" | "end"): string {
+  return isoTimestamp(boundary === "start" ? startOfLocalDay(day) : endOfLocalDay(day))
+}
+
+function formatCustomDate(value: string): string {
+  const date = parseTimestamp(value)
+  if (!date) return "Select date"
+
+  return date.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function telemetryRangeLabel(range: TelemetryRangeValue, fromIso?: string, toIso?: string): string {
+  if (range === "5m") return "Last 5 minutes"
+  if (range === "1h") return "Last hour"
+  if (range === "24h") return "Last 24 hours"
+  if (range === "7d") return "Last 7 days"
+
+  const from = fromIso ? new Date(fromIso) : null
+  const to = toIso ? new Date(toIso) : null
+  if (from && to && !Number.isNaN(from.getTime()) && !Number.isNaN(to.getTime())) {
+    return `${from.toLocaleDateString([], {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })} to ${to.toLocaleDateString([], {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })}`
+  }
+
+  return "Custom range"
+}
+
+function telemetryRangeSentenceLabel(range: TelemetryRangeValue): string {
+  if (range === "5m") return "last 5 minutes"
+  if (range === "1h") return "last hour"
+  if (range === "24h") return "last 24 hours"
+  if (range === "7d") return "last 7 days"
+  return "selected range"
+}
+
+function latestUpdateForProperty(
+  latestUpdates: Record<string, TelemetryUpdate>,
+  projectName: string,
+  objectIds: readonly string[],
+  propertyId: string
+): TelemetryUpdate | null {
+  let latest: TelemetryUpdate | null = null
+
+  for (const objectId of objectIds) {
+    const update = latestUpdates[telemetryUpdateKey(projectName, objectId, propertyId)]
+    if (!update) continue
+
+    if (!latest || +new Date(update.timestamp) > +new Date(latest.timestamp)) {
+      latest = update
+    }
+  }
+
+  return latest
 }
 
 interface ActionPresentation {
@@ -117,10 +240,17 @@ export function ObjectDetailPage({
   const { objectId } = useParams<{ objectId: string }>()
   const navigate = useNavigate()
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null)
+  const [trendDismissed, setTrendDismissed] = useState(false)
+  const [telemetryRange, setTelemetryRange] = useState<TelemetryRangeValue>(defaultTelemetryRange)
+  const [customFrom, setCustomFrom] = useState(() =>
+    isoTimestamp(startOfLocalDay(new Date(Date.now() - 7 * 86_400_000)))
+  )
+  const [customTo, setCustomTo] = useState(() => isoTimestamp(endOfLocalDay(new Date())))
 
   useEffect(() => {
     if (!objectId) return
     setSelectedPropertyId(null)
+    setTrendDismissed(false)
   }, [objectId])
 
   const canonicalObjectId = useMemo(() => {
@@ -144,21 +274,39 @@ export function ObjectDetailPage({
     enabled: !!objectId,
   })
 
+  const liveObjectIdAliases = useMemo(() => {
+    const ids = [objectId, canonicalObjectId, object?.id, object?.primaryId].filter(
+      (id): id is string => typeof id === "string" && id.length > 0
+    )
+    return Array.from(new Set(ids.flatMap((id) => objectIdAliases(id))))
+  }, [objectId, canonicalObjectId, object?.id, object?.primaryId])
+
+  const liveObjectIdAliasSet = useMemo(() => new Set(liveObjectIdAliases), [liveObjectIdAliases])
+
   const latestTelemetryUpdates = useMemo(() => {
-    if (!objectId) return {}
-    const prefix = `${projectName}:${objectId}:`
-    const entries = Object.entries(latestUpdates)
-      .filter(([key]) => key.startsWith(prefix))
-      .map(([, update]) => [update.propertyId, { value: update.value, quality: update.quality }])
-    return Object.fromEntries(entries)
-  }, [latestUpdates, projectName, objectId])
+    if (liveObjectIdAliasSet.size === 0) return {}
+
+    const byProperty = new Map<string, TelemetryUpdate>()
+    for (const update of Object.values(latestUpdates)) {
+      if (update.projectName !== projectName) continue
+      if (!liveObjectIdAliasSet.has(update.objectId)) continue
+
+      const previous = byProperty.get(update.propertyId)
+      if (!previous || +new Date(update.timestamp) > +new Date(previous.timestamp)) {
+        byProperty.set(update.propertyId, update)
+      }
+    }
+
+    return Object.fromEntries(
+      Array.from(byProperty.entries()).map(([propertyId, update]) => [
+        propertyId,
+        { value: update.value, quality: update.quality },
+      ])
+    )
+  }, [latestUpdates, projectName, liveObjectIdAliasSet])
 
   const telemetryProperties = useMemo(
-    () =>
-      (object?.telemetry as Record<
-        string,
-        { class?: string; dataType?: string; currentValue?: unknown; unit?: string }
-      >) ?? {},
+    () => (object?.telemetry as Record<string, TelemetryProperty>) ?? {},
     [object]
   )
 
@@ -193,30 +341,57 @@ export function ObjectDetailPage({
       .filter(
         (update) =>
           update.projectName === projectName &&
-          update.objectId === objectId &&
+          liveObjectIdAliasSet.has(update.objectId) &&
           numericPropertyIds.includes(update.propertyId)
       )
       .sort((left, right) => +new Date(right.timestamp) - +new Date(left.timestamp))[0]
     if (recentNumericUpdate) return recentNumericUpdate.propertyId
     return numericPropertyIds[0]
-  }, [objectId, numericPropertyIds, latestUpdates, projectName])
+  }, [objectId, numericPropertyIds, latestUpdates, projectName, liveObjectIdAliasSet])
 
   useEffect(() => {
     if (!object) return
+    if (trendDismissed) return
     if (selectedPropertyId && telemetryProperties[selectedPropertyId]) return
     if (defaultNumericPropertyId) {
       setSelectedPropertyId(defaultNumericPropertyId)
     }
-  }, [object, selectedPropertyId, telemetryProperties, defaultNumericPropertyId])
+  }, [object, trendDismissed, selectedPropertyId, telemetryProperties, defaultNumericPropertyId])
 
   const selectedPropertyUnit = selectedPropertyId
     ? telemetryProperties[selectedPropertyId]?.unit
     : undefined
 
-  const selectedPropertyLatestUpdate =
-    selectedPropertyId && objectId
-      ? (latestUpdates[`${projectName}:${objectId}:${selectedPropertyId}`] ?? null)
-      : null
+  const selectedProperty = selectedPropertyId ? telemetryProperties[selectedPropertyId] : undefined
+  const selectedPropertyLabel = selectedPropertyId
+    ? telemetryPropertyLabel(selectedPropertyId, selectedProperty)
+    : ""
+  const selectedPropertyLatestUpdate = selectedPropertyId
+    ? latestUpdateForProperty(latestUpdates, projectName, liveObjectIdAliases, selectedPropertyId)
+    : null
+  const customFromIso = useMemo(() => timestampIso(customFrom), [customFrom])
+  const customToIso = useMemo(() => timestampIso(customTo), [customTo])
+  const telemetryHistoryEnabled =
+    telemetryRange !== "custom" || (customFromIso !== undefined && customToIso !== undefined)
+  const telemetryHistoryQuery = useMemo<GetTelemetryHistoryOptions["query"]>(() => {
+    if (telemetryRange === "custom") {
+      return {
+        from: customFromIso,
+        to: customToIso,
+        order: "asc",
+      }
+    }
+
+    return {
+      range: telemetryRange,
+      order: "asc",
+    }
+  }, [telemetryRange, customFromIso, customToIso])
+  const telemetryRangeLabelText = useMemo(
+    () => telemetryRangeLabel(telemetryRange, customFromIso, customToIso),
+    [telemetryRange, customFromIso, customToIso]
+  )
+  const telemetryRangeSampleLabel = telemetryRangeSentenceLabel(telemetryRange)
 
   const selectedPropertyIsNumeric = useMemo(() => {
     if (!selectedPropertyId) return false
@@ -235,9 +410,10 @@ export function ObjectDetailPage({
   } = useQuery({
     ...getTelemetryHistoryOptions({
       path: { projectName, objectId: objectId!, propertyId: selectedPropertyId! },
-      query: { range: "5m" },
+      query: telemetryHistoryQuery,
     }),
-    enabled: !!objectId && !!selectedPropertyId && !selectedPropertyIsNumeric,
+    enabled:
+      !!objectId && !!selectedPropertyId && !selectedPropertyIsNumeric && telemetryHistoryEnabled,
   })
 
   const nonNumericHistory = useMemo(() => {
@@ -255,11 +431,12 @@ export function ObjectDetailPage({
         timestamp: selectedPropertyLatestUpdate.timestamp,
         quality: selectedPropertyLatestUpdate.quality,
       }
+      const bounds = getHistoryBounds(telemetryHistoryQuery)
       const duplicate = mergedSamples.some(
         (sample) =>
           sample.timestamp === latestSample.timestamp && sample.value === latestSample.value
       )
-      if (!duplicate) mergedSamples.push(latestSample)
+      if (!duplicate && isSampleInBounds(latestSample, bounds)) mergedSamples.push(latestSample)
     }
 
     mergedSamples.sort((left, right) => +new Date(left.timestamp) - +new Date(right.timestamp))
@@ -302,6 +479,7 @@ export function ObjectDetailPage({
     selectedPropertyIsNumeric,
     selectedPropertyHistory,
     selectedPropertyLatestUpdate,
+    telemetryHistoryQuery,
   ])
 
   const actions = useMemo(() => {
@@ -433,36 +611,85 @@ export function ObjectDetailPage({
       </header>
 
       {Object.keys(telemetryWithLive).length > 0 ? (
-        <Section title="Live state" count={Object.keys(telemetryWithLive).length}>
-          <Card className="p-4 sm:p-5">
-            <TelemetryGrid
-              telemetry={telemetryWithLive}
-              selectedPropertyId={selectedPropertyId}
-              onSelectProperty={setSelectedPropertyId}
-              latestUpdates={latestTelemetryUpdates}
-            />
-          </Card>
+        <Section title="Telemetries" count={Object.keys(telemetryWithLive).length}>
+          <TelemetryGrid
+            telemetry={telemetryWithLive}
+            selectedPropertyId={selectedPropertyId}
+            onSelectProperty={(propertyId) => {
+              setTrendDismissed(false)
+              setSelectedPropertyId(propertyId)
+            }}
+            latestUpdates={latestTelemetryUpdates}
+            hideSingleGroupHeader
+          />
         </Section>
       ) : null}
 
       {selectedPropertyId ? (
         <Section title="Trend">
-          <div className="space-y-2">
-            <code className="ml-1 inline-block rounded-md bg-muted px-2 py-0.5 font-mono text-xs text-foreground">
-              {selectedPropertyId}
-            </code>
+          <div className="space-y-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <ToggleGroup
+                type="single"
+                value={telemetryRange}
+                onValueChange={(next) => {
+                  if (next) setTelemetryRange(next as TelemetryRangeValue)
+                }}
+                variant="outline"
+                size="sm"
+                className="flex-wrap"
+              >
+                {telemetryRanges.map((range) => (
+                  <ToggleGroupItem key={range.value} value={range.value}>
+                    {range.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+              {telemetryRange === "custom" ? (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <TelemetryDatePicker
+                    label="From"
+                    boundary="start"
+                    value={customFrom}
+                    onChange={setCustomFrom}
+                  />
+                  <TelemetryDatePicker
+                    label="To"
+                    boundary="end"
+                    value={customTo}
+                    onChange={setCustomTo}
+                  />
+                </div>
+              ) : null}
+            </div>
             {selectedPropertyIsNumeric ? (
               <TelemetryChart
                 objectId={object.id}
                 propertyId={selectedPropertyId}
                 projectName={projectName}
+                propertyLabel={selectedPropertyLabel}
+                rangeLabel={telemetryRangeLabelText}
+                historyQuery={telemetryHistoryQuery}
+                historyEnabled={telemetryHistoryEnabled}
+                objectDisplayName={displayName}
                 unit={selectedPropertyUnit}
                 latestUpdate={selectedPropertyLatestUpdate}
-                onClose={() => setSelectedPropertyId(defaultNumericPropertyId)}
+                onClose={() => {
+                  setTrendDismissed(true)
+                  setSelectedPropertyId(null)
+                }}
               />
             ) : (
               <Card className="overflow-hidden p-0">
-                <div className="border-b border-border px-4 py-4">
+                <div className="space-y-3 border-b border-border px-4 py-4">
+                  <div className="min-w-0">
+                    <h3 className="text-[14px] font-semibold tracking-tight text-foreground sm:text-[15px]">
+                      {selectedPropertyLabel}
+                    </h3>
+                    <p className="mt-0.5 text-[11px] text-muted-foreground">
+                      {displayName} / {telemetryRangeLabelText}
+                    </p>
+                  </div>
                   {selectedPropertyHistoryLoading ? (
                     <LoadingState />
                   ) : nonNumericHistory?.current ? (
@@ -477,7 +704,9 @@ export function ObjectDetailPage({
                           Changed {formatRelativeTime(nonNumericHistory.current.timestamp)}
                         </span>
                         <span className="text-border">|</span>
-                        <span>{nonNumericHistory.sampleCount} samples in last 5m</span>
+                        <span>
+                          {nonNumericHistory.sampleCount} samples in {telemetryRangeSampleLabel}
+                        </span>
                       </div>
                     </div>
                   ) : (
@@ -603,6 +832,47 @@ export function ObjectDetailPage({
         </Section>
       ) : null}
     </div>
+  )
+}
+
+function TelemetryDatePicker({
+  label,
+  boundary,
+  value,
+  onChange,
+}: {
+  label: string
+  boundary: "start" | "end"
+  value: string
+  onChange: (value: string) => void
+}) {
+  const selectedDate = parseTimestamp(value) ?? new Date()
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-8 justify-start gap-2 px-2.5 text-left font-normal sm:w-56"
+        >
+          <CalendarIcon className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="min-w-0 truncate">
+            {label} {formatCustomDate(value)}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-auto p-0">
+        <Calendar
+          mode="single"
+          selected={selectedDate}
+          onSelect={(day) => {
+            if (day) onChange(dateBoundaryIso(day, boundary))
+          }}
+        />
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -33,7 +33,11 @@ import { SettingsServiceAccountsPage } from "../components/SettingsServiceAccoun
 import { SettingsSessionsPage } from "../components/SettingsSessionsPage"
 import { SettingsTokensPage } from "../components/SettingsTokensPage"
 import { WorkflowLiveUpdatesBoundary } from "../features/workflows/components/WorkflowLiveUpdatesBoundary"
-import { type TelemetryUpdate, telemetryUpdateFromEvent } from "../lib/telemetryEvents"
+import {
+  type TelemetryUpdate,
+  telemetryUpdateFromEvent,
+  telemetryUpdateKey,
+} from "../lib/telemetryEvents"
 import {
   getObjectSortPreference,
   type ObjectSortPreference,
@@ -238,7 +242,7 @@ export function ProjectWorkspace() {
     (update: TelemetryUpdate) => {
       if (resolvedProjectName && update.projectName !== resolvedProjectName) return
 
-      const key = `${update.projectName}:${update.objectId}:${update.propertyId}`
+      const key = telemetryUpdateKey(update.projectName, update.objectId, update.propertyId)
       setLatestUpdates((previous) => ({
         ...previous,
         [key]: update,

--- a/packages/atlas/tests/telemetryHistory.test.ts
+++ b/packages/atlas/tests/telemetryHistory.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { getHistoryBounds, isSampleInBounds } from "../src/lib/telemetryHistory"
+
+describe("telemetry history bounds", () => {
+  test("keeps live samples inside a custom range", () => {
+    const bounds = getHistoryBounds({
+      from: "2026-01-01T00:00:00.000Z",
+      to: "2026-01-01T23:59:59.999Z",
+    })
+
+    expect(isSampleInBounds({ timestamp: "2026-01-01T12:00:00.000Z" }, bounds)).toBe(true)
+    expect(isSampleInBounds({ timestamp: "2026-01-02T00:00:00.000Z" }, bounds)).toBe(false)
+  })
+
+  test("keeps live samples inside a relative range", () => {
+    const nowMs = new Date("2026-01-01T12:00:00.000Z").getTime()
+    const bounds = getHistoryBounds({ range: "5m" }, nowMs)
+
+    expect(isSampleInBounds({ timestamp: "2026-01-01T11:56:00.000Z" }, bounds)).toBe(true)
+    expect(isSampleInBounds({ timestamp: "2026-01-01T11:54:59.999Z" }, bounds)).toBe(false)
+    expect(isSampleInBounds({ timestamp: "2026-01-01T12:00:00.001Z" }, bounds)).toBe(false)
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -914,7 +914,8 @@ export {
 
 // ── Object Operations ───────────────────────────────────────
 
-export { objectService } from "./objects"
+export type { TelemetryHistoryOptions } from "./objects"
+export { getTelemetryHistoryBatch, objectService } from "./objects"
 export type {
   ExecuteObjectCountInput,
   ExecuteObjectCountResult,

--- a/packages/core/src/objects/index.ts
+++ b/packages/core/src/objects/index.ts
@@ -22,4 +22,5 @@ export { upsertObject, upsertObjectBatch } from "./object"
 export { createObjectSet } from "./sdk"
 // Service layer (resolve objectTypeId → delegate to leaf)
 export * as objectService from "./service"
-export { appendTelemetryBatch, writeTelemetryBatch } from "./telemetry"
+export type { TelemetryHistoryOptions } from "./telemetry"
+export { appendTelemetryBatch, getTelemetryHistoryBatch, writeTelemetryBatch } from "./telemetry"

--- a/packages/core/src/objects/telemetry/history.ts
+++ b/packages/core/src/objects/telemetry/history.ts
@@ -1,0 +1,32 @@
+import { type AuthorizationContext, assertAuthorized } from "../../authorization"
+import type {
+  TimeseriesHistoryBatchInput,
+  TimeseriesHistoryBatchResult,
+  TimeseriesHistorySeriesInput,
+  TimeseriesStorage,
+} from "../../storage"
+
+export interface TelemetryHistoryOptions {
+  readonly storage: TimeseriesStorage
+  readonly authorization?: AuthorizationContext | null
+}
+
+export async function getTelemetryHistoryBatch(
+  input: TimeseriesHistoryBatchInput,
+  options: TelemetryHistoryOptions
+): Promise<readonly TimeseriesHistoryBatchResult[]> {
+  assertTelemetrySeriesViewable(input.series, options.authorization)
+  return options.storage.getHistoryBatch(input)
+}
+
+function assertTelemetrySeriesViewable(
+  series: readonly TimeseriesHistorySeriesInput[],
+  authorization: AuthorizationContext | null | undefined
+): void {
+  for (const objectTypeId of new Set(series.map((entry) => entry.objectTypeId))) {
+    assertAuthorized(
+      { authorization: authorization ?? undefined },
+      { kind: "object.view", objectTypeId }
+    )
+  }
+}

--- a/packages/core/src/objects/telemetry/index.ts
+++ b/packages/core/src/objects/telemetry/index.ts
@@ -1,2 +1,4 @@
 export { appendTelemetryBatch } from "./append-batch"
+export type { TelemetryHistoryOptions } from "./history"
+export { getTelemetryHistoryBatch } from "./history"
 export { writeTelemetryBatch } from "./write-batch"

--- a/packages/server/src/routes/telemetry.ts
+++ b/packages/server/src/routes/telemetry.ts
@@ -1,4 +1,4 @@
-import { assertAuthorized, isAllowed, type OntologySource, type Sixb } from "@sixb/core"
+import { getTelemetryHistoryBatch, isAllowed, type OntologySource, type Sixb } from "@sixb/core"
 import type { Elysia } from "elysia"
 import { requestAuthState } from "../auth/scope"
 import { SIXB_CSRF_SECURITY_REQUIREMENT } from "../openapi/security"
@@ -12,11 +12,6 @@ import {
   TelemetryPointSchema,
 } from "../schemas/telemetry"
 import { handleRouteError, parseDate, parseOptionalInt, toIsoString } from "../utils/http"
-
-function assertCanReadTelemetry(context: unknown, objectTypeId: string): void {
-  const { authz } = requestAuthState(context)
-  assertAuthorized({ authorization: authz ?? undefined }, { kind: "object.view", objectTypeId })
-}
 
 function serializeTelemetryPoint(point: {
   projectId: string
@@ -78,23 +73,22 @@ export function registerTelemetryRoutes(app: Elysia, sixb: Sixb<readonly Ontolog
       "/api/telemetry/history",
       async (context) => {
         const { body, set } = context
+        const { authz } = requestAuthState(context)
         try {
           const parsedBody = BulkTelemetryHistoryBodySchema.parse(body)
-          for (const objectTypeId of new Set(
-            parsedBody.series.map((series) => series.objectTypeId)
-          )) {
-            assertCanReadTelemetry(context, objectTypeId)
-          }
           const from = parseDate(parsedBody.from)
           const to = parseDate(parsedBody.to)
-          const history = await sixb.storage.timeseries.getHistoryBatch({
-            projectId: sixb.id,
-            series: parsedBody.series,
-            from,
-            to,
-            limitPerSeries: parsedBody.limitPerSeries,
-            order: parsedBody.order,
-          })
+          const history = await getTelemetryHistoryBatch(
+            {
+              projectId: sixb.id,
+              series: parsedBody.series,
+              from,
+              to,
+              limitPerSeries: parsedBody.limitPerSeries,
+              order: parsedBody.order,
+            },
+            { storage: sixb.storage.timeseries, authorization: authz }
+          )
 
           return {
             series: history.map((series) => ({


### PR DESCRIPTION
## Problem

Atlas could only show a fixed recent telemetry trend. That made older ranges and custom windows hard to inspect, and live updates could leak current values into a historical non-numeric range.

## Change

This adds range controls to the object detail telemetry trend and wires the selected range into numeric charts, non-numeric history summaries, and the demo data used to exercise the view.

The object detail page now builds one history query from the selected range:

```ts
const telemetryHistoryQuery = useMemo<GetTelemetryHistoryOptions["query"]>(() => {
  if (telemetryRange === "custom") {
    return { from: customFromIso, to: customToIso, order: "asc" }
  }

  return { range: telemetryRange, order: "asc" }
}, [telemetryRange, customFromIso, customToIso])
```

Non-numeric live samples are only merged when they belong to the active range, matching the numeric chart behavior:

```ts
const latestSample = {
  value: selectedPropertyLatestUpdate.value,
  timestamp: selectedPropertyLatestUpdate.timestamp,
  quality: selectedPropertyLatestUpdate.quality,
}
const bounds = getHistoryBounds(telemetryHistoryQuery)

if (!duplicate && isSampleInBounds(latestSample, bounds)) {
  mergedSamples.push(latestSample)
}
```

The chart tooltip and x-axis now use local 12-hour formatting, with endpoint padding so `AM`/`PM` labels do not clip:

```ts
function formatChartTooltipTime(timestamp: string): string {
  return new Date(timestamp).toLocaleTimeString([], {
    hour: "numeric",
    minute: "2-digit",
    second: "2-digit",
    hour12: true,
  })
}

<XAxis padding={{ left: 16, right: 36 }} />
```

The Acme demo progress readings are generated relative to the current date so the sample project always has recent points across the built-in ranges:

```ts
recorded_at: recentTimestamp(35 * minuteMs)
```

## Tests

| Check | Result |
|---|---|
| `bun test packages/atlas/tests/` | 7 pass |
| `bun --filter @sixb/atlas typecheck` | pass |
| `bun --filter @sixb/atlas build` | pass |
| `bun run check packages/atlas/src/components/TelemetryChart.tsx packages/atlas/src/components/telemetry/TelemetryGrid.tsx packages/atlas/src/lib/telemetryEvents.ts packages/atlas/src/lib/telemetryHistory.ts packages/atlas/src/pages/ObjectDetailPage.tsx packages/atlas/src/pages/ProjectWorkspace.tsx packages/atlas/tests/telemetryHistory.test.ts examples/acme-corp/lib/acme-erp.ts` | pass |
| `bun run typecheck` | pass |

## Stack

Stacked on #108. Review the contract PR first; this PR is the Atlas UI and demo-data layer on top.



<img width="1111" height="936" alt="Screenshot 2026-06-23 at 7 10 05 PM" src="https://github.com/user-attachments/assets/7f2baad3-14f9-4374-a640-5459feae451c" />
