### PR TITLE
client: improve custom app action DX

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,4 +108,5 @@ it to an `Employee`, append telemetry, or render it in your app.
 - [Ontology](ontology/overview.md) — model your domain
 - [Objects](objects/overview.md) — read, write, and query object instances
 - [Building apps](apps/overview.md) — put a typed UI on top
+- [Running actions from apps](apps/actions.md) — wire action buttons with terminal state
 - [Manual install](fundamentals/manual-install.md) — add Sixb to an existing project

--- a/docs/actions/overview.md
+++ b/docs/actions/overview.md
@@ -246,6 +246,12 @@ await sixb.actions.request({
 request idempotent — re-requesting the same `runId` with the same action, subject, and params
 returns the existing run (`created: false`) instead of starting a new one.
 
+In browser apps, prefer `useActionRunMutation` from `@sixb/client/hooks` for button-driven
+commands. Its loading, success, and error states track the terminal run, and
+`invalidateOnCommit: true` refreshes object queries after committed edits. The generated
+`requestActionMutation()` remains enqueue-only and resolves as soon as the server accepts the
+request. See [running actions from apps](../apps/actions.md).
+
 | Option | Applies to | Meaning |
 | --- | --- | --- |
 | `action` / `actionId` | both | The action to run — pass the definition or its id. |
@@ -278,13 +284,22 @@ The runtime also appends [domain events](../events/overview.md) you can subscrib
 | `action.completed` | Run succeeded | `actionId`, `runId`, `subject`, `finishedAt` |
 | `action.failed` | Run failed | `actionId`, `runId`, `subject`, `error`, `finishedAt` |
 
-These are how `requestActionAndWait` detects completion. To react to a run, subscribe through
-`sixb.events`, or model the reaction as a [rule](../rules/overview.md) or
-[workflow](../workflows/overview.md).
+These are how `requestActionAndWait` detects completion. In client code, the fluent event
+builder can scope action events by run, action id, or object subject:
+
+```tsx
+events.actions().run(runId).terminal()
+events.actions().action("markPaid").completed()
+events.actions().subject(Invoice).object("inv-1").failed()
+```
+
+To react to a run on the server, subscribe through `sixb.events`, or model the reaction as a
+[rule](../rules/overview.md) or [workflow](../workflows/overview.md).
 
 ## Related
 
 - [Objects](../objects/overview.md) — the CRUD and edit facade actions stage into.
 - [Object CRUD](../objects/crud.md) — `create`/`update`/`delete`/`link` used inside `edits`.
 - [Events](../events/overview.md) — the domain-event stream actions emit.
+- [Running actions from apps](../apps/actions.md) — React action buttons and terminal state.
 - [Authorization](../auth/authorization.md) — `apply:action` grants gate who can request actions.

--- a/docs/apps/actions.md
+++ b/docs/apps/actions.md
@@ -1,0 +1,227 @@
+# Running Actions from Apps
+
+Apps usually want actions to feel like ordinary button clicks: press the button, show loading,
+surface success or failure, and refresh the data the action changed. Use
+`useActionRunMutation` for that path.
+
+For action definitions, phases, and server-side `edits(...)`, see
+[Actions](../actions/overview.md). This page covers the browser/app side.
+
+## Recommended Button Flow
+
+`useActionRunMutation` requests the action and waits for the durable run to reach a terminal
+status. `isPending` means the run is still queued or running. `isSuccess` means the action
+finished with status `succeeded`. `isError` covers request errors, failed runs, cancelled runs,
+and wait timeouts.
+
+```tsx
+import { useActionRunMutation } from "@sixb/client/hooks"
+import { Invoice } from "../../ontology/invoice"
+
+export function MarkPaidButton({ invoiceId }: { invoiceId: string }) {
+  const markPaid = useActionRunMutation<{ paymentMethod: "card" | "ach" }>({
+    actionId: "markPaid",
+    subject: { objectType: Invoice, primaryId: invoiceId },
+    invalidateOnCommit: true,
+    timeoutMs: 30_000,
+  })
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={markPaid.isPending}
+        onClick={() => markPaid.mutate({ paymentMethod: "card" })}
+      >
+        {markPaid.isPending ? "Marking paid..." : "Mark paid"}
+      </button>
+      {markPaid.isError ? <p role="alert">{markPaid.error.message}</p> : null}
+      {markPaid.isSuccess ? <p>Paid.</p> : null}
+    </>
+  )
+}
+```
+
+`invalidateOnCommit: true` invalidates action-run caches after the terminal run. When the run
+has a commit diff, it also invalidates the changed object detail caches and the typed
+object-query cache group, so `useObjectsQuery` screens refresh without a custom event listener.
+
+## Object and Global Actions
+
+For object actions, configure the action once and pass only params to `mutate`:
+
+```tsx
+const approveQuote = useActionRunMutation<{ note?: string }>({
+  actionId: "approveQuote",
+  subject: { objectType: Quote, primaryId: quoteId },
+  invalidateOnCommit: true,
+})
+
+approveQuote.mutate({ note: "Approved from the quote screen." })
+```
+
+For global actions, omit `subject`:
+
+```tsx
+const createDraft = useActionRunMutation<{ customerId: string }>({
+  actionId: "createDraftInvoice",
+  invalidateOnCommit: true,
+})
+
+createDraft.mutate({ customerId })
+```
+
+For dynamic action ids or subjects, call the hook without an `actionId` and pass a request-shaped
+value to `mutate`:
+
+```tsx
+const runAction = useActionRunMutation()
+
+runAction.mutate({
+  path: { actionId },
+  body: {
+    subject: { objectType, primaryId },
+    params,
+  },
+})
+```
+
+If you are building a generic screen and only have string ids, the generated subject shape still
+works: `{ kind: "object", objectTypeId, primaryId }`.
+
+## High-Frequency Controls
+
+For a single destructive command, disabling the button while `mutation.isPending` is usually
+right. For controls that users press repeatedly, such as volume buttons, do not globally block
+the control surface. Track local pending counts and call `mutateAsync` for each click:
+
+```tsx
+const pressButton = useActionRunMutation<{ button: string }>({
+  actionId: "pressButton",
+  subject: { objectType: Television, primaryId: televisionId },
+  invalidateOnCommit: true,
+})
+
+const [pendingByButton, setPendingByButton] = useState<Record<string, number>>({})
+
+function press(button: string) {
+  setPendingByButton((current) => ({
+    ...current,
+    [button]: (current[button] ?? 0) + 1,
+  }))
+
+  void pressButton
+    .mutateAsync({ button })
+    .catch((error) => console.error(error))
+    .finally(() => {
+      setPendingByButton((current) => {
+        const next = { ...current }
+        const count = (next[button] ?? 0) - 1
+        if (count > 0) next[button] = count
+        else delete next[button]
+        return next
+      })
+    })
+}
+```
+
+TanStack Query does not serialize these calls unless you configure a mutation `scope`, so each
+click creates its own action run. Show a compact side status, per-button spinner, or both.
+
+## Enqueue-Only vs Terminal Mutations
+
+Sixb keeps the generated `requestActionMutation()` and root `requestAction()` API enqueue-only.
+They resolve when the server accepts the request and returns `{ runId, queuedAt, created }`.
+Use them when the UI should not wait for the work, such as starting a long import, kicking off
+a background repair, or navigating directly to a run details page.
+
+Use `useActionRunMutation()` when the UI state should represent the action outcome:
+
+| Need | Use |
+| --- | --- |
+| Button loading until the action succeeds or fails | `useActionRunMutation` |
+| Toast or inline error for terminal action failure | `useActionRunMutation` |
+| Refresh object queries after committed edits | `useActionRunMutation({ invalidateOnCommit: true })` |
+| Fire-and-forget background work | generated `requestActionMutation()` or `requestAction()` |
+| Custom run history UI that watches many runs | enqueue-only request plus action-run queries/events |
+
+## React-Free Waiting
+
+Non-React code can use the same terminal semantics from `@sixb/client`:
+
+```ts
+import { requestActionAndWait, waitForActionRun } from "@sixb/client"
+
+const run = await requestActionAndWait({
+  path: { actionId: "approveQuote" },
+  body: {
+    subject: { kind: "object", objectTypeId: "Quote", primaryId: quoteId },
+    params: { note: "Approved." },
+  },
+  timeoutMs: 30_000,
+})
+
+await waitForActionRun({ runId: run.id })
+```
+
+By default, failed and cancelled terminal runs reject with `ActionRunFailedError`, and timeouts
+reject with `ActionRunTimeoutError`. Pass `rejectOnTerminalFailure: false` when you want to
+inspect the terminal run record yourself.
+
+## Scoped Action Events
+
+Most apps should not subscribe manually just to update a button. The wait helpers already listen
+for terminal events and fetch the final run detail. Use event builders when the screen needs
+broader live coordination:
+
+```tsx
+import { events, useEvents } from "@sixb/client/hooks"
+
+useEvents(events.actions().subject(Quote).object(quoteId).terminal(), (event) => {
+  console.log("quote action finished", event.payload.runId)
+})
+
+useEvents(events.actions().run(runId).completed(), () => {
+  console.log("this run succeeded")
+})
+```
+
+Useful scopes are:
+
+| Builder | Meaning |
+| --- | --- |
+| `events.actions().run(runId)` | One action run |
+| `events.actions().action("approveQuote")` | One action definition |
+| `events.actions().subject(Quote).object(quoteId)` | Actions against one object |
+| `.requested()` | Only enqueue events |
+| `.completed()` | Successful terminal events |
+| `.failed()` | Failed or cancelled terminal events |
+| `.terminal()` | Completed plus failed events |
+
+See [Client events](../client/events.md) for the full event builder and hook reference.
+
+## Manual Invalidation
+
+If you handle events yourself, use the exported object-query keys and invalidation helpers
+instead of copying cache keys:
+
+```tsx
+import { invalidateObjectQuery } from "@sixb/client/hooks"
+import { useQueryClient } from "@tanstack/react-query"
+import { openInvoices } from "../queries/invoices"
+
+const queryClient = useQueryClient()
+
+await invalidateObjectQuery(queryClient, openInvoices.limit(50))
+```
+
+`objectQueryKeys` also exposes `list`, `count`, `exists`, `facets`, `infinite`, and `all`
+keys for advanced TanStack Query integration.
+
+## Related
+
+- [Querying data](querying-data.md) - typed object reads in custom apps.
+- [Client SDK](../client/overview.md) - root SDK, hooks, events, and transport setup.
+- [Client events](../client/events.md) - event builders and React hooks.
+- [Actions](../actions/overview.md) - defining actions and server-side run lifecycle.
+- [Events](../events/overview.md) - event stream and scoped action subscriptions.

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -22,8 +22,9 @@ the API.
 | `app/public/` static assets | Same-origin `<a>` click interception (SPA nav) |
 
 Pages fetch data with the typed hooks from `@sixb/client/hooks` and the typed
-query builder from `@sixb/client/query`, then render with your own components or
-`@sixb/ui`. See [querying data](querying-data.md).
+query builder from `@sixb/client/query`, run action buttons with
+`useActionRunMutation`, then render with your own components or `@sixb/ui`. See
+[querying data](querying-data.md) and [running actions](actions.md).
 
 > `app/` is not discovered by `createSixb()` — it is built and served separately
 > by the CLI. Your ontology, datasets, functions, and the rest stay in their own
@@ -106,8 +107,9 @@ export default function ProjectsPage() {
 }
 ```
 
-Hooks, the query builder, filtering, faceting, telemetry, and actions are covered
-in [querying data](querying-data.md).
+Hooks, the query builder, filtering, faceting, and telemetry are covered in
+[querying data](querying-data.md). Button-driven action flows are covered in
+[running actions](actions.md).
 
 ### Navigation
 
@@ -198,8 +200,12 @@ bun sixb app
 
 ## Next
 
-- [Querying data](querying-data.md) — fetch objects, telemetry, facets, and
-  actions from pages with the typed `@sixb/client/hooks` and `@sixb/client/query`.
+- [Querying data](querying-data.md) — fetch objects, telemetry, and facets from
+  pages with the typed `@sixb/client/hooks` and `@sixb/client/query`.
+- [Client events](../client/events.md) — live telemetry, activity feeds, and
+  event-driven invalidation.
+- [Running actions](actions.md) — wire action buttons with terminal loading,
+  success, error, and cache invalidation states.
 - [Typed client](../client/overview.md) — the generated client the hooks build on,
   for non-app callers.
 - [Authentication](../auth/authentication.md) — how the app shell establishes the

--- a/docs/apps/querying-data.md
+++ b/docs/apps/querying-data.md
@@ -174,9 +174,31 @@ query.data?.map((object) => object.primaryId)
 For everything else — filtering, search, facets, link traversal, paging, and typed rows — use the
 typed builder.
 
+## Invalidating After Actions
+
+For app buttons that run actions, prefer `useActionRunMutation({ invalidateOnCommit: true })`.
+It waits for terminal action success or failure and refreshes object-query caches from the
+committed run, so most screens do not need custom event listeners.
+
+If you are handling events manually, use the exported key helpers instead of copying cache keys:
+
+```tsx
+import { invalidateObjectQuery } from "@sixb/client/hooks"
+import { useQueryClient } from "@tanstack/react-query"
+import { openInvoices } from "../queries/invoices"
+
+const queryClient = useQueryClient()
+
+await invalidateObjectQuery(queryClient, openInvoices.limit(50))
+```
+
+See [running actions](actions.md) for complete button, loading, and error patterns.
+
 ## Related
 
 - [Querying Objects](../objects/querying.md) — the full query language and predicate reference.
 - [Client](../client/overview.md) — the browser client and transport.
 - [Typed Queries](../client/typed-queries.md) — typed queries from the browser in depth.
+- [Client Events](../client/events.md) — live updates, telemetry hooks, and event invalidation.
+- [Running actions](actions.md) — action buttons and cache invalidation in apps.
 - [Apps](overview.md) — building app screens and routes.

--- a/docs/client/events.md
+++ b/docs/client/events.md
@@ -1,0 +1,140 @@
+# Client Events
+
+`@sixb/client` exposes the domain event stream to app pages. Use it when a screen needs live
+telemetry, an activity feed, or custom coordination around runs. For a normal action button, prefer
+[`useActionRunMutation`](../apps/actions.md) — it already waits for terminal action events and
+invalidates committed object changes.
+
+## Event Builders
+
+The `events(...)` builder creates a typed event filter. Start with an ontology object type when the
+screen is about one object family:
+
+```tsx
+import { events } from "@sixb/client/hooks"
+import { Device } from "../ontology/device"
+
+events(Device).object(deviceId).telemetry()
+events(Device).telemetry(Device.p.temperature)
+events(Device).object(deviceId).upserted()
+events(Device).object(deviceId).deleted()
+events(Device).linked(Device.l.installedIn)
+```
+
+Object-type builders carry type information. For example, `telemetry(Device.p.temperature)` narrows
+the event payload to that property, and `upserted()` types `payload.properties` from `Device`.
+
+Use topic builders when the screen is broader or dynamic:
+
+```tsx
+events.telemetry().object(deviceId)
+events.objects()
+events.links()
+events.datasets()
+events.rules()
+events.workflows().run(workflowRunId)
+events.pipelines().run(pipelineRunId)
+events.syncs().run(syncRunId)
+```
+
+Action events have extra scopes:
+
+```tsx
+events.actions().run(runId).terminal()
+events.actions().action("approveQuote").completed()
+events.actions().subject(Quote).object(quoteId).failed()
+events.actions().requested()
+```
+
+Use `.terminal()` for completed plus failed action events. Use `.completed()` only when successful
+terminal runs matter.
+
+## useEvents
+
+`useEvents(builder, onEvent, options?)` subscribes to matching events and returns the socket state:
+
+```tsx
+import { events, useEvents } from "@sixb/client/hooks"
+import { Invoice } from "../ontology/invoice"
+
+function InvoiceActivity({ invoiceId }: { invoiceId: string }) {
+  const state = useEvents(events(Invoice).object(invoiceId).upserted(), (event) => {
+    console.log("invoice changed", event.payload.properties)
+  })
+
+  return <span>{state.connected ? "Live" : "Offline"}</span>
+}
+```
+
+The handler can change without reopening the socket. The subscription is rebuilt only when the
+builder filter or transport options change.
+
+Common options:
+
+| Option | Purpose |
+| --- | --- |
+| `enabled` | Turn the subscription on or off. |
+| `afterCursor` | Replay events after a stored cursor. |
+| `limit` | Limit replayed events on subscribe. |
+| `reconnect` | Enable or disable reconnects. |
+| `reconnectDelayMs` | Delay before reconnecting. |
+| `onError` | Receive socket or subscription errors. |
+
+## Latest Telemetry
+
+Use `useLatest` when a component needs the current live value per telemetry property:
+
+```tsx
+import { events, useLatest } from "@sixb/client/hooks"
+import { Device } from "../ontology/device"
+
+function DeviceReading({ deviceId }: { deviceId: string }) {
+  const { values, connected } = useLatest(events(Device).object(deviceId).telemetry())
+  const temperature = values[Device.p.temperature.id]?.value
+
+  return (
+    <p>
+      {connected ? "Live" : "Offline"}: {temperature == null ? "No reading" : String(temperature)}
+    </p>
+  )
+}
+```
+
+Use `useLatestByObject` for a dashboard that buckets live telemetry by object id:
+
+```tsx
+import { events, useLatestByObject } from "@sixb/client/hooks"
+import { Device } from "../ontology/device"
+
+const { byObject } = useLatestByObject(events(Device).telemetry(Device.p.temperature))
+
+const value = byObject[deviceId]?.[Device.p.temperature.id]?.value
+```
+
+Both hooks reset their accumulated values when the builder scope changes.
+
+## Invalidate on Events
+
+Use `useInvalidateOnEvent` when an event should refresh TanStack Query caches:
+
+```tsx
+import { events, objectQueryKeys, useInvalidateOnEvent } from "@sixb/client/hooks"
+import { openInvoices } from "../queries/invoices"
+import { Invoice } from "../ontology/invoice"
+
+useInvalidateOnEvent(
+  events(Invoice).upserted(),
+  () => [objectQueryKeys.list(openInvoices.limit(50))],
+  { debounceMs: 50 }
+)
+```
+
+For action buttons, `useActionRunMutation({ invalidateOnCommit: true })` is usually simpler. It
+uses action events internally and invalidates from the terminal run's commit diff.
+
+## Related
+
+- [Client SDK](overview.md) - SDK subpaths and transport setup.
+- [Typed queries](typed-queries.md) - object query builders and cache keys.
+- [Running actions from apps](../apps/actions.md) - action buttons and terminal mutation state.
+- [Domain events](../events/overview.md) - event catalog, runtime reads, and server subscriptions.

--- a/docs/client/overview.md
+++ b/docs/client/overview.md
@@ -6,7 +6,7 @@ schema, so every route, request body, and response is typed end to end.
 
 The package ships as a set of focused subpaths. You import only the layer you
 need: the raw generated SDK, a typed object-query builder, TanStack Query
-hooks, a live WebSocket events hook, or the browser auth bootstrap.
+hooks, live WebSocket event hooks, or the browser auth bootstrap.
 
 ## Mental model
 
@@ -34,10 +34,10 @@ layer and never touch the transport directly. In a standalone app, configure
 
 | Import | What it gives you |
 | --- | --- |
-| `@sixb/client` | Generated per-route SDK functions, the shared `client`, and the UI models from `/models` |
+| `@sixb/client` | Generated per-route SDK functions, terminal action wait helpers, the shared `client`, and the UI models from `/models` |
 | `@sixb/client/query` | `objects(Type).query()` — typed object-query builder over HTTP |
 | `@sixb/client/hooks` | TanStack Query hooks and `*Options` factories, plus `SixbProvider` |
-| `@sixb/client/events` | `SixbEvent` types and the `isSixbEvent` guard |
+| `@sixb/client/events` | `SixbEvent` types and the `events(...)` builder |
 | `@sixb/client/browser` | CSRF/auth bootstrap and `__SIXB_RUNTIME__` handoff |
 | `@sixb/client/models` | `encode`/`decodeObjectId`, `executeAction`, UI shape mappers |
 
@@ -62,6 +62,27 @@ const { data } = await listObjects({
 Every SDK function accepts the standard hey-api options (`path`, `query`,
 `body`, `throwOnError`, `responseStyle`, and a per-call `client` override). The
 shared `client` is also exported here for configuration.
+
+For actions that should behave like a normal async command, use
+`requestActionAndWait`. It sends the enqueue request, listens for terminal action
+events, and fetches the final action-run detail as the source of truth.
+
+```ts
+import { requestActionAndWait } from "@sixb/client"
+
+const run = await requestActionAndWait({
+  path: { actionId: "markPaid" },
+  body: {
+    subject: { kind: "object", objectTypeId: "Invoice", primaryId: "inv-1" },
+    params: { paymentMethod: "card" },
+  },
+  timeoutMs: 30_000,
+})
+```
+
+Failed and cancelled terminal runs reject with `ActionRunFailedError`; timeouts
+reject with `ActionRunTimeoutError`. Keep the generated `requestAction()` when
+you only need enqueue acknowledgement.
 
 ## /query: typed object queries
 
@@ -117,26 +138,46 @@ import { SixbProvider } from "@sixb/client/hooks"
 For typed-query hooks (`useObjectsQuery` and friends), see
 [querying data](../apps/querying-data.md).
 
-## /events: live WebSocket
+### Action run mutations
 
-`@sixb/client/events` carries the `SixbEvent` union types and the `isSixbEvent`
-guard. The `useSixbEvents` hook (re-exported from `/hooks`) opens a WebSocket to
-`/ws/events`, subscribes by `topic` and/or `types`, and reconnects on drop.
+Use `useActionRunMutation` when mutation state should represent the final action
+run, not just the enqueue request.
 
 ```tsx
-import { useSixbEvents } from "@sixb/client/hooks"
+import { useActionRunMutation } from "@sixb/client/hooks"
+import { Invoice } from "../ontology/invoice"
 
-const { connected } = useSixbEvents({
-  topic: "telemetry",
-  types: ["telemetry.appended"],
-  onEvent(event) {
-    // event is narrowed to telemetry.appended
-  },
+const markPaid = useActionRunMutation<{ paymentMethod: "card" | "ach" }>({
+  actionId: "markPaid",
+  subject: { objectType: Invoice, primaryId: invoiceId },
+  invalidateOnCommit: true,
 })
 ```
 
-The subscription type is narrowed from `topic` and `types`. See the
-[events](../events/overview.md) section for the full topic and type catalog.
+With `invalidateOnCommit: true`, terminal runs refresh action-run caches and, when
+a commit diff exists, object detail caches plus the typed object-query cache
+group. See [running actions from apps](../apps/actions.md) for loading, error,
+high-frequency control, and manual invalidation patterns.
+
+## /events: live WebSocket
+
+`@sixb/client/events` carries the `SixbEvent` union types, the `isSixbEvent`
+guard, and the fluent `events(...)` builder. React apps use the builder through
+hooks re-exported from `/hooks`: `useEvents`, `useLatest`, `useLatestByObject`,
+and `useInvalidateOnEvent`.
+
+```tsx
+import { events, useEvents } from "@sixb/client/hooks"
+import { Invoice } from "../ontology/invoice"
+
+useEvents(events(Invoice).object(invoiceId).upserted(), (event) => {
+  console.log(event.payload.properties)
+})
+```
+
+The builder scopes and narrows event payloads by object type, topic, action run,
+and action subject. See [client events](events.md) for setup, builder methods,
+latest telemetry hooks, and cache invalidation patterns.
 
 ## /browser: auth bootstrap
 
@@ -191,14 +232,17 @@ so they are safe to pass through URLs and route params.
 | One-off API call, no React | root SDK function (`@sixb/client`) |
 | Typed object query, no React | `@sixb/client/query` |
 | React component reading data | `@sixb/client/hooks` |
-| Live updates in React | `useSixbEvents` (`@sixb/client/hooks`) |
+| React action button with terminal loading/error state | `useActionRunMutation` (`@sixb/client/hooks`) |
+| Live updates in React | `events(...)` with `useEvents` / `useLatest` (`@sixb/client/hooks`) |
 | Bootstrap a standalone browser client | `@sixb/client/browser` |
 | Encode/decode ids or fire actions | `@sixb/client/models` |
 
 ## Related
 
 - [Typed queries](typed-queries.md) — the object-query builder reference
+- [Client events](events.md) — live event builders and React hooks
 - [Querying data in apps](../apps/querying-data.md) — hooks in practice
+- [Running actions from apps](../apps/actions.md) — action buttons and terminal mutation state
 - [Events](../events/overview.md) — topics and event types
 - [Authentication](../auth/authentication.md) — sessions and CSRF
 - [Building apps](../apps/overview.md) — the Sixb-served app model

--- a/docs/client/typed-queries.md
+++ b/docs/client/typed-queries.md
@@ -178,6 +178,26 @@ const { data } = useQuery({
 })
 ```
 
+## Query Keys and Invalidation
+
+The hooks export stable object-query keys and exact invalidation helpers for apps that need
+manual cache control:
+
+```tsx
+import { invalidateObjectQuery, objectQueryKeys } from "@sixb/client/hooks"
+
+await queryClient.invalidateQueries({
+  queryKey: objectQueryKeys.count(openProjects),
+  exact: true,
+})
+
+await invalidateObjectQuery(queryClient, openProjects.limit(50))
+```
+
+For action buttons, prefer `useActionRunMutation({ invalidateOnCommit: true })`. It waits for
+the terminal action run and invalidates action-run caches plus object-query caches when the run
+commits edits.
+
 ## Transport overrides
 
 Hooks execute the query IR through the global SDK client (`client`, exported from
@@ -234,4 +254,6 @@ try {
 - [/objects/querying](../objects/querying.md) — fluent builder reference
 - [/objects/http-reference](../objects/http-reference.md) — query route contracts
 - [/apps/querying-data](../apps/querying-data.md) — querying from custom apps
+- [/client/events](events.md) — live event hooks and invalidation patterns
+- [/apps/actions](../apps/actions.md) — running actions and invalidating queries from apps
 - [/client](overview.md) — SDK setup and client configuration

--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -104,6 +104,10 @@ const unsubscribe = await sixb.events.subscribe(
 unsubscribe()
 ```
 
+In browser apps, use the `@sixb/client` event builder and React hooks instead of hand-written
+predicates. See [Client events](../client/events.md). For action buttons, prefer
+`useActionRunMutation` unless the screen needs broader live coordination.
+
 ### Appending events
 
 `sixb.events.append(input)` writes one or more events. The runtime emits domain events for
@@ -216,7 +220,9 @@ webhook delivery storage to be configured.
 ## Related
 
 - [Connectors](../data/connectors.md) — where webhooks live
+- [Client events](../client/events.md) — event builders and React hooks for apps
 - [Rules](../rules/overview.md) and [Workflows](../workflows/overview.md) — declarative
   reactions to object state and multi-step processes
+- [Running actions from apps](../apps/actions.md) — action button state and scoped action events
 - [Server](../server/overview.md) — the HTTP/WebSocket API
 - [Authorization](../auth/authorization.md) — how `/api/events` is scoped

--- a/examples/panasonic-ac/app/unit/[key]/page.tsx
+++ b/examples/panasonic-ac/app/unit/[key]/page.tsx
@@ -1,6 +1,6 @@
 import { encodeObjectId } from "@sixb/client"
-import { events, getObjectOptions, requestActionMutation, useLatest } from "@sixb/client/hooks"
-import { useMutation, useQuery } from "@tanstack/react-query"
+import { events, getObjectOptions, useActionRunMutation, useLatest } from "@sixb/client/hooks"
+import { useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
 import { useParams } from "react-router-dom"
 import {
@@ -9,6 +9,7 @@ import {
   FAN_SPEED_NAMES,
   MODE_NAMES,
 } from "../../../lib/acUnitConstants"
+import { PanasonicAcUnit } from "../../../ontology/acUnit"
 
 function decodeKey(input: string | undefined): string | null {
   if (!input) return null
@@ -286,9 +287,24 @@ function ThermostatGauge({
 
 /* ── Toggle ── */
 
-function Toggle({ label, on, onToggle }: { label: string; on: boolean; onToggle: () => void }) {
+function Toggle({
+  label,
+  on,
+  onToggle,
+  disabled = false,
+}: {
+  label: string
+  on: boolean
+  onToggle: () => void
+  disabled?: boolean
+}) {
   return (
-    <button type="button" className={`toggle ${on ? "is-on" : ""}`} onClick={onToggle}>
+    <button
+      type="button"
+      className={`toggle ${on ? "is-on" : ""}`}
+      onClick={onToggle}
+      disabled={disabled}
+    >
       <span className="toggle-track">
         <span className="toggle-thumb" />
       </span>
@@ -329,7 +345,9 @@ export default function UnitDetail() {
   const object = objectQuery.data
 
   const { values: liveState, connected } = useLatest(events.telemetry().object(objectKey ?? ""))
-  const { mutate: sendAction } = useMutation(requestActionMutation())
+  const { mutate: sendAction, isPending: actionPending } = useActionRunMutation({
+    invalidateOnCommit: true,
+  })
 
   function val(propId: string): unknown {
     return liveState[propId]?.value ?? object?.properties[propId]
@@ -363,15 +381,11 @@ export default function UnitDetail() {
   }, [objectKey, object?.properties])
 
   function doAction(actionId: string, params: Record<string, unknown>) {
-    if (!objectKey) return
+    if (!objectKey || actionPending) return
     sendAction({
       path: { actionId },
       body: {
-        subject: {
-          kind: "object",
-          objectTypeId: acUnitObjectTypeId,
-          primaryId: objectKey,
-        },
+        subject: { objectType: PanasonicAcUnit, primaryId: objectKey },
         params,
       },
     })
@@ -476,6 +490,7 @@ export default function UnitDetail() {
                   <button
                     type="button"
                     className="control-btn"
+                    disabled={actionPending || target == null}
                     onClick={() =>
                       target != null && doAction("setTemperature", { value: target - 0.5 })
                     }
@@ -488,6 +503,7 @@ export default function UnitDetail() {
                   <button
                     type="button"
                     className="control-btn"
+                    disabled={actionPending || target == null}
                     onClick={() =>
                       target != null && doAction("setTemperature", { value: target + 0.5 })
                     }
@@ -507,6 +523,7 @@ export default function UnitDetail() {
                       key={code}
                       type="button"
                       className={`control-btn ${mode === Number(code) ? "active" : ""}`}
+                      disabled={actionPending}
                       onClick={() => doAction("setMode", { mode: Number(code) })}
                     >
                       {name}
@@ -523,6 +540,7 @@ export default function UnitDetail() {
                       key={code}
                       type="button"
                       className={`control-btn ${fanSpeed === Number(code) ? "active" : ""}`}
+                      disabled={actionPending}
                       onClick={() => doAction("setFan", { speed: Number(code) })}
                     >
                       {name}
@@ -540,6 +558,7 @@ export default function UnitDetail() {
                     <button
                       type="button"
                       className={`control-btn ${power ? "power-on" : "power-off"}`}
+                      disabled={actionPending}
                       onClick={() => doAction("setPower", { on: !power })}
                       style={{ minWidth: "5.5rem" }}
                     >
@@ -550,11 +569,13 @@ export default function UnitDetail() {
                     label="ECO"
                     on={eco}
                     onToggle={() => doAction("setEco", { enabled: !eco })}
+                    disabled={actionPending}
                   />
                   <Toggle
                     label="nanoe"
                     on={nanoe}
                     onToggle={() => doAction("setNanoe", { enabled: !nanoe })}
+                    disabled={actionPending}
                   />
                 </div>
               </div>

--- a/examples/panasonic-ac/ontology/acUnit.ts
+++ b/examples/panasonic-ac/ontology/acUnit.ts
@@ -1,4 +1,4 @@
-import { defineObjectType, prop } from "@sixb/core"
+import { defineObjectType, prop } from "@sixb/core/ontology"
 
 export function acUnitKeyFromName(name: string): string {
   const normalized = name

--- a/examples/roku-tv/actions/pressButton.ts
+++ b/examples/roku-tv/actions/pressButton.ts
@@ -19,14 +19,37 @@ export const pressButton = defineAction("pressButton", {
     const client = await getRokuApi(sixb, target.properties.controlHost)
     await client.keypress(params.button)
 
-    if (params.button === "PowerOff") {
-      // TODO(actions-v2): move local telemetry writes out of writeback once EditBatch supports them.
+    const nextPowerState = expectedPowerStateAfterKeypress(
+      params.button,
+      target.properties.powerState
+    )
+    if (nextPowerState) {
+      // Telemetry is not part of EditBatch yet, so mirror action-known state
+      // immediately from writeback instead of waiting for the next device poll.
       await sixb.objects(Television).appendTelemetryBatch([
         {
           id: target.primaryId,
-          properties: { powerState: "PowerOff" },
+          properties: {
+            powerState: nextPowerState,
+            ...(nextPowerState === "PowerOff" ? { activeApp: null, mediaState: null } : {}),
+          },
           at: new Date(),
         },
       ])
     }
   })
+
+function expectedPowerStateAfterKeypress(
+  button: string,
+  currentPowerState: unknown
+): string | null {
+  if (button === "PowerOff") {
+    return "PowerOff"
+  }
+
+  if (button === "Power") {
+    return currentPowerState === "PowerOn" ? "PowerOff" : "PowerOn"
+  }
+
+  return null
+}

--- a/examples/roku-tv/app/globals.css
+++ b/examples/roku-tv/app/globals.css
@@ -320,10 +320,43 @@ a {
   color: var(--warn);
 }
 
+.telemetry-value.is-pending {
+  text-shadow: 0 0 18px currentColor;
+}
+
 .telemetry-footnote {
   margin-top: 1rem;
   font-size: 0.9rem;
   color: var(--muted);
+}
+
+.action-pending-row {
+  margin-top: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2rem;
+  padding: 0.42rem 0.72rem;
+  border: 1px solid rgba(83, 224, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(8, 19, 36, 0.72);
+  color: var(--accent-soft);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.action-pending-spinner,
+.remote-btn-spinner {
+  display: inline-block;
+  border-radius: 999px;
+  border: 2px solid rgba(255, 255, 255, 0.28);
+  border-top-color: currentColor;
+  animation: spin 700ms linear infinite;
+}
+
+.action-pending-spinner {
+  width: 0.9rem;
+  height: 0.9rem;
 }
 
 .code-tag {
@@ -423,6 +456,9 @@ a {
 }
 
 .remote-btn {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
   border: 0;
   color: #dce7ff;
   font-weight: 670;
@@ -441,6 +477,21 @@ a {
     0 10px 20px rgba(0, 0, 0, 0.35),
     inset 0 1px 1px rgba(255, 255, 255, 0.22);
   transition: transform 100ms ease, box-shadow 100ms ease, border-color 150ms ease;
+}
+
+.remote-btn-label {
+  grid-area: 1 / 1;
+}
+
+.remote-btn-spinner {
+  grid-area: 1 / 1;
+  width: 1rem;
+  height: 1rem;
+  color: var(--accent-soft);
+}
+
+.remote-btn.is-loading .remote-btn-label {
+  opacity: 0.24;
 }
 
 .remote-btn:hover {
@@ -535,7 +586,13 @@ a {
 }
 
 .remote-btn:disabled {
-  opacity: 1;
+  cursor: wait;
+}
+
+.remote-btn:disabled:not(.is-loading) {
+  cursor: default;
+  opacity: 0.52;
+  filter: saturate(0.72);
 }
 
 .shortcuts-row {
@@ -585,6 +642,12 @@ a {
   50% {
     opacity: 0.62;
     transform: scale(1.28);
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
   }
 }
 

--- a/examples/roku-tv/app/remote/[id]/page.tsx
+++ b/examples/roku-tv/app/remote/[id]/page.tsx
@@ -2,21 +2,22 @@ import {
   events,
   getObjectOptions,
   getObjectTypeOptions,
-  requestActionMutation,
+  useActionRunMutation,
   useLatest,
 } from "@sixb/client/hooks"
 import { encodeObjectId } from "@sixb/client/models"
-import { useMutation, useQuery } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useCallback, useMemo, useState } from "react"
 import { Link, useParams } from "react-router-dom"
 import { televisionObjectTypeId, televisionTwinProps } from "../../../lib/televisionTwin"
+import { Television } from "../../../ontology/television"
 
 const KEYS = {
   dpad: ["Up", "Down", "Left", "Right", "Select"],
   nav: ["Back", "Home", "Info"],
   media: ["Rev", "Play", "Fwd"],
   volume: ["VolumeUp", "VolumeDown", "VolumeMute"],
-  power: ["Power"],
+  power: ["Power", "PowerOff"],
 } as const
 
 type RokuKey = (typeof KEYS)[keyof typeof KEYS][number]
@@ -37,6 +38,7 @@ const KEY_LABELS: Partial<Record<RokuKey, string>> = {
   VolumeDown: "Vol-",
   VolumeMute: "Mute",
   Power: "Power",
+  PowerOff: "Off",
 }
 
 const APP_SHORTCUTS = ["Netflix", "Prime", "Hulu", "Disney+"] as const
@@ -47,15 +49,17 @@ function RemoteButton({
   onClick,
   variant = "default",
   active = false,
+  loading = false,
   disabled = false,
 }: {
   label: string
   onClick: () => void
   variant?: "default" | "power" | "small" | "ok" | "shortcut"
   active?: boolean
+  loading?: boolean
   disabled?: boolean
 }) {
-  const baseClasses = `remote-btn${active ? " is-active" : ""}`
+  const baseClasses = `remote-btn${active ? " is-active" : ""}${loading ? " is-loading" : ""}`
   const variants = {
     default: "",
     power: " power",
@@ -70,8 +74,10 @@ function RemoteButton({
       className={`${baseClasses}${variants[variant]}`}
       onClick={onClick}
       disabled={disabled}
+      aria-busy={loading}
     >
-      {label}
+      <span className="remote-btn-label">{label}</span>
+      {loading ? <span className="remote-btn-spinner" aria-hidden="true" /> : null}
     </button>
   )
 }
@@ -117,8 +123,31 @@ export default function RemoteControl() {
 
   const { values: liveState, connected } = useLatest(events.telemetry().object(objectKey ?? ""))
 
-  const { mutate: sendAction } = useMutation(requestActionMutation())
-  const [lastPressedKey, setLastPressedKey] = useState<RokuKey | null>(null)
+  const { mutateAsync: sendAction } = useActionRunMutation<{
+    button: RokuKey
+  }>({
+    actionId: "pressButton",
+    subject: objectKey ? { objectType: Television, primaryId: objectKey } : undefined,
+    invalidateOnCommit: true,
+  })
+  const [pendingByKey, setPendingByKey] = useState<Partial<Record<RokuKey, number>>>({})
+
+  const incrementPending = useCallback((key: RokuKey) => {
+    setPendingByKey((current) => ({ ...current, [key]: (current[key] ?? 0) + 1 }))
+  }, [])
+
+  const decrementPending = useCallback((key: RokuKey) => {
+    setPendingByKey((current) => {
+      const nextCount = (current[key] ?? 0) - 1
+      const next = { ...current }
+      if (nextCount > 0) {
+        next[key] = nextCount
+      } else {
+        delete next[key]
+      }
+      return next
+    })
+  }, [])
 
   const pressKey = useCallback(
     (key: RokuKey) => {
@@ -126,25 +155,19 @@ export default function RemoteControl() {
         return
       }
 
-      setLastPressedKey(key)
-      sendAction({
-        path: {
-          actionId: "pressButton",
-        },
-        body: {
-          subject: {
-            kind: "object",
-            objectTypeId: televisionObjectTypeId,
-            primaryId: objectKey,
-          },
-          params: { button: key },
-        },
-      })
-      setTimeout(() => {
-        setLastPressedKey((current) => (current === key ? null : current))
-      }, 170)
+      incrementPending(key)
+      void sendAction({ button: key })
+        .catch((error) => {
+          console.error(
+            `[Sixb] Roku action ${key} failed:`,
+            error instanceof Error ? error.message : String(error)
+          )
+        })
+        .finally(() => {
+          decrementPending(key)
+        })
     },
-    [objectKey, sendAction]
+    [decrementPending, incrementPending, objectKey, sendAction]
   )
 
   const powerState =
@@ -158,6 +181,21 @@ export default function RemoteControl() {
     object?.properties[televisionTwinProps.mediaState]
   const availableActions = objectTypeQuery.data?.actions?.map((a) => a.id) ?? []
   const isPoweredOn = powerState === "PowerOn"
+  const powerButtonKey: RokuKey = isPoweredOn ? "PowerOff" : "Power"
+  const pendingEntries = (Object.entries(pendingByKey) as [RokuKey, number][]).filter(
+    ([, count]) => count > 0
+  )
+  const pendingCount = pendingEntries.reduce((total, [, count]) => total + count, 0)
+  const pendingLabel =
+    pendingEntries.length === 1
+      ? `${KEY_LABELS[pendingEntries[0][0]] ?? pendingEntries[0][0]}${
+          pendingEntries[0][1] > 1 ? ` x${pendingEntries[0][1]}` : ""
+        }`
+      : pendingCount > 0
+        ? `${pendingCount} pending`
+        : null
+  const powerActionPending = (pendingByKey.Power ?? 0) > 0 || (pendingByKey.PowerOff ?? 0) > 0
+  const keyIsPending = (key: RokuKey) => (pendingByKey[key] ?? 0) > 0
 
   const title = useMemo(() => {
     return asString(object?.properties[televisionTwinProps.name]) ?? objectKey ?? "Television"
@@ -187,7 +225,11 @@ export default function RemoteControl() {
             <div className="telemetry-grid">
               <div className="panel-glass telemetry-card">
                 <p className="telemetry-label">Power</p>
-                <p className={`telemetry-value ${isPoweredOn ? "is-ok" : "is-warn"}`}>
+                <p
+                  className={`telemetry-value ${isPoweredOn ? "is-ok" : "is-warn"}${
+                    powerActionPending ? " is-pending" : ""
+                  }`}
+                >
                   {isPoweredOn ? "On" : "Standby"}
                 </p>
               </div>
@@ -203,6 +245,12 @@ export default function RemoteControl() {
             <div className="telemetry-footnote">
               Actions: {availableActions.join(", ") || "(none)"}
             </div>
+            {pendingLabel ? (
+              <div className="action-pending-row" role="status">
+                <span className="action-pending-spinner" aria-hidden="true" />
+                <span>{pendingLabel}</span>
+              </div>
+            ) : null}
           </section>
 
           <section className="device-remote fade-slide stagger-2">
@@ -219,15 +267,19 @@ export default function RemoteControl() {
 
             <div className="remote-row">
               <RemoteButton
-                label={KEY_LABELS.Power ?? "Power"}
-                onClick={() => pressKey("Power")}
+                label={KEY_LABELS[powerButtonKey] ?? powerButtonKey}
+                onClick={() => pressKey(powerButtonKey)}
                 variant="power"
-                active={lastPressedKey === "Power"}
+                active={powerActionPending}
+                loading={powerActionPending}
+                disabled={!objectKey || powerActionPending}
               />
               <RemoteButton
                 label={KEY_LABELS.Home ?? "Home"}
                 onClick={() => pressKey("Home")}
-                active={lastPressedKey === "Home"}
+                active={keyIsPending("Home")}
+                loading={keyIsPending("Home")}
+                disabled={!objectKey}
               />
             </div>
 
@@ -236,30 +288,40 @@ export default function RemoteControl() {
               <RemoteButton
                 label={KEY_LABELS.Up ?? "Up"}
                 onClick={() => pressKey("Up")}
-                active={lastPressedKey === "Up"}
+                active={keyIsPending("Up")}
+                loading={keyIsPending("Up")}
+                disabled={!objectKey}
               />
               <div />
               <RemoteButton
                 label={KEY_LABELS.Left ?? "Left"}
                 onClick={() => pressKey("Left")}
-                active={lastPressedKey === "Left"}
+                active={keyIsPending("Left")}
+                loading={keyIsPending("Left")}
+                disabled={!objectKey}
               />
               <RemoteButton
                 label={KEY_LABELS.Select ?? "OK"}
                 onClick={() => pressKey("Select")}
                 variant="ok"
-                active={lastPressedKey === "Select"}
+                active={keyIsPending("Select")}
+                loading={keyIsPending("Select")}
+                disabled={!objectKey}
               />
               <RemoteButton
                 label={KEY_LABELS.Right ?? "Right"}
                 onClick={() => pressKey("Right")}
-                active={lastPressedKey === "Right"}
+                active={keyIsPending("Right")}
+                loading={keyIsPending("Right")}
+                disabled={!objectKey}
               />
               <div />
               <RemoteButton
                 label={KEY_LABELS.Down ?? "Down"}
                 onClick={() => pressKey("Down")}
-                active={lastPressedKey === "Down"}
+                active={keyIsPending("Down")}
+                loading={keyIsPending("Down")}
+                disabled={!objectKey}
               />
               <div />
             </div>
@@ -271,7 +333,9 @@ export default function RemoteControl() {
                   label={KEY_LABELS[key] ?? key}
                   onClick={() => pressKey(key)}
                   variant="small"
-                  active={lastPressedKey === key}
+                  active={keyIsPending(key)}
+                  loading={keyIsPending(key)}
+                  disabled={!objectKey}
                 />
               ))}
             </div>
@@ -282,7 +346,9 @@ export default function RemoteControl() {
                   key={key}
                   label={KEY_LABELS[key] ?? key}
                   onClick={() => pressKey(key)}
-                  active={lastPressedKey === key}
+                  active={keyIsPending(key)}
+                  loading={keyIsPending(key)}
+                  disabled={!objectKey}
                 />
               ))}
             </div>
@@ -294,7 +360,9 @@ export default function RemoteControl() {
                   label={KEY_LABELS[key] ?? key}
                   onClick={() => pressKey(key)}
                   variant="small"
-                  active={lastPressedKey === key}
+                  active={keyIsPending(key)}
+                  loading={keyIsPending(key)}
+                  disabled={!objectKey}
                 />
               ))}
             </div>

--- a/examples/roku-tv/ontology/television.ts
+++ b/examples/roku-tv/ontology/television.ts
@@ -1,4 +1,4 @@
-import { defineObjectType, prop } from "@sixb/core"
+import { defineObjectType, prop } from "@sixb/core/ontology"
 import { televisionObjectTypeId } from "../lib/televisionTwin"
 
 export const Television = defineObjectType({

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -51,35 +51,32 @@ const { data: history } = await getTelemetryHistory({
   query: { from: "2025-01-01T00:00:00Z", to: "2025-01-02T00:00:00Z", order: "asc" },
 })
 
-// Request an action on an object, then inspect the durable run
-import { getActionRun, requestAction } from "@sixb/client"
+// Request an action on an object, then wait for terminal success/failure
+import { requestActionAndWait } from "@sixb/client"
 
-const { data: requested } = await requestAction({
+const run = await requestActionAndWait({
   path: { actionId: "setTemperature" },
   body: {
     subject: { kind: "object", objectTypeId: "thermostat", primaryId: "living-room" },
     params: { target: 72 },
   },
-  throwOnError: true,
-})
-
-const { data: run } = await getActionRun({
-  path: { runId: requested.runId },
-  throwOnError: true,
+  timeoutMs: 30_000,
 })
 ```
 
 ### React Query hooks
 
-```typescript
+```tsx
 import { useQuery } from "@tanstack/react-query"
 import {
   listObjectsOptions,
   getObjectOptions,
   getTelemetryHistoryOptions,
   telemetryHistoryQueryOptions,
+  useActionRunMutation,
   useTelemetryHistoryQuery,
 } from "@sixb/client/hooks"
+import { Thermostat } from "./ontology/Thermostat"
 
 // List objects with automatic caching and refetching
 const { data: objects } = useQuery(listObjectsOptions())
@@ -112,7 +109,31 @@ const temperatureHistoryOptions = telemetryHistoryQueryOptions({
   objectId: "living-room",
   property: Thermostat.p.temperature,
 })
+
+// Action mutation whose success means the action run reached terminal success.
+function SetTemperatureButton() {
+  const setTemperature = useActionRunMutation<{ target: number }>({
+    actionId: "setTemperature",
+    subject: { objectType: Thermostat, primaryId: "living-room" },
+    invalidateOnCommit: true,
+  })
+
+  return (
+    <button
+      type="button"
+      disabled={setTemperature.isPending}
+      onClick={() => setTemperature.mutate({ target: 72 })}
+    >
+      {setTemperature.isPending ? "Setting..." : "Set to 72"}
+    </button>
+  )
+}
 ```
+
+Use `useActionRunMutation()` for app buttons where loading, success, and error states should
+reflect the final action run. Keep the generated `requestActionMutation()` or root
+`requestAction()` for enqueue-only flows where accepting the request is enough, such as long
+background work or screens that immediately navigate to a run detail view.
 
 ### Domain events
 
@@ -120,7 +141,7 @@ Subscribe with the fluent `events(Type)` builder (mirrors `objects(Type)`):
 channels narrow the event and type the payload, `.object(key)` scopes to one
 instance, and the hooks take a built builder as their first argument.
 
-```typescript
+```tsx
 import { events, useEvents, useLatest } from "@sixb/client/hooks"
 import { Thermostat } from "./ontology/Thermostat"
 
@@ -138,10 +159,21 @@ function LiveDashboard() {
 }
 ```
 
-Mount `SixbEventsProvider` once near the app root to multiplex every hook onto a
-single shared WebSocket (without it, each hook opens its own socket). Use
-`useInvalidateOnEvent(builder, resolveKeys)` to invalidate TanStack Query keys on
-matching events.
+Action events can be scoped by run, action id, or object subject when a screen needs custom
+coordination:
+
+```typescript
+useEvents(events.actions().run("run_123").terminal(), (event) => {
+  console.log("action finished", event.payload.runId)
+})
+
+useEvents(events.actions().subject(Thermostat).object("living-room").completed(), () => {
+  console.log("thermostat action succeeded")
+})
+```
+
+Use `useInvalidateOnEvent(builder, resolveKeys)` to invalidate TanStack Query keys on
+matching events. See `docs/client/events.md` for the full event builder and hook guide.
 
 ### UI models
 
@@ -156,6 +188,6 @@ The models module provides normalized types and adapter functions that transform
 
 | Entry point | What it provides |
 |---|---|
-| `@sixb/client` | `client`, all generated SDK functions (`listObjects`, `getObject`, `upsertObject`, `requestAction`, `getActionRun`, `getTelemetryHistory`, etc.), all generated types, and UI model types/adapters |
-| `@sixb/client/hooks` | TanStack Query `queryOptions` factories (`listObjectsOptions`, `getObjectOptions`, `getTelemetryHistoryOptions`, `telemetryHistoryQueryOptions`, `listRelationshipsOptions`), typed hooks (`useTelemetryHistoryQuery`, object query hooks), the `events(Type)` builder, and event hooks (`useEvents`, `useLatest`, `useLatestByObject`, `useInvalidateOnEvent`, `SixbEventsProvider`) |
+| `@sixb/client` | `client`, all generated SDK functions (`listObjects`, `getObject`, `upsertObject`, `requestAction`, `getActionRun`, `getTelemetryHistory`, etc.), terminal action wait helpers (`requestActionAndWait`, `waitForActionRun`), all generated types, and UI model types/adapters |
+| `@sixb/client/hooks` | TanStack Query `queryOptions` factories (`listObjectsOptions`, `getObjectOptions`, `getTelemetryHistoryOptions`, `telemetryHistoryQueryOptions`, `listRelationshipsOptions`), typed hooks (`useTelemetryHistoryQuery`, object query hooks, `useActionRunMutation`), object-query key/invalidation helpers, the `events(Type)` builder, and event hooks (`useEvents`, `useLatest`, `useLatestByObject`, `useInvalidateOnEvent`, `SixbEventsProvider`) |
 | `@sixb/client/models` | UI model types (`ObjectSummary`, `ObjectDetail`, `TelemetryHistory`, `RelationshipEdge`, etc.) and adapters (`toObjectSummary`, `toObjectDetail`, `toTelemetryHistoryWithRange`, `executeAction`) |

--- a/packages/client/src/actions.ts
+++ b/packages/client/src/actions.ts
@@ -1,0 +1,302 @@
+import { events } from "./events-builder"
+import type { Client } from "./generated/client"
+import { getActionRun, type Options, requestAction } from "./generated/sdk.gen"
+import type {
+  GetActionRunResponse,
+  RequestActionData,
+  RequestActionResponse,
+} from "./generated/types.gen"
+
+const DEFAULT_ACTION_WAIT_TIMEOUT_MS = 60_000
+const DEFAULT_ACTION_WAIT_FALLBACK_POLL_MS = 10_000
+const DEFAULT_ACTION_WAIT_DISCONNECTED_POLL_MS = 1_000
+
+export type ActionRunDetail = GetActionRunResponse
+export type ActionRunTerminalFailureStatus = Extract<
+  ActionRunDetail["status"],
+  "failed" | "cancelled"
+>
+
+export interface ActionWaitOptions {
+  readonly timeoutMs?: number
+  /** Slow safety check while the event socket is healthy. */
+  readonly fallbackPollIntervalMs?: number
+  /** Faster storage check while the event socket is disconnected or reconnecting. */
+  readonly disconnectedPollIntervalMs?: number
+  readonly signal?: AbortSignal
+  /**
+   * When true, failed and cancelled terminal runs reject the promise. This is
+   * the default because it maps naturally to mutation error states.
+   */
+  readonly rejectOnTerminalFailure?: boolean
+}
+
+export interface WaitForActionRunInput extends ActionWaitOptions {
+  readonly runId: string
+  readonly client?: Client
+}
+
+export type RequestActionAndWaitInput = Options<RequestActionData> &
+  ActionWaitOptions & {
+    readonly onRequested?: (response: RequestActionResponse) => void | Promise<void>
+  }
+
+export class ActionRunFailedError extends Error {
+  readonly name = "ActionRunFailedError"
+  readonly run: ActionRunDetail
+  readonly runId: string
+  readonly actionId: string
+  readonly status: ActionRunTerminalFailureStatus
+  readonly subject: ActionRunDetail["subject"]
+  readonly error: ActionRunDetail["error"]
+
+  constructor(run: ActionRunDetail & { readonly status: ActionRunTerminalFailureStatus }) {
+    super(run.error?.message ?? `Action run '${run.id}' finished with status '${run.status}'.`)
+    this.run = run
+    this.runId = run.id
+    this.actionId = run.actionId
+    this.status = run.status
+    this.subject = run.subject
+    this.error = run.error
+  }
+}
+
+export class ActionRunTimeoutError extends Error {
+  readonly name = "ActionRunTimeoutError"
+  readonly runId: string
+  readonly timeoutMs: number
+
+  constructor(params: { readonly runId: string; readonly timeoutMs: number }) {
+    super(`Action run '${params.runId}' did not finish within ${params.timeoutMs}ms.`)
+    this.runId = params.runId
+    this.timeoutMs = params.timeoutMs
+  }
+}
+
+export async function requestActionAndWait(
+  input: RequestActionAndWaitInput
+): Promise<ActionRunDetail> {
+  const {
+    timeoutMs,
+    fallbackPollIntervalMs,
+    disconnectedPollIntervalMs,
+    rejectOnTerminalFailure,
+    onRequested,
+    ...requestOptions
+  } = input
+
+  const response = await requestAction<true>({
+    ...requestOptions,
+    throwOnError: true,
+  })
+  await onRequested?.(response.data)
+
+  return waitForActionRun({
+    runId: response.data.runId,
+    client: input.client,
+    signal: input.signal,
+    timeoutMs,
+    fallbackPollIntervalMs,
+    disconnectedPollIntervalMs,
+    rejectOnTerminalFailure,
+  })
+}
+
+/**
+ * Wait for a durable action run to reach a terminal status.
+ *
+ * Flow:
+ * 1. Fetch the run detail immediately, so very fast actions that finished
+ *    before the event socket opened are still observed.
+ * 2. Treat action terminal events as wakeups, then fetch the run detail again;
+ *    the detail endpoint is the source of truth and carries commit diff data.
+ * 3. Keep a slow safety poll while the socket is healthy, and use a faster
+ *    fallback poll only while the socket is disconnected or reconnecting.
+ */
+export function waitForActionRun(input: WaitForActionRunInput): Promise<ActionRunDetail> {
+  const timeoutMs = input.timeoutMs ?? DEFAULT_ACTION_WAIT_TIMEOUT_MS
+  const fallbackPollIntervalMs =
+    input.fallbackPollIntervalMs ?? DEFAULT_ACTION_WAIT_FALLBACK_POLL_MS
+  const disconnectedPollIntervalMs =
+    input.disconnectedPollIntervalMs ?? DEFAULT_ACTION_WAIT_DISCONNECTED_POLL_MS
+  const rejectOnTerminalFailure = input.rejectOnTerminalFailure ?? true
+  const signal = input.signal
+  const startedAt = Date.now()
+
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason ?? new Error("aborted"))
+  }
+
+  return new Promise<ActionRunDetail>((resolve, reject) => {
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined
+    let pollTimer: ReturnType<typeof setTimeout> | undefined
+    let unsubscribeFromTerminalEvents: (() => void) | undefined
+    let settled = false
+    let checking = false
+    let checkRequested = false
+    let socketHealthy = false
+
+    const clearTimer = (timer: ReturnType<typeof setTimeout> | undefined) => {
+      if (timer) clearTimeout(timer)
+    }
+
+    const cleanup = () => {
+      if (settled) return
+      settled = true
+      clearTimer(timeoutTimer)
+      clearTimer(pollTimer)
+      unsubscribeFromTerminalEvents?.()
+      signal?.removeEventListener("abort", onAbort)
+    }
+
+    const rejectWith = (error: unknown) => {
+      cleanup()
+      reject(error)
+    }
+
+    const resolveWith = (run: ActionRunDetail) => {
+      cleanup()
+      if (rejectOnTerminalFailure && isTerminalFailureRun(run)) {
+        reject(new ActionRunFailedError(run))
+        return
+      }
+      resolve(run)
+    }
+
+    const currentPollIntervalMs = () =>
+      socketHealthy ? fallbackPollIntervalMs : disconnectedPollIntervalMs
+
+    const schedulePoll = () => {
+      if (settled || pollTimer) return
+      pollTimer = setTimeout(() => {
+        pollTimer = undefined
+        void check()
+      }, currentPollIntervalMs())
+    }
+
+    const reschedulePoll = () => {
+      if (settled) return
+      clearTimer(pollTimer)
+      pollTimer = undefined
+      schedulePoll()
+    }
+
+    const wakeAndCheck = () => {
+      clearTimer(pollTimer)
+      pollTimer = undefined
+      void check()
+    }
+
+    const check = async () => {
+      if (settled) return
+      if (checking) {
+        checkRequested = true
+        return
+      }
+      checking = true
+      try {
+        const run = await fetchActionRun(input.runId, {
+          client: input.client,
+          signal,
+        })
+        if (run && isTerminalActionRun(run)) {
+          resolveWith(run)
+          return
+        }
+        schedulePoll()
+      } catch (error) {
+        rejectWith(error)
+      } finally {
+        checking = false
+        if (!settled && checkRequested) {
+          checkRequested = false
+          wakeAndCheck()
+        }
+      }
+    }
+
+    const onAbort = () => {
+      rejectWith(signal?.reason ?? new Error("aborted"))
+    }
+
+    timeoutTimer = setTimeout(
+      () => {
+        rejectWith(new ActionRunTimeoutError({ runId: input.runId, timeoutMs }))
+      },
+      Math.max(0, timeoutMs - (Date.now() - startedAt))
+    )
+
+    signal?.addEventListener("abort", onAbort, { once: true })
+
+    unsubscribeFromTerminalEvents = events
+      .actions({ client: input.client })
+      .run(input.runId)
+      .terminal()
+      .subscribe(
+        () => {
+          wakeAndCheck()
+        },
+        {
+          // Event delivery is only a wakeup path. Polling `getActionRun` remains
+          // authoritative, so transient WebSocket failures should not reject.
+          onError: () => undefined,
+          onStateChange: (state) => {
+            const nextSocketHealthy = state.connected && !state.reconnecting && !state.error
+            if (nextSocketHealthy !== socketHealthy) {
+              socketHealthy = nextSocketHealthy
+              reschedulePoll()
+            }
+          },
+        }
+      )
+
+    void check()
+  })
+}
+
+export function isTerminalActionRun(run: Pick<ActionRunDetail, "status">): boolean {
+  return run.status === "succeeded" || isTerminalFailureRun(run)
+}
+
+function isTerminalFailureRun(
+  run: Pick<ActionRunDetail, "status">
+): run is ActionRunDetail & { readonly status: ActionRunTerminalFailureStatus } {
+  return run.status === "failed" || run.status === "cancelled"
+}
+
+async function fetchActionRun(
+  runId: string,
+  options: {
+    readonly client?: Client
+    readonly signal?: AbortSignal
+  }
+): Promise<ActionRunDetail | null> {
+  const result = await getActionRun({
+    client: options.client,
+    path: { runId },
+    signal: options.signal,
+    throwOnError: false,
+  })
+
+  if (result.data) {
+    return result.data
+  }
+
+  if (result.response.status === 404) {
+    return null
+  }
+
+  throw toActionRunRequestError(result.error, runId)
+}
+
+function toActionRunRequestError(error: unknown, runId: string): Error {
+  if (error instanceof Error) {
+    return error
+  }
+
+  if (error && typeof error === "object" && "error" in error) {
+    return new Error(String((error as { readonly error?: unknown }).error))
+  }
+
+  return new Error(`[SixbClient] Failed to fetch action run '${runId}'.`)
+}

--- a/packages/client/src/events-builder.ts
+++ b/packages/client/src/events-builder.ts
@@ -40,6 +40,8 @@ export interface EventsFilterIR {
   readonly linkId?: string
   /** `.run(runId)` scope (workflows / pipelines / syncs). */
   readonly runId?: string
+  /** `.action(actionId)` scope (actions). */
+  readonly actionId?: string
 }
 
 // ── Payload typing ──────────────────────────────────────────────────────────
@@ -139,6 +141,42 @@ export interface EventsRunBuilder<TEvent extends SixbEvent> extends Subscribable
   run(runId: string): EventsRunBuilder<TEvent>
 }
 
+/** Object-subject scope builder for action events: `events.actions().subject(Type).object(id)`. */
+export interface EventsActionSubjectBuilder<TEvent extends SixbEvent>
+  extends SubscribableEvents<TEvent> {
+  /** Scope to a single action subject object. */
+  object(primaryId: string): EventsActionBuilder<TEvent>
+}
+
+/** Action-scoped topic builder: `events.actions().run(runId).completed()`. */
+export interface EventsActionBuilder<TEvent extends SixbEvent> extends SubscribableEvents<TEvent> {
+  /** Scope to a single action run id. */
+  run(runId: string): EventsActionBuilder<TEvent>
+
+  /** Scope to one action definition id. */
+  action(actionId: string): EventsActionBuilder<TEvent>
+
+  /** Scope to an object-bound action subject type. */
+  subject<TObjectType extends ObjectTypeWithTokens>(
+    objectType: TObjectType
+  ): EventsActionSubjectBuilder<TEvent>
+  subject(objectTypeId: string): EventsActionSubjectBuilder<TEvent>
+
+  /** Action request events. */
+  requested(): EventsActionBuilder<SixbEventOfType<"action.requested">>
+
+  /** Successful terminal action events. */
+  completed(): EventsActionBuilder<SixbEventOfType<"action.completed">>
+
+  /** Failed or cancelled terminal action events. */
+  failed(): EventsActionBuilder<SixbEventOfType<"action.failed">>
+
+  /** All terminal action events. */
+  terminal(): EventsActionBuilder<
+    SixbEventOfType<"action.completed"> | SixbEventOfType<"action.failed">
+  >
+}
+
 /**
  * The minimal builder contract the React hooks consume: a filter IR plus a
  * typed `subscribe`. Every builder surface satisfies it, and the hooks infer
@@ -160,10 +198,10 @@ export interface EventSubscribeExecutor {
 }
 
 /**
- * WebSocket-backed executor. The transport receives the coarse `topic`/`types`
- * subscription; the finer scope (objectTypeId / primaryId / propertyId / linkId
- * / runId) is applied client-side by `buildEventPredicate` before the handler
- * runs — exactly the manual filtering every call site reimplements today.
+ * WebSocket-backed executor. The transport sends the server-supported scope,
+ * then `buildEventPredicate` applies the full filter client-side before the
+ * handler runs. That keeps property/link filters local and makes server
+ * filtering an optimization rather than a correctness dependency.
  */
 export function createWsSubscribeExecutor(options?: { client?: Client }): EventSubscribeExecutor {
   const baseUrl = options?.client?.getConfig().baseUrl
@@ -173,11 +211,12 @@ export function createWsSubscribeExecutor(options?: { client?: Client }): EventS
       const socket = createEventSocket({
         topic: filter.topic,
         types: filter.types,
-        // Coarse object scope is filtered server-side; the client predicate
-        // still refines on propertyId/linkId/runId and is the fallback when the
-        // server ignores these fields.
+        // Object/action/run scope is filtered server-side; the client predicate
+        // still refines propertyId/linkId and guards correctness.
         objectTypeId: filter.objectTypeId,
         primaryId: filter.primaryId,
+        actionId: filter.actionId,
+        runId: filter.runId,
         afterCursor: subscribeOptions?.afterCursor,
         limit: subscribeOptions?.limit,
         reconnect: subscribeOptions?.reconnect,
@@ -213,6 +252,7 @@ export function buildEventPredicate(filter: EventsFilterIR): (event: SixbEvent) 
     if (filter.propertyId !== undefined && scope.propertyId !== filter.propertyId) return false
     if (filter.linkId !== undefined && scope.linkId !== filter.linkId) return false
     if (filter.runId !== undefined && scope.runId !== filter.runId) return false
+    if (filter.actionId !== undefined && scope.actionId !== filter.actionId) return false
 
     return true
   }
@@ -270,6 +310,31 @@ class EventsBuilderImpl {
     return this.withFilter({ runId })
   }
 
+  action(actionId: string): EventsBuilderImpl {
+    return this.withFilter({ actionId })
+  }
+
+  subject(objectType: ObjectTypeWithTokens | string): EventsBuilderImpl {
+    const objectTypeId = typeof objectType === "string" ? objectType : objectType.id
+    return this.withFilter({ objectTypeId })
+  }
+
+  requested(): EventsBuilderImpl {
+    return this.withFilter({ topic: "actions", types: ["action.requested"] })
+  }
+
+  completed(): EventsBuilderImpl {
+    return this.withFilter({ topic: "actions", types: ["action.completed"] })
+  }
+
+  failed(): EventsBuilderImpl {
+    return this.withFilter({ topic: "actions", types: ["action.failed"] })
+  }
+
+  terminal(): EventsBuilderImpl {
+    return this.withFilter({ topic: "actions", types: ["action.completed", "action.failed"] })
+  }
+
   subscribe(handler: (event: SixbEvent) => void, options?: EventSubscribeOptions): () => void {
     return this.params.executor.subscribe(this.params.filter, handler, options)
   }
@@ -308,7 +373,7 @@ export interface SixbEventsApi {
   objects(options?: SixbEventsClientOptions): EventsTopicBuilder<SixbEventOfTopic<"objects">>
   telemetry(options?: SixbEventsClientOptions): EventsTopicBuilder<SixbEventOfTopic<"telemetry">>
   links(options?: SixbEventsClientOptions): EventsTopicBuilder<SixbEventOfTopic<"links">>
-  actions(options?: SixbEventsClientOptions): EventsTopicBuilder<SixbEventOfTopic<"actions">>
+  actions(options?: SixbEventsClientOptions): EventsActionBuilder<SixbEventOfTopic<"actions">>
   schedules(options?: SixbEventsClientOptions): EventsTopicBuilder<SixbEventOfTopic<"schedules">>
   rules(options?: SixbEventsClientOptions): EventsTopicBuilder<SixbEventOfTopic<"rules">>
   datasets(options?: SixbEventsClientOptions): EventsTopicBuilder<SixbEventOfTopic<"datasets">>
@@ -331,6 +396,12 @@ function runBuilder<TEvent extends SixbEvent>(
   return createBuilder({ topic }, options) as unknown as EventsRunBuilder<TEvent>
 }
 
+function actionBuilder<TEvent extends SixbEvent>(
+  options?: SixbEventsClientOptions
+): EventsActionBuilder<TEvent> {
+  return createBuilder({ topic: "actions" }, options) as unknown as EventsActionBuilder<TEvent>
+}
+
 const eventsApi = (<TObjectType extends ObjectTypeWithTokens>(
   objectType: TObjectType,
   options?: SixbEventsClientOptions
@@ -344,7 +415,7 @@ eventsApi.all = (options) => createBuilder({}, options) as unknown as EventsTopi
 eventsApi.objects = (options) => topicBuilder("objects", options)
 eventsApi.telemetry = (options) => topicBuilder("telemetry", options)
 eventsApi.links = (options) => topicBuilder("links", options)
-eventsApi.actions = (options) => topicBuilder("actions", options)
+eventsApi.actions = (options) => actionBuilder(options)
 eventsApi.schedules = (options) => topicBuilder("schedules", options)
 eventsApi.rules = (options) => topicBuilder("rules", options)
 eventsApi.datasets = (options) => topicBuilder("datasets", options)

--- a/packages/client/src/events-transport.ts
+++ b/packages/client/src/events-transport.ts
@@ -24,6 +24,10 @@ export interface EventSocketOptions {
   readonly objectTypeId?: string
   /** Object-instance scope; the server narrows the stream when set. */
   readonly primaryId?: string
+  /** Action id scope; the server narrows the stream when set. */
+  readonly actionId?: string
+  /** Run id scope; the server narrows run/action streams when set. */
+  readonly runId?: string
   readonly afterCursor?: string
   readonly limit?: number
   readonly reconnect?: boolean
@@ -52,7 +56,7 @@ type EventStreamServerMessage =
  * the same fields when they are sent on the subscribe message).
  */
 export function createEventSocket(options: EventSocketOptions): EventSocket {
-  const { topic, types, objectTypeId, primaryId, limit } = options
+  const { topic, types, objectTypeId, primaryId, actionId, runId, limit } = options
   let latestCursor = options.afterCursor
 
   return createReconnectingSocket({
@@ -68,6 +72,8 @@ export function createEventSocket(options: EventSocketOptions): EventSocket {
       ...(types && types.length > 0 ? { types } : {}),
       ...(objectTypeId ? { objectTypeId } : {}),
       ...(primaryId ? { primaryId } : {}),
+      ...(actionId ? { actionId } : {}),
+      ...(runId ? { runId } : {}),
       ...(latestCursor ? { afterCursor: latestCursor } : {}),
       ...(limit ? { limit } : {}),
     }),

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 // Generated SDK surface (modern)
 
+export * from "./actions"
 export * from "./agent-streams"
 export * from "./api"
 export type {

--- a/packages/client/src/query-hooks.ts
+++ b/packages/client/src/query-hooks.ts
@@ -12,30 +12,166 @@ import type {
   ListResultWithoutTotal,
   ObjectQuery,
   ObjectQueryExecutor,
+  ObjectQueryExecutorFacetRequest,
   ObjectQueryFacetResult,
   ObjectQueryListOptions,
   ObjectTypeWithPropertyTokens,
 } from "@sixb/core/query"
 import {
   infiniteQueryOptions,
+  type QueryClient,
   queryOptions,
+  type UseMutationOptions,
   type UseMutationResult,
   type UseQueryResult,
   useInfiniteQuery,
   useMutation,
   useQuery,
+  useQueryClient,
 } from "@tanstack/react-query"
 import { createContext, createElement, type ReactNode, useContext, useMemo } from "react"
+import {
+  type ActionRunDetail,
+  ActionRunFailedError,
+  type ActionWaitOptions,
+  type RequestActionAndWaitInput,
+  requestActionAndWait,
+} from "./actions"
 import { type SixbFileUploadError, type UploadFileInput, uploadFile } from "./file"
+import {
+  getObjectQueryKey as generatedGetObjectQueryKey,
+  getActionRunQueryKey,
+  listActionRunsInfiniteQueryKey,
+  listActionRunsQueryKey,
+} from "./generated/@tanstack/react-query.gen"
 import type { Client } from "./generated/client"
 import { getBulkTelemetryHistory, getTelemetryHistory, type Options } from "./generated/sdk.gen"
-import type { GetBulkTelemetryHistoryData, GetTelemetryHistoryData } from "./generated/types.gen"
+import type {
+  GetBulkTelemetryHistoryData,
+  GetTelemetryHistoryData,
+  RequestActionData,
+} from "./generated/types.gen"
 import { createHttpQueryExecutor } from "./query"
 
 const objectQueryBaseKey = ["sixb", "objects"] as const
 
-function objectQueryKey(scope: string, ir: ObjectQuery, extra?: unknown) {
+export type ObjectQueryKeyScope = "query" | "count" | "exists" | "facets" | "infinite"
+
+export type ObjectQueryBaseKey = typeof objectQueryBaseKey
+
+export type ObjectQueryKey = readonly ["sixb", "objects", ObjectQueryKeyScope, ObjectQuery, unknown]
+
+export type ObjectQueryLike = {
+  readonly ir: ObjectQuery
+}
+
+export type ObjectQueryFacetKeyInput =
+  | ObjectQueryExecutorFacetRequest
+  | {
+      readonly property: { readonly id: string }
+      readonly limit: number
+    }
+
+export interface ObjectQueryInfiniteKeyOptions {
+  readonly pageSize: number
+}
+
+type ObjectQueryInvalidationClient = Pick<QueryClient, "invalidateQueries">
+
+function objectQueryKey(scope: ObjectQueryKeyScope, ir: ObjectQuery, extra?: unknown) {
   return [...objectQueryBaseKey, scope, ir, extra ?? null] as const
+}
+
+function objectQueryFacetKey(
+  facets: readonly ObjectQueryFacetKeyInput[]
+): ObjectQueryExecutorFacetRequest[] {
+  return facets.map((facet) => ({
+    propertyId: "propertyId" in facet ? facet.propertyId : facet.property.id,
+    limit: facet.limit,
+  }))
+}
+
+export const objectQueryKeys = {
+  all(): ObjectQueryBaseKey {
+    return objectQueryBaseKey
+  },
+
+  list(query: ObjectQueryLike, options?: ObjectQueryListOptions): ObjectQueryKey {
+    return objectQueryKey("query", query.ir, options)
+  },
+
+  count(query: ObjectQueryLike): ObjectQueryKey {
+    return objectQueryKey("count", query.ir)
+  },
+
+  exists(query: ObjectQueryLike): ObjectQueryKey {
+    return objectQueryKey("exists", query.ir)
+  },
+
+  facets(query: ObjectQueryLike, facets: readonly ObjectQueryFacetKeyInput[]): ObjectQueryKey {
+    return objectQueryKey("facets", query.ir, objectQueryFacetKey(facets))
+  },
+
+  infinite(query: ObjectQueryLike, options: ObjectQueryInfiniteKeyOptions): ObjectQueryKey {
+    return objectQueryKey("infinite", query.ir, options.pageSize)
+  },
+} as const
+
+export function invalidateObjectQueries(queryClient: ObjectQueryInvalidationClient): Promise<void> {
+  return queryClient.invalidateQueries({ queryKey: objectQueryKeys.all() })
+}
+
+export function invalidateObjectQuery(
+  queryClient: ObjectQueryInvalidationClient,
+  query: ObjectQueryLike,
+  options?: ObjectQueryListOptions
+): Promise<void> {
+  return queryClient.invalidateQueries({
+    queryKey: objectQueryKeys.list(query, options),
+    exact: true,
+  })
+}
+
+export function invalidateObjectCountQuery(
+  queryClient: ObjectQueryInvalidationClient,
+  query: ObjectQueryLike
+): Promise<void> {
+  return queryClient.invalidateQueries({
+    queryKey: objectQueryKeys.count(query),
+    exact: true,
+  })
+}
+
+export function invalidateObjectExistsQuery(
+  queryClient: ObjectQueryInvalidationClient,
+  query: ObjectQueryLike
+): Promise<void> {
+  return queryClient.invalidateQueries({
+    queryKey: objectQueryKeys.exists(query),
+    exact: true,
+  })
+}
+
+export function invalidateObjectFacetsQuery(
+  queryClient: ObjectQueryInvalidationClient,
+  query: ObjectQueryLike,
+  facets: readonly ObjectQueryFacetKeyInput[]
+): Promise<void> {
+  return queryClient.invalidateQueries({
+    queryKey: objectQueryKeys.facets(query, facets),
+    exact: true,
+  })
+}
+
+export function invalidateObjectInfiniteQuery(
+  queryClient: ObjectQueryInvalidationClient,
+  query: ObjectQueryLike,
+  options: ObjectQueryInfiniteKeyOptions
+): Promise<void> {
+  return queryClient.invalidateQueries({
+    queryKey: objectQueryKeys.infinite(query, options),
+    exact: true,
+  })
 }
 
 const telemetryHistoryBaseKey = ["sixb", "telemetry", "history"] as const
@@ -86,7 +222,7 @@ export function objectQueryOptions<TObject>(
   options?: ObjectQueryListOptions
 ) {
   return queryOptions({
-    queryKey: objectQueryKey("query", query.ir, options),
+    queryKey: objectQueryKeys.list(query, options),
     queryFn: () => query.list(options),
   })
 }
@@ -96,7 +232,7 @@ export function objectQueryCountOptions(query: {
   count(): Promise<number>
 }) {
   return queryOptions({
-    queryKey: objectQueryKey("count", query.ir),
+    queryKey: objectQueryKeys.count(query),
     queryFn: () => query.count(),
   })
 }
@@ -106,7 +242,7 @@ export function objectQueryExistsOptions(query: {
   exists(): Promise<boolean>
 }) {
   return queryOptions({
-    queryKey: objectQueryKey("exists", query.ir),
+    queryKey: objectQueryKeys.exists(query),
     queryFn: () => query.exists(),
   })
 }
@@ -119,14 +255,7 @@ export function objectQueryFacetsOptions<TFacetInput>(
   facets: readonly TFacetInput[]
 ) {
   return queryOptions({
-    queryKey: objectQueryKey(
-      "facets",
-      query.ir,
-      facets.map((facet) => {
-        const { property, limit } = facet as { property?: { id?: string }; limit?: number }
-        return { propertyId: property?.id, limit }
-      })
-    ),
+    queryKey: objectQueryKeys.facets(query, facets as readonly ObjectQueryFacetKeyInput[]),
     queryFn: () => query.facets(facets),
   })
 }
@@ -141,7 +270,7 @@ export function objectQueryInfiniteOptions<TObject>(
   options: { pageSize: number }
 ) {
   return infiniteQueryOptions({
-    queryKey: objectQueryKey("infinite", query.ir, options.pageSize),
+    queryKey: objectQueryKeys.infinite(query, options),
     initialPageParam: undefined as string | undefined,
     queryFn: ({ pageParam }) =>
       query.page({ pageSize: options.pageSize, pageToken: pageParam }).list({
@@ -188,6 +317,259 @@ export function useUploadFile(): UseMutationResult<
         signal,
       }),
   })
+}
+
+export type ActionRunMutationWireSubject = NonNullable<RequestActionData["body"]["subject"]>
+
+export type ActionRunMutationObjectSubject<
+  TObjectType extends ObjectTypeWithPropertyTokens = ObjectTypeWithPropertyTokens,
+> = {
+  readonly objectType: TObjectType
+  readonly primaryId: string
+}
+
+export type ActionRunMutationSubject = ActionRunMutationWireSubject | ActionRunMutationObjectSubject
+
+type ActionRunMutationRequestBody = Omit<RequestActionAndWaitInput["body"], "subject"> & {
+  readonly subject?: ActionRunMutationSubject
+}
+
+export type ActionRunMutationRequest = Omit<RequestActionAndWaitInput, "body"> & {
+  readonly body: ActionRunMutationRequestBody
+}
+
+export interface ActionRunMutationBaseOptions<TVariables, TContext>
+  extends ActionWaitOptions,
+    Omit<UseMutationOptions<ActionRunDetail, Error, TVariables, TContext>, "mutationFn"> {
+  /** hey-api client override. Defaults to the nearest SixbProvider client, then the global client. */
+  readonly client?: Client
+  /** Invalidate action-run caches, and object-query caches when the terminal run committed changes. */
+  readonly invalidateOnCommit?: boolean
+  /** Override used by tests and non-hook option factory consumers. */
+  readonly queryClient?: QueryClient
+}
+
+export interface ConfiguredActionRunMutationOptions<
+  TParams extends Record<string, unknown> = Record<string, unknown>,
+  TContext = unknown,
+> extends ActionRunMutationBaseOptions<TParams | undefined, TContext> {
+  readonly actionId: string
+  readonly subject?: ActionRunMutationSubject
+  readonly runId?: string
+}
+
+export interface DynamicActionRunMutationOptions<TContext = unknown>
+  extends ActionRunMutationBaseOptions<ActionRunMutationRequest, TContext> {
+  readonly actionId?: never
+  readonly subject?: never
+  readonly runId?: never
+}
+
+type InternalActionRunMutationOptions<TVariables, TContext> = ActionRunMutationBaseOptions<
+  TVariables,
+  TContext
+> & {
+  readonly actionId?: string
+  readonly subject?: ActionRunMutationSubject
+  readonly runId?: string
+}
+
+export function actionRunMutationOptions<
+  TParams extends Record<string, unknown> = Record<string, unknown>,
+  TContext = unknown,
+>(
+  options: ConfiguredActionRunMutationOptions<TParams, TContext>
+): UseMutationOptions<ActionRunDetail, Error, TParams | undefined, TContext>
+export function actionRunMutationOptions<TContext = unknown>(
+  options?: DynamicActionRunMutationOptions<TContext>
+): UseMutationOptions<ActionRunDetail, Error, ActionRunMutationRequest, TContext>
+export function actionRunMutationOptions<TVariables, TContext>(
+  options?: InternalActionRunMutationOptions<TVariables, TContext>
+): UseMutationOptions<ActionRunDetail, Error, TVariables, TContext> {
+  return createActionRunMutationOptions(options)
+}
+
+function createActionRunMutationOptions<TVariables, TContext>(
+  options?: InternalActionRunMutationOptions<TVariables, TContext>
+): UseMutationOptions<ActionRunDetail, Error, TVariables, TContext> {
+  const {
+    actionId,
+    subject,
+    runId,
+    timeoutMs,
+    fallbackPollIntervalMs,
+    disconnectedPollIntervalMs,
+    signal,
+    rejectOnTerminalFailure,
+    client,
+    invalidateOnCommit = false,
+    queryClient,
+    onSuccess,
+    onError,
+    ...mutationOptions
+  } = options ?? {}
+
+  const waitOptions: ActionWaitOptions = {
+    timeoutMs,
+    fallbackPollIntervalMs,
+    disconnectedPollIntervalMs,
+    signal,
+    rejectOnTerminalFailure,
+  }
+
+  return {
+    ...mutationOptions,
+    mutationFn: (variables) =>
+      requestActionAndWait(
+        buildActionRunMutationRequest(variables, {
+          actionId,
+          subject,
+          runId,
+          client,
+          waitOptions,
+        })
+      ),
+    onSuccess: async (run, variables, context, mutation) => {
+      if (invalidateOnCommit && queryClient) {
+        await invalidateActionRunMutationCaches(queryClient, run)
+      }
+      await onSuccess?.(run, variables, context, mutation)
+    },
+    onError: async (error, variables, context, mutation) => {
+      if (invalidateOnCommit && queryClient && error instanceof ActionRunFailedError) {
+        await invalidateActionRunMutationCaches(queryClient, error.run)
+      }
+      await onError?.(error, variables, context, mutation)
+    },
+  }
+}
+
+export function useActionRunMutation<
+  TParams extends Record<string, unknown> = Record<string, unknown>,
+  TContext = unknown,
+>(
+  options: ConfiguredActionRunMutationOptions<TParams, TContext>
+): UseMutationResult<ActionRunDetail, Error, TParams | undefined, TContext>
+export function useActionRunMutation<TContext = unknown>(
+  options?: DynamicActionRunMutationOptions<TContext>
+): UseMutationResult<ActionRunDetail, Error, ActionRunMutationRequest, TContext>
+export function useActionRunMutation<TVariables, TContext>(
+  options?: InternalActionRunMutationOptions<TVariables, TContext>
+): UseMutationResult<ActionRunDetail, Error, TVariables, TContext> {
+  const providerClient = useContext(SixbClientContext)
+  const queryClient = useQueryClient()
+  return useMutation(
+    createActionRunMutationOptions({
+      ...options,
+      client: options?.client ?? providerClient,
+      queryClient: options?.queryClient ?? queryClient,
+    } as InternalActionRunMutationOptions<TVariables, TContext>)
+  ) as UseMutationResult<ActionRunDetail, Error, TVariables, TContext>
+}
+
+function buildActionRunMutationRequest<TVariables>(
+  variables: TVariables,
+  options: {
+    readonly actionId?: string
+    readonly subject?: ActionRunMutationSubject
+    readonly runId?: string
+    readonly client?: Client
+    readonly waitOptions: ActionWaitOptions
+  }
+): RequestActionAndWaitInput {
+  if (options.actionId) {
+    const params = variables === undefined ? undefined : (variables as Record<string, unknown>)
+    const subject = normalizeActionRunMutationSubject(options.subject)
+    return {
+      ...options.waitOptions,
+      client: options.client,
+      path: { actionId: options.actionId },
+      body: {
+        ...(subject ? { subject } : {}),
+        ...(params ? { params } : {}),
+        ...(options.runId ? { runId: options.runId } : {}),
+      },
+    }
+  }
+
+  if (isActionRunMutationRequest(variables)) {
+    const subject = normalizeActionRunMutationSubject(variables.body.subject)
+    return {
+      ...options.waitOptions,
+      client: options.client,
+      ...variables,
+      body: {
+        ...(subject ? { subject } : {}),
+        ...(variables.body.params ? { params: variables.body.params } : {}),
+        ...(variables.body.runId ? { runId: variables.body.runId } : {}),
+      },
+    }
+  }
+
+  throw new Error(
+    "[SixbClient] useActionRunMutation() without an actionId requires full request options."
+  )
+}
+
+function normalizeActionRunMutationSubject(
+  subject: ActionRunMutationSubject | undefined
+): ActionRunMutationWireSubject | undefined {
+  if (!subject) {
+    return undefined
+  }
+
+  if ("objectType" in subject) {
+    return {
+      kind: "object",
+      objectTypeId: subject.objectType.id,
+      primaryId: subject.primaryId,
+    }
+  }
+
+  return subject
+}
+
+function isActionRunMutationRequest(value: unknown): value is ActionRunMutationRequest {
+  return (
+    isRecord(value) &&
+    isRecord(value.path) &&
+    typeof value.path.actionId === "string" &&
+    isRecord(value.body)
+  )
+}
+
+async function invalidateActionRunMutationCaches(
+  queryClient: Pick<QueryClient, "invalidateQueries">,
+  run: ActionRunDetail
+): Promise<void> {
+  const invalidations: Promise<unknown>[] = [
+    queryClient.invalidateQueries({
+      queryKey: getActionRunQueryKey({ path: { runId: run.id } }),
+      exact: true,
+    }),
+    queryClient.invalidateQueries({ queryKey: listActionRunsQueryKey() }),
+    queryClient.invalidateQueries({ queryKey: listActionRunsInfiniteQueryKey() }),
+  ]
+
+  if (run.commit) {
+    invalidations.push(invalidateObjectQueries(queryClient))
+    for (const object of run.commit.diff.objects) {
+      invalidations.push(
+        queryClient.invalidateQueries({
+          queryKey: generatedGetObjectQueryKey({
+            path: { objectTypeId: object.objectTypeId, objectId: object.primaryId },
+          }),
+          exact: true,
+        })
+      )
+    }
+  }
+
+  await Promise.all(invalidations)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
 }
 
 // Hooks accept any built query — anything carrying a normalized `.ir` — and
@@ -544,7 +926,7 @@ export function useObjectsQuery<TBuilt extends { readonly ir: ObjectQuery }>(
   const executor = useClientQueryExecutor()
   const ir = query.ir
   return useQuery({
-    queryKey: objectQueryKey("query", ir),
+    queryKey: objectQueryKeys.list(query),
     queryFn: async () => {
       const result = await executor.list(ir)
       return {
@@ -565,7 +947,7 @@ export function useObjectsCount(
   const executor = useClientQueryExecutor()
   const ir = query.ir
   return useQuery({
-    queryKey: objectQueryKey("count", ir),
+    queryKey: objectQueryKeys.count(query),
     queryFn: () => executor.count(ir),
     ...options,
   })
@@ -578,7 +960,7 @@ export function useObjectsExists(
   const executor = useClientQueryExecutor()
   const ir = query.ir
   return useQuery({
-    queryKey: objectQueryKey("exists", ir),
+    queryKey: objectQueryKeys.exists(query),
     queryFn: () => executor.exists(ir),
     ...options,
   })
@@ -599,7 +981,7 @@ export function useObjectsFacets(
     limit: facet.limit,
   }))
   return useQuery({
-    queryKey: objectQueryKey("facets", ir, facetRequests),
+    queryKey: objectQueryKeys.facets(query, facets),
     queryFn: () => executor.facets(ir, facetRequests),
     ...options,
   })
@@ -619,7 +1001,7 @@ export function useObjectsInfinite<TBuilt extends { readonly ir: ObjectQuery }>(
   const executor = useClientQueryExecutor()
   const ir = query.ir
   return useInfiniteQuery({
-    queryKey: objectQueryKey("infinite", ir, pageSize),
+    queryKey: objectQueryKeys.infinite(query, { pageSize }),
     initialPageParam: undefined as string | undefined,
     queryFn: async ({ pageParam }) => {
       const result = await executor.list(

--- a/packages/client/tests/actions.test.ts
+++ b/packages/client/tests/actions.test.ts
@@ -1,0 +1,415 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import {
+  type ActionRunDetail,
+  ActionRunFailedError,
+  ActionRunTimeoutError,
+  createSixbClient,
+  requestActionAndWait,
+  waitForActionRun,
+} from "../src"
+import type { SixbEvent } from "../src/events"
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  readonly sent: string[] = []
+  closed = false
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.closed = true
+    this.onclose?.()
+  }
+}
+
+const tick = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 200): Promise<void> {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error("Timed out waiting for condition.")
+    }
+    await tick(1)
+  }
+}
+
+function createActionRun(overrides: Partial<ActionRunDetail> = {}): ActionRunDetail {
+  return {
+    id: "act_1",
+    projectId: "proj",
+    actionId: "approveQuote",
+    subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_123" },
+    status: "queued",
+    queuedAt: "2026-06-29T12:00:00.000Z",
+    params: {},
+    ...overrides,
+  }
+}
+
+function actionEvent(type: "action.completed" | "action.failed", runId = "act_1"): SixbEvent {
+  return {
+    id: `evt_${type}`,
+    cursor: `cur_${type}`,
+    projectId: "proj",
+    occurredAt: "2026-06-29T12:00:02.000Z",
+    type,
+    topic: "actions",
+    partitionKey: runId,
+    payload:
+      type === "action.completed"
+        ? {
+            actionId: "approveQuote",
+            runId,
+            subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_123" },
+            finishedAt: "2026-06-29T12:00:02.000Z",
+          }
+        : {
+            actionId: "approveQuote",
+            runId,
+            subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_123" },
+            error: { message: "Action failed", phase: "writeback" },
+            finishedAt: "2026-06-29T12:00:02.000Z",
+          },
+  } as SixbEvent
+}
+
+function createTestClient(handler: (request: Request) => Response | Promise<Response>) {
+  const requests: Request[] = []
+  const fetchMock = Object.assign(
+    async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const request = input instanceof Request && !init ? input : new Request(input, init)
+      requests.push(request)
+      return handler(request)
+    },
+    { preconnect: fetch.preconnect }
+  ) satisfies typeof fetch
+
+  return {
+    client: createSixbClient({ baseUrl: "http://sixb.test", fetch: fetchMock }),
+    requests,
+  }
+}
+
+describe("action wait helpers", () => {
+  let originalWebSocket: typeof WebSocket
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket
+    FakeWebSocket.instances = []
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    globalThis.WebSocket = originalWebSocket
+  })
+
+  test("requests an action, waits for the terminal event, and returns final detail", async () => {
+    let getCount = 0
+    let requested = false
+    const succeeded = createActionRun({
+      status: "succeeded",
+      phase: "effects",
+      startedAt: "2026-06-29T12:00:01.000Z",
+      finishedAt: "2026-06-29T12:00:02.000Z",
+      commit: {
+        committedAt: "2026-06-29T12:00:01.500Z",
+        diff: {
+          objects: [
+            {
+              objectTypeId: "Quote",
+              primaryId: "q_123",
+              operation: "update",
+              changedProperties: ["status"],
+            },
+          ],
+          links: [],
+        },
+      },
+    })
+    const { client, requests } = createTestClient(async (request) => {
+      const url = new URL(request.url)
+      if (request.method === "POST" && url.pathname === "/api/actions/approveQuote") {
+        const body = await request.json()
+        expect(body).toMatchObject({ params: { note: "Approved" } })
+        return Response.json(
+          {
+            runId: "act_1",
+            queuedAt: "2026-06-29T12:00:00.000Z",
+            created: true,
+          },
+          { status: 202 }
+        )
+      }
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        getCount += 1
+        return Response.json(getCount === 1 ? createActionRun() : succeeded)
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    const promise = requestActionAndWait({
+      client,
+      path: { actionId: "approveQuote" },
+      body: {
+        subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_123" },
+        params: { note: "Approved" },
+      },
+      fallbackPollIntervalMs: 500,
+      timeoutMs: 1_000,
+      onRequested: (response) => {
+        requested = response.runId === "act_1"
+      },
+    })
+
+    await waitUntil(() => getCount === 1)
+    const ws = FakeWebSocket.instances[0]
+    if (!ws) throw new Error("expected a websocket")
+    ws.onopen?.()
+    expect(JSON.parse(ws.sent[0] ?? "{}")).toMatchObject({
+      type: "subscribe",
+      topic: "actions",
+      types: ["action.completed", "action.failed"],
+      runId: "act_1",
+    })
+
+    ws.onmessage?.({
+      data: JSON.stringify({ type: "event", event: actionEvent("action.completed") }),
+    })
+    const run = await promise
+
+    expect(requested).toBe(true)
+    expect(run).toEqual(succeeded)
+    expect(getCount).toBe(2)
+    expect(ws.closed).toBe(true)
+    expect(requests.map((request) => `${request.method} ${new URL(request.url).pathname}`)).toEqual(
+      ["POST /api/actions/approveQuote", "GET /api/action-runs/act_1", "GET /api/action-runs/act_1"]
+    )
+  })
+
+  test("uses slow fallback polling when the socket is healthy but no terminal event arrives", async () => {
+    let getCount = 0
+    const { client } = createTestClient((request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        getCount += 1
+        return Response.json(
+          getCount < 2
+            ? createActionRun({ status: "running" })
+            : createActionRun({ status: "succeeded", finishedAt: "2026-06-29T12:00:02.000Z" })
+        )
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    const promise = waitForActionRun({
+      client,
+      runId: "act_1",
+      fallbackPollIntervalMs: 5,
+      disconnectedPollIntervalMs: 500,
+      timeoutMs: 200,
+    })
+
+    await waitUntil(() => getCount === 1)
+    const ws = FakeWebSocket.instances[0]
+    if (!ws) throw new Error("expected a websocket")
+    ws.onopen?.()
+
+    const run = await promise
+
+    expect(ws.closed).toBe(true)
+    expect(run.status).toBe("succeeded")
+    expect(getCount).toBe(2)
+  })
+
+  test("runs a follow-up detail fetch when a terminal event arrives during an in-flight check", async () => {
+    let getCount = 0
+    const firstGet = {
+      resolve: undefined as ((response: Response) => void) | undefined,
+    }
+    const succeeded = createActionRun({
+      status: "succeeded",
+      finishedAt: "2026-06-29T12:00:02.000Z",
+    })
+    const { client } = createTestClient((request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        getCount += 1
+        if (getCount === 1) {
+          return new Promise<Response>((resolve) => {
+            firstGet.resolve = resolve
+          })
+        }
+        return Response.json(succeeded)
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    const promise = waitForActionRun({
+      client,
+      runId: "act_1",
+      fallbackPollIntervalMs: 1_000,
+      disconnectedPollIntervalMs: 1_000,
+      timeoutMs: 500,
+    })
+
+    await waitUntil(() => getCount === 1 && firstGet.resolve !== undefined)
+    const ws = FakeWebSocket.instances[0]
+    if (!ws) throw new Error("expected a websocket")
+    ws.onopen?.()
+    ws.onmessage?.({
+      data: JSON.stringify({ type: "event", event: actionEvent("action.completed") }),
+    })
+
+    const resolve = firstGet.resolve
+    if (!resolve) throw new Error("expected pending run detail request")
+    resolve(Response.json(createActionRun({ status: "running" })))
+    const run = await promise
+
+    expect(run).toEqual(succeeded)
+    expect(getCount).toBe(2)
+  })
+
+  test("uses faster fallback polling while the event socket is disconnected", async () => {
+    let getCount = 0
+    const { client } = createTestClient((request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        getCount += 1
+        return Response.json(
+          getCount < 2
+            ? createActionRun({ status: "running" })
+            : createActionRun({ status: "succeeded", finishedAt: "2026-06-29T12:00:02.000Z" })
+        )
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    const run = await waitForActionRun({
+      client,
+      runId: "act_1",
+      fallbackPollIntervalMs: 1_000,
+      disconnectedPollIntervalMs: 5,
+      timeoutMs: 200,
+    })
+
+    expect(run.status).toBe("succeeded")
+    expect(getCount).toBe(2)
+  })
+
+  test("rejects when the terminal action run failed", async () => {
+    const { client } = createTestClient((request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        return Response.json(
+          createActionRun({
+            status: "failed",
+            phase: "writeback",
+            finishedAt: "2026-06-29T12:00:02.000Z",
+            error: { name: "WritebackError", message: "Writeback failed", phase: "writeback" },
+          })
+        )
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    let error: unknown
+    try {
+      await waitForActionRun({ client, runId: "act_1", timeoutMs: 200 })
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(ActionRunFailedError)
+    expect((error as ActionRunFailedError).runId).toBe("act_1")
+    expect((error as ActionRunFailedError).status).toBe("failed")
+    expect((error as ActionRunFailedError).message).toBe("Writeback failed")
+  })
+
+  test("rejects when the terminal action run was cancelled", async () => {
+    const { client } = createTestClient((request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        return Response.json(
+          createActionRun({
+            status: "cancelled",
+            phase: "cancelled",
+            finishedAt: "2026-06-29T12:00:02.000Z",
+            error: { message: "Action was cancelled", phase: "cancelled" },
+          })
+        )
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    let error: unknown
+    try {
+      await waitForActionRun({ client, runId: "act_1", timeoutMs: 200 })
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(ActionRunFailedError)
+    expect((error as ActionRunFailedError).status).toBe("cancelled")
+    expect((error as ActionRunFailedError).message).toBe("Action was cancelled")
+  })
+
+  test("can return failed terminal records when rejection is disabled", async () => {
+    const failed = createActionRun({
+      status: "failed",
+      finishedAt: "2026-06-29T12:00:02.000Z",
+      error: { message: "Handled manually", phase: "effects" },
+    })
+    const { client } = createTestClient((request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        return Response.json(failed)
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    const run = await waitForActionRun({
+      client,
+      runId: "act_1",
+      rejectOnTerminalFailure: false,
+      timeoutMs: 200,
+    })
+
+    expect(run).toEqual(failed)
+  })
+
+  test("rejects when the wait times out", async () => {
+    const { client } = createTestClient((request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        return Response.json(createActionRun({ status: "running" }))
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    let error: unknown
+    try {
+      await waitForActionRun({
+        client,
+        runId: "act_1",
+        disconnectedPollIntervalMs: 5,
+        timeoutMs: 15,
+      })
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(ActionRunTimeoutError)
+    expect((error as ActionRunTimeoutError).runId).toBe("act_1")
+  })
+})

--- a/packages/client/tests/events-builder.test.ts
+++ b/packages/client/tests/events-builder.test.ts
@@ -85,6 +85,24 @@ describe("events builder IR", () => {
     expect(events.all().ir).toEqual({})
     expect(events.telemetry().ir).toEqual({ topic: "telemetry" })
     expect(events.workflows().run("run-1").ir).toEqual({ topic: "workflows", runId: "run-1" })
+    expect(events.actions().run("act-1").action("approveQuote").terminal().ir).toEqual({
+      topic: "actions",
+      runId: "act-1",
+      actionId: "approveQuote",
+      types: ["action.completed", "action.failed"],
+    })
+    expect(events.actions().subject(Sensor).object("sensor-1").completed().ir).toEqual({
+      topic: "actions",
+      objectTypeId: "Sensor",
+      primaryId: "sensor-1",
+      types: ["action.completed"],
+    })
+    expect(events.actions().subject("Sensor").object("sensor-1").failed().ir).toEqual({
+      topic: "actions",
+      objectTypeId: "Sensor",
+      primaryId: "sensor-1",
+      types: ["action.failed"],
+    })
   })
 })
 
@@ -137,6 +155,47 @@ describe("buildEventPredicate", () => {
     expect(matches(event({ ...wfEvent, payload: { workflowId: "wf-1", runId: "run-2" } }))).toBe(
       false
     )
+  })
+
+  test("actions match run, action id and object subject scope", () => {
+    const matches = buildEventPredicate(
+      events.actions().run("act-1").action("approveQuote").subject(Sensor).object("sensor-1").ir
+    )
+    const actionCompleted = event({
+      type: "action.completed",
+      topic: "actions",
+      payload: {
+        actionId: "approveQuote",
+        runId: "act-1",
+        subject: { kind: "object", objectTypeId: "Sensor", primaryId: "sensor-1" },
+        finishedAt: "2026-01-01T00:00:00.000Z",
+      },
+    })
+    expect(matches(actionCompleted)).toBe(true)
+    expect(
+      matches(
+        event({ ...actionCompleted, payload: { ...actionCompleted.payload, runId: "act-2" } })
+      )
+    ).toBe(false)
+    expect(
+      matches(
+        event({
+          ...actionCompleted,
+          payload: { ...actionCompleted.payload, actionId: "rejectQuote" },
+        })
+      )
+    ).toBe(false)
+    expect(
+      matches(
+        event({
+          ...actionCompleted,
+          payload: {
+            ...actionCompleted.payload,
+            subject: { kind: "object", objectTypeId: "Sensor", primaryId: "sensor-2" },
+          },
+        })
+      )
+    ).toBe(false)
   })
 
   test("an empty filter matches everything", () => {
@@ -246,6 +305,34 @@ describe("builder subscribe over the transport", () => {
       }),
     })
     expect(received).toHaveLength(1)
+
+    unsubscribe()
+    expect(ws.closed).toBe(true)
+  })
+
+  test("sends action run, action id and subject scope to the server", () => {
+    const unsubscribe = events
+      .actions()
+      .run("act-1")
+      .action("approveQuote")
+      .subject(Sensor)
+      .object("sensor-1")
+      .terminal()
+      .subscribe(() => undefined)
+
+    const ws = FakeWebSocket.instances.at(-1)
+    if (!ws) throw new Error("expected a websocket")
+
+    ws.onopen?.()
+    expect(JSON.parse(ws.sent[0])).toMatchObject({
+      type: "subscribe",
+      topic: "actions",
+      types: ["action.completed", "action.failed"],
+      runId: "act-1",
+      actionId: "approveQuote",
+      objectTypeId: "Sensor",
+      primaryId: "sensor-1",
+    })
 
     unsubscribe()
     expect(ws.closed).toBe(true)

--- a/packages/client/tests/events-builder.types.ts
+++ b/packages/client/tests/events-builder.types.ts
@@ -145,6 +145,45 @@ events
     void runId
   })
 
+events
+  .actions()
+  .run("act-1")
+  .action("approveQuote")
+  .subject(Sensor)
+  .object("sensor-1")
+  .completed()
+  .subscribe((event) => {
+    const runId: string = event.payload.runId
+    const actionId: string = event.payload.actionId
+    const finishedAt: string = event.payload.finishedAt
+    // @ts-expect-error — completed events do not carry an error payload.
+    void event.payload.error
+    void [runId, actionId, finishedAt]
+  })
+
+events
+  .actions()
+  .subject("Sensor")
+  .object("sensor-1")
+  .failed()
+  .subscribe((event) => {
+    const message: string = event.payload.error.message
+    void message
+  })
+
+events
+  .actions()
+  .terminal()
+  .subscribe((event) => {
+    if (event.type === "action.failed") {
+      const message: string = event.payload.error.message
+      void message
+    } else {
+      const finishedAt: string = event.payload.finishedAt
+      void finishedAt
+    }
+  })
+
 // ── TS2589 stressor: wide object type through `.upserted()` + `.map()` ────────
 
 const WideThing = defineObjectType({

--- a/packages/client/tests/query-hooks.test.ts
+++ b/packages/client/tests/query-hooks.test.ts
@@ -1,12 +1,54 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { defineObjectType, prop, stringEnum } from "@sixb/core"
+import { QueryClient } from "@tanstack/react-query"
+import { type ActionRunDetail, ActionRunFailedError } from "../src/actions"
+import {
+  getObjectQueryKey as generatedGetObjectQueryKey,
+  getActionRunQueryKey,
+  listActionRunsInfiniteQueryKey,
+  listActionRunsQueryKey,
+} from "../src/generated/@tanstack/react-query.gen"
 import { createClient, createConfig } from "../src/generated/client"
 import { objects } from "../src/query"
 import {
+  type ActionRunMutationRequest,
+  actionRunMutationOptions,
+  invalidateObjectCountQuery,
+  invalidateObjectExistsQuery,
+  invalidateObjectFacetsQuery,
+  invalidateObjectInfiniteQuery,
+  invalidateObjectQueries,
+  invalidateObjectQuery,
   objectQueryCountOptions,
+  objectQueryExistsOptions,
+  objectQueryFacetsOptions,
   objectQueryInfiniteOptions,
+  objectQueryKeys,
   objectQueryOptions,
 } from "../src/query-hooks"
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  readonly sent: string[] = []
+  closed = false
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  onclose: (() => void) | null = null
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.closed = true
+    this.onclose?.()
+  }
+}
 
 const Project = defineObjectType({
   id: "Project",
@@ -40,7 +82,81 @@ function activeProjects(client?: ReturnType<typeof createTestClient>["client"]) 
     .where((project) => project.p.status.eq("active"))
 }
 
+function createActionRun(overrides: Partial<ActionRunDetail> = {}): ActionRunDetail {
+  return {
+    id: "act_1",
+    projectId: "proj",
+    actionId: "approveQuote",
+    subject: { kind: "object", objectTypeId: "Project", primaryId: "p_1" },
+    status: "queued",
+    queuedAt: "2026-06-29T12:00:00.000Z",
+    params: {},
+    ...overrides,
+  }
+}
+
+function createActionTestClient() {
+  const requests: { method: string; path: string; body?: unknown }[] = []
+  const succeeded = createActionRun({
+    status: "succeeded",
+    finishedAt: "2026-06-29T12:00:02.000Z",
+  })
+  const client = createClient(
+    createConfig({
+      baseUrl: "http://sixb.test",
+      fetch: (async (request: Request) => {
+        const url = new URL(request.url)
+        const body = request.method === "POST" ? await request.json() : undefined
+        requests.push({ method: request.method, path: url.pathname, body })
+        if (request.method === "POST" && url.pathname.startsWith("/api/actions/")) {
+          return Response.json(
+            { runId: "act_1", queuedAt: "2026-06-29T12:00:00.000Z", created: true },
+            { status: 202 }
+          )
+        }
+        if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+          return Response.json(succeeded)
+        }
+        return Response.json({ error: "Unexpected request" }, { status: 500 })
+      }) as unknown as typeof fetch,
+    })
+  )
+  return { client, requests, succeeded }
+}
+
+let originalWebSocket: typeof WebSocket
+
+beforeEach(() => {
+  originalWebSocket = globalThis.WebSocket
+  FakeWebSocket.instances = []
+  globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+})
+
+afterEach(() => {
+  globalThis.WebSocket = originalWebSocket
+})
+
 describe("objectQueryOptions", () => {
+  test("objectQueryKeys match the option factory query keys", () => {
+    const query = activeProjects().limit(10)
+    const facets = [{ property: Project.p.status, limit: 10 }] as const
+    const pageOptions = { pageSize: 50 }
+
+    expect(objectQueryKeys.all()).toEqual(["sixb", "objects"])
+    expect(objectQueryKeys.list(query)).toEqual(objectQueryOptions(query).queryKey)
+    expect(objectQueryKeys.list(query, { includeTotal: false })).toEqual(
+      objectQueryOptions(query, { includeTotal: false }).queryKey
+    )
+    expect(objectQueryKeys.count(query)).toEqual(objectQueryCountOptions(query).queryKey)
+    expect(objectQueryKeys.exists(query)).toEqual(objectQueryExistsOptions(query).queryKey)
+    expect(objectQueryKeys.facets(query, facets)).toEqual(
+      objectQueryFacetsOptions(query, facets).queryKey
+    )
+    expect(objectQueryKeys.infinite(query, pageOptions)).toEqual(
+      objectQueryInfiniteOptions(query, pageOptions).queryKey
+    )
+  })
+
   test("query keys are stable across separately built identical queries", () => {
     const first = objectQueryOptions(activeProjects().limit(10))
     const second = objectQueryOptions(activeProjects().limit(10))
@@ -74,6 +190,275 @@ describe("objectQueryOptions", () => {
 
     expect(bodies[0]).toMatchObject({ includeTotal: false })
     expect(page.total).toBeUndefined()
+  })
+})
+
+describe("object query invalidation helpers", () => {
+  test("invalidates the exact list query key", async () => {
+    const queryClient = new QueryClient()
+    const query = activeProjects()
+    const listKey = objectQueryKeys.list(query)
+    const countKey = objectQueryKeys.count(query)
+
+    queryClient.setQueryData(listKey, ["list"])
+    queryClient.setQueryData(countKey, 1)
+
+    await invalidateObjectQuery(queryClient, query)
+
+    expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(countKey)?.isInvalidated).toBe(false)
+    queryClient.clear()
+  })
+
+  test("invalidates exact count, exists, facet, and infinite query keys", async () => {
+    const queryClient = new QueryClient()
+    const query = activeProjects()
+    const facets = [{ property: Project.p.status, limit: 10 }] as const
+    const countKey = objectQueryKeys.count(query)
+    const existsKey = objectQueryKeys.exists(query)
+    const facetsKey = objectQueryKeys.facets(query, facets)
+    const infiniteKey = objectQueryKeys.infinite(query, { pageSize: 50 })
+
+    queryClient.setQueryData(countKey, 1)
+    queryClient.setQueryData(existsKey, true)
+    queryClient.setQueryData(facetsKey, [])
+    queryClient.setQueryData(infiniteKey, { pages: [], pageParams: [] })
+
+    await invalidateObjectCountQuery(queryClient, query)
+    await invalidateObjectExistsQuery(queryClient, query)
+    await invalidateObjectFacetsQuery(queryClient, query, facets)
+    await invalidateObjectInfiniteQuery(queryClient, query, { pageSize: 50 })
+
+    expect(queryClient.getQueryState(countKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(existsKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(facetsKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(infiniteKey)?.isInvalidated).toBe(true)
+    queryClient.clear()
+  })
+
+  test("can invalidate the whole typed object query cache group", async () => {
+    const queryClient = new QueryClient()
+    const query = activeProjects()
+    const listKey = objectQueryKeys.list(query)
+    const existsKey = objectQueryKeys.exists(query)
+
+    queryClient.setQueryData(listKey, ["list"])
+    queryClient.setQueryData(existsKey, true)
+
+    await invalidateObjectQueries(queryClient)
+
+    expect(queryClient.getQueryState(listKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(existsKey)?.isInvalidated).toBe(true)
+    queryClient.clear()
+  })
+})
+
+describe("actionRunMutationOptions", () => {
+  test("configured mutations treat variables as action params and wait for the terminal run", async () => {
+    const { client, requests, succeeded } = createActionTestClient()
+    const options = actionRunMutationOptions<{ note: string }>({
+      client,
+      actionId: "approveQuote",
+      subject: { objectType: Project, primaryId: "p_1" },
+      timeoutMs: 500,
+    })
+
+    const mutationFn = options.mutationFn as (params: { note: string }) => Promise<ActionRunDetail>
+    const run = await mutationFn({ note: "Approved" })
+
+    expect(run).toEqual(succeeded)
+    expect(requests).toEqual([
+      {
+        method: "POST",
+        path: "/api/actions/approveQuote",
+        body: {
+          subject: { kind: "object", objectTypeId: "Project", primaryId: "p_1" },
+          params: { note: "Approved" },
+        },
+      },
+      { method: "GET", path: "/api/action-runs/act_1", body: undefined },
+    ])
+    expect(FakeWebSocket.instances[0]?.closed).toBe(true)
+  })
+
+  test("configured mutations still accept the generated object subject shape", async () => {
+    const { client, requests, succeeded } = createActionTestClient()
+    const options = actionRunMutationOptions<{ note: string }>({
+      client,
+      actionId: "approveQuote",
+      subject: { kind: "object", objectTypeId: "Project", primaryId: "p_1" },
+      timeoutMs: 500,
+    })
+
+    const mutationFn = options.mutationFn as (params: { note: string }) => Promise<ActionRunDetail>
+    const run = await mutationFn({ note: "Approved" })
+
+    expect(run).toEqual(succeeded)
+    expect(requests[0]).toEqual({
+      method: "POST",
+      path: "/api/actions/approveQuote",
+      body: {
+        subject: { kind: "object", objectTypeId: "Project", primaryId: "p_1" },
+        params: { note: "Approved" },
+      },
+    })
+  })
+
+  test("dynamic mutations accept the full generated request shape", async () => {
+    const { client, requests, succeeded } = createActionTestClient()
+    const options = actionRunMutationOptions({ client, timeoutMs: 500 })
+
+    const mutationFn = options.mutationFn as (
+      request: ActionRunMutationRequest
+    ) => Promise<ActionRunDetail>
+    const run = await mutationFn({
+      path: { actionId: "approveQuote" },
+      body: {
+        subject: { kind: "object", objectTypeId: "Project", primaryId: "p_1" },
+        params: { note: "Approved" },
+      },
+    })
+
+    expect(run).toEqual(succeeded)
+    expect(requests[0]).toEqual({
+      method: "POST",
+      path: "/api/actions/approveQuote",
+      body: {
+        subject: { kind: "object", objectTypeId: "Project", primaryId: "p_1" },
+        params: { note: "Approved" },
+      },
+    })
+  })
+
+  test("dynamic mutations accept ontology object subjects", async () => {
+    const { client, requests, succeeded } = createActionTestClient()
+    const options = actionRunMutationOptions({ client, timeoutMs: 500 })
+
+    const mutationFn = options.mutationFn as (
+      request: ActionRunMutationRequest
+    ) => Promise<ActionRunDetail>
+    const run = await mutationFn({
+      path: { actionId: "approveQuote" },
+      body: {
+        subject: { objectType: Project, primaryId: "p_1" },
+        params: { note: "Approved" },
+      },
+    })
+
+    expect(run).toEqual(succeeded)
+    expect(requests[0]).toEqual({
+      method: "POST",
+      path: "/api/actions/approveQuote",
+      body: {
+        subject: { kind: "object", objectTypeId: "Project", primaryId: "p_1" },
+        params: { note: "Approved" },
+      },
+    })
+  })
+
+  test("invalidateOnCommit invalidates action run and object query caches", async () => {
+    const queryClient = new QueryClient()
+    const query = activeProjects()
+    const run = createActionRun({
+      status: "succeeded",
+      finishedAt: "2026-06-29T12:00:02.000Z",
+      commit: {
+        committedAt: "2026-06-29T12:00:01.500Z",
+        diff: {
+          objects: [
+            {
+              objectTypeId: "Project",
+              primaryId: "p_1",
+              operation: "update",
+              changedProperties: ["status"],
+            },
+          ],
+          links: [],
+        },
+      },
+    })
+    const actionRunKey = getActionRunQueryKey({ path: { runId: "act_1" } })
+    const actionRunsKey = listActionRunsQueryKey()
+    const actionRunsInfiniteKey = listActionRunsInfiniteQueryKey()
+    const objectQueryKey = objectQueryKeys.list(query)
+    const generatedObjectKey = generatedGetObjectQueryKey({
+      path: { objectTypeId: "Project", objectId: "p_1" },
+    })
+    let userOnSuccessCalled = false
+
+    queryClient.setQueryData(actionRunKey, run)
+    queryClient.setQueryData(actionRunsKey, { runs: [], hasMore: false, total: 0 })
+    queryClient.setQueryData(actionRunsInfiniteKey, { pages: [], pageParams: [] })
+    queryClient.setQueryData(objectQueryKey, ["projects"])
+    queryClient.setQueryData(generatedObjectKey, { primaryId: "p_1" })
+
+    const options = actionRunMutationOptions<{ note: string }>({
+      actionId: "approveQuote",
+      queryClient,
+      invalidateOnCommit: true,
+      onSuccess: () => {
+        userOnSuccessCalled = true
+      },
+    })
+    const onSuccess = options.onSuccess as (
+      data: ActionRunDetail,
+      variables: { note: string },
+      context: unknown
+    ) => Promise<void>
+
+    await onSuccess(run, { note: "Approved" }, undefined)
+
+    expect(queryClient.getQueryState(actionRunKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(actionRunsKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(actionRunsInfiniteKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(objectQueryKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(generatedObjectKey)?.isInvalidated).toBe(true)
+    expect(userOnSuccessCalled).toBe(true)
+    queryClient.clear()
+  })
+
+  test("terminal failure errors invalidate action run caches without object commit invalidation", async () => {
+    const queryClient = new QueryClient()
+    const query = activeProjects()
+    const failed = createActionRun({
+      status: "failed",
+      finishedAt: "2026-06-29T12:00:02.000Z",
+      error: { message: "Writeback failed", phase: "writeback" },
+    })
+    const actionRunKey = getActionRunQueryKey({ path: { runId: "act_1" } })
+    const actionRunsKey = listActionRunsQueryKey()
+    const objectQueryKey = objectQueryKeys.list(query)
+    let userOnErrorCalled = false
+
+    queryClient.setQueryData(actionRunKey, failed)
+    queryClient.setQueryData(actionRunsKey, { runs: [], hasMore: false, total: 0 })
+    queryClient.setQueryData(objectQueryKey, ["projects"])
+
+    const options = actionRunMutationOptions<{ note: string }>({
+      actionId: "approveQuote",
+      queryClient,
+      invalidateOnCommit: true,
+      onError: () => {
+        userOnErrorCalled = true
+      },
+    })
+    const onError = options.onError as (
+      error: Error,
+      variables: { note: string },
+      context: unknown
+    ) => Promise<void>
+
+    await onError(
+      new ActionRunFailedError(failed as ActionRunDetail & { readonly status: "failed" }),
+      { note: "Approved" },
+      undefined
+    )
+
+    expect(queryClient.getQueryState(actionRunKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(actionRunsKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(objectQueryKey)?.isInvalidated).toBe(false)
+    expect(userOnErrorCalled).toBe(true)
+    queryClient.clear()
   })
 })
 

--- a/packages/core/src/events/scope.ts
+++ b/packages/core/src/events/scope.ts
@@ -16,6 +16,7 @@ export interface EventScopeKeys {
   readonly propertyId?: string
   readonly linkId?: string
   readonly runId?: string
+  readonly actionId?: string
 }
 
 export function scopeKeysForEvent(event: DomainEvent): EventScopeKeys {
@@ -39,6 +40,16 @@ export function scopeKeysForEvent(event: DomainEvent): EventScopeKeys {
     case "syncs":
       return { runId: event.payload.runId }
     case "actions":
+      return {
+        actionId: event.payload.actionId,
+        runId: event.payload.runId,
+        ...(event.payload.subject.kind === "object"
+          ? {
+              objectTypeId: event.payload.subject.objectTypeId,
+              primaryId: event.payload.subject.primaryId,
+            }
+          : {}),
+      }
     case "schedules":
     case "datasets":
     case "rules":

--- a/packages/core/tests/events-scope.test.ts
+++ b/packages/core/tests/events-scope.test.ts
@@ -57,8 +57,36 @@ describe("scopeKeysForEvent", () => {
     ).toEqual({ runId: "r3" })
   })
 
+  test("action topics carry action, run, and object subject scope", () => {
+    expect(
+      scopeKeysForEvent(
+        event("actions", "action.requested", {
+          actionId: "approveQuote",
+          runId: "act-1",
+          subject: { kind: "object", objectTypeId: "Quote", primaryId: "quote-1" },
+        })
+      )
+    ).toEqual({
+      actionId: "approveQuote",
+      runId: "act-1",
+      objectTypeId: "Quote",
+      primaryId: "quote-1",
+    })
+  })
+
+  test("global action topics carry action and run scope", () => {
+    expect(
+      scopeKeysForEvent(
+        event("actions", "action.completed", {
+          actionId: "refreshCache",
+          runId: "act-2",
+          subject: { kind: "none" },
+        })
+      )
+    ).toEqual({ actionId: "refreshCache", runId: "act-2" })
+  })
+
   test("topics without an object/run scope return no keys", () => {
-    expect(scopeKeysForEvent(event("actions", "action.requested", { actionId: "a" }))).toEqual({})
     expect(
       scopeKeysForEvent(
         event("rules", "rule.triggered", {

--- a/packages/server/src/routes/ws/events.ts
+++ b/packages/server/src/routes/ws/events.ts
@@ -10,6 +10,8 @@ interface EventSubscriptionState {
   types?: DomainEvent["type"][]
   objectTypeId?: string
   primaryId?: string
+  actionId?: string
+  runId?: string
   afterCursor?: string
   limit: number
   polling: boolean
@@ -22,6 +24,8 @@ const SubscribeSchema = z.object({
   types: z.array(z.enum(EVENT_TYPES)).optional(),
   objectTypeId: z.string().optional(),
   primaryId: z.string().optional(),
+  actionId: z.string().optional(),
+  runId: z.string().optional(),
   afterCursor: z.string().optional(),
   limit: z.number().int().positive().max(500).optional(),
 })
@@ -68,6 +72,8 @@ function createDefaultState(): EventSubscriptionState {
     types: undefined,
     objectTypeId: undefined,
     primaryId: undefined,
+    actionId: undefined,
+    runId: undefined,
     afterCursor: undefined,
     limit: 200,
     polling: false,
@@ -115,10 +121,10 @@ export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
 
         // Each event payload may carry object data, so visibility is derived
         // per-event from the principal's grants (see `canViewEvent`), and the
-        // optional object scope narrows the stream further. The cursor advances
-        // over every event read, not just the ones sent.
+        // optional scope narrows the stream further. The cursor advances over
+        // every event read, not just the ones sent.
         for (const event of events) {
-          if (!eventMatchesScope(event, state.objectTypeId, state.primaryId)) {
+          if (!eventMatchesScope(event, state)) {
             continue
           }
           if (canViewEvent(authz, event)) {
@@ -175,6 +181,8 @@ export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
         state.types = undefined
         state.objectTypeId = undefined
         state.primaryId = undefined
+        state.actionId = undefined
+        state.runId = undefined
         state.afterCursor = await resolveLatestCursor(server)
         safeSend(ws, { type: "unsubscribed" })
         return
@@ -184,6 +192,8 @@ export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
       state.types = parsed.data.types
       state.objectTypeId = parsed.data.objectTypeId
       state.primaryId = parsed.data.primaryId
+      state.actionId = parsed.data.actionId
+      state.runId = parsed.data.runId
       state.limit = parsed.data.limit ?? state.limit
       state.afterCursor = parsed.data.afterCursor ?? state.afterCursor
 
@@ -204,16 +214,18 @@ export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
 }
 
 /**
- * Narrow an event to an optional object scope. Scope keys are resolved by core's
+ * Narrow an event to an optional subscription scope. Scope keys are resolved by core's
  * `scopeKeysForEvent` (the same extraction the client predicate uses), so events
  * without those keys (e.g. workflows) never match a scoped subscription.
  */
-function eventMatchesScope(
-  event: DomainEvent,
-  objectTypeId: string | undefined,
-  primaryId: string | undefined
-): boolean {
-  if (objectTypeId === undefined && primaryId === undefined) {
+function eventMatchesScope(event: DomainEvent, filter: EventSubscriptionState): boolean {
+  const { objectTypeId, primaryId, actionId, runId } = filter
+  if (
+    objectTypeId === undefined &&
+    primaryId === undefined &&
+    actionId === undefined &&
+    runId === undefined
+  ) {
     return true
   }
 
@@ -222,6 +234,12 @@ function eventMatchesScope(
     return false
   }
   if (primaryId !== undefined && scope.primaryId !== primaryId) {
+    return false
+  }
+  if (actionId !== undefined && scope.actionId !== actionId) {
+    return false
+  }
+  if (runId !== undefined && scope.runId !== runId) {
     return false
   }
 

--- a/packages/server/tests/wsSubscribe.test.ts
+++ b/packages/server/tests/wsSubscribe.test.ts
@@ -80,6 +80,31 @@ describe("parseSubscriptionMessage", () => {
     })
   })
 
+  test("accepts action-scoped subscriptions", () => {
+    const result = parseSubscriptionMessage({
+      type: "subscribe",
+      topic: "actions",
+      types: ["action.completed", "action.failed"],
+      actionId: "approveQuote",
+      runId: "act-1",
+      objectTypeId: "Quote",
+      primaryId: "q_123",
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        type: "subscribe",
+        topic: "actions",
+        types: ["action.completed", "action.failed"],
+        actionId: "approveQuote",
+        runId: "act-1",
+        objectTypeId: "Quote",
+        primaryId: "q_123",
+      },
+    })
+  })
+
   test("rejects non-object payloads", () => {
     const result = parseSubscriptionMessage("subscribe")
 
@@ -216,6 +241,85 @@ describe("/ws/events subscriptions", () => {
         expect(await nextWsMessage(ws)).toMatchObject({
           type: "event",
           event: { cursor: matching?.cursor, payload: { objectId: "fan-1" } },
+        })
+        await expectNoWsMessage(ws)
+      } finally {
+        ws.close()
+      }
+    })
+  })
+
+  test("scopes action streams by run, action id and object subject", async () => {
+    await withWsServer(async ({ baseUrl, sixb }) => {
+      const ws = new WebSocket(`${baseUrl.replace("http://", "ws://")}/ws/events`)
+
+      try {
+        expect(await nextWsMessage(ws)).toEqual({ type: "connected", channel: "events" })
+
+        const [matching] = await sixb.events.append({
+          events: [
+            {
+              type: "action.completed",
+              payload: {
+                actionId: "approveQuote",
+                runId: "act-1",
+                subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_123" },
+                finishedAt: "2026-02-18T10:00:10.000Z",
+              },
+            },
+          ],
+        })
+        await sixb.events.append({
+          events: [
+            {
+              type: "action.completed",
+              payload: {
+                actionId: "approveQuote",
+                runId: "act-2",
+                subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_123" },
+                finishedAt: "2026-02-18T10:00:11.000Z",
+              },
+            },
+            {
+              type: "action.completed",
+              payload: {
+                actionId: "rejectQuote",
+                runId: "act-1",
+                subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_123" },
+                finishedAt: "2026-02-18T10:00:12.000Z",
+              },
+            },
+            {
+              type: "action.completed",
+              payload: {
+                actionId: "approveQuote",
+                runId: "act-1",
+                subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_999" },
+                finishedAt: "2026-02-18T10:00:13.000Z",
+              },
+            },
+          ],
+        })
+
+        ws.send(
+          JSON.stringify({
+            type: "subscribe",
+            topic: "actions",
+            types: ["action.completed"],
+            actionId: "approveQuote",
+            runId: "act-1",
+            objectTypeId: "Quote",
+            primaryId: "q_123",
+          })
+        )
+
+        expect(await nextWsMessage(ws)).toMatchObject({ type: "subscribed" })
+        expect(await nextWsMessage(ws)).toMatchObject({
+          type: "event",
+          event: {
+            cursor: matching?.cursor,
+            payload: { actionId: "approveQuote", runId: "act-1" },
+          },
         })
         await expectNoWsMessage(ws)
       } finally {


### PR DESCRIPTION
## Why

Custom apps should be able to wire an action to a button without reimplementing the same enqueue -> listen for events -> fetch run -> invalidate queries loop every time.

Before this change, the generated action mutation only represented enqueue success:

```tsx
const mutation = useMutation(requestActionMutation())
```

That made `isSuccess` mean "the run was queued", not "the action succeeded". App authors then had to subscribe to action events, detect terminal status, refetch the run, and decide which object queries to invalidate.

## What changed

This PR adds first-class terminal action waiting in the client:

```tsx
const markPaid = useActionRunMutation<{ paymentMethod: "card" | "ach" }>({
  actionId: "markPaid",
  subject: { objectType: Invoice, primaryId: invoiceId },
  invalidateOnCommit: true,
})

markPaid.mutate({ paymentMethod: "card" })
```

With this hook:

- `isPending` lasts until the action run reaches a terminal state.
- `isSuccess` means terminal `succeeded`.
- `isError` covers request failures, terminal `failed` / `cancelled`, and timeouts.
- `invalidateOnCommit: true` refreshes action-run caches and object caches affected by the commit diff.

The React-free path is available too:

```ts
const run = await requestActionAndWait({
  path: { actionId: "approveQuote" },
  body: {
    subject: { kind: "object", objectTypeId: "Quote", primaryId: quoteId },
    params: { note: "Approved." },
  },
})

await waitForActionRun({ runId: run.id })
```

## Event and invalidation DX

Action events can now be scoped naturally:

```tsx
events.actions().run(runId).terminal()
events.actions().action("approveQuote").completed()
events.actions().subject(Quote).object(quoteId).failed()
```

The server also accepts the new action `runId` / `actionId` / subject scope filters on `/ws/events`, while the client predicate still enforces the full filter locally.

Typed object-query cache helpers are exported so apps can invalidate exact query builders when they do handle events manually:

```tsx
await invalidateObjectQuery(queryClient, openInvoices.limit(50))

queryClient.invalidateQueries({
  queryKey: objectQueryKeys.count(openInvoices),
  exact: true,
})
```

## Example updates

The Roku example now uses the terminal action hook while keeping high-frequency controls non-blocking:

```tsx
const { mutateAsync: sendAction } = useActionRunMutation<{ button: RokuKey }>({
  actionId: "pressButton",
  subject: { objectType: Television, primaryId: objectKey },
  invalidateOnCommit: true,
})
```

It tracks pending counts per button, so repeated volume presses can continue while a side loader and per-button spinner show in-flight work. Power remains guarded while a power action is pending to avoid conflicting toggles.

The Roku `pressButton` action also mirrors known power-state telemetry immediately after successful writeback, so the UI does not have to wait for the next device poll to show power on/off.

The Panasonic example now uses `useActionRunMutation` and dynamic request-shaped variables with ontology object subjects:

```tsx
sendAction({
  path: { actionId },
  body: {
    subject: { objectType: PanasonicAcUnit, primaryId: objectKey },
    params,
  },
})
```

## Documentation

Added focused docs for app authors:

- `docs/apps/actions.md` for action buttons, loading/error states, high-frequency controls, and invalidation.
- `docs/client/events.md` for event builders, `useEvents`, telemetry hooks, and event-driven invalidation.

Updated existing client, apps, actions, events, and typed-query docs to point at those canonical pages instead of duplicating full examples.

## Validation

```bash
bun --filter @sixb/client typecheck
bun --filter @sixb/core typecheck
bun --filter @sixb/server typecheck
bun --filter @sixb/client build
bun test packages/client/tests/actions.test.ts packages/client/tests/events-builder.test.ts packages/client/tests/query-hooks.test.ts packages/server/tests/wsSubscribe.test.ts
bun --filter @sixb/example-roku-tv typecheck && bun --filter @sixb/example-roku-tv build
bun --filter @sixb/example-panasonic-ac typecheck && bun --filter @sixb/example-panasonic-ac build
git diff --check
```