### PR TITLE
connector-imap: add read-only IMAP connector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,18 @@
         "typescript": "^5.7.0",
       },
     },
+    "connectors/imap": {
+      "name": "@sixb/connector-imap",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sixb/core": "workspace:*",
+        "imapflow": "^1.4.7",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "connectors/meta": {
       "name": "@sixb/connector-meta",
       "version": "0.1.0",
@@ -874,6 +886,8 @@
 
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@radix-ui/number": ["@radix-ui/number@1.1.2", "", {}, "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.4", "", {}, "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ=="],
@@ -1058,6 +1072,8 @@
 
     "@sixb/connector-google": ["@sixb/connector-google@workspace:connectors/google"],
 
+    "@sixb/connector-imap": ["@sixb/connector-imap@workspace:connectors/imap"],
+
     "@sixb/connector-meta": ["@sixb/connector-meta@workspace:connectors/meta"],
 
     "@sixb/connector-pandadoc": ["@sixb/connector-pandadoc@workspace:connectors/pandadoc"],
@@ -1230,6 +1246,8 @@
 
     "@xyflow/system": ["@xyflow/system@0.0.76", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA=="],
 
+    "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.14", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.4.1", "libqp": "2.1.1" } }, "sha512-rz0FQOhN3Vq1XrSeSSa9+dPcaFbBxmQPjiZm6zS9oxdVHV7rOWIAYX3yP2YAUf0qBncY8CI+NogzPCmMVrMXcw=="],
+
     "ai": ["ai@7.0.4", "", { "dependencies": { "@ai-sdk/gateway": "4.0.4", "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-mZub080RWRxpWg8OY56KVnI3AoMVniccSWG+dwVb3nH81+GiNMDYBIdP41RLUivLpmU49pB7ssD7tvfIUaSaCA=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
@@ -1247,6 +1265,8 @@
     "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
 
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
@@ -1400,6 +1420,8 @@
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "encoding-japanese": ["encoding-japanese@2.2.0", "", {}, "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.22.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
@@ -1448,7 +1470,11 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "imapflow": ["imapflow@1.4.7", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.14", "encoding-japanese": "2.2.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libmime": "5.4.1", "libqp": "2.1.1", "nodemailer": "9.0.3", "pino": "10.3.1", "socks": "2.8.9" } }, "sha512-nK03WfN16inwm0//0Q70T21G0g4H9ArMVyzKDRjAshOVV8iw71PP9HTpAXNmWB9giZWfPiS+ltHByi37cqwSgg=="],
 
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
@@ -1463,6 +1489,8 @@
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -1501,6 +1529,12 @@
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
+
+    "libbase64": ["libbase64@1.3.0", "", {}, "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="],
+
+    "libmime": ["libmime@5.4.1", "", { "dependencies": { "encoding-japanese": "2.2.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-0wHGhsofo9IdQPenr3BBHXuxcwMq4atFUTsZ9Ogc1OvI5h4rUdDIrBQEN9JHjCXfDMrE59LUMJWsTD82wTYk8A=="],
+
+    "libqp": ["libqp@2.1.1", "", {}, "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1652,6 +1686,8 @@
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
+    "nodemailer": ["nodemailer@9.0.3", "", {}, "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw=="],
+
     "nypm": ["nypm@0.6.6", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.1.1" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q=="],
 
     "oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
@@ -1659,6 +1695,8 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
@@ -1686,15 +1724,25 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
     "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "radix-ui": ["radix-ui@1.6.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-accessible-icon": "1.1.10", "@radix-ui/react-accordion": "1.2.14", "@radix-ui/react-alert-dialog": "1.1.17", "@radix-ui/react-arrow": "1.1.10", "@radix-ui/react-aspect-ratio": "1.1.10", "@radix-ui/react-avatar": "1.2.0", "@radix-ui/react-checkbox": "1.3.5", "@radix-ui/react-collapsible": "1.1.14", "@radix-ui/react-collection": "1.1.10", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-context-menu": "2.3.1", "@radix-ui/react-dialog": "1.1.17", "@radix-ui/react-direction": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.13", "@radix-ui/react-dropdown-menu": "2.1.18", "@radix-ui/react-focus-guards": "1.1.4", "@radix-ui/react-focus-scope": "1.1.10", "@radix-ui/react-form": "0.1.10", "@radix-ui/react-hover-card": "1.1.17", "@radix-ui/react-label": "2.1.10", "@radix-ui/react-menu": "2.1.18", "@radix-ui/react-menubar": "1.1.18", "@radix-ui/react-navigation-menu": "1.2.16", "@radix-ui/react-one-time-password-field": "0.1.10", "@radix-ui/react-password-toggle-field": "0.1.5", "@radix-ui/react-popover": "1.1.17", "@radix-ui/react-popper": "1.3.1", "@radix-ui/react-portal": "1.1.12", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-progress": "1.1.10", "@radix-ui/react-radio-group": "1.4.1", "@radix-ui/react-roving-focus": "1.1.13", "@radix-ui/react-scroll-area": "1.2.12", "@radix-ui/react-select": "2.3.1", "@radix-ui/react-separator": "1.1.10", "@radix-ui/react-slider": "1.4.1", "@radix-ui/react-slot": "1.3.0", "@radix-ui/react-switch": "1.3.1", "@radix-ui/react-tabs": "1.1.15", "@radix-ui/react-toast": "1.2.17", "@radix-ui/react-toggle": "1.1.12", "@radix-ui/react-toggle-group": "1.1.13", "@radix-ui/react-toolbar": "1.1.13", "@radix-ui/react-tooltip": "1.2.10", "@radix-ui/react-use-callback-ref": "1.1.2", "@radix-ui/react-use-controllable-state": "1.2.3", "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-escape-keydown": "1.1.2", "@radix-ui/react-use-is-hydrated": "0.1.1", "@radix-ui/react-use-layout-effect": "1.1.2", "@radix-ui/react-use-size": "1.1.2", "@radix-ui/react-visually-hidden": "1.2.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-EUEC70O03EgxWMP5aoqfBZ6iLC5bczFagGy7zhSYRt8o5DP7IWNiP3ywetse3L9b8843ExB0OGWZvgbYVJuNeg=="],
 
@@ -1736,6 +1784,8 @@
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
     "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
 
     "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
@@ -1772,6 +1822,8 @@
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
@@ -1788,11 +1840,19 @@
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "ssh2": ["ssh2@1.17.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
 
@@ -1827,6 +1887,8 @@
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
+
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -2121,6 +2183,8 @@
     "radix-ui/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
 
     "react-devtools-core/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "vaul/@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.17", "", { "dependencies": { "@radix-ui/primitive": "1.1.4", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.1.4", "@radix-ui/react-dismissable-layer": "1.1.13", "@radix-ui/react-focus-guards": "1.1.4", "@radix-ui/react-focus-scope": "1.1.10", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-portal": "1.1.12", "@radix-ui/react-presence": "1.1.6", "@radix-ui/react-primitive": "2.1.6", "@radix-ui/react-slot": "1.3.0", "@radix-ui/react-use-controllable-state": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw=="],
 

--- a/connectors/imap/README.md
+++ b/connectors/imap/README.md
@@ -26,11 +26,19 @@ const client = await sixb.connector(mail)
 
 await client.withMailbox("INBOX", async (mailbox) => {
   const state = mailbox.state()
-  const messages = await mailbox.listMessages({ afterUid: lastUid, limit: 100 })
+  const messages = await mailbox.listMessages({
+    afterUid: lastUid,
+    limit: 100,
+    headers: ["auto-submitted", "list-id", "list-unsubscribe"],
+  })
 
-  console.log(state.uidValidity, messages.length)
+  console.log(state.uidValidity, messages[0]?.headers["list-id"])
 })
 ```
+
+Requested header names are validated and deduplicated case-insensitively. Returned keys are
+lowercase and repeated fields remain separate values. Header interpretation belongs to the
+consumer; the connector only transports the requested metadata.
 
 All mailbox sessions use IMAP `EXAMINE`; the client does not expose any write or flag mutation
 method. Consume a stream returned by `downloadPart()` before the `withMailbox()` callback ends.

--- a/connectors/imap/README.md
+++ b/connectors/imap/README.md
@@ -1,0 +1,36 @@
+# `@sixb/connector-imap`
+
+Read-only IMAP connector for Sixb. It opens a short-lived TLS session for each operation instead
+of keeping a fragile socket in the connector runtime cache.
+
+```ts
+import { imap } from "@sixb/connector-imap"
+import { defineConnector } from "@sixb/core"
+
+export const mail = defineConnector(
+  "mail",
+  imap({
+    host: "imap.example.com",
+    auth: {
+      user: process.env.IMAP_USER!,
+      pass: process.env.IMAP_PASSWORD!,
+    },
+  })
+)
+```
+
+Use the resolved client inside a function, sync, action, or workflow:
+
+```ts
+const client = await sixb.connector(mail)
+
+await client.withMailbox("INBOX", async (mailbox) => {
+  const state = mailbox.state()
+  const messages = await mailbox.listMessages({ afterUid: lastUid, limit: 100 })
+
+  console.log(state.uidValidity, messages.length)
+})
+```
+
+All mailbox sessions use IMAP `EXAMINE`; the client does not expose any write or flag mutation
+method. Consume a stream returned by `downloadPart()` before the `withMailbox()` callback ends.

--- a/connectors/imap/package.json
+++ b/connectors/imap/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@sixb/connector-imap",
+  "version": "0.1.0",
+  "description": "Read-only IMAP connector for Sixb built on ImapFlow",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun ../../scripts/build-package.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "prepack": "bun run build"
+  },
+  "dependencies": {
+    "@sixb/core": "workspace:*",
+    "imapflow": "^1.4.7"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ]
+}

--- a/connectors/imap/src/client.ts
+++ b/connectors/imap/src/client.ts
@@ -1,0 +1,552 @@
+import { Readable } from "node:stream"
+import {
+  type DownloadObject,
+  type FetchMessageObject,
+  type FetchOptions,
+  type FetchQueryObject,
+  ImapFlow,
+  type ImapFlowOptions,
+  type ListOptions,
+  type ListResponse,
+  type MailboxLockObject,
+  type MailboxObject,
+  type MessageAddressObject,
+  type MessageEnvelopeObject,
+  type MessageStructureObject,
+  type SearchObject,
+} from "imapflow"
+import {
+  ImapAbortedError,
+  ImapConnectorError,
+  ImapDownloadTooLargeError,
+  imapOperationError,
+} from "./errors"
+import type {
+  ImapAddress,
+  ImapBodyPart,
+  ImapClient,
+  ImapConnection,
+  ImapDownloadedPart,
+  ImapDownloadInput,
+  ImapEnvelope,
+  ImapListMessagesInput,
+  ImapMailboxInfo,
+  ImapMailboxSession,
+  ImapMailboxState,
+  ImapMessageSummary,
+  ImapOperationOptions,
+} from "./types"
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 30_000
+const DEFAULT_SOCKET_TIMEOUT_MS = 300_000
+const MAX_PAGE_SIZE = 1_000
+const MAX_UID = 0xffff_ffff
+
+export interface ImapTransport {
+  usable: boolean
+  mailbox: MailboxObject | false
+  connect(): Promise<void>
+  logout(): Promise<void>
+  close(): void
+  list(options?: ListOptions): Promise<ListResponse[]>
+  getMailboxLock(
+    path: string | string[],
+    options?: { readOnly?: boolean }
+  ): Promise<MailboxLockObject>
+  search(query: SearchObject, options?: { uid?: boolean }): Promise<number[] | false>
+  fetchAll(
+    range: string | number[] | SearchObject,
+    query: FetchQueryObject,
+    options?: FetchOptions
+  ): Promise<FetchMessageObject[]>
+  download(
+    range: string | number | bigint,
+    part?: string,
+    options?: { uid?: boolean; maxBytes?: number; chunkSize?: number }
+  ): Promise<DownloadObject>
+}
+
+export type ImapTransportFactory = (options: ImapFlowOptions) => ImapTransport
+
+const defaultTransportFactory: ImapTransportFactory = (options) => new ImapFlow(options)
+
+export function createImapClient(
+  connection: ImapConnection,
+  lifecycleSignal: AbortSignal,
+  transportFactory: ImapTransportFactory = defaultTransportFactory
+): ImapClient {
+  return new ImapGateway(connection, lifecycleSignal, transportFactory)
+}
+
+class ImapGateway implements ImapClient {
+  private readonly activeTransports = new Set<ImapTransport>()
+  private readonly flowOptions: ImapFlowOptions
+  private closed = false
+
+  constructor(
+    private readonly connection: ImapConnection,
+    private readonly lifecycleSignal: AbortSignal,
+    private readonly transportFactory: ImapTransportFactory
+  ) {
+    this.flowOptions = toImapFlowOptions(connection)
+    this.lifecycleSignal.addEventListener("abort", this.handleLifecycleAbort, { once: true })
+  }
+
+  async listMailboxes(options: ImapOperationOptions = {}): Promise<readonly ImapMailboxInfo[]> {
+    return this.runOperation(options.signal, async (transport) => {
+      try {
+        const mailboxes = await transport.list({
+          statusQuery: {
+            messages: true,
+            recent: true,
+            uidNext: true,
+            uidValidity: true,
+            unseen: true,
+            highestModseq: true,
+          },
+        })
+        return mailboxes.map(normalizeMailboxInfo)
+      } catch (error) {
+        throw imapOperationError("Mailbox listing", error, [this.connection.auth.pass])
+      }
+    })
+  }
+
+  async withMailbox<T>(
+    path: string,
+    task: (mailbox: ImapMailboxSession) => Promise<T>,
+    options: ImapOperationOptions = {}
+  ): Promise<T> {
+    const normalizedPath = path.trim()
+    if (!normalizedPath) {
+      throw new ImapConnectorError("Mailbox path must not be empty.")
+    }
+
+    return this.runOperation(options.signal, async (transport) => {
+      let lock: MailboxLockObject | undefined
+      let session: ImapMailboxSessionImpl | undefined
+
+      try {
+        lock = await transport.getMailboxLock(normalizedPath, { readOnly: true })
+        if (!transport.mailbox) {
+          throw new ImapConnectorError(`Mailbox ${normalizedPath} did not open.`)
+        }
+        if (!transport.mailbox.readOnly) {
+          throw new ImapConnectorError(`Mailbox ${normalizedPath} was not opened read-only.`)
+        }
+
+        session = new ImapMailboxSessionImpl(transport, this.connection.auth.pass)
+        return await task(session)
+      } catch (error) {
+        if (error instanceof ImapConnectorError || session) {
+          throw error
+        }
+        throw imapOperationError("Mailbox open", error, [this.connection.auth.pass])
+      } finally {
+        session?.deactivate()
+        lock?.release()
+      }
+    })
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return
+    }
+
+    this.closed = true
+    this.lifecycleSignal.removeEventListener("abort", this.handleLifecycleAbort)
+    for (const transport of this.activeTransports) {
+      transport.close()
+    }
+    this.activeTransports.clear()
+  }
+
+  private readonly handleLifecycleAbort = () => {
+    void this.close()
+  }
+
+  private async runOperation<T>(
+    operationSignal: AbortSignal | undefined,
+    task: (transport: ImapTransport) => Promise<T>
+  ): Promise<T> {
+    this.assertAvailable(operationSignal)
+
+    let transport: ImapTransport
+    try {
+      transport = this.transportFactory(this.flowOptions)
+    } catch (error) {
+      throw imapOperationError("Client creation", error, [this.connection.auth.pass])
+    }
+
+    this.activeTransports.add(transport)
+    const abort = () => transport.close()
+    this.lifecycleSignal.addEventListener("abort", abort, { once: true })
+    operationSignal?.addEventListener("abort", abort, { once: true })
+
+    let value: T | undefined
+    let failure: unknown
+    let phase: "connect" | "task" = "connect"
+
+    try {
+      await transport.connect()
+      this.assertAvailable(operationSignal)
+      phase = "task"
+      value = await task(transport)
+      this.assertAvailable(operationSignal)
+    } catch (error) {
+      if (this.isAborted(operationSignal)) {
+        failure = new ImapAbortedError()
+      } else if (phase === "connect") {
+        failure = imapOperationError("Connection", error, [this.connection.auth.pass])
+      } else {
+        failure = error
+      }
+    }
+
+    let cleanupFailure: unknown
+    try {
+      if (transport.usable) {
+        await transport.logout()
+      } else {
+        transport.close()
+      }
+    } catch (error) {
+      transport.close()
+      cleanupFailure = imapOperationError("Connection cleanup", error, [this.connection.auth.pass])
+    } finally {
+      this.lifecycleSignal.removeEventListener("abort", abort)
+      operationSignal?.removeEventListener("abort", abort)
+      this.activeTransports.delete(transport)
+    }
+
+    if (failure) {
+      throw failure
+    }
+    if (cleanupFailure) {
+      throw cleanupFailure
+    }
+    return value as T
+  }
+
+  private assertAvailable(operationSignal?: AbortSignal): void {
+    if (this.isAborted(operationSignal)) {
+      throw new ImapAbortedError()
+    }
+  }
+
+  private isAborted(operationSignal?: AbortSignal): boolean {
+    return this.closed || this.lifecycleSignal.aborted || operationSignal?.aborted === true
+  }
+}
+
+class ImapMailboxSessionImpl implements ImapMailboxSession {
+  private readonly activeStreams = new Map<Readable, Readable>()
+  private active = true
+
+  constructor(
+    private readonly transport: ImapTransport,
+    private readonly password: string
+  ) {}
+
+  state(): ImapMailboxState {
+    const mailbox = this.currentMailbox()
+    return {
+      path: mailbox.path,
+      uidValidity: mailbox.uidValidity,
+      uidNext: mailbox.uidNext,
+      exists: mailbox.exists,
+      readOnly: true,
+    }
+  }
+
+  async listMessages(input: ImapListMessagesInput): Promise<readonly ImapMessageSummary[]> {
+    this.assertActive()
+    validateListInput(input)
+
+    const startUid = (input.afterUid ?? 0) + 1
+    const search: SearchObject = {
+      uid: `${startUid}:*`,
+      ...(input.since ? { since: input.since } : {}),
+    }
+
+    try {
+      const searchResult = await this.transport.search(search, { uid: true })
+      this.assertActive()
+      if (!searchResult || searchResult.length === 0) {
+        return []
+      }
+
+      const uids = [...searchResult]
+        .filter((uid) => uid >= startUid)
+        .sort((left, right) => left - right)
+        .slice(0, input.limit)
+
+      if (uids.length === 0) {
+        return []
+      }
+
+      const messages = await this.transport.fetchAll(
+        uids,
+        {
+          uid: true,
+          envelope: true,
+          internalDate: true,
+          size: true,
+          bodyStructure: true,
+          headers: ["references"],
+        },
+        { uid: true }
+      )
+      this.assertActive()
+      return messages.map(normalizeMessage).sort((left, right) => left.uid - right.uid)
+    } catch (error) {
+      throw imapOperationError("Message listing", error, [this.password])
+    }
+  }
+
+  async downloadPart(input: ImapDownloadInput): Promise<ImapDownloadedPart> {
+    this.assertActive()
+    validateDownloadInput(input)
+
+    let downloaded: DownloadObject
+    try {
+      downloaded = await this.transport.download(input.uid, input.part, {
+        uid: true,
+        maxBytes: input.maxBytes + 1,
+      })
+      this.assertActive()
+    } catch (error) {
+      throw imapOperationError("Message part download", error, [this.password])
+    }
+
+    const content = limitReadable(downloaded.content, input)
+    this.activeStreams.set(content, downloaded.content)
+    content.once("close", () => {
+      const source = this.activeStreams.get(content)
+      this.activeStreams.delete(content)
+      if (source && !source.destroyed) {
+        source.destroy()
+      }
+    })
+
+    return {
+      meta: {
+        expectedSize: downloaded.meta.expectedSize,
+        contentType: downloaded.meta.contentType,
+        charset: downloaded.meta.charset ?? null,
+        disposition: downloaded.meta.disposition ?? null,
+        filename: downloaded.meta.filename ?? null,
+        encoding: downloaded.meta.encoding ?? null,
+      },
+      content,
+    }
+  }
+
+  deactivate(): void {
+    if (!this.active) {
+      return
+    }
+    this.active = false
+    for (const [content, source] of this.activeStreams) {
+      content.destroy()
+      source.destroy()
+    }
+    this.activeStreams.clear()
+  }
+
+  private assertActive(): void {
+    if (!this.active) {
+      throw new ImapConnectorError("Mailbox session is no longer active.")
+    }
+  }
+
+  private currentMailbox(): MailboxObject {
+    this.assertActive()
+    if (!this.transport.mailbox) {
+      throw new ImapConnectorError("No mailbox is open.")
+    }
+    return this.transport.mailbox
+  }
+}
+
+function toImapFlowOptions(connection: ImapConnection): ImapFlowOptions {
+  return {
+    host: connection.host,
+    port: connection.port ?? 993,
+    secure: true,
+    servername: connection.tls?.servername ?? connection.host,
+    auth: {
+      user: connection.auth.user,
+      pass: connection.auth.pass,
+    },
+    tls: {
+      rejectUnauthorized: connection.tls?.rejectUnauthorized ?? true,
+    },
+    logger: false,
+    logRaw: false,
+    emitLogs: false,
+    disableAutoIdle: true,
+    connectionTimeout: connection.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
+    socketTimeout: connection.socketTimeoutMs ?? DEFAULT_SOCKET_TIMEOUT_MS,
+  }
+}
+
+function normalizeMailboxInfo(mailbox: ListResponse): ImapMailboxInfo {
+  return {
+    path: mailbox.path,
+    name: mailbox.name,
+    delimiter: mailbox.delimiter,
+    parentPath: mailbox.parentPath,
+    flags: [...mailbox.flags].sort(),
+    specialUse: mailbox.specialUse ?? null,
+    listed: mailbox.listed,
+    subscribed: mailbox.subscribed,
+    status: mailbox.status
+      ? {
+          messages: mailbox.status.messages ?? null,
+          recent: mailbox.status.recent ?? null,
+          uidNext: mailbox.status.uidNext ?? null,
+          uidValidity: mailbox.status.uidValidity ?? null,
+          unseen: mailbox.status.unseen ?? null,
+          highestModseq: mailbox.status.highestModseq ?? null,
+        }
+      : null,
+  }
+}
+
+function normalizeMessage(message: FetchMessageObject): ImapMessageSummary {
+  return {
+    seq: message.seq,
+    uid: message.uid,
+    internalDate: normalizeDate(message.internalDate),
+    size: message.size ?? null,
+    envelope: message.envelope ? normalizeEnvelope(message.envelope) : null,
+    references: parseReferences(message.headers),
+    bodyStructure: message.bodyStructure ? normalizeBodyPart(message.bodyStructure) : null,
+  }
+}
+
+function normalizeEnvelope(envelope: MessageEnvelopeObject): ImapEnvelope {
+  return {
+    date: envelope.date ?? null,
+    subject: envelope.subject ?? null,
+    messageId: normalizeOptionalString(envelope.messageId),
+    inReplyTo: normalizeOptionalString(envelope.inReplyTo),
+    from: normalizeAddresses(envelope.from),
+    sender: normalizeAddresses(envelope.sender),
+    replyTo: normalizeAddresses(envelope.replyTo),
+    to: normalizeAddresses(envelope.to),
+    cc: normalizeAddresses(envelope.cc),
+    bcc: normalizeAddresses(envelope.bcc),
+  }
+}
+
+function normalizeAddresses(addresses?: MessageAddressObject[]): readonly ImapAddress[] {
+  return (addresses ?? []).map((address) => ({
+    name: normalizeOptionalString(address.name),
+    address: normalizeOptionalString(address.address),
+  }))
+}
+
+function normalizeBodyPart(part: MessageStructureObject): ImapBodyPart {
+  return {
+    part: part.part ?? null,
+    type: part.type,
+    parameters: { ...(part.parameters ?? {}) },
+    id: normalizeOptionalString(part.id),
+    encoding: normalizeOptionalString(part.encoding),
+    size: part.size ?? null,
+    disposition: normalizeOptionalString(part.disposition),
+    dispositionParameters: { ...(part.dispositionParameters ?? {}) },
+    childNodes: (part.childNodes ?? []).map(normalizeBodyPart),
+  }
+}
+
+function normalizeDate(value: Date | string | undefined): Date | null {
+  if (!value) {
+    return null
+  }
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function normalizeOptionalString(value: string | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized ? normalized : null
+}
+
+function parseReferences(headers: Buffer | undefined): readonly string[] {
+  if (!headers?.length) {
+    return []
+  }
+
+  const unfolded = headers.toString("utf8").replaceAll(/\r?\n[\t ]+/g, " ")
+  const references: string[] = []
+
+  for (const line of unfolded.split(/\r?\n/)) {
+    const match = /^references\s*:\s*(.+)$/i.exec(line)
+    if (!match?.[1]) {
+      continue
+    }
+
+    const value = match[1]
+    const messageIds = value.match(/<[^<>]+>/g) ?? value.split(/\s+/).filter(Boolean)
+    references.push(...messageIds)
+  }
+
+  return [...new Set(references)]
+}
+
+function validateListInput(input: ImapListMessagesInput): void {
+  if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > MAX_PAGE_SIZE) {
+    throw new ImapConnectorError(`Message page limit must be between 1 and ${MAX_PAGE_SIZE}.`)
+  }
+  if (
+    input.afterUid !== undefined &&
+    (!Number.isInteger(input.afterUid) || input.afterUid < 0 || input.afterUid >= MAX_UID)
+  ) {
+    throw new ImapConnectorError(`afterUid must be an integer between 0 and ${MAX_UID - 1}.`)
+  }
+  if (input.since && Number.isNaN(input.since.getTime())) {
+    throw new ImapConnectorError("since must be a valid Date.")
+  }
+}
+
+function validateDownloadInput(input: ImapDownloadInput): void {
+  if (!Number.isInteger(input.uid) || input.uid < 1 || input.uid > MAX_UID) {
+    throw new ImapConnectorError(`Message UID must be an integer between 1 and ${MAX_UID}.`)
+  }
+  if (!input.part.trim()) {
+    throw new ImapConnectorError("Message part must not be empty.")
+  }
+  if (
+    !Number.isSafeInteger(input.maxBytes) ||
+    input.maxBytes < 1 ||
+    input.maxBytes >= Number.MAX_SAFE_INTEGER
+  ) {
+    throw new ImapConnectorError("maxBytes must be a positive safe integer.")
+  }
+}
+
+function limitReadable(source: Readable, input: ImapDownloadInput): Readable {
+  return Readable.from(
+    (async function* () {
+      let received = 0
+      try {
+        for await (const value of source) {
+          const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value)
+          received += chunk.byteLength
+          if (received > input.maxBytes) {
+            throw new ImapDownloadTooLargeError(input.uid, input.part, input.maxBytes)
+          }
+          yield chunk
+        }
+      } finally {
+        if (!source.destroyed) {
+          source.destroy()
+        }
+      }
+    })()
+  )
+}

--- a/connectors/imap/src/client.ts
+++ b/connectors/imap/src/client.ts
@@ -29,6 +29,7 @@ import type {
   ImapDownloadedPart,
   ImapDownloadInput,
   ImapEnvelope,
+  ImapHeaders,
   ImapListMessagesInput,
   ImapMailboxInfo,
   ImapMailboxSession,
@@ -40,7 +41,10 @@ import type {
 const DEFAULT_CONNECT_TIMEOUT_MS = 30_000
 const DEFAULT_SOCKET_TIMEOUT_MS = 300_000
 const MAX_PAGE_SIZE = 1_000
+const MAX_REQUESTED_HEADERS = 64
+const MAX_HEADER_NAME_LENGTH = 128
 const MAX_UID = 0xffff_ffff
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
 
 export interface ImapTransport {
   usable: boolean
@@ -262,7 +266,8 @@ class ImapMailboxSessionImpl implements ImapMailboxSession {
 
   async listMessages(input: ImapListMessagesInput): Promise<readonly ImapMessageSummary[]> {
     this.assertActive()
-    validateListInput(input)
+    const requestedHeaders = validateListInput(input)
+    const fetchHeaders = [...new Set(["references", ...requestedHeaders])]
 
     const startUid = (input.afterUid ?? 0) + 1
     const search: SearchObject = {
@@ -294,12 +299,14 @@ class ImapMailboxSessionImpl implements ImapMailboxSession {
           internalDate: true,
           size: true,
           bodyStructure: true,
-          headers: ["references"],
+          headers: fetchHeaders,
         },
         { uid: true }
       )
       this.assertActive()
-      return messages.map(normalizeMessage).sort((left, right) => left.uid - right.uid)
+      return messages
+        .map((message) => normalizeMessage(message, requestedHeaders))
+        .sort((left, right) => left.uid - right.uid)
     } catch (error) {
       throw imapOperationError("Message listing", error, [this.password])
     }
@@ -415,14 +422,19 @@ function normalizeMailboxInfo(mailbox: ListResponse): ImapMailboxInfo {
   }
 }
 
-function normalizeMessage(message: FetchMessageObject): ImapMessageSummary {
+function normalizeMessage(
+  message: FetchMessageObject,
+  requestedHeaders: readonly string[]
+): ImapMessageSummary {
+  const parsedHeaders = parseHeaders(message.headers)
   return {
     seq: message.seq,
     uid: message.uid,
     internalDate: normalizeDate(message.internalDate),
     size: message.size ?? null,
     envelope: message.envelope ? normalizeEnvelope(message.envelope) : null,
-    references: parseReferences(message.headers),
+    headers: selectHeaders(parsedHeaders, requestedHeaders),
+    references: parseReferences(parsedHeaders),
     bodyStructure: message.bodyStructure ? normalizeBodyPart(message.bodyStructure) : null,
   }
 }
@@ -476,21 +488,48 @@ function normalizeOptionalString(value: string | undefined): string | null {
   return normalized ? normalized : null
 }
 
-function parseReferences(headers: Buffer | undefined): readonly string[] {
+function parseHeaders(headers: Buffer | undefined): ImapHeaders {
+  const result = new Map<string, string[]>()
   if (!headers?.length) {
-    return []
+    return Object.fromEntries(result)
   }
 
   const unfolded = headers.toString("utf8").replaceAll(/\r?\n[\t ]+/g, " ")
-  const references: string[] = []
 
   for (const line of unfolded.split(/\r?\n/)) {
-    const match = /^references\s*:\s*(.+)$/i.exec(line)
-    if (!match?.[1]) {
+    const separator = line.indexOf(":")
+    if (separator < 1) {
       continue
     }
+    const name = line.slice(0, separator).trim().toLowerCase()
+    if (!HEADER_NAME_PATTERN.test(name)) {
+      continue
+    }
+    const value = line.slice(separator + 1).trim()
+    const values = result.get(name)
+    if (values) {
+      values.push(value)
+    } else {
+      result.set(name, [value])
+    }
+  }
 
-    const value = match[1]
+  return Object.fromEntries(result)
+}
+
+function selectHeaders(headers: ImapHeaders, requestedHeaders: readonly string[]): ImapHeaders {
+  return Object.fromEntries(
+    requestedHeaders.flatMap((name) => {
+      const values = headers[name]
+      return values ? [[name, values] as const] : []
+    })
+  )
+}
+
+function parseReferences(headers: ImapHeaders): readonly string[] {
+  const references: string[] = []
+
+  for (const value of headers.references ?? []) {
     const messageIds = value.match(/<[^<>]+>/g) ?? value.split(/\s+/).filter(Boolean)
     references.push(...messageIds)
   }
@@ -498,7 +537,7 @@ function parseReferences(headers: Buffer | undefined): readonly string[] {
   return [...new Set(references)]
 }
 
-function validateListInput(input: ImapListMessagesInput): void {
+function validateListInput(input: ImapListMessagesInput): readonly string[] {
   if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > MAX_PAGE_SIZE) {
     throw new ImapConnectorError(`Message page limit must be between 1 and ${MAX_PAGE_SIZE}.`)
   }
@@ -511,6 +550,35 @@ function validateListInput(input: ImapListMessagesInput): void {
   if (input.since && Number.isNaN(input.since.getTime())) {
     throw new ImapConnectorError("since must be a valid Date.")
   }
+  return normalizeRequestedHeaders(input.headers)
+}
+
+function normalizeRequestedHeaders(headers: readonly string[] | undefined): readonly string[] {
+  if (!headers) {
+    return []
+  }
+  if (headers.length > MAX_REQUESTED_HEADERS) {
+    throw new ImapConnectorError(
+      `No more than ${MAX_REQUESTED_HEADERS} message headers may be requested.`
+    )
+  }
+
+  const normalized: string[] = []
+  const seen = new Set<string>()
+  for (const header of headers) {
+    if (typeof header !== "string") {
+      throw new ImapConnectorError("Message header names must be strings.")
+    }
+    const name = header.trim().toLowerCase()
+    if (!name || name.length > MAX_HEADER_NAME_LENGTH || !HEADER_NAME_PATTERN.test(name)) {
+      throw new ImapConnectorError("Message header names must be valid RFC 5322 field names.")
+    }
+    if (!seen.has(name)) {
+      normalized.push(name)
+      seen.add(name)
+    }
+  }
+  return normalized
 }
 
 function validateDownloadInput(input: ImapDownloadInput): void {

--- a/connectors/imap/src/errors.ts
+++ b/connectors/imap/src/errors.ts
@@ -1,0 +1,56 @@
+export class ImapConnectorError extends Error {
+  readonly name: string = "ImapConnectorError"
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(`[SixbImap] ${message}`, options)
+  }
+}
+
+export class ImapAbortedError extends ImapConnectorError {
+  override readonly name = "ImapAbortedError"
+
+  constructor() {
+    super("Operation aborted.")
+  }
+}
+
+export class ImapDownloadTooLargeError extends ImapConnectorError {
+  override readonly name = "ImapDownloadTooLargeError"
+
+  constructor(
+    readonly uid: number,
+    readonly part: string,
+    readonly maxBytes: number,
+    readonly expectedSize?: number
+  ) {
+    const expected = expectedSize === undefined ? "" : ` (expected ${expectedSize} bytes)`
+    super(`Message ${uid} part ${part} exceeds the ${maxBytes}-byte limit${expected}.`)
+  }
+}
+
+export function imapOperationError(
+  operation: string,
+  error: unknown,
+  secrets: readonly string[] = []
+): ImapConnectorError {
+  if (error instanceof ImapConnectorError) {
+    return error
+  }
+
+  const detail = sanitizedErrorMessage(error, secrets)
+  const suffix = detail ? `: ${detail}` : "."
+  return new ImapConnectorError(`${operation} failed${suffix}`, { cause: error })
+}
+
+function sanitizedErrorMessage(error: unknown, secrets: readonly string[]): string {
+  const raw = error instanceof Error ? error.message : typeof error === "string" ? error : ""
+  let sanitized = raw.replaceAll(/\s+/g, " ").trim()
+
+  for (const secret of secrets) {
+    if (secret) {
+      sanitized = sanitized.replaceAll(secret, "[redacted]")
+    }
+  }
+
+  return sanitized.slice(0, 300)
+}

--- a/connectors/imap/src/imap.ts
+++ b/connectors/imap/src/imap.ts
@@ -1,0 +1,83 @@
+import { createImapClient } from "./client"
+import { ImapAbortedError, ImapConnectorError } from "./errors"
+import type { ImapConnection, ImapConnector } from "./types"
+
+/**
+ * Create a read-only IMAP connector backed by ImapFlow.
+ *
+ * The connected value is a stateless gateway: every operation opens and closes its own
+ * authenticated TLS session so a stale socket is never retained by the Sixb connector runtime.
+ */
+export function imap(connection: ImapConnection): ImapConnector {
+  const normalizedConnection = normalizeConnection(connection)
+
+  return {
+    type: "imap",
+    async connect(context) {
+      if (context.signal.aborted) {
+        throw new ImapAbortedError()
+      }
+      return createImapClient(normalizedConnection, context.signal)
+    },
+    disconnect(client) {
+      return client.close()
+    },
+  }
+}
+
+function normalizeConnection(connection: ImapConnection): ImapConnection {
+  const host = connection.host?.trim()
+  const user = connection.auth?.user?.trim()
+
+  if (!host) {
+    throw new ImapConnectorError("host must not be empty.")
+  }
+  if (!user) {
+    throw new ImapConnectorError("auth.user must not be empty.")
+  }
+  if (!connection.auth?.pass) {
+    throw new ImapConnectorError("auth.pass must not be empty.")
+  }
+  validatePort(connection.port)
+  validateTimeout("connectTimeoutMs", connection.connectTimeoutMs)
+  validateTimeout("socketTimeoutMs", connection.socketTimeoutMs)
+
+  const servername = connection.tls?.servername?.trim()
+  if (connection.tls?.servername !== undefined && !servername) {
+    throw new ImapConnectorError("tls.servername must not be empty when provided.")
+  }
+
+  return {
+    host,
+    ...(connection.port === undefined ? {} : { port: connection.port }),
+    auth: { user, pass: connection.auth.pass },
+    ...(connection.tls
+      ? {
+          tls: {
+            ...(connection.tls.rejectUnauthorized === undefined
+              ? {}
+              : { rejectUnauthorized: connection.tls.rejectUnauthorized }),
+            ...(servername ? { servername } : {}),
+          },
+        }
+      : {}),
+    ...(connection.connectTimeoutMs === undefined
+      ? {}
+      : { connectTimeoutMs: connection.connectTimeoutMs }),
+    ...(connection.socketTimeoutMs === undefined
+      ? {}
+      : { socketTimeoutMs: connection.socketTimeoutMs }),
+  }
+}
+
+function validatePort(port: number | undefined): void {
+  if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65_535)) {
+    throw new ImapConnectorError("port must be an integer between 1 and 65535.")
+  }
+}
+
+function validateTimeout(field: string, timeout: number | undefined): void {
+  if (timeout !== undefined && (!Number.isSafeInteger(timeout) || timeout < 1)) {
+    throw new ImapConnectorError(`${field} must be a positive integer.`)
+  }
+}

--- a/connectors/imap/src/index.ts
+++ b/connectors/imap/src/index.ts
@@ -13,6 +13,7 @@ export type {
   ImapDownloadedPart,
   ImapDownloadInput,
   ImapEnvelope,
+  ImapHeaders,
   ImapListMessagesInput,
   ImapMailboxInfo,
   ImapMailboxSession,

--- a/connectors/imap/src/index.ts
+++ b/connectors/imap/src/index.ts
@@ -1,0 +1,23 @@
+export {
+  ImapAbortedError,
+  ImapConnectorError,
+  ImapDownloadTooLargeError,
+} from "./errors"
+export { imap } from "./imap"
+export type {
+  ImapAddress,
+  ImapBodyPart,
+  ImapClient,
+  ImapConnection,
+  ImapConnector,
+  ImapDownloadedPart,
+  ImapDownloadInput,
+  ImapEnvelope,
+  ImapListMessagesInput,
+  ImapMailboxInfo,
+  ImapMailboxSession,
+  ImapMailboxState,
+  ImapMailboxStatus,
+  ImapMessageSummary,
+  ImapOperationOptions,
+} from "./types"

--- a/connectors/imap/src/types.ts
+++ b/connectors/imap/src/types.ts
@@ -1,0 +1,136 @@
+import type { Readable } from "node:stream"
+import type { ConnectorAdapter } from "@sixb/core"
+
+export interface ImapConnection {
+  readonly host: string
+  readonly port?: number
+  readonly auth: {
+    readonly user: string
+    readonly pass: string
+  }
+  readonly tls?: {
+    readonly rejectUnauthorized?: boolean
+    readonly servername?: string
+  }
+  readonly connectTimeoutMs?: number
+  readonly socketTimeoutMs?: number
+}
+
+export interface ImapOperationOptions {
+  readonly signal?: AbortSignal
+}
+
+export interface ImapMailboxStatus {
+  readonly messages: number | null
+  readonly recent: number | null
+  readonly uidNext: number | null
+  readonly uidValidity: bigint | null
+  readonly unseen: number | null
+  readonly highestModseq: bigint | null
+}
+
+export interface ImapMailboxInfo {
+  readonly path: string
+  readonly name: string
+  readonly delimiter: string
+  readonly parentPath: string
+  readonly flags: readonly string[]
+  readonly specialUse: string | null
+  readonly listed: boolean
+  readonly subscribed: boolean
+  readonly status: ImapMailboxStatus | null
+}
+
+export interface ImapMailboxState {
+  readonly path: string
+  readonly uidValidity: bigint
+  readonly uidNext: number
+  readonly exists: number
+  readonly readOnly: true
+}
+
+export interface ImapAddress {
+  readonly name: string | null
+  readonly address: string | null
+}
+
+export interface ImapEnvelope {
+  readonly date: Date | null
+  readonly subject: string | null
+  readonly messageId: string | null
+  readonly inReplyTo: string | null
+  readonly from: readonly ImapAddress[]
+  readonly sender: readonly ImapAddress[]
+  readonly replyTo: readonly ImapAddress[]
+  readonly to: readonly ImapAddress[]
+  readonly cc: readonly ImapAddress[]
+  readonly bcc: readonly ImapAddress[]
+}
+
+export interface ImapBodyPart {
+  readonly part: string | null
+  readonly type: string
+  readonly parameters: Readonly<Record<string, string>>
+  readonly id: string | null
+  readonly encoding: string | null
+  readonly size: number | null
+  readonly disposition: string | null
+  readonly dispositionParameters: Readonly<Record<string, string>>
+  readonly childNodes: readonly ImapBodyPart[]
+}
+
+export interface ImapMessageSummary {
+  readonly seq: number
+  readonly uid: number
+  readonly internalDate: Date | null
+  readonly size: number | null
+  readonly envelope: ImapEnvelope | null
+  readonly references: readonly string[]
+  readonly bodyStructure: ImapBodyPart | null
+}
+
+export interface ImapListMessagesInput {
+  /** Exclusive UID checkpoint. Omit to start from the first message. */
+  readonly afterUid?: number
+  /** Optional server-side IMAP SINCE filter, based on the internal date. */
+  readonly since?: Date
+  /** Maximum page size, from 1 to 1000. */
+  readonly limit: number
+}
+
+export interface ImapDownloadInput {
+  readonly uid: number
+  readonly part: string
+  readonly maxBytes: number
+}
+
+export interface ImapDownloadedPart {
+  readonly meta: {
+    /** ImapFlow's server-reported size; it may describe the full message, not this MIME part. */
+    readonly expectedSize: number
+    readonly contentType: string
+    readonly charset: string | null
+    readonly disposition: string | null
+    readonly filename: string | null
+    readonly encoding: string | null
+  }
+  readonly content: Readable
+}
+
+export interface ImapMailboxSession {
+  state(): ImapMailboxState
+  listMessages(input: ImapListMessagesInput): Promise<readonly ImapMessageSummary[]>
+  downloadPart(input: ImapDownloadInput): Promise<ImapDownloadedPart>
+}
+
+export interface ImapClient {
+  listMailboxes(options?: ImapOperationOptions): Promise<readonly ImapMailboxInfo[]>
+  withMailbox<T>(
+    path: string,
+    task: (mailbox: ImapMailboxSession) => Promise<T>,
+    options?: ImapOperationOptions
+  ): Promise<T>
+  close(): Promise<void>
+}
+
+export type ImapConnector = ConnectorAdapter<"imap", ImapClient>

--- a/connectors/imap/src/types.ts
+++ b/connectors/imap/src/types.ts
@@ -85,9 +85,13 @@ export interface ImapMessageSummary {
   readonly internalDate: Date | null
   readonly size: number | null
   readonly envelope: ImapEnvelope | null
+  /** Requested header values, keyed by lowercase field name. Missing headers are omitted. */
+  readonly headers: ImapHeaders
   readonly references: readonly string[]
   readonly bodyStructure: ImapBodyPart | null
 }
+
+export type ImapHeaders = Readonly<Record<string, readonly string[] | undefined>>
 
 export interface ImapListMessagesInput {
   /** Exclusive UID checkpoint. Omit to start from the first message. */
@@ -96,6 +100,8 @@ export interface ImapListMessagesInput {
   readonly since?: Date
   /** Maximum page size, from 1 to 1000. */
   readonly limit: number
+  /** Optional RFC 5322 header fields to fetch. Names are deduplicated case-insensitively. */
+  readonly headers?: readonly string[]
 }
 
 export interface ImapDownloadInput {

--- a/connectors/imap/tests/imap.test.ts
+++ b/connectors/imap/tests/imap.test.ts
@@ -1,0 +1,571 @@
+import { describe, expect, test } from "bun:test"
+import { Readable } from "node:stream"
+import type {
+  DownloadObject,
+  FetchMessageObject,
+  FetchOptions,
+  FetchQueryObject,
+  ImapFlowOptions,
+  ListOptions,
+  ListResponse,
+  MailboxLockObject,
+  MailboxObject,
+  SearchObject,
+} from "imapflow"
+import { ImapAbortedError, ImapConnectorError, ImapDownloadTooLargeError, imap } from "../src"
+import { createImapClient, type ImapTransport } from "../src/client"
+import type { ImapConnection, ImapMailboxSession } from "../src/types"
+
+const CONNECTION: ImapConnection = {
+  host: "imap.example.com",
+  auth: { user: "reader@example.com", pass: "secret-password" },
+}
+
+describe("imap connector", () => {
+  test("validates connection settings before creating the adapter", () => {
+    expect(() => imap({ ...CONNECTION, host: " " })).toThrow("host must not be empty")
+    expect(() => imap({ ...CONNECTION, auth: { user: "", pass: "secret" } })).toThrow(
+      "auth.user must not be empty"
+    )
+    expect(() => imap({ ...CONNECTION, port: 70_000 })).toThrow(
+      "port must be an integer between 1 and 65535"
+    )
+    expect(() => imap({ ...CONNECTION, connectTimeoutMs: 0 })).toThrow(
+      "connectTimeoutMs must be a positive integer"
+    )
+  })
+
+  test("returns a read-only gateway and rejects an already-aborted runtime", async () => {
+    const adapter = imap(CONNECTION)
+    expect(adapter.type).toBe("imap")
+
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      adapter.connect({ projectId: "demo", connectorId: "mail", signal: controller.signal })
+    ).rejects.toBeInstanceOf(ImapAbortedError)
+  })
+
+  test("uses secure, non-idling ImapFlow options and normalizes mailbox status", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      transport.mailboxes = [mailboxListResponse()]
+    }
+
+    const result = await fixture.client.listMailboxes()
+
+    expect(fixture.options).toHaveLength(1)
+    expect(fixture.options[0]).toMatchObject({
+      host: "imap.example.com",
+      port: 993,
+      secure: true,
+      servername: "imap.example.com",
+      disableAutoIdle: true,
+      logger: false,
+      logRaw: false,
+      emitLogs: false,
+      connectionTimeout: 30_000,
+      socketTimeout: 300_000,
+      tls: { rejectUnauthorized: true },
+    })
+    expect(result).toEqual([
+      {
+        path: "Sent",
+        name: "Sent",
+        delimiter: "/",
+        parentPath: "",
+        flags: ["\\HasNoChildren"],
+        specialUse: "\\Sent",
+        listed: true,
+        subscribed: true,
+        status: {
+          messages: 12,
+          recent: 1,
+          uidNext: 42,
+          uidValidity: 123n,
+          unseen: 3,
+          highestModseq: 9n,
+        },
+      },
+    ])
+    expect(fixture.transports[0]?.events).toEqual(["connect", "list", "logout"])
+  })
+
+  test("opens a new read-only session for every mailbox operation", async () => {
+    const fixture = clientFixture()
+
+    const firstState = await fixture.client.withMailbox("INBOX", async (mailbox) => mailbox.state())
+    const secondState = await fixture.client.withMailbox("Sent", async (mailbox) => mailbox.state())
+
+    expect(firstState).toMatchObject({ path: "INBOX", uidValidity: 123n, readOnly: true })
+    expect(secondState).toMatchObject({ path: "Sent", uidValidity: 123n, readOnly: true })
+    expect(fixture.transports).toHaveLength(2)
+    expect(fixture.transports[0]?.events).toEqual([
+      "connect",
+      "lock:INBOX:true",
+      "release:INBOX",
+      "logout",
+    ])
+    expect(fixture.transports[1]?.events).toEqual([
+      "connect",
+      "lock:Sent:true",
+      "release:Sent",
+      "logout",
+    ])
+  })
+
+  test("releases the lock and logs out when the mailbox callback fails", async () => {
+    const fixture = clientFixture()
+    const failure = new Error("application failure")
+
+    await expect(
+      fixture.client.withMailbox("INBOX", async () => {
+        throw failure
+      })
+    ).rejects.toBe(failure)
+
+    expect(fixture.transports[0]?.events).toEqual([
+      "connect",
+      "lock:INBOX:true",
+      "release:INBOX",
+      "logout",
+    ])
+  })
+
+  test("rejects a mailbox that was not actually opened read-only", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      transport.forceReadOnly = false
+    }
+
+    await expect(fixture.client.withMailbox("INBOX", async () => undefined)).rejects.toThrow(
+      "was not opened read-only"
+    )
+    expect(fixture.transports[0]?.events).toContain("release:INBOX")
+  })
+
+  test("lists a bounded UID page and normalizes envelope, references, and MIME structure", async () => {
+    const fixture = clientFixture()
+    const since = new Date("2026-06-01T00:00:00.000Z")
+    fixture.configure = (transport) => {
+      transport.searchResult = [13, 11, 12]
+      transport.messages = [message(12), message(11)]
+    }
+
+    const messages = await fixture.client.withMailbox("INBOX", (mailbox) =>
+      mailbox.listMessages({ afterUid: 10, since, limit: 2 })
+    )
+
+    const transport = fixture.transports[0]
+    expect(transport?.searchQuery).toEqual({ uid: "11:*", since })
+    expect(transport?.fetchRange).toEqual([11, 12])
+    expect(transport?.fetchQuery).toMatchObject({
+      uid: true,
+      envelope: true,
+      internalDate: true,
+      size: true,
+      bodyStructure: true,
+      headers: ["references"],
+    })
+    expect(messages.map((item) => item.uid)).toEqual([11, 12])
+    expect(messages[0]).toMatchObject({
+      internalDate: new Date("2026-07-10T08:00:00.000Z"),
+      size: 1_024,
+      references: ["<root@example.com>", "<parent@example.com>"],
+      envelope: {
+        subject: "Project update",
+        messageId: "<message-11@example.com>",
+        inReplyTo: "<parent@example.com>",
+        from: [{ name: "Client", address: "client@example.com" }],
+      },
+      bodyStructure: {
+        type: "multipart/mixed",
+        childNodes: [
+          {
+            part: "1",
+            type: "text/plain",
+            parameters: { charset: "utf-8" },
+          },
+        ],
+      },
+    })
+  })
+
+  test("validates page inputs before issuing a search", async () => {
+    const fixture = clientFixture()
+
+    await expect(
+      fixture.client.withMailbox("INBOX", (mailbox) =>
+        mailbox.listMessages({ afterUid: 0, limit: 1_001 })
+      )
+    ).rejects.toThrow("Message page limit must be between 1 and 1000")
+    expect(fixture.transports[0]?.searchQuery).toBeUndefined()
+  })
+
+  test("streams a MIME part within the byte limit", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      transport.downloadResult = download(["ab", "cd"], 4)
+    }
+
+    const result = await fixture.client.withMailbox("INBOX", async (mailbox) => {
+      const part = await mailbox.downloadPart({ uid: 7, part: "2", maxBytes: 5 })
+      return { meta: part.meta, body: await readAll(part.content) }
+    })
+
+    expect(result.body.toString("utf8")).toBe("abcd")
+    expect(result.meta).toMatchObject({ expectedSize: 4, contentType: "application/pdf" })
+    expect(fixture.transports[0]?.downloadRequest).toEqual({
+      uid: 7,
+      part: "2",
+      options: { uid: true, maxBytes: 6 },
+    })
+  })
+
+  test("does not use the message-level expected size as the MIME part limit", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      transport.downloadResult = download(["abcd"], 10)
+    }
+
+    const body = await fixture.client.withMailbox("INBOX", async (mailbox) => {
+      const part = await mailbox.downloadPart({ uid: 7, part: "2", maxBytes: 5 })
+      return readAll(part.content)
+    })
+
+    expect(body.toString("utf8")).toBe("abcd")
+  })
+
+  test("enforces the byte limit while consuming an inaccurately-sized stream", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      transport.downloadResult = download(["ab", "cd"], 3)
+    }
+
+    await expect(
+      fixture.client.withMailbox("INBOX", async (mailbox) => {
+        const part = await mailbox.downloadPart({ uid: 7, part: "2", maxBytes: 3 })
+        await readAll(part.content)
+      })
+    ).rejects.toBeInstanceOf(ImapDownloadTooLargeError)
+  })
+
+  test("destroys an unconsumed part when its mailbox callback ends", async () => {
+    const fixture = clientFixture()
+    const source = Readable.from([Buffer.from("body")])
+    fixture.configure = (transport) => {
+      transport.downloadResult = downloadFromStream(source, 4)
+    }
+    let content: Readable | undefined
+
+    await fixture.client.withMailbox("INBOX", async (mailbox) => {
+      content = (await mailbox.downloadPart({ uid: 7, part: "1", maxBytes: 10 })).content
+    })
+
+    expect(content?.destroyed).toBe(true)
+    expect(source.destroyed).toBe(true)
+  })
+
+  test("makes a mailbox session unusable after its callback", async () => {
+    const fixture = clientFixture()
+    let escaped: ImapMailboxSession | undefined
+
+    await fixture.client.withMailbox("INBOX", async (mailbox) => {
+      escaped = mailbox
+    })
+
+    expect(() => escaped?.state()).toThrow("Mailbox session is no longer active")
+  })
+
+  test("close aborts active transport work, is idempotent, and prevents new operations", async () => {
+    const fixture = clientFixture()
+    let searchStartedResolve: (() => void) | undefined
+    const searchStarted = new Promise<void>((resolve) => {
+      searchStartedResolve = resolve
+    })
+    fixture.configure = (transport) => {
+      transport.blockSearch = true
+      transport.onSearchStart = () => searchStartedResolve?.()
+    }
+
+    const operation = fixture.client.withMailbox("INBOX", (mailbox) =>
+      mailbox.listMessages({ limit: 1 })
+    )
+    await searchStarted
+    await fixture.client.close()
+    await fixture.client.close()
+
+    await expect(operation).rejects.toBeInstanceOf(ImapAbortedError)
+    expect(fixture.transports[0]?.events.filter((event) => event === "close")).toHaveLength(1)
+    await expect(fixture.client.listMailboxes()).rejects.toBeInstanceOf(ImapAbortedError)
+  })
+
+  test("an operation signal aborts only its session and leaves the gateway reusable", async () => {
+    const fixture = clientFixture()
+    const controller = new AbortController()
+    let transportIndex = 0
+    let searchStartedResolve: (() => void) | undefined
+    const searchStarted = new Promise<void>((resolve) => {
+      searchStartedResolve = resolve
+    })
+    fixture.configure = (transport) => {
+      if (transportIndex++ === 0) {
+        transport.blockSearch = true
+        transport.onSearchStart = () => searchStartedResolve?.()
+      } else {
+        transport.mailboxes = [mailboxListResponse()]
+      }
+    }
+
+    const operation = fixture.client.withMailbox(
+      "INBOX",
+      (mailbox) => mailbox.listMessages({ limit: 1 }),
+      { signal: controller.signal }
+    )
+    await searchStarted
+    controller.abort()
+
+    await expect(operation).rejects.toBeInstanceOf(ImapAbortedError)
+    expect(await fixture.client.listMailboxes()).toHaveLength(1)
+  })
+
+  test("the connector lifecycle signal closes the gateway", async () => {
+    const fixture = clientFixture()
+
+    fixture.lifecycle.abort()
+
+    await expect(fixture.client.listMailboxes()).rejects.toBeInstanceOf(ImapAbortedError)
+    expect(fixture.transports).toHaveLength(0)
+  })
+
+  test("redacts the password from connection failures", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      transport.connectError = new Error("server rejected secret-password\r\nLOGIN")
+    }
+
+    let failure: unknown
+    try {
+      await fixture.client.listMailboxes()
+    } catch (error) {
+      failure = error
+    }
+
+    expect(failure).toBeInstanceOf(ImapConnectorError)
+    expect(String(failure)).not.toContain("secret-password")
+    expect(String(failure)).toContain("[redacted]")
+  })
+})
+
+function clientFixture() {
+  const transports: FakeTransport[] = []
+  const options: ImapFlowOptions[] = []
+  const lifecycle = new AbortController()
+  const fixture: {
+    client: ReturnType<typeof createImapClient>
+    transports: FakeTransport[]
+    options: ImapFlowOptions[]
+    lifecycle: AbortController
+    configure?: (transport: FakeTransport) => void
+  } = {
+    client: undefined as never,
+    transports,
+    options,
+    lifecycle,
+  }
+
+  fixture.client = createImapClient(CONNECTION, lifecycle.signal, (flowOptions) => {
+    options.push(flowOptions)
+    const transport = new FakeTransport()
+    fixture.configure?.(transport)
+    transports.push(transport)
+    return transport
+  })
+
+  return fixture
+}
+
+class FakeTransport implements ImapTransport {
+  usable = false
+  mailbox: MailboxObject | false = false
+  readonly events: string[] = []
+  mailboxes: ListResponse[] = []
+  searchResult: number[] | false = []
+  messages: FetchMessageObject[] = []
+  downloadResult: DownloadObject = download([], 0)
+  searchQuery?: SearchObject
+  fetchRange?: string | number[] | SearchObject
+  fetchQuery?: FetchQueryObject
+  downloadRequest?: { uid: number; part: string; options: object }
+  forceReadOnly: boolean | undefined
+  connectError: Error | undefined
+  blockSearch = false
+  onSearchStart: (() => void) | undefined
+  private searchReject: ((error: Error) => void) | undefined
+  private closed = false
+
+  async connect(): Promise<void> {
+    this.events.push("connect")
+    if (this.connectError) {
+      throw this.connectError
+    }
+    this.usable = true
+  }
+
+  async logout(): Promise<void> {
+    this.events.push("logout")
+    this.usable = false
+  }
+
+  close(): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    this.events.push("close")
+    this.usable = false
+    this.searchReject?.(new Error("transport closed"))
+  }
+
+  async list(_options?: ListOptions): Promise<ListResponse[]> {
+    this.events.push("list")
+    return this.mailboxes
+  }
+
+  async getMailboxLock(
+    path: string | string[],
+    options?: { readOnly?: boolean }
+  ): Promise<MailboxLockObject> {
+    const mailboxPath = Array.isArray(path) ? path.join("/") : path
+    const readOnly = this.forceReadOnly ?? options?.readOnly === true
+    this.events.push(`lock:${mailboxPath}:${String(options?.readOnly)}`)
+    this.mailbox = {
+      path: mailboxPath,
+      delimiter: "/",
+      flags: new Set(),
+      uidValidity: 123n,
+      uidNext: 42,
+      exists: 12,
+      readOnly,
+    }
+    return {
+      path: mailboxPath,
+      release: () => this.events.push(`release:${mailboxPath}`),
+    }
+  }
+
+  async search(query: SearchObject, _options?: { uid?: boolean }): Promise<number[] | false> {
+    this.events.push("search")
+    this.searchQuery = query
+    this.onSearchStart?.()
+    if (this.blockSearch) {
+      return new Promise<number[] | false>((_resolve, reject) => {
+        this.searchReject = reject
+      })
+    }
+    return this.searchResult
+  }
+
+  async fetchAll(
+    range: string | number[] | SearchObject,
+    query: FetchQueryObject,
+    _options?: FetchOptions
+  ): Promise<FetchMessageObject[]> {
+    this.events.push("fetchAll")
+    this.fetchRange = range
+    this.fetchQuery = query
+    if (!Array.isArray(range)) {
+      return this.messages
+    }
+    return this.messages.filter((item) => range.includes(item.uid))
+  }
+
+  async download(
+    range: string | number | bigint,
+    part = "",
+    options: { uid?: boolean; maxBytes?: number; chunkSize?: number } = {}
+  ): Promise<DownloadObject> {
+    this.events.push("download")
+    this.downloadRequest = { uid: Number(range), part, options }
+    return this.downloadResult
+  }
+}
+
+function mailboxListResponse(): ListResponse {
+  return {
+    path: "Sent",
+    pathAsListed: "Sent",
+    name: "Sent",
+    delimiter: "/",
+    parent: [],
+    parentPath: "",
+    flags: new Set(["\\HasNoChildren"]),
+    specialUse: "\\Sent",
+    listed: true,
+    subscribed: true,
+    status: {
+      path: "Sent",
+      messages: 12,
+      recent: 1,
+      uidNext: 42,
+      uidValidity: 123n,
+      unseen: 3,
+      highestModseq: 9n,
+    },
+  }
+}
+
+function message(uid: number): FetchMessageObject {
+  return {
+    seq: uid - 10,
+    uid,
+    internalDate: "2026-07-10T08:00:00.000Z",
+    size: 1_024,
+    envelope: {
+      date: new Date("2026-07-10T07:55:00.000Z"),
+      subject: "Project update",
+      messageId: `<message-${uid}@example.com>`,
+      inReplyTo: "<parent@example.com>",
+      from: [{ name: "Client", address: "client@example.com" }],
+      to: [{ name: "BeHome", address: "contact@example.com" }],
+    },
+    headers: Buffer.from(
+      "References: <root@example.com>\r\n\t<parent@example.com> <root@example.com>\r\n"
+    ),
+    bodyStructure: {
+      type: "multipart/mixed",
+      childNodes: [
+        {
+          part: "1",
+          type: "text/plain",
+          parameters: { charset: "utf-8" },
+          size: 100,
+        },
+      ],
+    },
+  }
+}
+
+function download(chunks: readonly string[], expectedSize: number): DownloadObject {
+  return downloadFromStream(Readable.from(chunks.map((chunk) => Buffer.from(chunk))), expectedSize)
+}
+
+function downloadFromStream(content: Readable, expectedSize: number): DownloadObject {
+  return {
+    meta: {
+      expectedSize,
+      contentType: "application/pdf",
+      filename: "document.pdf",
+    },
+    content,
+  }
+}
+
+async function readAll(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  for await (const value of stream) {
+    chunks.push(Buffer.isBuffer(value) ? value : Buffer.from(value))
+  }
+  return Buffer.concat(chunks)
+}

--- a/connectors/imap/tests/imap.test.ts
+++ b/connectors/imap/tests/imap.test.ts
@@ -172,6 +172,7 @@ describe("imap connector", () => {
     expect(messages[0]).toMatchObject({
       internalDate: new Date("2026-07-10T08:00:00.000Z"),
       size: 1_024,
+      headers: {},
       references: ["<root@example.com>", "<parent@example.com>"],
       envelope: {
         subject: "Project update",
@@ -192,6 +193,46 @@ describe("imap connector", () => {
     })
   })
 
+  test("fetches requested headers and preserves repeated unfolded values", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      transport.searchResult = [11]
+      transport.messages = [
+        {
+          ...message(11),
+          headers: Buffer.from(
+            [
+              "References: <root@example.com>",
+              "List-Id: first.example.com",
+              "List-ID: second.example.com",
+              "Auto-Submitted: auto-generated;",
+              "\towner-email=robot@example.com",
+              "",
+            ].join("\r\n")
+          ),
+        },
+      ]
+    }
+
+    const messages = await fixture.client.withMailbox("INBOX", (mailbox) =>
+      mailbox.listMessages({
+        limit: 1,
+        headers: ["List-Id", "list-id", "AUTO-SUBMITTED"],
+      })
+    )
+
+    expect(fixture.transports[0]?.fetchQuery?.headers).toEqual([
+      "references",
+      "list-id",
+      "auto-submitted",
+    ])
+    expect(messages[0]?.headers).toEqual({
+      "list-id": ["first.example.com", "second.example.com"],
+      "auto-submitted": ["auto-generated; owner-email=robot@example.com"],
+    })
+    expect(messages[0]?.references).toEqual(["<root@example.com>"])
+  })
+
   test("validates page inputs before issuing a search", async () => {
     const fixture = clientFixture()
 
@@ -201,6 +242,26 @@ describe("imap connector", () => {
       )
     ).rejects.toThrow("Message page limit must be between 1 and 1000")
     expect(fixture.transports[0]?.searchQuery).toBeUndefined()
+  })
+
+  test("rejects invalid or excessive requested header names before searching", async () => {
+    const fixture = clientFixture()
+
+    await expect(
+      fixture.client.withMailbox("INBOX", (mailbox) =>
+        mailbox.listMessages({ limit: 1, headers: ["List-Id: injected"] })
+      )
+    ).rejects.toThrow("valid RFC 5322 field names")
+    expect(fixture.transports[0]?.searchQuery).toBeUndefined()
+
+    await expect(
+      fixture.client.withMailbox("INBOX", (mailbox) =>
+        mailbox.listMessages({
+          limit: 1,
+          headers: Array.from({ length: 65 }, (_, index) => `X-Test-${index}`),
+        })
+      )
+    ).rejects.toThrow("No more than 64 message headers")
   })
 
   test("streams a MIME part within the byte limit", async () => {

--- a/connectors/imap/tsconfig.build.json
+++ b/connectors/imap/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../packages/core/tsconfig.build.json"
+    }
+  ]
+}

--- a/connectors/imap/tsconfig.json
+++ b/connectors/imap/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -135,6 +135,7 @@ When a system fits a common protocol, use a packaged adapter instead of writing 
 | `@sixb/connector-sql` | `sql(connection)` | `"sql"` | Bun `SQL` (Postgres, MySQL, SQLite) |
 | `@sixb/connector-rest` | `rest(options)` | `"rest"` | `RestClient` (`request`/`get`/`post`) |
 | `@sixb/connector-sftp` | `sftp(connection)` | `"sftp"` | `SftpClient` (`list`/`read`/`write`/…) |
+| `@sixb/connector-imap` | `imap(connection)` | `"imap"` | Read-only `ImapClient` (mailboxes/messages/MIME parts) |
 
 If the ERP were a real Postgres database, the connector would be one line:
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -23,6 +23,9 @@
       "path": "connectors/google/tsconfig.build.json"
     },
     {
+      "path": "connectors/imap/tsconfig.build.json"
+    },
+    {
       "path": "connectors/meta/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
       "@sixb/client/query": ["./packages/client/src/query.ts"],
       "@sixb/connector-companycam": ["./connectors/companycam/src/index.ts"],
       "@sixb/connector-github": ["./connectors/github/src/index.ts"],
+      "@sixb/connector-imap": ["./connectors/imap/src/index.ts"],
       "@sixb/connector-meta": ["./connectors/meta/src/index.ts"],
       "@sixb/connector-rest": ["./connectors/rest/src/index.ts"],
       "@sixb/connector-sftp": ["./connectors/sftp/src/index.ts"],


### PR DESCRIPTION
## What

Adds `@sixb/connector-imap`, a generic read-only IMAP connector based on ImapFlow.

```text
Sixb → TLS session → EXAMINE mailbox → fetch/stream → logout
```

Each operation uses a short-lived connection to avoid stale sockets.

## API

```ts
await client.withMailbox("INBOX", async (mailbox) => {
  const messages = await mailbox.listMessages({
    afterUid,
    limit: 100,
    headers: ["auto-submitted", "list-id"],
  })

  const part = await mailbox.downloadPart({
    uid: messages[0].uid,
    part: "1",
    maxBytes: 25 * 1024 * 1024,
  })
})
```

Supports:

- UID/UIDVALIDITY incremental reads
- mailbox discovery and special-use flags
- envelope, threading headers and MIME structure
- optional custom headers
- bounded attachment streaming
- AbortSignal and reliable cleanup
- TLS and strict read-only access

## Safety

- No write or flag mutation methods
- Mailboxes opened with IMAP `EXAMINE`
- Downloads use `BODY.PEEK`
- Passwords redacted from errors
- No persistent IMAP socket

## Validation

- 19 connector tests passing
- lint, typecheck, build and publish checks passing
- live Infomaniak smoke test validated authentication, folder discovery and read-only metadata access

Full suite: `2377 pass`, `2 skip`, `1` pre-existing unrelated `agent-worker` image-fixture failure.