### PR TITLE
rules: consume canonical mutation events

### DIFF
--- a/docs/rules/overview.md
+++ b/docs/rules/overview.md
@@ -89,8 +89,8 @@ Once registered, Sixb evaluates rules as objects and links change. When a rule s
 object, it is **triggered**; when the object stops matching, it is **resolved**. Active state is
 tracked so each object triggers once until it clears.
 
-Evaluation reacts to `object.upserted` for the watched type, plus `link.upserted` and `link.removed`
-for any links named in the predicate. See [Events](../events/overview.md) for the full domain-event
+Evaluation reacts to object/link `created`, `updated`, and `deleted` events for the watched type
+and any links named in the predicate. See [Events](../events/overview.md) for the full domain-event
 list.
 
 ## Register rules

--- a/packages/atlas/src/pages/RulesPage.tsx
+++ b/packages/atlas/src/pages/RulesPage.tsx
@@ -147,23 +147,35 @@ function predicateSearchText(predicate: unknown): string {
 
 function dependencyLabel(dependency: RuleSummary["dependencies"][number]): string {
   switch (dependency.type) {
-    case "object.upserted":
-      return `Object ${dependency.objectTypeId}`
-    case "link.upserted":
-      return `Link ${dependency.sourceTypeId}.${dependency.linkId} upserted`
-    case "link.removed":
-      return `Link ${dependency.sourceTypeId}.${dependency.linkId} removed`
+    case "object.created":
+      return `Object ${dependency.objectTypeId} created`
+    case "object.updated":
+      return `Object ${dependency.objectTypeId} updated`
+    case "object.deleted":
+      return `Object ${dependency.objectTypeId} deleted`
+    case "link.created":
+      return `Link ${dependency.sourceTypeId}.${dependency.linkId} created`
+    case "link.updated":
+      return `Link ${dependency.sourceTypeId}.${dependency.linkId} updated`
+    case "link.deleted":
+      return `Link ${dependency.sourceTypeId}.${dependency.linkId} deleted`
   }
 }
 
 function dependencyEventLabel(dependency: RuleSummary["dependencies"][number]): string {
   switch (dependency.type) {
-    case "object.upserted":
-      return `${dependency.objectTypeId} upserted`
-    case "link.upserted":
-      return `${dependency.sourceTypeId}.${dependency.linkId} added`
-    case "link.removed":
-      return `${dependency.sourceTypeId}.${dependency.linkId} removed`
+    case "object.created":
+      return `${dependency.objectTypeId} created`
+    case "object.updated":
+      return `${dependency.objectTypeId} updated`
+    case "object.deleted":
+      return `${dependency.objectTypeId} deleted`
+    case "link.created":
+      return `${dependency.sourceTypeId}.${dependency.linkId} created`
+    case "link.updated":
+      return `${dependency.sourceTypeId}.${dependency.linkId} updated`
+    case "link.deleted":
+      return `${dependency.sourceTypeId}.${dependency.linkId} deleted`
   }
 }
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -697,11 +697,17 @@ describe("startSixbRuntime", () => {
     await sixb.events.append({
       events: [
         {
-          type: "object.upserted",
+          type: "object.created",
           payload: {
             objectTypeId: "Transaction",
             primaryId: "tx-1",
             properties: { status: "posted" },
+            propertyChanges: {
+              status: {
+                operation: "created",
+                after: "posted",
+              },
+            },
           },
         },
       ],
@@ -1052,13 +1058,13 @@ class LifecycleBroker extends InMemoryBroker {
     params: Parameters<InMemoryBroker["subscribe"]>[0],
     handler: Parameters<InMemoryBroker["subscribe"]>[1]
   ): Promise<() => void> {
-    if (params.names?.includes("object.upserted")) {
+    if (params.names?.includes("object.created")) {
       this.calls.push("rules:start")
     }
 
     const unsubscribe = await super.subscribe(params, handler)
     return () => {
-      if (params.names?.includes("object.upserted")) {
+      if (params.names?.includes("object.created")) {
         this.calls.push("rules:stop")
       }
       unsubscribe()

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -10411,7 +10411,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["object.upserted"]
+                                  "enum": ["object.created", "object.updated", "object.deleted"]
                                 },
                                 "objectTypeId": {
                                   "type": "string"
@@ -10425,24 +10425,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["link.upserted"]
-                                },
-                                "sourceTypeId": {
-                                  "type": "string"
-                                },
-                                "linkId": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": ["type", "sourceTypeId", "linkId"],
-                              "additionalProperties": false
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "type": {
-                                  "type": "string",
-                                  "enum": ["link.removed"]
+                                  "enum": ["link.created", "link.updated", "link.deleted"]
                                 },
                                 "sourceTypeId": {
                                   "type": "string"
@@ -10939,7 +10922,7 @@
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["object.upserted"]
+                                "enum": ["object.created", "object.updated", "object.deleted"]
                               },
                               "objectTypeId": {
                                 "type": "string"
@@ -10953,24 +10936,7 @@
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["link.upserted"]
-                              },
-                              "sourceTypeId": {
-                                "type": "string"
-                              },
-                              "linkId": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["type", "sourceTypeId", "linkId"],
-                            "additionalProperties": false
-                          },
-                          {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "type": "string",
-                                "enum": ["link.removed"]
+                                "enum": ["link.created", "link.updated", "link.deleted"]
                               },
                               "sourceTypeId": {
                                 "type": "string"

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3683,16 +3683,11 @@ export type ListRulesResponses = {
         }
     dependencies: Array<
       | {
-          type: "object.upserted"
+          type: "object.created" | "object.updated" | "object.deleted"
           objectTypeId: string
         }
       | {
-          type: "link.upserted"
-          sourceTypeId: string
-          linkId: string
-        }
-      | {
-          type: "link.removed"
+          type: "link.created" | "link.updated" | "link.deleted"
           sourceTypeId: string
           linkId: string
         }
@@ -3830,16 +3825,11 @@ export type GetRuleResponses = {
         }
     dependencies: Array<
       | {
-          type: "object.upserted"
+          type: "object.created" | "object.updated" | "object.deleted"
           objectTypeId: string
         }
       | {
-          type: "link.upserted"
-          sourceTypeId: string
-          linkId: string
-        }
-      | {
-          type: "link.removed"
+          type: "link.created" | "link.updated" | "link.deleted"
           sourceTypeId: string
           linkId: string
         }

--- a/packages/core/src/rules/dependencies.ts
+++ b/packages/core/src/rules/dependencies.ts
@@ -3,15 +3,21 @@ import type { RuleDefinition, RuleEventDependency, RulePredicate } from "./types
 /**
  * Derive the event surface that can change whether a rule is active.
  *
- * Every object-scoped rule depends on object upserts for its subject type.
- * Link predicates also depend on link upserts/removals for the referenced
- * links. Property predicates need no extra dependency because property changes
- * arrive through `object.upserted`.
+ * Every object-scoped rule depends on object mutations for its subject type.
+ * Link predicates also depend on link mutations for the referenced links.
  */
 export function deriveRuleEventDependencies(rule: RuleDefinition): readonly RuleEventDependency[] {
   const dependencies: RuleEventDependency[] = [
     {
-      type: "object.upserted",
+      type: "object.created",
+      objectTypeId: rule.subject.objectTypeId,
+    },
+    {
+      type: "object.updated",
+      objectTypeId: rule.subject.objectTypeId,
+    },
+    {
+      type: "object.deleted",
       objectTypeId: rule.subject.objectTypeId,
     },
   ]
@@ -23,12 +29,17 @@ export function deriveRuleEventDependencies(rule: RuleDefinition): readonly Rule
   for (const linkId of linkIds) {
     dependencies.push(
       {
-        type: "link.upserted",
+        type: "link.created",
         sourceTypeId: rule.subject.objectTypeId,
         linkId,
       },
       {
-        type: "link.removed",
+        type: "link.updated",
+        sourceTypeId: rule.subject.objectTypeId,
+        linkId,
+      },
+      {
+        type: "link.deleted",
         sourceTypeId: rule.subject.objectTypeId,
         linkId,
       }

--- a/packages/core/src/rules/types.ts
+++ b/packages/core/src/rules/types.ts
@@ -72,11 +72,11 @@ export type RuleValue = string | number | boolean | null
  */
 export type RuleEventDependency =
   | {
-      readonly type: "object.upserted"
+      readonly type: "object.created" | "object.updated" | "object.deleted"
       readonly objectTypeId: string
     }
   | {
-      readonly type: "link.upserted" | "link.removed"
+      readonly type: "link.created" | "link.updated" | "link.deleted"
       readonly sourceTypeId: string
       readonly linkId: string
     }

--- a/packages/core/tests/rules.test.ts
+++ b/packages/core/tests/rules.test.ts
@@ -138,11 +138,13 @@ describe("rules", () => {
       .where((tx) => tx.p.status.eq("posted"))
 
     expect(deriveRuleEventDependencies(rule)).toEqual([
-      { type: "object.upserted", objectTypeId: "transaction" },
+      { type: "object.created", objectTypeId: "transaction" },
+      { type: "object.updated", objectTypeId: "transaction" },
+      { type: "object.deleted", objectTypeId: "transaction" },
     ])
   })
 
-  test("deriveRuleEventDependencies includes link upsert and remove events", () => {
+  test("deriveRuleEventDependencies includes link mutation events", () => {
     const rule = defineRule("transaction.linked-docs")
       .on(Transaction)
       .where((tx) =>
@@ -150,11 +152,15 @@ describe("rules", () => {
       )
 
     expect(deriveRuleEventDependencies(rule)).toEqual([
-      { type: "object.upserted", objectTypeId: "transaction" },
-      { type: "link.upserted", sourceTypeId: "transaction", linkId: "document" },
-      { type: "link.removed", sourceTypeId: "transaction", linkId: "document" },
-      { type: "link.upserted", sourceTypeId: "transaction", linkId: "receipt" },
-      { type: "link.removed", sourceTypeId: "transaction", linkId: "receipt" },
+      { type: "object.created", objectTypeId: "transaction" },
+      { type: "object.updated", objectTypeId: "transaction" },
+      { type: "object.deleted", objectTypeId: "transaction" },
+      { type: "link.created", sourceTypeId: "transaction", linkId: "document" },
+      { type: "link.updated", sourceTypeId: "transaction", linkId: "document" },
+      { type: "link.deleted", sourceTypeId: "transaction", linkId: "document" },
+      { type: "link.created", sourceTypeId: "transaction", linkId: "receipt" },
+      { type: "link.updated", sourceTypeId: "transaction", linkId: "receipt" },
+      { type: "link.deleted", sourceTypeId: "transaction", linkId: "receipt" },
     ])
   })
 

--- a/packages/rules-worker/README.md
+++ b/packages/rules-worker/README.md
@@ -9,7 +9,7 @@ arrive.
 
 ## Responsibilities
 
-- subscribe to `object.upserted`, `link.upserted`, and `link.removed`
+- subscribe to object/link `created`, `updated`, and `deleted` events
 - match each ontology event to the rules that depend on it
 - evaluate only the affected subject object
 - overlay the source event onto projected object/link storage before evaluation
@@ -69,9 +69,9 @@ For each received ontology event batch:
 1. Build candidate evaluations from the precomputed rule dependency index.
 2. Dedupe by `ruleId + subject` within the batch.
 3. Load the subject object from `storage.objects`.
-4. Overlay any matching `object.upserted` payloads from the accepted events.
+4. Overlay any matching object mutation payloads from the accepted events.
 5. Load only the outgoing links referenced by the rule predicate.
-6. Overlay matching `link.upserted` and `link.removed` payloads.
+6. Overlay matching link mutation payloads.
 7. Evaluate the rule predicate against the overlaid object/link view.
 8. Check `storage.rules` for active state.
 9. Append and apply `rule.triggered` or `rule.resolved` only when state changes.

--- a/packages/rules-worker/src/evaluate-rule-event.ts
+++ b/packages/rules-worker/src/evaluate-rule-event.ts
@@ -23,32 +23,39 @@ import type {
 
 /** Build the worker's cheap event-payload lookup table from rule dependencies. */
 export function buildRuleDependencyIndex(rules: readonly RuleDefinition[]): RuleDependencyIndex {
-  const objectUpserted = new Map<string, RuleDefinition[]>()
-  const linkUpserted = new Map<string, RuleDefinition[]>()
-  const linkRemoved = new Map<string, RuleDefinition[]>()
+  const objectMutations = new Map<string, RuleDefinition[]>()
+  const linkMutations = new Map<string, RuleDefinition[]>()
+  const linkDeletes = new Map<string, RuleDefinition[]>()
 
   // The events runtime can only filter by type today, so this in-memory index is
   // the cheap payload-level filter before any object storage reads happen.
   for (const rule of rules) {
     for (const dependency of deriveRuleEventDependencies(rule)) {
-      if (dependency.type === "object.upserted") {
-        addRule(objectUpserted, dependency.objectTypeId, rule)
-        continue
-      }
-
-      const key = linkDependencyKey(dependency.sourceTypeId, dependency.linkId)
-      if (dependency.type === "link.upserted") {
-        addRule(linkUpserted, key, rule)
-      } else {
-        addRule(linkRemoved, key, rule)
+      switch (dependency.type) {
+        case "object.created":
+        case "object.updated":
+        case "object.deleted":
+          addRule(objectMutations, dependency.objectTypeId, rule)
+          break
+        case "link.created":
+        case "link.updated":
+          addRule(
+            linkMutations,
+            linkDependencyKey(dependency.sourceTypeId, dependency.linkId),
+            rule
+          )
+          break
+        case "link.deleted":
+          addRule(linkDeletes, linkDependencyKey(dependency.sourceTypeId, dependency.linkId), rule)
+          break
       }
     }
   }
 
   return {
-    objectUpserted,
-    linkUpserted,
-    linkRemoved,
+    objectMutations,
+    linkMutations,
+    linkDeletes,
   }
 }
 
@@ -151,6 +158,22 @@ export async function evaluateRuleForSubject(
   // predicate sees the same state regardless of projection timing.
   const object = await loadSubjectObjectWithOverlay(input)
   if (!object) {
+    const active = await rulesStorage.getActive({
+      projectId: input.runtime.projectId,
+      ruleId: input.rule.id,
+      subject: input.subject,
+    })
+
+    if (active) {
+      await appendResolvedRuleEvent({ evaluation: input, rulesStorage })
+      return {
+        ruleId: input.rule.id,
+        subject: input.subject,
+        matched: false,
+        emitted: "resolved",
+      }
+    }
+
     return {
       ruleId: input.rule.id,
       subject: input.subject,
@@ -198,20 +221,7 @@ export async function evaluateRuleForSubject(
   }
 
   if (!matched && active) {
-    const [stored] = await input.runtime.events.append({
-      events: [
-        {
-          type: "rule.resolved",
-          payload: {
-            ruleId: input.rule.id,
-            subject: input.subject,
-            resolvedAt: input.evaluatedAt,
-          },
-        },
-      ],
-    })
-    const event = requireRuleResolvedEvent(stored)
-    await rulesStorage.applyResolved(event)
+    await appendResolvedRuleEvent({ evaluation: input, rulesStorage })
     return {
       ruleId: input.rule.id,
       subject: input.subject,
@@ -226,6 +236,26 @@ export async function evaluateRuleForSubject(
     matched,
     emitted: null,
   }
+}
+
+async function appendResolvedRuleEvent(params: {
+  readonly evaluation: EvaluateRuleForSubjectInput
+  readonly rulesStorage: RulesStorage
+}): Promise<void> {
+  const [stored] = await params.evaluation.runtime.events.append({
+    events: [
+      {
+        type: "rule.resolved",
+        payload: {
+          ruleId: params.evaluation.rule.id,
+          subject: params.evaluation.subject,
+          resolvedAt: params.evaluation.evaluatedAt,
+        },
+      },
+    ],
+  })
+  const event = requireRuleResolvedEvent(stored)
+  await params.rulesStorage.applyResolved(event)
 }
 
 function addRule(map: Map<string, RuleDefinition[]>, key: string, rule: RuleDefinition): void {
@@ -245,17 +275,20 @@ function rulesForEvent(
   event: OntologyRuleEvent
 ): readonly RuleDefinition[] {
   switch (event.type) {
-    case "object.upserted":
-      return index.objectUpserted.get(event.payload.objectTypeId) ?? []
-    case "link.upserted":
+    case "object.created":
+    case "object.updated":
+    case "object.deleted":
+      return index.objectMutations.get(event.payload.objectTypeId) ?? []
+    case "link.created":
+    case "link.updated":
       return (
-        index.linkUpserted.get(
+        index.linkMutations.get(
           linkDependencyKey(event.payload.sourceTypeId, event.payload.linkId)
         ) ?? []
       )
-    case "link.removed":
+    case "link.deleted":
       return (
-        index.linkRemoved.get(
+        index.linkDeletes.get(
           linkDependencyKey(event.payload.sourceTypeId, event.payload.linkId)
         ) ?? []
       )
@@ -273,15 +306,22 @@ async function loadSubjectObjectWithOverlay(
 
   for (const event of input.sourceEvents) {
     if (
-      event.type !== "object.upserted" ||
+      (event.type !== "object.created" &&
+        event.type !== "object.updated" &&
+        event.type !== "object.deleted") ||
       event.payload.objectTypeId !== input.subject.objectTypeId ||
       event.payload.primaryId !== input.subject.primaryId
     ) {
       continue
     }
 
-    // An object upsert can either amend the projected row or synthesize it when
-    // the evaluator observes the append before object storage has projected it.
+    if (event.type === "object.deleted") {
+      object = null
+      continue
+    }
+
+    // An object mutation can either amend the projected row or synthesize it
+    // when the evaluator observes the append before object storage projects it.
     const occurredAt = new Date(event.occurredAt)
     object = {
       projectId: input.runtime.projectId,
@@ -321,7 +361,9 @@ async function loadLinksWithOverlay(
 
   for (const event of input.sourceEvents) {
     if (
-      (event.type !== "link.upserted" && event.type !== "link.removed") ||
+      (event.type !== "link.created" &&
+        event.type !== "link.updated" &&
+        event.type !== "link.deleted") ||
       event.payload.sourceTypeId !== input.subject.objectTypeId ||
       event.payload.sourceId !== input.subject.primaryId ||
       !linkIds.includes(event.payload.linkId)
@@ -336,7 +378,7 @@ async function loadLinksWithOverlay(
       event.payload.targetId
     )
 
-    if (event.type === "link.removed") {
+    if (event.type === "link.deleted") {
       // Remove only the target edge named by the source event; other outgoing
       // links for the same link id must remain visible to `exists` predicates.
       links.set(
@@ -346,7 +388,7 @@ async function loadLinksWithOverlay(
       continue
     }
 
-    // Link upserts replace the matching target edge if it was already
+    // Link mutations replace the matching target edge if it was already
     // projected, otherwise they add the pending edge to the overlaid view.
     const occurredAt = new Date(event.occurredAt)
     const existing = rows.find(
@@ -381,7 +423,7 @@ function referencedLinkIds(rule: RuleDefinition): readonly string[] {
   const seen = new Set<string>()
 
   for (const dependency of deriveRuleEventDependencies(rule)) {
-    if (dependency.type === "link.upserted" && !seen.has(dependency.linkId)) {
+    if (dependency.type === "link.created" && !seen.has(dependency.linkId)) {
       seen.add(dependency.linkId)
       linkIds.push(dependency.linkId)
     }
@@ -393,14 +435,17 @@ function referencedLinkIds(rule: RuleDefinition): readonly string[] {
 /** Convert the source domain event into the object subject rules evaluate. */
 function subjectForEvent(event: OntologyRuleEvent): RuleEventSubject {
   switch (event.type) {
-    case "object.upserted":
+    case "object.created":
+    case "object.updated":
+    case "object.deleted":
       return {
         kind: "object",
         objectTypeId: event.payload.objectTypeId,
         primaryId: event.payload.primaryId,
       }
-    case "link.upserted":
-    case "link.removed":
+    case "link.created":
+    case "link.updated":
+    case "link.deleted":
       return {
         kind: "object",
         objectTypeId: event.payload.sourceTypeId,

--- a/packages/rules-worker/src/evaluate-rule-event.ts
+++ b/packages/rules-worker/src/evaluate-rule-event.ts
@@ -423,7 +423,12 @@ function referencedLinkIds(rule: RuleDefinition): readonly string[] {
   const seen = new Set<string>()
 
   for (const dependency of deriveRuleEventDependencies(rule)) {
-    if (dependency.type === "link.created" && !seen.has(dependency.linkId)) {
+    if (
+      (dependency.type === "link.created" ||
+        dependency.type === "link.updated" ||
+        dependency.type === "link.deleted") &&
+      !seen.has(dependency.linkId)
+    ) {
       seen.add(dependency.linkId)
       linkIds.push(dependency.linkId)
     }

--- a/packages/rules-worker/src/types.ts
+++ b/packages/rules-worker/src/types.ts
@@ -6,15 +6,21 @@ import type {
   RuleEventSubject,
   RulePredicate,
   Storage,
-  StoredLinkRemovedEvent,
-  StoredLinkUpsertedEvent,
-  StoredObjectUpsertedEvent,
+  StoredLinkCreatedEvent,
+  StoredLinkDeletedEvent,
+  StoredLinkUpdatedEvent,
+  StoredObjectCreatedEvent,
+  StoredObjectDeletedEvent,
+  StoredObjectUpdatedEvent,
 } from "@sixb/core"
 
 export type OntologyRuleEvent =
-  | StoredObjectUpsertedEvent
-  | StoredLinkUpsertedEvent
-  | StoredLinkRemovedEvent
+  | StoredObjectCreatedEvent
+  | StoredObjectUpdatedEvent
+  | StoredObjectDeletedEvent
+  | StoredLinkCreatedEvent
+  | StoredLinkUpdatedEvent
+  | StoredLinkDeletedEvent
 
 /** Outgoing links for the evaluated subject, grouped by ontology link id. */
 export type RuleLinkMap = ReadonlyMap<string, readonly ObjectLinkRow[]>
@@ -48,9 +54,9 @@ export interface RulesWorkerContext {
  * current object/link event.
  */
 export interface RuleDependencyIndex {
-  readonly objectUpserted: ReadonlyMap<string, readonly RuleDefinition[]>
-  readonly linkUpserted: ReadonlyMap<string, readonly RuleDefinition[]>
-  readonly linkRemoved: ReadonlyMap<string, readonly RuleDefinition[]>
+  readonly objectMutations: ReadonlyMap<string, readonly RuleDefinition[]>
+  readonly linkMutations: ReadonlyMap<string, readonly RuleDefinition[]>
+  readonly linkDeletes: ReadonlyMap<string, readonly RuleDefinition[]>
 }
 
 /**

--- a/packages/rules-worker/src/worker.ts
+++ b/packages/rules-worker/src/worker.ts
@@ -4,9 +4,12 @@ import { buildRuleDependencyIndex, evaluateRuleEvents } from "./evaluate-rule-ev
 import type { OntologyRuleEvent, RuleDependencyIndex, RulesWorkerSixb } from "./types"
 
 const ontologyEventTypes = [
-  "object.upserted",
-  "link.upserted",
-  "link.removed",
+  "object.created",
+  "object.updated",
+  "object.deleted",
+  "link.created",
+  "link.updated",
+  "link.deleted",
 ] as const satisfies readonly DomainEvent["type"][]
 
 /**
@@ -86,9 +89,12 @@ export class RulesWorker extends Worker {
 // still StoredDomainEvent[]. This guard gives the evaluator the narrower union.
 function isOntologyRuleEvent(event: StoredDomainEvent): event is OntologyRuleEvent {
   return (
-    event.type === "object.upserted" ||
-    event.type === "link.upserted" ||
-    event.type === "link.removed"
+    event.type === "object.created" ||
+    event.type === "object.updated" ||
+    event.type === "object.deleted" ||
+    event.type === "link.created" ||
+    event.type === "link.updated" ||
+    event.type === "link.deleted"
   )
 }
 

--- a/packages/rules-worker/tests/evaluate-rule-event.test.ts
+++ b/packages/rules-worker/tests/evaluate-rule-event.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test"
 import type {
   RuleDefinition,
   Storage,
-  StoredLinkRemovedEvent,
-  StoredLinkUpsertedEvent,
-  StoredObjectUpsertedEvent,
+  StoredLinkCreatedEvent,
+  StoredLinkDeletedEvent,
+  StoredObjectCreatedEvent,
+  StoredObjectDeletedEvent,
+  StoredObjectUpdatedEvent,
 } from "@sixb/core"
 import { EventsRuntime, InMemoryBroker, InMemoryStorage } from "@sixb/core"
 import {
@@ -64,23 +66,23 @@ describe("rule event matching", () => {
   test("buildRuleDependencyIndex indexes object and link dependencies", () => {
     const index = buildRuleDependencyIndex([postedRule, requiresDocumentRule])
 
-    expect(index.objectUpserted.get("transaction")?.map((candidate) => candidate.id)).toEqual([
+    expect(index.objectMutations.get("transaction")?.map((candidate) => candidate.id)).toEqual([
       "transaction.posted",
       "transaction.requires-document",
     ])
     expect(
-      index.linkUpserted.get("transaction:document")?.map((candidate) => candidate.id)
+      index.linkMutations.get("transaction:document")?.map((candidate) => candidate.id)
     ).toEqual(["transaction.requires-document"])
-    expect(index.linkRemoved.get("transaction:document")?.map((candidate) => candidate.id)).toEqual(
+    expect(index.linkDeletes.get("transaction:document")?.map((candidate) => candidate.id)).toEqual(
       ["transaction.requires-document"]
     )
   })
 
-  test("object upsert matches subject-object rules", () => {
+  test("object update matches subject-object rules", () => {
     const index = buildRuleDependencyIndex([postedRule])
     const [candidate] = matchRuleEvent({
       index,
-      event: objectUpsertedEvent("transaction", "tx-1"),
+      event: objectUpdatedEvent("transaction", "tx-1"),
     })
 
     expect(candidate?.rule.id).toBe("transaction.posted")
@@ -91,11 +93,11 @@ describe("rule event matching", () => {
     })
   })
 
-  test("link upsert matches rules that reference that subject link", () => {
+  test("link create matches rules that reference that subject link", () => {
     const index = buildRuleDependencyIndex([requiresDocumentRule, requiresReceiptRule])
     const candidates = matchRuleEvent({
       index,
-      event: linkUpsertedEvent("transaction", "tx-1", "document"),
+      event: linkCreatedEvent("transaction", "tx-1", "document"),
     })
 
     expect(candidates.map((candidate) => candidate.rule.id)).toEqual([
@@ -108,11 +110,11 @@ describe("rule event matching", () => {
     })
   })
 
-  test("link removed matches rules that reference that subject link", () => {
+  test("link deleted matches rules that reference that subject link", () => {
     const index = buildRuleDependencyIndex([requiresDocumentRule, requiresReceiptRule])
     const candidates = matchRuleEvent({
       index,
-      event: linkRemovedEvent("transaction", "tx-1", "document"),
+      event: linkDeletedEvent("transaction", "tx-1", "document"),
     })
 
     expect(candidates.map((candidate) => candidate.rule.id)).toEqual([
@@ -131,19 +133,19 @@ describe("rule event matching", () => {
     expect(
       matchRuleEvent({
         index,
-        event: objectUpsertedEvent("document", "doc-1"),
+        event: objectUpdatedEvent("document", "doc-1"),
       })
     ).toEqual([])
     expect(
       matchRuleEvent({
         index,
-        event: linkUpsertedEvent("transaction", "tx-1", "receipt"),
+        event: linkCreatedEvent("transaction", "tx-1", "receipt"),
       })
     ).toEqual([])
     expect(
       matchRuleEvent({
         index,
-        event: linkRemovedEvent("document", "doc-1", "transaction"),
+        event: linkDeletedEvent("document", "doc-1", "transaction"),
       })
     ).toEqual([])
   })
@@ -153,9 +155,9 @@ describe("rule event matching", () => {
     const candidates = matchRuleEvents({
       index,
       events: [
-        objectUpsertedEvent("transaction", "tx-1", "1"),
-        linkUpsertedEvent("transaction", "tx-1", "document", "2"),
-        linkRemovedEvent("transaction", "tx-1", "document", "3"),
+        objectUpdatedEvent("transaction", "tx-1", "1"),
+        linkCreatedEvent("transaction", "tx-1", "document", "2"),
+        linkDeletedEvent("transaction", "tx-1", "document", "3"),
       ],
     })
 
@@ -173,8 +175,8 @@ describe("rule event matching", () => {
 describe("rule subject evaluation", () => {
   test("new matching object emits rule.triggered", async () => {
     const runtime = createRuntime()
-    const event = objectUpsertedEvent("transaction", "tx-1", "1", { status: "posted" })
-    await runtime.storage.objects.applyObjectUpserted(event)
+    const event = objectCreatedEvent("transaction", "tx-1", "1", { status: "posted" })
+    await seedObject(runtime, "tx-1", { status: "posted" })
 
     const result = await evaluateRuleForSubject({
       runtime,
@@ -202,8 +204,8 @@ describe("rule subject evaluation", () => {
 
   test("still-matching active object emits no duplicate event", async () => {
     const runtime = createRuntime()
-    const event = objectUpsertedEvent("transaction", "tx-1", "1", { status: "posted" })
-    await runtime.storage.objects.applyObjectUpserted(event)
+    const event = objectCreatedEvent("transaction", "tx-1", "1", { status: "posted" })
+    await seedObject(runtime, "tx-1", { status: "posted" })
 
     await evaluateRuleForSubject({
       runtime,
@@ -213,8 +215,8 @@ describe("rule subject evaluation", () => {
       evaluatedAt,
     })
 
-    const repeatEvent = objectUpsertedEvent("transaction", "tx-1", "2", { status: "posted" })
-    await runtime.storage.objects.applyObjectUpserted(repeatEvent)
+    const repeatEvent = objectUpdatedEvent("transaction", "tx-1", "2", { status: "posted" })
+    await seedObject(runtime, "tx-1", { status: "posted" }, "2")
     const result = await evaluateRuleForSubject({
       runtime,
       rule: postedRule,
@@ -229,8 +231,8 @@ describe("rule subject evaluation", () => {
 
   test("previously active object that no longer matches emits rule.resolved", async () => {
     const runtime = createRuntime()
-    const event = objectUpsertedEvent("transaction", "tx-1", "1", { status: "posted" })
-    await runtime.storage.objects.applyObjectUpserted(event)
+    const event = objectCreatedEvent("transaction", "tx-1", "1", { status: "posted" })
+    await seedObject(runtime, "tx-1", { status: "posted" })
     await evaluateRuleForSubject({
       runtime,
       rule: postedRule,
@@ -239,7 +241,7 @@ describe("rule subject evaluation", () => {
       evaluatedAt,
     })
 
-    const resolvingEvent = objectUpsertedEvent("transaction", "tx-1", "2", { status: "draft" })
+    const resolvingEvent = objectUpdatedEvent("transaction", "tx-1", "2", { status: "draft" })
     const result = await evaluateRuleForSubject({
       runtime,
       rule: postedRule,
@@ -264,10 +266,40 @@ describe("rule subject evaluation", () => {
     ).resolves.toBeNull()
   })
 
+  test("previously active deleted object emits rule.resolved", async () => {
+    const runtime = createRuntime()
+    const event = objectCreatedEvent("transaction", "tx-1", "1", { status: "posted" })
+    await seedObject(runtime, "tx-1", { status: "posted" })
+    await evaluateRuleForSubject({
+      runtime,
+      rule: postedRule,
+      subject: subject("tx-1"),
+      sourceEvents: [event],
+      evaluatedAt,
+    })
+
+    const deletedEvent = objectDeletedEvent("transaction", "tx-1", "2")
+    const result = await evaluateRuleForSubject({
+      runtime,
+      rule: postedRule,
+      subject: subject("tx-1"),
+      sourceEvents: [deletedEvent],
+      evaluatedAt: "2026-05-07T10:32:00.000Z",
+    })
+
+    expect(result).toEqual({
+      ruleId: "transaction.posted",
+      subject: subject("tx-1"),
+      matched: false,
+      emitted: "resolved",
+    })
+    expect(await ruleEventTypes(runtime)).toEqual(["rule.triggered", "rule.resolved"])
+  })
+
   test("violating again after resolution emits rule.triggered again", async () => {
     const runtime = createRuntime()
-    const triggerEvent = objectUpsertedEvent("transaction", "tx-1", "1", { status: "posted" })
-    await runtime.storage.objects.applyObjectUpserted(triggerEvent)
+    const triggerEvent = objectCreatedEvent("transaction", "tx-1", "1", { status: "posted" })
+    await seedObject(runtime, "tx-1", { status: "posted" })
     await evaluateRuleForSubject({
       runtime,
       rule: postedRule,
@@ -276,7 +308,7 @@ describe("rule subject evaluation", () => {
       evaluatedAt,
     })
 
-    const resolveEvent = objectUpsertedEvent("transaction", "tx-1", "2", { status: "draft" })
+    const resolveEvent = objectUpdatedEvent("transaction", "tx-1", "2", { status: "draft" })
     await evaluateRuleForSubject({
       runtime,
       rule: postedRule,
@@ -285,7 +317,7 @@ describe("rule subject evaluation", () => {
       evaluatedAt: "2026-05-07T10:31:00.000Z",
     })
 
-    const retriggerEvent = objectUpsertedEvent("transaction", "tx-1", "3", { status: "posted" })
+    const retriggerEvent = objectUpdatedEvent("transaction", "tx-1", "3", { status: "posted" })
     const result = await evaluateRuleForSubject({
       runtime,
       rule: postedRule,
@@ -302,9 +334,9 @@ describe("rule subject evaluation", () => {
     ])
   })
 
-  test("object-upsert overlay evaluates new properties before storage projects the event", async () => {
+  test("object-update overlay evaluates new properties before storage projects the event", async () => {
     const runtime = createRuntime()
-    const event = objectUpsertedEvent("transaction", "tx-1", "1", { status: "posted" })
+    const event = objectUpdatedEvent("transaction", "tx-1", "1", { status: "posted" })
 
     const result = await evaluateRuleForSubject({
       runtime,
@@ -318,11 +350,10 @@ describe("rule subject evaluation", () => {
     expect(result.emitted).toBe("triggered")
   })
 
-  test("link-upsert overlay evaluates the new link before storage projects the event", async () => {
+  test("link-create overlay evaluates the new link before storage projects the event", async () => {
     const runtime = createRuntime()
-    const objectEvent = objectUpsertedEvent("transaction", "tx-1")
-    await runtime.storage.objects.applyObjectUpserted(objectEvent)
-    const linkEvent = linkUpsertedEvent("transaction", "tx-1", "receipt")
+    await seedObject(runtime, "tx-1")
+    const linkEvent = linkCreatedEvent("transaction", "tx-1", "receipt")
 
     const result = await evaluateRuleForSubject({
       runtime,
@@ -336,15 +367,12 @@ describe("rule subject evaluation", () => {
     expect(result.emitted).toBe("triggered")
   })
 
-  test("link-removed overlay removes the link before storage projects the event", async () => {
+  test("link-deleted overlay removes the link before storage projects the event", async () => {
     const runtime = createRuntime()
-    const objectEvent = objectUpsertedEvent("transaction", "tx-1")
-    await runtime.storage.objects.applyObjectUpserted(objectEvent)
-    await runtime.storage.objects.applyLinkUpserted(
-      linkUpsertedEvent("transaction", "tx-1", "document")
-    )
+    await seedObject(runtime, "tx-1")
+    await seedLink(runtime, "tx-1", "document")
 
-    const removeEvent = linkRemovedEvent("transaction", "tx-1", "document")
+    const removeEvent = linkDeletedEvent("transaction", "tx-1", "document")
     const result = await evaluateRuleForSubject({
       runtime,
       rule: requiresDocumentRule,
@@ -357,18 +385,13 @@ describe("rule subject evaluation", () => {
     expect(result.emitted).toBe("triggered")
   })
 
-  test("link-removed overlay leaves other targets for the same link id visible", async () => {
+  test("link-deleted overlay leaves other targets for the same link id visible", async () => {
     const runtime = createRuntime()
-    const objectEvent = objectUpsertedEvent("transaction", "tx-1")
-    await runtime.storage.objects.applyObjectUpserted(objectEvent)
-    await runtime.storage.objects.applyLinkUpserted(
-      linkUpsertedEvent("transaction", "tx-1", "document", "1", "doc-1")
-    )
-    await runtime.storage.objects.applyLinkUpserted(
-      linkUpsertedEvent("transaction", "tx-1", "document", "2", "doc-2")
-    )
+    await seedObject(runtime, "tx-1")
+    await seedLink(runtime, "tx-1", "document", "1", "doc-1")
+    await seedLink(runtime, "tx-1", "document", "2", "doc-2")
 
-    const removeEvent = linkRemovedEvent("transaction", "tx-1", "document", "3", "doc-1")
+    const removeEvent = linkDeletedEvent("transaction", "tx-1", "document", "3", "doc-1")
     const result = await evaluateRuleForSubject({
       runtime,
       rule: hasDocumentRule,
@@ -383,8 +406,8 @@ describe("rule subject evaluation", () => {
 
   test("link-missing rule works for transaction without a document", async () => {
     const runtime = createRuntime()
-    const event = objectUpsertedEvent("transaction", "tx-1")
-    await runtime.storage.objects.applyObjectUpserted(event)
+    const event = objectCreatedEvent("transaction", "tx-1")
+    await seedObject(runtime, "tx-1")
 
     const result = await evaluateRuleForSubject({
       runtime,
@@ -406,8 +429,8 @@ describe("rule subject evaluation", () => {
       rules: [postedRule],
       index: postedIndex,
       events: [
-        objectUpsertedEvent("transaction", "tx-1", "1", { status: "draft" }),
-        objectUpsertedEvent("transaction", "tx-1", "2", { status: "posted" }),
+        objectUpdatedEvent("transaction", "tx-1", "1", { status: "draft" }),
+        objectUpdatedEvent("transaction", "tx-1", "2", { status: "posted" }),
       ],
       evaluatedAt,
     })
@@ -422,8 +445,8 @@ describe("rule subject evaluation", () => {
       rules: [postedRule],
       index: postedIndex,
       events: [
-        objectUpsertedEvent("transaction", "tx-1", "1", { status: "posted" }),
-        objectUpsertedEvent("transaction", "tx-1", "2", { status: "draft" }),
+        objectUpdatedEvent("transaction", "tx-1", "1", { status: "posted" }),
+        objectUpdatedEvent("transaction", "tx-1", "2", { status: "draft" }),
       ],
       evaluatedAt,
     })
@@ -435,16 +458,15 @@ describe("rule subject evaluation", () => {
 
   test("same-batch link overlays use the final edge state", async () => {
     const missingRuntime = createRuntime()
-    const missingObjectEvent = objectUpsertedEvent("transaction", "tx-1")
-    await missingRuntime.storage.objects.applyObjectUpserted(missingObjectEvent)
+    await seedObject(missingRuntime, "tx-1")
     const index = buildRuleDependencyIndex([hasDocumentRule])
     const missingResult = await evaluateRuleEvents({
       runtime: missingRuntime,
       rules: [hasDocumentRule],
       index,
       events: [
-        linkUpsertedEvent("transaction", "tx-1", "document", "1", "doc-1"),
-        linkRemovedEvent("transaction", "tx-1", "document", "2", "doc-1"),
+        linkCreatedEvent("transaction", "tx-1", "document", "1", "doc-1"),
+        linkDeletedEvent("transaction", "tx-1", "document", "2", "doc-1"),
       ],
       evaluatedAt,
     })
@@ -454,15 +476,14 @@ describe("rule subject evaluation", () => {
     expect(missingResult.evaluations[0]?.emitted).toBeNull()
 
     const existsRuntime = createRuntime()
-    const existsObjectEvent = objectUpsertedEvent("transaction", "tx-1")
-    await existsRuntime.storage.objects.applyObjectUpserted(existsObjectEvent)
+    await seedObject(existsRuntime, "tx-1")
     const existsResult = await evaluateRuleEvents({
       runtime: existsRuntime,
       rules: [hasDocumentRule],
       index,
       events: [
-        linkRemovedEvent("transaction", "tx-1", "document", "1", "doc-1"),
-        linkUpsertedEvent("transaction", "tx-1", "document", "2", "doc-1"),
+        linkDeletedEvent("transaction", "tx-1", "document", "1", "doc-1"),
+        linkCreatedEvent("transaction", "tx-1", "document", "2", "doc-1"),
       ],
       evaluatedAt,
     })
@@ -480,9 +501,9 @@ describe("rule subject evaluation", () => {
       rules: [compositeRule],
       index,
       events: [
-        objectUpsertedEvent("transaction", "tx-1", "1", { status: "posted", amount: 100 }),
-        linkUpsertedEvent("transaction", "tx-1", "document", "2", "doc-1"),
-        linkUpsertedEvent("transaction", "tx-1", "receipt", "3", "doc-2"),
+        objectUpdatedEvent("transaction", "tx-1", "1", { status: "posted", amount: 100 }),
+        linkCreatedEvent("transaction", "tx-1", "document", "2", "doc-1"),
+        linkCreatedEvent("transaction", "tx-1", "receipt", "3", "doc-2"),
       ],
       evaluatedAt,
     })
@@ -505,8 +526,8 @@ describe("rule subject evaluation", () => {
       rules: [requiresDocumentRule],
       index,
       events: [
-        objectUpsertedEvent("transaction", "tx-1", "1"),
-        linkRemovedEvent("transaction", "tx-1", "document", "2"),
+        objectUpdatedEvent("transaction", "tx-1", "1"),
+        linkDeletedEvent("transaction", "tx-1", "document", "2"),
       ],
       evaluatedAt,
     })
@@ -529,24 +550,59 @@ function rule(id: string, predicate: RuleDefinition["predicate"]): RuleDefinitio
   }
 }
 
-function objectUpsertedEvent(
+function objectUpdatedEvent(
   objectTypeId: string,
   primaryId: string,
   cursor = "1",
   properties: Record<string, unknown> = {}
-): StoredObjectUpsertedEvent {
+): StoredObjectUpdatedEvent {
   return {
     id: `event-${cursor}`,
     cursor,
     schemaVersion: 1,
     projectId: "project-a",
-    type: "object.upserted",
+    type: "object.updated",
     topic: "objects",
     partitionKey: `${objectTypeId}:${primaryId}`,
     payload: {
       objectTypeId,
       primaryId,
       properties,
+      propertyChanges: {},
+    },
+    occurredAt: "2026-05-07T10:00:00.000Z",
+  }
+}
+
+function objectCreatedEvent(
+  objectTypeId: string,
+  primaryId: string,
+  cursor = "1",
+  properties: Record<string, unknown> = {}
+): StoredObjectCreatedEvent {
+  return {
+    ...objectUpdatedEvent(objectTypeId, primaryId, cursor, properties),
+    type: "object.created",
+  }
+}
+
+function objectDeletedEvent(
+  objectTypeId: string,
+  primaryId: string,
+  cursor = "1"
+): StoredObjectDeletedEvent {
+  return {
+    id: `event-${cursor}`,
+    cursor,
+    schemaVersion: 1,
+    projectId: "project-a",
+    type: "object.deleted",
+    topic: "objects",
+    partitionKey: `${objectTypeId}:${primaryId}`,
+    payload: {
+      objectTypeId,
+      primaryId,
+      propertyChanges: {},
     },
     occurredAt: "2026-05-07T10:00:00.000Z",
   }
@@ -582,19 +638,19 @@ async function ruleEventTypes(runtime: {
   return events.map((event) => event.type)
 }
 
-function linkUpsertedEvent(
+function linkCreatedEvent(
   sourceTypeId: string,
   sourceId: string,
   linkId: string,
   cursor = "1",
   targetId = "doc-1"
-): StoredLinkUpsertedEvent {
+): StoredLinkCreatedEvent {
   return {
     id: `event-${cursor}`,
     cursor,
     schemaVersion: 1,
     projectId: "project-a",
-    type: "link.upserted",
+    type: "link.created",
     topic: "links",
     partitionKey: `${sourceTypeId}:${sourceId}:${linkId}`,
     payload: {
@@ -603,24 +659,25 @@ function linkUpsertedEvent(
       linkId,
       targetTypeId: "document",
       targetId,
+      propertyChanges: {},
     },
     occurredAt: "2026-05-07T10:00:00.000Z",
   }
 }
 
-function linkRemovedEvent(
+function linkDeletedEvent(
   sourceTypeId: string,
   sourceId: string,
   linkId: string,
   cursor = "1",
   targetId = "doc-1"
-): StoredLinkRemovedEvent {
+): StoredLinkDeletedEvent {
   return {
     id: `event-${cursor}`,
     cursor,
     schemaVersion: 1,
     projectId: "project-a",
-    type: "link.removed",
+    type: "link.deleted",
     topic: "links",
     partitionKey: `${sourceTypeId}:${sourceId}:${linkId}`,
     payload: {
@@ -629,7 +686,57 @@ function linkRemovedEvent(
       linkId,
       targetTypeId: "document",
       targetId,
+      propertyChanges: {},
     },
     occurredAt: "2026-05-07T10:00:00.000Z",
   }
+}
+
+async function seedObject(
+  runtime: ReturnType<typeof createRuntime>,
+  primaryId: string,
+  properties: Record<string, unknown> = {},
+  cursor = "1"
+): Promise<void> {
+  await runtime.storage.objects.applyObjectUpserted({
+    id: `seed-object-${cursor}`,
+    cursor: `seed-object-${cursor}`,
+    schemaVersion: 1,
+    projectId: "project-a",
+    type: "object.upserted",
+    topic: "objects",
+    partitionKey: `transaction:${primaryId}`,
+    payload: {
+      objectTypeId: "transaction",
+      primaryId,
+      properties,
+    },
+    occurredAt: "2026-05-07T10:00:00.000Z",
+  })
+}
+
+async function seedLink(
+  runtime: ReturnType<typeof createRuntime>,
+  sourceId: string,
+  linkId: string,
+  cursor = "1",
+  targetId = "doc-1"
+): Promise<void> {
+  await runtime.storage.objects.applyLinkUpserted({
+    id: `seed-link-${cursor}`,
+    cursor: `seed-link-${cursor}`,
+    schemaVersion: 1,
+    projectId: "project-a",
+    type: "link.upserted",
+    topic: "links",
+    partitionKey: `transaction:${sourceId}:${linkId}`,
+    payload: {
+      sourceTypeId: "transaction",
+      sourceId,
+      linkId,
+      targetTypeId: "document",
+      targetId,
+    },
+    occurredAt: "2026-05-07T10:00:00.000Z",
+  })
 }

--- a/packages/rules-worker/tests/worker.test.ts
+++ b/packages/rules-worker/tests/worker.test.ts
@@ -71,7 +71,14 @@ describe("RulesWorker", () => {
 
     expect(events.subscriptions).toEqual([
       {
-        types: ["object.upserted", "link.upserted", "link.removed"],
+        types: [
+          "object.created",
+          "object.updated",
+          "object.deleted",
+          "link.created",
+          "link.updated",
+          "link.deleted",
+        ],
       },
     ])
   })
@@ -90,7 +97,7 @@ describe("RulesWorker", () => {
     await worker.start()
 
     await events.append({
-      events: [objectUpsertedEvent("posted")],
+      events: [objectUpdatedEvent("posted")],
     })
     await rules.waitForGetActive()
 
@@ -115,7 +122,7 @@ describe("RulesWorker", () => {
     await worker.stop()
 
     await events.append({
-      events: [objectUpsertedEvent("posted")],
+      events: [objectUpdatedEvent("posted")],
     })
     await Bun.sleep(20)
 
@@ -142,12 +149,12 @@ describe("RulesWorker", () => {
       await worker.start()
 
       await events.append({
-        events: [objectUpsertedEvent("posted")],
+        events: [objectUpdatedEvent("posted")],
       })
       await waitFor(() => errors.length === 1)
 
       await events.append({
-        events: [objectUpsertedEvent("posted", "tx-2")],
+        events: [objectUpdatedEvent("posted", "tx-2")],
       })
       await worker.stop()
 
@@ -253,13 +260,14 @@ function createStorageWithoutRules(): Storage {
   })
 }
 
-function objectUpsertedEvent(status: string, primaryId = "tx-1"): EventDraft {
+function objectUpdatedEvent(status: string, primaryId = "tx-1"): EventDraft {
   return {
-    type: "object.upserted",
+    type: "object.updated",
     payload: {
       objectTypeId: "transaction",
       primaryId,
       properties: { status },
+      propertyChanges: {},
     },
   }
 }

--- a/packages/server/src/schemas/rules.ts
+++ b/packages/server/src/schemas/rules.ts
@@ -66,16 +66,11 @@ export const RulePredicateSchema = NestedRulePredicateSchema as z.ZodType<RulePr
 
 const RuleEventDependencySchema = z.union([
   z.object({
-    type: z.literal("object.upserted"),
+    type: z.enum(["object.created", "object.updated", "object.deleted"]),
     objectTypeId: z.string(),
   }),
   z.object({
-    type: z.literal("link.upserted"),
-    sourceTypeId: z.string(),
-    linkId: z.string(),
-  }),
-  z.object({
-    type: z.literal("link.removed"),
+    type: z.enum(["link.created", "link.updated", "link.deleted"]),
     sourceTypeId: z.string(),
     linkId: z.string(),
   }),

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -1103,7 +1103,15 @@ describe("SixbServer HTTP contract", () => {
           },
           dependencies: [
             {
-              type: "object.upserted",
+              type: "object.created",
+              objectTypeId: "device",
+            },
+            {
+              type: "object.updated",
+              objectTypeId: "device",
+            },
+            {
+              type: "object.deleted",
               objectTypeId: "device",
             },
           ],


### PR DESCRIPTION
## What

Moves rule event consumers from legacy mutation events to canonical mutation events:

```ts
object.created | object.updated | object.deleted
link.created | link.updated | link.deleted
```

## Why

Rules should consume the same precise event surface exposed by the new selector builders, while legacy events stay available for compatibility until the final cleanup phase.

## Changes

- Rule dependencies now derive canonical object/link mutation dependencies.
- Rules worker subscribes to canonical object/link events.
- Event overlays handle created/updated/deleted object and link events.
- Deleted active objects now emit `rule.resolved`.
- API schema, generated client, Atlas labels, docs, and tests updated.

## Validation

```bash
bun run generate:client
bun run check
bun run typecheck
bun run build
bun test packages/core/tests/rules.test.ts packages/rules-worker/tests/evaluate-rule-event.test.ts packages/rules-worker/tests/worker.test.ts
bun test packages/server/tests/httpContract.test.ts
bun test packages/cli/tests/runtime.test.ts
```

`bun run test` was also run. It leaves one local unrelated failure:

```txt
AgentWorker > inlines supported image attachments when the model advertises image input
```

