### PR TITLE
agents: authorize caller access

### DIFF
--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -12786,6 +12786,23 @@
               }
             }
           },
+          "403": {
+            "description": "Response for status 403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
           "404": {
             "description": "Response for status 404",
             "content": {
@@ -13520,6 +13537,23 @@
           },
           "400": {
             "description": "Response for status 400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Response for status 403",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4394,6 +4394,12 @@ export type CreateAgentThreadErrors = {
     error: string
   }
   /**
+   * Response for status 403
+   */
+  403: {
+    error: string
+  }
+  /**
    * Response for status 404
    */
   404: {
@@ -4682,6 +4688,12 @@ export type PostAgentThreadMessageErrors = {
    * Response for status 400
    */
   400: {
+    error: string
+  }
+  /**
+   * Response for status 403
+   */
+  403: {
     error: string
   }
   /**

--- a/packages/core/src/agents/request.ts
+++ b/packages/core/src/agents/request.ts
@@ -1,4 +1,5 @@
 import type { Principal } from "../auth"
+import { assertAuthorized } from "../authorization"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type { AgentStorage, AgentThreadRecord } from "../storage/agents"
 import { AgentRequestError } from "./errors"
@@ -51,6 +52,8 @@ export async function requestAgentRun(
   agent: AgentDefinition,
   input: RequestAgentRunInput
 ): Promise<RequestAgentRunResult> {
+  assertAuthorized(runtime, { kind: "agent.run", agentId: agent.id })
+
   const agents = requireAgentStorage(runtime)
   const projectId = runtime.projectId
   const principal = input.principal ?? SYSTEM_PRINCIPAL

--- a/packages/core/src/agents/runtime.ts
+++ b/packages/core/src/agents/runtime.ts
@@ -33,10 +33,21 @@ export class AgentsRuntime {
 
   /** Trigger an agent turn: persist the user message and enqueue the run intent. */
   request(input: RequestAgentRunInput): Promise<RequestAgentRunResult> {
+    return this.requestAs(this.runtime, input)
+  }
+
+  /**
+   * Trigger an agent turn on behalf of an explicit runtime context, so scoped
+   * SDKs can enforce caller grants while reusing the registered definitions.
+   */
+  requestAs(
+    runtime: SixbRuntimeContext,
+    input: RequestAgentRunInput
+  ): Promise<RequestAgentRunResult> {
     const agent = this.getById(input.agentId)
     if (!agent) {
       throw new AgentRequestError("agent_not_found", `[Sixb] Unknown agent '${input.agentId}'.`)
     }
-    return requestAgentRun(this.runtime, agent, input)
+    return requestAgentRun(runtime, agent, input)
   }
 }

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -28,6 +28,7 @@ export type AuthzRequest =
   | { readonly kind: "workflow.run"; readonly workflowId: string }
   | { readonly kind: "sync.run"; readonly syncId: string }
   | { readonly kind: "pipeline.run"; readonly pipelineId: string }
+  | { readonly kind: "agent.run"; readonly agentId: string }
   | { readonly kind: "object.query"; readonly touchedObjectTypeIds: readonly string[] }
 
 export interface AuthzDecision {
@@ -65,6 +66,8 @@ function atomsFor(request: AuthzRequest): readonly Atom[] {
       return [{ kind: "run:sync", id: request.syncId }]
     case "pipeline.run":
       return [{ kind: "run:pipeline", id: request.pipelineId }]
+    case "agent.run":
+      return [{ kind: "run:agent", id: request.agentId }]
     case "object.query":
       return request.touchedObjectTypeIds.map((id) => ({ kind: "view:object", id }))
   }
@@ -144,6 +147,8 @@ function deniedMessage(
       return `[Sixb] Principal '${principalId}' is not allowed to run sync '${request.syncId}'.`
     case "pipeline.run":
       return `[Sixb] Principal '${principalId}' is not allowed to run pipeline '${request.pipelineId}'.`
+    case "agent.run":
+      return `[Sixb] Principal '${principalId}' is not allowed to run agent '${request.agentId}'.`
     case "object.query": {
       // Name the first touched type the principal cannot view.
       const blocked = request.touchedObjectTypeIds.find(

--- a/packages/core/src/authorization/grant-kinds.ts
+++ b/packages/core/src/authorization/grant-kinds.ts
@@ -17,6 +17,7 @@ export type GrantKind =
   | "run:workflow"
   | "run:sync"
   | "run:pipeline"
+  | "run:agent"
 
 /** Registered id universes a grant kind ranges over, plus subtype expansion. */
 export interface GrantUniverse {
@@ -26,6 +27,7 @@ export interface GrantUniverse {
   readonly workflowIds: ReadonlySet<string>
   readonly syncIds: ReadonlySet<string>
   readonly pipelineIds: ReadonlySet<string>
+  readonly agentIds: ReadonlySet<string>
   readonly getSubTypes: (objectTypeId: string) => readonly string[]
 }
 
@@ -78,6 +80,11 @@ export const GRANT_KINDS: Record<GrantKind, GrantKindSpec> = {
     universeKey: "pipelineIds",
     subject: "pipeline",
     fix: "Add it to 'pipelines/' or pass it to createSixb({ pipelines }).",
+  },
+  "run:agent": {
+    universeKey: "agentIds",
+    subject: "agent",
+    fix: "Add it to 'agents/' or pass it to createSixb({ agents }).",
   },
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -547,6 +547,7 @@ export type {
 } from "./security"
 export {
   actions,
+  agents,
   assertGrantDefinition,
   assertGroupDefinition,
   assertInvitePolicyDefinition,

--- a/packages/core/src/runtime/scoped.ts
+++ b/packages/core/src/runtime/scoped.ts
@@ -10,6 +10,12 @@
 
 import type { ActionDefinition, RequestActionInput, RequestActionResult } from "../actions"
 import { requestAction as requestRuntimeAction } from "../actions/request"
+import type {
+  AgentDefinition,
+  AgentsRuntime,
+  RequestAgentRunInput,
+  RequestAgentRunResult,
+} from "../agents"
 import {
   type AuthorizationContext,
   type AuthzRequest,
@@ -79,7 +85,7 @@ export interface ScopedObjectSet<
  * Principal-scoped runtime surface.
  *
  * Exposes only operations whose grants are enforceable end to end
- * (`can.view`, `can.apply`). Everything else — writes, links, telemetry,
+ * (`can.view`, `can.apply`, `can.run`). Everything else — writes, links, telemetry,
  * infra handles, lifecycle, auth — stays on the privileged runtime.
  */
 export interface ScopedSixb<TOntologySources extends readonly OntologySource[]> {
@@ -137,6 +143,15 @@ export interface ScopedSixb<TOntologySources extends readonly OntologySource[]> 
   /** Look up a runnable pipeline definition; null hides pipelines the principal cannot run. */
   getPipelineById(pipelineId: string): PipelineDefinition | null
 
+  /** Agent definitions the principal may run. */
+  listAgents(): readonly AgentDefinition[]
+
+  /** Look up a runnable agent definition; null hides agents the principal cannot run. */
+  getAgentById(agentId: string): AgentDefinition | null
+
+  /** Request an agent turn. Requires `can.run`. */
+  requestAgentRun(input: RequestAgentRunInput): Promise<RequestAgentRunResult>
+
   /** Read the domain events the principal is allowed to see (derived from grants). */
   readEvents(input?: EventsReadInput): Promise<readonly StoredDomainEvent[]>
 }
@@ -157,6 +172,7 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
       readonly getById: (pipelineId: string) => PipelineDefinition | null
     }
     readonly workflows: WorkflowsRuntime
+    readonly agents: AgentsRuntime
   }
 ): ScopedSixb<TOntologySources> {
   const canListAction = (action: ActionDefinition) =>
@@ -198,6 +214,7 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
     kind: "workflow.run",
     workflowId,
   }))
+  const agents = scopedCatalog(deps.agents, (agentId) => ({ kind: "agent.run", agentId }))
 
   const scoped = {
     authorization: runtime.authorization,
@@ -245,6 +262,10 @@ export function createScopedSixb<TOntologySources extends readonly OntologySourc
 
     listPipelines: pipelines.list,
     getPipelineById: pipelines.getById,
+
+    listAgents: agents.list,
+    getAgentById: agents.getById,
+    requestAgentRun: (input: RequestAgentRunInput) => deps.agents.requestAs(runtime, input),
 
     // No standalone events grant: the stream is filtered to events whose
     // subject the principal may view/apply/run. `limit` applies before this

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -158,6 +158,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     this.ontology = new OntologyRegistry({ sources: this.ontologySources })
     this.actionRegistry = new ActionRegistry(options.actions ?? [], this.ontology)
     const registeredActionIds = new Set(this.actionRegistry.list().map((action) => action.id))
+    const agents = options.agents ?? []
     this.security = createRuntimeSecurityRegistry({
       groups: options.groups ?? [],
       roles: options.roles ?? [],
@@ -168,6 +169,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       workflowIds: new Set((options.workflows ?? []).map((workflow) => workflow.id)),
       syncIds: new Set((options.syncs ?? []).map((sync) => sync.id)),
       pipelineIds: new Set((options.pipelines ?? []).map((pipeline) => pipeline.id)),
+      agentIds: new Set(agents.map((agent) => agent.id)),
       getSubTypes: (objectTypeId) => this.ontology.getSubTypes(objectTypeId),
     })
     this.auth = new AuthRuntime({
@@ -291,7 +293,6 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     this.actions = new ActionsRuntime(this.runtimeContext)
     this.workflows = new WorkflowsRuntime(this.runtimeContext, workflows)
 
-    const agents = options.agents ?? []
     const agentIds = new Set<string>()
     for (const agent of agents) {
       if (agentIds.has(agent.id)) {
@@ -516,6 +517,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
           getById: (pipelineId) => this.getPipelineById(pipelineId),
         },
         workflows: this.workflows,
+        agents: this.agents,
       }
     )
   }

--- a/packages/core/src/security/grants.ts
+++ b/packages/core/src/security/grants.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ActionDefinition } from "../actions/types"
+import type { AgentDefinition } from "../agents/types"
 import type { DatasetDefinition } from "../datasets"
 import type { ObjectType } from "../ontology"
 import type { PipelineDefinition } from "../pipelines"
@@ -85,22 +86,34 @@ function isPipelineDefinitionInput(value: unknown): value is PipelineDefinition 
   )
 }
 
+function isAgentDefinitionInput(value: unknown): value is AgentDefinition {
+  return typeof value === "object" && value !== null && (value as AgentDefinition).kind === "agent"
+}
+
 function runTargetFrom(
   input: GrantInput<
-    WorkflowDefinition | SyncDefinition | PipelineDefinition,
-    "workflow" | "sync" | "pipeline"
+    WorkflowDefinition | SyncDefinition | PipelineDefinition | AgentDefinition,
+    "workflow" | "sync" | "pipeline" | "agent"
   >
-): "workflow" | "sync" | "pipeline" {
+): "workflow" | "sync" | "pipeline" | "agent" {
   if (isScope(input)) {
-    if (input.target !== "workflow" && input.target !== "sync" && input.target !== "pipeline") {
+    if (
+      input.target !== "workflow" &&
+      input.target !== "sync" &&
+      input.target !== "pipeline" &&
+      input.target !== "agent"
+    ) {
       throw new SecurityValidationError(
-        "[Sixb] can.run scope target must be workflow, sync, or pipeline."
+        "[Sixb] can.run scope target must be workflow, sync, pipeline, or agent."
       )
     }
     return input.target
   }
 
   const first = Array.isArray(input) ? input[0] : input
+  if (isAgentDefinitionInput(first)) {
+    return "agent"
+  }
   if (isPipelineDefinitionInput(first)) {
     return "pipeline"
   }
@@ -110,10 +123,11 @@ function runTargetFrom(
 function run(input: GrantInput<WorkflowDefinition, "workflow">): RunGrant<"workflow">
 function run(input: GrantInput<SyncDefinition, "sync">): RunGrant<"sync">
 function run(input: GrantInput<PipelineDefinition, "pipeline">): RunGrant<"pipeline">
+function run(input: GrantInput<AgentDefinition, "agent">): RunGrant<"agent">
 function run(
   input: GrantInput<
-    WorkflowDefinition | SyncDefinition | PipelineDefinition,
-    "workflow" | "sync" | "pipeline"
+    WorkflowDefinition | SyncDefinition | PipelineDefinition | AgentDefinition,
+    "workflow" | "sync" | "pipeline" | "agent"
   >
 ): RunGrant {
   return {

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -9,7 +9,7 @@ export {
   resolveInvitePolicyScope,
 } from "./invite-policies"
 export type { Scope, ScopeTarget } from "./scopes"
-export { actions, datasets, ontology, pipelines, syncs, workflows } from "./scopes"
+export { actions, agents, datasets, ontology, pipelines, syncs, workflows } from "./scopes"
 export type {
   ApplyGrant,
   GrantCapability,

--- a/packages/core/src/security/runtime.ts
+++ b/packages/core/src/security/runtime.ts
@@ -54,6 +54,7 @@ export function createRuntimeSecurityRegistry(input: {
   readonly workflowIds?: ReadonlySet<string>
   readonly syncIds?: ReadonlySet<string>
   readonly pipelineIds?: ReadonlySet<string>
+  readonly agentIds?: ReadonlySet<string>
   readonly getSubTypes?: (objectTypeId: string) => readonly string[]
 }): SecurityRegistry {
   const securityDefinitions = validateSecurityDefinitionsAtStartup({
@@ -66,6 +67,7 @@ export function createRuntimeSecurityRegistry(input: {
     workflowIds: input.workflowIds,
     syncIds: input.syncIds,
     pipelineIds: input.pipelineIds,
+    agentIds: input.agentIds,
   })
 
   const universe = {
@@ -75,6 +77,7 @@ export function createRuntimeSecurityRegistry(input: {
     workflowIds: input.workflowIds ?? new Set<string>(),
     syncIds: input.syncIds ?? new Set<string>(),
     pipelineIds: input.pipelineIds ?? new Set<string>(),
+    agentIds: input.agentIds ?? new Set<string>(),
     getSubTypes: input.getSubTypes ?? (() => []),
   }
   const resolvedRoles = securityDefinitions.roles.map((role) => ({

--- a/packages/core/src/security/scopes.ts
+++ b/packages/core/src/security/scopes.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ActionDefinition } from "../actions/types"
+import type { AgentDefinition } from "../agents/types"
 import type { DatasetDefinition } from "../datasets"
 import type { ObjectType } from "../ontology"
 import type { PipelineDefinition } from "../pipelines"
@@ -17,7 +18,14 @@ import type { WorkflowDefinition } from "../workflows/types"
 import { SecurityValidationError } from "./errors"
 
 /** Capability targets a scope can range over. */
-export type ScopeTarget = "object" | "dataset" | "action" | "workflow" | "sync" | "pipeline"
+export type ScopeTarget =
+  | "object"
+  | "dataset"
+  | "action"
+  | "workflow"
+  | "sync"
+  | "pipeline"
+  | "agent"
 
 interface ScopeTargetInput {
   object: ObjectType
@@ -26,6 +34,7 @@ interface ScopeTargetInput {
   workflow: WorkflowDefinition
   sync: SyncDefinition
   pipeline: PipelineDefinition
+  agent: AgentDefinition
 }
 
 /**
@@ -85,3 +94,5 @@ export const workflows = (): Scope<"workflow"> => allScope("workflow")
 export const syncs = (): Scope<"sync"> => allScope("sync")
 
 export const pipelines = (): Scope<"pipeline"> => allScope("pipeline")
+
+export const agents = (): Scope<"agent"> => allScope("agent")

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -32,7 +32,7 @@ export interface ApplyGrant {
   readonly selection: Selection
 }
 
-export type RunGrantTarget = "workflow" | "sync" | "pipeline"
+export type RunGrantTarget = "workflow" | "sync" | "pipeline" | "agent"
 
 export interface RunGrant<TTarget extends RunGrantTarget = RunGrantTarget> {
   readonly kind: "grant"

--- a/packages/core/src/security/validation.ts
+++ b/packages/core/src/security/validation.ts
@@ -163,9 +163,12 @@ export function assertGrantDefinition(
     value.capability === "run" &&
     value.target !== "workflow" &&
     value.target !== "sync" &&
-    value.target !== "pipeline"
+    value.target !== "pipeline" &&
+    value.target !== "agent"
   ) {
-    throw createError(`[Sixb] ${field} run grant target must be 'workflow', 'sync', or 'pipeline'.`)
+    throw createError(
+      `[Sixb] ${field} run grant target must be 'workflow', 'sync', 'pipeline', or 'agent'.`
+    )
   }
 
   assertSelection(value.selection, field, createError)
@@ -241,6 +244,8 @@ export function validateSecurityDefinitionsAtStartup(input: {
   readonly syncIds?: ReadonlySet<string>
   /** Registered pipeline ids — when provided, pipeline run grants must reference them. */
   readonly pipelineIds?: ReadonlySet<string>
+  /** Registered agent ids — when provided, agent run grants must reference them. */
+  readonly agentIds?: ReadonlySet<string>
 }): RegisteredSecurityDefinitions {
   const groupsById = new Map<string, GroupDefinition>()
   const rolesById = new Map<string, RoleDefinition>()

--- a/packages/core/src/storage/agents/in-memory.ts
+++ b/packages/core/src/storage/agents/in-memory.ts
@@ -123,10 +123,12 @@ class InMemoryAgentThreadStore implements AgentThreadStore {
   async list(input: ListAgentThreadsInput): Promise<ListAgentThreadsResult> {
     const order = input.order ?? "desc"
     const statuses = input.statuses ? new Set(input.statuses) : null
+    const agentIds = input.agentIds ? new Set(input.agentIds) : null
 
     const filtered = [...this.state.threads.values()]
       .filter((thread) => thread.projectId === input.projectId)
       .filter((thread) => (input.agentId ? thread.agentId === input.agentId : true))
+      .filter((thread) => (agentIds ? agentIds.has(thread.agentId) : true))
       .filter((thread) => (statuses ? statuses.has(thread.status) : true))
       .filter((thread) =>
         input.ownerPrincipal ? principalsEqual(thread.ownerPrincipal, input.ownerPrincipal) : true

--- a/packages/core/src/storage/agents/types.ts
+++ b/packages/core/src/storage/agents/types.ts
@@ -36,6 +36,8 @@ export interface CreateAgentThreadInput {
 export interface ListAgentThreadsInput {
   readonly projectId: string
   readonly agentId?: string
+  /** Optional allowlist intersected with `agentId` when both are provided. Empty means no rows. */
+  readonly agentIds?: readonly string[]
   readonly statuses?: readonly AgentThreadStatus[]
   readonly ownerPrincipal?: Principal
   readonly limit?: number

--- a/packages/core/src/testing/agent-storage-contract.ts
+++ b/packages/core/src/testing/agent-storage-contract.ts
@@ -146,6 +146,22 @@ export function runAgentStorageContractSuite<TStorage extends AgentStorage>(
         const sales = await storage.threads.list({ projectId, agentId: "sales", order: "asc" })
         expect(sales.threads.map((thread) => thread.id)).toEqual(["thr_a", "thr_c"])
 
+        const visibleAgents = await storage.threads.list({
+          projectId,
+          agentIds: ["support"],
+          order: "asc",
+        })
+        expect(visibleAgents.threads.map((thread) => thread.id)).toEqual(["thr_b"])
+
+        const salesVisibleAgents = await storage.threads.list({
+          projectId,
+          agentId: "sales",
+          agentIds: ["support"],
+          order: "asc",
+        })
+        expect(salesVisibleAgents.threads).toEqual([])
+        expect(salesVisibleAgents.total).toBe(0)
+
         const active = await storage.threads.list({ projectId, statuses: ["active"], order: "asc" })
         expect(active.threads.map((thread) => thread.id)).toEqual(["thr_a", "thr_b"])
 

--- a/packages/core/tests/authorization-context.test.ts
+++ b/packages/core/tests/authorization-context.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import {
   actions,
+  agents,
   can,
   col,
   createSessionCredential,
   datasets,
   defineAction,
+  defineAgent,
   defineConnector,
   defineDataset,
   defineGroup,
@@ -83,6 +85,20 @@ const invoicesPipelineStep = definePipelineStep("pipeline-invoices-step")
 const contractsPipeline = definePipeline("pipeline-contracts").then(contractsPipelineStep)
 const invoicesPipeline = definePipeline("pipeline-invoices").then(invoicesPipelineStep)
 
+const model = {} as Parameters<typeof defineAgent>[1]["model"]
+
+const contractAgent = defineAgent("contract-agent", {
+  name: "Contract Agent",
+  model,
+  instructions: "Help with contracts.",
+})
+
+const invoiceAgent = defineAgent("invoice-agent", {
+  name: "Invoice Agent",
+  model,
+  instructions: "Help with invoices.",
+})
+
 const sendContract = defineAction("send-contract")
   .params({})
   .edits(() => {})
@@ -98,6 +114,7 @@ const contractOperator = defineRole("contract.operator", {
     can.apply(sendContract),
     can.run(syncContracts),
     can.run(contractsPipeline),
+    can.run(contractAgent),
   ],
 })
 
@@ -115,6 +132,7 @@ const adminOperator = defineRole("admin.operator", {
     can.run(workflows()),
     can.run(syncs()),
     can.run(pipelines()),
+    can.run(agents()),
   ],
 })
 
@@ -130,6 +148,7 @@ describe("resolveAuthorizationContext", () => {
     workflowIds: new Set<string>(),
     syncIds: new Set(["sync-contracts", "sync-invoices"]),
     pipelineIds: new Set(["pipeline-contracts", "pipeline-invoices"]),
+    agentIds: new Set(["contract-agent", "invoice-agent"]),
     getSubTypes: (objectTypeId: string) => (objectTypeId === "contract" ? ["signed-contract"] : []),
   }
 
@@ -161,6 +180,7 @@ describe("resolveAuthorizationContext", () => {
     expect(context.grants["apply:action"]).toEqual(new Set(["send-contract"]))
     expect(context.grants["run:sync"]).toEqual(new Set(["sync-contracts"]))
     expect(context.grants["run:pipeline"]).toEqual(new Set(["pipeline-contracts"]))
+    expect(context.grants["run:agent"]).toEqual(new Set(["contract-agent"]))
   })
 
   test("unions grants across all matched roles", () => {
@@ -173,6 +193,7 @@ describe("resolveAuthorizationContext", () => {
     expect(context.grants["view:dataset"]).toEqual(new Set(["raw.invoices"]))
     expect(context.grants["run:sync"]).toEqual(new Set(["sync-contracts"]))
     expect(context.grants["run:pipeline"]).toEqual(new Set(["pipeline-contracts"]))
+    expect(context.grants["run:agent"]).toEqual(new Set(["contract-agent"]))
   })
 
   test("principals without matching roles resolve to empty grants", () => {
@@ -185,6 +206,7 @@ describe("resolveAuthorizationContext", () => {
     expect(context.grants["run:workflow"].size).toBe(0)
     expect(context.grants["run:sync"].size).toBe(0)
     expect(context.grants["run:pipeline"].size).toBe(0)
+    expect(context.grants["run:agent"].size).toBe(0)
   })
 
   test("expands broad grants to the registered universe", () => {
@@ -201,6 +223,7 @@ describe("resolveAuthorizationContext", () => {
     expect(context.grants["run:pipeline"]).toEqual(
       new Set(["pipeline-contracts", "pipeline-invoices"])
     )
+    expect(context.grants["run:agent"]).toEqual(new Set(["contract-agent", "invoice-agent"]))
   })
 
   test("except() excludes named datasets and keeps the rest of the dataset universe", () => {
@@ -237,6 +260,18 @@ describe("resolveAuthorizationContext", () => {
 
     expect(context.grants["run:pipeline"]).toEqual(new Set(["pipeline-contracts"]))
     expect(context.grants["run:pipeline"].has("pipeline-invoices")).toBe(false)
+  })
+
+  test("except() excludes named agents and keeps the rest of the agent universe", () => {
+    const mostAgents = defineRole("most.agents", {
+      grantedTo: [admins],
+      grants: [can.run(agents().except([invoiceAgent]))],
+    })
+
+    const context = resolve(["admins"], [mostAgents])
+
+    expect(context.grants["run:agent"]).toEqual(new Set(["contract-agent"]))
+    expect(context.grants["run:agent"].has("invoice-agent")).toBe(false)
   })
 
   test("except() excludes the named types and keeps the rest of the universe", () => {
@@ -278,6 +313,7 @@ describe("auth.createAuthorizationContext", () => {
       syncs: [syncContracts, syncInvoices],
       pipelines: [contractsPipeline, invoicesPipeline],
       actions: [sendContract],
+      agents: [contractAgent, invoiceAgent],
       groups: [commercial, finance],
       roles: [contractOperator, invoiceViewer],
       auth: { id: "test", kind: "dev" },
@@ -347,6 +383,7 @@ describe("auth.createAuthorizationContext", () => {
     expect(context.grants["apply:action"]).toEqual(new Set(["send-contract"]))
     expect(context.grants["run:sync"]).toEqual(new Set(["sync-contracts"]))
     expect(context.grants["run:pipeline"]).toEqual(new Set(["pipeline-contracts"]))
+    expect(context.grants["run:agent"]).toEqual(new Set(["contract-agent"]))
   })
 
   test("rejects unauthenticated requests", async () => {

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -23,6 +23,7 @@ function context(grants: {
   run?: readonly string[]
   syncs?: readonly string[]
   pipelines?: readonly string[]
+  agents?: readonly string[]
 }): AuthorizationContext {
   return {
     principal: { type: "user", id: "u1" },
@@ -35,6 +36,7 @@ function context(grants: {
       "run:workflow": new Set(grants.run ?? []),
       "run:sync": new Set(grants.syncs ?? []),
       "run:pipeline": new Set(grants.pipelines ?? []),
+      "run:agent": new Set(grants.agents ?? []),
     },
   }
 }
@@ -104,6 +106,21 @@ describe("evaluate", () => {
       allowed: false,
       requirements: ["run:pipeline:pipeline-orders"],
       missing: ["run:pipeline:pipeline-orders"],
+    })
+  })
+
+  test("agent.run checks agent grants", () => {
+    expect(
+      evaluate(context({ agents: ["ops"] }), {
+        kind: "agent.run",
+        agentId: "ops",
+      })
+    ).toEqual({ allowed: true, requirements: ["run:agent:ops"], missing: [] })
+
+    expect(evaluate(context({}), { kind: "agent.run", agentId: "ops" })).toEqual({
+      allowed: false,
+      requirements: ["run:agent:ops"],
+      missing: ["run:agent:ops"],
     })
   })
 

--- a/packages/core/tests/projection-run-visibility.test.ts
+++ b/packages/core/tests/projection-run-visibility.test.ts
@@ -21,6 +21,7 @@ function authzViewing(...objectTypeIds: string[]): AuthorizationContext {
       "run:workflow": new Set(),
       "run:sync": new Set(),
       "run:pipeline": new Set(),
+      "run:agent": new Set(),
     },
   }
 }

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -5,6 +5,7 @@ import {
   can,
   col,
   defineAction,
+  defineAgent,
   defineConnector,
   defineDataset,
   defineGroup,
@@ -86,6 +87,20 @@ const contractPipeline: PipelineDefinition =
 const invoicePipeline: PipelineDefinition =
   definePipeline("invoice-pipeline").then(invoicePipelineStep)
 
+const model = {} as Parameters<typeof defineAgent>[1]["model"]
+
+const contractAgent = defineAgent("contract-agent", {
+  name: "Contract Agent",
+  model,
+  instructions: "Help with contracts.",
+})
+
+const invoiceAgent = defineAgent("invoice-agent", {
+  name: "Invoice Agent",
+  model,
+  instructions: "Help with invoices.",
+})
+
 // Widened to the base type, like renewContract below: keeps the registered
 // actions array out of the deep Sixb<tuple> instantiation (TS2589).
 const sendContract: ActionDefinition = defineAction("send-contract")
@@ -132,7 +147,12 @@ const contractSender = defineRole("contract.sender", {
 
 const operationsRunner = defineRole("operations.runner", {
   grantedTo: [operations],
-  grants: [can.run(renewContract), can.run(syncContracts), can.run(contractPipeline)],
+  grants: [
+    can.run(renewContract),
+    can.run(syncContracts),
+    can.run(contractPipeline),
+    can.run(contractAgent),
+  ],
 })
 
 const principal = { type: "user", id: "adam" } as const
@@ -148,6 +168,7 @@ function createRuntime() {
     syncs: [syncContracts, syncInvoices],
     pipelines: [contractPipeline, invoicePipeline],
     workflows: [renewContract],
+    agents: [contractAgent, invoiceAgent],
     groups: [commercial, finance, ops, operations],
     roles: [contractOperator, invoiceViewer, contractSender, operationsRunner],
     ...createTestRuntimeDeps(),
@@ -381,6 +402,38 @@ describe("sixb.as() operational access", () => {
     expect(operator.listPipelines()).toEqual([])
     expect(operator.getPipelineById("contract-pipeline")).toBeNull()
   })
+
+  test("agent catalog narrows to runnable agents", () => {
+    const sixb = createRuntime()
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    expect(runner.listAgents().map((agent) => agent.id)).toEqual(["contract-agent"])
+    expect(runner.getAgentById("contract-agent")?.id).toBe("contract-agent")
+    expect(runner.getAgentById("invoice-agent")).toBeNull()
+
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    expect(operator.listAgents()).toEqual([])
+    expect(operator.getAgentById("contract-agent")).toBeNull()
+  })
+
+  test("agent run requests require can.run", async () => {
+    const sixb = createRuntime()
+
+    const runner = sixb.as(contextFor(sixb, ["operations"]))
+    const result = await runner.requestAgentRun({
+      agentId: "contract-agent",
+      text: "Summarize this account.",
+    })
+    expect(result.runId).toBeString()
+
+    const operator = sixb.as(contextFor(sixb, ["commercial"]))
+    expect(
+      operator.requestAgentRun({
+        agentId: "contract-agent",
+        text: "Summarize this account.",
+      })
+    ).rejects.toThrow(AuthorizationError)
+  })
 })
 
 describe("sixb.as() fails closed on ungranted surfaces", () => {
@@ -440,12 +493,14 @@ describe("ScopedSixb surface", () => {
         "authorization",
         "getDatasetById",
         "getActionById",
+        "getAgentById",
         "getObject",
         "getPipelineById",
         "getSyncById",
         "getWorkflowById",
         "list",
         "listActions",
+        "listAgents",
         "listDatasets",
         "listPipelines",
         "listSyncs",
@@ -453,6 +508,7 @@ describe("ScopedSixb surface", () => {
         "objects",
         "readEvents",
         "requestAction",
+        "requestAgentRun",
         "runWorkflow",
       ].sort()
     )

--- a/packages/core/tests/security-definitions.test.ts
+++ b/packages/core/tests/security-definitions.test.ts
@@ -5,6 +5,8 @@ import { dirname, join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import {
   type ActionDefinition,
+  type AgentDefinition,
+  agents,
   can,
   canInviteGroupIds,
   col,
@@ -12,6 +14,7 @@ import {
   type DatasetDefinition,
   datasets,
   defineAction,
+  defineAgent,
   defineConnector,
   defineDataset,
   defineGroup,
@@ -47,6 +50,14 @@ const Account = defineObjectType({
 
 const AccountSnapshot = defineDataset("account.snapshot", {
   schema: [col("id", "string")],
+})
+
+const model = {} as Parameters<typeof defineAgent>[1]["model"]
+
+const opsAgent = defineAgent("ops", {
+  name: "Ops Agent",
+  model,
+  instructions: "Assist operators.",
 })
 
 const sourceConnector = defineConnector("source", {
@@ -353,7 +364,7 @@ describe("role definitions", () => {
     })
   })
 
-  test("can.run supports sync and pipeline definitions and scopes", () => {
+  test("can.run supports sync, pipeline, and agent definitions and scopes", () => {
     expect(can.run(syncAccounts)).toEqual({
       kind: "grant",
       capability: "run",
@@ -379,6 +390,19 @@ describe("role definitions", () => {
       capability: "run",
       target: "pipeline",
       selection: { all: true, except: ["normalize-accounts"] },
+    })
+    expect(can.run(opsAgent)).toEqual({
+      kind: "grant",
+      capability: "run",
+      target: "agent",
+      selection: { all: false, ids: ["ops"] },
+    })
+    expect(can.run(agents()).selection).toEqual({ all: true, except: [] })
+    expect(can.run(agents().except([opsAgent]))).toEqual({
+      kind: "grant",
+      capability: "run",
+      target: "agent",
+      selection: { all: true, except: ["ops"] },
     })
   })
 
@@ -524,6 +548,26 @@ describe("role definitions", () => {
     )
   })
 
+  test("runtime registration rejects run grants on unknown agents", () => {
+    const role: RoleDefinition = {
+      kind: "role",
+      id: "agent.runner",
+      grantedToGroupIds: ["commercial"],
+      grants: [
+        {
+          kind: "grant",
+          capability: "run",
+          target: "agent",
+          selection: { all: false, ids: ["missing"] },
+        },
+      ],
+    }
+
+    expect(() => createRuntime({ groups: [commercial], roles: [role] })).toThrow(
+      "unknown agent 'missing'"
+    )
+  })
+
   test("valid roles register and resolve from the security registry", () => {
     const role = defineRole("contract.operator", {
       grantedTo: [commercial],
@@ -629,6 +673,7 @@ function createRuntime(
     datasets?: readonly DatasetDefinition[]
     syncs?: readonly SyncDefinition[]
     pipelines?: readonly PipelineDefinition[]
+    agents?: readonly AgentDefinition[]
   } = {}
 ): Sixb<readonly [typeof Account]> {
   return new Sixb<readonly [typeof Account]>({

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -7,7 +7,9 @@ import {
   type AgentThreadRecord,
   type AuthorizationContext,
   agentRunStreamId,
+  assertAuthorized,
   createAgentThreadId,
+  isAllowed,
   type OntologySource,
   type Principal,
   type Sixb,
@@ -109,8 +111,15 @@ function principalsEqual(left: Principal, right: Principal): boolean {
   return left.type === right.type && left.id === right.id
 }
 
+function canRunAgent(authz: AuthorizationContext | null, agentId: string): boolean {
+  return !authz || isAllowed(authz, { kind: "agent.run", agentId })
+}
+
 function canAccessThread(authz: AuthorizationContext | null, thread: AgentThreadRecord): boolean {
-  return !authz || principalsEqual(authz.principal, thread.ownerPrincipal)
+  return (
+    !authz ||
+    (principalsEqual(authz.principal, thread.ownerPrincipal) && canRunAgent(authz, thread.agentId))
+  )
 }
 
 async function getAccessibleThread(params: {
@@ -162,18 +171,30 @@ function missingAgentStorageResponse(set: { status?: number | string }): { error
 
 export function registerAgentRoutes(app: Elysia, sixb: Sixb<readonly OntologySource[]>) {
   return app
-    .get("/api/agents", () => sixb.agents.list().map(serializeAgent), {
-      response: { 200: AgentCatalogItemSchema.array() },
-      detail: {
-        summary: "List registered agents",
-        tags: ["Agents"],
-        operationId: "listAgents",
+    .get(
+      "/api/agents",
+      (context) => {
+        const { scoped } = requestAuthState(context)
+        const agents = scoped ? scoped.listAgents() : sixb.agents.list()
+        return agents.map(serializeAgent)
       },
-    })
+      {
+        response: { 200: AgentCatalogItemSchema.array() },
+        detail: {
+          summary: "List registered agents",
+          tags: ["Agents"],
+          operationId: "listAgents",
+        },
+      }
+    )
     .get(
       "/api/agents/:agentId",
-      ({ params, set }) => {
-        const agent = sixb.agents.getById(params.agentId)
+      (context) => {
+        const { params, set } = context
+        const { scoped } = requestAuthState(context)
+        const agent = scoped
+          ? scoped.getAgentById(params.agentId)
+          : sixb.agents.getById(params.agentId)
         if (!agent) {
           set.status = 404
           return { error: "Agent not found" }
@@ -208,6 +229,7 @@ export function registerAgentRoutes(app: Elysia, sixb: Sixb<readonly OntologySou
           const result = await storage.threads.list({
             projectId: sixb.id,
             agentId: parsed.agentId,
+            agentIds: authz ? [...authz.grants["run:agent"]] : undefined,
             statuses: parsed.status ? [parsed.status] : undefined,
             ownerPrincipal: authz?.principal,
             limit,
@@ -246,6 +268,10 @@ export function registerAgentRoutes(app: Elysia, sixb: Sixb<readonly OntologySou
             set.status = 404
             return { error: "Agent not found" }
           }
+          assertAuthorized(
+            { authorization: authz ?? undefined },
+            { kind: "agent.run", agentId: agent.id }
+          )
 
           const storage = sixb.storage.agents
           if (!storage) {
@@ -271,6 +297,7 @@ export function registerAgentRoutes(app: Elysia, sixb: Sixb<readonly OntologySou
         response: {
           201: CreateAgentThreadResponseSchema,
           400: ErrorResponseSchema,
+          403: ErrorResponseSchema,
           404: ErrorResponseSchema,
         },
         detail: {
@@ -380,7 +407,7 @@ export function registerAgentRoutes(app: Elysia, sixb: Sixb<readonly OntologySou
       "/api/agent-threads/:threadId/messages",
       async (context) => {
         const { params, body, set } = context
-        const { authz } = requestAuthState(context)
+        const { authz, scoped } = requestAuthState(context)
         try {
           const storage = sixb.storage.agents
           if (!storage) {
@@ -399,13 +426,16 @@ export function registerAgentRoutes(app: Elysia, sixb: Sixb<readonly OntologySou
           }
 
           const parsed = PostAgentMessageBodySchema.parse(body)
-          const result = await sixb.agents.request({
+          const requestInput = {
             agentId: thread.agentId,
             threadId: thread.id,
             text: parsed.text,
             messageId: parsed.messageId,
             principal: principalForRequest(authz),
-          })
+          }
+          const result = await (scoped
+            ? scoped.requestAgentRun(requestInput)
+            : sixb.agents.request(requestInput))
 
           set.status = 202
           return PostAgentMessageResponseSchema.parse({
@@ -422,6 +452,7 @@ export function registerAgentRoutes(app: Elysia, sixb: Sixb<readonly OntologySou
         response: {
           202: PostAgentMessageResponseSchema,
           400: ErrorResponseSchema,
+          403: ErrorResponseSchema,
           404: ErrorResponseSchema,
           409: ErrorResponseSchema,
         },

--- a/packages/server/src/routes/ws/agents.ts
+++ b/packages/server/src/routes/ws/agents.ts
@@ -3,6 +3,7 @@ import {
   agentRunStreamDefinition,
   agentRunStreamId,
   type BrokerRecord,
+  isAllowed,
   type OntologySource,
   type Principal,
   type Sixb,
@@ -107,6 +108,10 @@ export async function canAccessAgentRunStream(
   }
 
   if (!principalsEqual(input.authz.principal, thread.ownerPrincipal)) {
+    return { ok: false, message: "Agent run not found." }
+  }
+
+  if (!isAllowed(input.authz, { kind: "agent.run", agentId: thread.agentId })) {
     return { ok: false, message: "Agent run not found." }
   }
 

--- a/packages/server/tests/agent-streams-ws.test.ts
+++ b/packages/server/tests/agent-streams-ws.test.ts
@@ -207,13 +207,55 @@ describe("canAccessAgentRunStream", () => {
       lease: { id: "lease_ws_1", expiresAt: new Date("2099-01-01T00:00:00.000Z") },
     })
 
-    await expect(canAccessAgentRunStream(sixb, { runId, authz: authz(owner) })).resolves.toEqual({
+    await expect(
+      canAccessAgentRunStream(sixb, { runId, authz: authz(owner, [agentId]) })
+    ).resolves.toEqual({
       ok: true,
+    })
+    await expect(canAccessAgentRunStream(sixb, { runId, authz: authz(owner) })).resolves.toEqual({
+      ok: false,
+      message: "Agent run not found.",
     })
     await expect(
       canAccessAgentRunStream(sixb, {
         runId,
-        authz: authz({ type: "user", id: "usr_other" }),
+        authz: authz({ type: "user", id: "usr_other" }, [agentId]),
+      })
+    ).resolves.toEqual({ ok: false, message: "Agent run not found." })
+  })
+
+  test("allows pre-claim subscriptions when the thread is owned and runnable", async () => {
+    const sixb = createSixbInstance<readonly OntologySource[]>({
+      id: projectId,
+      ontology: [],
+      broker: new InMemoryBroker(),
+      storage: new InMemoryStorage(),
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: new InMemoryBlobStorage(),
+      queues: new InMemoryQueues(),
+      auth: { id: "test", kind: "dev" },
+    })
+    const owner: Principal = { type: "user", id: "usr_owner" }
+    const agents = agentStorage(sixb)
+    await agents.threads.create({
+      id: threadId,
+      projectId,
+      agentId,
+      ownerPrincipal: owner,
+    })
+
+    await expect(
+      canAccessAgentRunStream(sixb, {
+        runId: "agt_run_not_reserved",
+        threadId,
+        authz: authz(owner, [agentId]),
+      })
+    ).resolves.toEqual({ ok: true })
+    await expect(
+      canAccessAgentRunStream(sixb, {
+        runId: "agt_run_not_reserved",
+        threadId,
+        authz: authz(owner),
       })
     ).resolves.toEqual({ ok: false, message: "Agent run not found." })
   })
@@ -462,7 +504,7 @@ function decodeWsData(value: unknown): string {
   return String(value)
 }
 
-function authz(principal: Principal): AuthorizationContext {
+function authz(principal: Principal, agentIds: readonly string[] = []): AuthorizationContext {
   return {
     principal,
     groupIds: [],
@@ -474,6 +516,7 @@ function authz(principal: Principal): AuthorizationContext {
       "run:workflow": new Set(),
       "run:sync": new Set(),
       "run:pipeline": new Set(),
+      "run:agent": new Set(agentIds),
     },
   }
 }

--- a/packages/server/tests/agents-routes.test.ts
+++ b/packages/server/tests/agents-routes.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import {
+  agents as agentScope,
+  can,
   createAgentRunLeaseId,
   createSessionCredential,
   defineAgent,
+  defineGroup,
+  defineRole,
   InMemoryBlobStorage,
   InMemoryBroker,
   InMemoryLakeStorage,
@@ -34,6 +38,25 @@ const ops = defineAgent("ops", {
   instructions: "Internal ops instructions.",
 })
 
+const supportUsers = defineGroup("support-users")
+const opsUsers = defineGroup("ops-users")
+const admins = defineGroup("admins")
+
+const supportAgentRunner = defineRole("support.agent-runner", {
+  grantedTo: [supportUsers],
+  grants: [can.run(assistant)],
+})
+
+const opsAgentRunner = defineRole("ops.agent-runner", {
+  grantedTo: [opsUsers],
+  grants: [can.run(ops)],
+})
+
+const adminAgentRunner = defineRole("admin.agent-runner", {
+  grantedTo: [admins],
+  grants: [can.run(agentScope())],
+})
+
 function createRuntime(options: { readonly auth?: boolean } = {}) {
   const storage = new InMemoryStorage()
   const queues = new InMemoryQueues()
@@ -46,6 +69,8 @@ function createRuntime(options: { readonly auth?: boolean } = {}) {
     lakeStorage: new InMemoryLakeStorage(),
     blobStorage: new InMemoryBlobStorage(),
     queues,
+    groups: [supportUsers, opsUsers, admins],
+    roles: [supportAgentRunner, opsAgentRunner, adminAgentRunner],
     auth: options.auth ? { id: "test", kind: "dev" as const } : undefined,
   })
 
@@ -61,13 +86,25 @@ function createApp(options: { readonly auth?: boolean } = {}) {
   return { app, sixb, storage, queues }
 }
 
-async function seedSession(storage: InMemoryStorage, userId: string) {
+async function seedSession(
+  storage: InMemoryStorage,
+  userId: string,
+  groupIds: readonly string[] = ["support-users"]
+) {
   const credential = createSessionCredential(`ses_${userId}`)
   await storage.auth.users.create({
     id: userId,
     projectId: "agent-route-tests",
     email: `${userId}@acme.com`,
   })
+  for (const groupId of groupIds) {
+    await storage.auth.groupMemberships.upsert({
+      projectId: "agent-route-tests",
+      userId,
+      groupId,
+      source: "manual",
+    })
+  }
   await storage.auth.sessions.create({
     id: credential.sessionId,
     projectId: "agent-route-tests",
@@ -136,6 +173,59 @@ describe("agent routes", () => {
     const missingResponse = await app.fetch(new Request("http://localhost/api/agents/missing"))
     expect(missingResponse.status).toBe(404)
     expect(await missingResponse.json()).toEqual({ error: "Agent not found" })
+  })
+
+  test("narrows the agent catalog and rejects thread creation without can.run", async () => {
+    const { app, storage } = createApp({ auth: true })
+    const support = await seedSession(storage, "usr_support", ["support-users"])
+    const opsSession = await seedSession(storage, "usr_ops", ["ops-users"])
+    const admin = await seedSession(storage, "usr_admin", ["admins"])
+    const noAccess = await seedSession(storage, "usr_none", [])
+
+    const supportList = await app.fetch(
+      new Request("http://localhost/api/agents", { headers: support.headers })
+    )
+    expect(((await supportList.json()) as { id: string }[]).map((agent) => agent.id)).toEqual([
+      "assistant",
+    ])
+
+    const hidden = await app.fetch(
+      new Request("http://localhost/api/agents/ops", { headers: support.headers })
+    )
+    expect(hidden.status).toBe(404)
+
+    const opsList = await app.fetch(
+      new Request("http://localhost/api/agents", { headers: opsSession.headers })
+    )
+    expect(((await opsList.json()) as { id: string }[]).map((agent) => agent.id)).toEqual(["ops"])
+
+    const adminList = await app.fetch(
+      new Request("http://localhost/api/agents", { headers: admin.headers })
+    )
+    expect(((await adminList.json()) as { id: string }[]).map((agent) => agent.id)).toEqual([
+      "assistant",
+      "ops",
+    ])
+
+    const deniedThread = await app.fetch(
+      jsonRequest(
+        "/api/agent-threads",
+        "POST",
+        { agentId: "assistant", title: "Denied" },
+        noAccess.csrfHeaders
+      )
+    )
+    expect(deniedThread.status).toBe(403)
+
+    const allowedThread = await app.fetch(
+      jsonRequest(
+        "/api/agent-threads",
+        "POST",
+        { agentId: "assistant", title: "Allowed" },
+        support.csrfHeaders
+      )
+    )
+    expect(allowedThread.status).toBe(201)
   })
 
   test("creates a thread, posts a message, and enqueues a reserve-at-claim run", async () => {
@@ -319,6 +409,13 @@ describe("agent routes", () => {
     expect(otherThreadResponse.status).toBe(201)
     const ownerThread = (await ownerThreadResponse.json()) as { thread: { id: string } }
     const otherThread = (await otherThreadResponse.json()) as { thread: { id: string } }
+    await storage.agents.threads.create({
+      id: "owner-ops-thread",
+      projectId: sixb.id,
+      agentId: "ops",
+      ownerPrincipal: { type: "user", id: "usr_owner" },
+      title: "Owned but ungranted",
+    })
 
     const ownerList = await app.fetch(
       new Request("http://localhost/api/agent-threads", { headers: owner.headers })
@@ -328,6 +425,13 @@ describe("agent routes", () => {
       total: 1,
       threads: [{ id: ownerThread.thread.id, ownerPrincipal: { type: "user", id: "usr_owner" } }],
     })
+
+    const hiddenOwnedThread = await app.fetch(
+      new Request("http://localhost/api/agent-threads/owner-ops-thread", {
+        headers: owner.headers,
+      })
+    )
+    expect(hiddenOwnedThread.status).toBe(404)
 
     const hiddenThread = await app.fetch(
       new Request(`http://localhost/api/agent-threads/${otherThread.thread.id}`, {

--- a/packages/server/tests/projections-routes.test.ts
+++ b/packages/server/tests/projections-routes.test.ts
@@ -64,6 +64,7 @@ function authzViewing(...objectTypeIds: string[]): AuthorizationContext {
       "run:workflow": new Set(),
       "run:sync": new Set(),
       "run:pipeline": new Set(),
+      "run:agent": new Set(),
     },
   }
 }

--- a/storage/pg/src/agents/threads.ts
+++ b/storage/pg/src/agents/threads.ts
@@ -66,7 +66,10 @@ export class PgAgentThreadStore implements AgentThreadStore {
   }
 
   async list(input: ListAgentThreadsInput): Promise<ListAgentThreadsResult> {
-    if (input.statuses !== undefined && input.statuses.length === 0) {
+    if (
+      (input.statuses !== undefined && input.statuses.length === 0) ||
+      (input.agentIds !== undefined && input.agentIds.length === 0)
+    ) {
       return { threads: [], hasMore: false, total: 0 }
     }
 
@@ -77,6 +80,12 @@ export class PgAgentThreadStore implements AgentThreadStore {
     if (input.agentId) {
       whereClauses.push(`agent_id = $${index++}`)
       params.push(input.agentId)
+    }
+
+    if (input.agentIds) {
+      const placeholders = input.agentIds.map(() => `$${index++}`)
+      whereClauses.push(`agent_id IN (${placeholders.join(", ")})`)
+      params.push(...input.agentIds)
     }
 
     if (input.statuses) {

--- a/storage/sqlite/src/agents/threads.ts
+++ b/storage/sqlite/src/agents/threads.ts
@@ -72,7 +72,10 @@ export class SqliteAgentThreadStore implements AgentThreadStore {
   }
 
   async list(input: ListAgentThreadsInput): Promise<ListAgentThreadsResult> {
-    if (input.statuses !== undefined && input.statuses.length === 0) {
+    if (
+      (input.statuses !== undefined && input.statuses.length === 0) ||
+      (input.agentIds !== undefined && input.agentIds.length === 0)
+    ) {
       return { threads: [], hasMore: false, total: 0 }
     }
 
@@ -82,6 +85,11 @@ export class SqliteAgentThreadStore implements AgentThreadStore {
     if (input.agentId) {
       whereClauses.push("agent_id = ?")
       args.push(input.agentId)
+    }
+
+    if (input.agentIds) {
+      whereClauses.push(`agent_id IN (${input.agentIds.map(() => "?").join(", ")})`)
+      args.push(...input.agentIds)
     }
 
     if (input.statuses) {


### PR DESCRIPTION
## Why

Phase 7 adds caller authorization for agents. Agents are now governed by the same group/role grant model that already controls object visibility, action application, dataset visibility, and operational runs.

Before this change, the agent API surface was owner-scoped for existing threads, but there was no `can.run` authorization boundary for discovering agents, creating new agent threads, posting messages that enqueue runs, or subscribing to run streams.

## What changed

Agent definitions can now be granted through `can.run(...)` alongside workflows, syncs, and pipelines:

```ts
defineRole("support-agent-users", {
  groups: [supportGroup],
  grants: [can.run(CustomerSupportAgent)],
})
```

The authorization decision model now includes an agent run request that resolves to a `run:agent` atom:

```ts
assertAuthorized(runtime, { kind: "agent.run", agentId: agent.id })
```

That check is applied at the core request boundary so every scoped caller must hold the matching grant before an agent run can be requested.

The scoped runtime also gained an agent catalog surface, so caller-facing routes can narrow what a principal can see:

```ts
const agents = scoped ? scoped.listAgents() : sixb.agents.list()
```

Agent thread access now requires both ownership and continued permission to run the thread's agent:

```ts
principalsEqual(authz.principal, thread.ownerPrincipal) && canRunAgent(authz, thread.agentId)
```

The server routes and WebSocket stream guard use that rule to:

- filter `GET /api/agents` and single-agent reads through scoped access
- reject thread creation and message posting without `can.run(agent)`
- filter thread listings by the caller's runnable agent ids
- reject run stream subscriptions when the caller owns the thread but no longer has access to the agent

The agent storage contract now accepts `agentIds` for filtered thread listings, with in-memory, SQLite, and Postgres implementations updated so route-level authorization can be pushed into the query boundary.

Generated OpenAPI and typed client artifacts were refreshed for the new `403` agent route responses.

## Reviewer notes

Privileged runtime callers with no authorization context keep the existing allow-all behavior. Scoped callers fail closed: if no role grants `run:agent` for a target agent, the catalog hides it and run-producing operations return authorization failures.

## Validation

```bash
bun run generate:client
bun run typecheck
bun run check
bun test packages/core/tests/authorization-decision.test.ts packages/core/tests/authorization-context.test.ts packages/core/tests/security-definitions.test.ts packages/core/tests/scoped-sixb.test.ts packages/core/tests/agents-storage.test.ts
bun test packages/server/tests/agents-routes.test.ts packages/server/tests/agent-streams-ws.test.ts
bun test storage/sqlite/tests/sqlite-agent-storage.test.ts
bun test --preload ./storage/pg/tests/setup.ts ./storage/pg/tests/pg-agent-storage.e2e.ts
```