### PR TITLE
atlas: add projection run-history pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ Repo-wide agent instructions for `sixb`.
 ## Repo Map
 
 - `packages/core`: runtime, ontology builders, providers, validation, and functions
-- `packages/server`: Elysia HTTP/WebSocket API, OpenAPI generation, and built-in React UI under `packages/server/src/ui`
+- `packages/server`: Elysia HTTP/WebSocket API and OpenAPI generation
+- `packages/atlas`: built-in React UI (the Atlas app); pages live in `src/pages/`
+- `packages/ui`: shared React component library used by Atlas
 - `packages/client`: generated typed client artifacts
 - `packages/cli`: CLI entrypoints for `sixb` and `create-sixb`
 - `packages/app`: custom app integration
@@ -83,7 +85,7 @@ CI currently runs:
 - Validate inputs early and throw clear, actionable errors.
 - Package-prefixed error messages such as `[Sixb] ...`, `[SixbServer] ...`, or `[RokuTV] ...` are preferred.
 - Keep builders and definitions declarative; avoid unnecessary indirection around ontology setup.
-- Preserve the existing visual language in `packages/server/src/ui` and keep both desktop and mobile behavior working.
+- Preserve the existing visual language in `packages/atlas` (and `packages/ui`) and keep both desktop and mobile behavior working.
 
 ## Tests
 
@@ -128,4 +130,4 @@ CI currently runs:
 - `packages/core/src/functions/`: functions runtime
 - `packages/server/src/routes/`: server routes
 - `packages/client/src/generated/`: generated client output
-- `packages/server/src/ui/src/`: built-in UI
+- `packages/atlas/src/`: built-in UI (pages in `pages/`, shared components in `packages/ui/src/`)

--- a/packages/atlas/src/components/common.tsx
+++ b/packages/atlas/src/components/common.tsx
@@ -97,8 +97,8 @@ export function PageFrame({
   children: ReactNode
 }) {
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 p-3 sm:p-4 lg:p-6">
-      <div className={cn("flex w-full flex-col gap-4", contentClassName)}>
+    <div className="mx-auto flex w-full max-w-7xl flex-col p-3 sm:p-4 lg:p-6">
+      <div className={cn("mx-auto flex w-full max-w-5xl flex-col gap-4", contentClassName)}>
         {backTo && backLabel ? (
           <Button
             variant="ghost"

--- a/packages/atlas/src/components/layout/AppLayout.tsx
+++ b/packages/atlas/src/components/layout/AppLayout.tsx
@@ -42,6 +42,7 @@ export function AppLayout() {
       datasetCount={sidebarData?.datasetCount}
       syncCount={sidebarData?.syncCount}
       pipelineCount={sidebarData?.pipelineCount}
+      projectionCount={sidebarData?.projectionCount}
       workflowCount={sidebarData?.workflowCount}
       actionCount={sidebarData?.actionCount}
       ruleCount={sidebarData?.ruleCount}

--- a/packages/atlas/src/components/layout/Sidebar.tsx
+++ b/packages/atlas/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   Database,
   GitBranch,
   Globe,
+  Layers,
   LayoutGrid,
   ListChecks,
   RefreshCw,
@@ -35,6 +36,7 @@ export type ViewMode =
   | "datasets"
   | "connectors"
   | "syncs"
+  | "projections"
   | "pipelines"
   | "workflows"
   | "actions"
@@ -53,10 +55,11 @@ const projectNavItems: NavItem[] = [
   { id: "datasets", label: "Datasets", Icon: Database },
   { id: "syncs", label: "Syncs", Icon: RefreshCw },
   { id: "pipelines", label: "Pipelines", Icon: Workflow },
-  { id: "workflows", label: "Workflows", Icon: GitBranch },
-  { id: "actions", label: "Actions", Icon: Bolt },
+  { id: "projections", label: "Projections", Icon: Layers },
   { id: "ontology", label: "Ontology", Icon: LayoutGrid },
   { id: "home", label: "Objects", Icon: Box },
+  { id: "actions", label: "Actions", Icon: Bolt },
+  { id: "workflows", label: "Workflows", Icon: GitBranch },
   { id: "rules", label: "Rules", Icon: ListChecks },
   { id: "settings", label: "Settings", Icon: Settings },
 ]
@@ -73,6 +76,7 @@ interface SidebarProps {
   connectorCount?: number
   syncCount?: number
   pipelineCount?: number
+  projectionCount?: number
   workflowCount?: number
   actionCount?: number
   ruleCount?: number
@@ -88,6 +92,7 @@ export function Sidebar({
   connectorCount,
   syncCount,
   pipelineCount,
+  projectionCount,
   workflowCount,
   actionCount,
   ruleCount,
@@ -99,6 +104,7 @@ export function Sidebar({
     if (id === "datasets") return datasetCount
     if (id === "connectors") return connectorCount
     if (id === "syncs") return syncCount
+    if (id === "projections") return projectionCount
     if (id === "pipelines") return pipelineCount
     if (id === "workflows") return workflowCount
     if (id === "actions") return actionCount

--- a/packages/atlas/src/components/layout/sidebarData.ts
+++ b/packages/atlas/src/components/layout/sidebarData.ts
@@ -6,6 +6,7 @@ export interface ProjectSidebarData {
   connectorCount: number
   syncCount: number
   pipelineCount: number
+  projectionCount: number
   workflowCount: number
   actionCount: number
   ruleCount: number

--- a/packages/atlas/src/components/layout/viewMode.ts
+++ b/packages/atlas/src/components/layout/viewMode.ts
@@ -5,6 +5,7 @@ export const KNOWN_VIEWS = new Set([
   "datasets",
   "connectors",
   "syncs",
+  "projections",
   "pipelines",
   "workflows",
   "actions",

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -7,6 +7,7 @@ import {
   listObjectsPageOptions,
   listObjectTypesOptions,
   listPipelinesOptions,
+  listProjectionsOptions,
   listRulesOptions,
   listSyncsOptions,
   listWorkflowsOptions,
@@ -52,6 +53,7 @@ import { ObjectsWorkbench, type ObjectTypePreviewSection } from "./ObjectsWorkbe
 import { ObjectTypeDetail } from "./ObjectTypeDetail"
 import { OntologyExplorer } from "./OntologyExplorer"
 import { PipelineDetailPage, PipelinesPage } from "./PipelinesPage"
+import { ProjectionDetailPage, ProjectionsPage } from "./ProjectionsPage"
 import { RuleDetailPage, RulesPage } from "./RulesPage"
 import { RunDetailPage } from "./RunDetailPage"
 import { SyncDetailPage, SyncsPage } from "./SyncsPage"
@@ -223,6 +225,16 @@ export function ProjectWorkspace() {
     enabled: !!projectInfo,
   })
 
+  const { data: projections } = useQuery({
+    ...listProjectionsOptions(),
+    enabled: !!projectInfo,
+  })
+  const projectionCount = projections
+    ? projections.objectProjections.length +
+      projections.linkProjections.length +
+      projections.telemetryProjections.length
+    : 0
+
   const { data: workflows = [] } = useQuery({
     ...listWorkflowsOptions(),
     enabled: !!projectInfo,
@@ -270,6 +282,7 @@ export function ProjectWorkspace() {
       connectorCount: connectors.length,
       syncCount: syncs.length,
       pipelineCount: pipelines.length,
+      projectionCount,
       workflowCount: workflows.length,
       actionCount: actions.length,
       ruleCount: rules.length,
@@ -282,6 +295,7 @@ export function ProjectWorkspace() {
     connectors.length,
     syncs.length,
     pipelines.length,
+    projectionCount,
     workflows.length,
     actions.length,
     rules.length,
@@ -356,6 +370,8 @@ export function ProjectWorkspace() {
   return (
     <Routes>
       <Route path="pipelines/:pipelineId" element={<PipelineDetailPage />} />
+      <Route path="actions" element={<ActionsPage />} />
+      <Route path="actions/runs/:runId" element={<ActionRunDetailPage />} />
       <Route element={<WorkflowLiveUpdatesBoundary />}>
         <Route path="workflows" element={<WorkflowsPage />} />
         <Route path="workflows/:workflowId" element={<WorkflowDetailPage />} />
@@ -396,9 +412,9 @@ export function ProjectWorkspace() {
             <Route path="connectors/:connectorId" element={<ConnectorDetailPage />} />
             <Route path="syncs" element={<SyncsPage />} />
             <Route path="syncs/:syncId" element={<SyncDetailPage />} />
+            <Route path="projections" element={<ProjectionsPage />} />
+            <Route path="projections/:projectionId" element={<ProjectionDetailPage />} />
             <Route path="pipelines" element={<PipelinesPage />} />
-            <Route path="actions" element={<ActionsPage />} />
-            <Route path="actions/runs/:runId" element={<ActionRunDetailPage />} />
             <Route path="rules" element={<RulesPage />} />
             <Route path="rules/:ruleId" element={<RuleDetailPage />} />
             <Route path="settings" element={<Navigate to="/settings/tokens" replace />} />

--- a/packages/atlas/src/pages/ProjectionsPage.tsx
+++ b/packages/atlas/src/pages/ProjectionsPage.tsx
@@ -1,0 +1,919 @@
+import type {
+  GetProjectionResponse,
+  ListProjectionRunsResponse,
+  ListProjectionsResponse,
+} from "@sixb/client"
+import {
+  getProjectionOptions,
+  listProjectionRunsOptions,
+  listProjectionsOptions,
+} from "@sixb/client/hooks"
+import {
+  Badge,
+  Button,
+  Card,
+  CollectionCardButton,
+  CollectionCardGrid,
+  CollectionHeader,
+  CollectionViewToggle,
+  EmptyState,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import { useQuery } from "@tanstack/react-query"
+import {
+  ArrowRight,
+  Ban,
+  Box,
+  CheckCircle2,
+  ChevronLeft,
+  Clock3,
+  Database,
+  Layers,
+  Loader2,
+  LoaderCircle,
+  Search,
+  XCircle,
+} from "lucide-react"
+import { useMemo, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { humanizeIdentifier } from "../lib/labels"
+import { formatRelativeTime } from "../lib/time"
+import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
+
+type Projection =
+  | ListProjectionsResponse["objectProjections"][number]
+  | ListProjectionsResponse["linkProjections"][number]
+  | ListProjectionsResponse["telemetryProjections"][number]
+type ProjectionRun = ListProjectionRunsResponse["runs"][number]
+type ProjectionKind = ProjectionRun["projectionKind"]
+type RunStatus = ProjectionRun["status"]
+type ListViewStyle = "cards" | "table"
+
+const listViewOptions = [
+  { value: "cards", label: "Cards" },
+  { value: "table", label: "Table" },
+] as const
+
+const KIND_LABEL: Record<ProjectionKind, string> = {
+  object: "Object",
+  link: "Link",
+  telemetry: "Telemetry",
+}
+
+function projectionKind(projection: Pick<Projection, "_tag">): ProjectionKind {
+  if (projection._tag === "ObjectProjectionDefinition") return "object"
+  if (projection._tag === "LinkProjectionDefinition") return "link"
+  return "telemetry"
+}
+
+function projectionName(projection: Pick<Projection, "id">): string {
+  return humanizeIdentifier(projection.id)
+}
+
+function runStatusLabel(status: RunStatus): string {
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}
+
+function runStatusClasses(status: RunStatus): string {
+  switch (status) {
+    case "succeeded":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300"
+    case "failed":
+      return "border-destructive/30 bg-destructive/10 text-destructive"
+    case "cancelled":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-300"
+    case "running":
+      return "border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-300"
+  }
+}
+
+function RunStatusBadge({ status }: { status: RunStatus }) {
+  const Icon =
+    status === "succeeded"
+      ? CheckCircle2
+      : status === "failed"
+        ? XCircle
+        : status === "cancelled"
+          ? Ban
+          : LoaderCircle
+
+  return (
+    <Badge variant="outline" className={cn("rounded-md", runStatusClasses(status))}>
+      <Icon className={cn("h-3 w-3", status === "running" && "animate-spin")} />
+      {runStatusLabel(status)}
+    </Badge>
+  )
+}
+
+function KindBadge({ kind }: { kind: ProjectionKind }) {
+  return (
+    <Badge variant="outline" className="rounded-md text-muted-foreground">
+      {KIND_LABEL[kind]}
+    </Badge>
+  )
+}
+
+// Each projection kind upserts a different target, so the counters worth
+// surfacing differ by kind.
+function runMetrics(run: ProjectionRun): { label: string; value: number }[] {
+  if (run.projectionKind === "telemetry") {
+    return [
+      { label: "Points", value: run.telemetryPointsAppended },
+      { label: "Skipped", value: run.telemetryPointsSkipped },
+      { label: "Failed", value: run.telemetryRowsFailed },
+    ]
+  }
+  if (run.projectionKind === "link") {
+    return [
+      { label: "Rows", value: run.rowsProcessed },
+      { label: "Links", value: run.linksUpserted },
+    ]
+  }
+  return [
+    { label: "Rows", value: run.rowsProcessed },
+    { label: "Objects", value: run.objectsUpserted },
+  ]
+}
+
+// The headline throughput counter for the summary band, by kind.
+function primaryMetric(run: ProjectionRun): { label: string; value: number } {
+  if (run.projectionKind === "telemetry") {
+    return { label: "Points", value: run.telemetryPointsAppended }
+  }
+  if (run.projectionKind === "link") {
+    return { label: "Links", value: run.linksUpserted }
+  }
+  return { label: "Objects", value: run.objectsUpserted }
+}
+
+// Runs are identified by `<uuid>:attempt:<n>`; surface a short, stable handle
+// (the uuid prefix + attempt) and keep the full id available on hover.
+function shortRunId(id: string): string {
+  const [base, , attempt] = id.split(":")
+  const head = base.length > 8 ? base.slice(0, 8) : base
+  return attempt ? `${head} · attempt ${attempt}` : head
+}
+
+function runDuration(run: ProjectionRun): string {
+  if (!run.finishedAt) {
+    return run.status === "running" ? "Running" : "Pending"
+  }
+
+  const durationMs = new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime()
+  if (!Number.isFinite(durationMs) || durationMs < 0) return "Unknown"
+  if (durationMs < 1000) return "<1s"
+  if (durationMs < 60_000) return `${Math.round(durationMs / 1000)}s`
+
+  const minutes = Math.floor(durationMs / 60_000)
+  const seconds = Math.round((durationMs % 60_000) / 1000)
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`
+}
+
+function ProjectionListItem({
+  projection,
+  onSelect,
+}: {
+  projection: Projection
+  onSelect: () => void
+}) {
+  const latestRun = projection.latestRun
+
+  return (
+    <CollectionCardButton onClick={onSelect}>
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+        <Layers className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <p className="truncate text-sm font-medium text-foreground">
+            {projectionName(projection)}
+          </p>
+          <KindBadge kind={projectionKind(projection)} />
+        </div>
+        <p className="mt-0.5 truncate text-xs text-muted-foreground">{projection.datasetId}</p>
+      </div>
+      {latestRun ? (
+        <div className="hidden shrink-0 flex-col items-end gap-1 sm:flex">
+          <RunStatusBadge status={latestRun.status} />
+          <span className="text-xs text-muted-foreground">
+            {formatRelativeTime(latestRun.startedAt)}
+          </span>
+        </div>
+      ) : (
+        <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">No runs</span>
+      )}
+    </CollectionCardButton>
+  )
+}
+
+function ProjectionTableView({
+  projections,
+  onSelect,
+}: {
+  projections: Projection[]
+  onSelect: (projectionId: string) => void
+}) {
+  return (
+    <Card className="overflow-hidden p-0">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Projection</TableHead>
+            <TableHead className="hidden sm:table-cell">Kind</TableHead>
+            <TableHead className="hidden md:table-cell">Dataset</TableHead>
+            <TableHead>Latest Run</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {projections.map((projection) => (
+            <TableRow
+              key={projection.id}
+              onClick={() => onSelect(projection.id)}
+              className="cursor-pointer"
+            >
+              <TableCell>
+                <div className="flex min-w-0 items-center gap-2">
+                  <Layers className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {projectionName(projection)}
+                  </p>
+                </div>
+              </TableCell>
+              <TableCell className="hidden sm:table-cell">
+                <KindBadge kind={projectionKind(projection)} />
+              </TableCell>
+              <TableCell className="hidden font-mono text-xs text-muted-foreground md:table-cell">
+                {projection.datasetId}
+              </TableCell>
+              <TableCell>
+                {projection.latestRun ? (
+                  <div className="flex flex-col items-start gap-1">
+                    <RunStatusBadge status={projection.latestRun.status} />
+                    <span className="text-xs text-muted-foreground">
+                      {formatRelativeTime(projection.latestRun.startedAt)}
+                    </span>
+                  </div>
+                ) : (
+                  <span className="text-xs text-muted-foreground">No runs</span>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Card>
+  )
+}
+
+export function ProjectionsPage() {
+  const { data, isLoading, isError } = useQuery(listProjectionsOptions())
+  const navigate = useNavigate()
+  const [searchQuery, setSearchQuery] = useState("")
+  const [viewStyle, setViewStyle] = useState<ListViewStyle>(() =>
+    getCollectionViewStyle("projections", ["cards", "table"], "cards")
+  )
+
+  const projections = useMemo<Projection[]>(
+    () => [
+      ...(data?.objectProjections ?? []),
+      ...(data?.linkProjections ?? []),
+      ...(data?.telemetryProjections ?? []),
+    ],
+    [data]
+  )
+
+  const filteredProjections = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+    if (!query) return projections
+
+    return projections.filter((projection) =>
+      [
+        projection.id,
+        projectionKind(projection),
+        projection.datasetId,
+        projection.latestRun?.status ?? "",
+      ].some((value) => value.toLowerCase().includes(query))
+    )
+  }, [projections, searchQuery])
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center py-24">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span className="text-sm">Loading projections...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <div className="w-full max-w-md rounded-lg border border-border bg-card p-6">
+          <EmptyState
+            icon={<Layers className="h-10 w-10" />}
+            title="Projections unavailable"
+            description="Could not load projection metadata."
+          />
+        </div>
+      </div>
+    )
+  }
+
+  const handleSelect = (projectionId: string) => {
+    navigate(`/projections/${encodeURIComponent(projectionId)}`)
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl">
+      <CollectionHeader
+        title="Projections"
+        count={filteredProjections.length}
+        actions={
+          projections.length > 0 ? (
+            <CollectionViewToggle
+              value={viewStyle}
+              options={listViewOptions}
+              onChange={(style) => {
+                setViewStyle(style)
+                setCollectionViewStyle("projections", style)
+              }}
+            />
+          ) : null
+        }
+      />
+
+      {projections.length > 0 && (
+        <div className="relative mt-2">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="text"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search projections, kinds, or datasets..."
+            className="pl-9"
+          />
+        </div>
+      )}
+
+      <div className="mt-4">
+        {projections.length === 0 ? (
+          <EmptyState
+            icon={<Layers className="h-10 w-10" />}
+            title="No projections"
+            description="Registered projections will appear here."
+          />
+        ) : filteredProjections.length === 0 ? (
+          <EmptyState
+            icon={<Search className="h-9 w-9" />}
+            title="No results"
+            description="Try another search."
+            className="py-12"
+          />
+        ) : viewStyle === "table" ? (
+          <ProjectionTableView projections={filteredProjections} onSelect={handleSelect} />
+        ) : (
+          <CollectionCardGrid>
+            {filteredProjections.map((projection) => (
+              <ProjectionListItem
+                key={projection.id}
+                projection={projection}
+                onSelect={() => handleSelect(projection.id)}
+              />
+            ))}
+          </CollectionCardGrid>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DetailSurface({
+  title,
+  trailing,
+  children,
+}: {
+  title: string
+  trailing?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <section className="min-w-0 max-w-full overflow-hidden rounded-lg border border-border bg-card px-4 py-5 sm:px-5">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold tracking-normal text-foreground">{title}</h2>
+        {trailing}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function MetricTile({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="min-w-0 px-4 py-3">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <div className="mt-1 min-w-0 text-sm text-foreground">{children}</div>
+    </div>
+  )
+}
+
+function LatestRunSummary({ run }: { run: ProjectionRun | null }) {
+  const metric = run ? primaryMetric(run) : null
+  const dash = <span className="text-muted-foreground">—</span>
+
+  return (
+    <div className="grid overflow-hidden rounded-lg border border-border bg-card sm:grid-cols-2 sm:divide-x sm:divide-border/60 lg:grid-cols-4">
+      <MetricTile label="Latest run">
+        {run ? (
+          <RunStatusBadge status={run.status} />
+        ) : (
+          <span className="text-muted-foreground">No runs yet</span>
+        )}
+      </MetricTile>
+      <MetricTile label="Started">{run ? formatRelativeTime(run.startedAt) : dash}</MetricTile>
+      <MetricTile label="Duration">
+        {run ? <span className="tabular-nums">{runDuration(run)}</span> : dash}
+      </MetricTile>
+      <MetricTile label={metric?.label ?? "Processed"}>
+        {metric ? <span className="tabular-nums">{metric.value.toLocaleString()}</span> : dash}
+      </MetricTile>
+    </div>
+  )
+}
+
+function ProjectionRunList({ runs }: { runs: ProjectionRun[] }) {
+  if (runs.length === 0) {
+    return (
+      <EmptyState
+        icon={<Clock3 className="h-10 w-10" />}
+        title="No runs yet"
+        description="Runs appear here after the projection's dataset is committed."
+        className="py-10"
+      />
+    )
+  }
+
+  const metricLabels = runMetrics(runs[0]).map((metric) => metric.label)
+  const headCell = "whitespace-nowrap pb-2 text-xs font-medium text-muted-foreground"
+  const numCell = "px-3 py-3 text-right tabular-nums text-foreground"
+
+  return (
+    <>
+      {/* Desktop: dense, scannable run-history table. */}
+      <div className="-mx-1 hidden max-h-[460px] overflow-auto px-1 md:block">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="sticky top-0 z-10 border-b border-border bg-card">
+              <th className={cn(headCell, "pr-3")}>Status</th>
+              <th className={cn(headCell, "px-3")}>Run</th>
+              <th className={cn(headCell, "px-3")}>Started</th>
+              <th className={cn(headCell, "px-3 text-right")}>Duration</th>
+              {metricLabels.map((label) => (
+                <th key={label} className={cn(headCell, "px-3 text-right")}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/60">
+            {runs.map((run) => (
+              <tr key={run.id} className="align-top transition-colors hover:bg-muted/40">
+                <td className="py-3 pr-3">
+                  <RunStatusBadge status={run.status} />
+                </td>
+                <td className="px-3 py-3">
+                  <p className="font-mono text-xs text-foreground" title={run.id}>
+                    {shortRunId(run.id)}
+                  </p>
+                  <p
+                    className="mt-0.5 max-w-[180px] truncate font-mono text-xs text-muted-foreground"
+                    title={run.datasetVersionId}
+                  >
+                    {run.datasetVersionId}
+                  </p>
+                  {run.errorMessage && (
+                    <p className="mt-1 break-words text-xs text-destructive">{run.errorMessage}</p>
+                  )}
+                </td>
+                <td className="whitespace-nowrap px-3 py-3 text-muted-foreground">
+                  {formatRelativeTime(run.startedAt)}
+                </td>
+                <td className={cn(numCell, "text-muted-foreground")}>{runDuration(run)}</td>
+                {runMetrics(run).map((metric) => (
+                  <td
+                    key={metric.label}
+                    className={cn(
+                      numCell,
+                      metric.label === "Failed" && metric.value > 0 && "text-destructive"
+                    )}
+                  >
+                    {metric.value.toLocaleString()}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile: stacked, divided rows. */}
+      <div className="divide-y divide-border/60 md:hidden">
+        {runs.map((run) => (
+          <div key={run.id} className="py-3 first:pt-0">
+            <div className="flex items-center justify-between gap-2">
+              <RunStatusBadge status={run.status} />
+              <span className="text-xs text-muted-foreground">
+                {formatRelativeTime(run.startedAt)}
+              </span>
+            </div>
+            <p className="mt-2 font-mono text-xs text-foreground" title={run.id}>
+              {shortRunId(run.id)}
+            </p>
+            <p
+              className="truncate font-mono text-xs text-muted-foreground"
+              title={run.datasetVersionId}
+            >
+              {run.datasetVersionId}
+            </p>
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground tabular-nums">
+              <span>{runDuration(run)}</span>
+              {runMetrics(run).map((metric) => (
+                <span key={metric.label}>
+                  {metric.value.toLocaleString()} {metric.label.toLowerCase()}
+                </span>
+              ))}
+            </div>
+            {run.errorMessage && (
+              <p className="mt-2 break-words text-xs text-destructive">{run.errorMessage}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}
+
+function Mono({ value, muted }: { value: string; muted?: boolean }) {
+  return <span className={cn("font-mono text-xs", muted && "text-muted-foreground")}>{value}</span>
+}
+
+function MappingTable({
+  columns,
+  rows,
+}: {
+  columns: string[]
+  rows: { key: string; cells: React.ReactNode[] }[]
+}) {
+  return (
+    <table className="w-full text-left text-sm">
+      <thead>
+        <tr className="border-b border-border">
+          {columns.map((column, index) => (
+            <th
+              key={column}
+              className={cn(
+                "pb-2 text-xs font-medium text-muted-foreground",
+                index === 0 ? "pr-3" : "px-3"
+              )}
+            >
+              {column}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border/60">
+        {rows.map((row) => (
+          <tr key={row.key}>
+            {row.cells.map((cell, index) => (
+              <td
+                key={columns[index]}
+                className={cn("py-2.5 align-top text-foreground", index === 0 ? "pr-3" : "px-3")}
+              >
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function FlowChip({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  onClick?: () => void
+}) {
+  const className = cn(
+    "inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1",
+    onClick && "transition-colors hover:bg-muted/50"
+  )
+  const content = (
+    <>
+      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="truncate font-mono text-xs text-foreground">{label}</span>
+    </>
+  )
+  return onClick ? (
+    <button type="button" onClick={onClick} className={className}>
+      {content}
+    </button>
+  ) : (
+    <span className={className}>{content}</span>
+  )
+}
+
+function FlowArrow() {
+  return <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+}
+
+// Source dataset → target object type (and, for telemetry/links, the precise
+// target property or relationship) — the projection's purpose at a glance.
+function ProjectionFlow({ projection }: { projection: GetProjectionResponse }) {
+  const navigate = useNavigate()
+  const toType = (id: string) => navigate(`/ontology/${encodeURIComponent(id)}`)
+  const dataset = (
+    <FlowChip
+      icon={Database}
+      label={projection.datasetId}
+      onClick={() => navigate(`/datasets/${encodeURIComponent(projection.datasetId)}`)}
+    />
+  )
+
+  if (projection._tag === "LinkProjectionDefinition") {
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        {dataset}
+        <FlowArrow />
+        <FlowChip
+          icon={Box}
+          label={projection.sourceObjectTypeId}
+          onClick={() => toType(projection.sourceObjectTypeId)}
+        />
+        <Mono value={projection.linkId} muted />
+        <FlowArrow />
+        <FlowChip
+          icon={Box}
+          label={projection.targetObjectTypeId}
+          onClick={() => toType(projection.targetObjectTypeId)}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {dataset}
+      <FlowArrow />
+      <FlowChip
+        icon={Box}
+        label={projection.objectTypeId}
+        onClick={() => toType(projection.objectTypeId)}
+      />
+      {projection._tag === "TelemetryProjectionDefinition" && (
+        <Mono value={`· ${projection.propertyId}`} muted />
+      )}
+    </div>
+  )
+}
+
+// Shows how dataset columns map onto the projected target, per projection kind.
+function ProjectionMapping({ projection }: { projection: GetProjectionResponse }) {
+  if (projection._tag === "ObjectProjectionDefinition") {
+    const properties = Object.entries(projection.properties)
+    const links = Object.entries(projection.links)
+    const propertiesTable = (
+      <MappingTable
+        columns={["Object property", "Dataset column"]}
+        rows={properties.map(([property, column]) => ({
+          key: property,
+          cells: [<Mono key="p" value={property} />, <Mono key="c" value={column} muted />],
+        }))}
+      />
+    )
+
+    // No links → the properties table is the whole mapping; keep it readable
+    // rather than stretched across the card.
+    if (links.length === 0) {
+      return <div className="max-w-xl">{propertiesTable}</div>
+    }
+
+    // Two self-describing tables side by side — the column headers ("Object
+    // property" vs "Link") identify each, so no extra section headings.
+    return (
+      <div className="grid gap-x-8 gap-y-6 md:grid-cols-2">
+        <div className="min-w-0">{propertiesTable}</div>
+        <div className="min-w-0">
+          <MappingTable
+            columns={["Link", "Target type", "From column"]}
+            rows={links.map(([linkId, descriptor]) => ({
+              key: linkId,
+              cells: [
+                <Mono key="l" value={linkId} />,
+                <Mono key="t" value={descriptor.targetObjectTypeId} />,
+                <Mono
+                  key="f"
+                  value={descriptor.sourceField ?? descriptor.sourcePropertyId ?? "—"}
+                  muted
+                />,
+              ],
+            }))}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (projection._tag === "LinkProjectionDefinition") {
+    return (
+      <div className="max-w-xl">
+        <MappingTable
+          columns={["Endpoint", "Object type", "Match column"]}
+          rows={[
+            {
+              key: "source",
+              cells: [
+                "Source",
+                <Mono key="t" value={projection.sourceObjectTypeId} />,
+                <Mono key="c" value={projection.sourceField} muted />,
+              ],
+            },
+            {
+              key: "target",
+              cells: [
+                "Target",
+                <Mono key="t" value={projection.targetObjectTypeId} />,
+                <Mono key="c" value={projection.targetField} muted />,
+              ],
+            },
+          ]}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-md">
+      <MappingTable
+        columns={["Point field", "Dataset column"]}
+        rows={[
+          {
+            key: "objectId",
+            cells: ["Object id", <Mono key="c" value={projection.objectIdField} muted />],
+          },
+          { key: "at", cells: ["Timestamp", <Mono key="c" value={projection.atField} muted />] },
+          { key: "value", cells: ["Value", <Mono key="c" value={projection.valueField} muted />] },
+          {
+            key: "unit",
+            cells: [
+              "Unit",
+              projection.unitField ? (
+                <Mono key="c" value={projection.unitField} muted />
+              ) : (
+                <span key="c" className="text-muted-foreground">
+                  —
+                </span>
+              ),
+            ],
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+export function ProjectionDetailPage() {
+  const { projectionId = "" } = useParams()
+  const navigate = useNavigate()
+  const decodedId = decodeURIComponent(projectionId)
+
+  const projectionQuery = useQuery({
+    ...getProjectionOptions({ path: { projectionId: decodedId } }),
+    enabled: decodedId.length > 0,
+  })
+
+  const runsQuery = useQuery({
+    ...listProjectionRunsOptions({
+      query: { projectionId: decodedId, limit: "20", order: "desc" },
+    }),
+    enabled: decodedId.length > 0,
+    refetchInterval: 5000,
+  })
+
+  const projection = projectionQuery.data
+  const runs = runsQuery.data?.runs ?? []
+  const latestRun = runs[0] ?? projection?.latestRun ?? null
+
+  if (projectionQuery.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center py-24">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span className="text-sm">Loading projection...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (projectionQuery.isError || !projection) {
+    return (
+      <div className="mx-auto w-full max-w-2xl space-y-4">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate("/projections")}
+          className="-ml-2 text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft />
+          Projections
+        </Button>
+        <div className="rounded-lg border border-border bg-card p-8">
+          <EmptyState
+            icon={<Layers className="h-10 w-10" />}
+            title="Projection not found"
+            description="This projection is not registered in the active Sixb runtime."
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto w-full min-w-0 max-w-5xl space-y-4 overflow-hidden">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => navigate("/projections")}
+        className="-ml-2 self-start text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft />
+        Projections
+      </Button>
+
+      <header className="min-w-0">
+        <div className="flex items-center gap-2">
+          <p className="text-sm text-muted-foreground">
+            {KIND_LABEL[projectionKind(projection)]} projection
+          </p>
+          <KindBadge kind={projectionKind(projection)} />
+        </div>
+        <h1 className="mt-1 text-2xl font-semibold tracking-normal text-foreground sm:text-3xl">
+          {projectionName(projection)}
+        </h1>
+        <p className="mt-2 break-all font-mono text-xs text-muted-foreground">{projection.id}</p>
+        <div className="mt-3">
+          <ProjectionFlow projection={projection} />
+        </div>
+      </header>
+
+      <LatestRunSummary run={latestRun} />
+
+      <DetailSurface title="Field mapping">
+        <ProjectionMapping projection={projection} />
+      </DetailSurface>
+
+      <DetailSurface
+        title="Recent Runs"
+        trailing={
+          runs.length > 0 ? (
+            <span className="tabular-nums text-xs text-muted-foreground">
+              {runs.length} {runs.length === 1 ? "run" : "runs"}
+            </span>
+          ) : undefined
+        }
+      >
+        {runsQuery.isLoading ? (
+          <div className="py-10">
+            <div className="flex items-center gap-3 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              <span className="text-sm">Loading runs...</span>
+            </div>
+          </div>
+        ) : runsQuery.isError ? (
+          <EmptyState
+            icon={<Clock3 className="h-10 w-10" />}
+            title="Runs unavailable"
+            description="Could not load projection run history."
+            className="py-8"
+          />
+        ) : (
+          <ProjectionRunList runs={runs} />
+        )}
+      </DetailSurface>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds the Projections section to Atlas: a list of projection definitions with their latest run, and a detail page that showcases the field mapping and run history. Consumes the read API from the stacked base PR.

> Stacked on `projection-runs-api` — merge that first.

## Pages

- **Projections list** — every projection with a kind badge (object / link / telemetry) and latest-run status; card or table view.
- **Projection detail** — three parts:
  - a `dataset → object type` flow header,
  - **Field mapping** — the actual column-to-target mapping per kind (object properties + links, link endpoints, or telemetry point fields) instead of bare counts,
  - **Recent runs** — a run-history table with kind-specific counters (points/skipped/failed, rows/objects, rows/links).

## Also here (UI-wide, not projection-specific)

- **Sidebar** reordered to follow the data → model → behavior hierarchy, with the new Projections entry:

  `Connectors · Datasets · Syncs · Pipelines · Projections · Ontology · Objects · Actions · Workflows · Rules · Settings`

- **Page-width consistency** — `PageFrame` now caps content at `max-w-5xl` (was `7xl`) and the Actions routes moved out of the double-padded wrapper, so Actions / Workflows / Run-detail match every other page's margins.

## Tests

| Check | Result |
|---|---|
| atlas typecheck | pass |
| build (browser bundle) | pass |
| biome check | clean |

## Notes

Field-mapping data comes straight from the projection definition. Dataset column *types* aren't shown — they live one click away on the dataset page — a possible follow-up.

<img width="1158" height="1011" alt="Screenshot 2026-06-23 at 8 46 11 PM" src="https://github.com/user-attachments/assets/1a15f63f-db12-4493-a318-fdba27a379c4" />

