### PR TITLE
meta: add Meta connector for Instagram & Facebook reads

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,18 @@
         "typescript": "^5.7.0",
       },
     },
+    "connectors/meta": {
+      "name": "@sixb/connector-meta",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sixb/connector-rest": "workspace:*",
+        "@sixb/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "connectors/rest": {
       "name": "@sixb/connector-rest",
       "version": "0.1.0",
@@ -893,6 +905,8 @@
     "@sixb/connector-companycam": ["@sixb/connector-companycam@workspace:connectors/companycam"],
 
     "@sixb/connector-github": ["@sixb/connector-github@workspace:connectors/github"],
+
+    "@sixb/connector-meta": ["@sixb/connector-meta@workspace:connectors/meta"],
 
     "@sixb/connector-rest": ["@sixb/connector-rest@workspace:connectors/rest"],
 

--- a/connectors/meta/README.md
+++ b/connectors/meta/README.md
@@ -1,0 +1,147 @@
+# @sixb/connector-meta
+
+A Meta connector for Sixb, built on `@sixb/connector-rest`. It is a thin,
+read-only, one-to-one client over the Graph API for Facebook Pages and Instagram
+Business/Creator accounts — one method per node/edge, nothing more.
+
+- **Pages** — list Facebook Pages and their linked Instagram accounts (`/me/accounts`)
+- **Instagram** — read the user profile, list media and stories, read account- and media-level insights
+- **Facebook** — read the Page profile, list published Page posts, read Page-level insights
+
+The connector stays metric-agnostic and returns Graph responses faithfully: it does
+not flatten attachments, coerce timestamps, reorder insights, or bake in a metric
+taxonomy. Account selection, metric choice, and row shaping are the project's job.
+
+## Register
+
+Drop this in your project's `connectors/` directory — `createSixb()` auto-discovers it:
+
+```ts
+import { defineConnector } from "@sixb/core"
+import { meta } from "@sixb/connector-meta"
+
+export const metaConnector = defineConnector(
+  "meta",
+  meta({
+    accessToken: process.env.META_GRAPH_ACCESS_TOKEN!,
+  })
+)
+```
+
+| Option         | Description                                                                       |
+| -------------- | --------------------------------------------------------------------------------- |
+| `accessToken`  | **Required.** Long-lived User or System-User access token.                        |
+| `graphVersion` | Graph API version segment. Defaults to `v23.0`.                                   |
+| `baseUrl`      | Full base URL override (takes precedence over `graphVersion`). Mainly for tests.  |
+| `maxRetries`   | Retries on 429/5xx responses. Defaults to `2`.                                    |
+| `timeoutMs`    | Per-request timeout in milliseconds.                                              |
+
+**Tokens.** The `accessToken` authorizes Page discovery (`/me/accounts`) and Instagram
+reads. `/me/accounts` returns a per-Page access token on each Page — pass it to
+`client.facebook(id, { accessToken })` for Page-level reads. The connector does not
+refresh tokens; supply a valid long-lived token.
+
+## Client API
+
+```ts
+const meta = await sixb.connector(metaConnector)
+```
+
+The client mirrors the Graph API graph:
+
+| API                                                  | Graph endpoint                       |
+| ---------------------------------------------------- | ------------------------------------ |
+| `meta.pages.list()` / `.listAll()`                   | `GET /me/accounts`                   |
+| `meta.instagram(id).get()`                           | `GET /{ig-user-id}`                  |
+| `meta.instagram(id).media.list()` / `.listAll()`     | `GET /{ig-user-id}/media`            |
+| `meta.instagram(id).stories.list()` / `.listAll()`   | `GET /{ig-user-id}/stories`          |
+| `meta.instagram(id).insights.get()`                  | `GET /{ig-user-id}/insights`         |
+| `meta.instagramMedia(id).insights.get()`             | `GET /{ig-media-id}/insights`        |
+| `meta.facebook(id, { accessToken }).get()`           | `GET /{page-id}`                     |
+| `meta.facebook(id, { accessToken }).posts.list()` / `.listAll()` | `GET /{page-id}/published_posts` |
+| `meta.facebook(id, { accessToken }).insights.get()`  | `GET /{page-id}/insights`            |
+
+> **Why `pages`, not `accounts`?** Meta's `/me/accounts` edge is a historical name —
+> it returns the Facebook **Pages** the token manages (`MetaFacebookPage`), each with
+> its linked `instagram_business_account`. It's named `pages` here to describe what it
+> returns and to avoid confusion with Instagram accounts (`meta.instagram(id)`).
+
+```ts
+// Pages and their linked Instagram accounts.
+for await (const page of meta.pages.listAll()) {
+  const ig = page.instagram_business_account
+  if (ig) {
+    // Instagram media, with insights expanded inline.
+    for await (const media of meta.instagram(ig.id).media.listAll({
+      metrics: ["views", "total_interactions"],
+    })) {
+      // media.insights is populated by the inline expansion
+    }
+  }
+
+  // Facebook posts, scoped with the Page access token from /me/accounts.
+  const fb = meta.facebook(page.id, { accessToken: page.access_token })
+  for await (const post of fb.posts.listAll({ since: new Date("2026-01-01") })) {
+    // post.attachments is the full array; post.created_time is the raw API string
+  }
+}
+
+// Account-level insights — the caller owns metric selection and metric_type.
+const insights = await meta.instagram("17841400000000000").insights.get({
+  metrics: ["views", "total_interactions"],
+  period: "day",
+  metricType: "total_value",
+  since: new Date("2026-01-01"),
+  until: new Date("2026-01-08"),
+})
+```
+
+### Fields
+
+Every list and `get` method takes an optional `fields` array. It defaults to a sensible
+selection exported for reuse — `DEFAULT_PAGE_FIELDS`, `DEFAULT_INSTAGRAM_USER_FIELDS`,
+`DEFAULT_INSTAGRAM_MEDIA_FIELDS`, `DEFAULT_INSTAGRAM_STORY_FIELDS`,
+`DEFAULT_FACEBOOK_PAGE_FIELDS`, `DEFAULT_FACEBOOK_POST_FIELDS`. Pass `metrics` to
+`media.list`, `stories.list`, or `posts.list` to expand insights inline via
+`insights.metric(...)` (the only way to capture story insights while a story is live).
+
+### Pagination
+
+List methods return a **single page** envelope. Pass `nextCursor` back as `after` to
+fetch the next page, or use `listAll()` to follow `paging.next` to exhaustion:
+
+```ts
+let after: string | undefined
+do {
+  const page = await meta.instagram(igUserId).media.list({ limit: 100, after })
+  // handle page.items
+  after = page.hasMore ? page.nextCursor : undefined
+} while (after)
+```
+
+## Insights & metric deprecations
+
+The connector is **metric-agnostic**: it passes `metrics`, `period`, `metricType`,
+`since`, `until`, and `breakdown` straight through. Meta requires some metrics to be
+requested with `metricType: "total_value"` and forbids mixing incompatible metrics in
+one call — partitioning metrics by type is the **caller's** responsibility, because
+Meta's valid metric set changes frequently. Notable recent changes:
+
+- **Instagram** (Jan 2025): `profile_views`, `website_clicks`, `email_contacts`, and
+  non-Reels `video_views` were deprecated. `impressions` is replaced by `views`.
+- **Facebook Pages** (Nov 2025): `page_impressions` → `page_media_view`; `page_fans` →
+  `page_follows`; `post_impressions` → `post_media_view`. A broader set of legacy Page
+  metrics was deprecated across **all** API versions in June 2026 — calling them returns
+  an invalid-metric error.
+
+Validate metric names against the live Graph API for your `graphVersion`.
+
+## Notes
+
+- **Read-only.** This connector issues `GET` requests only.
+- **Faithful responses.** Attachments are returned as a full array, timestamps as raw
+  API strings, and insights in API order. Flatten or normalize in your project layer.
+- **No account orchestration.** Deduping Pages/accounts and filtering to a specific
+  Page or Instagram account is project policy — build it on top of `pages.listAll()`.
+- **Webhooks** are out of scope (this is a sync/read use case). They can be added later
+  via `defineWebhook` from `@sixb/core`.

--- a/connectors/meta/package.json
+++ b/connectors/meta/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@sixb/connector-meta",
+  "version": "0.1.0",
+  "description": "Meta connector for Sixb — Instagram & Facebook Page reads via the Graph API",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun ../../scripts/build-package.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "prepack": "bun run build"
+  },
+  "dependencies": {
+    "@sixb/connector-rest": "workspace:*",
+    "@sixb/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ]
+}

--- a/connectors/meta/src/client.ts
+++ b/connectors/meta/src/client.ts
@@ -1,0 +1,16 @@
+import type { RestClient } from "@sixb/connector-rest"
+import type { MetaHttpContext } from "./http"
+import { createFacebookPageApi } from "./resources/facebook"
+import { createInstagramMediaApi, createInstagramUserApi } from "./resources/instagram"
+import { createPagesApi } from "./resources/pages"
+import type { MetaClient } from "./types/client"
+
+export function createMetaClient(http: RestClient): MetaClient {
+  const context: MetaHttpContext = { http }
+  return {
+    pages: createPagesApi(context),
+    instagram: (igUserId) => createInstagramUserApi(context, igUserId),
+    instagramMedia: (mediaId) => createInstagramMediaApi(context, mediaId),
+    facebook: (pageId, options) => createFacebookPageApi(context, pageId, options),
+  }
+}

--- a/connectors/meta/src/fields.ts
+++ b/connectors/meta/src/fields.ts
@@ -1,0 +1,82 @@
+/**
+ * Default field selections for each Graph API edge.
+ *
+ * Every list method accepts a `fields` option to override these. They are exported so
+ * callers can extend or trim the selection without restating the full list.
+ */
+
+/** Fields for `GET /me/accounts`, including the linked IG account and the Page access token. */
+export const DEFAULT_PAGE_FIELDS = [
+  "id",
+  "name",
+  "access_token",
+  "instagram_business_account{id,username,name,followers_count,media_count}",
+] as const
+
+/** Fields for `GET /{ig-user-id}` — the IG User profile node. */
+export const DEFAULT_INSTAGRAM_USER_FIELDS = [
+  "id",
+  "username",
+  "name",
+  "biography",
+  "website",
+  "profile_picture_url",
+  "followers_count",
+  "follows_count",
+  "media_count",
+] as const
+
+/** Fields for `GET /{page-id}` — the Facebook Page profile node (audience size). */
+export const DEFAULT_FACEBOOK_PAGE_FIELDS = ["id", "name", "fan_count", "followers_count"] as const
+
+/** Fields for `GET /{ig-user-id}/media`. `children{...}` expands carousel items. */
+export const DEFAULT_INSTAGRAM_MEDIA_FIELDS = [
+  "id",
+  "caption",
+  "media_type",
+  "media_product_type",
+  "media_url",
+  "thumbnail_url",
+  "permalink",
+  "timestamp",
+  "username",
+  "like_count",
+  "comments_count",
+  "children{id,media_type,media_url,permalink,timestamp,thumbnail_url}",
+] as const
+
+/** Fields for `GET /{ig-user-id}/stories`. Stories have no carousel children. */
+export const DEFAULT_INSTAGRAM_STORY_FIELDS = [
+  "id",
+  "caption",
+  "media_type",
+  "media_product_type",
+  "media_url",
+  "thumbnail_url",
+  "permalink",
+  "timestamp",
+  "username",
+  "like_count",
+  "comments_count",
+] as const
+
+/**
+ * Fields for `GET /{page-id}/published_posts`.
+ *
+ * `comments.summary(true).limit(0)` and `reactions.summary(total_count).limit(0)` are Graph
+ * field-expansion shorthand for "give me the aggregate count, not the rows" — `limit(0)`
+ * suppresses the nested data while `summary(...)` includes the `total_count`. `shares`
+ * carries `{ count }`. `attachments{...}` returns every attachment on the post.
+ */
+export const DEFAULT_FACEBOOK_POST_FIELDS = [
+  "id",
+  "message",
+  "story",
+  "created_time",
+  "permalink_url",
+  "status_type",
+  "comments.summary(true).limit(0)",
+  "reactions.summary(total_count).limit(0)",
+  "shares",
+  "attachments{title,description,url,type,media,target}",
+] as const

--- a/connectors/meta/src/http.ts
+++ b/connectors/meta/src/http.ts
@@ -1,0 +1,151 @@
+import type { RestClient } from "@sixb/connector-rest"
+import type { InsightsQuery, MetaInsight, MetaPage } from "./types/common"
+
+export interface MetaHttpContext {
+  readonly http: RestClient
+}
+
+/** Raised when the Graph API returns a non-2xx response. The raw error body is preserved. */
+export class MetaApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string
+  ) {
+    super(`[SixbMeta] Graph API request failed with ${status}: ${body || "(empty body)"}`)
+    this.name = "MetaApiError"
+  }
+}
+
+/** The standard Graph API list envelope with cursor pagination. */
+interface MetaListResponse<T> {
+  readonly data?: readonly T[]
+  readonly paging?: {
+    readonly cursors?: { readonly before?: string; readonly after?: string }
+    readonly next?: string
+    readonly previous?: string
+  }
+}
+
+export async function readJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    throw new MetaApiError(response.status, await response.text().catch(() => ""))
+  }
+  return (await response.json()) as T
+}
+
+/** Read a Graph list envelope into a `MetaPage`, mapping each raw item to a domain type. */
+export async function readPage<TRaw, TItem>(
+  response: Response,
+  map: (raw: TRaw) => TItem
+): Promise<MetaPage<TItem>> {
+  const body = await readJson<MetaListResponse<TRaw>>(response)
+  const items = (body.data ?? []).map(map)
+  const hasMore = body.paging?.next !== undefined
+  return { items, hasMore, nextCursor: hasMore ? body.paging?.cursors?.after : undefined }
+}
+
+/** Read a single Graph node, mapping the raw object to a domain type. */
+export async function readObject<TRaw, TItem>(
+  response: Response,
+  map: (raw: TRaw) => TItem
+): Promise<TItem> {
+  return map(await readJson<TRaw>(response))
+}
+
+/** Read a Graph list envelope of insights, returned in API order. */
+export async function readInsights(response: Response): Promise<readonly MetaInsight[]> {
+  const body = await readJson<MetaListResponse<RawInsight>>(response)
+  return (body.data ?? []).map(toInsight)
+}
+
+/**
+ * Drive an edge to exhaustion by following its `after` cursor.
+ *
+ * Re-requests against the relative path with `after=<cursor>` rather than blindly
+ * following the absolute `paging.next` URL, keeping every request on the configured base.
+ */
+export async function* paginate<TItem>(
+  fetchPage: (after: string | undefined) => Promise<MetaPage<TItem>>
+): AsyncIterable<TItem> {
+  let after: string | undefined
+  for (;;) {
+    const page = await fetchPage(after)
+    for (const item of page.items) {
+      yield item
+    }
+    if (!page.hasMore || !page.nextCursor) {
+      break
+    }
+    after = page.nextCursor
+  }
+}
+
+/** Build a relative path with a query string, skipping `undefined` values. */
+export function withQuery(
+  path: string,
+  params: Record<string, string | number | undefined>
+): string {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      search.set(key, String(value))
+    }
+  }
+  const query = search.toString()
+  return query ? `${path}?${query}` : path
+}
+
+/** Build an `/insights` request path from a metric-agnostic query. */
+export function insightsPath(path: string, query: InsightsQuery): string {
+  return withQuery(path, {
+    metric: query.metrics.join(","),
+    period: query.period,
+    metric_type: query.metricType,
+    since: query.since ? toUnixSeconds(query.since) : undefined,
+    until: query.until ? toUnixSeconds(query.until) : undefined,
+    breakdown: query.breakdown?.length ? query.breakdown.join(",") : undefined,
+  })
+}
+
+/** Bearer-token header override for a single request, or `undefined` to use the default token. */
+export function authInit(accessToken: string | undefined): RequestInit | undefined {
+  return accessToken ? { headers: { Authorization: `Bearer ${accessToken}` } } : undefined
+}
+
+export function toUnixSeconds(date: Date): number {
+  return Math.trunc(date.getTime() / 1000)
+}
+
+export function assertNonEmpty(value: string, field: string): void {
+  if (!value?.trim()) {
+    throw new Error(`[SixbMeta] ${field} must not be empty.`)
+  }
+}
+
+/** Validate and encode a Graph node id for use as a path segment. */
+export function nodePath(value: string, field: string): string {
+  assertNonEmpty(value, field)
+  return encodeURIComponent(value)
+}
+
+interface RawInsight {
+  readonly name: string
+  readonly period?: string
+  readonly title?: string
+  readonly description?: string
+  readonly values?: readonly { readonly value?: unknown; readonly end_time?: string }[]
+  readonly total_value?: unknown
+  readonly id?: string
+}
+
+function toInsight(raw: RawInsight): MetaInsight {
+  return {
+    name: raw.name,
+    period: raw.period,
+    title: raw.title,
+    description: raw.description,
+    values: raw.values,
+    total_value: raw.total_value,
+    id: raw.id,
+  }
+}

--- a/connectors/meta/src/index.ts
+++ b/connectors/meta/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  DEFAULT_FACEBOOK_PAGE_FIELDS,
+  DEFAULT_FACEBOOK_POST_FIELDS,
+  DEFAULT_INSTAGRAM_MEDIA_FIELDS,
+  DEFAULT_INSTAGRAM_STORY_FIELDS,
+  DEFAULT_INSTAGRAM_USER_FIELDS,
+  DEFAULT_PAGE_FIELDS,
+} from "./fields"
+export { MetaApiError } from "./http"
+export type { MetaConnector } from "./meta"
+export { meta } from "./meta"
+export type * from "./types/index"

--- a/connectors/meta/src/meta.ts
+++ b/connectors/meta/src/meta.ts
@@ -1,0 +1,51 @@
+import { rest } from "@sixb/connector-rest"
+import type { ConnectorAdapter } from "@sixb/core"
+import { createMetaClient } from "./client"
+import { assertNonEmpty } from "./http"
+import type { MetaClient } from "./types/client"
+import type { MetaConnectorOptions } from "./types/options"
+
+const GRAPH_API_HOST = "https://graph.facebook.com"
+const DEFAULT_GRAPH_VERSION = "v23.0"
+
+export type MetaConnector = ConnectorAdapter<"meta", MetaClient>
+
+/**
+ * Meta connector built on `@sixb/connector-rest`.
+ *
+ * Returns a typed, read-only client over the Graph API for Facebook Pages and
+ * Instagram Business/Creator accounts. The default user/system token authorizes
+ * Page discovery and Instagram reads; scope Facebook Page reads with a Page access
+ * token via `client.facebook(id, { accessToken })`.
+ *
+ * Register it from a project's `connectors/` directory:
+ *
+ * ```ts
+ * export const metaConnector = defineConnector("meta", meta({
+ *   accessToken: process.env.META_GRAPH_ACCESS_TOKEN!,
+ * }))
+ * ```
+ */
+export function meta(options: MetaConnectorOptions): MetaConnector {
+  assertNonEmpty(options.accessToken, "accessToken")
+
+  const version = options.graphVersion ?? DEFAULT_GRAPH_VERSION
+  const baseUrl = options.baseUrl ?? `${GRAPH_API_HOST}/${version}/`
+
+  const http = rest({
+    baseUrl,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${options.accessToken}`,
+    },
+    retry: { maxRetries: options.maxRetries ?? 2 },
+    timeoutMs: options.timeoutMs,
+  })
+
+  return {
+    type: "meta",
+    async connect(context) {
+      return createMetaClient(await http.connect(context))
+    },
+  }
+}

--- a/connectors/meta/src/resources/facebook.ts
+++ b/connectors/meta/src/resources/facebook.ts
@@ -1,0 +1,131 @@
+import { DEFAULT_FACEBOOK_PAGE_FIELDS, DEFAULT_FACEBOOK_POST_FIELDS } from "../fields"
+import {
+  authInit,
+  insightsPath,
+  type MetaHttpContext,
+  nodePath,
+  paginate,
+  readInsights,
+  readObject,
+  readPage,
+  toUnixSeconds,
+  withQuery,
+} from "../http"
+import type { InsightsQuery, MetaInsight, MetaPage } from "../types/common"
+import type {
+  FacebookPageApi,
+  MetaFacebookAttachment,
+  MetaFacebookPageProfile,
+  MetaFacebookPost,
+  PostsListOptions,
+} from "../types/facebook"
+
+export function createFacebookPageApi(
+  context: MetaHttpContext,
+  pageId: string,
+  options?: { readonly accessToken?: string }
+): FacebookPageApi {
+  const page = nodePath(pageId, "pageId")
+  const init = authInit(options?.accessToken)
+
+  return {
+    get: (getOptions) => {
+      const requested = withQuery(page, {
+        fields: (getOptions?.fields ?? DEFAULT_FACEBOOK_PAGE_FIELDS).join(","),
+      })
+      return context.http
+        .get(requested, init)
+        .then((response) => readObject(response, toPageProfile))
+    },
+    posts: {
+      list: (listOptions) =>
+        listPosts(context, `${page}/published_posts`, listOptions, listOptions?.after, init),
+      listAll: (listOptions) =>
+        paginate((after) =>
+          listPosts(context, `${page}/published_posts`, listOptions, after, init)
+        ),
+    },
+    insights: {
+      get: (query) => getInsights(context, `${page}/insights`, query, init),
+    },
+  }
+}
+
+function listPosts(
+  context: MetaHttpContext,
+  path: string,
+  options: PostsListOptions | undefined,
+  after: string | undefined,
+  init: RequestInit | undefined
+): Promise<MetaPage<MetaFacebookPost>> {
+  const baseFields = options?.fields ?? DEFAULT_FACEBOOK_POST_FIELDS
+  const fields = options?.metrics?.length
+    ? [...baseFields, `insights.metric(${options.metrics.join(",")}).period(lifetime)`]
+    : baseFields
+  const requested = withQuery(path, {
+    fields: fields.join(","),
+    limit: options?.limit ?? 100,
+    since: options?.since ? toUnixSeconds(options.since) : undefined,
+    until: options?.until ? toUnixSeconds(options.until) : undefined,
+    after,
+  })
+  return context.http.get(requested, init).then((response) => readPage(response, toPost))
+}
+
+function getInsights(
+  context: MetaHttpContext,
+  path: string,
+  query: InsightsQuery,
+  init: RequestInit | undefined
+): Promise<readonly MetaInsight[]> {
+  if (query.metrics.length === 0) {
+    return Promise.resolve([])
+  }
+  return context.http.get(insightsPath(path, query), init).then(readInsights)
+}
+
+interface RawPageProfile {
+  readonly id: string
+  readonly name?: string
+  readonly fan_count?: number
+  readonly followers_count?: number
+}
+
+function toPageProfile(raw: RawPageProfile): MetaFacebookPageProfile {
+  return {
+    id: raw.id,
+    name: raw.name,
+    fan_count: raw.fan_count,
+    followers_count: raw.followers_count,
+  }
+}
+
+interface RawPost {
+  readonly id: string
+  readonly message?: string
+  readonly story?: string
+  readonly created_time?: string
+  readonly permalink_url?: string
+  readonly status_type?: string
+  readonly comments?: { readonly summary?: { readonly total_count?: number } }
+  readonly reactions?: { readonly summary?: { readonly total_count?: number } }
+  readonly shares?: { readonly count?: number }
+  readonly attachments?: { readonly data?: readonly MetaFacebookAttachment[] }
+  readonly insights?: { readonly data?: readonly MetaInsight[] }
+}
+
+function toPost(raw: RawPost): MetaFacebookPost {
+  return {
+    id: raw.id,
+    message: raw.message,
+    story: raw.story,
+    created_time: raw.created_time,
+    permalink_url: raw.permalink_url,
+    status_type: raw.status_type,
+    attachments: raw.attachments?.data,
+    reactions_count: raw.reactions?.summary?.total_count,
+    comments_count: raw.comments?.summary?.total_count,
+    shares_count: raw.shares?.count,
+    insights: raw.insights?.data,
+  }
+}

--- a/connectors/meta/src/resources/instagram.ts
+++ b/connectors/meta/src/resources/instagram.ts
@@ -1,0 +1,173 @@
+import {
+  DEFAULT_INSTAGRAM_MEDIA_FIELDS,
+  DEFAULT_INSTAGRAM_STORY_FIELDS,
+  DEFAULT_INSTAGRAM_USER_FIELDS,
+} from "../fields"
+import {
+  insightsPath,
+  type MetaHttpContext,
+  nodePath,
+  paginate,
+  readInsights,
+  readObject,
+  readPage,
+  withQuery,
+} from "../http"
+import type { InsightsQuery, MetaInsight, MetaPage } from "../types/common"
+import type {
+  InstagramMediaApi,
+  InstagramUserApi,
+  MediaListOptions,
+  MetaInstagramMedia,
+  MetaInstagramMediaChild,
+  MetaInstagramUser,
+  StoriesListOptions,
+} from "../types/instagram"
+
+export function createInstagramUserApi(
+  context: MetaHttpContext,
+  igUserId: string
+): InstagramUserApi {
+  const userPath = nodePath(igUserId, "igUserId")
+
+  return {
+    get: (options) => {
+      const requested = withQuery(userPath, {
+        fields: (options?.fields ?? DEFAULT_INSTAGRAM_USER_FIELDS).join(","),
+      })
+      return context.http.get(requested).then((response) => readObject(response, toInstagramUser))
+    },
+    media: {
+      list: (options) => listMedia(context, `${userPath}/media`, options, options?.after),
+      listAll: (options) =>
+        paginate((after) => listMedia(context, `${userPath}/media`, options, after)),
+    },
+    stories: {
+      list: (options) => listStories(context, `${userPath}/stories`, options, options?.after),
+      listAll: (options) =>
+        paginate((after) => listStories(context, `${userPath}/stories`, options, after)),
+    },
+    insights: {
+      get: (options) => getInsights(context, `${userPath}/insights`, options),
+    },
+  }
+}
+
+export function createInstagramMediaApi(
+  context: MetaHttpContext,
+  mediaId: string
+): InstagramMediaApi {
+  const path = `${nodePath(mediaId, "mediaId")}/insights`
+  return {
+    insights: {
+      get: ({ metrics }) => getInsights(context, path, { metrics }),
+    },
+  }
+}
+
+function listMedia(
+  context: MetaHttpContext,
+  path: string,
+  options: MediaListOptions | undefined,
+  after: string | undefined
+): Promise<MetaPage<MetaInstagramMedia>> {
+  const baseFields = options?.fields ?? DEFAULT_INSTAGRAM_MEDIA_FIELDS
+  const fields = options?.metrics?.length
+    ? [...baseFields, `insights.metric(${options.metrics.join(",")})`]
+    : baseFields
+  const requested = withQuery(path, {
+    fields: fields.join(","),
+    limit: options?.limit ?? 100,
+    after,
+  })
+  return context.http.get(requested).then((response) => readPage(response, toMedia))
+}
+
+function listStories(
+  context: MetaHttpContext,
+  path: string,
+  options: StoriesListOptions | undefined,
+  after: string | undefined
+): Promise<MetaPage<MetaInstagramMedia>> {
+  const baseFields = options?.fields ?? DEFAULT_INSTAGRAM_STORY_FIELDS
+  const fields = options?.metrics?.length
+    ? [...baseFields, `insights.metric(${options.metrics.join(",")})`]
+    : baseFields
+  const requested = withQuery(path, {
+    fields: fields.join(","),
+    limit: options?.limit ?? 100,
+    after,
+  })
+  return context.http.get(requested).then((response) => readPage(response, toMedia))
+}
+
+function getInsights(
+  context: MetaHttpContext,
+  path: string,
+  query: InsightsQuery
+): Promise<readonly MetaInsight[]> {
+  if (query.metrics.length === 0) {
+    return Promise.resolve([])
+  }
+  return context.http.get(insightsPath(path, query)).then(readInsights)
+}
+
+interface RawInstagramUser {
+  readonly id: string
+  readonly username?: string
+  readonly name?: string
+  readonly biography?: string
+  readonly website?: string
+  readonly profile_picture_url?: string
+  readonly followers_count?: number
+  readonly follows_count?: number
+  readonly media_count?: number
+}
+
+function toInstagramUser(raw: RawInstagramUser): MetaInstagramUser {
+  return {
+    id: raw.id,
+    username: raw.username,
+    name: raw.name,
+    biography: raw.biography,
+    website: raw.website,
+    profile_picture_url: raw.profile_picture_url,
+    followers_count: raw.followers_count,
+    follows_count: raw.follows_count,
+    media_count: raw.media_count,
+  }
+}
+
+interface RawMedia {
+  readonly id: string
+  readonly caption?: string
+  readonly media_type?: string
+  readonly media_product_type?: string
+  readonly media_url?: string
+  readonly thumbnail_url?: string
+  readonly permalink?: string
+  readonly timestamp?: string
+  readonly username?: string
+  readonly like_count?: number
+  readonly comments_count?: number
+  readonly children?: { readonly data?: readonly MetaInstagramMediaChild[] }
+  readonly insights?: { readonly data?: readonly MetaInsight[] }
+}
+
+function toMedia(raw: RawMedia): MetaInstagramMedia {
+  return {
+    id: raw.id,
+    caption: raw.caption,
+    media_type: raw.media_type,
+    media_product_type: raw.media_product_type,
+    media_url: raw.media_url,
+    thumbnail_url: raw.thumbnail_url,
+    permalink: raw.permalink,
+    timestamp: raw.timestamp,
+    username: raw.username,
+    like_count: raw.like_count,
+    comments_count: raw.comments_count,
+    children: raw.children?.data,
+    insights: raw.insights?.data,
+  }
+}

--- a/connectors/meta/src/resources/pages.ts
+++ b/connectors/meta/src/resources/pages.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_PAGE_FIELDS } from "../fields"
+import { type MetaHttpContext, paginate, readPage, withQuery } from "../http"
+import type { MetaPage } from "../types/common"
+import type { MetaFacebookPage, PagesApi, PagesListOptions } from "../types/pages"
+
+export function createPagesApi(context: MetaHttpContext): PagesApi {
+  return {
+    list: (options) => listPage(context, options, options?.after),
+    listAll: (options) => paginate((after) => listPage(context, options, after)),
+  }
+}
+
+function listPage(
+  context: MetaHttpContext,
+  options: PagesListOptions | undefined,
+  after: string | undefined
+): Promise<MetaPage<MetaFacebookPage>> {
+  const path = withQuery("me/accounts", {
+    fields: (options?.fields ?? DEFAULT_PAGE_FIELDS).join(","),
+    limit: options?.limit ?? 100,
+    after,
+  })
+  return context.http.get(path).then((response) => readPage(response, toFacebookPage))
+}
+
+interface RawPage {
+  readonly id: string
+  readonly name?: string
+  readonly access_token?: string
+  readonly instagram_business_account?: {
+    readonly id: string
+    readonly username?: string
+    readonly name?: string
+    readonly followers_count?: number
+    readonly media_count?: number
+  }
+}
+
+function toFacebookPage(raw: RawPage): MetaFacebookPage {
+  return {
+    id: raw.id,
+    name: raw.name,
+    access_token: raw.access_token,
+    instagram_business_account: raw.instagram_business_account,
+  }
+}

--- a/connectors/meta/src/types/client.ts
+++ b/connectors/meta/src/types/client.ts
@@ -1,0 +1,21 @@
+import type { FacebookPageApi } from "./facebook"
+import type { InstagramMediaApi, InstagramUserApi } from "./instagram"
+import type { PagesApi } from "./pages"
+
+export interface MetaClient {
+  /** `GET /me/accounts` — Facebook Pages and their linked Instagram accounts. */
+  readonly pages: PagesApi
+
+  /** Scope for an Instagram Business/Creator user node. */
+  instagram(igUserId: string): InstagramUserApi
+
+  /** Scope for a single IG media node and its own insights edge. */
+  instagramMedia(mediaId: string): InstagramMediaApi
+
+  /**
+   * Scope for a Facebook Page node. Pass the Page access token (from
+   * `MetaFacebookPage.access_token`) to authorize Page-level reads; without it the
+   * connector falls back to the default user/system token.
+   */
+  facebook(pageId: string, options?: { readonly accessToken?: string }): FacebookPageApi
+}

--- a/connectors/meta/src/types/common.ts
+++ b/connectors/meta/src/types/common.ts
@@ -1,0 +1,59 @@
+/** One page of a cursor-paginated Graph API edge. */
+export interface MetaPage<T> {
+  readonly items: readonly T[]
+  /** True when the Graph API reported a `paging.next` link. */
+  readonly hasMore: boolean
+  /** The `paging.cursors.after` cursor — pass it back as `after` to fetch the next page. */
+  readonly nextCursor?: string
+}
+
+/** Shared cursor-pagination inputs for list edges. */
+export interface MetaPaginationOptions {
+  /** Page size sent as `limit`. Defaults to 100. */
+  readonly limit?: number
+  /** Cursor from a previous page's `nextCursor`, sent as `after`. */
+  readonly after?: string
+}
+
+/**
+ * A measured Graph API metric, returned by an `/insights` edge.
+ *
+ * Returned faithfully: `values` carries time-series points, `total_value` carries
+ * the aggregate for `metric_type=total_value` metrics. Callers decide which to read.
+ */
+export interface MetaInsight {
+  readonly name: string
+  readonly period?: string
+  readonly title?: string
+  readonly description?: string
+  readonly values?: readonly MetaInsightValue[]
+  readonly total_value?: unknown
+  readonly id?: string
+}
+
+export interface MetaInsightValue {
+  readonly value?: unknown
+  readonly end_time?: string
+}
+
+/**
+ * Query for an `/insights` edge.
+ *
+ * The connector stays metric-agnostic: it passes `metrics`, `period`, `metricType`,
+ * `since`, `until`, and `breakdown` straight through. Meta requires some metrics to be
+ * requested with `metric_type=total_value` and forbids mixing incompatible metrics in one
+ * call — that partitioning is the caller's responsibility, not the connector's.
+ */
+export interface InsightsQuery {
+  readonly metrics: readonly string[]
+  /** e.g. "day", "week", "days_28", "lifetime", "total_over_range". */
+  readonly period?: string
+  /** Omit to use the API default (time series). */
+  readonly metricType?: "total_value" | "time_series"
+  /** Lower bound, serialized to Unix seconds. */
+  readonly since?: Date
+  /** Upper bound, serialized to Unix seconds. */
+  readonly until?: Date
+  /** Breakdown dimensions, sent as a comma-separated `breakdown` param. */
+  readonly breakdown?: readonly string[]
+}

--- a/connectors/meta/src/types/facebook.ts
+++ b/connectors/meta/src/types/facebook.ts
@@ -1,0 +1,77 @@
+import type { InsightsQuery, MetaInsight, MetaPage, MetaPaginationOptions } from "./common"
+
+/** An attachment on a Facebook Page post. All attachments are returned, not just the first. */
+export interface MetaFacebookAttachment {
+  readonly title?: string
+  readonly description?: string
+  readonly url?: string
+  readonly type?: string
+  readonly media?: {
+    readonly image?: {
+      readonly src?: string
+      readonly width?: number
+      readonly height?: number
+    }
+  }
+  readonly target?: {
+    readonly id?: string
+    readonly url?: string
+  }
+}
+
+/** A published Facebook Page post. */
+export interface MetaFacebookPost {
+  readonly id: string
+  readonly message?: string
+  readonly story?: string
+  /** Raw Graph API timestamp — passed through unchanged. */
+  readonly created_time?: string
+  readonly permalink_url?: string
+  readonly status_type?: string
+  readonly attachments?: readonly MetaFacebookAttachment[]
+  /** From `reactions.summary.total_count`. */
+  readonly reactions_count?: number
+  /** From `comments.summary.total_count`. */
+  readonly comments_count?: number
+  /** From `shares.count`. */
+  readonly shares_count?: number
+  /** Present when `metrics` were requested inline via `insights.metric(...)` expansion. */
+  readonly insights?: readonly MetaInsight[]
+}
+
+export interface PostsListOptions extends MetaPaginationOptions {
+  /** Field selection. Defaults to `DEFAULT_FACEBOOK_POST_FIELDS`. */
+  readonly fields?: readonly string[]
+  /** When set, requests these insight metrics inline via `insights.metric(...).period(lifetime)`. */
+  readonly metrics?: readonly string[]
+  /** Only posts created at or after this time, serialized to Unix seconds. */
+  readonly since?: Date
+  /** Only posts created before this time, serialized to Unix seconds. */
+  readonly until?: Date
+}
+
+/** The Facebook Page profile node (`GET /{page-id}`), including audience size. */
+export interface MetaFacebookPageProfile {
+  readonly id: string
+  readonly name?: string
+  /** Total Page likes. */
+  readonly fan_count?: number
+  /** Total Page followers. */
+  readonly followers_count?: number
+}
+
+/** Scope for a Facebook Page node. */
+export interface FacebookPageApi {
+  /** `GET /{page-id}` — the Page profile node. */
+  get(options?: { readonly fields?: readonly string[] }): Promise<MetaFacebookPageProfile>
+  readonly posts: {
+    /** One page of `GET /{page-id}/published_posts`. */
+    list(options?: PostsListOptions): Promise<MetaPage<MetaFacebookPost>>
+    /** Every post, following `paging.next` across all pages. */
+    listAll(options?: PostsListOptions): AsyncIterable<MetaFacebookPost>
+  }
+  readonly insights: {
+    /** `GET /{page-id}/insights`. */
+    get(options: InsightsQuery): Promise<readonly MetaInsight[]>
+  }
+}

--- a/connectors/meta/src/types/index.ts
+++ b/connectors/meta/src/types/index.ts
@@ -1,0 +1,31 @@
+export type { MetaClient } from "./client"
+export type {
+  InsightsQuery,
+  MetaInsight,
+  MetaInsightValue,
+  MetaPage,
+  MetaPaginationOptions,
+} from "./common"
+export type {
+  FacebookPageApi,
+  MetaFacebookAttachment,
+  MetaFacebookPageProfile,
+  MetaFacebookPost,
+  PostsListOptions,
+} from "./facebook"
+export type {
+  InstagramMediaApi,
+  InstagramUserApi,
+  MediaListOptions,
+  MetaInstagramMedia,
+  MetaInstagramMediaChild,
+  MetaInstagramUser,
+  StoriesListOptions,
+} from "./instagram"
+export type { MetaConnectorOptions } from "./options"
+export type {
+  MetaFacebookPage,
+  MetaInstagramAccount,
+  PagesApi,
+  PagesListOptions,
+} from "./pages"

--- a/connectors/meta/src/types/instagram.ts
+++ b/connectors/meta/src/types/instagram.ts
@@ -1,0 +1,87 @@
+import type { InsightsQuery, MetaInsight, MetaPage, MetaPaginationOptions } from "./common"
+
+/** The IG User profile node (`GET /{ig-user-id}`). */
+export interface MetaInstagramUser {
+  readonly id: string
+  readonly username?: string
+  readonly name?: string
+  readonly biography?: string
+  readonly website?: string
+  readonly profile_picture_url?: string
+  readonly followers_count?: number
+  readonly follows_count?: number
+  readonly media_count?: number
+}
+
+/** A child item of a carousel (`CAROUSEL_ALBUM`) media. */
+export interface MetaInstagramMediaChild {
+  readonly id: string
+  readonly media_type?: string
+  readonly media_url?: string
+  readonly permalink?: string
+  readonly timestamp?: string
+  readonly thumbnail_url?: string
+}
+
+/** An IG media object (feed post, reel, or story). */
+export interface MetaInstagramMedia {
+  readonly id: string
+  readonly caption?: string
+  readonly media_type?: string
+  readonly media_product_type?: string
+  readonly media_url?: string
+  readonly thumbnail_url?: string
+  readonly permalink?: string
+  /** Raw Graph API timestamp — passed through unchanged. */
+  readonly timestamp?: string
+  readonly username?: string
+  readonly like_count?: number
+  readonly comments_count?: number
+  readonly children?: readonly MetaInstagramMediaChild[]
+  /** Present when `metrics` were requested inline via `insights.metric(...)` expansion. */
+  readonly insights?: readonly MetaInsight[]
+}
+
+export interface MediaListOptions extends MetaPaginationOptions {
+  /** Field selection. Defaults to `DEFAULT_INSTAGRAM_MEDIA_FIELDS`. */
+  readonly fields?: readonly string[]
+  /** When set, requests these insight metrics inline via `insights.metric(...)` expansion. */
+  readonly metrics?: readonly string[]
+}
+
+export interface StoriesListOptions extends MetaPaginationOptions {
+  /** Field selection. Defaults to `DEFAULT_INSTAGRAM_STORY_FIELDS`. */
+  readonly fields?: readonly string[]
+  /** When set, requests these insight metrics inline via `insights.metric(...)` expansion. */
+  readonly metrics?: readonly string[]
+}
+
+/** Scope for an Instagram Business/Creator user node. */
+export interface InstagramUserApi {
+  /** `GET /{ig-user-id}` — the IG User profile node. */
+  get(options?: { readonly fields?: readonly string[] }): Promise<MetaInstagramUser>
+  readonly media: {
+    /** One page of `GET /{ig-user-id}/media`. */
+    list(options?: MediaListOptions): Promise<MetaPage<MetaInstagramMedia>>
+    /** Every media item, following `paging.next` across all pages. */
+    listAll(options?: MediaListOptions): AsyncIterable<MetaInstagramMedia>
+  }
+  readonly stories: {
+    /** One page of `GET /{ig-user-id}/stories`. */
+    list(options?: StoriesListOptions): Promise<MetaPage<MetaInstagramMedia>>
+    /** Every active story, following `paging.next` across all pages. */
+    listAll(options?: StoriesListOptions): AsyncIterable<MetaInstagramMedia>
+  }
+  readonly insights: {
+    /** `GET /{ig-user-id}/insights`. */
+    get(options: InsightsQuery): Promise<readonly MetaInsight[]>
+  }
+}
+
+/** Scope for a single IG media node and its insights edge. */
+export interface InstagramMediaApi {
+  readonly insights: {
+    /** `GET /{ig-media-id}/insights`. */
+    get(options: { readonly metrics: readonly string[] }): Promise<readonly MetaInsight[]>
+  }
+}

--- a/connectors/meta/src/types/options.ts
+++ b/connectors/meta/src/types/options.ts
@@ -1,0 +1,12 @@
+export interface MetaConnectorOptions {
+  /** Long-lived User or System-User access token. Required. */
+  readonly accessToken: string
+  /** Graph API version segment, e.g. "v23.0". Defaults to the connector's pinned version. */
+  readonly graphVersion?: string
+  /** Full base URL override (takes precedence over `graphVersion`). Mainly for tests. */
+  readonly baseUrl?: string
+  /** Max retries on 429/5xx responses. Defaults to 2. */
+  readonly maxRetries?: number
+  /** Per-request timeout in milliseconds. */
+  readonly timeoutMs?: number
+}

--- a/connectors/meta/src/types/pages.ts
+++ b/connectors/meta/src/types/pages.ts
@@ -1,0 +1,31 @@
+import type { MetaPage, MetaPaginationOptions } from "./common"
+
+/** An Instagram Business/Creator account linked to a Facebook Page. */
+export interface MetaInstagramAccount {
+  readonly id: string
+  readonly username?: string
+  readonly name?: string
+  readonly followers_count?: number
+  readonly media_count?: number
+}
+
+/** A Facebook Page returned by `GET /me/accounts`. */
+export interface MetaFacebookPage {
+  readonly id: string
+  readonly name?: string
+  /** Page access token — use it to scope `client.facebook(id, { accessToken })` reads. */
+  readonly access_token?: string
+  readonly instagram_business_account?: MetaInstagramAccount
+}
+
+export interface PagesListOptions extends MetaPaginationOptions {
+  /** Field selection. Defaults to `DEFAULT_PAGE_FIELDS`. */
+  readonly fields?: readonly string[]
+}
+
+export interface PagesApi {
+  /** One page of `GET /me/accounts`. */
+  list(options?: PagesListOptions): Promise<MetaPage<MetaFacebookPage>>
+  /** Every Page, following `paging.next` across all pages. */
+  listAll(options?: PagesListOptions): AsyncIterable<MetaFacebookPage>
+}

--- a/connectors/meta/tests/facebook.test.ts
+++ b/connectors/meta/tests/facebook.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { meta } from "../src"
+
+const CONTEXT = {
+  projectId: "demo",
+  connectorId: "meta",
+  signal: new AbortController().signal,
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as unknown as typeof fetch
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+describe("meta connector — facebook", () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("posts.list unwraps summary counts and keeps every attachment", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        json({
+          data: [
+            {
+              id: "p1",
+              message: "hi",
+              created_time: "2026-01-01T00:00:00+0000",
+              comments: { summary: { total_count: 4 } },
+              reactions: { summary: { total_count: 9 } },
+              shares: { count: 2 },
+              attachments: {
+                data: [
+                  { type: "photo", url: "u1" },
+                  { type: "video", url: "u2" },
+                ],
+              },
+            },
+          ],
+        })
+      )
+    )
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const page = await client.facebook("page-1").posts.list()
+    const post = page.items[0]
+
+    expect(post?.comments_count).toBe(4)
+    expect(post?.reactions_count).toBe(9)
+    expect(post?.shares_count).toBe(2)
+    expect(post?.created_time).toBe("2026-01-01T00:00:00+0000") // raw passthrough, not coerced
+    expect(post?.attachments?.map((attachment) => attachment.url)).toEqual(["u1", "u2"])
+  })
+
+  test("posts.list applies a page access token override and serializes since to unix seconds", async () => {
+    let auth = ""
+    let requested = ""
+    mockFetch((input, init) => {
+      auth = new Headers(init?.headers).get("authorization") ?? ""
+      requested = String(input)
+      return Promise.resolve(json({ data: [] }))
+    })
+
+    const client = await meta({ accessToken: "user-tok" }).connect(CONTEXT)
+    await client.facebook("page-1", { accessToken: "page-tok" }).posts.list({
+      since: new Date("2026-01-01T00:00:00Z"),
+    })
+
+    const url = new URL(requested)
+    expect(url.pathname).toBe("/v23.0/page-1/published_posts")
+    expect(auth).toBe("Bearer page-tok") // overrides the default user token
+    expect(url.searchParams.get("since")).toBe(
+      String(Math.trunc(Date.parse("2026-01-01T00:00:00Z") / 1000))
+    )
+  })
+
+  test("posts.list with metrics adds a lifetime insights expansion", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(json({ data: [] }))
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    await client.facebook("page-1").posts.list({ metrics: ["post_media_view"] })
+
+    expect(new URL(requested).searchParams.get("fields")).toContain(
+      "insights.metric(post_media_view).period(lifetime)"
+    )
+  })
+
+  test("get fetches the page profile node with audience fields and the page token", async () => {
+    let auth = ""
+    let requested = ""
+    mockFetch((input, init) => {
+      auth = new Headers(init?.headers).get("authorization") ?? ""
+      requested = String(input)
+      return Promise.resolve(
+        json({ id: "page-1", name: "Acme", fan_count: 100, followers_count: 120 })
+      )
+    })
+
+    const client = await meta({ accessToken: "user-tok" }).connect(CONTEXT)
+    const profile = await client.facebook("page-1", { accessToken: "page-tok" }).get()
+
+    const url = new URL(requested)
+    expect(url.pathname).toBe("/v23.0/page-1")
+    expect(url.searchParams.get("fields")).toContain("fan_count")
+    expect(auth).toBe("Bearer page-tok")
+    expect(profile.followers_count).toBe(120)
+  })
+
+  test("falls back to the default token when no page token is given", async () => {
+    let auth = ""
+    mockFetch((_, init) => {
+      auth = new Headers(init?.headers).get("authorization") ?? ""
+      return Promise.resolve(json({ data: [] }))
+    })
+
+    const client = await meta({ accessToken: "user-tok" }).connect(CONTEXT)
+    await client.facebook("page-1").posts.list()
+
+    expect(auth).toBe("Bearer user-tok")
+  })
+})

--- a/connectors/meta/tests/insights.test.ts
+++ b/connectors/meta/tests/insights.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { MetaApiError, meta } from "../src"
+
+const CONTEXT = {
+  projectId: "demo",
+  connectorId: "meta",
+  signal: new AbortController().signal,
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as unknown as typeof fetch
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+describe("meta connector — insights", () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("account insights send metric, period, metric_type and unix-second windows", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(
+        json({
+          data: [
+            { name: "views", total_value: { value: 1 } },
+            { name: "total_interactions", total_value: { value: 2 } },
+          ],
+        })
+      )
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const insights = await client.instagram("ig-1").insights.get({
+      metrics: ["views", "total_interactions"],
+      period: "day",
+      metricType: "total_value",
+      since: new Date("2026-01-01T00:00:00Z"),
+      until: new Date("2026-01-02T00:00:00Z"),
+    })
+
+    const url = new URL(requested)
+    expect(url.pathname).toBe("/v23.0/ig-1/insights")
+    expect(url.searchParams.get("metric")).toBe("views,total_interactions")
+    expect(url.searchParams.get("period")).toBe("day")
+    expect(url.searchParams.get("metric_type")).toBe("total_value")
+    expect(url.searchParams.get("since")).toBe(String(Date.parse("2026-01-01T00:00:00Z") / 1000))
+    expect(url.searchParams.get("until")).toBe(String(Date.parse("2026-01-02T00:00:00Z") / 1000))
+    // Returned in API order — no reordering by the connector.
+    expect(insights.map((insight) => insight.name)).toEqual(["views", "total_interactions"])
+  })
+
+  test("omits metric_type when not requested", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(json({ data: [] }))
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    await client.instagram("ig-1").insights.get({ metrics: ["reach"], period: "day" })
+
+    expect(new URL(requested).searchParams.has("metric_type")).toBe(false)
+  })
+
+  test("empty metrics resolve to no request", async () => {
+    let called = false
+    mockFetch(() => {
+      called = true
+      return Promise.resolve(json({ data: [] }))
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const insights = await client.instagram("ig-1").insights.get({ metrics: [] })
+
+    expect(insights).toEqual([])
+    expect(called).toBe(false)
+  })
+
+  test("page insights apply the page token override", async () => {
+    let auth = ""
+    let path = ""
+    mockFetch((input, init) => {
+      auth = new Headers(init?.headers).get("authorization") ?? ""
+      path = new URL(String(input)).pathname
+      return Promise.resolve(json({ data: [{ name: "page_media_view" }] }))
+    })
+
+    const client = await meta({ accessToken: "user-tok" }).connect(CONTEXT)
+    await client
+      .facebook("page-1", { accessToken: "page-tok" })
+      .insights.get({ metrics: ["page_media_view"], period: "day" })
+
+    expect(path).toBe("/v23.0/page-1/insights")
+    expect(auth).toBe("Bearer page-tok")
+  })
+
+  test("media insights hit the media node insights edge", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(json({ data: [{ name: "reach" }] }))
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const insights = await client.instagramMedia("m1").insights.get({ metrics: ["reach"] })
+
+    const url = new URL(requested)
+    expect(url.pathname).toBe("/v23.0/m1/insights")
+    expect(url.searchParams.get("metric")).toBe("reach")
+    expect(insights[0]?.name).toBe("reach")
+  })
+
+  test("throws MetaApiError on a non-2xx response", async () => {
+    mockFetch(() =>
+      Promise.resolve(json({ error: { message: "Invalid metric" } }, { status: 400 }))
+    )
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const promise = client.instagram("ig-1").insights.get({ metrics: ["bogus"] })
+
+    await expect(promise).rejects.toBeInstanceOf(MetaApiError)
+    await expect(promise).rejects.toThrow("400")
+  })
+
+  test("retries 429 responses honoring Retry-After", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls += 1
+      return Promise.resolve(
+        calls === 1
+          ? json(
+              { error: { message: "rate limited" } },
+              { status: 429, headers: { "Retry-After": "0" } }
+            )
+          : json({ data: [{ name: "reach" }] })
+      )
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const insights = await client.instagram("ig-1").insights.get({ metrics: ["reach"] })
+
+    expect(calls).toBe(2)
+    expect(insights[0]?.name).toBe("reach")
+  })
+})

--- a/connectors/meta/tests/instagram.test.ts
+++ b/connectors/meta/tests/instagram.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { meta } from "../src"
+
+const CONTEXT = {
+  projectId: "demo",
+  connectorId: "meta",
+  signal: new AbortController().signal,
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as unknown as typeof fetch
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+describe("meta connector — instagram", () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("media.list requests default fields and preserves carousel children", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(
+        json({
+          data: [
+            {
+              id: "m1",
+              media_type: "CAROUSEL_ALBUM",
+              like_count: 3,
+              children: { data: [{ id: "c1", media_url: "u1" }, { id: "c2" }] },
+            },
+          ],
+        })
+      )
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const page = await client.instagram("ig-1").media.list()
+
+    const url = new URL(requested)
+    expect(url.pathname).toBe("/v23.0/ig-1/media")
+    expect(url.searchParams.get("fields")).toContain("like_count")
+    expect(url.searchParams.get("fields")).toContain(
+      "children{id,media_type,media_url,permalink,timestamp,thumbnail_url}"
+    )
+    expect(page.items[0]?.children?.map((child) => child.id)).toEqual(["c1", "c2"])
+  })
+
+  test("media.list with metrics adds an inline insights expansion and parses insights", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(
+        json({
+          data: [
+            {
+              id: "m1",
+              insights: { data: [{ name: "views", total_value: { value: 42 } }] },
+            },
+          ],
+        })
+      )
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const page = await client.instagram("ig-1").media.list({
+      metrics: ["views", "total_interactions"],
+    })
+
+    expect(new URL(requested).searchParams.get("fields")).toContain(
+      "insights.metric(views,total_interactions)"
+    )
+    expect(page.items[0]?.insights?.[0]?.name).toBe("views")
+  })
+
+  test("media.listAll follows the after cursor across pages", async () => {
+    const calls: string[] = []
+    mockFetch((input) => {
+      calls.push(String(input))
+      return Promise.resolve(
+        calls.length === 1
+          ? json({
+              data: [{ id: "m1" }],
+              paging: { cursors: { after: "C1" }, next: "https://graph.facebook.com/x" },
+            })
+          : json({ data: [{ id: "m2" }] })
+      )
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const ids: string[] = []
+    for await (const media of client.instagram("ig-1").media.listAll()) {
+      ids.push(media.id)
+    }
+
+    expect(calls).toHaveLength(2)
+    expect(new URL(calls[1] ?? "").searchParams.get("after")).toBe("C1")
+    expect(ids).toEqual(["m1", "m2"])
+  })
+
+  test("stories.list hits the stories edge with story fields", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(json({ data: [{ id: "s1", media_product_type: "STORY" }] }))
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const page = await client.instagram("ig-1").stories.list()
+
+    const url = new URL(requested)
+    expect(url.pathname).toBe("/v23.0/ig-1/stories")
+    expect(url.searchParams.get("fields")).not.toContain("children")
+    expect(page.items[0]?.id).toBe("s1")
+  })
+
+  test("stories.list with metrics adds an inline insights expansion", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(json({ data: [] }))
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    await client.instagram("ig-1").stories.list({ metrics: ["reach", "replies"] })
+
+    expect(new URL(requested).searchParams.get("fields")).toContain(
+      "insights.metric(reach,replies)"
+    )
+  })
+
+  test("get fetches the IG user profile node with default fields", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(
+        json({ id: "ig-1", username: "acme", followers_count: 601, follows_count: 12 })
+      )
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const user = await client.instagram("ig-1").get()
+
+    const url = new URL(requested)
+    expect(url.pathname).toBe("/v23.0/ig-1")
+    expect(url.searchParams.get("fields")).toContain("follows_count")
+    expect(user.username).toBe("acme")
+    expect(user.follows_count).toBe(12)
+  })
+
+  test("rejects an empty ig user id before requesting", () => {
+    const promise = meta({ accessToken: "t" })
+      .connect(CONTEXT)
+      .then((client) => client.instagram("  "))
+    expect(promise).rejects.toThrow("igUserId must not be empty")
+  })
+})

--- a/connectors/meta/tests/pages.test.ts
+++ b/connectors/meta/tests/pages.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { meta } from "../src"
+
+const CONTEXT = {
+  projectId: "demo",
+  connectorId: "meta",
+  signal: new AbortController().signal,
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as unknown as typeof fetch
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+describe("meta connector — pages", () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("connects with meta auth headers and a versioned base path", async () => {
+    let auth = ""
+    let accept = ""
+    let url = ""
+    mockFetch((input, init) => {
+      const headers = new Headers(init?.headers)
+      auth = headers.get("authorization") ?? ""
+      accept = headers.get("accept") ?? ""
+      url = String(input)
+      return Promise.resolve(json({ data: [] }))
+    })
+
+    const adapter = meta({ accessToken: "tok-123" })
+    const client = await adapter.connect(CONTEXT)
+    await client.pages.list()
+
+    expect(adapter.type).toBe("meta")
+    expect(auth).toBe("Bearer tok-123")
+    expect(accept).toBe("application/json")
+    expect(new URL(url).pathname).toBe("/v23.0/me/accounts")
+  })
+
+  test("pages.list requests the default field expansion and parses pages", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(
+        json({
+          data: [
+            {
+              id: "page-1",
+              name: "Acme",
+              access_token: "page-tok",
+              instagram_business_account: {
+                id: "ig-1",
+                username: "acme",
+                followers_count: 10,
+                media_count: 5,
+              },
+            },
+          ],
+        })
+      )
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const page = await client.pages.list()
+
+    const url = new URL(requested)
+    expect(url.searchParams.get("fields")).toContain(
+      "instagram_business_account{id,username,name,followers_count,media_count}"
+    )
+    expect(url.searchParams.get("limit")).toBe("100")
+    expect(page.items[0]?.access_token).toBe("page-tok")
+    expect(page.items[0]?.instagram_business_account?.username).toBe("acme")
+  })
+
+  test("pages.listAll follows the after cursor and does not dedup", async () => {
+    const calls: string[] = []
+    mockFetch((input) => {
+      calls.push(String(input))
+      return Promise.resolve(
+        calls.length === 1
+          ? json({
+              data: [{ id: "page-1" }, { id: "page-1" }],
+              paging: { cursors: { after: "CURSOR1" }, next: "https://graph.facebook.com/next" },
+            })
+          : json({ data: [{ id: "page-2" }], paging: { cursors: { after: "CURSOR2" } } })
+      )
+    })
+
+    const client = await meta({ accessToken: "t" }).connect(CONTEXT)
+    const ids: string[] = []
+    for await (const page of client.pages.listAll()) {
+      ids.push(page.id)
+    }
+
+    expect(calls).toHaveLength(2)
+    expect(new URL(calls[1] ?? "").searchParams.get("after")).toBe("CURSOR1")
+    // Raw passthrough: duplicates from page one are preserved, not deduped by the connector.
+    expect(ids).toEqual(["page-1", "page-1", "page-2"])
+  })
+
+  test("honors a custom graph version", async () => {
+    let url = ""
+    mockFetch((input) => {
+      url = String(input)
+      return Promise.resolve(json({ data: [] }))
+    })
+
+    const client = await meta({ accessToken: "t", graphVersion: "v21.0" }).connect(CONTEXT)
+    await client.pages.list()
+
+    expect(new URL(url).pathname).toBe("/v21.0/me/accounts")
+  })
+
+  test("rejects an empty access token before connecting", () => {
+    expect(() => meta({ accessToken: "  " })).toThrow("accessToken must not be empty")
+  })
+})

--- a/connectors/meta/tsconfig.build.json
+++ b/connectors/meta/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../packages/core/tsconfig.build.json"
+    },
+    {
+      "path": "../rest/tsconfig.build.json"
+    }
+  ]
+}

--- a/connectors/meta/tsconfig.json
+++ b/connectors/meta/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -17,6 +17,12 @@
       "path": "connectors/companycam/tsconfig.build.json"
     },
     {
+      "path": "connectors/github/tsconfig.build.json"
+    },
+    {
+      "path": "connectors/meta/tsconfig.build.json"
+    },
+    {
       "path": "connectors/rest/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
       "@sixb/client/query": ["./packages/client/src/query.ts"],
       "@sixb/connector-companycam": ["./connectors/companycam/src/index.ts"],
       "@sixb/connector-github": ["./connectors/github/src/index.ts"],
+      "@sixb/connector-meta": ["./connectors/meta/src/index.ts"],
       "@sixb/connector-rest": ["./connectors/rest/src/index.ts"],
       "@sixb/connector-sftp": ["./connectors/sftp/src/index.ts"],
       "@sixb/connector-sql": ["./connectors/sql/src/index.ts"],


### PR DESCRIPTION
## Problem

The Meta (Instagram + Facebook) integration lived inside a single project as a
hand-rolled `fetch` client with project-specific behavior baked into the transport:
hidden `metric_type` request-splitting over a hardcoded metric set, stringly-typed field
construction, first-attachment-only flattening, silent timestamp coercion, and no
retry/rate-limit handling. There was no reusable connector for other projects.

## Change

A new `@sixb/connector-meta` — a thin, read-only, one-to-one client over the Graph API for
Facebook Pages and Instagram Business/Creator accounts, built on `@sixb/connector-rest`
(so it gets base-URL resolution, async auth headers, 429/5xx retry, and timeouts for free).
It mirrors the `@sixb/connector-github` conventions: factory → scoped client builder →
resource factories → separated types → one error class.

The client maps one method per Graph node/edge:

| API | Graph endpoint |
|---|---|
| `pages.list()` / `.listAll()` | `GET /me/accounts` |
| `instagram(id).get()` | `GET /{ig-user-id}` |
| `instagram(id).media.list()` / `.listAll()` | `GET /{ig-user-id}/media` |
| `instagram(id).stories.list()` / `.listAll()` | `GET /{ig-user-id}/stories` |
| `instagram(id).insights.get()` | `GET /{ig-user-id}/insights` |
| `instagramMedia(id).insights.get()` | `GET /{ig-media-id}/insights` |
| `facebook(id, { accessToken }).get()` | `GET /{page-id}` |
| `facebook(id, { accessToken }).posts.list()` / `.listAll()` | `GET /{page-id}/published_posts` |
| `facebook(id, { accessToken }).insights.get()` | `GET /{page-id}/insights` |

Design choices that keep it clean and stable:

- **Metric-agnostic.** `insights.get()` is a faithful single request — `metrics`, `period`,
  `metricType`, `since`, `until`, `breakdown` pass straight through. Meta's volatile metric
  taxonomy and the `total_value` partitioning stay with the caller, not the transport.
- **Faithful responses.** All attachments returned as an array, timestamps as raw API
  strings, insights in API order. No flattening or coercion.
- **Cursor pagination.** `list()` returns a `MetaPage` (`items` / `hasMore` / `nextCursor`);
  `listAll()` follows the `after` cursor to exhaustion, staying on the configured base.
- **Auth.** Default user/system token via header; per-Page tokens applied as a per-request
  override for Facebook reads.
- **No account orchestration.** Page/account dedup and filtering are project policy, built
  on top of `pages.listAll()`.

This PR also wires the connector into the root `tsconfig.json` paths and
`tsconfig.build.json` references — and adds the previously-missing `connectors/github`
reference, which had been shipping without emitted `.d.ts`.

## Tests

Unit tests stub `fetch` and assert request shape + response mapping. Also validated live
against the real Graph API with a project token (pages, media + carousel children, account
insights with `total_value`, page posts with the page-token override, profile reads, and
live story insights).

| Check | Result |
|---|---|
| `connectors/meta` unit tests | 24 pass |
| `@sixb/connector-meta` typecheck | pass |
| `biome check` (meta) | clean |
| `bun run build` (types + js) | pass |
| Live smoke test (real API) | all endpoints OK |

## Scope

Read-only (`GET` only). Deliberately excluded until a use case needs them: comment-body
lists, business discovery, hashtag/mention search, writes/publishing, and webhooks
(addable later via `defineWebhook`). No changes to existing connectors beyond the github
build-reference fix.
