### PR TITLE
atlas: render enum options and complex property schemas in ontology manager

### DIFF
--- a/examples/acme-corp/ontology/project.ts
+++ b/examples/acme-corp/ontology/project.ts
@@ -1,6 +1,33 @@
-import { defineObjectType, link, prop, stringEnum } from "@sixb/core/ontology"
+import {
+  defineObjectType,
+  defineValueType,
+  integerEnum,
+  link,
+  prop,
+  stringEnum,
+  valueTypeRef,
+} from "@sixb/core/ontology"
 import { Customer } from "./customer"
 import { Employee } from "./employee"
+
+/**
+ * Reusable money value type: an amount paired with its currency.
+ *
+ * Referenced from properties via `valueTypeRef` so the same shape can be
+ * shared across the ontology and evolved in one place.
+ */
+export const Money = defineValueType({
+  id: "money",
+  name: "Money",
+  description: "A monetary amount and its currency.",
+  schema: {
+    type: "object",
+    properties: {
+      amount: { schema: "double", required: true },
+      currency: { schema: stringEnum(["EUR", "USD", "GBP"]), required: true },
+    },
+  },
+})
 
 export const Project = defineObjectType({
   id: "Project",
@@ -15,7 +42,12 @@ export const Project = defineObjectType({
     prop("description", "string", {
       query: { searchable: true, text: true },
     }),
+    // String enum — a finite set of string states.
     prop("status", stringEnum(["draft", "active", "paused", "completed", "cancelled"]), {
+      query: { searchable: true, filterable: true, exact: true, facet: true },
+    }),
+    // Integer enum — a finite set of numeric levels.
+    prop("priority", integerEnum([1, 2, 3, 4, 5]), {
       query: { searchable: true, filterable: true, exact: true, facet: true },
     }),
     prop("startDate", "date", {
@@ -28,6 +60,37 @@ export const Project = defineObjectType({
       query: { searchable: true, filterable: true, sortable: true },
     }),
     prop("progress", "integer", { mode: "telemetry" }),
+    // Array of primitives — free-form labels.
+    prop("tags", { type: "array", items: "string" }),
+    // Map — dynamic per-phase budgets keyed by phase name.
+    prop("phaseBudgets", { type: "map", keySchema: "string", valueSchema: "double" }),
+    // Nested object — structured contact details with a nested enum.
+    prop("primaryContact", {
+      type: "object",
+      properties: {
+        name: { schema: "string", required: true },
+        email: { schema: "string", required: true },
+        phone: { schema: "string" },
+        preferredChannel: { schema: stringEnum(["email", "phone", "chat"]) },
+      },
+    }),
+    // Array of objects — milestones, each a structured record with its own enum.
+    prop("milestones", {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: { schema: "string", required: true },
+          dueDate: { schema: "date", required: true },
+          status: {
+            schema: stringEnum(["pending", "in_progress", "done", "blocked"]),
+            required: true,
+          },
+        },
+      },
+    }),
+    // Value-type reference — resolves to the shared Money object shape.
+    prop("contractValue", valueTypeRef(Money)),
   ],
   search: {
     title: "name",

--- a/packages/atlas/src/pages/ObjectTypeDetail.tsx
+++ b/packages/atlas/src/pages/ObjectTypeDetail.tsx
@@ -317,9 +317,8 @@ export function ObjectTypeDetail() {
                           className="flex flex-wrap items-baseline gap-x-2 gap-y-1 font-mono text-xs"
                         >
                           <span className="text-foreground">{param.id}</span>
-                          <span className="text-muted-foreground">
-                            : {formatSchema(param.schema)}
-                          </span>
+                          <span className="text-muted-foreground/50">:</span>
+                          <SchemaType schema={param.schema} />
                           {param.required ? (
                             <Badge variant="outline" className="font-sans text-[9px]">
                               required
@@ -485,7 +484,7 @@ function PropertiesSection({
           <TableBody>
             {properties.map((prop) => (
               <TableRow key={prop.id}>
-                <TableCell>
+                <TableCell className="align-top">
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-xs text-foreground">{prop.id}</span>
                     {prop.primary ? (
@@ -495,15 +494,15 @@ function PropertiesSection({
                     ) : null}
                   </div>
                 </TableCell>
-                <TableCell className="font-mono text-xs text-muted-foreground">
-                  {formatSchema(prop.schema)}
+                <TableCell className="align-top">
+                  <SchemaType schema={prop.schema} />
                 </TableCell>
                 {anyDescriptions ? (
-                  <TableCell className="hidden text-xs text-muted-foreground md:table-cell">
+                  <TableCell className="hidden align-top text-xs text-muted-foreground md:table-cell">
                     {prop.description || <span className="text-muted-foreground/50">—</span>}
                   </TableCell>
                 ) : null}
-                <TableCell className="text-right">
+                <TableCell className="text-right align-top">
                   <div className="inline-flex gap-1">
                     {prop.required ? (
                       <Badge variant="outline" className="text-[9px]">
@@ -638,10 +637,200 @@ function formatForeignKeySource(fk: { sourcePropertyId?: string; sourceField?: s
   return fk.sourcePropertyId ?? fk.sourceField ?? "unknown"
 }
 
-function formatSchema(schema: unknown): string {
-  if (typeof schema === "string") return schema
-  if (typeof schema === "object" && schema !== null && "type" in schema) {
-    return String((schema as { type: unknown }).type)
+function isSchemaRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * A schema renders on a single (wrapping) line when it is a primitive, an
+ * enum, or a container whose element is itself inline. Objects — and any
+ * container of objects — expand into a stacked tree instead, so their fields
+ * always indent from a single, consistent left edge.
+ */
+function isInlineSchema(schema: unknown): boolean {
+  if (typeof schema === "string") return true
+  if (!isSchemaRecord(schema) || typeof schema.type !== "string") return true
+  switch (schema.type) {
+    case "object":
+      return false
+    case "array":
+      return isInlineSchema(schema.items)
+    case "map":
+      return isInlineSchema(schema.valueSchema)
+    case "valueTypeRef":
+      return schema._resolved === undefined || isInlineSchema(schema._resolved)
+    default:
+      return true
   }
-  return "unknown"
+}
+
+/**
+ * Renders an ontology property schema in a compact, readable form.
+ *
+ * Primitives render as their bare type name. Complex schemas expand:
+ * enums list their allowed values as chips, objects show their fields,
+ * arrays/maps show their element types, and value-type refs show the
+ * referenced id (plus the resolved schema when codegen populated it).
+ */
+function SchemaType({ schema }: { schema: unknown }): ReactNode {
+  if (typeof schema === "string") {
+    return <SchemaPrimitive>{schema}</SchemaPrimitive>
+  }
+  if (!isSchemaRecord(schema) || typeof schema.type !== "string") {
+    return <SchemaPrimitive>unknown</SchemaPrimitive>
+  }
+
+  switch (schema.type) {
+    case "enum":
+      return <EnumType schema={schema} />
+    case "object":
+      return <ObjectType schema={schema} />
+    case "array":
+      return (
+        <SchemaContainer
+          head={<SchemaKeyword>array</SchemaKeyword>}
+          lead="of"
+          child={schema.items}
+        />
+      )
+    case "map":
+      return (
+        <SchemaContainer
+          head={
+            <>
+              <SchemaKeyword>map</SchemaKeyword>
+              <SchemaPrimitive>string</SchemaPrimitive>
+            </>
+          }
+          lead="→"
+          child={schema.valueSchema}
+        />
+      )
+    case "valueTypeRef":
+      return (
+        <SchemaContainer
+          head={
+            <span className="font-mono text-xs text-foreground">{String(schema.valueTypeId)}</span>
+          }
+          lead={schema._resolved === undefined ? undefined : "ref →"}
+          child={schema._resolved}
+        />
+      )
+    default:
+      return <SchemaPrimitive>{schema.type}</SchemaPrimitive>
+  }
+}
+
+/**
+ * Lays out a container schema (`array`, `map`, `valueTypeRef`) as `<head> lead
+ * <child>`. When the child is inline it stays on one wrapping line; when the
+ * child is a block (an object), the head sits on its own line with the child
+ * indented beneath it — never vertically centered against a tall block.
+ */
+function SchemaContainer({
+  head,
+  lead,
+  child,
+}: {
+  head: ReactNode
+  lead?: string
+  child: unknown
+}) {
+  if (child === undefined) {
+    return <span className="inline-flex flex-wrap items-center gap-1.5">{head}</span>
+  }
+  if (isInlineSchema(child)) {
+    return (
+      <span className="inline-flex flex-wrap items-center gap-1.5">
+        {head}
+        {lead ? <SchemaLead>{lead}</SchemaLead> : null}
+        <SchemaType schema={child} />
+      </span>
+    )
+  }
+  return (
+    <div className="space-y-1">
+      <span className="inline-flex flex-wrap items-center gap-1.5">
+        {head}
+        {lead ? <SchemaLead>{lead}</SchemaLead> : null}
+      </span>
+      <SchemaNest>
+        <SchemaType schema={child} />
+      </SchemaNest>
+    </div>
+  )
+}
+
+function SchemaPrimitive({ children }: { children: ReactNode }) {
+  return <span className="font-mono text-xs text-muted-foreground">{children}</span>
+}
+
+function SchemaLead({ children }: { children: ReactNode }) {
+  return <span className="text-[10px] font-medium text-muted-foreground/70">{children}</span>
+}
+
+function SchemaNest({ children }: { children: ReactNode }) {
+  return <div className="border-l border-border pl-3">{children}</div>
+}
+
+function SchemaKeyword({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground">
+      {children}
+    </span>
+  )
+}
+
+function EnumType({ schema }: { schema: Record<string, unknown> }) {
+  const values = Array.isArray(schema.values) ? schema.values : []
+  const valueType = typeof schema.valueType === "string" ? schema.valueType : null
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      <SchemaKeyword>enum</SchemaKeyword>
+      {valueType ? <SchemaLead>{valueType}</SchemaLead> : null}
+      {values.map((value, index) => (
+        <span
+          key={index}
+          className="inline-flex items-center rounded border border-border bg-background px-1.5 py-0.5 font-mono text-[10px] text-foreground"
+        >
+          {String(value)}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function ObjectType({ schema }: { schema: Record<string, unknown> }) {
+  const properties = isSchemaRecord(schema.properties) ? schema.properties : {}
+  const entries = Object.entries(properties)
+  return (
+    <div className="space-y-1">
+      <SchemaKeyword>object</SchemaKeyword>
+      {entries.length > 0 ? (
+        <SchemaNest>
+          <div className="space-y-1.5">
+            {entries.map(([name, field]) => {
+              const fieldSchema = isSchemaRecord(field) ? field.schema : field
+              const required = isSchemaRecord(field) && field.required === true
+              const inline = isInlineSchema(fieldSchema)
+              return (
+                <div key={name} className="space-y-1">
+                  <div className="flex flex-wrap items-baseline gap-1.5">
+                    <span className="font-mono text-xs text-foreground">{name}</span>
+                    {required ? <SchemaLead>required</SchemaLead> : null}
+                    {inline ? <SchemaType schema={fieldSchema} /> : null}
+                  </div>
+                  {inline ? null : (
+                    <SchemaNest>
+                      <SchemaType schema={fieldSchema} />
+                    </SchemaNest>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </SchemaNest>
+      ) : null}
+    </div>
+  )
 }


### PR DESCRIPTION
## Why

The Ontology Manager collapsed every property schema to its bare type name — so an `enum` never showed its allowed values, and `object`/`array`/`map`/`valueTypeRef` rendered as a lone keyword with no structure:

```ts
function formatSchema(schema: unknown): string {
  if (typeof schema === "string") return schema
  if (typeof schema === "object" && schema !== null && "type" in schema) {
    return String((schema as { type: unknown }).type)
  }
  return "unknown"
}
```

## What

Replace `formatSchema` with a recursive **`SchemaType`** component (used in both the Properties table and action Parameters) that expands each schema shape in the existing minimal token style. Enums list their values as chips; containers pick their layout by content via a small predicate:

```ts
function isInlineSchema(schema: unknown): boolean {
  // primitives + enums stay inline; objects always expand;
  // array/map/valueTypeRef expand only if their element does
  ...
}
```

`array`/`map`/`valueTypeRef` route through one `SchemaContainer` that renders `<head> lead <child>` inline when the child is inline, and stacks head-over-indented-child when it's a block — so a label never floats centered against a tall object, and nested trees indent from one consistent left edge. Result:

- `tags` → `array of string`, `phaseBudgets` → `map string → double` (inline)
- `primaryContact` → `object` with fields indented below
- `milestones` → `array of` then the object indented beneath
- `contractValue` → `money ref →` then the resolved `Money` object indented beneath

Table cells also gained `align-top` so tall type cells line up with the name/flags columns.

To exercise it, the acme-corp **`Project`** ontology now uses every complex kind (all new props optional, so datasets/projections/tests are unaffected): integer enum, array, map, nested object with a nested enum, array-of-objects, and a `valueTypeRef` to a shared `Money` value type. The server already passes `schema` through as `z.unknown()`, so `valueTypeRef._resolved` reaches the UI unchanged — no route/contract changes.

## Testing

- `bun run typecheck` — clean
- `bun run test` — 2007 pass / 0 fail
- `bun run check` (Biome) — clean
- `bun run generate:client` — no diff


<img width="810" height="805" alt="Screenshot 2026-06-30 at 8 20 57 PM" src="https://github.com/user-attachments/assets/29ec8a1b-d72a-4923-aeb6-9c7d8c549920" />


