### PR TITLE
atlas: scope realtime event subscriptions

### DIFF
--- a/examples/acme-corp/scripts/sync-erp.ts
+++ b/examples/acme-corp/scripts/sync-erp.ts
@@ -71,6 +71,9 @@ async function main() {
   console.log(`[AcmeCorp] Root run: ${result.runId}`)
   console.log(`[AcmeCorp] Root job: ${result.jobId}`)
   console.log("[AcmeCorp] Downstream syncs will be requested by syncFinished triggers.")
+  console.log(
+    "[AcmeCorp] To slow each sync read for Atlas realtime checks, set ACME_SYNC_DELAY_MS."
+  )
 }
 
 main().catch((error) => {

--- a/examples/acme-corp/syncs/erp.ts
+++ b/examples/acme-corp/syncs/erp.ts
@@ -13,56 +13,75 @@ import {
 } from "../datasets/erp"
 import { hourlyErpSync } from "../schedules/erp"
 
+const demoSyncDelayMs = parseDemoSyncDelayMs(process.env.ACME_SYNC_DELAY_MS)
+
+async function readWithDemoDelay<T>(label: string, read: () => Promise<T>): Promise<T> {
+  if (demoSyncDelayMs > 0) {
+    console.log(`[AcmeCorp] Delaying ${label} sync read by ${demoSyncDelayMs}ms`)
+    await new Promise((resolve) => setTimeout(resolve, demoSyncDelayMs))
+  }
+
+  return read()
+}
+
+function parseDemoSyncDelayMs(value: string | undefined): number {
+  if (!value) return 0
+
+  const delayMs = Number.parseInt(value, 10)
+  if (!Number.isFinite(delayMs) || delayMs <= 0) return 0
+  return Math.min(delayMs, 30_000)
+}
+
 export const syncErpDepartments = defineSync("sync-erp-departments")
   .when(hourlyErpSync)
   .from(acmeErpConnector)
-  .read((client) => client.listDepartments())
+  .read((client) => readWithDemoDelay("departments", () => client.listDepartments()))
   .intoDataset(erpDepartmentsDataset)
 
 export const syncErpEmployees = defineSync("sync-erp-employees")
   .when(syncFinished(syncErpDepartments.id))
   .from(acmeErpConnector)
-  .read((client) => client.listEmployees())
+  .read((client) => readWithDemoDelay("employees", () => client.listEmployees()))
   .intoDataset(erpEmployeesDataset)
 
 export const syncErpCustomers = defineSync("sync-erp-customers")
   .when(syncFinished(syncErpEmployees.id))
   .from(acmeErpConnector)
-  .read((client) => client.listCustomers())
+  .read((client) => readWithDemoDelay("customers", () => client.listCustomers()))
   .intoDataset(erpCustomersDataset)
 
 export const syncErpProjects = defineSync("sync-erp-projects")
   .when(syncFinished(syncErpCustomers.id))
   .from(acmeErpConnector)
-  .read((client) => client.listProjects())
+  .read((client) => readWithDemoDelay("projects", () => client.listProjects()))
   .intoDataset(erpProjectsDataset)
 
 export const syncErpProjectMembers = defineSync("sync-erp-project-members")
   .when(syncFinished(syncErpProjects.id))
   .from(acmeErpConnector)
-  .read((client) => client.listProjectMembers())
+  .read((client) => readWithDemoDelay("project members", () => client.listProjectMembers()))
   .intoDataset(erpProjectMembersDataset)
 
 export const syncErpDocuments = defineSync("sync-erp-documents")
   .when(syncFinished(syncErpProjectMembers.id))
   .from(acmeErpConnector)
-  .read((client) => client.listDocuments())
+  .read((client) => readWithDemoDelay("documents", () => client.listDocuments()))
   .intoDataset(erpDocumentsDataset)
 
 export const syncErpInvoices = defineSync("sync-erp-invoices")
   .when(syncFinished(syncErpDocuments.id))
   .from(acmeErpConnector)
-  .read((client) => client.listInvoices())
+  .read((client) => readWithDemoDelay("invoices", () => client.listInvoices()))
   .intoDataset(erpInvoicesDataset)
 
 export const syncErpTasks = defineSync("sync-erp-tasks")
   .when(syncFinished(syncErpInvoices.id))
   .from(acmeErpConnector)
-  .read((client) => client.listTasks())
+  .read((client) => readWithDemoDelay("tasks", () => client.listTasks()))
   .intoDataset(erpTasksDataset)
 
 export const syncErpProjectProgress = defineSync("sync-erp-project-progress")
   .when(syncFinished(syncErpTasks.id))
   .from(acmeErpConnector)
-  .read((client) => client.listProjectProgress())
+  .read((client) => readWithDemoDelay("project progress", () => client.listProjectProgress()))
   .intoDataset(erpProjectProgressDataset)

--- a/packages/atlas/src/components/ActionButton.tsx
+++ b/packages/atlas/src/components/ActionButton.tsx
@@ -1,5 +1,6 @@
 import type { ActionParam, ObjectAction } from "@sixb/client"
-import { executeAction as executeActionRequest } from "@sixb/client"
+import { decodeObjectId } from "@sixb/client"
+import { useActionRunMutation } from "@sixb/client/hooks"
 import {
   Badge,
   Button,
@@ -39,6 +40,7 @@ interface ActionParamsDialogProps {
   action: ObjectAction
   actionId: string
   onSubmit: (params: ActionParams) => void
+  submitting?: boolean
 }
 
 function ActionParamsDialog({
@@ -47,6 +49,7 @@ function ActionParamsDialog({
   action,
   actionId,
   onSubmit,
+  submitting = false,
 }: ActionParamsDialogProps) {
   const [values, setValues] = useState<Record<string, string>>({})
 
@@ -137,10 +140,18 @@ function ActionParamsDialog({
           ))}
 
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
               Cancel
             </Button>
-            <Button type="submit">Run</Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              Run
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>
@@ -157,48 +168,58 @@ export function ActionButton({
   requireConfirm,
 }: ActionButtonProps) {
   const navigate = useNavigate()
-  const [isExecuting, setIsExecuting] = useState(false)
   const [showParams, setShowParams] = useState(false)
   const [result, setResult] = useState<{ success: boolean; message?: string } | null>(null)
-
-  const hasRequiredParams = Object.values(action.params ?? {}).some((p: ActionParam) => p.required)
-  const shouldConfirm = requireConfirm ?? tone === "danger"
-
-  const runAction = async (params?: ActionParams) => {
-    if (shouldConfirm) {
-      const confirmed = window.confirm(`Run "${actionId.replace(/-/g, " ")}" on ${objectId}?`)
-      if (!confirmed) return
-    }
-
-    setIsExecuting(true)
-    setResult(null)
-
-    try {
-      const response = await executeActionRequest({
-        path: { objectId, actionId },
-        body: { params },
-      })
-
-      if (response.data?.success && response.data.runId) {
-        setResult({ success: true })
-        navigate(`/actions/runs/${response.data.runId}`)
-      } else if (response.data?.success) {
-        setResult({ success: true })
-        setTimeout(() => setResult(null), 2000)
-      } else {
-        setResult({ success: false, message: response.data?.error ?? "Action failed" })
-        setTimeout(() => setResult(null), 3000)
-      }
-    } catch (error) {
+  const requestAction = useActionRunMutation({
+    invalidateOnCommit: true,
+    onSuccess: (run) => {
+      setResult({ success: true })
+      setShowParams(false)
+      navigate(`/actions/runs/${run.id}`)
+    },
+    onError: (error) => {
+      setShowParams(false)
       setResult({
         success: false,
         message: error instanceof Error ? error.message : "Action failed",
       })
       setTimeout(() => setResult(null), 3000)
-    } finally {
-      setIsExecuting(false)
-      setShowParams(false)
+    },
+  })
+
+  const hasRequiredParams = Object.values(action.params ?? {}).some((p: ActionParam) => p.required)
+  const shouldConfirm = requireConfirm ?? tone === "danger"
+
+  const runAction = (params?: ActionParams) => {
+    if (shouldConfirm) {
+      const confirmed = window.confirm(`Run "${actionId.replace(/-/g, " ")}" on ${objectId}?`)
+      if (!confirmed) return
     }
+
+    requestAction.reset()
+    setResult(null)
+
+    const parsed = decodeObjectId(objectId)
+    if (!parsed) {
+      setResult({
+        success: false,
+        message: `Invalid object id: ${objectId}`,
+      })
+      setTimeout(() => setResult(null), 3000)
+      return
+    }
+
+    requestAction.mutate({
+      path: { actionId },
+      body: {
+        subject: {
+          kind: "object",
+          objectTypeId: parsed.objectTypeId,
+          primaryId: parsed.primaryId,
+        },
+        ...(params && Object.keys(params).length > 0 ? { params } : {}),
+      },
+    })
   }
 
   const handleClick = () => {
@@ -218,6 +239,7 @@ export function ActionButton({
         : tone === "primary"
           ? "default"
           : "outline"
+  const isExecuting = requestAction.isPending
 
   return (
     <>
@@ -239,6 +261,7 @@ export function ActionButton({
         action={action}
         actionId={actionId}
         onSubmit={runAction}
+        submitting={isExecuting}
       />
     </>
   )

--- a/packages/atlas/src/features/actions/hooks/useActionLiveUpdates.ts
+++ b/packages/atlas/src/features/actions/hooks/useActionLiveUpdates.ts
@@ -1,0 +1,39 @@
+import { events, useInvalidateOnEvent } from "@sixb/client/hooks"
+import {
+  type InvalidationKey,
+  objectDetailKey,
+  queryKey,
+  queryKeyWithPath,
+} from "../../../lib/liveUpdateKeys"
+
+const debounceMs = 100
+
+export function useActionLiveUpdates(
+  options: { enabled?: boolean; runId?: string; actionId?: string } = {}
+) {
+  const enabled = options.enabled ?? true
+  const builder = options.runId
+    ? events.actions().run(options.runId)
+    : options.actionId
+      ? events.actions().action(options.actionId)
+      : events.actions()
+
+  useInvalidateOnEvent(
+    builder,
+    (event) => {
+      const keys: InvalidationKey[] = [
+        queryKey("listActionRuns"),
+        queryKeyWithPath("getActionRun", { runId: event.payload.runId }),
+      ]
+
+      if (event.type !== "action.requested" && event.payload.subject.kind === "object") {
+        keys.push(
+          objectDetailKey(event.payload.subject.objectTypeId, event.payload.subject.primaryId)
+        )
+      }
+
+      return keys
+    },
+    { enabled, debounceMs }
+  )
+}

--- a/packages/atlas/src/features/datasets/hooks/useDatasetLiveUpdates.ts
+++ b/packages/atlas/src/features/datasets/hooks/useDatasetLiveUpdates.ts
@@ -1,0 +1,15 @@
+import { events, useInvalidateOnEvent } from "@sixb/client/hooks"
+import { datasetChangedKeys } from "../../../lib/liveUpdateKeys"
+
+const debounceMs = 100
+
+export function useDatasetLiveUpdates(options: { enabled?: boolean; datasetId?: string } = {}) {
+  useInvalidateOnEvent(
+    events.datasets(),
+    (event) => {
+      if (options.datasetId && event.payload.datasetId !== options.datasetId) return []
+      return datasetChangedKeys(event.payload.datasetId)
+    },
+    { enabled: options.enabled ?? true, debounceMs }
+  )
+}

--- a/packages/atlas/src/features/objects/hooks/useObjectLiveUpdates.ts
+++ b/packages/atlas/src/features/objects/hooks/useObjectLiveUpdates.ts
@@ -1,0 +1,53 @@
+import { decodeObjectId } from "@sixb/client"
+import { events, useInvalidateOnEvent } from "@sixb/client/hooks"
+import {
+  objectChangedKeys,
+  objectDetailKey,
+  relationshipKey,
+  sameObject,
+} from "../../../lib/liveUpdateKeys"
+
+const debounceMs = 100
+
+export function useObjectLiveUpdates(
+  options: { enabled?: boolean; objectId?: string | null } = {}
+) {
+  const subject = options.objectId ? decodeObjectId(options.objectId) : null
+  const enabled = (options.enabled ?? true) && (options.objectId ? subject !== null : true)
+
+  useInvalidateOnEvent(
+    events.objects(),
+    (event) => {
+      const changed = {
+        objectTypeId: event.payload.objectTypeId,
+        primaryId: event.payload.primaryId,
+      }
+      if (subject && !sameObject(changed, subject)) return []
+      return objectChangedKeys(event.payload.objectTypeId, event.payload.primaryId)
+    },
+    { enabled, debounceMs }
+  )
+
+  useInvalidateOnEvent(
+    events.links(),
+    (event) => {
+      const source = {
+        objectTypeId: event.payload.sourceTypeId,
+        primaryId: event.payload.sourceId,
+      }
+      const target = {
+        objectTypeId: event.payload.targetTypeId,
+        primaryId: event.payload.targetId,
+      }
+      if (subject && !sameObject(source, subject) && !sameObject(target, subject)) return []
+
+      return [
+        objectDetailKey(event.payload.sourceTypeId, event.payload.sourceId),
+        objectDetailKey(event.payload.targetTypeId, event.payload.targetId),
+        relationshipKey(event.payload.sourceTypeId, event.payload.sourceId),
+        relationshipKey(event.payload.targetTypeId, event.payload.targetId),
+      ]
+    },
+    { enabled, debounceMs }
+  )
+}

--- a/packages/atlas/src/features/objects/hooks/useObjectTelemetryUpdates.ts
+++ b/packages/atlas/src/features/objects/hooks/useObjectTelemetryUpdates.ts
@@ -1,0 +1,45 @@
+import type { TelemetryUpdate } from "@sixb/client"
+import { decodeObjectId, telemetryUpdateKey } from "@sixb/client"
+import { events, useLatestByObject } from "@sixb/client/hooks"
+import { useMemo } from "react"
+
+export function useProjectTelemetryUpdates(
+  projectName: string,
+  options: { enabled?: boolean } = {}
+): readonly TelemetryUpdate[] {
+  const { byObject } = useLatestByObject(events.telemetry(), {
+    enabled: Boolean(projectName) && (options.enabled ?? true),
+  })
+
+  return useMemo(
+    () =>
+      Object.values(byObject)
+        .flatMap((updatesByProperty) => Object.values(updatesByProperty))
+        .filter((update) => update.projectName === projectName),
+    [byObject, projectName]
+  )
+}
+
+export function useObjectTelemetryUpdates(
+  projectName: string,
+  objectId: string | undefined,
+  options: { enabled?: boolean } = {}
+): Record<string, TelemetryUpdate> {
+  const parsed = objectId ? decodeObjectId(objectId) : null
+  const builder = parsed ? events.telemetry().object(parsed.primaryId) : events.telemetry()
+  const { byObject } = useLatestByObject(builder, {
+    enabled: Boolean(projectName && parsed) && (options.enabled ?? true),
+  })
+
+  return useMemo(() => {
+    const flattened: Record<string, TelemetryUpdate> = {}
+    for (const updatesByProperty of Object.values(byObject)) {
+      for (const update of Object.values(updatesByProperty)) {
+        if (update.projectName !== projectName) continue
+        flattened[telemetryUpdateKey(update.projectName, update.objectId, update.propertyId)] =
+          update
+      }
+    }
+    return flattened
+  }, [byObject, projectName])
+}

--- a/packages/atlas/src/features/pipelines/hooks/usePipelineLiveUpdates.ts
+++ b/packages/atlas/src/features/pipelines/hooks/usePipelineLiveUpdates.ts
@@ -1,0 +1,36 @@
+import { events, useInvalidateOnEvent } from "@sixb/client/hooks"
+import {
+  datasetChangedKeys,
+  type InvalidationKey,
+  queryKey,
+  queryKeyWithPath,
+} from "../../../lib/liveUpdateKeys"
+
+const debounceMs = 100
+
+export function usePipelineLiveUpdates(
+  options: { enabled?: boolean; pipelineId?: string; runId?: string } = {}
+) {
+  const builder = options.runId ? events.pipelines().run(options.runId) : events.pipelines()
+
+  useInvalidateOnEvent(
+    builder,
+    (event) => {
+      if (options.pipelineId && event.payload.pipelineId !== options.pipelineId) return []
+
+      const keys: InvalidationKey[] = [
+        queryKey("listPipelines"),
+        queryKey("listPipelineRuns"),
+        queryKeyWithPath("getPipeline", { pipelineId: event.payload.pipelineId }),
+        queryKeyWithPath("getPipelineRun", { runId: event.payload.runId }),
+      ]
+
+      if ("datasetId" in event.payload && event.payload.datasetId) {
+        keys.push(...datasetChangedKeys(event.payload.datasetId))
+      }
+
+      return keys
+    },
+    { enabled: options.enabled ?? true, debounceMs }
+  )
+}

--- a/packages/atlas/src/features/rules/hooks/useRuleLiveUpdates.ts
+++ b/packages/atlas/src/features/rules/hooks/useRuleLiveUpdates.ts
@@ -1,0 +1,33 @@
+import { events, useInvalidateOnEvent } from "@sixb/client/hooks"
+import {
+  objectDetailKey,
+  queryKey,
+  queryKeyWithPath,
+  sameObject,
+} from "../../../lib/liveUpdateKeys"
+
+const debounceMs = 100
+
+export function useRuleLiveUpdates(
+  options: {
+    enabled?: boolean
+    ruleId?: string
+    subject?: { readonly objectTypeId: string; readonly primaryId: string }
+  } = {}
+) {
+  useInvalidateOnEvent(
+    events.rules(),
+    (event) => {
+      if (options.ruleId && event.payload.ruleId !== options.ruleId) return []
+      if (options.subject && !sameObject(event.payload.subject, options.subject)) return []
+
+      return [
+        queryKey("listRules"),
+        queryKey("listRuleStates"),
+        queryKeyWithPath("getRule", { ruleId: event.payload.ruleId }),
+        objectDetailKey(event.payload.subject.objectTypeId, event.payload.subject.primaryId),
+      ]
+    },
+    { enabled: options.enabled ?? true, debounceMs }
+  )
+}

--- a/packages/atlas/src/features/syncs/hooks/useSyncLiveUpdates.ts
+++ b/packages/atlas/src/features/syncs/hooks/useSyncLiveUpdates.ts
@@ -1,0 +1,31 @@
+import { events, useInvalidateOnEvent } from "@sixb/client/hooks"
+import {
+  datasetChangedKeys,
+  type InvalidationKey,
+  queryKey,
+  queryKeyWithPath,
+} from "../../../lib/liveUpdateKeys"
+
+const debounceMs = 100
+
+export function useSyncLiveUpdates(options: { enabled?: boolean; syncId?: string } = {}) {
+  useInvalidateOnEvent(
+    events.syncs(),
+    (event) => {
+      if (options.syncId && event.payload.syncId !== options.syncId) return []
+
+      const keys: InvalidationKey[] = [
+        queryKey("listSyncs"),
+        queryKey("listSyncRuns"),
+        queryKeyWithPath("getSync", { syncId: event.payload.syncId }),
+      ]
+
+      if ("datasetId" in event.payload && event.payload.datasetId) {
+        keys.push(...datasetChangedKeys(event.payload.datasetId))
+      }
+
+      return keys
+    },
+    { enabled: options.enabled ?? true, debounceMs }
+  )
+}

--- a/packages/atlas/src/features/workflows/components/WorkflowLiveUpdatesBoundary.tsx
+++ b/packages/atlas/src/features/workflows/components/WorkflowLiveUpdatesBoundary.tsx
@@ -1,8 +1,0 @@
-import { Outlet } from "react-router-dom"
-import { useWorkflowLiveUpdates } from "../hooks/useWorkflowLiveUpdates"
-
-export function WorkflowLiveUpdatesBoundary() {
-  useWorkflowLiveUpdates()
-
-  return <Outlet />
-}

--- a/packages/atlas/src/features/workflows/components/nodes/WorkflowInterventionPanel.tsx
+++ b/packages/atlas/src/features/workflows/components/nodes/WorkflowInterventionPanel.tsx
@@ -42,7 +42,6 @@ export function WorkflowInterventionPanel({ node }: { node: WorkflowRunNode }) {
   }
   const interventionsQuery = useQuery({
     ...listWorkflowInterventionsOptions(interventionQueryOptions),
-    refetchInterval: 5000,
   })
   const workflowQuery = useQuery(getWorkflowOptions({ path: { workflowId: node.workflowId } }))
   const intervention = interventionsQuery.data?.interventions[0]

--- a/packages/atlas/src/features/workflows/components/runs/WorkflowRunHistoryTab.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/WorkflowRunHistoryTab.tsx
@@ -40,10 +40,6 @@ export function WorkflowRunHistoryTab() {
         },
       }
     },
-    refetchInterval:
-      selectedStatus === "all" || selectedStatus === "queued" || selectedStatus === "running"
-        ? 5000
-        : false,
   })
   const runs = useMemo(
     () => runsQuery.data?.pages.flatMap((page) => page.runs) ?? [],

--- a/packages/atlas/src/features/workflows/hooks/useWorkflowLiveUpdates.ts
+++ b/packages/atlas/src/features/workflows/hooks/useWorkflowLiveUpdates.ts
@@ -1,23 +1,28 @@
-import {
-  events,
-  getWorkflowQueryKey,
-  getWorkflowRunQueryKey,
-  listWorkflowRunsInfiniteQueryKey,
-  listWorkflowRunsQueryKey,
-  listWorkflowsQueryKey,
-  useInvalidateOnEvent,
-} from "@sixb/client/hooks"
+import { events, useInvalidateOnEvent } from "@sixb/client/hooks"
+import { type InvalidationKey, queryKey, queryKeyWithPath } from "../../../lib/liveUpdateKeys"
 
-export function useWorkflowLiveUpdates() {
+const debounceMs = 100
+
+export function useWorkflowLiveUpdates(
+  options: { enabled?: boolean; workflowId?: string; runId?: string } = {}
+) {
+  const builder = options.runId ? events.workflows().run(options.runId) : events.workflows()
+
   useInvalidateOnEvent(
-    events.workflows(),
-    (event) => [
-      listWorkflowsQueryKey(),
-      listWorkflowRunsQueryKey(),
-      listWorkflowRunsInfiniteQueryKey(),
-      getWorkflowQueryKey({ path: { workflowId: event.payload.workflowId } }),
-      getWorkflowRunQueryKey({ path: { runId: event.payload.runId } }),
-    ],
-    { debounceMs: 100 }
+    builder,
+    (event) => {
+      if (options.workflowId && event.payload.workflowId !== options.workflowId) return []
+
+      const keys: InvalidationKey[] = [
+        queryKey("listWorkflows"),
+        queryKey("listWorkflowRuns"),
+        queryKey("listWorkflowInterventions"),
+        queryKeyWithPath("getWorkflow", { workflowId: event.payload.workflowId }),
+        queryKeyWithPath("getWorkflowRun", { runId: event.payload.runId }),
+      ]
+
+      return keys
+    },
+    { enabled: options.enabled ?? true, debounceMs }
   )
 }

--- a/packages/atlas/src/lib/liveUpdateKeys.ts
+++ b/packages/atlas/src/lib/liveUpdateKeys.ts
@@ -1,0 +1,58 @@
+import { encodeObjectId } from "@sixb/client"
+
+export type InvalidationKey = readonly unknown[]
+
+export function queryKey(id: string): InvalidationKey {
+  return [{ _id: id }] as const
+}
+
+export function queryKeyWithPath(id: string, path: Record<string, unknown>): InvalidationKey {
+  return [{ _id: id, path }] as const
+}
+
+export function queryKeyWithQuery(id: string, query: Record<string, unknown>): InvalidationKey {
+  return [{ _id: id, query }] as const
+}
+
+export function objectIdKey(objectTypeId: string, primaryId: string): string {
+  return encodeObjectId(objectTypeId, primaryId)
+}
+
+export function objectCollectionKeys(): InvalidationKey[] {
+  return [
+    queryKey("listObjects"),
+    queryKey("listObjectsPage"),
+    queryKey("objectCount"),
+    ["atlas", "objects"] as const,
+  ]
+}
+
+export function objectDetailKey(objectTypeId: string, primaryId: string): InvalidationKey {
+  return queryKeyWithPath("getObject", { objectId: objectIdKey(objectTypeId, primaryId) })
+}
+
+export function relationshipKey(objectTypeId: string, primaryId: string): InvalidationKey {
+  return queryKeyWithQuery("listRelationships", {
+    objectId: objectIdKey(objectTypeId, primaryId),
+  })
+}
+
+export function objectChangedKeys(objectTypeId: string, primaryId: string): InvalidationKey[] {
+  return [objectDetailKey(objectTypeId, primaryId), ...objectCollectionKeys()]
+}
+
+export function datasetChangedKeys(datasetId: string): InvalidationKey[] {
+  return [
+    queryKey("listDatasets"),
+    queryKeyWithPath("getDataset", { datasetId }),
+    queryKeyWithPath("listDatasetVersions", { datasetId }),
+    queryKeyWithPath("listDatasetRows", { datasetId }),
+  ]
+}
+
+export function sameObject(
+  left: { readonly objectTypeId: string; readonly primaryId: string },
+  right: { readonly objectTypeId: string; readonly primaryId: string }
+): boolean {
+  return left.objectTypeId === right.objectTypeId && left.primaryId === right.primaryId
+}

--- a/packages/atlas/src/pages/ActionRunDetailPage.tsx
+++ b/packages/atlas/src/pages/ActionRunDetailPage.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@sixb/ui/components"
 import { useQuery } from "@tanstack/react-query"
 import { Navigate, useParams } from "react-router-dom"
 import { DataPanel, ErrorPage, LoadingPage, PageFrame } from "../components/common"
+import { useActionLiveUpdates } from "../features/actions/hooks/useActionLiveUpdates"
 import {
   ActionRunDiffSummary,
   ActionRunMetaGrid,
@@ -15,10 +16,12 @@ export function ActionRunDetailPage() {
   const runQuery = useQuery({
     ...getActionRunOptions({ path: { runId } }),
     enabled: runId.length > 0,
-    refetchInterval: (query) => {
-      const status = query.state.data?.status
-      return status === "queued" || status === "running" ? 2000 : false
-    },
+  })
+  const status = runQuery.data?.status
+  useActionLiveUpdates({
+    runId,
+    enabled:
+      runId.length > 0 && (status === undefined || status === "queued" || status === "running"),
   })
 
   if (!runId) {

--- a/packages/atlas/src/pages/ActionsPage.tsx
+++ b/packages/atlas/src/pages/ActionsPage.tsx
@@ -4,13 +4,10 @@ import type {
   ListActionsResponse,
 } from "@sixb/client"
 import {
-  getActionRunQueryKey,
   listActionRunsOptions,
-  listActionRunsQueryKey,
   listActionsOptions,
-  listActionsQueryKey,
   listObjectsInfiniteOptions,
-  requestActionMutation,
+  useActionRunMutation,
 } from "@sixb/client/hooks"
 import {
   Alert,
@@ -50,11 +47,12 @@ import {
   Textarea,
 } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import { AlertCircle, ArrowRight, CheckCircle2, Loader2, Play, SquareActivity } from "lucide-react"
 import { type SyntheticEvent, useMemo, useState } from "react"
 import { Link, useNavigate, useSearchParams } from "react-router-dom"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
+import { useActionLiveUpdates } from "../features/actions/hooks/useActionLiveUpdates"
 import { formatDate, formatRelativeTime } from "../features/workflows/utils/workflows"
 import {
   type ActionRequestPayload,
@@ -93,6 +91,7 @@ const actionRunStatusClasses: Record<ActionRunStatus, string> = {
 export function ActionsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab: ActionsPageTab = searchParams.get("tab") === "runs" ? "runs" : "actions"
+  useActionLiveUpdates({ enabled: activeTab === "runs" })
 
   const handleTabChange = (value: string) => {
     const nextTab: ActionsPageTab = value === "runs" ? "runs" : "actions"
@@ -206,10 +205,6 @@ function PhaseBadge({ active, children }: { active: boolean; children: string })
 function ActionRunHistoryTab() {
   const runsQuery = useQuery({
     ...listActionRunsOptions({ query: { limit: "50", order: "desc" } }),
-    refetchInterval: (query) =>
-      query.state.data?.runs.some((run) => run.status === "queued" || run.status === "running")
-        ? 2000
-        : false,
   })
   const runs = runsQuery.data?.runs ?? []
 
@@ -297,23 +292,15 @@ function ActionRequestDialog({
   subject?: { kind: "object"; objectTypeId: string; primaryId: string }
 }) {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
   const [values, setValues] = useState<Record<string, string>>({})
   const [subjectPrimaryId, setSubjectPrimaryId] = useState(subject?.primaryId ?? "")
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
-  const requestAction = useMutation({
-    ...requestActionMutation(),
-    onSuccess: async (response) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: listActionsQueryKey() }),
-        queryClient.invalidateQueries({ queryKey: listActionRunsQueryKey() }),
-        queryClient.invalidateQueries({
-          queryKey: getActionRunQueryKey({ path: { runId: response.runId } }),
-        }),
-      ])
+  const requestAction = useActionRunMutation({
+    invalidateOnCommit: true,
+    onSuccess: (run) => {
       setOpen(false)
-      navigate(`/actions/runs/${response.runId}`)
+      navigate(`/actions/runs/${run.id}`)
     },
   })
 
@@ -438,7 +425,7 @@ function ActionRequestDialog({
             </Button>
             <Button type="submit" disabled={requestAction.isPending}>
               {requestAction.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              Request action
+              {requestAction.isPending ? "Running action..." : "Request action"}
             </Button>
           </DialogFooter>
         </form>

--- a/packages/atlas/src/pages/DatasetsPage.tsx
+++ b/packages/atlas/src/pages/DatasetsPage.tsx
@@ -52,6 +52,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { DatasetDetails } from "../features/datasets/DatasetDetails"
 import { type DatasetGridColumnMeta, DatasetTableGrid } from "../features/datasets/DatasetTableGrid"
+import { useDatasetLiveUpdates } from "../features/datasets/hooks/useDatasetLiveUpdates"
 import {
   consumerCount,
   datasetName,
@@ -180,6 +181,7 @@ function DatasetTableView({
 
 export function DatasetsPage() {
   const { data: datasets = [], isLoading, isError } = useQuery(listDatasetsOptions())
+  useDatasetLiveUpdates({ enabled: datasets.length > 0 })
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState("")
   const [viewStyle, setViewStyle] = useState<DatasetListViewStyle>(() =>
@@ -346,6 +348,7 @@ export function DatasetDetailPage() {
   const navigate = useNavigate()
   const decodedDatasetId = decodeURIComponent(datasetId)
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null)
+  useDatasetLiveUpdates({ datasetId: decodedDatasetId, enabled: decodedDatasetId.length > 0 })
   const [rowsOffset, setRowsOffset] = useState(0)
   const [quickFilter, setQuickFilter] = useState("")
   const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(() => new Set())

--- a/packages/atlas/src/pages/ObjectDetailPage.tsx
+++ b/packages/atlas/src/pages/ObjectDetailPage.tsx
@@ -36,6 +36,8 @@ import { TelemetryChart } from "../components/TelemetryChart"
 import { TelemetryValue } from "../components/TelemetryValue"
 import { TelemetryGrid } from "../components/telemetry"
 import { UsageBar } from "../components/UsageBar"
+import { useObjectLiveUpdates } from "../features/objects/hooks/useObjectLiveUpdates"
+import { useObjectTelemetryUpdates } from "../features/objects/hooks/useObjectTelemetryUpdates"
 import { formatValue } from "../lib/formatValue"
 import { humanizeIdentifier } from "../lib/labels"
 import { getHistoryBounds, isSampleInBounds } from "../lib/telemetryHistory"
@@ -43,7 +45,6 @@ import { formatRelativeTime } from "../lib/time"
 
 interface ObjectDetailPageProps {
   projectName: string
-  latestUpdates: Record<string, TelemetryUpdate>
   objectLookup: Record<string, ObjectSummary>
 }
 
@@ -232,11 +233,7 @@ function getUsagePercent(
   return null
 }
 
-export function ObjectDetailPage({
-  projectName,
-  latestUpdates,
-  objectLookup,
-}: ObjectDetailPageProps) {
+export function ObjectDetailPage({ projectName, objectLookup }: ObjectDetailPageProps) {
   const { objectId } = useParams<{ objectId: string }>()
   const navigate = useNavigate()
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null)
@@ -246,6 +243,10 @@ export function ObjectDetailPage({
     isoTimestamp(startOfLocalDay(new Date(Date.now() - 7 * 86_400_000)))
   )
   const [customTo, setCustomTo] = useState(() => isoTimestamp(endOfLocalDay(new Date())))
+  useObjectLiveUpdates({ objectId, enabled: Boolean(projectName && objectId) })
+  const latestUpdates = useObjectTelemetryUpdates(projectName, objectId, {
+    enabled: Boolean(objectId),
+  })
 
   useEffect(() => {
     if (!objectId) return

--- a/packages/atlas/src/pages/ObjectsWorkbench.tsx
+++ b/packages/atlas/src/pages/ObjectsWorkbench.tsx
@@ -27,6 +27,8 @@ import { type ReactNode, useDeferredValue, useEffect, useMemo, useState } from "
 import { LetterAvatar, LoadingState } from "../components/common"
 import { ObjectIcon } from "../components/ObjectIcon"
 import { ObjectQueryBar, ObjectsQueryPagination } from "../components/objects/ObjectQueryBar"
+import { useObjectLiveUpdates } from "../features/objects/hooks/useObjectLiveUpdates"
+import { useProjectTelemetryUpdates } from "../features/objects/hooks/useObjectTelemetryUpdates"
 import { formatCount } from "../lib/formatValue"
 import { formatLocation, humanizeIdentifier } from "../lib/labels"
 import {
@@ -69,7 +71,6 @@ interface ObjectsWorkbenchProps {
   classFilter?: string | null
   selectedObjectType?: AtlasObjectType | null
   selectedObjectId?: string | null
-  latestProjectUpdates: TelemetryUpdate[]
   onSortByChange: (sortBy: ObjectSortPreference) => void
   onClassFilterChange: (objectTypeId: string | null) => void
   onSelectObject: (id: string) => void
@@ -122,7 +123,6 @@ export function ObjectsWorkbench({
   classFilter,
   selectedObjectType,
   selectedObjectId,
-  latestProjectUpdates,
   onSortByChange,
   onClassFilterChange,
   onSelectObject,
@@ -134,6 +134,7 @@ export function ObjectsWorkbench({
   const [querySort, setQuerySort] = useState<QuerySort | null>(null)
   const [viewStyle, setViewStyle] = useState<ViewStyle>(getObjectViewStyle)
   const selectedTypeMode = classFilter != null
+  useObjectLiveUpdates({ enabled: Boolean(projectName) })
 
   useEffect(() => {
     if (classFilter === undefined) return
@@ -182,6 +183,9 @@ export function ObjectsWorkbench({
     querySort,
     textSearchEnabled,
   ])
+  const latestProjectUpdates = useProjectTelemetryUpdates(projectName, {
+    enabled: queryMode && viewStyle === "table",
+  })
 
   const facetQuery = useMemo(() => {
     if (!queryMode || !classFilter) return null

--- a/packages/atlas/src/pages/PipelinesPage.tsx
+++ b/packages/atlas/src/pages/PipelinesPage.tsx
@@ -66,6 +66,7 @@ import {
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { type DatasetGridColumnMeta, DatasetTableGrid } from "../features/datasets/DatasetTableGrid"
+import { usePipelineLiveUpdates } from "../features/pipelines/hooks/usePipelineLiveUpdates"
 import { formatBytes, isNumericColumnType } from "../lib/datasets"
 import { humanizeIdentifier } from "../lib/labels"
 import { formatRelativeTime } from "../lib/time"
@@ -276,6 +277,7 @@ function PipelineTableView({
 
 export function PipelinesPage() {
   const { data: pipelines = [], isLoading, isError } = useQuery(listPipelinesOptions())
+  usePipelineLiveUpdates({ enabled: pipelines.length > 0 })
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState("")
   const [viewStyle, setViewStyle] = useState<PipelineListViewStyle>(() =>
@@ -720,7 +722,6 @@ function RunsFloatingPanel({
       query: { pipelineId, limit: "20", order: "desc" },
     }),
     enabled: open,
-    refetchInterval: open ? 5000 : false,
   })
 
   if (!open) return null
@@ -954,6 +955,10 @@ export function PipelineDetailPage() {
   const decodedPipelineId = decodeURIComponent(pipelineId)
   const [runsOpen, setRunsOpen] = useState(false)
   const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(null)
+  usePipelineLiveUpdates({
+    pipelineId: decodedPipelineId,
+    enabled: decodedPipelineId.length > 0,
+  })
 
   const pipelineQuery = useQuery({
     ...getPipelineOptions({ path: { pipelineId: decodedPipelineId } }),
@@ -969,7 +974,6 @@ export function PipelineDetailPage() {
       {
         onSuccess: () => {
           setRunsOpen(true)
-          void pipelineQuery.refetch()
         },
       }
     )

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -1,6 +1,5 @@
-import type { ObjectSummary, TelemetryUpdate } from "@sixb/client"
+import type { ObjectSummary } from "@sixb/client"
 import {
-  events,
   getProjectInfoOptions,
   listActionsOptions,
   listAgentsOptions,
@@ -14,7 +13,6 @@ import {
   listSyncsOptions,
   listWorkflowsOptions,
   objectCountOptions,
-  useLatestByObject,
 } from "@sixb/client/hooks"
 import { Button, Card, EmptyState } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
@@ -35,7 +33,6 @@ import { SettingsInvitationsPage } from "../components/SettingsInvitationsPage"
 import { SettingsServiceAccountsPage } from "../components/SettingsServiceAccountsPage"
 import { SettingsSessionsPage } from "../components/SettingsSessionsPage"
 import { SettingsTokensPage } from "../components/SettingsTokensPage"
-import { WorkflowLiveUpdatesBoundary } from "../features/workflows/components/WorkflowLiveUpdatesBoundary"
 import {
   getObjectSortPreference,
   type ObjectSortPreference,
@@ -247,23 +244,6 @@ export function ProjectWorkspace() {
     enabled: !!projectInfo,
   })
 
-  const { byObject: latestByObject } = useLatestByObject(events.telemetry(), {
-    enabled: Boolean(resolvedProjectName),
-  })
-
-  // Flatten the per-object live telemetry into the `project:object:property`
-  // keyed store the workspace renders from, scoped to the current project.
-  const latestUpdates = useMemo(() => {
-    const flattened: Record<string, TelemetryUpdate> = {}
-    for (const updatesByProperty of Object.values(latestByObject)) {
-      for (const update of Object.values(updatesByProperty)) {
-        if (resolvedProjectName && update.projectName !== resolvedProjectName) continue
-        flattened[`${update.projectName}:${update.objectId}:${update.propertyId}`] = update
-      }
-    }
-    return flattened
-  }, [latestByObject, resolvedProjectName])
-
   const selectedObjectIdForSidebar = objectIdFromUrl
 
   useEffect(() => {
@@ -299,12 +279,6 @@ export function ProjectWorkspace() {
   useEffect(() => {
     return () => setSidebarData(null)
   }, [setSidebarData])
-
-  const latestProjectUpdates = useMemo(
-    () =>
-      Object.values(latestUpdates).filter((update) => update.projectName === resolvedProjectName),
-    [latestUpdates, resolvedProjectName]
-  )
 
   const objectLookup = useMemo(
     () =>
@@ -369,12 +343,10 @@ export function ProjectWorkspace() {
       <Route path="agents" element={<AgentsPage />} />
       <Route path="agents/new/:agentId" element={<AgentsPage />} />
       <Route path="agents/:threadId" element={<AgentsPage />} />
-      <Route element={<WorkflowLiveUpdatesBoundary />}>
-        <Route path="workflows" element={<WorkflowsPage />} />
-        <Route path="workflows/:workflowId" element={<WorkflowDetailPage />} />
-        <Route path="runs" element={<RunsTabRedirect />} />
-        <Route path="runs/:runId" element={<RunDetailPage />} />
-      </Route>
+      <Route path="workflows" element={<WorkflowsPage />} />
+      <Route path="workflows/:workflowId" element={<WorkflowDetailPage />} />
+      <Route path="runs" element={<RunsTabRedirect />} />
+      <Route path="runs/:runId" element={<RunDetailPage />} />
       <Route
         path="*"
         element={constrained(
@@ -394,7 +366,6 @@ export function ProjectWorkspace() {
                   classFilter={classFilter}
                   selectedObjectType={selectedObjectType}
                   selectedObjectId={selectedObjectIdForSidebar}
-                  latestProjectUpdates={latestProjectUpdates}
                   onSortByChange={handleObjectSortByChange}
                   onClassFilterChange={setClassFilter}
                   onSelectObject={(objectId) => navigate(toProjectPath(objectId))}
@@ -430,11 +401,7 @@ export function ProjectWorkspace() {
             <Route
               path=":objectId"
               element={
-                <ObjectDetailPage
-                  projectName={resolvedProjectName}
-                  latestUpdates={latestUpdates}
-                  objectLookup={objectLookup}
-                />
+                <ObjectDetailPage projectName={resolvedProjectName} objectLookup={objectLookup} />
               }
             />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/packages/atlas/src/pages/RulesPage.tsx
+++ b/packages/atlas/src/pages/RulesPage.tsx
@@ -27,6 +27,7 @@ import { useQuery } from "@tanstack/react-query"
 import { BellRing, ChevronLeft, ChevronRight, ListChecks, Loader2, Search } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { useRuleLiveUpdates } from "../features/rules/hooks/useRuleLiveUpdates"
 import { formatValue } from "../lib/formatValue"
 import { humanizeIdentifier } from "../lib/labels"
 import { formatRelativeTime } from "../lib/time"
@@ -535,6 +536,7 @@ function RulesContent({
 export function RulesPage() {
   const rulesQuery = useQuery(listRulesOptions())
   const statesQuery = useQuery(listRuleStatesOptions({ query: { order: "desc" } }))
+  useRuleLiveUpdates({ enabled: (rulesQuery.data?.length ?? 0) > 0 })
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState("")
   const [viewStyle, setViewStyle] = useState<RulesListViewStyle>(() =>
@@ -645,6 +647,7 @@ export function RuleDetailPage() {
   const { ruleId = "" } = useParams()
   const navigate = useNavigate()
   const decodedRuleId = decodeURIComponent(ruleId)
+  useRuleLiveUpdates({ ruleId: decodedRuleId, enabled: decodedRuleId.length > 0 })
 
   const ruleQuery = useQuery({
     ...getRuleOptions({
@@ -658,7 +661,6 @@ export function RuleDetailPage() {
       query: { ruleId: decodedRuleId, order: "desc" },
     }),
     enabled: decodedRuleId.length > 0,
-    refetchInterval: 5000,
   })
 
   const rule = ruleQuery.data

--- a/packages/atlas/src/pages/RunDetailPage.tsx
+++ b/packages/atlas/src/pages/RunDetailPage.tsx
@@ -10,11 +10,11 @@ import { StructuredValue } from "../components/StructuredValue"
 import { RunNodeRow } from "../features/workflows/components/nodes/RunNodeRow"
 import { RunProgress } from "../features/workflows/components/runs/RunProgress"
 import { StatusBadge } from "../features/workflows/components/runs/StatusBadge"
+import { useWorkflowLiveUpdates } from "../features/workflows/hooks/useWorkflowLiveUpdates"
 import {
   formatDate,
   formatRunDuration,
   formatRunStartedDate,
-  isActiveRunStatus,
   runTimeLabel,
   type WorkflowRunDetail,
 } from "../features/workflows/utils/workflows"
@@ -24,10 +24,16 @@ export function RunDetailPage() {
   const runQuery = useQuery({
     ...getWorkflowRunOptions({ path: { runId } }),
     enabled: runId.length > 0,
-    refetchInterval: (query) => {
-      const status = query.state.data?.run.status
-      return status && isActiveRunStatus(status) ? 5000 : false
-    },
+  })
+  const runStatus = runQuery.data?.run.status
+  useWorkflowLiveUpdates({
+    runId,
+    enabled:
+      runId.length > 0 &&
+      (runStatus === undefined ||
+        runStatus === "queued" ||
+        runStatus === "running" ||
+        runStatus === "waiting"),
   })
   const workflowId = runQuery.data?.run.workflowId
   const workflowQuery = useQuery({

--- a/packages/atlas/src/pages/SyncsPage.tsx
+++ b/packages/atlas/src/pages/SyncsPage.tsx
@@ -40,6 +40,7 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { useSyncLiveUpdates } from "../features/syncs/hooks/useSyncLiveUpdates"
 import { humanizeIdentifier } from "../lib/labels"
 import { formatRelativeTime } from "../lib/time"
 import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
@@ -550,6 +551,7 @@ function SyncRunList({ runs, queuedRun }: { runs: SyncRun[]; queuedRun: QueuedRu
 
 export function SyncsPage() {
   const { data: syncs = [], isLoading, isError } = useQuery(listSyncsOptions())
+  useSyncLiveUpdates({ enabled: syncs.length > 0 })
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState("")
   const [viewStyle, setViewStyle] = useState<SyncListViewStyle>(() =>
@@ -666,6 +668,7 @@ export function SyncDetailPage() {
   const navigate = useNavigate()
   const decodedSyncId = decodeURIComponent(syncId)
   const [queuedRun, setQueuedRun] = useState<QueuedRun | null>(null)
+  useSyncLiveUpdates({ syncId: decodedSyncId, enabled: decodedSyncId.length > 0 })
 
   const syncQuery = useQuery({
     ...getSyncOptions({
@@ -679,7 +682,6 @@ export function SyncDetailPage() {
       query: { syncId: decodedSyncId, limit: "12", order: "desc" },
     }),
     enabled: decodedSyncId.length > 0,
-    refetchInterval: queuedRun ? 1000 : 5000,
   })
 
   const requestRun = useMutation(requestSyncRunMutation())
@@ -710,8 +712,6 @@ export function SyncDetailPage() {
       {
         onSuccess: (result) => {
           setQueuedRun({ id: result.runId, queuedAt: result.queuedAt })
-          void syncQuery.refetch()
-          void runsQuery.refetch()
         },
       }
     )

--- a/packages/atlas/src/pages/WorkflowDetailPage.tsx
+++ b/packages/atlas/src/pages/WorkflowDetailPage.tsx
@@ -26,6 +26,7 @@ import { WorkflowNodeRow } from "../features/workflows/components/nodes/Workflow
 import { RequestWorkflowRunDialog } from "../features/workflows/components/RequestWorkflowRunDialog"
 import { RunHistoryTable } from "../features/workflows/components/runs/RunHistoryTable"
 import { StatusBadge } from "../features/workflows/components/runs/StatusBadge"
+import { useWorkflowLiveUpdates } from "../features/workflows/hooks/useWorkflowLiveUpdates"
 import {
   allWorkflowRunStatuses,
   isWorkflowRunStatus,
@@ -42,6 +43,7 @@ type WorkflowTab = "definition" | "runs"
 export function WorkflowDetailPage() {
   const { workflowId = "" } = useParams()
   const [searchParams, setSearchParams] = useSearchParams()
+  useWorkflowLiveUpdates({ workflowId, enabled: workflowId.length > 0 })
   const workflowQuery = useQuery({
     ...getWorkflowOptions({ path: { workflowId } }),
     enabled: workflowId.length > 0,
@@ -338,10 +340,6 @@ function WorkflowDetailRunsTab({ workflowId }: { workflowId: string }) {
         },
       }
     },
-    refetchInterval:
-      selectedStatus === "all" || selectedStatus === "queued" || selectedStatus === "running"
-        ? 5000
-        : false,
   })
 
   const runs = useMemo(

--- a/packages/atlas/src/pages/WorkflowsPage.tsx
+++ b/packages/atlas/src/pages/WorkflowsPage.tsx
@@ -6,12 +6,14 @@ import { useSearchParams } from "react-router-dom"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
 import { WorkflowRunHistoryTab } from "../features/workflows/components/runs/WorkflowRunHistoryTab"
 import { WorkflowCard } from "../features/workflows/components/workflows/WorkflowCard"
+import { useWorkflowLiveUpdates } from "../features/workflows/hooks/useWorkflowLiveUpdates"
 
 type WorkflowsPageTab = "workflows" | "runs"
 
 export function WorkflowsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab: WorkflowsPageTab = searchParams.get("tab") === "runs" ? "runs" : "workflows"
+  useWorkflowLiveUpdates()
 
   const handleTabChange = (value: string) => {
     const nextTab: WorkflowsPageTab = value === "runs" ? "runs" : "workflows"


### PR DESCRIPTION
## Why

Stacked on #139 (`actions-app-dx`). That PR gives custom apps a cleaner action mutation/event API. This PR applies that shape inside Atlas so operational pages update from scoped events instead of relying on broad app-wide subscriptions or polling.

The motivating issue was visible on syncs: after starting a sync, the list/detail views often needed a manual refresh before statuses looked current. The same pattern existed across several Atlas surfaces.

## What Changed

- Replaced the broad project-level live update wiring with feature-scoped hooks mounted only by pages that need them.
- Added shared Atlas query-key helpers so event handlers invalidate the exact React Query keys they own.
- Updated Atlas action buttons to use `useActionRunMutation` from #139, so action UI state tracks terminal action success/failure instead of just enqueue success.
- Removed polling intervals from event-covered sync/workflow run views.
- Added an opt-in Acme ERP demo delay (`ACME_SYNC_DELAY_MS`) so realtime status transitions are easier to verify manually.

## Shape

Each page subscribes only to the event family it needs, and detail pages can narrow further with an id:

```tsx
export function SyncsPage() {
  const { data: syncs = [] } = useQuery(listSyncsOptions())
  useSyncLiveUpdates({ enabled: syncs.length > 0 })
  // ...
}

export function SyncDetailPage() {
  const decodedSyncId = decodeURIComponent(syncId)
  useSyncLiveUpdates({ syncId: decodedSyncId, enabled: decodedSyncId.length > 0 })
  // ...
}
```

The hook maps incoming sync events to the smallest useful invalidation set:

```tsx
useInvalidateOnEvent(
  events.syncs(),
  (event) => {
    if (options.syncId && event.payload.syncId !== options.syncId) return []

    const keys = [
      queryKey("listSyncs"),
      queryKey("listSyncRuns"),
      queryKeyWithPath("getSync", { syncId: event.payload.syncId }),
    ]

    if ("datasetId" in event.payload && event.payload.datasetId) {
      keys.push(...datasetChangedKeys(event.payload.datasetId))
    }

    return keys
  },
  { enabled: options.enabled ?? true, debounceMs: 100 }
)
```

Actions now use the terminal action-run mutation from the parent PR:

```tsx
const requestAction = useActionRunMutation({
  invalidateOnCommit: true,
  onSuccess: (run) => {
    setResult({ success: true })
    navigate(`/actions/runs/${run.id}`)
  },
})
```

## Validation

- `bun --filter @sixb/atlas typecheck`
- `bun --filter @sixb/atlas build`
- `bun --filter @sixb/example-acme-corp typecheck`
- `bun run check packages/atlas/src`
- `bun run check examples/acme-corp/syncs/erp.ts examples/acme-corp/scripts/sync-erp.ts`