### PR TITLE
agents: add worker loop to run and persist agent turns

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -244,6 +244,19 @@
         "typescript": "^5.7.0",
       },
     },
+    "packages/agent-worker": {
+      "name": "@sixb/agent-worker",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ai-sdk/provider": "^3.0.10",
+        "@sixb/core": "workspace:*",
+        "ai": "^6.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "packages/app": {
       "name": "@sixb/app",
       "version": "0.1.0",
@@ -286,6 +299,7 @@
       },
       "dependencies": {
         "@sixb/action-worker": "workspace:*",
+        "@sixb/agent-worker": "workspace:*",
         "@sixb/app": "workspace:*",
         "@sixb/atlas": "workspace:*",
         "@sixb/client": "workspace:*",
@@ -557,7 +571,11 @@
     },
   },
   "packages": {
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.134", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-PfUkQp01EihEyNM6e+nexXmVANiY5KcHMui/MmaHsC4KVVQYh/MwPeOsD3bTPu63e581BKO+AwaPPNmD4x943A=="],
+
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.30", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw=="],
 
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
@@ -662,6 +680,8 @@
     "@nats-io/transport-node": ["@nats-io/transport-node@3.4.0", "", { "dependencies": { "@nats-io/nats-core": "3.4.0", "@nats-io/nkeys": "2.0.3", "@nats-io/nuid": "3.0.0" } }, "sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA=="],
 
     "@octokit/webhooks-types": ["@octokit/webhooks-types@7.6.1", "", {}, "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
 
@@ -875,6 +895,8 @@
 
     "@sixb/action-worker": ["@sixb/action-worker@workspace:packages/action-worker"],
 
+    "@sixb/agent-worker": ["@sixb/agent-worker@workspace:packages/agent-worker"],
+
     "@sixb/app": ["@sixb/app@workspace:packages/app"],
 
     "@sixb/atlas": ["@sixb/atlas@workspace:packages/atlas"],
@@ -1037,9 +1059,13 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
     "@xyflow/react": ["@xyflow/react@12.10.2", "", { "dependencies": { "@xyflow/system": "0.0.76", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="],
 
     "@xyflow/system": ["@xyflow/system@0.0.76", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA=="],
+
+    "ai": ["ai@6.0.209", "", { "dependencies": { "@ai-sdk/gateway": "3.0.134", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NE7uErmxOe+i77BPT1+AhW4wr7xzilbQLsKVmvGEyil5AjaF6C/m92hlPI4Xwtnv5n77D/29bizwcR27/S/gSQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -1204,6 +1230,8 @@
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 

--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -1,0 +1,29 @@
+# @sixb/agent-worker
+
+The cohosted worker that turns `agent.run.requested` queue jobs into persisted agent runs.
+
+A trigger (`sixb.agents.request(...)`) persists the user message and enqueues an *intent*; this worker
+claims it, mints the run + lease (**reserve-at-claim**, so there is never an orphan run), streams the
+model with the AI SDK, and persists the assistant message + finalizes the run.
+
+## Liveness (two layers)
+
+- The **queue lane** delivers and redelivers (on lease expiry).
+- The **`agent_runs` lease** is the sole authority on who may write — every write is fenced on the
+  lease id, kept fresh by a heartbeat during the turn.
+
+## Run fate
+
+A run's terminal state lives on its record:
+
+- **model/tool failure** → `failed`, job acked;
+- **shutdown** → `cancelled`, job released for another process;
+- **turn timeout** (`turnTimeoutMs`, default 5 min) → `failed`, thread released;
+- **lease lost mid-turn** (reclaimed as a suspected crash) → writes nothing, acks the duplicate;
+- **finalize cannot be recorded** (storage unavailable) → the job is **not** acked; it is redelivered
+  (bounded) so a later delivery finalizes the run, rather than leaving the thread silently locked.
+
+## Not in this package
+
+HTTP/WebSocket surface, broker streaming (the `StreamSink` seam is a no-op by default), and the real
+sandbox + tools live in later slices.

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@sixb/agent-worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun ../../scripts/build-package.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "prepack": "bun run build"
+  },
+  "dependencies": {
+    "@ai-sdk/provider": "^3.0.10",
+    "@sixb/core": "workspace:*",
+    "ai": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ]
+}

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -19,11 +19,11 @@
     "prepack": "bun run build"
   },
   "dependencies": {
-    "@ai-sdk/provider": "^3.0.10",
     "@sixb/core": "workspace:*",
     "ai": "^6.0.0"
   },
   "devDependencies": {
+    "@ai-sdk/provider": "^3.0.10",
     "@types/bun": "latest",
     "typescript": "^5.7.0"
   },

--- a/packages/agent-worker/src/errors.ts
+++ b/packages/agent-worker/src/errors.ts
@@ -1,0 +1,33 @@
+/** Infra-level failure in the agent worker (unknown agent, missing storage, malformed job). */
+export class AgentWorkerError extends Error {
+  readonly name = "AgentWorkerError"
+  constructor(message: string, options?: ErrorOptions) {
+    super(`[SixbAgentWorker] ${message}`, options)
+  }
+}
+
+/**
+ * The thread's active run is still held by a live worker (its `agent_runs` lease has not expired),
+ * so this delivery cannot take it over yet. The worker retries the job at {@link availableAt}.
+ */
+export class AgentLeaseHeldError extends Error {
+  readonly name = "AgentLeaseHeldError"
+  constructor(
+    readonly availableAt: string,
+    message: string
+  ) {
+    super(`[SixbAgentWorker] ${message}`)
+  }
+}
+
+/**
+ * This worker lost the run's lease mid-turn (it was reclaimed by another worker after a crash was
+ * suspected). The run now belongs to someone else, so this worker writes nothing further and simply
+ * acknowledges its — now duplicate — delivery.
+ */
+export class AgentLeaseLostError extends Error {
+  readonly name = "AgentLeaseLostError"
+  constructor(readonly runId: string) {
+    super(`[SixbAgentWorker] Lost the lease on agent run '${runId}'; another worker owns it.`)
+  }
+}

--- a/packages/agent-worker/src/errors.ts
+++ b/packages/agent-worker/src/errors.ts
@@ -31,3 +31,38 @@ export class AgentLeaseLostError extends Error {
     super(`[SixbAgentWorker] Lost the lease on agent run '${runId}'; another worker owns it.`)
   }
 }
+
+/**
+ * Recording a run's terminal state failed on a non-terminal (infra) error that persisted across
+ * in-place retries. The run is still `running` and its thread is still locked, so the worker must
+ * **not** acknowledge the job: it lets the queue redeliver it, so a later delivery can finalize the
+ * run once storage recovers. Distinct from {@link AgentLeaseLostError} (run no longer ours → ack).
+ */
+export class AgentFinalizationError extends Error {
+  readonly name = "AgentFinalizationError"
+  constructor(
+    readonly runId: string,
+    options?: ErrorOptions
+  ) {
+    super(
+      `[SixbAgentWorker] Could not finalize agent run '${runId}'; storage is unavailable.`,
+      options
+    )
+  }
+}
+
+/**
+ * A turn exceeded its wall-clock budget. Unlike a shutdown abort, this is a run-level failure: the
+ * run is recorded `failed` and the thread released (a slow-but-alive model must not hold a thread
+ * forever). The name is intentionally **not** `AbortError`, so it routes through the normal failure
+ * path rather than the worker's shutdown-abort path.
+ */
+export class AgentTurnTimeoutError extends Error {
+  readonly name = "AgentTurnTimeoutError"
+  constructor(
+    readonly runId: string,
+    readonly timeoutMs: number
+  ) {
+    super(`[SixbAgentWorker] Agent run '${runId}' exceeded its ${timeoutMs}ms turn budget.`)
+  }
+}

--- a/packages/agent-worker/src/finalize.ts
+++ b/packages/agent-worker/src/finalize.ts
@@ -1,0 +1,56 @@
+import type { AgentRunRecord, AgentStorage } from "@sixb/core"
+import { AgentStorageError } from "@sixb/core"
+import { AgentFinalizationError, AgentLeaseLostError } from "./errors"
+
+/** Short in-place retries that absorb a transient storage blip without re-running the model. */
+const FINALIZE_BACKOFF_MS = [50, 200, 600] as const
+
+/**
+ * Terminal storage outcomes that mean "this run is no longer ours / already finalized". On any of
+ * these the worker stops touching the run: another worker owns it, or it is already in a terminal
+ * state — nothing more to record either way.
+ */
+export function isTerminalOrLeaseGone(error: unknown): boolean {
+  return (
+    error instanceof AgentStorageError &&
+    (error.code === "lease_lost" ||
+      error.code === "invalid_state" ||
+      error.code === "run_not_found")
+  )
+}
+
+/**
+ * Finalize a run, absorbing transient infra blips with a few short in-place retries.
+ *
+ * - returns the finalized record on success;
+ * - throws {@link AgentLeaseLostError} if the run is no longer ours (lease gone / already terminal),
+ *   so the caller acknowledges the (now duplicate) delivery;
+ * - throws {@link AgentFinalizationError} if a non-terminal (infra) error persists across retries,
+ *   so the caller leaves the job for redelivery instead of acking a still-locked thread.
+ */
+export async function finishRunOrThrow(
+  storage: AgentStorage,
+  input: Parameters<AgentStorage["runs"]["finish"]>[0],
+  runId: string
+): Promise<AgentRunRecord> {
+  let lastError: unknown
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await storage.runs.finish(input)
+    } catch (error) {
+      if (isTerminalOrLeaseGone(error)) {
+        throw new AgentLeaseLostError(runId)
+      }
+      lastError = error
+      const delay = FINALIZE_BACKOFF_MS[attempt]
+      if (delay === undefined) {
+        throw new AgentFinalizationError(runId, { cause: lastError })
+      }
+      await sleep(delay)
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/agent-worker/src/index.ts
+++ b/packages/agent-worker/src/index.ts
@@ -1,4 +1,11 @@
-export { AgentLeaseHeldError, AgentLeaseLostError, AgentWorkerError } from "./errors"
+export {
+  AgentFinalizationError,
+  AgentLeaseHeldError,
+  AgentLeaseLostError,
+  AgentTurnTimeoutError,
+  AgentWorkerError,
+} from "./errors"
+export { finishRunOrThrow, isTerminalOrLeaseGone } from "./finalize"
 export { DEFAULT_MAX_STEPS, type RunAgentTurnInput, runAgentTurn } from "./run-agent-turn"
 export type { AgentWorkerContext, AgentWorkerOptions, AgentWorkerSixb, StreamSink } from "./types"
 export { AgentWorker } from "./worker"

--- a/packages/agent-worker/src/index.ts
+++ b/packages/agent-worker/src/index.ts
@@ -1,0 +1,4 @@
+export { AgentLeaseHeldError, AgentLeaseLostError, AgentWorkerError } from "./errors"
+export { DEFAULT_MAX_STEPS, type RunAgentTurnInput, runAgentTurn } from "./run-agent-turn"
+export type { AgentWorkerContext, AgentWorkerOptions, AgentWorkerSixb, StreamSink } from "./types"
+export { AgentWorker } from "./worker"

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -1,0 +1,279 @@
+import type {
+  AgentDefinition,
+  AgentRunRecord,
+  AgentRunUsage,
+  AgentStorage,
+  SixbMessage,
+} from "@sixb/core"
+import { AgentStorageError, createAgentMessageId, fromAiSdk, toModelMessages } from "@sixb/core"
+import { type LanguageModelUsage, type ModelMessage, stepCountIs, streamText } from "ai"
+import { AgentLeaseLostError, AgentWorkerError } from "./errors"
+import type { AgentWorkerContext, StreamSink } from "./types"
+
+export const DEFAULT_MAX_STEPS = 8
+
+export interface RunAgentTurnInput {
+  /** The worker's stable execution context (storage, tools, stream sink, lease timings). */
+  readonly context: AgentWorkerContext
+  readonly agent: AgentDefinition
+  /** The run this worker already reserved (or reclaimed). We own `run.lease`. */
+  readonly run: AgentRunRecord
+  /** The worker's shutdown signal. */
+  readonly signal: AbortSignal
+}
+
+/**
+ * Drive one agent turn to completion and persist it.
+ *
+ * Loads thread history, streams the model with the configured stop condition, keeps the run lease
+ * fresh with a heartbeat, then persists the assistant message and finalizes the run with usage +
+ * finish reason — all fenced on the lease id. If the lease is lost mid-turn (we were reclaimed as a
+ * suspected crash), it throws {@link AgentLeaseLostError} and writes nothing: the run is no longer
+ * ours.
+ *
+ * On success it returns the finalized (`succeeded`) run record. Model/tool failures and shutdown
+ * aborts propagate to the caller (the worker), which records the run's terminal fate.
+ */
+export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRecord> {
+  const { context, agent, run, signal } = input
+  const {
+    id: projectId,
+    storage,
+    tools,
+    streamSink,
+    leaseMs,
+    heartbeatMs,
+    defaultMaxSteps,
+  } = context
+  const runId = run.id
+  const leaseId = run.lease?.id
+  if (!leaseId) {
+    throw new AgentWorkerError(`Agent run '${runId}' has no lease to run under.`)
+  }
+
+  const history = await storage.messages.list({ projectId, threadId: run.threadId, order: "asc" })
+  // `toModelMessages` is core's `ai`-free mirror of `convertToModelMessages`. The only type gap is
+  // `providerOptions`, which core types as the wider `JsonValue` (it cannot depend on `ai`); the
+  // values originate from the SDK, so the runtime shape is compatible. The worker is where `ai`
+  // lives, so this single boundary cast belongs here. Locked by `tests/ai-sdk-compat.types.ts`.
+  const modelMessages = toModelMessages(history.messages) as ModelMessage[]
+
+  const maxSteps = agent.loop?.stopWhen?.maxSteps ?? defaultMaxSteps
+
+  // The model call is aborted either by worker shutdown or by the heartbeat detecting a lost lease.
+  const heartbeatAbort = new AbortController()
+  const abortSignal = AbortSignal.any([signal, heartbeatAbort.signal])
+
+  const result = streamText({
+    model: agent.model,
+    system: agent.instructions,
+    messages: modelMessages,
+    tools,
+    stopWhen: stepCountIs(maxSteps),
+    abortSignal,
+  })
+
+  let responseMessage: SixbInboundLike | undefined
+  const uiStream = result.toUIMessageStream({
+    onFinish: (event) => {
+      responseMessage = event.responseMessage
+    },
+  })
+
+  let leaseLost = false
+  const heartbeat = startLeaseHeartbeat({
+    storage,
+    projectId,
+    runId,
+    leaseId,
+    leaseMs,
+    heartbeatMs,
+    onLost: () => {
+      leaseLost = true
+      heartbeatAbort.abort(new AgentLeaseLostError(runId))
+    },
+  })
+
+  let drainError: unknown
+  try {
+    // Draining the UI stream drives the model loop and fires `onFinish`. We do not forward chunks
+    // here — V1 emits final parts to the sink below (see `StreamSink`).
+    for await (const _chunk of uiStream) {
+      // intentional drain
+    }
+  } catch (error) {
+    drainError = error
+  } finally {
+    heartbeat.stop()
+  }
+
+  if (leaseLost) {
+    throw new AgentLeaseLostError(runId)
+  }
+  if (drainError !== undefined) {
+    throw drainError
+  }
+  if (!responseMessage) {
+    throw new AgentWorkerError(`Agent run '${runId}' produced no response message.`)
+  }
+
+  const assistant: SixbMessage = fromAiSdk(responseMessage)
+
+  // One last renew right before we write: a successful renew proves we still hold the lease, and it
+  // pushes expiry out by `leaseMs`, so the (lease-unfenced) message append cannot race a reclaim.
+  await renewOrLost({ storage, projectId, runId, leaseId, leaseMs })
+
+  for (const part of assistant.parts) {
+    await emitPart(streamSink, part)
+  }
+
+  await storage.messages.append({
+    id: createAgentMessageId(),
+    projectId,
+    threadId: run.threadId,
+    runId,
+    role: assistant.role,
+    parts: assistant.parts,
+    ...(assistant.metadata === undefined ? {} : { metadata: assistant.metadata }),
+  })
+
+  const usage = mapUsage(await result.totalUsage)
+  const finishReason = await result.finishReason
+
+  return storage.runs.finish({
+    projectId,
+    id: runId,
+    leaseId,
+    status: "succeeded",
+    modelId: agent.model.modelId,
+    finishReason,
+    ...(usage === undefined ? {} : { usage }),
+  })
+}
+
+// `toUIMessageStream`'s `onFinish` hands back the SDK `UIMessage`; `fromAiSdk` accepts the wider
+// inbound shape. We keep the parameter loose here and let `fromAiSdk` narrow/validate at runtime.
+type SixbInboundLike = Parameters<typeof fromAiSdk>[0]
+
+interface LeaseHeartbeatInput {
+  readonly storage: AgentStorage
+  readonly projectId: string
+  readonly runId: string
+  readonly leaseId: string
+  readonly leaseMs: number
+  readonly heartbeatMs: number
+  readonly onLost: () => void
+}
+
+/** A self-rescheduling timer that renews the run lease until stopped or the lease is lost. */
+function startLeaseHeartbeat(input: LeaseHeartbeatInput): { stop(): void } {
+  let stopped = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const tick = async (): Promise<void> => {
+    if (stopped) {
+      return
+    }
+    try {
+      await input.storage.runs.renewLease({
+        projectId: input.projectId,
+        id: input.runId,
+        leaseId: input.leaseId,
+        expiresAt: new Date(Date.now() + input.leaseMs),
+      })
+    } catch (error) {
+      if (isLeaseGone(error)) {
+        input.onLost()
+        return
+      }
+      // Transient storage error: leave the lease as-is and try again on the next tick.
+    }
+    schedule()
+  }
+
+  const schedule = (): void => {
+    if (stopped) {
+      return
+    }
+    timer = setTimeout(() => void tick(), input.heartbeatMs)
+  }
+
+  schedule()
+  return {
+    stop() {
+      stopped = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+    },
+  }
+}
+
+async function renewOrLost(input: {
+  readonly storage: AgentStorage
+  readonly projectId: string
+  readonly runId: string
+  readonly leaseId: string
+  readonly leaseMs: number
+}): Promise<void> {
+  try {
+    await input.storage.runs.renewLease({
+      projectId: input.projectId,
+      id: input.runId,
+      leaseId: input.leaseId,
+      expiresAt: new Date(Date.now() + input.leaseMs),
+    })
+  } catch (error) {
+    if (isLeaseGone(error)) {
+      throw new AgentLeaseLostError(input.runId)
+    }
+    throw error
+  }
+}
+
+function isLeaseGone(error: unknown): boolean {
+  return (
+    error instanceof AgentStorageError &&
+    (error.code === "lease_lost" ||
+      error.code === "invalid_state" ||
+      error.code === "run_not_found")
+  )
+}
+
+async function emitPart(sink: StreamSink, part: SixbMessage["parts"][number]): Promise<void> {
+  try {
+    await sink.onPart(part)
+  } catch (error) {
+    // The sink is observational; never let it break the turn.
+    console.error("[SixbAgentWorker] Stream sink failed:", error)
+  }
+}
+
+/** Map AI SDK v6 usage onto the stored {@link AgentRunUsage}, dropping unknown fields. */
+function mapUsage(usage: LanguageModelUsage): AgentRunUsage | undefined {
+  const mapped: {
+    inputTokens?: number
+    outputTokens?: number
+    totalTokens?: number
+    reasoningTokens?: number
+    cachedInputTokens?: number
+  } = {}
+  if (usage.inputTokens !== undefined) {
+    mapped.inputTokens = usage.inputTokens
+  }
+  if (usage.outputTokens !== undefined) {
+    mapped.outputTokens = usage.outputTokens
+  }
+  if (usage.totalTokens !== undefined) {
+    mapped.totalTokens = usage.totalTokens
+  }
+  const reasoning = usage.outputTokenDetails?.reasoningTokens ?? usage.reasoningTokens
+  if (reasoning !== undefined) {
+    mapped.reasoningTokens = reasoning
+  }
+  const cached = usage.inputTokenDetails?.cacheReadTokens ?? usage.cachedInputTokens
+  if (cached !== undefined) {
+    mapped.cachedInputTokens = cached
+  }
+  return Object.keys(mapped).length > 0 ? mapped : undefined
+}

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -1,9 +1,9 @@
 import type {
   AgentDefinition,
+  AgentMessage,
   AgentRunRecord,
   AgentRunUsage,
   AgentStorage,
-  SixbMessage,
 } from "@sixb/core"
 import { createAgentMessageId, fromAiSdk, toModelMessages } from "@sixb/core"
 import { type LanguageModelUsage, type ModelMessage, stepCountIs, streamText } from "ai"
@@ -82,7 +82,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     abortSignal,
   })
 
-  let responseMessage: SixbInboundLike | undefined
+  let responseMessage: AgentInboundLike | undefined
   const uiStream = result.toUIMessageStream({
     onFinish: (event) => {
       responseMessage = event.responseMessage
@@ -132,7 +132,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     throw new AgentWorkerError(`Agent run '${runId}' produced no response message.`)
   }
 
-  const assistant: SixbMessage = fromAiSdk(responseMessage)
+  const assistant: AgentMessage = fromAiSdk(responseMessage)
 
   // One last renew right before we write: a successful renew proves we still hold the lease, and it
   // pushes expiry out by `leaseMs`, so the (lease-unfenced) message append cannot race a reclaim.
@@ -175,7 +175,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
 
 // `toUIMessageStream`'s `onFinish` hands back the SDK `UIMessage`; `fromAiSdk` accepts the wider
 // inbound shape. We keep the parameter loose here and let `fromAiSdk` narrow/validate at runtime.
-type SixbInboundLike = Parameters<typeof fromAiSdk>[0]
+type AgentInboundLike = Parameters<typeof fromAiSdk>[0]
 
 interface LeaseHeartbeatInput {
   readonly storage: AgentStorage
@@ -253,7 +253,7 @@ async function renewOrLost(input: {
   }
 }
 
-async function emitPart(sink: StreamSink, part: SixbMessage["parts"][number]): Promise<void> {
+async function emitPart(sink: StreamSink, part: AgentMessage["parts"][number]): Promise<void> {
   try {
     await sink.onPart(part)
   } catch (error) {

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -5,9 +5,10 @@ import type {
   AgentStorage,
   SixbMessage,
 } from "@sixb/core"
-import { AgentStorageError, createAgentMessageId, fromAiSdk, toModelMessages } from "@sixb/core"
+import { createAgentMessageId, fromAiSdk, toModelMessages } from "@sixb/core"
 import { type LanguageModelUsage, type ModelMessage, stepCountIs, streamText } from "ai"
-import { AgentLeaseLostError, AgentWorkerError } from "./errors"
+import { AgentLeaseLostError, AgentTurnTimeoutError, AgentWorkerError } from "./errors"
+import { finishRunOrThrow, isTerminalOrLeaseGone } from "./finalize"
 import type { AgentWorkerContext, StreamSink } from "./types"
 
 export const DEFAULT_MAX_STEPS = 8
@@ -44,6 +45,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     leaseMs,
     heartbeatMs,
     defaultMaxSteps,
+    turnTimeoutMs,
   } = context
   const runId = run.id
   const leaseId = run.lease?.id
@@ -60,9 +62,16 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
 
   const maxSteps = agent.loop?.stopWhen?.maxSteps ?? defaultMaxSteps
 
-  // The model call is aborted either by worker shutdown or by the heartbeat detecting a lost lease.
+  // The model call is aborted by worker shutdown, by the heartbeat detecting a lost lease, or by the
+  // turn exceeding its wall-clock budget (a slow-but-alive model must not hold the thread forever).
   const heartbeatAbort = new AbortController()
-  const abortSignal = AbortSignal.any([signal, heartbeatAbort.signal])
+  const timeoutAbort = new AbortController()
+  let timedOut = false
+  const timeoutTimer = setTimeout(() => {
+    timedOut = true
+    timeoutAbort.abort()
+  }, turnTimeoutMs)
+  const abortSignal = AbortSignal.any([signal, heartbeatAbort.signal, timeoutAbort.signal])
 
   const result = streamText({
     model: agent.model,
@@ -105,10 +114,16 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     drainError = error
   } finally {
     heartbeat.stop()
+    clearTimeout(timeoutTimer)
   }
 
   if (leaseLost) {
     throw new AgentLeaseLostError(runId)
+  }
+  // A timeout aborts the stream, surfacing as `drainError`; check our flag first so a timed-out turn
+  // throws the typed (non-abort) error and is recorded `failed` rather than treated as a shutdown.
+  if (timedOut) {
+    throw new AgentTurnTimeoutError(runId, turnTimeoutMs)
   }
   if (drainError !== undefined) {
     throw drainError
@@ -140,15 +155,22 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
   const usage = mapUsage(await result.totalUsage)
   const finishReason = await result.finishReason
 
-  return storage.runs.finish({
-    projectId,
-    id: runId,
-    leaseId,
-    status: "succeeded",
-    modelId: agent.model.modelId,
-    finishReason,
-    ...(usage === undefined ? {} : { usage }),
-  })
+  // `finishRunOrThrow` retries transient blips in place; if the lease is gone it raises
+  // `AgentLeaseLostError` (ack), and a persistent infra failure raises `AgentFinalizationError`
+  // (redeliver) — so a finalize that cannot complete never leaves the thread silently locked.
+  return finishRunOrThrow(
+    storage,
+    {
+      projectId,
+      id: runId,
+      leaseId,
+      status: "succeeded",
+      modelId: agent.model.modelId,
+      finishReason,
+      ...(usage === undefined ? {} : { usage }),
+    },
+    runId
+  )
 }
 
 // `toUIMessageStream`'s `onFinish` hands back the SDK `UIMessage`; `fromAiSdk` accepts the wider
@@ -182,7 +204,7 @@ function startLeaseHeartbeat(input: LeaseHeartbeatInput): { stop(): void } {
         expiresAt: new Date(Date.now() + input.leaseMs),
       })
     } catch (error) {
-      if (isLeaseGone(error)) {
+      if (isTerminalOrLeaseGone(error)) {
         input.onLost()
         return
       }
@@ -224,20 +246,11 @@ async function renewOrLost(input: {
       expiresAt: new Date(Date.now() + input.leaseMs),
     })
   } catch (error) {
-    if (isLeaseGone(error)) {
+    if (isTerminalOrLeaseGone(error)) {
       throw new AgentLeaseLostError(input.runId)
     }
     throw error
   }
-}
-
-function isLeaseGone(error: unknown): boolean {
-  return (
-    error instanceof AgentStorageError &&
-    (error.code === "lease_lost" ||
-      error.code === "invalid_state" ||
-      error.code === "run_not_found")
-  )
 }
 
 async function emitPart(sink: StreamSink, part: SixbMessage["parts"][number]): Promise<void> {

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -1,9 +1,9 @@
 import type {
+  AgentMessagePart,
   AgentStorage,
   AgentsRuntime,
   EventsRuntime,
   Queues,
-  SixbMessagePart,
   Storage,
 } from "@sixb/core"
 import type { ToolSet } from "ai"
@@ -44,7 +44,7 @@ export interface AgentWorkerContext {
  * A sink failure is isolated by the loop: it never blocks the turn or the lease heartbeat.
  */
 export interface StreamSink {
-  onPart(part: SixbMessagePart): void | Promise<void>
+  onPart(part: AgentMessagePart): void | Promise<void>
 }
 
 export interface AgentWorkerOptions {

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -34,6 +34,7 @@ export interface AgentWorkerContext {
   readonly leaseMs: number
   readonly heartbeatMs: number
   readonly defaultMaxSteps: number
+  readonly turnTimeoutMs: number
 }
 
 /**
@@ -62,4 +63,10 @@ export interface AgentWorkerOptions {
   readonly streamSink?: StreamSink
   /** Step cap for agents that do not declare `loop.stopWhen.maxSteps`. Defaults to 8. */
   readonly defaultMaxSteps?: number
+  /**
+   * Wall-clock budget for a single turn, in ms. A turn that exceeds it is aborted and recorded
+   * `failed`, releasing the thread — a slow-but-alive model cannot hold a thread indefinitely.
+   * Defaults to 5 minutes.
+   */
+  readonly turnTimeoutMs?: number
 }

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -1,0 +1,65 @@
+import type {
+  AgentStorage,
+  AgentsRuntime,
+  EventsRuntime,
+  Queues,
+  SixbMessagePart,
+  Storage,
+} from "@sixb/core"
+import type { ToolSet } from "ai"
+
+/**
+ * The runtime surface the agent worker is constructed with (mirrors `ActionWorkerSixb`). `Sixb`
+ * satisfies it structurally, so cohosting passes `sixb` directly. The worker resolves a run's model
+ * via `agents.getById` (the model is a non-serialisable `LanguageModelV3`, never sent over the wire).
+ */
+export interface AgentWorkerSixb {
+  readonly id: string
+  readonly events: EventsRuntime
+  readonly storage: Storage
+  readonly queues: Queues
+  readonly agents: AgentsRuntime
+}
+
+/**
+ * The worker's derived, stable execution context (mirrors `ActionWorkerContext`): built once from
+ * {@link AgentWorkerSixb} + options, then handed to each turn alongside the per-turn run. `id` is the
+ * project id.
+ */
+export interface AgentWorkerContext {
+  readonly id: string
+  readonly storage: AgentStorage
+  readonly tools: ToolSet
+  readonly streamSink: StreamSink
+  readonly leaseMs: number
+  readonly heartbeatMs: number
+  readonly defaultMaxSteps: number
+}
+
+/**
+ * Where the loop routes streamed assistant parts. **No-op in production for this slice** — the
+ * stream is meant to flow through the broker on a dedicated per-run channel, which is a later slice.
+ * Baking the seam now keeps that slice a pure addition (provide a real sink) with zero loop change.
+ * A sink failure is isolated by the loop: it never blocks the turn or the lease heartbeat.
+ */
+export interface StreamSink {
+  onPart(part: SixbMessagePart): void | Promise<void>
+}
+
+export interface AgentWorkerOptions {
+  /**
+   * The `agent_runs` lease duration, in ms. Also used as the queue visibility timeout so that, on
+   * redelivery, the run lease is already reclaimable. Defaults to 60s.
+   */
+  readonly leaseMs?: number
+  /** Idle poll interval when the queue is empty, in ms. */
+  readonly idlePollMs?: number
+  /** Lease heartbeat interval during a turn, in ms. Defaults to `leaseMs / 3`. */
+  readonly heartbeatMs?: number
+  /** Tools exposed to the model. V1 ships an empty set; tests inject a generic tool. */
+  readonly tools?: ToolSet
+  /** Stream routing seam. Defaults to a no-op sink. */
+  readonly streamSink?: StreamSink
+  /** Step cap for agents that do not declare `loop.stopWhen.maxSteps`. Defaults to 8. */
+  readonly defaultMaxSteps?: number
+}

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -1,0 +1,264 @@
+import type {
+  AgentDefinition,
+  AgentRunLease,
+  AgentRunRecord,
+  AgentRunRequestedQueueJob,
+  ClaimedQueueJob,
+  QueueWorkerFailureDecision,
+} from "@sixb/core"
+import { AgentStorageError, createAgentRunId, createAgentRunLeaseId, QueueWorker } from "@sixb/core"
+import { AgentLeaseHeldError, AgentLeaseLostError, AgentWorkerError } from "./errors"
+import { DEFAULT_MAX_STEPS, runAgentTurn } from "./run-agent-turn"
+import type { AgentWorkerContext, AgentWorkerOptions, AgentWorkerSixb, StreamSink } from "./types"
+
+const DEFAULT_AGENT_LEASE_MS = 60_000
+const SHORT_BACKOFF_MS = 250
+const NOOP_SINK: StreamSink = { onPart() {} }
+
+/** Outcome of trying to own a run for a claimed job. */
+type Reservation =
+  | { readonly kind: "run"; readonly run: AgentRunRecord }
+  | { readonly kind: "held"; readonly availableAt: string }
+  | { readonly kind: "skip" }
+
+/**
+ * Cohosted worker that turns `agent.run.requested` jobs into persisted agent runs.
+ *
+ * Liveness is two-layered: the queue lane delivers (and redelivers on lease expiry), while the
+ * `agent_runs` lease is the sole authority on who may execute and finalize a run. The worker
+ * reserves the run at claim time, owns its lease, heartbeats it during the turn, and fences every
+ * write on the lease id. A run's terminal fate lives on its record (like the action worker), so
+ * model/tool failures still acknowledge the job — only infra failures fail the job.
+ */
+export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
+  private readonly sixb: AgentWorkerSixb
+  private readonly context: AgentWorkerContext | null
+  private readonly idleWithoutAgents: boolean
+
+  constructor(sixb: AgentWorkerSixb, options: AgentWorkerOptions = {}) {
+    const leaseMs = options.leaseMs ?? DEFAULT_AGENT_LEASE_MS
+    super({
+      projectId: sixb.id,
+      queue: sixb.queues.agents,
+      workerId: `agent-worker-${sixb.id}`,
+      claimLimit: 1,
+      // Queue visibility ≥ run lease so a redelivered run is already reclaimable.
+      leaseMs,
+      idlePollMs: options.idlePollMs,
+    })
+
+    this.sixb = sixb
+    this.idleWithoutAgents = sixb.agents.list().length === 0
+    this.context = this.idleWithoutAgents ? null : buildAgentContext(sixb, options, leaseMs)
+  }
+
+  protected override async run(signal: AbortSignal): Promise<void> {
+    if (!this.idleWithoutAgents) {
+      await super.run(signal)
+      return
+    }
+    await new Promise<void>((resolve) => {
+      if (signal.aborted) {
+        resolve()
+        return
+      }
+      signal.addEventListener("abort", () => resolve(), { once: true })
+    })
+  }
+
+  protected async execute(
+    claimed: ClaimedQueueJob<AgentRunRequestedQueueJob>,
+    signal: AbortSignal
+  ): Promise<void> {
+    const context = this.requireContext()
+    const { job } = claimed
+    if (job.type !== "agent.run.requested") {
+      throw new AgentWorkerError(`Unsupported agent job type '${job.type}'.`)
+    }
+
+    const { agentId, threadId, triggerMessageId } = job.payload
+    const agent = this.sixb.agents.getById(agentId)
+    if (!agent) {
+      throw new AgentWorkerError(`Unknown agent '${agentId}'.`)
+    }
+
+    const reservation = await this.reserveOrReclaim(context, { agent, threadId, triggerMessageId })
+    if (reservation.kind === "skip") {
+      return
+    }
+    if (reservation.kind === "held") {
+      throw new AgentLeaseHeldError(
+        reservation.availableAt,
+        `Agent thread '${threadId}' has a live active run; retrying.`
+      )
+    }
+    const run = reservation.run
+
+    try {
+      await runAgentTurn({ context, agent, run, signal })
+    } catch (error) {
+      if (error instanceof AgentLeaseLostError) {
+        // The run was reclaimed out from under us; this delivery is a duplicate. Ack, touch nothing.
+        return
+      }
+      const leaseId = run.lease?.id
+      if (signal.aborted || isAbortError(error)) {
+        if (leaseId) {
+          await this.finishQuietly(context, run.id, leaseId, "cancelled", error)
+        }
+        throw error
+      }
+      // Run-level failure: record it on the run and ack the job — the fate lives on the record.
+      if (leaseId) {
+        await this.finishQuietly(context, run.id, leaseId, "failed", error)
+      }
+    }
+  }
+
+  protected override onExecutionError(
+    _claimed: ClaimedQueueJob<AgentRunRequestedQueueJob>,
+    error: unknown
+  ): QueueWorkerFailureDecision {
+    if (error instanceof AgentLeaseHeldError) {
+      return { kind: "retry", availableAt: error.availableAt }
+    }
+    return { kind: "fail" }
+  }
+
+  protected override onAbortError(): QueueWorkerFailureDecision {
+    return { kind: "fail" }
+  }
+
+  private requireContext(): AgentWorkerContext {
+    if (!this.context) {
+      throw new AgentWorkerError("Agent worker has no agent storage configured.")
+    }
+    return this.context
+  }
+
+  private async reserveOrReclaim(
+    context: AgentWorkerContext,
+    input: { agent: AgentDefinition; threadId: string; triggerMessageId: string }
+  ): Promise<Reservation> {
+    try {
+      const run = await context.storage.runs.reserve({
+        id: createAgentRunId(),
+        projectId: context.id,
+        threadId: input.threadId,
+        agentId: input.agent.id,
+        triggerMessageId: input.triggerMessageId,
+        modelId: input.agent.model.modelId,
+        lease: freshLease(context.leaseMs),
+      })
+      return { kind: "run", run }
+    } catch (error) {
+      if (!(error instanceof AgentStorageError) || error.code !== "active_run_exists") {
+        throw error
+      }
+      return this.takeOverActiveRun(context, input)
+    }
+  }
+
+  private async takeOverActiveRun(
+    context: AgentWorkerContext,
+    input: { threadId: string; triggerMessageId: string }
+  ): Promise<Reservation> {
+    const { storage, id: projectId } = context
+    const thread = await storage.threads.getById({ projectId, id: input.threadId })
+    const activeRunId = thread?.activeRunId
+    if (!activeRunId) {
+      // The active run cleared between our reserve and this read; bounce briefly and try to win.
+      return { kind: "held", availableAt: backoff(SHORT_BACKOFF_MS) }
+    }
+
+    const active = await storage.runs.getById({ projectId, id: activeRunId })
+    if (!active) {
+      return { kind: "held", availableAt: backoff(SHORT_BACKOFF_MS) }
+    }
+    if (active.status !== "running") {
+      // Already terminal (late redelivery) — nothing to do.
+      return { kind: "skip" }
+    }
+    if (active.triggerMessageId !== input.triggerMessageId) {
+      // A different turn owns the thread (single-flight): wait for it to clear.
+      return { kind: "held", availableAt: backoff(context.leaseMs) }
+    }
+
+    // Crash redelivery of our own run: take it over iff its lease has actually expired.
+    try {
+      const reclaimed = await storage.runs.reclaim({
+        projectId,
+        id: activeRunId,
+        lease: freshLease(context.leaseMs),
+      })
+      return { kind: "run", run: reclaimed }
+    } catch (error) {
+      if (error instanceof AgentStorageError && error.code === "lease_not_expired") {
+        return { kind: "held", availableAt: backoff(context.leaseMs) }
+      }
+      if (error instanceof AgentStorageError && error.code === "invalid_state") {
+        return { kind: "skip" }
+      }
+      throw error
+    }
+  }
+
+  private async finishQuietly(
+    context: AgentWorkerContext,
+    runId: string,
+    leaseId: string,
+    status: "failed" | "cancelled",
+    error: unknown
+  ): Promise<void> {
+    try {
+      await context.storage.runs.finish({
+        projectId: context.id,
+        id: runId,
+        leaseId,
+        status,
+        error: toErrorMessage(error),
+      })
+    } catch {
+      // Lease already lost or run already terminal — nothing to finalize.
+    }
+  }
+}
+
+function buildAgentContext(
+  sixb: AgentWorkerSixb,
+  options: AgentWorkerOptions,
+  leaseMs: number
+): AgentWorkerContext {
+  const storage = sixb.storage.agents
+  if (!storage) {
+    throw new AgentWorkerError("Agent workers require storage.agents support.")
+  }
+  return {
+    id: sixb.id,
+    storage,
+    tools: options.tools ?? {},
+    streamSink: options.streamSink ?? NOOP_SINK,
+    leaseMs,
+    heartbeatMs: options.heartbeatMs ?? Math.max(1, Math.floor(leaseMs / 3)),
+    defaultMaxSteps: options.defaultMaxSteps ?? DEFAULT_MAX_STEPS,
+  }
+}
+
+function freshLease(leaseMs: number): AgentRunLease {
+  return { id: createAgentRunLeaseId(), expiresAt: new Date(Date.now() + leaseMs) }
+}
+
+function backoff(ms: number): string {
+  return new Date(Date.now() + ms).toISOString()
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError"
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -6,13 +6,33 @@ import type {
   ClaimedQueueJob,
   QueueWorkerFailureDecision,
 } from "@sixb/core"
-import { AgentStorageError, createAgentRunId, createAgentRunLeaseId, QueueWorker } from "@sixb/core"
-import { AgentLeaseHeldError, AgentLeaseLostError, AgentWorkerError } from "./errors"
+import {
+  AgentStorageError,
+  createAgentRunId,
+  createAgentRunLeaseId,
+  isAbortError,
+  QueueWorker,
+} from "@sixb/core"
+import {
+  AgentFinalizationError,
+  AgentLeaseHeldError,
+  AgentLeaseLostError,
+  AgentWorkerError,
+} from "./errors"
+import { finishRunOrThrow } from "./finalize"
 import { DEFAULT_MAX_STEPS, runAgentTurn } from "./run-agent-turn"
 import type { AgentWorkerContext, AgentWorkerOptions, AgentWorkerSixb, StreamSink } from "./types"
 
 const DEFAULT_AGENT_LEASE_MS = 60_000
+const DEFAULT_TURN_TIMEOUT_MS = 5 * 60_000
 const SHORT_BACKOFF_MS = 250
+/** Backoff before redelivering a job whose run could not be finalized (storage was unavailable). */
+const FINALIZE_RETRY_BACKOFF_MS = 5_000
+/**
+ * Cap on redeliveries for a run we cannot finalize. Beyond it the job dead-letters (visibly) instead
+ * of churning forever; the still-`running` run awaits storage recovery + a reaper (a later slice).
+ */
+const MAX_FINALIZE_ATTEMPTS = 10
 const NOOP_SINK: StreamSink = { onPart() {} }
 
 /** Outcome of trying to own a run for a claimed job. */
@@ -27,8 +47,10 @@ type Reservation =
  * Liveness is two-layered: the queue lane delivers (and redelivers on lease expiry), while the
  * `agent_runs` lease is the sole authority on who may execute and finalize a run. The worker
  * reserves the run at claim time, owns its lease, heartbeats it during the turn, and fences every
- * write on the lease id. A run's terminal fate lives on its record (like the action worker), so
- * model/tool failures still acknowledge the job — only infra failures fail the job.
+ * write on the lease id. A run's terminal fate lives on its record (like the action worker), so a
+ * model/tool failure that we successfully record still acknowledges the job. The job is only left
+ * for redelivery when we **cannot** record the fate (storage unavailable) — acking then would leave
+ * the thread silently locked forever, since nothing else reclaims a run but a redelivered job.
  */
 export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
   private readonly sixb: AgentWorkerSixb
@@ -93,39 +115,63 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
       )
     }
     const run = reservation.run
+    const leaseId = run.lease?.id
 
     try {
       await runAgentTurn({ context, agent, run, signal })
     } catch (error) {
+      // The run was reclaimed out from under us; this delivery is a duplicate. Ack, touch nothing.
       if (error instanceof AgentLeaseLostError) {
-        // The run was reclaimed out from under us; this delivery is a duplicate. Ack, touch nothing.
         return
       }
-      const leaseId = run.lease?.id
-      if (signal.aborted || isAbortError(error)) {
-        if (leaseId) {
-          await this.finishQuietly(context, run.id, leaseId, "cancelled", error)
-        }
+      // The turn succeeded but its finalize could not be recorded (storage down). Don't ack: let the
+      // job redeliver so a later delivery finalizes the run — onExecutionError turns this into retry.
+      if (error instanceof AgentFinalizationError) {
         throw error
       }
-      // Run-level failure: record it on the run and ack the job — the fate lives on the record.
-      if (leaseId) {
-        await this.finishQuietly(context, run.id, leaseId, "failed", error)
+      if (!leaseId) {
+        throw error
+      }
+      // Otherwise record the run's terminal fate. `recordFate` retries transient blips; if it cannot
+      // record the fate at all it raises `AgentFinalizationError`, which propagates here so the job
+      // is redelivered rather than acked with the thread left silently locked.
+      const aborted = signal.aborted || isAbortError(error)
+      await this.recordFate(context, run.id, leaseId, aborted ? "cancelled" : "failed", error)
+      // Shutdown abort: rethrow so `onAbortError` fails the job (the run is already `cancelled`).
+      // Model/tool failure or turn timeout: fate is on the record, so we ack by returning.
+      if (aborted) {
+        throw error
       }
     }
   }
 
   protected override onExecutionError(
-    _claimed: ClaimedQueueJob<AgentRunRequestedQueueJob>,
+    claimed: ClaimedQueueJob<AgentRunRequestedQueueJob>,
     error: unknown
   ): QueueWorkerFailureDecision {
     if (error instanceof AgentLeaseHeldError) {
       return { kind: "retry", availableAt: error.availableAt }
     }
+    // We could not finalize the run (storage unavailable). Redeliver so a later delivery records the
+    // fate — but cap the redeliveries so a persistent failure dead-letters instead of churning.
+    if (error instanceof AgentFinalizationError) {
+      if (claimed.job.attempt < MAX_FINALIZE_ATTEMPTS) {
+        return { kind: "retry", availableAt: backoff(FINALIZE_RETRY_BACKOFF_MS) }
+      }
+      return { kind: "fail" }
+    }
     return { kind: "fail" }
   }
 
-  protected override onAbortError(): QueueWorkerFailureDecision {
+  protected override onAbortError(
+    _claimed: ClaimedQueueJob<AgentRunRequestedQueueJob>,
+    error: unknown
+  ): QueueWorkerFailureDecision {
+    // Shutdown reached us before we could record the run's fate: redeliver so another process
+    // finalizes it. Otherwise the run is already terminal, so fail (no redelivery needed).
+    if (error instanceof AgentFinalizationError) {
+      return { kind: "retry", availableAt: backoff(FINALIZE_RETRY_BACKOFF_MS) }
+    }
     return { kind: "fail" }
   }
 
@@ -203,7 +249,7 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
     }
   }
 
-  private async finishQuietly(
+  private async recordFate(
     context: AgentWorkerContext,
     runId: string,
     leaseId: string,
@@ -211,15 +257,18 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
     error: unknown
   ): Promise<void> {
     try {
-      await context.storage.runs.finish({
-        projectId: context.id,
-        id: runId,
-        leaseId,
-        status,
-        error: toErrorMessage(error),
-      })
-    } catch {
-      // Lease already lost or run already terminal — nothing to finalize.
+      await finishRunOrThrow(
+        context.storage,
+        { projectId: context.id, id: runId, leaseId, status, error: toErrorMessage(error) },
+        runId
+      )
+    } catch (finalizeError) {
+      // Lease already lost / run already terminal — nothing more to record, the delivery is acked.
+      if (finalizeError instanceof AgentLeaseLostError) {
+        return
+      }
+      // Storage stayed unavailable across retries: propagate so the job is redelivered, not acked.
+      throw finalizeError
     }
   }
 }
@@ -241,6 +290,7 @@ function buildAgentContext(
     leaseMs,
     heartbeatMs: options.heartbeatMs ?? Math.max(1, Math.floor(leaseMs / 3)),
     defaultMaxSteps: options.defaultMaxSteps ?? DEFAULT_MAX_STEPS,
+    turnTimeoutMs: options.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
   }
 }
 
@@ -250,10 +300,6 @@ function freshLease(leaseMs: number): AgentRunLease {
 
 function backoff(ms: number): string {
   return new Date(Date.now() + ms).toISOString()
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError"
 }
 
 function toErrorMessage(error: unknown): string {

--- a/packages/agent-worker/tests/ai-sdk-compat.types.ts
+++ b/packages/agent-worker/tests/ai-sdk-compat.types.ts
@@ -2,20 +2,20 @@
  * Type-only contract between Sixb's `ai`-free message types and the AI SDK v6 shapes the worker
  * actually feeds. This file is never executed; it fails the build if the contract drifts.
  */
-import type { SixbInboundUiMessage, SixbMessage } from "@sixb/core"
+import type { AgentInboundUiMessage, AgentMessage } from "@sixb/core"
 import { toModelMessages } from "@sixb/core"
 import type { ModelMessage, UIMessage } from "ai"
 
 // A real v6 `UIMessage` must assign to `fromAiSdk`'s inbound shape *without a cast* — this is the
 // safety net at the SDK boundary and the reason the worker can pass `responseMessage` straight in.
 declare const sdkMessage: UIMessage
-const _inbound: SixbInboundUiMessage = sdkMessage
+const _inbound: AgentInboundUiMessage = sdkMessage
 
 // `toModelMessages` is core's mirror of `convertToModelMessages`. Its output is fed to
 // `streamText({ messages })` via a single boundary cast in `run-agent-turn.ts`; the only gap is
 // `providerOptions`, typed wider as `JsonValue` in core (it cannot depend on `ai`). This locks the
 // cast as a width-only relaxation, not a structural lie.
-declare const history: readonly SixbMessage[]
+declare const history: readonly AgentMessage[]
 const _model: ModelMessage[] = toModelMessages(history) as ModelMessage[]
 
 void _inbound

--- a/packages/agent-worker/tests/ai-sdk-compat.types.ts
+++ b/packages/agent-worker/tests/ai-sdk-compat.types.ts
@@ -1,0 +1,22 @@
+/**
+ * Type-only contract between Sixb's `ai`-free message types and the AI SDK v6 shapes the worker
+ * actually feeds. This file is never executed; it fails the build if the contract drifts.
+ */
+import type { SixbInboundUiMessage, SixbMessage } from "@sixb/core"
+import { toModelMessages } from "@sixb/core"
+import type { ModelMessage, UIMessage } from "ai"
+
+// A real v6 `UIMessage` must assign to `fromAiSdk`'s inbound shape *without a cast* — this is the
+// safety net at the SDK boundary and the reason the worker can pass `responseMessage` straight in.
+declare const sdkMessage: UIMessage
+const _inbound: SixbInboundUiMessage = sdkMessage
+
+// `toModelMessages` is core's mirror of `convertToModelMessages`. Its output is fed to
+// `streamText({ messages })` via a single boundary cast in `run-agent-turn.ts`; the only gap is
+// `providerOptions`, typed wider as `JsonValue` in core (it cannot depend on `ai`). This locks the
+// cast as a width-only relaxation, not a structural lie.
+declare const history: readonly SixbMessage[]
+const _model: ModelMessage[] = toModelMessages(history) as ModelMessage[]
+
+void _inbound
+void _model

--- a/packages/agent-worker/tests/helpers.ts
+++ b/packages/agent-worker/tests/helpers.ts
@@ -1,0 +1,19 @@
+/** Poll `fn` until it returns a truthy value or the timeout elapses (mirrors the action-worker helper). */
+export async function waitFor<T>(
+  fn: () => Promise<T | null | undefined | false> | T | null | undefined | false,
+  options: { timeoutMs?: number; intervalMs?: number; label?: string } = {}
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 3000
+  const intervalMs = options.intervalMs ?? 10
+  const start = Date.now()
+  for (;;) {
+    const value = await fn()
+    if (value !== null && value !== undefined && value !== false) {
+      return value
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor timed out${options.label ? `: ${options.label}` : ""}`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+}

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -7,6 +7,7 @@ import type {
 import {
   AgentRequestError,
   type AgentStorage,
+  AgentStorageError,
   type AgentsRuntime,
   createAgentRunId,
   createAgentRunLeaseId,
@@ -24,7 +25,8 @@ import {
 } from "@sixb/core"
 import { jsonSchema, type ToolSet, tool } from "ai"
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
-import { AgentLeaseLostError } from "../src/errors"
+import { AgentFinalizationError, AgentLeaseLostError } from "../src/errors"
+import { finishRunOrThrow } from "../src/finalize"
 import { runAgentTurn } from "../src/run-agent-turn"
 import { AgentWorker } from "../src/worker"
 import { waitFor } from "./helpers"
@@ -138,6 +140,50 @@ function agentStorageOf(sixb: TestSixb): AgentStorage {
 async function listMessages(storage: AgentStorage, threadId: string) {
   const result = await storage.messages.list({ projectId: PROJECT_ID, threadId, order: "asc" })
   return result.messages
+}
+
+/**
+ * Wrap an {@link AgentStorage} so `runs.finish` fails with a non-terminal (infra) error its first
+ * `failTimes` calls, then delegates. Method delegation is explicit (not spread) to preserve the
+ * underlying store's `this` binding.
+ */
+function withFlakyFinish(storage: AgentStorage, failTimes: number): AgentStorage {
+  let fails = 0
+  const runs: AgentStorage["runs"] = {
+    reserve: (input) => storage.runs.reserve(input),
+    renewLease: (input) => storage.runs.renewLease(input),
+    reclaim: (input) => storage.runs.reclaim(input),
+    getById: (params) => storage.runs.getById(params),
+    list: (input) => storage.runs.list(input),
+    finish: (input) => {
+      if (fails < failTimes) {
+        fails += 1
+        return Promise.reject(new Error("storage blip"))
+      }
+      return storage.runs.finish(input)
+    },
+  }
+  return { threads: storage.threads, runs, messages: storage.messages }
+}
+
+/** A model whose stream opens then hangs until aborted — used to force a turn timeout. */
+function hangingModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    modelId: "mock-model",
+    doStream: async (options) => ({
+      stream: new ReadableStream<LanguageModelV3StreamPart>({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] })
+          const abort = () => controller.error(new DOMException("Aborted", "AbortError"))
+          if (options.abortSignal?.aborted) {
+            abort()
+          } else {
+            options.abortSignal?.addEventListener("abort", abort, { once: true })
+          }
+        },
+      }),
+    }),
+  })
 }
 
 describe("AgentWorker", () => {
@@ -317,6 +363,7 @@ describe("AgentWorker", () => {
         leaseMs: 60_000,
         heartbeatMs: 20_000,
         defaultMaxSteps: 4,
+        turnTimeoutMs: 60_000,
       },
       agent: sixb.agents.getById("assistant")!,
       run: staleRun,
@@ -409,5 +456,154 @@ describe("AgentWorker", () => {
     expect(list.runs[0]?.status).toBe("cancelled")
     const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
     expect(thread?.activeRunId).toBeNull()
+  })
+
+  test("absorbs a transient finalize blip in place: one run, one message, no lock", async () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+    const storage = agentStorageOf(sixb)
+    // The worker sees a storage whose `finish` fails twice before succeeding; the trigger keeps using
+    // the real storage (both delegate to the same underlying state).
+    const workerSixb = {
+      id: sixb.id,
+      events: sixb.events,
+      storage: { agents: withFlakyFinish(storage, 2) } as unknown as Storage,
+      queues: sixb.queues,
+      agents: sixb.agents,
+    }
+
+    const worker = new AgentWorker(workerSixb, { tools: echoTool })
+    await worker.start()
+    try {
+      const { threadId } = await sixb.agents.request({ agentId: "assistant", text: "echo hi" })
+      const run = await waitFor(
+        async () => {
+          const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+          const found = list.runs[0]
+          return found && found.status !== "running" ? found : null
+        },
+        { label: "run finalized after blip" }
+      )
+
+      // The in-place retry recovered: the run succeeded on this delivery, with exactly one assistant
+      // message (no redelivery, so no duplicate turn), and the thread is released (no silent lock).
+      expect(run.status).toBe("succeeded")
+      expect(run.attempt).toBe(1)
+      const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
+      expect(thread?.activeRunId).toBeNull()
+      const assistants = (await listMessages(storage, threadId)).filter(
+        (m) => m.role === "assistant"
+      )
+      expect(assistants).toHaveLength(1)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("fails the run and releases the thread when a turn exceeds its wall-clock budget", async () => {
+    const sixb = buildSixb(hangingModel())
+    const storage = agentStorageOf(sixb)
+
+    const worker = new AgentWorker(sixb, { turnTimeoutMs: 50 })
+    await worker.start()
+    try {
+      const { threadId } = await sixb.agents.request({ agentId: "assistant", text: "hang" })
+      const run = await waitFor(
+        async () => {
+          const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+          const found = list.runs[0]
+          return found && found.status !== "running" ? found : null
+        },
+        { label: "run timed out" }
+      )
+
+      expect(run.status).toBe("failed")
+      expect(run.error).toContain("turn budget")
+      // Thread released so a later message can run, and no assistant message was persisted.
+      const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
+      expect(thread?.activeRunId).toBeNull()
+      const messages = await listMessages(storage, threadId)
+      expect(messages.every((m) => m.role !== "assistant")).toBe(true)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("holds a different turn behind a live active run without stealing it (single-flight, worker layer)", async () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+    const storage = agentStorageOf(sixb)
+
+    // A live run (valid, far-future lease) owns the thread, triggered by message "A".
+    const { threadId } = await sixb.agents.request({ agentId: "assistant", text: "first" })
+    const activeRunId = createAgentRunId()
+    await storage.runs.reserve({
+      id: activeRunId,
+      projectId: PROJECT_ID,
+      threadId,
+      agentId: "assistant",
+      triggerMessageId: "trigger-A",
+      lease: { id: createAgentRunLeaseId(), expiresAt: new Date(Date.now() + 300_000) },
+    })
+
+    // A redelivered job for a *different* trigger lands while that run is live. The worker must hold
+    // it (single-flight), never reclaiming the still-leased run.
+    await sixb.queues.agents.enqueue({
+      projectId: PROJECT_ID,
+      jobs: [
+        {
+          type: "agent.run.requested",
+          payload: { agentId: "assistant", threadId, triggerMessageId: "trigger-B" },
+        },
+      ],
+    })
+
+    const worker = new AgentWorker(sixb, { tools: echoTool })
+    await worker.start()
+    try {
+      // Let the worker claim + hold the job (held jobs are rescheduled a full lease out, so B will
+      // not run again inside the test window). The active run must be untouched: not reclaimed, no
+      // second run created, and no assistant message written.
+      await Bun.sleep(150)
+
+      const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+      expect(list.runs).toHaveLength(1)
+      expect(list.runs[0]?.id).toBe(activeRunId)
+      expect(list.runs[0]?.status).toBe("running")
+      expect(list.runs[0]?.attempt).toBe(1)
+      const assistants = (await listMessages(storage, threadId)).filter(
+        (m) => m.role === "assistant"
+      )
+      expect(assistants).toHaveLength(0)
+    } finally {
+      await worker.stop()
+    }
+  })
+})
+
+describe("finishRunOrThrow", () => {
+  function finishingStorage(finish: AgentStorage["runs"]["finish"]): AgentStorage {
+    return { runs: { finish } } as unknown as AgentStorage
+  }
+
+  const succeededInput = {
+    projectId: PROJECT_ID,
+    id: "agt_run_x",
+    leaseId: "agt_lease_x",
+    status: "succeeded",
+  } as const
+
+  test("raises AgentFinalizationError when an infra error persists across retries", async () => {
+    const storage = finishingStorage(() => Promise.reject(new Error("db down")))
+    await expect(finishRunOrThrow(storage, succeededInput, "agt_run_x")).rejects.toBeInstanceOf(
+      AgentFinalizationError
+    )
+  })
+
+  test("raises AgentLeaseLostError when the run is no longer ours (terminal storage error)", async () => {
+    const storage = finishingStorage(() =>
+      Promise.reject(new AgentStorageError("lease_lost", "gone"))
+    )
+    await expect(finishRunOrThrow(storage, succeededInput, "agt_run_x")).rejects.toBeInstanceOf(
+      AgentLeaseLostError
+    )
   })
 })

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -24,7 +24,7 @@ import {
   type Storage,
 } from "@sixb/core"
 import { jsonSchema, type ToolSet, tool } from "ai"
-import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
+import { convertArrayToReadableStream, MockLanguageModelV3 } from "ai/test"
 import { AgentFinalizationError, AgentLeaseLostError } from "../src/errors"
 import { finishRunOrThrow } from "../src/finalize"
 import { runAgentTurn } from "../src/run-agent-turn"
@@ -39,7 +39,7 @@ const USAGE: LanguageModelV3Usage = {
 }
 
 function stream(chunks: LanguageModelV3StreamPart[]) {
-  return { stream: simulateReadableStream({ chunks, initialDelayInMs: 0, chunkDelayInMs: 0 }) }
+  return { stream: convertArrayToReadableStream(chunks) }
 }
 
 function finish(unified: "stop" | "tool-calls"): LanguageModelV3StreamPart {

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -5,6 +5,7 @@ import type {
   LanguageModelV3Usage,
 } from "@ai-sdk/provider"
 import {
+  type AgentMessagePart,
   AgentRequestError,
   type AgentStorage,
   AgentStorageError,
@@ -20,7 +21,6 @@ import {
   InMemoryStorage,
   type Queues,
   Sixb,
-  type SixbMessagePart,
   type Storage,
 } from "@sixb/core"
 import { jsonSchema, type ToolSet, tool } from "ai"
@@ -211,7 +211,7 @@ describe("AgentWorker", () => {
   test("runs a full multi-step turn: reserves, persists the assistant message, finalizes with usage", async () => {
     const sixb = buildSixb(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
-    const streamed: SixbMessagePart[] = []
+    const streamed: AgentMessagePart[] = []
 
     const worker = new AgentWorker(sixb, {
       tools: echoTool,

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  LanguageModelV3,
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
+} from "@ai-sdk/provider"
+import {
+  AgentRequestError,
+  type AgentStorage,
+  type AgentsRuntime,
+  createAgentRunId,
+  createAgentRunLeaseId,
+  defineAgent,
+  type EventsRuntime,
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  InMemoryStorage,
+  type Queues,
+  Sixb,
+  type SixbMessagePart,
+  type Storage,
+} from "@sixb/core"
+import { jsonSchema, type ToolSet, tool } from "ai"
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test"
+import { AgentLeaseLostError } from "../src/errors"
+import { runAgentTurn } from "../src/run-agent-turn"
+import { AgentWorker } from "../src/worker"
+import { waitFor } from "./helpers"
+
+const PROJECT_ID = "agent-worker-tests"
+
+const USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 7, text: 7, reasoning: 0 },
+}
+
+function stream(chunks: LanguageModelV3StreamPart[]) {
+  return { stream: simulateReadableStream({ chunks, initialDelayInMs: 0, chunkDelayInMs: 0 }) }
+}
+
+function finish(unified: "stop" | "tool-calls"): LanguageModelV3StreamPart {
+  return { type: "finish", finishReason: { unified, raw: unified }, usage: USAGE }
+}
+
+/**
+ * A model that, on its first call, calls the `echo` tool, then on its second call answers with
+ * reasoning + text. A stateful `doStream` (not the array form) guarantees per-call ordering.
+ */
+function toolThenAnswerModel(): MockLanguageModelV3 {
+  let call = 0
+  return new MockLanguageModelV3({
+    modelId: "mock-model",
+    doStream: async () => {
+      call += 1
+      if (call === 1) {
+        return stream([
+          { type: "stream-start", warnings: [] },
+          {
+            type: "tool-call",
+            toolCallId: "c1",
+            toolName: "echo",
+            input: JSON.stringify({ value: "hi" }),
+          },
+          finish("tool-calls"),
+        ])
+      }
+      return stream([
+        { type: "stream-start", warnings: [] },
+        { type: "reasoning-start", id: "r" },
+        { type: "reasoning-delta", id: "r", delta: "echo it back" },
+        { type: "reasoning-end", id: "r" },
+        { type: "text-start", id: "t" },
+        { type: "text-delta", id: "t", delta: "Echoed hi" },
+        { type: "text-end", id: "t" },
+        finish("stop"),
+      ])
+    },
+  })
+}
+
+const echoTool: ToolSet = {
+  echo: tool({
+    description: "Echo a value back.",
+    inputSchema: jsonSchema<{ value: string }>({
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+      additionalProperties: false,
+    }),
+    async execute(input) {
+      return { echoed: input.value }
+    },
+  }),
+}
+
+// Sixb's generics overflow TS2589 when instantiated with an empty ontology in a test; we only need a
+// structural `AgentWorkerSixb`, so we construct through a narrowed constructor cast (as the
+// action-worker tests do).
+interface TestSixb {
+  readonly id: string
+  readonly events: EventsRuntime
+  readonly storage: Storage
+  readonly queues: Queues
+  readonly agents: AgentsRuntime
+}
+
+const SixbCtor = Sixb as unknown as new (options: Record<string, unknown>) => TestSixb
+
+function buildSixb(model: LanguageModelV3): TestSixb {
+  const agent = defineAgent("assistant", {
+    name: "Assistant",
+    model,
+    instructions: "You are a helpful test assistant.",
+    loop: { stopWhen: { maxSteps: 4 } },
+  })
+  return new SixbCtor({
+    id: PROJECT_ID,
+    ontology: [],
+    agents: [agent],
+    broker: new InMemoryBroker(),
+    storage: new InMemoryStorage(),
+    lakeStorage: new InMemoryLakeStorage(),
+    blobStorage: new InMemoryBlobStorage(),
+    queues: new InMemoryQueues(),
+  })
+}
+
+function agentStorageOf(sixb: TestSixb): AgentStorage {
+  const storage = sixb.storage.agents
+  if (!storage) {
+    throw new Error("expected agent storage")
+  }
+  return storage
+}
+
+async function listMessages(storage: AgentStorage, threadId: string) {
+  const result = await storage.messages.list({ projectId: PROJECT_ID, threadId, order: "asc" })
+  return result.messages
+}
+
+describe("AgentWorker", () => {
+  test("trigger persists the user message and enqueues an intent without creating a run", async () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+    const storage = agentStorageOf(sixb)
+
+    const result = await sixb.agents.request({ agentId: "assistant", text: "hello" })
+
+    expect(result.createdThread).toBe(true)
+    expect(result.jobId).toBeDefined()
+
+    const messages = await listMessages(storage, result.threadId)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toMatchObject({ role: "user", runId: null })
+    expect(messages[0]?.parts).toEqual([{ type: "text", text: "hello" }])
+
+    // Reserve-at-claim: no run record exists yet, and the thread is still idle.
+    const runs = await storage.runs.list({ projectId: PROJECT_ID, threadId: result.threadId })
+    expect(runs.runs).toHaveLength(0)
+    const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: result.threadId })
+    expect(thread?.activeRunId).toBeNull()
+  })
+
+  test("runs a full multi-step turn: reserves, persists the assistant message, finalizes with usage", async () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+    const storage = agentStorageOf(sixb)
+    const streamed: SixbMessagePart[] = []
+
+    const worker = new AgentWorker(sixb, {
+      tools: echoTool,
+      streamSink: { onPart: (part) => void streamed.push(part) },
+    })
+    await worker.start()
+    try {
+      const { threadId } = await sixb.agents.request({ agentId: "assistant", text: "echo hi" })
+
+      const run = await waitFor(
+        async () => {
+          const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+          const found = list.runs[0]
+          return found && found.status !== "running" ? found : null
+        },
+        { label: "run terminal" }
+      )
+
+      expect(run.status).toBe("succeeded")
+      expect(run.attempt).toBe(1)
+      expect(run.finishReason).toBe("stop")
+      expect(run.modelId).toBe("mock-model")
+      expect(run.usage?.outputTokens).toBeGreaterThan(0)
+      expect(run.usage?.inputTokens).toBeGreaterThan(0)
+
+      // Thread released after finalization (single-flight pointer cleared).
+      const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
+      expect(thread?.activeRunId).toBeNull()
+
+      const messages = await listMessages(storage, threadId)
+      const assistant = messages.find((message) => message.role === "assistant")
+      expect(assistant).toBeDefined()
+      expect(assistant?.runId).toBe(run.id)
+
+      const parts = assistant?.parts ?? []
+      expect(parts.some((part) => part.type === "reasoning")).toBe(true)
+      expect(parts.some((part) => part.type === "step-start")).toBe(true)
+      expect(
+        parts.some(
+          (part) =>
+            part.type === "tool-call" &&
+            part.toolName === "echo" &&
+            part.state === "output-available"
+        )
+      ).toBe(true)
+      expect(parts.some((part) => part.type === "text" && part.text.includes("Echoed hi"))).toBe(
+        true
+      )
+
+      // The stream seam saw exactly the persisted parts, in order.
+      expect(streamed).toEqual([...parts])
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("rejects a second message while a run is active (single-flight, trigger layer)", async () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+    const storage = agentStorageOf(sixb)
+
+    // Open a thread and simulate an in-flight run by reserving directly.
+    const first = await sixb.agents.request({ agentId: "assistant", text: "first" })
+    await storage.runs.reserve({
+      id: createAgentRunId(),
+      projectId: PROJECT_ID,
+      threadId: first.threadId,
+      agentId: "assistant",
+      triggerMessageId: first.triggerMessageId,
+      lease: { id: createAgentRunLeaseId(), expiresAt: new Date(Date.now() + 60_000) },
+    })
+
+    const promise = sixb.agents.request({
+      agentId: "assistant",
+      text: "second",
+      threadId: first.threadId,
+    })
+    await expect(promise).rejects.toBeInstanceOf(AgentRequestError)
+    await expect(promise).rejects.toMatchObject({ code: "active_run_exists" })
+  })
+
+  test("reclaims a crashed run on redelivery and completes it (attempt++)", async () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+    const storage = agentStorageOf(sixb)
+
+    // Trigger normally, then simulate a worker that crashed mid-run: an active run whose lease has
+    // already expired, with the same trigger message the redelivered job carries.
+    const { threadId, triggerMessageId } = await sixb.agents.request({
+      agentId: "assistant",
+      text: "echo hi",
+    })
+    const crashedRunId = createAgentRunId()
+    await storage.runs.reserve({
+      id: crashedRunId,
+      projectId: PROJECT_ID,
+      threadId,
+      agentId: "assistant",
+      triggerMessageId,
+      lease: { id: createAgentRunLeaseId(), expiresAt: new Date(Date.now() - 1_000) },
+    })
+
+    const worker = new AgentWorker(sixb, { tools: echoTool })
+    await worker.start()
+    try {
+      const reclaimed = await waitFor(
+        async () => {
+          const run = await storage.runs.getById({ projectId: PROJECT_ID, id: crashedRunId })
+          return run && run.status !== "running" ? run : null
+        },
+        { label: "crashed run reclaimed + finished" }
+      )
+      expect(reclaimed.status).toBe("succeeded")
+      expect(reclaimed.attempt).toBe(2)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("a worker whose lease was reclaimed writes nothing (fencing)", async () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+    const storage = agentStorageOf(sixb)
+
+    const { threadId, triggerMessageId } = await sixb.agents.request({
+      agentId: "assistant",
+      text: "echo hi",
+    })
+
+    // This worker reserved the run, but its lease already expired and another worker reclaimed it.
+    const runId = createAgentRunId()
+    const staleRun = await storage.runs.reserve({
+      id: runId,
+      projectId: PROJECT_ID,
+      threadId,
+      agentId: "assistant",
+      triggerMessageId,
+      lease: { id: createAgentRunLeaseId(), expiresAt: new Date(Date.now() - 1_000) },
+    })
+    await storage.runs.reclaim({
+      projectId: PROJECT_ID,
+      id: runId,
+      lease: { id: createAgentRunLeaseId(), expiresAt: new Date(Date.now() + 60_000) },
+    })
+
+    const promise = runAgentTurn({
+      context: {
+        id: PROJECT_ID,
+        storage,
+        tools: echoTool,
+        streamSink: { onPart() {} },
+        leaseMs: 60_000,
+        heartbeatMs: 20_000,
+        defaultMaxSteps: 4,
+      },
+      agent: sixb.agents.getById("assistant")!,
+      run: staleRun,
+      signal: new AbortController().signal,
+    })
+    await expect(promise).rejects.toBeInstanceOf(AgentLeaseLostError)
+
+    // No assistant message was written; the run is still owned by the reclaiming worker.
+    const messages = await listMessages(storage, threadId)
+    expect(messages.every((message) => message.role !== "assistant")).toBe(true)
+    const run = await storage.runs.getById({ projectId: PROJECT_ID, id: runId })
+    expect(run?.status).toBe("running")
+  })
+
+  test("records a run-level failure on the record (model error)", async () => {
+    const failingModel = new MockLanguageModelV3({
+      modelId: "mock-model",
+      doStream: async () => ({
+        stream: new ReadableStream<LanguageModelV3StreamPart>({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] })
+            controller.error(new Error("provider boom"))
+          },
+        }),
+      }),
+    })
+    const sixb = buildSixb(failingModel)
+    const storage = agentStorageOf(sixb)
+
+    const worker = new AgentWorker(sixb)
+    await worker.start()
+    try {
+      const { threadId } = await sixb.agents.request({ agentId: "assistant", text: "hi" })
+      const run = await waitFor(
+        async () => {
+          const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+          const found = list.runs[0]
+          return found && found.status !== "running" ? found : null
+        },
+        { label: "run failed" }
+      )
+      expect(run.status).toBe("failed")
+      expect(run.error).toBeDefined()
+
+      // Thread released so a later message can run.
+      const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
+      expect(thread?.activeRunId).toBeNull()
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("cancels the run when the worker is stopped mid-turn", async () => {
+    // A model whose stream blocks until the call is aborted, so the turn is reliably in-flight.
+    const blockingModel = new MockLanguageModelV3({
+      modelId: "mock-model",
+      doStream: async (options) => {
+        const blocked = new ReadableStream<LanguageModelV3StreamPart>({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] })
+            const abort = () => controller.error(new DOMException("Aborted", "AbortError"))
+            if (options.abortSignal?.aborted) {
+              abort()
+            } else {
+              options.abortSignal?.addEventListener("abort", abort, { once: true })
+            }
+          },
+        })
+        return { stream: blocked }
+      },
+    })
+    const sixb = buildSixb(blockingModel)
+    const storage = agentStorageOf(sixb)
+
+    const worker = new AgentWorker(sixb)
+    await worker.start()
+    const { threadId } = await sixb.agents.request({ agentId: "assistant", text: "hang" })
+
+    // Wait until the run is reserved and in-flight, then stop the worker.
+    await waitFor(
+      async () => {
+        const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+        return list.runs[0]?.status === "running" ? list.runs[0] : null
+      },
+      { label: "run running" }
+    )
+    await worker.stop()
+
+    const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+    expect(list.runs[0]?.status).toBe("cancelled")
+    const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
+    expect(thread?.activeRunId).toBeNull()
+  })
+})

--- a/packages/agent-worker/tsconfig.build.json
+++ b/packages/agent-worker/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/agent-worker/tsconfig.json
+++ b/packages/agent-worker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "compilerOptions": {
+    "types": ["bun"],
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@sixb/app": "workspace:*",
     "@sixb/action-worker": "workspace:*",
+    "@sixb/agent-worker": "workspace:*",
     "@sixb/atlas": "workspace:*",
     "@sixb/client": "workspace:*",
     "@sixb/core": "workspace:*",

--- a/packages/cli/src/lib/loadSixb.ts
+++ b/packages/cli/src/lib/loadSixb.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from "node:url"
 import type {
   ActionDefinition,
+  AgentsRuntime,
   AuthRuntime,
   ConnectorAdapter,
   ConnectorClient,
@@ -32,6 +33,7 @@ export interface LoadedSixb extends SixbRuntimeContext {
   getPipelineById(pipelineId: string): PipelineDefinition | null
   getScheduleDefinitions(): readonly ScheduleDefinition[]
   readonly workflows: WorkflowsRuntime
+  readonly agents: AgentsRuntime
   getObjectProjections(): readonly ObjectProjectionDefinition[]
   getLinkProjections(): readonly LinkProjectionDefinition[]
   getTelemetryProjections(): readonly TelemetryProjectionDefinition[]

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -1,5 +1,6 @@
 import { appendFileSync } from "node:fs"
 import { ActionWorker } from "@sixb/action-worker"
+import { AgentWorker } from "@sixb/agent-worker"
 import { assertLakeDatasetDefinitionsCompatible, migrateStorage } from "@sixb/core"
 import {
   type CompileRoutesDiagnostic,
@@ -28,6 +29,7 @@ export interface RunningSixbRuntime {
   readonly rulesWorker: RulesWorker | null
   readonly syncWorker: SyncWorker | null
   readonly actionWorker: ActionWorker | null
+  readonly agentWorker: AgentWorker | null
   readonly projectionWorker: ProjectionWorker | null
   readonly pipelineWorker: PipelineWorker | null
   readonly workflowWorker: WorkflowWorker | null
@@ -157,12 +159,13 @@ export async function startOrchestratorRuntime(
  *   1. RulesWorker (subscribes to ontology events)
  *   2. Functions
  *   3. ActionWorker (subscribes to events)
- *   4. ProjectionWorker (claims from queues)
- *   5. PipelineWorker (claims from queues)
- *   6. WorkflowWorker (claims from queues)
- *   7. SyncWorker (claims from queues)
- *   8. Orchestrator (subscribes to events and enqueues jobs)
- *   9. Scheduler (emits schedule.triggered)
+ *   4. AgentWorker (claims from queues)
+ *   5. ProjectionWorker (claims from queues)
+ *   6. PipelineWorker (claims from queues)
+ *   7. WorkflowWorker (claims from queues)
+ *   8. SyncWorker (claims from queues)
+ *   9. Orchestrator (subscribes to events and enqueues jobs)
+ *   10. Scheduler (emits schedule.triggered)
  *
  * Shutdown order (producers before consumers):
  *   1. Scheduler
@@ -171,10 +174,11 @@ export async function startOrchestratorRuntime(
  *   4. WorkflowWorker
  *   5. PipelineWorker
  *   6. ProjectionWorker
- *   7. ActionWorker
- *   8. Functions
- *   9. RulesWorker (drains pending evaluations)
- *   10. Runtime providers (connectors, broker)
+ *   7. AgentWorker
+ *   8. ActionWorker
+ *   9. Functions
+ *   10. RulesWorker (drains pending evaluations)
+ *   11. Runtime providers (connectors, broker)
  */
 export async function startSixbRuntime(
   sixb: LoadedSixb,
@@ -190,6 +194,7 @@ export async function startSixbRuntime(
   let rulesWorker: RulesWorker | null = null
   let syncWorker: SyncWorker | null = null
   let actionWorker: ActionWorker | null = null
+  let agentWorker: AgentWorker | null = null
   let pipelineWorker: PipelineWorker | null = null
   let workflowWorker: WorkflowWorker | null = null
   let orchestratorWorker: OrchestratorWorker | null = null
@@ -203,6 +208,7 @@ export async function startSixbRuntime(
     await stopQuietly(() => workflowWorker?.stop() ?? Promise.resolve())
     await stopQuietly(() => pipelineWorker?.stop() ?? Promise.resolve())
     await stopQuietly(() => projectionWorker?.stop() ?? Promise.resolve())
+    await stopQuietly(() => agentWorker?.stop() ?? Promise.resolve())
     await stopQuietly(() => actionWorker?.stop() ?? Promise.resolve())
     await stopQuietly(() => functionsRuntime?.stop() ?? Promise.resolve())
     await stopQuietly(() => rulesRuntime?.stop() ?? Promise.resolve())
@@ -219,6 +225,11 @@ export async function startSixbRuntime(
       if (sixb.getActionDefinitions().length > 0) {
         actionWorker = new ActionWorker(sixb)
         await actionWorker.start()
+      }
+
+      if (sixb.agents.list().length > 0 && sixb.storage.agents) {
+        agentWorker = new AgentWorker(sixb)
+        await agentWorker.start()
       }
 
       const projectionCount =
@@ -260,6 +271,7 @@ export async function startSixbRuntime(
     rulesWorker,
     syncWorker,
     actionWorker,
+    agentWorker,
     projectionWorker,
     pipelineWorker,
     workflowWorker,

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -15,6 +15,9 @@
       "path": "../action-worker/tsconfig.build.json"
     },
     {
+      "path": "../agent-worker/tsconfig.build.json"
+    },
+    {
       "path": "../app/tsconfig.build.json"
     },
     {

--- a/packages/core/src/agents/adapters.ts
+++ b/packages/core/src/agents/adapters.ts
@@ -13,10 +13,11 @@ export interface AgentInboundUiMessagePart {
   readonly type: string
   readonly text?: string
   readonly state?: string
-  // v6 types provider metadata as `Record<string, JSONObject>`, so we constrain it to JSON. `input`,
-  // `output` and `rawInput` stay `unknown` — they are the tool's generic schema types, which we
-  // cannot know at this boundary (no tool registry), and which fromAiSdk validates to JSON anyway.
-  readonly providerMetadata?: JsonValue
+  // Provider metadata stays `unknown` here, exactly like `input` / `output` / `rawInput`: the SDK
+  // types it as `SharedV3ProviderMetadata` (a nested record), which is not structurally a Sixb
+  // `JsonValue`, so constraining it would break the "real SDK message assigns without a cast"
+  // contract (locked by the consumer's compat test). `fromAiSdk` validates it to JSON at runtime.
+  readonly providerMetadata?: unknown
   readonly toolName?: string
   readonly toolCallId?: string
   readonly providerExecuted?: boolean
@@ -24,7 +25,7 @@ export interface AgentInboundUiMessagePart {
   readonly rawInput?: unknown
   readonly output?: unknown
   readonly errorText?: string
-  readonly callProviderMetadata?: JsonValue
+  readonly callProviderMetadata?: unknown
 }
 
 export interface AgentInboundUiMessage {

--- a/packages/core/src/agents/errors.ts
+++ b/packages/core/src/agents/errors.ts
@@ -15,3 +15,25 @@ export class AgentDefinitionError extends Error {
 export class AgentMessageAdapterError extends Error {
   readonly name = "AgentMessageAdapterError"
 }
+
+export type AgentRequestErrorCode =
+  | "agent_not_found"
+  | "thread_not_found"
+  | "thread_agent_mismatch"
+  | "active_run_exists"
+  | "storage_unavailable"
+
+/**
+ * Raised by {@link requestAgentRun} (the trigger). Callers branch on `code` rather than message text
+ * — e.g. the HTTP layer maps `active_run_exists` to 409 and `agent_not_found` to 404.
+ */
+export class AgentRequestError extends Error {
+  readonly name = "AgentRequestError"
+
+  constructor(
+    readonly code: AgentRequestErrorCode,
+    message: string
+  ) {
+    super(message)
+  }
+}

--- a/packages/core/src/agents/ids.ts
+++ b/packages/core/src/agents/ids.ts
@@ -1,0 +1,24 @@
+import { randomUUID } from "node:crypto"
+
+/**
+ * Id helpers for agent persistence. Threads and the user (trigger) message are minted by the
+ * trigger; the run id is minted by the **worker** at claim time (reserve-at-claim), and the
+ * assistant message id when the turn finalizes. Prefixes make ids self-describing in logs and stores.
+ */
+
+export function createAgentThreadId(): string {
+  return `agt_thr_${randomUUID()}`
+}
+
+export function createAgentRunId(): string {
+  return `agt_run_${randomUUID()}`
+}
+
+export function createAgentMessageId(): string {
+  return `agt_msg_${randomUUID()}`
+}
+
+/** A worker's lease id on an `agent_runs` record (distinct from the queue lease). */
+export function createAgentRunLeaseId(): string {
+  return `agt_lease_${randomUUID()}`
+}

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -14,7 +14,18 @@ export type {
 } from "./adapters"
 export { fromAiSdk, toModelMessages, toUiMessage } from "./adapters"
 export { defineAgent } from "./builders"
-export { AgentDefinitionError, AgentMessageAdapterError } from "./errors"
+export {
+  AgentDefinitionError,
+  AgentMessageAdapterError,
+  AgentRequestError,
+  type AgentRequestErrorCode,
+} from "./errors"
+export {
+  createAgentMessageId,
+  createAgentRunId,
+  createAgentRunLeaseId,
+  createAgentThreadId,
+} from "./ids"
 export {
   AGENT_MESSAGE_CONTENT_VERSION,
   type AgentMessage,
@@ -27,6 +38,11 @@ export {
   type AgentToolCallPart,
   type AgentToolCallState,
 } from "./message"
+export {
+  type RequestAgentRunInput,
+  type RequestAgentRunResult,
+  requestAgentRun,
+} from "./request"
 export { AgentsRuntime } from "./runtime"
 export type { AgentDefinition, AgentLoopConfig, DefineAgentConfig } from "./types"
 export { isAgentDefinition } from "./validation"

--- a/packages/core/src/agents/request.ts
+++ b/packages/core/src/agents/request.ts
@@ -1,0 +1,144 @@
+import type { Principal } from "../auth"
+import type { SixbRuntimeContext } from "../runtime/types"
+import type { AgentStorage, AgentThreadRecord } from "../storage/agents"
+import { AgentRequestError } from "./errors"
+import { createAgentMessageId, createAgentThreadId } from "./ids"
+import type { AgentDefinition } from "./types"
+
+export interface RequestAgentRunInput {
+  /** The agent to run. */
+  readonly agentId: string
+  /** The user's message that triggers the turn. V1 input is plain text. */
+  readonly text: string
+  /** Continue an existing thread. Omitted → a fresh thread is created for this agent. */
+  readonly threadId?: string
+  /** Title to stamp on the thread when one is created. */
+  readonly title?: string
+  /** Explicit id for the trigger (user) message. Defaults to a generated id. */
+  readonly messageId?: string
+  /** Owner principal for a newly created thread. Defaults to the system principal until auth lands. */
+  readonly principal?: Principal
+}
+
+export interface RequestAgentRunResult {
+  /** The thread the turn runs in (created when no `threadId` was supplied). */
+  readonly threadId: string
+  /** The persisted user message that triggers the run. */
+  readonly triggerMessageId: string
+  /** The enqueued job id, when the queue returns one. */
+  readonly jobId?: string
+  /** Whether this call created the thread. */
+  readonly createdThread: boolean
+}
+
+const SYSTEM_PRINCIPAL: Principal = { type: "system", id: "system" }
+
+/**
+ * Trigger an agent turn.
+ *
+ * Reserve-at-claim: this only persists the user message and enqueues an *intent* — no `agent_runs`
+ * record is created here. The worker generates the run id and reserves the run when it claims the
+ * job, so it owns the lease from birth and there is never an orphan run between request and pickup.
+ *
+ * Single-flight is enforced at two layers: this trigger rejects a second message while a run is
+ * already active (`active_run_exists`, surfaced to the caller — the HTTP layer maps it to 409), and
+ * the worker's atomic `runs.reserve` is the ultimate authority on the race + crash redelivery.
+ */
+export async function requestAgentRun(
+  runtime: SixbRuntimeContext,
+  agent: AgentDefinition,
+  input: RequestAgentRunInput
+): Promise<RequestAgentRunResult> {
+  const agents = requireAgentStorage(runtime)
+  const projectId = runtime.projectId
+
+  const { thread, createdThread } = await resolveThread(agents, {
+    projectId,
+    agentId: agent.id,
+    threadId: input.threadId,
+    title: input.title,
+    principal: input.principal ?? SYSTEM_PRINCIPAL,
+  })
+
+  // Single-flight (trigger layer): a thread runs one turn at a time in V1. The worker's `reserve`
+  // is the atomic authority, but rejecting here avoids persisting an orphan message we cannot serve.
+  if (thread.activeRunId !== null) {
+    throw new AgentRequestError(
+      "active_run_exists",
+      `[Sixb] Agent thread '${thread.id}' already has an active run '${thread.activeRunId}'.`
+    )
+  }
+
+  const triggerMessageId = input.messageId ?? createAgentMessageId()
+  await agents.messages.append({
+    id: triggerMessageId,
+    projectId,
+    threadId: thread.id,
+    runId: null,
+    role: "user",
+    parts: [{ type: "text", text: input.text }],
+  })
+
+  // Enqueue the intent. Nothing to roll back on failure: no run was reserved, and the user message
+  // is durable — the caller may retry, which re-enqueues against the same thread.
+  const [job] = await runtime.queues.agents.enqueue({
+    projectId,
+    jobs: [
+      {
+        type: "agent.run.requested",
+        payload: { agentId: agent.id, threadId: thread.id, triggerMessageId },
+      },
+    ],
+  })
+
+  return {
+    threadId: thread.id,
+    triggerMessageId,
+    ...(job?.id ? { jobId: job.id } : {}),
+    createdThread,
+  }
+}
+
+async function resolveThread(
+  agents: AgentStorage,
+  params: {
+    readonly projectId: string
+    readonly agentId: string
+    readonly threadId?: string
+    readonly title?: string
+    readonly principal: Principal
+  }
+): Promise<{ thread: AgentThreadRecord; createdThread: boolean }> {
+  if (params.threadId) {
+    const existing = await agents.threads.getById({
+      projectId: params.projectId,
+      id: params.threadId,
+    })
+    if (existing) {
+      if (existing.agentId !== params.agentId) {
+        throw new AgentRequestError(
+          "thread_agent_mismatch",
+          `[Sixb] Agent thread '${existing.id}' belongs to agent '${existing.agentId}', not '${params.agentId}'.`
+        )
+      }
+      return { thread: existing, createdThread: false }
+    }
+  }
+
+  const thread = await agents.threads.create({
+    id: params.threadId ?? createAgentThreadId(),
+    projectId: params.projectId,
+    agentId: params.agentId,
+    ownerPrincipal: params.principal,
+    ...(params.title === undefined ? {} : { title: params.title }),
+  })
+  return { thread, createdThread: true }
+}
+
+function requireAgentStorage(runtime: SixbRuntimeContext): AgentStorage {
+  const agents = runtime.storage.agents
+  if (!agents) {
+    throw new AgentRequestError("storage_unavailable", "[Sixb] Agent storage is not configured.")
+  }
+  return agents
+}

--- a/packages/core/src/agents/runtime.ts
+++ b/packages/core/src/agents/runtime.ts
@@ -1,18 +1,23 @@
+import type { SixbRuntimeContext } from "../runtime/types"
+import { AgentRequestError } from "./errors"
+import { type RequestAgentRunInput, type RequestAgentRunResult, requestAgentRun } from "./request"
 import type { AgentDefinition } from "./types"
 
 /**
- * Holds the agent definitions registered with a Sixb instance and exposes lookup.
+ * Holds the agent definitions registered with a Sixb instance and exposes lookup + the run trigger.
  *
- * The PR1 surface is definition-only (`list` / `getById`). Runtime behaviour
- * (starting a run, streaming) lands in later slices on this same `sixb.agents`
- * namespace, mirroring `sixb.workflows` / `sixb.actions`.
+ * Definition lookup (`list` / `getById`) is what the worker uses to resolve a run's model (the model
+ * is a non-serialisable `LanguageModelV3`, so it is never sent over the wire). `request(...)` is the
+ * trigger surface, mirroring `sixb.actions.request`.
  *
  * Duplicate ids are rejected by the `Sixb` constructor before this is built.
  */
 export class AgentsRuntime {
+  private readonly runtime: SixbRuntimeContext
   private readonly agentsById: ReadonlyMap<string, AgentDefinition>
 
-  constructor(agents: readonly AgentDefinition[]) {
+  constructor(runtime: SixbRuntimeContext, agents: readonly AgentDefinition[]) {
+    this.runtime = runtime
     this.agentsById = new Map(agents.map((agent) => [agent.id, agent]))
   }
 
@@ -24,5 +29,14 @@ export class AgentsRuntime {
   /** Look up a registered agent definition by id. */
   getById(agentId: string): AgentDefinition | null {
     return this.agentsById.get(agentId) ?? null
+  }
+
+  /** Trigger an agent turn: persist the user message and enqueue the run intent. */
+  request(input: RequestAgentRunInput): Promise<RequestAgentRunResult> {
+    const agent = this.getById(input.agentId)
+    if (!agent) {
+      throw new AgentRequestError("agent_not_found", `[Sixb] Unknown agent '${input.agentId}'.`)
+    }
+    return requestAgentRun(this.runtime, agent, input)
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -909,6 +909,7 @@ export {
 
 export type {
   ActionRunRequestedQueueJob,
+  AgentRunRequestedQueueJob,
   ClaimedQueueJob,
   NewQueueJob,
   PipelineRunRequestedQueueJob,
@@ -1268,6 +1269,7 @@ export type {
   AgentModelToolOutput,
   AgentModelToolResultPart,
   AgentReasoningPart,
+  AgentRequestErrorCode,
   AgentStepStartPart,
   AgentTextPart,
   AgentToolCallPart,
@@ -1276,15 +1278,23 @@ export type {
   AgentUiMessagePart,
   AgentUiToolPart,
   DefineAgentConfig,
+  RequestAgentRunInput,
+  RequestAgentRunResult,
 } from "./agents"
 export {
   AGENT_MESSAGE_CONTENT_VERSION,
   AgentDefinitionError,
   AgentMessageAdapterError,
+  AgentRequestError,
   AgentsRuntime,
+  createAgentMessageId,
+  createAgentRunId,
+  createAgentRunLeaseId,
+  createAgentThreadId,
   defineAgent,
   fromAiSdk,
   isAgentDefinition,
+  requestAgentRun,
   toModelMessages,
   toUiMessage,
 } from "./agents"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -929,7 +929,7 @@ export { InMemoryQueues, QueueError } from "./queues"
 // ── Workers ────────────────────────────────────────────────
 
 export type { QueueWorkerConfig, QueueWorkerFailureDecision } from "./workers"
-export { QueueWorker, Worker, WorkerAbortError } from "./workers"
+export { isAbortError, QueueWorker, Worker, WorkerAbortError } from "./workers"
 
 // ── Sandboxes ──────────────────────────────────────────────
 

--- a/packages/core/src/queues/in-memory.ts
+++ b/packages/core/src/queues/in-memory.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto"
 import { QueueError } from "./errors"
 import type {
   ActionRunRequestedQueueJob,
+  AgentRunRequestedQueueJob,
   ClaimedQueueJob,
   NewQueueJob,
   PipelineRunRequestedQueueJob,
@@ -348,4 +349,5 @@ export class InMemoryQueues implements Queues {
   )
   readonly workflows = new InMemoryQueue<WorkflowQueueJob>(this.store, "workflow.runs")
   readonly actions = new InMemoryQueue<ActionRunRequestedQueueJob>(this.store, "action.runs")
+  readonly agents = new InMemoryQueue<AgentRunRequestedQueueJob>(this.store, "agent.runs")
 }

--- a/packages/core/src/queues/index.ts
+++ b/packages/core/src/queues/index.ts
@@ -2,6 +2,7 @@ export { QueueError } from "./errors"
 export { InMemoryQueues } from "./in-memory"
 export type {
   ActionRunRequestedQueueJob,
+  AgentRunRequestedQueueJob,
   ClaimedQueueJob,
   NewQueueJob,
   PipelineRunRequestedQueueJob,

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -159,10 +159,26 @@ export interface ActionRunRequestedQueueJob
     }
   > {}
 
+/**
+ * An agent turn is requested for a thread. The payload carries only the *intent* — the worker
+ * generates the run id and reserves the run at claim time (reserve-at-claim), so it owns the
+ * `agent_runs` lease from birth and there is never an orphan run between request and pickup.
+ */
+export interface AgentRunRequestedQueueJob
+  extends QueueJob<
+    "agent.run.requested",
+    {
+      readonly agentId: string
+      readonly threadId: string
+      readonly triggerMessageId: string
+    }
+  > {}
+
 export interface Queues {
   readonly syncRuns: Queue<SyncRunRequestedQueueJob>
   readonly pipelines: Queue<PipelineRunRequestedQueueJob>
   readonly projections: Queue<ProjectionRunRequestedQueueJob>
   readonly workflows: Queue<WorkflowQueueJob>
   readonly actions: Queue<ActionRunRequestedQueueJob>
+  readonly agents: Queue<AgentRunRequestedQueueJob>
 }

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -299,7 +299,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       }
       agentIds.add(agent.id)
     }
-    this.agents = new AgentsRuntime(agents)
+    this.agents = new AgentsRuntime(this.runtimeContext, agents)
 
     const { objectProjections, linkProjections, telemetryProjections } = categorizeProjections(
       options.projections ?? []

--- a/packages/core/src/workers/index.ts
+++ b/packages/core/src/workers/index.ts
@@ -1,4 +1,4 @@
 export { WorkerAbortError } from "./errors"
 export type { QueueWorkerConfig, QueueWorkerFailureDecision } from "./queue-worker"
-export { QueueWorker } from "./queue-worker"
+export { isAbortError, QueueWorker } from "./queue-worker"
 export { Worker } from "./worker"

--- a/packages/core/src/workers/queue-worker.ts
+++ b/packages/core/src/workers/queue-worker.ts
@@ -143,7 +143,8 @@ function toQueueJobError(error: unknown): QueueJobError {
   return { message: String(error) }
 }
 
-function isAbortError(error: unknown): boolean {
+/** True for a standard abort (`AbortController`/`AbortSignal.timeout`) error. */
+export function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError"
 }
 

--- a/queues/bullmq/src/bullmq-queues.ts
+++ b/queues/bullmq/src/bullmq-queues.ts
@@ -1,5 +1,6 @@
 import type {
   ActionRunRequestedQueueJob,
+  AgentRunRequestedQueueJob,
   PipelineRunRequestedQueueJob,
   ProjectionRunRequestedQueueJob,
   Queues,
@@ -73,6 +74,7 @@ export class BullMqQueues implements Queues {
   readonly projections: BullMqQueue<ProjectionRunRequestedQueueJob>
   readonly workflows: BullMqQueue<WorkflowQueueJob>
   readonly actions: BullMqQueue<ActionRunRequestedQueueJob>
+  readonly agents: BullMqQueue<AgentRunRequestedQueueJob>
 
   private readonly connections: BullMqConnections
 
@@ -94,6 +96,7 @@ export class BullMqQueues implements Queues {
     this.projections = new BullMqQueue<ProjectionRunRequestedQueueJob>(shared, "projection.runs")
     this.workflows = new BullMqQueue<WorkflowQueueJob>(shared, "workflow.runs")
     this.actions = new BullMqQueue<ActionRunRequestedQueueJob>(shared, "action.runs")
+    this.agents = new BullMqQueue<AgentRunRequestedQueueJob>(shared, "agent.runs")
   }
 
   async close(): Promise<void> {
@@ -103,6 +106,7 @@ export class BullMqQueues implements Queues {
       this.projections.close(),
       this.workflows.close(),
       this.actions.close(),
+      this.agents.close(),
     ])
     // Short grace so a just-dispatched Redis command (typically the final stalled-check tick)
     // can settle on the socket before owned IORedis handles are quit. No-op when connections

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -32,6 +32,9 @@
       "path": "packages/action-worker/tsconfig.build.json"
     },
     {
+      "path": "packages/agent-worker/tsconfig.build.json"
+    },
+    {
       "path": "packages/app/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "noEmit": true,
     "paths": {
       "@sixb/action-worker": ["./packages/action-worker/src/index.ts"],
+      "@sixb/agent-worker": ["./packages/agent-worker/src/index.ts"],
       "@sixb/app": ["./packages/app/src/index.ts"],
       "@sixb/atlas": ["./packages/atlas/src/index.ts"],
       "@sixb/auth-magic-link": ["./auth/magic-link/src/index.ts"],


### PR DESCRIPTION
# Agents: worker loop — persist a full agent run end-to-end

A message sent to an agent now runs and persists end-to-end, through a **queue + a listening worker** (the sixb DNA). No HTTP/WS surface and no real sandbox yet — this is the loop + persistence spine.

## How a turn flows

```mermaid
sequenceDiagram
    participant C as Caller<br/>(sixb.agents.request)
    participant S as Agent storage
    participant Q as Queue · agents lane
    participant W as AgentWorker
    participant M as Model · AI SDK v6

    C->>S: append user message (runId = null)
    C->>Q: enqueue intent {agentId, threadId, triggerMessageId}
    W->>Q: claim
    W->>S: reserve run + lease  «single-flight»
    W->>S: list thread history
    W->>M: streamText(history, tools, stopWhen)
    Note over W,S: heartbeat keeps the lease alive during the turn
    M-->>W: assistant message (text · reasoning · tool calls)
    W->>S: append assistant message
    W->>S: finish run (usage, finishReason)  «fenced on lease»
    W->>Q: complete
```

**Reserve-at-claim:** the trigger only persists the user message and enqueues an *intent* — the worker mints the run id and lease when it claims, so there's never an orphan run between request and pickup.

## What's included

| Area | Change |
| --- | --- |
| 🧵 Queue | New `agents` lane (in-memory + BullMQ) |
| ⚡ Trigger | `sixb.agents.request(...)` → persists the user message + enqueues the intent |
| 🤖 Worker | New `@sixb/agent-worker`: streamText loop, lease heartbeat, run persistence |
| 🏠 Cohosting | CLI starts the worker automatically when agents are registered |

## Liveness & safety (2 layers)

- **Queue** delivers and redelivers on lease expiry. The **`agent_runs` lease** is the *sole authority* on who may write — every write is fenced on the lease id.
- **Crash** → another worker reclaims the run on redelivery · **shutdown** → run `cancelled` · **model/tool error** → run `failed` (fate lives on the record, job is acked) · **zombie** (lease reclaimed mid-turn) → writes nothing.
- **Single-flight**: one active run per thread; a 2nd message during an active run is rejected (V1).

## Not in this slice

HTTP routes / WebSocket · broker streaming (the `StreamSink` seam is a no-op for now) · real sandbox + `bash` tools · live token streaming / reactivity.

## Heads-up for review

- One core adapter tweak: inbound UI-message provider metadata is now `unknown` (was `JsonValue`) so a real AI SDK v6 `UIMessage` assigns without a cast — `fromAiSdk` still validates it to JSON at runtime. Locked by `ai-sdk-compat.types.ts`.
- `toModelMessages(...) as ModelMessage[]` is a single, documented boundary cast at the `streamText` call (only `providerOptions` width differs).

## Verified

Full repo typecheck ✓ · `@sixb/agent-worker` 7/7 · core 932 · agents 51 · BullMQ typecheck ✓ · CLI 95/95 · `generate:client` zero drift (no routes) · Biome clean.

