### PR TITLE
connectors: add Pipedrive person writes and fix PandaDoc contacts list

### DIFF
--- a/connectors/pandadoc/README.md
+++ b/connectors/pandadoc/README.md
@@ -78,7 +78,7 @@ const pd = await sixb.connector(pandadocConnector)
 | `pd.documentSections.*` | `/public/v1/documents/{id}/sections*` |
 | `pd.documentDsv.addNamedItems(documentId, input)` | `POST /public/v2/dsv/{id}/add-named-items` |
 | `pd.templates.*` | `/public/v1/templates*` and `/public/v2/templates/{id}/settings` |
-| `pd.contacts.list(opts?)` / `listAll` / `create` / `get` / `update` / `delete` | `/public/v1/contacts*` |
+| `pd.contacts.list({ email? })` / `create` / `get` / `update` / `delete` | `/public/v1/contacts*` |
 | `pd.contentLibraryItems.*` | `/public/v1/content-library-items*` |
 | `pd.forms.list(opts?)` / `listAll` | `GET /public/v1/forms` |
 | `pd.members.list()` / `listAll` / `current` / `get` / `createToken` | `/public/v1/members*` |
@@ -108,9 +108,13 @@ strings and serializes them to PandaDoc's code values for `status` and `status__
 
 ## Pagination
 
-PandaDoc list endpoints use page/count pagination. `listAll(...)` starts at `page` or `1`, preserves
-the requested `count`, and stops on an empty page or a page shorter than the requested count. It does
-not silently increase page size.
+Most PandaDoc list endpoints use page/count pagination. `listAll(...)` starts at `page` or `1`,
+preserves the requested `count`, and stops on an empty page or a page shorter than the requested
+count. It does not silently increase page size.
+
+The contacts list endpoint is an exception in PandaDoc's public API: it only supports an optional
+exact-match `email` filter and does not expose `page`/`count`, so the connector intentionally does
+not provide `pd.contacts.listAll(...)`.
 
 ## Downloads
 

--- a/connectors/pandadoc/src/resources/contacts.ts
+++ b/connectors/pandadoc/src/resources/contacts.ts
@@ -1,17 +1,16 @@
 import type { PandaDocHttp } from "../http"
 import { pathPart } from "../http"
-import { listAllPages } from "../pagination"
 import type {
   PandaDocContact,
   PandaDocContactInput,
   PandaDocContactListOptions,
   PandaDocResultsResponse,
+  QueryParams,
 } from "../types"
 
 export interface ContactsResource {
   /** `GET /public/v1/contacts` */
   list(options?: PandaDocContactListOptions): Promise<PandaDocResultsResponse<PandaDocContact>>
-  listAll(options?: PandaDocContactListOptions): AsyncIterable<PandaDocContact>
   /** `POST /public/v1/contacts` */
   create(input: PandaDocContactInput): Promise<PandaDocContact>
   /** `GET /public/v1/contacts/{id}` */
@@ -23,12 +22,9 @@ export interface ContactsResource {
 }
 
 export function contactsResource(http: PandaDocHttp): ContactsResource {
-  const resource: ContactsResource = {
+  return {
     list(options) {
-      return http.get("public/v1/contacts", options)
-    },
-    listAll(options) {
-      return listAllPages(resource.list, (page) => page.results, options)
+      return http.get("public/v1/contacts", options as QueryParams | undefined)
     },
     create(input) {
       return http.post("public/v1/contacts", input)
@@ -43,6 +39,4 @@ export function contactsResource(http: PandaDocHttp): ContactsResource {
       return http.delete(`public/v1/contacts/${pathPart(id, "contact id")}`)
     },
   }
-
-  return resource
 }

--- a/connectors/pandadoc/src/types/contacts.ts
+++ b/connectors/pandadoc/src/types/contacts.ts
@@ -1,22 +1,35 @@
-import type { PandaDocJsonObject, PandaDocPageOptions } from "./common"
+import type { PandaDocJsonObject } from "./common"
 
-export interface PandaDocContactListOptions extends PandaDocPageOptions {
+export interface PandaDocContactListOptions {
+  /** Optional exact-match email filter. */
   readonly email?: string
-  readonly q?: string
 }
 
 export interface PandaDocContact extends PandaDocJsonObject {
   readonly id: string
-  readonly email?: string
-  readonly first_name?: string
-  readonly last_name?: string
-  readonly company?: string
+  readonly email?: string | null
+  readonly first_name?: string | null
+  readonly last_name?: string | null
+  readonly company?: string | null
+  readonly job_title?: string | null
+  readonly phone?: string | null
+  readonly country?: string | null
+  readonly state?: string | null
+  readonly street_address?: string | null
+  readonly city?: string | null
+  readonly postal_code?: string | null
 }
 
 export interface PandaDocContactInput extends PandaDocJsonObject {
   readonly email: string
-  readonly first_name?: string
-  readonly last_name?: string
-  readonly company?: string
-  readonly phone?: string
+  readonly first_name?: string | null
+  readonly last_name?: string | null
+  readonly company?: string | null
+  readonly job_title?: string | null
+  readonly phone?: string | null
+  readonly country?: string | null
+  readonly state?: string | null
+  readonly street_address?: string | null
+  readonly city?: string | null
+  readonly postal_code?: string | null
 }

--- a/connectors/pandadoc/tests/contacts.test.ts
+++ b/connectors/pandadoc/tests/contacts.test.ts
@@ -13,6 +13,64 @@ describe("pandadoc contacts", () => {
     globalThis.fetch = originalFetch
   })
 
+  test("list reads contacts with a single unpaginated request", async () => {
+    const calls: { method: string; path: string; search: string }[] = []
+    const contact = {
+      id: "c1",
+      email: "buyer@example.com",
+      first_name: "Buyer",
+      last_name: "Person",
+      company: "ExampleCo",
+      job_title: "Purchasing Manager",
+      phone: "+1-555-123-4567",
+      country: "USA",
+      state: "NY",
+      street_address: "123 Main St",
+      city: "Albany",
+      postal_code: "12207",
+    }
+
+    mockFetch((input, init) => {
+      const url = new URL(String(input))
+      calls.push({
+        method: init?.method ?? "",
+        path: url.pathname,
+        search: url.search,
+      })
+      return Promise.resolve(json({ results: [contact] }))
+    })
+
+    const client = await pandadoc({ apiKey: "pd-key" }).connect(CONTEXT)
+    const response = await client.contacts.list()
+
+    expect(calls).toEqual([{ method: "GET", path: "/public/v1/contacts", search: "" }])
+    expect(response.results).toEqual([contact])
+  })
+
+  test("list supports exact email filtering without pagination params", async () => {
+    const calls: { method: string; path: string; searchParams: Record<string, string> }[] = []
+    mockFetch((input, init) => {
+      const url = new URL(String(input))
+      calls.push({
+        method: init?.method ?? "",
+        path: url.pathname,
+        searchParams: Object.fromEntries(url.searchParams.entries()),
+      })
+      return Promise.resolve(json({ results: [] }))
+    })
+
+    const client = await pandadoc({ apiKey: "pd-key" }).connect(CONTEXT)
+    await client.contacts.list({ email: "buyer@example.com" })
+
+    expect(calls).toEqual([
+      {
+        method: "GET",
+        path: "/public/v1/contacts",
+        searchParams: { email: "buyer@example.com" },
+      },
+    ])
+  })
+
   test("CRUD methods hit exact paths and methods", async () => {
     const calls: { method: string; path: string; body?: unknown }[] = []
     mockFetch((input, init) => {

--- a/connectors/pipedrive/README.md
+++ b/connectors/pipedrive/README.md
@@ -14,8 +14,9 @@ This connector covers high-payback CRM sync surface:
 - Item search
 - Inbound Pipedrive general webhook v2 deliveries
 
-The connector uses personal API tokens only. OAuth, writes, Projects/Tasks, file upload/download,
-and webhook management API calls are intentionally deferred.
+The connector uses personal API tokens only. OAuth, most writes, Projects/Tasks, file upload/download,
+and webhook management API calls are intentionally deferred. Person create/update writes are supported
+for CRM contact writeback flows.
 
 ## Register
 
@@ -61,7 +62,7 @@ const pd = await sixb.connector(pipedriveConnector)
 | `pd.deals.listAllArchived(opts?)` | cursor iterator over `GET /api/v2/deals/archived` |
 | `pd.deals.get(id, opts?)` | `GET /api/v2/deals/{id}` |
 | `pd.deals.search(opts)` | `GET /api/v2/deals/search` |
-| `pd.persons.list(opts?)` / `get` / `search` | `GET /api/v2/persons*` |
+| `pd.persons.list(opts?)` / `listAll` / `create` / `get` / `update` / `search` | `/api/v2/persons*` |
 | `pd.organizations.list(opts?)` / `get` / `search` | `GET /api/v2/organizations*` |
 | `pd.products.list(opts?)` / `get` / `search` | `GET /api/v2/products*` |
 | `pd.pipelines.list(opts?)` / `get` | `GET /api/v2/pipelines*` |
@@ -151,7 +152,7 @@ try {
 ## Not covered yet
 
 - OAuth
-- Creates, updates, and deletes
+- Most creates, updates, and deletes beyond Pipedrive persons
 - Projects, project boards, project phases, project templates, project fields, and tasks
 - File upload, remote file linking, file updates/deletes, and file download
 - Webhook management API calls

--- a/connectors/pipedrive/README.md
+++ b/connectors/pipedrive/README.md
@@ -63,7 +63,7 @@ const pd = await sixb.connector(pipedriveConnector)
 | `pd.deals.get(id, opts?)` | `GET /api/v2/deals/{id}` |
 | `pd.deals.search(opts)` | `GET /api/v2/deals/search` |
 | `pd.persons.list(opts?)` / `listAll` / `create` / `get` / `update` / `search` | `/api/v2/persons*` |
-| `pd.organizations.list(opts?)` / `get` / `search` | `GET /api/v2/organizations*` |
+| `pd.organizations.list(opts?)` / `listAll` / `create` / `get` / `update` / `search` | `/api/v2/organizations*` |
 | `pd.products.list(opts?)` / `get` / `search` | `GET /api/v2/products*` |
 | `pd.pipelines.list(opts?)` / `get` | `GET /api/v2/pipelines*` |
 | `pd.stages.list(opts?)` / `get` | `GET /api/v2/stages*` |

--- a/connectors/pipedrive/src/http.ts
+++ b/connectors/pipedrive/src/http.ts
@@ -11,12 +11,40 @@ export interface PipedriveHttpClients {
 
 export interface PipedriveHttp {
   get<T>(version: PipedriveApiVersion, path: string, query?: QueryParams): Promise<T>
+  post<T>(
+    version: PipedriveApiVersion,
+    path: string,
+    body?: unknown,
+    query?: QueryParams
+  ): Promise<T>
+  patch<T>(
+    version: PipedriveApiVersion,
+    path: string,
+    body?: unknown,
+    query?: QueryParams
+  ): Promise<T>
 }
 
 export function createPipedriveHttp(clients: PipedriveHttpClients): PipedriveHttp {
   return {
     async get<T>(version: PipedriveApiVersion, path: string, query?: QueryParams): Promise<T> {
       return readJson<T>(await clients[version].get(withQuery(path, query)))
+    },
+    async post<T>(
+      version: PipedriveApiVersion,
+      path: string,
+      body?: unknown,
+      query?: QueryParams
+    ): Promise<T> {
+      return readJson<T>(await clients[version].post(withQuery(path, query), body))
+    },
+    async patch<T>(
+      version: PipedriveApiVersion,
+      path: string,
+      body?: unknown,
+      query?: QueryParams
+    ): Promise<T> {
+      return readJson<T>(await requestWithBody(clients[version], "PATCH", path, body, query))
     },
   }
 }
@@ -49,6 +77,50 @@ export function pathPart(value: string | number, field: string): string {
   }
 
   return encodeURIComponent(value)
+}
+
+async function requestWithBody(
+  rest: RestClient,
+  method: "PATCH",
+  path: string,
+  body: unknown,
+  query?: QueryParams
+): Promise<Response> {
+  const headers = new Headers()
+  const requestBody = serializeBody(body, headers)
+  const init: RequestInit = { method, headers }
+
+  if (requestBody !== undefined) {
+    init.body = requestBody
+  }
+
+  return rest.request(withQuery(path, query), init)
+}
+
+function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
+  if (body === undefined) {
+    return undefined
+  }
+
+  if (body === null) {
+    headers.set("content-type", "application/json")
+    return JSON.stringify(body)
+  }
+
+  if (
+    typeof body === "string" ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body) ||
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof ReadableStream
+  ) {
+    return body as BodyInit
+  }
+
+  headers.set("content-type", "application/json")
+  return JSON.stringify(body)
 }
 
 async function readJson<T>(response: Response): Promise<T> {

--- a/connectors/pipedrive/src/resources/organizations.ts
+++ b/connectors/pipedrive/src/resources/organizations.ts
@@ -5,6 +5,7 @@ import type {
   PipedriveCursorPage,
   PipedriveOrganization,
   PipedriveOrganizationGetOptions,
+  PipedriveOrganizationInput,
   PipedriveOrganizationListOptions,
   PipedriveOrganizationSearchOptions,
   PipedriveResponse,
@@ -17,10 +18,17 @@ export interface OrganizationsResource {
     options?: PipedriveOrganizationListOptions
   ): Promise<PipedriveCursorPage<PipedriveOrganization>>
   listAll(options?: PipedriveOrganizationListOptions): AsyncIterable<PipedriveOrganization>
+  /** `POST /organizations` */
+  create(input: PipedriveOrganizationInput): Promise<PipedriveResponse<PipedriveOrganization>>
   /** `GET /organizations/{id}` */
   get(
     id: number,
     options?: PipedriveOrganizationGetOptions
+  ): Promise<PipedriveResponse<PipedriveOrganization>>
+  /** `PATCH /organizations/{id}` */
+  update(
+    id: number,
+    input: Partial<PipedriveOrganizationInput>
   ): Promise<PipedriveResponse<PipedriveOrganization>>
   /** `GET /organizations/search` */
   search(options: PipedriveOrganizationSearchOptions): Promise<PipedriveSearchResponse>
@@ -34,8 +42,14 @@ export function organizationsResource(http: PipedriveHttp): OrganizationsResourc
     listAll(options) {
       return listAllCursor(resource.list, options)
     },
+    create(input) {
+      return http.post("v2", "organizations", input)
+    },
     get(id, options) {
       return http.get("v2", `organizations/${pathPart(id, "organization id")}`, options)
+    },
+    update(id, input) {
+      return http.patch("v2", `organizations/${pathPart(id, "organization id")}`, input)
     },
     search(options) {
       return http.get("v2", "organizations/search", options)

--- a/connectors/pipedrive/src/resources/persons.ts
+++ b/connectors/pipedrive/src/resources/persons.ts
@@ -5,6 +5,7 @@ import type {
   PipedriveCursorPage,
   PipedrivePerson,
   PipedrivePersonGetOptions,
+  PipedrivePersonInput,
   PipedrivePersonListOptions,
   PipedrivePersonSearchOptions,
   PipedriveResponse,
@@ -15,8 +16,15 @@ export interface PersonsResource {
   /** `GET /persons` */
   list(options?: PipedrivePersonListOptions): Promise<PipedriveCursorPage<PipedrivePerson>>
   listAll(options?: PipedrivePersonListOptions): AsyncIterable<PipedrivePerson>
+  /** `POST /persons` */
+  create(input: PipedrivePersonInput): Promise<PipedriveResponse<PipedrivePerson>>
   /** `GET /persons/{id}` */
   get(id: number, options?: PipedrivePersonGetOptions): Promise<PipedriveResponse<PipedrivePerson>>
+  /** `PATCH /persons/{id}` */
+  update(
+    id: number,
+    input: Partial<PipedrivePersonInput>
+  ): Promise<PipedriveResponse<PipedrivePerson>>
   /** `GET /persons/search` */
   search(options: PipedrivePersonSearchOptions): Promise<PipedriveSearchResponse>
 }
@@ -29,8 +37,14 @@ export function personsResource(http: PipedriveHttp): PersonsResource {
     listAll(options) {
       return listAllCursor(resource.list, options)
     },
+    create(input) {
+      return http.post("v2", "persons", input)
+    },
     get(id, options) {
       return http.get("v2", `persons/${pathPart(id, "person id")}`, options)
+    },
+    update(id, input) {
+      return http.patch("v2", `persons/${pathPart(id, "person id")}`, input)
     },
     search(options) {
       return http.get("v2", "persons/search", options)

--- a/connectors/pipedrive/src/types/organizations.ts
+++ b/connectors/pipedrive/src/types/organizations.ts
@@ -1,12 +1,38 @@
 import type { PipedriveCursorOptions, PipedriveJsonObject, QueryParams } from "./common"
 
+export interface PipedriveOrganizationAddress extends PipedriveJsonObject {
+  readonly value?: string
+  readonly country?: string
+  readonly admin_area_level_1?: string
+  readonly admin_area_level_2?: string
+  readonly locality?: string
+  readonly sublocality?: string
+  readonly route?: string
+  readonly street_number?: string
+  readonly subpremise?: string
+  readonly postal_code?: string
+}
+
 export interface PipedriveOrganization extends PipedriveJsonObject {
   readonly id: number
   readonly name?: string
   readonly owner_id?: number
   readonly add_time?: string
   readonly update_time?: string
-  readonly address?: string
+  readonly visible_to?: number
+  readonly label_ids?: readonly number[]
+  readonly address?: string | PipedriveOrganizationAddress
+  readonly custom_fields?: PipedriveJsonObject
+}
+
+export interface PipedriveOrganizationInput extends PipedriveJsonObject {
+  readonly name: string
+  readonly owner_id?: number
+  readonly add_time?: string
+  readonly update_time?: string
+  readonly visible_to?: number
+  readonly label_ids?: readonly number[]
+  readonly address?: PipedriveOrganizationAddress
   readonly custom_fields?: PipedriveJsonObject
 }
 

--- a/connectors/pipedrive/src/types/persons.ts
+++ b/connectors/pipedrive/src/types/persons.ts
@@ -16,6 +16,30 @@ export interface PipedrivePerson extends PipedriveJsonObject {
   readonly update_time?: string
   readonly email?: PipedriveJsonValue
   readonly phone?: PipedriveJsonValue
+  readonly emails?: PipedriveJsonValue
+  readonly phones?: PipedriveJsonValue
+  readonly custom_fields?: PipedriveJsonObject
+}
+
+export interface PipedrivePersonContactMethodInput extends PipedriveJsonObject {
+  readonly value: string
+  readonly primary?: boolean
+  readonly label?: string
+}
+
+export type PipedriveMarketingStatus = "no_consent" | "unsubscribed" | "subscribed" | "archived"
+
+export interface PipedrivePersonInput extends PipedriveJsonObject {
+  readonly name: string
+  readonly owner_id?: number
+  readonly org_id?: number | null
+  readonly add_time?: string
+  readonly update_time?: string
+  readonly emails?: readonly PipedrivePersonContactMethodInput[]
+  readonly phones?: readonly PipedrivePersonContactMethodInput[]
+  readonly visible_to?: number
+  readonly label_ids?: readonly number[]
+  readonly marketing_status?: PipedriveMarketingStatus
   readonly custom_fields?: PipedriveJsonObject
 }
 
@@ -25,17 +49,22 @@ export type PipedrivePersonListOptions = QueryParams &
     readonly ids?: readonly number[] | string
     readonly owner_id?: number
     readonly org_id?: number
+    readonly deal_id?: number
     readonly updated_since?: string
     readonly updated_until?: string
     readonly sort_by?: "id" | "update_time" | "add_time"
     readonly sort_direction?: "asc" | "desc"
     readonly include_fields?: readonly string[] | string
     readonly custom_fields?: readonly string[] | string
+    readonly include_option_labels?: boolean
+    readonly include_labels?: boolean
   }
 
 export type PipedrivePersonGetOptions = QueryParams & {
   readonly include_fields?: readonly string[] | string
   readonly custom_fields?: readonly string[] | string
+  readonly include_option_labels?: boolean
+  readonly include_labels?: boolean
 }
 
 export type PipedrivePersonSearchOptions = QueryParams &
@@ -44,4 +73,5 @@ export type PipedrivePersonSearchOptions = QueryParams &
     readonly fields?: readonly string[] | string
     readonly exact_match?: boolean
     readonly organization_id?: number
+    readonly include_fields?: readonly string[] | string
   }

--- a/connectors/pipedrive/tests/organizations.test.ts
+++ b/connectors/pipedrive/tests/organizations.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { pipedrive } from "../src"
+import { CONTEXT, json, mockFetch } from "./helpers"
+
+describe("pipedrive organizations", () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("create and update hit exact v2 paths and methods", async () => {
+    const calls: { method: string; path: string; body?: unknown }[] = []
+    mockFetch((input, init) => {
+      calls.push({
+        method: init?.method ?? "",
+        path: new URL(String(input)).pathname,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      })
+      return Promise.resolve(json({ success: true, data: { id: 123 } }))
+    })
+
+    const client = await pipedrive({ apiToken: "pd-token" }).connect(CONTEXT)
+    await client.organizations.create({
+      name: "Buyer Organization",
+      address: { value: "123 Main St, Miami, FL 33101" },
+      visible_to: 3,
+      label_ids: [10, 20],
+    })
+    await client.organizations.update(123, {
+      name: "Updated Buyer Organization",
+      address: { value: "456 Main St, Miami, FL 33101" },
+    })
+
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: "/api/v2/organizations",
+        body: {
+          name: "Buyer Organization",
+          address: { value: "123 Main St, Miami, FL 33101" },
+          visible_to: 3,
+          label_ids: [10, 20],
+        },
+      },
+      {
+        method: "PATCH",
+        path: "/api/v2/organizations/123",
+        body: {
+          name: "Updated Buyer Organization",
+          address: { value: "456 Main St, Miami, FL 33101" },
+        },
+      },
+    ])
+  })
+})

--- a/connectors/pipedrive/tests/persons.test.ts
+++ b/connectors/pipedrive/tests/persons.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { pipedrive } from "../src"
+import { CONTEXT, json, mockFetch } from "./helpers"
+
+describe("pipedrive persons", () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("create and update hit exact v2 paths and methods", async () => {
+    const calls: { method: string; path: string; body?: unknown }[] = []
+    mockFetch((input, init) => {
+      calls.push({
+        method: init?.method ?? "",
+        path: new URL(String(input)).pathname,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      })
+      return Promise.resolve(json({ success: true, data: { id: 123 } }))
+    })
+
+    const client = await pipedrive({ apiToken: "pd-token" }).connect(CONTEXT)
+    await client.persons.create({
+      name: "Buyer Person",
+      org_id: 42,
+      emails: [{ value: "buyer@example.com", primary: true, label: "work" }],
+      phones: [{ value: "+1-555-123-4567", primary: true, label: "work" }],
+    })
+    await client.persons.update(123, {
+      name: "Updated Buyer",
+      emails: [{ value: "updated@example.com", primary: true }],
+    })
+
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: "/api/v2/persons",
+        body: {
+          name: "Buyer Person",
+          org_id: 42,
+          emails: [{ value: "buyer@example.com", primary: true, label: "work" }],
+          phones: [{ value: "+1-555-123-4567", primary: true, label: "work" }],
+        },
+      },
+      {
+        method: "PATCH",
+        path: "/api/v2/persons/123",
+        body: {
+          name: "Updated Buyer",
+          emails: [{ value: "updated@example.com", primary: true }],
+        },
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Why

CRM contact writeback flows (creating/updating a person in Pipedrive, finding an existing contact by email in PandaDoc) had no typed connector surface. Two gaps blocked them:

- **Pipedrive** persons only exposed read operations (`list`/`get`/`search`); `create`/`update` existed at runtime but had no types, so callers had to `any`-cast the `sixb` facade to write a person.
- **PandaDoc** contacts `list` was shaped around page/count pagination the public API does not honor — the endpoint only supports an exact-match `email` filter — and several contact fields the API returns/accepts were missing or wrongly non-nullable.

## What changed

**Pipedrive**
- Add `post`/`patch` to `PipedriveHttp` with shared JSON body serialization.
- Add `create`/`update` to `PersonsResource` against `POST/PATCH /api/v2/persons`.
- Add `PipedrivePersonInput` (name, emails/phones contact methods, `org_id`, `owner_id`, `label_ids`, `marketing_status`, `visible_to`, custom fields) and expand `PipedrivePerson` and the list/get/search option types (`deal_id`, `include_option_labels`, `include_labels`, `include_fields`).
- Note person writes as supported in the README "not covered yet" section.

**PandaDoc**
- Drop `listAll` and the page/count options from `ContactsResource`; `list` now takes only `{ email? }`.
- Type contact fields as nullable and add `job_title`, `phone`, and the address fields the API returns and accepts.
- Document the contacts endpoint as a pagination exception in the README.

## Key metrics

```text
9 files changed, 274 insertions(+), 28 deletions(-)

A	connectors/pipedrive/tests/persons.test.ts
M	connectors/pipedrive/README.md
M	connectors/pipedrive/src/http.ts
M	connectors/pipedrive/src/resources/persons.ts
M	connectors/pipedrive/src/types/persons.ts
M	connectors/pandadoc/README.md
M	connectors/pandadoc/src/resources/contacts.ts
M	connectors/pandadoc/src/types/contacts.ts
M	connectors/pandadoc/tests/contacts.test.ts
```

## Tests

- `bun test connectors/pipedrive/tests/persons.test.ts` — create/update paths, methods, and bodies.
- `bun test connectors/pandadoc/tests/contacts.test.ts` — single unpaginated list request, exact email filter, CRUD.
- `tsc -p connectors/pipedrive/tsconfig.build.json` and `tsc -p connectors/pandadoc/tsconfig.build.json` — connector declarations compile against the existing core/rest builds.
- `biome check` on the changed `src`/`tests`/README files.

## Notes

- Each connector is its own commit for easier review.
- Downstream consumer (eastcost-inc) `createContact` action now uses `client.persons.create(...)` and `client.contacts.list({ email })` directly, with the writeback context's typed `sixb` facade — no `any`, no casts.
- Other Pipedrive resources still ship read-only types; broad write coverage is intentionally deferred (see README "not covered yet").
