### PR TITLE
connectors/imap: surface empty download results as a typed error

### DIFF
--- a/connectors/imap/src/client.ts
+++ b/connectors/imap/src/client.ts
@@ -19,6 +19,7 @@ import {
   ImapAbortedError,
   ImapConnectorError,
   ImapDownloadTooLargeError,
+  ImapPartUnavailableError,
   imapOperationError,
 } from "./errors"
 import type {
@@ -67,7 +68,7 @@ export interface ImapTransport {
     range: string | number | bigint,
     part?: string,
     options?: { uid?: boolean; maxBytes?: number; chunkSize?: number }
-  ): Promise<DownloadObject>
+  ): Promise<Partial<DownloadObject>>
 }
 
 export type ImapTransportFactory = (options: ImapFlowOptions) => ImapTransport
@@ -316,7 +317,7 @@ class ImapMailboxSessionImpl implements ImapMailboxSession {
     this.assertActive()
     validateDownloadInput(input)
 
-    let downloaded: DownloadObject
+    let downloaded: Partial<DownloadObject>
     try {
       downloaded = await this.transport.download(input.uid, input.part, {
         uid: true,
@@ -325,6 +326,13 @@ class ImapMailboxSessionImpl implements ImapMailboxSession {
       this.assertActive()
     } catch (error) {
       throw imapOperationError("Message part download", error, [this.password])
+    }
+
+    // ImapFlow resolves an empty object (no `meta`/`content`) when the mailbox is no
+    // longer selected or the requested body part is absent from the server response.
+    // Surface that as a typed, actionable error before it poisons `activeStreams`.
+    if (!downloaded.content || !downloaded.meta) {
+      throw new ImapPartUnavailableError(input.uid, input.part)
     }
 
     const content = limitReadable(downloaded.content, input)
@@ -355,9 +363,16 @@ class ImapMailboxSessionImpl implements ImapMailboxSession {
       return
     }
     this.active = false
+    // Cleanup runs inside withMailbox's `finally`, so a throw here would mask the real
+    // operation error. Guard every stream (undefined source, already destroyed) so
+    // teardown always completes.
     for (const [content, source] of this.activeStreams) {
-      content.destroy()
-      source.destroy()
+      if (!content.destroyed) {
+        content.destroy()
+      }
+      if (source && !source.destroyed) {
+        source.destroy()
+      }
     }
     this.activeStreams.clear()
   }

--- a/connectors/imap/src/errors.ts
+++ b/connectors/imap/src/errors.ts
@@ -28,6 +28,17 @@ export class ImapDownloadTooLargeError extends ImapConnectorError {
   }
 }
 
+export class ImapPartUnavailableError extends ImapConnectorError {
+  override readonly name = "ImapPartUnavailableError"
+
+  constructor(
+    readonly uid: number,
+    readonly part: string
+  ) {
+    super(`Message ${uid} part ${part} is unavailable: the server returned no content.`)
+  }
+}
+
 export function imapOperationError(
   operation: string,
   error: unknown,

--- a/connectors/imap/src/index.ts
+++ b/connectors/imap/src/index.ts
@@ -2,6 +2,7 @@ export {
   ImapAbortedError,
   ImapConnectorError,
   ImapDownloadTooLargeError,
+  ImapPartUnavailableError,
 } from "./errors"
 export { imap } from "./imap"
 export type {

--- a/connectors/imap/tests/imap.test.ts
+++ b/connectors/imap/tests/imap.test.ts
@@ -12,7 +12,13 @@ import type {
   MailboxObject,
   SearchObject,
 } from "imapflow"
-import { ImapAbortedError, ImapConnectorError, ImapDownloadTooLargeError, imap } from "../src"
+import {
+  ImapAbortedError,
+  ImapConnectorError,
+  ImapDownloadTooLargeError,
+  ImapPartUnavailableError,
+  imap,
+} from "../src"
 import { createImapClient, type ImapTransport } from "../src/client"
 import type { ImapConnection, ImapMailboxSession } from "../src/types"
 
@@ -328,6 +334,44 @@ describe("imap connector", () => {
     expect(source.destroyed).toBe(true)
   })
 
+  test("reports an unavailable part when the server returns no content", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      // ImapFlow resolves an empty object when the requested part is absent.
+      transport.downloadResult = {}
+    }
+
+    await expect(
+      fixture.client.withMailbox("INBOX", (mailbox) =>
+        mailbox.downloadPart({ uid: 7, part: "2", maxBytes: 5 })
+      )
+    ).rejects.toBeInstanceOf(ImapPartUnavailableError)
+
+    // Teardown must surface the typed error, not a masking `source.destroy` TypeError
+    // from an entry poisoned with an undefined stream.
+    expect(fixture.transports[0]?.events).toEqual([
+      "connect",
+      "lock:INBOX:true",
+      "download",
+      "release:INBOX",
+      "logout",
+    ])
+  })
+
+  test("reports an unavailable part for a partial download result", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      // The `part === "1"` fetch-miss path resolves { response: false, chunk: false }.
+      transport.downloadResult = { response: false, chunk: false } as Partial<DownloadObject>
+    }
+
+    await expect(
+      fixture.client.withMailbox("INBOX", (mailbox) =>
+        mailbox.downloadPart({ uid: 7, part: "1", maxBytes: 5 })
+      )
+    ).rejects.toBeInstanceOf(ImapPartUnavailableError)
+  })
+
   test("makes a mailbox session unusable after its callback", async () => {
     const fixture = clientFixture()
     let escaped: ImapMailboxSession | undefined
@@ -454,7 +498,7 @@ class FakeTransport implements ImapTransport {
   mailboxes: ListResponse[] = []
   searchResult: number[] | false = []
   messages: FetchMessageObject[] = []
-  downloadResult: DownloadObject = download([], 0)
+  downloadResult: Partial<DownloadObject> = download([], 0)
   searchQuery?: SearchObject
   fetchRange?: string | number[] | SearchObject
   fetchQuery?: FetchQueryObject
@@ -546,7 +590,7 @@ class FakeTransport implements ImapTransport {
     range: string | number | bigint,
     part = "",
     options: { uid?: boolean; maxBytes?: number; chunkSize?: number } = {}
-  ): Promise<DownloadObject> {
+  ): Promise<Partial<DownloadObject>> {
     this.events.push("download")
     this.downloadRequest = { uid: Number(range), part, options }
     return this.downloadResult


### PR DESCRIPTION
## Problem

ImapFlow's `download()` can resolve an **empty object** (no `meta`/`content`) when the mailbox is deselected or the requested body part is absent from the server response — observed on Infomaniak accounts across several messages.

`downloadPart()` assumed content was always present. It registered an `undefined` source stream in `activeStreams`, then dereferenced `meta` and threw. That throw propagated into `withMailbox()`'s `finally`, where `deactivate()` called `destroy()` on the `undefined` stream — a **second throw that replaced the real cause**, so the only symptom was a misleading `TypeError: undefined is not an object (source.destroy)` at cleanup. Affected messages could never be finalized and looped forever in retry.

## Fix

- `downloadPart()` validates the result and throws a typed **`ImapPartUnavailableError`** before it can poison `activeStreams`.
- `deactivate()` guards every stream so teardown can never throw and mask the operation error.
- `ImapTransport.download` now reflects the real contract (`Partial<DownloadObject>`).

Consumers can catch `ImapPartUnavailableError` to skip an unavailable part gracefully instead of failing the whole operation.

## Tests

Two regression tests: an empty result (and a partial `{ response, chunk }` shape) now rejects with `ImapPartUnavailableError`, and teardown surfaces that typed error rather than a masking `source.destroy` crash. Full connector suite green (21/21), typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)