### PR TITLE
expand: push graph reads into a single SQL query on Postgres

### DIFF
--- a/packages/core/src/objects/query/executor.ts
+++ b/packages/core/src/objects/query/executor.ts
@@ -20,11 +20,18 @@ import {
   ObjectQueryPlanningError,
   ObjectQueryValidationError,
 } from "./errors"
-import type { ObjectExpansion, ObjectQuery, ObjectQueryPredicate, ObjectQuerySortField } from "./ir"
+import type {
+  ObjectExpansion,
+  ObjectQuery,
+  ObjectQueryPredicate,
+  ObjectQueryResultShape,
+  ObjectQuerySortField,
+} from "./ir"
 import { normalizeObjectQuery } from "./normalize"
 import { type ObjectQueryPlan, type ObjectQueryPlanningOptions, planObjectQuery } from "./planner"
 import {
   type ObjectQueryValidationIssue,
+  resolveObjectQueryResultShape,
   type ValidatedObjectQuery,
   validateObjectQuery,
 } from "./validate"
@@ -149,15 +156,21 @@ export async function executeObjectQuery(
   const hasCountObjects = typeof options.storage.countObjects === "function"
   const hasExistsObjects = typeof options.storage.existsObjects === "function"
   const hasFacetObjects = typeof options.storage.facetObjects === "function"
-  const plannedQuery = expandPushdownQuery(validated.query, options.ontology, capabilities, {
-    hasQueryObjects,
-    hasCountObjects,
-    hasExistsObjects,
-    hasFacetObjects,
-    allowFallback: options.allowFallback,
-    maxFallbackRows: options.maxFallbackRows,
-    requiresExplicitFallbackBound: options.requiresExplicitFallbackBound,
-  })
+  const plannedQuery = expandPushdownQuery(
+    validated.query,
+    options.ontology,
+    capabilities,
+    {
+      hasQueryObjects,
+      hasCountObjects,
+      hasExistsObjects,
+      hasFacetObjects,
+      allowFallback: options.allowFallback,
+      maxFallbackRows: options.maxFallbackRows,
+      requiresExplicitFallbackBound: options.requiresExplicitFallbackBound,
+    },
+    options.maxExpansionFanout
+  )
   const plan = planObjectQuery(plannedQuery, {
     capabilities,
     hasQueryObjects,
@@ -393,17 +406,154 @@ function assertQueryViewable(
   )
 }
 
+interface ExpansionResolutionContext {
+  ontology: OntologyRegistry
+  maxExpansionFanout: number | undefined
+}
+
 function expandPushdownQuery(
   query: ObjectQuery,
   ontology: OntologyRegistry,
   capabilities: ObjectQueryCapabilities,
-  planning: Omit<ObjectQueryPlanningOptions, "capabilities">
+  planning: Omit<ObjectQueryPlanningOptions, "capabilities">,
+  maxExpansionFanout?: number
 ): ObjectQuery {
-  const expanded = expandIncludeSubtypes(query, ontology)
-  if (expanded === query) return query
+  // Resolve each expansion's cardinality and effective per-parent limit from the
+  // ontology so a provider can push the graph read down without one. The planner
+  // only admits expand pushdown once every expansion carries a cardinality, so a
+  // mixed/unresolved expansion (e.g. a polymorphic parent whose branches
+  // disagree) cleanly stays on the fallback.
+  const ctx: ExpansionResolutionContext = { ontology, maxExpansionFanout }
+  const annotated = resolveExpansions(query, ctx)
+  const expanded = expandIncludeSubtypes(annotated, ontology)
+  if (expanded === annotated) return annotated
 
   const plan = planObjectQuery(expanded, { ...planning, capabilities, allowFallback: false })
-  return plan.mode === "pushdown" ? expanded : query
+  return plan.mode === "pushdown" ? expanded : annotated
+}
+
+// Walk to the (normalized, outermost) expand node and annotate every expansion
+// with its resolved cardinality and bounded limit. Output-shaping only — never
+// changes which objects match — so it composes with `expandIncludeSubtypes`.
+function resolveExpansions(query: ObjectQuery, ctx: ExpansionResolutionContext): ObjectQuery {
+  switch (query.kind) {
+    case "expand": {
+      const parentShape = safeResultShape(query.input, ctx.ontology)
+      return {
+        ...query,
+        input: resolveExpansions(query.input, ctx),
+        expansions: query.expansions.map((expansion) =>
+          annotateExpansion(expansion, parentShape, ctx)
+        ),
+      }
+    }
+    case "start":
+      return query
+    case "set":
+      return {
+        ...query,
+        inputs: query.inputs.map((input) => resolveExpansions(input, ctx)),
+      }
+    case "filter":
+    case "text":
+    case "vector":
+    case "traverse":
+    case "sort":
+    case "limit":
+    case "page":
+    case "project":
+      return { ...query, input: resolveExpansions(query.input, ctx) }
+  }
+}
+
+function annotateExpansion(
+  expansion: ObjectExpansion,
+  parentShape: ObjectQueryResultShape,
+  ctx: ExpansionResolutionContext
+): ObjectExpansion {
+  const cardinality = resolveUniformCardinality(expansion, parentShape, ctx.ontology)
+  // Bake the per-parent top-N the provider must apply: the authored limit clamped
+  // by the fanout backstop (the fallback computes the same via
+  // `effectiveExpansionFanout`). Always defined afterwards, so the compiler need
+  // not re-derive the cap.
+  const limit = effectiveExpansionFanout(expansion.limit, ctx.maxExpansionFanout)
+  const base: ObjectExpansion = cardinality
+    ? { ...expansion, cardinality, limit }
+    : { ...expansion, limit }
+
+  if (!expansion.expand || expansion.expand.length === 0) return base
+
+  const targetShape = resolveExpansionTargetShape(expansion, parentShape, ctx.ontology)
+  return {
+    ...base,
+    expand: expansion.expand.map((nested) => annotateExpansion(nested, targetShape, ctx)),
+  }
+}
+
+// The attached value shape is uniform only when every parent type resolves the
+// link to the same cardinality. A non-declaring parent type contributes "many"
+// (matching the fallback's `link?.cardinality ?? "many"`); incoming is always
+// many-to-one. A mixed result returns undefined, keeping the query on fallback.
+function resolveUniformCardinality(
+  expansion: ObjectExpansion,
+  parentShape: ObjectQueryResultShape,
+  ontology: OntologyRegistry
+): "one" | "many" | undefined {
+  if (expansion.direction === "incoming") return "many"
+  if (parentShape.objectTypeIds.length === 0) return undefined
+
+  const cardinalities = new Set<"one" | "many">()
+  for (const objectTypeId of parentShape.objectTypeIds) {
+    const objectType = ontology.getObjectTypeById(objectTypeId)
+    const link = objectType?.links.find((candidate) => candidate.id === expansion.linkId)
+    cardinalities.add(link?.cardinality ?? "many")
+  }
+  return cardinalities.size === 1 ? [...cardinalities][0] : undefined
+}
+
+// The objects reached by an expansion are exactly the result of the equivalent
+// traverse, so reuse the shared shape resolver instead of re-deriving link
+// targets. Used to carry the parent context into nested expansions.
+function resolveExpansionTargetShape(
+  expansion: ObjectExpansion,
+  parentShape: ObjectQueryResultShape,
+  ontology: OntologyRegistry
+): ObjectQueryResultShape {
+  if (parentShape.objectTypeIds.length === 0) return { objectTypeIds: [] }
+
+  const input: ObjectQuery =
+    parentShape.objectTypeIds.length === 1
+      ? { kind: "start", objectTypeId: parentShape.objectTypeIds[0] }
+      : {
+          kind: "set",
+          op: "union",
+          inputs: parentShape.objectTypeIds.map((objectTypeId) => ({
+            kind: "start",
+            objectTypeId,
+          })),
+        }
+  const traverse: ObjectQuery = {
+    kind: "traverse",
+    input,
+    linkId: expansion.linkId,
+    direction: expansion.direction,
+    ...(expansion.sourceObjectTypeId === undefined
+      ? {}
+      : { sourceObjectTypeId: expansion.sourceObjectTypeId }),
+  }
+  return safeResultShape(traverse, ontology)
+}
+
+// Cardinality resolution is a pushdown optimization, never a correctness
+// requirement: any failure to resolve a shape (the resolver throws on a query it
+// considers invalid) must degrade to "unresolved", which the planner reads as
+// "keep this on the fallback" rather than surfacing an error.
+function safeResultShape(query: ObjectQuery, ontology: OntologyRegistry): ObjectQueryResultShape {
+  try {
+    return resolveObjectQueryResultShape(query, { ontology })
+  } catch {
+    return { objectTypeIds: [] }
+  }
 }
 
 function expandIncludeSubtypes(query: ObjectQuery, ontology: OntologyRegistry): ObjectQuery {

--- a/packages/core/src/objects/query/ir.ts
+++ b/packages/core/src/objects/query/ir.ts
@@ -127,6 +127,17 @@ export interface ObjectExpansion {
   orderBy?: readonly ObjectQuerySortField[]
   /** Nested expansions, hydrated from the target objects of this expansion. */
   expand?: readonly ObjectExpansion[]
+  /**
+   * Resolved link cardinality, driving the attached value shape: `"one"` yields a
+   * single object (or `null`), `"many"` yields an array.
+   *
+   * Core-resolved, never authored: the core executor fills this from the ontology
+   * before provider pushdown (like {@link ObjectQueryText.fieldsByObjectType}), so
+   * a storage provider can shape the result without an ontology. The bounded
+   * fallback re-derives cardinality per parent row and ignores this field. The
+   * planner only pushes an expansion down once it is set.
+   */
+  cardinality?: "one" | "many"
 }
 
 export type ObjectQueryPredicate =

--- a/packages/core/src/objects/query/planner.ts
+++ b/packages/core/src/objects/query/planner.ts
@@ -1,6 +1,6 @@
 import type { ObjectQueryCapabilities } from "../../storage"
 import type { ObjectQueryPlanningIssue } from "./errors"
-import type { ObjectQuery, ObjectQueryPredicate, ObjectQuerySortField } from "./ir"
+import type { ObjectExpansion, ObjectQuery, ObjectQueryPredicate, ObjectQuerySortField } from "./ir"
 
 export type ObjectQueryPlanMode = "pushdown" | "fallback" | "rejected"
 export type ObjectQueryProviderOperation =
@@ -248,7 +248,35 @@ function collectNodeProviderIssues(
       })
       collectNodeProviderIssues(query.input, `${path}.input`, capabilities, issues)
       return
+    case "expand":
+      query.expansions.forEach((expansion, index) => {
+        collectExpansionProviderIssues(expansion, `${path}.expansions[${index}]`, issues)
+      })
+      collectNodeProviderIssues(query.input, `${path}.input`, capabilities, issues)
+      return
   }
+}
+
+// An expansion only pushes down once core has resolved its cardinality; an
+// unresolved one (e.g. a polymorphic parent whose branches disagree) keeps the
+// whole query on the bounded fallback, which re-derives cardinality per row.
+function collectExpansionProviderIssues(
+  expansion: ObjectExpansion,
+  path: string,
+  issues: ObjectQueryPlanningIssue[]
+): void {
+  if (expansion.cardinality === undefined) {
+    addIssue(
+      issues,
+      path,
+      "expand_cardinality_unresolved",
+      `Provider cannot push down expansion '${expansion.linkId}' without a resolved cardinality`
+    )
+  }
+
+  expansion.expand?.forEach((nested, index) => {
+    collectExpansionProviderIssues(nested, `${path}.expand[${index}]`, issues)
+  })
 }
 
 function collectPredicateProviderIssues(

--- a/packages/core/src/testing/object-query-contract.ts
+++ b/packages/core/src/testing/object-query-contract.ts
@@ -776,7 +776,7 @@ export function runObjectQueryProviderContractSuite<TStorage extends ObjectStora
       })
     })
 
-    test("hydrates expand links through bounded fallback", async () => {
+    test("hydrates expand links identically via pushdown or bounded fallback", async () => {
       await withStorage(async (storage) => {
         await seedObjectQueryContractData(storage)
 
@@ -800,8 +800,11 @@ export function runObjectQueryProviderContractSuite<TStorage extends ObjectStora
           { ontology: objectQueryContractOntology, storage }
         )
 
-        // No provider declares expand pushdown yet, so it routes through fallback.
-        expect(outgoing.plan.mode).toBe("fallback")
+        // A provider that declares expand pushdown hydrates links in-database;
+        // otherwise the same links come back through the bounded fallback. Either
+        // path must produce identical results.
+        const expandMode = storage.queryCapabilities().nodes?.expand ? "pushdown" : "fallback"
+        expect(outgoing.plan.mode).toBe(expandMode)
         expect(expandedIds(outgoing, "room-alpha", "hasDevice")).toEqual(["device-projector"])
         expect(expandedIds(outgoing, "room-beta", "hasDevice")).toEqual(["device-sensor"])
 
@@ -822,6 +825,7 @@ export function runObjectQueryProviderContractSuite<TStorage extends ObjectStora
         )
 
         // device-projector is linked from both a Room and a Zone.
+        expect(incoming.plan.mode).toBe(expandMode)
         expect(expandedIds(incoming, "device-projector", "hasDevice")).toEqual([
           "room-alpha",
           "zone-one",

--- a/packages/core/tests/object-query-expand-exec.test.ts
+++ b/packages/core/tests/object-query-expand-exec.test.ts
@@ -36,6 +36,7 @@ const Company = defineObjectType({
     prop("id", "string", { required: true, primary: true }),
     prop("name", "string", { required: true, query: sortable }),
   ],
+  links: [link.self("parent", { cardinality: "one" })],
 })
 
 const Opportunity = defineObjectType({
@@ -137,6 +138,11 @@ async function seed(storage: InMemoryObjectStorage): Promise<void> {
   )
 
   await storage.applyObjectUpserted(objectEvent("Company", "acme", { id: "acme", name: "Acme" }))
+  await storage.applyObjectUpserted(
+    objectEvent("Company", "globex", { id: "globex", name: "Globex" })
+  )
+  // acme rolls up to globex — the third hop for the deep-expansion fixture.
+  await storage.applyLinkUpserted(linkEvent("Company", "acme", "parent", "Company", "globex"))
 
   await storage.applyObjectUpserted(
     objectEvent("Opportunity", "opp-1", { id: "opp-1", title: "Deal A" })
@@ -256,6 +262,37 @@ describe("object query expand — execution", () => {
     const opportunity = single(byId(result.objects, "proj-1").links?.opportunity)
     const company = single(opportunity.links?.company)
     expect(company.properties.name).toBe("Acme")
+  })
+
+  test("hydrates a three-hop expansion end to end", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId: PROJECT,
+        query: expandProjects([
+          {
+            linkId: "opportunity",
+            direction: "outgoing",
+            expand: [
+              {
+                linkId: "company",
+                direction: "outgoing",
+                expand: [{ linkId: "parent", direction: "outgoing" }],
+              },
+            ],
+          },
+        ]),
+      },
+      { ontology, storage }
+    )
+
+    // proj-1 → opp-1 → acme → globex, asserting identity + a property at each hop.
+    const opportunity = single(byId(result.objects, "proj-1").links?.opportunity)
+    expect(opportunity.properties.title).toBe("Deal A")
+    const company = single(opportunity.links?.company)
+    expect(company.primaryId).toBe("acme")
+    const parent = single(company.links?.parent)
+    expect(parent.primaryId).toBe("globex")
+    expect(parent.properties.name).toBe("Globex")
   })
 
   test("fetches a target shared across parents exactly once", async () => {

--- a/packages/core/tests/object-query.test.ts
+++ b/packages/core/tests/object-query.test.ts
@@ -753,6 +753,83 @@ describe("object query planner and executor", () => {
     expect(result.objects[0].properties).toEqual({ id: "cust-3", name: "Acme Co" })
   })
 
+  test("plans expand pushdown only when every expansion has a resolved cardinality", () => {
+    const capabilities: ObjectQueryCapabilities = {
+      queryObjects: true,
+      nodes: { start: true, limit: true, expand: true },
+    }
+    const resolved: ObjectQuery = {
+      kind: "expand",
+      input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Customer" } },
+      expansions: [{ linkId: "orders", direction: "outgoing", cardinality: "many" }],
+    }
+    expect(planObjectQuery(resolved, { capabilities, hasQueryObjects: true }).mode).toBe("pushdown")
+
+    // An unresolved cardinality (e.g. a polymorphic parent whose branches
+    // disagree) keeps the query on the bounded fallback.
+    const unresolved: ObjectQuery = {
+      kind: "expand",
+      input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Customer" } },
+      expansions: [{ linkId: "orders", direction: "outgoing" }],
+    }
+    const plan = planObjectQuery(unresolved, {
+      capabilities,
+      hasQueryObjects: true,
+      maxFallbackRows: 10,
+    })
+    expect(plan.mode).toBe("fallback")
+    expect(plan.providerIssues.map((issue) => issue.code)).toContain(
+      "expand_cardinality_unresolved"
+    )
+  })
+
+  test("keeps expand on the fallback when the provider lacks the capability", () => {
+    const capabilities: ObjectQueryCapabilities = {
+      queryObjects: true,
+      nodes: { start: true, limit: true },
+    }
+    const query: ObjectQuery = {
+      kind: "expand",
+      input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Customer" } },
+      expansions: [{ linkId: "orders", direction: "outgoing", cardinality: "many" }],
+    }
+    const plan = planObjectQuery(query, {
+      capabilities,
+      hasQueryObjects: true,
+      maxFallbackRows: 10,
+    })
+    expect(plan.mode).toBe("fallback")
+    expect(plan.providerIssues.map((issue) => issue.code)).toContain("query_node_not_supported")
+  })
+
+  test("requires a resolved cardinality on nested expansions too", () => {
+    const capabilities: ObjectQueryCapabilities = {
+      queryObjects: true,
+      nodes: { start: true, limit: true, expand: true },
+    }
+    const query: ObjectQuery = {
+      kind: "expand",
+      input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Customer" } },
+      expansions: [
+        {
+          linkId: "orders",
+          direction: "outgoing",
+          cardinality: "many",
+          expand: [{ linkId: "items", direction: "outgoing" }],
+        },
+      ],
+    }
+    const plan = planObjectQuery(query, {
+      capabilities,
+      hasQueryObjects: true,
+      maxFallbackRows: 10,
+    })
+    expect(plan.mode).toBe("fallback")
+    expect(plan.providerIssues.map((issue) => issue.code)).toContain(
+      "expand_cardinality_unresolved"
+    )
+  })
+
   test("counts through provider pushdown without materializing rows", async () => {
     const storage = new CountingQueryStorage()
     await seedCustomers(storage)

--- a/storage/pg/src/pg-object-query-compiler.ts
+++ b/storage/pg/src/pg-object-query-compiler.ts
@@ -1,4 +1,5 @@
 import {
+  type ObjectExpansion,
   type ObjectQuery,
   ObjectQueryExecutionError,
   type ObjectQueryPredicate,
@@ -87,6 +88,9 @@ interface EncodedCursorValue {
 
 const PAGE_TOKEN_PREFIX = "keyset:"
 const exactContext: CompileContext = { probeLimit: false }
+// Per-parent fanout the core executor bakes into every pushed-down expansion;
+// this default only guards a malformed (un-baked) IR and mirrors the core cap.
+const DEFAULT_EXPANSION_FANOUT = 1_000
 
 export function compilePgObjectQuery(
   projectId: string,
@@ -199,10 +203,9 @@ function compileObjectQueryInternal(
         query.fields,
         query.fieldsByObjectType
       )
-    case "vector":
-    // `expand` (link hydration) has no provider pushdown yet; the planner gates
-    // it off via capabilities, so this is unreachable until a later slice.
     case "expand":
+      return compileExpand(projectId, query.input, query.expansions)
+    case "vector":
       throw new Error(
         `[SixbPg] PostgreSQL object storage does not support query node '${query.kind}'`
       )
@@ -455,6 +458,198 @@ function compileTraversal(
     trimRows: identityRows,
     nextPageToken: () => undefined,
   }
+}
+
+/** Correlation handle for an expansion: the parent row's identity columns. */
+interface ExpansionParent {
+  project: string
+  type: string
+  id: string
+}
+
+// `expand` attaches linked objects to each result row without changing which
+// objects match (unlike `traverse`, which pivots to the targets). Each expansion
+// becomes a correlated subquery that hydrates its links into a JSONB value, and
+// all expansions are folded into one `_expand` object column the row mapper reads
+// back. The input set is otherwise untouched, so pagination/order pass through.
+function compileExpand(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  expansions: readonly ObjectExpansion[]
+): CompiledPgObjectQuery {
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const expand = compileExpansionsObject(
+    expansions,
+    { project: "input.project_id", type: "input.object_type_id", id: "input.primary_id" },
+    ""
+  )
+  const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
+  const sql = `
+    SELECT input.*, ${expand.sql} AS _expand
+    FROM (${input.sql}) AS input
+    ORDER BY ${inputOrder.sql}
+  `
+
+  return {
+    sql,
+    args: [...expand.args, ...input.args, ...inputOrder.args],
+    totalSql: input.totalSql,
+    totalArgs: input.totalArgs,
+    order: input.order,
+    hasMoreProbe: input.hasMoreProbe,
+    hasMore: input.hasMore,
+    trimRows: input.trimRows,
+    nextPageToken: input.nextPageToken,
+  }
+}
+
+// `jsonb_build_object(linkId, value, ...)` over a set of expansions sharing one
+// parent. Link ids are user data, so they ride as parameters. Used both for the
+// outer `_expand` column and for each child's nested `links`.
+function compileExpansionsObject(
+  expansions: readonly ObjectExpansion[],
+  parent: ExpansionParent,
+  pathPrefix: string
+): CompiledPredicate {
+  const parts: string[] = []
+  const args: unknown[] = []
+  expansions.forEach((expansion, index) => {
+    const path = pathPrefix === "" ? `${index}` : `${pathPrefix}_${index}`
+    const value = compileExpansionValue(expansion, parent, path)
+    parts.push("?::text", value.sql)
+    args.push(expansion.linkId, ...value.args)
+  })
+  return { sql: `jsonb_build_object(${parts.join(", ")})`, args }
+}
+
+// One expansion's hydrated value. `row_number()` numbers a parent's links by the
+// order from `compileExpansionOrder` (the expansion's `orderBy` against the target
+// object's properties, then an identity tiebreak); `WHERE _ord <= N` keeps the
+// top-N per parent in-DB; each retained neighbour becomes a JSONB object; and the
+// value is an ordered array ("many") or the first element or null ("one"). The
+// cardinality is core-resolved before pushdown.
+function compileExpansionValue(
+  expansion: ObjectExpansion,
+  parent: ExpansionParent,
+  path: string
+): CompiledPredicate {
+  const edge = `edge_${path}`
+  const target = `tgt_${path}`
+  const ranked = `ranked_${path}`
+  const incoming = expansion.direction === "incoming"
+  // The hydrated neighbour is the link target (outgoing) or source (incoming);
+  // the parent sits on the opposite end, mirroring `compileTraversal`.
+  const neighborType = incoming ? `${edge}.source_type_id` : `${edge}.target_type_id`
+  const neighborId = incoming ? `${edge}.source_id` : `${edge}.target_id`
+  const parentType = incoming ? `${edge}.target_type_id` : `${edge}.source_type_id`
+  const parentId = incoming ? `${edge}.target_id` : `${edge}.source_id`
+
+  const child = compileExpansionChildJson(expansion, edge, target, path)
+  const order = compileExpansionOrder(expansion, target, neighborType, neighborId)
+
+  const whereParts = [
+    `${edge}.project_id = ${parent.project}`,
+    `${parentType} = ${parent.type}`,
+    `${parentId} = ${parent.id}`,
+    `${edge}.link_id = ?::text`,
+  ]
+  const whereArgs: unknown[] = [expansion.linkId]
+  if (incoming && expansion.sourceObjectTypeId !== undefined) {
+    whereParts.push(`${edge}.source_type_id = ?::text`)
+    whereArgs.push(expansion.sourceObjectTypeId)
+  }
+
+  const inner = `
+    SELECT ${child.sql} AS elem, row_number() OVER (ORDER BY ${order.sql}) AS _ord
+    FROM links AS ${edge}
+    JOIN objects AS ${target}
+      ON ${target}.project_id = ${edge}.project_id
+     AND ${target}.object_type_id = ${neighborType}
+     AND ${target}.primary_id = ${neighborId}
+    WHERE ${whereParts.join(" AND ")}
+  `
+  const innerArgs = [...child.args, ...order.args, ...whereArgs]
+
+  if (expansion.cardinality === "one") {
+    return {
+      sql: `(SELECT ${ranked}.elem FROM (${inner}) AS ${ranked} WHERE ${ranked}._ord = 1)`,
+      args: innerArgs,
+    }
+  }
+
+  // The fanout cap is baked into `limit` by the core executor before pushdown.
+  const limit = expansion.limit ?? DEFAULT_EXPANSION_FANOUT
+  return {
+    sql: `COALESCE((SELECT jsonb_agg(${ranked}.elem ORDER BY ${ranked}._ord) FROM (${inner}) AS ${ranked} WHERE ${ranked}._ord <= ?), '[]'::jsonb)`,
+    args: [...innerArgs, limit],
+  }
+}
+
+// Build one hydrated neighbour as an `ExpandedObjectRow`-shaped JSONB object.
+// `linkProperties` always rides along (the mapper drops it when empty), and
+// nested expansions recurse under `links`, correlated on this neighbour.
+function compileExpansionChildJson(
+  expansion: ObjectExpansion,
+  edge: string,
+  target: string,
+  path: string
+): CompiledPredicate {
+  const fields = [
+    `'projectId', ${target}.project_id`,
+    `'objectTypeId', ${target}.object_type_id`,
+    `'primaryId', ${target}.primary_id`,
+    `'properties', ${target}.properties`,
+    `'createdAt', ${target}.created_at`,
+    `'updatedAt', ${target}.updated_at`,
+    `'version', ${target}.version`,
+    `'sourceEventId', ${target}.source_event_id`,
+    `'linkProperties', ${edge}.properties`,
+  ]
+  const args: unknown[] = []
+
+  if (expansion.expand && expansion.expand.length > 0) {
+    const nested = compileExpansionsObject(
+      expansion.expand,
+      {
+        project: `${target}.project_id`,
+        type: `${target}.object_type_id`,
+        id: `${target}.primary_id`,
+      },
+      path
+    )
+    fields.push(`'links', ${nested.sql}`)
+    args.push(...nested.args)
+  }
+
+  return { sql: `jsonb_build_object(${fields.join(", ")})`, args }
+}
+
+// Order a parent's links the way the fallback's per-parent trim does: each
+// property sorts nulls last with the requested direction (against the neighbour's
+// JSONB properties), then a deterministic identity tiebreak on the neighbour.
+function compileExpansionOrder(
+  expansion: ObjectExpansion,
+  target: string,
+  neighborType: string,
+  neighborId: string
+): CompiledPredicate {
+  const propertyColumn = `${target}.properties`
+  const clauses: string[] = []
+  const args: unknown[] = []
+
+  for (const field of expansion.orderBy ?? []) {
+    // Relevance is a no-op in the fallback comparator; mirror that by skipping it.
+    if (field.kind !== "property") continue
+    const direction = field.direction === "desc" ? "DESC" : "ASC"
+    clauses.push(
+      `CASE WHEN ${jsonTypeExpression(propertyColumn)} IS NULL OR ${jsonTypeExpression(propertyColumn)} = 'null' THEN 1 ELSE 0 END ASC`,
+      `${jsonValueExpression(propertyColumn)} ${direction}`
+    )
+    args.push(field.propertyId, field.propertyId, field.propertyId)
+  }
+
+  clauses.push(`${neighborType} ASC`, `${neighborId} ASC`)
+  return { sql: clauses.join(", "), args }
 }
 
 function compileSet(

--- a/storage/pg/src/pg-object-storage.ts
+++ b/storage/pg/src/pg-object-storage.ts
@@ -4,6 +4,8 @@ import type {
   EditCommitPlan,
   ExistsObjectsInput,
   ExistsObjectsResult,
+  ExpandedLinkValue,
+  ExpandedObjectRow,
   FacetObjectsInput,
   FacetObjectsResult,
   LinkDirection,
@@ -11,6 +13,7 @@ import type {
   ObjectQuery,
   ObjectQueryCapabilities,
   ObjectRow,
+  ObjectRowLinks,
   ObjectStorage,
   QueryObjectsInput,
   QueryObjectsResult,
@@ -51,6 +54,7 @@ const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
     traverse: true,
     set: true,
     project: true,
+    expand: true,
   },
   predicateOps: {
     and: true,
@@ -83,7 +87,8 @@ const PG_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
     stablePageTokens: true,
   },
   notes: [
-    "PostgreSQL object query pushdown supports start/filter/text/sort/limit/page/traverse/set/project over JSONB properties and object links.",
+    "PostgreSQL object query pushdown supports start/filter/text/sort/limit/page/traverse/set/project/expand over JSONB properties and object links.",
+    "expand hydrates linked objects in-database (top-N per parent via LATERAL + jsonb_agg); core resolves each expansion's cardinality before pushdown, and a mixed/unresolved one stays on the fallback.",
     "Relevance sorting, vector search, and unresolved start.includeSubtypes remain planner fallback or rejection cases.",
   ],
 }
@@ -175,7 +180,7 @@ export class PgObjectStorage implements ObjectStorage {
         : compiled.hasMore(rawRows.length, total)
 
     return {
-      objects: rows.map((row) => rowToObject(row)),
+      objects: rows.map((row) => queryRowToObject(row)),
       hasMore,
       nextPageToken: compiled.nextPageToken(rows, rawRows.length),
       ...(total === undefined ? {} : { total }),
@@ -1223,6 +1228,59 @@ function rowToObject(row: ObjectDatabaseRow): ObjectRow {
   }
 }
 
+// Map a query row, attaching `links` when an `expand` pushdown produced them. The
+// base columns map as usual; `_expand` (a `jsonb_build_object`) is revived into
+// the runtime link shape the core executor's fallback also produces.
+function queryRowToObject(row: ObjectQueryDatabaseRow): ObjectRow {
+  const base = rowToObject(row)
+  const links = reviveExpandedLinks(row._expand)
+  return links ? { ...base, links } : base
+}
+
+function reviveExpandedLinks(value: unknown): ObjectRowLinks | undefined {
+  if (!isPlainRecord(value)) return undefined
+  const links: ObjectRowLinks = {}
+  for (const [linkId, raw] of Object.entries(value)) {
+    links[linkId] = reviveExpandedLinkValue(raw)
+  }
+  return links
+}
+
+// A "one" expansion arrives as a single object or null; a "many" expansion as an
+// array (already ordered and trimmed in the database).
+function reviveExpandedLinkValue(value: unknown): ExpandedLinkValue {
+  if (value === null || value === undefined) return null
+  if (Array.isArray(value)) return value.map(reviveExpandedRow)
+  return reviveExpandedRow(value)
+}
+
+// Revive one hydrated neighbour from `compileExpansionChildJson`: JSONB timestamp
+// strings back to `Date`, empty link properties dropped (matching the fallback),
+// and nested links recursed.
+function reviveExpandedRow(value: unknown): ExpandedObjectRow {
+  const row = isPlainRecord(value) ? value : {}
+  const expanded: ExpandedObjectRow = {
+    projectId: String(row.projectId),
+    objectTypeId: String(row.objectTypeId),
+    primaryId: String(row.primaryId),
+    properties: isPlainRecord(row.properties) ? row.properties : {},
+    createdAt: new Date(row.createdAt as string),
+    updatedAt: new Date(row.updatedAt as string),
+    version: Number(row.version),
+  }
+  if (row.sourceEventId != null) expanded.sourceEventId = String(row.sourceEventId)
+  if (isPlainRecord(row.linkProperties) && Object.keys(row.linkProperties).length > 0) {
+    expanded.linkProperties = row.linkProperties
+  }
+  const links = reviveExpandedLinks(row.links)
+  if (links) expanded.links = links
+  return expanded
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
 function rowToLink(row: LinkDatabaseRow): ObjectLinkRow {
   return {
     projectId: row.project_id,
@@ -1251,6 +1309,8 @@ interface ObjectDatabaseRow {
 
 interface ObjectQueryDatabaseRow extends ObjectDatabaseRow {
   _cursor_properties?: unknown
+  /** `jsonb_build_object(linkId, value, ...)` from an `expand` pushdown; absent otherwise. */
+  _expand?: unknown
 }
 
 interface FacetDatabaseRow {

--- a/storage/pg/tests/pg-object-query-compiler.test.ts
+++ b/storage/pg/tests/pg-object-query-compiler.test.ts
@@ -99,3 +99,119 @@ test("incoming traversal SQL filters by source object type when constrained", ()
   expect(constrainedCount.sql).toContain("AND edge.source_type_id = $4")
   expect(constrainedCount.args).toEqual(["project-a", "Customer", "customer", "Project"])
 })
+
+test("expand SQL hydrates an outgoing many link as an ordered jsonb array", () => {
+  const compiled = compilePgObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Room" } },
+    expansions: [{ linkId: "hasDevice", direction: "outgoing", cardinality: "many", limit: 50 }],
+  })
+
+  // Output-shaping: the input row set rides through under `_expand`.
+  expect(compiled.sql).toContain("SELECT input.*,")
+  expect(compiled.sql).toContain("AS _expand")
+  // Top-N per parent pushed into the DB, then aggregated in rank order.
+  expect(compiled.sql).toContain("row_number() OVER (ORDER BY")
+  expect(compiled.sql).toContain("jsonb_agg(ranked_0.elem ORDER BY ranked_0._ord)")
+  expect(compiled.sql).toContain("WHERE ranked_0._ord <= $3")
+  expect(compiled.sql).toContain("'[]'::jsonb")
+  // Outgoing: parent on the link source, neighbour hydrated from the target.
+  expect(compiled.sql).toContain("edge_0.source_type_id = input.object_type_id")
+  expect(compiled.sql).toContain("tgt_0.object_type_id = edge_0.target_type_id")
+  expect(compiled.sql).toContain("'linkProperties', edge_0.properties")
+  expect(compiled.sql).toContain("edge_0.link_id = $2::text")
+  // Link id rides as a param twice (the json key and the edge filter); then the
+  // baked fanout, then the input's own params.
+  expect(compiled.args).toEqual(["hasDevice", "hasDevice", 50, "project-a", "Room", 10])
+})
+
+test("expand SQL takes the first ranked element for a one link", () => {
+  const compiled = compilePgObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 5, input: { kind: "start", objectTypeId: "User" } },
+    expansions: [{ linkId: "manager", direction: "outgoing", cardinality: "one", limit: 1000 }],
+  })
+
+  expect(compiled.sql).toContain("WHERE ranked_0._ord = 1")
+  expect(compiled.sql).not.toContain("jsonb_agg")
+  expect(compiled.sql).not.toContain("_ord <=")
+  // No fanout param for a "one" link — it always takes a single element.
+  expect(compiled.args).toEqual(["manager", "manager", "project-a", "User", 5])
+})
+
+test("expand SQL flips parent/neighbour columns and filters source type for incoming", () => {
+  const compiled = compilePgObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 5, input: { kind: "start", objectTypeId: "Device" } },
+    expansions: [
+      {
+        linkId: "hasDevice",
+        direction: "incoming",
+        sourceObjectTypeId: "Room",
+        cardinality: "many",
+        limit: 1000,
+      },
+    ],
+  })
+
+  // Incoming: parent on the link target, neighbour hydrated from the source.
+  expect(compiled.sql).toContain("edge_0.target_type_id = input.object_type_id")
+  expect(compiled.sql).toContain("edge_0.target_id = input.primary_id")
+  expect(compiled.sql).toContain("tgt_0.object_type_id = edge_0.source_type_id")
+  expect(compiled.sql).toContain("edge_0.source_type_id = $3::text")
+  expect(compiled.args).toEqual(["hasDevice", "hasDevice", "Room", 1000, "project-a", "Device", 5])
+})
+
+test("expand SQL orders a bounded many link by target properties, nulls last", () => {
+  const compiled = compilePgObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Room" } },
+    expansions: [
+      {
+        linkId: "hasDevice",
+        direction: "outgoing",
+        cardinality: "many",
+        limit: 5,
+        orderBy: [{ kind: "property", propertyId: "name", direction: "desc" }],
+      },
+    ],
+  })
+
+  // Null-rank first (always ASC so nulls sort last), then the value descending,
+  // against the neighbour's JSONB properties — mirroring the fallback comparator.
+  expect(compiled.sql).toContain("jsonb_typeof(tgt_0.properties -> ($2::text))")
+  expect(compiled.sql).toContain("tgt_0.properties -> ($4::text) DESC")
+  expect(compiled.args).toEqual([
+    "hasDevice",
+    "name",
+    "name",
+    "name",
+    "hasDevice",
+    5,
+    "project-a",
+    "Room",
+    10,
+  ])
+})
+
+test("expand SQL nests a child expansion correlated on the parent neighbour", () => {
+  const compiled = compilePgObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Project" } },
+    expansions: [
+      {
+        linkId: "owner",
+        direction: "outgoing",
+        cardinality: "one",
+        limit: 1000,
+        expand: [{ linkId: "members", direction: "outgoing", cardinality: "many", limit: 1000 }],
+      },
+    ],
+  })
+
+  // The nested expansion uses its own aliases and correlates on the parent's
+  // hydrated neighbour (tgt_0), under a `links` key in the child object.
+  expect(compiled.sql).toContain("'links', jsonb_build_object(")
+  expect(compiled.sql).toContain("edge_0_0.source_id = tgt_0.primary_id")
+  expect(compiled.sql).toContain("jsonb_agg(ranked_0_0.elem")
+})

--- a/storage/pg/tests/pg-object-query-expand.e2e.ts
+++ b/storage/pg/tests/pg-object-query-expand.e2e.ts
@@ -1,0 +1,312 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import {
+  defineObjectType,
+  type ExpandedObjectRow,
+  executeObjectQuery,
+  link,
+  OntologyRegistry,
+  prop,
+  type StoredLinkUpsertedEvent,
+  type StoredObjectUpsertedEvent,
+} from "@sixb/core"
+import type { PostgresStorage } from "../src"
+import { createTestStorage } from "./helpers"
+
+// Self-contained ontology exercising the runtime shapes the in-memory contract
+// can't: a "one" link, a "many" link, a nested "one" hop, link properties, and a
+// dangling edge. All assertions hold for both pushdown (here, against Postgres)
+// and the bounded fallback the cross-provider contract covers separately.
+const Tag = defineObjectType({
+  id: "ExpandTag",
+  name: "Expand Tag",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("label", "string", {
+      query: { searchable: true, filterable: true, sortable: true, exact: true },
+    }),
+  ],
+})
+
+const Author = defineObjectType({
+  id: "ExpandAuthor",
+  name: "Expand Author",
+  properties: [prop("id", "string", { required: true, primary: true }), prop("name", "string")],
+  links: [
+    link("favoriteTag", Tag, { cardinality: "one" }),
+    link.self("manager", { cardinality: "one" }),
+  ],
+})
+
+const Post = defineObjectType({
+  id: "ExpandPost",
+  name: "Expand Post",
+  properties: [prop("id", "string", { required: true, primary: true }), prop("title", "string")],
+  links: [
+    link("author", Author, { cardinality: "one" }),
+    link("tags", Tag, { cardinality: "many" }),
+  ],
+})
+
+const ontology = new OntologyRegistry({ sources: [Tag, Author, Post] })
+const projectId = "expand-e2e"
+
+let storage: PostgresStorage
+let cursor = 0
+
+beforeAll(async () => {
+  const created = await createTestStorage()
+  storage = created.storage
+  const objects = storage.objects
+
+  await objects.applyObjectUpserted(objectEvent(Tag.id, "tag-a", { id: "tag-a", label: "Apple" }))
+  await objects.applyObjectUpserted(objectEvent(Tag.id, "tag-b", { id: "tag-b", label: "Banana" }))
+  await objects.applyObjectUpserted(objectEvent(Tag.id, "tag-c", { id: "tag-c", label: "Cherry" }))
+  await objects.applyObjectUpserted(
+    objectEvent(Author.id, "author-1", { id: "author-1", name: "Alice" })
+  )
+  await objects.applyObjectUpserted(
+    objectEvent(Author.id, "author-2", { id: "author-2", name: "Bob" })
+  )
+  await objects.applyObjectUpserted(
+    objectEvent(Post.id, "post-1", { id: "post-1", title: "First" })
+  )
+
+  await objects.applyLinkUpserted(linkEvent(Post.id, "post-1", "author", Author.id, "author-1"))
+  await objects.applyLinkUpserted(linkEvent(Author.id, "author-1", "favoriteTag", Tag.id, "tag-b"))
+  // author-1 → manager author-2 → favoriteTag tag-c: the third hop for deep expansion.
+  await objects.applyLinkUpserted(
+    linkEvent(Author.id, "author-1", "manager", Author.id, "author-2")
+  )
+  await objects.applyLinkUpserted(linkEvent(Author.id, "author-2", "favoriteTag", Tag.id, "tag-c"))
+  // post-1 → three real tags plus one dangling edge; tag-a carries link properties.
+  await objects.applyLinkUpserted(
+    linkEvent(Post.id, "post-1", "tags", Tag.id, "tag-a", { weight: 10 })
+  )
+  await objects.applyLinkUpserted(linkEvent(Post.id, "post-1", "tags", Tag.id, "tag-b"))
+  await objects.applyLinkUpserted(linkEvent(Post.id, "post-1", "tags", Tag.id, "tag-c"))
+  await objects.applyLinkUpserted(linkEvent(Post.id, "post-1", "tags", Tag.id, "tag-missing"))
+})
+
+afterAll(async () => {
+  await storage.dropSchema()
+  await storage.close()
+})
+
+describe("PgObjectStorage expand pushdown", () => {
+  test("hydrates one and many links in-database, dropping a dangling edge", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [
+            { linkId: "author", direction: "outgoing" },
+            { linkId: "tags", direction: "outgoing" },
+          ],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage: storage.objects }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    const post = postRow(result, "post-1")
+
+    // "one" → a single object (not an array), with timestamps revived to Date.
+    const author = post.links?.author as ExpandedObjectRow
+    expect(Array.isArray(author)).toBe(false)
+    expect(author.primaryId).toBe("author-1")
+    expect(author.properties.name).toBe("Alice")
+    expect(author.createdAt).toBeInstanceOf(Date)
+    expect(author.updatedAt).toBeInstanceOf(Date)
+
+    // "many" → an array; the dangling tag-missing edge hydrates to nothing.
+    const tags = post.links?.tags as ExpandedObjectRow[]
+    expect(tags.map((tag) => tag.primaryId).sort()).toEqual(["tag-a", "tag-b", "tag-c"])
+  })
+
+  test("orders and bounds a many expansion to the top-N by target property", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [
+            {
+              linkId: "tags",
+              direction: "outgoing",
+              limit: 2,
+              orderBy: [{ kind: "property", propertyId: "label", direction: "asc" }],
+            },
+          ],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage: storage.objects }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    const tags = postRow(result, "post-1").links?.tags as ExpandedObjectRow[]
+    // Apple, Banana, Cherry → top-2 ascending, in order.
+    expect(tags.map((tag) => tag.primaryId)).toEqual(["tag-a", "tag-b"])
+  })
+
+  test("attaches link properties only when present", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [{ linkId: "tags", direction: "outgoing" }],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage: storage.objects }
+    )
+
+    const tags = postRow(result, "post-1").links?.tags as ExpandedObjectRow[]
+    const tagA = tags.find((tag) => tag.primaryId === "tag-a")
+    const tagB = tags.find((tag) => tag.primaryId === "tag-b")
+    expect(tagA?.linkProperties).toEqual({ weight: 10 })
+    expect(tagB?.linkProperties).toBeUndefined()
+  })
+
+  test("hydrates a nested expansion correlated on the parent neighbour", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [
+            {
+              linkId: "author",
+              direction: "outgoing",
+              expand: [{ linkId: "favoriteTag", direction: "outgoing" }],
+            },
+          ],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage: storage.objects }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    const author = postRow(result, "post-1").links?.author as ExpandedObjectRow
+    const favorite = author.links?.favoriteTag as ExpandedObjectRow
+    expect(favorite.primaryId).toBe("tag-b")
+    expect(favorite.properties.label).toBe("Banana")
+  })
+
+  test("hydrates a three-hop expansion end to end", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [
+            {
+              linkId: "author",
+              direction: "outgoing",
+              expand: [
+                {
+                  linkId: "manager",
+                  direction: "outgoing",
+                  expand: [{ linkId: "favoriteTag", direction: "outgoing" }],
+                },
+              ],
+            },
+          ],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage: storage.objects }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    // post-1 → author-1 → manager author-2 → favoriteTag tag-c, verified at each hop.
+    const author = postRow(result, "post-1").links?.author as ExpandedObjectRow
+    const manager = author.links?.manager as ExpandedObjectRow
+    expect(manager.primaryId).toBe("author-2")
+    const favorite = manager.links?.favoriteTag as ExpandedObjectRow
+    expect(favorite.primaryId).toBe("tag-c")
+    expect(favorite.properties.label).toBe("Cherry")
+  })
+
+  test("hydrates an incoming expansion back to its sources", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [{ linkId: "tags", direction: "incoming", sourceObjectTypeId: Post.id }],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Tag.id } },
+        },
+      },
+      { ontology, storage: storage.objects }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    const tagA = result.objects.find((row) => row.primaryId === "tag-a")
+    const sources = tagA?.links?.tags as ExpandedObjectRow[]
+    expect(sources.map((source) => source.primaryId)).toEqual(["post-1"])
+  })
+})
+
+function postRow(
+  result: Awaited<ReturnType<typeof executeObjectQuery>>,
+  primaryId: string
+): { links?: Record<string, unknown> } & { primaryId: string } {
+  const row = result.objects.find((candidate) => candidate.primaryId === primaryId)
+  if (!row) throw new Error(`row '${primaryId}' not found`)
+  return row
+}
+
+function objectEvent(
+  objectTypeId: string,
+  primaryId: string,
+  properties: Record<string, unknown>
+): StoredObjectUpsertedEvent {
+  cursor += 1
+  const tag = String(cursor).padStart(3, "0")
+  return {
+    id: `expand-e2e-object-${tag}`,
+    cursor: tag,
+    schemaVersion: 1,
+    projectId,
+    type: "object.upserted",
+    topic: "objects",
+    partitionKey: `${objectTypeId}:${primaryId}`,
+    payload: { objectTypeId, primaryId, properties },
+    occurredAt: `2026-01-01T00:00:${tag.slice(-2)}.000Z`,
+  }
+}
+
+function linkEvent(
+  sourceTypeId: string,
+  sourceId: string,
+  linkId: string,
+  targetTypeId: string,
+  targetId: string,
+  properties?: Record<string, unknown>
+): StoredLinkUpsertedEvent {
+  cursor += 1
+  const tag = String(cursor).padStart(3, "0")
+  return {
+    id: `expand-e2e-link-${tag}`,
+    cursor: tag,
+    schemaVersion: 1,
+    projectId,
+    type: "link.upserted",
+    topic: "links",
+    partitionKey: `${sourceTypeId}:${sourceId}:${linkId}`,
+    payload: {
+      sourceTypeId,
+      sourceId,
+      linkId,
+      targetTypeId,
+      targetId,
+      ...(properties === undefined ? {} : { properties }),
+    },
+    occurredAt: `2026-01-01T00:00:${tag.slice(-2)}.000Z`,
+  }
+}


### PR DESCRIPTION
# Push `.expand()` graph reads into a single SQL query on Postgres

`.expand()` reads objects together with their linked objects. Until now it always
ran through an in-memory fallback: it pulled **every** link per parent over the
wire, fetched their targets, and trimmed the top-N in JS — across `~2×depth`
round-trips. This pushes the whole graph read into **one Postgres query** with the
top-N trimmed **in the database**.

## Before → After

```
  Fallback (in-memory)                  Postgres pushdown
  ────────────────────                  ─────────────────
  1. fetch page of parents              ┌ one query:
  2. fetch ALL links per parent  ──►    │   page of parents
  3. fetch ALL target objects           │   + top-N links per parent (in-DB)
  4. trim top-N in JS                    │   + nested objects, as JSONB
  …repeat per nesting level             └ rows arrive with .links attached

  ~2×depth round-trips                  1 round-trip
  over-fetches every link               top-N trimmed in-DB
```

## How it works

| Layer        | Change |
|--------------|--------|
| **IR**       | `ObjectExpansion` gains a core-resolved `cardinality` + bounded `limit` — never authored, injected before pushdown |
| **Executor** | resolves each expansion's cardinality from the ontology; a mixed/polymorphic one is left unresolved |
| **Planner**  | routes `expand` to a provider only when it declares `nodes.expand` **and** every expansion has a resolved cardinality |
| **Postgres** | compiles each expansion to a correlated subquery (`row_number` top-N + `jsonb_build_object` / `jsonb_agg`) folded into one `_expand` column, then revives the nested links |

The compiled value per expansion, in spirit:

```sql
SELECT jsonb_agg(child ORDER BY rank)        -- "many" → array, "one" → first or null
FROM ( SELECT <child as jsonb>,
              row_number() OVER (ORDER BY <target props>, <id>) AS rank
       FROM links JOIN objects ON …
       WHERE <edge matches this parent> ) ranked
WHERE rank <= <limit>                          -- top-N per parent, in-DB
```

## Scope & safety

- ✅ **Postgres** pushes down; **SQLite & in-memory keep the existing (correct) fallback.** Pushdown is opt-in per provider and all-or-nothing — nothing else changes.
- ✅ **Same results either way.** The cross-provider contract now derives the expected plan mode from capabilities with *identical* result assertions → it **is** the pushdown-vs-fallback differential.
- ✅ **Output-shaping only.** The matched set, pagination, and ordering are untouched; `count` / `exists` ignore expansions.

## Testing

- ✅ core `845/845` · in-memory & SQLite conformance `20/20` each
- ✅ Postgres compiler unit `9` · planner routing `3` · new Postgres e2e (one/many, bounded + orderBy, nested, link properties, dangling, incoming)
- ✅ typecheck + lint · `generate:client` zero drift
- ✅ Postgres e2e

## Notes

- A **dangling link** (target removed) is dropped before the bound, so it never wastes a result slot.
- A **polymorphic parent** whose branches disagree on a nested link's cardinality stays on the fallback — correct, just not pushed down.
- Timestamps come back from JSONB as `Date`; link properties are attached only when non-empty.
