### PR TITLE
auth: add controlled application invites

### DIFF
--- a/auth/magic-link/tests/magic-link.test.ts
+++ b/auth/magic-link/tests/magic-link.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import { type CompleteAuthSessionInput, InMemoryAuthStorage } from "@sixb/core"
+import {
+  type AuthSessionAudience,
+  type CompleteAuthSessionInput,
+  InMemoryAuthStorage,
+} from "@sixb/core"
 import { magicLink, type SendMagicLinkInput } from "../src"
 import { hashMagicLinkToken } from "../src/tokens"
 
@@ -47,7 +51,7 @@ async function requestMagicLink(input: {
   readonly storage: InMemoryAuthStorage
   readonly strategy: ReturnType<typeof magicLink>
   readonly email: string
-  readonly audience?: string
+  readonly audience?: AuthSessionAudience
   readonly requesterHash?: string
   readonly now?: Date
 }) {
@@ -569,7 +573,7 @@ describe("magicLink", () => {
       email: "ava@acme.com",
     })
 
-    for (const audience of ["atlas", "app"]) {
+    for (const audience of ["atlas", "app"] as const) {
       await expect(
         requestMagicLink({
           storage,

--- a/auth/oidc/src/strategy.ts
+++ b/auth/oidc/src/strategy.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto"
 import type {
+  AuthSessionAudience,
   AuthStorage,
   GroupDefinition,
   InvitationDeliveryInput,
@@ -294,7 +295,7 @@ class OidcAuthStrategyImpl implements OidcAuthStrategy {
   }
 
   private createSignInUrl(input: {
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly requestOrigin: string
     readonly returnTo: string
   }): string {

--- a/auth/oidc/tests/oidc.test.ts
+++ b/auth/oidc/tests/oidc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { InMemoryAuthStorage } from "@sixb/core"
+import { type CompleteAuthSessionInput, InMemoryAuthStorage } from "@sixb/core"
 import { OidcAuthError, type OidcClientAdapter, type OidcTokenResponse, oidc } from "../src"
 
 const projectId = "project-a"
@@ -65,7 +65,7 @@ class FakeOidcClient implements OidcClientAdapter {
   }
 }
 
-function sessionInput(id = "ses_1") {
+function sessionInput(id = "ses_1"): CompleteAuthSessionInput {
   return {
     id,
     audience: "atlas",

--- a/bun.lock
+++ b/bun.lock
@@ -238,14 +238,22 @@
     "examples/auth": {
       "name": "@sixb/example-auth",
       "dependencies": {
+        "@sixb/app": "workspace:*",
         "@sixb/auth-magic-link": "workspace:*",
         "@sixb/auth-oidc": "workspace:*",
+        "@sixb/client": "workspace:*",
         "@sixb/core": "workspace:*",
         "@sixb/sqlite": "workspace:*",
+        "@tanstack/react-query": "^5.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.13.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^22.15.30",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
       },
     },
     "examples/panasonic-ac": {
@@ -361,6 +369,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@sixb/agent-ui": "workspace:*",
+        "@sixb/core": "workspace:*",
         "@sixb/ui": "workspace:*",
         "@tailwindcss/cli": "^4.2.2",
         "tailwindcss": "^4.1.18",

--- a/docs/auth/authentication.md
+++ b/docs/auth/authentication.md
@@ -180,6 +180,13 @@ const { invitation, delivery } = await sixb.auth.invite(request, {
 `expiresAt`, and `returnTo`. The companion methods are `listInvitations`, `revokeInvitation`, and
 `getInvitationOptions`.
 
+In Atlas, the invite form also offers every browser application configured on the API. Selecting
+**Custom app** sends a link with the `app` session audience and returns the recipient to the custom
+app origin; selecting **Atlas** uses the `atlas` audience. The HTTP API accepts this as
+`destinationId: "app" | "atlas"` and resolves the URL server-side, so callers cannot turn
+invitations into arbitrary redirects. If an application has access grants configured, the
+selected invitation groups must grant that destination.
+
 For existing users, the runtime exposes the same policy boundary through member-management methods:
 
 ```ts
@@ -237,13 +244,13 @@ When you serve the runtime, these endpoints are registered for you:
 | `GET /auth/sign-in` | Sign-in form (magic link) or redirect to the provider (OIDC) |
 | `POST /auth/sign-in` | Request a magic link, or start the OIDC flow |
 | `GET /auth/callback` | Complete the link or provider redirect and start a session |
-| `GET /api/auth/session` | Current session and CSRF token, or `{ authenticated: false }` |
+| `GET /api/auth/session` | Current session, application-access decision, and CSRF token, or `{ authenticated: false }` |
 | `POST /api/auth/sign-out` | End the current session |
 | `POST /api/auth/sign-out-all` | End every session for the current user |
 | `GET /api/auth/invitations` | List invitations |
 | `POST /api/auth/invitations` | Create an invitation |
 | `POST /api/auth/invitations/:invitationId/revoke` | Revoke an invitation |
-| `GET /api/auth/invitation-options` | Groups and capabilities for the invite form |
+| `GET /api/auth/invitation-options` | Groups, destinations, and capabilities for the invite form |
 | `GET /api/auth/membership-options` | Groups and capabilities for member management |
 | `GET /api/auth/members` | List visible members with per-member capabilities |
 | `PATCH /api/auth/members/:userId/groups` | Replace a member's groups |

--- a/docs/auth/authorization.md
+++ b/docs/auth/authorization.md
@@ -11,7 +11,7 @@ may do. Sixb builds it from four small layers:
 | --- | --- |
 | **Groups** | Named buckets that principals belong to |
 | **Roles** | Bundles of grants attached to groups |
-| **Grants** | The capabilities a role gives — view, apply, run |
+| **Grants** | The capabilities a role gives — access, view, apply, run |
 | **Membership policies** | Who can administer membership for which groups |
 
 At request time these resolve into one set of grants per principal, and a scoped runtime enforces
@@ -48,7 +48,7 @@ group receives the role's grants.
 
 ```ts
 // security/roles/billing-access.ts
-import { can, defineRole } from "@sixb/core"
+import { applications, can, defineRole } from "@sixb/core"
 import { sendReminder } from "../../actions/sendReminder"
 import { Customer } from "../../ontology/customer"
 import { Invoice } from "../../ontology/invoice"
@@ -56,7 +56,11 @@ import { teamMembers } from "../groups/team-members"
 
 export const teamMemberBillingAccess = defineRole("team-member.billing-access", {
   grantedTo: [teamMembers],
-  grants: [can.view([Customer, Invoice]), can.apply(sendReminder)],
+  grants: [
+    can.access(applications.app),
+    can.view([Customer, Invoice]),
+    can.apply(sendReminder),
+  ],
 })
 ```
 
@@ -68,6 +72,7 @@ Every member of `team-members` can now view `Customer` and `Invoice` objects and
 | `defineRole("team-member.billing-access")` | Names the role |
 | `grantedTo: [teamMembers]` | Groups whose members receive the role |
 | `grants: [...]` | The capabilities the role gives |
+| `can.access(applications.app)` | Allow access to the custom app |
 | `can.view([Customer, Invoice])` | Allow viewing those object types |
 | `can.apply(sendReminder)` | Allow applying the `sendReminder` action |
 
@@ -76,12 +81,13 @@ are the union of every role whose `grantedTo` group it belongs to.
 
 ## Grants
 
-A grant pairs a capability with the definitions it covers. Three capability builders —
-`can.view`, `can.apply`, and `can.run` — resolve to **seven grant kinds**, one per protected target
-family.
+A grant pairs a capability with the definitions it covers. Four capability builders —
+`can.access`, `can.view`, `can.apply`, and `can.run` — resolve to **eight grant kinds**, one per
+protected target family.
 
 | Grant kind | Builder | Allows | Targets |
 | --- | --- | --- | --- |
+| `access:application` | `can.access(...)` | Open a grant-controlled browser application | `applications.atlas`, `applications.app` |
 | `view:object` | `can.view(...)` | Read objects: `get`, `list`, `query`, telemetry, related events | [Object types](../ontology/object-types.md) |
 | `view:dataset` | `can.view(...)` | Read datasets and their versions | [Datasets](../data/datasets.md) |
 | `apply:action` | `can.apply(...)` | Request actions | [Actions](../actions/overview.md) |
@@ -90,6 +96,7 @@ family.
 | `run:pipeline` | `can.run(...)` | Run pipelines | [Pipelines](../data/pipelines.md) |
 | `run:agent` | `can.run(...)` | Run agents and read their threads | [Agents](../agents/overview.md) |
 
+`can.access` accepts the built-in `applications.atlas` and `applications.app` definitions.
 `can.view` resolves to `view:object` or `view:dataset` from the definition you pass; `can.run`
 picks between `run:workflow`, `run:sync`, `run:pipeline`, and `run:agent` the same way. Each is
 type-checked, so mixing target families in one call does not compile. `can.view(Type)` also covers
@@ -101,6 +108,7 @@ Each builder takes one definition, a list, or a breadth selector.
 
 | Want | Write |
 | --- | --- |
+| One application | `can.access(applications.atlas)` |
 | One definition | `can.view(Invoice)` |
 | Several definitions | `can.view([Customer, Invoice])` |
 | Every object type | `can.view(ontology.objects())` |
@@ -141,6 +149,31 @@ export const financeAdminFullAccess = defineRole("finance-admin.full-access", {
 // Grant every object type except Customer
 can.view(ontology.objects().except([Customer]))
 ```
+
+## Application access
+
+Application grants control whether a signed-in principal may open Atlas or the custom app. They are
+opt-in per application for compatibility: when no role grants an application, every authenticated
+user may open it. Once any role grants that application, it becomes an allowlist and principals
+without the grant receive an access-denied page before application data loads.
+
+```ts
+import { applications, can, defineRole } from "@sixb/core"
+
+export const securityAdminAtlasAccess = defineRole("security-admin.atlas-access", {
+  grantedTo: [securityAdmins],
+  grants: [can.access(applications.atlas)],
+})
+
+export const customerAppAccess = defineRole("customer.app-access", {
+  grantedTo: [customers],
+  grants: [can.access(applications.app)],
+})
+```
+
+Application access complements resource grants rather than replacing them. For example, a user may
+be allowed into the custom app but still see only the object types granted to their groups. Atlas
+and the custom app enforce application grants at the session, HTTP, and WebSocket boundaries.
 
 ## Membership policies
 

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -3,7 +3,7 @@
 Auth in Sixb is two independent layers. Reach for it whenever more than one person touches your runtime.
 
 - **Authentication** answers **who** a principal is — identity, login strategies, and sessions.
-- **Authorization** answers **what** that principal may do — grants on objects, datasets, actions, workflows, syncs, and pipelines, defined against groups and roles.
+- **Authorization** answers **what** that principal may do — application access and grants on objects, datasets, actions, workflows, syncs, and pipelines, defined against groups and roles.
 
 A request first resolves an identity (authentication), then resolves that identity's group memberships into a set of grants (authorization). The layers never overlap: being signed in says nothing about what you can reach, and a grant means nothing until a principal is attached to it.
 
@@ -19,7 +19,7 @@ A request first resolves an identity (authentication), then resolves that identi
 You configure authentication through the `auth` option on `createSixb()`, and authorization through `defineGroup`, `defineRole`, and `defineMembershipPolicy`.
 
 ```ts
-import { createSixb, can, defineGroup, defineRole } from "@sixb/core"
+import { applications, createSixb, can, defineGroup, defineRole } from "@sixb/core"
 import { magicLink } from "@sixb/auth-magic-link"
 import { Customer } from "./ontology/customer"
 import { Invoice } from "./ontology/invoice"
@@ -31,7 +31,12 @@ export const financeAdmins = defineGroup("finance-admins", { label: "Finance adm
 // WHAT: a role attaches grants to one or more groups.
 export const financeAccess = defineRole("finance-admin.access", {
   grantedTo: [financeAdmins],
-  grants: [can.view(Customer), can.view(Invoice), can.apply([markPaid, sendReminder])],
+  grants: [
+    can.access(applications.atlas),
+    can.view(Customer),
+    can.view(Invoice),
+    can.apply([markPaid, sendReminder]),
+  ],
 })
 
 export const sixb = await createSixb({

--- a/docs/server/overview.md
+++ b/docs/server/overview.md
@@ -33,8 +33,8 @@ const server = createSixbServer({
   browser: {
     publicOrigin: "https://api.acme.example",
     allowedOrigins: [
-      { origin: "https://atlas.acme.example", audience: "atlas", kind: "atlas" },
-      { origin: "https://app.acme.example", audience: "app", kind: "app" },
+      { origin: "https://atlas.acme.example", audience: "atlas" },
+      { origin: "https://app.acme.example", audience: "app" },
     ],
   },
 })
@@ -56,7 +56,7 @@ await server.stop()
 | `host`    | `string`               | `"0.0.0.0"` | Bind host.                                                      |
 | `quiet`   | `boolean`              | `false`     | Suppress startup logging.                                       |
 
-The `browser` policy is load-bearing for security: it drives CORS, rejects disallowed `Origin` headers up front, and resolves the public origin used to mint auth redirects. Each `allowedOrigins` entry maps a front-end origin to its auth `audience` (`atlas` or `app`); list every browser front-end you serve.
+The `browser` policy is load-bearing for security: it drives CORS, rejects disallowed `Origin` headers up front, and resolves the public origin used to mint auth redirects. Each `allowedOrigins` entry maps one front-end origin to its auth `audience` (`atlas` or `app`), and each audience can have only one origin. Configured audiences become invitation destinations and application-access boundaries.
 
 ## Route groups
 

--- a/docs/testing/overview.md
+++ b/docs/testing/overview.md
@@ -217,10 +217,10 @@ await expect(
 expect(await anonymous.list({})).toEqual({ objects: [], hasMore: false, total: 0 })
 ```
 
-There are seven grant kinds, each gated by its own scoped method: `view:object`
-(`list`/`getObject`), `view:dataset` (`listDatasets`), `apply:action`
-(`requestAction`), `run:workflow` (`runWorkflow`), `run:sync`, `run:pipeline`,
-and `run:agent`. See [authorization](../auth/authorization.md) for how roles,
+There are eight grant kinds. `access:application` gates browser applications at the server
+boundary. The scoped runtime gates `view:object` (`list`/`getObject`), `view:dataset`
+(`listDatasets`), `apply:action` (`requestAction`), `run:workflow` (`runWorkflow`), `run:sync`,
+`run:pipeline`, and `run:agent`. See [authorization](../auth/authorization.md) for how roles,
 grants, groups, and membership policies resolve; the full pattern lives in
 `examples/auth/tests/atlas-authorization.test.ts`.
 
@@ -254,7 +254,7 @@ beforeAll(async () => {
     quiet: true,
     browser: {
       publicOrigin: baseUrl,
-      allowedOrigins: [{ origin: baseUrl, audience: "atlas", kind: "atlas" }],
+      allowedOrigins: [{ origin: baseUrl, audience: "atlas" }],
     },
   })
   await server.start()

--- a/examples/acme-corp/tests/client-query.test.ts
+++ b/examples/acme-corp/tests/client-query.test.ts
@@ -201,7 +201,7 @@ beforeAll(async () => {
     quiet: true,
     browser: {
       publicOrigin: baseUrl,
-      allowedOrigins: [{ origin: baseUrl, audience: "atlas", kind: "atlas" }],
+      allowedOrigins: [{ origin: baseUrl, audience: "atlas" }],
     },
   })
   await server.start()

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -1,7 +1,8 @@
 # Auth example
 
-A tiny Sixb app for testing authentication. Auth state (users, sessions,
-groups) persists to a local SQLite database in `.sixb/`, so you stay signed in
+A tiny Sixb project for testing authentication, invitations, and application grants. It serves
+Atlas at `http://localhost:3000` and a small custom app at `http://localhost:3001`. Auth state
+(users, sessions, groups) persists to a local SQLite database in `.sixb/`, so you stay signed in
 across restarts. Pick the strategy with `SIXB_AUTH_MODE` (defaults to
 `magic-link`). Delete `.sixb/` to start fresh.
 
@@ -37,32 +38,29 @@ whole flow, not just sign-in:
   `security-admins`.
 - **Membership policy** — security admins can invite, assign groups, suspend,
   and reactivate members in `security-admins` and `team-members`
-  (`security/policies/default-membership.ts`). Group-less invitations are also
-  allowed; those users can sign in but receive no group-derived grants until an
-  admin assigns a group.
-- **Roles** — `team-members` can view `Note`, view the team-notes dataset,
+  (`security/policies/default-membership.ts`).
+- **Application access** — `team-members` can open the custom app but not Atlas.
+  `security-admins` can open both applications.
+- **Resource grants** — `team-members` can view `Note`, view the team-notes dataset,
   and apply `acknowledge-note`. `security-admins` use wildcard grants: view all
   objects, view all datasets, apply all actions, run all workflows, and view events
   (`security/roles/atlas-access.ts`).
 - **Seed data** — startup writes one `Note`, one `AdminNote`, and one
   `AccessRequest` (`seed.ts`).
 
-Try this in Atlas:
+Try the complete flow:
 
-1. Sign in as `admin@example.com`.
-2. Go to **Settings → Members**, click **Invite member**, and invite a teammate
-   into `team-members` (or invite with no groups to test default-deny access).
-3. Open the sign-in link for the teammate — printed to the terminal, or emailed
-   if Resend is configured.
-4. Return as the admin and go to **Settings → Members**. You can edit the
-   teammate's groups, suspend them, and reactivate them. Suspending revokes
-   active sessions immediately; reactivation does not restore old sessions.
+1. Sign in to Atlas at `http://localhost:3000` as `admin@example.com`.
+2. Go to **Settings → Members** and invite a teammate into `team-members`, choosing
+   **Custom app** as the destination.
+3. Open the sign-in link for the teammate. It should create an `app` session and land at
+   `http://localhost:3001`, where the page shows the teammate, their groups, and granted notes.
+4. Try signing that teammate into Atlas. Atlas should show the application access-denied page.
+5. Return as the admin to edit the teammate's groups, suspend them, or reactivate them.
+   Suspending revokes active sessions immediately; reactivation does not restore old sessions.
 
-In Atlas, a `team-members` user should only see `Note` objects, the
-`auth.team_notes` dataset, and the `acknowledge-note` action. A group-less user
-should see no domain resources. Requests for `AdminNote`, `AccessRequest`,
-admin-only datasets, admin actions, workflows, and events are denied by the
-scoped SDK that backs the server routes.
+The custom app is intentionally small: it proves the selected invitation destination, audience
+cookie, application grant, group membership, and scoped `Note` read in one screen.
 
 ## Use OIDC instead (Google Workspace)
 

--- a/examples/auth/app/globals.css
+++ b/examples/auth/app/globals.css
@@ -1,0 +1,238 @@
+:root {
+  color-scheme: light dark;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f6f7f8;
+  color: #17191c;
+}
+
+body {
+  margin: 0;
+  background: #f6f7f8;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+.auth-app-shell {
+  width: min(960px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 72px 0 48px;
+}
+
+.auth-app-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 28px;
+}
+
+.auth-app-header h1 {
+  margin: 6px 0 0;
+  font-size: clamp(2rem, 6vw, 3.5rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.auth-app-eyebrow,
+.auth-app-label {
+  margin: 0;
+  color: #6d737c;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.auth-app-lede {
+  max-width: 620px;
+  margin: 16px 0 0;
+  color: #626871;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.auth-app-status {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid #d8dce1;
+  border-radius: 999px;
+  background: #fff;
+  padding: 8px 12px;
+  color: #555b64;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.auth-app-status > span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22a06b;
+  box-shadow: 0 0 0 4px rgb(34 160 107 / 12%);
+}
+
+.auth-app-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: 16px;
+}
+
+.auth-app-card {
+  min-width: 0;
+  border: 1px solid #dfe2e6;
+  border-radius: 16px;
+  background: #fff;
+  padding: 24px;
+  box-shadow: 0 1px 2px rgb(17 24 39 / 4%);
+}
+
+.auth-app-card h2 {
+  margin: 8px 0 0;
+  overflow-wrap: anywhere;
+  font-size: 1.15rem;
+}
+
+.auth-app-muted {
+  margin: 7px 0 0;
+  color: #747a83;
+  font-size: 0.88rem;
+}
+
+.auth-app-error {
+  color: #b42318;
+  font-size: 0.88rem;
+}
+
+.auth-app-groups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 24px;
+}
+
+.auth-app-groups span {
+  border-radius: 7px;
+  background: #f0f1f3;
+  padding: 5px 8px;
+  color: #555b64;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.auth-app-card-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.auth-app-card-heading > strong {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border-radius: 10px;
+  background: #17191c;
+  color: #fff;
+}
+
+.auth-app-notes {
+  display: grid;
+  gap: 0;
+  margin: 20px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.auth-app-notes li {
+  border-top: 1px solid #eceef0;
+  padding: 14px 0;
+}
+
+.auth-app-notes li:last-child {
+  padding-bottom: 0;
+}
+
+.auth-app-notes p {
+  margin: 5px 0 0;
+  color: #747a83;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.auth-app-help {
+  margin: 22px 0 0;
+  color: #747a83;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.auth-app-help strong {
+  color: #33373d;
+}
+
+@media (max-width: 700px) {
+  .auth-app-shell {
+    padding-top: 40px;
+  }
+
+  .auth-app-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .auth-app-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root,
+  body {
+    background: #111315;
+    color: #f4f5f6;
+  }
+
+  .auth-app-lede,
+  .auth-app-muted,
+  .auth-app-help,
+  .auth-app-notes p,
+  .auth-app-eyebrow,
+  .auth-app-label {
+    color: #9ca2ab;
+  }
+
+  .auth-app-card,
+  .auth-app-status {
+    border-color: #30343a;
+    background: #1b1e22;
+  }
+
+  .auth-app-status,
+  .auth-app-groups span {
+    color: #c9cdd2;
+  }
+
+  .auth-app-groups span {
+    background: #292d32;
+  }
+
+  .auth-app-card-heading > strong {
+    background: #f4f5f6;
+    color: #17191c;
+  }
+
+  .auth-app-notes li {
+    border-color: #30343a;
+  }
+
+  .auth-app-help strong {
+    color: #e2e4e7;
+  }
+}

--- a/examples/auth/app/page.tsx
+++ b/examples/auth/app/page.tsx
@@ -1,0 +1,85 @@
+import { getAuthSessionOptions, listObjectsOptions } from "@sixb/client/hooks"
+import { useQuery } from "@tanstack/react-query"
+
+const notesQueryOptions = listObjectsOptions({
+  query: { objectTypeId: "note", order: "asc", limit: "20" },
+})
+
+function text(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value : fallback
+}
+
+export default function AuthExampleApp() {
+  const sessionQuery = useQuery(getAuthSessionOptions())
+  const notesQuery = useQuery(notesQueryOptions)
+  const session = sessionQuery.data?.authenticated ? sessionQuery.data : null
+  const notes = notesQuery.data ?? []
+
+  return (
+    <main className="auth-app-shell">
+      <header className="auth-app-header">
+        <div>
+          <p className="auth-app-eyebrow">Sixb auth example</p>
+          <h1>Custom app</h1>
+          <p className="auth-app-lede">
+            This page uses the app audience, so it is a simple target for testing direct invitations
+            and application grants.
+          </p>
+        </div>
+        <span className="auth-app-status">
+          <span /> App session active
+        </span>
+      </header>
+
+      <section className="auth-app-grid">
+        <article className="auth-app-card">
+          <p className="auth-app-label">Signed in as</p>
+          <h2>{session?.user.displayName ?? session?.user.email ?? "Loading…"}</h2>
+          {session?.user.displayName ? (
+            <p className="auth-app-muted">{session.user.email}</p>
+          ) : null}
+
+          <div className="auth-app-groups">
+            {session?.user.groupIds.length ? (
+              session.user.groupIds.map((groupId) => <span key={groupId}>{groupId}</span>)
+            ) : (
+              <span>No groups</span>
+            )}
+          </div>
+        </article>
+
+        <article className="auth-app-card">
+          <div className="auth-app-card-heading">
+            <div>
+              <p className="auth-app-label">Granted data</p>
+              <h2>Notes</h2>
+            </div>
+            <strong>{notes.length}</strong>
+          </div>
+
+          {notesQuery.isLoading ? (
+            <p className="auth-app-muted">Loading notes…</p>
+          ) : notesQuery.isError ? (
+            <p className="auth-app-error">Notes are not available to this account.</p>
+          ) : notes.length === 0 ? (
+            <p className="auth-app-muted">No notes yet.</p>
+          ) : (
+            <ul className="auth-app-notes">
+              {notes.map((note) => (
+                <li key={note.id}>
+                  <strong>{text(note.properties.title, note.id)}</strong>
+                  <p>{text(note.properties.body, "No body")}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+      </section>
+
+      <p className="auth-app-help">
+        In Atlas, invite a member to <strong>Custom app</strong> and assign the
+        <strong> team-members</strong> group. The invitation should return here with an app session.
+      </p>
+    </main>
+  )
+}

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -9,13 +9,21 @@
     "typecheck": "bun ../../packages/cli/src/index.tsx typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@sixb/app": "workspace:*",
     "@sixb/auth-magic-link": "workspace:*",
     "@sixb/auth-oidc": "workspace:*",
+    "@sixb/client": "workspace:*",
     "@sixb/core": "workspace:*",
-    "@sixb/sqlite": "workspace:*"
+    "@sixb/sqlite": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/node": "^22.15.30"
+    "@types/node": "^22.15.30",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   }
 }

--- a/examples/auth/security/roles/atlas-access.ts
+++ b/examples/auth/security/roles/atlas-access.ts
@@ -1,4 +1,4 @@
-import { actions, can, datasets, defineRole, ontology, workflows } from "@sixb/core"
+import { actions, applications, can, datasets, defineRole, ontology, workflows } from "@sixb/core"
 import { acknowledgeNote } from "../../actions/acknowledge-note"
 import { teamNotesDataset } from "../../datasets/auth-data"
 import { Note } from "../../ontology/note"
@@ -7,12 +7,18 @@ import { teamMembers } from "../groups/team-members"
 
 export const teamMemberAtlasAccess = defineRole("team-member.atlas-access", {
   grantedTo: [teamMembers],
-  grants: [can.view(Note), can.view(teamNotesDataset), can.apply(acknowledgeNote)],
+  grants: [
+    can.access(applications.app),
+    can.view(Note),
+    can.view(teamNotesDataset),
+    can.apply(acknowledgeNote),
+  ],
 })
 
 export const securityAdminFullAccess = defineRole("security-admin.full-access", {
   grantedTo: [securityAdmins],
   grants: [
+    can.access([applications.atlas, applications.app]),
     can.view(ontology.objects()),
     can.view(datasets()),
     can.apply(actions()),

--- a/examples/auth/tests/atlas-authorization.test.ts
+++ b/examples/auth/tests/atlas-authorization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { resolve } from "node:path"
 import {
+  canAccessApplication,
   canPerformMembershipOperation,
   createSixb,
   InMemoryBlobStorage,
@@ -46,9 +47,20 @@ describe("auth example Atlas authorization", () => {
     const sixb = await createAuthExampleRuntime()
     await seedAuthExampleObjects(sixb)
 
-    const teamMember = sixb.as(atlasContext(sixb, ["team-members"]))
-    const admin = sixb.as(atlasContext(sixb, ["security-admins"]))
-    const noGroups = sixb.as(atlasContext(sixb, []))
+    const roles = sixb.security.getResolvedRoles()
+    const teamMemberContext = atlasContext(sixb, ["team-members"])
+    const adminContext = atlasContext(sixb, ["security-admins"])
+    const noGroupsContext = atlasContext(sixb, [])
+    const teamMember = sixb.as(teamMemberContext)
+    const admin = sixb.as(adminContext)
+    const noGroups = sixb.as(noGroupsContext)
+
+    expect(canAccessApplication(teamMemberContext, roles, "app")).toBe(true)
+    expect(canAccessApplication(teamMemberContext, roles, "atlas")).toBe(false)
+    expect(canAccessApplication(adminContext, roles, "app")).toBe(true)
+    expect(canAccessApplication(adminContext, roles, "atlas")).toBe(true)
+    expect(canAccessApplication(noGroupsContext, roles, "app")).toBe(false)
+    expect(canAccessApplication(noGroupsContext, roles, "atlas")).toBe(false)
 
     expect((await teamMember.list({})).objects.map((object) => object.objectTypeId)).toEqual([
       "note",

--- a/examples/auth/tsconfig.json
+++ b/examples/auth/tsconfig.json
@@ -1,9 +1,17 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "types": ["bun", "node"],
     "incremental": true,
     "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
   },
-  "include": ["ontology/**/*.ts", "security/**/*.ts", "sixb.config.ts", ".sixb/types/**/*.d.ts"]
+  "include": [
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "ontology/**/*.ts",
+    "security/**/*.ts",
+    "sixb.config.ts",
+    ".sixb/types/**/*.d.ts"
+  ]
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@sixb/agent-ui": "workspace:*",
+    "@sixb/core": "workspace:*",
     "@sixb/ui": "workspace:*",
     "@tailwindcss/cli": "^4.2.2",
     "tailwindcss": "^4.1.18"

--- a/packages/app/src/codegen.ts
+++ b/packages/app/src/codegen.ts
@@ -1,5 +1,6 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, relative, resolve } from "node:path"
+import type { AuthSessionAudience } from "@sixb/core"
 import { renderCustomAppRuntimeScript } from "./runtime"
 import type { PageRoute } from "./scanner"
 
@@ -76,7 +77,7 @@ export async function generateAppEntry(
   generatedDir: string,
   options: {
     apiBaseUrl?: string
-    audience?: string
+    audience?: AuthSessionAudience
     authEnabled?: boolean
     appDir?: string
     /**
@@ -127,6 +128,7 @@ export async function generateAppEntry(
   // Generate main.tsx
   const mainContent = `import React from "react"
 import { createRoot } from "react-dom/client"
+import { signOut } from "@sixb/client"
 import { BrowserRouter, Routes, Route, matchPath, useNavigate, useLocation } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import {
@@ -145,7 +147,11 @@ const browserClient = configureSixbBrowserClient(runtimeConfig)
 const authSession = runtimeConfig.auth.enabled
   ? await requireSixbBrowserAuthSession(runtimeConfig, browserClient)
   : null
-const canRenderApp = !runtimeConfig.auth.enabled || authSession?.authenticated === true
+const applicationAccessDenied =
+  authSession?.authenticated === true && !authSession.applicationAccess.allowed
+const canRenderApp =
+  !runtimeConfig.auth.enabled ||
+  (authSession?.authenticated === true && authSession.applicationAccess.allowed)
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -258,10 +264,12 @@ function AppFallback({
   title,
   detail,
   showReload = true,
+  action,
 }: {
   title: string
   detail: string
   showReload?: boolean
+  action?: React.ReactNode
 }) {
   return (
     <div
@@ -286,36 +294,79 @@ function AppFallback({
         {detail}
       </p>
       <div style={{ display: "flex", gap: "0.75rem" }}>
-        <a
-          href="/"
+        {action ?? (
+          <>
+            <a
+              href="/"
+              style={{
+                padding: "0.5rem 1rem",
+                borderRadius: "var(--radius, 0.5rem)",
+                background: "var(--primary, #1f2933)",
+                color: "var(--primary-foreground, #ffffff)",
+                textDecoration: "none",
+              }}
+            >
+              Go home
+            </a>
+            {showReload ? (
+              <button
+                type="button"
+                onClick={() => window.location.reload()}
+                style={{
+                  padding: "0.5rem 1rem",
+                  borderRadius: "var(--radius, 0.5rem)",
+                  border: "1px solid var(--border, #cbd2d9)",
+                  background: "transparent",
+                  color: "inherit",
+                  cursor: "pointer",
+                }}
+              >
+                Reload
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function AccessDeniedView() {
+  const [isSigningOut, setIsSigningOut] = React.useState(false)
+
+  async function handleSignOut() {
+    setIsSigningOut(true)
+    try {
+      await signOut({ throwOnError: true })
+      window.location.reload()
+    } catch {
+      setIsSigningOut(false)
+    }
+  }
+
+  return (
+    <AppFallback
+      title="Access required"
+      detail="Your account is signed in, but it does not have permission to access this app."
+      showReload={false}
+      action={
+        <button
+          type="button"
+          disabled={isSigningOut}
+          onClick={handleSignOut}
           style={{
             padding: "0.5rem 1rem",
             borderRadius: "var(--radius, 0.5rem)",
-            background: "var(--primary, #1f2933)",
-            color: "var(--primary-foreground, #ffffff)",
-            textDecoration: "none",
+            border: "1px solid var(--border, #cbd2d9)",
+            background: "transparent",
+            color: "inherit",
+            cursor: isSigningOut ? "default" : "pointer",
           }}
         >
-          Go home
-        </a>
-        {showReload ? (
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            style={{
-              padding: "0.5rem 1rem",
-              borderRadius: "var(--radius, 0.5rem)",
-              border: "1px solid var(--border, #cbd2d9)",
-              background: "transparent",
-              color: "inherit",
-              cursor: "pointer",
-            }}
-          >
-            Reload
-          </button>
-        ) : null}
-      </div>
-    </div>
+          {isSigningOut ? "Signing out…" : "Sign out"}
+        </button>
+      }
+    />
   )
 }
 
@@ -408,6 +459,8 @@ function App() {
 
 if (canRenderApp) {
   createRoot(document.getElementById("root")!).render(<App />)
+} else if (applicationAccessDenied) {
+  createRoot(document.getElementById("root")!).render(<AccessDeniedView />)
 }
 `
 

--- a/packages/app/src/createCustomApp.ts
+++ b/packages/app/src/createCustomApp.ts
@@ -2,6 +2,7 @@ import { watch } from "node:fs"
 import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, join, normalize, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
+import type { AuthSessionAudience } from "@sixb/core"
 import { type BuildAppResult, buildApp } from "./build"
 import { type BuiltInRouteManifestEntry, generateAppEntry, generateRouteManifest } from "./codegen"
 import { renderCustomAppRuntimeScript } from "./runtime"
@@ -15,7 +16,7 @@ export interface CreateCustomAppOptions {
   generatedDir?: string
   publicDir?: string
   apiBaseUrl?: string
-  audience?: string
+  audience?: AuthSessionAudience
   authEnabled?: boolean
   agentRoutes?: boolean
 }
@@ -34,7 +35,7 @@ export interface CustomAppStartOptions {
   port?: number
   outdir?: string
   apiBaseUrl?: string
-  audience?: string
+  audience?: AuthSessionAudience
   authEnabled?: boolean
 }
 
@@ -570,7 +571,7 @@ function injectRuntimeConfig(
   html: string,
   config: {
     readonly apiBaseUrl?: string
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly authEnabled: boolean
   }
 ): string {

--- a/packages/app/src/runtime.ts
+++ b/packages/app/src/runtime.ts
@@ -1,9 +1,11 @@
+import type { AuthSessionAudience } from "@sixb/core"
+
 export interface CustomAppRuntimeConfig {
   readonly api: {
     readonly baseUrl: string
   }
   readonly auth: {
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly enabled: boolean
   }
 }

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -233,6 +233,16 @@ describe("createCustomApp.dev", () => {
     expect(main).toContain("requireSixbBrowserAuthSession(runtimeConfig")
   })
 
+  test("renders an access-denied view without starting the application", async () => {
+    const { mainPath } = await generateAppEntry(tempRoot, join(tempRoot, ".sixb", "generated"))
+    const main = await readFile(mainPath, "utf-8")
+
+    expect(main).toContain("!authSession.applicationAccess.allowed")
+    expect(main).toContain("function AccessDeniedView()")
+    expect(main).toContain("<AccessDeniedView />")
+    expect(main).toContain("await signOut({ throwOnError: true })")
+  })
+
   test("wraps routes in an error boundary that special-cases 404s", async () => {
     const { mainPath } = await generateAppEntry(tempRoot, join(tempRoot, ".sixb", "generated"))
     const main = await readFile(mainPath, "utf-8")

--- a/packages/atlas/src/components/SettingsMembersPage.tsx
+++ b/packages/atlas/src/components/SettingsMembersPage.tsx
@@ -43,6 +43,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   EmptyState,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Sheet,
   SheetContent,
   SheetDescription,
@@ -85,6 +90,7 @@ type StatusFilter = "all" | MemberStatus
 type Invitation = ListAuthInvitationsResponse["invitations"][number]
 type InvitationCreateCapability =
   GetAuthInvitationOptionsResponse["capabilities"]["createInvitation"]
+type InvitationDestination = GetAuthInvitationOptionsResponse["destinations"][number]
 type MemberAction = "suspend" | "reactivate"
 
 const memberListOptions = {
@@ -248,10 +254,13 @@ function inviteDisabledMessage(capability: InvitationCreateCapability | undefine
 
 function InviteMembersCard({
   groups,
+  destinations,
+  destinationId,
   canInviteWithoutGroups,
   disabledReason,
   email,
   onEmailChange,
+  onDestinationChange,
   selectedGroupIds,
   onGroupsChange,
   onSubmit,
@@ -259,13 +268,20 @@ function InviteMembersCard({
   errorMessage,
 }: {
   readonly groups: readonly AuthGroupOption[]
+  readonly destinations: readonly InvitationDestination[]
+  readonly destinationId: string
   readonly canInviteWithoutGroups: boolean
   readonly disabledReason: string | null
   readonly email: string
   readonly onEmailChange: (email: string) => void
+  readonly onDestinationChange: (destinationId: string) => void
   readonly selectedGroupIds: readonly string[]
   readonly onGroupsChange: (groupIds: string[]) => void
-  readonly onSubmit: (body: { email: string; groupIds: string[] }) => void
+  readonly onSubmit: (body: {
+    email: string
+    groupIds: string[]
+    destinationId?: "atlas" | "app"
+  }) => void
   readonly isSubmitting: boolean
   readonly errorMessage: string | null
 }) {
@@ -273,37 +289,46 @@ function InviteMembersCard({
   const canSubmit =
     !disabled &&
     email.trim().length > 0 &&
+    (destinations.length === 0 || destinationId.length > 0) &&
     (selectedGroupIds.length > 0 || canInviteWithoutGroups) &&
     !isSubmitting
 
   const submit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault()
     if (!canSubmit) return
-    onSubmit({ email: email.trim(), groupIds: [...selectedGroupIds] })
+    onSubmit({
+      email: email.trim(),
+      groupIds: [...selectedGroupIds],
+      ...(destinationId === "atlas" || destinationId === "app" ? { destinationId } : {}),
+    })
   }
 
   return (
     <section className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
       <form onSubmit={submit}>
-        <div className="p-6">
+        <div className="p-5 sm:p-6">
           <h2 className="text-lg font-semibold tracking-tight text-foreground">Invite members</h2>
-          <p className="mt-1.5 text-sm text-muted-foreground">
-            Add people to this workspace by email and choose the groups they join.
+          <p className="mt-1 text-sm text-muted-foreground">
+            Send an invitation and choose where the member lands and what they can access.
           </p>
 
           {disabled ? (
-            <p className="mt-5 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
+            <p className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
               {disabledReason}
             </p>
           ) : null}
 
-          <div className="mt-6 grid gap-x-6 gap-y-5 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
-            <div className="space-y-2">
-              <label
-                htmlFor="invite-email"
-                className="block text-sm font-medium text-muted-foreground"
-              >
-                Email
+          <div
+            className={cn(
+              "mt-5 grid gap-4",
+              destinations.length > 0
+                ? "sm:grid-cols-[minmax(0,1fr)_minmax(13rem,0.42fr)]"
+                : "sm:grid-cols-1"
+            )}
+          >
+            <div className="space-y-1.5">
+              <label htmlFor="invite-email" className="block text-sm font-medium text-foreground">
+                Email address
               </label>
               <input
                 id="invite-email"
@@ -313,40 +338,68 @@ function InviteMembersCard({
                 onChange={(event) => onEmailChange(event.target.value)}
                 disabled={disabled || isSubmitting}
                 placeholder="ava@acme.com"
-                className="h-11 w-full rounded-lg border border-border/60 bg-background px-3.5 text-sm outline-none transition-colors placeholder:text-muted-foreground/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50"
+                className="h-10 w-full rounded-lg border border-border/60 bg-background px-3.5 text-sm outline-none transition-colors placeholder:text-muted-foreground/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50"
               />
             </div>
 
-            <div className="space-y-2">
-              <span className="block text-sm font-medium text-muted-foreground">Groups</span>
-              <GroupPicker
-                groups={groups}
-                selectedGroupIds={selectedGroupIds}
-                onChange={onGroupsChange}
-                disabled={disabled || isSubmitting}
-                emptyMessage="You have no groups available to assign."
-              />
+            {destinations.length > 0 ? (
+              <div className="space-y-1.5">
+                <label
+                  htmlFor="invite-destination"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  Destination
+                </label>
+                <Select
+                  value={destinationId || undefined}
+                  onValueChange={onDestinationChange}
+                  disabled={disabled || isSubmitting}
+                >
+                  <SelectTrigger
+                    id="invite-destination"
+                    className="h-10 w-full rounded-lg border-border/60 bg-background px-3.5 shadow-none focus-visible:ring-ring/20 data-[size=default]:h-10 dark:bg-background dark:hover:bg-background"
+                  >
+                    <SelectValue placeholder="Choose an app" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {destinations.map((destination) => (
+                      <SelectItem key={destination.id} value={destination.id}>
+                        {destination.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-5 border-t border-border/60 pt-4">
+            <div className="mb-2.5 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+              <span className="text-sm font-medium text-foreground">Access groups</span>
+              {groups.length > 0 && !canInviteWithoutGroups ? (
+                <span className="text-xs text-muted-foreground">Select at least one group</span>
+              ) : null}
             </div>
+            <GroupPicker
+              groups={groups}
+              selectedGroupIds={selectedGroupIds}
+              onChange={onGroupsChange}
+              disabled={disabled || isSubmitting}
+              emptyMessage="You have no groups available to assign."
+            />
           </div>
 
           {errorMessage && (
-            <p className="mt-5 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <p className="mt-4 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
               {errorMessage}
             </p>
           )}
         </div>
 
-        <div className="flex items-center justify-between gap-3 border-t border-border/60 bg-muted/30 px-6 py-3.5">
-          <p className="text-sm text-muted-foreground">
-            {groups.length === 0
-              ? ""
-              : canInviteWithoutGroups
-                ? "Groups are optional — members without groups start with no access."
-                : "Select at least one group before sending."}
-          </p>
+        <div className="flex justify-end border-t border-border/60 bg-muted/20 px-5 py-3 sm:px-6">
           <Button type="submit" disabled={!canSubmit} className="shrink-0">
             {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-            Invite
+            Send invite
           </Button>
         </div>
       </form>
@@ -440,6 +493,7 @@ export function SettingsMembersPage() {
   } | null>(null)
   const [activeTab, setActiveTab] = useState<"members" | "invitations">("members")
   const [inviteEmail, setInviteEmail] = useState("")
+  const [inviteDestinationId, setInviteDestinationId] = useState("")
   const [inviteGroupIds, setInviteGroupIds] = useState<string[]>([])
   const [revokingInvitationId, setRevokingInvitationId] = useState<string | null>(null)
   const [showPastInvitations, setShowPastInvitations] = useState(false)
@@ -467,6 +521,12 @@ export function SettingsMembersPage() {
   )
 
   const inviteOptions = inviteOptionsQuery.data
+  const inviteDestinations = inviteOptions?.destinations ?? []
+  const resolvedInviteDestinationId = inviteDestinations.some(
+    (destination) => destination.id === inviteDestinationId
+  )
+    ? inviteDestinationId
+    : (inviteOptions?.defaultDestinationId ?? inviteDestinations[0]?.id ?? "")
   const inviteGroupOptions = useMemo<readonly AuthGroupOption[]>(
     () => inviteOptions?.groups ?? [],
     [inviteOptions]
@@ -698,10 +758,13 @@ export function SettingsMembersPage() {
 
       <InviteMembersCard
         groups={inviteGroupOptions}
+        destinations={inviteDestinations}
+        destinationId={resolvedInviteDestinationId}
         canInviteWithoutGroups={inviteOptions?.canInviteWithoutGroups === true}
         disabledReason={inviteDisabledReason}
         email={inviteEmail}
         onEmailChange={setInviteEmail}
+        onDestinationChange={setInviteDestinationId}
         selectedGroupIds={inviteGroupIds}
         onGroupsChange={setInviteGroupIds}
         onSubmit={(body) =>
@@ -709,6 +772,7 @@ export function SettingsMembersPage() {
             body: {
               email: body.email,
               ...(body.groupIds.length > 0 ? { groupIds: body.groupIds } : {}),
+              ...(body.destinationId ? { destinationId: body.destinationId } : {}),
             },
           })
         }

--- a/packages/atlas/src/main.tsx
+++ b/packages/atlas/src/main.tsx
@@ -1,3 +1,4 @@
+import { signOut } from "@sixb/client"
 import {
   configureSixbBrowserClient,
   readSixbBrowserRuntimeConfig,
@@ -5,6 +6,7 @@ import {
   type SixbBrowserRuntimeConfig,
 } from "@sixb/client/browser"
 import { SixbEventsProvider } from "@sixb/client/hooks"
+import { Button } from "@sixb/ui/components"
 import { ThemeProvider } from "@sixb/ui/hooks"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import React from "react"
@@ -38,13 +40,54 @@ async function start(): Promise<void> {
   const authSession = runtimeConfig.auth.enabled
     ? await requireSixbBrowserAuthSession(runtimeConfig, browserClient)
     : null
-  canRenderApp = !runtimeConfig.auth.enabled || authSession?.authenticated === true
+  canRenderApp =
+    !runtimeConfig.auth.enabled ||
+    (authSession?.authenticated === true && authSession.applicationAccess.allowed)
 
-  if (!canRenderApp) {
+  if (canRenderApp) {
+    renderApp()
     return
   }
 
-  renderApp()
+  if (authSession?.authenticated === true && !authSession.applicationAccess.allowed) {
+    renderAccessDenied()
+  }
+}
+
+function renderAccessDenied(): void {
+  getRoot().render(
+    <React.StrictMode>
+      <AtlasAccessDenied />
+    </React.StrictMode>
+  )
+}
+
+function AtlasAccessDenied() {
+  const [isSigningOut, setIsSigningOut] = React.useState(false)
+
+  const handleSignOut = async () => {
+    setIsSigningOut(true)
+    try {
+      await signOut({ throwOnError: true })
+      window.location.reload()
+    } catch {
+      setIsSigningOut(false)
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground">
+      <section className="w-full max-w-md rounded-xl border border-border bg-card p-6 text-center shadow-sm">
+        <h1 className="text-xl font-semibold tracking-tight">Atlas access required</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Your account is signed in, but it does not have permission to access Atlas.
+        </p>
+        <Button className="mt-6" variant="outline" disabled={isSigningOut} onClick={handleSignOut}>
+          {isSigningOut ? "Signing out…" : "Sign out"}
+        </Button>
+      </section>
+    </main>
+  )
 }
 
 function renderApp(): void {

--- a/packages/cli/src/lib/browser-topology.ts
+++ b/packages/cli/src/lib/browser-topology.ts
@@ -123,11 +123,11 @@ function createAllowedBrowserOrigins(origins: BrowserPublicOrigins): readonly Si
   const allowedOrigins: SixbBrowserOrigin[] = []
 
   if (origins.atlasPublicOrigin) {
-    allowedOrigins.push({ origin: origins.atlasPublicOrigin, audience: "atlas", kind: "atlas" })
+    allowedOrigins.push({ origin: origins.atlasPublicOrigin, audience: "atlas" })
   }
 
   if (origins.appPublicOrigin) {
-    allowedOrigins.push({ origin: origins.appPublicOrigin, audience: "app", kind: "app" })
+    allowedOrigins.push({ origin: origins.appPublicOrigin, audience: "app" })
   }
 
   return allowedOrigins

--- a/packages/cli/tests/browser-topology.test.ts
+++ b/packages/cli/tests/browser-topology.test.ts
@@ -42,8 +42,8 @@ describe("browser topology", () => {
       apiPublicOrigin: "http://localhost:3002",
     })
     expect(topology.allowedBrowserOrigins).toEqual([
-      { origin: "http://localhost:3000", audience: "atlas", kind: "atlas" },
-      { origin: "http://localhost:3001", audience: "app", kind: "app" },
+      { origin: "http://localhost:3000", audience: "atlas" },
+      { origin: "http://localhost:3001", audience: "app" },
     ])
     expect(apiUrl(topology)).toBe("http://localhost:3002/api")
     expect(apiDocsUrl(topology)).toBe("http://localhost:3002/docs")
@@ -58,7 +58,7 @@ describe("browser topology", () => {
 
     expect(topology.appPublicOrigin).toBeNull()
     expect(topology.allowedBrowserOrigins).toEqual([
-      { origin: "http://localhost:3000", audience: "atlas", kind: "atlas" },
+      { origin: "http://localhost:3000", audience: "atlas" },
     ])
   })
 
@@ -96,8 +96,8 @@ describe("browser topology", () => {
       apiPublicOrigin: "https://api.example.com",
     })
     expect(topology.allowedBrowserOrigins).toEqual([
-      { origin: "https://atlas.example.com", audience: "atlas", kind: "atlas" },
-      { origin: "https://app.example.com", audience: "app", kind: "app" },
+      { origin: "https://atlas.example.com", audience: "atlas" },
+      { origin: "https://app.example.com", audience: "app" },
     ])
     expect(apiEventsUrl(topology)).toBe("wss://api.example.com/ws/events")
   })

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -917,6 +917,20 @@
                         "csrfToken": {
                           "type": "string"
                         },
+                        "applicationAccess": {
+                          "type": "object",
+                          "properties": {
+                            "allowed": {
+                              "type": "boolean"
+                            },
+                            "audience": {
+                              "type": "string",
+                              "enum": ["atlas", "app"]
+                            }
+                          },
+                          "required": ["allowed", "audience"],
+                          "additionalProperties": false
+                        },
                         "user": {
                           "type": "object",
                           "properties": {
@@ -956,7 +970,13 @@
                           "additionalProperties": false
                         }
                       },
-                      "required": ["authenticated", "csrfToken", "user", "session"],
+                      "required": [
+                        "authenticated",
+                        "csrfToken",
+                        "applicationAccess",
+                        "user",
+                        "session"
+                      ],
                       "additionalProperties": false
                     }
                   ]
@@ -1037,7 +1057,8 @@
                             "type": "string"
                           },
                           "audience": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": ["atlas", "app"]
                           },
                           "current": {
                             "type": "boolean"
@@ -3000,6 +3021,10 @@
                       "minLength": 1
                     }
                   },
+                  "destinationId": {
+                    "type": "string",
+                    "enum": ["atlas", "app"]
+                  },
                   "expiresAt": {
                     "type": "string"
                   },
@@ -3026,6 +3051,10 @@
                       "minLength": 1
                     }
                   },
+                  "destinationId": {
+                    "type": "string",
+                    "enum": ["atlas", "app"]
+                  },
                   "expiresAt": {
                     "type": "string"
                   },
@@ -3051,6 +3080,10 @@
                       "type": "string",
                       "minLength": 1
                     }
+                  },
+                  "destinationId": {
+                    "type": "string",
+                    "enum": ["atlas", "app"]
                   },
                   "expiresAt": {
                     "type": "string"
@@ -3479,6 +3512,27 @@
                         "additionalProperties": false
                       }
                     },
+                    "destinations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "enum": ["atlas", "app"]
+                          },
+                          "label": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["id", "label"],
+                        "additionalProperties": false
+                      }
+                    },
+                    "defaultDestinationId": {
+                      "type": "string",
+                      "enum": ["atlas", "app"]
+                    },
                     "canInviteWithoutGroups": {
                       "type": "boolean"
                     },
@@ -3523,7 +3577,7 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": ["groups", "canInviteWithoutGroups", "capabilities"],
+                  "required": ["groups", "destinations", "canInviteWithoutGroups", "capabilities"],
                   "additionalProperties": false
                 }
               }

--- a/packages/client/src/browser.ts
+++ b/packages/client/src/browser.ts
@@ -1,3 +1,4 @@
+import type { AuthSessionAudience } from "@sixb/core"
 import { configureSixbClient as configureGeneratedSixbClient, normalizeSixbApiBaseUrl } from "./api"
 import { client } from "./generated/client.gen"
 
@@ -12,14 +13,14 @@ export interface SixbBrowserRuntimeConfig {
     readonly baseUrl: string
   }
   readonly auth: {
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly enabled: boolean
   }
 }
 
 export interface SixbBrowserRuntimeDefaults {
   readonly apiBaseUrl?: string
-  readonly audience: string
+  readonly audience: AuthSessionAudience
   readonly authEnabled?: boolean
 }
 

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -235,6 +235,10 @@ export type GetAuthSessionResponses = {
     | {
         authenticated: true
         csrfToken: string
+        applicationAccess: {
+          allowed: boolean
+          audience: "atlas" | "app"
+        }
         user: {
           id: string
           email: string
@@ -305,7 +309,7 @@ export type ListAuthSessionsResponses = {
   200: {
     sessions: Array<{
       id: string
-      audience: string
+      audience: "atlas" | "app"
       current: boolean
       createdAt: string
       expiresAt: string
@@ -1082,6 +1086,7 @@ export type CreateAuthInvitationData = {
   body: {
     email: string
     groupIds?: Array<string>
+    destinationId?: "atlas" | "app"
     expiresAt?: string
     returnTo?: string
   }
@@ -1191,6 +1196,11 @@ export type GetAuthInvitationOptionsResponses = {
       label?: string
       description?: string
     }>
+    destinations: Array<{
+      id: "atlas" | "app"
+      label: string
+    }>
+    defaultDestinationId?: "atlas" | "app"
     canInviteWithoutGroups: boolean
     capabilities: {
       createInvitation:

--- a/packages/core/src/auth/audience.ts
+++ b/packages/core/src/auth/audience.ts
@@ -1,16 +1,15 @@
 import { AuthRuntimeError } from "./errors"
 
 export const DEFAULT_AUTH_SESSION_AUDIENCE = "atlas"
-export const AUTH_SESSION_AUDIENCE_PATTERN = /^[a-z][a-z0-9-]{0,47}$/
 
-export type AuthSessionAudience = typeof DEFAULT_AUTH_SESSION_AUDIENCE | "app" | (string & {})
+export type AuthSessionAudience = typeof DEFAULT_AUTH_SESSION_AUDIENCE | "app"
 
 export interface AuthSessionAudienceOptions {
   readonly audience?: AuthSessionAudience
 }
 
 export function isValidAuthSessionAudience(value: string): value is AuthSessionAudience {
-  return AUTH_SESSION_AUDIENCE_PATTERN.test(value)
+  return value === "atlas" || value === "app"
 }
 
 export function resolveAuthSessionAudience(
@@ -21,7 +20,7 @@ export function resolveAuthSessionAudience(
   if (!isValidAuthSessionAudience(audience)) {
     throw new AuthRuntimeError(
       "invalid_auth_config",
-      `[Sixb] Auth session audience '${audience}' is invalid. Use a lower-case slug matching ${AUTH_SESSION_AUDIENCE_PATTERN.source}.`
+      `[Sixb] Auth session audience '${audience}' is invalid. Expected 'atlas' or 'app'.`
     )
   }
 

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -11,7 +11,6 @@ export {
 } from "./access-tokens"
 export type { AuthSessionAudience, AuthSessionAudienceOptions } from "./audience"
 export {
-  AUTH_SESSION_AUDIENCE_PATTERN,
   DEFAULT_AUTH_SESSION_AUDIENCE,
   isValidAuthSessionAudience,
   resolveAuthSessionAudience,

--- a/packages/core/src/auth/runtime.ts
+++ b/packages/core/src/auth/runtime.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto"
-import { type AuthorizationContext, resolveAuthorizationContext } from "../authorization"
+import {
+  type AuthorizationContext,
+  canAccessApplication,
+  resolveAuthorizationContext,
+} from "../authorization"
 import {
   canPerformMembershipOperation,
   type MembershipOperation,
@@ -25,6 +29,7 @@ import {
   hashAccessTokenSecret,
   parseAccessTokenValue,
 } from "./access-tokens"
+import type { AuthSessionAudience } from "./audience"
 import {
   getCookie,
   type ResolvedAuthCookieOptions,
@@ -1144,6 +1149,10 @@ export class AuthRuntime {
     }
 
     await this.assertCanInviteRecipient(strategy, authStorage, input.email, now)
+    const deliveryAudience = resolveAuthSessionAudience(
+      options.delivery?.audience ?? options.audience
+    )
+    this.assertInvitationApplicationAccess(groupIds, deliveryAudience)
 
     const invitation = await authStorage.invitations.createOrUpdateActive({
       id: `inv_${randomUUID()}`,
@@ -1163,7 +1172,7 @@ export class AuthRuntime {
         projectId: this.projectId,
         authStorage,
         invitation,
-        audience: resolveAuthSessionAudience(options.audience),
+        audience: deliveryAudience,
         returnTo: options.delivery?.returnTo ?? sanitizeReturnTo(input.returnTo),
         requestOrigin: options.delivery?.requestOrigin ?? new URL(request.url).origin,
         now,
@@ -1304,6 +1313,27 @@ export class AuthRuntime {
     }
 
     return { state: "enabled" }
+  }
+
+  private assertInvitationApplicationAccess(
+    groupIds: readonly string[],
+    audience: AuthSessionAudience
+  ): void {
+    // Check only the groups this invitation assigns. Existing memberships may
+    // be outside the caller's policy scope and must not affect this response.
+    const roles = this.security.getResolvedRoles()
+    const authorization = resolveAuthorizationContext({
+      principal: { type: "user", id: "invited-user" },
+      groupIds,
+      roles,
+    })
+
+    if (canAccessApplication(authorization, roles, audience)) return
+
+    throw new AuthRuntimeError(
+      "authorization_denied",
+      `[Sixb] Invitation groups do not grant access to application '${audience}'.`
+    )
   }
 
   private async assertCanInviteRecipient(

--- a/packages/core/src/auth/session-cache.ts
+++ b/packages/core/src/auth/session-cache.ts
@@ -1,8 +1,9 @@
+import type { AuthSessionAudience } from "./audience"
 import type { AuthenticatedAuthSession } from "./types"
 
 interface SessionCacheEntry {
   readonly tokenHash: string
-  readonly audience: string
+  readonly audience: AuthSessionAudience
   readonly session: AuthenticatedAuthSession
   readonly expiresAtMs: number
 }
@@ -10,7 +11,7 @@ interface SessionCacheEntry {
 export interface SessionCacheGetInput {
   readonly sessionId: string
   readonly tokenHash: string
-  readonly audience: string
+  readonly audience: AuthSessionAudience
   readonly nowMs: number
 }
 

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -335,6 +335,7 @@ export interface AuthSessionResolutionOptions extends AuthSessionAudienceOptions
 
 export interface InviteUserOptions extends AuthSessionAudienceOptions {
   readonly delivery?: {
+    readonly audience?: AuthSessionAudience
     readonly requestOrigin?: string
     readonly returnTo?: string
   }

--- a/packages/core/src/authorization/application-access.ts
+++ b/packages/core/src/authorization/application-access.ts
@@ -1,0 +1,26 @@
+import type { AuthSessionAudience } from "../auth/audience"
+import { isAllowed } from "./decision"
+import type { AuthorizationContext, ResolvedRole } from "./types"
+
+/** Whether declaring roles has enabled an allowlist for an application. */
+export function isApplicationAccessControlled(
+  roles: readonly ResolvedRole[],
+  audience: AuthSessionAudience
+): boolean {
+  return roles.some((role) => role.grants["access:application"].has(audience))
+}
+
+/**
+ * Application access is opt-in for compatibility. Once any role grants an
+ * application, principals without that grant are denied.
+ */
+export function canAccessApplication(
+  authorization: AuthorizationContext,
+  roles: readonly ResolvedRole[],
+  audience: AuthSessionAudience
+): boolean {
+  return (
+    !isApplicationAccessControlled(roles, audience) ||
+    isAllowed(authorization, { kind: "application.access", audience })
+  )
+}

--- a/packages/core/src/authorization/decision.ts
+++ b/packages/core/src/authorization/decision.ts
@@ -16,12 +16,14 @@
  * never the raw runtime. See `RequestAuthState` in the server for the rule.
  */
 
+import type { AuthSessionAudience } from "../auth/audience"
 import { AuthorizationError } from "./errors"
 import type { GrantKind } from "./grant-kinds"
 import type { AuthorizationContext, GrantIndex } from "./types"
 
 /** Something a principal may attempt, paired with the resource it targets. */
 export type AuthzRequest =
+  | { readonly kind: "application.access"; readonly audience: AuthSessionAudience }
   | { readonly kind: "object.view"; readonly objectTypeId: string }
   | { readonly kind: "dataset.view"; readonly datasetId: string }
   | { readonly kind: "action.apply"; readonly actionId: string }
@@ -55,6 +57,8 @@ interface Atom {
 
 function atomsFor(request: AuthzRequest): readonly Atom[] {
   switch (request.kind) {
+    case "application.access":
+      return [{ kind: "access:application", id: request.audience }]
     case "object.view":
       return [{ kind: "view:object", id: request.objectTypeId }]
     case "dataset.view":
@@ -139,6 +143,8 @@ function deniedMessage(
 ): string {
   const principalId = authorization?.principal.id ?? "unknown"
   switch (request.kind) {
+    case "application.access":
+      return `[Sixb] Principal '${principalId}' is not allowed to access application '${request.audience}'.`
     case "object.view":
       return `[Sixb] Principal '${principalId}' is not allowed to view object type '${request.objectTypeId}'.`
     case "dataset.view":

--- a/packages/core/src/authorization/grant-kinds.ts
+++ b/packages/core/src/authorization/grant-kinds.ts
@@ -11,6 +11,7 @@
 import type { GrantDefinition } from "../security/types"
 
 export type GrantKind =
+  | "access:application"
   | "view:object"
   | "view:dataset"
   | "apply:action"
@@ -22,6 +23,7 @@ export type GrantKind =
 
 /** Registered id universes a grant kind ranges over, plus subtype expansion. */
 export interface GrantUniverse {
+  readonly applicationIds: ReadonlySet<string>
   readonly objectTypeIds: ReadonlySet<string>
   readonly datasetIds: ReadonlySet<string>
   readonly actionIds: ReadonlySet<string>
@@ -52,6 +54,11 @@ interface GrantKindSpec {
  * `Record<GrantKind, …>` makes every omission a compile error.
  */
 export const GRANT_KINDS: Record<GrantKind, GrantKindSpec> = {
+  "access:application": {
+    universeKey: "applicationIds",
+    subject: "application",
+    fix: "Use an application exported from '@sixb/core'.",
+  },
   "view:object": {
     universeKey: "objectTypeIds",
     subject: "object type",
@@ -100,6 +107,8 @@ export const GRANT_KIND_KEYS = Object.keys(GRANT_KINDS) as readonly GrantKind[]
 /** The grant kind a stored grant resolves to. */
 export function grantKindOf(grant: GrantDefinition): GrantKind {
   switch (grant.capability) {
+    case "access":
+      return "access:application"
     case "view":
       return `view:${grant.target}`
     case "apply":

--- a/packages/core/src/authorization/index.ts
+++ b/packages/core/src/authorization/index.ts
@@ -1,3 +1,4 @@
+export { canAccessApplication, isApplicationAccessControlled } from "./application-access"
 export type { AuthzDecision, AuthzRequest } from "./decision"
 export { assertAuthorized, assertPrivileged, evaluate, isAllowed } from "./decision"
 export { AuthorizationError } from "./errors"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -593,7 +593,6 @@ export type {
   UpdateMemberGroupsResult,
 } from "./auth"
 export {
-  AUTH_SESSION_AUDIENCE_PATTERN,
   AuthRuntime,
   AuthRuntimeError,
   CSRF_HEADER_NAME,
@@ -652,6 +651,7 @@ export type {
 export {
   AuthorizationError,
   assertAuthorized,
+  canAccessApplication,
   canViewActionRun,
   canViewEvent,
   canViewPipelineRun,
@@ -661,6 +661,7 @@ export {
   canViewWorkflowRun,
   evaluate,
   isAllowed,
+  isApplicationAccessControlled,
   resolveAuthorizationContext,
   resolveRoleGrants,
 } from "./authorization"
@@ -668,6 +669,8 @@ export {
 // ── Security Definitions ───────────────────────────────────
 
 export type {
+  AccessGrant,
+  ApplicationDefinition,
   ApplyGrant,
   DefineGroupOptions,
   DefineMembershipPolicyOptions,
@@ -695,6 +698,7 @@ export type {
 export {
   actions,
   agents,
+  applications,
   assertGrantDefinition,
   assertGroupDefinition,
   assertMembershipPolicyDefinition,

--- a/packages/core/src/security/applications.ts
+++ b/packages/core/src/security/applications.ts
@@ -1,0 +1,11 @@
+import type { ApplicationDefinition } from "./types"
+
+/** Browser applications that can be protected by role grants. */
+export const applications = {
+  atlas: { kind: "application", id: "atlas", label: "Atlas" },
+  app: { kind: "application", id: "app", label: "Custom app" },
+} as const satisfies Readonly<Record<string, ApplicationDefinition>>
+
+export const APPLICATION_IDS: ReadonlySet<string> = new Set(
+  Object.values(applications).map((application) => application.id)
+)

--- a/packages/core/src/security/grants.ts
+++ b/packages/core/src/security/grants.ts
@@ -1,7 +1,7 @@
 /**
  * Grant builders for role definitions.
  *
- * Grants are plain data referencing ontology, action, and workflow definitions
+ * Grants are plain data referencing application and runtime definitions
  * by id. They carry no enforcement logic — the authorization engine expands
  * each grant's selection into per-principal id sets at startup, so runtime
  * checks stay simple `set.has(id)` lookups.
@@ -16,7 +16,15 @@ import type { SyncDefinition } from "../syncs"
 import type { WorkflowDefinition } from "../workflows/types"
 import { SecurityValidationError } from "./errors"
 import { isScope, type Scope, scopeIdOf } from "./scopes"
-import type { ApplyGrant, ObserveGrant, RunGrant, Selection, ViewGrant } from "./types"
+import type {
+  AccessGrant,
+  ApplicationDefinition,
+  ApplyGrant,
+  ObserveGrant,
+  RunGrant,
+  Selection,
+  ViewGrant,
+} from "./types"
 
 type GrantInput<TDefinition, TTarget extends Scope["target"]> =
   | TDefinition
@@ -59,6 +67,15 @@ function viewTargetFrom(
 
   const first = Array.isArray(input) ? input[0] : input
   return isDatasetDefinitionInput(first) ? "dataset" : "object"
+}
+
+function access(input: ApplicationDefinition | readonly ApplicationDefinition[]): AccessGrant {
+  return {
+    kind: "grant",
+    capability: "access",
+    target: "application",
+    selection: selectionFrom(input, "can.access"),
+  }
 }
 
 function view(input: GrantInput<ObjectType, "object">): ViewGrant<"object">
@@ -148,6 +165,7 @@ function observe(target: "logs"): ObserveGrant {
 }
 
 export const can = {
+  access,
   view,
   apply,
   run,

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -1,3 +1,4 @@
+export { applications } from "./applications"
 export type {
   DefineGroupOptions,
   DefineMembershipPolicyOptions,
@@ -16,6 +17,8 @@ export {
 export type { Scope, ScopeTarget } from "./scopes"
 export { actions, agents, datasets, ontology, pipelines, syncs, workflows } from "./scopes"
 export type {
+  AccessGrant,
+  ApplicationDefinition,
   ApplyGrant,
   GrantCapability,
   GrantDefinition,

--- a/packages/core/src/security/runtime.ts
+++ b/packages/core/src/security/runtime.ts
@@ -1,4 +1,5 @@
 import { type ResolvedRole, resolveRoleGrants } from "../authorization"
+import { APPLICATION_IDS } from "./applications"
 import type {
   GroupDefinition,
   MembershipPolicyDefinition,
@@ -48,6 +49,7 @@ export function createRuntimeSecurityRegistry(input: {
   readonly groups?: readonly GroupDefinition[]
   readonly roles?: readonly RoleDefinition[]
   readonly membershipPolicies?: readonly MembershipPolicyDefinition[]
+  readonly applicationIds?: ReadonlySet<string>
   readonly objectTypeIds?: ReadonlySet<string>
   readonly datasetIds?: ReadonlySet<string>
   readonly actionIds?: ReadonlySet<string>
@@ -61,6 +63,7 @@ export function createRuntimeSecurityRegistry(input: {
     groups: input.groups ?? [],
     roles: input.roles ?? [],
     membershipPolicies: input.membershipPolicies ?? [],
+    applicationIds: input.applicationIds ?? APPLICATION_IDS,
     objectTypeIds: input.objectTypeIds,
     datasetIds: input.datasetIds,
     actionIds: input.actionIds,
@@ -72,6 +75,7 @@ export function createRuntimeSecurityRegistry(input: {
   })
 
   const universe = {
+    applicationIds: input.applicationIds ?? APPLICATION_IDS,
     objectTypeIds: input.objectTypeIds ?? new Set<string>(),
     datasetIds: input.datasetIds ?? new Set<string>(),
     actionIds: input.actionIds ?? new Set<string>(),

--- a/packages/core/src/security/types.ts
+++ b/packages/core/src/security/types.ts
@@ -1,3 +1,4 @@
+import type { AuthSessionAudience } from "../auth/audience"
 import type { ResolvedRole } from "../authorization/types"
 
 export interface GroupDefinition<TId extends string = string> {
@@ -16,6 +17,19 @@ export interface GroupDefinition<TId extends string = string> {
 export type Selection =
   | { readonly all: true; readonly except: readonly string[] }
   | { readonly all: false; readonly ids: readonly string[] }
+
+export interface ApplicationDefinition<TId extends AuthSessionAudience = AuthSessionAudience> {
+  readonly kind: "application"
+  readonly id: TId
+  readonly label: string
+}
+
+export interface AccessGrant {
+  readonly kind: "grant"
+  readonly capability: "access"
+  readonly target: "application"
+  readonly selection: Selection
+}
 
 export type ViewGrantTarget = "object" | "dataset"
 
@@ -50,7 +64,7 @@ export interface ObserveGrant {
   readonly selection: Selection
 }
 
-export type GrantDefinition = ViewGrant | ApplyGrant | RunGrant | ObserveGrant
+export type GrantDefinition = AccessGrant | ViewGrant | ApplyGrant | RunGrant | ObserveGrant
 
 export type GrantCapability = GrantDefinition["capability"]
 

--- a/packages/core/src/security/validation.ts
+++ b/packages/core/src/security/validation.ts
@@ -168,14 +168,19 @@ export function assertGrantDefinition(
   }
 
   if (
+    value.capability !== "access" &&
     value.capability !== "view" &&
     value.capability !== "apply" &&
     value.capability !== "run" &&
     value.capability !== "observe"
   ) {
     throw createError(
-      `[Sixb] ${field} grant capability must be 'view', 'apply', 'run', or 'observe'.`
+      `[Sixb] ${field} grant capability must be 'access', 'view', 'apply', 'run', or 'observe'.`
     )
+  }
+
+  if (value.capability === "access" && value.target !== "application") {
+    throw createError(`[Sixb] ${field} access grant target must be 'application'.`)
   }
 
   if (value.capability === "view" && value.target !== "object" && value.target !== "dataset") {
@@ -259,6 +264,8 @@ export function validateSecurityDefinitionsAtStartup(input: {
   readonly groups: readonly GroupDefinition[]
   readonly membershipPolicies: readonly MembershipPolicyDefinition[]
   readonly roles?: readonly RoleDefinition[]
+  /** Registered browser application ids — when provided, access grants must reference them. */
+  readonly applicationIds?: ReadonlySet<string>
   /** Registered object type ids — when provided, view grants must reference them. */
   readonly objectTypeIds?: ReadonlySet<string>
   /** Registered dataset ids — when provided, dataset view grants must reference them. */

--- a/packages/core/src/storage/auth/in-memory/sessions.ts
+++ b/packages/core/src/storage/auth/in-memory/sessions.ts
@@ -1,3 +1,4 @@
+import type { AuthSessionAudience } from "../../../auth/audience"
 import { AuthStorageError } from "../errors"
 import type { AuthSessionStore, CreateAuthSessionInput, SessionRecord } from "../types"
 import type { AuthStorageState } from "./shared"
@@ -30,7 +31,7 @@ export class InMemoryAuthSessionStore implements AuthSessionStore {
   async getActiveByUserId(params: {
     readonly projectId: string
     readonly userId: string
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly now: Date
   }): Promise<SessionRecord | null> {
     const sessions = [...this.state.sessions.values()]
@@ -65,7 +66,7 @@ export class InMemoryAuthSessionStore implements AuthSessionStore {
   async findValidByTokenHash(params: {
     readonly projectId: string
     readonly id: string
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly tokenHash: string
     readonly now: Date
   }): Promise<SessionRecord | null> {
@@ -108,7 +109,7 @@ export class InMemoryAuthSessionStore implements AuthSessionStore {
   async revokeActiveForUser(params: {
     readonly projectId: string
     readonly userId: string
-    readonly audience?: string
+    readonly audience?: AuthSessionAudience
     readonly revokedAt: Date
   }): Promise<readonly SessionRecord[]> {
     return revokeActiveSessionsForUser(

--- a/packages/core/src/storage/auth/in-memory/shared.ts
+++ b/packages/core/src/storage/auth/in-memory/shared.ts
@@ -1,3 +1,4 @@
+import { type AuthSessionAudience, resolveAuthSessionAudience } from "../../../auth/audience"
 import { AuthStorageError } from "../errors"
 import type {
   AccessTokenRecord,
@@ -202,7 +203,7 @@ export function revokeActiveSessionsForUser(
   projectId: string,
   userId: string,
   revokedAt: Date,
-  audience?: string
+  audience?: AuthSessionAudience
 ): readonly SessionRecord[] {
   const revoked: SessionRecord[] = []
 
@@ -291,7 +292,7 @@ export function createSessionRecord(
   const projectId = assertNonEmpty(input.projectId, "Project id")
   const userId = assertNonEmpty(input.userId, "User id")
   const strategyId = assertNonEmpty(input.strategyId, "Strategy id")
-  const audience = assertNonEmpty(input.audience, "Session audience")
+  const audience = resolveAuthSessionAudience(input.audience)
   const tokenHash = assertNonEmpty(input.tokenHash, "Session token hash")
 
   assertSessionIdAvailable(state, projectId, id)

--- a/packages/core/tests/auth-runtime.test.ts
+++ b/packages/core/tests/auth-runtime.test.ts
@@ -534,7 +534,7 @@ describe("Sixb auth runtime", () => {
         { audience: "atlas" }
       )
     ).resolves.toEqual({ authenticated: false, reason: "invalid_session" })
-    expect(() => sixb.auth.getCookieOptions({ audience: "app prod" })).toThrow(
+    expect(() => sixb.auth.getCookieOptions({ audience: "app prod" as never })).toThrow(
       "Auth session audience 'app prod' is invalid"
     )
   })

--- a/packages/core/tests/authorization-context.test.ts
+++ b/packages/core/tests/authorization-context.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test"
 import {
   actions,
   agents,
+  applications,
   can,
+  canAccessApplication,
   col,
   createSessionCredential,
   datasets,
@@ -16,6 +18,7 @@ import {
   definePipelineStep,
   defineRole,
   defineSync,
+  isApplicationAccessControlled,
   ontology,
   pipelines,
   prop,
@@ -142,6 +145,7 @@ describe("resolveAuthorizationContext", () => {
   // The registry expands grants against the registered universe at startup;
   // here we expand by hand so the resolver can be exercised in isolation.
   const universe = {
+    applicationIds: new Set(["atlas", "app"]),
     objectTypeIds: new Set(["contract", "signed-contract", "invoice"]),
     datasetIds: new Set(["raw.contracts", "raw.invoices"]),
     actionIds: new Set(["send-contract"]),
@@ -168,6 +172,25 @@ describe("resolveAuthorizationContext", () => {
         grants: resolveRoleGrants(role, universe),
       })),
     })
+
+  test("application access becomes an allowlist when a role grants it", () => {
+    const atlasAccess = defineRole("atlas.access", {
+      grantedTo: [admins],
+      grants: [can.access(applications.atlas)],
+    })
+    const roles = [atlasAccess].map((role) => ({
+      id: role.id,
+      grantedToGroupIds: role.grantedToGroupIds,
+      grants: resolveRoleGrants(role, universe),
+    }))
+    const allowed = resolveAuthorizationContext({ principal, groupIds: [admins.id], roles })
+    const denied = resolveAuthorizationContext({ principal, groupIds: [finance.id], roles })
+
+    expect(isApplicationAccessControlled(roles, "atlas")).toBe(true)
+    expect(canAccessApplication(allowed, roles, "atlas")).toBe(true)
+    expect(canAccessApplication(denied, roles, "atlas")).toBe(false)
+    expect(canAccessApplication(denied, roles, "app")).toBe(true)
+  })
 
   test("matches roles by group membership and expands view grants to subtypes", () => {
     const context = resolve(["commercial"], [contractOperator, invoiceViewer], "ses_adam")

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src"
 
 function context(grants: {
+  applications?: readonly string[]
   view?: readonly string[]
   datasets?: readonly string[]
   apply?: readonly string[]
@@ -31,6 +32,7 @@ function context(grants: {
     groupIds: [],
     roleIds: [],
     grants: {
+      "access:application": new Set(grants.applications ?? []),
       "view:object": new Set(grants.view ?? []),
       "view:dataset": new Set(grants.datasets ?? []),
       "apply:action": new Set(grants.apply ?? []),
@@ -54,6 +56,21 @@ describe("evaluate", () => {
       allowed: false,
       requirements: ["observe:logs"],
       missing: ["observe:logs"],
+    })
+  })
+
+  test("application.access checks application grants", () => {
+    expect(
+      evaluate(context({ applications: ["atlas"] }), {
+        kind: "application.access",
+        audience: "atlas",
+      })
+    ).toEqual({ allowed: true, requirements: ["access:application:atlas"], missing: [] })
+
+    expect(evaluate(context({}), { kind: "application.access", audience: "atlas" })).toEqual({
+      allowed: false,
+      requirements: ["access:application:atlas"],
+      missing: ["access:application:atlas"],
     })
   })
 

--- a/packages/core/tests/projection-run-visibility.test.ts
+++ b/packages/core/tests/projection-run-visibility.test.ts
@@ -15,6 +15,7 @@ function authzViewing(...objectTypeIds: string[]): AuthorizationContext {
     groupIds: [],
     roleIds: [],
     grants: {
+      "access:application": new Set(),
       "view:object": new Set(objectTypeIds),
       "view:dataset": new Set(),
       "apply:action": new Set(),

--- a/packages/core/tests/security-definitions.test.ts
+++ b/packages/core/tests/security-definitions.test.ts
@@ -7,6 +7,7 @@ import {
   type ActionDefinition,
   type AgentDefinition,
   agents,
+  applications,
   can,
   canPerformMembershipOperation,
   col,
@@ -375,6 +376,15 @@ describe("role definitions", () => {
     })
   })
 
+  test("can.access grants browser applications", () => {
+    expect(can.access([applications.atlas, applications.app])).toEqual({
+      kind: "grant",
+      capability: "access",
+      target: "application",
+      selection: { all: false, ids: ["atlas", "app"] },
+    })
+  })
+
   test("can.view dedupes ids within an explicit selection", () => {
     expect(can.view([Account, Account])).toEqual({
       kind: "grant",
@@ -498,6 +508,29 @@ describe("role definitions", () => {
     })
 
     expect(() => createRuntime({ roles: [role] })).toThrow("unknown group 'commercial'")
+  })
+
+  test("runtime registration rejects access grants on unknown applications", () => {
+    expect(() =>
+      createRuntime({
+        groups: [commercial],
+        roles: [
+          {
+            kind: "role",
+            id: "unknown.application",
+            grantedToGroupIds: [commercial.id],
+            grants: [
+              {
+                kind: "grant",
+                capability: "access",
+                target: "application",
+                selection: { all: false, ids: ["unknown"] },
+              },
+            ],
+          },
+        ],
+      })
+    ).toThrow("access on unknown application 'unknown'")
   })
 
   test("runtime registration rejects view grants on unknown object types", () => {

--- a/packages/core/tests/security-definitions.types.ts
+++ b/packages/core/tests/security-definitions.types.ts
@@ -1,5 +1,5 @@
-import type { SecurityContext } from "../src"
-import { can, defineGroup, defineMembershipPolicy } from "../src"
+import type { AuthSessionAudience, SecurityContext } from "../src"
+import { applications, can, defineGroup, defineMembershipPolicy } from "../src"
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
@@ -14,6 +14,10 @@ can.observe("events")
 
 type _groupId = Expect<Equal<typeof commercial.id, "commercial">>
 
+// @ts-expect-error auth audiences are the registered browser applications
+const unsupportedAudience: AuthSessionAudience = "backoffice"
+void unsupportedAudience
+
 const membershipPolicy = defineMembershipPolicy("member-admin", {
   grantedTo: [securityAdmins],
   scope: [commercial],
@@ -21,6 +25,10 @@ const membershipPolicy = defineMembershipPolicy("member-admin", {
 })
 
 type _membershipPolicyId = Expect<Equal<typeof membershipPolicy.id, "member-admin">>
+
+can.access(applications.atlas)
+// @ts-expect-error access grants accept application definitions, not groups
+can.access(commercial)
 
 defineMembershipPolicy("invalid", {
   // @ts-expect-error grantedTo accepts group definitions, not arbitrary objects

--- a/packages/core/tests/session-cache.test.ts
+++ b/packages/core/tests/session-cache.test.ts
@@ -16,7 +16,7 @@ const base = {
   sessionId: "ses_1",
   tokenHash: "hash_1",
   audience: "atlas",
-}
+} as const
 
 describe("SessionCache", () => {
   test("returns undefined on miss, hit after set within ttl", () => {
@@ -77,7 +77,7 @@ describe("SessionCache", () => {
     const mk = (id: string) => ({
       sessionId: id,
       tokenHash: `h_${id}`,
-      audience: "atlas",
+      audience: "atlas" as const,
       session: fakeSession(id),
       nowMs: 0,
       sessionExpiresAtMs: 1_000_000,

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -22,13 +22,20 @@ const server = createSixbServer({
   port: 3002,
   browser: {
     publicOrigin: "https://api.example.com",
-    allowedOrigins: [{ origin: "https://atlas.example.com", audience: "atlas" }],
+    allowedOrigins: [
+      { origin: "https://atlas.example.com", audience: "atlas" },
+      { origin: "https://app.example.com", audience: "app" },
+    ],
   },
 })
 await server.start()
 // Server running at http://0.0.0.0:3002
 // OpenAPI docs at http://0.0.0.0:3002/docs
 ```
+
+Each configured audience identifies the browser application for exactly one origin. Configured
+origins are shown as invitation destinations and participate in `can.access(applications.atlas)` or
+`can.access(applications.app)` authorization.
 
 ## API Routes
 

--- a/packages/server/scripts/generate-openapi.ts
+++ b/packages/server/scripts/generate-openapi.ts
@@ -67,7 +67,7 @@ async function main() {
     quiet: true,
     browser: {
       publicOrigin,
-      allowedOrigins: [{ origin: publicOrigin, audience: "atlas", kind: "atlas" }],
+      allowedOrigins: [{ origin: publicOrigin, audience: "atlas" }],
     },
   })
   await server.start()

--- a/packages/server/src/auth/application-access.ts
+++ b/packages/server/src/auth/application-access.ts
@@ -1,0 +1,16 @@
+import {
+  type AuthenticatedRequestAuthSession,
+  type AuthSessionAudience,
+  canAccessApplication,
+  type OntologySource,
+  type Sixb,
+} from "@sixb/core"
+
+export function sessionCanAccessApplication(
+  sixb: Sixb<readonly OntologySource[]>,
+  session: AuthenticatedRequestAuthSession,
+  audience: AuthSessionAudience
+): boolean {
+  const authorization = sixb.auth.contextFromSession(session)
+  return canAccessApplication(authorization, sixb.security.getResolvedRoles(), audience)
+}

--- a/packages/server/src/auth/browser-origin.ts
+++ b/packages/server/src/auth/browser-origin.ts
@@ -1,5 +1,6 @@
 import {
   type AuthSessionAudience,
+  applications,
   DEFAULT_AUTH_SESSION_AUDIENCE,
   isValidAuthSessionAudience,
   resolveAuthSessionAudience,
@@ -8,7 +9,6 @@ import {
 export interface SixbBrowserOrigin {
   readonly origin: string
   readonly audience: AuthSessionAudience
-  readonly kind?: "atlas" | "app"
 }
 
 export interface SixbApiBrowserPolicy {
@@ -20,7 +20,6 @@ export interface SixbApiBrowserPolicy {
 export interface ResolvedSixbBrowserOrigin {
   readonly origin: string
   readonly audience: AuthSessionAudience
-  readonly kind?: "atlas" | "app"
 }
 
 export interface ResolvedSixbApiBrowserPolicy {
@@ -34,6 +33,23 @@ export interface RequestAuthContext {
   readonly browserOrigin?: string
   readonly absoluteReturnTo?: boolean
 }
+
+export interface AuthInvitationDestination {
+  readonly id: AuthSessionAudience
+  readonly label: string
+}
+
+export interface AuthInvitationDestinationOptions {
+  readonly destinations: readonly AuthInvitationDestination[]
+  readonly defaultDestinationId?: AuthSessionAudience
+}
+
+export interface AuthInvitationRedirectInput {
+  readonly destinationId?: AuthSessionAudience
+  readonly returnTo?: string
+}
+
+export type AuthInvitationRedirectContext = AuthRedirectContext
 
 export type ResolveRequestAuthContext = (request: Request) => RequestAuthContext
 
@@ -65,10 +81,19 @@ export function resolveApiBrowserPolicy(
     policy.apiOriginAudience ?? DEFAULT_AUTH_SESSION_AUDIENCE
   )
   const origins = new Map<string, ResolvedSixbBrowserOrigin>()
+  const audienceOrigins = new Map<AuthSessionAudience, string>()
 
   for (const entry of policy.allowedOrigins) {
     const origin = normalizeHttpOrigin(entry.origin, "browser origin")
     const audience = resolveAuthSessionAudience(entry.audience)
+    const existingAudienceOrigin = audienceOrigins.get(audience)
+    if (existingAudienceOrigin && existingAudienceOrigin !== origin) {
+      throw new Error(
+        `[SixbServer] Auth audience '${audience}' is mapped to multiple browser origins.`
+      )
+    }
+    audienceOrigins.set(audience, origin)
+
     const existing = origins.get(origin)
     if (existing) {
       if (existing.audience !== audience) {
@@ -79,11 +104,7 @@ export function resolveApiBrowserPolicy(
       continue
     }
 
-    origins.set(origin, {
-      origin,
-      audience,
-      kind: entry.kind,
-    })
+    origins.set(origin, { origin, audience })
   }
 
   if (origins.size === 0) {
@@ -122,7 +143,11 @@ export function resolveApiBrowserAuthContext(
 
   const allowed = findAllowedBrowserOrigin(policy, origin)
   if (allowed) {
-    return { audience: allowed.audience, browserOrigin: allowed.origin, absoluteReturnTo: true }
+    return {
+      audience: allowed.audience,
+      browserOrigin: allowed.origin,
+      absoluteReturnTo: true,
+    }
   }
 
   if (isSameOriginApiRequest(policy, origin, request)) {
@@ -162,6 +187,52 @@ export function resolveApiBrowserAuthRedirectContext(
   }
 }
 
+export function getApiBrowserInvitationDestinationOptions(
+  policy: ResolvedSixbApiBrowserPolicy
+): AuthInvitationDestinationOptions {
+  const destinations = policy.allowedOrigins.map((entry) => ({
+    id: entry.audience,
+    label: applications[entry.audience].label,
+  }))
+  const defaultDestinationId = destinations.some((destination) => destination.id === "app")
+    ? applications.app.id
+    : destinations.some((destination) => destination.id === "atlas")
+      ? applications.atlas.id
+      : undefined
+
+  return {
+    destinations,
+    ...(defaultDestinationId ? { defaultDestinationId } : {}),
+  }
+}
+
+export function resolveApiBrowserInvitationRedirectContext(
+  policy: ResolvedSixbApiBrowserPolicy,
+  request: Request,
+  input: AuthInvitationRedirectInput
+): AuthInvitationRedirectContext {
+  const authContext = resolveApiBrowserAuthContext(policy, request)
+  if (!input.destinationId) {
+    return resolveApiBrowserAuthRedirectContext(policy, request, {
+      audience: authContext.audience,
+      fallbackReturnToOrigin: authContext.browserOrigin,
+      returnTo: input.returnTo,
+    })
+  }
+
+  const destination = policy.allowedOrigins.find((entry) => entry.audience === input.destinationId)
+  if (!destination) {
+    throw new BrowserOriginError("[SixbServer] Invitation destination is not allowed.")
+  }
+  assertInvitationReturnToOrigin(input.returnTo, destination.origin)
+
+  return resolveApiBrowserAuthRedirectContext(policy, request, {
+    audience: destination.audience,
+    fallbackReturnToOrigin: destination.origin,
+    returnTo: input.returnTo,
+  })
+}
+
 export function resolveApiBrowserPublicOrigin(
   policy: ResolvedSixbApiBrowserPolicy,
   request: Request
@@ -183,6 +254,21 @@ function isSameOriginApiRequest(
 ): boolean {
   const apiOrigin = resolveApiBrowserPublicOrigin(policy, request)
   return origin === apiOrigin
+}
+
+function assertInvitationReturnToOrigin(
+  returnTo: string | undefined,
+  destinationOrigin: string
+): void {
+  if (!returnTo?.trim()) return
+
+  try {
+    if (new URL(returnTo).origin === destinationOrigin) return
+  } catch {
+    // Fall through to the same public validation error as an origin mismatch.
+  }
+
+  throw new BrowserOriginError("[SixbServer] Invitation return target is not allowed.")
 }
 
 function resolveRequiredAuthAudience(value: string | null | undefined): AuthSessionAudience {

--- a/packages/server/src/auth/guard.ts
+++ b/packages/server/src/auth/guard.ts
@@ -5,6 +5,7 @@ import {
   verifyDoubleSubmitCsrf,
 } from "@sixb/core"
 import { isAccessTokenRoute, shouldVerifyCsrfForAuthSource } from "./access-token-boundary"
+import { sessionCanAccessApplication } from "./application-access"
 import { BrowserOriginError, type ResolveRequestAuthContext } from "./browser-origin"
 import { classifyRoute } from "./public-routes"
 import {
@@ -83,6 +84,13 @@ export class ServerAuthGuard {
       }
 
       return { kind: "deny", response: jsonAuthRequiredResponse() }
+    }
+
+    if (!sessionCanAccessApplication(this.sixb, session, authContext.audience)) {
+      return {
+        kind: "deny",
+        response: jsonForbiddenResponse("Application access is not allowed"),
+      }
     }
 
     if (session.credentialSource === "accessToken" && !isAccessTokenRoute(request)) {

--- a/packages/server/src/auth/responses.ts
+++ b/packages/server/src/auth/responses.ts
@@ -1,3 +1,4 @@
+import type { AuthSessionAudience } from "@sixb/core"
 import { returnToForRequest } from "./return-to"
 
 export function jsonAuthRequiredResponse(): Response {
@@ -16,7 +17,7 @@ export function htmlAuthRedirectResponse(
   request: Request,
   options: {
     readonly absoluteReturnTo?: boolean
-    readonly audience?: string
+    readonly audience?: AuthSessionAudience
   } = {}
 ): Response {
   const requestUrl = new URL(request.url)

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -29,7 +29,11 @@ import {
 } from "@sixb/core"
 import { type Elysia, t } from "elysia"
 import { bearerSecurityRequirement } from "../auth/access-token-boundary"
+import { sessionCanAccessApplication } from "../auth/application-access"
 import {
+  type AuthInvitationDestinationOptions,
+  type AuthInvitationRedirectContext,
+  type AuthInvitationRedirectInput,
   type AuthRedirectContext,
   BrowserOriginError,
   type ResolveAuthRedirectContext,
@@ -83,6 +87,10 @@ type ResolvedCookieOptions = Parameters<typeof createCsrfCookieHeader>[0]["optio
 type AuthenticatedAuthSessionResponse = {
   readonly authenticated: true
   readonly csrfToken: string
+  readonly applicationAccess: {
+    readonly allowed: boolean
+    readonly audience: AuthSessionAudience
+  }
   readonly user: {
     readonly id: string
     readonly email: string
@@ -99,7 +107,12 @@ type AuthenticatedAuthSessionResponse = {
 export interface AuthRoutesOptions {
   readonly resolveAuthContext: ResolveRequestAuthContext
   readonly resolveAuthRedirectContext: ResolveAuthRedirectContext
+  readonly getInvitationDestinationOptions: (request: Request) => AuthInvitationDestinationOptions
   readonly resolveAuthRequestOrigin: (request: Request) => string
+  readonly resolveInvitationRedirectContext: (
+    request: Request,
+    input: AuthInvitationRedirectInput
+  ) => AuthInvitationRedirectContext
 }
 
 export function registerAuthRoutes(
@@ -123,6 +136,10 @@ export function registerAuthRoutes(
           {
             authenticated: true as const,
             csrfToken: csrf.token,
+            applicationAccess: {
+              allowed: sessionCanAccessApplication(sixb, session, authOptions.audience),
+              audience: authOptions.audience,
+            },
             user: {
               id: session.user.id,
               email: session.user.email,
@@ -822,12 +839,10 @@ export function registerAuthRoutes(
         try {
           const authOptions = resolveAuthOptions(options, request)
           const parsed = CreateAuthInvitationBodySchema.parse(body)
-          const deliveryContext = resolveInvitationDeliveryContext(
-            options,
-            request,
-            parsed.returnTo,
-            authOptions
-          )
+          const deliveryContext = resolveInvitationDeliveryContext(options, request, {
+            destinationId: parsed.destinationId,
+            returnTo: parsed.returnTo,
+          })
           if (deliveryContext instanceof Response) {
             return deliveryContext
           }
@@ -843,6 +858,7 @@ export function registerAuthRoutes(
             {
               ...authOptions,
               delivery: {
+                audience: deliveryContext.audience,
                 returnTo: deliveryContext.returnTo,
                 requestOrigin: deliveryContext.requestOrigin,
               },
@@ -884,7 +900,13 @@ export function registerAuthRoutes(
       async ({ request }) => {
         try {
           const authOptions = resolveAuthOptions(options, request)
-          return jsonResponse(await sixb.auth.getInvitationOptions(request, authOptions), 200)
+          return jsonResponse(
+            {
+              ...(await sixb.auth.getInvitationOptions(request, authOptions)),
+              ...options.getInvitationDestinationOptions(request),
+            },
+            200
+          )
         } catch (error) {
           return authRouteErrorResponse(error)
         }
@@ -1649,18 +1671,13 @@ function resolveAuthRedirectContext(
 function resolveInvitationDeliveryContext(
   options: AuthRoutesOptions,
   request: Request,
-  returnTo: string | undefined,
-  authContext: ReturnType<ResolveRequestAuthContext>
-): AuthRedirectContext | Response {
+  input: AuthInvitationRedirectInput
+): AuthInvitationRedirectContext | Response {
   try {
-    return options.resolveAuthRedirectContext(request, {
-      audience: authContext.audience,
-      fallbackReturnToOrigin: authContext.browserOrigin,
-      returnTo,
-    })
+    return options.resolveInvitationRedirectContext(request, input)
   } catch (error) {
     if (error instanceof BrowserOriginError) {
-      return jsonResponse({ error: "Invitation return target is not allowed" }, 400)
+      return jsonResponse({ error: "Invitation destination is not allowed" }, 400)
     }
 
     throw error

--- a/packages/server/src/schemas/auth.ts
+++ b/packages/server/src/schemas/auth.ts
@@ -168,8 +168,15 @@ export const AuthCreateInvitationCapabilitySchema = z.union([
   }),
 ])
 
+export const AuthInvitationDestinationSchema = z.object({
+  id: z.enum(["atlas", "app"]),
+  label: z.string(),
+})
+
 export const GetAuthInvitationOptionsResponseSchema = z.object({
   groups: z.array(AuthInvitationGroupOptionSchema),
+  destinations: z.array(AuthInvitationDestinationSchema),
+  defaultDestinationId: z.enum(["atlas", "app"]).optional(),
   canInviteWithoutGroups: z.boolean(),
   capabilities: z.object({
     createInvitation: AuthCreateInvitationCapabilitySchema,
@@ -220,6 +227,7 @@ export const ReactivateAuthMemberResponseSchema = z.object({
 export const CreateAuthInvitationBodySchema = z.object({
   email: z.string().min(1),
   groupIds: z.array(z.string().min(1)).optional(),
+  destinationId: z.enum(["atlas", "app"]).optional(),
   expiresAt: z.string().optional(),
   returnTo: z.string().optional(),
 })
@@ -258,6 +266,10 @@ export const AuthSessionResponseSchema = z.union([
   z.object({
     authenticated: z.literal(true),
     csrfToken: z.string(),
+    applicationAccess: z.object({
+      allowed: z.boolean(),
+      audience: z.enum(["atlas", "app"]),
+    }),
     user: z.object({
       id: z.string(),
       email: z.string(),
@@ -278,7 +290,7 @@ export const AuthSignOutResponseSchema = z.object({
 
 export const AuthSessionSummarySchema = z.object({
   id: z.string(),
-  audience: z.string(),
+  audience: z.enum(["atlas", "app"]),
   current: z.boolean(),
   createdAt: z.string(),
   expiresAt: z.string(),

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -5,14 +5,19 @@ import { Elysia } from "elysia"
 import { websocket as elysiaWebSocket } from "elysia/ws"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import {
+  type AuthInvitationDestinationOptions,
+  type AuthInvitationRedirectContext,
+  type AuthInvitationRedirectInput,
   BrowserOriginError,
   createApiBrowserAuthContextResolver,
   createApiBrowserAuthRedirectContextResolver,
+  getApiBrowserInvitationDestinationOptions,
   isAllowedApiBrowserOrigin,
   type RequestAuthContext,
   type ResolveAuthRedirectContext,
   type ResolvedSixbApiBrowserPolicy,
   type ResolveRequestAuthContext,
+  resolveApiBrowserInvitationRedirectContext,
   resolveApiBrowserPolicy,
   resolveApiBrowserPublicOrigin,
   type SixbApiBrowserPolicy,
@@ -89,6 +94,17 @@ export class SixbServer {
 
   resolveAuthRequestOrigin(request: Request): string {
     return resolveApiBrowserPublicOrigin(this.apiBrowserPolicy, request)
+  }
+
+  getInvitationDestinationOptions(_request: Request): AuthInvitationDestinationOptions {
+    return getApiBrowserInvitationDestinationOptions(this.apiBrowserPolicy)
+  }
+
+  resolveInvitationRedirectContext(
+    request: Request,
+    input: AuthInvitationRedirectInput
+  ): AuthInvitationRedirectContext {
+    return resolveApiBrowserInvitationRedirectContext(this.apiBrowserPolicy, request, input)
   }
 
   getApiBrowserPolicy(): ResolvedSixbApiBrowserPolicy {
@@ -215,7 +231,10 @@ export function createSixbApi(server: SixbServer) {
     resolveAuthContext: (request) => server.resolveAuthContext(request),
     resolveAuthRedirectContext: (request, input) =>
       server.resolveAuthRedirectContext(request, input),
+    getInvitationDestinationOptions: (request) => server.getInvitationDestinationOptions(request),
     resolveAuthRequestOrigin: (request) => server.resolveAuthRequestOrigin(request),
+    resolveInvitationRedirectContext: (request, input) =>
+      server.resolveInvitationRedirectContext(request, input),
   })
   registerHttpRoutes(app, sixb)
   registerWebhookRoutes(app, sixb)

--- a/packages/server/tests/agent-streams-ws.test.ts
+++ b/packages/server/tests/agent-streams-ws.test.ts
@@ -555,6 +555,7 @@ function authz(principal: Principal, agentIds: readonly string[] = []): Authoriz
     groupIds: [],
     roleIds: [],
     grants: {
+      "access:application": new Set(),
       "view:object": new Set(),
       "view:dataset": new Set(),
       "apply:action": new Set(),

--- a/packages/server/tests/auth-guard.test.ts
+++ b/packages/server/tests/auth-guard.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { createServer } from "node:net"
 import {
+  applications,
+  can,
   createAccessTokenCredential,
   createSessionCredential,
   defineConnector,
+  defineGroup,
   defineObjectType,
+  defineRole,
   defineWebhook,
   InMemoryBlobStorage,
   InMemoryBroker,
@@ -13,10 +17,14 @@ import {
   InMemoryStorage,
   type OntologySource,
   prop,
+  type RoleDefinition,
   Sixb,
 } from "@sixb/core"
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
+
+const securityAdmins = defineGroup("security-admins")
+const atlasUsers = defineGroup("atlas-users")
 
 const authStrategy = {
   id: "test",
@@ -54,7 +62,13 @@ async function getFreePort(): Promise<number> {
   })
 }
 
-function createRuntime(options: { readonly auth?: boolean; readonly connector?: boolean } = {}) {
+function createRuntime(
+  options: {
+    readonly auth?: boolean
+    readonly connector?: boolean
+    readonly roles?: readonly RoleDefinition[]
+  } = {}
+) {
   const storage = new InMemoryStorage()
   const connector = defineConnector("github", {
     type: "test",
@@ -81,6 +95,8 @@ function createRuntime(options: { readonly auth?: boolean; readonly connector?: 
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
     connectors: options.connector ? [connector] : [],
+    groups: [securityAdmins, atlasUsers],
+    roles: options.roles,
     auth: options.auth ? authStrategy : undefined,
   })
 
@@ -179,6 +195,24 @@ describe("server auth guard", () => {
     }
   })
 
+  test("maps each auth audience to exactly one browser origin", () => {
+    const { sixb } = createRuntime({ auth: true })
+
+    expect(
+      () =>
+        new SixbServer({
+          sixb,
+          quiet: true,
+          browser: {
+            allowedOrigins: [
+              { origin: "http://atlas.localhost", audience: "atlas" },
+              { origin: "http://admin.localhost", audience: "atlas" },
+            ],
+          },
+        })
+    ).toThrow("Auth audience 'atlas' is mapped to multiple browser origins")
+  })
+
   test("protects API routes with generic JSON 401", async () => {
     const { sixb } = createRuntime({ auth: true })
     const app = createSixbApi(
@@ -255,6 +289,7 @@ describe("server auth guard", () => {
     expect(await response.json()).toEqual({
       authenticated: true,
       csrfToken: expect.any(String),
+      applicationAccess: { audience: "atlas", allowed: true },
       user: {
         id: "usr_1",
         email: "ava@acme.com",
@@ -267,6 +302,66 @@ describe("server auth guard", () => {
       },
     })
     expect(response.headers.get("set-cookie")).toContain("sixb_csrf=")
+  })
+
+  test("application grants restrict Atlas at the session and API boundaries", async () => {
+    const atlasAccess = defineRole("atlas.access", {
+      grantedTo: [atlasUsers],
+      grants: [can.access(applications.atlas)],
+    })
+    const { sixb, storage } = createRuntime({ auth: true, roles: [atlasAccess] })
+    const atlasSession = await seedSession(storage)
+    const app = createSixbApi(
+      new SixbServer({ sixb, quiet: true, browser: createTestBrowserPolicy() })
+    )
+
+    const deniedSession = await app.fetch(
+      new Request("http://api.localhost/api/auth/session", {
+        headers: {
+          origin: "http://atlas.localhost",
+          cookie: atlasSession.cookie,
+        },
+      })
+    )
+    const deniedApi = await app.fetch(
+      new Request("http://api.localhost/api/project", {
+        headers: {
+          origin: "http://atlas.localhost",
+          cookie: atlasSession.cookie,
+        },
+      })
+    )
+
+    expect(deniedSession.status).toBe(200)
+    expect(await deniedSession.json()).toMatchObject({
+      authenticated: true,
+      applicationAccess: { audience: "atlas", allowed: false },
+    })
+    expect(deniedApi.status).toBe(403)
+    expect(await deniedApi.json()).toEqual({ error: "Application access is not allowed" })
+  })
+
+  test("application grants allow Atlas for a matching group", async () => {
+    const atlasAccess = defineRole("atlas.access", {
+      grantedTo: [securityAdmins],
+      grants: [can.access(applications.atlas)],
+    })
+    const { sixb, storage } = createRuntime({ auth: true, roles: [atlasAccess] })
+    const seeded = await seedSession(storage)
+    const app = createSixbApi(
+      new SixbServer({ sixb, quiet: true, browser: createTestBrowserPolicy() })
+    )
+
+    const response = await app.fetch(
+      new Request("http://api.localhost/api/project", {
+        headers: {
+          origin: "http://atlas.localhost",
+          cookie: seeded.cookie,
+        },
+      })
+    )
+
+    expect(response.status).toBe(200)
   })
 
   test("resolves sessions with the app audience cookie names", async () => {

--- a/packages/server/tests/helpers.ts
+++ b/packages/server/tests/helpers.ts
@@ -55,12 +55,10 @@ export function createTestBrowserPolicy(
   const atlasOrigin = options.atlasOrigin ?? "http://atlas.localhost"
   const appOrigin = options.appOrigin ?? "http://app.localhost"
   const includeApp = options.includeApp ?? true
-  const allowedOrigins: SixbBrowserOrigin[] = [
-    { origin: atlasOrigin, audience: "atlas", kind: "atlas" },
-  ]
+  const allowedOrigins: SixbBrowserOrigin[] = [{ origin: atlasOrigin, audience: "atlas" }]
 
   if (includeApp) {
-    allowedOrigins.push({ origin: appOrigin, audience: "app", kind: "app" })
+    allowedOrigins.push({ origin: appOrigin, audience: "app" })
   }
 
   return {

--- a/packages/server/tests/invitations-auth-routes.test.ts
+++ b/packages/server/tests/invitations-auth-routes.test.ts
@@ -3,10 +3,13 @@ import { magicLink, type SendMagicLinkInput } from "@sixb/auth-magic-link"
 import { oidc, type SendOidcInvitationInput } from "@sixb/auth-oidc"
 import {
   type AuthStrategy,
+  applications,
+  can,
   createSessionCredential,
   defineGroup,
   defineMembershipPolicy,
   defineObjectType,
+  defineRole,
   InMemoryBlobStorage,
   InMemoryBroker,
   InMemoryLakeStorage,
@@ -15,6 +18,7 @@ import {
   type MembershipPolicyDefinition,
   type OntologySource,
   prop,
+  type RoleDefinition,
   Sixb,
   type SixbAuthConfig,
 } from "@sixb/core"
@@ -25,6 +29,13 @@ const projectId = "test-project"
 const securityAdmins = defineGroup("security-admins")
 const commercial = defineGroup("commercial")
 const finance = defineGroup("finance")
+const invitationDestinationOptions = {
+  destinations: [
+    { id: "atlas", label: "Atlas" },
+    { id: "app", label: "Custom app" },
+  ],
+  defaultDestinationId: "app",
+}
 
 const Device = defineObjectType({
   id: "device",
@@ -49,6 +60,7 @@ function createRuntime(
   options: {
     readonly auth?: SixbAuthConfig
     readonly membershipPolicies?: readonly MembershipPolicyDefinition[]
+    readonly roles?: readonly RoleDefinition[]
   } = {}
 ) {
   const storage = new InMemoryStorage()
@@ -66,6 +78,7 @@ function createRuntime(
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
     groups: [securityAdmins, commercial, finance],
+    roles: options.roles,
     membershipPolicies: options.membershipPolicies ?? [
       defineMembershipPolicy("default-membership", {
         grantedTo: [securityAdmins],
@@ -229,6 +242,150 @@ describe("auth invitation routes", () => {
     })
   })
 
+  test("Atlas can invite an allowed group directly to the configured custom app", async () => {
+    const commercialAppAccess = defineRole("commercial.app-access", {
+      grantedTo: [commercial],
+      grants: [can.access(applications.app)],
+    })
+    const { app, messages, storage } = createRuntime({ roles: [commercialAppAccess] })
+    const admin = await seedAdminSession(storage)
+
+    const response = await app.fetch(
+      new Request("http://api.localhost/api/auth/invitations", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://atlas.localhost",
+          cookie: admin.cookie,
+          ...admin.csrfHeader,
+        },
+        body: JSON.stringify({
+          email: "app-user@acme.com",
+          groupIds: ["commercial"],
+          destinationId: "app",
+        }),
+      })
+    )
+
+    expect(response.status).toBe(201)
+    const link = linkFromLatestMessage(messages)
+    const magicLink = await storage.auth.magicLinks.getById({
+      projectId,
+      id: link.searchParams.get("magicLinkId") ?? "",
+    })
+    expect(magicLink).toMatchObject({
+      audience: "app",
+      returnTo: "http://app.localhost/",
+    })
+
+    const callback = await confirmCallback(app, link)
+    expect(callback.status).toBe(303)
+    expect(callback.headers.get("location")).toBe("http://app.localhost/")
+    expect(callback.headers.get("set-cookie")).toContain("sixb_session_app=")
+  })
+
+  test("rejects an invitation destination that is not configured", async () => {
+    const { sixb, storage } = createRuntime()
+    const app = createSixbApi(
+      new SixbServer({
+        sixb,
+        quiet: true,
+        browser: createTestBrowserPolicy({ includeApp: false }),
+      })
+    )
+    const admin = await seedAdminSession(storage)
+    const destinationOptions = await app.fetch(
+      new Request("http://api.localhost/api/auth/invitation-options", {
+        headers: {
+          origin: "http://atlas.localhost",
+          cookie: admin.cookie,
+        },
+      })
+    )
+
+    const response = await app.fetch(
+      new Request("http://api.localhost/api/auth/invitations", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://atlas.localhost",
+          cookie: admin.cookie,
+          ...admin.csrfHeader,
+        },
+        body: JSON.stringify({
+          email: "app-user@acme.com",
+          groupIds: ["commercial"],
+          destinationId: "app",
+        }),
+      })
+    )
+
+    expect(destinationOptions.status).toBe(200)
+    expect(await destinationOptions.json()).toMatchObject({
+      destinations: [{ id: "atlas", label: "Atlas" }],
+      defaultDestinationId: "atlas",
+    })
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: "Invitation destination is not allowed" })
+  })
+
+  test("rejects a return target outside the selected destination", async () => {
+    const { app, storage } = createRuntime()
+    const admin = await seedAdminSession(storage)
+
+    const response = await app.fetch(
+      new Request("http://api.localhost/api/auth/invitations", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://atlas.localhost",
+          cookie: admin.cookie,
+          ...admin.csrfHeader,
+        },
+        body: JSON.stringify({
+          email: "app-user@acme.com",
+          groupIds: ["commercial"],
+          destinationId: "app",
+          returnTo: "http://atlas.localhost/objects",
+        }),
+      })
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: "Invitation destination is not allowed" })
+  })
+
+  test("rejects invitation groups without access to a controlled destination", async () => {
+    const financeAppAccess = defineRole("finance.app-access", {
+      grantedTo: [finance],
+      grants: [can.access(applications.app)],
+    })
+    const { app, storage } = createRuntime({ roles: [financeAppAccess] })
+    const admin = await seedAdminSession(storage)
+
+    const response = await app.fetch(
+      new Request("http://api.localhost/api/auth/invitations", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://atlas.localhost",
+          cookie: admin.cookie,
+          ...admin.csrfHeader,
+        },
+        body: JSON.stringify({
+          email: "app-user@acme.com",
+          groupIds: ["commercial"],
+          destinationId: "app",
+        }),
+      })
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({
+      error: "[Sixb] Invitation groups do not grant access to application 'app'.",
+    })
+  })
+
   test("creates OIDC invitations without magic-link delivery", async () => {
     const { app, storage } = createRuntime({
       auth: oidc({
@@ -307,7 +464,7 @@ describe("auth invitation routes", () => {
         body: JSON.stringify({
           email: "oidc-user@acme.com",
           groupIds: ["commercial"],
-          returnTo: "http://atlas.localhost/objects",
+          destinationId: "app",
         }),
       })
     )
@@ -327,7 +484,8 @@ describe("auth invitation routes", () => {
     expect(messages).toHaveLength(1)
     expect(signInUrl.origin).toBe("https://app.example.com")
     expect(signInUrl.pathname).toBe("/auth/sign-in")
-    expect(signInUrl.searchParams.get("returnTo")).toBe("http://atlas.localhost/objects")
+    expect(signInUrl.searchParams.get("audience")).toBe("app")
+    expect(signInUrl.searchParams.get("returnTo")).toBe("http://app.localhost/")
   })
 
   test("revokes OIDC invitations when invitation email sending fails", async () => {
@@ -423,6 +581,7 @@ describe("auth invitation routes", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       groups: [{ id: "commercial" }],
+      ...invitationDestinationOptions,
       canInviteWithoutGroups: true,
       capabilities: {
         createInvitation: { state: "enabled" },
@@ -456,6 +615,7 @@ describe("auth invitation routes", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       groups: [{ id: "commercial" }, { id: "finance" }],
+      ...invitationDestinationOptions,
       canInviteWithoutGroups: true,
       capabilities: {
         createInvitation: { state: "enabled" },
@@ -476,6 +636,7 @@ describe("auth invitation routes", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       groups: [],
+      ...invitationDestinationOptions,
       canInviteWithoutGroups: false,
       capabilities: {
         createInvitation: {
@@ -500,6 +661,7 @@ describe("auth invitation routes", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       groups: [{ id: "commercial" }],
+      ...invitationDestinationOptions,
       canInviteWithoutGroups: true,
       capabilities: {
         createInvitation: {
@@ -526,6 +688,7 @@ describe("auth invitation routes", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toMatchObject({
       groups: [{ id: "commercial" }],
+      defaultDestinationId: "app",
       capabilities: {
         createInvitation: { state: "enabled" },
       },

--- a/packages/server/tests/logs-routes.test.ts
+++ b/packages/server/tests/logs-routes.test.ts
@@ -424,6 +424,7 @@ function authzWithoutLogs(): AuthorizationContext {
     groupIds: [],
     roleIds: [],
     grants: {
+      "access:application": new Set(),
       "view:object": new Set(),
       "view:dataset": new Set(),
       "apply:action": new Set(),

--- a/packages/server/tests/projections-routes.test.ts
+++ b/packages/server/tests/projections-routes.test.ts
@@ -58,6 +58,7 @@ function authzViewing(...objectTypeIds: string[]): AuthorizationContext {
     groupIds: [],
     roleIds: [],
     grants: {
+      "access:application": new Set(),
       "view:object": new Set(objectTypeIds),
       "view:dataset": new Set(),
       "apply:action": new Set(),

--- a/storage/pg/src/auth-storage/sessions.ts
+++ b/storage/pg/src/auth-storage/sessions.ts
@@ -1,4 +1,9 @@
-import type { AuthSessionStore, CreateAuthSessionInput, SessionRecord } from "@sixb/core"
+import type {
+  AuthSessionAudience,
+  AuthSessionStore,
+  CreateAuthSessionInput,
+  SessionRecord,
+} from "@sixb/core"
 import { AuthStorageError } from "@sixb/core"
 import {
   authLockKey,
@@ -35,7 +40,7 @@ export class PgAuthSessionStore implements AuthSessionStore {
   async getActiveByUserId(params: {
     readonly projectId: string
     readonly userId: string
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly now: Date
   }): Promise<SessionRecord | null> {
     const [row] = await this.sql<PgAuthSessionRow[]>`
@@ -74,7 +79,7 @@ export class PgAuthSessionStore implements AuthSessionStore {
   async findValidByTokenHash(params: {
     readonly projectId: string
     readonly id: string
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly tokenHash: string
     readonly now: Date
   }): Promise<SessionRecord | null> {
@@ -123,7 +128,7 @@ export class PgAuthSessionStore implements AuthSessionStore {
   async revokeActiveForUser(params: {
     readonly projectId: string
     readonly userId: string
-    readonly audience?: string
+    readonly audience?: AuthSessionAudience
     readonly revokedAt: Date
   }): Promise<readonly SessionRecord[]> {
     return runPgTransaction(this.sql, async (tx) => {

--- a/storage/pg/src/auth-storage/shared.ts
+++ b/storage/pg/src/auth-storage/shared.ts
@@ -1,4 +1,5 @@
 import type {
+  AuthSessionAudience,
   CompleteAuthSessionInput,
   CreateAuthSessionInput,
   GroupMembershipRecord,
@@ -525,7 +526,7 @@ export async function revokeActiveSessionsForUser(
   params: {
     readonly projectId: string
     readonly userId: string
-    readonly audience?: string
+    readonly audience?: AuthSessionAudience
     readonly revokedAt: Date
   }
 ): Promise<readonly SessionRecord[]> {

--- a/storage/sqlite/src/auth-storage/sessions.ts
+++ b/storage/sqlite/src/auth-storage/sessions.ts
@@ -1,5 +1,10 @@
 import type { Database } from "bun:sqlite"
-import type { AuthSessionStore, CreateAuthSessionInput, SessionRecord } from "@sixb/core"
+import type {
+  AuthSessionAudience,
+  AuthSessionStore,
+  CreateAuthSessionInput,
+  SessionRecord,
+} from "@sixb/core"
 import { AuthStorageError } from "@sixb/core"
 import { runImmediateTransaction } from "../transactions"
 import type { SqliteAuthSessionRow } from "./rows"
@@ -30,7 +35,7 @@ export class SqliteAuthSessionStore implements AuthSessionStore {
   async getActiveByUserId(params: {
     readonly projectId: string
     readonly userId: string
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly now: Date
   }): Promise<SessionRecord | null> {
     const row = this.db
@@ -82,7 +87,7 @@ export class SqliteAuthSessionStore implements AuthSessionStore {
   async findValidByTokenHash(params: {
     readonly projectId: string
     readonly id: string
-    readonly audience: string
+    readonly audience: AuthSessionAudience
     readonly tokenHash: string
     readonly now: Date
   }): Promise<SessionRecord | null> {
@@ -137,7 +142,7 @@ export class SqliteAuthSessionStore implements AuthSessionStore {
   async revokeActiveForUser(params: {
     readonly projectId: string
     readonly userId: string
-    readonly audience?: string
+    readonly audience?: AuthSessionAudience
     readonly revokedAt: Date
   }): Promise<readonly SessionRecord[]> {
     return runImmediateTransaction(this.db, () => revokeActiveSessionsForUser(this.db, params))

--- a/storage/sqlite/src/auth-storage/shared.ts
+++ b/storage/sqlite/src/auth-storage/shared.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite"
 import type {
+  AuthSessionAudience,
   CompleteAuthSessionInput,
   CreateAuthSessionInput,
   GroupMembershipRecord,
@@ -476,7 +477,7 @@ export function revokeActiveSessionsForUser(
   params: {
     readonly projectId: string
     readonly userId: string
-    readonly audience?: string
+    readonly audience?: AuthSessionAudience
     readonly revokedAt: Date
   }
 ): readonly ReturnType<typeof rowToSessionRecord>[] {


### PR DESCRIPTION
## Summary

Adds server-controlled invitation destinations and application-level access for Atlas (`atlas`) and the custom app (`app`). Invitations now select a configured application origin, validate that assigned groups can access it, and create the correct audience-specific session.

## Stack

This PR is intentionally stacked on #181 and currently targets `fix-magic-links`:

```text
main
  └─ #181 fix-magic-links
       └─ #188 control-invites (this PR)
```

Merge #181 first, then retarget this PR to `main`. This work uses #181's corrected confirmation flow; scanner-safe magic-link consumption remains scoped to #181.

## What changed

### One application identity

Auth audience is now the single application identity. Arbitrary audiences and the duplicate browser-origin `kind` field are removed.

```text
Browser origin                   Audience   Cookie             Access target
--------------------------------------------------------------------------------
atlas.example.com          ────> atlas  ──> sixb_session   ──> applications.atlas
app.example.com            ────> app    ──> sixb_session_app ─> applications.app
```

```ts
browser: {
  publicOrigin: "https://api.example.com",
  allowedOrigins: [
    { origin: "https://atlas.example.com", audience: "atlas" },
    { origin: "https://app.example.com", audience: "app" },
  ],
}
```

Each audience maps to exactly one browser origin. Configured origins automatically become invitation destinations and application-access boundaries.

### Controlled invitations

```text
Atlas admin
   │
   ├─ fetch configured destinations
   ├─ select email, destination, and groups
   ▼
Server
   ├─ resolve destination from allowedOrigins
   ├─ reject return URLs outside that origin
   ├─ validate access using only the invitation's groups
   └─ deliver a link for the destination audience
   ▼
Recipient session + redirect to selected application
```

- Adds `destinationId` to invitation options, creation, OpenAPI, and generated clients.
- Defaults to the custom app when configured, otherwise Atlas.
- Never accepts an arbitrary destination origin.
- Keeps destination context out of invitation storage; no invitation migration is required.

### Application grants

```ts
can.access(applications.atlas)
can.access(applications.app)
```

Allowlists are opt-in per application:

```text
No role grants the application  ──> allow authenticated users (compatibility)
Any role grants the application ──> require a matching grant, otherwise deny
```

Application access gates entry; existing `can.view`, `can.apply`, and `can.run` grants continue governing resources inside the application.

Enforcement covers HTTP requests, WebSockets, invitation validation, and `/api/auth/session`. Atlas and generated custom apps also provide access-denied screens with sign-out, but server enforcement remains authoritative.

### UI and example

- Adds a destination selector and cleaned-up invitation flow in Atlas.
- Adds a small custom app to `examples/auth` at `http://localhost:3001` showing the user, groups, and granted notes.
- `team-members` can access the custom app but not Atlas.
- `security-admins` can access both.

## Contract and security notes

- `AuthSessionAudience` is now `"atlas" | "app"`.
- `/api/auth/session` returns:

  ```ts
  applicationAccess: {
    audience: "atlas" | "app"
    allowed: boolean
  }
  ```

- Existing auth storage retains its `audience` columns; no storage migration is required.
- Invitation group checks ignore unrelated existing memberships.
- Origin and return-target validation happen server-side.
- OpenAPI, generated clients, documentation, and auth tests are updated.

## Review focus

1. Origin-to-audience uniqueness and return-target validation.
2. Opt-in allowlist behavior.
3. Invitation checks using only selected groups.
4. HTTP/WebSocket enforcement and audience-specific cookies.

## Verification

```text
bun run check       passed
bun run typecheck   passed
bun run build       passed
bun run test        2,341 passed, 2 skipped, 0 failed
```

Generated artifacts were refreshed with `bun run generate:client`.
