### PR TITLE
agents: add execution identity

### DIFF
--- a/packages/agent-worker/src/identity.ts
+++ b/packages/agent-worker/src/identity.ts
@@ -1,0 +1,181 @@
+import type {
+  AccessTokenRecord,
+  AgentDefinition,
+  AgentRunRecord,
+  Principal,
+  ServiceAccountGroupMembershipRecord,
+  ServiceAccountRecord,
+} from "@sixb/core"
+import { createAccessTokenCredential } from "@sixb/core"
+import type { AgentWorkerStorage } from "./types"
+
+const SYSTEM_PRINCIPAL: Principal = { type: "system", id: "agent-worker" }
+
+// Token TTL knobs: 5 minute safety buffer, 15 minute minimum, 1 hour maximum.
+const TOKEN_TTL_SAFETY_MS = 5 * 60_000
+const MIN_TOKEN_TTL_MS = 15 * 60_000
+const MAX_TOKEN_TTL_MS = 60 * 60_000
+
+/** Stable auth identity the worker uses when an agent acts on Sixb resources. */
+export interface AgentExecutionIdentity {
+  readonly serviceAccount: ServiceAccountRecord
+  readonly principal: Extract<Principal, { readonly type: "serviceAccount" }>
+  readonly groupMemberships: readonly ServiceAccountGroupMembershipRecord[]
+}
+
+/** Persisted token metadata plus the raw bearer value, which is only available at mint time. */
+export interface AgentRunAccessToken {
+  readonly accessToken: AccessTokenRecord
+  readonly tokenValue: string
+}
+
+export function agentServiceAccountId(agent: AgentDefinition): string {
+  return `svc_agent_${agent.id}`
+}
+
+export async function reconcileAgentExecutionIdentities(
+  storage: AgentWorkerStorage,
+  projectId: string,
+  agents: readonly AgentDefinition[]
+): Promise<readonly AgentExecutionIdentity[]> {
+  // Startup reconciliation catches bad or stale managed identities before the
+  // worker starts claiming jobs. Each claim reconciles lazily too, so a worker
+  // can recover from partial startup or missed deploy-time setup.
+  const identities: AgentExecutionIdentity[] = []
+  for (const agent of agents) {
+    identities.push(await reconcileAgentExecutionIdentity(storage, projectId, agent))
+  }
+  return identities
+}
+
+export async function reconcileAgentExecutionIdentity(
+  storage: AgentWorkerStorage,
+  projectId: string,
+  agent: AgentDefinition
+): Promise<AgentExecutionIdentity> {
+  const auth = storage.auth
+  const serviceAccountId = agentServiceAccountId(agent)
+  const name = agent.name
+  const description = `Managed service account for agent '${agent.id}'.`
+  const now = new Date()
+  // The service account is durable and stable across runs. Runs get short-lived
+  // tokens, but attribution points back to this managed principal.
+  const existing = await auth.serviceAccounts.getById({ projectId, id: serviceAccountId })
+  const serviceAccount = existing
+    ? await reconcileExistingServiceAccount(storage, {
+        projectId,
+        id: serviceAccountId,
+        existing,
+        name,
+        description,
+        updatedAt: now,
+      })
+    : await auth.serviceAccounts.create({
+        id: serviceAccountId,
+        projectId,
+        name,
+        description,
+        status: "active",
+        createdByPrincipal: SYSTEM_PRINCIPAL,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+  // Agent-owned memberships should exactly match the current definition. The
+  // store preserves manual memberships while pruning stale memberships whose
+  // source is "agent".
+  const groupMemberships = await auth.serviceAccountGroupMemberships.reconcileForServiceAccount({
+    projectId,
+    serviceAccountId,
+    groupIds: agent.groupIds,
+    source: "agent",
+    updatedAt: now,
+  })
+
+  return {
+    serviceAccount,
+    principal: { type: "serviceAccount", id: serviceAccountId },
+    groupMemberships,
+  }
+}
+
+export async function mintAgentRunAccessToken(input: {
+  readonly storage: AgentWorkerStorage
+  readonly projectId: string
+  readonly agent: AgentDefinition
+  readonly run: AgentRunRecord
+  readonly turnTimeoutMs: number
+}): Promise<AgentRunAccessToken> {
+  const serviceAccountId = agentServiceAccountId(input.agent)
+  const credential = createAccessTokenCredential("serviceAccount")
+  const createdAt = new Date()
+  // Token values are returned once and only the hash is stored. The worker hands
+  // the raw value to tools that need to call Sixb APIs during this run.
+  const accessToken = await input.storage.auth.accessTokens.create({
+    id: credential.tokenId,
+    projectId: input.projectId,
+    name: `Agent run ${input.run.id}`,
+    kind: "serviceAccount",
+    subjectType: "serviceAccount",
+    subjectId: serviceAccountId,
+    tokenHash: credential.tokenHash,
+    groupIds: input.agent.groupIds,
+    createdByPrincipal: SYSTEM_PRINCIPAL,
+    createdAt,
+    expiresAt: new Date(createdAt.getTime() + defaultAgentRunTokenTtlMs(input.turnTimeoutMs)),
+  })
+
+  return { accessToken, tokenValue: credential.tokenValue }
+}
+
+export async function revokeAgentRunAccessToken(input: {
+  readonly storage: AgentWorkerStorage
+  readonly projectId: string
+  readonly tokenId: string
+}): Promise<void> {
+  // Normal completion revokes the per-run token. Expiry is still the fallback if
+  // the process crashes before cleanup.
+  await input.storage.auth.accessTokens.revoke({
+    projectId: input.projectId,
+    id: input.tokenId,
+    revokedAt: new Date(),
+  })
+}
+
+export function defaultAgentRunTokenTtlMs(turnTimeoutMs: number): number {
+  // Give cleanup a small buffer beyond the turn timeout, but cap the blast radius
+  // if the worker dies before revoking the token.
+  const requested = Math.max(turnTimeoutMs + TOKEN_TTL_SAFETY_MS, MIN_TOKEN_TTL_MS)
+  return Math.min(requested, MAX_TOKEN_TTL_MS)
+}
+
+async function reconcileExistingServiceAccount(
+  storage: AgentWorkerStorage,
+  input: {
+    readonly projectId: string
+    readonly id: string
+    readonly existing: ServiceAccountRecord
+    readonly name: string
+    readonly description: string
+    readonly updatedAt: Date
+  }
+): Promise<ServiceAccountRecord> {
+  // Agent definitions own the display metadata and should reactivate their
+  // managed account if an earlier cleanup or operator action suspended it.
+  if (
+    input.existing.name === input.name &&
+    input.existing.description === input.description &&
+    input.existing.status === "active"
+  ) {
+    return input.existing
+  }
+
+  return storage.auth.serviceAccounts.update({
+    projectId: input.projectId,
+    id: input.id,
+    name: input.name,
+    description: input.description,
+    status: "active",
+    updatedAt: input.updatedAt,
+  })
+}

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -2,14 +2,18 @@ import type {
   AgentMessagePart,
   AgentStorage,
   AgentsRuntime,
+  AuthStorage,
   EventsRuntime,
   Queues,
   Storage,
 } from "@sixb/core"
 import type { ToolSet } from "ai"
 
-// Keep root storage for transactions while making agent storage non-optional after context setup.
-export type AgentWorkerStorage = Storage & { readonly agents: AgentStorage }
+// Keep root storage for transactions while making worker-required stores non-optional after setup.
+export type AgentWorkerStorage = Storage & {
+  readonly agents: AgentStorage
+  readonly auth: AuthStorage
+}
 
 /**
  * The runtime surface the agent worker is constructed with (mirrors `ActionWorkerSixb`). `Sixb`

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -15,6 +15,13 @@ import {
   AgentWorkerError,
 } from "./errors"
 import { finishRunOrThrow } from "./finalize"
+import {
+  type AgentRunAccessToken,
+  mintAgentRunAccessToken,
+  reconcileAgentExecutionIdentities,
+  reconcileAgentExecutionIdentity,
+  revokeAgentRunAccessToken,
+} from "./identity"
 import { DEFAULT_MAX_STEPS, runAgentTurn } from "./run-agent-turn"
 import type {
   AgentWorkerContext,
@@ -85,6 +92,11 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
 
   protected override async run(signal: AbortSignal): Promise<void> {
     if (!this.idleWithoutAgents) {
+      await reconcileAgentExecutionIdentities(
+        this.requireContext().storage,
+        this.sixb.id,
+        this.sixb.agents.list()
+      )
       await super.run(signal)
       return
     }
@@ -112,6 +124,7 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
     if (!agent) {
       throw new AgentWorkerError(`Unknown agent '${agentId}'.`)
     }
+    const identity = await reconcileAgentExecutionIdentity(context.storage, context.id, agent)
 
     const reservation = await this.reserveOrReclaim(context, {
       agent,
@@ -119,6 +132,7 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
       runId,
       triggerMessageId,
       requestedByPrincipal: job.payload.requestedByPrincipal ?? SYSTEM_PRINCIPAL,
+      executionPrincipal: identity.principal,
     })
     if (reservation.kind === "skip") {
       return
@@ -131,8 +145,16 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
     }
     const run = reservation.run
     const leaseId = run.lease?.id
+    let runToken: AgentRunAccessToken | null = null
 
     try {
+      runToken = await mintAgentRunAccessToken({
+        storage: context.storage,
+        projectId: context.id,
+        agent,
+        run,
+        turnTimeoutMs: context.turnTimeoutMs,
+      })
       await runAgentTurn({ context, agent, run, signal })
     } catch (error) {
       // The run was reclaimed out from under us; this delivery is a duplicate. Ack, touch nothing.
@@ -156,6 +178,16 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
       // Model/tool failure or turn timeout: fate is on the record, so we ack by returning.
       if (aborted) {
         throw error
+      }
+    } finally {
+      if (runToken) {
+        await revokeAgentRunAccessToken({
+          storage: context.storage,
+          projectId: context.id,
+          tokenId: runToken.accessToken.id,
+        }).catch((error) => {
+          console.error("[SixbAgentWorker] Could not revoke agent run token:", error)
+        })
       }
     }
   }
@@ -205,6 +237,7 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
       runId: string
       triggerMessageId: string
       requestedByPrincipal: Principal
+      executionPrincipal: Extract<Principal, { readonly type: "serviceAccount" }>
     }
   ): Promise<Reservation> {
     try {
@@ -215,6 +248,7 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
         agentId: input.agent.id,
         triggerMessageId: input.triggerMessageId,
         requestedByPrincipal: input.requestedByPrincipal,
+        executionPrincipal: input.executionPrincipal,
         modelId: input.agent.model.modelId,
         lease: freshLease(context.leaseMs),
       })
@@ -320,6 +354,9 @@ function buildAgentContext(
   const storage = sixb.storage
   if (!storage.agents) {
     throw new AgentWorkerError("Agent workers require storage.agents support.")
+  }
+  if (!storage.auth) {
+    throw new AgentWorkerError("Agent workers require storage.auth support.")
   }
   return {
     id: sixb.id,

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -13,6 +13,7 @@ import {
   createAgentRunId,
   createAgentRunLeaseId,
   defineAgent,
+  defineGroup,
   type EventsRuntime,
   InMemoryBlobStorage,
   InMemoryBroker,
@@ -33,6 +34,7 @@ import { waitFor } from "./helpers"
 
 const PROJECT_ID = "agent-worker-tests"
 const REQUESTER = { type: "user", id: "usr_requester" } as const
+const AGENT_RUNTIME_GROUP = defineGroup("agent-runtime", { label: "Agent runtime" })
 
 const USAGE: LanguageModelV3Usage = {
   inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
@@ -116,12 +118,14 @@ function buildSixb(model: LanguageModelV3): TestSixb {
     name: "Assistant",
     model,
     instructions: "You are a helpful test assistant.",
+    groups: [AGENT_RUNTIME_GROUP],
     loop: { stopWhen: { maxSteps: 4 } },
   })
   return new SixbCtor({
     id: PROJECT_ID,
     ontology: [],
     agents: [agent],
+    groups: [AGENT_RUNTIME_GROUP],
     broker: new InMemoryBroker(),
     storage: new InMemoryStorage(),
     lakeStorage: new InMemoryLakeStorage(),
@@ -138,9 +142,20 @@ function agentStorageOf(sixb: TestSixb): AgentStorage {
   return storage
 }
 
+function authStorageOf(sixb: TestSixb) {
+  const storage = sixb.storage.auth
+  if (!storage) {
+    throw new Error("expected auth storage")
+  }
+  return storage
+}
+
 function workerStorageOf(storage: Storage): AgentWorkerStorage {
   if (!storage.agents) {
     throw new Error("expected agent storage")
+  }
+  if (!storage.auth) {
+    throw new Error("expected auth storage")
   }
   return storage as AgentWorkerStorage
 }
@@ -274,6 +289,7 @@ describe("AgentWorker", () => {
   test("runs a full multi-step turn: reserves, persists the assistant message, finalizes with usage", async () => {
     const sixb = buildSixb(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
+    const auth = authStorageOf(sixb)
     const streamed: AgentMessagePart[] = []
 
     const worker = new AgentWorker(sixb, {
@@ -303,6 +319,10 @@ describe("AgentWorker", () => {
       expect(run.modelId).toBe("mock-model")
       expect(run.usage?.outputTokens).toBeGreaterThan(0)
       expect(run.usage?.inputTokens).toBeGreaterThan(0)
+      expect(run.executionPrincipal).toEqual({
+        type: "serviceAccount",
+        id: "svc_agent_assistant",
+      })
 
       // Thread released after finalization (single-flight pointer cleared).
       const thread = await storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
@@ -312,6 +332,10 @@ describe("AgentWorker", () => {
       const assistant = messages.find((message) => message.role === "assistant")
       expect(assistant).toBeDefined()
       expect(assistant?.runId).toBe(run.id)
+      expect(assistant?.authorPrincipal).toEqual({
+        type: "serviceAccount",
+        id: "svc_agent_assistant",
+      })
 
       const parts = assistant?.parts ?? []
       expect(parts.some((part) => part.type === "reasoning")).toBe(true)
@@ -330,6 +354,45 @@ describe("AgentWorker", () => {
 
       // The stream seam saw exactly the persisted parts, in order.
       expect(streamed).toEqual([...parts])
+
+      await expect(
+        auth.serviceAccounts.getById({ projectId: PROJECT_ID, id: "svc_agent_assistant" })
+      ).resolves.toMatchObject({
+        id: "svc_agent_assistant",
+        name: "Assistant",
+        status: "active",
+      })
+      const memberships = await auth.serviceAccountGroupMemberships.listForServiceAccount({
+        projectId: PROJECT_ID,
+        serviceAccountId: "svc_agent_assistant",
+      })
+      expect(memberships.map((membership) => [membership.groupId, membership.source])).toEqual([
+        ["agent-runtime", "agent"],
+      ])
+
+      const token = await waitFor(
+        async () => {
+          const tokens = await auth.accessTokens.list({
+            projectId: PROJECT_ID,
+            kind: "serviceAccount",
+            subjectType: "serviceAccount",
+            subjectId: "svc_agent_assistant",
+            includeRevoked: true,
+          })
+          return tokens.accessTokens.find(
+            (accessToken) => accessToken.name === `Agent run ${runId}`
+          )
+        },
+        { label: "agent run token persisted" }
+      )
+      expect(token.groupIds).toEqual(["agent-runtime"])
+      await waitFor(
+        async () => {
+          const refreshed = await auth.accessTokens.getById({ projectId: PROJECT_ID, id: token.id })
+          return refreshed?.revokedAt ? refreshed : null
+        },
+        { label: "agent run token revoked" }
+      )
     } finally {
       await worker.stop()
     }

--- a/packages/core/src/agents/builders.ts
+++ b/packages/core/src/agents/builders.ts
@@ -1,6 +1,6 @@
 import { AgentDefinitionError } from "./errors"
 import type { AgentDefinition, DefineAgentConfig } from "./types"
-import { assertNonEmpty, assertValidLoopConfig } from "./validation"
+import { assertNonEmpty, assertValidLoopConfig, groupIdsFromDefinitions } from "./validation"
 
 /**
  * Define an agent: a conversational, looping actor auto-discovered from `agents/`.
@@ -21,6 +21,7 @@ export function defineAgent<const TId extends string>(
     throw new AgentDefinitionError("[Sixb] Agent model is required.")
   }
   assertValidLoopConfig(config.loop)
+  const groupIds = groupIdsFromDefinitions(id, config.groups)
 
   return {
     kind: "agent",
@@ -28,6 +29,7 @@ export function defineAgent<const TId extends string>(
     name: config.name,
     model: config.model,
     instructions: config.instructions,
+    groupIds,
     ...(config.description !== undefined ? { description: config.description } : {}),
     ...(config.loop !== undefined ? { loop: config.loop } : {}),
   }

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -45,4 +45,4 @@ export {
 } from "./request"
 export { AgentsRuntime } from "./runtime"
 export type { AgentDefinition, AgentLoopConfig, DefineAgentConfig } from "./types"
-export { isAgentDefinition } from "./validation"
+export { isAgentDefinition, validateAgentGroupReferences } from "./validation"

--- a/packages/core/src/agents/types.ts
+++ b/packages/core/src/agents/types.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider"
+import type { GroupDefinition } from "../security"
 
 /**
  * Loop / stop controls for an agent run.
@@ -22,6 +23,7 @@ export interface DefineAgentConfig {
   readonly description?: string
   readonly model: LanguageModelV3
   readonly instructions: string
+  readonly groups?: readonly GroupDefinition[]
   readonly loop?: AgentLoopConfig
 }
 
@@ -40,5 +42,6 @@ export interface AgentDefinition<TId extends string = string> {
   readonly description?: string
   readonly model: LanguageModelV3
   readonly instructions: string
+  readonly groupIds: readonly string[]
   readonly loop?: AgentLoopConfig
 }

--- a/packages/core/src/agents/validation.ts
+++ b/packages/core/src/agents/validation.ts
@@ -1,3 +1,4 @@
+import type { GroupDefinition, SecurityRegistry } from "../security"
 import { AgentDefinitionError } from "./errors"
 import type { AgentDefinition, AgentLoopConfig } from "./types"
 
@@ -13,7 +14,8 @@ export function isAgentDefinition(value: unknown): value is AgentDefinition {
     value.kind === "agent" &&
     typeof value.id === "string" &&
     typeof value.name === "string" &&
-    typeof value.instructions === "string"
+    typeof value.instructions === "string" &&
+    Array.isArray(value.groupIds)
   )
 }
 
@@ -26,6 +28,54 @@ export function assertValidLoopConfig(loop: AgentLoopConfig | undefined): void {
     throw new AgentDefinitionError(
       "[Sixb] Agent loop.stopWhen.maxSteps must be a positive finite integer."
     )
+  }
+}
+
+export function groupIdsFromDefinitions(
+  agentId: string,
+  groups: readonly GroupDefinition[] | undefined
+): readonly string[] {
+  const groupIds = (groups ?? []).map((group) => {
+    if (!isRecord(group) || group.kind !== "group") {
+      throw new AgentDefinitionError(
+        `[Sixb] Agent '${agentId}' groups must contain only group definitions.`
+      )
+    }
+
+    assertNonEmpty(group.id, `Agent '${agentId}' group id`)
+    return group.id
+  })
+
+  assertNoDuplicateGroupIds(agentId, groupIds)
+  return groupIds
+}
+
+export function validateAgentGroupReferences(
+  agents: readonly AgentDefinition[],
+  security: SecurityRegistry
+): void {
+  for (const agent of agents) {
+    assertNoDuplicateGroupIds(agent.id, agent.groupIds)
+    for (const groupId of agent.groupIds) {
+      if (!security.getGroupById(groupId)) {
+        throw new AgentDefinitionError(
+          `[Sixb] Agent '${agent.id}' groups references unknown group '${groupId}'. Add it to 'security/groups/' or pass it to createSixb({ groups }).`
+        )
+      }
+    }
+  }
+}
+
+function assertNoDuplicateGroupIds(agentId: string, groupIds: readonly string[]): void {
+  const seen = new Set<string>()
+  for (const groupId of groupIds) {
+    assertNonEmpty(groupId, `Agent '${agentId}' group id`)
+    if (seen.has(groupId)) {
+      throw new AgentDefinitionError(
+        `[Sixb] Agent '${agentId}' groups contains duplicate group id '${groupId}'.`
+      )
+    }
+    seen.add(groupId)
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -737,6 +737,7 @@ export type {
   QueueActionRunInput,
   QueueWorkflowRunInput,
   ReclaimAgentRunInput,
+  ReconcileAuthServiceAccountGroupMembershipsInput,
   RecordActionCommitInput,
   RecordActionEffectsInput,
   RecordActionWritebackInput,

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -9,7 +9,7 @@
 import { ActionRegistry, ActionsRuntime } from "../actions"
 import type { ActionDefinition } from "../actions/types"
 import type { AgentDefinition } from "../agents"
-import { AgentsRuntime } from "../agents"
+import { AgentsRuntime, validateAgentGroupReferences } from "../agents"
 import {
   AuthRuntime,
   AuthRuntimeError,
@@ -299,6 +299,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       }
       agentIds.add(agent.id)
     }
+    validateAgentGroupReferences(agents, this.security)
     this.agents = new AgentsRuntime(this.runtimeContext, agents)
 
     const { objectProjections, linkProjections, telemetryProjections } = categorizeProjections(

--- a/packages/core/src/storage/auth/in-memory/service-account-group-memberships.ts
+++ b/packages/core/src/storage/auth/in-memory/service-account-group-memberships.ts
@@ -1,10 +1,20 @@
+import { AuthStorageError } from "../errors"
 import type {
   AuthServiceAccountGroupMembershipStore,
+  ReconcileAuthServiceAccountGroupMembershipsInput,
   ServiceAccountGroupMembershipRecord,
   UpsertAuthServiceAccountGroupMembershipInput,
 } from "../types"
 import type { AuthStorageState } from "./shared"
-import { cloneRecord, upsertServiceAccountGroupMembershipRecord } from "./shared"
+import {
+  assertNonEmpty,
+  cloneRecord,
+  dateOrNow,
+  normalizeGroupIds,
+  serviceAccountGroupMembershipKey,
+  serviceAccountKey,
+  upsertServiceAccountGroupMembershipRecord,
+} from "./shared"
 
 export class InMemoryAuthServiceAccountGroupMembershipStore
   implements AuthServiceAccountGroupMembershipStore
@@ -15,6 +25,57 @@ export class InMemoryAuthServiceAccountGroupMembershipStore
     input: UpsertAuthServiceAccountGroupMembershipInput
   ): Promise<ServiceAccountGroupMembershipRecord> {
     return cloneRecord(upsertServiceAccountGroupMembershipRecord(this.state, input))
+  }
+
+  async reconcileForServiceAccount(
+    input: ReconcileAuthServiceAccountGroupMembershipsInput
+  ): Promise<readonly ServiceAccountGroupMembershipRecord[]> {
+    const projectId = assertNonEmpty(input.projectId, "Project id")
+    const serviceAccountId = assertNonEmpty(input.serviceAccountId, "Service account id")
+    if (!this.state.serviceAccounts.has(serviceAccountKey(projectId, serviceAccountId))) {
+      throw new AuthStorageError(
+        "missing_service_account",
+        `[Sixb] Service account '${serviceAccountId}' not found for project '${projectId}'.`
+      )
+    }
+
+    const groupIds = normalizeGroupIds(input.groupIds)
+    const desired = new Set(groupIds)
+    for (const [key, membership] of this.state.serviceAccountGroupMemberships) {
+      if (
+        membership.projectId === projectId &&
+        membership.serviceAccountId === serviceAccountId &&
+        membership.source === input.source &&
+        !desired.has(membership.groupId)
+      ) {
+        this.state.serviceAccountGroupMemberships.delete(key)
+      }
+    }
+
+    const updatedAt = dateOrNow(input.updatedAt)
+    for (const groupId of groupIds) {
+      const key = serviceAccountGroupMembershipKey(projectId, serviceAccountId, groupId)
+      const existing = this.state.serviceAccountGroupMemberships.get(key)
+      if (existing) {
+        this.state.serviceAccountGroupMemberships.set(
+          key,
+          cloneRecord({ ...existing, source: input.source })
+        )
+        continue
+      }
+      this.state.serviceAccountGroupMemberships.set(
+        key,
+        cloneRecord({
+          projectId,
+          serviceAccountId,
+          groupId,
+          source: input.source,
+          createdAt: updatedAt,
+        })
+      )
+    }
+
+    return this.listForServiceAccount({ projectId, serviceAccountId })
   }
 
   async listForServiceAccount(params: {

--- a/packages/core/src/storage/auth/index.ts
+++ b/packages/core/src/storage/auth/index.ts
@@ -40,6 +40,7 @@ export type {
   ListAuthUsersResult,
   MagicLinkRecord,
   OidcAuthorizationAttemptRecord,
+  ReconcileAuthServiceAccountGroupMembershipsInput,
   ServiceAccountGroupMembershipRecord,
   ServiceAccountRecord,
   ServiceAccountStatus,

--- a/packages/core/src/storage/auth/types.ts
+++ b/packages/core/src/storage/auth/types.ts
@@ -3,7 +3,7 @@ import type { AccessTokenKind, AuthSessionAudience, Principal } from "../../auth
 export type UserStatus = "active" | "suspended"
 export type ServiceAccountStatus = "active" | "suspended"
 export type InvitationStatus = "pending" | "accepted" | "revoked"
-export type GroupMembershipSource = "invitation" | "manual"
+export type GroupMembershipSource = "invitation" | "manual" | "agent"
 export type AccessTokenSubjectType = "user" | "serviceAccount"
 
 export interface UserRecord {
@@ -232,6 +232,14 @@ export interface UpsertAuthServiceAccountGroupMembershipInput {
   readonly createdAt?: Date
 }
 
+export interface ReconcileAuthServiceAccountGroupMembershipsInput {
+  readonly projectId: string
+  readonly serviceAccountId: string
+  readonly groupIds: readonly string[]
+  readonly source: "agent"
+  readonly updatedAt?: Date
+}
+
 export interface CreateAuthSessionInput {
   readonly id: string
   readonly projectId: string
@@ -434,6 +442,9 @@ export interface AuthServiceAccountGroupMembershipStore {
   upsert(
     input: UpsertAuthServiceAccountGroupMembershipInput
   ): Promise<ServiceAccountGroupMembershipRecord>
+  reconcileForServiceAccount(
+    input: ReconcileAuthServiceAccountGroupMembershipsInput
+  ): Promise<readonly ServiceAccountGroupMembershipRecord[]>
   listForServiceAccount(params: {
     readonly projectId: string
     readonly serviceAccountId: string

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -115,6 +115,7 @@ export type {
   ListAuthUsersResult,
   MagicLinkRecord,
   OidcAuthorizationAttemptRecord,
+  ReconcileAuthServiceAccountGroupMembershipsInput,
   ServiceAccountGroupMembershipRecord,
   ServiceAccountRecord,
   ServiceAccountStatus,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -74,6 +74,7 @@ export type {
   ListAuthUsersResult,
   MagicLinkRecord,
   OidcAuthorizationAttemptRecord,
+  ReconcileAuthServiceAccountGroupMembershipsInput,
   SessionRecord,
   SuspendUserAndRevokeSessionsInput,
   UpdateAuthUserProfileInput,

--- a/packages/core/src/testing/auth-storage-contract.ts
+++ b/packages/core/src/testing/auth-storage-contract.ts
@@ -562,6 +562,56 @@ export function runAuthStorageContractSuite<TStorage extends AuthStorage>(
       })
     })
 
+    test("reconciles agent-managed service account memberships", async () => {
+      await withStorage(async (storage) => {
+        await storage.serviceAccounts.create({
+          id: "svc_agent_ops",
+          projectId,
+          name: "Ops agent",
+          createdAt: at("2026-05-14T10:00:00.000Z"),
+        })
+        await storage.serviceAccountGroupMemberships.upsert({
+          projectId,
+          serviceAccountId: "svc_agent_ops",
+          groupId: "manual-extra",
+          source: "manual",
+          createdAt: at("2026-05-14T10:01:00.000Z"),
+        })
+        await storage.serviceAccountGroupMemberships.upsert({
+          projectId,
+          serviceAccountId: "svc_agent_ops",
+          groupId: "stale-agent",
+          source: "agent",
+          createdAt: at("2026-05-14T10:02:00.000Z"),
+        })
+
+        const first = await storage.serviceAccountGroupMemberships.reconcileForServiceAccount({
+          projectId,
+          serviceAccountId: "svc_agent_ops",
+          groupIds: ["agent-runtime", "agent-runtime", "ops"],
+          source: "agent",
+          updatedAt: at("2026-05-14T10:03:00.000Z"),
+        })
+        expect(first.map((membership) => [membership.groupId, membership.source])).toEqual([
+          ["agent-runtime", "agent"],
+          ["manual-extra", "manual"],
+          ["ops", "agent"],
+        ])
+
+        const second = await storage.serviceAccountGroupMemberships.reconcileForServiceAccount({
+          projectId,
+          serviceAccountId: "svc_agent_ops",
+          groupIds: ["ops"],
+          source: "agent",
+          updatedAt: at("2026-05-14T10:04:00.000Z"),
+        })
+        expect(second.map((membership) => [membership.groupId, membership.source])).toEqual([
+          ["manual-extra", "manual"],
+          ["ops", "agent"],
+        ])
+      })
+    })
+
     test("creates, resolves, touches, lists, and revokes access tokens", async () => {
       await withStorage(async (storage) => {
         await createUser(storage)

--- a/packages/core/tests/agents.test.ts
+++ b/packages/core/tests/agents.test.ts
@@ -8,6 +8,7 @@ import {
   AgentDefinitionError,
   createSixb,
   defineAgent,
+  defineGroup,
   defineObjectType,
   isAgentDefinition,
   prop,
@@ -20,6 +21,7 @@ const tempRoots = new Set<string>()
 
 // PR1 never reads the model, so a stub conforming to the type is enough.
 const model = {} as LanguageModelV3
+const agentRuntime = defineGroup("agent-runtime", { label: "Agent runtime" })
 
 const Room = defineObjectType({
   id: "Room",
@@ -75,20 +77,23 @@ describe("defineAgent", () => {
     expect(agent.id).toBe("sales")
     expect(agent.name).toBe("Sales Assistant")
     expect(agent.instructions).toBe("Assist.")
+    expect(agent.groupIds).toEqual([])
     expect(agent.description).toBeUndefined()
     expect(agent.loop).toBeUndefined()
   })
 
-  test("keeps description and loop when provided", () => {
+  test("keeps description, groups, and loop when provided", () => {
     const agent = defineAgent("sales", {
       name: "Sales Assistant",
       description: "Quotes and contacts.",
       model,
       instructions: "Assist.",
+      groups: [agentRuntime],
       loop: { stopWhen: { maxSteps: 16 } },
     })
 
     expect(agent.description).toBe("Quotes and contacts.")
+    expect(agent.groupIds).toEqual(["agent-runtime"])
     expect(agent.loop).toEqual({ stopWhen: { maxSteps: 16 } })
   })
 
@@ -125,6 +130,26 @@ describe("defineAgent", () => {
         })
       ).toThrow(AgentDefinitionError)
     }
+  })
+
+  test("rejects invalid group definitions", () => {
+    expect(() =>
+      defineAgent("bad", {
+        name: "Bad",
+        model,
+        instructions: "x",
+        groups: [{ kind: "not-a-group", id: "x" } as never],
+      })
+    ).toThrow(AgentDefinitionError)
+
+    expect(() =>
+      defineAgent("bad", {
+        name: "Bad",
+        model,
+        instructions: "x",
+        groups: [agentRuntime, agentRuntime],
+      })
+    ).toThrow(AgentDefinitionError)
   })
 })
 
@@ -213,5 +238,44 @@ describe("agent discovery + registry", () => {
     await expect(
       createSixb({ projectRoot, ontologies: [Room], agents: [dup], ...createTestRuntimeDeps() })
     ).rejects.toThrow(RuntimeError)
+  })
+
+  test("rejects agents that reference unregistered execution groups", async () => {
+    const projectRoot = await createTempProjectRoot()
+    const agent = defineAgent("ops", {
+      name: "Ops",
+      model,
+      instructions: "x",
+      groups: [agentRuntime],
+    })
+
+    await expect(
+      createSixb({
+        projectRoot,
+        ontologies: [Room],
+        agents: [agent],
+        ...createTestRuntimeDeps(),
+      })
+    ).rejects.toThrow(AgentDefinitionError)
+  })
+
+  test("accepts agents whose execution groups are registered", async () => {
+    const projectRoot = await createTempProjectRoot()
+    const agent = defineAgent("ops", {
+      name: "Ops",
+      model,
+      instructions: "x",
+      groups: [agentRuntime],
+    })
+
+    const sixb = await createSixb({
+      projectRoot,
+      ontologies: [Room],
+      agents: [agent],
+      groups: [agentRuntime],
+      ...createTestRuntimeDeps(),
+    })
+
+    expect(sixb.agents.getById("ops")?.groupIds).toEqual(["agent-runtime"])
   })
 })

--- a/storage/pg/src/auth-storage/service-account-group-memberships.ts
+++ b/storage/pg/src/auth-storage/service-account-group-memberships.ts
@@ -1,5 +1,6 @@
 import type {
   AuthServiceAccountGroupMembershipStore,
+  ReconcileAuthServiceAccountGroupMembershipsInput,
   ServiceAccountGroupMembershipRecord,
   UpsertAuthServiceAccountGroupMembershipInput,
 } from "@sixb/core"
@@ -53,6 +54,68 @@ export class PgAuthServiceAccountGroupMembershipStore
     `
 
     return rowToServiceAccountGroupMembershipRecord(row)
+  }
+
+  async reconcileForServiceAccount(
+    input: ReconcileAuthServiceAccountGroupMembershipsInput
+  ): Promise<readonly ServiceAccountGroupMembershipRecord[]> {
+    const projectId = assertNonEmpty(input.projectId, "Project id")
+    const serviceAccountId = assertNonEmpty(input.serviceAccountId, "Service account id")
+    const groupIds = [
+      ...new Set(input.groupIds.map((groupId) => assertNonEmpty(groupId, "Group id"))),
+    ]
+    const [serviceAccount] = await this.sql<PgAuthServiceAccountRow[]>`
+      SELECT *
+      FROM auth_service_accounts
+      WHERE project_id = ${projectId}
+        AND id = ${serviceAccountId}
+    `
+    if (!serviceAccount) {
+      throw new AuthStorageError(
+        "missing_service_account",
+        `[Sixb] Service account '${serviceAccountId}' not found for project '${projectId}'.`
+      )
+    }
+
+    if (groupIds.length === 0) {
+      await this.sql`
+        DELETE FROM auth_service_account_group_memberships
+        WHERE project_id = ${projectId}
+          AND service_account_id = ${serviceAccountId}
+          AND source = ${input.source}
+      `
+    } else {
+      await this.sql`
+        DELETE FROM auth_service_account_group_memberships
+        WHERE project_id = ${projectId}
+          AND service_account_id = ${serviceAccountId}
+          AND source = ${input.source}
+          AND group_id NOT IN ${this.sql(groupIds)}
+      `
+    }
+
+    const updatedAt = dateOrNow(input.updatedAt)
+    for (const groupId of groupIds) {
+      await this.sql<PgAuthServiceAccountGroupMembershipRow[]>`
+        INSERT INTO auth_service_account_group_memberships (
+          project_id,
+          service_account_id,
+          group_id,
+          source,
+          created_at
+        ) VALUES (
+          ${projectId},
+          ${serviceAccountId},
+          ${groupId},
+          ${input.source},
+          ${updatedAt}
+        )
+        ON CONFLICT (project_id, service_account_id, group_id) DO UPDATE
+        SET source = EXCLUDED.source
+      `
+    }
+
+    return this.listForServiceAccount({ projectId, serviceAccountId })
   }
 
   async listForServiceAccount(params: {

--- a/storage/pg/src/migrations/001-initial-schema.sql
+++ b/storage/pg/src/migrations/001-initial-schema.sql
@@ -573,7 +573,7 @@ CREATE TABLE IF NOT EXISTS auth_service_account_group_memberships (
   project_id TEXT NOT NULL,
   service_account_id TEXT NOT NULL,
   group_id TEXT NOT NULL,
-  source TEXT NOT NULL CHECK (source IN ('invitation', 'manual')),
+  source TEXT NOT NULL CHECK (source IN ('invitation', 'manual', 'agent')),
   created_at TIMESTAMPTZ NOT NULL,
   PRIMARY KEY (project_id, service_account_id, group_id),
   FOREIGN KEY (project_id, service_account_id)
@@ -681,7 +681,7 @@ CREATE TABLE IF NOT EXISTS auth_group_memberships (
   project_id TEXT NOT NULL,
   user_id TEXT NOT NULL,
   group_id TEXT NOT NULL,
-  source TEXT NOT NULL CHECK (source IN ('invitation', 'manual')),
+  source TEXT NOT NULL CHECK (source IN ('invitation', 'manual', 'agent')),
   created_at TIMESTAMPTZ NOT NULL,
   PRIMARY KEY (project_id, user_id, group_id),
   FOREIGN KEY (project_id, user_id)

--- a/storage/sqlite/src/auth-storage/service-account-group-memberships.ts
+++ b/storage/sqlite/src/auth-storage/service-account-group-memberships.ts
@@ -1,6 +1,7 @@
 import type { Database } from "bun:sqlite"
 import type {
   AuthServiceAccountGroupMembershipStore,
+  ReconcileAuthServiceAccountGroupMembershipsInput,
   ServiceAccountGroupMembershipRecord,
   UpsertAuthServiceAccountGroupMembershipInput,
 } from "@sixb/core"
@@ -10,7 +11,7 @@ import type {
   SqliteAuthServiceAccountRow,
 } from "./rows"
 import { rowToServiceAccountGroupMembershipRecord } from "./rows"
-import { assertNonEmpty, dateOrNow, toIso } from "./shared"
+import { assertNonEmpty, dateOrNow, normalizeGroupIds, toIso } from "./shared"
 
 export class SqliteAuthServiceAccountGroupMembershipStore
   implements AuthServiceAccountGroupMembershipStore
@@ -59,6 +60,62 @@ export class SqliteAuthServiceAccountGroupMembershipStore
       )
       .get(projectId, serviceAccountId, groupId) as SqliteAuthServiceAccountGroupMembershipRow
     return rowToServiceAccountGroupMembershipRecord(row)
+  }
+
+  async reconcileForServiceAccount(
+    input: ReconcileAuthServiceAccountGroupMembershipsInput
+  ): Promise<readonly ServiceAccountGroupMembershipRecord[]> {
+    const projectId = assertNonEmpty(input.projectId, "Project id")
+    const serviceAccountId = assertNonEmpty(input.serviceAccountId, "Service account id")
+    const serviceAccount = this.db
+      .query("SELECT * FROM auth_service_accounts WHERE project_id = ? AND id = ?")
+      .get(projectId, serviceAccountId) as SqliteAuthServiceAccountRow | null
+    if (!serviceAccount) {
+      throw new AuthStorageError(
+        "missing_service_account",
+        `[Sixb] Service account '${serviceAccountId}' not found for project '${projectId}'.`
+      )
+    }
+
+    const groupIds = normalizeGroupIds(input.groupIds)
+    const desired = new Set(groupIds)
+    const existing = await this.listForServiceAccount({ projectId, serviceAccountId })
+    for (const membership of existing) {
+      if (membership.source === input.source && !desired.has(membership.groupId)) {
+        this.db
+          .query(
+            `
+            DELETE FROM auth_service_account_group_memberships
+            WHERE project_id = ?
+              AND service_account_id = ?
+              AND group_id = ?
+              AND source = ?
+          `
+          )
+          .run(projectId, serviceAccountId, membership.groupId, input.source)
+      }
+    }
+
+    const updatedAt = toIso(dateOrNow(input.updatedAt))
+    for (const groupId of groupIds) {
+      this.db
+        .query(
+          `
+          INSERT INTO auth_service_account_group_memberships (
+            project_id,
+            service_account_id,
+            group_id,
+            source,
+            created_at
+          ) VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(project_id, service_account_id, group_id) DO UPDATE
+          SET source = excluded.source
+        `
+        )
+        .run(projectId, serviceAccountId, groupId, input.source, updatedAt)
+    }
+
+    return this.listForServiceAccount({ projectId, serviceAccountId })
   }
 
   async listForServiceAccount(params: {

--- a/storage/sqlite/src/migrations/001-initial-schema.sql
+++ b/storage/sqlite/src/migrations/001-initial-schema.sql
@@ -535,7 +535,7 @@ CREATE TABLE IF NOT EXISTS auth_service_account_group_memberships (
   project_id TEXT NOT NULL,
   service_account_id TEXT NOT NULL,
   group_id TEXT NOT NULL,
-  source TEXT NOT NULL CHECK (source IN ('invitation', 'manual')),
+  source TEXT NOT NULL CHECK (source IN ('invitation', 'manual', 'agent')),
   created_at TEXT NOT NULL,
   PRIMARY KEY (project_id, service_account_id, group_id)
 );
@@ -638,7 +638,7 @@ CREATE TABLE IF NOT EXISTS auth_group_memberships (
   project_id TEXT NOT NULL,
   user_id TEXT NOT NULL,
   group_id TEXT NOT NULL,
-  source TEXT NOT NULL CHECK (source IN ('invitation', 'manual')),
+  source TEXT NOT NULL CHECK (source IN ('invitation', 'manual', 'agent')),
   created_at TEXT NOT NULL,
   PRIMARY KEY (project_id, user_id, group_id)
 );


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the agents feature, stacked on #125 (`feature/agent-base-hardening`). It gives each agent a durable execution identity and mints short-lived per-run credentials for the worker.

The previous PR hardened the run lifecycle: durable messages, reserve-at-claim runs, leases, reclaim, and finalization. This PR builds on that foundation by answering: when an agent run later calls Sixb APIs or tools, which principal is it acting as?

## Why

Agent definitions need a constrained service identity before we expose tools or API access to the model loop. The caller principal answers who requested a run. The execution principal answers who the agent is while it runs.

That distinction lets us keep these concerns separate:

```ts
await sixb.agents.request({
  agentId: "ops",
  text: "Check the failed sync run.",
  principal: { type: "user", id: "usr_123" },
})

// The run is requested by usr_123, but executes as svc_agent_ops.
```

## What Changed

Agents can now declare execution groups:

```ts
export const agentRuntime = defineGroup("agent-runtime", {
  label: "Agent runtime",
})

export const opsAgent = defineAgent("ops", {
  name: "Ops Agent",
  model,
  instructions: "Investigate operational issues.",
  groups: [agentRuntime],
})
```

At startup, Sixb validates that every agent group is registered. Bad references fail early instead of becoming a runtime authorization surprise.

The worker now reconciles a managed service account for each agent:

```ts
serviceAccountId = `svc_agent_${agent.id}`
principal = { type: "serviceAccount", id: serviceAccountId }
```

The worker uses that principal when reserving the run, so run and assistant-message attribution are durable:

```ts
await storage.agents.runs.reserve({
  id: runId,
  requestedByPrincipal,
  executionPrincipal: { type: "serviceAccount", id: "svc_agent_ops" },
  lease,
})
```

Auth storage now has a reconciliation operation for agent-managed service-account memberships:

```ts
await auth.serviceAccountGroupMemberships.reconcileForServiceAccount({
  projectId,
  serviceAccountId: "svc_agent_ops",
  groupIds: agent.groupIds,
  source: "agent",
})
```

This intentionally mirrors the current definition: stale `source: "agent"` memberships are removed, while manual memberships are preserved.

Each run also gets a short-lived service-account token:

```ts
name = `Agent run ${run.id}`
groupIds = agent.groupIds
expiresAt = now + max(turnTimeoutMs + 5 minutes, 15 minutes), capped at 1 hour
```

The token is revoked after the run reaches a terminal path. Expiry is the crash fallback.

## What This Does Not Do

This PR does not add HTTP agent APIs, WebSocket streams, bash tools, or caller-side `can.run(agent)` authorization. Those remain later phases. This is the identity layer those features will rely on.

## Review Notes

The main behavioral points to review are:

- `defineAgent(..., { groups })` stores normalized `groupIds` while preserving existing agents with no groups.
- Startup validation rejects unknown agent groups.
- `reconcileForServiceAccount(...)` prunes stale agent-managed memberships without touching manual memberships.
- The worker reconciles identities both at startup and lazily before a run.
- Per-run tokens are scoped to agent groups, revoked on cleanup, and bounded by expiry if cleanup never runs.

## Validation

```bash
bun test packages/core/tests/agents.test.ts
bun test packages/core/tests/auth-storage.test.ts
bun test storage/sqlite/tests/sqlite-auth-storage.test.ts
bun test packages/agent-worker/tests/worker.test.ts
bun run check
bun run typecheck
```

Postgres e2e was not run locally, but `@sixb/pg` passed workspace typecheck and the shared auth-storage contract now covers the new reconciliation behavior across in-memory and SQLite.
