### PR TITLE
objects/query: type expanded client links

### DIFF
--- a/docs/concepts/ontology.md
+++ b/docs/concepts/ontology.md
@@ -164,24 +164,37 @@ export const Customer = defineObjectType({
 })
 ```
 
-`link(...)` takes these parameters:
+For links to object types you can import directly, use `link(...)`:
+
+```ts
+link("belongsTo", Organization)
+link("relatedTo", [Organization, Customer])
+```
+
+For id references, self-links, or intentionally open links, use the explicit helpers:
+
+```ts
+link.ref("belongsTo", "Organization")
+link.self("parent", { cardinality: "one" })
+link.any("relatedTo", { cardinality: "many" })
+```
+
+Use `link.ref(...)` when you want to reference another object type by id instead of importing it.
+Sixb's generated ontology type manifest lets typed client queries resolve those ids.
+
+Use `link.self(...)` for recursive relationships such as folders, org charts, or threaded
+comments. The target id is filled in from the object type that declares the link.
+
+Use `link.any(...)` only for wildcard relationships that can point to any object type. Prefer a
+specific target for relationships your app understands.
+
+All link forms take these parameters:
 
 | Parameter | Required | Expected |
 | --- | --- | --- |
 | `id` | Yes | A stable relationship key, unique within the source object type |
-| `target` | No | The object type this link can point to |
+| `target` | Depends on helper | The object type or object type id this link can point to |
 | `options` | No | An object for metadata and relationship behavior |
-
-The `target` can be an object type, an object type id, or an array of allowed object types or ids:
-
-```ts
-link("belongsTo", Organization)
-link("belongsTo", "Organization")
-link("relatedTo", [Organization, Customer])
-```
-
-When the target is omitted or set to `"*"`, the link is a wildcard link and can point to any
-object type. Prefer a specific target for relationships your app understands.
 
 `options` accepts these fields:
 

--- a/examples/acme-corp/app/projects/page.tsx
+++ b/examples/acme-corp/app/projects/page.tsx
@@ -1,13 +1,24 @@
 import { useObjectsFacets, useObjectsQuery } from "@sixb/client/hooks"
 import { objects } from "@sixb/client/query"
-import type { TwinObject } from "@sixb/core/query"
 import { useState } from "react"
+import { Customer } from "../../ontology/customer"
+import { Employee } from "../../ontology/employee"
 import { Project } from "../../ontology/project"
 
-type ProjectRow = TwinObject<typeof Project, readonly []>
 type ProjectStatus = "draft" | "active" | "paused" | "completed" | "cancelled"
+type QueryRow<TQuery> = TQuery extends { first(): Promise<infer TRow> } ? NonNullable<TRow> : never
 
-const allProjects = objects(Project).query().orderBy(Project.p.deadline, "asc")
+const allProjects = objects(Project)
+  .query()
+  .expand(Project.l.customer, (customer) => customer.expand(Customer.l.accountManager))
+  .expand(Project.l.lead, (lead) => lead.expand(Employee.l.department))
+  .expand(Project.l.members, {
+    limit: 4,
+    orderBy: [{ property: Employee.p.name, direction: "asc" }],
+  })
+  .orderBy(Project.p.deadline, "asc")
+
+type ProjectRow = QueryRow<typeof allProjects>
 
 function formatBudget(value: unknown): string {
   return typeof value === "number"
@@ -24,7 +35,20 @@ function titleCase(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
+function memberSummary(members: ProjectRow["links"]["members"]): string {
+  if (members.length === 0) return "No assigned members"
+  const names = members.map((member) => member.properties.name)
+  return names.length < 4
+    ? names.join(", ")
+    : `${names.slice(0, 3).join(", ")} +${names.length - 3}`
+}
+
 function ProjectCard({ project }: { project: ProjectRow }) {
+  const customer = project.links.customer
+  const accountManager = customer?.links.accountManager
+  const lead = project.links.lead
+  const department = lead?.links.department
+
   return (
     <article className="grid grid-cols-[minmax(0,1fr)_auto] gap-4 rounded-lg border bg-card p-4 shadow-sm transition hover:-translate-y-px hover:border-primary max-md:grid-cols-1">
       <div>
@@ -35,6 +59,24 @@ function ProjectCard({ project }: { project: ProjectRow }) {
         <p className="mt-2 max-w-3xl leading-snug text-muted-foreground">
           {project.properties.description ?? "No description."}
         </p>
+        <dl className="mt-4 grid gap-3 text-sm text-muted-foreground sm:grid-cols-3">
+          <div>
+            <dt className="text-xs font-bold tracking-wide text-foreground uppercase">Customer</dt>
+            <dd className="mt-1 text-foreground">{customer?.properties.company ?? "Unassigned"}</dd>
+            <dd className="text-xs">
+              {accountManager ? `AM: ${accountManager.properties.name}` : "No account manager"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-bold tracking-wide text-foreground uppercase">Lead</dt>
+            <dd className="mt-1 text-foreground">{lead?.properties.name ?? "Unassigned"}</dd>
+            <dd className="text-xs">{department?.properties.name ?? "No department"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-bold tracking-wide text-foreground uppercase">Team</dt>
+            <dd className="mt-1 text-foreground">{memberSummary(project.links.members)}</dd>
+          </div>
+        </dl>
       </div>
       <div className="grid min-w-44 content-center gap-1.5 text-right text-sm text-muted-foreground max-md:min-w-0 max-md:text-left">
         <span>{formatBudget(project.properties.budget)}</span>

--- a/examples/acme-corp/package.json
+++ b/examples/acme-corp/package.json
@@ -8,7 +8,7 @@
     "check": "bun ../../packages/cli/src/index.tsx check",
     "sync:erp": "bun scripts/sync-erp.ts",
     "webhooks:demo": "bun scripts/send-webhooks.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bun ../../packages/cli/src/index.tsx typegen && tsc --noEmit"
   },
   "dependencies": {
     "@sixb/app": "workspace:*",

--- a/examples/acme-corp/tests/client-query.test.ts
+++ b/examples/acme-corp/tests/client-query.test.ts
@@ -18,6 +18,7 @@ import {
 import { SixbServer } from "@sixb/server"
 import { SqliteStorage } from "@sixb/sqlite"
 import { Customer } from "../ontology/customer"
+import { Department } from "../ontology/department"
 import { Employee } from "../ontology/employee"
 import { Invoice } from "../ontology/invoice"
 import { Project } from "../ontology/project"
@@ -55,7 +56,7 @@ const storage = new SqliteStorage()
 
 const sixb = createSixbInstance({
   id: "acme-client-query-e2e",
-  ontology: [Project, Customer, Employee, Invoice] as const,
+  ontology: [Project, Customer, Employee, Invoice, Department] as const,
   broker: new InMemoryBroker(),
   storage,
   lakeStorage: new InMemoryLakeStorage(),
@@ -67,6 +68,53 @@ let server: SixbServer
 let previousBaseUrl: string | undefined
 
 beforeAll(async () => {
+  await sixb.objects(Department).upsert({
+    properties: { id: "dept-delivery", name: "Delivery", code: "DEL" },
+  })
+  await sixb.objects(Department).upsert({
+    properties: { id: "dept-success", name: "Customer Success", code: "CS" },
+  })
+
+  const employees = [
+    {
+      id: "emp-account",
+      name: "Ada Account",
+      email: "ada@acme.test",
+      role: "Account Manager",
+      department: "dept-success",
+    },
+    {
+      id: "emp-lead",
+      name: "Lena Lead",
+      email: "lena@acme.test",
+      role: "Project Lead",
+      department: "dept-delivery",
+    },
+    {
+      id: "emp-builder",
+      name: "Ben Builder",
+      email: "ben@acme.test",
+      role: "Engineer",
+      department: "dept-delivery",
+    },
+  ] as const
+  for (const employee of employees) {
+    await sixb.objects(Employee).upsert({
+      properties: {
+        id: employee.id,
+        name: employee.name,
+        email: employee.email,
+        role: employee.role,
+      },
+    })
+    await sixb.objects(Employee).upsertLink({
+      sourceId: employee.id,
+      linkId: "department",
+      targetTypeId: Department.id,
+      targetId: employee.department,
+    })
+  }
+
   await sixb.objects(Customer).upsert({
     properties: {
       id: "cust-001",
@@ -75,6 +123,12 @@ beforeAll(async () => {
       company: "Globex",
       tier: "gold",
     },
+  })
+  await sixb.objects(Customer).upsertLink({
+    sourceId: "cust-001",
+    linkId: "accountManager",
+    targetTypeId: Employee.id,
+    targetId: "emp-account",
   })
 
   const projects = [
@@ -109,6 +163,20 @@ beforeAll(async () => {
       linkId: "customer",
       targetTypeId: Customer.id,
       targetId: "cust-001",
+    })
+  }
+  await sixb.objects(Project).upsertLink({
+    sourceId: "proj-001",
+    linkId: "lead",
+    targetTypeId: Employee.id,
+    targetId: "emp-lead",
+  })
+  for (const employeeId of ["emp-lead", "emp-builder"]) {
+    await sixb.objects(Project).upsertLink({
+      sourceId: "proj-001",
+      linkId: "members",
+      targetTypeId: Employee.id,
+      targetId: employeeId,
     })
   }
 
@@ -185,6 +253,30 @@ describe("client object queries against a live server", () => {
     expect(primaryIds(viaHttp.objects)).toEqual(primaryIds(viaRuntime.objects))
     expect(viaHttp.objects[0]?.properties.name).toBe("Energy Dashboard")
     expect(viaHttp.objects[0]?.createdAt).toBeInstanceOf(Date)
+  })
+
+  test("expands the real projects page graph", async () => {
+    const project = await objects(Project)
+      .query()
+      .where((project) => project.p.id.eq("proj-001"))
+      .expand(Project.l.customer, (customer) => customer.expand(Customer.l.accountManager))
+      .expand(Project.l.lead, (lead) => lead.expand(Employee.l.department))
+      .expand(Project.l.members, {
+        limit: 2,
+        orderBy: [{ property: Employee.p.name, direction: "asc" }],
+      })
+      .first()
+
+    expect(project?.links.customer?.properties.company).toBe("Globex")
+    expect(project?.links.customer?.links.accountManager?.properties.name).toBe("Ada Account")
+    expect(project?.links.lead?.properties.name).toBe("Lena Lead")
+    expect(project?.links.lead?.links.department?.properties.name).toBe("Delivery")
+
+    const memberNames: string[] = []
+    for (const member of project?.links.members ?? []) {
+      memberNames.push(member.properties.name)
+    }
+    expect(memberNames).toEqual(["Ben Builder", "Lena Lead"])
   })
 
   test("Date predicate values survive the JSON wire format", async () => {

--- a/examples/acme-corp/tsconfig.json
+++ b/examples/acme-corp/tsconfig.json
@@ -23,6 +23,7 @@
     "syncs/**/*.ts",
     "tests/**/*.ts",
     "workflows/**/*.ts",
-    "sixb.config.ts"
+    "sixb.config.ts",
+    ".sixb/types/**/*.d.ts"
   ]
 }

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -7,7 +7,7 @@
     "build": "bun ../../packages/cli/src/index.tsx build",
     "start": "bun ../../packages/cli/src/index.tsx start",
     "check": "bun ../../packages/cli/src/index.tsx check",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bun ../../packages/cli/src/index.tsx typegen && tsc --noEmit"
   },
   "dependencies": {
     "@sixb/auth-magic-link": "workspace:*",

--- a/examples/auth/tsconfig.json
+++ b/examples/auth/tsconfig.json
@@ -5,5 +5,5 @@
     "incremental": true,
     "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
   },
-  "include": ["ontology/**/*.ts", "security/**/*.ts", "sixb.config.ts"]
+  "include": ["ontology/**/*.ts", "security/**/*.ts", "sixb.config.ts", ".sixb/types/**/*.d.ts"]
 }

--- a/examples/panasonic-ac/package.json
+++ b/examples/panasonic-ac/package.json
@@ -6,7 +6,7 @@
     "dev": "bun ../../packages/cli/src/index.tsx dev",
     "build": "bun ../../packages/cli/src/index.tsx build",
     "check": "bun ../../packages/cli/src/index.tsx check",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bun ../../packages/cli/src/index.tsx typegen && tsc --noEmit"
   },
   "dependencies": {
     "@sixb/app": "workspace:*",

--- a/examples/panasonic-ac/tsconfig.json
+++ b/examples/panasonic-ac/tsconfig.json
@@ -14,6 +14,7 @@
     "functions/**/*.ts",
     "lib/**/*.ts",
     "connectors/**/*.ts",
-    "sixb.config.ts"
+    "sixb.config.ts",
+    ".sixb/types/**/*.d.ts"
   ]
 }

--- a/examples/roku-tv/package.json
+++ b/examples/roku-tv/package.json
@@ -6,7 +6,7 @@
     "dev": "bun ../../packages/cli/src/index.tsx dev",
     "build": "bun ../../packages/cli/src/index.tsx build",
     "check": "bun ../../packages/cli/src/index.tsx check",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "bun ../../packages/cli/src/index.tsx typegen && tsc --noEmit"
   },
   "dependencies": {
     "@sixb/app": "workspace:*",

--- a/examples/roku-tv/tsconfig.json
+++ b/examples/roku-tv/tsconfig.json
@@ -15,6 +15,7 @@
     "lib/**/*.ts",
     "ontology/**/*.ts",
     "pipelines/**/*.ts",
-    "sixb.config.ts"
+    "sixb.config.ts",
+    ".sixb/types/**/*.d.ts"
   ]
 }

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -27,7 +27,7 @@ const Device = defineObjectType({
     prop("name", "string", { required: true }),
     prop("status", "string"),
   ],
-  links: [link("sensor", "Sensor", { cardinality: "one" })],
+  links: [link.ref("sensor", "Sensor", { cardinality: "one" })],
 })
 
 const Sensor = defineObjectType({

--- a/packages/cli/src/commands/build.tsx
+++ b/packages/cli/src/commands/build.tsx
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
 import { createCustomApp } from "@sixb/app"
 import { buildAtlasAssets } from "@sixb/atlas"
+import { generateProjectTypes } from "../lib/typegen"
 import { BuildView, ErrorView, renderStatic } from "../ui"
 
 export interface BuildOptions {
@@ -14,6 +15,7 @@ export async function runBuild(options: BuildOptions = {}) {
   const outdir = resolve(options.outdir ?? ".sixb/dist")
   const projectRoot = dirname(entry)
 
+  await generateProjectTypes({ entry })
   await mkdir(outdir, { recursive: true })
 
   // Build sixb.config.ts

--- a/packages/cli/src/commands/check.tsx
+++ b/packages/cli/src/commands/check.tsx
@@ -1,5 +1,6 @@
 import { resolve } from "node:path"
 import { loadSixbFromEntry } from "../lib/loadSixb"
+import { generateProjectTypes } from "../lib/typegen"
 import { CheckView, renderStatic } from "../ui"
 
 export interface CheckOptions {
@@ -8,6 +9,7 @@ export interface CheckOptions {
 
 export async function runCheck(options: CheckOptions = {}) {
   const entry = resolve(options.entry ?? "sixb.config.ts")
+  await generateProjectTypes({ entry })
   const sixb = await loadSixbFromEntry(entry)
   const objectTypes = sixb.listObjectTypes()
 

--- a/packages/cli/src/commands/dev.tsx
+++ b/packages/cli/src/commands/dev.tsx
@@ -5,6 +5,7 @@ import { createSixbServer, type SixbServer } from "@sixb/server"
 import { apiDocsUrl, apiEventsUrl, apiUrl, resolveBrowserTopology } from "../lib/browser-topology"
 import { type LoadedSixb, loadSixbFromEntry } from "../lib/loadSixb"
 import { runUntilSignal, startSixbRuntime, stopQuietly } from "../lib/runtime"
+import { generateProjectTypes } from "../lib/typegen"
 import { DevView, ErrorView, LoadingView, renderPersistent, renderStatic } from "../ui"
 
 export interface DevOptions {
@@ -35,6 +36,7 @@ export async function runDev(options: DevOptions = {}) {
   let runtime: Awaited<ReturnType<typeof startSixbRuntime>> | null = null
 
   try {
+    await generateProjectTypes({ entry })
     sixb = await loadSixbFromEntry(entry)
     const projectRoot = dirname(resolve(entry))
 

--- a/packages/cli/src/commands/typegen.tsx
+++ b/packages/cli/src/commands/typegen.tsx
@@ -1,0 +1,18 @@
+import { generateProjectTypes } from "../lib/typegen"
+import { renderStatic, TypegenView } from "../ui"
+
+export interface TypegenOptions {
+  entry?: string
+}
+
+export async function runTypegen(options: TypegenOptions = {}) {
+  const result = await generateProjectTypes(options)
+  await renderStatic(
+    <TypegenView
+      path={result.path}
+      objectTypes={result.entries.length}
+      skipped={result.skipped}
+      written={result.written}
+    />
+  )
+}

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -206,6 +206,12 @@ async function main(): Promise<void> {
       break
     }
 
+    case "typegen": {
+      const { runTypegen } = await import("./commands/typegen")
+      await runTypegen({ entry: getFlag("entry") })
+      break
+    }
+
     case "build": {
       const { runBuild } = await import("./commands/build")
       await runBuild({ entry: getFlag("entry"), outdir: getFlag("outdir") })

--- a/packages/cli/src/lib/typegen.ts
+++ b/packages/cli/src/lib/typegen.ts
@@ -1,0 +1,12 @@
+import { dirname, resolve } from "node:path"
+import { generateOntologyTypeManifest } from "@sixb/core"
+
+export interface GenerateProjectTypesOptions {
+  readonly entry?: string
+}
+
+export async function generateProjectTypes(options: GenerateProjectTypesOptions = {}) {
+  const entry = resolve(options.entry ?? "sixb.config.ts")
+  const projectRoot = dirname(entry)
+  return generateOntologyTypeManifest({ projectRoot })
+}

--- a/packages/cli/src/ui/index.tsx
+++ b/packages/cli/src/ui/index.tsx
@@ -180,6 +180,7 @@ export function HelpView({ errorMessage }: { errorMessage?: string }) {
             value: "Co-host multiple queue workers in one process (constrained resources)",
           },
           { label: "check", value: "Validate project configuration and health" },
+          { label: "typegen", value: "Generate ontology types for client query inference" },
           { label: "build", value: "Build runtime and production UI/app assets" },
           { label: "db migrate", value: "Run adapter-owned database migrations" },
           { label: "lake check", value: "Check lake dataset definitions for drift" },
@@ -228,6 +229,7 @@ export function HelpView({ errorMessage }: { errorMessage?: string }) {
           "sixb worker-group sync pipeline projection",
           "sixb dev --entry examples/mac-os/sixb.config.ts --port 8080",
           "sixb check",
+          "sixb typegen",
           "sixb db migrate",
           "sixb lake check",
           "sixb lake cleanup --dry-run",
@@ -587,6 +589,33 @@ export function BuildView({ entry, outdir }: { entry: string; outdir: string }) 
         items={[
           { label: "Entry", value: entry },
           { label: "Output", value: outdir },
+        ]}
+      />
+    </Box>
+  )
+}
+
+export function TypegenView({
+  path,
+  objectTypes,
+  skipped,
+  written,
+}: {
+  path: string
+  objectTypes: number
+  skipped: boolean
+  written: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <Text color="green" bold>
+        Ontology types {skipped ? "skipped" : written ? "generated" : "current"}
+      </Text>
+      <Spacer />
+      <KeyValueList
+        items={[
+          { label: "Output", value: path },
+          { label: "Object types", value: String(objectTypes) },
         ]}
       />
     </Box>

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -67,7 +67,7 @@ describe("sixb init", () => {
     }
 
     expect(packageJson.name).toBe("starter")
-    expect(packageJson.scripts.typecheck).toBe("tsc --noEmit")
+    expect(packageJson.scripts.typecheck).toBe("sixb typegen && tsc --noEmit")
     expect(packageJson.dependencies["@sixb/client"]).toBe("latest")
     expect(packageJson.dependencies.react).toBe("^19.0.0")
     expect(packageJson.dependencies["react-router-dom"]).toBe("^7.13.0")

--- a/packages/client/src/query-hooks.ts
+++ b/packages/client/src/query-hooks.ts
@@ -148,7 +148,7 @@ type BuiltRow<TBuilt> = TBuilt extends { first(): Promise<infer TRow> }
         properties: TProperties
         createdAt: Date
         updatedAt: Date
-      }
+      } & (NonNullable<TRow> extends { links: infer TLinks } ? { links: TLinks } : unknown)
     : never
   : never
 

--- a/packages/client/src/query.ts
+++ b/packages/client/src/query.ts
@@ -5,6 +5,8 @@
  * uses, wired to the object query routes through the generated SDK. Queries
  * are validated server-side; failures surface as `SixbQueryError`.
  */
+
+import type { SixbObjectTypeMap } from "@sixb/core/ontology"
 import type {
   ObjectQuery,
   ObjectQueryBuilder,
@@ -44,8 +46,12 @@ export interface SixbQueryClientOptions {
 // Value types are typed as "none registered": custom value-type refs resolve
 // like a runtime without them, and the empty tuple keeps property-value
 // inference shallow enough for TypeScript's recursion limits.
+type ClientRegisteredObjectTypes<TObjectType extends ObjectTypeWithPropertyTokens> =
+  | TObjectType
+  | Extract<SixbObjectTypeMap[keyof SixbObjectTypeMap], ObjectTypeWithPropertyTokens>
+
 export type ClientObjectQueryBuilder<TObjectType extends ObjectTypeWithPropertyTokens> =
-  ObjectQueryBuilder<TObjectType, TObjectType, readonly []>
+  ObjectQueryBuilder<TObjectType, ClientRegisteredObjectTypes<TObjectType>, readonly []>
 
 export function objects<TObjectType extends ObjectTypeWithPropertyTokens>(
   objectType: TObjectType,
@@ -53,7 +59,7 @@ export function objects<TObjectType extends ObjectTypeWithPropertyTokens>(
 ): { query: () => ClientObjectQueryBuilder<TObjectType> } {
   return {
     query: () =>
-      createObjectQueryBuilder<TObjectType, TObjectType, readonly []>({
+      createObjectQueryBuilder<TObjectType, ClientRegisteredObjectTypes<TObjectType>, readonly []>({
         query: { kind: "start", objectTypeId: objectType.id },
         executor: createHttpQueryExecutor(options?.client),
       }),

--- a/packages/client/tests/query-expand-degradation.types.ts
+++ b/packages/client/tests/query-expand-degradation.types.ts
@@ -1,0 +1,46 @@
+// Typecheck-only proof that expansion-target degradation is LOUD, not silent,
+// when a manifest IS present but a link's target type is missing from it (a stale
+// manifest, or a wrong target id). Reading a real property of such a target must
+// be a COMPILE ERROR — the old behavior degraded it silently to
+// `Record<string, unknown>`. The no-manifest loose default stays graceful and is
+// covered elsewhere (query-expand-manifest.types.ts / query-expand-hook.types.ts).
+import { defineObjectType, link, prop } from "@sixb/core/ontology"
+import { objects } from "../src/query"
+
+// `ghost` points at "DegradeGhost", deliberately absent from the manifest below —
+// while the manifest IS concrete (this file augments DegradeOrder; sibling test
+// files augment more). That is exactly the "precision expected but lost" case.
+const Order = defineObjectType({
+  id: "DegradeOrder",
+  name: "Order",
+  properties: [prop("ref", "string", { required: true })],
+  links: [link("ghost", "DegradeGhost", { cardinality: "one" })],
+})
+
+declare module "@sixb/core/ontology" {
+  interface SixbObjectTypeMap {
+    DegradeOrder: typeof Order
+    // DegradeGhost intentionally NOT registered → expanding `ghost` must go loud.
+  }
+}
+
+type RowOf<TBuilt> = TBuilt extends { first(): Promise<infer TRow> } ? NonNullable<TRow> : never
+
+const built = objects(Order).query().expand(Order.l.ghost)
+type Row = RowOf<typeof built>
+
+function unresolvedExpansionIsLoud(row: Row): void {
+  // The start type resolves precisely (only the unresolved target degrades).
+  const orderTypeId: "DegradeOrder" = row.objectTypeId
+  const orderRef: string = row.properties.ref
+
+  const ghost = row.links.ghost
+  // The sentinel key is readable and carries the fix instructions.
+  const guidance: string | undefined = ghost?.properties.sixb_unresolvedExpansionTarget
+  // @ts-expect-error — unresolved expansion target: reading a real property is now
+  // a compile error instead of a silent `unknown`. This is the whole point.
+  void ghost?.properties.ref
+
+  void [orderTypeId, orderRef, guidance]
+}
+void unresolvedExpansionIsLoud

--- a/packages/client/tests/query-expand-degradation.types.ts
+++ b/packages/client/tests/query-expand-degradation.types.ts
@@ -14,7 +14,7 @@ const Order = defineObjectType({
   id: "DegradeOrder",
   name: "Order",
   properties: [prop("ref", "string", { required: true })],
-  links: [link("ghost", "DegradeGhost", { cardinality: "one" })],
+  links: [link.ref("ghost", "DegradeGhost", { cardinality: "one" })],
 })
 
 declare module "@sixb/core/ontology" {

--- a/packages/client/tests/query-expand-direct-target.types.ts
+++ b/packages/client/tests/query-expand-direct-target.types.ts
@@ -1,0 +1,90 @@
+import { defineObjectType, link, prop } from "@sixb/core/ontology"
+import { objects } from "../src/query"
+
+const Region = defineObjectType({
+  id: "DirectRegion",
+  name: "Region",
+  properties: [prop("code", "string", { required: true })],
+})
+
+const Customer = defineObjectType({
+  id: "DirectCustomer",
+  name: "Customer",
+  properties: [prop("name", "string", { required: true })],
+  links: [link("region", Region, { cardinality: "one" })],
+})
+
+const User = defineObjectType({
+  id: "DirectUser",
+  name: "User",
+  properties: [prop("email", "string", { required: true })],
+  links: [link("region", Region, { cardinality: "one" })],
+})
+
+const Team = defineObjectType({
+  id: "DirectTeam",
+  name: "Team",
+  properties: [prop("slug", "string", { required: true })],
+})
+
+const Project = defineObjectType({
+  id: "DirectProject",
+  name: "Project",
+  properties: [prop("name", "string", { required: true })],
+  links: [
+    link("customer", Customer, { cardinality: "one" }),
+    link("owner", [User, Team], { cardinality: "one" }),
+  ],
+})
+
+type RowOf<TBuilt> = TBuilt extends { first(): Promise<infer TRow> } ? NonNullable<TRow> : never
+
+const built = objects(Project)
+  .query()
+  .expand(Project.l.customer, (customer) => customer.expand(Customer.l.region))
+  .expand(Project.l.owner, (owner) => owner.expand(User.l.region))
+
+type ProjectRow = RowOf<typeof built>
+
+function projectRowAssertions(row: ProjectRow): void {
+  const projectTypeId: "DirectProject" = row.objectTypeId
+  const projectName: string = row.properties.name
+  const customerTypeId: "DirectCustomer" = row.links.customer!.objectTypeId
+  const customerName: string = row.links.customer!.properties.name
+  const regionTypeId: "DirectRegion" = row.links.customer!.links.region!.objectTypeId
+  const regionCode: string = row.links.customer!.links.region!.properties.code
+
+  const owner = row.links.owner
+  const ownerTypeId: "DirectUser" | "DirectTeam" | undefined = owner?.objectTypeId
+  const ownerTypeIds: ("DirectUser" | "DirectTeam" | undefined)[] = [row].map(
+    (project) => project.links.owner?.objectTypeId
+  )
+  if (owner?.objectTypeId === "DirectUser") {
+    const email: string = owner.properties.email
+    const userRegionCode: string = owner.links.region!.properties.code
+    // @ts-expect-error — DirectUser owners do not have Team properties.
+    const slug: string = owner.properties.slug
+    void [email, userRegionCode, slug]
+  }
+  if (owner?.objectTypeId === "DirectTeam") {
+    const slug: string = owner.properties.slug
+    // @ts-expect-error — DirectTeam owners do not have User properties.
+    const email: string = owner.properties.email
+    // @ts-expect-error — User-only nested expansion is not present on Team rows.
+    const userRegion = owner.links.region
+    void [slug, email, userRegion]
+  }
+
+  void [
+    projectTypeId,
+    projectName,
+    customerTypeId,
+    customerName,
+    regionTypeId,
+    regionCode,
+    ownerTypeId,
+    ownerTypeIds,
+  ]
+}
+
+void projectRowAssertions

--- a/packages/client/tests/query-expand-hook.types.ts
+++ b/packages/client/tests/query-expand-hook.types.ts
@@ -1,0 +1,164 @@
+// Typecheck-only proof for the slice-5 `BuiltRow.links` hook fix: a row coming
+// out of `useObjectsQuery`/`useObjectsInfinite` must carry PRECISE nested
+// `.links` AND survive `.map()`/`.flatMap()` over the result set WITHOUT tripping
+// TS2589. The builder-path proof (object-query-expand-recursion.types.ts) only
+// exercises `first()`/`RowOf`; the hook path re-attaches the full `ExpandedLinkType`
+// recursion via `BuiltRow`'s `& { links: TLinks }` passthrough (query-hooks.ts),
+// which is exactly the recursion-prone combo real app code hits in components.
+// This mirrors that stress (polymorphic target, "many" arrays, 5-deep self-cycle)
+// through the hooks. Augmentation injects the ontology so nested targets resolve.
+import { defineObjectType, link, prop } from "@sixb/core/ontology"
+import { objects } from "../src/query"
+import { useObjectsInfinite, useObjectsQuery } from "../src/query-hooks"
+
+const HookDepartment = defineObjectType({
+  id: "HookDepartment",
+  name: "Department",
+  properties: [prop("name", "string", { required: true })],
+})
+
+const HookSkill = defineObjectType({
+  id: "HookSkill",
+  name: "Skill",
+  properties: [prop("name", "string", { required: true })],
+})
+
+const HookUser = defineObjectType({
+  id: "HookUser",
+  name: "User",
+  properties: [prop("email", "string", { required: true })],
+  links: [
+    link("manager", "HookUser", { cardinality: "one" }),
+    link("department", "HookDepartment", { cardinality: "one" }),
+    link("skills", "HookSkill", { cardinality: "many" }),
+  ],
+})
+
+const HookTeam = defineObjectType({
+  id: "HookTeam",
+  name: "Team",
+  properties: [prop("slug", "string", { required: true })],
+  links: [link("members", "HookUser", { cardinality: "many" })],
+})
+
+const HookProject = defineObjectType({
+  id: "HookProject",
+  name: "Project",
+  properties: [prop("name", "string", { required: true })],
+  links: [link("owner", ["HookUser", "HookTeam"], { cardinality: "one" })],
+})
+
+const HookFolder = defineObjectType({
+  id: "HookFolder",
+  name: "Folder",
+  properties: [prop("name", "string", { required: true })],
+  links: [
+    link("parent", "HookFolder", { cardinality: "one" }),
+    link("children", "HookFolder", { cardinality: "many" }),
+  ],
+})
+
+declare module "@sixb/core/ontology" {
+  interface SixbObjectTypeMap {
+    HookDepartment: typeof HookDepartment
+    HookFolder: typeof HookFolder
+    HookProject: typeof HookProject
+    HookSkill: typeof HookSkill
+    HookTeam: typeof HookTeam
+    HookUser: typeof HookUser
+  }
+}
+
+// Polymorphic owner + nested "many" arrays, hydrated, then consumed through the
+// useObjectsQuery row in `.map()`/`.flatMap()`.
+const projectQuery = objects(HookProject)
+  .query()
+  .expand(HookProject.l.owner, (owner) =>
+    owner
+      .expand(HookUser.l.department)
+      .expand(HookUser.l.skills, { limit: 5 })
+      .expand(HookTeam.l.members, { limit: 10 }, (member) => member.expand(HookUser.l.manager))
+  )
+
+function useProjectGraphView(): void {
+  const { data } = useObjectsQuery(projectQuery)
+  const rows = data?.objects ?? []
+
+  // Collection helpers reaching nested `.links` — the recursion-prone real path.
+  const ownerLabels: string[] = rows.map((p) => p.links.owner?.objectTypeId ?? "none")
+  const teamMemberEmails: string[] = rows.flatMap((p) => {
+    const owner = p.links.owner
+    return owner?.objectTypeId === "HookTeam"
+      ? owner.links.members.map((m) => m.properties.email)
+      : []
+  })
+  const managerEmails: (string | undefined)[] = rows.flatMap((p) => {
+    const owner = p.links.owner
+    return owner?.objectTypeId === "HookTeam"
+      ? owner.links.members.map((m) => m.links.manager?.properties.email)
+      : []
+  })
+
+  // Per-row precision + polymorphic per-branch narrowing, through the hook row.
+  const first = rows[0]
+  if (first) {
+    const owner = first.links.owner
+    const ownerTypeId: "HookUser" | "HookTeam" | undefined = owner?.objectTypeId
+    if (owner?.objectTypeId === "HookUser") {
+      const departmentName: string | undefined = owner.links.department?.properties.name
+      const skillNames: string[] = owner.links.skills.map((s) => s.properties.name)
+      // @ts-expect-error — `members` is a Team-only expansion, absent on User rows.
+      void owner.links.members
+      void [departmentName, skillNames]
+    }
+    if (owner?.objectTypeId === "HookTeam") {
+      const memberEmails: string[] = owner.links.members.map((m) => m.properties.email)
+      // @ts-expect-error — `department` is a User-only expansion, absent on Team rows.
+      void owner.links.department
+      void memberEmails
+    }
+    void ownerTypeId
+  }
+
+  void [ownerLabels, teamMemberEmails, managerEmails]
+}
+void useProjectGraphView
+
+// 5-deep self-cycle + nested "many" children, through the infinite hook.
+const folderQuery = objects(HookFolder)
+  .query()
+  .expand(HookFolder.l.parent, (p1) =>
+    p1.expand(HookFolder.l.parent, (p2) =>
+      p2.expand(HookFolder.l.parent, (p3) =>
+        p3.expand(HookFolder.l.parent, (p4) => p4.expand(HookFolder.l.parent))
+      )
+    )
+  )
+  .expand(HookFolder.l.children, { limit: 10 }, (child) =>
+    child.expand(HookFolder.l.children, { limit: 5 }, (grandchild) =>
+      grandchild.expand(HookFolder.l.parent)
+    )
+  )
+
+function useFolderTreeView(): void {
+  const { data } = useObjectsInfinite(folderQuery, { pageSize: 20 })
+  const rows = data?.pages.flatMap((page) => page.objects) ?? []
+
+  const ancestorNames: (string | undefined)[] = rows.map(
+    (folder) =>
+      folder.links.parent?.links.parent?.links.parent?.links.parent?.links.parent?.properties.name
+  )
+  const descendantNames: string[] = rows.flatMap((folder) =>
+    folder.links.children.flatMap((child) =>
+      child.links.children.map((g) => g.links.parent?.properties.name ?? g.properties.name)
+    )
+  )
+  const descendantTypeIds: ("HookFolder" | undefined)[] = rows.flatMap((folder) =>
+    folder.links.children.flatMap((child) =>
+      child.links.children.map((g) => g.links.parent?.objectTypeId)
+    )
+  )
+
+  void [ancestorNames, descendantNames, descendantTypeIds]
+}
+void useFolderTreeView

--- a/packages/client/tests/query-expand-hook.types.ts
+++ b/packages/client/tests/query-expand-hook.types.ts
@@ -28,9 +28,9 @@ const HookUser = defineObjectType({
   name: "User",
   properties: [prop("email", "string", { required: true })],
   links: [
-    link("manager", "HookUser", { cardinality: "one" }),
-    link("department", "HookDepartment", { cardinality: "one" }),
-    link("skills", "HookSkill", { cardinality: "many" }),
+    link.self("manager", { cardinality: "one" }),
+    link.ref("department", "HookDepartment", { cardinality: "one" }),
+    link.ref("skills", "HookSkill", { cardinality: "many" }),
   ],
 })
 
@@ -38,14 +38,14 @@ const HookTeam = defineObjectType({
   id: "HookTeam",
   name: "Team",
   properties: [prop("slug", "string", { required: true })],
-  links: [link("members", "HookUser", { cardinality: "many" })],
+  links: [link.ref("members", "HookUser", { cardinality: "many" })],
 })
 
 const HookProject = defineObjectType({
   id: "HookProject",
   name: "Project",
   properties: [prop("name", "string", { required: true })],
-  links: [link("owner", ["HookUser", "HookTeam"], { cardinality: "one" })],
+  links: [link.ref("owner", ["HookUser", "HookTeam"], { cardinality: "one" })],
 })
 
 const HookFolder = defineObjectType({
@@ -53,8 +53,8 @@ const HookFolder = defineObjectType({
   name: "Folder",
   properties: [prop("name", "string", { required: true })],
   links: [
-    link("parent", "HookFolder", { cardinality: "one" }),
-    link("children", "HookFolder", { cardinality: "many" }),
+    link.self("parent", { cardinality: "one" }),
+    link.self("children", { cardinality: "many" }),
   ],
 })
 

--- a/packages/client/tests/query-expand-manifest.types.ts
+++ b/packages/client/tests/query-expand-manifest.types.ts
@@ -1,0 +1,62 @@
+import { defineObjectType, link, prop } from "@sixb/core/ontology"
+import { objects } from "../src/query"
+
+const Region = defineObjectType({
+  id: "ManifestRegion",
+  name: "Region",
+  properties: [prop("code", "string", { required: true })],
+})
+
+const Customer = defineObjectType({
+  id: "ManifestCustomer",
+  name: "Customer",
+  properties: [prop("name", "string", { required: true })],
+  links: [link("region", "ManifestRegion", { cardinality: "one" })],
+})
+
+const Project = defineObjectType({
+  id: "ManifestProject",
+  name: "Project",
+  properties: [prop("name", "string", { required: true })],
+  links: [link("customer", "ManifestCustomer", { cardinality: "one" })],
+})
+
+declare module "@sixb/core/ontology" {
+  interface SixbObjectTypeMap {
+    ManifestCustomer: typeof Customer
+    ManifestProject: typeof Project
+    ManifestRegion: typeof Region
+  }
+}
+
+type RowOf<TBuilt> = TBuilt extends { first(): Promise<infer TRow> } ? NonNullable<TRow> : never
+
+const built = objects(Project)
+  .query()
+  .expand(Project.l.customer, (customer) => customer.expand(Customer.l.region))
+
+type ProjectRow = RowOf<typeof built>
+
+function projectRowAssertions(row: ProjectRow): void {
+  const projectTypeId: "ManifestProject" = row.objectTypeId
+  const projectName: string = row.properties.name
+  const customerTypeId: "ManifestCustomer" = row.links.customer!.objectTypeId
+  const customerName: string = row.links.customer!.properties.name
+  const regionTypeId: "ManifestRegion" = row.links.customer!.links.region!.objectTypeId
+  const regionCode: string = row.links.customer!.links.region!.properties.code
+
+  // @ts-expect-error — the generated-style map resolves customer to Customer, not Region.
+  const wrongCustomerTypeId: "ManifestRegion" = row.links.customer!.objectTypeId
+
+  void [
+    projectTypeId,
+    projectName,
+    customerTypeId,
+    customerName,
+    regionTypeId,
+    regionCode,
+    wrongCustomerTypeId,
+  ]
+}
+
+void projectRowAssertions

--- a/packages/client/tests/query-expand-manifest.types.ts
+++ b/packages/client/tests/query-expand-manifest.types.ts
@@ -11,14 +11,14 @@ const Customer = defineObjectType({
   id: "ManifestCustomer",
   name: "Customer",
   properties: [prop("name", "string", { required: true })],
-  links: [link("region", "ManifestRegion", { cardinality: "one" })],
+  links: [link.ref("region", "ManifestRegion", { cardinality: "one" })],
 })
 
 const Project = defineObjectType({
   id: "ManifestProject",
   name: "Project",
   properties: [prop("name", "string", { required: true })],
-  links: [link("customer", "ManifestCustomer", { cardinality: "one" })],
+  links: [link.ref("customer", "ManifestCustomer", { cardinality: "one" })],
 })
 
 declare module "@sixb/core/ontology" {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -65,7 +65,7 @@ const Room = defineObjectType({
       semanticType: "Temperature",
     }),
   ],
-  links: [link("hasThermostat", "Thermostat", { cardinality: "one" })],
+  links: [link.ref("hasThermostat", "Thermostat", { cardinality: "one" })],
 })
 
 const Thermostat = defineObjectType({
@@ -393,7 +393,10 @@ src/
 | `defineValueType(input)` | Define a reusable value type |
 | `defineInterface(input)` | Define a reusable interface contract |
 | `prop(id, schema, options?)` | Shorthand for creating a property |
-| `link(id, targetTypeId, options?)` | Shorthand for creating a link |
+| `link(id, target, options?)` | Create a link to direct ObjectType target(s) |
+| `link.ref(id, targetTypeId, options?)` | Create an id-only link reference |
+| `link.self(id, options?)` | Create a self-link |
+| `link.any(id, options?)` | Create a wildcard link |
 | `stringEnum(values)` | Create a string enum schema |
 | `integerEnum(values)` | Create an integer enum schema |
 | `valueTypeRef(valueType)` | Reference a value type in a property schema |

--- a/packages/core/src/bootstrap/index.ts
+++ b/packages/core/src/bootstrap/index.ts
@@ -14,3 +14,13 @@ export {
   discoverSyncs,
   discoverWorkflows,
 } from "./discovery"
+export type {
+  GenerateOntologyTypeManifestOptions,
+  GenerateOntologyTypeManifestResult,
+  OntologyTypeManifestDiscovery,
+  OntologyTypeManifestEntry,
+} from "./ontology-type-manifest"
+export {
+  discoverOntologyTypeManifest,
+  generateOntologyTypeManifest,
+} from "./ontology-type-manifest"

--- a/packages/core/src/bootstrap/ontology-type-manifest.ts
+++ b/packages/core/src/bootstrap/ontology-type-manifest.ts
@@ -1,0 +1,316 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, extname, join, relative, resolve, sep } from "node:path"
+import { pathToFileURL } from "node:url"
+import type { OntologyDocumentInput } from "../ontology/registry"
+import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
+import { RuntimeError } from "../runtime/errors"
+
+const moduleExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"])
+
+export interface OntologyTypeManifestEntry {
+  readonly objectTypeId: string
+  readonly modulePath: string
+  readonly exportName: string
+  readonly typeExpression: string
+}
+
+export interface OntologyTypeManifestDiscovery {
+  readonly entries: readonly OntologyTypeManifestEntry[]
+  readonly moduleCount: number
+}
+
+export interface GenerateOntologyTypeManifestOptions {
+  readonly projectRoot: string
+  readonly outFile?: string
+}
+
+export interface GenerateOntologyTypeManifestResult extends OntologyTypeManifestDiscovery {
+  readonly path: string
+  readonly written: boolean
+  readonly skipped: boolean
+}
+
+export async function discoverOntologyTypeManifest(
+  projectRoot: string
+): Promise<OntologyTypeManifestDiscovery> {
+  const resolvedProjectRoot = resolve(projectRoot)
+  const ontologyDir = join(resolvedProjectRoot, "ontology")
+  const modulePaths = await listModuleFiles(ontologyDir)
+  const entries = new Map<string, OntologyTypeManifestEntry>()
+  const seenObjectTypes = new Set<unknown>()
+
+  for (const modulePath of modulePaths) {
+    const moduleSpecifier = toGeneratedModuleSpecifier({
+      fromDir: join(resolvedProjectRoot, ".sixb", "types"),
+      modulePath,
+    })
+    const moduleNamespace = await loadOntologyModule({
+      modulePath,
+      projectRoot: resolvedProjectRoot,
+    })
+
+    for (const [exportName, exportedValue] of Object.entries(moduleNamespace)) {
+      collectManifestEntries({
+        exportedValue,
+        exportName,
+        modulePath,
+        moduleSpecifier,
+        entries,
+        seenObjectTypes,
+      })
+    }
+  }
+
+  return {
+    entries: [...entries.values()].sort((a, b) => a.objectTypeId.localeCompare(b.objectTypeId)),
+    moduleCount: modulePaths.length,
+  }
+}
+
+export async function generateOntologyTypeManifest(
+  options: GenerateOntologyTypeManifestOptions
+): Promise<GenerateOntologyTypeManifestResult> {
+  const projectRoot = resolve(options.projectRoot)
+  const outFile = resolve(projectRoot, options.outFile ?? join(".sixb", "types", "ontology.d.ts"))
+  const discovery = await discoverOntologyTypeManifest(projectRoot)
+
+  if (discovery.moduleCount === 0) {
+    return {
+      ...discovery,
+      path: outFile,
+      written: false,
+      skipped: true,
+    }
+  }
+
+  const content = renderOntologyTypeManifest(discovery.entries)
+  await mkdir(dirname(outFile), { recursive: true })
+  const written = await writeFileIfChanged(outFile, content)
+
+  return {
+    ...discovery,
+    path: outFile,
+    written,
+    skipped: false,
+  }
+}
+
+function collectManifestEntries(input: {
+  readonly exportedValue: unknown
+  readonly exportName: string
+  readonly modulePath: string
+  readonly moduleSpecifier: string
+  readonly entries: Map<string, OntologyTypeManifestEntry>
+  readonly seenObjectTypes: Set<unknown>
+}): void {
+  if (isObjectTypeWithPropertyTokens(input.exportedValue)) {
+    addManifestEntry({
+      objectType: input.exportedValue,
+      modulePath: input.modulePath,
+      exportName: input.exportName,
+      typeExpression: `typeof import(${JSON.stringify(input.moduleSpecifier)})[${JSON.stringify(
+        input.exportName
+      )}]`,
+      entries: input.entries,
+      seenObjectTypes: input.seenObjectTypes,
+    })
+    return
+  }
+
+  if (isOntologyDocumentInput(input.exportedValue)) {
+    for (const objectType of input.exportedValue.objectTypes) {
+      addManifestEntry({
+        objectType,
+        modulePath: input.modulePath,
+        exportName: input.exportName,
+        typeExpression: `Extract<(typeof import(${JSON.stringify(
+          input.moduleSpecifier
+        )})[${JSON.stringify(input.exportName)}])["objectTypes"][number], { id: ${JSON.stringify(
+          objectType.id
+        )} }>`,
+        entries: input.entries,
+        seenObjectTypes: input.seenObjectTypes,
+      })
+    }
+    return
+  }
+
+  if (Array.isArray(input.exportedValue)) {
+    for (const item of input.exportedValue) {
+      if (!isObjectTypeWithPropertyTokens(item)) continue
+      addManifestEntry({
+        objectType: item,
+        modulePath: input.modulePath,
+        exportName: input.exportName,
+        typeExpression: `Extract<(typeof import(${JSON.stringify(
+          input.moduleSpecifier
+        )})[${JSON.stringify(input.exportName)}])[number], { id: ${JSON.stringify(item.id)} }>`,
+        entries: input.entries,
+        seenObjectTypes: input.seenObjectTypes,
+      })
+    }
+  }
+}
+
+function addManifestEntry(input: {
+  readonly objectType: ObjectTypeWithPropertyTokens
+  readonly modulePath: string
+  readonly exportName: string
+  readonly typeExpression: string
+  readonly entries: Map<string, OntologyTypeManifestEntry>
+  readonly seenObjectTypes: Set<unknown>
+}): void {
+  if (input.seenObjectTypes.has(input.objectType)) {
+    return
+  }
+  input.seenObjectTypes.add(input.objectType)
+
+  const existing = input.entries.get(input.objectType.id)
+  const entry: OntologyTypeManifestEntry = {
+    objectTypeId: input.objectType.id,
+    modulePath: input.modulePath,
+    exportName: input.exportName,
+    typeExpression: input.typeExpression,
+  }
+
+  if (!existing) {
+    input.entries.set(input.objectType.id, entry)
+    return
+  }
+
+  throw new RuntimeError(
+    `[Sixb] Duplicate ontology object type id "${input.objectType.id}" while generating `.concat(
+      `the type manifest: ${relative(process.cwd(), existing.modulePath)} and `,
+      `${relative(process.cwd(), input.modulePath)}.`
+    )
+  )
+}
+
+function renderOntologyTypeManifest(entries: readonly OntologyTypeManifestEntry[]): string {
+  const lines = [
+    "// This file is auto-generated by Sixb.",
+    "// Do not edit this file directly.",
+    "",
+    'declare module "@sixb/core/ontology" {',
+    "  interface SixbObjectTypeMap {",
+  ]
+
+  for (const entry of entries) {
+    lines.push(`    ${JSON.stringify(entry.objectTypeId)}: ${entry.typeExpression}`)
+  }
+
+  lines.push("  }", "}", "", "export {}", "")
+  return lines.join("\n")
+}
+
+async function writeFileIfChanged(path: string, content: string): Promise<boolean> {
+  try {
+    const existing = await readFile(path, "utf-8")
+    if (existing === content) return false
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error
+  }
+
+  await writeFile(path, content, "utf-8")
+  return true
+}
+
+async function loadOntologyModule(input: {
+  readonly modulePath: string
+  readonly projectRoot: string
+}): Promise<Record<string, unknown>> {
+  try {
+    return (await import(pathToFileURL(input.modulePath).href)) as Record<string, unknown>
+  } catch (error) {
+    const relPath = relative(input.projectRoot, input.modulePath)
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new RuntimeError(`Failed to load ontology module '${relPath}': ${reason}`)
+  }
+}
+
+async function listModuleFiles(dir: string): Promise<string[]> {
+  let entries: import("node:fs").Dirent[]
+  try {
+    entries = (await readdir(dir, { withFileTypes: true })) as import("node:fs").Dirent[]
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return []
+    }
+    throw error
+  }
+
+  const files: string[] = []
+  const sortedEntries = [...entries].sort((a, b) => a.name.localeCompare(b.name))
+
+  for (const entry of sortedEntries) {
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await listModuleFiles(fullPath)))
+      continue
+    }
+
+    if (!entry.isFile() || !hasSupportedModuleExtension(entry.name)) {
+      continue
+    }
+
+    files.push(fullPath)
+  }
+
+  return files
+}
+
+function toGeneratedModuleSpecifier(input: {
+  readonly fromDir: string
+  readonly modulePath: string
+}): string {
+  const withoutExtension = stripSupportedModuleExtension(input.modulePath)
+  const relativePath = relative(input.fromDir, withoutExtension).split(sep).join("/")
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`
+}
+
+function stripSupportedModuleExtension(path: string): string {
+  const extension = extname(path)
+  return moduleExtensions.has(extension) ? path.slice(0, -extension.length) : path
+}
+
+function hasSupportedModuleExtension(fileName: string): boolean {
+  return moduleExtensions.has(extname(fileName).toLowerCase())
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const code = (error as NodeJS.ErrnoException).code
+  return code === "ENOENT" || code === "ENOTDIR"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isObjectTypeWithPropertyTokens(value: unknown): value is ObjectTypeWithPropertyTokens {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return (
+    typeof value.id === "string" &&
+    Array.isArray(value.properties) &&
+    Array.isArray(value.links) &&
+    isRecord(value.p)
+  )
+}
+
+function isOntologyDocumentInput(value: unknown): value is OntologyDocumentInput {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return (
+    typeof value.id === "string" &&
+    typeof value.version === "string" &&
+    Array.isArray(value.objectTypes)
+  )
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,8 @@
 export type {
   ArraySchema,
   ComplexSchema,
+  DirectLinkResult,
+  DirectLinkTarget,
   EnumSchema,
   InferSchemaOrRef,
   Interface,
@@ -12,6 +14,8 @@ export type {
   MapSchema,
   ObjectFieldSchema,
   ObjectLink,
+  ObjectLinkTargetMetadata,
+  ObjectLinkTargetType,
   ObjectRef,
   ObjectRefSchema,
   ObjectSchema,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export type {
   PropertyTokenMap,
   Schema,
   SchemaOrRef,
+  SixbObjectTypeMap,
   ValueType,
   ValueTypeRefSchema,
 } from "./ontology"
@@ -49,6 +50,16 @@ export {
   validateSchemaOrRefValue,
   valueTypeRef,
 } from "./ontology"
+
+// ── Bootstrap / Codegen ─────────────────────────────────────
+
+export type {
+  GenerateOntologyTypeManifestOptions,
+  GenerateOntologyTypeManifestResult,
+  OntologyTypeManifestDiscovery,
+  OntologyTypeManifestEntry,
+} from "./bootstrap"
+export { discoverOntologyTypeManifest, generateOntologyTypeManifest } from "./bootstrap"
 
 // ── Edits ───────────────────────────────────────────────────
 

--- a/packages/core/src/objects/sdk/object-handle.ts
+++ b/packages/core/src/objects/sdk/object-handle.ts
@@ -19,6 +19,7 @@ import { removeLink as removeLinkLeaf, upsertLink as upsertLinkLeaf } from "../l
 import { createTelemetryAppender } from "./telemetry-appender"
 
 type ObjectRefInput = ObjectRef
+type AnyLinkToken = LinkToken<string, string, string | readonly string[], ObjectLink>
 
 export function createObjectByIdHandle<
   TObjectType extends ObjectTypeWithPropertyTokens,
@@ -35,7 +36,7 @@ export function createObjectByIdHandle<
       return row ? (row as unknown as TwinObject<TObjectType, TValueTypes>) : null
     },
 
-    listLinks: async (linkToken?: LinkToken<string, string, string, ObjectLink>) => {
+    listLinks: async (linkToken?: AnyLinkToken) => {
       // Link rows reveal target types; no link grant semantics exist yet.
       assertPrivileged(ctx, "listLinks")
       if (linkToken) {
@@ -50,7 +51,7 @@ export function createObjectByIdHandle<
     },
 
     link: async (
-      linkToken: LinkToken<string, string, string, ObjectLink>,
+      linkToken: AnyLinkToken,
       target: ObjectRefInput,
       options?: { properties?: Record<string, unknown> }
     ) => {
@@ -66,10 +67,7 @@ export function createObjectByIdHandle<
       })
     },
 
-    unlink: async (
-      linkToken: LinkToken<string, string, string, ObjectLink>,
-      target: ObjectRefInput
-    ) => {
+    unlink: async (linkToken: AnyLinkToken, target: ObjectRefInput) => {
       assertLinkTokenBelongsToObjectType(ctx.objectType, linkToken)
 
       const linkCtx: ResolvedLinkContext = { ...ctx, linkDefinition: linkToken.link }

--- a/packages/core/src/objects/sdk/query-builder.ts
+++ b/packages/core/src/objects/sdk/query-builder.ts
@@ -147,7 +147,7 @@ class ObjectQueryBuilderImpl<
   }
 
   expand(
-    link: LinkToken<string, string, string>,
+    link: LinkToken<string, string, string | readonly string[]>,
     optionsOrBuild?: ObjectExpandOptions<ObjectTypeWithPropertyTokens> | NestedExpandBuild,
     build?: NestedExpandBuild
   ): ObjectQueryBuilder<TObjectType, TRegisteredObjectTypes, TValueTypes> {
@@ -311,7 +311,7 @@ class ObjectExpandBuilderImpl {
   constructor(readonly expansions: readonly ObjectExpansion[] = []) {}
 
   expand(
-    link: LinkToken<string, string, string>,
+    link: LinkToken<string, string, string | readonly string[]>,
     optionsOrBuild?: ObjectExpandOptions<ObjectTypeWithPropertyTokens> | NestedExpandBuild,
     build?: NestedExpandBuild
   ): ObjectExpandBuilderImpl {
@@ -323,7 +323,7 @@ class ObjectExpandBuilderImpl {
 }
 
 function buildExpansion(
-  link: LinkToken<string, string, string>,
+  link: LinkToken<string, string, string | readonly string[]>,
   optionsOrBuild: ObjectExpandOptions<ObjectTypeWithPropertyTokens> | NestedExpandBuild | undefined,
   build: NestedExpandBuild | undefined
 ): ObjectExpansion {

--- a/packages/core/src/ontology/builders.ts
+++ b/packages/core/src/ontology/builders.ts
@@ -20,19 +20,20 @@
  *     prop("mode", stringEnum(["off", "heat", "cool", "auto"])),
  *   ],
  *   links: [
- *     link("controls", "hvacZone", { cardinality: "one" }),
+ *     link.ref("controls", "hvacZone", { cardinality: "one" }),
  *   ],
  * })
  * ```
  */
 
-import type { ObjectTypeWithTokens } from "./tokens"
+import type { ObjectTypeWithPropertyTokens, ObjectTypeWithTokens, PropertyTokenMap } from "./tokens"
 import { createLinkTokenMap, createPropertyTokenMap } from "./tokens"
 import type {
   EnumSchema,
   Interface,
   LinkCardinality,
   ObjectLink,
+  ObjectLinkTargetMetadata,
   ObjectType,
   Ontology,
   Property,
@@ -62,6 +63,19 @@ type FieldFromOptions<TOptions, TKey extends string, TFallback> =
     ? { [K in TKey]: TValue }
     : { [K in TKey]?: TFallback }
 
+const selfLinkTargetObjectTypeId = "__sixb.self__"
+type SelfLinkTargetObjectTypeId = typeof selfLinkTargetObjectTypeId
+
+type NormalizeSelfLink<TObjectTypeId extends string, TLink> = TLink extends {
+  targetObjectTypeId: SelfLinkTargetObjectTypeId
+}
+  ? Omit<TLink, "targetObjectTypeId"> & { targetObjectTypeId: TObjectTypeId }
+  : TLink
+
+type NormalizeSelfLinks<TObjectTypeId extends string, TLinks extends readonly ObjectLink[]> = {
+  -readonly [K in keyof TLinks]: NormalizeSelfLink<TObjectTypeId, TLinks[K]>
+}
+
 // ── Extends type utilities ───────────────────────────────────
 
 /**
@@ -78,6 +92,12 @@ type MergedCollection<
  */
 type OwnCollection<TInput, TKey extends string, TItem> =
   TInput extends Record<TKey, infer T extends readonly TItem[]> ? [...T] : []
+
+type OwnLinks<TInput> = TInput extends { id: infer TObjectTypeId extends string }
+  ? TInput extends Record<"links", infer TLinks extends readonly ObjectLink[]>
+    ? NormalizeSelfLinks<TObjectTypeId, TLinks>
+    : []
+  : []
 
 /**
  * Merge two arrays by id: parent items first, child items override by id.
@@ -138,19 +158,19 @@ type DefineObjectTypeResult<TInput extends DefineObjectTypeInput> = Omit<
           TParent["properties"],
           OwnCollection<TInput, "properties", Property>
         >
-        links: MergedCollection<TParent["links"], OwnCollection<TInput, "links", ObjectLink>>
+        links: MergedCollection<TParent["links"], OwnLinks<TInput>>
       }
     : TInput extends { extends: infer TParentId extends string }
       ? {
           extends: TParentId
           parents: string[]
           properties: OwnCollection<TInput, "properties", Property>
-          links: OwnCollection<TInput, "links", ObjectLink>
+          links: OwnLinks<TInput>
         }
       : NormalizeParents<TInput> & {
           extends: undefined
           properties: OwnCollection<TInput, "properties", Property>
-          links: OwnCollection<TInput, "links", ObjectLink>
+          links: OwnLinks<TInput>
         })
 
 type DefineObjectTypeWithTokensResult<TInput extends DefineObjectTypeInput> = ObjectTypeWithTokens<
@@ -170,7 +190,9 @@ export function defineObjectType(input: DefineObjectTypeInput): ObjectTypeWithTo
   const ext = input.extends
 
   const ownProperties = input.properties ? [...input.properties] : []
-  const ownLinks = input.links ? [...input.links] : []
+  const ownLinks = input.links
+    ? input.links.map((link) => normalizeSelfLinkTarget(input.id, link))
+    : []
 
   let extendsId: string | undefined
   let parentIds: string[] | undefined
@@ -215,6 +237,17 @@ export function defineObjectType(input: DefineObjectTypeInput): ObjectTypeWithTo
     ...objectType,
     l: createLinkTokenMap(objectType),
     p: createPropertyTokenMap(objectType),
+  }
+}
+
+function normalizeSelfLinkTarget(objectTypeId: string, link: ObjectLink): ObjectLink {
+  if (link.targetObjectTypeId !== selfLinkTargetObjectTypeId) {
+    return link
+  }
+
+  return {
+    ...link,
+    targetObjectTypeId: objectTypeId,
   }
 }
 
@@ -405,68 +438,137 @@ type LinkResult<
   FieldFromOptions<TOptions, "cardinality", LinkCardinality> &
   FieldFromOptions<TOptions, "properties", Property[]>
 
+export type DirectLinkResult<
+  TId extends string,
+  TTargetObjectTypeId,
+  TOptions extends LinkOptions | undefined,
+  TTarget,
+> = LinkResult<TId, TTargetObjectTypeId, TOptions> & ObjectLinkTargetMetadata<TTarget>
+
+type ObjectTypeIdArray<TTargets extends readonly ObjectType[]> = Array<TTargets[number]["id"]>
+export type DirectLinkTarget<
+  TId extends string,
+  TName extends string,
+  TProperties extends Property[],
+> = {
+  id: TId
+  name: TName
+  properties: TProperties
+  links: ObjectLink[]
+  readonly p: PropertyTokenMap<{
+    id: TId
+    name: TName
+    properties: TProperties
+    links: ObjectLink[]
+  }>
+}
+
+type DirectLinkTargetFor<TTarget extends ObjectType> = TTarget extends ObjectTypeWithPropertyTokens
+  ? DirectLinkTarget<TTarget["id"], TTarget["name"], TTarget["properties"]>
+  : TTarget
+
 /**
  * Shorthand for creating an {@link ObjectLink}.
  *
- * `name` defaults to `id`. `targetObjectTypeId` defaults to `"*"` when omitted.
+ * `link(...)` accepts direct ObjectType targets and preserves their type for
+ * query authoring. Use `link.ref(...)` for id-only references, `link.self(...)`
+ * for recursive links, and `link.any(...)` for wildcard links.
  *
  * ```ts
- * // String target
- * link("controls", "hvacZone", { cardinality: "one" })
- *
- * // ObjectType target — extracts .id at build time
+ * // ObjectType target — extracts .id at runtime and preserves the target type
  * link("controls", HVACZone, { cardinality: "one" })
+ *
+ * // Id target — resolved by the generated ontology type manifest
+ * link.ref("controls", "hvacZone", { cardinality: "one" })
+ *
+ * // Self target — normalized to the source object type id by defineObjectType()
+ * link.self("parent", { cardinality: "one" })
  *
  * // Multiple targets
  * link("rel", [TypeA, TypeB])
  *
  * // Wildcard — accepts any target type
- * link("anything")
- * link("anything", { cardinality: "many" })
+ * link.any("anything")
+ * link.any("anything", { cardinality: "many" })
  * ```
  */
+interface LinkCallable {
+  <const TId extends string, const TTarget extends ObjectType>(
+    id: TId,
+    target: TTarget
+  ): DirectLinkResult<TId, TTarget["id"], undefined, DirectLinkTargetFor<TTarget>>
 
-// 1. Wildcard: no target → "*"
-export function link<const TId extends string>(id: TId): LinkResult<TId, "*", undefined>
+  <const TId extends string, const TTarget extends ObjectType, const TOptions extends LinkOptions>(
+    id: TId,
+    target: TTarget,
+    options: TOptions
+  ): DirectLinkResult<TId, TTarget["id"], TOptions, DirectLinkTargetFor<TTarget>>
 
-// 2. Single ObjectType target
-export function link<const TId extends string, const TTarget extends ObjectType>(
-  id: TId,
-  target: TTarget
-): LinkResult<TId, TTarget["id"], undefined>
+  <const TId extends string, const TTargets extends readonly ObjectType[]>(
+    id: TId,
+    targets: TTargets
+  ): DirectLinkResult<
+    TId,
+    ObjectTypeIdArray<TTargets>,
+    undefined,
+    DirectLinkTargetFor<TTargets[number]>
+  >
 
-// 3. Single ObjectType target + options
-export function link<
-  const TId extends string,
-  const TTarget extends ObjectType,
-  const TOptions extends LinkOptions,
->(id: TId, target: TTarget, options: TOptions): LinkResult<TId, TTarget["id"], TOptions>
+  <
+    const TId extends string,
+    const TTargets extends readonly ObjectType[],
+    const TOptions extends LinkOptions,
+  >(
+    id: TId,
+    targets: TTargets,
+    options: TOptions
+  ): DirectLinkResult<
+    TId,
+    ObjectTypeIdArray<TTargets>,
+    TOptions,
+    DirectLinkTargetFor<TTargets[number]>
+  >
+}
 
-// 4. ObjectType array target
-export function link<const TId extends string, const TTargetId extends string>(
-  id: TId,
-  targets: readonly (ObjectType & { id: TTargetId })[]
-): LinkResult<TId, TTargetId[], undefined>
+interface LinkBuilder extends LinkCallable {
+  ref: typeof linkRef
+  self: typeof linkSelf
+  any: typeof linkAny
+}
 
-// 5. ObjectType array target + options
-export function link<
-  const TId extends string,
-  const TTargetId extends string,
-  const TOptions extends LinkOptions,
->(
-  id: TId,
-  targets: readonly (ObjectType & { id: TTargetId })[],
-  options: TOptions
-): { id: TId; name: NameFromOptions<TId, TOptions>; targetObjectTypeId: TTargetId[] } & TOptions
+const linkImpl = ((
+  id: string,
+  targetOrTargets: ObjectType | readonly ObjectType[],
+  options?: LinkOptions
+): ObjectLink => {
+  if (Array.isArray(targetOrTargets)) {
+    return {
+      id,
+      name: options?.name ?? id,
+      targetObjectTypeId: targetOrTargets.map((target) => target.id),
+      ...options,
+    }
+  }
 
-// 6. String or string-array target (existing)
-export function link<
+  if (isObjectTypeLike(targetOrTargets)) {
+    return {
+      id,
+      name: options?.name ?? id,
+      targetObjectTypeId: targetOrTargets.id,
+      ...options,
+    }
+  }
+
+  throw new Error(
+    `[Sixb] link("${id}", ...) requires an ObjectType target. Use link.ref(...) for id references, link.self(...) for self-links, or link.any(...) for wildcard links.`
+  )
+}) as LinkCallable
+
+function linkRef<
   const TId extends string,
   const TTargetObjectTypeId extends string | readonly string[],
 >(id: TId, targetObjectTypeId: TTargetObjectTypeId): LinkResult<TId, TTargetObjectTypeId, undefined>
-
-// 7. String or string-array target + options (existing)
-export function link<
+function linkRef<
   const TId extends string,
   const TTargetObjectTypeId extends string | readonly string[],
   const TOptions extends LinkOptions,
@@ -475,68 +577,49 @@ export function link<
   targetObjectTypeId: TTargetObjectTypeId,
   options: TOptions
 ): LinkResult<TId, TTargetObjectTypeId, TOptions>
-
-// 8. Wildcard with options — MUST be LAST (ObjectType satisfies LinkOptions structurally)
-export function link<const TId extends string, const TOptions extends LinkOptions>(
-  id: TId,
-  options: TOptions
-): { id: TId; name: NameFromOptions<TId, TOptions>; targetObjectTypeId: "*" } & TOptions
-
-// Implementation
-export function link(
+function linkRef(
   id: string,
-  targetOrOptions?: string | readonly string[] | ObjectType | readonly ObjectType[] | LinkOptions,
+  targetObjectTypeId: string | readonly string[],
   options?: LinkOptions
 ): ObjectLink {
-  // No second argument → wildcard
-  if (targetOrOptions === undefined) {
-    return { id, name: id, targetObjectTypeId: "*" }
-  }
-
-  // String → string target
-  if (typeof targetOrOptions === "string") {
-    return {
-      id,
-      name: options?.name ?? id,
-      targetObjectTypeId: targetOrOptions,
-      ...options,
-    }
-  }
-
-  // Array → determine element type
-  if (Array.isArray(targetOrOptions)) {
-    const first = targetOrOptions[0]
-    const ids =
-      first !== undefined && isObjectTypeLike(first)
-        ? (targetOrOptions as readonly ObjectType[]).map((ot) => ot.id)
-        : (targetOrOptions as string[])
-    return {
-      id,
-      name: options?.name ?? id,
-      targetObjectTypeId: ids,
-      ...options,
-    }
-  }
-
-  // Object with properties + links → ObjectType
-  if (isObjectTypeLike(targetOrOptions)) {
-    return {
-      id,
-      name: options?.name ?? id,
-      targetObjectTypeId: (targetOrOptions as ObjectType).id,
-      ...options,
-    }
-  }
-
-  // Otherwise → LinkOptions (wildcard with options)
-  const linkOptions = targetOrOptions as LinkOptions
   return {
     id,
-    name: linkOptions.name ?? id,
-    targetObjectTypeId: "*",
-    ...linkOptions,
+    name: options?.name ?? id,
+    targetObjectTypeId:
+      typeof targetObjectTypeId === "string" ? targetObjectTypeId : [...targetObjectTypeId],
+    ...options,
   }
 }
+
+function linkSelf<
+  const TId extends string,
+  const TOptions extends LinkOptions | undefined = undefined,
+>(id: TId, options?: TOptions): LinkResult<TId, SelfLinkTargetObjectTypeId, TOptions> {
+  return {
+    id,
+    name: options?.name ?? id,
+    targetObjectTypeId: selfLinkTargetObjectTypeId,
+    ...options,
+  } as LinkResult<TId, SelfLinkTargetObjectTypeId, TOptions>
+}
+
+function linkAny<
+  const TId extends string,
+  const TOptions extends LinkOptions | undefined = undefined,
+>(id: TId, options?: TOptions): LinkResult<TId, "*", TOptions> {
+  return {
+    id,
+    name: options?.name ?? id,
+    targetObjectTypeId: "*",
+    ...options,
+  } as LinkResult<TId, "*", TOptions>
+}
+
+export const link: LinkBuilder = Object.assign(linkImpl, {
+  ref: linkRef,
+  self: linkSelf,
+  any: linkAny,
+})
 
 // ── ValueType ref shorthand ─────────────────────────────────
 

--- a/packages/core/src/ontology/index.ts
+++ b/packages/core/src/ontology/index.ts
@@ -29,6 +29,8 @@ export type {
   MapSchema,
   ObjectFieldSchema,
   ObjectLink,
+  ObjectLinkTargetMetadata,
+  ObjectLinkTargetType,
   ObjectSchema,
   ObjectType,
   ObjectTypeSearchMetadata,
@@ -54,6 +56,7 @@ export { OntologyValidationError } from "./errors"
 
 // ── Helpers ─────────────────────────────────────────────────
 
+export type { DirectLinkResult, DirectLinkTarget } from "./builders"
 export {
   defineInterface,
   defineObjectType,

--- a/packages/core/src/ontology/index.ts
+++ b/packages/core/src/ontology/index.ts
@@ -38,6 +38,7 @@ export type {
   PropertyMode,
   PropertyQueryMetadata,
   Schema,
+  SixbObjectTypeMap,
   ValueType,
   ValueTypeRefSchema,
 } from "./types"

--- a/packages/core/src/ontology/types.ts
+++ b/packages/core/src/ontology/types.ts
@@ -317,6 +317,25 @@ export interface ObjectLink {
   properties?: Property[]
 }
 
+declare const objectLinkTargetTypeBrand: unique symbol
+
+/**
+ * Type-only metadata attached by `link("id", Target)`.
+ *
+ * The runtime ontology still stores only `targetObjectTypeId`; this brand exists
+ * only in TypeScript so query builders can resolve direct link targets without
+ * consulting a generated id-to-type map.
+ */
+export type ObjectLinkTargetMetadata<TTarget> = {
+  readonly [objectLinkTargetTypeBrand]?: TTarget
+}
+
+export type ObjectLinkTargetType<TLink> = typeof objectLinkTargetTypeBrand extends keyof TLink
+  ? TLink extends ObjectLinkTargetMetadata<infer TTarget>
+    ? TTarget
+    : never
+  : never
+
 /**
  * Reusable ontology contract of properties and links.
  *
@@ -392,7 +411,7 @@ export interface ObjectType {
 }
 
 /**
- * App-augmentable id-to-object-type map for client query typing.
+ * Ambient id-to-object-type index for app ontology definitions.
  *
  * Sixb generates a `.sixb/types/ontology.d.ts` module augmentation that adds
  * entries here, letting client-side query types resolve string link targets

--- a/packages/core/src/ontology/types.ts
+++ b/packages/core/src/ontology/types.ts
@@ -392,6 +392,17 @@ export interface ObjectType {
 }
 
 /**
+ * App-augmentable id-to-object-type map for client query typing.
+ *
+ * Sixb generates a `.sixb/types/ontology.d.ts` module augmentation that adds
+ * entries here, letting client-side query types resolve string link targets
+ * like `"Customer"` to the exported `Customer` object type without changing the
+ * runtime ontology shape.
+ */
+// biome-ignore lint/suspicious/noEmptyInterface: App code augments this interface.
+export interface SixbObjectTypeMap {}
+
+/**
  * Root ontology document for object type modeling.
  *
  * Use this as the top-level container when you want to version and ship

--- a/packages/core/src/ontology/validation/properties.ts
+++ b/packages/core/src/ontology/validation/properties.ts
@@ -27,7 +27,7 @@ export function assertPropertyTokenBelongsToObjectType(
 
 export function assertLinkTokenBelongsToObjectType(
   objectType: ObjectTypeWithPropertyTokens,
-  link: LinkToken<string, string, string, ObjectLink>
+  link: LinkToken<string, string, string | readonly string[], ObjectLink>
 ): void {
   if (link.objectTypeId !== objectType.id) {
     throw new OntologyValidationError(

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -139,6 +139,19 @@ export type TwinObject<TObjectType extends ObjectType, TValueTypes extends reado
   updatedAt: Date
 }
 
+type MaterializedObjectRow<
+  TObjectType extends Pick<ObjectType, "id" | "properties">,
+  TValueTypes extends readonly ValueType[],
+> = {
+  primaryId: string
+  objectTypeId: TObjectType["id"]
+  properties: InferObjectProperties<TObjectType, TValueTypes>
+  createdAt: Date
+  updatedAt: Date
+}
+
+type Simplify<T> = { [K in keyof T]: T[K] } & {}
+
 export type { ObjectRef }
 
 /**
@@ -431,6 +444,8 @@ export type ObjectSetListInput = {
   order?: "asc" | "desc"
 }
 
+type LinkTargetObjectTypeIdValue = string | readonly string[]
+
 type LinkTargetObjectTypeId<TLinkToken> =
   TLinkToken extends LinkToken<string, string, infer TTargetObjectTypeId>
     ? TTargetObjectTypeId extends readonly (infer TTargetId extends string)[]
@@ -446,6 +461,11 @@ type ObjectTypeForId<
 > = [Extract<TRegisteredObjectTypes, { id: TObjectTypeId }>] extends [never]
   ? ObjectTypeWithPropertyTokens
   : Extract<TRegisteredObjectTypes, { id: TObjectTypeId }>
+
+type ObjectTypeForLinkTarget<
+  TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
+  TLinkToken,
+> = ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>
 
 /**
  * True when the target type is a concrete ontology type rather than the degraded
@@ -490,17 +510,48 @@ export type ObjectExpandOptions<TObjectType extends ObjectTypeWithPropertyTokens
  * the ontology default.
  */
 type LinkTokenCardinality<TLinkToken> =
-  TLinkToken extends LinkToken<string, string, string, infer TLink>
+  TLinkToken extends LinkToken<string, string, LinkTargetObjectTypeIdValue, infer TLink>
     ? TLink extends { cardinality: infer TCardinality extends string }
       ? TCardinality
       : "many"
     : "many"
 
+type LinkTokenId<TLinkToken> =
+  TLinkToken extends LinkToken<string, infer TLinkId, LinkTargetObjectTypeIdValue> ? TLinkId : never
+
+type LinkTokenSourceObjectTypeId<TLinkToken> =
+  TLinkToken extends LinkToken<infer TObjectTypeId, string, LinkTargetObjectTypeIdValue>
+    ? TObjectTypeId
+    : string
+
+type ObjectLinkCardinality<TLink> = TLink extends { cardinality: infer TCardinality extends string }
+  ? TCardinality
+  : "many"
+
+type ObjectLinkTarget<
+  TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
+  TLink,
+> = TLink extends {
+  targetObjectTypeId: infer TTargetObjectTypeId extends LinkTargetObjectTypeIdValue
+}
+  ? ObjectTypeForId<TRegisteredObjectTypes, ResolveTargetTypeId<TTargetObjectTypeId>>
+  : ObjectTypeWithPropertyTokens
+
+type ObjectLinkById<
+  TObjectType extends Pick<ObjectType, "links">,
+  TLinkId extends string,
+> = Extract<TObjectType["links"][number], { id: TLinkId }>
+
+type HasKnownObjectLinkIds<TObjectType extends Pick<ObjectType, "links">> =
+  string extends TObjectType["links"][number]["id"] ? false : true
+
 /**
  * A branded accumulator entry for one expanded link. Unconstrained on purpose —
  * keeping recursion out of constraints is what avoids TS2589.
  */
-type ExpansionNode<TTarget, TCardinality, TChildren> = {
+type ExpansionNode<TLinkToken, TRegisteredObjectTypes, TTarget, TCardinality, TChildren> = {
+  readonly __linkToken: TLinkToken
+  readonly __registeredObjectTypes: TRegisteredObjectTypes
   readonly __target: TTarget
   readonly __cardinality: TCardinality
   readonly __children: TChildren
@@ -508,20 +559,59 @@ type ExpansionNode<TTarget, TCardinality, TChildren> = {
 
 /** The single-key accumulator contribution of one `.expand(link, …)` call. */
 type ExpansionEntry<
-  TLinkToken extends LinkToken<string, string, string>,
+  TLinkToken extends LinkToken<string, string, LinkTargetObjectTypeIdValue>,
   TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
   TChild,
 > = {
   [K in TLinkToken["id"]]: ExpansionNode<
-    ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>,
+    TLinkToken,
+    TRegisteredObjectTypes,
+    ObjectTypeForLinkTarget<TRegisteredObjectTypes, TLinkToken>,
     LinkTokenCardinality<TLinkToken>,
     TChild
   >
 }
 
+type ExpansionNodeForSource<TNode, TObjectType extends Pick<ObjectType, "id" | "links">> =
+  TNode extends ExpansionNode<
+    infer TLinkToken,
+    infer TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
+    infer TTarget,
+    infer TCardinality,
+    infer TChildren
+  >
+    ? LinkTokenId<TLinkToken> extends infer TLinkId extends string
+      ? HasKnownObjectLinkIds<TObjectType> extends true
+        ? [ObjectLinkById<TObjectType, TLinkId>] extends [never]
+          ? never
+          : ExpansionNode<
+              TLinkToken,
+              TRegisteredObjectTypes,
+              ObjectLinkTarget<TRegisteredObjectTypes, ObjectLinkById<TObjectType, TLinkId>>,
+              ObjectLinkCardinality<ObjectLinkById<TObjectType, TLinkId>>,
+              TChildren
+            >
+        : LinkTokenSourceObjectTypeId<TLinkToken> extends TObjectType["id"]
+          ? ExpansionNode<TLinkToken, TRegisteredObjectTypes, TTarget, TCardinality, TChildren>
+          : never
+      : never
+    : never
+
+type ExpansionLinksForSource<TLinks, TObjectType extends Pick<ObjectType, "id" | "links">> = {
+  [K in keyof TLinks as [ExpansionNodeForSource<TLinks[K], TObjectType>] extends [never]
+    ? never
+    : K]: ExpansionNodeForSource<TLinks[K], TObjectType>
+}
+
 /** Materialize one accumulated expansion entry into its row value. */
 type ExpandedLinkType<TNode, TValueTypes extends readonly ValueType[]> =
-  TNode extends ExpansionNode<infer TTarget, infer TCardinality, infer TChildren>
+  TNode extends ExpansionNode<
+    unknown,
+    ObjectTypeWithPropertyTokens,
+    infer TTarget,
+    infer TCardinality,
+    infer TChildren
+  >
     ? TCardinality extends "one"
       ? ExpandedRowType<TTarget, TChildren, TValueTypes> | null
       : ExpandedRowType<TTarget, TChildren, TValueTypes>[]
@@ -533,30 +623,41 @@ type ExpandedLinkType<TNode, TValueTypes extends readonly ValueType[]> =
  * nested `links` (present only when the child was itself expanded). The recursion
  * is confined to this lazily-evaluated position.
  */
-type ExpandedRowType<
-  TTarget,
-  TChildren,
+type ExpandedRowType<TTarget, TChildren, TValueTypes extends readonly ValueType[]> =
+  TTarget extends Pick<ObjectType, "id" | "properties" | "links">
+    ? ExpandedRowForSource<
+        TTarget,
+        TValueTypes,
+        ExpansionLinksForSource<TChildren, TTarget>,
+        { linkProperties?: Record<string, unknown> }
+      >
+    : never
+
+type ExpandedRowForSource<
+  TObjectType extends Pick<ObjectType, "id" | "properties" | "links">,
   TValueTypes extends readonly ValueType[],
-> = (TTarget extends ObjectTypeWithPropertyTokens ? TwinObject<TTarget, TValueTypes> : never) & {
-  linkProperties?: Record<string, unknown>
-} & ([keyof TChildren] extends [never]
-    ? unknown
-    : { links: { [K in keyof TChildren]: ExpandedLinkType<TChildren[K], TValueTypes> } })
+  TLinks,
+  TExtra = unknown,
+> = Simplify<
+  MaterializedObjectRow<TObjectType, TValueTypes> &
+    TExtra &
+    ([keyof TLinks] extends [never]
+      ? unknown
+      : { links: { [K in keyof TLinks]: ExpandedLinkType<TLinks[K], TValueTypes> } })
+>
 
 /**
  * The terminal row of a query: the matched object, plus a typed `links` map once
  * the query accumulated expansions. A query with no `.expand(...)` returns the
- * plain `TwinObject`, so existing `list`/`first` consumers are unchanged.
+ * plain materialized row, so existing `list`/`first` consumers are unchanged.
  */
 export type ObjectQueryRow<
   TObjectType extends ObjectTypeWithPropertyTokens,
   TValueTypes extends readonly ValueType[],
   TLinks,
-> = [keyof TLinks] extends [never]
-  ? TwinObject<TObjectType, TValueTypes>
-  : TwinObject<TObjectType, TValueTypes> & {
-      links: { [K in keyof TLinks]: ExpandedLinkType<TLinks[K], TValueTypes> }
-    }
+> = TObjectType extends ObjectTypeWithPropertyTokens
+  ? ExpandedRowForSource<TObjectType, TValueTypes, ExpansionLinksForSource<TLinks, TObjectType>>
+  : never
 
 /**
  * Builder passed to the nested `.expand(..., (e) => …)` callback. Exposes only
@@ -590,7 +691,10 @@ export type ObjectExpandBuilder<
         // degradation conditional above resolves (which otherwise buries the
         // accumulator inside `expand`'s return and defeats inference).
         readonly __links?: TAccumulated
-        expand<TLinkToken extends LinkToken<TObjectType["id"], string, string>, TChild = unknown>(
+        expand<
+          TLinkToken extends LinkToken<TObjectType["id"], string, LinkTargetObjectTypeIdValue>,
+          TChild = unknown,
+        >(
           link: TLinkToken,
           build: ObjectExpandNested<TLinkToken, TRegisteredObjectTypes, TChild>
         ): ObjectExpandBuilder<
@@ -598,10 +702,13 @@ export type ObjectExpandBuilder<
           TRegisteredObjectTypes,
           TAccumulated & ExpansionEntry<TLinkToken, TRegisteredObjectTypes, TChild>
         >
-        expand<TLinkToken extends LinkToken<TObjectType["id"], string, string>, TChild = unknown>(
+        expand<
+          TLinkToken extends LinkToken<TObjectType["id"], string, LinkTargetObjectTypeIdValue>,
+          TChild = unknown,
+        >(
           link: TLinkToken,
           options?: ObjectExpandOptions<
-            ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>
+            ObjectTypeForLinkTarget<TRegisteredObjectTypes, TLinkToken>
           >,
           build?: ObjectExpandNested<TLinkToken, TRegisteredObjectTypes, TChild>
         ): ObjectExpandBuilder<
@@ -637,16 +744,16 @@ type UntypedExpandBuilder = {
  * `TChild` from the argument, so it would silently fall back to `unknown`.
  */
 type ObjectExpandNested<
-  TLinkToken extends LinkToken<string, string, string>,
+  TLinkToken extends LinkToken<string, string, LinkTargetObjectTypeIdValue>,
   TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
   TChild,
 > = (
   nested: ObjectExpandBuilder<
-    ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>,
+    ObjectTypeForLinkTarget<TRegisteredObjectTypes, TLinkToken>,
     TRegisteredObjectTypes
   >
 ) => ObjectExpandBuilder<
-  ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>,
+  ObjectTypeForLinkTarget<TRegisteredObjectTypes, TLinkToken>,
   TRegisteredObjectTypes,
   TChild
 >
@@ -686,11 +793,11 @@ export interface ObjectQueryBuilder<
   ): ObjectQueryBuilder<TObjectType, TRegisteredObjectTypes, TValueTypes, TLinks>
 
   /** Follow an outgoing link and make the linked object type the current result type. */
-  traverse<TLinkToken extends LinkToken<TObjectType["id"], string, string>>(
+  traverse<TLinkToken extends LinkToken<TObjectType["id"], string, LinkTargetObjectTypeIdValue>>(
     link: TLinkToken,
     options?: { direction?: "outgoing" }
   ): ObjectQueryBuilder<
-    ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>,
+    ObjectTypeForLinkTarget<TRegisteredObjectTypes, TLinkToken>,
     TRegisteredObjectTypes,
     TValueTypes
   >
@@ -716,7 +823,10 @@ export interface ObjectQueryBuilder<
    * targets stay precise on the server path (full registry) and degrade to the
    * loose base on the client until the generated registry sharpens them.
    */
-  expand<TLinkToken extends LinkToken<TObjectType["id"], string, string>, TChild = unknown>(
+  expand<
+    TLinkToken extends LinkToken<TObjectType["id"], string, LinkTargetObjectTypeIdValue>,
+    TChild = unknown,
+  >(
     link: TLinkToken,
     build: ObjectExpandNested<TLinkToken, TRegisteredObjectTypes, TChild>
   ): ObjectQueryBuilder<
@@ -725,11 +835,12 @@ export interface ObjectQueryBuilder<
     TValueTypes,
     TLinks & ExpansionEntry<TLinkToken, TRegisteredObjectTypes, TChild>
   >
-  expand<TLinkToken extends LinkToken<TObjectType["id"], string, string>, TChild = unknown>(
+  expand<
+    TLinkToken extends LinkToken<TObjectType["id"], string, LinkTargetObjectTypeIdValue>,
+    TChild = unknown,
+  >(
     link: TLinkToken,
-    options?: ObjectExpandOptions<
-      ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>
-    >,
+    options?: ObjectExpandOptions<ObjectTypeForLinkTarget<TRegisteredObjectTypes, TLinkToken>>,
     build?: ObjectExpandNested<TLinkToken, TRegisteredObjectTypes, TChild>
   ): ObjectQueryBuilder<
     TObjectType,

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -607,14 +607,14 @@ type ExpansionLinksForSource<TLinks, TObjectType extends Pick<ObjectType, "id" |
 type ExpandedLinkType<TNode, TValueTypes extends readonly ValueType[]> =
   TNode extends ExpansionNode<
     unknown,
-    ObjectTypeWithPropertyTokens,
+    infer TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
     infer TTarget,
     infer TCardinality,
     infer TChildren
   >
     ? TCardinality extends "one"
-      ? ExpandedRowType<TTarget, TChildren, TValueTypes> | null
-      : ExpandedRowType<TTarget, TChildren, TValueTypes>[]
+      ? ExpandedRowType<TTarget, TChildren, TValueTypes, TRegisteredObjectTypes> | null
+      : ExpandedRowType<TTarget, TChildren, TValueTypes, TRegisteredObjectTypes>[]
     : never
 
 /**
@@ -623,14 +623,49 @@ type ExpandedLinkType<TNode, TValueTypes extends readonly ValueType[]> =
  * nested `links` (present only when the child was itself expanded). The recursion
  * is confined to this lazily-evaluated position.
  */
-type ExpandedRowType<TTarget, TChildren, TValueTypes extends readonly ValueType[]> =
+/**
+ * Loud row substituted for a `.expand()` whose target type is MISSING from an
+ * otherwise-present ontology manifest (a stale manifest, or a wrong link target
+ * id). Reading a real property is then a compile error pointing at the fix,
+ * instead of the old silent `Record<string, unknown>`. The no-manifest loose
+ * default stays graceful — this only fires when the registry is concrete yet the
+ * target id is absent, i.e. precision was expected but lost.
+ */
+type UnresolvedExpansionRow = {
+  primaryId: string
+  objectTypeId: string
+  properties: {
+    readonly sixb_unresolvedExpansionTarget: "This expansion target is not in the generated ontology manifest. Run `sixb build` / `dev` / `check` to regenerate types, or fix the link's target id."
+  }
+  createdAt: Date
+  updatedAt: Date
+}
+
+type ExpandedRowType<
+  TTarget,
+  TChildren,
+  TValueTypes extends readonly ValueType[],
+  TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
+> =
   TTarget extends Pick<ObjectType, "id" | "properties" | "links">
-    ? ExpandedRowForSource<
-        TTarget,
-        TValueTypes,
-        ExpansionLinksForSource<TChildren, TTarget>,
-        { linkProperties?: Record<string, unknown> }
-      >
+    ? string extends TTarget["id"]
+      ? // Target degraded to the loose base. Distinguish the two causes:
+        string extends TRegisteredObjectTypes["id"]
+        ? // No manifest at all → graceful loose default (unchanged, non-breaking).
+          ExpandedRowForSource<
+            TTarget,
+            TValueTypes,
+            ExpansionLinksForSource<TChildren, TTarget>,
+            { linkProperties?: Record<string, unknown> }
+          >
+        : // Manifest present but this target id is absent → loud (was silent).
+          UnresolvedExpansionRow
+      : ExpandedRowForSource<
+          TTarget,
+          TValueTypes,
+          ExpansionLinksForSource<TChildren, TTarget>,
+          { linkProperties?: Record<string, unknown> }
+        >
     : never
 
 type ExpandedRowForSource<

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -34,7 +34,7 @@ import type {
   ObjectQuerySortDirection,
   ValidatedObjectQuery,
 } from "../objects/query"
-import type { ObjectRef, ObjectType, Property, ValueType } from "../ontology"
+import type { ObjectLinkTargetType, ObjectRef, ObjectType, Property, ValueType } from "../ontology"
 import type {
   InferObjectProperties,
   InferPropertyUnit,
@@ -462,19 +462,26 @@ type ObjectTypeForId<
   ? ObjectTypeWithPropertyTokens
   : Extract<TRegisteredObjectTypes, { id: TObjectTypeId }>
 
+type DirectObjectTypeForLink<TLinkToken> =
+  TLinkToken extends LinkToken<string, string, LinkTargetObjectTypeIdValue, infer TLink>
+    ? Extract<ObjectLinkTargetType<TLink>, ObjectTypeWithPropertyTokens>
+    : never
+
 type ObjectTypeForLinkTarget<
   TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
   TLinkToken,
-> = ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>
+> = [DirectObjectTypeForLink<TLinkToken>] extends [never]
+  ? ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>
+  : DirectObjectTypeForLink<TLinkToken>
 
 /**
  * True when the target type is a concrete ontology type rather than the degraded
- * generic base. When a link's target is not in the registry (the client path
- * until a registry is generated), `ObjectTypeForId` falls back to the base type,
- * whose property ids are `string`; instantiating the typed token map over the
- * broad `Property` union there overflows TypeScript (the same reason
- * `UntypedPropertyPredicate` exists). The expand option/sort types degrade to a
- * loose shape in that case so the client path stays shallow instead of failing.
+ * generic base. Direct ObjectType links resolve before this point; unresolved
+ * id-only refs fall back to the base type, whose property ids are `string`.
+ * Instantiating the typed token map over the broad `Property` union there
+ * overflows TypeScript (the same reason `UntypedPropertyPredicate` exists). The
+ * expand option/sort types degrade to a loose shape in that case so unresolved
+ * client paths stay shallow instead of failing.
  */
 type HasKnownObjectType<TObjectType extends ObjectTypeWithPropertyTokens> =
   string extends TObjectType["id"] ? false : true
@@ -501,8 +508,9 @@ export type ObjectExpandOptions<TObjectType extends ObjectTypeWithPropertyTokens
 // via {@link ObjectQueryRow}. The discipline that keeps this within TypeScript's
 // recursion limits (proven on the real ADN graph): recursion lives ONLY in the
 // lazily-evaluated row types below, never in constraints (which are eager); the
-// builders are type aliases; targets resolve by id against the registry; and the
-// row is read through a direct conditional `infer` (see `BuiltRow`).
+// builders are type aliases; targets resolve through direct metadata first and
+// the id registry second; and the row is read through a direct conditional
+// `infer` (see `BuiltRow`).
 
 /**
  * Cardinality declared on a link token's underlying link; absent cardinality is
@@ -528,14 +536,15 @@ type ObjectLinkCardinality<TLink> = TLink extends { cardinality: infer TCardinal
   ? TCardinality
   : "many"
 
-type ObjectLinkTarget<
-  TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
-  TLink,
-> = TLink extends {
-  targetObjectTypeId: infer TTargetObjectTypeId extends LinkTargetObjectTypeIdValue
-}
-  ? ObjectTypeForId<TRegisteredObjectTypes, ResolveTargetTypeId<TTargetObjectTypeId>>
-  : ObjectTypeWithPropertyTokens
+type ObjectLinkTarget<TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens, TLink> = [
+  Extract<ObjectLinkTargetType<TLink>, ObjectTypeWithPropertyTokens>,
+] extends [never]
+  ? TLink extends {
+      targetObjectTypeId: infer TTargetObjectTypeId extends LinkTargetObjectTypeIdValue
+    }
+    ? ObjectTypeForId<TRegisteredObjectTypes, ResolveTargetTypeId<TTargetObjectTypeId>>
+    : ObjectTypeWithPropertyTokens
+  : Extract<ObjectLinkTargetType<TLink>, ObjectTypeWithPropertyTokens>
 
 type ObjectLinkById<
   TObjectType extends Pick<ObjectType, "links">,
@@ -696,21 +705,20 @@ export type ObjectQueryRow<
 
 /**
  * Builder passed to the nested `.expand(..., (e) => …)` callback. Exposes only
- * `expand`, resolving the next target type by id against the registry so deeper
- * hops stay typed and accumulating `TAccumulated` so the nested `.links` shape is
- * recovered from the callback's return.
+ * `expand`, resolving the next target type from direct metadata or the id
+ * registry so deeper hops stay typed and accumulating `TAccumulated` so the
+ * nested `.links` shape is recovered from the callback's return.
  *
  * A type alias (not an interface) so relating two instantiations stays
  * structural — the same discipline `TwinObject` follows to avoid TS2589
  * (see the note above `TwinObject`). The only recursion is in the lazily
  * evaluated return/callback positions.
  *
- * When the target type is the degraded base (an unregistered link target, i.e.
- * the client path until a registry is generated), the builder collapses to the
- * untyped, non-generic {@link UntypedExpandBuilder}: nested expansion still
- * works, just without target-specific link/property checking, and — crucially —
- * without the self-referential generic instantiation over the broad base type
- * that would otherwise overflow TypeScript.
+ * When the target type is the degraded base (an unresolved id-only target), the
+ * builder collapses to the untyped, non-generic {@link UntypedExpandBuilder}:
+ * nested expansion still works, just without target-specific link/property
+ * checking, and — crucially — without the self-referential generic instantiation
+ * over the broad base type that would otherwise overflow TypeScript.
  */
 export type ObjectExpandBuilder<
   TObjectType extends ObjectTypeWithPropertyTokens,
@@ -855,8 +863,8 @@ export interface ObjectQueryBuilder<
    * Each call widens `TLinks`, so `list`/`first` rows gain a typed `.links` entry
    * for this link (cardinality `"one"` → `Target | null`, `"many"` → `Target[]`,
    * each carrying optional `linkProperties` and its own nested `.links`). Nested
-   * targets stay precise on the server path (full registry) and degrade to the
-   * loose base on the client until the generated registry sharpens them.
+   * targets stay precise when the link uses direct object targets or when the id
+   * target resolves through the registry, and otherwise degrade to the loose base.
    */
   expand<
     TLinkToken extends LinkToken<TObjectType["id"], string, LinkTargetObjectTypeIdValue>,

--- a/packages/core/tests/batch-upsert.test.ts
+++ b/packages/core/tests/batch-upsert.test.ts
@@ -27,7 +27,7 @@ const Room = defineObjectType({
   ],
   links: [
     link("inBuilding", Building, { cardinality: "one" }),
-    link("hasSensors", "sensor", { cardinality: "many" }),
+    link.ref("hasSensors", "sensor", { cardinality: "many" }),
   ],
 })
 

--- a/packages/core/tests/define.test.ts
+++ b/packages/core/tests/define.test.ts
@@ -29,7 +29,7 @@ describe("defineObjectType", () => {
       id: "thermostat",
       name: "Thermostat",
       properties: [prop("id", "string", { required: true, primary: true }), prop("mode", "string")],
-      links: [link("controls", "hvacZone")],
+      links: [link.ref("controls", "hvacZone")],
     })
     expect(ot.properties).toHaveLength(2)
     expect(ot.links).toHaveLength(1)
@@ -149,42 +149,62 @@ describe("prop", () => {
 // ── link ────────────────────────────────────────────────────
 
 describe("link", () => {
-  test("uses id as default name", () => {
-    const l = link("locatedIn", "space")
+  test("ref target uses id as default name", () => {
+    const l = link.ref("locatedIn", "space")
     expect(l.id).toBe("locatedIn")
     expect(l.name).toBe("locatedIn")
     expect(l.targetObjectTypeId).toBe("space")
   })
 
-  test("accepts cardinality and other options", () => {
-    const l = link("contains", "room", {
+  test("ref target accepts options", () => {
+    const l = link.ref("contains", "room", {
       name: "Contains",
       cardinality: "many",
       description: "Rooms in this building",
     })
     expect(l.name).toBe("Contains")
+    expect(l.targetObjectTypeId).toBe("room")
     expect(l.cardinality).toBe("many")
     expect(l.description).toBe("Rooms in this building")
   })
 
+  test("ref target accepts id arrays", () => {
+    const l = link.ref("controls", ["thermostat", "valve"])
+    expect(l.targetObjectTypeId).toEqual(["thermostat", "valve"])
+  })
+
+  // ── Self target ─────────────────────────────────────────────
+
+  test("self target resolves to the defining object type id", () => {
+    const Folder = defineObjectType({
+      id: "Folder",
+      name: "Folder",
+      properties: [prop("id", "string", { required: true, primary: true })],
+      links: [link.self("parent", { cardinality: "one" })],
+    })
+
+    expect(Folder.links[0]?.targetObjectTypeId).toBe("Folder")
+    expect(Folder.l.parent.targetObjectTypeId).toBe("Folder")
+  })
+
   // ── Wildcard ────────────────────────────────────────────────
 
-  test("wildcard: no target defaults to '*'", () => {
-    const l = link("assignedTo")
+  test("wildcard target stores '*'", () => {
+    const l = link.any("assignedTo")
     expect(l.id).toBe("assignedTo")
     expect(l.name).toBe("assignedTo")
     expect(l.targetObjectTypeId).toBe("*")
   })
 
   test("wildcard with options", () => {
-    const l = link("assignedTo", { cardinality: "one", description: "Assigned entity" })
+    const l = link.any("assignedTo", { cardinality: "one", description: "Assigned entity" })
     expect(l.targetObjectTypeId).toBe("*")
     expect(l.cardinality).toBe("one")
     expect(l.description).toBe("Assigned entity")
   })
 
   test("wildcard with name override", () => {
-    const l = link("assignedTo", { name: "Assigned To" })
+    const l = link.any("assignedTo", { name: "Assigned To" })
     expect(l.targetObjectTypeId).toBe("*")
     expect(l.name).toBe("Assigned To")
   })
@@ -201,6 +221,12 @@ describe("link", () => {
     expect(l.id).toBe("locatedIn")
     expect(l.targetObjectTypeId).toBe("room")
     expect(l.name).toBe("locatedIn")
+    expect(Object.getOwnPropertySymbols(l)).toEqual([])
+    expect(l).toEqual({
+      id: "locatedIn",
+      name: "locatedIn",
+      targetObjectTypeId: "room",
+    })
   })
 
   test("single ObjectType target with options", () => {
@@ -212,6 +238,7 @@ describe("link", () => {
     const l = link("locatedIn", Room, { cardinality: "one" })
     expect(l.targetObjectTypeId).toBe("room")
     expect(l.cardinality).toBe("one")
+    expect(Object.getOwnPropertySymbols(l)).toEqual([])
   })
 
   test("ObjectType array target extracts ids", () => {
@@ -227,6 +254,7 @@ describe("link", () => {
     })
     const l = link("locatedIn", [Room, Floor])
     expect(l.targetObjectTypeId).toEqual(["room", "floor"])
+    expect(Object.getOwnPropertySymbols(l)).toEqual([])
   })
 
   test("ObjectType array target with options", () => {
@@ -243,29 +271,6 @@ describe("link", () => {
     const l = link("locatedIn", [Room, Floor], { cardinality: "many" })
     expect(l.targetObjectTypeId).toEqual(["room", "floor"])
     expect(l.cardinality).toBe("many")
-  })
-
-  // ── Backward compatibility ─────────────────────────────────
-
-  test("backward compat: string target", () => {
-    const l = link("locatedIn", "space")
-    expect(l.targetObjectTypeId).toBe("space")
-  })
-
-  test("backward compat: string target with options", () => {
-    const l = link("locatedIn", "space", { cardinality: "one" })
-    expect(l.targetObjectTypeId).toBe("space")
-    expect(l.cardinality).toBe("one")
-  })
-
-  test("backward compat: string array target", () => {
-    const l = link("controls", ["thermostat", "valve"])
-    expect(l.targetObjectTypeId).toEqual(["thermostat", "valve"])
-  })
-
-  test("backward compat: explicit wildcard string", () => {
-    const l = link("anything", "*")
-    expect(l.targetObjectTypeId).toBe("*")
   })
 })
 
@@ -390,7 +395,7 @@ describe("nested object schemas", () => {
 
 describe("links with properties", () => {
   test("link carries metadata properties", () => {
-    const l = link("installedIn", "room", {
+    const l = link.ref("installedIn", "room", {
       name: "Installed In",
       cardinality: "one",
       properties: [
@@ -424,7 +429,7 @@ describe("interface composition", () => {
         prop("serialNumber", "string"),
         prop("firmwareVersion", "string", { nullable: true }),
       ],
-      links: [link("locatedIn", "space", { cardinality: "one" })],
+      links: [link.ref("locatedIn", "space", { cardinality: "one" })],
     })
     expect(sensor.properties).toHaveLength(4)
     expect(sensor.links).toHaveLength(1)
@@ -491,7 +496,7 @@ describe("realistic ontology", () => {
         prop("floorCount", "integer"),
         prop("totalArea", "double", { semanticType: "Area" }),
       ],
-      links: [link("contains", "floor", { cardinality: "many" })],
+      links: [link.ref("contains", "floor", { cardinality: "many" })],
     })
 
     const floor = defineObjectType({
@@ -503,8 +508,8 @@ describe("realistic ontology", () => {
         prop("area", "double", { semanticType: "Area" }),
       ],
       links: [
-        link("contains", "room", { cardinality: "many" }),
-        link("partOf", "building", { cardinality: "one" }),
+        link.ref("contains", "room", { cardinality: "many" }),
+        link.ref("partOf", "building", { cardinality: "one" }),
       ],
     })
 
@@ -519,8 +524,8 @@ describe("realistic ontology", () => {
         prop("occupancy", "boolean"),
       ],
       links: [
-        link("partOf", "floor", { cardinality: "one" }),
-        link("hasThermostat", "thermostat", { cardinality: "one" }),
+        link.ref("partOf", "floor", { cardinality: "one" }),
+        link.ref("hasThermostat", "thermostat", { cardinality: "one" }),
       ],
     })
 
@@ -544,7 +549,7 @@ describe("realistic ontology", () => {
         prop("fanSpeed", integerEnum([0, 1, 2, 3]), { name: "Fan Speed" }),
         prop("humidity", "double", { semanticType: "RelativeHumidity" }),
       ],
-      links: [link("controls", "room", { cardinality: "one" })],
+      links: [link.ref("controls", "room", { cardinality: "one" })],
     })
 
     // Verify the full graph
@@ -662,7 +667,7 @@ describe("realistic ontology", () => {
         prop("temperature", "double", { semanticType: "Temperature", required: true }),
         prop("accuracy", "double", { semanticType: "Temperature" }),
       ],
-      links: [link("locatedIn", "room", { cardinality: "one" })],
+      links: [link.ref("locatedIn", "room", { cardinality: "one" })],
     })
 
     const co2Sensor = defineObjectType({
@@ -674,7 +679,7 @@ describe("realistic ontology", () => {
         ...measurable.properties,
         prop("concentration", "double", { semanticType: "Concentration", required: true }),
       ],
-      links: [link("locatedIn", "room", { cardinality: "one" })],
+      links: [link.ref("locatedIn", "room", { cardinality: "one" })],
     })
 
     // Both implement measurable

--- a/packages/core/tests/extends.test.ts
+++ b/packages/core/tests/extends.test.ts
@@ -13,7 +13,7 @@ const Equipment = defineObjectType({
     prop("name", "string", { required: true }),
     prop("manufacturer", "string"),
   ],
-  links: [link("locatedIn", "Location", { cardinality: "one" })],
+  links: [link.ref("locatedIn", "Location", { cardinality: "one" })],
 })
 
 const HVACEquipment = defineObjectType({
@@ -21,7 +21,7 @@ const HVACEquipment = defineObjectType({
   id: "HVACEquipment",
   name: "HVAC Equipment",
   properties: [prop("capacity", "double")],
-  links: [link("feeds", "Equipment", { cardinality: "many" })],
+  links: [link.ref("feeds", "Equipment", { cardinality: "many" })],
 })
 
 const AHU = defineObjectType({
@@ -115,7 +115,7 @@ describe("defineObjectType with string extends (pre-flattened)", () => {
     name: "Pre-Flattened Type",
     extends: "brick:Equipment",
     properties: [prop("inheritedProp", "string"), prop("ownProp", "double", { required: true })],
-    links: [link("hasLocation", "brick:Location")],
+    links: [link.ref("hasLocation", "brick:Location")],
   })
 
   test(".extends stores the string directly", () => {
@@ -573,7 +573,7 @@ describe("link target validation", () => {
       id: "Source",
       name: "Source",
       properties: [prop("id", "string", { required: true, primary: true })],
-      links: [link("rel", ["TypeA", "TypeB"])],
+      links: [link.ref("rel", ["TypeA", "TypeB"])],
     })
 
     const sixb = new Sixb({
@@ -605,7 +605,7 @@ describe("link target validation", () => {
       id: "Src",
       name: "Src",
       properties: [prop("id", "string", { required: true, primary: true })],
-      links: [link("rel", ["Equipment"])],
+      links: [link.ref("rel", ["Equipment"])],
     })
 
     const sixb = new Sixb({
@@ -630,7 +630,7 @@ describe("link target validation", () => {
       id: "WildSrc",
       name: "WildSrc",
       properties: [prop("id", "string", { required: true, primary: true })],
-      links: [link("anything", "*")],
+      links: [link.any("anything")],
     })
 
     const sixb = new Sixb({

--- a/packages/core/tests/extends.types.ts
+++ b/packages/core/tests/extends.types.ts
@@ -19,7 +19,7 @@ const Equipment = defineObjectType({
     prop("name", "string", { required: true }),
     prop("manufacturer", "string"),
   ],
-  links: [link("locatedIn", "location", { cardinality: "one" })],
+  links: [link.ref("locatedIn", "location", { cardinality: "one" })],
 })
 
 const HVACEquipment = defineObjectType({
@@ -27,7 +27,7 @@ const HVACEquipment = defineObjectType({
   id: "hvac",
   name: "HVAC Equipment",
   properties: [prop("capacity", "double")],
-  links: [link("feeds", "hvac", { cardinality: "many" })],
+  links: [link.ref("feeds", "hvac", { cardinality: "many" })],
 })
 
 // ── extends stores parent id as string ──────────────────────
@@ -83,7 +83,7 @@ const Entity = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("entityName", "string", { required: true }),
   ],
-  links: [link("partOf", "entity", { cardinality: "one" })],
+  links: [link.ref("partOf", "entity", { cardinality: "one" })],
 })
 
 const Equipment2 = defineObjectType({
@@ -91,7 +91,7 @@ const Equipment2 = defineObjectType({
   id: "equipment2",
   name: "Equipment",
   properties: [prop("serialNumber", "string")],
-  links: [link("serves", "entity", { cardinality: "many" })],
+  links: [link.ref("serves", "entity", { cardinality: "many" })],
 })
 
 const HVACEquipment2 = defineObjectType({

--- a/packages/core/tests/object-query-expand-recursion.types.ts
+++ b/packages/core/tests/object-query-expand-recursion.types.ts
@@ -1,0 +1,163 @@
+import { defineObjectType, link, type ObjectQueryBuilder, prop } from "../src"
+
+const StressDepartment = defineObjectType({
+  id: "StressDepartment",
+  name: "Department",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+  ],
+})
+
+const StressSkill = defineObjectType({
+  id: "StressSkill",
+  name: "Skill",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+  ],
+})
+
+const StressUser = defineObjectType({
+  id: "StressUser",
+  name: "User",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("email", "string", { required: true }),
+  ],
+  links: [
+    link("manager", "StressUser", { cardinality: "one" }),
+    link("department", StressDepartment, { cardinality: "one" }),
+    link("skills", StressSkill, { cardinality: "many" }),
+  ],
+})
+
+const StressTeam = defineObjectType({
+  id: "StressTeam",
+  name: "Team",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("slug", "string", { required: true }),
+  ],
+  links: [link("members", StressUser, { cardinality: "many" })],
+})
+
+const StressProject = defineObjectType({
+  id: "StressProject",
+  name: "Project",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+  ],
+  links: [link("owner", ["StressUser", "StressTeam"], { cardinality: "one" })],
+})
+
+const StressFolder = defineObjectType({
+  id: "StressFolder",
+  name: "Folder",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+  ],
+  links: [
+    link("parent", "StressFolder", { cardinality: "one" }),
+    link("children", "StressFolder", { cardinality: "many" }),
+  ],
+})
+
+type StressRegistry =
+  | typeof StressDepartment
+  | typeof StressFolder
+  | typeof StressProject
+  | typeof StressSkill
+  | typeof StressTeam
+  | typeof StressUser
+
+declare const projects: ObjectQueryBuilder<typeof StressProject, StressRegistry, []>
+declare const folders: ObjectQueryBuilder<typeof StressFolder, StressRegistry, []>
+
+type RowOf<TBuilt> = TBuilt extends { first(): Promise<infer TRow> } ? NonNullable<TRow> : never
+
+const builtProjects = projects.expand(StressProject.l.owner, (owner) =>
+  owner
+    .expand(StressUser.l.department)
+    .expand(StressUser.l.skills, { limit: 5 })
+    .expand(StressTeam.l.members, { limit: 10 }, (member) => member.expand(StressUser.l.manager))
+)
+type ProjectRow = RowOf<typeof builtProjects>
+
+function projectRowAssertions(row: ProjectRow): void {
+  const owner = row.links.owner
+  const ownerTypeId: "StressUser" | "StressTeam" | undefined = owner?.objectTypeId
+
+  if (owner?.objectTypeId === "StressUser") {
+    const departmentName: string | undefined = owner.links.department?.properties.name
+    const skillNames: string[] = owner.links.skills.map((skill) => skill.properties.name)
+    // @ts-expect-error — Team-only nested expansion is not present on User rows.
+    const members = owner.links.members
+    void [departmentName, skillNames, members]
+  }
+
+  if (owner?.objectTypeId === "StressTeam") {
+    const memberEmails: string[] = owner.links.members.map((member) => member.properties.email)
+    const managerEmails: (string | undefined)[] = owner.links.members.map(
+      (member) => member.links.manager?.properties.email
+    )
+    // @ts-expect-error — User-only nested expansion is not present on Team rows.
+    const department = owner.links.department
+    void [memberEmails, managerEmails, department]
+  }
+
+  void ownerTypeId
+}
+void projectRowAssertions
+
+function projectCollectionAssertions(rows: ProjectRow[]): void {
+  const ownerLabels: string[] = rows.map((project) => project.links.owner?.objectTypeId ?? "none")
+  const memberEmails: string[] = rows.flatMap((project) => {
+    const owner = project.links.owner
+    return owner?.objectTypeId === "StressTeam"
+      ? owner.links.members.map((member) => member.properties.email)
+      : []
+  })
+  const expandedOwnerCount: number = rows.reduce(
+    (total, project) => total + (project.links.owner ? 1 : 0),
+    0
+  )
+
+  void [ownerLabels, memberEmails, expandedOwnerCount]
+}
+void projectCollectionAssertions
+
+const builtFolders = folders
+  .expand(StressFolder.l.parent, (p1) =>
+    p1.expand(StressFolder.l.parent, (p2) =>
+      p2.expand(StressFolder.l.parent, (p3) =>
+        p3.expand(StressFolder.l.parent, (p4) => p4.expand(StressFolder.l.parent))
+      )
+    )
+  )
+  .expand(StressFolder.l.children, { limit: 10 }, (child) =>
+    child.expand(StressFolder.l.children, { limit: 5 }, (grandchild) =>
+      grandchild.expand(StressFolder.l.parent)
+    )
+  )
+type FolderRow = RowOf<typeof builtFolders>
+
+function folderRowAssertions(row: FolderRow): void {
+  const ancestorNames: (string | undefined)[] = [row].map(
+    (folder) =>
+      folder.links.parent?.links.parent?.links.parent?.links.parent?.links.parent?.properties.name
+  )
+  const descendantNames: string[] = row.links.children.flatMap((child) =>
+    child.links.children.map(
+      (grandchild) => grandchild.links.parent?.properties.name ?? grandchild.properties.name
+    )
+  )
+  const descendantTypeIds: ("StressFolder" | undefined)[] = row.links.children.flatMap((child) =>
+    child.links.children.map((grandchild) => grandchild.links.parent?.objectTypeId)
+  )
+
+  void [ancestorNames, descendantNames, descendantTypeIds]
+}
+void folderRowAssertions

--- a/packages/core/tests/object-query-expand-recursion.types.ts
+++ b/packages/core/tests/object-query-expand-recursion.types.ts
@@ -26,7 +26,7 @@ const StressUser = defineObjectType({
     prop("email", "string", { required: true }),
   ],
   links: [
-    link("manager", "StressUser", { cardinality: "one" }),
+    link.self("manager", { cardinality: "one" }),
     link("department", StressDepartment, { cardinality: "one" }),
     link("skills", StressSkill, { cardinality: "many" }),
   ],
@@ -49,7 +49,7 @@ const StressProject = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
   ],
-  links: [link("owner", ["StressUser", "StressTeam"], { cardinality: "one" })],
+  links: [link.ref("owner", ["StressUser", "StressTeam"], { cardinality: "one" })],
 })
 
 const StressFolder = defineObjectType({
@@ -60,8 +60,8 @@ const StressFolder = defineObjectType({
     prop("name", "string", { required: true }),
   ],
   links: [
-    link("parent", "StressFolder", { cardinality: "one" }),
-    link("children", "StressFolder", { cardinality: "many" }),
+    link.self("parent", { cardinality: "one" }),
+    link.self("children", { cardinality: "many" }),
   ],
 })
 

--- a/packages/core/tests/object-query-expand.test.ts
+++ b/packages/core/tests/object-query-expand.test.ts
@@ -59,7 +59,7 @@ const Folder = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
   ],
-  links: [link("parent", "Folder", { cardinality: "one" })],
+  links: [link.self("parent", { cardinality: "one" })],
 })
 
 const ProjectFolder = defineObjectType({

--- a/packages/core/tests/object-query-expand.types.ts
+++ b/packages/core/tests/object-query-expand.types.ts
@@ -6,9 +6,10 @@
  * ("type instantiation is excessively deep"). The `@ts-expect-error` lines prove
  * links and `orderBy` properties are constrained to the resolved target type.
  *
- * Each `.expand(...)` widens the row's `.links` (cardinality `"one"` →
- * `Target | null`, `"many"` → `Target[]`, with optional `.linkProperties` and
- * nested `.links`).
+ * Slice 3 adds the row-typing section: each `.expand(...)` widens the row's
+ * `.links` (cardinality `"one"` → `Target | null`, `"many"` → `Target[]`, with
+ * optional `.linkProperties` and nested `.links`). Direct ObjectType links are
+ * precise without a generated registry; id-only refs still use the registry.
  */
 import { defineObjectType, link, type ObjectQueryBuilder, prop } from "../src"
 
@@ -53,7 +54,7 @@ const Folder = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
   ],
-  links: [link("parent", "Folder", { cardinality: "one" })],
+  links: [link.self("parent", { cardinality: "one" })],
 })
 
 const ProjectFolder = defineObjectType({
@@ -91,6 +92,8 @@ type AppRegistry =
 // Server path: `objects(T)` binds the full registry, so nested targets resolve.
 declare const projects: ObjectQueryBuilder<typeof Project, AppRegistry, []>
 declare const folders: ObjectQueryBuilder<typeof Folder, AppRegistry, []>
+// Client path with no full registry. Direct ObjectType links still resolve.
+declare const startTypeOnly: ObjectQueryBuilder<typeof Project, typeof Project, []>
 
 function authoring(): void {
   // 2-hop, precise: Project -> opportunity -> { company, contact }.
@@ -126,6 +129,13 @@ function authoring(): void {
 
   // @ts-expect-error — `name` is a Project property, not on the Opportunity target.
   projects.expand(Project.l.opportunity, { orderBy: [{ property: Project.p.name }] })
+
+  startTypeOnly.expand(Project.l.opportunity, (o) =>
+    o.expand(
+      // @ts-expect-error — direct target metadata resolves Opportunity without a registry.
+      Folder.l.parent
+    )
+  )
 }
 
 void authoring
@@ -213,3 +223,12 @@ function folderRowAssertions(row: FolderRow): void {
   void [_p1Id, _p2Id]
 }
 void folderRowAssertions
+
+// Client path with direct ObjectType targets: no generated registry is needed.
+const builtDirectClient = startTypeOnly.expand(Project.l.opportunity)
+type DirectClientRow = RowOf<typeof builtDirectClient>
+function directClientRowAssertions(row: DirectClientRow): void {
+  const _id: "Opportunity" = row.links.opportunity!.objectTypeId
+  void _id
+}
+void directClientRowAssertions

--- a/packages/core/tests/object-query-expand.types.ts
+++ b/packages/core/tests/object-query-expand.types.ts
@@ -4,13 +4,11 @@
  * The file compiling at all is the core assertion: the expand builder types
  * resolve the 2-hop ADN graph AND the `Folder.parent` self-cycle with NO TS2589
  * ("type instantiation is excessively deep"). The `@ts-expect-error` lines prove
- * links and `orderBy` properties are constrained to the resolved target type on
- * the full-registry (server) path.
+ * links and `orderBy` properties are constrained to the resolved target type.
  *
- * Slice 3 adds the row-typing section: each `.expand(...)` widens the row's
- * `.links` (cardinality `"one"` → `Target | null`, `"many"` → `Target[]`, with
- * optional `.linkProperties` and nested `.links`), precise on the server path and
- * degraded-but-compiling on the client path until the generated registry lands.
+ * Each `.expand(...)` widens the row's `.links` (cardinality `"one"` →
+ * `Target | null`, `"many"` → `Target[]`, with optional `.linkProperties` and
+ * nested `.links`).
  */
 import { defineObjectType, link, type ObjectQueryBuilder, prop } from "../src"
 
@@ -93,8 +91,6 @@ type AppRegistry =
 // Server path: `objects(T)` binds the full registry, so nested targets resolve.
 declare const projects: ObjectQueryBuilder<typeof Project, AppRegistry, []>
 declare const folders: ObjectQueryBuilder<typeof Folder, AppRegistry, []>
-// Client path today: only the start type is registered, so nested targets degrade.
-declare const startTypeOnly: ObjectQueryBuilder<typeof Project, typeof Project, []>
 
 function authoring(): void {
   // 2-hop, precise: Project -> opportunity -> { company, contact }.
@@ -130,10 +126,6 @@ function authoring(): void {
 
   // @ts-expect-error — `name` is a Project property, not on the Opportunity target.
   projects.expand(Project.l.opportunity, { orderBy: [{ property: Project.p.name }] })
-
-  // Without a full registry the nested target degrades to the base type, so even
-  // an unrelated link compiles — the gap a generated client registry closes.
-  startTypeOnly.expand(Project.l.opportunity, (o) => o.expand(Folder.l.parent))
 }
 
 void authoring
@@ -169,6 +161,9 @@ function projectRowAssertions(row: ProjectRow): void {
 
   // "many" cardinality → array (not nullable).
   const _firstContactId: "Contact" | undefined = row.links.contacts[0]?.objectTypeId
+  const _contactNames: string[] = row.links.contacts.map(
+    (contact) => contact.properties.displayName
+  )
 
   // Edge metadata is optional (the executor attaches it only when present).
   const _edge: Record<string, unknown> | undefined = row.links.opportunity!.linkProperties
@@ -183,7 +178,19 @@ function projectRowAssertions(row: ProjectRow): void {
   // @ts-expect-error — projectFolder resolves to "ProjectFolder", not "Opportunity".
   const _wrong: "Opportunity" = row.links.projectFolder!.objectTypeId
 
-  void [_rootId, _name, _pfId, _nas, _firstContactId, _edge, _coId, _coName, _ctId, _wrong]
+  void [
+    _rootId,
+    _name,
+    _pfId,
+    _nas,
+    _firstContactId,
+    _contactNames,
+    _edge,
+    _coId,
+    _coName,
+    _ctId,
+    _wrong,
+  ]
 }
 void projectRowAssertions
 
@@ -206,15 +213,3 @@ function folderRowAssertions(row: FolderRow): void {
   void [_p1Id, _p2Id]
 }
 void folderRowAssertions
-
-// Client path: the nested target degrades to the base type, so `objectTypeId`
-// widens to `string` — but the row still compiles (no TS2589). The gap the
-// generated client registry closes.
-const builtDegraded = startTypeOnly.expand(Project.l.opportunity)
-type DegradedRow = RowOf<typeof builtDegraded>
-function degradedRowAssertions(row: DegradedRow): void {
-  // @ts-expect-error — no registry: the target is not resolved to "Opportunity".
-  const _id: "Opportunity" = row.links.opportunity!.objectTypeId
-  void _id
-}
-void degradedRowAssertions

--- a/packages/core/tests/object-query.test.ts
+++ b/packages/core/tests/object-query.test.ts
@@ -83,7 +83,7 @@ const WildcardSource = defineObjectType({
   id: "WildcardSource",
   name: "Wildcard Source",
   properties: [prop("id", "string", { required: true, primary: true })],
-  links: [link("anything")],
+  links: [link.any("anything")],
 })
 
 const SearchProfileCustomer = defineObjectType({

--- a/packages/core/tests/object-type-literals.types.ts
+++ b/packages/core/tests/object-type-literals.types.ts
@@ -1,4 +1,11 @@
-import { defineObjectType, integerEnum, link, prop, stringEnum } from "../src"
+import {
+  defineObjectType,
+  integerEnum,
+  link,
+  type ObjectLinkTargetType,
+  prop,
+  stringEnum,
+} from "../src"
 
 /**
  * Compile-time contract tests for builder literal inference.
@@ -53,7 +60,7 @@ const thermostat = defineObjectType({
     prop("mode", stringEnum(["off", "heat", "cool", "auto"]), { required: true }),
     prop("fanSpeed", integerEnum([1, 2, 3, 4])),
   ],
-  links: [link("locatedIn", "room", { cardinality: "one" })],
+  links: [link.ref("locatedIn", "room", { cardinality: "one" })],
   search: {
     title: "externalId",
     defaultText: ["externalId"],
@@ -90,12 +97,18 @@ type _modeEnumUnion = Expect<
 
 // ── link() overload type tests ─────────────────────────────
 
-// Wildcard: no target → "*"
-const wildcardLink = link("anything")
+// Ambiguous legacy forms are intentionally rejected.
+// @ts-expect-error — id references must use link.ref(...).
+link("locatedIn", "space")
+// @ts-expect-error — wildcard links must use link.any(...).
+link("anything")
+
+// Wildcard target → "*"
+const wildcardLink = link.any("anything")
 type _wildcardTarget = Expect<Equal<typeof wildcardLink.targetObjectTypeId, "*">>
 
 // Wildcard with options
-const wildcardWithOptions = link("anything", { cardinality: "many" })
+const wildcardWithOptions = link.any("anything", { cardinality: "many" })
 type _wildcardOptsTarget = Expect<Equal<typeof wildcardWithOptions.targetObjectTypeId, "*">>
 type _wildcardOptsCardinality = Expect<Equal<typeof wildcardWithOptions.cardinality, "many">>
 
@@ -107,6 +120,7 @@ const _Room = defineObjectType({
 })
 const objectTypeLink = link("locatedIn", _Room)
 type _otLinkTarget = Expect<Equal<typeof objectTypeLink.targetObjectTypeId, "room">>
+type _otLinkTargetType = Expect<Equal<ObjectLinkTargetType<typeof objectTypeLink>["id"], "room">>
 
 // ObjectType target + options
 const objectTypeLinkWithOpts = link("locatedIn", _Room, { cardinality: "one" })
@@ -123,17 +137,29 @@ const objectTypeArrayLink = link("locatedIn", [_Room, _Floor])
 type _otArrayTarget = Expect<
   Equal<typeof objectTypeArrayLink.targetObjectTypeId, ("room" | "floor")[]>
 >
-
-// String target (backward compat)
-const stringLink = link("locatedIn", "space")
-type _stringTarget = Expect<Equal<typeof stringLink.targetObjectTypeId, "space">>
-
-// String array target (backward compat)
-const stringArrayLink = link("controls", ["a", "b"] as const)
-type _stringArrayTarget = Expect<
-  Equal<typeof stringArrayLink.targetObjectTypeId, readonly ["a", "b"]>
+type _otArrayTargetType = Expect<
+  Equal<ObjectLinkTargetType<typeof objectTypeArrayLink>["id"], "room" | "floor">
 >
 
-// Explicit wildcard string (backward compat)
-const explicitWildcard = link("anything", "*")
-type _explicitWildcardTarget = Expect<Equal<typeof explicitWildcard.targetObjectTypeId, "*">>
+// Explicit id reference target
+const refLink = link.ref("locatedIn", "space")
+type _refTarget = Expect<Equal<typeof refLink.targetObjectTypeId, "space">>
+type _refTargetType = Expect<Equal<ObjectLinkTargetType<typeof refLink>, never>>
+
+const refLinkWithOpts = link.ref("locatedIn", "space", { cardinality: "one" })
+type _refTargetWithOpts = Expect<Equal<typeof refLinkWithOpts.targetObjectTypeId, "space">>
+type _refCardinalityWithOpts = Expect<Equal<typeof refLinkWithOpts.cardinality, "one">>
+
+// Explicit id reference array target
+const refArrayLink = link.ref("controls", ["a", "b"] as const)
+type _refArrayTarget = Expect<Equal<typeof refArrayLink.targetObjectTypeId, readonly ["a", "b"]>>
+
+// Self target normalizes to the source object type id inside defineObjectType.
+const _Folder = defineObjectType({
+  id: "folder",
+  name: "Folder",
+  properties: [prop("id", "string", { required: true, primary: true })],
+  links: [link.self("parent", { cardinality: "one" })],
+})
+type _selfLinkTarget = Expect<Equal<typeof _Folder.l.parent.targetObjectTypeId, "folder">>
+type _selfLinkCardinality = Expect<Equal<typeof _Folder.l.parent.link.cardinality, "one">>

--- a/packages/core/tests/ontology-type-manifest.test.ts
+++ b/packages/core/tests/ontology-type-manifest.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { generateOntologyTypeManifest } from "../src"
+
+describe("ontology type manifest", () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()
+      if (dir) await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("generates an ambient object type map from discovered ontology exports", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "sixb-type-manifest-"))
+    tempDirs.push(projectRoot)
+    await mkdir(join(projectRoot, "ontology"), { recursive: true })
+
+    await writeFile(
+      join(projectRoot, "ontology", "customer.ts"),
+      [
+        "export const Customer = {",
+        '  id: "Customer",',
+        '  name: "Customer",',
+        "  properties: [],",
+        "  links: [],",
+        "  p: {},",
+        "}",
+        "",
+        "const Region = {",
+        '  id: "Region",',
+        '  name: "Region",',
+        "  properties: [],",
+        "  links: [],",
+        "  p: {},",
+        "}",
+        "",
+        "export const AppOntology = {",
+        '  id: "app",',
+        '  version: "1.0.0",',
+        "  objectTypes: [Region],",
+        "}",
+        "",
+      ].join("\n"),
+      "utf-8"
+    )
+
+    const result = await generateOntologyTypeManifest({ projectRoot })
+    const content = await readFile(result.path, "utf-8")
+
+    expect(result.skipped).toBe(false)
+    expect(result.written).toBe(true)
+    expect(result.entries.map((entry) => entry.objectTypeId)).toEqual(["Customer", "Region"])
+    expect(content).toContain('"Customer": typeof import("../../ontology/customer")["Customer"]')
+    expect(content).toContain(
+      '"Region": Extract<(typeof import("../../ontology/customer")["AppOntology"])'
+    )
+    expect(content).toContain('declare module "@sixb/core/ontology"')
+  })
+
+  test("skips writing when there is no ontology directory", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "sixb-type-manifest-empty-"))
+    tempDirs.push(projectRoot)
+
+    const result = await generateOntologyTypeManifest({ projectRoot })
+
+    expect(result.skipped).toBe(true)
+    expect(result.written).toBe(false)
+    expect(result.entries).toEqual([])
+  })
+})

--- a/packages/core/tests/projection.test.ts
+++ b/packages/core/tests/projection.test.ts
@@ -33,7 +33,7 @@ const Room = defineObjectType({
   ],
   links: [
     link("inBuilding", Building, { cardinality: "one" }),
-    link("hasSensors", "sensor", { cardinality: "many" }),
+    link.ref("hasSensors", "sensor", { cardinality: "many" }),
   ],
 })
 
@@ -65,7 +65,7 @@ const TypeWithWildcardLink = defineObjectType({
   id: "wild",
   name: "Wild",
   properties: [prop("id", "string", { required: true, primary: true }), prop("ref", "string")],
-  links: [link("anything")],
+  links: [link.any("anything")],
 })
 
 // ── defineProjection ─────────────────────────────────────────

--- a/packages/core/tests/projection.types.ts
+++ b/packages/core/tests/projection.types.ts
@@ -56,7 +56,7 @@ const _Room = defineObjectType({
   ],
   links: [
     link("inBuilding", _Building, { cardinality: "one" }),
-    link("hasSensors", "sensor", { cardinality: "many" }),
+    link.ref("hasSensors", "sensor", { cardinality: "many" }),
   ],
 })
 

--- a/packages/core/tests/sixb-runtime.test.ts
+++ b/packages/core/tests/sixb-runtime.test.ts
@@ -38,7 +38,7 @@ const Room = defineObjectType({
     }),
     prop("currentTemperature", "double", { mode: "telemetry", semanticType: "Temperature" }),
   ],
-  links: [link("hasThermostat", "Thermostat", { cardinality: "one" })],
+  links: [link.ref("hasThermostat", "Thermostat", { cardinality: "one" })],
 })
 
 const Thermostat = defineObjectType({

--- a/packages/core/tests/sixb-runtime.types.ts
+++ b/packages/core/tests/sixb-runtime.types.ts
@@ -16,7 +16,7 @@ const Room = defineObjectType({
       semanticType: "Temperature",
     }),
   ],
-  links: [link("hasThermostat", "Thermostat", { cardinality: "one" })],
+  links: [link.ref("hasThermostat", "Thermostat", { cardinality: "one" })],
 })
 
 const Thermostat = defineObjectType({

--- a/packages/core/tests/validation.test.ts
+++ b/packages/core/tests/validation.test.ts
@@ -625,10 +625,10 @@ describe("validateLinkProperties", () => {
     name: "Room",
     properties: [prop("id", "string", { required: true, primary: true })],
     links: [
-      link("hasDevice", "Device", {
+      link.ref("hasDevice", "Device", {
         properties: [prop("installedBy", "string", { required: true }), prop("notes", "string")],
       }),
-      link("hasNeighbor", "Room"),
+      link.ref("hasNeighbor", "Room"),
     ],
   })
 

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -63,7 +63,7 @@ const Space = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
   ],
-  links: [link("contains", "device", { cardinality: "many" })],
+  links: [link.ref("contains", "device", { cardinality: "many" })],
 })
 
 const Device = defineObjectType({

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -6,7 +6,7 @@
     "dev": "sixb dev",
     "check": "sixb check",
     "build": "sixb build",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "sixb typegen && tsc --noEmit"
   },
   "dependencies": {
     "@sixb/blob-local": "latest",

--- a/templates/basic/tsconfig.json
+++ b/templates/basic/tsconfig.json
@@ -17,6 +17,7 @@
     "app/**/*.tsx",
     "ontology/**/*.ts",
     "functions/**/*.ts",
-    "sixb.config.ts"
+    "sixb.config.ts",
+    ".sixb/types/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
## Problem

`.expand()` could hydrate linked objects at runtime, but client-side TypeScript could not always describe the hydrated graph precisely.

The wall was link target resolution. A link token only carries the target as an id string:

```ts
link("customer", "Customer", { cardinality: "one" })
```

On the server, `sixb.objects(Project)` has the full ontology registry, so `"Customer"` can be resolved to the `Customer` object type. On the client, `objects(Project).query()` started from only `Project`, so nested targets were not available to the type system. That meant a query like this could execute correctly while losing precise client row types:

```ts
const query = objects(Project)
  .query()
  .expand(Project.l.customer, (customer) =>
    customer.expand(Customer.l.accountManager)
  )

const row = await query.first()
row?.links.customer?.links.accountManager?.properties.name
```

While testing the real app path, there was a second TypeScript issue: deeply expanded rows could hit recursion cliffs in normal app code, especially when using array helpers like `.map()` over expanded rows.

## Change

Add a generated, type-only ontology manifest and wire client object queries through it.

The generated file augments a public `SixbObjectTypeMap`:

```ts
declare module "@sixb/core/ontology" {
  interface SixbObjectTypeMap {
    Customer: typeof Customer
    Employee: typeof Employee
    Project: typeof Project
  }
}
```

The client query builder now uses that map as its registered object type set:

```ts
type ClientRegisteredObjectTypes<TObjectType> =
  | TObjectType
  | Extract<SixbObjectTypeMap[keyof SixbObjectTypeMap], ObjectTypeWithPropertyTokens>
```

That gives client-side `.expand(...)` the same id-to-type lookup table the server already has, without changing runtime ontology data or requiring app code to import a generated client object.

The manifest is generated into:

```text
.sixb/types/ontology.d.ts
```

and app/template `tsconfig.json` files include `.sixb/types/**/*.d.ts` so TypeScript sees the augmentation automatically.

## Row Type Fix

Expanded query rows now materialize into shallow structural row types instead of recursively flowing through the full object/token shape.

The important part is that row output is modeled as row data:

```ts
type MaterializedObjectRow<TObjectType, TValueTypes> = {
  primaryId: string
  objectTypeId: TObjectType["id"]
  properties: InferObjectProperties<TObjectType, TValueTypes>
  createdAt: Date
  updatedAt: Date
}
```

Nested expanded links are still precise, but the compiler no longer has to relate the full token-bearing ontology object every time app code maps over rows. The row materializer also re-checks nested expansions against the concrete source type, so polymorphic targets do not expose links from the wrong variant.

## Real App Proof

The Acme projects page now uses `.expand()` for the graph it renders:

```ts
const allProjects = objects(Project)
  .query()
  .expand(Project.l.customer, (customer) => customer.expand(Customer.l.accountManager))
  .expand(Project.l.lead, (lead) => lead.expand(Employee.l.department))
  .expand(Project.l.members, {
    limit: 4,
    orderBy: [{ property: Employee.p.name, direction: "asc" }],
  })
  .orderBy(Project.p.deadline, "asc")
```

The page reads nested linked objects directly from `project.links.*`, including normal `.map()` usage over expanded members. The previous hand-typed row/hydration approach is no longer needed for this view.

## Scope

This PR is the core fix and manifest layer only.

It intentionally does not introduce the follow-up link modeling DX changes:

- no `link.ref(...)`
- no `link.self(...)`
- no `link.any(...)`
- no direct target metadata for `link("customer", Customer)`

Those are isolated in the next stacked branch so this PR stays focused on correctness for existing id-based links.

## Tests

| Check | Result |
|---|---|
| `bun --filter @sixb/core typecheck` | pass |
| `bun --filter @sixb/client typecheck` | pass |
| `bun --filter @sixb/example-acme-corp typecheck` | pass |
| `bun test examples/acme-corp/tests/client-query.test.ts packages/client/tests/query.test.ts packages/core/tests/object-query-expand.test.ts packages/core/tests/object-query-expand-exec.test.ts packages/core/tests/ontology-type-manifest.test.ts` | 40 pass |
| `bun run check` | pass |
| `bun run typecheck` | pass |
| `git diff --check` | pass |
