### PR TITLE
events: harden websocket readiness and action waits

### DIFF
--- a/broker/nats/src/nats-broker.ts
+++ b/broker/nats/src/nats-broker.ts
@@ -180,6 +180,20 @@ export class NatsBroker implements Broker {
     })
   }
 
+  async latestCursor(params: { projectId: string; streamId: string }): Promise<string | undefined> {
+    this.assertOpen()
+    validateProjectId(params.projectId)
+    assertStreamId(params.streamId)
+
+    const streamName = await this.streamManager.getExistingStream(params.projectId, params.streamId)
+    if (!streamName) {
+      return undefined
+    }
+
+    const streamInfo = await this.fetchStreamInfo(streamName)
+    return streamInfo.state.messages > 0 ? String(streamInfo.state.last_seq) : undefined
+  }
+
   async subscribe(
     params: {
       projectId: string

--- a/broker/redis/src/redis-broker.ts
+++ b/broker/redis/src/redis-broker.ts
@@ -249,6 +249,23 @@ export class RedisBroker implements Broker {
     return records
   }
 
+  async latestCursor(params: { projectId: string; streamId: string }): Promise<string | undefined> {
+    this.assertOpen()
+    validateProjectId(params.projectId)
+    assertStreamId(params.streamId)
+
+    const ensured = await this.streamManager.getExistingStream(params.projectId, params.streamId)
+    if (ensured === null) {
+      return undefined
+    }
+
+    return this.connectionManager.useCommandClient(async (client) => {
+      await this.enforceAgeRetention(client, ensured)
+      const entries = await this.readReverseRange(client, ensured, "+", "-", 1)
+      return entries[0]?.id
+    })
+  }
+
   async subscribe(
     params: {
       projectId: string
@@ -298,7 +315,7 @@ export class RedisBroker implements Broker {
         params.afterCursor ??
         (params.from === "earliest"
           ? (lastTrimmedId ?? "0-0")
-          : await this.latestCursor(client, ensured))
+          : await this.subscriptionStartCursor(client, ensured))
       this.assertOpen()
 
       pump = (async () => {
@@ -514,7 +531,10 @@ export class RedisBroker implements Broker {
     }
   }
 
-  private async latestCursor(client: RedisBrokerClient, ensured: EnsuredStream): Promise<string> {
+  private async subscriptionStartCursor(
+    client: RedisBrokerClient,
+    ensured: EnsuredStream
+  ): Promise<string> {
     const entries = await this.readReverseRange(client, ensured, "+", "-", 1)
     const latest = entries[0]
     if (latest !== undefined) {

--- a/broker/redis/tests/redis-broker.e2e.ts
+++ b/broker/redis/tests/redis-broker.e2e.ts
@@ -302,26 +302,26 @@ describe("RedisBroker", () => {
     await broker.ensureStream({ projectId, stream })
 
     const brokerInternals = broker as unknown as {
-      latestCursor(client: unknown, ensured: unknown): Promise<string>
+      subscriptionStartCursor(client: unknown, ensured: unknown): Promise<string>
     }
-    const originalLatestCursor = brokerInternals.latestCursor.bind(broker)
-    let releaseLatestCursor!: () => void
-    const latestCursorGate = new Promise<void>((resolve) => {
-      releaseLatestCursor = resolve
+    const originalSubscriptionStartCursor = brokerInternals.subscriptionStartCursor.bind(broker)
+    let releaseSubscriptionStartCursor!: () => void
+    const subscriptionStartCursorGate = new Promise<void>((resolve) => {
+      releaseSubscriptionStartCursor = resolve
     })
-    const blockedInLatestCursor = new Promise<void>((resolve) => {
-      brokerInternals.latestCursor = async (client, ensured) => {
+    const blockedInSubscriptionStartCursor = new Promise<void>((resolve) => {
+      brokerInternals.subscriptionStartCursor = async (client, ensured) => {
         resolve()
-        await latestCursorGate
-        return originalLatestCursor(client, ensured)
+        await subscriptionStartCursorGate
+        return originalSubscriptionStartCursor(client, ensured)
       }
     })
 
     const subscribe = broker.subscribe({ projectId, streamId: stream.id }, () => {})
 
-    await blockedInLatestCursor
+    await blockedInSubscriptionStartCursor
     await broker.close()
-    releaseLatestCursor()
+    releaseSubscriptionStartCursor()
 
     await expect(subscribe).rejects.toThrow()
   })

--- a/docs/client/events.md
+++ b/docs/client/events.md
@@ -78,6 +78,7 @@ Common options:
 | `limit` | Limit replayed events on subscribe. |
 | `reconnect` | Enable or disable reconnects. |
 | `reconnectDelayMs` | Delay before reconnecting. |
+| `handshakeTimeoutMs` | Maximum time to establish and acknowledge the event subscription. |
 | `onError` | Receive socket or subscription errors. |
 
 ## Latest Telemetry

--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -78,6 +78,10 @@ for (const event of recent) {
 }
 ```
 
+`sixb.events.latestCursor()` returns the newest retained cursor without loading event payloads.
+It is intended for efficient subscription baselines and returns `undefined` when the retained
+stream is empty.
+
 | Option | Type | Notes |
 | --- | --- | --- |
 | `topics` | `readonly Topic[]` | Filter by topic (e.g. `"objects"`) |

--- a/docs/infrastructure/overview.md
+++ b/docs/infrastructure/overview.md
@@ -54,7 +54,7 @@ The two messaging slots are **not** the same thing — keep them distinct.
 | --- | --- | --- |
 | Shape | Append-only event log | Lease-based work lanes |
 | Purpose | Records what happened, fans out to subscribers | Dispatches and retries background jobs |
-| Operations | `append`, `read`, `subscribe` | `enqueue`, `claim`, `complete`, `retry`, `fail`, `renewLease` |
+| Operations | `append`, `read`, `latestCursor`, `subscribe` | `enqueue`, `claim`, `complete`, `retry`, `fail`, `renewLease` |
 | Carries | Domain [events](../events/overview.md) (`object.upserted`, `telemetry.appended`, `link.upserted`, `action.requested`, …) | Run requests, one per lane |
 | Replayable | Yes — retained, ordered history | No — jobs are consumed |
 

--- a/packages/client/src/actions.ts
+++ b/packages/client/src/actions.ts
@@ -244,7 +244,15 @@ export function waitForActionRun(input: WaitForActionRunInput): Promise<ActionRu
             const nextSocketHealthy = state.connected && !state.reconnecting && !state.error
             if (nextSocketHealthy !== socketHealthy) {
               socketHealthy = nextSocketHealthy
-              reschedulePoll()
+              // The subscription baseline may have been captured after a fast
+              // action completed. Check storage once at acknowledgement so a
+              // terminal event skipped by that baseline cannot strand the wait
+              // on the slow safety poll.
+              if (socketHealthy) {
+                wakeAndCheck()
+              } else {
+                reschedulePoll()
+              }
             }
           },
         }

--- a/packages/client/src/events-builder.ts
+++ b/packages/client/src/events-builder.ts
@@ -92,6 +92,7 @@ export interface EventSubscribeOptions {
   readonly limit?: number
   readonly reconnect?: boolean
   readonly reconnectDelayMs?: number
+  readonly handshakeTimeoutMs?: number
   readonly onError?: (error: string) => void
   readonly onStateChange?: (state: EventSocketState) => void
 }
@@ -221,6 +222,7 @@ export function createWsSubscribeExecutor(options?: { client?: Client }): EventS
         limit: subscribeOptions?.limit,
         reconnect: subscribeOptions?.reconnect,
         reconnectDelayMs: subscribeOptions?.reconnectDelayMs,
+        handshakeTimeoutMs: subscribeOptions?.handshakeTimeoutMs,
         baseUrl: typeof baseUrl === "string" ? baseUrl : undefined,
         onEvent: (event) => {
           if (matches(event)) handler(event)

--- a/packages/client/src/events-hooks.ts
+++ b/packages/client/src/events-hooks.ts
@@ -23,6 +23,7 @@ export interface UseEventsOptions {
   readonly limit?: number
   readonly reconnect?: boolean
   readonly reconnectDelayMs?: number
+  readonly handshakeTimeoutMs?: number
   readonly onError?: (error: string) => void
 }
 
@@ -51,6 +52,7 @@ export function useEvents<TEvent extends SixbEvent>(
   const limit = options?.limit
   const reconnect = options?.reconnect
   const reconnectDelayMs = options?.reconnectDelayMs
+  const handshakeTimeoutMs = options?.handshakeTimeoutMs
   const irKey = JSON.stringify(builder.ir)
 
   // Re-subscribe only when the serialized filter IR (or a transport option)
@@ -78,10 +80,20 @@ export function useEvents<TEvent extends SixbEvent>(
       limit,
       reconnect,
       reconnectDelayMs,
+      handshakeTimeoutMs,
       onError,
       onStateChange: setState,
     })
-  }, [enabled, irKey, afterCursor, limit, reconnect, reconnectDelayMs, registry])
+  }, [
+    enabled,
+    irKey,
+    afterCursor,
+    limit,
+    reconnect,
+    reconnectDelayMs,
+    handshakeTimeoutMs,
+    registry,
+  ])
 
   return state
 }

--- a/packages/client/src/events-transport.ts
+++ b/packages/client/src/events-transport.ts
@@ -82,6 +82,9 @@ export function createEventSocket(options: EventSocketOptions): EventSocket {
       ...(latestCursor ? { afterCursor: latestCursor } : {}),
       ...(limit ? { limit } : {}),
     }),
+    // The event server resolves its initial cursor before announcing readiness.
+    // Waiting for that frame prevents subscribe from racing server-side state setup.
+    subscribeWhen: (data) => parseEventStreamMessage(data)?.type === "connected",
     onMessage: (data, sink) => {
       const message = parseEventStreamMessage(data)
       if (!message) return

--- a/packages/client/src/events-transport.ts
+++ b/packages/client/src/events-transport.ts
@@ -38,6 +38,8 @@ export interface EventSocketOptions {
   readonly limit?: number
   readonly reconnect?: boolean
   readonly reconnectDelayMs?: number
+  /** Maximum time to complete the event protocol handshake. */
+  readonly handshakeTimeoutMs?: number
   /** Override the API base url. Defaults to the global client config. */
   readonly baseUrl?: string
   readonly onEvent: (event: SixbEvent) => void
@@ -82,6 +84,8 @@ export function createEventSocket(options: EventSocketOptions): EventSocket {
     url: createSixbEventsWebSocketUrl(options.baseUrl),
     reconnect: options.reconnect,
     reconnectDelayMs: options.reconnectDelayMs,
+    readyTimeoutMs: options.handshakeTimeoutMs,
+    readyTimeoutMessage: "Event websocket handshake timed out.",
     connectionErrorMessage: "Event websocket connection failed.",
     onError: options.onError,
     onStateChange: (state) => {
@@ -103,6 +107,7 @@ export function createEventSocket(options: EventSocketOptions): EventSocket {
     // The event server resolves its initial cursor before announcing readiness.
     // Waiting for that frame prevents subscribe from racing server-side state setup.
     subscribeWhen: (data) => parseEventStreamMessage(data)?.type === "connected",
+    readyWhen: (data) => parseEventStreamMessage(data)?.type === "subscribed",
     onMessage: (data, sink) => {
       const message = parseEventStreamMessage(data)
       if (!message) return

--- a/packages/client/src/events-transport.ts
+++ b/packages/client/src/events-transport.ts
@@ -20,6 +20,7 @@ import {
   type ReconnectingSocketState,
 } from "./ws-socket"
 
+/** Event-level state: `connected` becomes true only after the subscription is acknowledged. */
 export type EventSocketState = ReconnectingSocketState
 
 export interface EventSocketOptions {
@@ -63,6 +64,19 @@ type EventStreamServerMessage =
 export function createEventSocket(options: EventSocketOptions): EventSocket {
   const { topic, types, objectTypeId, primaryId, actionId, runId, limit } = options
   let latestCursor = options.afterCursor
+  let transportState: ReconnectingSocketState = {
+    connected: false,
+    reconnecting: false,
+    error: null,
+  }
+  let subscribed = false
+
+  const publishState = () => {
+    options.onStateChange?.({
+      ...transportState,
+      connected: transportState.connected && subscribed,
+    })
+  }
 
   return createReconnectingSocket({
     url: createSixbEventsWebSocketUrl(options.baseUrl),
@@ -70,7 +84,11 @@ export function createEventSocket(options: EventSocketOptions): EventSocket {
     reconnectDelayMs: options.reconnectDelayMs,
     connectionErrorMessage: "Event websocket connection failed.",
     onError: options.onError,
-    onStateChange: options.onStateChange,
+    onStateChange: (state) => {
+      transportState = state
+      if (!state.connected) subscribed = false
+      publishState()
+    },
     subscribeMessage: () => ({
       type: "subscribe",
       ...(topic ? { topic } : {}),
@@ -94,6 +112,12 @@ export function createEventSocket(options: EventSocketOptions): EventSocket {
         if (matchesSubscription(message.event, topic, types)) {
           options.onEvent(message.event)
         }
+        return
+      }
+
+      if (message.type === "subscribed") {
+        subscribed = true
+        publishState()
         return
       }
 

--- a/packages/client/src/ws-socket.ts
+++ b/packages/client/src/ws-socket.ts
@@ -11,6 +11,7 @@ import { client } from "./generated/client.gen"
 
 const DEFAULT_SIXB_API_BASE_URL = "http://localhost:3002"
 const DEFAULT_RECONNECT_DELAY_MS = 1000
+const DEFAULT_READY_TIMEOUT_MS = 10_000
 
 export interface ReconnectingSocketState {
   readonly connected: boolean
@@ -35,6 +36,11 @@ export interface ReconnectingSocketOptions {
    * soon as the websocket opens.
    */
   readonly subscribeWhen?: (data: unknown) => boolean
+  /** Inbound message that marks the protocol handshake as complete. */
+  readonly readyWhen?: (data: unknown) => boolean
+  /** Close and reconnect when `readyWhen` does not pass within this duration. */
+  readonly readyTimeoutMs?: number
+  readonly readyTimeoutMessage?: string
   /** Handle one inbound message; call `sink.reportError` for stream-level error frames. */
   readonly onMessage: (data: unknown, sink: ReconnectingSocketErrorSink) => void
   /** Message surfaced when the socket itself errors (connection failure). */
@@ -81,7 +87,15 @@ export function createReconnectingSocket(options: ReconnectingSocketOptions): Re
     const ws = new WebSocket(options.url)
     socket = ws
     let subscribed = false
+    let readyTimer: ReturnType<typeof setTimeout> | null = null
     setState({ connected: false, reconnecting: openedOnce || state.reconnecting, error: null })
+
+    const clearReadyTimer = () => {
+      if (readyTimer) {
+        clearTimeout(readyTimer)
+        readyTimer = null
+      }
+    }
 
     const subscribe = () => {
       if (stopped || subscribed || socket !== ws) return
@@ -94,11 +108,27 @@ export function createReconnectingSocket(options: ReconnectingSocketOptions): Re
       openedOnce = true
       setState({ connected: true, reconnecting: false, error: null })
       if (!options.subscribeWhen) subscribe()
+      if (options.readyWhen) {
+        readyTimer = setTimeout(
+          () => {
+            if (stopped || socket !== ws) return
+            try {
+              sink.reportError(
+                options.readyTimeoutMessage ?? "Websocket protocol handshake timed out."
+              )
+            } finally {
+              ws.close()
+            }
+          },
+          Math.max(0, options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS)
+        )
+      }
     }
 
     ws.onmessage = (messageEvent) => {
       if (stopped) return
       if (options.subscribeWhen?.(messageEvent.data)) subscribe()
+      if (options.readyWhen?.(messageEvent.data)) clearReadyTimer()
       options.onMessage(messageEvent.data, sink)
     }
 
@@ -108,6 +138,7 @@ export function createReconnectingSocket(options: ReconnectingSocketOptions): Re
     }
 
     ws.onclose = () => {
+      clearReadyTimer()
       if (socket === ws) {
         socket = null
       }

--- a/packages/client/src/ws-socket.ts
+++ b/packages/client/src/ws-socket.ts
@@ -27,8 +27,14 @@ export interface ReconnectingSocketOptions {
   readonly url: string
   readonly reconnect?: boolean
   readonly reconnectDelayMs?: number
-  /** Built fresh on each (re)open so it can carry the latest resume cursor. */
+  /** Built fresh for each subscription so it can carry the latest resume cursor. */
   readonly subscribeMessage: () => unknown
+  /**
+   * Optional protocol-level readiness check. When provided, defer the subscribe
+   * frame until an inbound message passes this check. Without it, subscribe as
+   * soon as the websocket opens.
+   */
+  readonly subscribeWhen?: (data: unknown) => boolean
   /** Handle one inbound message; call `sink.reportError` for stream-level error frames. */
   readonly onMessage: (data: unknown, sink: ReconnectingSocketErrorSink) => void
   /** Message surfaced when the socket itself errors (connection failure). */
@@ -74,17 +80,25 @@ export function createReconnectingSocket(options: ReconnectingSocketOptions): Re
 
     const ws = new WebSocket(options.url)
     socket = ws
+    let subscribed = false
     setState({ connected: false, reconnecting: openedOnce || state.reconnecting, error: null })
+
+    const subscribe = () => {
+      if (stopped || subscribed || socket !== ws) return
+      subscribed = true
+      ws.send(JSON.stringify(options.subscribeMessage()))
+    }
 
     ws.onopen = () => {
       if (stopped) return
       openedOnce = true
       setState({ connected: true, reconnecting: false, error: null })
-      ws.send(JSON.stringify(options.subscribeMessage()))
+      if (!options.subscribeWhen) subscribe()
     }
 
     ws.onmessage = (messageEvent) => {
       if (stopped) return
+      if (options.subscribeWhen?.(messageEvent.data)) subscribe()
       options.onMessage(messageEvent.data, sink)
     }
 

--- a/packages/client/tests/actions.test.ts
+++ b/packages/client/tests/actions.test.ts
@@ -205,7 +205,7 @@ describe("action wait helpers", () => {
       if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
         getCount += 1
         return Response.json(
-          getCount < 2
+          getCount < 3
             ? createActionRun({ status: "running" })
             : createActionRun({ status: "succeeded", finishedAt: "2026-06-29T12:00:02.000Z" })
         )
@@ -225,12 +225,56 @@ describe("action wait helpers", () => {
     const ws = FakeWebSocket.instances[0]
     if (!ws) throw new Error("expected a websocket")
     ws.onopen?.()
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
+    ws.onmessage?.({ data: JSON.stringify({ type: "subscribed" }) })
 
     const run = await promise
 
     expect(ws.closed).toBe(true)
     expect(run.status).toBe("succeeded")
+    expect(getCount).toBe(3)
+  })
+
+  test("rechecks when a fast action completes before its subscription is ready", async () => {
+    let getCount = 0
+    let completed = false
+    const succeeded = createActionRun({
+      status: "succeeded",
+      finishedAt: "2026-06-29T12:00:02.000Z",
+    })
+    const { client } = createTestClient((request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname === "/api/action-runs/act_1") {
+        getCount += 1
+        return Response.json(completed ? succeeded : createActionRun({ status: "running" }))
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+
+    const promise = waitForActionRun({
+      client,
+      runId: "act_1",
+      fallbackPollIntervalMs: 1_000,
+      disconnectedPollIntervalMs: 1_000,
+      timeoutMs: 200,
+    })
+
+    await waitUntil(() => getCount === 1)
+    completed = true
+
+    const ws = FakeWebSocket.instances[0]
+    if (!ws) throw new Error("expected a websocket")
+    ws.onopen?.()
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
+    // The server's baseline already includes the terminal event, so no event
+    // frame follows. Subscription acknowledgement must trigger the second read.
+    ws.onmessage?.({ data: JSON.stringify({ type: "subscribed" }) })
+
+    const run = await promise
+
+    expect(run).toEqual(succeeded)
     expect(getCount).toBe(2)
+    expect(ws.closed).toBe(true)
   })
 
   test("runs a follow-up detail fetch when a terminal event arrives during an in-flight check", async () => {

--- a/packages/client/tests/actions.test.ts
+++ b/packages/client/tests/actions.test.ts
@@ -176,6 +176,7 @@ describe("action wait helpers", () => {
     const ws = FakeWebSocket.instances[0]
     if (!ws) throw new Error("expected a websocket")
     ws.onopen?.()
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     expect(JSON.parse(ws.sent[0] ?? "{}")).toMatchObject({
       type: "subscribe",
       topic: "actions",
@@ -267,6 +268,7 @@ describe("action wait helpers", () => {
     const ws = FakeWebSocket.instances[0]
     if (!ws) throw new Error("expected a websocket")
     ws.onopen?.()
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     ws.onmessage?.({
       data: JSON.stringify({ type: "event", event: actionEvent("action.completed") }),
     })

--- a/packages/client/tests/events-builder.test.ts
+++ b/packages/client/tests/events-builder.test.ts
@@ -283,6 +283,7 @@ describe("builder subscribe over the transport", () => {
     if (!ws) throw new Error("expected a websocket")
 
     ws.onopen?.()
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     const subscribeMessage = JSON.parse(ws.sent[0])
     expect(subscribeMessage).toMatchObject({
       type: "subscribe",
@@ -324,6 +325,7 @@ describe("builder subscribe over the transport", () => {
     if (!ws) throw new Error("expected a websocket")
 
     ws.onopen?.()
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     expect(JSON.parse(ws.sent[0])).toMatchObject({
       type: "subscribe",
       topic: "actions",

--- a/packages/client/tests/events-provider.test.ts
+++ b/packages/client/tests/events-provider.test.ts
@@ -124,6 +124,7 @@ describe("createEventsRegistry", () => {
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")
     ws1.onopen?.()
+    ws1.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     deliver(ws1, telemetryEvent("device", "fan-1", "c9"))
 
     off()
@@ -134,6 +135,7 @@ describe("createEventsRegistry", () => {
     const ws2 = FakeWebSocket.instances[1]
     if (!ws2) throw new Error("expected a reopen")
     ws2.onopen?.()
+    ws2.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     expect(JSON.parse(ws2.sent[0]).afterCursor).toBe("c9")
   })
 

--- a/packages/client/tests/events-provider.test.ts
+++ b/packages/client/tests/events-provider.test.ts
@@ -188,6 +188,8 @@ describe("createEventsRegistry", () => {
     const ws = FakeWebSocket.instances[0]
     if (!ws) throw new Error("expected a websocket")
     ws.onopen?.()
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
+    ws.onmessage?.({ data: JSON.stringify({ type: "subscribed" }) })
 
     const states: { connected: boolean }[] = []
     registry.register(events(Sensor).telemetry().ir, () => {}, {

--- a/packages/client/tests/events-transport.test.ts
+++ b/packages/client/tests/events-transport.test.ts
@@ -74,6 +74,7 @@ describe("createEventSocket", () => {
     expect(ws1.sent).toHaveLength(0)
     ws1.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     expect(JSON.parse(ws1.sent[0]).afterCursor).toBeUndefined()
+    ws1.onmessage?.({ data: JSON.stringify({ type: "subscribed" }) })
 
     ws1.onmessage?.({ data: JSON.stringify({ type: "event", event: telemetryEvent("c5") }) })
     expect(received).toHaveLength(1)
@@ -137,6 +138,28 @@ describe("createEventSocket", () => {
 
     ws.onmessage?.({ data: JSON.stringify({ type: "subscribed" }) })
     expect(states.at(-1)).toMatchObject({ connected: true })
+
+    socket.close()
+  })
+
+  test("closes and reconnects when the protocol handshake times out", async () => {
+    const errors: string[] = []
+    const socket = createEventSocket({
+      reconnect: true,
+      reconnectDelayMs: 1,
+      handshakeTimeoutMs: 5,
+      onEvent: () => {},
+      onError: (message) => errors.push(message),
+    })
+
+    const ws1 = FakeWebSocket.instances[0]
+    if (!ws1) throw new Error("expected a websocket")
+    ws1.onopen?.()
+    await tick(15)
+
+    expect(ws1.closed).toBe(true)
+    expect(errors).toEqual(["Event websocket handshake timed out."])
+    expect(FakeWebSocket.instances).toHaveLength(2)
 
     socket.close()
   })

--- a/packages/client/tests/events-transport.test.ts
+++ b/packages/client/tests/events-transport.test.ts
@@ -71,6 +71,8 @@ describe("createEventSocket", () => {
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")
     ws1.onopen?.()
+    expect(ws1.sent).toHaveLength(0)
+    ws1.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     expect(JSON.parse(ws1.sent[0]).afterCursor).toBeUndefined()
 
     ws1.onmessage?.({ data: JSON.stringify({ type: "event", event: telemetryEvent("c5") }) })
@@ -83,9 +85,34 @@ describe("createEventSocket", () => {
     const ws2 = FakeWebSocket.instances[1]
     if (!ws2) throw new Error("expected a reconnect")
     ws2.onopen?.()
+    expect(ws2.sent).toHaveLength(0)
+    ws2.onmessage?.({ data: JSON.stringify({ type: "connected" }) })
     // The resubscribe resumes after the last delivered cursor — no replay, no gap.
     expect(JSON.parse(ws2.sent[0]).afterCursor).toBe("c5")
 
+    socket.close()
+  })
+
+  test("subscribes once after the event server announces readiness", () => {
+    const socket = createEventSocket({
+      topic: "telemetry",
+      reconnect: false,
+      onEvent: () => {},
+    })
+
+    const ws = FakeWebSocket.instances[0]
+    if (!ws) throw new Error("expected a websocket")
+    ws.onopen?.()
+    expect(ws.sent).toHaveLength(0)
+
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected", channel: "events" }) })
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected", channel: "events" }) })
+
+    expect(ws.sent).toHaveLength(1)
+    expect(JSON.parse(ws.sent[0])).toMatchObject({
+      type: "subscribe",
+      topic: "telemetry",
+    })
     socket.close()
   })
 

--- a/packages/client/tests/events-transport.test.ts
+++ b/packages/client/tests/events-transport.test.ts
@@ -116,6 +116,31 @@ describe("createEventSocket", () => {
     socket.close()
   })
 
+  test("reports connected only after the server acknowledges the subscription", () => {
+    const states: { connected: boolean }[] = []
+    const socket = createEventSocket({
+      topic: "telemetry",
+      reconnect: false,
+      onEvent: () => {},
+      onStateChange: (state) => states.push(state),
+    })
+
+    const ws = FakeWebSocket.instances[0]
+    if (!ws) throw new Error("expected a websocket")
+
+    ws.onopen?.()
+    expect(states.at(-1)).toMatchObject({ connected: false })
+
+    ws.onmessage?.({ data: JSON.stringify({ type: "connected", channel: "events" }) })
+    expect(ws.sent).toHaveLength(1)
+    expect(states.at(-1)).toMatchObject({ connected: false })
+
+    ws.onmessage?.({ data: JSON.stringify({ type: "subscribed" }) })
+    expect(states.at(-1)).toMatchObject({ connected: true })
+
+    socket.close()
+  })
+
   test("does not reconnect when reconnect is disabled", async () => {
     const socket = createEventSocket({
       topic: "telemetry",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -453,7 +453,7 @@ src/
 | Interface | Description |
 |---|---|
 | `Broker` | Retained stream provider used by runtime services |
-| `EventsRuntime` | Project-scoped domain event API with append, read, and subscribe |
+| `EventsRuntime` | Project-scoped domain event API with append, read, latest-cursor, and subscribe |
 | `ObjectStorage` | Latest-state projection storage for objects and links |
 | `TimeseriesStorage` | Time-series storage for telemetry history |
 | `MigrationSet<TContext>` | Ordered migration steps owned by one durable adapter |

--- a/packages/core/src/broker/in-memory.ts
+++ b/packages/core/src/broker/in-memory.ts
@@ -108,6 +108,19 @@ export class InMemoryBroker implements Broker {
     })
   }
 
+  async latestCursor(params: { projectId: string; streamId: string }): Promise<string | undefined> {
+    assertProjectId(params.projectId)
+    assertStreamId(params.streamId)
+
+    const storedStream = this.streams.get(streamKey(params.projectId, params.streamId))
+    if (!storedStream) {
+      return undefined
+    }
+
+    this.applyRetention(storedStream)
+    return storedStream.records.at(-1)?.cursor
+  }
+
   async subscribe(
     params: {
       projectId: string

--- a/packages/core/src/broker/types.ts
+++ b/packages/core/src/broker/types.ts
@@ -61,6 +61,12 @@ export interface Broker {
   }): Promise<readonly BrokerRecord[]>
 
   /**
+   * Returns the latest retained cursor without reading the stream contents.
+   * Returns undefined when the stream is missing or has no retained records.
+   */
+  latestCursor(params: { projectId: string; streamId: string }): Promise<BrokerCursor | undefined>
+
+  /**
    * Subscribes to retained/live records. Defaults to `from: "latest"` unless
    * `afterCursor` is provided.
    */

--- a/packages/core/src/events/runtime.ts
+++ b/packages/core/src/events/runtime.ts
@@ -113,6 +113,14 @@ export class EventsRuntime {
     return records.map(hydrateEventRecord)
   }
 
+  async latestCursor(): Promise<string | undefined> {
+    await this.ensureStream()
+    return this.broker.latestCursor({
+      projectId: this.projectId,
+      streamId: this.stream.id,
+    })
+  }
+
   async subscribe(
     input: EventsSubscribeInput,
     handler: (events: readonly StoredDomainEvent[]) => void

--- a/packages/core/src/testing/broker-contract.ts
+++ b/packages/core/src/testing/broker-contract.ts
@@ -297,6 +297,35 @@ export function runBrokerContractSuite<TBroker extends Broker>(
       })
     })
 
+    describe("latestCursor", () => {
+      test("returns undefined for missing and empty streams", async () => {
+        await withBroker(async (broker) => {
+          expect(
+            await broker.latestCursor({ projectId: "project-a", streamId: "missing" })
+          ).toBeUndefined()
+
+          await broker.ensureStream({ projectId: "project-a", stream: eventsStream })
+          expect(
+            await broker.latestCursor({ projectId: "project-a", streamId: eventsStream.id })
+          ).toBeUndefined()
+        })
+      })
+
+      test("returns the newest retained record cursor", async () => {
+        await withBroker(async (broker) => {
+          const records = await appendRecords(broker, {
+            projectId: "project-a",
+            stream: retainedStream,
+            records: [{ payload: "one" }, { payload: "two" }, { payload: "three" }],
+          })
+
+          expect(
+            await broker.latestCursor({ projectId: "project-a", streamId: retainedStream.id })
+          ).toBe(records.at(-1)?.cursor)
+        })
+      })
+    })
+
     describe("subscribe", () => {
       test("requires streams to be ensured before subscribing", async () => {
         await withBroker(async (broker) => {

--- a/packages/core/tests/events-runtime.test.ts
+++ b/packages/core/tests/events-runtime.test.ts
@@ -85,6 +85,20 @@ describe("EventsRuntime", () => {
     expect(limited.map(primaryIds)).toEqual(["room-1"])
   })
 
+  test("returns the latest event cursor without reading retained events", async () => {
+    const broker = new LatestCursorRecordingBroker()
+    const events = new EventsRuntime({ projectId: "project-a", broker })
+
+    expect(await events.latestCursor()).toBeUndefined()
+    const appended = await events.append({
+      events: [objectUpserted("room-1"), objectUpserted("room-2")],
+    })
+
+    expect(await events.latestCursor()).toBe(appended.at(-1)?.cursor)
+    expect(broker.latestCursorCalls).toBe(2)
+    expect(broker.readCalls).toBe(0)
+  })
+
   test("isolates projects on a shared broker", async () => {
     const broker = new InMemoryBroker()
     const projectAEvents = new EventsRuntime({ projectId: "project-a", broker })
@@ -124,6 +138,23 @@ describe("EventsRuntime", () => {
 
 function primaryIds(event: StoredDomainEvent): string | undefined {
   return event.type === "object.upserted" ? event.payload.primaryId : undefined
+}
+
+class LatestCursorRecordingBroker extends InMemoryBroker {
+  latestCursorCalls = 0
+  readCalls = 0
+
+  override latestCursor(
+    params: Parameters<InMemoryBroker["latestCursor"]>[0]
+  ): ReturnType<InMemoryBroker["latestCursor"]> {
+    this.latestCursorCalls += 1
+    return super.latestCursor(params)
+  }
+
+  override read(params: Parameters<InMemoryBroker["read"]>[0]): ReturnType<InMemoryBroker["read"]> {
+    this.readCalls += 1
+    return super.read(params)
+  }
 }
 
 class RecordingBroker extends InMemoryBroker {

--- a/packages/server/src/routes/ws/events.ts
+++ b/packages/server/src/routes/ws/events.ts
@@ -62,9 +62,7 @@ export function parseSubscriptionMessage(payload: unknown):
 }
 
 async function resolveLatestCursor(server: SixbServer): Promise<string | undefined> {
-  const p = server.getSixb()
-  const events = await p.events.read()
-  return events.at(-1)?.cursor
+  return server.getSixb().events.latestCursor()
 }
 
 function createDefaultState(): EventSubscriptionState {

--- a/packages/server/src/routes/ws/events.ts
+++ b/packages/server/src/routes/ws/events.ts
@@ -16,6 +16,7 @@ interface EventSubscriptionState {
   limit: number
   polling: boolean
   timer: ReturnType<typeof setInterval> | null
+  initialized: Promise<void>
 }
 
 const SubscribeSchema = z.object({
@@ -78,6 +79,7 @@ function createDefaultState(): EventSubscriptionState {
     limit: 200,
     polling: false,
     timer: null,
+    initialized: Promise.resolve(),
   }
 }
 
@@ -156,8 +158,11 @@ export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
       // Any authenticated principal may connect; events are filtered per-event
       // by grants as they stream (see the poll loop in `startPolling`).
       const state = createDefaultState()
-      state.afterCursor = await resolveLatestCursor(server)
       states.set(wsStateKey(ws), state)
+      state.initialized = resolveLatestCursor(server).then((cursor) => {
+        state.afterCursor = cursor
+      })
+      await state.initialized
       safeSend(ws, { type: "connected", channel: "events" })
     },
 
@@ -174,6 +179,10 @@ export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
         safeSend(ws, { type: "error", message: "Subscription state not found." })
         return
       }
+
+      // Older clients may subscribe immediately on websocket open. Wait for the
+      // initial cursor instead of allowing that message to race connection setup.
+      await state.initialized
 
       if (parsed.data.type === "unsubscribe") {
         stopPolling(ws)

--- a/packages/server/src/routes/ws/events.ts
+++ b/packages/server/src/routes/ws/events.ts
@@ -17,6 +17,7 @@ interface EventSubscriptionState {
   polling: boolean
   timer: ReturnType<typeof setInterval> | null
   initialized: Promise<void>
+  initializationFailureHandled: boolean
 }
 
 const SubscribeSchema = z.object({
@@ -78,11 +79,32 @@ function createDefaultState(): EventSubscriptionState {
     polling: false,
     timer: null,
     initialized: Promise.resolve(),
+    initializationFailureHandled: false,
   }
 }
 
 export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
   const states = new WeakMap<object, EventSubscriptionState>()
+
+  const awaitInitialization = async (
+    ws: { close: () => void; send: (message: string) => void },
+    state: EventSubscriptionState
+  ): Promise<boolean> => {
+    try {
+      await state.initialized
+      return true
+    } catch (error) {
+      if (state.initializationFailureHandled) return false
+      state.initializationFailureHandled = true
+      const message = error instanceof Error ? error.message : String(error)
+      safeSend(ws, {
+        type: "error",
+        message: `[SixbServer] Failed to initialize event websocket: ${message}`,
+      })
+      ws.close()
+      return false
+    }
+  }
 
   const stopPolling = (ws: object) => {
     const state = states.get(wsStateKey(ws))
@@ -160,7 +182,7 @@ export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
       state.initialized = resolveLatestCursor(server).then((cursor) => {
         state.afterCursor = cursor
       })
-      await state.initialized
+      if (!(await awaitInitialization(ws, state))) return
       safeSend(ws, { type: "connected", channel: "events" })
     },
 
@@ -180,7 +202,7 @@ export function registerEventStreamRoutes(app: Elysia, server: SixbServer) {
 
       // Older clients may subscribe immediately on websocket open. Wait for the
       // initial cursor instead of allowing that message to race connection setup.
-      await state.initialized
+      if (!(await awaitInitialization(ws, state))) return
 
       if (parsed.data.type === "unsubscribe") {
         stopPolling(ws)

--- a/packages/server/tests/wsSubscribe.test.ts
+++ b/packages/server/tests/wsSubscribe.test.ts
@@ -233,6 +233,26 @@ describe("/ws/events subscriptions", () => {
     })
   })
 
+  test("reports initialization failures and closes the websocket", async () => {
+    await withWsServer(
+      async ({ baseUrl }) => {
+        const ws = new WebSocket(`${baseUrl.replace("http://", "ws://")}/ws/events`)
+        const closed = new Promise<void>((resolve) => ws.addEventListener("close", () => resolve()))
+
+        try {
+          expect(await nextWsMessage(ws)).toEqual({
+            type: "error",
+            message: "[SixbServer] Failed to initialize event websocket: latest cursor unavailable",
+          })
+          await closed
+        } finally {
+          ws.close()
+        }
+      },
+      { broker: new FailingLatestCursorBroker() }
+    )
+  })
+
   test("scopes the stream to one object when objectTypeId/primaryId are set", async () => {
     await withWsServer(async ({ baseUrl, sixb }) => {
       const ws = new WebSocket(`${baseUrl.replace("http://", "ws://")}/ws/events`)
@@ -386,6 +406,12 @@ class SlowLatestCursorBroker extends InMemoryBroker {
   override async latestCursor(params: Parameters<InMemoryBroker["latestCursor"]>[0]) {
     await new Promise<void>((resolve) => setTimeout(resolve, 100))
     return super.latestCursor(params)
+  }
+}
+
+class FailingLatestCursorBroker extends InMemoryBroker {
+  override async latestCursor(): Promise<string | undefined> {
+    throw new Error("latest cursor unavailable")
   }
 }
 

--- a/packages/server/tests/wsSubscribe.test.ts
+++ b/packages/server/tests/wsSubscribe.test.ts
@@ -178,7 +178,7 @@ describe("/ws/events subscriptions", () => {
           ws.close()
         }
       },
-      { broker: new SlowReadBroker() }
+      { broker: new SlowLatestCursorBroker() }
     )
   })
 
@@ -382,10 +382,10 @@ function createSixbInstance<TOntologySources extends readonly OntologySource[]>(
   return new SixbConstructor(options)
 }
 
-class SlowReadBroker extends InMemoryBroker {
-  override async read(params: Parameters<InMemoryBroker["read"]>[0]) {
+class SlowLatestCursorBroker extends InMemoryBroker {
+  override async latestCursor(params: Parameters<InMemoryBroker["latestCursor"]>[0]) {
     await new Promise<void>((resolve) => setTimeout(resolve, 100))
-    return super.read(params)
+    return super.latestCursor(params)
   }
 }
 

--- a/packages/server/tests/wsSubscribe.test.ts
+++ b/packages/server/tests/wsSubscribe.test.ts
@@ -139,6 +139,49 @@ describe("parseSubscriptionMessage", () => {
 })
 
 describe("/ws/events subscriptions", () => {
+  test("accepts an immediate subscription while the initial cursor is loading", async () => {
+    await withWsServer(
+      async ({ baseUrl }) => {
+        const ws = new WebSocket(`${baseUrl.replace("http://", "ws://")}/ws/events`)
+
+        try {
+          const messages = await new Promise<Record<string, unknown>[]>((resolve, reject) => {
+            const received: Record<string, unknown>[] = []
+            const timeout = setTimeout(
+              () => reject(new Error("Timed out waiting for subscribe")),
+              3_000
+            )
+
+            ws.addEventListener("open", () => {
+              ws.send(JSON.stringify({ type: "subscribe", topic: "objects" }))
+            })
+            ws.addEventListener("message", (event) => {
+              const message = JSON.parse(decodeWsData(event.data)) as Record<string, unknown>
+              received.push(message)
+              if (message.type === "error") {
+                clearTimeout(timeout)
+                reject(new Error(String(message.message)))
+              } else if (message.type === "subscribed") {
+                clearTimeout(timeout)
+                resolve(received)
+              }
+            })
+            ws.addEventListener("error", () => {
+              clearTimeout(timeout)
+              reject(new Error("WebSocket error"))
+            })
+          })
+
+          expect(messages.map((message) => message.type)).toContain("connected")
+          expect(messages.map((message) => message.type)).toContain("subscribed")
+        } finally {
+          ws.close()
+        }
+      },
+      { broker: new SlowReadBroker() }
+    )
+  })
+
   test("streams after subscribe and keeps events emitted after open", async () => {
     await withWsServer(async ({ baseUrl, sixb }) => {
       const ws = new WebSocket(`${baseUrl.replace("http://", "ws://")}/ws/events`)
@@ -339,15 +382,23 @@ function createSixbInstance<TOntologySources extends readonly OntologySource[]>(
   return new SixbConstructor(options)
 }
 
+class SlowReadBroker extends InMemoryBroker {
+  override async read(params: Parameters<InMemoryBroker["read"]>[0]) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100))
+    return super.read(params)
+  }
+}
+
 async function withWsServer(
-  run: (context: { baseUrl: string; sixb: Sixb<readonly OntologySource[]> }) => Promise<void>
+  run: (context: { baseUrl: string; sixb: Sixb<readonly OntologySource[]> }) => Promise<void>,
+  options: { readonly broker?: InMemoryBroker } = {}
 ): Promise<void> {
   const port = await getFreePort()
   const baseUrl = `http://127.0.0.1:${port}`
   const sixb = createSixbInstance<readonly OntologySource[]>({
     id: "ws-test-project",
     ontology: [],
-    broker: new InMemoryBroker(),
+    broker: options.broker ?? new InMemoryBroker(),
     storage: new InMemoryStorage(),
     lakeStorage: new InMemoryLakeStorage(),
     blobStorage: new InMemoryBlobStorage(),


### PR DESCRIPTION
## Why

A downstream PandaDoc quote flow exposed three related problems in the event-socket startup path.

First, event clients sent `subscribe` on the browser's WebSocket `open` event while the server was still resolving its initial cursor and had not registered connection state. The server could reject the otherwise valid subscription with:

```text
Subscription state not found.
```

Second, fixing that handshake exposed a smaller action-wait blind spot. A fast action could finish after the waiter's initial status read but before the event subscription established its baseline. The terminal event was then correctly treated as historical, but the client considered the raw socket healthy and waited for the 10-second safety poll before reading the completed run.

Third, the server established that baseline with `events.read()` and selected the final event, decoding the full retained stream for every socket. In the downstream production stream, 18,141 retained events took about 543 ms to scan while a direct latest-cursor lookup took about 1 ms.

## Before and after

### Before

```text
Browser                              Server / worker
   |                                       |
   |------ WebSocket opens --------------->| Loading every retained event...
   |------ Subscribe --------------------->| State may not exist yet
   |<----- Subscription state missing -----|
   |
   |  or, for a fast action:
   |
   |------ GET action run ---------------->| running
   |                                       | Action completes
   |                                       | Terminal event enters baseline
   |<----- Connected ----------------------|
   |------ Subscribe --------------------->|
   |                                       | No new terminal event to deliver
   |------ fallback GET after 10 sec ----->| succeeded
```

### After

```text
Browser                              Server / worker
   |                                       |
   |------ WebSocket opens --------------->| Register connection state
   |                                       | Read latest cursor directly
   |<----- Connected ----------------------|
   |------ Subscribe --------------------->|
   |<----- Subscribed ---------------------|
   |------ GET action run ---------------->| Recheck at acknowledgement
   |<----- succeeded ----------------------| Fast completion cannot be missed
   |
   |<----- Future object/action events ----| Normal live delivery continues
```

## What changed

### Race-free event handshake

- Add an optional protocol-readiness predicate to the shared reconnecting WebSocket transport.
- Make event sockets wait for the server's `connected` frame before sending `subscribe`; agent streams keep their existing subscribe-on-open behavior.
- Register server connection state before cursor initialization and make immediate subscriptions from older clients await that initialization.
- Preserve the latest delivered cursor across reconnects.

### Action wait readiness

- Report an event socket as connected only after the server acknowledges `subscribed`, rather than on the raw WebSocket open.
- Immediately reread the authoritative action run when that acknowledgement arrives.
- Keep terminal events as wakeups and retain the existing 10-second healthy / 1-second disconnected polling as safety paths.
- Add regression coverage for an action that completes between the initial detail read and subscription readiness without producing a post-baseline event.

### Constant-time event startup

- Add `Broker.latestCursor()` with shared contract coverage.
- Implement it for in-memory, Redis, and NATS brokers:
  - Redis reads the newest retained stream entry directly.
  - NATS reads the stream's latest retained sequence from metadata.
  - In-memory reads the final retained record.
- Expose `EventsRuntime.latestCursor()` and use it for WebSocket connect/unsubscribe baselines instead of reading every retained event.

## Compatibility and semantics

- Older event clients that subscribe immediately remain supported by the server-side initialization wait.
- Generic reconnecting sockets and agent streams retain their existing raw connection behavior; only event-socket readiness is subscription-aware.
- `latestCursor()` returns `undefined` for missing or empty streams and honors provider retention.
- Action run detail remains the source of truth; event delivery only accelerates the next detail read.

## Stack

This PR is stacked on #165 because the downstream integration that exposed the race currently pins that branch. Retarget it to `main` after #165 merges.

## Validation

```bash
bun test packages/core/tests/broker.test.ts packages/core/tests/events-runtime.test.ts packages/server/tests/wsSubscribe.test.ts packages/client/tests
# 127 passed

bun --filter @sixb/broker-redis test:e2e
# 34 passed

bun --filter @sixb/broker-nats test:e2e
# 23 passed

bun run build:types
bun run typecheck:tests
bun run check
```
