### PR TITLE
agent-worker: add project Agent Skills

### DIFF
--- a/docs/agents/defining-agents.md
+++ b/docs/agents/defining-agents.md
@@ -50,6 +50,21 @@ model: gateway("deepseek/deepseek-v4-flash")
 model: gateway("openai/gpt-5.5")
 ```
 
+## Instructions vs Agent Skills
+
+Keep `instructions` short and always relevant: the agent role, hard behavioral rules, and domain
+boundaries. Put larger company standards, examples, templates, and repeatable procedures in Agent
+Skills instead:
+
+```txt
+skills/acme-writing-style/SKILL.md
+skills/acme-writing-style/references/examples.md
+```
+
+Project skills are installed into each run sandbox under `$SIXB_SKILLS_DIR`. The worker advertises
+only each skill's `name` and `description` up front, and the agent reads the full `SKILL.md` when the
+skill is relevant.
+
 ## Loop
 
 An agent runs a tool-calling loop: the model produces output, may call tools, sees the results, and

--- a/docs/agents/tools-and-gateway.md
+++ b/docs/agents/tools-and-gateway.md
@@ -53,6 +53,26 @@ Requests run under the agent's [execution identity](./authorization.md), so the 
 and act on what its groups allow — the same checks as any other caller, and only while the run is
 active.
 
+## Agent Skills in the sandbox
+
+Every run also gets Agent Skills under `$SIXB_SKILLS_DIR`. Sixb installs built-in API skills such as
+`sixb-query`, `sixb-telemetry`, and `sixb-actions`, then adds project skills from
+`skills/<name>/SKILL.md` when that folder exists.
+
+A project skill follows the Agent Skills folder format:
+
+```txt
+skills/acme-writing-style/
+├── SKILL.md
+└── references/
+    └── examples.md
+```
+
+`SKILL.md` starts with `name` and `description` frontmatter. Only those metadata fields are listed in
+the model's always-on catalog; the agent reads the full `SKILL.md` and any referenced files from
+`$SIXB_SKILLS_DIR/<name>` only when the task matches. Use skills for company standards, examples,
+templates, and multi-step procedures that should not live in every agent's base prompt.
+
 ## Related
 
 - [Sandboxes](../sandboxes/overview.md)

--- a/docs/fundamentals/project-structure.md
+++ b/docs/fundamentals/project-structure.md
@@ -1,9 +1,10 @@
 # Project Structure
 
 A Sixb project is a set of convention folders plus one entry file. [`createSixb()`](../runtime/overview.md)
-scans well-known directories under your project root, loads every module it finds, and
-registers the definitions you export. There is no central manifest: you write a definition,
-export it from the matching folder, and it is wired in.
+scans definition directories under your project root, loads every module it finds, and registers the
+definitions you export. Other runtime components can recognize their own folders too; for example,
+the agent worker reads `skills/` as Agent Skills. There is no central manifest: you write the file in
+the matching folder, and Sixb wires it in.
 
 ## Directory tree
 
@@ -35,6 +36,11 @@ acme-corp/
 │   └── invoice-reminder.ts
 ├── agents/
 │   └── invoice-assistant.ts
+├── skills/
+│   └── acme-writing-style/
+│       ├── SKILL.md
+│       └── references/
+│           └── examples.md
 ├── security/
 │   ├── groups/
 │   │   └── finance-admins.ts
@@ -51,9 +57,11 @@ of these definitions in-line to `createSixb()` instead of (or alongside) the fol
 
 ## Discovered folders
 
-`createSixb()` discovers exactly these folders. Each scan recurses into subdirectories and
-loads `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, and `.cjs` files. The folder selects the *kind*:
-a definition picked up depends on where it lives, not what the file is named.
+Sixb recognizes these convention folders. Most are `createSixb()` definition folders: each scan
+recurses into subdirectories and loads `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, and `.cjs` files. The
+folder selects the *kind*: a definition picked up depends on where it lives, not what the file is
+named. `skills/` is different: the agent worker reads Agent Skill folders and materializes them into
+agent sandboxes.
 
 | Folder | Holds | Related page |
 | --- | --- | --- |
@@ -69,6 +77,7 @@ a definition picked up depends on where it lives, not what the file is named.
 | `rules/` | Rule definitions | [Rules](../rules/overview.md) |
 | `workflows/` | Workflow definitions | [Workflows](../workflows/overview.md) |
 | `agents/` | Agent definitions | [Agents](../agents/overview.md) |
+| `skills/` | Agent Skills (`<name>/SKILL.md` plus references/assets/scripts) read by the agent worker | [Agents](../agents/overview.md) |
 | `security/groups/` | Group definitions | [Authorization](../auth/authorization.md) |
 | `security/roles/` | Role definitions | [Authorization](../auth/authorization.md) |
 | `security/policies/` | Membership-policy definitions | [Authorization](../auth/authorization.md) |

--- a/examples/acme-corp/skills/acme-writing-style/SKILL.md
+++ b/examples/acme-corp/skills/acme-writing-style/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: acme-writing-style
+description: Use when drafting Acme operational summaries, customer updates, invoice notes, or executive-ready follow-ups.
+---
+
+# Acme Writing Style
+
+Use this skill before drafting customer-facing or executive-facing text for Acme operators.
+
+## Style
+
+- Be concise and operational.
+- Lead with the business state, then the recommended next action.
+- Use active voice and specific object names when the data provides them.
+- Say when Sixb data is insufficient rather than filling gaps.
+- Never claim an invoice reminder was sent unless the data shows it was approved or sent.
+
+## References
+
+- Read [examples](references/examples.md) for sample wording and tone.

--- a/examples/acme-corp/skills/acme-writing-style/references/examples.md
+++ b/examples/acme-corp/skills/acme-writing-style/references/examples.md
@@ -1,0 +1,25 @@
+# Acme Writing Examples
+
+## Overdue invoice summary
+
+Good:
+
+> Globex has 2 overdue invoices totaling $14,200. The oldest is 18 days past due. Recommended next action: review account context, then approve a payment reminder if no recent follow-up is recorded.
+
+Avoid:
+
+> Globex is late and we should send them a reminder now.
+
+The good version states the available data, avoids assuming approval, and gives the operator a clear next step.
+
+## Customer project update
+
+Good:
+
+> The Website Refresh project is active with 3 open tasks and no blocked tasks in Sixb. Next action: confirm the design review date before updating the customer.
+
+Avoid:
+
+> Everything is on track.
+
+The good version is grounded in visible Sixb data and names the missing confirmation.

--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -66,11 +66,13 @@ The terminal run state is stored on the run record:
   `SIXB_SKILLS_DIR`, and creates the sandbox with a restricted network policy allowing the server
   origin. The gateway authorizes scoped ontology, object, telemetry read, and action routes from the
   run lease and managed agent service account; no bearer token is exposed to the sandbox.
+- `skillsDir`: optional project Agent Skills directory. Defaults to `<projectRoot>/skills`. Set to
+  `false` to install only the built-in Sixb skills.
 - `concurrency`: maximum number of agent run jobs this worker claims and executes at once; defaults
   to `4`.
 - `streamSink`: stream sink override; defaults to a broker-backed sink.
 - `leaseMs`: run lease and queue visibility duration; defaults to 60 seconds.
 - `heartbeatMs`: lease renewal interval; defaults to one third of `leaseMs`.
 - `turnTimeoutMs`: wall-clock turn budget; defaults to 5 minutes.
-- `defaultMaxSteps`: model step cap when an agent does not specify one; defaults to `8`.
+- `defaultMaxSteps`: model step cap when an agent does not specify one; defaults to `25`.
 - `idlePollMs`: queue polling interval while idle.

--- a/packages/agent-worker/src/agent-skills.ts
+++ b/packages/agent-worker/src/agent-skills.ts
@@ -1,74 +1,62 @@
-import { readFile } from "node:fs/promises"
-import { join } from "node:path"
+import { lstat, readdir, readFile } from "node:fs/promises"
+import { basename, join, relative, sep } from "node:path"
+import { fileURLToPath } from "node:url"
 import type { SandboxFileRecord } from "@sixb/core"
 
-interface AgentSkill {
+export interface AgentSkillFile {
+  readonly relativePath: string
+  readonly contents: string | Uint8Array
+  readonly mode?: number
+}
+
+export interface AgentSkill {
   readonly name: string
   readonly description: string
-  /** Reference file names under the skill's `references/` directory. */
-  readonly references?: readonly string[]
+  readonly files: readonly AgentSkillFile[]
 }
 
-/**
- * Catalog of the skills shipped with the worker. The prose bodies live as real markdown under
- * `./skills/<name>/` (SKILL.md + references/*.md) and are bundled into dist via the package's
- * `sixbBuild.assets`; only the name/description metadata lives here so {@link renderAgentSkillCatalog}
- * stays synchronous.
- */
-const SIXB_AGENT_SKILLS: readonly AgentSkill[] = [
-  {
-    name: "sixb-query",
-    description:
-      "Use when discovering ontology, reading Sixb objects, filtering, sorting, paging, counting, faceting, traversing links, or expanding object query results.",
-    references: ["query-api.md", "query-shapes.md", "predicates.md", "examples.md"],
-  },
-  {
-    name: "sixb-telemetry",
-    description:
-      "Use when reading Sixb telemetry latest values or history for ontology telemetry properties.",
-    references: ["telemetry-api.md"],
-  },
-  {
-    name: "sixb-actions",
-    description:
-      "Use when requesting declared Sixb ontology actions as the preferred mutation path.",
-    references: ["actions-api.md"],
-  },
-]
+interface AgentSkillMetadata {
+  readonly name?: string
+  readonly description?: string
+}
 
-/**
- * Resolve the packaged skills directory. `import.meta.url` points at this module wherever it runs —
- * `src/` under the `bun` dev condition, `dist/` for a published build (where `sixbBuild.assets`
- * copies the tree) — so the same relative URL finds the bundled markdown in both layouts.
- */
-const SKILLS_ROOT = new URL("./skills/", import.meta.url)
+const SKILL_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/
+const BUNDLED_SKILLS_DIR = fileURLToPath(new URL("./skills/", import.meta.url))
 
-/**
- * Build the file records that install the agent skills into a sandbox, reading the packaged
- * markdown. Returns records targeting `<skillsDir>/<name>/SKILL.md` and
- * `<skillsDir>/<name>/references/<file>`, ready to hand to {@link Sandbox.writeFiles}.
- */
-export async function buildAgentSkillFiles(
-  skillsDir: string
-): Promise<readonly SandboxFileRecord[]> {
-  const records: SandboxFileRecord[] = []
-  for (const skill of SIXB_AGENT_SKILLS) {
-    const source = new URL(`${skill.name}/`, SKILLS_ROOT)
-    records.push({
-      path: join(skillsDir, skill.name, "SKILL.md"),
-      contents: await readFile(new URL("SKILL.md", source), "utf-8"),
-    })
-    for (const reference of skill.references ?? []) {
-      records.push({
-        path: join(skillsDir, skill.name, "references", reference),
-        contents: await readFile(new URL(`references/${reference}`, source), "utf-8"),
-      })
-    }
+export async function loadAgentSkills(
+  input: { readonly projectSkillsDir?: string | false } = {}
+): Promise<readonly AgentSkill[]> {
+  const bundledSkills = await loadSkillsDirectory(BUNDLED_SKILLS_DIR, { source: "bundled" })
+  if (input.projectSkillsDir === false || input.projectSkillsDir === undefined) {
+    return bundledSkills
   }
-  return records
+
+  const projectSkills = await loadSkillsDirectory(input.projectSkillsDir, {
+    source: "project",
+    missingAllowed: true,
+    builtInNames: new Set(bundledSkills.map((skill) => skill.name)),
+  })
+  return [...bundledSkills, ...projectSkills]
 }
 
-export function renderAgentSkillCatalog(): string {
+/**
+ * Build the file records that install the agent skills into a sandbox. Returns records targeting
+ * `<skillsDir>/<name>/...`, ready to hand to {@link Sandbox.writeFiles}.
+ */
+export function buildAgentSkillFiles(
+  skillsDir: string,
+  skills: readonly AgentSkill[]
+): readonly SandboxFileRecord[] {
+  return skills.flatMap((skill) =>
+    skill.files.map((file) => ({
+      path: join(skillsDir, skill.name, file.relativePath),
+      contents: file.contents,
+      ...(file.mode === undefined ? {} : { mode: file.mode }),
+    }))
+  )
+}
+
+export function renderAgentSkillCatalog(skills: readonly AgentSkill[]): string {
   return [
     "Sixb API access is available from the sandboxed bash tool through a per-run gateway URL.",
     "Agent Skills are installed under $SIXB_SKILLS_DIR.",
@@ -76,14 +64,177 @@ export function renderAgentSkillCatalog(): string {
     "Prepare user-facing files under $SIXB_OUTPUT_STAGING_DIR, then atomically publish each complete file or directory with mv into $SIXB_OUTPUT_DIR. Only files under $SIXB_OUTPUT_DIR are attached to the final chat message when size limits allow.",
     "Never write a file directly in $SIXB_OUTPUT_DIR and never modify it after publication; publish only complete outputs.",
     "Use $SIXB_SKILLS_DIR and attachment/output env vars to reference file paths; do not hardcode sandbox directory paths.",
-    "Before using a matching Sixb ontology API surface, read that skill's SKILL.md with bash/cat.",
+    "Before applying a matching skill, read that skill's SKILL.md with bash/cat.",
+    "Load referenced files only when needed.",
     "Use live ontology and object APIs rather than guessing schema or relying on stale context.",
     "Do not add Authorization or Cookie headers. The gateway authenticates allowed requests.",
-    "Operate through the ontology layer: object types, object reads/queries, telemetry reads, and declared actions.",
+    [
+      "Operate through the ontology layer: object types, object reads/queries, telemetry reads,",
+      "and declared actions.",
+    ].join(" "),
     "",
     "Available Agent Skills:",
-    ...SIXB_AGENT_SKILLS.map(
+    ...skills.map(
       (skill) => `- ${skill.name}: ${skill.description} Path: $SIXB_SKILLS_DIR/${skill.name}`
     ),
   ].join("\n")
+}
+
+interface LoadSkillsDirectoryOptions {
+  readonly source: "bundled" | "project"
+  readonly missingAllowed?: boolean
+  readonly builtInNames?: ReadonlySet<string>
+}
+
+async function loadSkillsDirectory(
+  skillsDir: string,
+  options: LoadSkillsDirectoryOptions
+): Promise<readonly AgentSkill[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(skillsDir)
+  } catch (error) {
+    if (options.missingAllowed && isNotFound(error)) {
+      return []
+    }
+    throw error
+  }
+
+  const skills: AgentSkill[] = []
+  for (const entry of entries.sort((a, b) => a.localeCompare(b))) {
+    const skillDir = join(skillsDir, entry)
+    const info = await lstat(skillDir)
+    if (info.isSymbolicLink()) {
+      throw skillError(skillDir, "Skill directories must not be symlinks.")
+    }
+    if (!info.isDirectory()) {
+      continue
+    }
+    skills.push(await loadAgentSkill(skillDir, options))
+  }
+  return skills
+}
+
+async function loadAgentSkill(
+  skillDir: string,
+  options: LoadSkillsDirectoryOptions
+): Promise<AgentSkill> {
+  const files = await collectSkillFiles(skillDir)
+  const skillFile = files.find((file) => file.relativePath === "SKILL.md")
+  if (!skillFile || typeof skillFile.contents !== "string") {
+    throw skillError(skillDir, "Missing required regular SKILL.md.")
+  }
+
+  const metadata = parseSkillMetadata(skillFile.contents, skillDir)
+  validateSkillMetadata(skillDir, metadata, options)
+  return {
+    name: metadata.name,
+    description: metadata.description,
+    files,
+  }
+}
+
+function validateSkillMetadata(
+  skillDir: string,
+  metadata: AgentSkillMetadata,
+  options: LoadSkillsDirectoryOptions
+): asserts metadata is Required<AgentSkillMetadata> {
+  if (!metadata.name?.trim()) {
+    throw skillError(skillDir, "SKILL.md frontmatter must include a non-empty string name.")
+  }
+  if (!metadata.description?.trim()) {
+    throw skillError(skillDir, "SKILL.md frontmatter must include a non-empty string description.")
+  }
+  if (!SKILL_NAME_RE.test(metadata.name)) {
+    throw skillError(skillDir, `Skill name '${metadata.name}' must match ${String(SKILL_NAME_RE)}.`)
+  }
+
+  const dirName = basename(skillDir)
+  if (metadata.name !== dirName) {
+    throw skillError(skillDir, `Skill name '${metadata.name}' must match directory '${dirName}'.`)
+  }
+  if (options.source === "project" && options.builtInNames?.has(metadata.name)) {
+    throw skillError(
+      skillDir,
+      `Skill name '${metadata.name}' collides with a built-in agent skill.`
+    )
+  }
+  if (options.source === "project" && metadata.name.startsWith("sixb-")) {
+    throw skillError(skillDir, `Skill name '${metadata.name}' uses the reserved 'sixb-' prefix.`)
+  }
+}
+
+async function collectSkillFiles(
+  skillDir: string,
+  currentDir = skillDir
+): Promise<readonly AgentSkillFile[]> {
+  const files: AgentSkillFile[] = []
+  const entries = await readdir(currentDir)
+  for (const entry of entries.sort((a, b) => a.localeCompare(b))) {
+    const path = join(currentDir, entry)
+    const info = await lstat(path)
+    const relativePath = toPosixRelative(skillDir, path)
+    if (info.isSymbolicLink()) {
+      throw skillError(skillDir, `Skill file '${relativePath}' must not be a symlink.`)
+    }
+    if (info.isDirectory()) {
+      files.push(...(await collectSkillFiles(skillDir, path)))
+      continue
+    }
+    if (!info.isFile()) {
+      continue
+    }
+
+    const mode = info.mode & 0o777
+    files.push({
+      relativePath,
+      contents: relativePath === "SKILL.md" ? await readFile(path, "utf-8") : await readFile(path),
+      ...((mode & 0o111) === 0 ? {} : { mode }),
+    })
+  }
+  return files
+}
+
+function parseSkillMetadata(markdown: string, skillDir: string): AgentSkillMetadata {
+  const lines = markdown.replaceAll("\r\n", "\n").split("\n")
+  if (lines[0] !== "---") {
+    throw skillError(skillDir, "SKILL.md must start with YAML frontmatter delimited by ---.")
+  }
+
+  const end = lines.findIndex((line, index) => index > 0 && line === "---")
+  if (end < 0) {
+    throw skillError(skillDir, "SKILL.md frontmatter is missing the closing --- delimiter.")
+  }
+
+  let parsed: unknown
+  try {
+    parsed = Bun.YAML.parse(lines.slice(1, end).join("\n"))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw skillError(skillDir, `SKILL.md frontmatter is not valid YAML: ${message}`)
+  }
+  if (!isRecord(parsed)) {
+    throw skillError(skillDir, "SKILL.md frontmatter must be a YAML mapping.")
+  }
+
+  return {
+    ...(typeof parsed.name === "string" ? { name: parsed.name.trim() } : {}),
+    ...(typeof parsed.description === "string" ? { description: parsed.description.trim() } : {}),
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function toPosixRelative(from: string, to: string): string {
+  return relative(from, to).split(sep).join("/")
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"
+}
+
+function skillError(skillDir: string, message: string): Error {
+  return new Error(`[SixbAgentWorker] Agent skill '${skillDir}' is invalid: ${message}`)
 }

--- a/packages/agent-worker/src/run-environment.ts
+++ b/packages/agent-worker/src/run-environment.ts
@@ -26,10 +26,10 @@ export interface CreateAgentRunEnvironmentInput {
 /**
  * Build the per-run turn context.
  *
- * Attachment preparation runs first so the same manifest drives both model projection and sandbox
- * files. Sandbox creation (boot + writing the run's API context) is still kicked off here without
- * awaiting: the bash tool awaits the sandbox on first use, while the ~boot latency overlaps the
- * model's first response when bash is not immediately needed. dispose() awaits or tracks teardown.
+ * Attachment preparation and the cached skill catalog resolve first. Sandbox creation (boot plus
+ * writing the run context, attachments, and skills) is then kicked off without awaiting: the bash
+ * tool awaits the sandbox on first use, while boot latency overlaps the model's first response when
+ * bash is not immediately needed. dispose() awaits or tracks teardown.
  */
 export async function createAgentRunEnvironment(
   input: CreateAgentRunEnvironmentInput
@@ -42,6 +42,7 @@ export async function createAgentRunEnvironment(
     run,
   })
   const apiOrigin = new URL(apiBaseUrl).origin
+  const skills = await context.agentSkills
 
   const history = await context.storage.agents.messages.list({
     projectId: context.id,
@@ -58,7 +59,15 @@ export async function createAgentRunEnvironment(
   })
 
   // Provision concurrently; do NOT await. The bash tool, the turn, and dispose() await this.
-  const ready = provisionSandbox({ context, agent, run, apiBaseUrl, apiOrigin, attachmentContext })
+  const ready = provisionSandbox({
+    context,
+    agent,
+    run,
+    apiBaseUrl,
+    apiOrigin,
+    attachmentContext,
+    skills,
+  })
   let sandboxWasUsed = false
   // Creation failure is surfaced where it is awaited (turn / bash tool / dispose); attach a no-op
   // catch so a rejection observed by none of them is not reported as unhandled.
@@ -84,7 +93,7 @@ export async function createAgentRunEnvironment(
           return ready
         }),
       },
-      systemAddendum: renderAgentSkillCatalog(),
+      systemAddendum: renderAgentSkillCatalog(skills),
       sandboxReady: ready,
       sandboxWasUsed: () => sandboxWasUsed,
       streamSink: context.streamSink,
@@ -104,10 +113,11 @@ interface ProvisionSandboxInput {
   readonly apiBaseUrl: string
   readonly apiOrigin: string
   readonly attachmentContext: Awaited<ReturnType<typeof prepareAgentAttachments>>
+  readonly skills: Awaited<AgentWorkerContext["agentSkills"]>
 }
 
 async function provisionSandbox(input: ProvisionSandboxInput): Promise<BashSandboxHandle> {
-  const { context, agent, run, apiBaseUrl, apiOrigin } = input
+  const { context, agent, run, apiBaseUrl, apiOrigin, skills } = input
   let sandbox: Sandbox | null = null
   try {
     sandbox = await context.sandboxes.create({
@@ -121,6 +131,7 @@ async function provisionSandbox(input: ProvisionSandboxInput): Promise<BashSandb
       threadId: run.threadId,
       runId: run.id,
       attachments: input.attachmentContext,
+      skills,
     })
     return { sandbox, env: apiContext.env }
   } catch (error) {

--- a/packages/agent-worker/src/sandbox-api-context.ts
+++ b/packages/agent-worker/src/sandbox-api-context.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path"
 import type { Sandbox } from "@sixb/core"
-import { buildAgentSkillFiles } from "./agent-skills"
+import { type AgentSkill, buildAgentSkillFiles } from "./agent-skills"
 import type { PreparedAgentAttachmentContext } from "./attachments"
 
 export interface AgentSandboxApiContext {
@@ -15,6 +15,7 @@ export interface PrepareAgentSandboxApiContextInput {
   readonly threadId: string
   readonly runId: string
   readonly attachments?: PreparedAgentAttachmentContext
+  readonly skills: readonly AgentSkill[]
 }
 
 export async function prepareAgentSandboxApiContext(
@@ -51,7 +52,7 @@ export async function prepareAgentSandboxApiContext(
   // filesystem, so any provider (including non-host-path ones like smolvm) places the bytes in the
   // guest. Awaited before the bash tool runs, so the agent never sees an un-provisioned sandbox.
   await input.sandbox.writeFiles([
-    ...(await buildAgentSkillFiles(skillsDir)),
+    ...buildAgentSkillFiles(skillsDir, input.skills),
     { path: runContextPath, contents: runContext },
     {
       path: attachmentsManifestPath,

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -10,6 +10,7 @@ import type {
   Storage,
 } from "@sixb/core"
 import type { ToolSet } from "ai"
+import type { AgentSkill } from "./agent-skills"
 import type { PreparedAgentAttachmentContext } from "./attachments"
 import type { BashSandboxHandle } from "./bash-tool"
 import type { StreamSink } from "./stream-sink"
@@ -34,6 +35,7 @@ export interface AgentWorkerSixb {
   readonly agents: AgentsRuntime
   readonly blobStorage: BlobStorage
   readonly sandboxes?: SandboxFactory
+  readonly projectRoot?: string
 }
 
 /**
@@ -49,6 +51,7 @@ export interface AgentWorkerContext {
   readonly baseTools: ToolSet
   readonly apiBaseUrl: string
   readonly streamSink: StreamSink
+  readonly agentSkills: Promise<readonly AgentSkill[]>
   readonly leaseMs: number
   readonly heartbeatMs: number
   readonly defaultMaxSteps: number
@@ -94,6 +97,8 @@ export interface AgentWorkerOptions {
   readonly apiBaseUrl: string
   /** Tools exposed to the model in addition to the built-in `bash` tool. */
   readonly tools?: ToolSet
+  /** Project Agent Skills directory. Defaults to `<projectRoot>/skills`; `false` disables project skills. */
+  readonly skillsDir?: string | false
   /** Maximum number of agent run jobs this worker claims and executes at once. Defaults to 4. */
   readonly concurrency?: number
   /** Stream routing seam. Defaults to broker backed. */

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path"
 import type {
   AgentDefinition,
   AgentRunLease,
@@ -15,6 +16,7 @@ import {
   SYSTEM_PRINCIPAL,
   subscribeAgentRunCancel,
 } from "@sixb/core"
+import { loadAgentSkills } from "./agent-skills"
 import { normalizeApiBaseUrl } from "./api-url"
 import {
   AgentFinalizationError,
@@ -95,6 +97,13 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
     this.sixb = sixb
     this.idleWithoutAgents = sixb.agents.list().length === 0
     this.context = this.idleWithoutAgents ? null : buildAgentContext(sixb, options, leaseMs)
+  }
+
+  override async start(): Promise<void> {
+    if (this.context) {
+      await this.context.agentSkills
+    }
+    await super.start()
   }
 
   protected override async run(signal: AbortSignal): Promise<void> {
@@ -418,6 +427,14 @@ function buildAgentContext(
       "Agent workers require createSixb({ sandboxes }) for the built-in bash tool."
     )
   }
+  const agentSkills = loadAgentSkills({
+    projectSkillsDir:
+      options.skillsDir === undefined
+        ? join(sixb.projectRoot ?? process.cwd(), "skills")
+        : options.skillsDir,
+  })
+  agentSkills.catch(() => {})
+
   return {
     id: sixb.id,
     storage: storage as AgentWorkerStorage,
@@ -430,6 +447,7 @@ function buildAgentContext(
     streamSink: isolateStreamSink(
       options.streamSink ?? createBrokerStreamSink({ broker: sixb.broker, projectId: sixb.id })
     ),
+    agentSkills,
     leaseMs,
     heartbeatMs: options.heartbeatMs ?? Math.max(1, Math.floor(leaseMs / 3)),
     defaultMaxSteps: options.defaultMaxSteps ?? DEFAULT_MAX_STEPS,

--- a/packages/agent-worker/tests/agent-skills.test.ts
+++ b/packages/agent-worker/tests/agent-skills.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test"
+import { chmod, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { loadAgentSkills } from "../src/agent-skills"
+import { writeProjectSkill } from "./helpers"
+
+async function createProjectRoot(label: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), `sixb-agent-skills-${label}-`))
+}
+
+describe("Agent Skills", () => {
+  test("discovers packaged built-ins and tolerates a missing project skills directory", async () => {
+    const projectRoot = await createProjectRoot("missing")
+    try {
+      const skills = await loadAgentSkills({ projectSkillsDir: join(projectRoot, "skills") })
+      expect(skills.map((skill) => skill.name)).toEqual([
+        "sixb-actions",
+        "sixb-query",
+        "sixb-telemetry",
+      ])
+      for (const skill of skills) {
+        const skillFile = skill.files.find((file) => file.relativePath === "SKILL.md")
+        expect(skillFile?.contents).toContain(`name: ${skill.name}`)
+        expect(skill.description.length).toBeGreaterThan(0)
+      }
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("parses YAML metadata and recursively preserves binary files and executable modes", async () => {
+    const projectRoot = await createProjectRoot("files")
+    try {
+      await writeProjectSkill(
+        projectRoot,
+        "acme-style",
+        [
+          "---",
+          'name: "acme-style"',
+          "description: >",
+          "  Use when drafting Acme customer-facing",
+          "  messages.",
+          "compatibility: Ignored but preserved in SKILL.md.",
+          "---",
+          "",
+          "# Acme Style",
+        ].join("\n"),
+        {
+          "assets/template.bin": new Uint8Array([0, 127, 255]),
+          "scripts/validate.sh": "#!/bin/sh\nexit 0\n",
+        }
+      )
+      await chmod(join(projectRoot, "skills", "acme-style", "scripts", "validate.sh"), 0o755)
+
+      const skills = await loadAgentSkills({ projectSkillsDir: join(projectRoot, "skills") })
+      const skill = skills.find((candidate) => candidate.name === "acme-style")
+      expect(skill?.description).toBe("Use when drafting Acme customer-facing messages.")
+      expect(
+        skill?.files.find((file) => file.relativePath === "assets/template.bin")?.contents
+      ).toEqual(new Uint8Array([0, 127, 255]))
+      expect(skill?.files.find((file) => file.relativePath === "scripts/validate.sh")?.mode).toBe(
+        0o755
+      )
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("rejects invalid project skill frontmatter", async () => {
+    const projectRoot = await createProjectRoot("invalid")
+    try {
+      await writeProjectSkill(
+        projectRoot,
+        "acme-style",
+        ["---", "name: acme-style", "---", "", "# Acme Style"].join("\n")
+      )
+      await expect(
+        loadAgentSkills({ projectSkillsDir: join(projectRoot, "skills") })
+      ).rejects.toThrow("[SixbAgentWorker] Agent skill")
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("rejects built-in collisions and the reserved project prefix", async () => {
+    const collisionRoot = await createProjectRoot("collision")
+    const reservedRoot = await createProjectRoot("reserved")
+    try {
+      await writeProjectSkill(
+        collisionRoot,
+        "sixb-query",
+        [
+          "---",
+          "name: sixb-query",
+          "description: Invalid attempt to replace a built-in skill.",
+          "---",
+        ].join("\n")
+      )
+      await expect(
+        loadAgentSkills({ projectSkillsDir: join(collisionRoot, "skills") })
+      ).rejects.toThrow("collides with a built-in agent skill")
+
+      await writeProjectSkill(
+        reservedRoot,
+        "sixb-custom",
+        [
+          "---",
+          "name: sixb-custom",
+          "description: Invalid use of the reserved prefix.",
+          "---",
+        ].join("\n")
+      )
+      await expect(
+        loadAgentSkills({ projectSkillsDir: join(reservedRoot, "skills") })
+      ).rejects.toThrow("uses the reserved 'sixb-' prefix")
+    } finally {
+      await Promise.all([
+        rm(collisionRoot, { recursive: true, force: true }),
+        rm(reservedRoot, { recursive: true, force: true }),
+      ])
+    }
+  })
+
+  test("rejects symlinks instead of copying their targets", async () => {
+    const projectRoot = await createProjectRoot("symlink")
+    try {
+      await writeProjectSkill(
+        projectRoot,
+        "acme-style",
+        [
+          "---",
+          "name: acme-style",
+          "description: Use when drafting Acme customer-facing messages.",
+          "---",
+        ].join("\n")
+      )
+      const target = join(projectRoot, "target.md")
+      await writeFile(target, "secret")
+      await symlink(target, join(projectRoot, "skills", "acme-style", "leak.md"))
+
+      await expect(
+        loadAgentSkills({ projectSkillsDir: join(projectRoot, "skills") })
+      ).rejects.toThrow("must not be a symlink")
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/agent-worker/tests/helpers.ts
+++ b/packages/agent-worker/tests/helpers.ts
@@ -1,3 +1,22 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+export async function writeProjectSkill(
+  projectRoot: string,
+  name: string,
+  skillMd: string,
+  files: Readonly<Record<string, string | Uint8Array>> = {}
+): Promise<void> {
+  const skillRoot = join(projectRoot, "skills", name)
+  await mkdir(skillRoot, { recursive: true })
+  await writeFile(join(skillRoot, "SKILL.md"), skillMd)
+  for (const [path, contents] of Object.entries(files)) {
+    const absolutePath = join(skillRoot, path)
+    await mkdir(dirname(absolutePath), { recursive: true })
+    await writeFile(absolutePath, contents)
+  }
+}
+
 /** Poll `fn` until it returns a truthy value or the timeout elapses (mirrors the action-worker helper). */
 export async function waitFor<T>(
   fn: () => Promise<T | null | undefined | false> | T | null | undefined | false,

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type {
   LanguageModelV4,
@@ -48,6 +50,7 @@ import {
   createBrokerStreamSink,
   NOOP_STREAM_SINK,
 } from "../src"
+import { loadAgentSkills } from "../src/agent-skills"
 import { normalizeApiBaseUrl } from "../src/api-url"
 import { prepareAgentAttachments } from "../src/attachments"
 import { AgentFinalizationError, AgentLeaseLostError } from "../src/errors"
@@ -55,7 +58,7 @@ import { finishRunOrThrow } from "../src/finalize"
 import { reconcileAgentExecutionIdentity } from "../src/identity"
 import { runAgentTurn } from "../src/run-agent-turn"
 import { createAgentRunEnvironment } from "../src/run-environment"
-import { waitFor } from "./helpers"
+import { waitFor, writeProjectSkill } from "./helpers"
 
 const PROJECT_ID = "agent-worker-tests"
 const TEST_AGENT_API_BASE_URL = "http://localhost:3002/api/"
@@ -193,11 +196,14 @@ function outputBashThenAnswerModel(): MockLanguageModelV4 {
   })
 }
 
-function apiBashThenAnswerModel(): MockLanguageModelV4 {
+function apiBashThenAnswerModel(
+  captureSystem?: (system: string | undefined) => void
+): MockLanguageModelV4 {
   let call = 0
   return new MockLanguageModelV4({
     modelId: "mock-model",
-    doStream: async () => {
+    doStream: async (options) => {
+      captureSystem?.(options.prompt.find((message) => message.role === "system")?.content)
       call += 1
       if (call === 1) {
         return stream([
@@ -350,6 +356,7 @@ const echoTool: ToolSet = {
 // action-worker tests do).
 interface TestSixb {
   readonly id: string
+  readonly projectRoot: string
   readonly broker: Broker
   readonly events: EventsRuntime
   readonly storage: Storage
@@ -587,6 +594,7 @@ function buildSixb(
   options: {
     readonly reasoning?: AgentReasoningLevel
     readonly providerOptions?: LanguageModelV4CallOptions["providerOptions"]
+    readonly projectRoot?: string
   } = {}
 ): TestSixb {
   const agent = defineAgent("assistant", {
@@ -609,6 +617,7 @@ function buildSixb(
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
     sandboxes,
+    ...(options.projectRoot === undefined ? {} : { projectRoot: options.projectRoot }),
   })
 }
 
@@ -665,6 +674,7 @@ function buildAgentWorkerContext(
     // Mirror the production boundary (worker.ts buildAgentContext): normalize the server base once.
     apiBaseUrl: normalizeApiBaseUrl(input.apiBaseUrl ?? TEST_AGENT_API_BASE_URL),
     streamSink: NOOP_STREAM_SINK,
+    agentSkills: loadAgentSkills({ projectSkillsDir: false }),
     leaseMs: 60_000,
     heartbeatMs: 20_000,
     defaultMaxSteps: 4,
@@ -871,6 +881,28 @@ describe("AgentWorker", () => {
     expect(() => new AgentWorker(sixb, { apiBaseUrl: "" })).toThrow(
       "Agent workers require options.apiBaseUrl."
     )
+  })
+
+  test("fails startup when a project Agent Skill is invalid", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "sixb-agent-skills-startup-"))
+    try {
+      await writeProjectSkill(
+        projectRoot,
+        "acme-style",
+        ["---", "name: acme-style", "---", "", "# Acme Style"].join("\n")
+      )
+      const worker = new AgentWorker(
+        buildSixb(toolThenAnswerModel(), new InMemoryBroker(), new RecordingSandboxFactory(), {
+          projectRoot,
+        }),
+        workerOptions()
+      )
+
+      await expect(worker.start()).rejects.toThrow("[SixbAgentWorker] Agent skill")
+      await worker.stop()
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
+    }
   })
 
   test("attributes a managed service account to the agent worker, not to system at large", async () => {
@@ -1727,6 +1759,84 @@ describe("AgentWorker", () => {
       ).toBe(false)
     } finally {
       await worker.stop()
+    }
+  })
+
+  test("advertises and materializes project Agent Skills", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "sixb-agent-skills-"))
+    try {
+      await writeProjectSkill(
+        projectRoot,
+        "acme-style",
+        [
+          "---",
+          "name: acme-style",
+          "description: >",
+          "  Use when drafting Acme customer-facing",
+          "  messages.",
+          "---",
+          "",
+          "# Acme Style",
+          "",
+          "Read references/examples.md before drafting customer-facing copy.",
+        ].join("\n"),
+        { "references/examples.md": "Prefer concise, operational summaries." }
+      )
+
+      let capturedSystem: string | undefined
+      const sandboxes = new RecordingSandboxFactory()
+      const sixb = buildSixb(
+        apiBashThenAnswerModel((system) => {
+          capturedSystem = system
+        }),
+        new InMemoryBroker(),
+        sandboxes,
+        { projectRoot }
+      )
+      const storage = agentStorageOf(sixb)
+      const worker = new AgentWorker(sixb, workerOptions())
+      await worker.start()
+      try {
+        const { threadId } = await sixb.agents.request({
+          agentId: "assistant",
+          text: "draft a note",
+        })
+        const run = await waitFor(
+          async () => {
+            const list = await storage.runs.list({ projectId: PROJECT_ID, threadId })
+            const found = list.runs[0]
+            return found && found.status !== "running" ? found : null
+          },
+          { label: "project skills run terminal" }
+        )
+        expect(run.status).toBe("succeeded")
+        expect(capturedSystem).toContain("Path: $SIXB_SKILLS_DIR/acme-style")
+        expect(capturedSystem).toContain("Use when drafting Acme customer-facing messages.")
+        expect(capturedSystem).toContain("Path: $SIXB_SKILLS_DIR/sixb-query")
+
+        const command = sandboxes.sandboxes[0]?.commands[0]
+        const skillsDir = command?.options.env?.SIXB_SKILLS_DIR
+        if (!skillsDir) {
+          throw new Error("Expected project skill sandbox env.")
+        }
+        const sandbox = sandboxes.sandboxes[0]
+        if (!sandbox) {
+          throw new Error("Expected project skill sandbox.")
+        }
+        expect(sandbox.readFileContents(join(skillsDir, "acme-style", "SKILL.md"))).toContain(
+          "# Acme Style"
+        )
+        expect(
+          sandbox.readFileContents(join(skillsDir, "acme-style", "references", "examples.md"))
+        ).toContain("Prefer concise")
+        expect(sandbox.readFileContents(join(skillsDir, "sixb-query", "SKILL.md"))).toContain(
+          "name: sixb-query"
+        )
+      } finally {
+        await worker.stop()
+      }
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
     }
   })
 

--- a/packages/core/src/runtime/create.ts
+++ b/packages/core/src/runtime/create.ts
@@ -140,6 +140,7 @@ export async function createSixb(
     sandboxes: options.sandboxes,
     logger: options.logger,
     observability: options.observability,
+    projectRoot,
     actions,
     datasets: [...(options.datasets ?? []), ...datasets],
     connectors: [...(options.connectors ?? []), ...connectors],

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -6,6 +6,7 @@
  * `sixb.broker`, `sixb.events`, `sixb.storage`, and `sixb.queues`.
  */
 
+import { resolve } from "node:path"
 import { ActionRegistry, ActionsRuntime } from "../actions"
 import type { ActionDefinition } from "../actions/types"
 import type { AgentDefinition } from "../agents"
@@ -92,6 +93,7 @@ export interface SixbOptions<TOntologySources extends readonly OntologySource[]>
   logger?: LoggerProvider
   /** Broker capture controls, independent from the output provider. */
   observability?: ObservabilityOptions
+  projectRoot?: string
   actions?: readonly ActionDefinition[]
   datasets?: readonly DatasetDefinition[]
   /** Connector definitions registered with this runtime. */
@@ -142,6 +144,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
   readonly blobStorage: BlobStorage
   readonly queues: Queues
   readonly sandboxes?: SandboxFactory
+  readonly projectRoot: string
   readonly rules: readonly RuleDefinition[]
   readonly security: SecurityRegistry
   readonly auth: AuthRuntime
@@ -165,6 +168,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
     this.blobStorage = options.blobStorage
     this.queues = options.queues
     this.sandboxes = options.sandboxes
+    this.projectRoot = resolve(options.projectRoot ?? process.cwd())
     this.rules = options.rules ?? []
     // Ontology and actions resolve first so every later registry (security,
     // rules, workflows, projections) can validate its references against them.


### PR DESCRIPTION
## Summary

The agent worker now loads project-defined Agent Skills from `skills/<name>/SKILL.md`, advertises only their metadata to the model, and copies their complete file trees into each run sandbox alongside built-in Sixb skills. This supports reusable standards, examples, templates, and procedures without expanding every agent’s base instructions.

| Area | Before | After |
| --- | --- | --- |
| Sources | Built-in Sixb skills only | Built-ins plus project skills |
| Prompt | Static built-in catalog | Catalog generated from loaded metadata |
| Sandbox | Bundled Markdown files | Recursive text, binary, and executable files |
| Invalid configuration | Not applicable | Worker startup fails |
| Default max steps | 8 | 25 |

## Scope

Project skills default to `<projectRoot>/skills`; a missing directory is allowed. `AgentWorkerOptions.skillsDir` selects another directory, while `false` keeps only built-in skills.

- `createSixb()` now propagates `projectRoot` to `Sixb`, which resolves it to an absolute path.
- Each skill requires YAML frontmatter with non-empty `name` and `description`.
- The name must match its directory and `/^[a-z0-9][a-z0-9._-]*$/`.
- Project skills cannot collide with built-ins or use the reserved `sixb-` prefix.
- Skill directories and files cannot be symlinks.

## Implementation

One loaded skill set drives both model context and sandbox contents, preventing the advertised catalog from diverging from installed files.

```mermaid
flowchart LR
    A["Bundled skills"] --> C["loadAgentSkills"]
    B["Project skills directory"] --> C
    C --> D["Validate metadata and file tree"]
    D --> E["AgentWorker.start"]
    D --> F["renderAgentSkillCatalog"]
    D --> G["buildAgentSkillFiles"]
    G --> H["Run sandbox"]
```

- `packages/agent-worker/src/agent-skills.ts` recursively loads skills, parses `SKILL.md` with `Bun.YAML.parse`, preserves binary contents and executable modes, and produces deterministic ordering.
- `AgentWorker.start()` awaits the cached `agentSkills` promise before queue processing, so invalid skills fail startup.
- `createAgentRunEnvironment()` resolves skills before provisioning and passes them to both the system addendum and `prepareAgentSandboxApiContext()`.
- The prompt exposes only `name`, `description`, and `$SIXB_SKILLS_DIR/<name>`; agents load full instructions and references on demand.

## Design and review guide

Built-in `sixb-query`, `sixb-telemetry`, and `sixb-actions` remain available and cannot be overridden. The `skills/` convention is worker-owned rather than a `createSixb()` definition-discovery folder.

Review in this order:

1. Validate traversal, frontmatter, collision, and symlink handling in `agent-skills.ts`.
2. Confirm startup failure and skill caching behavior in `worker.ts`.
3. Trace the shared skill set through `run-environment.ts` and `sandbox-api-context.ts`.
4. Check the documented project layout and `examples/acme-corp/skills/acme-writing-style`.

## Validation

Not run (not requested).

Tests were added for discovery, binary and executable files, invalid metadata, reserved names, built-in collisions, symlink rejection, startup failure, and catalog/sandbox materialization, but these checks were not executed.
