### PR TITLE
core: align action listLinks with link tokens

### DIFF
--- a/docs/actions/overview.md
+++ b/docs/actions/overview.md
@@ -204,6 +204,29 @@ export const sendReminder = defineAction("sendReminder", {
 
 The runtime commits every staged edit in a single atomic batch once the handler returns.
 
+The normal link rules apply inside `edits(...)`. For `cardinality: "one"` links, `link(...)` does not replace a different existing target. To reassign one, read the current link and stage `unlink(...)`
+followed by `link(...)`; the two staged edits commit atomically:
+
+```ts
+.edits(async ({ objects, read, subject, params }) => {
+  const [currentProject] = await read
+    .objects(Transcript)
+    .byId(subject.primaryId)
+    .listLinks(Transcript.l.project)
+
+  const transcript = objects(Transcript).byId(subject.primaryId)
+
+  if (currentProject) {
+    transcript.unlink(Transcript.l.project, {
+      objectTypeId: currentProject.targetTypeId,
+      primaryId: currentProject.targetId,
+    })
+  }
+
+  transcript.link(Transcript.l.project, params.project)
+})
+```
+
 ## Requesting actions
 
 Actions run asynchronously. Requesting one enqueues a durable run and returns immediately; a worker

--- a/docs/ontology/links.md
+++ b/docs/ontology/links.md
@@ -176,6 +176,29 @@ await projects.byId("proj-001").unlink(Project.l.members, {
 The target is an `ObjectRef` (`{ objectTypeId, primaryId }`). TypeScript checks it against the
 link's declared target, so linking `members` to a `Customer` is a compile error.
 
+For a `cardinality: "one"` link, `link(...)` is not a setter. Calling `link(...)` with the same
+target updates that relationship's properties, but calling it with a different target while one is
+already present is rejected. Reassign by removing the current target, then linking the new one:
+
+```ts
+const [currentLead] = await sixb.objects(Project).byId("proj-001").listLinks(Project.l.lead)
+
+if (currentLead) {
+  await projects.byId("proj-001").unlink(Project.l.lead, {
+    objectTypeId: currentLead.targetTypeId,
+    primaryId: currentLead.targetId,
+  })
+}
+
+await projects.byId("proj-001").link(Project.l.lead, {
+  objectTypeId: "Employee",
+  primaryId: "emp-027",
+})
+```
+
+`unlink(...)` removes one exact relationship row. Even for `cardinality: "one"` links, pass the
+current target; when you only know the `linkId`, read it first with `listLinks(Project.l.lead)`.
+
 Writing a link emits a `link.upserted` [event](../events/overview.md); removing one emits
 `link.removed`.
 

--- a/packages/core/src/actions/types/context.ts
+++ b/packages/core/src/actions/types/context.ts
@@ -1,7 +1,7 @@
 import type { ConnectorAdapter, ConnectorClient, ConnectorDefinition } from "../../connectors"
 import type { EditCommitDiff, RecordEditsContext } from "../../edits"
 import type { ObjectType, ValueType } from "../../ontology"
-import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
+import type { LinkToken, ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
 import type {
   ListResult,
   ObjectQueryBuilder,
@@ -57,6 +57,13 @@ export type ActionBinding<TObjectType extends ObjectType = ObjectType> =
   | { readonly kind: "global" }
   | { readonly kind: "object"; readonly objectType: TObjectType }
 
+type ActionLinkTokenForObjectType<TObjectType extends ObjectTypeWithPropertyTokens> = LinkToken<
+  TObjectType["id"],
+  TObjectType["links"][number]["id"],
+  TObjectType["links"][number]["targetObjectTypeId"],
+  TObjectType["links"][number]
+>
+
 export interface ActionRunPhaseInfo {
   readonly id: string
   readonly startedAt: Date
@@ -68,7 +75,7 @@ export interface ActionReadObjectByIdHandle<
   TValueTypes extends readonly ValueType[],
 > {
   get(): Promise<TwinObject<TObjectType, TValueTypes> | null>
-  listLinks(link?: { readonly id: string }): Promise<
+  listLinks(link?: ActionLinkTokenForObjectType<TObjectType>): Promise<
     readonly {
       readonly linkId: string
       readonly targetTypeId: string

--- a/packages/core/src/ontology/validation/properties.ts
+++ b/packages/core/src/ontology/validation/properties.ts
@@ -27,13 +27,49 @@ export function assertPropertyTokenBelongsToObjectType(
 
 export function assertLinkTokenBelongsToObjectType(
   objectType: ObjectTypeWithPropertyTokens,
-  link: LinkToken<string, string, string | readonly string[], ObjectLink>
-): void {
+  link: unknown
+): asserts link is LinkToken<string, string, string | readonly string[], ObjectLink> {
+  if (!isLinkTokenLike(link)) {
+    throw new OntologyValidationError(
+      `[Sixb] Expected a link token from ${objectType.id}.l.<linkId>, not a plain link id.`
+    )
+  }
+
   if (link.objectTypeId !== objectType.id) {
     throw new OntologyValidationError(
       `[Sixb] Link token ${link.objectTypeId}.${link.id} cannot be used with ${objectType.id}`
     )
   }
+}
+
+function isLinkTokenLike(
+  value: unknown
+): value is LinkToken<string, string, string | readonly string[], ObjectLink> {
+  if (typeof value !== "object" || value === null) return false
+  if (
+    !("objectTypeId" in value) ||
+    !("id" in value) ||
+    !("targetObjectTypeId" in value) ||
+    !("link" in value)
+  ) {
+    return false
+  }
+
+  return (
+    typeof value.objectTypeId === "string" &&
+    typeof value.id === "string" &&
+    isLinkTargetTypeId(value.targetObjectTypeId) &&
+    typeof value.link === "object" &&
+    value.link !== null
+  )
+}
+
+function isLinkTargetTypeId(value: unknown): value is string | readonly string[] {
+  return typeof value === "string" || (Array.isArray(value) && value.every(isString))
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string"
 }
 
 export function assertKnownProperties(

--- a/packages/core/tests/actions.types.ts
+++ b/packages/core/tests/actions.types.ts
@@ -4,6 +4,7 @@ import {
   defineObjectType,
   type InferActionParams,
   type InferSchemaOrRef,
+  link,
   type ObjectRef,
   type ObjectRefSchema,
   optional,
@@ -22,6 +23,15 @@ function actionDefinition(action: unknown): ActionDefinition {
   return action as ActionDefinition
 }
 
+const Building = defineObjectType({
+  id: "Building",
+  name: "Building",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+  ],
+})
+
 const Room = defineObjectType({
   id: "Room",
   name: "Room",
@@ -30,6 +40,7 @@ const Room = defineObjectType({
     prop("externalId", "string", { required: true }),
     prop("name", "string", { required: true }),
   ],
+  links: [link("building", Building, { cardinality: "one" })],
 })
 
 const RoomRefSchema = ref(Room)
@@ -174,6 +185,16 @@ const createInvoice = defineAction("createInvoice")
     const changedObjects = commit.diff.objects
     void externalId
     void changedObjects
+  })
+
+defineAction("inspectRoomLinks")
+  .on(Room)
+  .params({})
+  .edits(async ({ read, subject }) => {
+    await read.objects(Room).byId(subject.primaryId).listLinks(Room.l.building)
+
+    // @ts-expect-error action read listLinks requires a link token, not a plain id object
+    await read.objects(Room).byId(subject.primaryId).listLinks({ id: "building" })
   })
 
 defineAction("writebackOnly")

--- a/packages/core/tests/sixb-runtime.test.ts
+++ b/packages/core/tests/sixb-runtime.test.ts
@@ -868,6 +868,21 @@ describe("Sixb runtime", () => {
     expect(events).toHaveLength(1)
   })
 
+  test("rejects plain link id objects in listLinks", async () => {
+    const sixb = new Sixb({
+      id: "list-links-token-test",
+      ontology: [Room, Thermostat],
+      ...createTestRuntimeDeps(),
+    })
+
+    await expect(
+      sixb
+        .objects(Room)
+        .byId("room:101")
+        .listLinks({ id: "hasThermostat" } as unknown as typeof Room.l.hasThermostat)
+    ).rejects.toThrow("Expected a link token from Room.l.<linkId>")
+  })
+
   test("removes a link via ObjectSet.removeLink", async () => {
     const runtimeDeps = createTestRuntimeDeps()
     const sixb = new Sixb({


### PR DESCRIPTION
# Align action `listLinks` with link-token runtime behavior

## Why

While using an action `.edits()` phase to reassign a `cardinality: "one"` link, the action read
facade allowed this at type level:

```ts
await read.objects(Transcript).byId(id).listLinks({ id: "project" })
```

But the runtime expects a full link token and validates it with the source object type. That meant
code could compile and only fail later in the async action worker.

## What Changed

### 1. Action read typing now matches runtime behavior

`ActionReadObjectByIdHandle.listLinks(...)` now accepts a typed link token:

```ts
await read.objects(Transcript).byId(id).listLinks(Transcript.l.project)
```

Plain `{ id: "project" }` objects no longer type-check.

### 2. Runtime error is clearer for invalid link-token inputs

If JavaScript or casted TypeScript still passes a plain id object, Sixb now reports that callers
should use `Type.l.<linkId>` instead of producing an `undefined.project` style message.

### 3. Link reassignment behavior is documented

The docs now make the current `cardinality: "one"` behavior explicit:

```ts
// link(...) is not a setter for an existing one-link target
transcript.link(Transcript.l.project, newProject)
```

To reassign, read the current target and stage the exact delete before the new link:

```ts
const [currentProject] = await read
  .objects(Transcript)
  .byId(subject.primaryId)
  .listLinks(Transcript.l.project)

if (currentProject) {
  transcript.unlink(Transcript.l.project, {
    objectTypeId: currentProject.targetTypeId,
    primaryId: currentProject.targetId,
  })
}

transcript.link(Transcript.l.project, params.project)
```

## Out of Scope

No new mutation API was added. `unlink(...) + link(...)` remains the supported reassignment flow for
now.

## Validation

```sh
bun --filter @sixb/core typecheck
bun run typecheck:tests
bun test packages/core/tests/sixb-runtime.test.ts
bun run check
bun run typecheck
```
