### PR TITLE
Add Teamleader deal actions

### DIFF
--- a/connectors/teamleader/README.md
+++ b/connectors/teamleader/README.md
@@ -5,6 +5,7 @@ Teamleader Focus connector for Sixb.
 V1 covers:
 
 - Deals
+- Deal actions
 - Quotations
 - Quotation actions
 - Quotation reference data
@@ -56,6 +57,12 @@ Responses keep the Teamleader envelope:
 client.deals.list(...)
 client.deals.listAll(...)
 client.deals.info(...)
+client.deals.create(...)
+client.deals.update(...)
+client.deals.move(...)
+client.deals.win(...)
+client.deals.lose(...)
+client.deals.delete(...)
 
 client.quotations.list(...)
 client.quotations.listAll(...)

--- a/connectors/teamleader/src/resources/deals.ts
+++ b/connectors/teamleader/src/resources/deals.ts
@@ -6,6 +6,7 @@ import type {
   TeamleaderDealListItem,
   TeamleaderListResponse,
   TeamleaderSingleResponse,
+  TeamleaderTypeAndId,
 } from "../types"
 
 export function createDealsResource(request: TeamleaderRequester): TeamleaderClient["deals"] {
@@ -22,6 +23,28 @@ export function createDealsResource(request: TeamleaderRequester): TeamleaderCli
     },
     info(body, requestOptions) {
       return request<TeamleaderSingleResponse<TeamleaderDeal>>("/deals.info", body, requestOptions)
+    },
+    create(body, requestOptions) {
+      return request<TeamleaderSingleResponse<TeamleaderTypeAndId<"deal">>>(
+        "/deals.create",
+        body,
+        requestOptions
+      )
+    },
+    update(body, requestOptions) {
+      return request<void>("/deals.update", body, requestOptions)
+    },
+    move(body, requestOptions) {
+      return request<void>("/deals.move", body, requestOptions)
+    },
+    win(body, requestOptions) {
+      return request<void>("/deals.win", body, requestOptions)
+    },
+    lose(body, requestOptions) {
+      return request<void>("/deals.lose", body, requestOptions)
+    },
+    delete(body, requestOptions) {
+      return request<void>("/deals.delete", body, requestOptions)
     },
   }
 

--- a/connectors/teamleader/src/types/client.ts
+++ b/connectors/teamleader/src/types/client.ts
@@ -23,7 +23,15 @@ import type {
   TeamleaderCustomFieldDefinition,
   TeamleaderCustomFieldDefinitionListRequest,
 } from "./custom-fields"
-import type { TeamleaderDeal, TeamleaderDealListItem, TeamleaderDealsListRequest } from "./deals"
+import type {
+  TeamleaderDeal,
+  TeamleaderDealCreateRequest,
+  TeamleaderDealListItem,
+  TeamleaderDealLoseRequest,
+  TeamleaderDealMoveRequest,
+  TeamleaderDealsListRequest,
+  TeamleaderDealUpdateRequest,
+} from "./deals"
 import type {
   TeamleaderProduct,
   TeamleaderProductInfoRequest,
@@ -77,6 +85,15 @@ export interface TeamleaderClient {
       request: TeamleaderInfoRequest,
       options?: TeamleaderRequestOptions
     ): Promise<TeamleaderSingleResponse<TeamleaderDeal>>
+    create(
+      request: TeamleaderDealCreateRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<TeamleaderSingleResponse<TeamleaderTypeAndId<"deal">>>
+    update(request: TeamleaderDealUpdateRequest, options?: TeamleaderRequestOptions): Promise<void>
+    move(request: TeamleaderDealMoveRequest, options?: TeamleaderRequestOptions): Promise<void>
+    win(request: TeamleaderInfoRequest, options?: TeamleaderRequestOptions): Promise<void>
+    lose(request: TeamleaderDealLoseRequest, options?: TeamleaderRequestOptions): Promise<void>
+    delete(request: TeamleaderInfoRequest, options?: TeamleaderRequestOptions): Promise<void>
   }
   readonly quotations: {
     list(

--- a/connectors/teamleader/src/types/deals.ts
+++ b/connectors/teamleader/src/types/deals.ts
@@ -1,11 +1,12 @@
 import type {
+  TeamleaderCurrencyCode,
   TeamleaderCurrencyExchangeRate,
   TeamleaderMoney,
   TeamleaderPage,
   TeamleaderSort,
   TeamleaderTypeAndId,
 } from "./common"
-import type { TeamleaderCustomField } from "./custom-fields"
+import type { TeamleaderCustomField, TeamleaderCustomFieldInput } from "./custom-fields"
 
 export type TeamleaderDealStatus = "new" | "open" | "won" | "lost"
 
@@ -33,6 +34,59 @@ export interface TeamleaderDealsListRequest {
 export interface TeamleaderLead {
   readonly customer?: TeamleaderTypeAndId<"contact" | "company">
   readonly contact_person?: TeamleaderTypeAndId
+}
+
+export interface TeamleaderDealLeadRequest {
+  readonly customer: TeamleaderTypeAndId<"contact" | "company">
+  readonly contact_person_id?: string
+}
+
+export interface TeamleaderDealCurrencyRequest {
+  readonly code: TeamleaderCurrencyCode
+  readonly exchange_rate: number
+}
+
+export interface TeamleaderDealCreateRequest {
+  readonly lead: TeamleaderDealLeadRequest
+  readonly title: string
+  readonly summary?: string
+  readonly source_id?: string
+  readonly department_id?: string
+  readonly responsible_user_id?: string
+  readonly phase_id?: string
+  readonly estimated_value?: TeamleaderMoney | null
+  readonly estimated_probability?: number
+  readonly estimated_closing_date?: string
+  readonly custom_fields?: readonly TeamleaderCustomFieldInput[]
+  readonly currency?: TeamleaderDealCurrencyRequest
+  readonly purchase_order_number?: string | null
+}
+
+export interface TeamleaderDealUpdateRequest {
+  readonly id: string
+  readonly lead?: TeamleaderDealLeadRequest
+  readonly title?: string
+  readonly summary?: string | null
+  readonly source_id?: string | null
+  readonly department_id?: string | null
+  readonly responsible_user_id?: string | null
+  readonly estimated_value?: TeamleaderMoney | null
+  readonly estimated_probability?: number | null
+  readonly estimated_closing_date?: string | null
+  readonly custom_fields?: readonly TeamleaderCustomFieldInput[]
+  readonly currency?: TeamleaderDealCurrencyRequest
+  readonly purchase_order_number?: string | null
+}
+
+export interface TeamleaderDealMoveRequest {
+  readonly id: string
+  readonly phase_id: string
+}
+
+export interface TeamleaderDealLoseRequest {
+  readonly id: string
+  readonly reason_id?: string
+  readonly extra_info?: string
 }
 
 export interface TeamleaderDealListItem {

--- a/connectors/teamleader/tests/teamleader.test.ts
+++ b/connectors/teamleader/tests/teamleader.test.ts
@@ -77,6 +77,114 @@ describe("teamleader connector", () => {
     expect(response.data).toEqual([{ id: "deal-1" }])
   })
 
+  test("supports documented deal actions", async () => {
+    const requests: CapturedRequest[] = []
+    const client = createTeamleaderClient({
+      accessToken: "test-token",
+      fetch: mockFetch((input, init) => {
+        requests.push({ input, init })
+        const path = new URL(String(input)).pathname
+
+        if (path === "/deals.create") {
+          return Promise.resolve(
+            jsonResponse({ data: { type: "deal", id: "deal-1" } }, { status: 201 })
+          )
+        }
+
+        return Promise.resolve(new Response(undefined, { status: 204 }))
+      }),
+    })
+
+    const created = await client.deals.create({
+      lead: {
+        customer: { type: "company", id: "company-1" },
+        contact_person_id: "contact-1",
+      },
+      title: "Interesting business deal",
+      summary: "Additional information",
+      source_id: "source-1",
+      department_id: "department-1",
+      responsible_user_id: "user-1",
+      phase_id: "phase-1",
+      estimated_value: { amount: 123.3, currency: "EUR" },
+      estimated_probability: 0.75,
+      estimated_closing_date: "2017-05-09",
+      custom_fields: [{ id: "field-1", value: "BeHome" }],
+      currency: { code: "EUR", exchange_rate: 1 },
+      purchase_order_number: "000023",
+    })
+    await client.deals.update({
+      id: "deal-1",
+      title: "Updated deal",
+      summary: null,
+      source_id: null,
+      department_id: null,
+      responsible_user_id: null,
+      estimated_value: null,
+      estimated_probability: null,
+      estimated_closing_date: null,
+      custom_fields: [{ id: "field-1", value: ["BeHome", "Placard"] }],
+      currency: { code: "EUR", exchange_rate: 1 },
+      purchase_order_number: null,
+    })
+    await client.deals.move({ id: "deal-1", phase_id: "phase-2" })
+    await client.deals.win({ id: "deal-1" })
+    await client.deals.lose({
+      id: "deal-1",
+      reason_id: "lost-reason-1",
+      extra_info: "Decision postponed",
+    })
+    await client.deals.delete({ id: "deal-1" })
+
+    expect(created.data).toEqual({ type: "deal", id: "deal-1" })
+    expect(requests.map((request) => new URL(String(request.input)).pathname)).toEqual([
+      "/deals.create",
+      "/deals.update",
+      "/deals.move",
+      "/deals.win",
+      "/deals.lose",
+      "/deals.delete",
+    ])
+    expect(requests.map((request) => JSON.parse(String(request.init?.body)))).toEqual([
+      {
+        lead: {
+          customer: { type: "company", id: "company-1" },
+          contact_person_id: "contact-1",
+        },
+        title: "Interesting business deal",
+        summary: "Additional information",
+        source_id: "source-1",
+        department_id: "department-1",
+        responsible_user_id: "user-1",
+        phase_id: "phase-1",
+        estimated_value: { amount: 123.3, currency: "EUR" },
+        estimated_probability: 0.75,
+        estimated_closing_date: "2017-05-09",
+        custom_fields: [{ id: "field-1", value: "BeHome" }],
+        currency: { code: "EUR", exchange_rate: 1 },
+        purchase_order_number: "000023",
+      },
+      {
+        id: "deal-1",
+        title: "Updated deal",
+        summary: null,
+        source_id: null,
+        department_id: null,
+        responsible_user_id: null,
+        estimated_value: null,
+        estimated_probability: null,
+        estimated_closing_date: null,
+        custom_fields: [{ id: "field-1", value: ["BeHome", "Placard"] }],
+        currency: { code: "EUR", exchange_rate: 1 },
+        purchase_order_number: null,
+      },
+      { id: "deal-1", phase_id: "phase-2" },
+      { id: "deal-1" },
+      { id: "deal-1", reason_id: "lost-reason-1", extra_info: "Decision postponed" },
+      { id: "deal-1" },
+    ])
+  })
+
   test("supports documented quotation actions", async () => {
     const requests: CapturedRequest[] = []
     const client = createTeamleaderClient({


### PR DESCRIPTION
## Summary

- Adds the remaining Teamleader `deals.*` endpoints to `@sixb/connector-teamleader`.
- Exposes `create`, `update`, `move`, `win`, `lose`, and `delete` on `client.deals`.
- Adds documented request types, including deal custom fields and lifecycle action payloads.
- Covers the new methods with request/response contract tests.

## Validation

- `bun --filter @sixb/connector-teamleader typecheck`
- `bun --filter @sixb/connector-teamleader test`
- `bun --filter @sixb/connector-teamleader build`
- Real Teamleader smoke with valid credentials:
  - read-only checks passed
  - deal write smoke passed for create, update, move, win, lose, and delete
  - temporary smoke deals were deleted successfully
