### PR TITLE
atlas: rebuild the dataset viewer as a full-height data grid

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -248,11 +248,11 @@
       "name": "@sixb/agent-worker",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/provider": "^3.0.10",
         "@sixb/core": "workspace:*",
         "ai": "^6.0.0",
       },
       "devDependencies": {
+        "@ai-sdk/provider": "^3.0.10",
         "@types/bun": "latest",
         "typescript": "^5.7.0",
       },
@@ -434,6 +434,7 @@
       "name": "@sixb/ui",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -1006,6 +1007,10 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.100.13", "", {}, "sha512-mlKVKMTzZWGTKAC1CKOgt7axAjJ921emkEvYIp27I/PdP1yEYL/BteLY8iK35gn8hoYeKB4mgJ/ve3lrDI6/Fw=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.100.13", "", { "dependencies": { "@tanstack/query-core": "5.100.13" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-HSBr8CycQEAoXsJR7KNDawBnINJEJ96Eme8oE0hCXjyodE2I97vg3IDzDJBDu18LsbzpVVJcKo80eqLfVCykxw=="],
+
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 

--- a/packages/atlas/src/features/datasets/DatasetDetails.tsx
+++ b/packages/atlas/src/features/datasets/DatasetDetails.tsx
@@ -1,0 +1,172 @@
+import type { GetDatasetResponse } from "@sixb/client"
+import { Badge, Button } from "@sixb/ui/components"
+import { GitBranch } from "lucide-react"
+import { consumerCount, formatBytes, formatCount, sourceCount } from "../../lib/datasets"
+import { formatRelativeTime } from "../../lib/time"
+
+type DatasetVersionSummary = {
+  versionId?: string
+  rowCount?: number
+  sizeBytes?: number
+  createdAt?: string
+  mode?: string
+  producer?: { kind: string; id?: string; runId?: string }
+}
+
+type DatasetDetailsProps = {
+  dataset: GetDatasetResponse
+  columnCount: number
+  versionSummary: DatasetVersionSummary
+  onNavigate: (path: string) => void
+}
+
+export function DatasetDetails({
+  dataset,
+  columnCount,
+  versionSummary,
+  onNavigate,
+}: DatasetDetailsProps) {
+  const hasReferences = sourceCount(dataset) + consumerCount(dataset) > 0
+  const producer = versionSummary.producer
+    ? `${versionSummary.producer.kind}${
+        versionSummary.producer.id ? ` · ${versionSummary.producer.id}` : ""
+      }`
+    : null
+
+  return (
+    <div className="max-h-[70vh] space-y-4 overflow-auto scrollbar-auto-hide">
+      <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+        <StatItem label="Rows" value={formatCount(versionSummary.rowCount)} />
+        <StatItem label="Columns" value={columnCount} />
+        <StatItem label="Size" value={formatBytes(versionSummary.sizeBytes)} />
+        <StatItem
+          label="Created"
+          value={versionSummary.createdAt ? formatRelativeTime(versionSummary.createdAt) : "—"}
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        <Badge variant="secondary" className="font-normal">
+          {dataset.materialized ? "Materialized" : "Declared"}
+        </Badge>
+        {versionSummary.mode ? (
+          <Badge variant="outline" className="font-normal">
+            {versionSummary.mode}
+          </Badge>
+        ) : null}
+      </div>
+
+      {versionSummary.versionId ? (
+        <Field label="Version">
+          <p className="break-all font-mono text-xs text-foreground">{versionSummary.versionId}</p>
+        </Field>
+      ) : null}
+
+      <Field label="Description">
+        <p className="text-sm text-foreground">{dataset.description ?? "No description"}</p>
+      </Field>
+
+      {producer ? (
+        <Field label="Producer">
+          <p className="break-all font-mono text-xs text-foreground">{producer}</p>
+        </Field>
+      ) : null}
+
+      {dataset.partitionBy?.length ? (
+        <Field label="Partitioned by">
+          <div className="flex flex-wrap gap-1.5">
+            {dataset.partitionBy.map((column) => (
+              <Badge key={column} variant="outline" className="font-mono text-[11px] font-normal">
+                {column}
+              </Badge>
+            ))}
+          </div>
+        </Field>
+      ) : null}
+
+      {hasReferences ? (
+        <div className="space-y-4 border-t border-border/50 pt-4">
+          <ReferenceGroup
+            label="Syncs"
+            ids={dataset.syncIds}
+            onSelect={(id) => onNavigate(`/syncs/${encodeURIComponent(id)}`)}
+          />
+          <ReferenceGroup label="Source pipelines" ids={dataset.sourcePipelineIds} />
+          <ReferenceGroup label="Target pipelines" ids={dataset.targetPipelineIds} />
+          <ReferenceGroup label="Projections" ids={dataset.projectionIds} />
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function StatItem({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-0.5 truncate text-sm font-medium tabular-nums text-foreground">{value}</p>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+      {children}
+    </div>
+  )
+}
+
+function ReferenceGroup({
+  label,
+  ids,
+  onSelect,
+}: {
+  label: string
+  ids: string[]
+  onSelect?: (id: string) => void
+}) {
+  if (ids.length === 0) return null
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex flex-col gap-0.5">
+        {ids.map((id) => {
+          const content = (
+            <>
+              <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate">{id}</span>
+            </>
+          )
+          return onSelect ? (
+            <Button
+              key={id}
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onSelect(id)}
+              className="-mx-2 h-7 max-w-full justify-start gap-2 font-mono text-xs text-foreground"
+            >
+              {content}
+            </Button>
+          ) : (
+            <span
+              key={id}
+              className="flex max-w-full items-center gap-2 py-1 font-mono text-xs text-foreground"
+            >
+              {content}
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/packages/atlas/src/features/datasets/DatasetTableGrid.tsx
+++ b/packages/atlas/src/features/datasets/DatasetTableGrid.tsx
@@ -1,0 +1,210 @@
+import {
+  Button,
+  DataTable,
+  type DataTableColumn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  EmptyState,
+} from "@sixb/ui/components"
+import { cn } from "@sixb/ui/lib/utils"
+import { Check, Copy, Database } from "lucide-react"
+import { useMemo, useState } from "react"
+import { formatValue } from "../../lib/formatValue"
+
+export type DatasetGridColumnMeta = {
+  type: string
+  numeric: boolean
+}
+
+type Row = Record<string, unknown>
+
+type DatasetTableGridProps = {
+  columns: string[]
+  columnMeta: Map<string, DatasetGridColumnMeta>
+  rows: Row[]
+  offset: number
+  isLoading: boolean
+  isError: boolean
+  emptyDescription?: string
+}
+
+function defaultColumnWidth(meta: DatasetGridColumnMeta | undefined): number {
+  if (!meta) return 200
+  switch (meta.type.replace("?", "")) {
+    case "boolean":
+      return 110
+    case "int64":
+    case "float64":
+    case "decimal":
+      return 140
+    case "date":
+      return 150
+    case "timestamp":
+      return 200
+    case "json":
+    case "fileRef":
+      return 280
+    default:
+      return 220
+  }
+}
+
+function isNullish(value: unknown): boolean {
+  return value === null || value === undefined
+}
+
+function prettyValue(value: unknown): string {
+  if (value === undefined) return "undefined"
+  if (value === null) return "null"
+  if (typeof value === "object") return JSON.stringify(value, null, 2)
+  return String(value)
+}
+
+export function DatasetTableGrid({
+  columns,
+  columnMeta,
+  rows,
+  offset,
+  isLoading,
+  isError,
+  emptyDescription,
+}: DatasetTableGridProps) {
+  const [expandedCell, setExpandedCell] = useState<{
+    column: string
+    rowNumber: number
+    value: unknown
+  } | null>(null)
+
+  const gridColumns = useMemo<DataTableColumn<Row>[]>(
+    () =>
+      columns.map((name) => {
+        const meta = columnMeta.get(name)
+        return {
+          id: name,
+          header: name,
+          typeLabel: meta?.type,
+          accessor: (row) => row[name],
+          align: meta?.numeric ? "right" : "left",
+          size: defaultColumnWidth(meta),
+          cell: (value) => {
+            const nullish = isNullish(value)
+            const text = nullish ? "null" : formatValue(value)
+            return (
+              <span
+                title={text}
+                className={cn(
+                  "block truncate font-mono",
+                  nullish ? "italic text-muted-foreground/50" : "text-foreground"
+                )}
+              >
+                {text}
+              </span>
+            )
+          },
+        }
+      }),
+    [columns, columnMeta]
+  )
+
+  if (isError) {
+    return (
+      <GridMessage
+        title="Rows unavailable"
+        description="Could not load the selected dataset version."
+      />
+    )
+  }
+
+  if (columns.length === 0) {
+    return <GridMessage title="No schema" description="This dataset has no declared columns." />
+  }
+
+  return (
+    <>
+      <DataTable
+        columns={gridColumns}
+        data={rows}
+        showRowIndex
+        rowIndexOffset={offset}
+        isLoading={isLoading}
+        className="scrollbar-auto-hide"
+        empty={
+          <EmptyState
+            icon={<Database className="h-10 w-10" />}
+            title="No rows"
+            description={emptyDescription ?? "This dataset version does not have preview rows."}
+          />
+        }
+        onCellClick={({ columnId, value, rowIndex }) =>
+          setExpandedCell({ column: columnId, rowNumber: offset + rowIndex + 1, value })
+        }
+      />
+      <CellDetailDialog cell={expandedCell} onClose={() => setExpandedCell(null)} />
+    </>
+  )
+}
+
+function CellDetailDialog({
+  cell,
+  onClose,
+}: {
+  cell: { column: string; rowNumber: number; value: unknown } | null
+  onClose: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+  const text = cell ? prettyValue(cell.value) : ""
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard?.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard may be unavailable (insecure context / permissions).
+    }
+  }
+
+  return (
+    <Dialog
+      open={cell !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          setCopied(false)
+          onClose()
+        }
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-sm">{cell?.column}</DialogTitle>
+          <DialogDescription>Row {cell?.rowNumber}</DialogDescription>
+        </DialogHeader>
+        <pre className="max-h-[55vh] overflow-auto rounded-md border border-border bg-muted/40 p-3 font-mono text-xs leading-relaxed text-foreground scrollbar-auto-hide">
+          {text}
+        </pre>
+        <DialogFooter>
+          <Button type="button" variant="outline" size="sm" onClick={handleCopy}>
+            {copied ? <Check className="text-success" /> : <Copy />}
+            {copied ? "Copied" : "Copy value"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function GridMessage({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+      <EmptyState
+        icon={<Database className="h-10 w-10" />}
+        title={title}
+        description={description}
+      />
+    </div>
+  )
+}

--- a/packages/atlas/src/lib/datasets.ts
+++ b/packages/atlas/src/lib/datasets.ts
@@ -1,0 +1,45 @@
+import { humanizeIdentifier } from "./labels"
+
+// Structural shape shared by the catalog list item and the full dataset detail.
+type DatasetRefs = {
+  syncIds: string[]
+  sourcePipelineIds: string[]
+  targetPipelineIds: string[]
+  projectionIds: string[]
+}
+
+export function datasetName(dataset: { id: string }): string {
+  return humanizeIdentifier(dataset.id)
+}
+
+export function formatCount(value?: number): string {
+  return typeof value === "number" ? value.toLocaleString() : "—"
+}
+
+export function formatBytes(value?: number): string {
+  if (typeof value !== "number") return "—"
+  if (value === 0) return "0 B"
+
+  const units = ["B", "KB", "MB", "GB", "TB"]
+  const index = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1)
+  const scaled = value / 1024 ** index
+  const precision = scaled >= 10 || index === 0 ? 0 : 1
+
+  return `${scaled.toFixed(precision)} ${units[index]}`
+}
+
+export function sourceCount(dataset: DatasetRefs): number {
+  return dataset.syncIds.length + dataset.sourcePipelineIds.length + dataset.projectionIds.length
+}
+
+export function consumerCount(dataset: DatasetRefs): number {
+  return dataset.targetPipelineIds.length
+}
+
+// Column types the lake schema can declare. Numeric types are right-aligned in
+// the grid and get tabular figures.
+const numericColumnTypes = new Set(["int64", "float64", "decimal"])
+
+export function isNumericColumnType(type: string): boolean {
+  return numericColumnTypes.has(type)
+}

--- a/packages/atlas/src/pages/DatasetsPage.tsx
+++ b/packages/atlas/src/pages/DatasetsPage.tsx
@@ -1,9 +1,4 @@
-import type {
-  GetDatasetResponse,
-  ListDatasetRowsResponse,
-  ListDatasetsResponse,
-  ListDatasetVersionsResponse,
-} from "@sixb/client"
+import type { ListDatasetsResponse, ListDatasetVersionsResponse } from "@sixb/client"
 import {
   getDatasetOptions,
   listDatasetRowsOptions,
@@ -11,15 +6,24 @@ import {
   listDatasetVersionsOptions,
 } from "@sixb/client/hooks"
 import {
+  Badge,
   Button,
   Card,
   CollectionCardButton,
   CollectionCardGrid,
   CollectionHeader,
   CollectionViewToggle,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   EmptyState,
   Input,
-  Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -37,27 +41,30 @@ import { useQuery } from "@tanstack/react-query"
 import {
   ChevronLeft,
   ChevronRight,
-  Clock3,
   Columns3,
   Database,
-  GitBranch,
+  Info,
   Loader2,
+  RefreshCw,
   Search,
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
-import { formatValue } from "../lib/formatValue"
-import { humanizeIdentifier } from "../lib/labels"
+import { DatasetDetails } from "../features/datasets/DatasetDetails"
+import { type DatasetGridColumnMeta, DatasetTableGrid } from "../features/datasets/DatasetTableGrid"
+import {
+  consumerCount,
+  datasetName,
+  formatBytes,
+  formatCount,
+  isNumericColumnType,
+  sourceCount,
+} from "../lib/datasets"
 import { formatRelativeTime } from "../lib/time"
 import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
 
-type Dataset = ListDatasetsResponse[number] | GetDatasetResponse
 type DatasetListItem = ListDatasetsResponse[number]
-// The catalog list/detail routes return a lightweight `latestVersion` summary.
-// Full version metadata (schema, producer, sizeBytes) comes from the versions
-// route, so detail views type their versions from that response.
 type DatasetVersion = ListDatasetVersionsResponse["versions"][number]
-type DatasetColumn = Dataset["schema"]["columns"][number]
 type DatasetListViewStyle = "cards" | "table"
 
 const datasetListViewOptions = [
@@ -65,49 +72,9 @@ const datasetListViewOptions = [
   { value: "table", label: "Table" },
 ] as const
 
-const rowPreviewLimit = 50
+const pageSizeOptions = ["50", "100", "250", "500", "1000"] as const
 const emptyDatasetVersions: DatasetVersion[] = []
-
-function datasetName(dataset: Pick<Dataset, "id">): string {
-  return humanizeIdentifier(dataset.id)
-}
-
-function formatCount(value?: number): string {
-  return typeof value === "number" ? value.toLocaleString() : "-"
-}
-
-function formatBytes(value?: number): string {
-  if (typeof value !== "number") return "-"
-  if (value === 0) return "0 B"
-
-  const units = ["B", "KB", "MB", "GB", "TB"]
-  const index = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1)
-  const scaled = value / 1024 ** index
-  const precision = scaled >= 10 || index === 0 ? 0 : 1
-
-  return `${scaled.toFixed(precision)} ${units[index]}`
-}
-
-function datasetSummary(dataset: Dataset): string {
-  const parts = [
-    dataset.materialized ? "Materialized dataset" : "Declared dataset",
-    `${dataset.schema.columns.length} column${dataset.schema.columns.length === 1 ? "" : "s"}`,
-  ]
-
-  if (dataset.latestVersion?.rowCount !== undefined) {
-    parts.push(`${formatCount(dataset.latestVersion.rowCount)} rows`)
-  }
-
-  return parts.join(" · ")
-}
-
-function sourceCount(dataset: Dataset): number {
-  return dataset.syncIds.length + dataset.sourcePipelineIds.length + dataset.projectionIds.length
-}
-
-function consumerCount(dataset: Dataset): number {
-  return dataset.targetPipelineIds.length
-}
+const emptyRows: Array<Record<string, unknown>> = []
 
 function datasetSearchText(dataset: DatasetListItem): string {
   return [
@@ -208,437 +175,6 @@ function DatasetTableView({
         </TableBody>
       </Table>
     </Card>
-  )
-}
-
-function DetailSurface({
-  title,
-  actions,
-  children,
-  className,
-}: {
-  title: string
-  actions?: React.ReactNode
-  children: React.ReactNode
-  className?: string
-}) {
-  return (
-    <section
-      className={cn(
-        "min-w-0 max-w-full overflow-hidden rounded-lg border border-border bg-card px-5 py-5 sm:px-6",
-        className
-      )}
-    >
-      <div className="mb-4 flex min-w-0 items-center justify-between gap-4">
-        <h2 className="text-[15px] font-semibold tracking-tight text-foreground">{title}</h2>
-        {actions}
-      </div>
-      {children}
-    </section>
-  )
-}
-
-function MetricTile({
-  label,
-  value,
-  detail,
-}: {
-  label: string
-  value: React.ReactNode
-  detail?: React.ReactNode
-}) {
-  return (
-    <div className="min-w-0 px-5 py-4">
-      <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-        {label}
-      </p>
-      <div className="mt-2 min-w-0 truncate text-2xl font-semibold tracking-tight tabular-nums text-foreground">
-        {value}
-      </div>
-      {detail && (
-        <div className="mt-1 truncate font-mono text-[11px] text-muted-foreground">{detail}</div>
-      )}
-    </div>
-  )
-}
-
-function DatasetMetrics({
-  dataset,
-  selectedVersion,
-}: {
-  dataset: Dataset
-  selectedVersion: DatasetVersion | null
-}) {
-  const versionMode = selectedVersion?.mode
-  const versionValue = versionMode
-    ? versionMode.charAt(0).toUpperCase() + versionMode.slice(1)
-    : "—"
-
-  return (
-    <div className="grid overflow-hidden rounded-lg border border-border bg-card sm:grid-cols-2 sm:divide-x sm:divide-y-0 sm:divide-border/40 lg:grid-cols-4">
-      <MetricTile
-        label="Version"
-        value={versionValue}
-        detail={selectedVersion?.versionId ?? undefined}
-      />
-      <MetricTile label="Rows" value={formatCount(selectedVersion?.rowCount)} />
-      <MetricTile
-        label="Columns"
-        value={selectedVersion?.schema.columns.length ?? dataset.schema.columns.length}
-        detail={
-          dataset.partitionBy?.length
-            ? `Partitioned by ${dataset.partitionBy.join(", ")}`
-            : undefined
-        }
-      />
-      <MetricTile
-        label="Storage"
-        value={formatBytes(selectedVersion?.sizeBytes)}
-        detail={dataset.materialized ? "Materialized" : "Declared only"}
-      />
-    </div>
-  )
-}
-
-function VersionSelect({
-  versions,
-  selectedVersionId,
-  onSelect,
-}: {
-  versions: DatasetVersion[]
-  selectedVersionId: string | null
-  onSelect: (versionId: string) => void
-}) {
-  if (versions.length === 0) return null
-
-  return (
-    <div className="flex min-w-0 items-center gap-2">
-      <Label className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-        Version
-      </Label>
-      <Select value={selectedVersionId ?? undefined} onValueChange={onSelect}>
-        <SelectTrigger className="h-9 max-w-[280px] font-mono text-xs">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {versions.map((version) => (
-            <SelectItem key={version.versionId} value={version.versionId} className="font-mono">
-              {version.versionId}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  )
-}
-
-function SchemaTable({
-  columns,
-  partitionBy,
-}: {
-  columns: DatasetColumn[]
-  partitionBy?: string[]
-}) {
-  if (columns.length === 0) {
-    return (
-      <EmptyState
-        icon={<Columns3 className="h-10 w-10" />}
-        title="No schema"
-        description="This dataset has no declared columns."
-        className="py-8"
-      />
-    )
-  }
-
-  const partitionColumns = new Set(partitionBy ?? [])
-
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-left text-sm">
-        <thead>
-          <tr className="border-b border-border text-[11px] uppercase tracking-wider text-muted-foreground">
-            <th className="pb-2.5 font-medium">Column</th>
-            <th className="px-3 pb-2.5 font-medium">Type</th>
-            <th className="pb-2.5 text-right font-medium">Role</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border/30">
-          {columns.map((column) => (
-            <tr key={column.name}>
-              <td className="py-3 pr-4 font-mono text-xs text-foreground">{column.name}</td>
-              <td className="px-3 py-3 font-mono text-xs text-muted-foreground">
-                {column.type}
-                {column.nullable ? "?" : ""}
-              </td>
-              <td className="py-3 text-right">
-                {partitionColumns.has(column.name) ? (
-                  <span className="inline-flex items-center rounded-md bg-muted px-1.5 py-0.5 text-[11px] font-medium text-foreground">
-                    Partition
-                  </span>
-                ) : (
-                  <span className="text-xs text-muted-foreground">Column</span>
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  )
-}
-
-function RowPreview({
-  rows,
-  isLoading,
-  isError,
-  offset,
-  onPrevious,
-  onNext,
-}: {
-  rows: ListDatasetRowsResponse | undefined
-  isLoading: boolean
-  isError: boolean
-  offset: number
-  onPrevious: () => void
-  onNext: () => void
-}) {
-  if (isLoading) {
-    return (
-      <div className="py-10">
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <Loader2 className="h-5 w-5 animate-spin" />
-          <span className="text-sm">Loading rows...</span>
-        </div>
-      </div>
-    )
-  }
-
-  if (isError) {
-    return (
-      <EmptyState
-        icon={<Database className="h-10 w-10" />}
-        title="Rows unavailable"
-        description="Could not load the selected dataset version."
-        className="py-8"
-      />
-    )
-  }
-
-  if (!rows || rows.rows.length === 0) {
-    return (
-      <EmptyState
-        icon={<Database className="h-10 w-10" />}
-        title="No rows"
-        description="This dataset version does not have preview rows."
-        className="py-8"
-      />
-    )
-  }
-
-  const rangeStart = offset + 1
-  const rangeEnd = offset + rows.rows.length
-  const rangeLabel =
-    typeof rows.total === "number"
-      ? `${rangeStart}-${rangeEnd} of ${formatCount(rows.total)}`
-      : `${rangeStart}-${rangeEnd}`
-
-  return (
-    <div className="-mx-5 min-w-0 border-y border-border sm:-mx-6">
-      <div className="max-h-[520px] overflow-auto">
-        <Table className="min-w-[720px] table-fixed">
-          <TableHeader className="sticky top-0 z-10">
-            <TableRow>
-              {rows.columns.map((column, columnIndex) => (
-                <TableHead
-                  key={column}
-                  className={cn(
-                    "w-48 font-mono normal-case",
-                    columnIndex === 0 && "pl-5 sm:pl-6",
-                    columnIndex === rows.columns.length - 1 && "pr-5 sm:pr-6"
-                  )}
-                >
-                  <span className="block truncate">{column}</span>
-                </TableHead>
-              ))}
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {rows.rows.map((row, index) => (
-              <TableRow key={`${rows.offset}:${index}`} className="align-top">
-                {rows.columns.map((column, columnIndex) => (
-                  <TableCell
-                    key={column}
-                    className={cn(
-                      columnIndex === 0 && "pl-5 sm:pl-6",
-                      columnIndex === rows.columns.length - 1 && "pr-5 sm:pr-6"
-                    )}
-                  >
-                    <span className="block max-h-16 overflow-hidden break-words font-mono text-xs text-foreground">
-                      {formatValue(row[column])}
-                    </span>
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-
-      <div className="mt-3 flex flex-col gap-2 px-5 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:px-6">
-        <span className="tabular-nums">{rangeLabel}</span>
-        <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={onPrevious}
-            disabled={offset === 0}
-            aria-label="Previous page"
-          >
-            <ChevronLeft />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={onNext}
-            disabled={!rows.hasMore}
-            aria-label="Next page"
-          >
-            <ChevronRight />
-          </Button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function VersionsTable({
-  versions,
-  selectedVersionId,
-  onSelect,
-}: {
-  versions: DatasetVersion[]
-  selectedVersionId: string | null
-  onSelect: (versionId: string) => void
-}) {
-  if (versions.length === 0) {
-    return (
-      <EmptyState
-        icon={<Clock3 className="h-10 w-10" />}
-        title="No versions"
-        description="Committed dataset versions will appear here."
-        className="py-8"
-      />
-    )
-  }
-
-  return (
-    <div className="-mx-2 max-h-[420px] overflow-auto">
-      <ul className="divide-y divide-border/30">
-        {versions.map((version) => {
-          const selected = version.versionId === selectedVersionId
-
-          return (
-            <li key={version.versionId}>
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={() => onSelect(version.versionId)}
-                className={cn(
-                  "h-auto w-full justify-start py-2.5 text-left",
-                  selected && "bg-muted"
-                )}
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate font-mono text-xs text-foreground">{version.versionId}</p>
-                  <p className="mt-1 truncate text-[11px] font-normal text-muted-foreground">
-                    {version.producer
-                      ? `${version.producer.kind}${
-                          version.producer.id ? ` / ${version.producer.id}` : ""
-                        }`
-                      : formatRelativeTime(version.createdAt)}
-                  </p>
-                </div>
-              </Button>
-            </li>
-          )
-        })}
-      </ul>
-    </div>
-  )
-}
-
-function DetailField({
-  label,
-  value,
-  mono,
-}: {
-  label: string
-  value: React.ReactNode
-  mono?: boolean
-}) {
-  return (
-    <div className="min-w-0">
-      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
-      <dd className={cn("mt-1 break-words text-sm text-foreground", mono && "font-mono text-xs")}>
-        {value}
-      </dd>
-    </div>
-  )
-}
-
-function ReferenceList({
-  label,
-  ids,
-  onSelect,
-}: {
-  label: string
-  ids: string[]
-  onSelect?: (id: string) => void
-}) {
-  if (ids.length === 0) return null
-
-  return (
-    <div className="min-w-0">
-      <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-        {label}
-      </p>
-      <div className="mt-2 flex flex-col">
-        {ids.map((id) => {
-          const content = (
-            <>
-              <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <span className="truncate">{id}</span>
-            </>
-          )
-
-          if (onSelect) {
-            return (
-              <Button
-                key={id}
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => onSelect(id)}
-                className="-mx-2 max-w-full justify-start font-mono text-xs text-foreground"
-              >
-                {content}
-              </Button>
-            )
-          }
-
-          return (
-            <span
-              key={id}
-              className="inline-flex max-w-full items-center gap-2 px-0 py-1.5 font-mono text-xs text-foreground"
-            >
-              {content}
-            </span>
-          )
-        })}
-      </div>
-    </div>
   )
 }
 
@@ -749,17 +285,84 @@ export function DatasetsPage() {
   )
 }
 
+function ColumnsMenu({
+  columns,
+  hiddenColumns,
+  onToggle,
+  onShowAll,
+}: {
+  columns: string[]
+  hiddenColumns: Set<string>
+  onToggle: (column: string) => void
+  onShowAll: () => void
+}) {
+  const visibleCount = columns.length - hiddenColumns.size
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 gap-1.5 text-xs">
+          <Columns3 className="size-3.5" />
+          Columns
+          {hiddenColumns.size > 0 ? (
+            <span className="tabular-nums text-muted-foreground">
+              {visibleCount}/{columns.length}
+            </span>
+          ) : null}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-h-[60vh] w-56 overflow-auto">
+        <div className="flex items-center justify-between px-2 py-1">
+          <DropdownMenuLabel className="p-0">Columns</DropdownMenuLabel>
+          {hiddenColumns.size > 0 ? (
+            <button
+              type="button"
+              onClick={onShowAll}
+              className="text-[11px] text-muted-foreground hover:text-foreground"
+            >
+              Show all
+            </button>
+          ) : null}
+        </div>
+        <DropdownMenuSeparator />
+        {columns.map((column) => (
+          <DropdownMenuCheckboxItem
+            key={column}
+            checked={!hiddenColumns.has(column)}
+            onCheckedChange={() => onToggle(column)}
+            onSelect={(event) => event.preventDefault()}
+            className="font-mono text-xs"
+          >
+            <span className="truncate">{column}</span>
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
 export function DatasetDetailPage() {
   const { datasetId = "" } = useParams()
   const navigate = useNavigate()
   const decodedDatasetId = decodeURIComponent(datasetId)
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null)
   const [rowsOffset, setRowsOffset] = useState(0)
+  const [quickFilter, setQuickFilter] = useState("")
+  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(() => new Set())
+  const [pageSize, setPageSize] = useState<number>(() =>
+    Number(getCollectionViewStyle("dataset-page-size", pageSizeOptions, "100"))
+  )
+
+  // Different dataset → drop column/filter state that only made sense before.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: effect is keyed on the dataset id to reset state on navigation, not because the body reads it
+  useEffect(() => {
+    setHiddenColumns(new Set())
+    setQuickFilter("")
+    setRowsOffset(0)
+  }, [decodedDatasetId])
 
   const datasetQuery = useQuery({
-    ...getDatasetOptions({
-      path: { datasetId: decodedDatasetId },
-    }),
+    ...getDatasetOptions({ path: { datasetId: decodedDatasetId } }),
     enabled: decodedDatasetId.length > 0,
   })
 
@@ -788,8 +391,6 @@ export function DatasetDetailPage() {
     }
   }, [dataset?.latestVersion?.versionId, selectedVersionId, versions])
 
-  // Full version metadata lives in the versions route; the catalog summary on
-  // `dataset.latestVersion` only drives selection defaults above.
   const selectedVersion =
     versions.find((version) => version.versionId === selectedVersionId) ?? null
 
@@ -803,16 +404,85 @@ export function DatasetDetailPage() {
       path: { datasetId: decodedDatasetId },
       query: {
         versionId: selectedVersionId ?? undefined,
-        limit: String(rowPreviewLimit),
+        limit: String(pageSize),
         offset: String(rowsOffset),
       },
     }),
     enabled: decodedDatasetId.length > 0 && selectedVersionId !== null,
   })
 
+  const rowsData = rowsQuery.data
+
+  // Prefer the full version metadata; fall back to the version embedded in the
+  // rows response so stats render before the versions list resolves.
+  const schemaColumns =
+    selectedVersion?.schema.columns ??
+    rowsData?.version?.schema.columns ??
+    dataset?.schema.columns ??
+    []
+
+  const columnMeta = useMemo(() => {
+    const map = new Map<string, DatasetGridColumnMeta>()
+    for (const column of schemaColumns) {
+      map.set(column.name, {
+        type: `${column.type}${column.nullable ? "?" : ""}`,
+        numeric: isNumericColumnType(column.type),
+      })
+    }
+    return map
+  }, [schemaColumns])
+
+  const allColumns = rowsData?.columns ?? schemaColumns.map((column) => column.name)
+
+  const visibleColumns = useMemo(
+    () => allColumns.filter((column) => !hiddenColumns.has(column)),
+    [allColumns, hiddenColumns]
+  )
+
+  const rawRows = rowsData?.rows ?? emptyRows
+
+  const filteredRows = useMemo(() => {
+    const query = quickFilter.trim().toLowerCase()
+    if (!query) return rawRows
+    return rawRows.filter((row) =>
+      visibleColumns.some((column) => {
+        const value = row[column]
+        if (value === null || value === undefined) return false
+        return String(typeof value === "object" ? JSON.stringify(value) : value)
+          .toLowerCase()
+          .includes(query)
+      })
+    )
+  }, [rawRows, quickFilter, visibleColumns])
+
+  const toggleColumn = (column: string) => {
+    setHiddenColumns((previous) => {
+      const next = new Set(previous)
+      if (next.has(column)) {
+        next.delete(column)
+      } else if (allColumns.length - next.size > 1) {
+        // Keep at least one column visible.
+        next.add(column)
+      }
+      return next
+    })
+  }
+
+  const handlePageSizeChange = (next: string) => {
+    setPageSize(Number(next))
+    setRowsOffset(0)
+    setCollectionViewStyle("dataset-page-size", next)
+  }
+
+  const handleRefresh = () => {
+    datasetQuery.refetch()
+    versionsQuery.refetch()
+    if (selectedVersionId !== null) rowsQuery.refetch()
+  }
+
   if (datasetQuery.isLoading) {
     return (
-      <div className="flex h-full items-center justify-center py-24">
+      <div className="flex h-full items-center justify-center">
         <div className="flex items-center gap-3 text-muted-foreground">
           <Loader2 className="h-5 w-5 animate-spin" />
           <span className="text-sm">Loading dataset...</span>
@@ -823,18 +493,20 @@ export function DatasetDetailPage() {
 
   if (datasetQuery.isError || !dataset) {
     return (
-      <div className="mx-auto w-full max-w-2xl space-y-4">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate("/datasets")}
-          className="-ml-2 self-start text-muted-foreground hover:text-foreground"
-        >
-          <ChevronLeft />
-          Datasets
-        </Button>
-        <div className="rounded-lg border border-border bg-card p-8">
+      <div className="flex h-full flex-col">
+        <div className="border-b border-border px-4 py-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate("/datasets")}
+            className="-ml-2 text-muted-foreground hover:text-foreground"
+          >
+            <ChevronLeft />
+            Datasets
+          </Button>
+        </div>
+        <div className="flex flex-1 items-center justify-center p-6">
           <EmptyState
             icon={<Database className="h-10 w-10" />}
             title="Dataset not found"
@@ -845,115 +517,236 @@ export function DatasetDetailPage() {
     )
   }
 
-  const schemaColumns = selectedVersion?.schema.columns ?? dataset.schema.columns
+  const rowCount = selectedVersion?.rowCount ?? rowsData?.version?.rowCount ?? rowsData?.total
+  const sizeBytes = selectedVersion?.sizeBytes ?? rowsData?.version?.sizeBytes
+  const rangeStart = rawRows.length > 0 ? rowsOffset + 1 : 0
+  const rangeEnd = rowsOffset + rawRows.length
+  const totalRows = rowsData?.total ?? rowCount
+  const rangeLabel =
+    typeof totalRows === "number"
+      ? `${rangeStart.toLocaleString()}–${rangeEnd.toLocaleString()} of ${formatCount(totalRows)}`
+      : `${rangeStart.toLocaleString()}–${rangeEnd.toLocaleString()}`
+  const filterActive = quickFilter.trim().length > 0
+  const noCommittedVersions = selectedVersionId === null && versions.length === 0
+
+  const versionSummary = {
+    versionId:
+      selectedVersion?.versionId ?? rowsData?.version?.versionId ?? selectedVersionId ?? undefined,
+    rowCount,
+    sizeBytes,
+    createdAt: selectedVersion?.createdAt ?? rowsData?.version?.createdAt,
+    mode: selectedVersion?.mode ?? rowsData?.version?.mode,
+    producer: selectedVersion?.producer ?? rowsData?.version?.producer,
+  }
+
+  const latestVersionId = dataset.latestVersion?.versionId
+  const isLatestVersion = selectedVersionId != null && selectedVersionId === latestVersionId
+  const versionLabel = isLatestVersion
+    ? "Latest"
+    : selectedVersion?.createdAt
+      ? formatRelativeTime(selectedVersion.createdAt)
+      : "Version"
 
   return (
-    <div className="mx-auto w-full max-w-6xl min-w-0 space-y-4 overflow-hidden">
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        onClick={() => navigate("/datasets")}
-        className="-ml-2 self-start text-muted-foreground hover:text-foreground"
-      >
-        <ChevronLeft />
-        Datasets
-      </Button>
+    <div className="flex h-full w-full min-w-0 flex-col overflow-hidden">
+      <header className="flex shrink-0 items-start gap-2 border-b border-border px-3 py-3 sm:px-4">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => navigate("/datasets")}
+          aria-label="Back to datasets"
+          className="-ml-1 shrink-0 text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft />
+        </Button>
 
-      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div className="min-w-0">
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground sm:text-[32px]">
-            {datasetName(dataset)}
-          </h1>
-          <p className="mt-1.5 break-all font-mono text-xs text-muted-foreground">{dataset.id}</p>
-          <p className="mt-2 text-sm text-muted-foreground">{datasetSummary(dataset)}</p>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <h1 className="min-w-0 truncate text-[15px] font-semibold tracking-tight text-foreground">
+              {datasetName(dataset)}
+            </h1>
+            <Badge variant="secondary" className="h-5 shrink-0 px-1.5 text-[10px] font-normal">
+              {dataset.materialized ? "Materialized" : "Declared"}
+            </Badge>
+          </div>
+          <p className="truncate text-[11px] text-muted-foreground">
+            <span className="font-mono">{dataset.id}</span>
+            <span className="hidden sm:inline">
+              {" · "}
+              {[
+                versionSummary.mode,
+                `${formatCount(rowCount)} rows`,
+                `${schemaColumns.length} cols`,
+                formatBytes(sizeBytes),
+                versionSummary.createdAt
+                  ? `updated ${formatRelativeTime(versionSummary.createdAt)}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </span>
+          </p>
         </div>
-        <VersionSelect
-          versions={versions}
-          selectedVersionId={selectedVersionId}
-          onSelect={handleSelectVersion}
-        />
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 shrink-0 gap-1.5 self-center px-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <Info className="size-3.5" />
+              <span className="hidden sm:inline">Details</span>
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-80">
+            <DatasetDetails
+              dataset={dataset}
+              columnCount={schemaColumns.length}
+              versionSummary={versionSummary}
+              onNavigate={(path) => navigate(path)}
+            />
+          </PopoverContent>
+        </Popover>
       </header>
 
-      <DatasetMetrics dataset={dataset} selectedVersion={selectedVersion} />
-
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="space-y-4">
-          <DetailSurface title="Rows">
-            {selectedVersion ? (
-              <RowPreview
-                rows={rowsQuery.data}
-                isLoading={rowsQuery.isLoading}
-                isError={rowsQuery.isError}
-                offset={rowsOffset}
-                onPrevious={() => setRowsOffset((offset) => Math.max(0, offset - rowPreviewLimit))}
-                onNext={() => setRowsOffset((offset) => offset + rowPreviewLimit)}
-              />
-            ) : (
-              <EmptyState
-                icon={<Database className="h-10 w-10" />}
-                title="No version selected"
-                description="Rows are available after the dataset has a committed version."
-                className="py-8"
-              />
-            )}
-          </DetailSurface>
-
-          <DetailSurface title="Schema">
-            <SchemaTable columns={schemaColumns} partitionBy={dataset.partitionBy} />
-          </DetailSurface>
+      <div className="flex min-h-11 shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 sm:px-4">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={quickFilter}
+            onChange={(event) => setQuickFilter(event.target.value)}
+            placeholder="Filter rows..."
+            className="h-8 w-44 pl-8 text-xs sm:w-64"
+          />
         </div>
+        {filterActive ? (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {filteredRows.length.toLocaleString()} of {rawRows.length.toLocaleString()}
+          </span>
+        ) : null}
 
-        <aside className="space-y-4">
-          <DetailSurface title="Details">
-            <dl className="grid gap-x-8 gap-y-5 sm:grid-cols-2 lg:grid-cols-1">
-              <DetailField
-                label="Type"
-                value={dataset.materialized ? "Materialized" : "Declared"}
-              />
-              <DetailField label="Description" value={dataset.description ?? "No description"} />
-            </dl>
-          </DetailSurface>
+        <div className="ml-auto flex items-center gap-2">
+          {versions.length > 0 ? (
+            <Select value={selectedVersionId ?? undefined} onValueChange={handleSelectVersion}>
+              <SelectTrigger
+                size="sm"
+                className="h-8 w-[140px] text-xs"
+                aria-label="Select version"
+                title={selectedVersionId ?? undefined}
+              >
+                <span className="truncate">{versionLabel}</span>
+              </SelectTrigger>
+              <SelectContent position="popper" align="end" className="max-w-[320px]">
+                {versions.map((version) => (
+                  <SelectItem key={version.versionId} value={version.versionId} className="text-xs">
+                    <div className="flex min-w-0 flex-col gap-0.5">
+                      <span className="flex items-center gap-1.5">
+                        <span className="max-w-[190px] truncate font-mono">
+                          {version.versionId}
+                        </span>
+                        {version.versionId === latestVersionId ? (
+                          <span className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+                            Latest
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="max-w-[210px] truncate text-[10px] text-muted-foreground">
+                        {[
+                          version.mode,
+                          formatRelativeTime(version.createdAt),
+                          typeof version.rowCount === "number"
+                            ? `${formatCount(version.rowCount)} rows`
+                            : null,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ")}
+                      </span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
+          <ColumnsMenu
+            columns={allColumns}
+            hiddenColumns={hiddenColumns}
+            onToggle={toggleColumn}
+            onShowAll={() => setHiddenColumns(new Set())}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleRefresh}
+            aria-label="Refresh"
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <RefreshCw className={cn(rowsQuery.isFetching && "animate-spin")} />
+          </Button>
+        </div>
+      </div>
 
-          <DetailSurface title="Versions">
-            {versionsQuery.isLoading ? (
-              <div className="py-10">
-                <div className="flex items-center gap-3 text-muted-foreground">
-                  <Loader2 className="h-5 w-5 animate-spin" />
-                  <span className="text-sm">Loading versions...</span>
-                </div>
-              </div>
-            ) : versionsQuery.isError ? (
-              <EmptyState
-                icon={<Clock3 className="h-10 w-10" />}
-                title="Versions unavailable"
-                description="Could not load dataset version history."
-                className="py-8"
-              />
-            ) : (
-              <VersionsTable
-                versions={versions}
-                selectedVersionId={selectedVersionId}
-                onSelect={handleSelectVersion}
-              />
-            )}
-          </DetailSurface>
+      <DatasetTableGrid
+        key={decodedDatasetId}
+        columns={visibleColumns}
+        columnMeta={columnMeta}
+        rows={filteredRows}
+        offset={rowsOffset}
+        isLoading={selectedVersionId !== null && rowsQuery.isLoading}
+        isError={rowsQuery.isError}
+        emptyDescription={
+          noCommittedVersions
+            ? "No committed versions yet. Rows appear after the dataset is materialized."
+            : filterActive
+              ? "No rows on this page match your filter."
+              : "This dataset version does not have preview rows."
+        }
+      />
 
-          {sourceCount(dataset) + consumerCount(dataset) > 0 && (
-            <DetailSurface title="References">
-              <div className="space-y-5">
-                <ReferenceList
-                  label="Syncs"
-                  ids={dataset.syncIds}
-                  onSelect={(syncId) => navigate(`/syncs/${encodeURIComponent(syncId)}`)}
-                />
-                <ReferenceList label="Source pipelines" ids={dataset.sourcePipelineIds} />
-                <ReferenceList label="Target pipelines" ids={dataset.targetPipelineIds} />
-                <ReferenceList label="Projections" ids={dataset.projectionIds} />
-              </div>
-            </DetailSurface>
-          )}
-        </aside>
+      <div className="flex shrink-0 items-center justify-between gap-3 border-t border-border px-3 py-1.5 sm:px-4">
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {rowsOffset > 0 || rowsData?.hasMore ? rangeLabel : `${formatCount(rowCount)} rows`}
+          {filterActive ? ` · ${filteredRows.length.toLocaleString()} shown` : ""}
+        </span>
+        <div className="flex items-center gap-2">
+          <Select value={String(pageSize)} onValueChange={handlePageSizeChange}>
+            <SelectTrigger size="sm" className="h-8 w-[104px] text-xs" aria-label="Rows per page">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent position="popper" align="end">
+              {pageSizeOptions.map((option) => (
+                <SelectItem key={option} value={option} className="text-xs">
+                  {option} rows
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="flex items-center">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => setRowsOffset((offset) => Math.max(0, offset - pageSize))}
+              disabled={rowsOffset === 0}
+              aria-label="Previous page"
+            >
+              <ChevronLeft />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => setRowsOffset((offset) => offset + pageSize)}
+              disabled={!rowsData?.hasMore}
+              aria-label="Next page"
+            >
+              <ChevronRight />
+            </Button>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/packages/atlas/src/pages/PipelinesPage.tsx
+++ b/packages/atlas/src/pages/PipelinesPage.tsx
@@ -58,7 +58,6 @@ import {
   Loader2,
   LoaderCircle,
   Play,
-  Rows3,
   Search,
   Workflow,
   X,
@@ -66,6 +65,8 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { type DatasetGridColumnMeta, DatasetTableGrid } from "../features/datasets/DatasetTableGrid"
+import { isNumericColumnType } from "../lib/datasets"
 import { humanizeIdentifier } from "../lib/labels"
 import { formatRelativeTime } from "../lib/time"
 import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
@@ -796,18 +797,6 @@ function formatRowCount(value: number): string {
   return new Intl.NumberFormat().format(value)
 }
 
-function formatCellValue(value: unknown): string {
-  if (value === null || value === undefined) return "—"
-  if (typeof value === "string") return value
-  if (typeof value === "number" || typeof value === "boolean") return String(value)
-  if (value instanceof Date) return value.toISOString()
-  try {
-    return JSON.stringify(value)
-  } catch {
-    return String(value)
-  }
-}
-
 function DatasetPreviewDrawer({
   datasetId,
   open,
@@ -834,14 +823,18 @@ function DatasetPreviewDrawer({
 
   const dataset: GetDatasetResponse | undefined = datasetQuery.data
   const rowsData: ListDatasetRowsResponse | undefined = rowsQuery.data
-  const columns = rowsData?.columns ?? dataset?.schema.columns.map((c) => c.name) ?? []
-  const columnTypes = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const col of dataset?.schema.columns ?? []) {
-      map.set(col.name, `${col.type}${col.nullable ? "?" : ""}`)
+  const schemaColumns = rowsData?.version?.schema.columns ?? dataset?.schema.columns ?? []
+  const columns = rowsData?.columns ?? schemaColumns.map((c) => c.name)
+  const columnMeta = useMemo(() => {
+    const map = new Map<string, DatasetGridColumnMeta>()
+    for (const col of rowsData?.version?.schema.columns ?? dataset?.schema.columns ?? []) {
+      map.set(col.name, {
+        type: `${col.type}${col.nullable ? "?" : ""}`,
+        numeric: isNumericColumnType(col.type),
+      })
     }
     return map
-  }, [dataset])
+  }, [dataset, rowsData])
 
   const rows = rowsData?.rows ?? []
   const version = dataset?.latestVersion ?? rowsData?.version ?? null
@@ -938,85 +931,16 @@ function DatasetPreviewDrawer({
           </div>
         </div>
 
-        {/* Table */}
-        <div className="min-h-0 flex-1 overflow-auto">
-          {datasetQuery.isLoading || rowsQuery.isLoading ? (
-            <div className="flex h-full items-center justify-center">
-              <div className="flex items-center gap-3 text-muted-foreground">
-                <Loader2 className="h-5 w-5 animate-spin" />
-                <span className="text-sm">Loading dataset...</span>
-              </div>
-            </div>
-          ) : errorText ? (
-            <div className="flex h-full items-center justify-center px-6">
-              <EmptyState
-                icon={<Rows3 className="h-9 w-9" />}
-                title="Could not load preview"
-                description={errorText}
-                className="py-6"
-              />
-            </div>
-          ) : columns.length === 0 ? (
-            <div className="flex h-full items-center justify-center px-6">
-              <EmptyState
-                icon={<Rows3 className="h-9 w-9" />}
-                title="No schema"
-                description="This dataset has no declared columns."
-                className="py-6"
-              />
-            </div>
-          ) : rows.length === 0 ? (
-            <div className="flex h-full items-center justify-center px-6">
-              <EmptyState
-                icon={<Rows3 className="h-9 w-9" />}
-                title="No rows yet"
-                description="This dataset hasn't been materialized. Trigger a run to populate it."
-                className="py-6"
-              />
-            </div>
-          ) : (
-            <Table>
-              <TableHeader className="sticky top-0 z-10">
-                <TableRow>
-                  {columns.map((column) => (
-                    <TableHead key={column} className="font-mono normal-case first:pl-5 last:pr-5">
-                      <div className="flex flex-col">
-                        <span className="text-[11px] text-foreground">{column}</span>
-                        {columnTypes.get(column) && (
-                          <span className="text-[10px] text-muted-foreground">
-                            {columnTypes.get(column)}
-                          </span>
-                        )}
-                      </div>
-                    </TableHead>
-                  ))}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {rows.map((row, rowIndex) => (
-                  <TableRow key={`row-${rowIndex}`}>
-                    {columns.map((column) => {
-                      const raw = (row as Record<string, unknown>)[column]
-                      const isNullish = raw === null || raw === undefined
-                      return (
-                        <TableCell
-                          key={column}
-                          className={cn(
-                            "max-w-[320px] truncate whitespace-nowrap font-mono text-[11px] first:pl-5 last:pr-5",
-                            isNullish ? "italic text-muted-foreground/60" : "text-foreground"
-                          )}
-                          title={formatCellValue(raw)}
-                        >
-                          {formatCellValue(raw)}
-                        </TableCell>
-                      )
-                    })}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </div>
+        {/* Rows — shared dataset grid (sticky header, resizable columns, click-to-expand) */}
+        <DatasetTableGrid
+          columns={columns}
+          columnMeta={columnMeta}
+          rows={rows}
+          offset={rowsData?.offset ?? 0}
+          isLoading={datasetQuery.isLoading || rowsQuery.isLoading}
+          isError={Boolean(errorText)}
+          emptyDescription="This dataset hasn't been materialized. Trigger a run to populate it."
+        />
 
         {rowsData && rows.length > 0 && (
           <div className="flex shrink-0 items-center justify-between border-t border-border bg-background/40 px-5 py-2 text-[11px] text-muted-foreground">

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -370,6 +370,7 @@ export function ProjectWorkspace() {
   return (
     <Routes>
       <Route path="pipelines/:pipelineId" element={<PipelineDetailPage />} />
+      <Route path="datasets/:datasetId" element={<DatasetDetailPage />} />
       <Route path="actions" element={<ActionsPage />} />
       <Route path="actions/runs/:runId" element={<ActionRunDetailPage />} />
       <Route element={<WorkflowLiveUpdatesBoundary />}>
@@ -407,7 +408,6 @@ export function ProjectWorkspace() {
             <Route path="home" element={<Navigate to="/" replace />} />
             <Route path="objects" element={<Navigate to="/" replace />} />
             <Route path="datasets" element={<DatasetsPage />} />
-            <Route path="datasets/:datasetId" element={<DatasetDetailPage />} />
             <Route path="connectors" element={<ConnectorsPage />} />
             <Route path="connectors/:connectorId" element={<ConnectorDetailPage />} />
             <Route path="syncs" element={<SyncsPage />} />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -78,6 +78,7 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -110,6 +110,7 @@ export {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "./ui/context-menu"
+export { DataTable, type DataTableColumn } from "./ui/data-table"
 export {
   Dialog,
   DialogClose,

--- a/packages/ui/src/components/ui/data-table.tsx
+++ b/packages/ui/src/components/ui/data-table.tsx
@@ -1,0 +1,248 @@
+"use client"
+
+import { cn } from "@sixb/ui/lib/utils"
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type RowData,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table"
+import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react"
+import * as React from "react"
+import { Skeleton } from "./skeleton"
+
+// Lets a column carry presentational hints (right-align numerics, a type
+// caption under the header) without leaking into the row data.
+declare module "@tanstack/react-table" {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    align?: "left" | "right"
+    typeLabel?: React.ReactNode
+  }
+}
+
+export interface DataTableColumn<TData> {
+  /** Stable id; also the key used for sizing/sorting state. */
+  id: string
+  /** Header label (string or node). */
+  header: React.ReactNode
+  /** Optional caption rendered under the header (e.g. a column type). */
+  typeLabel?: React.ReactNode
+  /** Reads the cell value from a row. */
+  accessor: (row: TData) => unknown
+  /** Renders the cell. Defaults to the stringified value. */
+  cell?: (value: unknown, row: TData) => React.ReactNode
+  align?: "left" | "right"
+  size?: number
+  minSize?: number
+  enableSorting?: boolean
+}
+
+interface DataTableProps<TData> {
+  columns: DataTableColumn<TData>[]
+  data: TData[]
+  /** Render a sticky left gutter with 1-based row numbers. */
+  showRowIndex?: boolean
+  /** Added to the row's original index for the gutter number. */
+  rowIndexOffset?: number
+  onCellClick?: (cell: { columnId: string; value: unknown; row: TData; rowIndex: number }) => void
+  isLoading?: boolean
+  /** Shown when there are no rows (and not loading). */
+  empty?: React.ReactNode
+  /** Applied to the scroll container. */
+  className?: string
+}
+
+const GUTTER_WIDTH = 56
+const skeletonRows = Array.from({ length: 14 }, (_, index) => `dt-skeleton-${index}`)
+
+export function DataTable<TData>({
+  columns,
+  data,
+  showRowIndex = false,
+  rowIndexOffset = 0,
+  onCellClick,
+  isLoading = false,
+  empty,
+  className,
+}: DataTableProps<TData>) {
+  const [sorting, setSorting] = React.useState<SortingState>([])
+
+  const columnDefs = React.useMemo<ColumnDef<TData>[]>(
+    () =>
+      columns.map((column) => ({
+        id: column.id,
+        accessorFn: (row) => column.accessor(row),
+        header: () => column.header,
+        cell: (info) =>
+          column.cell ? column.cell(info.getValue(), info.row.original) : String(info.getValue()),
+        enableSorting: column.enableSorting ?? true,
+        size: column.size,
+        minSize: column.minSize ?? 80,
+        meta: { align: column.align, typeLabel: column.typeLabel },
+      })),
+    [columns]
+  )
+
+  const table = useReactTable({
+    data,
+    columns: columnDefs,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    enableColumnResizing: true,
+    columnResizeMode: "onChange",
+    defaultColumn: { size: 200, minSize: 80, maxSize: 800 },
+  })
+
+  if (isLoading) {
+    return (
+      <div className={cn("min-h-0 flex-1 space-y-px overflow-hidden p-3", className)}>
+        {skeletonRows.map((key) => (
+          <Skeleton key={key} className="h-7 w-full" />
+        ))}
+      </div>
+    )
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className={cn("flex min-h-0 flex-1 items-center justify-center p-6", className)}>
+        {empty}
+      </div>
+    )
+  }
+
+  const cellPadY = "py-1"
+  const cellText = "text-[11px]"
+  const totalWidth = table.getTotalSize() + (showRowIndex ? GUTTER_WIDTH : 0)
+
+  return (
+    <div className={cn("min-h-0 flex-1 overflow-auto", className)}>
+      <table
+        className="border-separate border-spacing-0 text-left"
+        style={{ width: totalWidth, tableLayout: "fixed" }}
+      >
+        <colgroup>
+          {showRowIndex ? <col style={{ width: GUTTER_WIDTH }} /> : null}
+          {table.getVisibleLeafColumns().map((column) => (
+            <col key={column.id} style={{ width: column.getSize() }} />
+          ))}
+        </colgroup>
+
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {showRowIndex ? (
+                <th className="sticky left-0 top-0 z-30 h-9 border-b border-r border-border bg-muted align-middle">
+                  <span className="block pr-2 text-right text-[10px] font-medium tabular-nums text-muted-foreground">
+                    #
+                  </span>
+                </th>
+              ) : null}
+              {headerGroup.headers.map((header) => {
+                const meta = header.column.columnDef.meta
+                const sorted = header.column.getIsSorted()
+                const canSort = header.column.getCanSort()
+                return (
+                  <th
+                    key={header.id}
+                    className="group/h sticky top-0 z-20 border-b border-r border-border bg-muted p-0 align-bottom last:border-r-0"
+                  >
+                    <button
+                      type="button"
+                      onClick={header.column.getToggleSortingHandler()}
+                      disabled={!canSort}
+                      className="flex w-full items-center gap-1.5 px-3 py-1.5 text-left transition-colors enabled:hover:bg-muted-foreground/10"
+                    >
+                      <span className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate font-mono text-[11px] font-medium text-foreground">
+                          {flexRender(header.column.columnDef.header, header.getContext())}
+                        </span>
+                        {meta?.typeLabel ? (
+                          <span className="truncate font-mono text-[10px] font-normal text-muted-foreground">
+                            {meta.typeLabel}
+                          </span>
+                        ) : null}
+                      </span>
+                      {sorted === "asc" ? (
+                        <ArrowUp className="size-3 shrink-0 text-foreground" />
+                      ) : sorted === "desc" ? (
+                        <ArrowDown className="size-3 shrink-0 text-foreground" />
+                      ) : canSort ? (
+                        <ChevronsUpDown className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/h:opacity-60" />
+                      ) : null}
+                    </button>
+                    {header.column.getCanResize() ? (
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        aria-hidden="true"
+                        onMouseDown={header.getResizeHandler()}
+                        onTouchStart={header.getResizeHandler()}
+                        onClick={(event) => event.stopPropagation()}
+                        className={cn(
+                          "absolute right-0 top-0 z-10 h-full w-1.5 cursor-col-resize touch-none select-none bg-transparent transition-colors hover:bg-primary/40",
+                          header.column.getIsResizing() && "bg-primary/60"
+                        )}
+                      />
+                    ) : null}
+                  </th>
+                )
+              })}
+            </tr>
+          ))}
+        </thead>
+
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id} className="group">
+              {showRowIndex ? (
+                <td
+                  className={cn(
+                    "sticky left-0 z-10 border-b border-r border-border bg-card text-right align-top tabular-nums text-[10px] text-muted-foreground transition-colors group-hover:bg-muted",
+                    cellPadY
+                  )}
+                >
+                  <span className="block pr-2">{rowIndexOffset + row.index + 1}</span>
+                </td>
+              ) : null}
+              {row.getVisibleCells().map((cell) => {
+                const align = cell.column.columnDef.meta?.align
+                return (
+                  <td
+                    key={cell.id}
+                    onClick={
+                      onCellClick
+                        ? () =>
+                            onCellClick({
+                              columnId: cell.column.id,
+                              value: cell.getValue(),
+                              row: row.original,
+                              rowIndex: row.index,
+                            })
+                        : undefined
+                    }
+                    className={cn(
+                      "border-b border-r border-border align-top transition-colors last:border-r-0 group-hover:bg-muted",
+                      "px-3",
+                      cellPadY,
+                      cellText,
+                      align === "right" && "text-right tabular-nums",
+                      onCellClick && "cursor-pointer"
+                    )}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem

The dataset detail page boxed its data into a doubly-constrained window: the route sat inside the app's `max-w-7xl` shell, the page added its own `max-w-6xl`, a 320px metadata sidebar took the rest, and the row table was capped at `max-h-[520px]`. The data — the point of the page — was the smallest thing on screen, with no way to sort, resize columns, filter, or inspect long/JSON values.

## Change

Move the route out of the constrained shell (like the pipeline/workflow detail pages) and rebuild the page around a reusable grid. Four bands, each with one job:

## Scope

UI only — `packages/atlas` (dataset page + pipeline preview) and one new `packages/ui` component. No server, route, schema, or generated-client changes.

<img width="1474" height="415" alt="Screenshot 2026-06-26 at 11 06 29 PM" src="https://github.com/user-attachments/assets/9554cee4-c58f-4010-9f16-c09d5ec89ade" />
