### PR TITLE
blob-storage: stream connector uploads end to end

### DIFF
--- a/connectors/sftp/README.md
+++ b/connectors/sftp/README.md
@@ -1,0 +1,33 @@
+# @sixb/connector-sftp
+
+Promise-based SFTP connector for Sixb, backed by `ssh2`.
+
+## Usage
+
+```ts
+import { defineConnector } from "@sixb/core"
+import { sftp } from "@sixb/connector-sftp"
+
+export const files = defineConnector(
+  "files",
+  sftp({
+    host: process.env.SFTP_HOST,
+    username: process.env.SFTP_USER,
+    password: process.env.SFTP_PASSWORD,
+  })
+)
+```
+
+The connected `SftpClient` exposes directory and file operations such as `list`, `stat`, `open`,
+`read`, `write`, `rename`, and `delete`.
+
+Use `open(...)` for large files. It preserves backpressure and closes the remote handle when the
+stream is canceled or its signal aborts:
+
+```ts
+const body = await client.open("/exports/video.mov", { signal })
+const fileRef = await blobs.put({ body, expectedSizeBytes: size, signal })
+```
+
+`read(...)` returns a `Buffer` and remains useful when the complete file is intentionally needed in
+memory.

--- a/connectors/sftp/src/client.ts
+++ b/connectors/sftp/src/client.ts
@@ -1,6 +1,7 @@
 import { posix } from "node:path"
-import type { Callback, SFTPWrapper } from "ssh2"
-import type { SftpClient, SftpStats, SftpWriteData } from "./types"
+import { Readable } from "node:stream"
+import type { Callback, SFTPWrapper, ReadStream as Ssh2ReadStream } from "ssh2"
+import type { SftpClient, SftpOpenOptions, SftpStats, SftpWriteData } from "./types"
 
 export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
   return {
@@ -17,6 +18,9 @@ export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
     },
     ensureDir(path) {
       return ensureSftpDirectory(sftpClient, path)
+    },
+    open(path, options) {
+      return openSftpStream(sftpClient, path, options)
     },
     read(path) {
       return callResult((callback) => sftpClient.readFile(path, callback))
@@ -37,6 +41,84 @@ export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
       return callVoid((callback) => sftpClient.rmdir(path, callback))
     },
   }
+}
+
+async function openSftpStream(
+  sftpClient: SFTPWrapper,
+  path: string,
+  options: SftpOpenOptions = {}
+): Promise<ReadableStream<Uint8Array>> {
+  options.signal?.throwIfAborted()
+  const nodeStream = sftpClient.createReadStream(path)
+
+  await waitForOpen(nodeStream, options.signal)
+  if (options.signal?.aborted) {
+    nodeStream.destroy()
+    throw abortError(options.signal)
+  }
+
+  const stream = Readable.toWeb(nodeStream, {
+    strategy: {
+      highWaterMark: nodeStream.readableHighWaterMark,
+      size(chunk: Buffer) {
+        return chunk.byteLength
+      },
+    },
+  }) as unknown as ReadableStream<Uint8Array>
+
+  if (options.signal) {
+    const signal = options.signal
+    const onAbort = () => nodeStream.destroy(abortError(signal))
+    const cleanup = () => signal.removeEventListener("abort", onAbort)
+
+    signal.addEventListener("abort", onAbort, { once: true })
+    nodeStream.once("close", cleanup)
+    nodeStream.once("end", cleanup)
+    nodeStream.once("error", cleanup)
+    if (signal.aborted) {
+      onAbort()
+    }
+  }
+
+  return stream
+}
+
+function waitForOpen(stream: Ssh2ReadStream, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      stream.off("open", onOpen)
+      stream.off("error", onError)
+      signal?.removeEventListener("abort", onAbort)
+    }
+    const onOpen = () => {
+      cleanup()
+      resolve()
+    }
+    const onError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+    const onAbort = () => {
+      cleanup()
+      stream.destroy()
+      reject(
+        signal ? abortError(signal) : new DOMException("The operation was aborted", "AbortError")
+      )
+    }
+
+    stream.once("open", onOpen)
+    stream.once("error", onError)
+    signal?.addEventListener("abort", onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+    }
+  })
+}
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("The operation was aborted", "AbortError")
 }
 
 async function ensureSftpDirectory(sftpClient: SFTPWrapper, path: string): Promise<void> {

--- a/connectors/sftp/src/client.ts
+++ b/connectors/sftp/src/client.ts
@@ -3,12 +3,8 @@ import { Readable } from "node:stream"
 import type { Callback, SFTPWrapper, ReadStream as Ssh2ReadStream } from "ssh2"
 import type { SftpClient, SftpOpenOptions, SftpStats, SftpWriteData } from "./types"
 
-const readStreamsByClient = new WeakMap<SftpClient, Set<Ssh2ReadStream>>()
-
 export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
-  const activeReadStreams = new Set<Ssh2ReadStream>()
-
-  const client: SftpClient = {
+  return {
     list(path) {
       return callResult((callback) => sftpClient.readdir(path, callback))
     },
@@ -24,7 +20,7 @@ export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
       return ensureSftpDirectory(sftpClient, path)
     },
     open(path, options) {
-      return openSftpStream(sftpClient, path, activeReadStreams, options)
+      return openSftpStream(sftpClient, path, options)
     },
     read(path) {
       return callResult((callback) => sftpClient.readFile(path, callback))
@@ -45,31 +41,15 @@ export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
       return callVoid((callback) => sftpClient.rmdir(path, callback))
     },
   }
-
-  readStreamsByClient.set(client, activeReadStreams)
-  return client
-}
-
-export async function closeSftpReadStreams(client: SftpClient): Promise<void> {
-  const activeReadStreams = readStreamsByClient.get(client)
-  if (!activeReadStreams) {
-    return
-  }
-
-  await Promise.all([...activeReadStreams].map(closeReadStream))
-  readStreamsByClient.delete(client)
 }
 
 async function openSftpStream(
   sftpClient: SFTPWrapper,
   path: string,
-  activeReadStreams: Set<Ssh2ReadStream>,
   options: SftpOpenOptions = {}
 ): Promise<ReadableStream<Uint8Array>> {
   options.signal?.throwIfAborted()
   const nodeStream = sftpClient.createReadStream(path)
-  activeReadStreams.add(nodeStream)
-  nodeStream.once("close", () => activeReadStreams.delete(nodeStream))
 
   await waitForOpen(nodeStream, options.signal)
   if (options.signal?.aborted) {
@@ -101,17 +81,6 @@ async function openSftpStream(
   }
 
   return stream
-}
-
-function closeReadStream(stream: Ssh2ReadStream): Promise<void> {
-  if (stream.closed) {
-    return Promise.resolve()
-  }
-
-  return new Promise((resolve) => {
-    stream.once("close", resolve)
-    stream.destroy()
-  })
 }
 
 function waitForOpen(stream: Ssh2ReadStream, signal?: AbortSignal): Promise<void> {

--- a/connectors/sftp/src/client.ts
+++ b/connectors/sftp/src/client.ts
@@ -3,8 +3,12 @@ import { Readable } from "node:stream"
 import type { Callback, SFTPWrapper, ReadStream as Ssh2ReadStream } from "ssh2"
 import type { SftpClient, SftpOpenOptions, SftpStats, SftpWriteData } from "./types"
 
+const readStreamsByClient = new WeakMap<SftpClient, Set<Ssh2ReadStream>>()
+
 export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
-  return {
+  const activeReadStreams = new Set<Ssh2ReadStream>()
+
+  const client: SftpClient = {
     list(path) {
       return callResult((callback) => sftpClient.readdir(path, callback))
     },
@@ -20,7 +24,7 @@ export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
       return ensureSftpDirectory(sftpClient, path)
     },
     open(path, options) {
-      return openSftpStream(sftpClient, path, options)
+      return openSftpStream(sftpClient, path, activeReadStreams, options)
     },
     read(path) {
       return callResult((callback) => sftpClient.readFile(path, callback))
@@ -41,15 +45,31 @@ export function createSftpClient(sftpClient: SFTPWrapper): SftpClient {
       return callVoid((callback) => sftpClient.rmdir(path, callback))
     },
   }
+
+  readStreamsByClient.set(client, activeReadStreams)
+  return client
+}
+
+export async function closeSftpReadStreams(client: SftpClient): Promise<void> {
+  const activeReadStreams = readStreamsByClient.get(client)
+  if (!activeReadStreams) {
+    return
+  }
+
+  await Promise.all([...activeReadStreams].map(closeReadStream))
+  readStreamsByClient.delete(client)
 }
 
 async function openSftpStream(
   sftpClient: SFTPWrapper,
   path: string,
+  activeReadStreams: Set<Ssh2ReadStream>,
   options: SftpOpenOptions = {}
 ): Promise<ReadableStream<Uint8Array>> {
   options.signal?.throwIfAborted()
   const nodeStream = sftpClient.createReadStream(path)
+  activeReadStreams.add(nodeStream)
+  nodeStream.once("close", () => activeReadStreams.delete(nodeStream))
 
   await waitForOpen(nodeStream, options.signal)
   if (options.signal?.aborted) {
@@ -81,6 +101,17 @@ async function openSftpStream(
   }
 
   return stream
+}
+
+function closeReadStream(stream: Ssh2ReadStream): Promise<void> {
+  if (stream.closed) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve) => {
+    stream.once("close", resolve)
+    stream.destroy()
+  })
 }
 
 function waitForOpen(stream: Ssh2ReadStream, signal?: AbortSignal): Promise<void> {

--- a/connectors/sftp/src/index.ts
+++ b/connectors/sftp/src/index.ts
@@ -4,6 +4,7 @@ export type {
   SftpConnection,
   SftpConnector,
   SftpListEntry,
+  SftpOpenOptions,
   SftpStats,
   SftpWriteData,
 } from "./types"

--- a/connectors/sftp/src/sftp.ts
+++ b/connectors/sftp/src/sftp.ts
@@ -1,6 +1,6 @@
 import type { SFTPWrapper } from "ssh2"
 import { Client } from "ssh2"
-import { createSftpClient } from "./client"
+import { closeSftpReadStreams, createSftpClient } from "./client"
 import type { SftpClient, SftpConnection, SftpConnector } from "./types"
 
 type ConnectionState = {
@@ -47,8 +47,12 @@ export function sftp(connection: SftpConnection): SftpConnector {
         return
       }
 
-      await closeClient(state)
-      connections.delete(client)
+      try {
+        await closeSftpReadStreams(client)
+      } finally {
+        await closeClient(state)
+        connections.delete(client)
+      }
     },
   }
 }

--- a/connectors/sftp/src/sftp.ts
+++ b/connectors/sftp/src/sftp.ts
@@ -1,6 +1,6 @@
 import type { SFTPWrapper } from "ssh2"
 import { Client } from "ssh2"
-import { closeSftpReadStreams, createSftpClient } from "./client"
+import { createSftpClient } from "./client"
 import type { SftpClient, SftpConnection, SftpConnector } from "./types"
 
 type ConnectionState = {
@@ -47,12 +47,8 @@ export function sftp(connection: SftpConnection): SftpConnector {
         return
       }
 
-      try {
-        await closeSftpReadStreams(client)
-      } finally {
-        await closeClient(state)
-        connections.delete(client)
-      }
+      await closeClient(state)
+      connections.delete(client)
     },
   }
 }
@@ -128,18 +124,14 @@ async function closeClient(state: ConnectionState): Promise<void> {
       resolve()
     }
 
-    const forceClose = () => {
-      state.client.destroy()
-    }
-
     const cleanup = () => {
       state.client.off("close", finish)
-      state.client.off("error", forceClose)
+      state.client.off("error", finish)
     }
 
     state.client.once("close", finish)
-    state.client.once("error", forceClose)
-    state.client.destroy()
+    state.client.once("error", finish)
+    state.client.end()
   })
 }
 

--- a/connectors/sftp/src/sftp.ts
+++ b/connectors/sftp/src/sftp.ts
@@ -124,13 +124,17 @@ async function closeClient(state: ConnectionState): Promise<void> {
       resolve()
     }
 
+    const forceClose = () => {
+      state.client.destroy()
+    }
+
     const cleanup = () => {
       state.client.off("close", finish)
-      state.client.off("error", finish)
+      state.client.off("error", forceClose)
     }
 
     state.client.once("close", finish)
-    state.client.once("error", finish)
+    state.client.once("error", forceClose)
     state.client.end()
   })
 }

--- a/connectors/sftp/src/sftp.ts
+++ b/connectors/sftp/src/sftp.ts
@@ -139,7 +139,7 @@ async function closeClient(state: ConnectionState): Promise<void> {
 
     state.client.once("close", finish)
     state.client.once("error", forceClose)
-    state.client.end()
+    state.client.destroy()
   })
 }
 

--- a/connectors/sftp/src/types.ts
+++ b/connectors/sftp/src/types.ts
@@ -7,11 +7,16 @@ export type SftpStats = Stats
 
 export type SftpWriteData = string | Buffer | ArrayBuffer | ArrayBufferView
 
+export interface SftpOpenOptions {
+  readonly signal?: AbortSignal
+}
+
 export interface SftpClient {
   list(path: string): Promise<readonly SftpListEntry[]>
   stat(path: string): Promise<SftpStats>
   exists(path: string): Promise<boolean>
   ensureDir(path: string): Promise<void>
+  open(path: string, options?: SftpOpenOptions): Promise<ReadableStream<Uint8Array>>
   read(path: string): Promise<Buffer>
   write(path: string, data: SftpWriteData): Promise<void>
   rename(sourcePath: string, destinationPath: string): Promise<void>

--- a/connectors/sftp/tests/sftp.test.ts
+++ b/connectors/sftp/tests/sftp.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { sftp } from "../src"
@@ -18,6 +18,10 @@ describe("sftp connector", () => {
   beforeEach(async () => {
     await rm(join(server.rootDir, "files"), { force: true, recursive: true })
     await mkdir(join(server.rootDir, "files"), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await server.waitForIdle()
   })
 
   test("lists and stats remote files", async () => {
@@ -265,6 +269,5 @@ describe("sftp connector", () => {
     })
 
     await adapter.disconnect?.(client)
-    await server.waitForIdle()
   })
 })

--- a/connectors/sftp/tests/sftp.test.ts
+++ b/connectors/sftp/tests/sftp.test.ts
@@ -77,6 +77,80 @@ describe("sftp connector", () => {
     }
   })
 
+  test("opens remote files as web streams", async () => {
+    await writeFile(join(server.rootDir, "files", "stream.txt"), "streamed over sftp")
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+
+    try {
+      const stream = await client.open("/files/stream.txt")
+      expect(await new Response(stream).text()).toBe("streamed over sftp")
+      await expect(client.open("/files/missing.txt")).rejects.toThrow()
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
+  test("aborts an active remote file stream", async () => {
+    await writeFile(join(server.rootDir, "files", "large.bin"), Buffer.alloc(2 * 1024 * 1024, 1))
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+    const abort = new AbortController()
+
+    try {
+      const reader = (await client.open("/files/large.bin", { signal: abort.signal })).getReader()
+      expect((await reader.read()).done).toBe(false)
+
+      abort.abort(new Error("stop sftp read"))
+
+      await expect(reader.read()).rejects.toThrow("stop sftp read")
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
+  test("rejects an open canceled before it starts", async () => {
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+    const abort = new AbortController()
+    abort.abort(new Error("already canceled"))
+
+    try {
+      await expect(
+        client.open("/files/never-opened.bin", { signal: abort.signal })
+      ).rejects.toThrow("already canceled")
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
   test("creates and removes directories", async () => {
     const adapter = sftp({
       host: server.host,

--- a/connectors/sftp/tests/testServer.ts
+++ b/connectors/sftp/tests/testServer.ts
@@ -95,6 +95,14 @@ export async function startTestSftpServer(): Promise<TestSftpServer> {
           idleWaiters = []
         }
       })
+      .on("end", () => {
+        // Bun can leave ssh2's accepted socket half-open after the peer ends
+        // a connection with an errored SFTP read still settling. The ssh2
+        // server connection does not expose its transport publicly, so the
+        // test server closes that transport explicitly.
+        const transport = (client as unknown as { _sock?: { destroy(): void } })._sock
+        transport?.destroy()
+      })
   })
 
   const port = await listen(server)

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -134,7 +134,7 @@ When a system fits a common protocol, use a packaged adapter instead of writing 
 | --- | --- | --- | --- |
 | `@sixb/connector-sql` | `sql(connection)` | `"sql"` | Bun `SQL` (Postgres, MySQL, SQLite) |
 | `@sixb/connector-rest` | `rest(options)` | `"rest"` | `RestClient` (`request`/`get`/`post`) |
-| `@sixb/connector-sftp` | `sftp(connection)` | `"sftp"` | `SftpClient` (`list`/`read`/`write`/…) |
+| `@sixb/connector-sftp` | `sftp(connection)` | `"sftp"` | `SftpClient` (`list`/`open`/`read`/`write`/…) |
 | `@sixb/connector-imap` | `imap(connection)` | `"imap"` | Read-only `ImapClient` (mailboxes/messages/MIME parts) |
 
 If the ERP were a real Postgres database, the connector would be one line:
@@ -179,8 +179,10 @@ rest({
 
 `sql` takes a connection string, a `URL`, or a Bun `SQL.Options` object; the connected client is the
 native Bun SQL client, shared across Postgres, MySQL, and SQLite. `sftp` takes an ssh2
-`ConnectConfig`; its `SftpClient` exposes `list`, `stat`, `exists`, `ensureDir`, `read`, `write`,
-`rename`, `delete`, `mkdir`, and `rmdir`. Both adapters close their client on `disconnect`.
+`ConnectConfig`; its `SftpClient` exposes `list`, `stat`, `exists`, `ensureDir`, `open`, `read`,
+`write`, `rename`, `delete`, `mkdir`, and `rmdir`. `open(path, { signal? })` returns a backpressured
+`ReadableStream<Uint8Array>` for large files; `read(path)` remains the buffered convenience for
+small files. Both adapters close their client on `disconnect`.
 
 ### Hosted-service connectors
 

--- a/docs/testing/overview.md
+++ b/docs/testing/overview.md
@@ -295,14 +295,14 @@ expect(objects(Project).query().where((p) => p.p.status.eq("active")).ir).toEqua
 
 ## Provider contract suites
 
-If you author a backend provider (storage, broker, queue, lake, sandbox, or
-agent/auth storage), `@sixb/core/testing` exports conformance suites —
+If you author a backend provider (storage, broker, queue, lake, blob storage,
+sandbox, or agent/auth storage), `@sixb/core/testing` exports conformance suites —
 `runObjectQueryProviderContractSuite`, `runBrokerContractSuite`,
 `runQueueContractSuite`, `runLakeStorageContractSuite`,
-`runAgentStorageContractSuite`, `runAuthStorageContractSuite`, and
-`runSandboxesContractSuite` — that assert your implementation satisfies the
-provider contract. This is only relevant when building an integration, not when
-testing an app.
+`runBlobStorageContractSuite`, `runAgentStorageContractSuite`,
+`runAuthStorageContractSuite`, and `runSandboxesContractSuite` — that assert your
+implementation satisfies the provider contract. This is only relevant when
+building an integration, not when testing an app.
 
 ## Related
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -456,6 +456,7 @@ src/
 | `EventsRuntime` | Project-scoped domain event API with append, read, latest-cursor, and subscribe |
 | `ObjectStorage` | Latest-state projection storage for objects and links |
 | `TimeseriesStorage` | Time-series storage for telemetry history |
+| `BlobStorage` | Content-addressed binary storage with streaming `put` and `open` operations |
 | `MigrationSet<TContext>` | Ordered migration steps owned by one durable adapter |
 | `MigrationHistoryStore` | Provider-owned persistence for migration history records |
 | `StorageMigrator` | Plan and run one adapter's migration set |
@@ -463,7 +464,8 @@ src/
 | `Queues` | Queue provider with typed job lanes |
 | `Queue<TQueueJob>` | One typed queue lane with lease-based claim/complete/retry/fail semantics |
 
-In-memory implementations included: `InMemoryBroker`, `InMemoryObjectStorage`, `InMemoryTimeseriesStorage`, `InMemoryQueues`.
+In-memory implementations included: `InMemoryBroker`, `InMemoryObjectStorage`,
+`InMemoryTimeseriesStorage`, `InMemoryBlobStorage`, `InMemoryQueues`.
 
 ### Events
 

--- a/packages/core/src/blob-storage/in-memory.ts
+++ b/packages/core/src/blob-storage/in-memory.ts
@@ -8,7 +8,13 @@ import type {
   PutBlobInput,
   RangeReadableBlobStorage,
 } from "./types"
-import { computeBlobDigest, createFileRef, readBlobBody } from "./utils"
+import {
+  assertExpectedBlobSize,
+  assertValidExpectedBlobSize,
+  computeBlobDigest,
+  createFileRef,
+  readBlobBody,
+} from "./utils"
 
 type StoredBlob = {
   readonly bytes: Uint8Array
@@ -19,7 +25,9 @@ export class InMemoryBlobStorage implements BlobStorage, RangeReadableBlobStorag
   private readonly blobsById = new Map<string, StoredBlob>()
 
   async put(input: PutBlobInput): Promise<FileRef> {
-    const bytes = await readBlobBody(input.body)
+    assertValidExpectedBlobSize(input.expectedSizeBytes)
+    const bytes = await readBlobBody(input.body, input.signal)
+    assertExpectedBlobSize(input.expectedSizeBytes, bytes.byteLength, "BlobStorage")
     const digest = computeBlobDigest(bytes)
     const blobId = blobIdFromDigest(digest)
 

--- a/packages/core/src/blob-storage/index.ts
+++ b/packages/core/src/blob-storage/index.ts
@@ -11,6 +11,7 @@ export { BlobStorageError } from "./errors"
 export { InMemoryBlobStorage } from "./in-memory"
 export type {
   AbortBlobUploadInput,
+  BlobBody,
   BlobByteRange,
   BlobStorage,
   BlobUploadPart,
@@ -25,5 +26,12 @@ export type {
   SignBlobUploadPartInput,
   SignedBlobUploadPart,
 } from "./types"
-export { computeBlobDigest, createFileRef, readBlobBody } from "./utils"
+export {
+  assertExpectedBlobSize,
+  assertValidExpectedBlobSize,
+  computeBlobDigest,
+  createFileRef,
+  readBlobBody,
+  streamBlobBody,
+} from "./utils"
 export { supportsDirectUpload, supportsRangeRead } from "./validation"

--- a/packages/core/src/blob-storage/types.ts
+++ b/packages/core/src/blob-storage/types.ts
@@ -18,8 +18,14 @@ export interface FileRef {
   readonly logicalPath?: string
 }
 
+export type BlobBody = ArrayBuffer | Uint8Array | Blob | ReadableStream<Uint8Array>
+
 export interface PutBlobInput {
-  readonly body: ArrayBuffer | Uint8Array | Blob | ReadableStream<Uint8Array>
+  readonly body: BlobBody
+  /** Reject the write when the consumed byte count differs from this value. */
+  readonly expectedSizeBytes?: number
+  /** Cancels body consumption and provider-side staging work. */
+  readonly signal?: AbortSignal
   readonly fileName?: string
   readonly mediaType?: string
   readonly logicalPath?: string

--- a/packages/core/src/blob-storage/utils.ts
+++ b/packages/core/src/blob-storage/utils.ts
@@ -1,8 +1,33 @@
 import { createHash } from "node:crypto"
-import type { BlobDigest, BlobInfo, FileRef, PutBlobInput } from "./types"
+import { BlobStorageError } from "./errors"
+import type { BlobBody, BlobDigest, BlobInfo, FileRef, PutBlobInput } from "./types"
 
-export async function readBlobBody(input: PutBlobInput["body"]): Promise<Uint8Array> {
-  // Hashing requires a stable byte buffer regardless of the caller's body shape.
+/** Normalize every supported blob body to the streaming representation used by providers. */
+export function streamBlobBody(input: BlobBody): ReadableStream<Uint8Array> {
+  if (input instanceof ReadableStream) {
+    return input
+  }
+
+  if (input instanceof Blob) {
+    return input.stream()
+  }
+
+  if (input instanceof ArrayBuffer) {
+    return new Blob([input.slice(0)]).stream()
+  }
+
+  const bytes = new Uint8Array(new ArrayBuffer(input.byteLength))
+  bytes.set(input)
+  return new Blob([bytes]).stream()
+}
+
+export async function readBlobBody(
+  input: PutBlobInput["body"],
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  // In-memory providers intentionally materialize bodies; durable providers should stream instead.
+  signal?.throwIfAborted()
+
   if (input instanceof Uint8Array) {
     return new Uint8Array(input)
   }
@@ -12,22 +37,34 @@ export async function readBlobBody(input: PutBlobInput["body"]): Promise<Uint8Ar
   }
 
   if (input instanceof Blob) {
-    return new Uint8Array(await input.arrayBuffer())
+    const bytes = new Uint8Array(await input.arrayBuffer())
+    signal?.throwIfAborted()
+    return bytes
   }
 
   const reader = input.getReader()
   const chunks: Uint8Array[] = []
   let totalBytes = 0
+  const cancelOnAbort = () => {
+    void reader.cancel(signal?.reason)
+  }
+  signal?.addEventListener("abort", cancelOnAbort, { once: true })
 
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) {
-      break
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      signal?.throwIfAborted()
+      if (done) {
+        break
+      }
+
+      const chunk = new Uint8Array(value)
+      chunks.push(chunk)
+      totalBytes += chunk.byteLength
     }
-
-    const chunk = new Uint8Array(value)
-    chunks.push(chunk)
-    totalBytes += chunk.byteLength
+  } finally {
+    signal?.removeEventListener("abort", cancelOnAbort)
+    reader.releaseLock()
   }
 
   const bytes = new Uint8Array(totalBytes)
@@ -38,6 +75,38 @@ export async function readBlobBody(input: PutBlobInput["body"]): Promise<Uint8Ar
   }
 
   return bytes
+}
+
+export function assertExpectedBlobSize(
+  expectedSizeBytes: number | undefined,
+  actualSizeBytes: number,
+  provider = "BlobStorage"
+): void {
+  assertValidExpectedBlobSize(expectedSizeBytes, provider)
+  if (expectedSizeBytes === undefined) {
+    return
+  }
+
+  if (actualSizeBytes !== expectedSizeBytes) {
+    throw new BlobStorageError(
+      `[${provider}] Blob size mismatch: expected ${expectedSizeBytes} bytes, received ${actualSizeBytes}.`
+    )
+  }
+}
+
+export function assertValidExpectedBlobSize(
+  expectedSizeBytes: number | undefined,
+  provider = "BlobStorage"
+): void {
+  if (expectedSizeBytes === undefined) {
+    return
+  }
+
+  if (!Number.isSafeInteger(expectedSizeBytes) || expectedSizeBytes < 0) {
+    throw new BlobStorageError(
+      `[${provider}] expectedSizeBytes must be a non-negative safe integer.`
+    )
+  }
 }
 
 export function computeBlobDigest(bytes: Uint8Array): BlobDigest {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1039,6 +1039,7 @@ export {
 
 export type {
   AbortBlobUploadInput,
+  BlobBody,
   BlobByteRange,
   BlobDigest,
   BlobInfo,
@@ -1057,6 +1058,8 @@ export type {
   SignedBlobUploadPart,
 } from "./blob-storage"
 export {
+  assertExpectedBlobSize,
+  assertValidExpectedBlobSize,
   BlobStorageError,
   blobDigestHex,
   blobIdFromDigest,
@@ -1068,6 +1071,7 @@ export {
   isBlobDigest,
   isFileRef,
   readBlobBody,
+  streamBlobBody,
   supportsDirectUpload,
   supportsRangeRead,
 } from "./blob-storage"

--- a/packages/core/src/testing/blob-storage-contract.ts
+++ b/packages/core/src/testing/blob-storage-contract.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test"
+import { blobIdFromDigest, computeBlobDigest } from "../blob-storage"
+import type { BlobStorage } from "../blob-storage/types"
+
+export interface BlobStorageContractSuiteOptions<TStorage extends BlobStorage = BlobStorage> {
+  /** Factory that produces an isolated storage instance for each test case. */
+  readonly createStorage: () => TStorage | Promise<TStorage>
+  /** Optional cleanup invoked after every test case. */
+  readonly teardown?: (storage: TStorage) => void | Promise<void>
+}
+
+/** Runs the shared content, streaming, size-validation, and cancellation contract. */
+export function runBlobStorageContractSuite<TStorage extends BlobStorage>(
+  label: string,
+  options: BlobStorageContractSuiteOptions<TStorage>
+): void {
+  const encoder = new TextEncoder()
+
+  const withStorage = async (body: (storage: TStorage) => Promise<void>): Promise<void> => {
+    const storage = await options.createStorage()
+    try {
+      await body(storage)
+    } finally {
+      await options.teardown?.(storage)
+    }
+  }
+
+  describe(label, () => {
+    test("streams bodies into stable content-addressed references", async () => {
+      await withStorage(async (storage) => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode("streamed "))
+            controller.enqueue(encoder.encode("body"))
+            controller.close()
+          },
+        })
+
+        const fileRef = await storage.put({
+          body,
+          expectedSizeBytes: 13,
+          fileName: "report.bin",
+          mediaType: "application/octet-stream",
+          logicalPath: "reports/report.bin",
+        })
+
+        expect(fileRef.sizeBytes).toBe(13)
+        expect(fileRef.blobId).toBe(blobIdFromDigest(fileRef.digest))
+        expect(fileRef.fileName).toBe("report.bin")
+        expect(fileRef.mediaType).toBe("application/octet-stream")
+        expect(fileRef.logicalPath).toBe("reports/report.bin")
+        expect(await new Response(await storage.open(fileRef.blobId)).text()).toBe("streamed body")
+      })
+    })
+
+    test("rejects an expected size mismatch without publishing a blob", async () => {
+      await withStorage(async (storage) => {
+        const bytes = encoder.encode("wrong size")
+        const blobId = blobIdFromDigest(computeBlobDigest(bytes))
+
+        await expect(
+          storage.put({ body: bytes, expectedSizeBytes: bytes.byteLength + 1 })
+        ).rejects.toThrow(
+          `Blob size mismatch: expected ${bytes.byteLength + 1} bytes, received ${bytes.byteLength}.`
+        )
+        await expect(storage.stat(blobId)).resolves.toBeNull()
+      })
+    })
+
+    test("rejects invalid expected sizes", async () => {
+      await withStorage(async (storage) => {
+        const body = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            controller.close()
+          },
+        })
+
+        await expect(storage.put({ body, expectedSizeBytes: -1 })).rejects.toThrow(
+          "expectedSizeBytes must be a non-negative safe integer"
+        )
+      })
+    })
+
+    test("cancels an active body without publishing partial bytes", async () => {
+      await withStorage(async (storage) => {
+        const abort = new AbortController()
+        let bodyCancelled = false
+        const firstChunk = encoder.encode("partial")
+        const blobId = blobIdFromDigest(computeBlobDigest(firstChunk))
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(firstChunk)
+          },
+          cancel() {
+            bodyCancelled = true
+          },
+        })
+
+        const put = storage.put({ body, signal: abort.signal })
+        abort.abort(new Error("cancel blob put"))
+
+        await expect(put).rejects.toThrow("cancel blob put")
+        expect(bodyCancelled).toBe(true)
+        await expect(storage.stat(blobId)).resolves.toBeNull()
+      })
+    })
+  })
+}

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -7,6 +7,10 @@ export {
   runAuthStorageContractSuite,
 } from "./auth-storage-contract"
 export {
+  type BlobStorageContractSuiteOptions,
+  runBlobStorageContractSuite,
+} from "./blob-storage-contract"
+export {
   type BrokerContractSuiteOptions,
   runBrokerContractSuite,
 } from "./broker-contract"

--- a/packages/core/tests/blob-storage-contract.test.ts
+++ b/packages/core/tests/blob-storage-contract.test.ts
@@ -1,0 +1,6 @@
+import { InMemoryBlobStorage } from "../src"
+import { runBlobStorageContractSuite } from "../src/testing"
+
+runBlobStorageContractSuite("InMemoryBlobStorage contract", {
+  createStorage: () => new InMemoryBlobStorage(),
+})

--- a/storage/blob-local/README.md
+++ b/storage/blob-local/README.md
@@ -20,7 +20,9 @@ const blobStorage = new LocalBlobStorage({
 })
 
 const fileRef = await blobStorage.put({
-  body: invoicePdfBytes,
+  body: invoicePdfStream,
+  expectedSizeBytes: invoiceSize,
+  signal,
   fileName: "invoice-1001.pdf",
   mediaType: "application/pdf",
   logicalPath: "invoices/2026/04/invoice-1001.pdf",
@@ -29,6 +31,12 @@ const fileRef = await blobStorage.put({
 const info = await blobStorage.stat(fileRef.blobId)
 const stream = await blobStorage.open(fileRef.blobId)
 ```
+
+`put(...)` consumes `ReadableStream<Uint8Array>` bodies with backpressure, computes SHA-256 while
+writing to a temporary file, validates `expectedSizeBytes` when supplied, then atomically promotes
+the completed file into the content-addressed layout. Failed and canceled writes remove their
+temporary file. Byte arrays and `Blob` bodies remain supported for small or already-materialized
+payloads.
 
 ## What Gets Stored On Disk
 

--- a/storage/blob-local/src/local-blob-storage.ts
+++ b/storage/blob-local/src/local-blob-storage.ts
@@ -1,21 +1,22 @@
-import { randomUUID } from "node:crypto"
-import { createReadStream } from "node:fs"
-import { mkdir, rename, stat, writeFile } from "node:fs/promises"
+import { createHash, randomUUID } from "node:crypto"
+import { createReadStream, createWriteStream } from "node:fs"
+import { mkdir, rename, rm, stat } from "node:fs/promises"
 import { join, resolve } from "node:path"
-import { Readable } from "node:stream"
+import { Readable, Writable } from "node:stream"
 import {
+  assertExpectedBlobSize,
+  assertValidExpectedBlobSize,
   type BlobByteRange,
   type BlobInfo,
   type BlobStorage,
   BlobStorageError,
   blobDigestHex,
   blobIdFromDigest,
-  computeBlobDigest,
   createFileRef,
   type FileRef,
   type PutBlobInput,
   type RangeReadableBlobStorage,
-  readBlobBody,
+  streamBlobBody,
 } from "@sixb/core"
 import type { LocalBlobStorageOptions } from "./types"
 
@@ -23,9 +24,16 @@ async function pathExists(path: string): Promise<boolean> {
   try {
     await stat(path)
     return true
-  } catch {
-    return false
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return false
+    }
+    throw error
   }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT"
 }
 
 function hexFromBlobId(blobId: string): string | null {
@@ -44,41 +52,75 @@ export class LocalBlobStorage implements BlobStorage, RangeReadableBlobStorage {
   }
 
   async put(input: PutBlobInput): Promise<FileRef> {
-    const bytes = await readBlobBody(input.body)
-    const digest = computeBlobDigest(bytes)
-    const hex = blobDigestHex(digest)
-    const info: BlobInfo = {
-      blobId: blobIdFromDigest(digest),
-      digest,
-      sizeBytes: bytes.byteLength,
-    }
-    const contentPath = this.contentPathForHex(hex)
-
+    assertValidExpectedBlobSize(input.expectedSizeBytes, "BlobLocal")
     await mkdir(this.sha256RootPath(), { recursive: true })
-    if (!(await pathExists(contentPath))) {
-      // Write to a temp file first so interrupted uploads do not leave a partial object at the digest path.
-      const tempPath = join(this.sha256RootPath(), `.tmp-${randomUUID()}`)
-      await writeFile(tempPath, bytes)
-      await rename(tempPath, contentPath)
-    }
+    const tempPath = join(this.sha256RootPath(), `.tmp-${randomUUID()}`)
+    const hash = createHash("sha256")
+    let sizeBytes = 0
 
-    return createFileRef(input, info)
+    try {
+      const trackedBody = streamBlobBody(input.body).pipeThrough(
+        new TransformStream<Uint8Array, Uint8Array>({
+          transform(chunk, controller) {
+            hash.update(chunk)
+            sizeBytes += chunk.byteLength
+            if (input.expectedSizeBytes !== undefined && sizeBytes > input.expectedSizeBytes) {
+              assertExpectedBlobSize(input.expectedSizeBytes, sizeBytes, "BlobLocal")
+            }
+            controller.enqueue(chunk)
+          },
+        })
+      )
+      const destination = Writable.toWeb(createWriteStream(tempPath, { flags: "wx" }))
+
+      await trackedBody.pipeTo(destination, {
+        ...(input.signal === undefined ? {} : { signal: input.signal }),
+      })
+      assertExpectedBlobSize(input.expectedSizeBytes, sizeBytes, "BlobLocal")
+
+      const digest = `sha256:${hash.digest("hex")}` as const
+      const hex = blobDigestHex(digest)
+      const contentPath = this.contentPathForHex(hex)
+      const info: BlobInfo = {
+        blobId: blobIdFromDigest(digest),
+        digest,
+        sizeBytes,
+      }
+
+      if (await pathExists(contentPath)) {
+        await rm(tempPath, { force: true })
+      } else {
+        try {
+          await rename(tempPath, contentPath)
+        } catch (error) {
+          if (!(await pathExists(contentPath))) {
+            throw error
+          }
+          await rm(tempPath, { force: true })
+        }
+      }
+
+      return createFileRef(input, info)
+    } catch (error) {
+      await rm(tempPath, { force: true }).catch(() => undefined)
+      throw error
+    }
   }
 
   async open(blobId: string): Promise<ReadableStream<Uint8Array>> {
     const contentPath = await this.requireContentPath(blobId)
     // Stream from disk rather than buffering the whole blob into memory (mirrors openRange).
-    return Readable.toWeb(createReadStream(contentPath)) as unknown as ReadableStream<Uint8Array>
+    return toByteReadableStream(createReadStream(contentPath))
   }
 
   async openRange(blobId: string, range: BlobByteRange): Promise<ReadableStream<Uint8Array>> {
     const contentPath = await this.requireContentPath(blobId)
-    return Readable.toWeb(
+    return toByteReadableStream(
       createReadStream(contentPath, {
         start: range.start,
         end: range.endInclusive,
       })
-    ) as unknown as ReadableStream<Uint8Array>
+    )
   }
 
   async stat(blobId: string): Promise<BlobInfo | null> {
@@ -121,4 +163,17 @@ export class LocalBlobStorage implements BlobStorage, RangeReadableBlobStorage {
   private contentPathForHex(hex: string): string {
     return join(this.sha256RootPath(), hex)
   }
+}
+
+function toByteReadableStream(
+  stream: ReturnType<typeof createReadStream>
+): ReadableStream<Uint8Array> {
+  return Readable.toWeb(stream, {
+    strategy: {
+      highWaterMark: stream.readableHighWaterMark,
+      size(chunk: Buffer) {
+        return chunk.byteLength
+      },
+    },
+  }) as unknown as ReadableStream<Uint8Array>
 }

--- a/storage/blob-local/tests/local-blob-storage-contract.test.ts
+++ b/storage/blob-local/tests/local-blob-storage-contract.test.ts
@@ -1,0 +1,22 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { runBlobStorageContractSuite } from "@sixb/core/testing"
+import { LocalBlobStorage } from "../src"
+
+const basePaths = new WeakMap<LocalBlobStorage, string>()
+
+runBlobStorageContractSuite("LocalBlobStorage contract", {
+  async createStorage() {
+    const basePath = await mkdtemp(join(tmpdir(), "sixb-blob-local-contract-"))
+    const storage = new LocalBlobStorage({ basePath })
+    basePaths.set(storage, basePath)
+    return storage
+  },
+  async teardown(storage) {
+    const basePath = basePaths.get(storage)
+    if (basePath) {
+      await rm(basePath, { recursive: true, force: true })
+    }
+  },
+})

--- a/storage/blob-s3/README.md
+++ b/storage/blob-s3/README.md
@@ -21,10 +21,15 @@ const blobStorage = new S3BlobStorage({
   bucket: "company-lake",
   region: "us-east-1",
   basePath: "sixb",
+  putPartSizeBytes: 8 * 1024 * 1024,
+  putConcurrency: 2,
+  putRetries: 3,
 })
 
 const fileRef = await blobStorage.put({
-  body: invoicePdfBytes,
+  body: invoicePdfStream,
+  expectedSizeBytes: invoiceSize,
+  signal,
   fileName: "invoice-1001.pdf",
   mediaType: "application/pdf",
   logicalPath: "invoices/2026/04/invoice-1001.pdf",
@@ -33,6 +38,12 @@ const fileRef = await blobStorage.put({
 const info = await blobStorage.stat(fileRef.blobId)
 const stream = await blobStorage.open(fileRef.blobId)
 ```
+
+`put(...)` streams bodies to a temporary S3 object while computing SHA-256, then promotes the
+completed object into the content-addressed layout with a server-side copy. `putPartSizeBytes` and
+`putConcurrency` bound multipart upload memory per active write; their defaults are 8 MiB and 2.
+Failed and canceled writes attempt to remove their staging object. Byte arrays and `Blob` bodies
+remain supported for small or already-materialized payloads.
 
 ## Staged Direct Uploads
 
@@ -80,10 +91,10 @@ checksums cannot be used for direct uploads.
 
 ### Staging cleanup
 
-Direct uploads land under `<basePath>/uploads/<uploadId>/object` before being promoted to the
-content-addressed `blobs/sha256/` prefix. A crashed or abandoned upload can leave bytes under
-`uploads/`, so configure an S3 lifecycle rule to expire objects under that prefix (there is no
-in-repo sweeper).
+Direct uploads and streamed `put(...)` calls land under `<basePath>/uploads/<uploadId>/object`
+before being promoted to the content-addressed `blobs/sha256/` prefix. A crashed or abandoned
+upload can leave bytes under `uploads/`, so configure an S3 lifecycle rule to expire objects under
+that prefix (there is no in-repo sweeper).
 
 For S3-compatible providers, pass an `endpoint`:
 

--- a/storage/blob-s3/src/s3-blob-storage.ts
+++ b/storage/blob-s3/src/s3-blob-storage.ts
@@ -1,6 +1,9 @@
 import { Buffer } from "node:buffer"
+import { createHash, randomUUID } from "node:crypto"
 import {
   type AbortBlobUploadInput,
+  assertExpectedBlobSize,
+  assertValidExpectedBlobSize,
   type BlobByteRange,
   type BlobDigest,
   type BlobInfo,
@@ -11,15 +14,14 @@ import {
   blobIdFromDigest,
   type CompleteBlobUploadInput,
   type CreateBlobUploadInput,
-  computeBlobDigest,
   createFileRef,
   type DirectUploadBlobStorage,
   type FileRef,
   type PutBlobInput,
   type RangeReadableBlobStorage,
-  readBlobBody,
   type SignBlobUploadPartInput,
   type SignedBlobUploadPart,
+  streamBlobBody,
 } from "@sixb/core"
 import { S3Client } from "bun"
 import { encodeRfc3986, encodeS3Path, presignS3Url } from "./sigv4"
@@ -27,6 +29,10 @@ import type { S3BlobStorageAcl, S3BlobStorageOptions } from "./types"
 
 const MAX_PRESIGNED_URL_EXPIRES_SECONDS = 7 * 24 * 60 * 60 // 7 days
 const READ_URL_EXPIRES_SECONDS = 60
+const MIN_S3_MULTIPART_PART_SIZE_BYTES = 5 * 1024 * 1024
+const DEFAULT_PUT_PART_SIZE_BYTES = 8 * 1024 * 1024
+const DEFAULT_PUT_CONCURRENCY = 2
+const DEFAULT_PUT_RETRIES = 3
 
 export function normalizeS3BlobBasePath(basePath: string): string {
   return basePath
@@ -122,6 +128,9 @@ export class S3BlobStorage
   private readonly sessionToken: string | undefined
   private readonly acl: S3BlobStorageAcl | undefined
   private readonly pathStyle: boolean
+  private readonly putPartSizeBytes: number
+  private readonly putConcurrency: number
+  private readonly putRetries: number
   private readonly client: S3Client
 
   constructor(options: S3BlobStorageOptions = {}) {
@@ -139,6 +148,23 @@ export class S3BlobStorage
     this.sessionToken = options.sessionToken ?? envValue("S3_SESSION_TOKEN", "AWS_SESSION_TOKEN")
     this.acl = options.acl
     this.pathStyle = options.pathStyle ?? defaultPathStyle(this.endpoint)
+    this.putPartSizeBytes = requireIntegerOption(
+      "putPartSizeBytes",
+      options.putPartSizeBytes ?? DEFAULT_PUT_PART_SIZE_BYTES,
+      MIN_S3_MULTIPART_PART_SIZE_BYTES
+    )
+    this.putConcurrency = requireIntegerOption(
+      "putConcurrency",
+      options.putConcurrency ?? DEFAULT_PUT_CONCURRENCY,
+      1,
+      255
+    )
+    this.putRetries = requireIntegerOption(
+      "putRetries",
+      options.putRetries ?? DEFAULT_PUT_RETRIES,
+      0,
+      255
+    )
     this.client = new S3Client({
       bucket: this.bucket,
       region: this.region,
@@ -151,20 +177,57 @@ export class S3BlobStorage
   }
 
   async put(input: PutBlobInput): Promise<FileRef> {
-    const bytes = await readBlobBody(input.body)
-    const digest = computeBlobDigest(bytes)
-    const hex = blobDigestHex(digest)
-    const info: BlobInfo = {
-      blobId: blobIdFromDigest(digest),
-      digest,
-      sizeBytes: bytes.byteLength,
+    assertValidExpectedBlobSize(input.expectedSizeBytes, "BlobS3")
+    input.signal?.throwIfAborted()
+    const stagingKey = this.uploadKeyForId(`put_${randomUUID().replaceAll("-", "")}`)
+    const hash = createHash("sha256")
+    let sizeBytes = 0
+
+    try {
+      const trackedBody = streamBlobBody(input.body).pipeThrough(
+        new TransformStream<Uint8Array, Uint8Array>({
+          transform(chunk, controller) {
+            hash.update(chunk)
+            sizeBytes += chunk.byteLength
+            if (input.expectedSizeBytes !== undefined && sizeBytes > input.expectedSizeBytes) {
+              assertExpectedBlobSize(input.expectedSizeBytes, sizeBytes, "BlobS3")
+            }
+            controller.enqueue(chunk)
+          },
+        })
+      )
+      const uploadBody = input.signal
+        ? trackedBody.pipeThrough(new TransformStream<Uint8Array, Uint8Array>(), {
+            signal: input.signal,
+          })
+        : trackedBody
+
+      await this.client.write(stagingKey, new Response(uploadBody), {
+        type: input.mediaType,
+        partSize: this.putPartSizeBytes,
+        queueSize: this.putConcurrency,
+        retry: this.putRetries,
+      })
+
+      assertExpectedBlobSize(input.expectedSizeBytes, sizeBytes, "BlobS3")
+      const staged = await this.client.stat(stagingKey)
+      assertExpectedBlobSize(sizeBytes, staged.size, "BlobS3")
+      input.signal?.throwIfAborted()
+
+      const digest = `sha256:${hash.digest("hex")}` as BlobDigest
+      const info: BlobInfo = {
+        blobId: blobIdFromDigest(digest),
+        digest,
+        sizeBytes,
+      }
+
+      await this.copyObject(stagingKey, this.contentKeyForHex(blobDigestHex(digest)))
+      await this.client.delete(stagingKey)
+      return createFileRef(input, info)
+    } catch (error) {
+      await this.deleteStagedObjectQuietly(stagingKey)
+      throw error
     }
-
-    await this.client.write(this.contentKeyForHex(hex), bytes, {
-      type: input.mediaType,
-    })
-
-    return createFileRef(input, info)
   }
 
   async createUpload(input: CreateBlobUploadInput): Promise<BlobUploadSession> {
@@ -352,6 +415,14 @@ export class S3BlobStorage
       : `uploads/${uploadId}/object`
   }
 
+  private async deleteStagedObjectQuietly(stagingKey: string): Promise<void> {
+    try {
+      await this.client.delete(stagingKey)
+    } catch {
+      // Preserve the upload failure. Bucket lifecycle rules are the final cleanup safety net.
+    }
+  }
+
   private async copyObject(sourceKey: string, destinationKey: string): Promise<void> {
     const headers: Record<string, string> = {
       "x-amz-copy-source": this.copySourceHeader(sourceKey),
@@ -423,4 +494,19 @@ export class S3BlobStorage
       secretAccessKey: this.secretAccessKey,
     }
   }
+}
+
+function requireIntegerOption(
+  name: string,
+  value: number,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER
+): number {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new BlobStorageError(
+      `[BlobS3] ${name} must be an integer between ${minimum} and ${maximum}.`
+    )
+  }
+
+  return value
 }

--- a/storage/blob-s3/src/types.ts
+++ b/storage/blob-s3/src/types.ts
@@ -30,4 +30,10 @@ export interface S3BlobStorageOptions {
   readonly pathStyle?: boolean
   /** Key prefix that contains the blobs/sha256 object layout. Defaults to "sixb". */
   readonly basePath?: string
+  /** Multipart part size for streamed `put(...)` calls. Defaults to 8 MiB. */
+  readonly putPartSizeBytes?: number
+  /** Maximum parallel multipart parts per streamed `put(...)`. Defaults to 2. */
+  readonly putConcurrency?: number
+  /** Retry attempts for streamed multipart parts. Defaults to 3. */
+  readonly putRetries?: number
 }

--- a/storage/blob-s3/tests/s3-blob-storage.e2e.ts
+++ b/storage/blob-s3/tests/s3-blob-storage.e2e.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
-import { randomUUID } from "node:crypto"
+import { createHash, randomUUID } from "node:crypto"
 import { BlobStorageError, computeBlobDigest } from "@sixb/core"
+import { runBlobStorageContractSuite } from "@sixb/core/testing"
 import { S3Client } from "bun"
 import { S3BlobStorage } from "../src"
 
@@ -26,6 +27,10 @@ function rawS3Client(): S3Client {
     region: "us-east-1",
   })
 }
+
+runBlobStorageContractSuite("S3BlobStorage contract", {
+  createStorage,
+})
 
 describe("S3BlobStorage", () => {
   test("stores and opens blobs through S3", async () => {
@@ -64,6 +69,42 @@ describe("S3BlobStorage", () => {
     expect(second.blobId).toBe(first.blobId)
     expect(second.digest).toBe(first.digest)
     expect(third.blobId).not.toBe(first.blobId)
+  })
+
+  test("streams multipart bodies through bounded staging", async () => {
+    const storage = createStorage()
+    const chunk = new Uint8Array(1024 * 1024).fill(7)
+    const chunkCount = 12
+    const expectedSizeBytes = chunk.byteLength * chunkCount
+    const hash = createHash("sha256")
+    for (let index = 0; index < chunkCount; index += 1) {
+      hash.update(chunk)
+    }
+    let emittedChunks = 0
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (emittedChunks === chunkCount) {
+          controller.close()
+          return
+        }
+        emittedChunks += 1
+        controller.enqueue(chunk)
+      },
+    })
+
+    const fileRef = await storage.put({ body, expectedSizeBytes })
+
+    expect(fileRef.sizeBytes).toBe(expectedSizeBytes)
+    expect(fileRef.digest).toBe(`sha256:${hash.digest("hex")}`)
+    expect(emittedChunks).toBe(chunkCount)
+    expect(
+      await new Response(
+        await storage.openRange(fileRef.blobId, {
+          start: expectedSizeBytes - 1,
+          endInclusive: expectedSizeBytes - 1,
+        })
+      ).bytes()
+    ).toEqual(new Uint8Array([7]))
   })
 
   test("stats existing blobs and treats missing blobs as null", async () => {


### PR DESCRIPTION
# Stream large connector files into BlobStorage end to end

## Summary

This PR adds true end-to-end streaming for large binary files. SFTP files can now flow into local
or S3 blob storage without first loading the complete payload into memory.

```mermaid
flowchart LR
    A["SFTP file"] --> B["ReadableStream"]
    B --> C["Incremental SHA-256<br/>and byte count"]
    C -->|"Local"| D["Temporary file"]
    C -->|"S3"| E["Multipart staging object"]
    D --> F["Content-addressed blob"]
    E --> F
```

| Before | After |
| --- | --- |
| `SftpClient.read()` materialized the whole file as a `Buffer` | `SftpClient.open()` exposes a backpressured Web Stream |
| Durable blob providers buffered streamed bodies | Local and S3 providers hash and persist each chunk incrementally |
| Memory grew with file size | Memory is bounded by stream and multipart buffers |

## What changed

- Added `SftpClient.open(path, { signal? })` with cancellation and byte-based backpressure.
- Added optional `expectedSizeBytes` and `signal` to `BlobStorage.put()`.
- Made `LocalBlobStorage.put()` stream through a temporary file before atomic promotion.
- Made `S3BlobStorage.put()` stream through bounded multipart staging before server-side promotion.
- Added configurable S3 part size, concurrency, and retries with conservative defaults.
- Added a shared BlobStorage contract suite covering streaming, size validation, and cancellation.
- Kept buffered APIs such as `SftpClient.read()` backward compatible.

## Failure safety

- Size mismatches fail before publishing a final blob.
- Cancellation closes the SFTP handle and stops body consumption.
- Failed or canceled writes clean up temporary files and staging objects when possible.
- Partial content is never promoted to the content-addressed blob path.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun run test` — 2,486 passed, 2 skipped
- S3/MinIO E2E — 10 passed, including a 12 MiB multipart stream