### PR TITLE
agent-worker: fix sixb query skill IR docs

### DIFF
--- a/packages/agent-worker/src/skills/sixb-query/references/examples.md
+++ b/packages/agent-worker/src/skills/sixb-query/references/examples.md
@@ -14,7 +14,48 @@ curl -sS -H "Content-Type: application/json" \
       "input": {
         "kind": "filter",
         "input": { "kind": "start", "objectTypeId": "customer" },
-        "predicate": { "kind": "eq", "propertyId": "status", "value": "active" }
+        "predicate": { "op": "eq", "propertyId": "status", "value": "active" }
+      },
+      "limit": 20
+    },
+    "includeTotal": true
+  }'
+```
+
+## Recent Customers
+
+```bash
+curl -sS -H "Content-Type: application/json" \
+  -X POST "$SIXB_API_BASE_URL/api/objects/query" \
+  --data '{
+    "query": {
+      "kind": "limit",
+      "input": {
+        "kind": "sort",
+        "input": { "kind": "start", "objectTypeId": "customer" },
+        "fields": [{ "kind": "property", "propertyId": "createdAt", "direction": "desc" }]
+      },
+      "limit": 20
+    }
+  }'
+```
+
+## Active Customers Sorted By Creation Time
+
+```bash
+curl -sS -H "Content-Type: application/json" \
+  -X POST "$SIXB_API_BASE_URL/api/objects/query" \
+  --data '{
+    "query": {
+      "kind": "limit",
+      "input": {
+        "kind": "sort",
+        "input": {
+          "kind": "filter",
+          "input": { "kind": "start", "objectTypeId": "customer" },
+          "predicate": { "op": "eq", "propertyId": "status", "value": "active" }
+        },
+        "fields": [{ "kind": "property", "propertyId": "createdAt", "direction": "desc" }]
       },
       "limit": 20
     },
@@ -31,7 +72,7 @@ curl -sS -H "Content-Type: application/json" \
     "query": {
       "kind": "filter",
       "input": { "kind": "start", "objectTypeId": "workOrder" },
-      "predicate": { "kind": "eq", "propertyId": "status", "value": "open" }
+      "predicate": { "op": "eq", "propertyId": "status", "value": "open" }
     }
   }'
 ```
@@ -43,6 +84,6 @@ curl -sS -H "Content-Type: application/json" \
   -X POST "$SIXB_API_BASE_URL/api/objects/query/facets" \
   --data '{
     "query": { "kind": "start", "objectTypeId": "workOrder" },
-    "facets": [{ "propertyId": "status" }]
+    "facets": [{ "propertyId": "status", "limit": 10 }]
   }'
 ```

--- a/packages/agent-worker/src/skills/sixb-query/references/predicates.md
+++ b/packages/agent-worker/src/skills/sixb-query/references/predicates.md
@@ -2,43 +2,47 @@
 
 Use property ids from `/api/object-types`. Match value shapes to the property type.
 
+Predicates use `op`, not `kind` (unlike query nodes). Boolean groups use `items`, and `not` uses `item`.
+
 ```json
-{ "kind": "eq", "propertyId": "status", "value": "active" }
-{ "kind": "neq", "propertyId": "status", "value": "archived" }
-{ "kind": "lt", "propertyId": "score", "value": 50 }
-{ "kind": "lte", "propertyId": "score", "value": 50 }
-{ "kind": "gt", "propertyId": "score", "value": 50 }
-{ "kind": "gte", "propertyId": "score", "value": 50 }
-{ "kind": "in", "propertyId": "status", "values": ["active", "trial"] }
-{ "kind": "exists", "propertyId": "ownerId" }
-{ "kind": "contains", "propertyId": "name", "value": "acme" }
+{ "op": "eq", "propertyId": "status", "value": "active" }
+{ "op": "neq", "propertyId": "status", "value": "archived" }
+{ "op": "lt", "propertyId": "score", "value": 50 }
+{ "op": "lte", "propertyId": "score", "value": 50 }
+{ "op": "gt", "propertyId": "score", "value": 50 }
+{ "op": "gte", "propertyId": "score", "value": 50 }
+{ "op": "in", "propertyId": "status", "values": ["active", "trial"] }
+{ "op": "exists", "propertyId": "ownerId", "value": true }
+{ "op": "contains", "propertyId": "name", "value": "acme" }
 ```
 
 Compose predicates with boolean operators:
 
 ```json
 {
-  "kind": "and",
-  "predicates": [
-    { "kind": "eq", "propertyId": "status", "value": "active" },
-    { "kind": "gte", "propertyId": "score", "value": 80 }
+  "op": "and",
+  "items": [
+    { "op": "eq", "propertyId": "status", "value": "active" },
+    { "op": "gte", "propertyId": "score", "value": 80 }
   ]
 }
 ```
 
 ```json
 {
-  "kind": "or",
-  "predicates": [
-    { "kind": "eq", "propertyId": "tier", "value": "enterprise" },
-    { "kind": "eq", "propertyId": "tier", "value": "strategic" }
+  "op": "or",
+  "items": [
+    { "op": "eq", "propertyId": "tier", "value": "enterprise" },
+    { "op": "eq", "propertyId": "tier", "value": "strategic" }
   ]
 }
 ```
 
 ```json
 {
-  "kind": "not",
-  "predicate": { "kind": "eq", "propertyId": "status", "value": "archived" }
+  "op": "not",
+  "item": { "op": "eq", "propertyId": "status", "value": "archived" }
 }
 ```
+
+Set `value: false` on `exists` to match a missing property.

--- a/packages/agent-worker/src/skills/sixb-query/references/query-api.md
+++ b/packages/agent-worker/src/skills/sixb-query/references/query-api.md
@@ -21,7 +21,7 @@ objects; that path is not an API route.
 curl -sS "$SIXB_API_BASE_URL/api/objects?objectTypeId=customer&limit=20"
 ```
 
-Common query params: `objectTypeId`, `limit`, `cursor`, `includeSubtypes`.
+Common query params: `objectTypeId`, `limit`, `offset`, `orderBy`, `order`, `idPrefix`, `idSuffix`, `createdAfter`, `createdBefore`, `updatedAfter`, `updatedBefore`.
 
 ## Get One Object
 
@@ -59,7 +59,7 @@ curl -sS -H "Content-Type: application/json" \
 
 curl -sS -H "Content-Type: application/json" \
   -X POST "$SIXB_API_BASE_URL/api/objects/query/facets" \
-  --data '{"query":{"kind":"start","objectTypeId":"customer"},"facets":[{"propertyId":"status"}]}'
+  --data '{"query":{"kind":"start","objectTypeId":"customer"},"facets":[{"propertyId":"status","limit":10}]}'
 ```
 
 ## Common Mistakes

--- a/packages/agent-worker/src/skills/sixb-query/references/query-shapes.md
+++ b/packages/agent-worker/src/skills/sixb-query/references/query-shapes.md
@@ -2,6 +2,8 @@
 
 Query payloads use a nested `query` object. Start with an object set, then compose transforms.
 
+Query nodes use `kind`. Filter predicates use `op` instead (see [predicates](predicates.md)).
+
 ## Start
 
 ```json
@@ -14,11 +16,13 @@ Query payloads use a nested `query` object. Start with an object set, then compo
 {
   "kind": "filter",
   "input": { "kind": "start", "objectTypeId": "customer" },
-  "predicate": { "kind": "eq", "propertyId": "status", "value": "active" }
+  "predicate": { "op": "eq", "propertyId": "status", "value": "active" }
 }
 ```
 
 ## Sort And Limit
+
+Sort nodes use `fields`. Each field item must declare whether it is a property sort or relevance sort.
 
 ```json
 {
@@ -26,7 +30,7 @@ Query payloads use a nested `query` object. Start with an object set, then compo
   "input": {
     "kind": "sort",
     "input": { "kind": "start", "objectTypeId": "customer" },
-    "by": [{ "propertyId": "createdAt", "direction": "desc" }]
+    "fields": [{ "kind": "property", "propertyId": "createdAt", "direction": "desc" }]
   },
   "limit": 20
 }
@@ -47,25 +51,27 @@ Use `page` instead of a top-level cursor when continuing through query results.
 
 ## Traverse Links
 
-Use link ids from the ontology.
+Use link ids from the ontology. Direction is `outgoing` or `incoming`.
 
 ```json
 {
   "kind": "traverse",
   "input": { "kind": "start", "objectTypeId": "customer" },
   "linkId": "customerOrders",
-  "direction": "out"
+  "direction": "outgoing"
 }
 ```
 
+For incoming traversals, add `sourceObjectTypeId` when multiple object types may declare the same link id.
+
 ## Expand
 
-Use expand when the answer needs related objects alongside the root objects.
+Use expand when the answer needs related objects alongside the root objects. The query node uses `expansions`.
 
 ```json
 {
   "kind": "expand",
   "input": { "kind": "start", "objectTypeId": "customer" },
-  "links": [{ "linkId": "customerOrders", "direction": "out", "limit": 5 }]
+  "expansions": [{ "linkId": "customerOrders", "direction": "outgoing", "limit": 5 }]
 }
 ```


### PR DESCRIPTION
## Why

The bundled `sixb-query` agent skill references documented stale raw object-query IR shapes. Agents following those examples sent predicates with `kind` instead of `op`, sort nodes with `by` instead of `fields`, and sort fields without `kind: "property"`, causing schema validation failures before query planning.

## What changed

- Align predicate examples with the live schema: `op`, `items`, and `item`.
- Update query-shape docs for filter, sort fields, traverse direction, and expand `expansions`.
- Add standalone sort and combined filter + sort + limit examples.
- Add required facet `limit` values and fix stale list-route parameter guidance.

## Key metrics

```text
4 files changed, 81 insertions(+), 30 deletions(-)

Changed files:
M	packages/agent-worker/src/skills/sixb-query/references/examples.md
M	packages/agent-worker/src/skills/sixb-query/references/predicates.md
M	packages/agent-worker/src/skills/sixb-query/references/query-api.md
M	packages/agent-worker/src/skills/sixb-query/references/query-shapes.md
```

## Reviewer notes

Docs-only update for bundled agent skill references; no runtime behavior changes.

## Tests

- Validated 12 documented query shapes against the live `ObjectQuery*` Zod schemas.
- Confirmed no stale predicate/sort/traverse/expand mismatch patterns remain with `rg`.
- `cd vendor/sixb && bun test packages/agent-worker/tests/worker.test.ts -t 'passes Sixb API gateway env and skills into the per-run sandbox'`
