### PR TITLE
cli: tear down providers so sixb check exits instead of hanging

### DIFF
--- a/packages/cli/src/commands/check.tsx
+++ b/packages/cli/src/commands/check.tsx
@@ -1,5 +1,6 @@
 import { resolve } from "node:path"
 import { loadSixbFromEntry } from "../lib/loadSixb"
+import { stopSixbProviders } from "../lib/runtime"
 import { generateProjectTypes } from "../lib/typegen"
 import { CheckView, renderStatic } from "../ui"
 
@@ -11,31 +12,38 @@ export async function runCheck(options: CheckOptions = {}) {
   const entry = resolve(options.entry ?? "sixb.config.ts")
   await generateProjectTypes({ entry })
   const sixb = await loadSixbFromEntry(entry)
-  const objectTypes = sixb.listObjectTypes()
 
-  const providerStatus = { ok: true, message: "configured" }
-  const projectValidation =
-    objectTypes.length > 0
-      ? { ok: true, message: `${objectTypes.length} object type(s)` }
-      : { ok: false, message: "No object types loaded" }
+  try {
+    const objectTypes = sixb.listObjectTypes()
 
-  await renderStatic(
-    <CheckView
-      projectId={sixb.id}
-      events={providerStatus}
-      storage={providerStatus}
-      timeseries={providerStatus}
-      broker={providerStatus}
-      projectValidation={projectValidation}
-      ontology={{
-        enabled: true,
-        source: entry,
-        errors: objectTypes.length > 0 ? 0 : 1,
-        warnings: 0,
-      }}
-      warnings={[]}
-    />
-  )
+    const providerStatus = { ok: true, message: "configured" }
+    const projectValidation =
+      objectTypes.length > 0
+        ? { ok: true, message: `${objectTypes.length} object type(s)` }
+        : { ok: false, message: "No object types loaded" }
 
-  if (objectTypes.length === 0) process.exit(1)
+    await renderStatic(
+      <CheckView
+        projectId={sixb.id}
+        events={providerStatus}
+        storage={providerStatus}
+        timeseries={providerStatus}
+        broker={providerStatus}
+        projectValidation={projectValidation}
+        ontology={{
+          enabled: true,
+          source: entry,
+          errors: objectTypes.length > 0 ? 0 : 1,
+          warnings: 0,
+        }}
+        warnings={[]}
+      />
+    )
+
+    if (objectTypes.length === 0) process.exit(1)
+  } finally {
+    // Tear down runtime providers (broker, queues, storage, connectors) so the
+    // process can exit instead of hanging on open connections. Mirrors lake-check.
+    await stopSixbProviders(sixb)
+  }
 }

--- a/packages/cli/tests/check.test.ts
+++ b/packages/cli/tests/check.test.ts
@@ -24,6 +24,33 @@ function runCheckFixture(fixtureName: string): {
   }
 }
 
+async function spawnCheckWithTimeout(
+  fixtureName: string,
+  timeoutMs: number
+): Promise<{ exitCode: number | null; timedOut: boolean }> {
+  const repoRoot = resolve(import.meta.dir, "..", "..", "..")
+  const cliEntry = resolve(import.meta.dir, "..", "src", "index.tsx")
+  const fixtureEntry = resolve(import.meta.dir, "fixtures", fixtureName, "sixb.config.ts")
+
+  const proc = Bun.spawn({
+    cmd: ["bun", cliEntry, "check", "--entry", fixtureEntry],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+  })
+
+  let timedOut = false
+  const timer = setTimeout(() => {
+    timedOut = true
+    proc.kill("SIGKILL")
+  }, timeoutMs)
+
+  const exitCode = await proc.exited
+  clearTimeout(timer)
+
+  return { exitCode, timedOut }
+}
+
 describe("sixb check", () => {
   test("passes for a valid project", () => {
     const result = runCheckFixture("valid-project")
@@ -34,4 +61,14 @@ describe("sixb check", () => {
     expect(result.stdout).not.toContain("validation error(s)")
     expect(result.stderr).toBe("")
   })
+
+  test("exits instead of hanging when a provider holds the event loop open", async () => {
+    // Without provider teardown, a ref'd handle (redis/pg connection, here a
+    // setInterval) keeps the process alive forever after rendering. A timeout
+    // here means that regressed.
+    const result = await spawnCheckWithTimeout("lingering-handle-project", 15_000)
+
+    expect(result.timedOut).toBe(false)
+    expect(result.exitCode).toBe(0)
+  }, 30_000)
 })

--- a/packages/cli/tests/fixtures/lingering-handle-project/sixb.config.ts
+++ b/packages/cli/tests/fixtures/lingering-handle-project/sixb.config.ts
@@ -1,0 +1,41 @@
+import {
+  defineObjectType,
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  InMemoryStorage,
+  prop,
+  Sixb,
+} from "@sixb/core"
+
+const Room = defineObjectType({
+  id: "Room",
+  name: "Room",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+  ],
+})
+
+// Simulates a real provider (redis broker, pg pool) that holds a ref'd handle
+// keeping the event loop alive until it is explicitly closed. `sixb check` must
+// tear providers down or the process hangs after rendering — this fixture makes
+// that hang observable in a test.
+const keepAlive = setInterval(() => {}, 1_000)
+
+const queues = Object.assign(new InMemoryQueues(), {
+  async close() {
+    clearInterval(keepAlive)
+  },
+})
+
+export const sixb = new Sixb({
+  id: "cli-check-lingering",
+  ontology: [Room],
+  broker: new InMemoryBroker(),
+  storage: new InMemoryStorage(),
+  lakeStorage: new InMemoryLakeStorage(),
+  blobStorage: new InMemoryBlobStorage(),
+  queues,
+})


### PR DESCRIPTION
## Problem

`sixb check` renders its health report and then hangs forever — the process never exits. `runCheck` loads the runtime via `loadSixbFromEntry`, which instantiates the full `Sixb` and opens its providers (redis broker, queues, pg storage). Those connections hold ref'd handles that keep the event loop alive, but `check` never tears them down and never force-exits on success.

The sibling command `lake-check` already does the right thing — it wraps its body in `try/finally` and calls `stopSixbProviders(sixb)`. `check` simply never got that treatment.

It doesn't reproduce in the existing test because the fixture uses in-memory providers, which hold no OS handles. Only real providers (redis/pg) keep the loop open — which is why it bites on real projects like `bacnet-example`.

## Change

Wrap `runCheck` in `try/finally` and tear providers down on the way out, mirroring `lake-check`:

```ts
const sixb = await loadSixbFromEntry(entry)
try {
  // ...render the check report, process.exit(1) on no object types
} finally {
  await stopSixbProviders(sixb)
}
```

`stopSixbProviders` disconnects connectors and closes queues/storage/lake/blob/broker, letting the process exit cleanly.

## Tests

Added a fixture (`lingering-handle-project`) whose queues provider owns a ref'd `setInterval` cleared only on `close()` — reproducing the "real provider holds the loop open" condition that in-memory fixtures can't. The new test spawns `sixb check` against it and asserts the process exits within 15s instead of hanging.

| Check | Result |
|---|---|
| New regression test | pass |
| New test vs. pre-change code | fails (times out) |
| `packages/cli/tests/` suite | 70 pass |
| `@sixb/cli` typecheck | pass |
| biome check | clean |

Verified end-to-end: `bun run check` in a real project now exits cleanly instead of hanging.

## Scope

No public API change. Only `check` gains the teardown that `lake-check` already had.
