### PR TITLE
sqlite: add expand query pushdown to object storage

### DIFF
--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -1546,8 +1546,8 @@ describe("SixbServer HTTP contract", () => {
         }>
       }
 
-      // No provider speaks expand, so it runs through the bounded fallback.
-      expect(body.plan.mode).toBe("fallback")
+      // The SQLite provider speaks expand, so it hydrates links via pushdown.
+      expect(body.plan.mode).toBe("pushdown")
       const system = body.objects.find((object) => object.primaryId === "system")
       // "many" cardinality serializes as an array of the linked objects.
       expect(system?.links?.contains).toEqual([

--- a/storage/sqlite/src/object-query-compiler.ts
+++ b/storage/sqlite/src/object-query-compiler.ts
@@ -1,4 +1,5 @@
 import {
+  type ObjectExpansion,
   type ObjectQuery,
   ObjectQueryExecutionError,
   type ObjectQueryPredicate,
@@ -75,6 +76,11 @@ interface EncodedCursorValue {
 const PAGE_TOKEN_PREFIX = "keyset:"
 const exactContext: CompileContext = { probeLimit: false }
 
+// Fallback fanout cap for a "many" expansion that arrives without an explicit
+// limit. The core executor normally bakes a limit in before pushdown; this only
+// bounds the degenerate uncapped case. Mirrors the PostgreSQL compiler.
+const DEFAULT_EXPANSION_FANOUT = 1_000
+
 export function compileObjectQuery(
   projectId: string,
   query: ObjectQuery,
@@ -120,10 +126,9 @@ function compileObjectQueryInternal(
         query.fields,
         query.fieldsByObjectType
       )
-    case "vector":
-    // `expand` (link hydration) has no provider pushdown yet; the planner gates
-    // it off via capabilities, so this is unreachable until a later slice.
     case "expand":
+      return compileExpand(projectId, query.input, query.expansions)
+    case "vector":
       throw new Error(`[Sixb] SQLite object storage does not support query node '${query.kind}'`)
   }
 }
@@ -379,6 +384,205 @@ function compileTraversal(
     trimRows: identityRows,
     nextPageToken: () => undefined,
   }
+}
+
+/** Correlation handle for an expansion: the parent row's identity columns. */
+interface ExpansionParent {
+  project: string
+  type: string
+  id: string
+}
+
+// `expand` attaches linked objects to each result row without changing which
+// objects match (unlike `traverse`, which pivots to the targets). Each expansion
+// becomes a correlated subquery that hydrates its links into a JSON value, and
+// all expansions are folded into one `_expand` object column the row mapper reads
+// back. The input set is otherwise untouched, so pagination/order pass through.
+function compileExpand(
+  projectId: string,
+  inputQuery: ObjectQuery,
+  expansions: readonly ObjectExpansion[]
+): CompiledObjectQuery {
+  const input = compileObjectQueryInternal(projectId, inputQuery, exactContext)
+  const expand = compileExpansionsObject(
+    expansions,
+    { project: "input.project_id", type: "input.object_type_id", id: "input.primary_id" },
+    ""
+  )
+  const inputOrder = compileOrder(input.order.fields, "input", "input._cursor_properties")
+  const sql = `
+    SELECT input.*, ${expand.sql} AS _expand
+    FROM (${input.sql}) AS input
+    ORDER BY ${inputOrder.sql}
+  `
+
+  return {
+    sql,
+    args: [...expand.args, ...input.args, ...inputOrder.args],
+    totalSql: input.totalSql,
+    totalArgs: input.totalArgs,
+    order: input.order,
+    hasMoreProbe: input.hasMoreProbe,
+    hasMore: input.hasMore,
+    trimRows: input.trimRows,
+    nextPageToken: input.nextPageToken,
+  }
+}
+
+// `json_object(linkId, value, ...)` over a set of expansions sharing one parent.
+// Link ids are user data, so they ride as parameters. Each value is a correlated
+// subquery whose JSON subtype is lost crossing the subquery boundary, so it is
+// re-parsed with `json(...)` to embed as nested JSON rather than a quoted string.
+// Used both for the outer `_expand` column and for each child's nested `links`.
+function compileExpansionsObject(
+  expansions: readonly ObjectExpansion[],
+  parent: ExpansionParent,
+  pathPrefix: string
+): CompiledPredicate {
+  const parts: string[] = []
+  const args: SqliteValue[] = []
+  expansions.forEach((expansion, index) => {
+    const path = pathPrefix === "" ? `${index}` : `${pathPrefix}_${index}`
+    const value = compileExpansionValue(expansion, parent, path)
+    parts.push("?", `json(${value.sql})`)
+    args.push(expansion.linkId, ...value.args)
+  })
+  return { sql: `json_object(${parts.join(", ")})`, args }
+}
+
+// One expansion's hydrated value. `row_number()` numbers a parent's links by the
+// order from `compileExpansionOrder` (the expansion's `orderBy` against the target
+// object's properties, then an identity tiebreak); `WHERE _ord <= N` keeps the
+// top-N per parent in-DB; each retained neighbour becomes a JSON object; and the
+// value is an ordered array ("many") or the first element or null ("one"). The
+// cardinality is core-resolved before pushdown.
+function compileExpansionValue(
+  expansion: ObjectExpansion,
+  parent: ExpansionParent,
+  path: string
+): CompiledPredicate {
+  const edge = `edge_${path}`
+  const target = `tgt_${path}`
+  const ranked = `ranked_${path}`
+  const incoming = expansion.direction === "incoming"
+  // The hydrated neighbour is the link target (outgoing) or source (incoming);
+  // the parent sits on the opposite end, mirroring `compileTraversal`.
+  const neighborType = incoming ? `${edge}.source_type_id` : `${edge}.target_type_id`
+  const neighborId = incoming ? `${edge}.source_id` : `${edge}.target_id`
+  const parentType = incoming ? `${edge}.target_type_id` : `${edge}.source_type_id`
+  const parentId = incoming ? `${edge}.target_id` : `${edge}.source_id`
+
+  const child = compileExpansionChildJson(expansion, edge, target, path)
+  const order = compileExpansionOrder(expansion, target, neighborType, neighborId)
+
+  const whereParts = [
+    `${edge}.project_id = ${parent.project}`,
+    `${parentType} = ${parent.type}`,
+    `${parentId} = ${parent.id}`,
+    `${edge}.link_id = ?`,
+  ]
+  const whereArgs: SqliteValue[] = [expansion.linkId]
+  if (incoming && expansion.sourceObjectTypeId !== undefined) {
+    whereParts.push(`${edge}.source_type_id = ?`)
+    whereArgs.push(expansion.sourceObjectTypeId)
+  }
+
+  const inner = `
+    SELECT ${child.sql} AS elem, row_number() OVER (ORDER BY ${order.sql}) AS _ord
+    FROM links AS ${edge}
+    JOIN objects AS ${target}
+      ON ${target}.project_id = ${edge}.project_id
+     AND ${target}.object_type_id = ${neighborType}
+     AND ${target}.primary_id = ${neighborId}
+    WHERE ${whereParts.join(" AND ")}
+  `
+  const innerArgs = [...child.args, ...order.args, ...whereArgs]
+
+  if (expansion.cardinality === "one") {
+    return {
+      sql: `(SELECT ${ranked}.elem FROM (${inner}) AS ${ranked} WHERE ${ranked}._ord = 1)`,
+      args: innerArgs,
+    }
+  }
+
+  // The fanout cap is baked into `limit` by the core executor before pushdown.
+  // Each element is re-parsed with `json(...)` so the aggregate embeds objects
+  // rather than the quoted JSON text the subquery column hands back.
+  const limit = expansion.limit ?? DEFAULT_EXPANSION_FANOUT
+  return {
+    sql: `COALESCE((SELECT json_group_array(json(${ranked}.elem) ORDER BY ${ranked}._ord) FROM (${inner}) AS ${ranked} WHERE ${ranked}._ord <= ?), '[]')`,
+    args: [...innerArgs, limit],
+  }
+}
+
+// Build one hydrated neighbour as an `ExpandedObjectRow`-shaped JSON object. The
+// JSON-valued columns (`properties`, the edge's `linkProperties`) are re-parsed
+// with `json(...)` so they embed as JSON rather than strings; `linkProperties`
+// always rides along (the mapper drops it when null/empty), and nested expansions
+// recurse under `links`, correlated on this neighbour.
+function compileExpansionChildJson(
+  expansion: ObjectExpansion,
+  edge: string,
+  target: string,
+  path: string
+): CompiledPredicate {
+  const fields = [
+    `'projectId', ${target}.project_id`,
+    `'objectTypeId', ${target}.object_type_id`,
+    `'primaryId', ${target}.primary_id`,
+    `'properties', json(${target}.properties)`,
+    `'createdAt', ${target}.created_at`,
+    `'updatedAt', ${target}.updated_at`,
+    `'version', ${target}.version`,
+    `'sourceEventId', ${target}.source_event_id`,
+    `'linkProperties', json(${edge}.properties)`,
+  ]
+  const args: SqliteValue[] = []
+
+  if (expansion.expand && expansion.expand.length > 0) {
+    const nested = compileExpansionsObject(
+      expansion.expand,
+      {
+        project: `${target}.project_id`,
+        type: `${target}.object_type_id`,
+        id: `${target}.primary_id`,
+      },
+      path
+    )
+    fields.push(`'links', ${nested.sql}`)
+    args.push(...nested.args)
+  }
+
+  return { sql: `json_object(${fields.join(", ")})`, args }
+}
+
+// Order a parent's links the way the fallback's per-parent trim does: each
+// property sorts nulls last with the requested direction (against the neighbour's
+// JSON properties), then a deterministic identity tiebreak on the neighbour.
+function compileExpansionOrder(
+  expansion: ObjectExpansion,
+  target: string,
+  neighborType: string,
+  neighborId: string
+): CompiledPredicate {
+  const propertyColumn = `${target}.properties`
+  const clauses: string[] = []
+  const args: SqliteValue[] = []
+
+  for (const field of expansion.orderBy ?? []) {
+    // Relevance is a no-op in the fallback comparator; mirror that by skipping it.
+    if (field.kind !== "property") continue
+    const direction = field.direction === "desc" ? "DESC" : "ASC"
+    const path = jsonPath(field.propertyId)
+    clauses.push(
+      `CASE WHEN ${jsonTypeExpression(propertyColumn)} IS NULL OR ${jsonTypeExpression(propertyColumn)} = 'null' THEN 1 ELSE 0 END ASC`,
+      `${jsonValueExpression(propertyColumn)} ${direction}`
+    )
+    args.push(path, path, path)
+  }
+
+  clauses.push(`${neighborType} ASC`, `${neighborId} ASC`)
+  return { sql: clauses.join(", "), args }
 }
 
 function compileSet(

--- a/storage/sqlite/src/object-storage.ts
+++ b/storage/sqlite/src/object-storage.ts
@@ -5,6 +5,8 @@ import type {
   EditCommitPlan,
   ExistsObjectsInput,
   ExistsObjectsResult,
+  ExpandedLinkValue,
+  ExpandedObjectRow,
   FacetObjectsInput,
   FacetObjectsResult,
   LinkDirection,
@@ -13,6 +15,7 @@ import type {
   ObjectQuery,
   ObjectQueryCapabilities,
   ObjectRow,
+  ObjectRowLinks,
   ObjectStorage,
   QueryObjectsInput,
   QueryObjectsResult,
@@ -57,6 +60,7 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
     traverse: true,
     set: true,
     project: true,
+    expand: true,
   },
   predicateOps: {
     and: true,
@@ -89,7 +93,8 @@ const SQLITE_OBJECT_QUERY_CAPABILITIES: ObjectQueryCapabilities = {
     stablePageTokens: true,
   },
   notes: [
-    "SQLite object query pushdown supports start/filter/text/sort/limit/page/traverse/set/project over JSON properties and object links.",
+    "SQLite object query pushdown supports start/filter/text/sort/limit/page/traverse/set/project/expand over JSON properties and object links.",
+    "expand hydrates linked objects in-database (top-N per parent via row_number() + json_group_array); core resolves each expansion's cardinality before pushdown, and a mixed/unresolved one stays on the fallback.",
     "Relevance sorting, vector search, and unresolved start.includeSubtypes remain planner fallback or rejection cases.",
   ],
 }
@@ -122,8 +127,8 @@ export class SqliteObjectStorage implements ObjectStorage {
       includeTotal: params.includeTotal,
     })
     const total = params.includeTotal === false ? undefined : readTotal(this.db, compiled)
-    const rawRows = this.db.query(compiled.sql).all(...compiled.args) as DatabaseRow[]
-    const rows = compiled.trimRows(rawRows) as readonly DatabaseRow[]
+    const rawRows = this.db.query(compiled.sql).all(...compiled.args) as ObjectQueryDatabaseRow[]
+    const rows = compiled.trimRows(rawRows) as readonly ObjectQueryDatabaseRow[]
     const hasMore =
       total === undefined && compiled.hasMoreProbe
         ? compiled.hasMoreProbe.hasMore(
@@ -132,7 +137,7 @@ export class SqliteObjectStorage implements ObjectStorage {
         : compiled.hasMore(rawRows.length, total)
 
     return {
-      objects: rows.map((row) => this.rowToObject(row)),
+      objects: rows.map((row) => this.queryRowToObject(row)),
       hasMore,
       nextPageToken: compiled.nextPageToken(rows, rawRows.length),
       ...(total === undefined ? {} : { total }),
@@ -894,6 +899,16 @@ export class SqliteObjectStorage implements ObjectStorage {
     }
   }
 
+  // Map a query row, attaching `links` when an `expand` pushdown produced them.
+  // The base columns map as usual; `_expand` (a `json_object` serialized to TEXT)
+  // is parsed and revived into the runtime link shape the core executor's
+  // fallback also produces.
+  private queryRowToObject(row: ObjectQueryDatabaseRow): ObjectRow {
+    const base = this.rowToObject(row)
+    const links = reviveExpandedLinks(parseExpandColumn(row._expand))
+    return links ? { ...base, links } : base
+  }
+
   private rowToLink(row: LinkDatabaseRow): ObjectLinkRow {
     return {
       projectId: row.project_id,
@@ -961,6 +976,57 @@ function sqliteFacetValue(valueType: string | null, value: unknown): unknown {
   return value
 }
 
+// The `_expand` column comes back from SQLite as a JSON string (or null/absent
+// when the query carried no expansion); parse it before reviving.
+function parseExpandColumn(value: unknown): unknown {
+  if (typeof value !== "string") return value ?? undefined
+  return JSON.parse(value)
+}
+
+function reviveExpandedLinks(value: unknown): ObjectRowLinks | undefined {
+  if (!isPlainObject(value)) return undefined
+  const links: ObjectRowLinks = {}
+  for (const [linkId, raw] of Object.entries(value)) {
+    links[linkId] = reviveExpandedLinkValue(raw)
+  }
+  return links
+}
+
+// A "one" expansion arrives as a single object or null; a "many" expansion as an
+// array (already ordered and trimmed in the database).
+function reviveExpandedLinkValue(value: unknown): ExpandedLinkValue {
+  if (value === null || value === undefined) return null
+  if (Array.isArray(value)) return value.map(reviveExpandedRow)
+  return reviveExpandedRow(value)
+}
+
+// Revive one hydrated neighbour from `compileExpansionChildJson`: timestamp
+// strings back to `Date`, null/empty link properties dropped (matching the
+// fallback), and nested links recursed.
+function reviveExpandedRow(value: unknown): ExpandedObjectRow {
+  const row = isPlainObject(value) ? value : {}
+  const expanded: ExpandedObjectRow = {
+    projectId: String(row.projectId),
+    objectTypeId: String(row.objectTypeId),
+    primaryId: String(row.primaryId),
+    properties: isPlainObject(row.properties) ? row.properties : {},
+    createdAt: new Date(row.createdAt as string),
+    updatedAt: new Date(row.updatedAt as string),
+    version: Number(row.version),
+  }
+  if (row.sourceEventId != null) expanded.sourceEventId = String(row.sourceEventId)
+  if (isPlainObject(row.linkProperties) && Object.keys(row.linkProperties).length > 0) {
+    expanded.linkProperties = row.linkProperties
+  }
+  const links = reviveExpandedLinks(row.links)
+  if (links) expanded.links = links
+  return expanded
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
 function existsProbeQuery(query: ObjectQuery): ObjectQuery {
   return { kind: "limit", limit: 1, input: stripOuterRowShape(query) }
 }
@@ -986,6 +1052,12 @@ interface DatabaseRow {
   updated_at: string
   version: number
   source_event_id: string | null
+}
+
+interface ObjectQueryDatabaseRow extends DatabaseRow {
+  _cursor_properties?: string
+  /** `json_object(linkId, value, ...)` serialized text from an `expand` pushdown; absent otherwise. */
+  _expand?: string | null
 }
 
 interface FacetDatabaseRow {

--- a/storage/sqlite/tests/sqlite-object-query-compiler.test.ts
+++ b/storage/sqlite/tests/sqlite-object-query-compiler.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test"
+import type { ObjectQuery } from "@sixb/core"
+import { compileObjectQuery } from "../src/object-query-compiler"
+
+test("expand SQL hydrates an outgoing many link as an ordered json array", () => {
+  const compiled = compileObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Room" } },
+    expansions: [{ linkId: "hasDevice", direction: "outgoing", cardinality: "many", limit: 50 }],
+  })
+
+  // Output-shaping: the input row set rides through under `_expand`.
+  expect(compiled.sql).toContain("SELECT input.*,")
+  expect(compiled.sql).toContain("AS _expand")
+  // Top-N per parent pushed into the DB, then aggregated in rank order.
+  expect(compiled.sql).toContain("row_number() OVER (ORDER BY")
+  expect(compiled.sql).toContain("json_group_array(json(ranked_0.elem) ORDER BY ranked_0._ord)")
+  expect(compiled.sql).toContain("WHERE ranked_0._ord <= ?")
+  expect(compiled.sql).toContain("'[]'")
+  // Outgoing: parent on the link source, neighbour hydrated from the target.
+  expect(compiled.sql).toContain("edge_0.source_type_id = input.object_type_id")
+  expect(compiled.sql).toContain("tgt_0.object_type_id = edge_0.target_type_id")
+  expect(compiled.sql).toContain("'linkProperties', json(edge_0.properties)")
+  // Link id rides as a param twice (the json key and the edge filter); then the
+  // baked fanout, then the input's own params.
+  expect(compiled.args).toEqual(["hasDevice", "hasDevice", 50, "project-a", "Room", 10])
+})
+
+test("expand SQL takes the first ranked element for a one link", () => {
+  const compiled = compileObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 5, input: { kind: "start", objectTypeId: "User" } },
+    expansions: [{ linkId: "manager", direction: "outgoing", cardinality: "one", limit: 1000 }],
+  })
+
+  expect(compiled.sql).toContain("WHERE ranked_0._ord = 1")
+  expect(compiled.sql).not.toContain("json_group_array")
+  expect(compiled.sql).not.toContain("_ord <=")
+  // No fanout param for a "one" link — it always takes a single element.
+  expect(compiled.args).toEqual(["manager", "manager", "project-a", "User", 5])
+})
+
+test("expand SQL flips parent/neighbour columns and filters source type for incoming", () => {
+  const compiled = compileObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 5, input: { kind: "start", objectTypeId: "Device" } },
+    expansions: [
+      {
+        linkId: "hasDevice",
+        direction: "incoming",
+        sourceObjectTypeId: "Room",
+        cardinality: "many",
+        limit: 1000,
+      },
+    ],
+  })
+
+  // Incoming: parent on the link target, neighbour hydrated from the source.
+  expect(compiled.sql).toContain("edge_0.target_type_id = input.object_type_id")
+  expect(compiled.sql).toContain("edge_0.target_id = input.primary_id")
+  expect(compiled.sql).toContain("tgt_0.object_type_id = edge_0.source_type_id")
+  expect(compiled.sql).toContain("edge_0.source_type_id = ?")
+  expect(compiled.args).toEqual(["hasDevice", "hasDevice", "Room", 1000, "project-a", "Device", 5])
+})
+
+test("expand SQL orders a bounded many link by target properties, nulls last", () => {
+  const compiled = compileObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Room" } },
+    expansions: [
+      {
+        linkId: "hasDevice",
+        direction: "outgoing",
+        cardinality: "many",
+        limit: 5,
+        orderBy: [{ kind: "property", propertyId: "name", direction: "desc" }],
+      },
+    ],
+  })
+
+  // Null-rank first (always ASC so nulls sort last), then the value descending,
+  // against the neighbour's JSON properties — mirroring the fallback comparator.
+  expect(compiled.sql).toContain("json_type(tgt_0.properties, ?)")
+  expect(compiled.sql).toContain("json_extract(tgt_0.properties, ?) DESC")
+  expect(compiled.args).toEqual([
+    "hasDevice",
+    '$."name"',
+    '$."name"',
+    '$."name"',
+    "hasDevice",
+    5,
+    "project-a",
+    "Room",
+    10,
+  ])
+})
+
+test("expand SQL nests a child expansion correlated on the parent neighbour", () => {
+  const compiled = compileObjectQuery("project-a", {
+    kind: "expand",
+    input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: "Project" } },
+    expansions: [
+      {
+        linkId: "owner",
+        direction: "outgoing",
+        cardinality: "one",
+        limit: 1000,
+        expand: [{ linkId: "members", direction: "outgoing", cardinality: "many", limit: 1000 }],
+      },
+    ],
+  })
+
+  // The nested expansion uses its own aliases and correlates on the parent's
+  // hydrated neighbour (tgt_0), under a `links` key in the child object.
+  expect(compiled.sql).toContain("'links', json_object(")
+  expect(compiled.sql).toContain("edge_0_0.source_id = tgt_0.primary_id")
+  expect(compiled.sql).toContain("json_group_array(json(ranked_0_0.elem)")
+})
+
+const expandableQuery: ObjectQuery = {
+  kind: "expand",
+  input: { kind: "start", objectTypeId: "Room" },
+  expansions: [{ linkId: "hasDevice", direction: "outgoing", cardinality: "many", limit: 50 }],
+}
+
+test("vector remains an unsupported query node", () => {
+  expect(() =>
+    compileObjectQuery("project-a", { kind: "vector" } as unknown as ObjectQuery)
+  ).toThrow("does not support query node 'vector'")
+  // expand is now supported and compiles without throwing.
+  expect(() => compileObjectQuery("project-a", expandableQuery)).not.toThrow()
+})

--- a/storage/sqlite/tests/sqlite-object-query-expand.test.ts
+++ b/storage/sqlite/tests/sqlite-object-query-expand.test.ts
@@ -1,0 +1,312 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import {
+  defineObjectType,
+  type ExpandedObjectRow,
+  executeObjectQuery,
+  link,
+  OntologyRegistry,
+  prop,
+  type StoredLinkUpsertedEvent,
+  type StoredObjectUpsertedEvent,
+} from "@sixb/core"
+import { SqliteObjectStorage } from "../src/object-storage"
+
+// Self-contained ontology exercising the runtime shapes the in-memory contract
+// can't: a "one" link, a "many" link, a nested "one" hop, link properties, and a
+// dangling edge. All assertions hold for both pushdown (here, against SQLite) and
+// the bounded fallback the cross-provider contract covers separately.
+const Tag = defineObjectType({
+  id: "ExpandTag",
+  name: "Expand Tag",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("label", "string", {
+      query: { searchable: true, filterable: true, sortable: true, exact: true },
+    }),
+  ],
+})
+
+const Author = defineObjectType({
+  id: "ExpandAuthor",
+  name: "Expand Author",
+  properties: [prop("id", "string", { required: true, primary: true }), prop("name", "string")],
+  links: [
+    link("favoriteTag", Tag, { cardinality: "one" }),
+    link.self("manager", { cardinality: "one" }),
+  ],
+})
+
+const Post = defineObjectType({
+  id: "ExpandPost",
+  name: "Expand Post",
+  properties: [prop("id", "string", { required: true, primary: true }), prop("title", "string")],
+  links: [
+    link("author", Author, { cardinality: "one" }),
+    link("tags", Tag, { cardinality: "many" }),
+  ],
+})
+
+const ontology = new OntologyRegistry({ sources: [Tag, Author, Post] })
+const projectId = "expand-e2e"
+
+let storage: SqliteObjectStorage
+let cursor = 0
+
+beforeAll(async () => {
+  storage = new SqliteObjectStorage()
+
+  await storage.applyObjectUpserted(objectEvent(Tag.id, "tag-a", { id: "tag-a", label: "Apple" }))
+  await storage.applyObjectUpserted(objectEvent(Tag.id, "tag-b", { id: "tag-b", label: "Banana" }))
+  await storage.applyObjectUpserted(objectEvent(Tag.id, "tag-c", { id: "tag-c", label: "Cherry" }))
+  await storage.applyObjectUpserted(
+    objectEvent(Author.id, "author-1", { id: "author-1", name: "Alice" })
+  )
+  await storage.applyObjectUpserted(
+    objectEvent(Author.id, "author-2", { id: "author-2", name: "Bob" })
+  )
+  await storage.applyObjectUpserted(
+    objectEvent(Post.id, "post-1", { id: "post-1", title: "First" })
+  )
+
+  await storage.applyLinkUpserted(linkEvent(Post.id, "post-1", "author", Author.id, "author-1"))
+  await storage.applyLinkUpserted(linkEvent(Author.id, "author-1", "favoriteTag", Tag.id, "tag-b"))
+  // author-1 → manager author-2 → favoriteTag tag-c: the third hop for deep expansion.
+  await storage.applyLinkUpserted(
+    linkEvent(Author.id, "author-1", "manager", Author.id, "author-2")
+  )
+  await storage.applyLinkUpserted(linkEvent(Author.id, "author-2", "favoriteTag", Tag.id, "tag-c"))
+  // post-1 → three real tags plus one dangling edge; tag-a carries link properties.
+  await storage.applyLinkUpserted(
+    linkEvent(Post.id, "post-1", "tags", Tag.id, "tag-a", { weight: 10 })
+  )
+  await storage.applyLinkUpserted(linkEvent(Post.id, "post-1", "tags", Tag.id, "tag-b"))
+  await storage.applyLinkUpserted(linkEvent(Post.id, "post-1", "tags", Tag.id, "tag-c"))
+  await storage.applyLinkUpserted(linkEvent(Post.id, "post-1", "tags", Tag.id, "tag-missing"))
+})
+
+afterAll(() => {
+  storage.close()
+})
+
+describe("SqliteObjectStorage expand pushdown", () => {
+  test("declares expand pushdown support", () => {
+    expect(storage.queryCapabilities().nodes?.expand).toBe(true)
+  })
+
+  test("hydrates one and many links in-database, dropping a dangling edge", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [
+            { linkId: "author", direction: "outgoing" },
+            { linkId: "tags", direction: "outgoing" },
+          ],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    const post = postRow(result, "post-1")
+
+    // "one" → a single object (not an array), with timestamps revived to Date.
+    const author = post.links?.author as ExpandedObjectRow
+    expect(Array.isArray(author)).toBe(false)
+    expect(author.primaryId).toBe("author-1")
+    expect(author.properties.name).toBe("Alice")
+    expect(author.createdAt).toBeInstanceOf(Date)
+    expect(author.updatedAt).toBeInstanceOf(Date)
+
+    // "many" → an array; the dangling tag-missing edge hydrates to nothing.
+    const tags = post.links?.tags as ExpandedObjectRow[]
+    expect(tags.map((tag) => tag.primaryId).sort()).toEqual(["tag-a", "tag-b", "tag-c"])
+  })
+
+  test("orders and bounds a many expansion to the top-N by target property", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [
+            {
+              linkId: "tags",
+              direction: "outgoing",
+              limit: 2,
+              orderBy: [{ kind: "property", propertyId: "label", direction: "asc" }],
+            },
+          ],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    const tags = postRow(result, "post-1").links?.tags as ExpandedObjectRow[]
+    // Apple, Banana, Cherry → top-2 ascending, in order.
+    expect(tags.map((tag) => tag.primaryId)).toEqual(["tag-a", "tag-b"])
+  })
+
+  test("attaches link properties only when present", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [{ linkId: "tags", direction: "outgoing" }],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage }
+    )
+
+    const tags = postRow(result, "post-1").links?.tags as ExpandedObjectRow[]
+    const tagA = tags.find((tag) => tag.primaryId === "tag-a")
+    const tagB = tags.find((tag) => tag.primaryId === "tag-b")
+    expect(tagA?.linkProperties).toEqual({ weight: 10 })
+    expect(tagB?.linkProperties).toBeUndefined()
+  })
+
+  test("hydrates a nested expansion correlated on the parent neighbour", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [
+            {
+              linkId: "author",
+              direction: "outgoing",
+              expand: [{ linkId: "favoriteTag", direction: "outgoing" }],
+            },
+          ],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    const author = postRow(result, "post-1").links?.author as ExpandedObjectRow
+    const favorite = author.links?.favoriteTag as ExpandedObjectRow
+    expect(favorite.primaryId).toBe("tag-b")
+    expect(favorite.properties.label).toBe("Banana")
+  })
+
+  test("hydrates a three-hop expansion end to end", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [
+            {
+              linkId: "author",
+              direction: "outgoing",
+              expand: [
+                {
+                  linkId: "manager",
+                  direction: "outgoing",
+                  expand: [{ linkId: "favoriteTag", direction: "outgoing" }],
+                },
+              ],
+            },
+          ],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Post.id } },
+        },
+      },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    // post-1 → author-1 → manager author-2 → favoriteTag tag-c, verified at each hop.
+    const author = postRow(result, "post-1").links?.author as ExpandedObjectRow
+    const manager = author.links?.manager as ExpandedObjectRow
+    expect(manager.primaryId).toBe("author-2")
+    const favorite = manager.links?.favoriteTag as ExpandedObjectRow
+    expect(favorite.primaryId).toBe("tag-c")
+    expect(favorite.properties.label).toBe("Cherry")
+  })
+
+  test("hydrates an incoming expansion back to its sources", async () => {
+    const result = await executeObjectQuery(
+      {
+        projectId,
+        query: {
+          kind: "expand",
+          expansions: [{ linkId: "tags", direction: "incoming", sourceObjectTypeId: Post.id }],
+          input: { kind: "limit", limit: 10, input: { kind: "start", objectTypeId: Tag.id } },
+        },
+      },
+      { ontology, storage }
+    )
+
+    expect(result.plan.mode).toBe("pushdown")
+    const tagA = result.objects.find((row) => row.primaryId === "tag-a")
+    const sources = tagA?.links?.tags as ExpandedObjectRow[]
+    expect(sources.map((source) => source.primaryId)).toEqual(["post-1"])
+  })
+})
+
+function postRow(
+  result: Awaited<ReturnType<typeof executeObjectQuery>>,
+  primaryId: string
+): { links?: Record<string, unknown> } & { primaryId: string } {
+  const row = result.objects.find((candidate) => candidate.primaryId === primaryId)
+  if (!row) throw new Error(`row '${primaryId}' not found`)
+  return row
+}
+
+function objectEvent(
+  objectTypeId: string,
+  primaryId: string,
+  properties: Record<string, unknown>
+): StoredObjectUpsertedEvent {
+  cursor += 1
+  const tag = String(cursor).padStart(3, "0")
+  return {
+    id: `expand-e2e-object-${tag}`,
+    cursor: tag,
+    schemaVersion: 1,
+    projectId,
+    type: "object.upserted",
+    topic: "objects",
+    partitionKey: `${objectTypeId}:${primaryId}`,
+    payload: { objectTypeId, primaryId, properties },
+    occurredAt: `2026-01-01T00:00:${tag.slice(-2)}.000Z`,
+  }
+}
+
+function linkEvent(
+  sourceTypeId: string,
+  sourceId: string,
+  linkId: string,
+  targetTypeId: string,
+  targetId: string,
+  properties?: Record<string, unknown>
+): StoredLinkUpsertedEvent {
+  cursor += 1
+  const tag = String(cursor).padStart(3, "0")
+  return {
+    id: `expand-e2e-link-${tag}`,
+    cursor: tag,
+    schemaVersion: 1,
+    projectId,
+    type: "link.upserted",
+    topic: "links",
+    partitionKey: `${sourceTypeId}:${sourceId}:${linkId}`,
+    payload: {
+      sourceTypeId,
+      sourceId,
+      linkId,
+      targetTypeId,
+      targetId,
+      ...(properties === undefined ? {} : { properties }),
+    },
+    occurredAt: `2026-01-01T00:00:${tag.slice(-2)}.000Z`,
+  }
+}


### PR DESCRIPTION
## Why

`.expand()` attaches linked objects to query results (the runtime behind `TwinObject.links`). PostgreSQL hydrates expansions **in-database** — declaring `nodes.expand` and compiling each expansion to a correlated subquery. SQLite did not: its compiler threw on the `expand` node and its capabilities omitted `expand`, so every expand query silently dropped to the core executor's **in-memory bounded fallback** (fetch all candidate links per row, hydrate in JS).

That gap meant SQLite-backed deployments paid an N+1-shaped round trip for a query Postgres answers in one statement, and the two providers diverged on a public query feature. This PR closes the gap so SQLite hydrates expansions in-database too.

The fallback is correctness-equivalent, so this is a performance + parity change, not a behavior change for callers — the shared cross-provider contract already asserts pushdown and fallback return identical results.

## What

### 1. Compile `expand` to correlated subqueries

The compiler now mirrors `pg-object-query-compiler.ts` structurally, swapping Postgres JSON builtins for SQLite's. Each expansion becomes a correlated subquery folded into one `_expand` column on the input row set, which otherwise passes through untouched (pagination/order preserved):

```sql
SELECT input.*, json_object('hasDevice', json(<expansion subquery>)) AS _expand
FROM (<input query>) AS input
ORDER BY <input order>
```

Per-parent top-N uses `row_number()` + an outer trim, exactly like the pg path:

```sql
-- "many" → ordered, bounded JSON array (fanout baked in by the core executor)
COALESCE((
  SELECT json_group_array(json(ranked_0.elem) ORDER BY ranked_0._ord)
  FROM (
    SELECT <child json> AS elem,
           row_number() OVER (ORDER BY <expansion order>) AS _ord
    FROM links AS edge_0
    JOIN objects AS tgt_0 ON ...
    WHERE edge_0.project_id = input.project_id AND ... AND edge_0.link_id = ?
  ) AS ranked_0
  WHERE ranked_0._ord <= ?
), '[]')

-- "one" → first ranked element, or NULL
(SELECT ranked_0.elem FROM (...) AS ranked_0 WHERE ranked_0._ord = 1)
```

Mapping table (Postgres → SQLite): `jsonb_build_object` → `json_object`, `jsonb_agg(... ORDER BY ...)` → `json_group_array(... ORDER BY ...)`, `row_number() OVER (...)` is identical. Incoming/outgoing column flipping, `sourceObjectTypeId` filtering, nulls-last ordering against neighbour properties, and nested expansions (recursed under a `links` key) all match the pg semantics.

### 2. The one genuinely SQLite-specific subtlety: JSON subtype across subquery boundaries

SQLite tracks an internal "this TEXT is JSON" subtype so `json_object`/`json_group_array` embed nested JSON instead of re-quoting it. **That subtype is lost when a value passes through a subquery-column boundary** — so a hydrated child selected as `elem` in an inner query gets double-encoded as a string when the outer query embeds it. I verified this against the bundled SQLite 3.51 before settling on the fix:

```
-- elem flows through a subquery column → subtype lost → double-encoded:
json_object('k', (SELECT elem FROM (...) WHERE o=1))   -- {"k":"{\"id\":1}"}  ✗
-- re-parse at the boundary with json() → embedded as JSON:
json_object('k', json((SELECT elem FROM (...) WHERE o=1)))  -- {"k":{"id":1}}  ✓
```

So every value crossing such a boundary is wrapped in `json(...)`: the neighbour `properties`, the edge `linkProperties` (`json(NULL)` → `NULL`, which the mapper drops), and each expansion subquery result. This is the main thing worth a careful look in review.

### 3. Capability + row revival

`object-storage.ts` declares the node and revives the column. Unlike the pg driver (which returns parsed `jsonb`), bun:sqlite hands back `_expand` as TEXT, so it's `JSON.parse`d first, then revived into the exact runtime shape the fallback produces (timestamps → `Date`, empty `linkProperties` dropped, nested `links` recursed):

```ts
nodes: { ..., project: true, expand: true },
```
```ts
private queryRowToObject(row: ObjectQueryDatabaseRow): ObjectRow {
  const base = this.rowToObject(row)
  const links = reviveExpandedLinks(parseExpandColumn(row._expand))
  return links ? { ...base, links } : base
}
```

## Tests

- **`sqlite-object-query-compiler.test.ts`** (new) — SQL-shape + arg-ordering unit tests: many/one cardinality, incoming direction + source-type filter, nulls-last ordering, nested expansions, and `vector` still throwing.
- **`sqlite-object-query-expand.test.ts`** (new) — runtime e2e mirroring `pg-object-query-expand.e2e.ts`: one/many links, dangling edges, top-N ordering, link properties, nested + three-hop deep expansions, incoming direction — all asserting `pushdown` mode.
- **Shared cross-provider contract** (`sqlite-object-query-conformance.test.ts`) now runs SQLite through expand in **pushdown** mode and confirms results identical to the fallback.
- **`packages/server/tests/httpContract.test.ts`** — updated one assertion that assumed expand always fell back; it now correctly expects `pushdown`. The serialization assertion (the test's real purpose) is unchanged.

## Checks

`bun run typecheck`, `bunx biome check .`, and `bun run generate:client` (no diff) are clean. Full `bun run test`: **1919 pass / 0 fail**.
