### PR TITLE
sandboxes: add Vercel sandbox provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -585,6 +585,18 @@
         "typescript": "^5.7.0",
       },
     },
+    "sandboxes/vercel": {
+      "name": "@sixb/sandboxes-vercel",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sixb/core": "workspace:*",
+        "@vercel/sandbox": "^2.3.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "storage/blob-local": {
       "name": "@sixb/blob-local",
       "version": "0.1.0",
@@ -1053,6 +1065,8 @@
 
     "@sixb/sandboxes-smolvm": ["@sixb/sandboxes-smolvm@workspace:sandboxes/smolvm"],
 
+    "@sixb/sandboxes-vercel": ["@sixb/sandboxes-vercel@workspace:sandboxes/vercel"],
+
     "@sixb/server": ["@sixb/server@workspace:packages/server"],
 
     "@sixb/sqlite": ["@sixb/sqlite@workspace:storage/sqlite"],
@@ -1167,7 +1181,9 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
-    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+    "@vercel/sandbox": ["@vercel/sandbox@2.3.0", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@workflow/serde": "4.1.0-beta.2", "async-retry": "1.3.3", "jose": "6.2.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.27.1", "xdg-app-paths": "5.1.0", "zod": "^4.1.1" } }, "sha512-KLhc/sj2JuftgWEivPmmDq3iFLIoYU0XIv+44paTyhk5eGGaqNl6dQdxXSqOf+N31jh55m4UWY7i8oJy8oJRrQ=="],
+
+    "@workflow/serde": ["@workflow/serde@4.1.0-beta.2", "", {}, "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww=="],
 
     "@xyflow/react": ["@xyflow/react@12.10.2", "", { "dependencies": { "@xyflow/system": "0.0.76", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="],
 
@@ -1189,9 +1205,15 @@
 
     "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
 
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
+
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
@@ -1349,6 +1371,8 @@
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
@@ -1360,6 +1384,8 @@
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
 
@@ -1432,6 +1458,8 @@
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1603,6 +1631,8 @@
 
     "openid-client": ["openid-client@6.8.4", "", { "dependencies": { "jose": "^6.2.2", "oauth4webapi": "^3.8.5" } }, "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw=="],
 
+    "os-paths": ["os-paths@4.4.0", "", {}, "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
@@ -1697,6 +1727,8 @@
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -1727,6 +1759,8 @@
 
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
+    "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
+
     "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
@@ -1747,7 +1781,11 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
+
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -1770,6 +1808,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -1807,6 +1847,10 @@
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
+    "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
+
+    "xdg-portable": ["xdg-portable@7.3.0", "", { "dependencies": { "os-paths": "^4.0.1" } }, "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw=="],
+
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1816,6 +1860,8 @@
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@ai-sdk/provider-utils/@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
 
     "@radix-ui/react-accordion/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
 
@@ -2012,6 +2058,8 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@vercel/sandbox/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "bcrypt-pbkdf/tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 

--- a/docs/sandboxes/_meta.json
+++ b/docs/sandboxes/_meta.json
@@ -1,1 +1,1 @@
-["overview.md", "local.md", "smolvm.md"]
+["overview.md", "local.md", "smolvm.md", "vercel.md"]

--- a/docs/sandboxes/overview.md
+++ b/docs/sandboxes/overview.md
@@ -21,7 +21,7 @@ interface SandboxFactory {
 
 interface Sandbox {
   readonly id: string
-  readonly provider: string // "local" | "smolvm"
+  readonly provider: string // "local" | "smolvm" | "vercel"
   readonly status: "running" | "stopped" | "failed"
   readonly workingDirectory: string
 
@@ -96,6 +96,15 @@ import { SmolvmSandboxFactory } from "@sixb/sandboxes-smolvm"
 createSixb({ sandboxes: new SmolvmSandboxFactory() })
 ```
 
+Or use Vercel-hosted Firecracker microVMs when the agent worker already has Vercel Sandbox
+credentials and the Sixb API gateway is reachable from Vercel:
+
+```ts
+import { VercelSandboxFactory } from "@sixb/sandboxes-vercel"
+
+createSixb({ sandboxes: new VercelSandboxFactory() })
+```
+
 ## Network policy
 
 Every provider speaks the same `SandboxNetworkPolicy`. It is set per-run at `create(...)` (or as a
@@ -111,9 +120,11 @@ Each `restricted` entry is a `{ name, origin }` target, for example
 `{ name: "sixb-api", origin: "http://10.0.0.5:3002" }`.
 
 Providers differ in how precisely they can enforce `restricted`. The [smolvm](./smolvm.md) provider
-enforces a real per-host allow list inside the microVM. The [local](./local.md) provider's isolation
-backends are all-or-nothing today: `none` blocks outbound network, any other mode allows host
-network. The contract is the same; read each provider page for what it actually enforces.
+enforces a real per-host allow list inside the microVM. The [Vercel](./vercel.md) provider maps
+restricted HTTPS origins to Vercel's TLS/SNI firewall and IP origins to CIDR rules. The
+[local](./local.md) provider's isolation backends are all-or-nothing today: `none` blocks outbound
+network, any other mode allows host network. The contract is the same; read each provider page for
+what it actually enforces.
 
 ## How agents use a sandbox
 
@@ -136,15 +147,19 @@ that gateway — there is no open internet. See
 | Provider | Package | Isolation | Use when |
 | --- | --- | --- | --- |
 | [Local](./local.md) | `@sixb/sandboxes-local` | OS sandboxing (seatbelt / bwrap) or passthrough | Development and local iteration |
-| [smolvm](./smolvm.md) | `@sixb/sandboxes-smolvm` | Hardware-isolated microVM | Production, or whenever stronger isolation is required |
+| [smolvm](./smolvm.md) | `@sixb/sandboxes-smolvm` | Hardware-isolated microVM | Production on hosts where you can run smolvm |
+| [Vercel](./vercel.md) | `@sixb/sandboxes-vercel` | Vercel-hosted Firecracker microVM | Production on Vercel, or hosted workers with Vercel Sandbox credentials |
 
-Rule of thumb: **local for dev, smolvm for stronger isolation in prod.** The local provider always
-boots — it falls back to no isolation when OS tooling is missing — so it is friction-free for
+Rule of thumb: **local for dev, smolvm or Vercel for stronger isolation in prod.** The local provider
+always boots — it falls back to no isolation when OS tooling is missing — so it is friction-free for
 development. smolvm gives each run its own microVM with a true per-host egress allow list, at the
-cost of a one-time binary install and image build.
+cost of a one-time binary install and image build. Vercel gives you remote managed microVMs with no
+host hypervisor setup, but the Sixb API gateway must be reachable from Vercel (usually a public HTTPS
+origin, not localhost).
 
 ## Related
 
 - [Local sandbox](./local.md) — OS-level isolation backends and auto-detection
 - [smolvm sandbox](./smolvm.md) — hardware-isolated microVMs
+- [Vercel sandbox](./vercel.md) — managed Vercel-hosted microVMs
 - [Agent tools and the gateway](../agents/tools-and-gateway.md) — what the bash tool can reach

--- a/docs/sandboxes/vercel.md
+++ b/docs/sandboxes/vercel.md
@@ -1,0 +1,180 @@
+# Vercel sandbox
+
+Use `@sixb/sandboxes-vercel` to run the agent `bash` tool in managed Vercel Sandbox
+microVMs. It is a drop-in sandbox provider for `createSixb({ sandboxes })`.
+
+Choose this provider when you want strong hosted isolation and do not want to install a local
+hypervisor or build a smolvm image on your worker host.
+
+## Quick start
+
+Install the provider:
+
+```bash
+bun add @sixb/sandboxes-vercel
+```
+
+Wire it into your Sixb runtime:
+
+```ts
+import { createSixb } from "@sixb/core"
+import { VercelSandboxFactory } from "@sixb/sandboxes-vercel"
+
+export const sixb = createSixb({
+  // ...storage, broker, queues, ontology, agents
+  sandboxes: new VercelSandboxFactory({
+    timeout: 30_000, // default per-command timeout
+    sessionTimeoutMs: 10 * 60_000, // Vercel VM lifetime
+  }),
+})
+```
+
+That is all the Sixb code you need. The agent worker will create one Vercel sandbox per agent run,
+write the run context into it, run `bash -lc ...`, and delete the sandbox on teardown.
+
+## Required: a Vercel project
+
+Vercel Sandboxes are scoped to a Vercel project. You do not need to deploy an app, but you do need a
+linked project for auth, usage, snapshots, and observability.
+
+For local development:
+
+```bash
+vercel link
+vercel env pull .env.local
+```
+
+`vercel env pull` writes a development `VERCEL_OIDC_TOKEN`. The token expires, so run it again if
+sandbox creation starts failing with auth errors.
+
+For a worker running outside Vercel, pass access-token credentials:
+
+```ts
+new VercelSandboxFactory({
+  credentials: {
+    token: process.env.VERCEL_TOKEN!,
+    teamId: process.env.VERCEL_TEAM_ID!,
+    projectId: process.env.VERCEL_PROJECT_ID!,
+  },
+})
+```
+
+When running on Vercel with OIDC configured, you can omit `credentials`; the Vercel SDK resolves them
+from the environment.
+
+## Required: a reachable API origin
+
+The agent sandbox talks to Sixb through the run-scoped API gateway. Because Vercel sandboxes run
+remotely, they cannot reach your local `localhost`.
+
+For local development, expose the Sixb API with an HTTPS tunnel and set the public API origin:
+
+```bash
+SIXB_API_PUBLIC_ORIGIN=https://your-tunnel.example.com
+bun sixb dev
+```
+
+For production, use the public HTTPS origin of your Sixb API server.
+
+The provider rejects restricted gateway origins that are clearly unreachable or unsafe to enforce:
+
+- `localhost` / `127.0.0.1` / loopback addresses
+- plain HTTP hostnames, because Vercel's domain firewall is TLS/SNI-based
+
+## Network policy
+
+Sixb's agent worker creates sandboxes with restricted egress to the Sixb API gateway. The Vercel
+provider maps Sixb policies to Vercel's firewall:
+
+| Sixb policy | Vercel behavior |
+| --- | --- |
+| `{ mode: "none" }` | deny all egress |
+| `{ mode: "all" }` | allow all egress |
+| restricted HTTPS origins | allow those domains by TLS SNI |
+| restricted IP origins | allow those IPs as CIDRs |
+
+IP/CIDR rules are address-wide; the URL port is not enforced by the firewall rule.
+
+## Runtime and tools
+
+The default Vercel runtime is `node24`. That is the recommended starting point.
+
+```ts
+new VercelSandboxFactory({
+  runtime: "node24",
+})
+```
+
+The stock Vercel runtimes include common development tools. Sixb's built-in bash tool needs `bash`
+and `curl`. If you use a custom image, make sure both are installed.
+
+For heavier setup, prefer a snapshot or Vercel Container Registry image instead of installing
+packages on every agent run:
+
+```ts
+// Start from a Vercel Sandbox snapshot
+new VercelSandboxFactory({
+  snapshotId: "snp_...",
+})
+
+// Or start from a VCR image
+new VercelSandboxFactory({
+  image: "sixb-agent:v1",
+})
+```
+
+Runtime package installs are possible with Vercel `sudo` + `dnf`, but setup commands need egress to
+package repositories and add latency to every run.
+
+## Common options
+
+| Option | What it does |
+| --- | --- |
+| `timeout` | Default per-command timeout in milliseconds. |
+| `sessionTimeoutMs` | Vercel sandbox session lifetime. Different from `timeout`. |
+| `runtime` | Stock Vercel runtime: `node26`, `node24`, `node22`, or `python3.13`. |
+| `image` | Vercel Container Registry image reference. |
+| `snapshotId` | Existing Vercel Sandbox snapshot to boot from. |
+| `resources` | Vercel resources, e.g. `{ vcpus: 2 }`. |
+| `env` | Environment variables merged into every sandbox command. |
+| `credentials` | Explicit Vercel `{ token, teamId, projectId }` for non-OIDC environments. |
+| `persistent` | Defaults to `false`; set `true` only if you intentionally want Vercel snapshots. |
+
+## Example configurations
+
+Default hosted sandbox:
+
+```ts
+new VercelSandboxFactory({
+  timeout: 30_000,
+  sessionTimeoutMs: 10 * 60_000,
+})
+```
+
+More CPU:
+
+```ts
+new VercelSandboxFactory({
+  resources: { vcpus: 4 },
+  sessionTimeoutMs: 20 * 60_000,
+})
+```
+
+External worker with explicit credentials:
+
+```ts
+new VercelSandboxFactory({
+  credentials: {
+    token: process.env.VERCEL_TOKEN!,
+    teamId: process.env.VERCEL_TEAM_ID!,
+    projectId: process.env.VERCEL_PROJECT_ID!,
+  },
+  timeout: 30_000,
+})
+```
+
+## Related
+
+- [Sandboxes overview](./overview.md)
+- [Agent tools and the gateway](../agents/tools-and-gateway.md)
+- [smolvm sandbox](./smolvm.md)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "biome check auth/*/src packages/*/src connectors/*/src sandboxes/*/src",
     "typecheck": "bun run build:types && bun run typecheck:tests && bun run typecheck:examples",
     "typecheck:tests": "tsc -p tsconfig.tests.json",
-    "typecheck:examples": "bun --filter '@sixb/docs' --filter '@sixb/example-*' --filter '@sixb/sandboxes-local' typecheck",
+    "typecheck:examples": "bun --filter '@sixb/docs' --filter '@sixb/example-*' --filter '@sixb/sandboxes-local' --filter '@sixb/sandboxes-vercel' typecheck",
     "link-cli": "ln -sf \"$(pwd)/packages/cli/src/index.tsx\" ~/.bun/bin/sixb && echo 'Linked sixb CLI to ~/.bun/bin/sixb'",
     "sixb": "bun packages/cli/src/index.tsx",
     "create-sixb": "bun packages/cli/src/index.tsx create",

--- a/packages/agent-ui/src/components/Composer.tsx
+++ b/packages/agent-ui/src/components/Composer.tsx
@@ -43,11 +43,14 @@ export function Composer({
   }, [draftNonce])
 
   // Grow the textarea to fit its content, up to a max height where it starts scrolling.
+  // Keep overflow hidden until the content actually exceeds the cap so an empty input does not
+  // render a scrollbar in browsers configured to always show scroll bars.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure whenever the text changes
   useLayoutEffect(() => {
     const el = textareaRef.current
     if (!el) return
     el.style.height = "auto"
+    el.style.overflowY = el.scrollHeight > MAX_HEIGHT_PX ? "auto" : "hidden"
     el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT_PX)}px`
   }, [value])
 
@@ -98,7 +101,7 @@ export function Composer({
             rows={1}
             placeholder={placeholder ?? "Send a message…"}
             aria-label="Message"
-            className="max-h-[200px] min-h-9 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-0 py-1.5 text-[15px] leading-relaxed shadow-none focus-visible:ring-0 md:text-[15px]"
+            className="max-h-[200px] min-h-9 flex-1 resize-none overflow-y-hidden border-0 bg-transparent px-0 py-1.5 text-[15px] leading-relaxed shadow-none focus-visible:ring-0 md:text-[15px]"
           />
           <button
             type="button"

--- a/sandboxes/vercel/README.md
+++ b/sandboxes/vercel/README.md
@@ -1,0 +1,143 @@
+# @sixb/sandboxes-vercel
+
+Runs each agent's bash inside a managed [Vercel Sandbox](https://vercel.com/docs/sandbox)
+Firecracker microVM. Drop-in `Sandbox` provider — wire it once into `createSixb({ sandboxes })`;
+agent code still uses the provider-neutral Sixb sandbox contract.
+
+## Setup
+
+Install dependencies with Bun from the repo root:
+
+```bash
+bun install
+```
+
+The package uses Vercel's `@vercel/sandbox` SDK. Authentication is resolved by the SDK in one of two
+ways:
+
+- **OIDC**: on Vercel, OIDC is automatic when configured; locally, run `vercel link` and
+  `vercel env pull` so `VERCEL_OIDC_TOKEN` is available.
+- **Access token**: pass `credentials: { token, teamId, projectId }` to `VercelSandboxFactory` for
+  non-Vercel workers or CI.
+
+Local OIDC tokens expire; rerun `vercel env pull` if sandbox creation starts failing with auth
+errors.
+
+## Use
+
+```ts
+import { createSixb } from "@sixb/core"
+import { VercelSandboxFactory } from "@sixb/sandboxes-vercel"
+
+createSixb({ sandboxes: new VercelSandboxFactory() })
+```
+
+Each Sixb agent run creates a fresh Vercel sandbox, materializes skills/context with
+`writeFiles(...)`, runs bash commands via `runCommand(...)`, then permanently deletes the sandbox on
+`destroy()`.
+
+Persistence is disabled by default (`persistent: false`) because Sixb sandboxes are per-run. If you
+want a long-lived Vercel sandbox model, opt in explicitly and manage snapshot/storage cost.
+
+## Gateway and network policy
+
+The agent worker creates sandboxes with a restricted network policy that allows only the Sixb API
+gateway. This provider maps Sixb policies to Vercel's firewall:
+
+| Sixb policy | Vercel policy |
+| --- | --- |
+| `{ mode: "none" }` | `"deny-all"` |
+| `{ mode: "all" }` | `"allow-all"` |
+| HTTPS restricted origins | domain allow rules matched by TLS SNI |
+| IP restricted origins | CIDR allow rules |
+
+Important caveats:
+
+- Vercel sandboxes run remotely. They cannot reach `localhost`, `127.0.0.1`, or your machine's
+  loopback; those restricted targets are rejected.
+- Vercel's domain firewall is TLS/SNI-based. Plain HTTP hostnames cannot be enforced as domain
+  allow rules; use HTTPS or an IP/CIDR target.
+- IP/CIDR rules are address-wide; the URL port is not enforced by the firewall rule.
+
+For production, expose the Sixb API gateway at a public HTTPS origin reachable from Vercel.
+
+## Runtime and dependencies
+
+By default, Vercel boots its stock `node24` runtime. Sixb's built-in bash tool expects at least
+`bash` and `curl`. The stock runtimes are usually enough for API-oriented agent work.
+
+For additional tools, prefer one of these setup strategies:
+
+| Strategy | Option | Notes |
+| --- | --- | --- |
+| Stock runtime | `runtime: "node24"` | Default, no image build. |
+| Snapshot | `snapshotId: "..."` | Install deps once, snapshot, then boot future runs from it. |
+| VCR image | `image: "sixb-agent:v1"` | Use a Vercel Container Registry image prepared from a Dockerfile. |
+
+Avoid package installs on every agent run. If you do install at runtime, Vercel supports `sudo` and
+`dnf`, but setup needs egress to package repositories.
+
+## Options
+
+```ts
+new VercelSandboxFactory({
+  runtime: "node24",
+  sessionTimeoutMs: 10 * 60_000,
+  timeout: 30_000,
+  resources: { vcpus: 2 },
+})
+```
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `runtime` | Vercel default (`node24`) | `"node26"`, `"node24"`, `"node22"`, or `"python3.13"`; ignored with `image`/`snapshotId`. |
+| `image` | — | Vercel Container Registry image reference. |
+| `snapshotId` | — | Boot from a Vercel Sandbox snapshot; mutually exclusive with `runtime`, `image`, and `source`. |
+| `source` | — | Git or tarball source for Vercel to clone/mount at create time. |
+| `resources` | Vercel default | `{ vcpus }`; memory is 2048 MB per vCPU. |
+| `ports` | `[]` | Ports to expose through Vercel sandbox domains. |
+| `sessionTimeoutMs` | Vercel default | Sandbox session lifetime; separate from Sixb's per-command timeout. |
+| `timeout` | — | Default Sixb per-command timeout, in ms. |
+| `setupTimeoutMs` | `30_000` | Timeout for provider setup commands like creating a custom working directory. |
+| `persistent` | `false` | Auto-snapshot on stop; off by default for per-run sandboxes. |
+| `credentials` | SDK OIDC/env resolution | `{ token, teamId, projectId }` for external workers. |
+| `env` | `{}` | Env merged into every sandbox. |
+| `network` | `{ mode: "none" }` | Default network policy; the agent worker normally overrides per run. |
+
+## Examples
+
+With explicit credentials on a non-Vercel worker:
+
+```ts
+new VercelSandboxFactory({
+  credentials: {
+    token: process.env.VERCEL_TOKEN!,
+    teamId: process.env.VERCEL_TEAM_ID!,
+    projectId: process.env.VERCEL_PROJECT_ID!,
+  },
+  sessionTimeoutMs: 10 * 60_000,
+})
+```
+
+With a prebuilt VCR image:
+
+```ts
+new VercelSandboxFactory({
+  image: "sixb-agent:v1",
+  resources: { vcpus: 2 },
+})
+```
+
+## Tests
+
+```bash
+bun --filter @sixb/sandboxes-vercel test
+bun --filter @sixb/sandboxes-vercel typecheck
+```
+
+The regular test suite uses fakes and does not require Vercel credentials. A live smoke test is gated
+behind an environment variable because it consumes metered Vercel Sandbox resources:
+
+```bash
+SIXB_VERCEL_SANDBOX_INTEGRATION=1 bun --filter @sixb/sandboxes-vercel test
+```

--- a/sandboxes/vercel/package.json
+++ b/sandboxes/vercel/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sixb/sandboxes-vercel",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@sixb/core": "workspace:*",
+    "@vercel/sandbox": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  }
+}

--- a/sandboxes/vercel/src/index.ts
+++ b/sandboxes/vercel/src/index.ts
@@ -1,0 +1,18 @@
+export { toVercelNetworkPolicy } from "./network"
+export {
+  type VercelCommandClient,
+  type VercelCommandFinishedClient,
+  type VercelRunCommandParams,
+  VercelSandbox,
+  type VercelSandboxClient,
+  type VercelSandboxOptions,
+} from "./vercel-sandbox"
+export {
+  type VercelCreateSandbox,
+  type VercelSandboxCredentials,
+  VercelSandboxFactory,
+  type VercelSandboxFactoryOptions,
+  type VercelSandboxRuntime,
+  type VercelSandboxSource,
+  type VercelSnapshotRetentionPolicy,
+} from "./vercel-sandbox-factory"

--- a/sandboxes/vercel/src/network.ts
+++ b/sandboxes/vercel/src/network.ts
@@ -1,0 +1,97 @@
+import { isIP } from "node:net"
+import { SandboxError, type SandboxNetworkPolicy } from "@sixb/core"
+import type { NetworkPolicy } from "@vercel/sandbox"
+
+/**
+ * Translate Sixb's provider-neutral egress policy into Vercel Sandbox's firewall policy.
+ *
+ * Vercel domain allow rules are TLS/SNI-based. HTTPS origins map to domain rules; plain HTTP can
+ * only be constrained by IP/CIDR, so hostname-only HTTP origins are rejected with an actionable
+ * error instead of silently widening egress.
+ */
+export function toVercelNetworkPolicy(policy: SandboxNetworkPolicy | undefined): NetworkPolicy {
+  if (policy === undefined || policy.mode === "none") {
+    return "deny-all"
+  }
+  if (policy.mode === "all") {
+    return "allow-all"
+  }
+  if (policy.allow.length === 0) {
+    return "deny-all"
+  }
+
+  const domains = new Set<string>()
+  const cidrs = new Set<string>()
+
+  for (const target of policy.allow) {
+    const origin = parseNetworkTarget(target.origin)
+    if (isLoopbackHost(origin.host)) {
+      throw new SandboxError(
+        `[Sandbox] Vercel Sandbox runs remotely and cannot reach restricted target '${target.name}' at ${target.origin}. Use a public HTTPS gateway origin instead of localhost/loopback.`
+      )
+    }
+
+    const cidr = cidrForHost(origin.host)
+    if (cidr) {
+      cidrs.add(cidr)
+      continue
+    }
+
+    if (origin.protocol === "http:") {
+      throw new SandboxError(
+        `[Sandbox] Vercel Sandbox cannot enforce a hostname allow-list for plain HTTP target '${target.name}' (${target.origin}); Vercel's domain firewall is TLS/SNI-based. Use HTTPS, or point the target at an IP/CIDR-reachable origin.`
+      )
+    }
+
+    domains.add(origin.host)
+  }
+
+  if (domains.size === 0 && cidrs.size === 0) {
+    return "deny-all"
+  }
+
+  return {
+    ...(domains.size > 0 ? { allow: [...domains] } : {}),
+    ...(cidrs.size > 0 ? { subnets: { allow: [...cidrs] } } : {}),
+  }
+}
+
+interface ParsedNetworkTarget {
+  readonly protocol: string | undefined
+  readonly host: string
+}
+
+function parseNetworkTarget(origin: string): ParsedNetworkTarget {
+  try {
+    const url = new URL(origin)
+    return { protocol: url.protocol, host: stripIpv6Brackets(url.hostname) }
+  } catch {
+    // Accept provider-neutral targets that are already bare hosts (or host:port) even though the
+    // agent worker normally passes URL origins. Treat them as HTTPS-domain style targets.
+    try {
+      const url = new URL(`https://${origin}`)
+      return { protocol: "https:", host: stripIpv6Brackets(url.hostname) }
+    } catch {
+      return { protocol: undefined, host: stripIpv6Brackets(origin) }
+    }
+  }
+}
+
+function cidrForHost(host: string): string | undefined {
+  const version = isIP(host)
+  if (version === 4) {
+    return `${host}/32`
+  }
+  if (version === 6) {
+    return `${host}/128`
+  }
+  return undefined
+}
+
+function isLoopbackHost(host: string): boolean {
+  return host === "localhost" || host === "::1" || host.startsWith("127.")
+}
+
+function stripIpv6Brackets(value: string): string {
+  return value.replace(/^\[/, "").replace(/\]$/, "")
+}

--- a/sandboxes/vercel/src/vercel-sandbox-factory.ts
+++ b/sandboxes/vercel/src/vercel-sandbox-factory.ts
@@ -1,0 +1,258 @@
+import { randomUUID } from "node:crypto"
+import {
+  type CreateSandboxOptions,
+  type Sandbox,
+  SandboxError,
+  type SandboxFactory,
+  type SandboxNetworkPolicy,
+} from "@sixb/core"
+import { Sandbox as VercelSdkSandbox } from "@vercel/sandbox"
+import { toVercelNetworkPolicy } from "./network"
+import {
+  type VercelCommandFinishedClient,
+  VercelSandbox,
+  type VercelSandboxClient,
+} from "./vercel-sandbox"
+
+export type VercelSandboxRuntime = "node26" | "node24" | "node22" | "python3.13"
+
+export type VercelSandboxSource =
+  | {
+      readonly type: "git"
+      readonly url: string
+      readonly username?: string
+      readonly password?: string
+      readonly depth?: number
+      readonly revision?: string
+    }
+  | {
+      readonly type: "tarball"
+      readonly url: string
+    }
+
+export interface VercelSandboxCredentials {
+  readonly token: string
+  readonly teamId: string
+  readonly projectId: string
+}
+
+export interface VercelSnapshotRetentionPolicy {
+  readonly count: number
+  readonly expiration?: number
+  readonly deleteEvicted?: boolean
+}
+
+export interface VercelSandboxFactoryOptions {
+  /** Stock Vercel runtime. Ignored when `image` or `snapshotId` is set. Defaults to Vercel's node24. */
+  readonly runtime?: VercelSandboxRuntime | (string & {})
+  /** Vercel Container Registry image reference. Mutually exclusive with `snapshotId`. */
+  readonly image?: string
+  /** Existing Vercel Sandbox snapshot id to boot from. Mutually exclusive with `image` and `source`. */
+  readonly snapshotId?: string
+  /** Optional git/tarball source cloned or mounted by Vercel at sandbox creation. */
+  readonly source?: VercelSandboxSource
+  /** vCPU allocation; memory is 2048 MB per vCPU. */
+  readonly resources?: { readonly vcpus: number }
+  /** Ports to expose through Vercel sandbox domains. */
+  readonly ports?: readonly number[]
+  /** Vercel session lifetime in milliseconds. Separate from Sixb's per-command `timeout`. */
+  readonly sessionTimeoutMs?: number
+  /** Timeout used only for provider bootstrap commands, such as creating a custom cwd. */
+  readonly setupTimeoutMs?: number
+  /** Persist/snapshot the sandbox when stopped. Defaults to false for Sixb's per-run model. */
+  readonly persistent?: boolean
+  readonly snapshotExpiration?: number
+  readonly keepLastSnapshots?: VercelSnapshotRetentionPolicy
+  readonly tags?: Readonly<Record<string, string>>
+  /** Prefix for generated Vercel sandbox names. */
+  readonly namePrefix?: string
+  /** Explicit Vercel API credentials. If omitted, the SDK resolves OIDC/env credentials. */
+  readonly credentials?: VercelSandboxCredentials
+  /** Default env merged into every sandbox the factory creates. */
+  readonly env?: Readonly<Record<string, string>>
+  /** Default per-command timeout in milliseconds. */
+  readonly timeout?: number
+  /** Default network policy. Overridable per-create. Defaults to deny-all. */
+  readonly network?: SandboxNetworkPolicy
+}
+
+type VercelCreateSandboxParams = NonNullable<Parameters<typeof VercelSdkSandbox.create>[0]>
+export type VercelCreateSandbox = (
+  params: VercelCreateSandboxParams
+) => Promise<VercelSandboxClient>
+
+const DEFAULT_NAME_PREFIX = "sixb-"
+const DEFAULT_SETUP_TIMEOUT_MS = 30_000
+
+/** Pluggable factory for Vercel Sandbox-backed Sixb sandboxes. */
+export class VercelSandboxFactory implements SandboxFactory {
+  constructor(
+    private readonly defaults: VercelSandboxFactoryOptions = {},
+    private readonly createRemote: VercelCreateSandbox = createVercelSandbox
+  ) {}
+
+  async create(options: CreateSandboxOptions = {}): Promise<Sandbox> {
+    validateSourceOptions(this.defaults)
+    const env = { ...(this.defaults.env ?? {}), ...(options.env ?? {}) }
+    const network = options.network ?? this.defaults.network ?? { mode: "none" }
+    const params = buildCreateParams({
+      defaults: this.defaults,
+      env,
+      network,
+      name: `${this.defaults.namePrefix ?? DEFAULT_NAME_PREFIX}${randomUUID()}`,
+    })
+
+    let client: VercelSandboxClient | undefined
+    try {
+      client = await this.createRemote(params)
+      const sandbox = new VercelSandbox({
+        client,
+        env,
+        timeout: options.timeout ?? this.defaults.timeout,
+        workingDirectory: options.workingDirectory,
+      })
+      await ensureWorkingDirectory({
+        client,
+        workingDirectory: sandbox.workingDirectory,
+        setupTimeoutMs: this.defaults.setupTimeoutMs ?? DEFAULT_SETUP_TIMEOUT_MS,
+      })
+      return sandbox
+    } catch (error) {
+      await client?.delete().catch(() => {})
+      if (error instanceof SandboxError) {
+        throw error
+      }
+      throw new SandboxError(`[Sandbox] vercel create failed: ${errorMessage(error)}`)
+    }
+  }
+}
+
+function buildCreateParams(input: {
+  readonly defaults: VercelSandboxFactoryOptions
+  readonly env: Readonly<Record<string, string>>
+  readonly network: SandboxNetworkPolicy
+  readonly name: string
+}): VercelCreateSandboxParams {
+  const { defaults } = input
+  const credentials = resolveCredentials(defaults.credentials)
+  const base: Record<string, unknown> = {
+    name: input.name,
+    env: input.env,
+    networkPolicy: toVercelNetworkPolicy(input.network),
+    persistent: defaults.persistent ?? false,
+    ...(defaults.ports !== undefined ? { ports: [...defaults.ports] } : {}),
+    ...(defaults.sessionTimeoutMs !== undefined ? { timeout: defaults.sessionTimeoutMs } : {}),
+    ...(defaults.resources !== undefined ? { resources: defaults.resources } : {}),
+    ...(defaults.tags !== undefined ? { tags: defaults.tags } : {}),
+    ...(defaults.snapshotExpiration !== undefined
+      ? { snapshotExpiration: defaults.snapshotExpiration }
+      : {}),
+    ...(defaults.keepLastSnapshots !== undefined
+      ? { keepLastSnapshots: defaults.keepLastSnapshots }
+      : {}),
+    ...credentials,
+  }
+
+  if (defaults.snapshotId !== undefined) {
+    return {
+      ...base,
+      source: { type: "snapshot", snapshotId: defaults.snapshotId },
+    } as VercelCreateSandboxParams
+  }
+
+  return {
+    ...base,
+    ...(defaults.source !== undefined ? { source: normalizeSource(defaults.source) } : {}),
+    ...(defaults.image !== undefined ? { image: defaults.image } : { runtime: defaults.runtime }),
+  } as VercelCreateSandboxParams
+}
+
+function normalizeSource(source: VercelSandboxSource): Record<string, unknown> {
+  if (source.type === "tarball") {
+    return { type: "tarball", url: source.url }
+  }
+  return {
+    type: "git",
+    url: source.url,
+    ...(source.username !== undefined ? { username: source.username } : {}),
+    ...(source.password !== undefined ? { password: source.password } : {}),
+    ...(source.depth !== undefined ? { depth: source.depth } : {}),
+    ...(source.revision !== undefined ? { revision: source.revision } : {}),
+  }
+}
+
+function validateSourceOptions(options: VercelSandboxFactoryOptions): void {
+  if (options.snapshotId === undefined) {
+    return
+  }
+  const conflicts = [
+    options.image !== undefined ? "image" : undefined,
+    options.source !== undefined ? "source" : undefined,
+    options.runtime !== undefined ? "runtime" : undefined,
+  ].filter((value): value is string => value !== undefined)
+  if (conflicts.length > 0) {
+    throw new SandboxError(
+      `[Sandbox] Vercel snapshotId cannot be combined with ${conflicts.join(", ")}.`
+    )
+  }
+}
+
+function resolveCredentials(
+  credentials: VercelSandboxCredentials | undefined
+): Partial<VercelSandboxCredentials> {
+  if (credentials === undefined) {
+    return {}
+  }
+  if (!credentials.token || !credentials.teamId || !credentials.projectId) {
+    throw new SandboxError(
+      "[Sandbox] Vercel sandbox credentials require token, teamId, and projectId. Omit credentials to let the Vercel SDK resolve OIDC/env credentials."
+    )
+  }
+  return credentials
+}
+
+async function ensureWorkingDirectory(input: {
+  readonly client: VercelSandboxClient
+  readonly workingDirectory: string
+  readonly setupTimeoutMs: number
+}): Promise<void> {
+  const defaultCwd = input.client.cwd ?? "/vercel/sandbox"
+  if (input.workingDirectory === defaultCwd) {
+    return
+  }
+
+  const command = await input.client.runCommand({
+    cmd: "mkdir",
+    args: ["-p", input.workingDirectory],
+    cwd: "/",
+    env: {},
+    detached: true,
+    timeoutMs: input.setupTimeoutMs,
+  })
+  const finished = await command.wait()
+  if (finished.exitCode !== 0) {
+    throw new SandboxError(
+      `[Sandbox] vercel working directory setup failed: ${await safeStderr(finished)}`
+    )
+  }
+}
+
+async function safeStderr(finished: VercelCommandFinishedClient): Promise<string> {
+  try {
+    const stderr = await finished.stderr()
+    return stderr.trim() || `exit ${finished.exitCode}`
+  } catch {
+    return `exit ${finished.exitCode}`
+  }
+}
+
+async function createVercelSandbox(
+  params: VercelCreateSandboxParams
+): Promise<VercelSandboxClient> {
+  const sandbox = await VercelSdkSandbox.create(params)
+  return sandbox as unknown as VercelSandboxClient
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/sandboxes/vercel/src/vercel-sandbox.ts
+++ b/sandboxes/vercel/src/vercel-sandbox.ts
@@ -1,0 +1,295 @@
+import { posix } from "node:path"
+import {
+  type CommandResult,
+  type CreateSandboxOptions,
+  type RunCommandOptions,
+  type Sandbox,
+  SandboxError,
+  type SandboxFileRecord,
+  SandboxNotRunningError,
+  type SandboxStatus,
+} from "@sixb/core"
+
+const DEFAULT_WORKING_DIRECTORY = "/vercel/sandbox"
+const KILLED_EXIT_CODE = 137
+
+export interface VercelRunCommandParams {
+  readonly cmd: string
+  readonly args?: readonly string[]
+  readonly cwd?: string
+  readonly env?: Readonly<Record<string, string>>
+  readonly detached: true
+  readonly timeoutMs?: number
+}
+
+export interface VercelCommandFinishedClient {
+  readonly exitCode: number
+  stdout(opts?: { readonly signal?: AbortSignal }): Promise<string>
+  stderr(opts?: { readonly signal?: AbortSignal }): Promise<string>
+}
+
+export interface VercelCommandClient {
+  wait(params?: { readonly signal?: AbortSignal }): Promise<VercelCommandFinishedClient>
+  kill(signal?: string, opts?: { readonly abortSignal?: AbortSignal }): Promise<void>
+}
+
+export interface VercelSandboxClient {
+  readonly name: string
+  readonly cwd?: string
+  readonly status?: string
+  runCommand(params: VercelRunCommandParams): Promise<VercelCommandClient>
+  writeFiles(
+    files: readonly {
+      readonly path: string
+      readonly content: string | Uint8Array
+      readonly mode?: number
+    }[],
+    opts?: { readonly signal?: AbortSignal }
+  ): Promise<void>
+  stop(opts?: { readonly signal?: AbortSignal }): Promise<unknown>
+  delete(opts?: { readonly signal?: AbortSignal }): Promise<void>
+}
+
+export interface VercelSandboxOptions extends CreateSandboxOptions {
+  readonly id?: string
+  readonly client: VercelSandboxClient
+}
+
+/** Sandbox wrapper around a Vercel Sandbox SDK instance. */
+export class VercelSandbox implements Sandbox {
+  readonly id: string
+  readonly provider = "vercel"
+  readonly workingDirectory: string
+
+  private currentStatus: SandboxStatus = "running"
+  private readonly client: VercelSandboxClient
+  private readonly sandboxEnv: Readonly<Record<string, string>>
+  private readonly defaultTimeoutMs: number | undefined
+  private readonly inFlight = new Set<VercelCommandClient>()
+  private destroyed = false
+
+  constructor(options: VercelSandboxOptions) {
+    this.client = options.client
+    this.id = options.id ?? options.client.name
+    this.workingDirectory = normalizeWorkingDirectory(
+      options.workingDirectory ?? options.client.cwd
+    )
+    this.sandboxEnv = options.env ?? {}
+    this.defaultTimeoutMs = options.timeout
+  }
+
+  get status(): SandboxStatus {
+    if (this.currentStatus !== "running") {
+      return this.currentStatus
+    }
+    if (this.client.status === "failed") {
+      return "failed"
+    }
+    if (this.client.status === "stopped") {
+      return "stopped"
+    }
+    return "running"
+  }
+
+  async runCommand(
+    command: string,
+    args: readonly string[] = [],
+    options: RunCommandOptions = {}
+  ): Promise<CommandResult> {
+    this.assertRunning("run commands")
+
+    const start = Date.now()
+    const timeoutMs = options.timeout ?? this.defaultTimeoutMs
+    const env = { ...this.sandboxEnv, ...(options.env ?? {}) }
+    const cwd = options.cwd ?? this.workingDirectory
+
+    if (options.signal?.aborted) {
+      return abortedResult(start)
+    }
+
+    let timedOut = false
+    let aborted = false
+    let killStarted = false
+    let commandHandle: VercelCommandClient
+
+    try {
+      commandHandle = await this.client.runCommand({
+        cmd: command,
+        args: [...args],
+        cwd,
+        env,
+        detached: true,
+        ...(timeoutMs !== undefined && timeoutMs > 0 ? { timeoutMs } : {}),
+      })
+    } catch (error) {
+      throw new SandboxError(
+        `[Sandbox] vercel runCommand failed for ${this.id}: ${errorMessage(error)}`
+      )
+    }
+
+    this.inFlight.add(commandHandle)
+
+    const kill = (): void => {
+      if (killStarted) {
+        return
+      }
+      killStarted = true
+      commandHandle.kill("SIGKILL").catch(() => {})
+    }
+
+    const timer =
+      timeoutMs !== undefined && timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true
+            kill()
+          }, timeoutMs)
+        : undefined
+
+    const onAbort = (): void => {
+      aborted = true
+      kill()
+    }
+    options.signal?.addEventListener("abort", onAbort)
+    if (options.signal?.aborted) {
+      onAbort()
+    }
+
+    try {
+      const finished = await commandHandle.wait()
+      const [stdout, stderr] = await Promise.all([finished.stdout(), finished.stderr()])
+      const exitCode = normalizeExitCode(finished.exitCode, killStarted)
+      return {
+        exitCode,
+        stdout,
+        stderr,
+        durationMs: Date.now() - start,
+        ...(timedOut ? { timedOut: true } : {}),
+      }
+    } catch (error) {
+      if (timedOut || aborted) {
+        return {
+          exitCode: KILLED_EXIT_CODE,
+          stdout: "",
+          stderr: timedOut
+            ? `[Sandbox] command timed out after ${timeoutMs}ms`
+            : "[Sandbox] command aborted",
+          durationMs: Date.now() - start,
+          ...(timedOut ? { timedOut: true } : {}),
+        }
+      }
+      throw new SandboxError(
+        `[Sandbox] vercel command failed for ${this.id}: ${errorMessage(error)}`
+      )
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer)
+      }
+      options.signal?.removeEventListener("abort", onAbort)
+      this.inFlight.delete(commandHandle)
+    }
+  }
+
+  async writeFiles(files: readonly SandboxFileRecord[]): Promise<void> {
+    this.assertRunning("write files")
+    if (files.length === 0) {
+      return
+    }
+
+    const mapped = files.map((file) => ({
+      path: this.resolveWithinWorkingDirectory(file.path),
+      content: file.contents,
+      ...(file.mode !== undefined ? { mode: file.mode } : {}),
+    }))
+
+    try {
+      await this.client.writeFiles(mapped)
+    } catch (error) {
+      throw new SandboxError(
+        `[Sandbox] vercel writeFiles failed for ${this.id}: ${errorMessage(error)}`
+      )
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.currentStatus !== "running") {
+      return
+    }
+    this.currentStatus = "stopped"
+    for (const commandHandle of this.inFlight) {
+      commandHandle.kill("SIGKILL").catch(() => {})
+    }
+    this.inFlight.clear()
+    try {
+      await this.client.stop()
+    } catch (error) {
+      throw new SandboxError(`[Sandbox] vercel stop failed for ${this.id}: ${errorMessage(error)}`)
+    }
+  }
+
+  async destroy(): Promise<void> {
+    if (this.destroyed) {
+      return
+    }
+
+    if (this.currentStatus === "running") {
+      try {
+        await this.stop()
+      } catch {
+        // Deleting the sandbox is the real reclamation step; keep going if stop failed.
+      }
+    }
+
+    try {
+      await this.client.delete()
+      this.destroyed = true
+      this.currentStatus = "stopped"
+    } catch (error) {
+      throw new SandboxError(
+        `[Sandbox] vercel delete failed for ${this.id}: ${errorMessage(error)}`
+      )
+    }
+  }
+
+  private assertRunning(action: string): void {
+    const status = this.status
+    if (status !== "running") {
+      throw new SandboxNotRunningError(
+        `[Sandbox] sandbox ${this.id} is ${status}; cannot ${action}`
+      )
+    }
+  }
+
+  private resolveWithinWorkingDirectory(path: string): string {
+    const target = posix.resolve(this.workingDirectory, path)
+    if (target !== this.workingDirectory && !target.startsWith(`${this.workingDirectory}/`)) {
+      throw new Error(
+        `[Sandbox] writeFiles path '${path}' escapes the sandbox working directory ${this.workingDirectory}`
+      )
+    }
+    return target
+  }
+}
+
+function normalizeWorkingDirectory(value: string | undefined): string {
+  return value && value.length > 0 ? posix.resolve("/", value) : DEFAULT_WORKING_DIRECTORY
+}
+
+function normalizeExitCode(exitCode: number | null | undefined, killed: boolean): number {
+  if (typeof exitCode === "number") {
+    return killed && exitCode === 0 ? KILLED_EXIT_CODE : exitCode
+  }
+  return killed ? KILLED_EXIT_CODE : 1
+}
+
+function abortedResult(start: number): CommandResult {
+  return {
+    exitCode: KILLED_EXIT_CODE,
+    stdout: "",
+    stderr: "[Sandbox] command aborted",
+    durationMs: Date.now() - start,
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/sandboxes/vercel/tests/network.test.ts
+++ b/sandboxes/vercel/tests/network.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { toVercelNetworkPolicy } from "../src/network"
+
+describe("toVercelNetworkPolicy", () => {
+  test("maps deny-all and allow-all modes", () => {
+    expect(toVercelNetworkPolicy(undefined)).toBe("deny-all")
+    expect(toVercelNetworkPolicy({ mode: "none" })).toBe("deny-all")
+    expect(toVercelNetworkPolicy({ mode: "all" })).toBe("allow-all")
+  })
+
+  test("maps empty restricted allow list to deny-all", () => {
+    expect(toVercelNetworkPolicy({ mode: "restricted", allow: [] })).toBe("deny-all")
+  })
+
+  test("maps HTTPS restricted targets to domain allow rules", () => {
+    expect(
+      toVercelNetworkPolicy({
+        mode: "restricted",
+        allow: [
+          { name: "sixb-api", origin: "https://api.example.com:443" },
+          { name: "assets", origin: "https://assets.example.com" },
+        ],
+      })
+    ).toEqual({ allow: ["api.example.com", "assets.example.com"] })
+  })
+
+  test("maps IP targets to subnet allow rules", () => {
+    expect(
+      toVercelNetworkPolicy({
+        mode: "restricted",
+        allow: [
+          { name: "gateway", origin: "http://10.0.0.5:3002" },
+          { name: "v6", origin: "https://[2001:db8::1]:8443" },
+        ],
+      })
+    ).toEqual({ subnets: { allow: ["10.0.0.5/32", "2001:db8::1/128"] } })
+  })
+
+  test("rejects loopback targets because Vercel runs remotely", () => {
+    expect(() =>
+      toVercelNetworkPolicy({
+        mode: "restricted",
+        allow: [{ name: "local", origin: "http://127.0.0.1:3002" }],
+      })
+    ).toThrow("cannot reach restricted target")
+  })
+
+  test("rejects plain HTTP hostname targets because Vercel domain filtering is TLS-only", () => {
+    expect(() =>
+      toVercelNetworkPolicy({
+        mode: "restricted",
+        allow: [{ name: "api", origin: "http://api.example.com" }],
+      })
+    ).toThrow("plain HTTP")
+  })
+})

--- a/sandboxes/vercel/tests/vercel-integration.test.ts
+++ b/sandboxes/vercel/tests/vercel-integration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { posix } from "node:path"
+import { VercelSandboxFactory } from "../src/vercel-sandbox-factory"
+
+/**
+ * Live Vercel Sandbox smoke test. Disabled by default because it requires Vercel credentials and
+ * consumes metered sandbox resources. Run with SIXB_VERCEL_SANDBOX_INTEGRATION=1.
+ */
+const guard = process.env.SIXB_VERCEL_SANDBOX_INTEGRATION === "1" ? describe : describe.skip
+
+guard("VercelSandbox (live)", () => {
+  test("runs commands and reads materialized files", async () => {
+    const sandbox = await new VercelSandboxFactory({ sessionTimeoutMs: 5 * 60_000 }).create()
+    try {
+      const echo = await sandbox.runCommand("bash", ["-lc", "echo vercel-ok"])
+      expect(echo.exitCode).toBe(0)
+      expect(echo.stdout.trim()).toBe("vercel-ok")
+
+      const path = posix.join(sandbox.workingDirectory, "sixb-live.txt")
+      await sandbox.writeFiles([{ path, contents: "from-sixb" }])
+      const cat = await sandbox.runCommand("cat", [path])
+      expect(cat.exitCode).toBe(0)
+      expect(cat.stdout.trim()).toBe("from-sixb")
+    } finally {
+      await sandbox.destroy()
+    }
+  }, 180_000)
+})

--- a/sandboxes/vercel/tests/vercel-sandbox.test.ts
+++ b/sandboxes/vercel/tests/vercel-sandbox.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from "bun:test"
+import { SandboxNotRunningError } from "@sixb/core"
+import type {
+  VercelCommandClient,
+  VercelCommandFinishedClient,
+  VercelRunCommandParams,
+  VercelSandboxClient,
+} from "../src/vercel-sandbox"
+import { VercelSandbox } from "../src/vercel-sandbox"
+import { type VercelCreateSandbox, VercelSandboxFactory } from "../src/vercel-sandbox-factory"
+
+class FakeFinished implements VercelCommandFinishedClient {
+  constructor(
+    readonly exitCode: number,
+    private readonly out = "stdout-from-vercel",
+    private readonly err = "stderr-from-vercel"
+  ) {}
+
+  async stdout(): Promise<string> {
+    return this.out
+  }
+
+  async stderr(): Promise<string> {
+    return this.err
+  }
+}
+
+class FakeCommand implements VercelCommandClient {
+  killed = false
+  private release: ((value: VercelCommandFinishedClient) => void) | undefined
+
+  constructor(private readonly waitForKill = false) {}
+
+  async wait(): Promise<VercelCommandFinishedClient> {
+    if (!this.waitForKill) {
+      return new FakeFinished(0)
+    }
+    if (this.killed) {
+      return new FakeFinished(137, "", "killed")
+    }
+    return await new Promise<VercelCommandFinishedClient>((resolve) => {
+      this.release = resolve
+    })
+  }
+
+  async kill(): Promise<void> {
+    this.killed = true
+    this.release?.(new FakeFinished(137, "", "killed"))
+  }
+}
+
+class FakeVercelClient implements VercelSandboxClient {
+  readonly commands: VercelRunCommandParams[] = []
+  readonly writes: {
+    readonly path: string
+    readonly content: string | Uint8Array
+    readonly mode?: number
+  }[][] = []
+  readonly commandHandles: FakeCommand[] = []
+  stopCalls = 0
+  deleteCalls = 0
+  status = "running"
+  nextCommandWaitsForKill = false
+
+  constructor(
+    readonly name = "vercel-sandbox-1",
+    readonly cwd = "/vercel/sandbox"
+  ) {}
+
+  async runCommand(params: VercelRunCommandParams): Promise<VercelCommandClient> {
+    this.commands.push(params)
+    const command = new FakeCommand(this.nextCommandWaitsForKill)
+    this.nextCommandWaitsForKill = false
+    this.commandHandles.push(command)
+    return command
+  }
+
+  async writeFiles(
+    files: readonly {
+      readonly path: string
+      readonly content: string | Uint8Array
+      readonly mode?: number
+    }[]
+  ): Promise<void> {
+    this.writes.push([...files])
+  }
+
+  async stop(): Promise<void> {
+    this.status = "stopped"
+    this.stopCalls += 1
+  }
+
+  async delete(): Promise<void> {
+    this.deleteCalls += 1
+  }
+}
+
+describe("VercelSandbox", () => {
+  test("runCommand forwards cwd/env/timeout and maps output", async () => {
+    const client = new FakeVercelClient()
+    const sandbox = new VercelSandbox({ client, env: { A: "factory" }, timeout: 5_000 })
+
+    const result = await sandbox.runCommand("bash", ["-lc", "echo hi"], {
+      cwd: "/tmp",
+      env: { B: "call" },
+      timeout: 123,
+    })
+
+    expect(result).toMatchObject({
+      exitCode: 0,
+      stdout: "stdout-from-vercel",
+      stderr: "stderr-from-vercel",
+    })
+    expect(client.commands[0]).toEqual({
+      cmd: "bash",
+      args: ["-lc", "echo hi"],
+      cwd: "/tmp",
+      env: { A: "factory", B: "call" },
+      detached: true,
+      timeoutMs: 123,
+    })
+  })
+
+  test("writeFiles materializes paths within workingDirectory", async () => {
+    const client = new FakeVercelClient()
+    const sandbox = new VercelSandbox({ client })
+
+    await sandbox.writeFiles([
+      { path: `${sandbox.workingDirectory}/a.txt`, contents: "a", mode: 0o644 },
+      { path: "nested/b.txt", contents: new Uint8Array([1, 2]) },
+    ])
+
+    expect(client.writes[0]).toEqual([
+      { path: "/vercel/sandbox/a.txt", content: "a", mode: 0o644 },
+      { path: "/vercel/sandbox/nested/b.txt", content: new Uint8Array([1, 2]) },
+    ])
+    await expect(sandbox.writeFiles([{ path: "/etc/passwd", contents: "nope" }])).rejects.toThrow(
+      "escapes"
+    )
+  })
+
+  test("timeout kills the remote command and marks the result", async () => {
+    const client = new FakeVercelClient()
+    client.nextCommandWaitsForKill = true
+    const sandbox = new VercelSandbox({ client })
+
+    const result = await sandbox.runCommand("sleep", ["30"], { timeout: 5 })
+
+    expect(result.exitCode).toBe(137)
+    expect(result.timedOut).toBe(true)
+    expect(client.commandHandles[0].killed).toBe(true)
+  })
+
+  test("stop and destroy are idempotent and reject further work", async () => {
+    const client = new FakeVercelClient()
+    const sandbox = new VercelSandbox({ client })
+
+    await sandbox.stop()
+    await sandbox.stop()
+    expect(sandbox.status).toBe("stopped")
+    expect(client.stopCalls).toBe(1)
+    await expect(sandbox.runCommand("echo", ["nope"])).rejects.toBeInstanceOf(
+      SandboxNotRunningError
+    )
+
+    await sandbox.destroy()
+    await sandbox.destroy()
+    expect(client.deleteCalls).toBe(1)
+  })
+})
+
+describe("VercelSandboxFactory", () => {
+  test("builds Vercel create params and keeps Sixb command timeout separate", async () => {
+    const client = new FakeVercelClient()
+    let captured: unknown
+    const createRemote: VercelCreateSandbox = async (params) => {
+      captured = params
+      return client
+    }
+
+    const factory = new VercelSandboxFactory(
+      {
+        credentials: { token: "tok", teamId: "team", projectId: "project" },
+        env: { A: "factory" },
+        timeout: 111,
+        sessionTimeoutMs: 60_000,
+        resources: { vcpus: 1 },
+      },
+      createRemote
+    )
+
+    const sandbox = await factory.create({
+      env: { B: "call" },
+      timeout: 222,
+      network: { mode: "none" },
+    })
+
+    expect(captured).toMatchObject({
+      env: { A: "factory", B: "call" },
+      networkPolicy: "deny-all",
+      persistent: false,
+      timeout: 60_000,
+      resources: { vcpus: 1 },
+      token: "tok",
+      teamId: "team",
+      projectId: "project",
+    })
+    expect((captured as { name: string }).name).toStartWith("sixb-")
+
+    await sandbox.runCommand("echo", ["ok"])
+    expect(client.commands[0].timeoutMs).toBe(222)
+  })
+
+  test("creates a configured working directory in the remote sandbox", async () => {
+    const client = new FakeVercelClient()
+    const factory = new VercelSandboxFactory({}, async () => client)
+
+    const sandbox = await factory.create({ workingDirectory: "/workspace/run-1" })
+
+    expect(sandbox.workingDirectory).toBe("/workspace/run-1")
+    expect(client.commands[0]).toMatchObject({
+      cmd: "mkdir",
+      args: ["-p", "/workspace/run-1"],
+      cwd: "/",
+      env: {},
+      detached: true,
+      timeoutMs: 30_000,
+    })
+  })
+
+  test("rejects snapshot configuration conflicts", async () => {
+    const factory = new VercelSandboxFactory({ snapshotId: "snap_1", image: "agent:latest" })
+    await expect(factory.create()).rejects.toThrow("snapshotId cannot be combined")
+  })
+})

--- a/sandboxes/vercel/tsconfig.json
+++ b/sandboxes/vercel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,7 @@
       "@sixb/rules-worker": ["./packages/rules-worker/src/index.ts"],
       "@sixb/sandboxes-local": ["./sandboxes/local/src/index.ts"],
       "@sixb/sandboxes-smolvm": ["./sandboxes/smolvm/src/index.ts"],
+      "@sixb/sandboxes-vercel": ["./sandboxes/vercel/src/index.ts"],
       "@sixb/server": ["./packages/server/src/index.ts"],
       "@sixb/sqlite": ["./storage/sqlite/src/index.ts"],
       "@sixb/sync-worker": ["./packages/sync-worker/src/index.ts"],


### PR DESCRIPTION
Closes #148.

## Why

Sixb has local sandboxes for development and smolvm sandboxes for self-hosted microVM isolation. This adds a hosted option for teams that want managed Vercel Sandbox microVMs without installing a hypervisor or building an agent image on the worker host.

## What changed

### `@sixb/sandboxes-vercel`

Adds a new drop-in sandbox provider:

```ts
import { VercelSandboxFactory } from "@sixb/sandboxes-vercel"

createSixb({
  sandboxes: new VercelSandboxFactory({
    timeout: 30_000, // Sixb per-command timeout
    sessionTimeoutMs: 10 * 60_000, // Vercel VM lifetime
  }),
})
```

The provider maps the existing Sixb sandbox contract to the Vercel SDK:

| Sixb | Vercel |
| --- | --- |
| `create()` | `Sandbox.create(...)` with `persistent: false` by default |
| `runCommand(...)` | detached command + `wait()` |
| `writeFiles(...)` | Vercel file upload API |
| `stop()` | stop the current Vercel session |
| `destroy()` | delete the Vercel sandbox |

### Network policy mapping

Sixb policies are translated into Vercel firewall policies:

| Sixb policy | Vercel behavior |
| --- | --- |
| `{ mode: "none" }` | deny all egress |
| `{ mode: "all" }` | allow all egress |
| restricted HTTPS origins | allow domains by TLS SNI |
| restricted IP origins | allow CIDRs |

The provider rejects restricted loopback targets and plain HTTP hostnames, because Vercel sandboxes run remotely and Vercel's domain firewall is TLS/SNI-based.

### Docs and UI polish

- Adds end-developer docs at `docs/sandboxes/vercel.md`.
- Adds package README and tests.
- Includes the small Composer fix so the chat textarea does not show a scrollbar until content exceeds the max height.

## Manual test with Acme + ngrok

The Acme example still defaults to smolvm, but you can manually test this provider there without committing the local swap.

1. Temporarily wire the Vercel sandbox in `examples/acme-corp/sixb.config.ts`:

```ts
import { VercelSandboxFactory } from "@sixb/sandboxes-vercel"

// ...inside createSixb(...)
sandboxes: new VercelSandboxFactory({
  timeout: 30_000,
  sessionTimeoutMs: 10 * 60_000,
}),
```

2. Link a Vercel project and pull a local OIDC token:

```bash
cd examples/acme-corp
vercel link
vercel env pull .env.local
```

3. Expose the Sixb API port with ngrok:

```bash
ngrok http 3002
```

4. Start Acme with the ngrok HTTPS origin as the API public origin:

```bash
SIXB_API_PUBLIC_ORIGIN=https://<your-ngrok-domain> bun run dev
```

5. In Atlas, trigger an agent prompt that uses bash, for example:

```txt
Use bash to print the working directory, then curl the Sixb API object-types endpoint.
```

The Vercel sandbox should be created for the run, receive the gateway env/context files, and reach the Sixb API through the ngrok HTTPS origin. Do not commit `.vercel/`, `.env.local`, or the temporary Acme config swap.

The live provider smoke test is also available, but gated because it consumes Vercel Sandbox resources:

```bash
SIXB_VERCEL_SANDBOX_INTEGRATION=1 bun --filter @sixb/sandboxes-vercel test
```

## Validation

```bash
bun --filter @sixb/sandboxes-vercel test
bun --filter @sixb/sandboxes-vercel typecheck
bun --filter @sixb/agent-ui typecheck
bunx biome check packages/agent-ui/src/components/Composer.tsx sandboxes/vercel/src sandboxes/vercel/tests
bun run typecheck
bun run build
bun run check
```
