### PR TITLE
agent chat: group work steps, calm tool errors, and valid-JSON tool output

### DIFF
--- a/packages/agent-ui/src/bash/BashToolView.tsx
+++ b/packages/agent-ui/src/bash/BashToolView.tsx
@@ -78,15 +78,25 @@ export function BashToolView({ tool }: { tool: BashTool }) {
   const Icon = ICONS[description.icon]
   const label = running ? description.runningTitle : description.title
 
-  // Failures surface inline — never hidden behind a disclosure.
+  // A failed command reads as a quiet, neutral step — same calm marker as any other tool line, no
+  // alarming red in the transcript. The error itself is tucked behind the disclosure so advanced
+  // users can still expand and debug it. (Exploratory commands often fail and the agent recovers;
+  // surfacing that in red just makes a working run look broken.)
   if (isError && !running) {
     return (
-      <div>
-        <ToolLine icon={Terminal} label={label} tone="error" />
-        <p className="mt-1.5 border-l-2 border-destructive/30 pl-3 text-xs whitespace-pre-wrap text-destructive">
-          {errorMessage(parsed, tool.errorText)}
-        </p>
-      </div>
+      <Collapsible>
+        <CollapsibleTrigger className="group flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal text-muted-foreground transition-colors hover:text-foreground">
+          <Icon className="size-3.5 shrink-0" />
+          <span className="min-w-0 truncate font-medium">{label}</span>
+          <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-3 space-y-2 text-xs">
+            {command ? <RawBlock label="Command" value={command} /> : null}
+            <RawBlock label="Details" value={errorMessage(parsed, tool.errorText)} />
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     )
   }
 
@@ -130,22 +140,15 @@ function ToolLine({
   icon: Icon,
   label,
   detail,
-  tone = "default",
   running,
 }: {
   icon: LucideIcon
   label: string
   detail?: string
-  tone?: "default" | "error"
   running?: boolean
 }) {
   return (
-    <div
-      className={cn(
-        "flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal",
-        tone === "error" ? "text-destructive" : "text-muted-foreground"
-      )}
-    >
+    <div className="flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal text-muted-foreground">
       <Icon className="size-3.5 shrink-0" />
       <span className={cn("min-w-0 truncate font-medium", running && "shimmer")}>{label}</span>
       {detail ? (

--- a/packages/agent-ui/src/bash/interpret.ts
+++ b/packages/agent-ui/src/bash/interpret.ts
@@ -271,7 +271,8 @@ export function describeBash(intent: BashIntent, parsed: ParsedBashOutput | null
     }
     case "api-count": {
       const value = numberField(parsed?.json, "count")
-      const label = humanize(intent.objectTypeId) || "objects"
+      // Singular base — `plural()` adds the suffix, so "objects" here would become "objectses".
+      const label = humanize(intent.objectTypeId) || "object"
       return icon(
         "count",
         `Counted ${plural(label)}`,

--- a/packages/agent-ui/src/components/MessageParts.tsx
+++ b/packages/agent-ui/src/components/MessageParts.tsx
@@ -1,127 +1,151 @@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger, Markdown } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
-import { AlertTriangle, ChevronRight, Wrench } from "lucide-react"
+import { ChevronRight, Wrench } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { BashToolView } from "../bash/BashToolView"
 import type { NormalizedPart, NormalizedTool } from "../parts"
 
 /**
- * Render an assistant body from normalized parts. Adjacent text parts are merged into a single
- * readable block; reasoning collapses away from the main reading path; tool calls render as
- * structured rows. `step-start` markers are intentionally skipped.
+ * Render an assistant body from normalized parts. Narration text stays on the main reading path;
+ * every run of consecutive reasoning + tool parts collapses into a single "work" disclosure, so a
+ * long chain of thinking and tool calls reads as one quiet line above the answer instead of a stack
+ * of separate dropdowns. `step-start` markers are intentionally skipped.
  */
-export function AssistantBody({ parts }: { parts: readonly NormalizedPart[] }) {
+export function AssistantBody({
+  parts,
+  live = false,
+}: {
+  parts: readonly NormalizedPart[]
+  /** True while this body is driven by an in-flight run, so the trailing work group stays open. */
+  live?: boolean
+}) {
   const blocks: React.ReactNode[] = []
   let textBuffer: string[] = []
+  let workBuffer: NormalizedPart[] = []
+  let key = 0
 
-  const flushText = (key: string) => {
+  const flushText = () => {
     if (textBuffer.length === 0) return
     const text = textBuffer.join("")
     textBuffer = []
     if (!text.trim()) return
-    blocks.push(<TextBlock key={key} text={text} />)
+    blocks.push(<TextBlock key={`block-${key++}`} text={text} />)
   }
 
-  parts.forEach((part, index) => {
+  const flushWork = (inProgress: boolean) => {
+    if (workBuffer.length === 0) return
+    const work = workBuffer
+    workBuffer = []
+    // A run of only step boundaries has nothing to show.
+    if (work.every((part) => part.kind === "step-start")) return
+    blocks.push(<WorkGroup key={`block-${key++}`} parts={work} inProgress={inProgress} />)
+  }
+
+  parts.forEach((part) => {
     if (part.kind === "text") {
       textBuffer.push(part.text)
+      // Only real narration ends a work run. Whitespace-only text parts (the model emits one per
+      // step boundary) must not fragment a chain into a stack of separate "Worked" groups. A group
+      // flushed here has narration after it, so it is settled — never the in-progress trailing run.
+      if (part.text.trim()) flushWork(false)
       return
     }
-    flushText(`text-${index}`)
-    if (part.kind === "reasoning") {
-      blocks.push(
-        <ReasoningBlock key={`reasoning-${index}`} text={part.text} streaming={part.streaming} />
-      )
-    } else if (part.kind === "tool") {
-      blocks.push(<ToolCallRow key={`tool-${index}`} tool={part.tool} />)
-    }
+    // reasoning | tool | step-start — buffered together into one work run.
+    flushText()
+    workBuffer.push(part)
   })
-  flushText("text-final")
+  flushText()
+  // The final work run is the only one that can still be receiving steps: keep it open while live.
+  flushWork(live)
 
   return <div className="flex flex-col gap-3">{blocks}</div>
 }
 
 function TextBlock({ text }: { text: string }) {
-  return <Markdown>{text}</Markdown>
+  return <Markdown className="prose-chat">{text}</Markdown>
 }
 
-function ReasoningBlock({ text, streaming }: { text: string; streaming: boolean }) {
-  const [open, setOpen] = useState(streaming)
-  const wasStreamingRef = useRef(streaming)
+/**
+ * A consecutive run of reasoning + tool parts, folded into a single disclosure. It stays open while
+ * `inProgress` — i.e. this is the trailing run of a live turn still receiving steps — and collapses
+ * once it settles (the run finishes, or narration text moves past it). Open/close is keyed off that
+ * single signal, never per-part streaming, so it doesn't flicker as each step settles before the
+ * next begins. Inside, items flow in a single indented column — reasoning as plain text, tools as
+ * their own quiet markers that expand inline — never as dropdowns stacked inside this dropdown.
+ */
+function WorkGroup({
+  parts,
+  inProgress,
+}: {
+  parts: readonly NormalizedPart[]
+  inProgress: boolean
+}) {
+  const [open, setOpen] = useState(inProgress)
+  const wasInProgressRef = useRef(inProgress)
 
   useEffect(() => {
-    if (streaming && !wasStreamingRef.current) {
+    if (inProgress && !wasInProgressRef.current) {
       setOpen(true)
-    } else if (!streaming && wasStreamingRef.current) {
+    } else if (!inProgress && wasInProgressRef.current) {
       setOpen(false)
     }
+    wasInProgressRef.current = inProgress
+  }, [inProgress])
 
-    wasStreamingRef.current = streaming
-  }, [streaming])
+  const toolCount = parts.reduce((count, part) => count + (part.kind === "tool" ? 1 : 0), 0)
+  const hasTools = toolCount > 0
+  const label = inProgress
+    ? hasTools
+      ? "Working…"
+      : "Reasoning…"
+    : hasTools
+      ? "Worked"
+      : "Reasoning"
+  const detail =
+    !inProgress && hasTools ? `${toolCount} ${toolCount === 1 ? "step" : "steps"}` : undefined
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen} className="w-fit max-w-full">
-      <CollapsibleTrigger className="group mb-1 flex items-center gap-1.5 text-[13px] leading-normal text-muted-foreground transition-colors hover:text-foreground">
-        <span className={cn(streaming && "shimmer")}>{streaming ? "Reasoning…" : "Reasoning"}</span>
+    <Collapsible open={open} onOpenChange={setOpen} className="max-w-full">
+      <CollapsibleTrigger className="group flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal text-muted-foreground transition-colors hover:text-foreground">
+        <span className={cn(inProgress && "shimmer")}>{label}</span>
+        {detail ? <span className="text-muted-foreground/60">· {detail}</span> : null}
         <ChevronRight className="size-4 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <ReasoningPreview text={text} streaming={streaming} />
+        <div className="mt-2 ml-1.5 flex flex-col gap-3 border-l-2 border-border pl-3">
+          {parts.map((part, index) => {
+            if (part.kind === "reasoning") {
+              return <GroupReasoning key={index} text={part.text} streaming={part.streaming} />
+            }
+            if (part.kind === "tool") {
+              return <ToolCallRow key={index} tool={part.tool} />
+            }
+            return null
+          })}
+        </div>
       </CollapsibleContent>
     </Collapsible>
   )
 }
 
-function ReasoningPreview({ text, streaming }: { text: string; streaming: boolean }) {
-  const viewportRef = useRef<HTMLDivElement | null>(null)
-  const stickToBottomRef = useRef(true)
-  const [showTopFade, setShowTopFade] = useState(false)
-  const textLength = text.length
-
-  useEffect(() => {
-    if (textLength === 0) {
-      setShowTopFade(false)
-      return
-    }
-
-    const viewport = viewportRef.current
-    if (!viewport || !streaming || !stickToBottomRef.current) {
-      return
-    }
-
-    const frame = requestAnimationFrame(() => {
-      viewport.scrollTop = viewport.scrollHeight
-      setShowTopFade(viewport.scrollTop > 4)
-    })
-
-    return () => cancelAnimationFrame(frame)
-  }, [streaming, textLength])
-
+/** Reasoning inside a work group: plain, quiet text that flows with the rest of the chain. */
+function GroupReasoning({ text, streaming }: { text: string; streaming: boolean }) {
+  if (!text.trim()) return null
   return (
-    <div className="relative mt-1.5 ml-1.5 max-w-full border-l-2 border-border pl-3">
-      {showTopFade ? (
-        <div className="pointer-events-none absolute top-0 right-0 left-3 z-10 h-7 bg-gradient-to-b from-background via-background/85 to-transparent" />
-      ) : null}
-      <div
-        ref={viewportRef}
-        className="scrollbar-thin max-h-52 overflow-y-auto pr-3 text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground overscroll-contain sm:max-h-64"
-        onScroll={(event) => {
-          const viewport = event.currentTarget
-          const distanceFromBottom =
-            viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight
-          stickToBottomRef.current = distanceFromBottom < 24
-          setShowTopFade(viewport.scrollTop > 4)
-        }}
-      >
-        {text}
-      </div>
-    </div>
+    <p className="text-xs leading-relaxed whitespace-pre-wrap text-muted-foreground/80">
+      {text}
+      {streaming ? <span className="shimmer">▍</span> : null}
+    </p>
   )
 }
 
+/**
+ * A single tool call within a work group. `bash` — the agent's one tool — renders through its
+ * intent-aware view; anything else falls back to the generic inspector. Both keep their bodies
+ * borderless and inline so an expanded result flows within the group rather than reading as a
+ * nested dropdown.
+ */
 function ToolCallRow({ tool }: { tool: NormalizedTool }) {
-  // The agent's one tool is `bash`; render it through the friendly, intent-aware view. Any other
-  // tool falls back to the generic input/output inspector below.
   if (tool.toolName === "bash") {
     return (
       <BashToolView
@@ -139,52 +163,43 @@ function ToolCallRow({ tool }: { tool: NormalizedTool }) {
   const isError = tool.state === "output-error"
   const hasInput = tool.input !== undefined || Boolean(tool.inputText)
   const hasOutput = tool.state === "output-available" && tool.output !== undefined
+  const hasErrorDetail = isError && Boolean(tool.errorText)
+  const expandable = hasInput || hasOutput || hasErrorDetail
 
+  // Errors read as the same quiet marker as any other tool — no red in the transcript. The failure
+  // detail lives inside the disclosure for anyone who wants to expand and debug it.
   return (
-    <div
-      className={cn(
-        "w-full max-w-full overflow-hidden rounded-md border text-xs",
-        isError ? "border-destructive/30 bg-destructive/5" : "border-border bg-muted/30"
-      )}
-    >
+    <div className="min-w-0">
       <Collapsible>
-        <CollapsibleTrigger className="group flex w-full items-center gap-2 px-2.5 py-1.5 text-left">
-          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
-          {isError ? (
-            <AlertTriangle className="size-3.5 shrink-0 text-destructive" />
-          ) : (
-            <Wrench className="size-3.5 shrink-0 text-muted-foreground" />
-          )}
-          <span className="min-w-0 truncate font-medium text-foreground">{tool.toolName}</span>
+        <CollapsibleTrigger
+          disabled={!expandable}
+          className="group flex w-fit max-w-full items-center gap-1.5 text-[13px] leading-normal text-muted-foreground transition-colors hover:text-foreground disabled:cursor-default disabled:hover:text-muted-foreground"
+        >
+          <Wrench className="size-3.5 shrink-0" />
+          <span className="min-w-0 truncate font-medium">{tool.toolName}</span>
           <ToolStatus state={tool.state} />
+          {expandable ? (
+            <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
+          ) : null}
         </CollapsibleTrigger>
-        <CollapsibleContent className="space-y-2 px-2.5 pb-2.5">
+        <CollapsibleContent className="mt-2 space-y-2">
           {hasInput ? <JsonViewer label="Input" value={tool.input ?? tool.inputText} /> : null}
           {hasOutput ? <JsonViewer label="Output" value={tool.output} /> : null}
+          {hasErrorDetail ? <JsonViewer label="Details" value={tool.errorText} /> : null}
         </CollapsibleContent>
       </Collapsible>
-      {isError && tool.errorText ? (
-        <p className="whitespace-pre-wrap border-t border-destructive/20 px-2.5 py-1.5 text-destructive">
-          {tool.errorText}
-        </p>
-      ) : null}
     </div>
   )
 }
 
 function ToolStatus({ state }: { state: NormalizedTool["state"] }) {
+  // Only the in-flight state is worth a badge; a finished call (done or errored) reads from the
+  // marker itself, keeping failures from flashing red in the transcript.
   const running = state === "input-streaming" || state === "input-available"
-  const label =
-    state === "output-error" ? "error" : state === "output-available" ? "done" : "running"
+  if (!running) return null
   return (
-    <span
-      className={cn(
-        "ml-auto shrink-0 text-[10px] font-medium uppercase tracking-wide",
-        state === "output-error" ? "text-destructive" : "text-muted-foreground",
-        running && "shimmer"
-      )}
-    >
-      {label}
+    <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/60 shimmer">
+      running
     </span>
   )
 }
@@ -195,7 +210,7 @@ function JsonViewer({ label, value }: { label: string; value: unknown }) {
       <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </p>
-      <pre className="scrollbar-thin max-h-60 overflow-auto rounded bg-background/60 p-2 text-[11px] leading-relaxed text-foreground">
+      <pre className="scrollbar-thin max-h-60 overflow-auto rounded bg-muted/50 p-2 text-[11px] leading-relaxed text-foreground">
         {formatValue(value)}
       </pre>
     </div>

--- a/packages/agent-ui/src/components/MessageView.tsx
+++ b/packages/agent-ui/src/components/MessageView.tsx
@@ -36,7 +36,7 @@ export function LiveAssistant({ live }: { live: LiveRunState }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <AssistantBody parts={live.parts} />
+      <AssistantBody parts={live.parts} live={live.active} />
       {live.finishStatus === "failed" ? (
         <RunErrorMarker message={live.finishError ?? "The agent run failed."} />
       ) : null}

--- a/packages/agent-worker/src/bash-tool.ts
+++ b/packages/agent-worker/src/bash-tool.ts
@@ -3,7 +3,7 @@ import { jsonSchema, type Tool, tool } from "ai"
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 30_000
 const MAX_COMMAND_TIMEOUT_MS = 120_000
-const DEFAULT_MAX_OUTPUT_CHARS = 16_000
+const DEFAULT_MAX_OUTPUT_CHARS = 20_000
 
 interface BashToolInput {
   readonly command: string
@@ -64,7 +64,10 @@ function normalizeTimeout(timeoutMs: number | undefined): number {
 }
 
 function truncateCommandResult(result: CommandResult): BashToolOutput {
-  const stdout = truncateText(result.stdout, DEFAULT_MAX_OUTPUT_CHARS)
+  // stdout is usually a Sixb API JSON response: compact it (and, if still oversized, keep a valid
+  // structural prefix) so both the model and the chat UI receive parseable JSON rather than a body
+  // cut mid-structure. stderr is diagnostics, so it just gets a lossless-in-the-middle text trim.
+  const stdout = compressStdout(result.stdout, DEFAULT_MAX_OUTPUT_CHARS)
   const stderr = truncateText(result.stderr, DEFAULT_MAX_OUTPUT_CHARS)
   return {
     ...result,
@@ -75,15 +78,75 @@ function truncateCommandResult(result: CommandResult): BashToolOutput {
   }
 }
 
-function truncateText(
-  text: string,
-  maxChars: number
-): { readonly text: string; readonly truncated: boolean } {
-  if (text.length <= maxChars) {
-    return { text, truncated: false }
+interface TruncateResult {
+  readonly text: string
+  readonly truncated: boolean
+}
+
+/**
+ * Fit a command's stdout under `maxChars`, preferring to keep it valid JSON.
+ *
+ * The agent's commands (and any `jq` pretty-printing it adds) mostly produce JSON API responses. We
+ * compress in the order the field recommends — reformat first, drop data only if we must:
+ *   1. Under budget already → leave it untouched.
+ *   2. Valid JSON → re-serialize compact; whitespace alone often brings it under budget with zero
+ *      data loss (compact JSON is also fewer tokens and no worse for model comprehension).
+ *   3. Still oversized JSON array → keep the largest whole-element prefix that fits, as a bare array
+ *      (same shape the caller expects, still valid JSON, just fewer rows).
+ *   4. Anything else still oversized (a huge single object, or non-JSON) → middle-truncate the text.
+ */
+export function compressStdout(text: string, maxChars: number): TruncateResult {
+  if (text.length <= maxChars) return { text, truncated: false }
+
+  const json = tryParseJsonDocument(text)
+  if (json !== undefined) {
+    const compact = JSON.stringify(json)
+    if (compact.length <= maxChars) return { text: compact, truncated: false }
+    if (Array.isArray(json)) return { text: fitJsonArrayPrefix(json, maxChars), truncated: true }
+    // A single object too large even compacted: fall through to a text trim of the compact form.
+    return truncateText(compact, maxChars)
   }
+
+  return truncateText(text, maxChars)
+}
+
+/** The largest whole-element prefix of `items` whose compact JSON fits under `maxChars`. */
+function fitJsonArrayPrefix(items: readonly unknown[], maxChars: number): string {
+  let low = 0
+  let high = items.length
+  let best = 0
+  while (low <= high) {
+    const mid = (low + high) >> 1
+    if (JSON.stringify(items.slice(0, mid)).length <= maxChars) {
+      best = mid
+      low = mid + 1
+    } else {
+      high = mid - 1
+    }
+  }
+  return JSON.stringify(items.slice(0, best))
+}
+
+/** JSON.parse, but only for object/array documents — never a bare number/string/bool. */
+function tryParseJsonDocument(text: string): unknown {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return undefined
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return undefined
+  }
+}
+
+/** Keep the head and tail, dropping the middle — so trailing errors and exit lines survive. */
+function truncateText(text: string, maxChars: number): TruncateResult {
+  if (text.length <= maxChars) return { text, truncated: false }
+  const marker = `\n…[SixbAgentWorker] output truncated to ${maxChars} characters]…\n`
+  const budget = Math.max(0, maxChars - marker.length)
+  const head = Math.ceil(budget / 2)
+  const tail = budget - head
   return {
-    text: `${text.slice(0, maxChars)}\n[SixbAgentWorker] output truncated to ${maxChars} characters.`,
+    text: text.slice(0, head) + marker + (tail > 0 ? text.slice(text.length - tail) : ""),
     truncated: true,
   }
 }

--- a/packages/agent-worker/tests/bash-tool.test.ts
+++ b/packages/agent-worker/tests/bash-tool.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { compressStdout } from "../src/bash-tool"
+
+const CAP = 200
+
+describe("compressStdout", () => {
+  test("leaves output under the cap untouched", () => {
+    const text = `[{"id":"Customer"}]`
+    expect(compressStdout(text, CAP)).toEqual({ text, truncated: false })
+  })
+
+  test("compacts pretty-printed JSON that fits once whitespace is dropped", () => {
+    const value = Array.from({ length: 6 }, (_, index) => ({
+      id: `type-${index}`,
+      name: `Type ${index}`,
+    }))
+    const pretty = JSON.stringify(value, null, 2)
+    const cap = 250
+    // The pretty form overflows the cap purely on whitespace; the compact form fits.
+    expect(pretty.length).toBeGreaterThan(cap)
+    expect(JSON.stringify(value).length).toBeLessThanOrEqual(cap)
+
+    const result = compressStdout(pretty, cap)
+    expect(result.truncated).toBe(false)
+    expect(result.text).toBe(JSON.stringify(value))
+    // Round-trips to the same data — nothing was dropped.
+    expect(JSON.parse(result.text)).toEqual(value)
+  })
+
+  test("keeps a valid whole-element array prefix when compaction is not enough", () => {
+    const value = Array.from({ length: 200 }, (_, index) => ({
+      id: `type-${index}`,
+      name: `Type ${index}`,
+    }))
+    const result = compressStdout(JSON.stringify(value), CAP)
+
+    expect(result.truncated).toBe(true)
+    const parsed = JSON.parse(result.text) // must still be valid JSON
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed.length).toBeGreaterThan(0)
+    expect(parsed.length).toBeLessThan(value.length)
+    expect(result.text.length).toBeLessThanOrEqual(CAP)
+    // The kept elements are the untouched leading originals.
+    expect(parsed[0]).toEqual(value[0])
+  })
+
+  test("middle-truncates a single oversized object, preserving head and tail", () => {
+    const value = { id: "Customer", blob: "x".repeat(500), tail: "END" }
+    const result = compressStdout(JSON.stringify(value), CAP)
+
+    expect(result.truncated).toBe(true)
+    expect(result.text.length).toBeLessThanOrEqual(CAP)
+    expect(result.text.startsWith(`{"id":"Customer"`)).toBe(true)
+    expect(result.text.endsWith(`"tail":"END"}`)).toBe(true)
+    expect(result.text).toContain("truncated to")
+  })
+
+  test("middle-truncates non-JSON output, keeping head and tail", () => {
+    const text = `START ${"a".repeat(500)} FINISH`
+    const result = compressStdout(text, CAP)
+
+    expect(result.truncated).toBe(true)
+    expect(result.text.length).toBeLessThanOrEqual(CAP)
+    expect(result.text.startsWith("START ")).toBe(true)
+    expect(result.text.endsWith(" FINISH")).toBe(true)
+  })
+})

--- a/packages/app/tests/styles.test.ts
+++ b/packages/app/tests/styles.test.ts
@@ -240,9 +240,13 @@ describe("custom app Tailwind build (e2e)", () => {
     }
 
     // The compiled stylesheet lands under .sixb/generated, not app/.
+    // Canary classes, one per scanned source — proves Tailwind compiled the app's own page plus the
+    // linked component libraries, not just one of them. `line-through` is the app page, `max-h-60`
+    // comes only from @sixb/agent-ui, `h-dvh` only from @sixb/app. (Repoint these if a class is
+    // removed from its source rather than asserting a class that no longer exists.)
     const generatedCss = await readFile(join(tempRoot, ".sixb", "generated", "app.css"), "utf-8")
     expect(generatedCss).toContain("line-through")
-    expect(generatedCss).toContain("max-h-52")
+    expect(generatedCss).toContain("max-h-60")
     expect(generatedCss).toContain("h-dvh")
     expect(generatedCss.lastIndexOf("--background: #123456")).toBeGreaterThan(
       generatedCss.lastIndexOf("--background: #fafafa")


### PR DESCRIPTION
A few focused touches to the agent chat so a long, tool-heavy turn reads as a clean answer with the work tucked neatly behind it — and so a failed exploratory command never makes a working run look broken. Also fixes the underlying reason large API responses were showing up as raw JSON.

All changes are scoped to `packages/agent-ui` (chat rendering) and `packages/agent-worker` (the bash tool's output handling).

## Core fixes

### 1. Group consecutive reasoning + tool steps into one collapsible

**Why:** models do a lot of back-to-back reasoning and tool calls before answering. Each was its own dropdown, so a single turn became a tall stack of ~20 separate `Reasoning ›` / tool rows — noisy, and hard to find the actual answer.

**What:** `AssistantBody` now splits parts into two lanes — narration text stays on the reading path, and each *run* of consecutive reasoning + tool parts folds into one collapsible **`Worked · N steps`** group. Inside, items flow in a single indented column (reasoning as text, tools as their quiet markers) — no nested dropdown-in-a-dropdown.

Two subtleties that make it feel right:

```tsx
// Whitespace-only text parts (the model emits one per step boundary) must NOT
// split a chain into a stack of separate "Worked" groups — only real narration does.
if (part.text.trim()) flushWork(false)
```

```tsx
// The final run is the only one that can still be receiving steps: keep it open
// while the run is live. Open/close keys off this single signal, not per-part
// streaming state — so it doesn't flicker open/closed between steps.
flushWork(live)
```

The group auto-opens while the live run streams and collapses once it settles (or once narration text moves past it).

### 2. Calm, non-alarming tool errors

**Why:** exploratory commands fail sometimes and the agent just retries — but we surfaced those in red with a raw traceback, so a healthy run looked like it was on fire. Bad for demos.

**What:** a failed tool call now renders as the same quiet neutral marker as any other step (no red in the transcript), with the raw error tucked inside the disclosure for advanced debugging. Reuses the existing `JsonViewer`/`RawBlock` — no new error UI.

```tsx
// A failed command reads as a quiet, neutral step — the error itself is tucked
// behind the disclosure so advanced users can still expand and debug it.
if (isError && !running) {
  return (
    <Collapsible>
      <CollapsibleTrigger className="…text-muted-foreground hover:text-foreground">
        <Icon className="size-3.5 shrink-0" />
        <span className="min-w-0 truncate font-medium">{label}</span>
        <ChevronRight … />
      </CollapsibleTrigger>
      <CollapsibleContent>
        {command ? <RawBlock label="Command" value={command} /> : null}
        <RawBlock label="Details" value={errorMessage(parsed, tool.errorText)} />
      </CollapsibleContent>
    </Collapsible>
  )
}
```

The run-level failure marker (shown only when the *whole* turn dead-ends) stays red on purpose — that one's worth signaling.

### 3. Compress bash output to valid JSON at the tool boundary

**Why:** the worker capped bash stdout at 16k chars with a head-only cut. When the model piped a large response through `jq '.'` (pretty-printed, 2-3× bigger), it got sliced mid-object → invalid JSON → the chat's structured renderers bailed to a raw JSON dump (and the *model* also received broken JSON). This is the root cause behind the "Explored the ontology" raw-dump.

**What:** `compressStdout` compresses in the order the field recommends — reformat first, drop data only if forced — so both the model and the UI get parseable JSON:

```ts
function compressStdout(text: string, maxChars: number): TruncateResult {
  if (text.length <= maxChars) return { text, truncated: false }

  const json = tryParseJsonDocument(text)
  if (json !== undefined) {
    const compact = JSON.stringify(json)                 // 1. strip jq whitespace — often enough
    if (compact.length <= maxChars) return { text: compact, truncated: false }
    if (Array.isArray(json))                             // 2. valid whole-element array prefix
      return { text: fitJsonArrayPrefix(json, maxChars), truncated: true }
    return truncateText(compact, maxChars)               // 3. else middle-truncate the compact form
  }
  return truncateText(text, maxChars)                    //    non-JSON logs: middle-truncate
}
```

Two supporting details:
- `truncateText` now keeps the **head *and* tail** (dropping the middle) so trailing errors/exit lines survive — matching Claude Code's own bash truncation.
- Cap bumped **16k → 20k** to reduce how often truncation triggers at all.

This is backed by the compact-JSON benchmarks (compacting is ~30-60% fewer tokens for uniform arrays and *no worse* for model comprehension), and it keeps the fix at the right layer — the UI needs zero changes.

### 4. Small label fix

`Counted objectses` → `Counted objects` (the `api-count` label fell back to an already-plural base, so `plural()` double-suffixed it).

## Screenshots

<img width="787" height="557" alt="Screenshot 2026-07-01 at 8 57 42 PM" src="https://github.com/user-attachments/assets/e04fe709-ff77-43c4-8b8d-72406cf3b881" />

<img width="623" height="372" alt="Screenshot 2026-07-01 at 8 57 57 PM" src="https://github.com/user-attachments/assets/c28482b7-5c79-4378-a299-9bddcf93aba4" />


## Testing

- New `compressStdout` unit tests (compact-fits, valid array prefix, oversized-object + non-JSON middle-truncation).
- `bun run check`, `bun run typecheck`, `bun run build` all pass; `agent-ui` + `agent-worker` suites green (78 tests).

## Notes / follow-ups

- The array-prefix truncation keeps a valid bare array but doesn't carry the original total count in the payload — a structured view could read "8 types" when more existed (the `truncated` flag still signals incompleteness). Preserving the count would come with the typed-tools direction below.
