### PR TITLE
app: default error boundary, not-found, and structured API errors

### DIFF
--- a/examples/acme-corp/app/crash/page.tsx
+++ b/examples/acme-corp/app/crash/page.tsx
@@ -1,0 +1,6 @@
+// Dev-only fixture for the custom app's default error boundary. This route
+// throws on render, so visiting /crash lands directly on the built-in
+// "Something went wrong" fallback (no app/error.tsx override defined).
+export default function CrashTest(): never {
+  throw new Error("Forced render error from /crash")
+}

--- a/examples/acme-corp/app/not-found/page.tsx
+++ b/examples/acme-corp/app/not-found/page.tsx
@@ -1,0 +1,20 @@
+import { getObjectOptions } from "@sixb/client/hooks"
+import { encodeObjectId } from "@sixb/client/models"
+import { useQuery } from "@tanstack/react-query"
+
+// Dev-only fixture for the custom app's default not-found view. Querying a
+// guaranteed-missing object with `throwOnError` escalates the 404 (a
+// SixbApiError with status 404) to the error boundary, which renders the
+// built-in "Not found" view. Visit /not-found.
+//
+// (An unknown URL such as /does-not-exist hits the catch-all route and renders
+// the same view without any fixture.)
+export default function NotFoundTest() {
+  const objectId = encodeObjectId("Project", "does-not-exist:forced-404")
+  useQuery({
+    ...getObjectOptions({ path: { objectId } }),
+    throwOnError: true,
+    retry: false,
+  })
+  return null
+}

--- a/examples/acme-corp/tests/review-app.test.ts
+++ b/examples/acme-corp/tests/review-app.test.ts
@@ -16,6 +16,9 @@ describe("Acme review app", () => {
     const routes = await app.scanRoutes()
     expect(routes.map((route) => route.path).sort()).toEqual([
       "/",
+      // Dev fixtures for the custom app's default error boundary / not-found view.
+      "/crash",
+      "/not-found",
       "/projects",
       "/review/:interventionId",
     ])

--- a/packages/app/src/codegen.ts
+++ b/packages/app/src/codegen.ts
@@ -127,10 +127,11 @@ export async function generateAppEntry(
   // Generate main.tsx
   const mainContent = `import React from "react"
 import { createRoot } from "react-dom/client"
-import { BrowserRouter, Routes, Route, matchPath, useNavigate } from "react-router-dom"
+import { BrowserRouter, Routes, Route, matchPath, useNavigate, useLocation } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
   configureSixbBrowserClient,
+  isSixbApiError,
   readSixbBrowserRuntimeConfig,
   requireSixbBrowserAuthSession,
 } from "@sixb/client/browser"
@@ -247,18 +248,159 @@ function InternalLinkInterceptor() {
   return null
 }
 
+// Shared presentational fallback used by the not-found view and the error
+// boundary. Styled with @sixb/ui design tokens (var(--token)) so it adopts the
+// app's theme when those tokens are loaded, but every token has a hardcoded
+// fallback so it stays self-contained and readable when they are not. The
+// background/foreground pair is always set together so text stays legible
+// regardless of the surrounding app's background.
+function AppFallback({
+  title,
+  detail,
+  showReload = true,
+}: {
+  title: string
+  detail: string
+  showReload?: boolean
+}) {
+  return (
+    <div
+      role="alert"
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "1rem",
+        padding: "2rem",
+        textAlign: "center",
+        fontFamily:
+          "var(--font-sans, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif)",
+        background: "var(--background, #ffffff)",
+        color: "var(--foreground, #1f2933)",
+      }}
+    >
+      <h1 style={{ margin: 0, fontSize: "1.5rem", fontWeight: 600 }}>{title}</h1>
+      <p style={{ margin: 0, maxWidth: "32rem", color: "var(--muted-foreground, #52606d)" }}>
+        {detail}
+      </p>
+      <div style={{ display: "flex", gap: "0.75rem" }}>
+        <a
+          href="/"
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "var(--radius, 0.5rem)",
+            background: "var(--primary, #1f2933)",
+            color: "var(--primary-foreground, #ffffff)",
+            textDecoration: "none",
+          }}
+        >
+          Go home
+        </a>
+        {showReload ? (
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              padding: "0.5rem 1rem",
+              borderRadius: "var(--radius, 0.5rem)",
+              border: "1px solid var(--border, #cbd2d9)",
+              background: "transparent",
+              color: "inherit",
+              cursor: "pointer",
+            }}
+          >
+            Reload
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+// The not-found view. Rendered both for unmatched client routes (the catch-all
+// route below) and for an expected 404 surfaced through a query. Apps will be
+// able to override this via app/not-found.tsx.
+function NotFoundView() {
+  return (
+    <AppFallback
+      title="Not found"
+      detail="The page or resource you requested does not exist."
+      showReload={false}
+    />
+  )
+}
+
+// Last-resort safety net so an uncaught render throw (a 404 surfaced through a
+// suspense/throwOnError query, a bug, a failed import) shows a fallback instead
+// of a blank page and a console error. A missing object is an expected state,
+// so a 404 reuses the not-found view rather than the generic crash screen.
+// Apps will be able to override this via app/error.tsx.
+function AppErrorFallback({ error }: { error: unknown }) {
+  if (isSixbApiError(error) && error.status === 404) {
+    return <NotFoundView />
+  }
+  return (
+    <AppFallback
+      title="Something went wrong"
+      detail={error instanceof Error ? error.message : String(error)}
+    />
+  )
+}
+
+class AppErrorBoundary extends React.Component<
+  { resetKey: string; children: React.ReactNode },
+  { error: unknown }
+> {
+  state: { error: unknown } = { error: null }
+
+  static getDerivedStateFromError(error: unknown) {
+    return { error }
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("[SixbApp] Uncaught render error:", error)
+  }
+
+  // Clear the error when the route changes so navigating away (or an in-app
+  // link) recovers without a full reload.
+  componentDidUpdate(prevProps: { resetKey: string }) {
+    if (this.state.error !== null && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null })
+    }
+  }
+
+  render() {
+    if (this.state.error !== null) {
+      return <AppErrorFallback error={this.state.error} />
+    }
+    return this.props.children
+  }
+}
+
+function RoutedErrorBoundary({ children }: { children: React.ReactNode }) {
+  const location = useLocation()
+  return (
+    <AppErrorBoundary resetKey={location.pathname + location.search}>{children}</AppErrorBoundary>
+  )
+}
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <InternalLinkInterceptor />
-        ${layoutWrapperStart}
-          <Routes>
-            {routes.map((route) => (
-              <Route key={route.path} path={route.path} element={<route.component />} />
-            ))}
-          </Routes>
-        ${layoutWrapperEnd}
+        <RoutedErrorBoundary>
+          ${layoutWrapperStart}
+            <Routes>
+              {routes.map((route) => (
+                <Route key={route.path} path={route.path} element={<route.component />} />
+              ))}
+              <Route path="*" element={<NotFoundView />} />
+            </Routes>
+          ${layoutWrapperEnd}
+        </RoutedErrorBoundary>
       </BrowserRouter>
     </QueryClientProvider>
   )

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -233,6 +233,22 @@ describe("createCustomApp.dev", () => {
     expect(main).toContain("requireSixbBrowserAuthSession(runtimeConfig")
   })
 
+  test("wraps routes in an error boundary that special-cases 404s", async () => {
+    const { mainPath } = await generateAppEntry(tempRoot, join(tempRoot, ".sixb", "generated"))
+    const main = await readFile(mainPath, "utf-8")
+
+    // A safety net catches uncaught render throws instead of blanking the page.
+    expect(main).toContain("class AppErrorBoundary")
+    expect(main).toContain("getDerivedStateFromError")
+    expect(main).toContain("<RoutedErrorBoundary>")
+    // A 404 is an expected "not found" state, not the generic crash screen.
+    expect(main).toContain("isSixbApiError(error) && error.status === 404")
+    expect(main).toContain("import {\n  configureSixbBrowserClient,\n  isSixbApiError,")
+    // Unmatched client routes render the not-found view instead of a blank page.
+    expect(main).toContain('<Route path="*" element={<NotFoundView />} />')
+    expect(main).toContain("function NotFoundView()")
+  })
+
   test("route manifest statically imports every page", async () => {
     const generatedDir = join(tempRoot, ".sixb", "generated")
     const manifestPath = await generateRouteManifest(

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -25,8 +25,61 @@ export interface SixbClientOptions {
   readonly credentials?: RequestCredentials
 }
 
+export interface SixbApiErrorInit {
+  readonly status: number
+  readonly statusText?: string
+  readonly url?: string
+  readonly method?: string
+  readonly body?: unknown
+}
+
+/**
+ * A structured HTTP error thrown by the Sixb client. The raw generated client
+ * throws the bare response body (a string, or parsed JSON) with no status code
+ * or identity, which makes failures impossible to branch on and prints as
+ * cryptic quoted text in dev tooling. `SixbApiError` carries the status, the
+ * parsed `body`, and a readable `message`, so callers and error boundaries can
+ * tell a `404` apart from a `500` instead of catching a stringy blob.
+ */
+export class SixbApiError extends Error {
+  readonly status: number
+  readonly statusText: string
+  readonly url: string
+  readonly method: string
+  readonly body: unknown
+
+  constructor(message: string, init: SixbApiErrorInit) {
+    super(message)
+    this.name = "SixbApiError"
+    this.status = init.status
+    this.statusText = init.statusText ?? ""
+    this.url = init.url ?? ""
+    this.method = init.method ?? ""
+    this.body = init.body
+  }
+}
+
+/**
+ * Identifies a `SixbApiError` across bundle boundaries. The custom app and the
+ * client are bundled separately, so a plain `instanceof` would miss errors that
+ * crossed packages; the structural fallback recognizes them by shape.
+ */
+export function isSixbApiError(value: unknown): value is SixbApiError {
+  if (value instanceof SixbApiError) {
+    return true
+  }
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { name?: unknown }).name === "SixbApiError" &&
+    typeof (value as { status?: unknown }).status === "number"
+  )
+}
+
 export function createSixbClient(options: SixbClientOptions = {}): SixbClient {
-  return createClient(createSixbClientConfig(options))
+  const client = createClient(createSixbClientConfig(options))
+  installSixbErrorInterceptor(client)
+  return client
 }
 
 export function configureSixbClient(
@@ -34,6 +87,7 @@ export function configureSixbClient(
   options: SixbClientOptions = {}
 ): SixbClient {
   client.setConfig(createSixbClientConfig(options))
+  installSixbErrorInterceptor(client)
   return client
 }
 
@@ -103,4 +157,72 @@ function stripTrailingApiPath(pathname: string): string {
   }
 
   return trimmed
+}
+
+/**
+ * Maps the generated client's raw error (bare body) into a `SixbApiError`.
+ * Runs for every failed response regardless of `throwOnError`, so both thrown
+ * errors and the `{ error }` result field carry the structured type. Network
+ * failures (no `response`) are already native `Error`s and pass through.
+ */
+function sixbErrorInterceptor(
+  error: unknown,
+  response: Response | undefined,
+  request: Request | undefined
+): unknown {
+  if (isSixbApiError(error) || !response) {
+    return error
+  }
+
+  const method = request?.method ?? ""
+  const url = response.url || request?.url || ""
+  return new SixbApiError(buildSixbApiErrorMessage(method, url, response, error), {
+    status: response.status,
+    statusText: response.statusText,
+    url,
+    method,
+    body: error,
+  })
+}
+
+function buildSixbApiErrorMessage(
+  method: string,
+  url: string,
+  response: Response,
+  body: unknown
+): string {
+  const status = response.statusText
+    ? `${response.status} ${response.statusText}`
+    : String(response.status)
+  const target = [method, safeRequestPath(url)].filter(Boolean).join(" ")
+  const head = target ? `[SixbClient] ${target} → ${status}` : `[SixbClient] request → ${status}`
+  const detail = extractErrorDetail(body)
+  return detail ? `${head}: ${detail}` : head
+}
+
+function extractErrorDetail(body: unknown): string | undefined {
+  if (typeof body === "string") {
+    return body.trim() || undefined
+  }
+  if (body && typeof body === "object" && "error" in body) {
+    const message = (body as { error: unknown }).error
+    if (typeof message === "string" && message.trim()) {
+      return message
+    }
+  }
+  return undefined
+}
+
+function safeRequestPath(url: string): string {
+  try {
+    return new URL(url).pathname
+  } catch {
+    return url
+  }
+}
+
+function installSixbErrorInterceptor(client: SixbClient): void {
+  if (!client.interceptors.error.exists(sixbErrorInterceptor)) {
+    client.interceptors.error.use(sixbErrorInterceptor)
+  }
 }

--- a/packages/client/src/browser.ts
+++ b/packages/client/src/browser.ts
@@ -1,5 +1,9 @@
 import { configureSixbClient as configureGeneratedSixbClient, normalizeSixbApiBaseUrl } from "./api"
 import { client } from "./generated/client.gen"
+
+export type { SixbApiErrorInit } from "./api"
+export { isSixbApiError, SixbApiError } from "./api"
+
 import { getAuthSession } from "./generated/sdk.gen"
 import type { GetAuthSessionResponse } from "./generated/types.gen"
 

--- a/packages/client/src/query.ts
+++ b/packages/client/src/query.ts
@@ -18,6 +18,7 @@ import type {
   ObjectTypeWithPropertyTokens,
 } from "@sixb/core/query"
 import { createObjectQueryBuilder } from "@sixb/core/query"
+import { isSixbApiError } from "./api"
 import type { Client } from "./generated/client"
 import { countObjects, existsObjects, facetObjects, queryObjects } from "./generated/sdk.gen"
 import type {
@@ -162,9 +163,13 @@ function toWireQuery(query: ObjectQuery): WireObjectQuery {
 }
 
 function toSixbQueryError(error: unknown): SixbQueryError {
-  if (error && typeof error === "object" && "error" in error) {
-    const body = error as { error: unknown; issues?: ObjectQueryIssue[] }
-    return new SixbQueryError(`[SixbClient] ${String(body.error)}`, body.issues ?? [])
+  // The browser client wraps failures in `SixbApiError`; tests and bare clients
+  // surface the raw response body. Unwrap to the body either way so server-sent
+  // query issues survive.
+  const body = isSixbApiError(error) ? error.body : error
+  if (body && typeof body === "object" && "error" in body) {
+    const payload = body as { error: unknown; issues?: ObjectQueryIssue[] }
+    return new SixbQueryError(`[SixbClient] ${String(payload.error)}`, payload.issues ?? [])
   }
   return new SixbQueryError("[SixbClient] Object query request failed")
 }

--- a/packages/client/tests/api.test.ts
+++ b/packages/client/tests/api.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test"
 import {
   createAuthPersonalAccessToken,
   createSixbClient,
+  isSixbApiError,
   listAuthAccessTokens,
   normalizeSixbApiBaseUrl,
   requestSyncRun,
+  SixbApiError,
 } from "../src"
 
 function createObservedFetch(responseBody: unknown = {}) {
@@ -105,5 +107,70 @@ describe("createSixbClient", () => {
     expect(requests[0]?.credentials).toBe("include")
     expect(requests[0]?.headers.get("x-sixb-csrf")).toBe("csrf_1")
     expect(requests[0]?.headers.get("authorization")).toBeNull()
+  })
+})
+
+function createRespondingFetch(response: () => Response) {
+  return Object.assign(async () => response(), { preconnect: fetch.preconnect }) as typeof fetch
+}
+
+describe("SixbApiError", () => {
+  test("wraps a plain-text error response with status and body", async () => {
+    const client = createSixbClient({
+      baseUrl: "http://localhost:3002",
+      fetch: createRespondingFetch(() => new Response("Not Found", { status: 404 })),
+    })
+
+    const promise = listAuthAccessTokens({ client, throwOnError: true })
+    await expect(promise).rejects.toBeInstanceOf(SixbApiError)
+
+    const error = (await promise.catch((caught) => caught)) as SixbApiError
+    expect(error.status).toBe(404)
+    expect(error.body).toBe("Not Found")
+    expect(error.method).toBe("GET")
+    expect(error.url).toContain("/api/auth/access-tokens")
+    expect(error.message).toContain("404")
+    expect(error.message).toContain("/api/auth/access-tokens")
+    expect(error.message).toContain("Not Found")
+    expect(isSixbApiError(error)).toBe(true)
+  })
+
+  test("keeps the parsed JSON body and folds its error string into the message", async () => {
+    const client = createSixbClient({
+      baseUrl: "http://localhost:3002",
+      fetch: createRespondingFetch(
+        () =>
+          new Response(JSON.stringify({ error: "Object not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          })
+      ),
+    })
+
+    const error = (await listAuthAccessTokens({ client, throwOnError: true }).catch(
+      (caught) => caught
+    )) as SixbApiError
+    expect(error.status).toBe(404)
+    expect(error.body).toEqual({ error: "Object not found" })
+    expect(error.message).toContain("Object not found")
+  })
+
+  test("surfaces the structured error on the non-throwing result path too", async () => {
+    const client = createSixbClient({
+      baseUrl: "http://localhost:3002",
+      fetch: createRespondingFetch(() => new Response("Boom", { status: 500 })),
+    })
+
+    const { data, error } = await listAuthAccessTokens({ client })
+    expect(data).toBeUndefined()
+    expect(isSixbApiError(error)).toBe(true)
+    expect((error as unknown as SixbApiError).status).toBe(500)
+  })
+
+  test("isSixbApiError recognizes structurally-equal errors across bundles", () => {
+    const lookalike = { name: "SixbApiError", status: 404, body: "Not Found" }
+    expect(isSixbApiError(lookalike)).toBe(true)
+    expect(isSixbApiError(new Error("nope"))).toBe(false)
+    expect(isSixbApiError("Not Found")).toBe(false)
   })
 })


### PR DESCRIPTION
## Why

In local dev, editing a custom app intermittently produced a **blank page** and a dev-log line like:

```
frontend error: "Not Found"
    from browser tab http://localhost:3001/quotes/quote%3Acompanycam%3A108705010
```

Reproducing it (drove the `roku-tv` example's `/remote/[id]` route headlessly) surfaced two distinct gaps:

1. **The deep, URL-encoded route was a red herring** — it serves `200` + the SPA shell fine. The `"Not Found"` was an **API 404** for a missing object that escalated to an *uncaught* throw.
2. **The thrown value was a bare string.** The generated client throws the raw response body, so a 404 is indistinguishable from any other error — and the generated app shell had **no error boundary** and **no catch-all route**, so an unknown URL or any uncaught throw renders nothing.

The raw-body throw, straight from the generated client (unchanged, shown for context):

```ts
// packages/client/src/generated/client/client.gen.ts  (generated)
const textError = await response.text()
const error = jsonError ?? textError      // a 404 → the string "Not Found"
if (opts.throwOnError) throw finalError    // throws a bare string: no status, no identity
```

That's also why the dev log shows it *quoted* (`"Not Found"`) — Bun forwards a thrown string verbatim.

## What changed

Two complementary layers. They're not redundant — one makes errors *structured*, the other makes the app *resilient*.

### 1. `client`: structured API errors

A typed error so callers, boundaries, and logs can tell a 404 from a 500:

```ts
// packages/client/src/api.ts
export class SixbApiError extends Error {
  readonly status: number
  readonly statusText: string
  readonly url: string
  readonly method: string
  readonly body: unknown
}

// Structural fallback so instanceof survives separate client/app bundles.
export function isSixbApiError(value: unknown): value is SixbApiError { /* … */ }
```

A global error interceptor (installed by `createSixbClient` / `configureSixbClient`) wraps every failed response — both the thrown path and the `{ error }` result field — into a `SixbApiError` with a readable message like `[SixbClient] GET /api/objects/Quote/… → 404 Not Found`. No edits to generated code; it hooks `client.interceptors.error`.

`toSixbQueryError` unwraps `.body` so server-sent query issues still surface:

```ts
// packages/client/src/query.ts
const body = isSixbApiError(error) ? error.body : error   // tests use a bare client; browser wraps
```

`SixbApiError` is re-exported from `@sixb/client/browser` for the app shell.

### 2. `app`: default error boundary + not-found

The generated shell (`packages/app/src/codegen.ts`) now wraps routes in a boundary (that resets on navigation) and adds a catch-all route:

```tsx
<RoutedErrorBoundary>
  <RootLayout>
    <Routes>
      {routes.map((route) => (
        <Route key={route.path} path={route.path} element={<route.component />} />
      ))}
      <Route path="*" element={<NotFoundView />} />   {/* unknown URLs → Not found, not blank */}
    </Routes>
  </RootLayout>
</RoutedErrorBoundary>
```

A 404 is an *expected* state, so it reuses the not-found view rather than the generic crash screen:

```tsx
function AppErrorFallback({ error }: { error: unknown }) {
  if (isSixbApiError(error) && error.status === 404) return <NotFoundView />
  return <AppFallback title="Something went wrong" detail={error instanceof Error ? error.message : String(error)} />
}
```

The fallback is styled with `@sixb/ui` tokens via `var(--token, fallback)` — it adopts the app theme when those tokens are loaded and stays self-contained (and readable) when they aren't:

```tsx
background: "var(--background, #ffffff)",
color: "var(--foreground, #1f2933)",
borderRadius: "var(--radius, 0.5rem)",
fontFamily: "var(--font-sans, system-ui, …)",
```

### Resulting behavior

| Case | Before | After |
|---|---|---|
| Unknown URL (`/foo`) | blank page | **Not found** (catch-all) |
| API 404 from a page | blank + `frontend error` | **Not found** (boundary) |
| Any other render throw | blank + `frontend error` | **Something went wrong** (boundary) |

### `examples/acme-corp`: dev fixtures

`/crash` (throws on render) and `/not-found` (queries a missing object with `throwOnError`) so the default views are easy to exercise. Nothing added to the home page.

## Verification

Drove a headless browser against the running dev server. Confirmed the previously-uncaught condition now renders the fallback with **no `frontend error` line** and **no uncaught exception**, and that the `@sixb/ui` tokens actually resolve (e.g. `--primary #0a0a0a` → the "Go home" button's computed background) with the hardcoded values as fallbacks.

## Testing

- `bun run typecheck` ✓ (incl. `example-acme-corp`)
- `bun run build` ✓
- `bun run check` (Biome) ✓
- `bun run generate:client` → no diff ✓ (public API surface unchanged)
- `bun run test` → all relevant suites pass. One unrelated failure in `packages/orchestrator/tests/worker.test.ts` (a workflow-enqueue retry test) only under full-suite concurrency; it passes in isolation and this branch touches no orchestrator files.

New tests: `SixbApiError`/interceptor coverage in `packages/client/tests/api.test.ts`; boundary + catch-all assertions in `packages/app/tests/createCustomApp.test.ts`.

## Potential Follow-up

Author-overridable `app/error.tsx` and `app/not-found.tsx` (Next.js-style, discovered like other `app/` routes). The shared `NotFoundView` / `AppErrorFallback` are the seams it will replace. Happy to file as a separate issue.

## Screenshots

<img width="492" height="254" alt="Screenshot 2026-06-29 at 9 20 00 PM" src="https://github.com/user-attachments/assets/5369fd2c-40a4-4b76-88af-93f916db21f9" />
<img width="629" height="355" alt="Screenshot 2026-06-29 at 9 19 40 PM" src="https://github.com/user-attachments/assets/9523bb90-4113-4b9f-b0b0-508a9ce55aae" />
