### PR TITLE
actions: expose read facade in the writeback phase

### DIFF
--- a/packages/action-worker/src/action-execution/writeback.ts
+++ b/packages/action-worker/src/action-execution/writeback.ts
@@ -1,5 +1,10 @@
-import type { ActionRunRecord, JsonValue } from "@sixb/core"
-import { assertJsonValue, cloneJsonValue, isObjectActionDefinition } from "@sixb/core"
+import type { ActionReadObjectSetSource, ActionRunRecord, JsonValue } from "@sixb/core"
+import {
+  assertJsonValue,
+  cloneJsonValue,
+  createActionReadFacade,
+  isObjectActionDefinition,
+} from "@sixb/core"
 import { toActionRunFailure } from "../normalize"
 import { type BasePhaseContext, requireObjectTarget, toActionRuntimeFacade } from "./context"
 import type {
@@ -34,13 +39,20 @@ export async function runWritebackPhase(
   input.updateActiveRun(run)
 
   try {
+    // Reads are side-effect-free, so the writeback phase can safely enrich its
+    // external payload from related objects (links, traversals) before the edit
+    // batch exists. This mirrors the read facade the edits phase receives.
+    const read = createActionReadFacade(
+      (objectType) => input.runtime.sixb.objects(objectType) as ActionReadObjectSetSource
+    )
     const rawResult = isObjectActionDefinition(input.action)
       ? await handler({
           ...input.baseContext,
           sixb: toActionRuntimeFacade(input.runtime),
+          read,
           target: requireObjectTarget(input.objectTarget, input.action.id).snapshot,
         })
-      : await handler({ ...input.baseContext, sixb: toActionRuntimeFacade(input.runtime) })
+      : await handler({ ...input.baseContext, sixb: toActionRuntimeFacade(input.runtime), read })
     const result = normalizeWritebackResult(rawResult)
     run = await input.runtime.actionRunsStorage.recordWriteback({
       projectId: input.runtime.id,

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -368,6 +368,65 @@ describe("runActionJob", () => {
     expect(linksAfter).toEqual([])
   })
 
+  test("exposes object reads inside action writeback", async () => {
+    // The writeback phase must be able to enrich its external payload from
+    // related objects (here: the linked Sensor) before the edit batch exists.
+    const captureSensorName = defineAction("captureSensorName")
+      .on(Device)
+      .params({})
+      .writeback(async ({ read, target }) => {
+        const links = await read.objects(Device).byId(target.primaryId).listLinks(Device.l.sensor)
+        const sensor = await read.objects(Sensor).byId(links[0].targetId).get()
+        return { sensorName: String(sensor?.properties.name ?? "unknown") }
+      })
+      .edits(({ objects, subject, writeback }) => {
+        objects(Device).byId(subject.primaryId).update({ status: writeback.sensorName })
+      })
+
+    const sixb = createSixb([captureSensorName], [Device, Sensor])
+    await sixb.upsertObject("Device", {
+      id: "device-1",
+      name: "Device 1",
+    })
+    await sixb.upsertObject("Sensor", {
+      id: "sensor-1",
+      name: "Sensor 1",
+    })
+    await (
+      sixb as unknown as {
+        objects(objectType: typeof Device): {
+          byId(id: string): {
+            link(
+              linkToken: typeof Device.l.sensor,
+              target: { objectTypeId: "Sensor"; primaryId: string }
+            ): Promise<void>
+          }
+        }
+      }
+    )
+      .objects(Device)
+      .byId("device-1")
+      .link(Device.l.sensor, { objectTypeId: "Sensor", primaryId: "sensor-1" })
+    await queueActionRun(sixb, {
+      id: "act_1",
+      actionId: "captureSensorName",
+      subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
+      params: {},
+    })
+
+    const result = await runActionJob({
+      runtime: createContext(sixb),
+      job: {
+        id: "act_1",
+        actionId: "captureSensorName",
+      },
+    })
+
+    expect(result.status).toBe("succeeded")
+    const updated = await deviceObjects(sixb).get("device-1")
+    expect(updated?.properties.status).toBe("Sensor 1")
+  })
+
   test("marks queued runs failed when the action definition is missing", async () => {
     const sixb = createSixb([])
     await queueActionRun(sixb, {

--- a/packages/core/src/actions/types/context.ts
+++ b/packages/core/src/actions/types/context.ts
@@ -145,6 +145,7 @@ export interface ActionValidationContext<
 export interface GlobalActionWritebackContext<TParams extends Record<string, unknown>>
   extends BaseActionPhaseContext<TParams> {
   readonly sixb: ActionRuntimeFacade
+  readonly read: ActionReadFacade
 }
 
 export interface ActionWritebackContext<
@@ -153,6 +154,7 @@ export interface ActionWritebackContext<
 > extends BaseActionPhaseContext<TParams> {
   readonly sixb: ActionRuntimeFacade
   readonly target: ActionTargetObject<TObjectType>
+  readonly read: ActionReadFacade
 }
 
 export interface GlobalActionEditsContext<TParams extends Record<string, unknown>, TWriteback>

--- a/packages/core/tests/actions.types.ts
+++ b/packages/core/tests/actions.types.ts
@@ -83,14 +83,18 @@ const reboot = defineAction("reboot")
 const runtimeFacade = defineAction("runtimeFacade")
   .on(Room)
   .params({})
-  .writeback(({ sixb }) => {
+  .writeback(({ sixb, read }) => {
     sixb.objects(Room).appendTelemetryBatch([{ id: "room:1", properties: {}, at: new Date() }])
 
-    // @ts-expect-error writeback cannot perform local object writes
+    // @ts-expect-error the runtime (telemetry) facade cannot perform local object writes
     sixb.objects(Room).upsert({ properties: { id: "room:1" } })
 
-    // @ts-expect-error writeback cannot perform local object reads
+    // @ts-expect-error the runtime (telemetry) facade cannot perform local object reads
     sixb.objects(Room).get("room:1")
+
+    // writeback can enrich its external payload with side-effect-free reads
+    read.objects(Room).get("room:1")
+    read.objects(Room).query()
   })
 
 defineAction("targetAlias")


### PR DESCRIPTION
## Why

While building a real connector integration (a PandaDoc "send quote" flow) we hit a wall in the action phase model. The `writeback` phase is the only place an object action can call a connector, but it can't read domain objects — its only data handles are `target` (the subject's own property snapshot) and the telemetry-only runtime facade. The single object-read facade (`read`) is exposed exclusively on the `edits` phase, which runs *after* `writeback`.

That ordering makes a common integration pattern inexpressible as an action: *read a graph of related objects, call an external API with that data, then persist the result.* Our create-document payload needs the linked contact's email (the external API requires it to create at all), the linked organization/site, and a reverse traversal to line items — none of which are reachable from `target`. So the operation had to become a workflow purely because `writeback` is blind to related objects:

```ts
defineAction("createQuoteDocument")
  .on(Quote)
  .writeback(async ({ sixb, target }) => {
    // ✗ no way to read the linked Contact's email or traverse to line items here
    const client = await sixb.connector(pandadocConnector)
    return client.documents.create(/* ...can't assemble the payload */)
  })
  // the write-after-connector half already works fine:
  .edits(({ objects, writeback }) => {
    objects(QuoteDocument).create({ externalId: writeback.id, /* ... */ })
  })
```

## What changed

- Expose the same side-effect-free `read` facade the `edits` phase already receives on both `ActionWritebackContext` and `GlobalActionWritebackContext`.
- Inject it in the action-worker writeback executor, mirroring how the `edits` phase is wired.

Reads are idempotent and require no edit batch, so this stays within the phase model and changes nothing about ordering, commit, or retry semantics — it only lets `writeback` enrich its payload from related objects before calling the connector. The runtime facade (`sixb.objects(...)`) remains telemetry-only; reads and writes through it still error, as before.

## Tests

- `bun test packages/action-worker/tests/run-action-job.test.ts` — added "exposes object reads inside action writeback" (a writeback handler reads a linked object and hands it to `edits`)
- `bun run typecheck` — added a writeback `read` type assertion in `packages/core/tests/actions.types.ts`
- `bun run check`
