### PR TITLE
auth: prevent scanners from consuming magic links

### DIFF
--- a/auth/magic-link/src/strategy.ts
+++ b/auth/magic-link/src/strategy.ts
@@ -9,6 +9,8 @@ import type {
   MagicLinkCallbackResult,
   MagicLinkInvitationRecipientInput,
   MagicLinkInvitationRecipientResult,
+  MagicLinkPeekInput,
+  MagicLinkPeekResult,
   MagicLinkRequestInput,
   MagicLinkRequestResult,
 } from "@sixb/core"
@@ -59,10 +61,11 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
   readonly id: string
   readonly bootstrapGroupIds: readonly string[]
 
+  readonly magicLinkTtlMs: number
+
   private readonly allowedDomains: ReadonlySet<string>
   private readonly bootstrapUsers: ReadonlySet<string>
   private readonly publicOrigin?: string
-  private readonly magicLinkTtlMs: number
   private readonly rateLimiter: MagicLinkRateLimiter
   private readonly sendMagicLink: (message: SendMagicLinkInput) => Promise<void>
   private readonly from?: string
@@ -120,6 +123,7 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
       magicLinkId,
       requestOrigin: input.requestOrigin,
       token: credential.token,
+      requesterHash: input.requesterHash,
     })
 
     try {
@@ -181,6 +185,31 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
     }
 
     return { status: "allowed", email }
+  }
+
+  // Read-only twin of completeMagicLinkSignIn's validity rules: same record
+  // checks plus token verification, but never consumes the token. Keeps the
+  // "can this link still sign in?" logic in one package so the server's GET
+  // handler cannot drift from the rules applied on completion.
+  async peekMagicLink(input: MagicLinkPeekInput): Promise<MagicLinkPeekResult | null> {
+    const now = input.now ? new Date(input.now) : new Date()
+    const magicLink = await input.authStorage.magicLinks.getById({
+      projectId: input.projectId,
+      id: input.magicLinkId,
+    })
+
+    if (
+      !magicLink ||
+      !this.isAllowedEmail(magicLink.email) ||
+      magicLink.consumedAt ||
+      magicLink.revokedAt ||
+      magicLink.expiresAt.getTime() <= now.getTime() ||
+      hashMagicLinkToken(input.token) !== magicLink.tokenHash
+    ) {
+      return null
+    }
+
+    return { email: magicLink.email }
   }
 
   async completeMagicLinkSignIn(input: MagicLinkCallbackInput): Promise<MagicLinkCallbackResult> {
@@ -255,11 +284,15 @@ class MagicLinkAuthStrategyImpl implements MagicLinkAuthStrategy {
     readonly magicLinkId: string
     readonly requestOrigin: string
     readonly token: string
+    readonly requesterHash?: string
   }): string {
     const origin = this.publicOrigin ?? normalizePublicOrigin(input.requestOrigin)
     const url = new URL("/auth/callback", origin)
     url.searchParams.set("magicLinkId", input.magicLinkId)
     url.searchParams.set("token", input.token)
+    if (input.requesterHash) {
+      url.searchParams.set("requester", input.requesterHash)
+    }
     return url.toString()
   }
 

--- a/auth/magic-link/tests/magic-link.test.ts
+++ b/auth/magic-link/tests/magic-link.test.ts
@@ -48,6 +48,7 @@ async function requestMagicLink(input: {
   readonly strategy: ReturnType<typeof magicLink>
   readonly email: string
   readonly audience?: string
+  readonly requesterHash?: string
   readonly now?: Date
 }) {
   return input.strategy.requestMagicLink({
@@ -57,6 +58,7 @@ async function requestMagicLink(input: {
     audience: input.audience ?? "atlas",
     returnTo: "/dashboard",
     requestOrigin,
+    requesterHash: input.requesterHash,
     now: input.now ?? at("2026-05-16T10:00:00.000Z"),
   })
 }
@@ -189,6 +191,7 @@ describe("magicLink", () => {
     expect(link.origin).toBe(requestOrigin)
     expect(link.pathname).toBe("/auth/callback")
     expect(link.searchParams.get("returnTo")).toBeNull()
+    expect(link.searchParams.get("requester")).toBeNull()
     expect(token).toBeTruthy()
     expect(magicLinkId).toBeTruthy()
 
@@ -204,6 +207,77 @@ describe("magicLink", () => {
       tokenHash: hashMagicLinkToken(token ?? ""),
     })
     expect(record?.tokenHash).not.toBe(token)
+  })
+
+  test("embeds the requester hash in the callback URL when provided", async () => {
+    const storage = new InMemoryAuthStorage()
+    const { messages, sendMagicLink } = createSender()
+    const strategy = magicLink({
+      allowedDomains: ["acme.com"],
+      sendMagicLink,
+    })
+
+    await storage.users.create({
+      id: "usr_1",
+      projectId,
+      email: "ava@acme.com",
+    })
+
+    await requestMagicLink({
+      storage,
+      strategy,
+      email: "ava@acme.com",
+      requesterHash: "requester-hash-value",
+    })
+
+    const link = linkFromLatestMessage(messages)
+    expect(link.searchParams.get("requester")).toBe("requester-hash-value")
+  })
+
+  test("peekMagicLink validates without consuming and rejects bad tokens", async () => {
+    const storage = new InMemoryAuthStorage()
+    const { messages, sendMagicLink } = createSender()
+    const strategy = magicLink({
+      allowedDomains: ["acme.com"],
+      bootstrapUsers: ["ava@acme.com"],
+      sendMagicLink,
+    })
+
+    await requestMagicLink({ storage, strategy, email: "ava@acme.com" })
+    const link = linkFromLatestMessage(messages)
+    const magicLinkId = link.searchParams.get("magicLinkId") ?? ""
+    const token = link.searchParams.get("token") ?? ""
+    const peek = (peekToken: string, now?: Date) =>
+      strategy.peekMagicLink!({
+        projectId,
+        authStorage: storage,
+        magicLinkId,
+        token: peekToken,
+        now: now ?? at("2026-05-16T10:01:00.000Z"),
+      })
+
+    // Valid link peeks the email — repeatedly, without consuming it.
+    await expect(peek(token)).resolves.toEqual({ email: "ava@acme.com" })
+    await expect(peek(token)).resolves.toEqual({ email: "ava@acme.com" })
+    await expect(peek("wrong-token")).resolves.toBeNull()
+    await expect(peek(token, at("2026-05-16T10:16:00.000Z"))).resolves.toBeNull()
+
+    // Completion still works after peeking, and a consumed link peeks null.
+    await strategy.completeMagicLinkSignIn({
+      projectId,
+      authStorage: storage,
+      magicLinkId,
+      token,
+      now: at("2026-05-16T10:02:00.000Z"),
+      session: {
+        id: "ses_1",
+        audience: "atlas",
+        tokenHash: "session-hash",
+        createdAt: at("2026-05-16T10:02:00.000Z"),
+        expiresAt: at("2026-05-16T22:02:00.000Z"),
+      },
+    })
+    await expect(peek(token, at("2026-05-16T10:03:00.000Z"))).resolves.toBeNull()
   })
 
   test("does not send for unknown, suspended, or disallowed emails", async () => {

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -108,6 +108,8 @@ export type {
   MagicLinkInvitationRecipientInput,
   MagicLinkInvitationRecipientResult,
   MagicLinkInvitationRecipientStatus,
+  MagicLinkPeekInput,
+  MagicLinkPeekResult,
   MagicLinkRequestInput,
   MagicLinkRequestResult,
   MagicLinkRequestStatus,

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -96,6 +96,14 @@ export interface MagicLinkRequestInput {
   readonly audience: AuthSessionAudience
   readonly returnTo: string
   readonly requestOrigin: string
+  /**
+   * Opaque hash the strategy appends to the callback URL as the `requester`
+   * query param. The server keeps the preimage in a cookie on the requesting
+   * browser so the callback can sign that same browser in without the extra
+   * confirmation click. Omitted for deliveries with no requesting browser
+   * (invitations).
+   */
+  readonly requesterHash?: string
   readonly now?: Date
 }
 
@@ -131,13 +139,38 @@ export interface MagicLinkCallbackResult extends CompleteSignInResult {
   readonly returnTo: string
 }
 
+export interface MagicLinkPeekInput {
+  readonly projectId: string
+  readonly authStorage: AuthStorage
+  readonly magicLinkId: string
+  readonly token: string
+  readonly now?: Date
+}
+
+export interface MagicLinkPeekResult {
+  readonly email: string
+}
+
 export interface MagicLinkAuthStrategy extends InvitationDeliveryAuthStrategy {
   readonly kind: "magicLink"
   readonly bootstrapGroupIds?: readonly string[]
+  /**
+   * How long issued links stay valid (ms). Lets the server align dependent
+   * lifetimes (e.g. the same-device pending cookie) with the configured TTL.
+   */
+  readonly magicLinkTtlMs?: number
   validateInvitationRecipient?(
     input: MagicLinkInvitationRecipientInput
   ): Promise<MagicLinkInvitationRecipientResult>
   requestMagicLink(input: MagicLinkRequestInput): Promise<MagicLinkRequestResult>
+  /**
+   * Read-only validity check for a link the user has not confirmed yet. Must
+   * never consume the token, and must apply the same rules that would make
+   * {@link completeMagicLinkSignIn} fail (including token verification), so a
+   * link that peeks as valid only fails to complete when raced. Returns null
+   * for links that cannot complete sign-in.
+   */
+  peekMagicLink?(input: MagicLinkPeekInput): Promise<MagicLinkPeekResult | null>
   completeMagicLinkSignIn(input: MagicLinkCallbackInput): Promise<MagicLinkCallbackResult>
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -433,6 +433,8 @@ export type {
   MagicLinkInvitationRecipientInput,
   MagicLinkInvitationRecipientResult,
   MagicLinkInvitationRecipientStatus,
+  MagicLinkPeekInput,
+  MagicLinkPeekResult,
   MagicLinkRequestInput,
   MagicLinkRequestResult,
   MagicLinkRequestStatus,

--- a/packages/server/src/auth/public-routes.ts
+++ b/packages/server/src/auth/public-routes.ts
@@ -65,7 +65,12 @@ export function isPublicRoute(pathname: string, method: string): boolean {
     return true
   }
 
-  if (pathname === "/auth/callback" && normalizedMethod === "GET") {
+  // GET renders the magic-link confirmation page; POST consumes the emailed
+  // token. The token itself is the credential, and no CSRF cookie exists yet.
+  if (
+    pathname === "/auth/callback" &&
+    (normalizedMethod === "GET" || normalizedMethod === "POST")
+  ) {
     return true
   }
 

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,3 +1,4 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto"
 import {
   type AccessTokenRecord,
   type AuthenticatedUserRequestSession,
@@ -17,10 +18,12 @@ import {
   type InvitationRecord,
   isMagicLinkAuthStrategy,
   isOidcAuthStrategy,
+  type MagicLinkAuthStrategy,
   type MemberSummary,
   type OntologySource,
   type ServiceAccountRecord,
   type Sixb,
+  shouldUseSecureCookies,
   type UserRecord,
   verifyDoubleSubmitCsrf,
 } from "@sixb/core"
@@ -1174,20 +1177,41 @@ export function registerAuthRoutes(
         const authStorage = requireAuthStorage(sixb)
 
         if (isMagicLinkAuthStrategy(strategy)) {
-          await strategy.requestMagicLink({
+          const pending = createMagicLinkPendingCredential()
+          const result = await strategy.requestMagicLink({
             projectId: sixb.id,
             authStorage,
             email: body.email ?? "",
             audience: authRedirect.audience,
             returnTo: authRedirect.returnTo,
             requestOrigin: authRedirect.requestOrigin,
+            requesterHash: pending.hash,
           })
 
-          return htmlMessageResponse(
+          const response = htmlMessageResponse(
             "If this email can sign in, we sent a link. Check your inbox to continue.",
             200,
             "Check your email"
           )
+          // Same-device fast path: this browser keeps the preimage of the
+          // `requester` hash embedded in the emailed callback URL, so opening
+          // the link here signs in without the confirmation click. Always
+          // answer with a pending cookie of identical shape (a missing
+          // Set-Cookie for ineligible emails would leak which addresses can
+          // sign in), but only rotate the stored secret when a link was
+          // actually delivered — a rate-limited or skipped request must not
+          // orphan the hash in the previously emailed, still-valid link.
+          const existingPending = getCookie(request, MAGIC_LINK_PENDING_COOKIE_NAME)?.trim()
+          response.headers.append(
+            "set-cookie",
+            magicLinkPendingCookieHeader({
+              request,
+              sixb,
+              value: result.status === "sent" ? pending.secret : existingPending || pending.secret,
+              maxAgeSeconds: magicLinkPendingCookieMaxAgeSeconds(strategy),
+            })
+          )
+          return response
         }
 
         if (isOidcAuthStrategy(strategy)) {
@@ -1249,12 +1273,8 @@ export function registerAuthRoutes(
       "/auth/callback",
       async ({ request }) => {
         const strategy = sixb.auth.getStrategy()
-        const now = new Date()
-        const sessionCredential = createSessionCredential()
-        const device = resolveSessionDevice(request)
 
         if (isMagicLinkAuthStrategy(strategy)) {
-          const authOptions = resolveAuthOptions(options, request)
           const url = new URL(request.url)
           const magicLinkId = url.searchParams.get("magicLinkId")?.trim()
           const token = url.searchParams.get("token")?.trim()
@@ -1263,35 +1283,61 @@ export function registerAuthRoutes(
             return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
           }
 
-          try {
-            const result = await strategy.completeMagicLinkSignIn({
-              projectId: sixb.id,
-              authStorage: requireAuthStorage(sixb),
+          // Read-only peek so the page can greet the user by email and dead
+          // links fail before the confirmation click. Email security scanners
+          // (Safe Links, Avanan, Mimecast, ...) prefetch emailed URLs, so this
+          // GET must not consume the single-use token — a scanner would
+          // invalidate the link before the user ever opens it. The strategy
+          // owns the validity rules (including token verification, so a bare
+          // magicLinkId cannot disclose the account email).
+          let email: string | undefined
+          if (strategy.peekMagicLink) {
+            try {
+              const peeked = await strategy.peekMagicLink({
+                projectId: sixb.id,
+                authStorage: requireAuthStorage(sixb),
+                magicLinkId,
+                token,
+              })
+              if (!peeked) {
+                return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+              }
+              email = peeked.email
+            } catch {
+              return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+            }
+          }
+
+          // Same-device fast path: only the browser that requested this link
+          // holds the preimage of the URL's `requester` hash, so it may sign in
+          // straight from the navigation. Scanners and other browsers get the
+          // confirmation page; POST /auth/callback completes the sign-in there.
+          const requesterHash = url.searchParams.get("requester")?.trim()
+          const pendingSecret = getCookie(request, MAGIC_LINK_PENDING_COOKIE_NAME)?.trim()
+          if (
+            requesterHash &&
+            pendingSecret &&
+            matchesMagicLinkRequester(pendingSecret, requesterHash)
+          ) {
+            return completeMagicLinkCallback({
+              sixb,
+              strategy,
+              options,
+              request,
               magicLinkId,
               token,
-              session: {
-                id: sessionCredential.sessionId,
-                audience: authOptions.audience,
-                tokenHash: sessionCredential.tokenHash,
-                createdAt: now,
-                expiresAt: new Date(now.getTime() + sixb.auth.getSessionTtlMs()),
-                ...device,
-              },
+              clearPendingCookie: true,
             })
-
-            return sessionCallbackCompletionResponse({
-              sixb,
-              request,
-              sessionCredential,
-              audience: result.session.audience,
-              returnTo: result.returnTo,
-            })
-          } catch {
-            return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
           }
+
+          return magicLinkConfirmResponse({ magicLinkId, token, email })
         }
 
         if (isOidcAuthStrategy(strategy)) {
+          const now = new Date()
+          const sessionCredential = createSessionCredential()
+          const device = resolveSessionDevice(request)
+
           try {
             const authOptions = resolveAuthOptions(options, request)
             const result = await strategy.completeOidcSignIn({
@@ -1312,6 +1358,7 @@ export function registerAuthRoutes(
             return sessionCallbackCompletionResponse({
               sixb,
               request,
+              apiOrigin: options.resolveAuthRequestOrigin(request),
               sessionCredential,
               audience: result.session.audience,
               returnTo: result.returnTo,
@@ -1326,6 +1373,144 @@ export function registerAuthRoutes(
       },
       { detail: { hide: true } }
     )
+    .post(
+      "/auth/callback",
+      async ({ body, request }) => {
+        const strategy = sixb.auth.getStrategy()
+
+        if (!isMagicLinkAuthStrategy(strategy)) {
+          return strategyNotImplementedResponse("Auth callback is not implemented yet.")
+        }
+
+        const magicLinkId = body.magicLinkId?.trim()
+        const token = body.token?.trim()
+        if (!magicLinkId || !token) {
+          return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+        }
+
+        return completeMagicLinkCallback({ sixb, strategy, options, request, magicLinkId, token })
+      },
+      {
+        body: t.Object({
+          magicLinkId: t.Optional(t.String()),
+          token: t.Optional(t.String()),
+        }),
+        parse: "urlencoded",
+        detail: { hide: true },
+      }
+    )
+}
+
+// The pending cookie carries the preimage of the `requester` hash embedded in
+// the emailed callback URL. Only the browser that requested the link holds it,
+// so GET /auth/callback can distinguish that browser (sign in immediately) from
+// scanners and other devices (confirmation page). It is an anti-burn shortcut,
+// not an auth credential — the magic-link token still authenticates the sign-in.
+const MAGIC_LINK_PENDING_COOKIE_NAME = "sixb_pending"
+// Fallback when a strategy doesn't expose its link TTL; matches the default
+// magic-link TTL. An expired cookie only costs the confirmation click.
+const MAGIC_LINK_PENDING_COOKIE_FALLBACK_MAX_AGE_SECONDS = 15 * 60
+
+function magicLinkPendingCookieMaxAgeSeconds(strategy: MagicLinkAuthStrategy): number {
+  return strategy.magicLinkTtlMs && strategy.magicLinkTtlMs > 0
+    ? Math.max(1, Math.trunc(strategy.magicLinkTtlMs / 1000))
+    : MAGIC_LINK_PENDING_COOKIE_FALLBACK_MAX_AGE_SECONDS
+}
+
+function createMagicLinkPendingCredential(): {
+  readonly secret: string
+  readonly hash: string
+} {
+  const secret = randomBytes(32).toString("base64url")
+  return { secret, hash: hashMagicLinkPendingSecret(secret) }
+}
+
+function hashMagicLinkPendingSecret(secret: string): string {
+  return createHash("sha256").update(secret).digest("base64url")
+}
+
+function matchesMagicLinkRequester(pendingSecret: string, requesterHash: string): boolean {
+  const expected = Buffer.from(hashMagicLinkPendingSecret(pendingSecret))
+  const provided = Buffer.from(requesterHash)
+  return expected.length === provided.length && timingSafeEqual(expected, provided)
+}
+
+// SameSite=Lax, not Strict: the emailed link arrives as a cross-site top-level
+// navigation and the cookie must accompany that GET for the fast path to work.
+function magicLinkPendingCookieHeader(params: {
+  readonly request: Request
+  readonly sixb: Sixb<readonly OntologySource[]>
+  readonly value: string
+  readonly maxAgeSeconds: number
+}): string {
+  const parts = [
+    `${MAGIC_LINK_PENDING_COOKIE_NAME}=${params.value}`,
+    "Path=/auth/callback",
+    "SameSite=Lax",
+    "HttpOnly",
+    `Max-Age=${params.maxAgeSeconds}`,
+  ]
+  if (shouldUseSecureCookies(params.request, params.sixb.auth.getCookieOptions())) {
+    parts.push("Secure")
+  }
+  return parts.join("; ")
+}
+
+// Shared by POST /auth/callback (confirmation click) and the same-device fast
+// path on GET. Consumes the single-use token and mints the session cookies.
+async function completeMagicLinkCallback(input: {
+  readonly sixb: Sixb<readonly OntologySource[]>
+  readonly strategy: MagicLinkAuthStrategy
+  readonly options: AuthRoutesOptions
+  readonly request: Request
+  readonly magicLinkId: string
+  readonly token: string
+  readonly clearPendingCookie?: boolean
+}): Promise<Response> {
+  const authOptions = resolveAuthOptions(input.options, input.request)
+  const now = new Date()
+  const sessionCredential = createSessionCredential()
+  const device = resolveSessionDevice(input.request)
+
+  try {
+    const result = await input.strategy.completeMagicLinkSignIn({
+      projectId: input.sixb.id,
+      authStorage: requireAuthStorage(input.sixb),
+      magicLinkId: input.magicLinkId,
+      token: input.token,
+      session: {
+        id: sessionCredential.sessionId,
+        audience: authOptions.audience,
+        tokenHash: sessionCredential.tokenHash,
+        createdAt: now,
+        expiresAt: new Date(now.getTime() + input.sixb.auth.getSessionTtlMs()),
+        ...device,
+      },
+    })
+
+    const response = sessionCallbackCompletionResponse({
+      sixb: input.sixb,
+      request: input.request,
+      apiOrigin: input.options.resolveAuthRequestOrigin(input.request),
+      sessionCredential,
+      audience: result.session.audience,
+      returnTo: result.returnTo,
+    })
+    if (input.clearPendingCookie) {
+      response.headers.append(
+        "set-cookie",
+        magicLinkPendingCookieHeader({
+          request: input.request,
+          sixb: input.sixb,
+          value: "",
+          maxAgeSeconds: 0,
+        })
+      )
+    }
+    return response
+  } catch {
+    return htmlMessageResponse("This sign-in link is invalid or expired.", 400)
+  }
 }
 
 // Best-effort client metadata for the active-sessions view. `x-forwarded-for`
@@ -1347,6 +1532,7 @@ function resolveSessionDevice(request: Request): {
 function sessionCallbackCompletionResponse(input: {
   readonly sixb: Sixb<readonly OntologySource[]>
   readonly request: Request
+  readonly apiOrigin: string
   readonly sessionCredential: ReturnType<typeof createSessionCredential>
   readonly audience: AuthSessionAudience
   readonly returnTo: string
@@ -1374,17 +1560,44 @@ function sessionCallbackCompletionResponse(input: {
     })
   )
 
-  return authCallbackCompletionResponse(input.returnTo, headers)
+  return authCallbackCompletionResponse(input.returnTo, headers, input.apiOrigin)
 }
 
-// OAuth and magic-link callbacks arrive from a cross-site navigation. A direct 3xx after
-// setting SameSite=Strict cookies can keep the next request in that cross-site redirect
-// chain. Finish on a Sixb document first, then navigate to the sanitized return path.
-function authCallbackCompletionResponse(returnTo: string, headers: Headers): Response {
+// OAuth and magic-link callbacks can arrive as a cross-site navigation, and a direct
+// 3xx after setting SameSite=Strict cookies keeps the chained request cross-site — the
+// cookies get dropped. That only matters when the return target is on the API origin
+// itself (e.g. /docs); there, finish on a Sixb document first and navigate from it.
+// Any other origin doesn't need our cookies on the navigation, so redirect straight
+// through — the page the user is on (email client or the confirmation page with its
+// loading button) stays visible until the app renders.
+function authCallbackCompletionResponse(
+  returnTo: string,
+  headers: Headers,
+  apiOrigin: string
+): Response {
+  if (!isSameOriginReturnTarget(returnTo, apiOrigin)) {
+    headers.set("location", returnTo)
+    return new Response(null, { status: 303, headers })
+  }
+
+  return authCallbackCompletionDocumentResponse(returnTo, headers)
+}
+
+function isSameOriginReturnTarget(returnTo: string, apiOrigin: string): boolean {
+  try {
+    return new URL(returnTo).origin === apiOrigin
+  } catch {
+    return true
+  }
+}
+
+// `style-src 'unsafe-inline'` lets the shared auth-page stylesheet apply; the page
+// stays script-free and everything else is locked down by `default-src 'none'`.
+function authCallbackCompletionDocumentResponse(returnTo: string, headers: Headers): Response {
   headers.set("content-type", "text/html; charset=utf-8")
   headers.set(
     "content-security-policy",
-    `default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to ${resolveNavigateToSources(
+    `default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to ${resolveNavigateToSources(
       returnTo
     )}`
   )
@@ -1392,24 +1605,17 @@ function authCallbackCompletionResponse(returnTo: string, headers: Headers): Res
   headers.set("x-content-type-options", "nosniff")
 
   return new Response(
-    [
-      "<!doctype html>",
-      '<html lang="en">',
-      "<head>",
-      '<meta charset="utf-8">',
-      '<meta name="viewport" content="width=device-width, initial-scale=1">',
-      '<meta name="referrer" content="no-referrer">',
-      `<meta http-equiv="refresh" content="0;url=${escapeHtml(returnTo)}">`,
-      "<title>Signing in</title>",
-      "</head>",
-      "<body>",
-      "<main>",
-      "<p>Signing you in...</p>",
-      `<p><a href="${escapeHtml(returnTo)}">Continue</a></p>`,
-      "</main>",
-      "</body>",
-      "</html>",
-    ].join(""),
+    authPageDocument(
+      [
+        "<h1>Signing you in&hellip;</h1>",
+        `<p>If you are not redirected automatically, <a href="${escapeHtml(returnTo)}">continue</a>.</p>`,
+      ].join(""),
+      "Signing in",
+      [
+        '<meta name="referrer" content="no-referrer">',
+        `<meta http-equiv="refresh" content="0;url=${escapeHtml(returnTo)}">`,
+      ].join("")
+    ),
     {
       status: 200,
       headers,
@@ -1579,6 +1785,14 @@ p {
   color: var(--muted-foreground);
   font-size: 0.875rem;
 }
+p strong {
+  color: var(--foreground);
+  font-weight: 500;
+}
+a {
+  color: var(--foreground);
+  text-underline-offset: 0.2em;
+}
 form { margin: 1.75rem 0 0; }
 input[type="email"] {
   width: 100%;
@@ -1610,14 +1824,26 @@ button {
   border-radius: calc(var(--radius) - 2px);
   cursor: pointer;
 }
-button:hover { opacity: 0.9; }
+button:hover:not(:disabled) { opacity: 0.9; }
 button:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 2px;
 }
+button:disabled { cursor: default; }
+.spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  vertical-align: -0.2em;
+  border: 2px solid color-mix(in srgb, var(--primary-foreground) 35%, transparent);
+  border-top-color: var(--primary-foreground);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
 </style>`
 
-function authPageDocument(body: string, title = "Sign in"): string {
+function authPageDocument(body: string, title = "Sign in", head = ""): string {
   return [
     "<!doctype html>",
     '<html lang="en">',
@@ -1625,6 +1851,7 @@ function authPageDocument(body: string, title = "Sign in"): string {
     '<meta charset="utf-8">',
     '<meta name="viewport" content="width=device-width, initial-scale=1">',
     `<title>${escapeHtml(title)}</title>`,
+    head,
     AUTH_PAGE_STYLE,
     "</head>",
     "<body>",
@@ -1661,6 +1888,55 @@ function signInFormResponse(context: AuthRedirectContext): Response {
       "</form>",
     ].join("")
   )
+}
+
+// Deliberately a plain form with no auto-submit: link scanners that execute
+// pages headlessly still won't press the button, so the token survives until a
+// person clicks Continue. The extra click also keeps the link reusable when a
+// phone opens it in a preview or hands it to a different default browser. The
+// inline script never submits anything — it only turns the clicked button into
+// a disabled spinner. The form POST is a normal navigation, so this page stays
+// visible (spinner and all) until the server responds; the pageshow handler
+// resets the button when the page is restored from the back/forward cache.
+function magicLinkConfirmResponse(input: {
+  readonly magicLinkId: string
+  readonly token: string
+  // Absent when the strategy doesn't support the read-only peek.
+  readonly email?: string
+}): Response {
+  const response = authPageResponse(
+    [
+      "<h1>Sign in</h1>",
+      input.email
+        ? `<p>You're signing in as <strong>${escapeHtml(input.email)}</strong>.</p>`
+        : "<p>Click continue to finish signing in.</p>",
+      '<form method="post" action="/auth/callback" id="confirm">',
+      `<input type="hidden" name="magicLinkId" value="${escapeHtml(input.magicLinkId)}">`,
+      `<input type="hidden" name="token" value="${escapeHtml(input.token)}">`,
+      '<button type="submit" id="confirm-button">Continue</button>',
+      "</form>",
+      "<script>",
+      '(function () {var button = document.getElementById("confirm-button");',
+      'document.getElementById("confirm").addEventListener("submit", function () {',
+      "button.disabled = true;",
+      'button.setAttribute("aria-busy", "true");',
+      'button.innerHTML = \'<span class="spinner" aria-hidden="true"></span>\';',
+      "});",
+      'window.addEventListener("pageshow", function (event) {',
+      "if (!event.persisted) return;",
+      "button.disabled = false;",
+      'button.removeAttribute("aria-busy");',
+      'button.textContent = "Continue";',
+      "});})();",
+      "</script>",
+    ].join("")
+  )
+  // The single-use token is in this page's URL; keep it out of cross-origin
+  // referrers. Must stay `same-origin`, not `no-referrer` — a no-referrer policy
+  // makes browsers send `Origin: null` on the form POST, which the browser-origin
+  // guard rejects before the callback route runs.
+  response.headers.set("referrer-policy", "same-origin")
+  return response
 }
 
 function resolveNavigateToSources(returnTo: string): string {

--- a/packages/server/tests/helpers.ts
+++ b/packages/server/tests/helpers.ts
@@ -1,5 +1,49 @@
 import type { SixbApiBrowserPolicy, SixbBrowserOrigin } from "../src"
 
+interface TestApp {
+  fetch(request: Request): Response | Promise<Response>
+}
+
+export function linkFromLatestMessage(messages: readonly { readonly text: string }[]): URL {
+  const text = messages.at(-1)?.text ?? ""
+  const match = text.match(/https?:\/\/\S+/)
+  if (!match) {
+    throw new Error("No magic link found in sent email")
+  }
+  return new URL(match[0])
+}
+
+// Emulates a user opening the emailed magic link: GET the confirmation page,
+// then submit its form. The GET must never consume the single-use token.
+export async function confirmCallback(app: TestApp, link: URL): Promise<Response> {
+  const confirm = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
+  if (confirm.status !== 200) {
+    throw new Error(`Expected confirmation page, got ${confirm.status}`)
+  }
+  const html = await confirm.text()
+  const body = new URLSearchParams()
+  for (const name of ["magicLinkId", "token"]) {
+    const match = html.match(new RegExp(`name="${name}" value="([^"]+)"`))
+    if (!match) {
+      throw new Error(`Confirmation form is missing the ${name} field`)
+    }
+    body.set(name, match[1])
+  }
+  return app.fetch(
+    new Request(new URL("/auth/callback", link).toString(), {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        // Browsers send the page origin on form POST navigations; the
+        // browser-origin guard must accept this same-origin submission.
+        origin: link.origin,
+      },
+      body,
+      redirect: "manual",
+    })
+  )
+}
+
 export function createTestBrowserPolicy(
   options: {
     readonly apiOrigin?: string

--- a/packages/server/tests/invitations-auth-routes.test.ts
+++ b/packages/server/tests/invitations-auth-routes.test.ts
@@ -19,7 +19,7 @@ import {
   type SixbAuthConfig,
 } from "@sixb/core"
 import { createSixbApi, SixbServer } from "../src/server"
-import { createTestBrowserPolicy } from "./helpers"
+import { confirmCallback, createTestBrowserPolicy, linkFromLatestMessage } from "./helpers"
 
 const projectId = "test-project"
 const securityAdmins = defineGroup("security-admins")
@@ -123,15 +123,6 @@ async function seedAdminSession(
     cookie: `sixb_session${cookieSuffix}=${credential.cookieValue}; sixb_csrf${cookieSuffix}=csrf_1`,
     csrfHeader: { "x-sixb-csrf": "csrf_1" },
   }
-}
-
-function linkFromLatestMessage(messages: readonly { readonly text: string }[]): URL {
-  const text = messages.at(-1)?.text ?? ""
-  const match = text.match(/https?:\/\/\S+/)
-  if (!match) {
-    throw new Error("No magic link found in sent email")
-  }
-  return new URL(match[0])
 }
 
 describe("auth invitation routes", () => {
@@ -591,17 +582,12 @@ describe("auth invitation routes", () => {
     )
 
     const link = linkFromLatestMessage(messages)
-    const callback = await app.fetch(
-      new Request(link.toString(), {
-        redirect: "manual",
-      })
-    )
+    // Invitations have no requesting browser, so no same-device fast path.
+    expect(link.searchParams.get("requester")).toBeNull()
+    const callback = await confirmCallback(app, link)
 
-    expect(callback.status).toBe(200)
-    expect(callback.headers.get("location")).toBeNull()
-    expect(await callback.text()).toContain(
-      '<meta http-equiv="refresh" content="0;url=http://atlas.localhost/dashboard">'
-    )
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("location")).toBe("http://atlas.localhost/dashboard")
     await expect(
       storage.auth.groupMemberships.listForGroup({
         projectId,

--- a/packages/server/tests/magic-link-auth-routes.test.ts
+++ b/packages/server/tests/magic-link-auth-routes.test.ts
@@ -13,7 +13,7 @@ import {
   Sixb,
 } from "@sixb/core"
 import { createSixbApi, SixbServer } from "../src/server"
-import { createTestBrowserPolicy } from "./helpers"
+import { confirmCallback, createTestBrowserPolicy, linkFromLatestMessage } from "./helpers"
 
 const projectId = "test-project"
 const securityAdmins = defineGroup("security-admins")
@@ -41,6 +41,7 @@ function createRuntime(
   options: {
     readonly bootstrapUsers?: readonly string[]
     readonly bootstrapGroups?: readonly [typeof securityAdmins]
+    readonly rateLimit?: false | { readonly perMinute?: number; readonly perHour?: number }
   } = {}
 ) {
   const storage = new InMemoryStorage()
@@ -58,6 +59,7 @@ function createRuntime(
       allowedDomains: ["acme.com"],
       bootstrapUsers: options.bootstrapUsers ?? [],
       bootstrapGroups: options.bootstrapGroups ?? [],
+      rateLimit: options.rateLimit,
       sendMagicLink,
     }),
   })
@@ -76,18 +78,14 @@ function createRuntime(
   }
 }
 
-function linkFromLatestMessage(messages: readonly { readonly text: string }[]): URL {
-  const text = messages.at(-1)?.text ?? ""
-  const match = text.match(/https?:\/\/\S+/)
-  if (!match) {
-    throw new Error("No magic link found in sent email")
-  }
-  return new URL(match[0])
-}
-
 async function postSignIn(
   app: ReturnType<typeof createSixbApi>,
-  input: { readonly email: string; readonly audience?: string; readonly returnTo?: string }
+  input: {
+    readonly email: string
+    readonly audience?: string
+    readonly returnTo?: string
+    readonly cookie?: string
+  }
 ): Promise<Response> {
   const body = new URLSearchParams()
   body.set("audience", input.audience ?? "atlas")
@@ -99,6 +97,7 @@ async function postSignIn(
       method: "POST",
       headers: {
         "content-type": "application/x-www-form-urlencoded",
+        ...(input.cookie ? { cookie: input.cookie } : {}),
       },
       body,
     })
@@ -124,7 +123,7 @@ async function signInAtlas(
 }> {
   await postSignIn(app, { email })
   const link = linkFromLatestMessage(messages)
-  const callback = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
+  const callback = await confirmCallback(app, link)
   const setCookie = callback.headers.get("set-cookie")
   const sessionCookie = cookieValue(setCookie, "sixb_session")
   const csrfCookie = cookieValue(setCookie, "sixb_csrf")
@@ -191,20 +190,22 @@ describe("magic-link auth routes", () => {
       returnTo: "http://atlas.localhost/dashboard",
     })
     const link = linkFromLatestMessage(messages)
-    const callback = await app.fetch(
-      new Request(link.toString(), {
-        redirect: "manual",
-      })
-    )
+    const confirm = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
 
-    expect(callback.status).toBe(200)
-    expect(callback.headers.get("location")).toBeNull()
-    expect(callback.headers.get("content-security-policy")).toBe(
-      "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to 'self' http://atlas.localhost"
-    )
-    expect(await callback.clone().text()).toContain(
-      '<meta http-equiv="refresh" content="0;url=http://atlas.localhost/dashboard">'
-    )
+    expect(confirm.status).toBe(200)
+    expect(confirm.headers.get("set-cookie")).toBeNull()
+    // `no-referrer` would make browsers POST the form with `Origin: null`,
+    // which the browser-origin guard rejects.
+    expect(confirm.headers.get("referrer-policy")).toBe("same-origin")
+    const confirmHtml = await confirm.text()
+    expect(confirmHtml).toContain("You're signing in as <strong>founder@acme.com</strong>.")
+    expect(confirmHtml).toContain('<form method="post" action="/auth/callback" id="confirm">')
+    expect(confirmHtml).toContain('<button type="submit" id="confirm-button">Continue</button>')
+
+    const callback = await confirmCallback(app, link)
+
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("location")).toBe("http://atlas.localhost/dashboard")
     const setCookie = callback.headers.get("set-cookie")
     const sessionCookie = cookieValue(setCookie, "sixb_session")
     const csrfCookie = cookieValue(setCookie, "sixb_csrf")
@@ -232,20 +233,184 @@ describe("magic-link auth routes", () => {
     })
   })
 
-  test("callback refuses replayed links without setting cookies", async () => {
+  test("GET with a wrong token is rejected without disclosing the email", async () => {
     const { app, messages } = createRuntime({
       bootstrapUsers: ["founder@acme.com"],
     })
 
     await postSignIn(app, { email: "founder@acme.com" })
     const link = linkFromLatestMessage(messages)
-    const callbackUrl = link.toString()
+    link.searchParams.set("token", "not-the-real-token")
 
-    await app.fetch(new Request(callbackUrl, { redirect: "manual" }))
-    const replay = await app.fetch(new Request(callbackUrl, { redirect: "manual" }))
+    const response = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
+
+    expect(response.status).toBe(400)
+    expect(await response.text()).not.toContain("founder@acme.com")
+  })
+
+  test("a rate-limited resend keeps the pending cookie for the delivered link", async () => {
+    const { app, messages } = createRuntime({
+      bootstrapUsers: ["founder@acme.com"],
+      rateLimit: { perMinute: 1 },
+    })
+
+    const first = await postSignIn(app, { email: "founder@acme.com" })
+    const pending = cookieValue(first.headers.get("set-cookie"), "sixb_pending")
+    const link = linkFromLatestMessage(messages)
+
+    // A second click within the rate limit sends no email and must not rotate
+    // the secret backing the already-delivered link.
+    const resend = await postSignIn(app, {
+      email: "founder@acme.com",
+      cookie: `sixb_pending=${pending}`,
+    })
+
+    expect(messages).toHaveLength(1)
+    expect(cookieValue(resend.headers.get("set-cookie"), "sixb_pending")).toBe(pending)
+
+    // The first (only) emailed link still fast-paths on this device.
+    const callback = await app.fetch(
+      new Request(link.toString(), {
+        headers: { cookie: `sixb_pending=${pending}` },
+        redirect: "manual",
+      })
+    )
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("set-cookie")).toContain("sixb_session=")
+  })
+
+  test("emailed link survives repeated GET prefetches by email link scanners", async () => {
+    const { app, messages } = createRuntime({
+      bootstrapUsers: ["founder@acme.com"],
+    })
+
+    await postSignIn(app, { email: "founder@acme.com" })
+    const link = linkFromLatestMessage(messages)
+
+    // Safe Links / Avanan style scanners fetch the URL before the user does.
+    for (let i = 0; i < 3; i++) {
+      const prefetch = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
+      expect(prefetch.status).toBe(200)
+      expect(prefetch.headers.get("set-cookie")).toBeNull()
+    }
+
+    const callback = await confirmCallback(app, link)
+
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("set-cookie")).toContain("sixb_session=")
+  })
+
+  test("callback refuses replayed confirmations without setting cookies", async () => {
+    const { app, messages } = createRuntime({
+      bootstrapUsers: ["founder@acme.com"],
+    })
+
+    await postSignIn(app, { email: "founder@acme.com" })
+    const link = linkFromLatestMessage(messages)
+
+    await confirmCallback(app, link)
+
+    // Consumed links fail on GET before the confirmation click...
+    const replayGet = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
+    expect(replayGet.status).toBe(400)
+
+    // ...and a replayed POST with the original credentials is refused too.
+    const body = new URLSearchParams()
+    body.set("magicLinkId", link.searchParams.get("magicLinkId") ?? "")
+    body.set("token", link.searchParams.get("token") ?? "")
+    const replay = await app.fetch(
+      new Request(new URL("/auth/callback", link).toString(), {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          origin: link.origin,
+        },
+        body,
+        redirect: "manual",
+      })
+    )
 
     expect(replay.status).toBe(400)
     expect(replay.headers.get("set-cookie")).toBeNull()
+  })
+
+  test("same-device fast path signs in straight from the emailed link", async () => {
+    const { app, messages } = createRuntime({
+      bootstrapUsers: ["founder@acme.com"],
+    })
+
+    const signIn = await postSignIn(app, { email: "founder@acme.com" })
+    const pendingCookie = cookieValue(signIn.headers.get("set-cookie"), "sixb_pending")
+    const link = linkFromLatestMessage(messages)
+    expect(link.searchParams.get("requester")).toBeTruthy()
+
+    // Scanners never hold the pending cookie, so their GETs stay inert.
+    const prefetch = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
+    expect(prefetch.status).toBe(200)
+    expect(prefetch.headers.get("set-cookie")).toBeNull()
+
+    const callback = await app.fetch(
+      new Request(link.toString(), {
+        headers: { cookie: `sixb_pending=${pendingCookie}` },
+        redirect: "manual",
+      })
+    )
+
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("location")).toBe("http://atlas.localhost/")
+    const setCookie = callback.headers.get("set-cookie")
+    expect(cookieValue(setCookie, "sixb_session")).toContain(".")
+    expect(setCookie).toContain("sixb_pending=;")
+  })
+
+  // A direct 3xx after a cross-site navigation drops SameSite=Strict cookies on
+  // the chained request, so API-origin return targets must finish on a document.
+  test("API-origin return targets finish on a completion document", async () => {
+    const { app, messages } = createRuntime({
+      bootstrapUsers: ["founder@acme.com"],
+    })
+
+    await postSignIn(app, {
+      email: "founder@acme.com",
+      returnTo: "http://api.localhost/docs",
+    })
+    const link = linkFromLatestMessage(messages)
+    const callback = await confirmCallback(app, link)
+
+    expect(callback.status).toBe(200)
+    expect(callback.headers.get("location")).toBeNull()
+    expect(callback.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to 'self' http://api.localhost"
+    )
+    expect(await callback.clone().text()).toContain(
+      '<meta http-equiv="refresh" content="0;url=http://api.localhost/docs">'
+    )
+    expect(cookieValue(callback.headers.get("set-cookie"), "sixb_session")).toContain(".")
+  })
+
+  test("a mismatched pending cookie falls back to the confirmation page", async () => {
+    const { app, messages } = createRuntime({
+      bootstrapUsers: ["founder@acme.com"],
+    })
+
+    await postSignIn(app, { email: "founder@acme.com" })
+    const link = linkFromLatestMessage(messages)
+
+    const callback = await app.fetch(
+      new Request(link.toString(), {
+        headers: { cookie: "sixb_pending=not-the-requester-preimage" },
+        redirect: "manual",
+      })
+    )
+
+    expect(callback.status).toBe(200)
+    expect(callback.headers.get("set-cookie")).toBeNull()
+    expect(await callback.text()).toContain('action="/auth/callback"')
+
+    // The link stays valid: the confirmation click still completes sign-in.
+    const completed = await confirmCallback(app, link)
+    expect(completed.status).toBe(303)
+    expect(cookieValue(completed.headers.get("set-cookie"), "sixb_session")).toContain(".")
   })
 
   test("sign-in rejects unsafe returnTo values before sending a link", async () => {
@@ -283,17 +448,12 @@ describe("magic-link auth routes", () => {
     )
     const link = linkFromLatestMessage(messages)
     link.searchParams.set("returnTo", "http://evil.localhost/steal")
-    const callback = await app.fetch(new Request(link.toString(), { redirect: "manual" }))
+    const callback = await confirmCallback(app, link)
 
     expect(signIn.status).toBe(200)
     expect(link.origin).toBe("http://api.localhost")
-    expect(callback.status).toBe(200)
-    expect(callback.headers.get("content-security-policy")).toBe(
-      "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to 'self' http://app.localhost"
-    )
-    expect(await callback.clone().text()).toContain(
-      '<meta http-equiv="refresh" content="0;url=http://app.localhost/dashboard">'
-    )
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("location")).toBe("http://app.localhost/dashboard")
 
     const setCookie = callback.headers.get("set-cookie")
     const sessionCookie = cookieValue(setCookie, "sixb_session_app")
@@ -344,11 +504,7 @@ describe("magic-link auth routes", () => {
 
     await postSignIn(app, { email: "founder@acme.com" })
     const link = linkFromLatestMessage(messages)
-    const callback = await app.fetch(
-      new Request(link.toString(), {
-        redirect: "manual",
-      })
-    )
+    const callback = await confirmCallback(app, link)
     const setCookie = callback.headers.get("set-cookie")
     const sessionCookie = cookieValue(setCookie, "sixb_session")
     const csrfCookie = cookieValue(setCookie, "sixb_csrf")

--- a/packages/server/tests/oidc-auth-routes.test.ts
+++ b/packages/server/tests/oidc-auth-routes.test.ts
@@ -212,14 +212,8 @@ describe("oidc auth routes", () => {
       })
     )
 
-    expect(callback.status).toBe(200)
-    expect(callback.headers.get("location")).toBeNull()
-    expect(callback.headers.get("content-security-policy")).toBe(
-      "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to 'self' http://atlas.localhost"
-    )
-    expect(await callback.clone().text()).toContain(
-      '<meta http-equiv="refresh" content="0;url=http://atlas.localhost/dashboard">'
-    )
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("location")).toBe("http://atlas.localhost/dashboard")
     const setCookie = callback.headers.get("set-cookie")
     const sessionCookie = cookieValue(setCookie, "sixb_session")
     const csrfCookie = cookieValue(setCookie, "sixb_csrf")
@@ -268,13 +262,8 @@ describe("oidc auth routes", () => {
 
     expect(signIn.status).toBe(303)
     expect(providerUrl.searchParams.get("redirect_uri")).toBe("http://api.localhost/auth/callback")
-    expect(callback.status).toBe(200)
-    expect(callback.headers.get("content-security-policy")).toBe(
-      "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; navigate-to 'self' http://app.localhost"
-    )
-    expect(await callback.clone().text()).toContain(
-      '<meta http-equiv="refresh" content="0;url=http://app.localhost/dashboard">'
-    )
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("location")).toBe("http://app.localhost/dashboard")
     const setCookie = callback.headers.get("set-cookie")
     const sessionCookie = cookieValue(setCookie, "sixb_session_app")
     expect(sessionCookie).toContain(".")
@@ -368,11 +357,8 @@ describe("oidc auth routes", () => {
       )
     )
 
-    expect(callback.status).toBe(200)
-    expect(callback.headers.get("location")).toBeNull()
-    expect(await callback.text()).toContain(
-      '<meta http-equiv="refresh" content="0;url=http://atlas.localhost/dashboard">'
-    )
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("location")).toBe("http://atlas.localhost/dashboard")
     await expect(
       storage.auth.groupMemberships.listForGroup({
         projectId,


### PR DESCRIPTION
## Why
Email security scanners may prefetch magic-link URLs and consume single-use tokens before users open them. Magic-link GET requests must remain non-destructive while preserving a fast path for the requesting browser.

## What changed
- Add a read-only magic-link validity check that verifies tokens without consuming them.
- Render a confirmation page on GET and consume the token through POST.
- Add a hashed requester value and pending cookie for same-device sign-in.
- Preserve pending credentials across skipped or rate-limited requests.
- Use direct redirects for cross-origin return targets and completion documents for API-origin targets.
- Update magic-link, invitation, and OIDC route coverage for the revised callback flow.

## Key metrics
```text
11 files changed
735 insertions(+)
138 deletions(-)
```

## Reviewer notes
Focus on token non-consumption during GET requests, pending-cookie matching and lifetime, replay handling, and callback redirect behavior.

## Tests
- Not run (not requested).
