### PR TITLE
ontology: clarify link targets

### DIFF
--- a/docs/concepts/ontology.md
+++ b/docs/concepts/ontology.md
@@ -164,24 +164,37 @@ export const Customer = defineObjectType({
 })
 ```
 
-`link(...)` takes these parameters:
+For links to object types you can import directly, use `link(...)`:
+
+```ts
+link("belongsTo", Organization)
+link("relatedTo", [Organization, Customer])
+```
+
+For id references, self-links, or intentionally open links, use the explicit helpers:
+
+```ts
+link.ref("belongsTo", "Organization")
+link.self("parent", { cardinality: "one" })
+link.any("relatedTo", { cardinality: "many" })
+```
+
+Use `link.ref(...)` when you want to reference another object type by id instead of importing it.
+Sixb's generated ontology type manifest lets typed client queries resolve those ids.
+
+Use `link.self(...)` for recursive relationships such as folders, org charts, or threaded
+comments. The target id is filled in from the object type that declares the link.
+
+Use `link.any(...)` only for wildcard relationships that can point to any object type. Prefer a
+specific target for relationships your app understands.
+
+All link forms take these parameters:
 
 | Parameter | Required | Expected |
 | --- | --- | --- |
 | `id` | Yes | A stable relationship key, unique within the source object type |
-| `target` | No | The object type this link can point to |
+| `target` | Depends on helper | The object type or object type id this link can point to |
 | `options` | No | An object for metadata and relationship behavior |
-
-The `target` can be an object type, an object type id, or an array of allowed object types or ids:
-
-```ts
-link("belongsTo", Organization)
-link("belongsTo", "Organization")
-link("relatedTo", [Organization, Customer])
-```
-
-When the target is omitted or set to `"*"`, the link is a wildcard link and can point to any
-object type. Prefer a specific target for relationships your app understands.
 
 `options` accepts these fields:
 

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -27,7 +27,7 @@ const Device = defineObjectType({
     prop("name", "string", { required: true }),
     prop("status", "string"),
   ],
-  links: [link("sensor", "Sensor", { cardinality: "one" })],
+  links: [link.ref("sensor", "Sensor", { cardinality: "one" })],
 })
 
 const Sensor = defineObjectType({

--- a/packages/client/tests/query-expand-degradation.types.ts
+++ b/packages/client/tests/query-expand-degradation.types.ts
@@ -14,7 +14,7 @@ const Order = defineObjectType({
   id: "DegradeOrder",
   name: "Order",
   properties: [prop("ref", "string", { required: true })],
-  links: [link("ghost", "DegradeGhost", { cardinality: "one" })],
+  links: [link.ref("ghost", "DegradeGhost", { cardinality: "one" })],
 })
 
 declare module "@sixb/core/ontology" {

--- a/packages/client/tests/query-expand-direct-target.types.ts
+++ b/packages/client/tests/query-expand-direct-target.types.ts
@@ -1,0 +1,90 @@
+import { defineObjectType, link, prop } from "@sixb/core/ontology"
+import { objects } from "../src/query"
+
+const Region = defineObjectType({
+  id: "DirectRegion",
+  name: "Region",
+  properties: [prop("code", "string", { required: true })],
+})
+
+const Customer = defineObjectType({
+  id: "DirectCustomer",
+  name: "Customer",
+  properties: [prop("name", "string", { required: true })],
+  links: [link("region", Region, { cardinality: "one" })],
+})
+
+const User = defineObjectType({
+  id: "DirectUser",
+  name: "User",
+  properties: [prop("email", "string", { required: true })],
+  links: [link("region", Region, { cardinality: "one" })],
+})
+
+const Team = defineObjectType({
+  id: "DirectTeam",
+  name: "Team",
+  properties: [prop("slug", "string", { required: true })],
+})
+
+const Project = defineObjectType({
+  id: "DirectProject",
+  name: "Project",
+  properties: [prop("name", "string", { required: true })],
+  links: [
+    link("customer", Customer, { cardinality: "one" }),
+    link("owner", [User, Team], { cardinality: "one" }),
+  ],
+})
+
+type RowOf<TBuilt> = TBuilt extends { first(): Promise<infer TRow> } ? NonNullable<TRow> : never
+
+const built = objects(Project)
+  .query()
+  .expand(Project.l.customer, (customer) => customer.expand(Customer.l.region))
+  .expand(Project.l.owner, (owner) => owner.expand(User.l.region))
+
+type ProjectRow = RowOf<typeof built>
+
+function projectRowAssertions(row: ProjectRow): void {
+  const projectTypeId: "DirectProject" = row.objectTypeId
+  const projectName: string = row.properties.name
+  const customerTypeId: "DirectCustomer" = row.links.customer!.objectTypeId
+  const customerName: string = row.links.customer!.properties.name
+  const regionTypeId: "DirectRegion" = row.links.customer!.links.region!.objectTypeId
+  const regionCode: string = row.links.customer!.links.region!.properties.code
+
+  const owner = row.links.owner
+  const ownerTypeId: "DirectUser" | "DirectTeam" | undefined = owner?.objectTypeId
+  const ownerTypeIds: ("DirectUser" | "DirectTeam" | undefined)[] = [row].map(
+    (project) => project.links.owner?.objectTypeId
+  )
+  if (owner?.objectTypeId === "DirectUser") {
+    const email: string = owner.properties.email
+    const userRegionCode: string = owner.links.region!.properties.code
+    // @ts-expect-error — DirectUser owners do not have Team properties.
+    const slug: string = owner.properties.slug
+    void [email, userRegionCode, slug]
+  }
+  if (owner?.objectTypeId === "DirectTeam") {
+    const slug: string = owner.properties.slug
+    // @ts-expect-error — DirectTeam owners do not have User properties.
+    const email: string = owner.properties.email
+    // @ts-expect-error — User-only nested expansion is not present on Team rows.
+    const userRegion = owner.links.region
+    void [slug, email, userRegion]
+  }
+
+  void [
+    projectTypeId,
+    projectName,
+    customerTypeId,
+    customerName,
+    regionTypeId,
+    regionCode,
+    ownerTypeId,
+    ownerTypeIds,
+  ]
+}
+
+void projectRowAssertions

--- a/packages/client/tests/query-expand-hook.types.ts
+++ b/packages/client/tests/query-expand-hook.types.ts
@@ -28,9 +28,9 @@ const HookUser = defineObjectType({
   name: "User",
   properties: [prop("email", "string", { required: true })],
   links: [
-    link("manager", "HookUser", { cardinality: "one" }),
-    link("department", "HookDepartment", { cardinality: "one" }),
-    link("skills", "HookSkill", { cardinality: "many" }),
+    link.self("manager", { cardinality: "one" }),
+    link.ref("department", "HookDepartment", { cardinality: "one" }),
+    link.ref("skills", "HookSkill", { cardinality: "many" }),
   ],
 })
 
@@ -38,14 +38,14 @@ const HookTeam = defineObjectType({
   id: "HookTeam",
   name: "Team",
   properties: [prop("slug", "string", { required: true })],
-  links: [link("members", "HookUser", { cardinality: "many" })],
+  links: [link.ref("members", "HookUser", { cardinality: "many" })],
 })
 
 const HookProject = defineObjectType({
   id: "HookProject",
   name: "Project",
   properties: [prop("name", "string", { required: true })],
-  links: [link("owner", ["HookUser", "HookTeam"], { cardinality: "one" })],
+  links: [link.ref("owner", ["HookUser", "HookTeam"], { cardinality: "one" })],
 })
 
 const HookFolder = defineObjectType({
@@ -53,8 +53,8 @@ const HookFolder = defineObjectType({
   name: "Folder",
   properties: [prop("name", "string", { required: true })],
   links: [
-    link("parent", "HookFolder", { cardinality: "one" }),
-    link("children", "HookFolder", { cardinality: "many" }),
+    link.self("parent", { cardinality: "one" }),
+    link.self("children", { cardinality: "many" }),
   ],
 })
 

--- a/packages/client/tests/query-expand-manifest.types.ts
+++ b/packages/client/tests/query-expand-manifest.types.ts
@@ -11,14 +11,14 @@ const Customer = defineObjectType({
   id: "ManifestCustomer",
   name: "Customer",
   properties: [prop("name", "string", { required: true })],
-  links: [link("region", "ManifestRegion", { cardinality: "one" })],
+  links: [link.ref("region", "ManifestRegion", { cardinality: "one" })],
 })
 
 const Project = defineObjectType({
   id: "ManifestProject",
   name: "Project",
   properties: [prop("name", "string", { required: true })],
-  links: [link("customer", "ManifestCustomer", { cardinality: "one" })],
+  links: [link.ref("customer", "ManifestCustomer", { cardinality: "one" })],
 })
 
 declare module "@sixb/core/ontology" {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -65,7 +65,7 @@ const Room = defineObjectType({
       semanticType: "Temperature",
     }),
   ],
-  links: [link("hasThermostat", "Thermostat", { cardinality: "one" })],
+  links: [link.ref("hasThermostat", "Thermostat", { cardinality: "one" })],
 })
 
 const Thermostat = defineObjectType({
@@ -393,7 +393,10 @@ src/
 | `defineValueType(input)` | Define a reusable value type |
 | `defineInterface(input)` | Define a reusable interface contract |
 | `prop(id, schema, options?)` | Shorthand for creating a property |
-| `link(id, targetTypeId, options?)` | Shorthand for creating a link |
+| `link(id, target, options?)` | Create a link to direct ObjectType target(s) |
+| `link.ref(id, targetTypeId, options?)` | Create an id-only link reference |
+| `link.self(id, options?)` | Create a self-link |
+| `link.any(id, options?)` | Create a wildcard link |
 | `stringEnum(values)` | Create a string enum schema |
 | `integerEnum(values)` | Create an integer enum schema |
 | `valueTypeRef(valueType)` | Reference a value type in a property schema |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,8 @@
 export type {
   ArraySchema,
   ComplexSchema,
+  DirectLinkResult,
+  DirectLinkTarget,
   EnumSchema,
   InferSchemaOrRef,
   Interface,
@@ -12,6 +14,8 @@ export type {
   MapSchema,
   ObjectFieldSchema,
   ObjectLink,
+  ObjectLinkTargetMetadata,
+  ObjectLinkTargetType,
   ObjectRef,
   ObjectRefSchema,
   ObjectSchema,

--- a/packages/core/src/objects/sdk/object-handle.ts
+++ b/packages/core/src/objects/sdk/object-handle.ts
@@ -19,6 +19,7 @@ import { removeLink as removeLinkLeaf, upsertLink as upsertLinkLeaf } from "../l
 import { createTelemetryAppender } from "./telemetry-appender"
 
 type ObjectRefInput = ObjectRef
+type AnyLinkToken = LinkToken<string, string, string | readonly string[], ObjectLink>
 
 export function createObjectByIdHandle<
   TObjectType extends ObjectTypeWithPropertyTokens,
@@ -35,7 +36,7 @@ export function createObjectByIdHandle<
       return row ? (row as unknown as TwinObject<TObjectType, TValueTypes>) : null
     },
 
-    listLinks: async (linkToken?: LinkToken<string, string, string, ObjectLink>) => {
+    listLinks: async (linkToken?: AnyLinkToken) => {
       // Link rows reveal target types; no link grant semantics exist yet.
       assertPrivileged(ctx, "listLinks")
       if (linkToken) {
@@ -50,7 +51,7 @@ export function createObjectByIdHandle<
     },
 
     link: async (
-      linkToken: LinkToken<string, string, string, ObjectLink>,
+      linkToken: AnyLinkToken,
       target: ObjectRefInput,
       options?: { properties?: Record<string, unknown> }
     ) => {
@@ -66,10 +67,7 @@ export function createObjectByIdHandle<
       })
     },
 
-    unlink: async (
-      linkToken: LinkToken<string, string, string, ObjectLink>,
-      target: ObjectRefInput
-    ) => {
+    unlink: async (linkToken: AnyLinkToken, target: ObjectRefInput) => {
       assertLinkTokenBelongsToObjectType(ctx.objectType, linkToken)
 
       const linkCtx: ResolvedLinkContext = { ...ctx, linkDefinition: linkToken.link }

--- a/packages/core/src/objects/sdk/query-builder.ts
+++ b/packages/core/src/objects/sdk/query-builder.ts
@@ -147,7 +147,7 @@ class ObjectQueryBuilderImpl<
   }
 
   expand(
-    link: LinkToken<string, string, string>,
+    link: LinkToken<string, string, string | readonly string[]>,
     optionsOrBuild?: ObjectExpandOptions<ObjectTypeWithPropertyTokens> | NestedExpandBuild,
     build?: NestedExpandBuild
   ): ObjectQueryBuilder<TObjectType, TRegisteredObjectTypes, TValueTypes> {
@@ -311,7 +311,7 @@ class ObjectExpandBuilderImpl {
   constructor(readonly expansions: readonly ObjectExpansion[] = []) {}
 
   expand(
-    link: LinkToken<string, string, string>,
+    link: LinkToken<string, string, string | readonly string[]>,
     optionsOrBuild?: ObjectExpandOptions<ObjectTypeWithPropertyTokens> | NestedExpandBuild,
     build?: NestedExpandBuild
   ): ObjectExpandBuilderImpl {
@@ -323,7 +323,7 @@ class ObjectExpandBuilderImpl {
 }
 
 function buildExpansion(
-  link: LinkToken<string, string, string>,
+  link: LinkToken<string, string, string | readonly string[]>,
   optionsOrBuild: ObjectExpandOptions<ObjectTypeWithPropertyTokens> | NestedExpandBuild | undefined,
   build: NestedExpandBuild | undefined
 ): ObjectExpansion {

--- a/packages/core/src/ontology/builders.ts
+++ b/packages/core/src/ontology/builders.ts
@@ -20,19 +20,20 @@
  *     prop("mode", stringEnum(["off", "heat", "cool", "auto"])),
  *   ],
  *   links: [
- *     link("controls", "hvacZone", { cardinality: "one" }),
+ *     link.ref("controls", "hvacZone", { cardinality: "one" }),
  *   ],
  * })
  * ```
  */
 
-import type { ObjectTypeWithTokens } from "./tokens"
+import type { ObjectTypeWithPropertyTokens, ObjectTypeWithTokens, PropertyTokenMap } from "./tokens"
 import { createLinkTokenMap, createPropertyTokenMap } from "./tokens"
 import type {
   EnumSchema,
   Interface,
   LinkCardinality,
   ObjectLink,
+  ObjectLinkTargetMetadata,
   ObjectType,
   Ontology,
   Property,
@@ -62,6 +63,19 @@ type FieldFromOptions<TOptions, TKey extends string, TFallback> =
     ? { [K in TKey]: TValue }
     : { [K in TKey]?: TFallback }
 
+const selfLinkTargetObjectTypeId = "__sixb.self__"
+type SelfLinkTargetObjectTypeId = typeof selfLinkTargetObjectTypeId
+
+type NormalizeSelfLink<TObjectTypeId extends string, TLink> = TLink extends {
+  targetObjectTypeId: SelfLinkTargetObjectTypeId
+}
+  ? Omit<TLink, "targetObjectTypeId"> & { targetObjectTypeId: TObjectTypeId }
+  : TLink
+
+type NormalizeSelfLinks<TObjectTypeId extends string, TLinks extends readonly ObjectLink[]> = {
+  -readonly [K in keyof TLinks]: NormalizeSelfLink<TObjectTypeId, TLinks[K]>
+}
+
 // ── Extends type utilities ───────────────────────────────────
 
 /**
@@ -78,6 +92,12 @@ type MergedCollection<
  */
 type OwnCollection<TInput, TKey extends string, TItem> =
   TInput extends Record<TKey, infer T extends readonly TItem[]> ? [...T] : []
+
+type OwnLinks<TInput> = TInput extends { id: infer TObjectTypeId extends string }
+  ? TInput extends Record<"links", infer TLinks extends readonly ObjectLink[]>
+    ? NormalizeSelfLinks<TObjectTypeId, TLinks>
+    : []
+  : []
 
 /**
  * Merge two arrays by id: parent items first, child items override by id.
@@ -138,19 +158,19 @@ type DefineObjectTypeResult<TInput extends DefineObjectTypeInput> = Omit<
           TParent["properties"],
           OwnCollection<TInput, "properties", Property>
         >
-        links: MergedCollection<TParent["links"], OwnCollection<TInput, "links", ObjectLink>>
+        links: MergedCollection<TParent["links"], OwnLinks<TInput>>
       }
     : TInput extends { extends: infer TParentId extends string }
       ? {
           extends: TParentId
           parents: string[]
           properties: OwnCollection<TInput, "properties", Property>
-          links: OwnCollection<TInput, "links", ObjectLink>
+          links: OwnLinks<TInput>
         }
       : NormalizeParents<TInput> & {
           extends: undefined
           properties: OwnCollection<TInput, "properties", Property>
-          links: OwnCollection<TInput, "links", ObjectLink>
+          links: OwnLinks<TInput>
         })
 
 type DefineObjectTypeWithTokensResult<TInput extends DefineObjectTypeInput> = ObjectTypeWithTokens<
@@ -170,7 +190,9 @@ export function defineObjectType(input: DefineObjectTypeInput): ObjectTypeWithTo
   const ext = input.extends
 
   const ownProperties = input.properties ? [...input.properties] : []
-  const ownLinks = input.links ? [...input.links] : []
+  const ownLinks = input.links
+    ? input.links.map((link) => normalizeSelfLinkTarget(input.id, link))
+    : []
 
   let extendsId: string | undefined
   let parentIds: string[] | undefined
@@ -215,6 +237,17 @@ export function defineObjectType(input: DefineObjectTypeInput): ObjectTypeWithTo
     ...objectType,
     l: createLinkTokenMap(objectType),
     p: createPropertyTokenMap(objectType),
+  }
+}
+
+function normalizeSelfLinkTarget(objectTypeId: string, link: ObjectLink): ObjectLink {
+  if (link.targetObjectTypeId !== selfLinkTargetObjectTypeId) {
+    return link
+  }
+
+  return {
+    ...link,
+    targetObjectTypeId: objectTypeId,
   }
 }
 
@@ -405,68 +438,137 @@ type LinkResult<
   FieldFromOptions<TOptions, "cardinality", LinkCardinality> &
   FieldFromOptions<TOptions, "properties", Property[]>
 
+export type DirectLinkResult<
+  TId extends string,
+  TTargetObjectTypeId,
+  TOptions extends LinkOptions | undefined,
+  TTarget,
+> = LinkResult<TId, TTargetObjectTypeId, TOptions> & ObjectLinkTargetMetadata<TTarget>
+
+type ObjectTypeIdArray<TTargets extends readonly ObjectType[]> = Array<TTargets[number]["id"]>
+export type DirectLinkTarget<
+  TId extends string,
+  TName extends string,
+  TProperties extends Property[],
+> = {
+  id: TId
+  name: TName
+  properties: TProperties
+  links: ObjectLink[]
+  readonly p: PropertyTokenMap<{
+    id: TId
+    name: TName
+    properties: TProperties
+    links: ObjectLink[]
+  }>
+}
+
+type DirectLinkTargetFor<TTarget extends ObjectType> = TTarget extends ObjectTypeWithPropertyTokens
+  ? DirectLinkTarget<TTarget["id"], TTarget["name"], TTarget["properties"]>
+  : TTarget
+
 /**
  * Shorthand for creating an {@link ObjectLink}.
  *
- * `name` defaults to `id`. `targetObjectTypeId` defaults to `"*"` when omitted.
+ * `link(...)` accepts direct ObjectType targets and preserves their type for
+ * query authoring. Use `link.ref(...)` for id-only references, `link.self(...)`
+ * for recursive links, and `link.any(...)` for wildcard links.
  *
  * ```ts
- * // String target
- * link("controls", "hvacZone", { cardinality: "one" })
- *
- * // ObjectType target — extracts .id at build time
+ * // ObjectType target — extracts .id at runtime and preserves the target type
  * link("controls", HVACZone, { cardinality: "one" })
+ *
+ * // Id target — resolved by the generated ontology type manifest
+ * link.ref("controls", "hvacZone", { cardinality: "one" })
+ *
+ * // Self target — normalized to the source object type id by defineObjectType()
+ * link.self("parent", { cardinality: "one" })
  *
  * // Multiple targets
  * link("rel", [TypeA, TypeB])
  *
  * // Wildcard — accepts any target type
- * link("anything")
- * link("anything", { cardinality: "many" })
+ * link.any("anything")
+ * link.any("anything", { cardinality: "many" })
  * ```
  */
+interface LinkCallable {
+  <const TId extends string, const TTarget extends ObjectType>(
+    id: TId,
+    target: TTarget
+  ): DirectLinkResult<TId, TTarget["id"], undefined, DirectLinkTargetFor<TTarget>>
 
-// 1. Wildcard: no target → "*"
-export function link<const TId extends string>(id: TId): LinkResult<TId, "*", undefined>
+  <const TId extends string, const TTarget extends ObjectType, const TOptions extends LinkOptions>(
+    id: TId,
+    target: TTarget,
+    options: TOptions
+  ): DirectLinkResult<TId, TTarget["id"], TOptions, DirectLinkTargetFor<TTarget>>
 
-// 2. Single ObjectType target
-export function link<const TId extends string, const TTarget extends ObjectType>(
-  id: TId,
-  target: TTarget
-): LinkResult<TId, TTarget["id"], undefined>
+  <const TId extends string, const TTargets extends readonly ObjectType[]>(
+    id: TId,
+    targets: TTargets
+  ): DirectLinkResult<
+    TId,
+    ObjectTypeIdArray<TTargets>,
+    undefined,
+    DirectLinkTargetFor<TTargets[number]>
+  >
 
-// 3. Single ObjectType target + options
-export function link<
-  const TId extends string,
-  const TTarget extends ObjectType,
-  const TOptions extends LinkOptions,
->(id: TId, target: TTarget, options: TOptions): LinkResult<TId, TTarget["id"], TOptions>
+  <
+    const TId extends string,
+    const TTargets extends readonly ObjectType[],
+    const TOptions extends LinkOptions,
+  >(
+    id: TId,
+    targets: TTargets,
+    options: TOptions
+  ): DirectLinkResult<
+    TId,
+    ObjectTypeIdArray<TTargets>,
+    TOptions,
+    DirectLinkTargetFor<TTargets[number]>
+  >
+}
 
-// 4. ObjectType array target
-export function link<const TId extends string, const TTargetId extends string>(
-  id: TId,
-  targets: readonly (ObjectType & { id: TTargetId })[]
-): LinkResult<TId, TTargetId[], undefined>
+interface LinkBuilder extends LinkCallable {
+  ref: typeof linkRef
+  self: typeof linkSelf
+  any: typeof linkAny
+}
 
-// 5. ObjectType array target + options
-export function link<
-  const TId extends string,
-  const TTargetId extends string,
-  const TOptions extends LinkOptions,
->(
-  id: TId,
-  targets: readonly (ObjectType & { id: TTargetId })[],
-  options: TOptions
-): { id: TId; name: NameFromOptions<TId, TOptions>; targetObjectTypeId: TTargetId[] } & TOptions
+const linkImpl = ((
+  id: string,
+  targetOrTargets: ObjectType | readonly ObjectType[],
+  options?: LinkOptions
+): ObjectLink => {
+  if (Array.isArray(targetOrTargets)) {
+    return {
+      id,
+      name: options?.name ?? id,
+      targetObjectTypeId: targetOrTargets.map((target) => target.id),
+      ...options,
+    }
+  }
 
-// 6. String or string-array target (existing)
-export function link<
+  if (isObjectTypeLike(targetOrTargets)) {
+    return {
+      id,
+      name: options?.name ?? id,
+      targetObjectTypeId: targetOrTargets.id,
+      ...options,
+    }
+  }
+
+  throw new Error(
+    `[Sixb] link("${id}", ...) requires an ObjectType target. Use link.ref(...) for id references, link.self(...) for self-links, or link.any(...) for wildcard links.`
+  )
+}) as LinkCallable
+
+function linkRef<
   const TId extends string,
   const TTargetObjectTypeId extends string | readonly string[],
 >(id: TId, targetObjectTypeId: TTargetObjectTypeId): LinkResult<TId, TTargetObjectTypeId, undefined>
-
-// 7. String or string-array target + options (existing)
-export function link<
+function linkRef<
   const TId extends string,
   const TTargetObjectTypeId extends string | readonly string[],
   const TOptions extends LinkOptions,
@@ -475,68 +577,49 @@ export function link<
   targetObjectTypeId: TTargetObjectTypeId,
   options: TOptions
 ): LinkResult<TId, TTargetObjectTypeId, TOptions>
-
-// 8. Wildcard with options — MUST be LAST (ObjectType satisfies LinkOptions structurally)
-export function link<const TId extends string, const TOptions extends LinkOptions>(
-  id: TId,
-  options: TOptions
-): { id: TId; name: NameFromOptions<TId, TOptions>; targetObjectTypeId: "*" } & TOptions
-
-// Implementation
-export function link(
+function linkRef(
   id: string,
-  targetOrOptions?: string | readonly string[] | ObjectType | readonly ObjectType[] | LinkOptions,
+  targetObjectTypeId: string | readonly string[],
   options?: LinkOptions
 ): ObjectLink {
-  // No second argument → wildcard
-  if (targetOrOptions === undefined) {
-    return { id, name: id, targetObjectTypeId: "*" }
-  }
-
-  // String → string target
-  if (typeof targetOrOptions === "string") {
-    return {
-      id,
-      name: options?.name ?? id,
-      targetObjectTypeId: targetOrOptions,
-      ...options,
-    }
-  }
-
-  // Array → determine element type
-  if (Array.isArray(targetOrOptions)) {
-    const first = targetOrOptions[0]
-    const ids =
-      first !== undefined && isObjectTypeLike(first)
-        ? (targetOrOptions as readonly ObjectType[]).map((ot) => ot.id)
-        : (targetOrOptions as string[])
-    return {
-      id,
-      name: options?.name ?? id,
-      targetObjectTypeId: ids,
-      ...options,
-    }
-  }
-
-  // Object with properties + links → ObjectType
-  if (isObjectTypeLike(targetOrOptions)) {
-    return {
-      id,
-      name: options?.name ?? id,
-      targetObjectTypeId: (targetOrOptions as ObjectType).id,
-      ...options,
-    }
-  }
-
-  // Otherwise → LinkOptions (wildcard with options)
-  const linkOptions = targetOrOptions as LinkOptions
   return {
     id,
-    name: linkOptions.name ?? id,
-    targetObjectTypeId: "*",
-    ...linkOptions,
+    name: options?.name ?? id,
+    targetObjectTypeId:
+      typeof targetObjectTypeId === "string" ? targetObjectTypeId : [...targetObjectTypeId],
+    ...options,
   }
 }
+
+function linkSelf<
+  const TId extends string,
+  const TOptions extends LinkOptions | undefined = undefined,
+>(id: TId, options?: TOptions): LinkResult<TId, SelfLinkTargetObjectTypeId, TOptions> {
+  return {
+    id,
+    name: options?.name ?? id,
+    targetObjectTypeId: selfLinkTargetObjectTypeId,
+    ...options,
+  } as LinkResult<TId, SelfLinkTargetObjectTypeId, TOptions>
+}
+
+function linkAny<
+  const TId extends string,
+  const TOptions extends LinkOptions | undefined = undefined,
+>(id: TId, options?: TOptions): LinkResult<TId, "*", TOptions> {
+  return {
+    id,
+    name: options?.name ?? id,
+    targetObjectTypeId: "*",
+    ...options,
+  } as LinkResult<TId, "*", TOptions>
+}
+
+export const link: LinkBuilder = Object.assign(linkImpl, {
+  ref: linkRef,
+  self: linkSelf,
+  any: linkAny,
+})
 
 // ── ValueType ref shorthand ─────────────────────────────────
 

--- a/packages/core/src/ontology/index.ts
+++ b/packages/core/src/ontology/index.ts
@@ -29,6 +29,8 @@ export type {
   MapSchema,
   ObjectFieldSchema,
   ObjectLink,
+  ObjectLinkTargetMetadata,
+  ObjectLinkTargetType,
   ObjectSchema,
   ObjectType,
   ObjectTypeSearchMetadata,
@@ -54,6 +56,7 @@ export { OntologyValidationError } from "./errors"
 
 // ── Helpers ─────────────────────────────────────────────────
 
+export type { DirectLinkResult, DirectLinkTarget } from "./builders"
 export {
   defineInterface,
   defineObjectType,

--- a/packages/core/src/ontology/types.ts
+++ b/packages/core/src/ontology/types.ts
@@ -317,6 +317,25 @@ export interface ObjectLink {
   properties?: Property[]
 }
 
+declare const objectLinkTargetTypeBrand: unique symbol
+
+/**
+ * Type-only metadata attached by `link("id", Target)`.
+ *
+ * The runtime ontology still stores only `targetObjectTypeId`; this brand exists
+ * only in TypeScript so query builders can resolve direct link targets without
+ * consulting a generated id-to-type map.
+ */
+export type ObjectLinkTargetMetadata<TTarget> = {
+  readonly [objectLinkTargetTypeBrand]?: TTarget
+}
+
+export type ObjectLinkTargetType<TLink> = typeof objectLinkTargetTypeBrand extends keyof TLink
+  ? TLink extends ObjectLinkTargetMetadata<infer TTarget>
+    ? TTarget
+    : never
+  : never
+
 /**
  * Reusable ontology contract of properties and links.
  *
@@ -392,7 +411,7 @@ export interface ObjectType {
 }
 
 /**
- * App-augmentable id-to-object-type map for client query typing.
+ * Ambient id-to-object-type index for app ontology definitions.
  *
  * Sixb generates a `.sixb/types/ontology.d.ts` module augmentation that adds
  * entries here, letting client-side query types resolve string link targets

--- a/packages/core/src/ontology/validation/properties.ts
+++ b/packages/core/src/ontology/validation/properties.ts
@@ -27,7 +27,7 @@ export function assertPropertyTokenBelongsToObjectType(
 
 export function assertLinkTokenBelongsToObjectType(
   objectType: ObjectTypeWithPropertyTokens,
-  link: LinkToken<string, string, string, ObjectLink>
+  link: LinkToken<string, string, string | readonly string[], ObjectLink>
 ): void {
   if (link.objectTypeId !== objectType.id) {
     throw new OntologyValidationError(

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -34,7 +34,7 @@ import type {
   ObjectQuerySortDirection,
   ValidatedObjectQuery,
 } from "../objects/query"
-import type { ObjectRef, ObjectType, Property, ValueType } from "../ontology"
+import type { ObjectLinkTargetType, ObjectRef, ObjectType, Property, ValueType } from "../ontology"
 import type {
   InferObjectProperties,
   InferPropertyUnit,
@@ -462,19 +462,26 @@ type ObjectTypeForId<
   ? ObjectTypeWithPropertyTokens
   : Extract<TRegisteredObjectTypes, { id: TObjectTypeId }>
 
+type DirectObjectTypeForLink<TLinkToken> =
+  TLinkToken extends LinkToken<string, string, LinkTargetObjectTypeIdValue, infer TLink>
+    ? Extract<ObjectLinkTargetType<TLink>, ObjectTypeWithPropertyTokens>
+    : never
+
 type ObjectTypeForLinkTarget<
   TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
   TLinkToken,
-> = ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>
+> = [DirectObjectTypeForLink<TLinkToken>] extends [never]
+  ? ObjectTypeForId<TRegisteredObjectTypes, LinkTargetObjectTypeId<TLinkToken>>
+  : DirectObjectTypeForLink<TLinkToken>
 
 /**
  * True when the target type is a concrete ontology type rather than the degraded
- * generic base. When a link's target is not in the registry (the client path
- * until a registry is generated), `ObjectTypeForId` falls back to the base type,
- * whose property ids are `string`; instantiating the typed token map over the
- * broad `Property` union there overflows TypeScript (the same reason
- * `UntypedPropertyPredicate` exists). The expand option/sort types degrade to a
- * loose shape in that case so the client path stays shallow instead of failing.
+ * generic base. Direct ObjectType links resolve before this point; unresolved
+ * id-only refs fall back to the base type, whose property ids are `string`.
+ * Instantiating the typed token map over the broad `Property` union there
+ * overflows TypeScript (the same reason `UntypedPropertyPredicate` exists). The
+ * expand option/sort types degrade to a loose shape in that case so unresolved
+ * client paths stay shallow instead of failing.
  */
 type HasKnownObjectType<TObjectType extends ObjectTypeWithPropertyTokens> =
   string extends TObjectType["id"] ? false : true
@@ -501,8 +508,9 @@ export type ObjectExpandOptions<TObjectType extends ObjectTypeWithPropertyTokens
 // via {@link ObjectQueryRow}. The discipline that keeps this within TypeScript's
 // recursion limits (proven on the real ADN graph): recursion lives ONLY in the
 // lazily-evaluated row types below, never in constraints (which are eager); the
-// builders are type aliases; targets resolve by id against the registry; and the
-// row is read through a direct conditional `infer` (see `BuiltRow`).
+// builders are type aliases; targets resolve through direct metadata first and
+// the id registry second; and the row is read through a direct conditional
+// `infer` (see `BuiltRow`).
 
 /**
  * Cardinality declared on a link token's underlying link; absent cardinality is
@@ -528,14 +536,15 @@ type ObjectLinkCardinality<TLink> = TLink extends { cardinality: infer TCardinal
   ? TCardinality
   : "many"
 
-type ObjectLinkTarget<
-  TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens,
-  TLink,
-> = TLink extends {
-  targetObjectTypeId: infer TTargetObjectTypeId extends LinkTargetObjectTypeIdValue
-}
-  ? ObjectTypeForId<TRegisteredObjectTypes, ResolveTargetTypeId<TTargetObjectTypeId>>
-  : ObjectTypeWithPropertyTokens
+type ObjectLinkTarget<TRegisteredObjectTypes extends ObjectTypeWithPropertyTokens, TLink> = [
+  Extract<ObjectLinkTargetType<TLink>, ObjectTypeWithPropertyTokens>,
+] extends [never]
+  ? TLink extends {
+      targetObjectTypeId: infer TTargetObjectTypeId extends LinkTargetObjectTypeIdValue
+    }
+    ? ObjectTypeForId<TRegisteredObjectTypes, ResolveTargetTypeId<TTargetObjectTypeId>>
+    : ObjectTypeWithPropertyTokens
+  : Extract<ObjectLinkTargetType<TLink>, ObjectTypeWithPropertyTokens>
 
 type ObjectLinkById<
   TObjectType extends Pick<ObjectType, "links">,
@@ -696,21 +705,20 @@ export type ObjectQueryRow<
 
 /**
  * Builder passed to the nested `.expand(..., (e) => …)` callback. Exposes only
- * `expand`, resolving the next target type by id against the registry so deeper
- * hops stay typed and accumulating `TAccumulated` so the nested `.links` shape is
- * recovered from the callback's return.
+ * `expand`, resolving the next target type from direct metadata or the id
+ * registry so deeper hops stay typed and accumulating `TAccumulated` so the
+ * nested `.links` shape is recovered from the callback's return.
  *
  * A type alias (not an interface) so relating two instantiations stays
  * structural — the same discipline `TwinObject` follows to avoid TS2589
  * (see the note above `TwinObject`). The only recursion is in the lazily
  * evaluated return/callback positions.
  *
- * When the target type is the degraded base (an unregistered link target, i.e.
- * the client path until a registry is generated), the builder collapses to the
- * untyped, non-generic {@link UntypedExpandBuilder}: nested expansion still
- * works, just without target-specific link/property checking, and — crucially —
- * without the self-referential generic instantiation over the broad base type
- * that would otherwise overflow TypeScript.
+ * When the target type is the degraded base (an unresolved id-only target), the
+ * builder collapses to the untyped, non-generic {@link UntypedExpandBuilder}:
+ * nested expansion still works, just without target-specific link/property
+ * checking, and — crucially — without the self-referential generic instantiation
+ * over the broad base type that would otherwise overflow TypeScript.
  */
 export type ObjectExpandBuilder<
   TObjectType extends ObjectTypeWithPropertyTokens,
@@ -855,8 +863,8 @@ export interface ObjectQueryBuilder<
    * Each call widens `TLinks`, so `list`/`first` rows gain a typed `.links` entry
    * for this link (cardinality `"one"` → `Target | null`, `"many"` → `Target[]`,
    * each carrying optional `linkProperties` and its own nested `.links`). Nested
-   * targets stay precise on the server path (full registry) and degrade to the
-   * loose base on the client until the generated registry sharpens them.
+   * targets stay precise when the link uses direct object targets or when the id
+   * target resolves through the registry, and otherwise degrade to the loose base.
    */
   expand<
     TLinkToken extends LinkToken<TObjectType["id"], string, LinkTargetObjectTypeIdValue>,

--- a/packages/core/tests/batch-upsert.test.ts
+++ b/packages/core/tests/batch-upsert.test.ts
@@ -27,7 +27,7 @@ const Room = defineObjectType({
   ],
   links: [
     link("inBuilding", Building, { cardinality: "one" }),
-    link("hasSensors", "sensor", { cardinality: "many" }),
+    link.ref("hasSensors", "sensor", { cardinality: "many" }),
   ],
 })
 

--- a/packages/core/tests/define.test.ts
+++ b/packages/core/tests/define.test.ts
@@ -29,7 +29,7 @@ describe("defineObjectType", () => {
       id: "thermostat",
       name: "Thermostat",
       properties: [prop("id", "string", { required: true, primary: true }), prop("mode", "string")],
-      links: [link("controls", "hvacZone")],
+      links: [link.ref("controls", "hvacZone")],
     })
     expect(ot.properties).toHaveLength(2)
     expect(ot.links).toHaveLength(1)
@@ -149,42 +149,62 @@ describe("prop", () => {
 // ── link ────────────────────────────────────────────────────
 
 describe("link", () => {
-  test("uses id as default name", () => {
-    const l = link("locatedIn", "space")
+  test("ref target uses id as default name", () => {
+    const l = link.ref("locatedIn", "space")
     expect(l.id).toBe("locatedIn")
     expect(l.name).toBe("locatedIn")
     expect(l.targetObjectTypeId).toBe("space")
   })
 
-  test("accepts cardinality and other options", () => {
-    const l = link("contains", "room", {
+  test("ref target accepts options", () => {
+    const l = link.ref("contains", "room", {
       name: "Contains",
       cardinality: "many",
       description: "Rooms in this building",
     })
     expect(l.name).toBe("Contains")
+    expect(l.targetObjectTypeId).toBe("room")
     expect(l.cardinality).toBe("many")
     expect(l.description).toBe("Rooms in this building")
   })
 
+  test("ref target accepts id arrays", () => {
+    const l = link.ref("controls", ["thermostat", "valve"])
+    expect(l.targetObjectTypeId).toEqual(["thermostat", "valve"])
+  })
+
+  // ── Self target ─────────────────────────────────────────────
+
+  test("self target resolves to the defining object type id", () => {
+    const Folder = defineObjectType({
+      id: "Folder",
+      name: "Folder",
+      properties: [prop("id", "string", { required: true, primary: true })],
+      links: [link.self("parent", { cardinality: "one" })],
+    })
+
+    expect(Folder.links[0]?.targetObjectTypeId).toBe("Folder")
+    expect(Folder.l.parent.targetObjectTypeId).toBe("Folder")
+  })
+
   // ── Wildcard ────────────────────────────────────────────────
 
-  test("wildcard: no target defaults to '*'", () => {
-    const l = link("assignedTo")
+  test("wildcard target stores '*'", () => {
+    const l = link.any("assignedTo")
     expect(l.id).toBe("assignedTo")
     expect(l.name).toBe("assignedTo")
     expect(l.targetObjectTypeId).toBe("*")
   })
 
   test("wildcard with options", () => {
-    const l = link("assignedTo", { cardinality: "one", description: "Assigned entity" })
+    const l = link.any("assignedTo", { cardinality: "one", description: "Assigned entity" })
     expect(l.targetObjectTypeId).toBe("*")
     expect(l.cardinality).toBe("one")
     expect(l.description).toBe("Assigned entity")
   })
 
   test("wildcard with name override", () => {
-    const l = link("assignedTo", { name: "Assigned To" })
+    const l = link.any("assignedTo", { name: "Assigned To" })
     expect(l.targetObjectTypeId).toBe("*")
     expect(l.name).toBe("Assigned To")
   })
@@ -201,6 +221,12 @@ describe("link", () => {
     expect(l.id).toBe("locatedIn")
     expect(l.targetObjectTypeId).toBe("room")
     expect(l.name).toBe("locatedIn")
+    expect(Object.getOwnPropertySymbols(l)).toEqual([])
+    expect(l).toEqual({
+      id: "locatedIn",
+      name: "locatedIn",
+      targetObjectTypeId: "room",
+    })
   })
 
   test("single ObjectType target with options", () => {
@@ -212,6 +238,7 @@ describe("link", () => {
     const l = link("locatedIn", Room, { cardinality: "one" })
     expect(l.targetObjectTypeId).toBe("room")
     expect(l.cardinality).toBe("one")
+    expect(Object.getOwnPropertySymbols(l)).toEqual([])
   })
 
   test("ObjectType array target extracts ids", () => {
@@ -227,6 +254,7 @@ describe("link", () => {
     })
     const l = link("locatedIn", [Room, Floor])
     expect(l.targetObjectTypeId).toEqual(["room", "floor"])
+    expect(Object.getOwnPropertySymbols(l)).toEqual([])
   })
 
   test("ObjectType array target with options", () => {
@@ -243,29 +271,6 @@ describe("link", () => {
     const l = link("locatedIn", [Room, Floor], { cardinality: "many" })
     expect(l.targetObjectTypeId).toEqual(["room", "floor"])
     expect(l.cardinality).toBe("many")
-  })
-
-  // ── Backward compatibility ─────────────────────────────────
-
-  test("backward compat: string target", () => {
-    const l = link("locatedIn", "space")
-    expect(l.targetObjectTypeId).toBe("space")
-  })
-
-  test("backward compat: string target with options", () => {
-    const l = link("locatedIn", "space", { cardinality: "one" })
-    expect(l.targetObjectTypeId).toBe("space")
-    expect(l.cardinality).toBe("one")
-  })
-
-  test("backward compat: string array target", () => {
-    const l = link("controls", ["thermostat", "valve"])
-    expect(l.targetObjectTypeId).toEqual(["thermostat", "valve"])
-  })
-
-  test("backward compat: explicit wildcard string", () => {
-    const l = link("anything", "*")
-    expect(l.targetObjectTypeId).toBe("*")
   })
 })
 
@@ -390,7 +395,7 @@ describe("nested object schemas", () => {
 
 describe("links with properties", () => {
   test("link carries metadata properties", () => {
-    const l = link("installedIn", "room", {
+    const l = link.ref("installedIn", "room", {
       name: "Installed In",
       cardinality: "one",
       properties: [
@@ -424,7 +429,7 @@ describe("interface composition", () => {
         prop("serialNumber", "string"),
         prop("firmwareVersion", "string", { nullable: true }),
       ],
-      links: [link("locatedIn", "space", { cardinality: "one" })],
+      links: [link.ref("locatedIn", "space", { cardinality: "one" })],
     })
     expect(sensor.properties).toHaveLength(4)
     expect(sensor.links).toHaveLength(1)
@@ -491,7 +496,7 @@ describe("realistic ontology", () => {
         prop("floorCount", "integer"),
         prop("totalArea", "double", { semanticType: "Area" }),
       ],
-      links: [link("contains", "floor", { cardinality: "many" })],
+      links: [link.ref("contains", "floor", { cardinality: "many" })],
     })
 
     const floor = defineObjectType({
@@ -503,8 +508,8 @@ describe("realistic ontology", () => {
         prop("area", "double", { semanticType: "Area" }),
       ],
       links: [
-        link("contains", "room", { cardinality: "many" }),
-        link("partOf", "building", { cardinality: "one" }),
+        link.ref("contains", "room", { cardinality: "many" }),
+        link.ref("partOf", "building", { cardinality: "one" }),
       ],
     })
 
@@ -519,8 +524,8 @@ describe("realistic ontology", () => {
         prop("occupancy", "boolean"),
       ],
       links: [
-        link("partOf", "floor", { cardinality: "one" }),
-        link("hasThermostat", "thermostat", { cardinality: "one" }),
+        link.ref("partOf", "floor", { cardinality: "one" }),
+        link.ref("hasThermostat", "thermostat", { cardinality: "one" }),
       ],
     })
 
@@ -544,7 +549,7 @@ describe("realistic ontology", () => {
         prop("fanSpeed", integerEnum([0, 1, 2, 3]), { name: "Fan Speed" }),
         prop("humidity", "double", { semanticType: "RelativeHumidity" }),
       ],
-      links: [link("controls", "room", { cardinality: "one" })],
+      links: [link.ref("controls", "room", { cardinality: "one" })],
     })
 
     // Verify the full graph
@@ -662,7 +667,7 @@ describe("realistic ontology", () => {
         prop("temperature", "double", { semanticType: "Temperature", required: true }),
         prop("accuracy", "double", { semanticType: "Temperature" }),
       ],
-      links: [link("locatedIn", "room", { cardinality: "one" })],
+      links: [link.ref("locatedIn", "room", { cardinality: "one" })],
     })
 
     const co2Sensor = defineObjectType({
@@ -674,7 +679,7 @@ describe("realistic ontology", () => {
         ...measurable.properties,
         prop("concentration", "double", { semanticType: "Concentration", required: true }),
       ],
-      links: [link("locatedIn", "room", { cardinality: "one" })],
+      links: [link.ref("locatedIn", "room", { cardinality: "one" })],
     })
 
     // Both implement measurable

--- a/packages/core/tests/extends.test.ts
+++ b/packages/core/tests/extends.test.ts
@@ -13,7 +13,7 @@ const Equipment = defineObjectType({
     prop("name", "string", { required: true }),
     prop("manufacturer", "string"),
   ],
-  links: [link("locatedIn", "Location", { cardinality: "one" })],
+  links: [link.ref("locatedIn", "Location", { cardinality: "one" })],
 })
 
 const HVACEquipment = defineObjectType({
@@ -21,7 +21,7 @@ const HVACEquipment = defineObjectType({
   id: "HVACEquipment",
   name: "HVAC Equipment",
   properties: [prop("capacity", "double")],
-  links: [link("feeds", "Equipment", { cardinality: "many" })],
+  links: [link.ref("feeds", "Equipment", { cardinality: "many" })],
 })
 
 const AHU = defineObjectType({
@@ -115,7 +115,7 @@ describe("defineObjectType with string extends (pre-flattened)", () => {
     name: "Pre-Flattened Type",
     extends: "brick:Equipment",
     properties: [prop("inheritedProp", "string"), prop("ownProp", "double", { required: true })],
-    links: [link("hasLocation", "brick:Location")],
+    links: [link.ref("hasLocation", "brick:Location")],
   })
 
   test(".extends stores the string directly", () => {
@@ -573,7 +573,7 @@ describe("link target validation", () => {
       id: "Source",
       name: "Source",
       properties: [prop("id", "string", { required: true, primary: true })],
-      links: [link("rel", ["TypeA", "TypeB"])],
+      links: [link.ref("rel", ["TypeA", "TypeB"])],
     })
 
     const sixb = new Sixb({
@@ -605,7 +605,7 @@ describe("link target validation", () => {
       id: "Src",
       name: "Src",
       properties: [prop("id", "string", { required: true, primary: true })],
-      links: [link("rel", ["Equipment"])],
+      links: [link.ref("rel", ["Equipment"])],
     })
 
     const sixb = new Sixb({
@@ -630,7 +630,7 @@ describe("link target validation", () => {
       id: "WildSrc",
       name: "WildSrc",
       properties: [prop("id", "string", { required: true, primary: true })],
-      links: [link("anything", "*")],
+      links: [link.any("anything")],
     })
 
     const sixb = new Sixb({

--- a/packages/core/tests/extends.types.ts
+++ b/packages/core/tests/extends.types.ts
@@ -19,7 +19,7 @@ const Equipment = defineObjectType({
     prop("name", "string", { required: true }),
     prop("manufacturer", "string"),
   ],
-  links: [link("locatedIn", "location", { cardinality: "one" })],
+  links: [link.ref("locatedIn", "location", { cardinality: "one" })],
 })
 
 const HVACEquipment = defineObjectType({
@@ -27,7 +27,7 @@ const HVACEquipment = defineObjectType({
   id: "hvac",
   name: "HVAC Equipment",
   properties: [prop("capacity", "double")],
-  links: [link("feeds", "hvac", { cardinality: "many" })],
+  links: [link.ref("feeds", "hvac", { cardinality: "many" })],
 })
 
 // ── extends stores parent id as string ──────────────────────
@@ -83,7 +83,7 @@ const Entity = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("entityName", "string", { required: true }),
   ],
-  links: [link("partOf", "entity", { cardinality: "one" })],
+  links: [link.ref("partOf", "entity", { cardinality: "one" })],
 })
 
 const Equipment2 = defineObjectType({
@@ -91,7 +91,7 @@ const Equipment2 = defineObjectType({
   id: "equipment2",
   name: "Equipment",
   properties: [prop("serialNumber", "string")],
-  links: [link("serves", "entity", { cardinality: "many" })],
+  links: [link.ref("serves", "entity", { cardinality: "many" })],
 })
 
 const HVACEquipment2 = defineObjectType({

--- a/packages/core/tests/object-query-expand-recursion.types.ts
+++ b/packages/core/tests/object-query-expand-recursion.types.ts
@@ -26,7 +26,7 @@ const StressUser = defineObjectType({
     prop("email", "string", { required: true }),
   ],
   links: [
-    link("manager", "StressUser", { cardinality: "one" }),
+    link.self("manager", { cardinality: "one" }),
     link("department", StressDepartment, { cardinality: "one" }),
     link("skills", StressSkill, { cardinality: "many" }),
   ],
@@ -49,7 +49,7 @@ const StressProject = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
   ],
-  links: [link("owner", ["StressUser", "StressTeam"], { cardinality: "one" })],
+  links: [link.ref("owner", ["StressUser", "StressTeam"], { cardinality: "one" })],
 })
 
 const StressFolder = defineObjectType({
@@ -60,8 +60,8 @@ const StressFolder = defineObjectType({
     prop("name", "string", { required: true }),
   ],
   links: [
-    link("parent", "StressFolder", { cardinality: "one" }),
-    link("children", "StressFolder", { cardinality: "many" }),
+    link.self("parent", { cardinality: "one" }),
+    link.self("children", { cardinality: "many" }),
   ],
 })
 

--- a/packages/core/tests/object-query-expand.test.ts
+++ b/packages/core/tests/object-query-expand.test.ts
@@ -59,7 +59,7 @@ const Folder = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
   ],
-  links: [link("parent", "Folder", { cardinality: "one" })],
+  links: [link.self("parent", { cardinality: "one" })],
 })
 
 const ProjectFolder = defineObjectType({

--- a/packages/core/tests/object-query-expand.types.ts
+++ b/packages/core/tests/object-query-expand.types.ts
@@ -6,9 +6,10 @@
  * ("type instantiation is excessively deep"). The `@ts-expect-error` lines prove
  * links and `orderBy` properties are constrained to the resolved target type.
  *
- * Each `.expand(...)` widens the row's `.links` (cardinality `"one"` →
- * `Target | null`, `"many"` → `Target[]`, with optional `.linkProperties` and
- * nested `.links`).
+ * Slice 3 adds the row-typing section: each `.expand(...)` widens the row's
+ * `.links` (cardinality `"one"` → `Target | null`, `"many"` → `Target[]`, with
+ * optional `.linkProperties` and nested `.links`). Direct ObjectType links are
+ * precise without a generated registry; id-only refs still use the registry.
  */
 import { defineObjectType, link, type ObjectQueryBuilder, prop } from "../src"
 
@@ -53,7 +54,7 @@ const Folder = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
   ],
-  links: [link("parent", "Folder", { cardinality: "one" })],
+  links: [link.self("parent", { cardinality: "one" })],
 })
 
 const ProjectFolder = defineObjectType({
@@ -91,6 +92,8 @@ type AppRegistry =
 // Server path: `objects(T)` binds the full registry, so nested targets resolve.
 declare const projects: ObjectQueryBuilder<typeof Project, AppRegistry, []>
 declare const folders: ObjectQueryBuilder<typeof Folder, AppRegistry, []>
+// Client path with no full registry. Direct ObjectType links still resolve.
+declare const startTypeOnly: ObjectQueryBuilder<typeof Project, typeof Project, []>
 
 function authoring(): void {
   // 2-hop, precise: Project -> opportunity -> { company, contact }.
@@ -126,6 +129,13 @@ function authoring(): void {
 
   // @ts-expect-error — `name` is a Project property, not on the Opportunity target.
   projects.expand(Project.l.opportunity, { orderBy: [{ property: Project.p.name }] })
+
+  startTypeOnly.expand(Project.l.opportunity, (o) =>
+    o.expand(
+      // @ts-expect-error — direct target metadata resolves Opportunity without a registry.
+      Folder.l.parent
+    )
+  )
 }
 
 void authoring
@@ -213,3 +223,12 @@ function folderRowAssertions(row: FolderRow): void {
   void [_p1Id, _p2Id]
 }
 void folderRowAssertions
+
+// Client path with direct ObjectType targets: no generated registry is needed.
+const builtDirectClient = startTypeOnly.expand(Project.l.opportunity)
+type DirectClientRow = RowOf<typeof builtDirectClient>
+function directClientRowAssertions(row: DirectClientRow): void {
+  const _id: "Opportunity" = row.links.opportunity!.objectTypeId
+  void _id
+}
+void directClientRowAssertions

--- a/packages/core/tests/object-query.test.ts
+++ b/packages/core/tests/object-query.test.ts
@@ -83,7 +83,7 @@ const WildcardSource = defineObjectType({
   id: "WildcardSource",
   name: "Wildcard Source",
   properties: [prop("id", "string", { required: true, primary: true })],
-  links: [link("anything")],
+  links: [link.any("anything")],
 })
 
 const SearchProfileCustomer = defineObjectType({

--- a/packages/core/tests/object-type-literals.types.ts
+++ b/packages/core/tests/object-type-literals.types.ts
@@ -1,4 +1,11 @@
-import { defineObjectType, integerEnum, link, prop, stringEnum } from "../src"
+import {
+  defineObjectType,
+  integerEnum,
+  link,
+  type ObjectLinkTargetType,
+  prop,
+  stringEnum,
+} from "../src"
 
 /**
  * Compile-time contract tests for builder literal inference.
@@ -53,7 +60,7 @@ const thermostat = defineObjectType({
     prop("mode", stringEnum(["off", "heat", "cool", "auto"]), { required: true }),
     prop("fanSpeed", integerEnum([1, 2, 3, 4])),
   ],
-  links: [link("locatedIn", "room", { cardinality: "one" })],
+  links: [link.ref("locatedIn", "room", { cardinality: "one" })],
   search: {
     title: "externalId",
     defaultText: ["externalId"],
@@ -90,12 +97,18 @@ type _modeEnumUnion = Expect<
 
 // ── link() overload type tests ─────────────────────────────
 
-// Wildcard: no target → "*"
-const wildcardLink = link("anything")
+// Ambiguous legacy forms are intentionally rejected.
+// @ts-expect-error — id references must use link.ref(...).
+link("locatedIn", "space")
+// @ts-expect-error — wildcard links must use link.any(...).
+link("anything")
+
+// Wildcard target → "*"
+const wildcardLink = link.any("anything")
 type _wildcardTarget = Expect<Equal<typeof wildcardLink.targetObjectTypeId, "*">>
 
 // Wildcard with options
-const wildcardWithOptions = link("anything", { cardinality: "many" })
+const wildcardWithOptions = link.any("anything", { cardinality: "many" })
 type _wildcardOptsTarget = Expect<Equal<typeof wildcardWithOptions.targetObjectTypeId, "*">>
 type _wildcardOptsCardinality = Expect<Equal<typeof wildcardWithOptions.cardinality, "many">>
 
@@ -107,6 +120,7 @@ const _Room = defineObjectType({
 })
 const objectTypeLink = link("locatedIn", _Room)
 type _otLinkTarget = Expect<Equal<typeof objectTypeLink.targetObjectTypeId, "room">>
+type _otLinkTargetType = Expect<Equal<ObjectLinkTargetType<typeof objectTypeLink>["id"], "room">>
 
 // ObjectType target + options
 const objectTypeLinkWithOpts = link("locatedIn", _Room, { cardinality: "one" })
@@ -123,17 +137,29 @@ const objectTypeArrayLink = link("locatedIn", [_Room, _Floor])
 type _otArrayTarget = Expect<
   Equal<typeof objectTypeArrayLink.targetObjectTypeId, ("room" | "floor")[]>
 >
-
-// String target (backward compat)
-const stringLink = link("locatedIn", "space")
-type _stringTarget = Expect<Equal<typeof stringLink.targetObjectTypeId, "space">>
-
-// String array target (backward compat)
-const stringArrayLink = link("controls", ["a", "b"] as const)
-type _stringArrayTarget = Expect<
-  Equal<typeof stringArrayLink.targetObjectTypeId, readonly ["a", "b"]>
+type _otArrayTargetType = Expect<
+  Equal<ObjectLinkTargetType<typeof objectTypeArrayLink>["id"], "room" | "floor">
 >
 
-// Explicit wildcard string (backward compat)
-const explicitWildcard = link("anything", "*")
-type _explicitWildcardTarget = Expect<Equal<typeof explicitWildcard.targetObjectTypeId, "*">>
+// Explicit id reference target
+const refLink = link.ref("locatedIn", "space")
+type _refTarget = Expect<Equal<typeof refLink.targetObjectTypeId, "space">>
+type _refTargetType = Expect<Equal<ObjectLinkTargetType<typeof refLink>, never>>
+
+const refLinkWithOpts = link.ref("locatedIn", "space", { cardinality: "one" })
+type _refTargetWithOpts = Expect<Equal<typeof refLinkWithOpts.targetObjectTypeId, "space">>
+type _refCardinalityWithOpts = Expect<Equal<typeof refLinkWithOpts.cardinality, "one">>
+
+// Explicit id reference array target
+const refArrayLink = link.ref("controls", ["a", "b"] as const)
+type _refArrayTarget = Expect<Equal<typeof refArrayLink.targetObjectTypeId, readonly ["a", "b"]>>
+
+// Self target normalizes to the source object type id inside defineObjectType.
+const _Folder = defineObjectType({
+  id: "folder",
+  name: "Folder",
+  properties: [prop("id", "string", { required: true, primary: true })],
+  links: [link.self("parent", { cardinality: "one" })],
+})
+type _selfLinkTarget = Expect<Equal<typeof _Folder.l.parent.targetObjectTypeId, "folder">>
+type _selfLinkCardinality = Expect<Equal<typeof _Folder.l.parent.link.cardinality, "one">>

--- a/packages/core/tests/projection.test.ts
+++ b/packages/core/tests/projection.test.ts
@@ -33,7 +33,7 @@ const Room = defineObjectType({
   ],
   links: [
     link("inBuilding", Building, { cardinality: "one" }),
-    link("hasSensors", "sensor", { cardinality: "many" }),
+    link.ref("hasSensors", "sensor", { cardinality: "many" }),
   ],
 })
 
@@ -65,7 +65,7 @@ const TypeWithWildcardLink = defineObjectType({
   id: "wild",
   name: "Wild",
   properties: [prop("id", "string", { required: true, primary: true }), prop("ref", "string")],
-  links: [link("anything")],
+  links: [link.any("anything")],
 })
 
 // ── defineProjection ─────────────────────────────────────────

--- a/packages/core/tests/projection.types.ts
+++ b/packages/core/tests/projection.types.ts
@@ -56,7 +56,7 @@ const _Room = defineObjectType({
   ],
   links: [
     link("inBuilding", _Building, { cardinality: "one" }),
-    link("hasSensors", "sensor", { cardinality: "many" }),
+    link.ref("hasSensors", "sensor", { cardinality: "many" }),
   ],
 })
 

--- a/packages/core/tests/sixb-runtime.test.ts
+++ b/packages/core/tests/sixb-runtime.test.ts
@@ -38,7 +38,7 @@ const Room = defineObjectType({
     }),
     prop("currentTemperature", "double", { mode: "telemetry", semanticType: "Temperature" }),
   ],
-  links: [link("hasThermostat", "Thermostat", { cardinality: "one" })],
+  links: [link.ref("hasThermostat", "Thermostat", { cardinality: "one" })],
 })
 
 const Thermostat = defineObjectType({

--- a/packages/core/tests/sixb-runtime.types.ts
+++ b/packages/core/tests/sixb-runtime.types.ts
@@ -16,7 +16,7 @@ const Room = defineObjectType({
       semanticType: "Temperature",
     }),
   ],
-  links: [link("hasThermostat", "Thermostat", { cardinality: "one" })],
+  links: [link.ref("hasThermostat", "Thermostat", { cardinality: "one" })],
 })
 
 const Thermostat = defineObjectType({

--- a/packages/core/tests/validation.test.ts
+++ b/packages/core/tests/validation.test.ts
@@ -625,10 +625,10 @@ describe("validateLinkProperties", () => {
     name: "Room",
     properties: [prop("id", "string", { required: true, primary: true })],
     links: [
-      link("hasDevice", "Device", {
+      link.ref("hasDevice", "Device", {
         properties: [prop("installedBy", "string", { required: true }), prop("notes", "string")],
       }),
-      link("hasNeighbor", "Room"),
+      link.ref("hasNeighbor", "Room"),
     ],
   })
 

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -63,7 +63,7 @@ const Space = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true }),
   ],
-  links: [link("contains", "device", { cardinality: "many" })],
+  links: [link.ref("contains", "device", { cardinality: "many" })],
 })
 
 const Device = defineObjectType({


### PR DESCRIPTION
## Problem

The first PR in this stack gives client queries a generated id-to-type map so string link targets can resolve during `.expand(...)` typing.

That fixes the real blocker, but the ontology modeling API still had an ambiguity problem. The old `link(...)` overloads allowed several very different meanings through the same call shape:

```ts
link("customer", "Customer") // id reference
link("parent", "Folder")     // often a self-link by convention
link("anything")             // wildcard link
link("customer", Customer)   // direct object target
```

Those calls all produce runtime link ids, but they carry very different type-system implications. The ambiguous string overloads made it too easy to model a link whose runtime shape was valid but whose authoring intent was unclear.

There was also a second DX gap: when app code already imports the target object type, this should be enough for precise client query typing:

```ts
link("customer", Customer, { cardinality: "one" })
```

That direct object reference should not require waiting for the generated manifest to resolve `"Customer"` back to `Customer`.

## Change

Make link target intent explicit.

```ts
// Direct object target. Best when the target type is in scope.
link("customer", Customer, { cardinality: "one" })

// Id-only reference. Best for decoupled modules or generated/late-bound targets.
link.ref("customer", "Customer", { cardinality: "one" })

// Self-link. Normalized by defineObjectType() to the source object type id.
link.self("parent", { cardinality: "one" })

// Wildcard link. Explicit because it cannot infer a concrete target type.
link.any("relatedTo", { cardinality: "many" })
```

The ambiguous string/wildcard overloads are removed:

```ts
link("customer", "Customer") // use link.ref(...)
link("parent", "Folder")     // use link.self(...) when recursive
link("anything")             // use link.any(...)
```

That gives ontology definitions a cleaner split:

| API | Meaning |
|---|---|
| `link("id", ObjectType)` | direct typed target |
| `link("id", [A, B])` | direct typed union target |
| `link.ref("id", "ObjectTypeId")` | id-only target reference |
| `link.self("id")` | recursive link to the containing object type |
| `link.any("id")` | wildcard target |

## Direct Target Metadata

Direct object links now preserve type-only target metadata:

```ts
const Project = defineObjectType({
  id: "Project",
  name: "Project",
  properties: [prop("name", "string", { required: true })],
  links: [
    link("customer", Customer, { cardinality: "one" }),
    link("owner", [User, Team], { cardinality: "one" }),
  ],
})
```

That lets client query typing resolve direct targets without the generated manifest:

```ts
const query = objects(Project)
  .query()
  .expand(Project.l.customer, (customer) =>
    customer.expand(Customer.l.region)
  )
  .expand(Project.l.owner)

type Row = Awaited<ReturnType<typeof query.first>>
```

`row.links.customer` is typed as `Customer | null`, and `row.links.owner` narrows by `objectTypeId`:

```ts
const owner = row?.links.owner

if (owner?.objectTypeId === "User") {
  owner.properties.email
}

if (owner?.objectTypeId === "Team") {
  owner.properties.slug
}
```

The emitted runtime ontology is unchanged: links still store only ids in `targetObjectTypeId`. The direct target metadata exists only in TypeScript.

## Query Resolution Order

Expanded target typing now resolves in this order:

1. direct object metadata from `link("id", Target)`
2. generated `SixbObjectTypeMap` from the previous PR
3. loose fallback for unresolved id-only or wildcard cases

That keeps direct object links ergonomic, while preserving the generated manifest path for decoupled ontology modules.

## Scope

This PR is stacked on #114.

It only contains the link modeling/API cleanup and direct-target typing layer. The generated ontology manifest, Acme `.expand()` proof, and row recursion fix are intentionally in the base PR.

This is a clean break for the early API: ambiguous string overloads are removed instead of kept as compatibility aliases.

## Tests

| Check | Result |
|---|---|
| `bun --filter @sixb/core typecheck` | pass |
| `bun --filter @sixb/client typecheck` | pass |
| `bun --filter @sixb/example-acme-corp typecheck` | pass |
| `bun test examples/acme-corp/tests/client-query.test.ts packages/client/tests/query.test.ts packages/core/tests/object-query-expand.test.ts packages/core/tests/object-query-expand-exec.test.ts packages/core/tests/ontology-type-manifest.test.ts` | 40 pass |
| `bun run check` | pass |
| `bun run typecheck` | pass |
| `git diff --check` | pass |
