### PR TITLE
core: strip undefined provider metadata fields

### DIFF
--- a/packages/core/src/agents/adapters.ts
+++ b/packages/core/src/agents/adapters.ts
@@ -142,7 +142,50 @@ function requireJson(value: unknown, label: string): JsonValue {
 }
 
 function optionalJson(value: unknown, label: string): JsonValue | undefined {
-  return value === undefined ? undefined : requireJson(value, label)
+  if (value === undefined) return undefined
+  return requireJson(omitUndefinedObjectProperties(value), label)
+}
+
+/**
+ * Provider metadata is opaque SDK-owned data that can contain optional object keys with
+ * `undefined` values. `undefined` is not JSON, but on an object property it means the same thing as
+ * "field absent", so omit those properties before validating/persisting the metadata.
+ *
+ * Keep the scope deliberately narrow: arrays, tool inputs/outputs, Dates, functions, bigint, cycles,
+ * and every other non-JSON shape are left for `requireJson` to accept or reject. This helper only
+ * turns `{ key: undefined }` into `{}` for metadata compatibility with SDK output.
+ */
+function omitUndefinedObjectProperties(value: unknown, seen = new Set<object>()): unknown {
+  if (typeof value !== "object" || value === null) return value
+
+  // Avoid recursing forever on a malformed/cyclic metadata object. Leaving the cycle in place lets
+  // `requireJson` below report the canonical JSON-contract error.
+  if (seen.has(value)) return value
+
+  seen.add(value)
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => omitUndefinedObjectProperties(entry, seen))
+    }
+
+    if (!isPlainRecord(value)) return value
+
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entry]) => entry !== undefined)
+        .map(([key, entry]) => [key, omitUndefinedObjectProperties(entry, seen)])
+    )
+  } finally {
+    seen.delete(value)
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }
 
 function isToolType(type: string): boolean {

--- a/packages/core/tests/agents-adapters.test.ts
+++ b/packages/core/tests/agents-adapters.test.ts
@@ -88,6 +88,43 @@ describe("fromAiSdk", () => {
     ])
   })
 
+  test("strips undefined provider metadata object fields", () => {
+    const message = {
+      role: "assistant",
+      metadata: { traceId: "t1", omitted: undefined },
+      parts: [
+        {
+          type: "tool-bash",
+          toolCallId: "call_1",
+          state: "output-available",
+          input: { cmd: "ls" },
+          output: "file.txt",
+          callProviderMetadata: {
+            anthropic: { caller: { toolId: undefined, toolName: "bash" } },
+          },
+        },
+      ],
+    } as unknown as AgentInboundUiMessage
+
+    expect(fromAiSdk(message)).toEqual({
+      role: "assistant",
+      metadata: { traceId: "t1" },
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "call_1",
+          toolName: "bash",
+          input: { cmd: "ls" },
+          state: "output-available",
+          output: "file.txt",
+          providerMetadata: {
+            anthropic: { caller: { toolName: "bash" } },
+          },
+        },
+      ],
+    })
+  })
+
   test("is total: throws on unmodeled part kinds", () => {
     const message = {
       role: "assistant",


### PR DESCRIPTION
## Why

Assistant responses can include AI SDK provider metadata with object fields set to `undefined`. Those fields are not valid JSON, so the adapter rejected otherwise valid assistant messages while persisting the thread after an agent response.

## What changed

- Normalize optional JSON metadata by dropping `undefined` object properties before validating/persisting.
- Keep JSON validation strict for unsupported shapes such as functions, `bigint`, dates, cycles, and `undefined` array entries.
- Add regression coverage for assistant message metadata and nested tool provider metadata.

## Tests

- `bun test packages/core/tests/agents-adapters.test.ts`
