### PR TITLE
workers: keep queue consumers alive through long deliveries

### DIFF
--- a/packages/cli/src/commands/dev.tsx
+++ b/packages/cli/src/commands/dev.tsx
@@ -119,14 +119,17 @@ export async function runDev(options: DevOptions = {}) {
       />
     )
 
-    await runUntilSignal(async () => {
-      app.unmount()
-      console.log("\nShutting down...")
-      await stopQuietly(() => customAppServer?.stop() ?? Promise.resolve())
-      await stopQuietly(() => atlasServer?.stop() ?? Promise.resolve())
-      await stopQuietly(() => server?.stop() ?? Promise.resolve())
-      await stopQuietly(() => runtime?.stop() ?? Promise.resolve())
-    })
+    await Promise.race([
+      runUntilSignal(async () => {
+        app.unmount()
+        console.log("\nShutting down...")
+        await stopQuietly(() => customAppServer?.stop() ?? Promise.resolve())
+        await stopQuietly(() => atlasServer?.stop() ?? Promise.resolve())
+        await stopQuietly(() => server?.stop() ?? Promise.resolve())
+        await stopQuietly(() => runtime?.stop() ?? Promise.resolve())
+      }),
+      runtime.waitForWorkerFailure(),
+    ])
   } catch (error) {
     app.unmount()
     await stopQuietly(() => customAppServer?.stop() ?? Promise.resolve())

--- a/packages/cli/src/commands/orchestrator.tsx
+++ b/packages/cli/src/commands/orchestrator.tsx
@@ -6,6 +6,7 @@ import {
   startOrchestratorRuntime,
   stopQuietly,
   stopSixbProviders,
+  waitForWorkerFailure,
 } from "../lib/runtime"
 import { ErrorView, LoadingView, RoleView, renderPersistent, renderStatic } from "../ui"
 
@@ -46,15 +47,18 @@ export async function runOrchestrator(options: OrchestratorOptions = {}) {
       />
     )
 
-    await runUntilSignal(async () => {
-      app.unmount()
-      console.log("\nShutting down orchestrator...")
-      await stopQuietly(() => runtime?.stop() ?? Promise.resolve())
-      if (sixb) {
-        await stopSixbProviders(sixb)
-      }
-      sixb = null
-    })
+    await Promise.race([
+      runUntilSignal(async () => {
+        app.unmount()
+        console.log("\nShutting down orchestrator...")
+        await stopQuietly(() => runtime?.stop() ?? Promise.resolve())
+        if (sixb) {
+          await stopSixbProviders(sixb)
+        }
+        sixb = null
+      }),
+      waitForWorkerFailure(runtime.orchestratorWorker),
+    ])
   } catch (error) {
     app.unmount()
     await stopQuietly(() => runtime?.stop() ?? Promise.resolve())

--- a/packages/cli/src/commands/rules.tsx
+++ b/packages/cli/src/commands/rules.tsx
@@ -6,6 +6,7 @@ import {
   startRulesRuntime,
   stopQuietly,
   stopSixbProviders,
+  waitForWorkerFailure,
 } from "../lib/runtime"
 import { ErrorView, LoadingView, RoleView, renderPersistent, renderStatic } from "../ui"
 
@@ -40,15 +41,18 @@ export async function runRules(options: RulesOptions = {}) {
       />
     )
 
-    await runUntilSignal(async () => {
-      app.unmount()
-      console.log("\nShutting down rules...")
-      await stopQuietly(() => runtime?.stop() ?? Promise.resolve())
-      if (sixb) {
-        await stopSixbProviders(sixb)
-      }
-      sixb = null
-    })
+    await Promise.race([
+      runUntilSignal(async () => {
+        app.unmount()
+        console.log("\nShutting down rules...")
+        await stopQuietly(() => runtime?.stop() ?? Promise.resolve())
+        if (sixb) {
+          await stopSixbProviders(sixb)
+        }
+        sixb = null
+      }),
+      waitForWorkerFailure(runtime.rulesWorker),
+    ])
   } catch (error) {
     app.unmount()
     await stopQuietly(() => runtime?.stop() ?? Promise.resolve())

--- a/packages/cli/src/commands/worker-group.tsx
+++ b/packages/cli/src/commands/worker-group.tsx
@@ -1,7 +1,12 @@
 import type { Worker } from "@sixb/core"
 import { type LoadedSixb, loadSixbFromEntry } from "../lib/loadSixb"
 import { resolveRuntimeEntry } from "../lib/production"
-import { runUntilSignal, stopQuietly, stopSixbProviders } from "../lib/runtime"
+import {
+  runUntilSignal,
+  stopQuietly,
+  stopSixbProviders,
+  waitForWorkerFailure,
+} from "../lib/runtime"
 import {
   createWorkerForType,
   resolveRegisteredWorkerTypes,
@@ -63,10 +68,6 @@ export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
 
     app.rerender(<WorkerGroupView name={sixb.id} workerTypes={workerTypes} warnings={warnings} />)
 
-    const workerFailure =
-      workers.length === 0
-        ? new Promise<void>(() => {})
-        : Promise.race(workers.map((worker) => worker.wait()))
     await Promise.race([
       runUntilSignal(async () => {
         app.unmount()
@@ -74,7 +75,7 @@ export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
         await stopWorkersAndProviders()
         sixb = null
       }),
-      workerFailure,
+      ...workers.map(waitForWorkerFailure),
     ])
   } catch (error) {
     app.unmount()

--- a/packages/cli/src/commands/worker-group.tsx
+++ b/packages/cli/src/commands/worker-group.tsx
@@ -63,12 +63,19 @@ export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
 
     app.rerender(<WorkerGroupView name={sixb.id} workerTypes={workerTypes} warnings={warnings} />)
 
-    await runUntilSignal(async () => {
-      app.unmount()
-      console.log("\nShutting down worker group...")
-      await stopWorkersAndProviders()
-      sixb = null
-    })
+    const workerFailure =
+      workers.length === 0
+        ? new Promise<void>(() => {})
+        : Promise.race(workers.map((worker) => worker.wait()))
+    await Promise.race([
+      runUntilSignal(async () => {
+        app.unmount()
+        console.log("\nShutting down worker group...")
+        await stopWorkersAndProviders()
+        sixb = null
+      }),
+      workerFailure,
+    ])
   } catch (error) {
     app.unmount()
     await stopWorkersAndProviders()

--- a/packages/cli/src/commands/worker.tsx
+++ b/packages/cli/src/commands/worker.tsx
@@ -46,15 +46,18 @@ export async function runWorker(options: WorkerOptions = {}) {
     const workerId = `${workerType}-worker-${sixb.id}`
     app.rerender(<WorkerView name={sixb.id} workerId={workerId} />)
 
-    await runUntilSignal(async () => {
-      app.unmount()
-      console.log("\nShutting down worker...")
-      await stopQuietly(() => worker?.stop() ?? Promise.resolve())
-      if (sixb) {
-        await stopSixbProviders(sixb)
-      }
-      sixb = null
-    })
+    await Promise.race([
+      runUntilSignal(async () => {
+        app.unmount()
+        console.log("\nShutting down worker...")
+        await stopQuietly(() => worker?.stop() ?? Promise.resolve())
+        if (sixb) {
+          await stopSixbProviders(sixb)
+        }
+        sixb = null
+      }),
+      worker.wait(),
+    ])
   } catch (error) {
     app.unmount()
     await stopQuietly(() => worker?.stop() ?? Promise.resolve())

--- a/packages/cli/src/commands/worker.tsx
+++ b/packages/cli/src/commands/worker.tsx
@@ -1,7 +1,12 @@
 import type { Worker } from "@sixb/core"
 import { type LoadedSixb, loadSixbFromEntry } from "../lib/loadSixb"
 import { resolveRuntimeEntry } from "../lib/production"
-import { runUntilSignal, stopQuietly, stopSixbProviders } from "../lib/runtime"
+import {
+  runUntilSignal,
+  stopQuietly,
+  stopSixbProviders,
+  waitForWorkerFailure,
+} from "../lib/runtime"
 import {
   createWorkerForType,
   resolveWorkerTypeToStart,
@@ -56,7 +61,7 @@ export async function runWorker(options: WorkerOptions = {}) {
         }
         sixb = null
       }),
-      worker.wait(),
+      waitForWorkerFailure(worker),
     ])
   } catch (error) {
     app.unmount()

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -1,7 +1,7 @@
 import { appendFileSync } from "node:fs"
 import { ActionWorker } from "@sixb/action-worker"
 import { AgentWorker } from "@sixb/agent-worker"
-import { assertLakeDatasetDefinitionsCompatible, migrateStorage } from "@sixb/core"
+import { assertLakeDatasetDefinitionsCompatible, migrateStorage, type Worker } from "@sixb/core"
 import {
   type CompileRoutesDiagnostic,
   compileRoutesWithDiagnostics,
@@ -13,6 +13,12 @@ import { RulesWorker } from "@sixb/rules-worker"
 import { SyncWorker } from "@sixb/sync-worker"
 import { WorkflowWorker } from "@sixb/workflow-worker"
 import type { LoadedSixb } from "./loadSixb"
+
+export function waitForWorkerFailure(worker: Worker | null | undefined): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    worker?.wait().catch(reject)
+  })
+}
 
 export async function stopQuietly(stopFn: (() => Promise<void>) | undefined | null): Promise<void> {
   if (!stopFn) return
@@ -35,6 +41,7 @@ export interface RunningSixbRuntime {
   readonly workflowWorker: WorkflowWorker | null
   readonly orchestratorWorker: OrchestratorWorker | null
   readonly warnings: readonly string[]
+  waitForWorkerFailure(): Promise<never>
   stop(): Promise<void>
 }
 
@@ -272,6 +279,19 @@ export async function startSixbRuntime(
     throw error
   }
 
+  const activeWorkers = (): Worker[] => {
+    const workers: Worker[] = []
+    if (rulesWorker) workers.push(rulesWorker)
+    if (syncWorker) workers.push(syncWorker)
+    if (actionWorker) workers.push(actionWorker)
+    if (agentWorker) workers.push(agentWorker)
+    if (projectionWorker) workers.push(projectionWorker)
+    if (pipelineWorker) workers.push(pipelineWorker)
+    if (workflowWorker) workers.push(workflowWorker)
+    if (orchestratorWorker) workers.push(orchestratorWorker)
+    return workers
+  }
+
   return {
     rulesWorker,
     syncWorker,
@@ -282,6 +302,9 @@ export async function startSixbRuntime(
     workflowWorker,
     orchestratorWorker,
     warnings,
+    waitForWorkerFailure() {
+      return Promise.race(activeWorkers().map(waitForWorkerFailure))
+    },
     stop,
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1138,8 +1138,19 @@ export { InMemoryQueues, QueueError } from "./queues"
 
 // ── Workers ────────────────────────────────────────────────
 
-export type { QueueWorkerConfig, QueueWorkerFailureDecision } from "./workers"
-export { isAbortError, QueueWorker, Worker, WorkerAbortError } from "./workers"
+export type {
+  QueueDelivery,
+  QueueDeliveryState,
+  QueueWorkerConfig,
+  QueueWorkerFailureDecision,
+} from "./workers"
+export {
+  isAbortError,
+  QueueDeliveryLeaseLostError,
+  QueueWorker,
+  Worker,
+  WorkerAbortError,
+} from "./workers"
 
 // ── HTTP ──────────────────────────────────────────────
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1141,6 +1141,7 @@ export { InMemoryQueues, QueueError } from "./queues"
 export type {
   QueueDelivery,
   QueueDeliveryState,
+  QueueSettlementResult,
   QueueWorkerConfig,
   QueueWorkerFailureDecision,
 } from "./workers"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1150,6 +1150,7 @@ export {
   QueueWorker,
   Worker,
   WorkerAbortError,
+  WorkerUnhealthyError,
 } from "./workers"
 
 // ── HTTP ──────────────────────────────────────────────

--- a/packages/core/src/workers/errors.ts
+++ b/packages/core/src/workers/errors.ts
@@ -7,3 +7,19 @@
 export class WorkerAbortError extends Error {
   readonly name = "AbortError"
 }
+
+/** Raised after a worker exhausts its bounded restart budget. */
+export class WorkerUnhealthyError extends Error {
+  readonly name = "WorkerUnhealthyError"
+
+  constructor(
+    readonly workerName: string,
+    readonly restartCount: number,
+    options?: ErrorOptions
+  ) {
+    super(
+      `[SixbWorker] ${workerName} is unhealthy after ${restartCount} restart attempt(s).`,
+      options
+    )
+  }
+}

--- a/packages/core/src/workers/index.ts
+++ b/packages/core/src/workers/index.ts
@@ -1,4 +1,4 @@
-export { WorkerAbortError } from "./errors"
+export { WorkerAbortError, WorkerUnhealthyError } from "./errors"
 export type { QueueDelivery, QueueDeliveryState } from "./queue-delivery"
 export { QueueDeliveryLeaseLostError } from "./queue-delivery"
 export type { QueueWorkerConfig, QueueWorkerFailureDecision } from "./queue-worker"

--- a/packages/core/src/workers/index.ts
+++ b/packages/core/src/workers/index.ts
@@ -1,5 +1,5 @@
 export { WorkerAbortError, WorkerUnhealthyError } from "./errors"
-export type { QueueDelivery, QueueDeliveryState } from "./queue-delivery"
+export type { QueueDelivery, QueueDeliveryState, QueueSettlementResult } from "./queue-delivery"
 export { QueueDeliveryLeaseLostError } from "./queue-delivery"
 export type { QueueWorkerConfig, QueueWorkerFailureDecision } from "./queue-worker"
 export { isAbortError, QueueWorker } from "./queue-worker"

--- a/packages/core/src/workers/index.ts
+++ b/packages/core/src/workers/index.ts
@@ -1,4 +1,6 @@
 export { WorkerAbortError } from "./errors"
+export type { QueueDelivery, QueueDeliveryState } from "./queue-delivery"
+export { QueueDeliveryLeaseLostError } from "./queue-delivery"
 export type { QueueWorkerConfig, QueueWorkerFailureDecision } from "./queue-worker"
 export { isAbortError, QueueWorker } from "./queue-worker"
 export { Worker } from "./worker"

--- a/packages/core/src/workers/queue-delivery.ts
+++ b/packages/core/src/workers/queue-delivery.ts
@@ -1,0 +1,296 @@
+import type { ClaimedQueueJob, Queue, QueueJob, QueueJobError } from "../queues"
+import { WorkerAbortError } from "./errors"
+
+export type QueueDeliveryState = "active" | "lost" | "settled"
+
+export interface QueueDelivery<TJob extends QueueJob> {
+  readonly claimed: ClaimedQueueJob<TJob>
+  readonly signal: AbortSignal
+  readonly state: QueueDeliveryState
+  /** Expiration from the latest queue-confirmed claim or renewal. */
+  readonly leaseExpiresAt: string
+
+  /** Observe successful queue renewals. The listener is not called for failed renewals. */
+  onLeaseRenewed(listener: (claimed: ClaimedQueueJob<TJob>) => void): () => void
+  complete(): Promise<void>
+  retry(input?: { readonly availableAt?: string; readonly error?: QueueJobError }): Promise<void>
+  fail(error: QueueJobError): Promise<void>
+  close(): Promise<void>
+}
+
+export interface CreateQueueDeliveryOptions<TJob extends QueueJob> {
+  readonly queue: Queue<TJob>
+  readonly claimed: ClaimedQueueJob<TJob>
+  readonly leaseMs: number
+  readonly signal: AbortSignal
+  readonly onLeaseLost?: () => void
+  readonly onRenewalError?: (error: unknown) => void
+}
+
+const MIN_RENEWAL_INTERVAL_MS = 1
+
+export class QueueDeliveryLeaseLostError extends WorkerAbortError {}
+
+type RenewalAttempt<TJob extends QueueJob> =
+  | { readonly kind: "renewed"; readonly claimed: ClaimedQueueJob<TJob> | null }
+  | { readonly kind: "failed"; readonly error: unknown }
+  | { readonly kind: "expired" }
+
+/** Owns lease renewal, loss detection, and settlement for one claimed queue job. */
+export function createQueueDelivery<TJob extends QueueJob>(
+  options: CreateQueueDeliveryOptions<TJob>
+): QueueDelivery<TJob> {
+  return new ManagedQueueDelivery(options)
+}
+
+class ManagedQueueDelivery<TJob extends QueueJob> implements QueueDelivery<TJob> {
+  readonly claimed: ClaimedQueueJob<TJob>
+  readonly signal: AbortSignal
+
+  private readonly queue: Queue<TJob>
+  private readonly leaseMs: number
+  private readonly renewLease: Queue<TJob>["renewLease"]
+  private readonly onLeaseLost: (() => void) | undefined
+  private readonly onRenewalError: ((error: unknown) => void) | undefined
+  private readonly lossController = new AbortController()
+  private readonly stopController = new AbortController()
+  private readonly renewalIntervalMs: number
+  private readonly renewalLoop: Promise<void>
+  private readonly leaseRenewedListeners = new Set<(claimed: ClaimedQueueJob<TJob>) => void>()
+  private currentState: QueueDeliveryState = "active"
+  private currentLeaseExpiresAt: string
+  private leaseExpiresAtTimestamp: number
+  private renewalErrorReported = false
+  private closing: Promise<void> | null = null
+  private settling = false
+
+  constructor(options: CreateQueueDeliveryOptions<TJob>) {
+    this.queue = options.queue
+    this.claimed = options.claimed
+    this.leaseMs = options.leaseMs
+    this.renewLease = options.queue.renewLease?.bind(options.queue)
+    this.onLeaseLost = options.onLeaseLost
+    this.onRenewalError = options.onRenewalError
+    this.currentLeaseExpiresAt = options.claimed.leaseExpiresAt
+    this.leaseExpiresAtTimestamp = parseLeaseExpiration(options.claimed.leaseExpiresAt)
+    this.renewalIntervalMs = Math.max(MIN_RENEWAL_INTERVAL_MS, Math.floor(options.leaseMs / 3))
+    this.signal = AbortSignal.any([options.signal, this.lossController.signal])
+    this.renewalLoop = this.runRenewalLoop()
+  }
+
+  get state(): QueueDeliveryState {
+    return this.currentState
+  }
+
+  get leaseExpiresAt(): string {
+    return this.currentLeaseExpiresAt
+  }
+
+  onLeaseRenewed(listener: (claimed: ClaimedQueueJob<TJob>) => void): () => void {
+    this.leaseRenewedListeners.add(listener)
+    return () => this.leaseRenewedListeners.delete(listener)
+  }
+
+  complete(): Promise<void> {
+    return this.settle(() =>
+      this.queue.complete({
+        projectId: this.claimed.job.projectId,
+        jobId: this.claimed.job.id,
+        leaseId: this.claimed.leaseId,
+      })
+    )
+  }
+
+  retry(
+    input: { readonly availableAt?: string; readonly error?: QueueJobError } = {}
+  ): Promise<void> {
+    return this.settle(() =>
+      this.queue.retry({
+        projectId: this.claimed.job.projectId,
+        jobId: this.claimed.job.id,
+        leaseId: this.claimed.leaseId,
+        availableAt: input.availableAt,
+        error: input.error,
+      })
+    )
+  }
+
+  fail(error: QueueJobError): Promise<void> {
+    return this.settle(() =>
+      this.queue.fail({
+        projectId: this.claimed.job.projectId,
+        jobId: this.claimed.job.id,
+        leaseId: this.claimed.leaseId,
+        error,
+      })
+    )
+  }
+
+  close(): Promise<void> {
+    if (this.closing) return this.closing
+    this.closing = this.stopRenewal()
+    return this.closing
+  }
+
+  private async settle(operation: () => Promise<void>): Promise<void> {
+    if (this.currentState !== "active") return
+    if (this.settling) {
+      throw new Error(`[SixbQueueWorker] Queue job '${this.claimed.job.id}' is already settling.`)
+    }
+
+    this.settling = true
+    try {
+      await this.stopRenewal()
+      if (!(await this.confirmSettlementLease())) return
+      await operation()
+      this.currentState = "settled"
+    } finally {
+      this.settling = false
+    }
+  }
+
+  private async confirmSettlementLease(): Promise<boolean> {
+    if (this.currentState !== "active") return false
+    if (Date.now() >= this.leaseExpiresAtTimestamp) {
+      this.markLost()
+      return false
+    }
+    if (!this.renewLease) return true
+
+    const attempt = await this.attemptRenewal()
+    if (attempt.kind === "renewed") {
+      if (!attempt.claimed) {
+        this.markLost()
+        return false
+      }
+      this.recordRenewal(attempt.claimed)
+      return true
+    }
+    if (attempt.kind === "failed") {
+      this.reportRenewalError(attempt.error)
+    }
+    if (attempt.kind === "expired" || Date.now() >= this.leaseExpiresAtTimestamp) {
+      this.markLost()
+      return false
+    }
+    return true
+  }
+
+  private async runRenewalLoop(): Promise<void> {
+    while (this.currentState === "active" && !this.stopController.signal.aborted) {
+      const remainingMs = this.leaseExpiresAtTimestamp - Date.now()
+      if (remainingMs <= 0) {
+        this.markLost()
+        return
+      }
+
+      const delayMs = this.renewLease ? Math.min(this.renewalIntervalMs, remainingMs) : remainingMs
+      await sleep(delayMs, this.stopController.signal).catch(() => {})
+      if (this.stopController.signal.aborted || this.currentState !== "active") return
+      if (Date.now() >= this.leaseExpiresAtTimestamp) {
+        this.markLost()
+        return
+      }
+      if (!this.renewLease) continue
+
+      const attempt = await this.attemptRenewal()
+      if (attempt.kind === "expired") {
+        this.markLost()
+        return
+      }
+      if (attempt.kind === "failed") {
+        this.reportRenewalError(attempt.error)
+        continue
+      }
+      if (!attempt.claimed) {
+        this.markLost()
+        return
+      }
+      this.recordRenewal(attempt.claimed)
+    }
+  }
+
+  private attemptRenewal(): Promise<RenewalAttempt<TJob>> {
+    if (!this.renewLease || Date.now() >= this.leaseExpiresAtTimestamp) {
+      return Promise.resolve({ kind: "expired" })
+    }
+
+    const remainingMs = Math.max(1, this.leaseExpiresAtTimestamp - Date.now())
+    return new Promise((resolve) => {
+      let finished = false
+      const finish = (attempt: RenewalAttempt<TJob>): void => {
+        if (finished) return
+        finished = true
+        clearTimeout(timer)
+        resolve(attempt)
+      }
+      const timer = setTimeout(() => finish({ kind: "expired" }), remainingMs)
+
+      this.renewLease?.({
+        projectId: this.claimed.job.projectId,
+        jobId: this.claimed.job.id,
+        leaseId: this.claimed.leaseId,
+        leaseMs: this.leaseMs,
+      }).then(
+        (claimed) => finish({ kind: "renewed", claimed }),
+        (error) => finish({ kind: "failed", error })
+      )
+    })
+  }
+
+  private recordRenewal(claimed: ClaimedQueueJob<TJob>): void {
+    this.currentLeaseExpiresAt = claimed.leaseExpiresAt
+    this.leaseExpiresAtTimestamp = parseLeaseExpiration(claimed.leaseExpiresAt)
+    this.renewalErrorReported = false
+    for (const listener of this.leaseRenewedListeners) {
+      try {
+        listener(claimed)
+      } catch (error) {
+        this.onRenewalError?.(error)
+      }
+    }
+  }
+
+  private reportRenewalError(error: unknown): void {
+    if (this.renewalErrorReported) return
+    this.renewalErrorReported = true
+    this.onRenewalError?.(error)
+  }
+
+  private markLost(): void {
+    if (this.currentState !== "active") return
+    this.currentState = "lost"
+    this.lossController.abort(
+      new QueueDeliveryLeaseLostError(
+        `[SixbQueueWorker] Queue job '${this.claimed.job.id}' lost its lease.`
+      )
+    )
+    this.onLeaseLost?.()
+  }
+
+  private async stopRenewal(): Promise<void> {
+    this.stopController.abort()
+    await this.renewalLoop.catch(() => {})
+  }
+}
+
+function parseLeaseExpiration(value: string): number {
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`[SixbQueueWorker] Invalid queue lease expiration '${value}'.`)
+  }
+  return timestamp
+}
+
+async function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(finish, ms)
+    function finish(): void {
+      clearTimeout(timer)
+      signal.removeEventListener("abort", finish)
+      resolve()
+    }
+    signal.addEventListener("abort", finish, { once: true })
+  })
+}

--- a/packages/core/src/workers/queue-delivery.ts
+++ b/packages/core/src/workers/queue-delivery.ts
@@ -3,6 +3,13 @@ import { WorkerAbortError } from "./errors"
 
 export type QueueDeliveryState = "active" | "lost" | "settled"
 
+/**
+ * Outcome of a settlement call. `"lost"` means the queue job was **not** acknowledged because
+ * ownership was already gone — the job may be redelivered. Settlement never throws for a lost
+ * lease; exceptions are reserved for queue calls that themselves fail (outcome then unknown).
+ */
+export type QueueSettlementResult = "settled" | "lost"
+
 export interface QueueDelivery<TJob extends QueueJob> {
   readonly claimed: ClaimedQueueJob<TJob>
   readonly signal: AbortSignal
@@ -12,9 +19,12 @@ export interface QueueDelivery<TJob extends QueueJob> {
 
   /** Observe successful queue renewals. The listener is not called for failed renewals. */
   onLeaseRenewed(listener: (claimed: ClaimedQueueJob<TJob>) => void): () => void
-  complete(): Promise<void>
-  retry(input?: { readonly availableAt?: string; readonly error?: QueueJobError }): Promise<void>
-  fail(error: QueueJobError): Promise<void>
+  complete(): Promise<QueueSettlementResult>
+  retry(input?: {
+    readonly availableAt?: string
+    readonly error?: QueueJobError
+  }): Promise<QueueSettlementResult>
+  fail(error: QueueJobError): Promise<QueueSettlementResult>
   close(): Promise<void>
 }
 
@@ -91,7 +101,7 @@ class ManagedQueueDelivery<TJob extends QueueJob> implements QueueDelivery<TJob>
     return () => this.leaseRenewedListeners.delete(listener)
   }
 
-  complete(): Promise<void> {
+  complete(): Promise<QueueSettlementResult> {
     return this.settle(() =>
       this.queue.complete({
         projectId: this.claimed.job.projectId,
@@ -103,7 +113,7 @@ class ManagedQueueDelivery<TJob extends QueueJob> implements QueueDelivery<TJob>
 
   retry(
     input: { readonly availableAt?: string; readonly error?: QueueJobError } = {}
-  ): Promise<void> {
+  ): Promise<QueueSettlementResult> {
     return this.settle(() =>
       this.queue.retry({
         projectId: this.claimed.job.projectId,
@@ -115,7 +125,7 @@ class ManagedQueueDelivery<TJob extends QueueJob> implements QueueDelivery<TJob>
     )
   }
 
-  fail(error: QueueJobError): Promise<void> {
+  fail(error: QueueJobError): Promise<QueueSettlementResult> {
     return this.settle(() =>
       this.queue.fail({
         projectId: this.claimed.job.projectId,
@@ -132,8 +142,10 @@ class ManagedQueueDelivery<TJob extends QueueJob> implements QueueDelivery<TJob>
     return this.closing
   }
 
-  private async settle(operation: () => Promise<void>): Promise<void> {
-    if (this.currentState !== "active") return
+  private async settle(operation: () => Promise<void>): Promise<QueueSettlementResult> {
+    if (this.currentState !== "active") {
+      return this.currentState === "settled" ? "settled" : "lost"
+    }
     if (this.settling) {
       throw new Error(`[SixbQueueWorker] Queue job '${this.claimed.job.id}' is already settling.`)
     }
@@ -141,9 +153,10 @@ class ManagedQueueDelivery<TJob extends QueueJob> implements QueueDelivery<TJob>
     this.settling = true
     try {
       await this.stopRenewal()
-      if (!(await this.confirmSettlementLease())) return
+      if (!(await this.confirmSettlementLease())) return "lost"
       await operation()
       this.currentState = "settled"
+      return "settled"
     } finally {
       this.settling = false
     }

--- a/packages/core/src/workers/queue-worker.ts
+++ b/packages/core/src/workers/queue-worker.ts
@@ -20,9 +20,11 @@ export interface QueueWorkerFailureDecision {
 const DEFAULT_LEASE_MS = 15 * 60_000
 const DEFAULT_CLAIM_LIMIT = 1
 const DEFAULT_IDLE_POLL_MS = 1_000
+const MAX_CONSECUTIVE_CLAIM_FAILURES = 5
 
 export abstract class QueueWorker<TJob extends QueueJob> extends Worker {
   protected readonly config: Required<QueueWorkerConfig<TJob>>
+  private consecutiveClaimFailures = 0
 
   constructor(config: QueueWorkerConfig<TJob>) {
     super()
@@ -106,12 +108,21 @@ export abstract class QueueWorker<TJob extends QueueJob> extends Worker {
         limit,
         leaseMs,
       })
+      this.consecutiveClaimFailures = 0
       if (claimed.length === 0) {
         await sleep(idlePollMs, signal).catch(() => {})
       }
       return claimed
-    } catch {
+    } catch (error) {
       if (signal.aborted) return []
+      this.consecutiveClaimFailures += 1
+      if (this.consecutiveClaimFailures >= MAX_CONSECUTIVE_CLAIM_FAILURES) {
+        this.consecutiveClaimFailures = 0
+        throw new Error(
+          `[SixbQueueWorker] Queue claim failed ${MAX_CONSECUTIVE_CLAIM_FAILURES} consecutive times.`,
+          { cause: error }
+        )
+      }
       await sleep(idlePollMs, signal).catch(() => {})
       return []
     }

--- a/packages/core/src/workers/queue-worker.ts
+++ b/packages/core/src/workers/queue-worker.ts
@@ -1,5 +1,6 @@
 import type { ClaimedQueueJob, Queue, QueueJob, QueueJobError } from "../queues"
 import { WorkerAbortError } from "./errors"
+import { createQueueDelivery, type QueueDelivery } from "./queue-delivery"
 import { Worker } from "./worker"
 
 export interface QueueWorkerConfig<TJob extends QueueJob> {
@@ -70,7 +71,11 @@ export abstract class QueueWorker<TJob extends QueueJob> extends Worker {
     }
   }
 
-  protected abstract execute(claimed: ClaimedQueueJob<TJob>, signal: AbortSignal): Promise<void>
+  protected abstract execute(
+    claimed: ClaimedQueueJob<TJob>,
+    signal: AbortSignal,
+    delivery: QueueDelivery<TJob>
+  ): Promise<void>
 
   protected onExecutionError(
     _claimed: ClaimedQueueJob<TJob>,
@@ -113,55 +118,96 @@ export abstract class QueueWorker<TJob extends QueueJob> extends Worker {
   }
 
   private async handle(claimed: ClaimedQueueJob<TJob>, signal: AbortSignal): Promise<void> {
-    const { projectId, queue } = this.config
-    const jobId = claimed.job.id
-    const leaseId = claimed.leaseId
+    const delivery = createQueueDelivery({
+      queue: this.config.queue,
+      claimed,
+      leaseMs: this.config.leaseMs,
+      signal,
+      onLeaseLost: () => {
+        console.error(
+          `[SixbQueueWorker] Lost lease for queue job '${claimed.job.id}'; leaving it for redelivery.`
+        )
+      },
+      onRenewalError: (error) => {
+        console.error(
+          `[SixbQueueWorker] Could not renew lease for queue job '${claimed.job.id}'; retrying.`,
+          error
+        )
+      },
+    })
 
     try {
-      await this.execute(claimed, signal)
-      await queue.complete({ projectId, jobId, leaseId })
-      return
-    } catch (error) {
-      if (signal.aborted || isAbortError(error)) {
-        const decision = await this.onAbortError(claimed, error)
-        await this.applyFailureDecision({ decision, projectId, jobId, leaseId, error }).catch(
-          () => {}
-        )
+      let outcome: { readonly ok: true } | { readonly ok: false; readonly error: unknown }
+      try {
+        await this.execute(claimed, delivery.signal, delivery)
+        outcome = { ok: true }
+      } catch (error) {
+        outcome = { ok: false, error }
+      }
+
+      if (delivery.state === "lost") return
+
+      if (outcome.ok) {
+        await settleOrLog(delivery, "complete", () => delivery.complete())
         return
       }
 
-      const decision = await this.onExecutionError(claimed, error)
-      await this.applyFailureDecision({ decision, projectId, jobId, leaseId, error })
+      const error = outcome.error
+      if (signal.aborted || isAbortError(error)) {
+        try {
+          const decision = await this.onAbortError(claimed, error)
+          await this.applyFailureDecision(delivery, decision, error)
+        } catch {
+          // Shutdown is already in progress. The unacknowledged job becomes visible after its lease.
+        }
+        return
+      }
+
+      try {
+        const decision = await this.onExecutionError(claimed, error)
+        await this.applyFailureDecision(delivery, decision, error)
+      } catch (settlementError) {
+        logQueueOperationError("apply failure decision to", claimed, settlementError)
+      }
+    } finally {
+      await delivery.close()
     }
   }
 
-  private async applyFailureDecision(input: {
-    readonly decision: QueueWorkerFailureDecision
-    readonly projectId: string
-    readonly jobId: string
-    readonly leaseId: string
-    readonly error: unknown
-  }): Promise<void> {
-    const { queue } = this.config
-
-    if (input.decision.kind === "retry") {
-      await queue.retry({
-        projectId: input.projectId,
-        jobId: input.jobId,
-        leaseId: input.leaseId,
-        availableAt: input.decision.availableAt,
-        error: toQueueJobError(input.error),
+  private async applyFailureDecision(
+    delivery: QueueDelivery<TJob>,
+    decision: QueueWorkerFailureDecision,
+    error: unknown
+  ): Promise<void> {
+    if (decision.kind === "retry") {
+      await delivery.retry({
+        availableAt: decision.availableAt,
+        error: toQueueJobError(error),
       })
       return
     }
 
-    await queue.fail({
-      projectId: input.projectId,
-      jobId: input.jobId,
-      leaseId: input.leaseId,
-      error: toQueueJobError(input.error),
-    })
+    await delivery.fail(toQueueJobError(error))
   }
+}
+
+async function settleOrLog<TJob extends QueueJob>(
+  delivery: QueueDelivery<TJob>,
+  operation: string,
+  settle: () => Promise<void>
+): Promise<void> {
+  try {
+    await settle()
+  } catch (error) {
+    logQueueOperationError(operation, delivery.claimed, error)
+  }
+}
+
+function logQueueOperationError(operation: string, claimed: ClaimedQueueJob, error: unknown): void {
+  console.error(
+    `[SixbQueueWorker] Could not ${operation} queue job '${claimed.job.id}'; it may be redelivered.`,
+    error
+  )
 }
 
 function toQueueJobError(error: unknown): QueueJobError {

--- a/packages/core/src/workers/queue-worker.ts
+++ b/packages/core/src/workers/queue-worker.ts
@@ -1,6 +1,10 @@
 import type { ClaimedQueueJob, Queue, QueueJob, QueueJobError } from "../queues"
 import { WorkerAbortError } from "./errors"
-import { createQueueDelivery, type QueueDelivery } from "./queue-delivery"
+import {
+  createQueueDelivery,
+  type QueueDelivery,
+  type QueueSettlementResult,
+} from "./queue-delivery"
 import { Worker } from "./worker"
 
 export interface QueueWorkerConfig<TJob extends QueueJob> {
@@ -205,9 +209,10 @@ export abstract class QueueWorker<TJob extends QueueJob> extends Worker {
 async function settleOrLog<TJob extends QueueJob>(
   delivery: QueueDelivery<TJob>,
   operation: string,
-  settle: () => Promise<void>
+  settle: () => Promise<QueueSettlementResult>
 ): Promise<void> {
   try {
+    // A "lost" result needs no extra logging here: loss is already reported via onLeaseLost.
     await settle()
   } catch (error) {
     logQueueOperationError(operation, delivery.claimed, error)

--- a/packages/core/src/workers/worker.ts
+++ b/packages/core/src/workers/worker.ts
@@ -1,12 +1,16 @@
 import { WorkerUnhealthyError } from "./errors"
 
-const MAX_RESTARTS = 5
+// The budget rides out ~80s of continuous failure (0.1s -> 30s backoffs) before the worker is
+// declared unhealthy, so a transient infra outage does not kill an otherwise healthy process.
+const MAX_RESTARTS = 10
 const RESTART_BACKOFF_MS = 100
 const MAX_RESTART_BACKOFF_MS = 30_000
 const STABLE_RUN_MS = 60_000
 
 /** Base worker lifecycle with bounded restart supervision. */
 export abstract class Worker {
+  /** Base restart backoff. Overridable so budget-exhaustion tests do not wait out real backoffs. */
+  protected readonly restartBackoffMs: number = RESTART_BACKOFF_MS
   private controller: AbortController | null = null
   private running: Promise<void> | null = null
 
@@ -62,7 +66,7 @@ export abstract class Worker {
         throw new WorkerUnhealthyError(this.constructor.name, restartCount, { cause: failure })
       }
 
-      const delayMs = Math.min(RESTART_BACKOFF_MS * 2 ** restartCount, MAX_RESTART_BACKOFF_MS)
+      const delayMs = Math.min(this.restartBackoffMs * 2 ** restartCount, MAX_RESTART_BACKOFF_MS)
       restartCount += 1
       await waitForAbort(delayMs, signal)
     }

--- a/packages/core/src/workers/worker.ts
+++ b/packages/core/src/workers/worker.ts
@@ -1,21 +1,83 @@
+import { WorkerUnhealthyError } from "./errors"
+
+const MAX_RESTARTS = 5
+const RESTART_BACKOFF_MS = 100
+const MAX_RESTART_BACKOFF_MS = 30_000
+const STABLE_RUN_MS = 60_000
+
+/** Base worker lifecycle with bounded restart supervision. */
 export abstract class Worker {
   private controller: AbortController | null = null
   private running: Promise<void> | null = null
 
   async start(): Promise<void> {
     if (this.controller) return
+
     this.controller = new AbortController()
-    this.running = this.run(this.controller.signal)
+    this.running = this.supervise(this.controller.signal)
+    // `wait()` exposes terminal failure. Keep a handler attached for embedded callers that only use
+    // start/stop, so an exhausted restart budget does not become an unhandled rejection.
     this.running.catch(() => {})
   }
 
   async stop(): Promise<void> {
-    if (!this.controller) return
-    this.controller.abort()
+    const controller = this.controller
+    if (!controller) return
+
+    controller.abort()
     await this.running?.catch(() => {})
-    this.controller = null
-    this.running = null
+    if (this.controller === controller) {
+      this.controller = null
+      this.running = null
+    }
+  }
+
+  /** Resolves after stop and rejects if the bounded restart budget is exhausted. */
+  wait(): Promise<void> {
+    return this.running ?? Promise.resolve()
   }
 
   protected abstract run(signal: AbortSignal): Promise<void>
+
+  private async supervise(signal: AbortSignal): Promise<void> {
+    let restartCount = 0
+
+    while (!signal.aborted) {
+      const startedAt = Date.now()
+      let failure: unknown
+
+      try {
+        await this.run(signal)
+        if (signal.aborted) return
+        failure = new Error(`[SixbWorker] ${this.constructor.name} stopped unexpectedly.`)
+      } catch (error) {
+        if (signal.aborted) return
+        failure = error
+      }
+
+      if (Date.now() - startedAt >= STABLE_RUN_MS) {
+        restartCount = 0
+      }
+      if (restartCount >= MAX_RESTARTS) {
+        throw new WorkerUnhealthyError(this.constructor.name, restartCount, { cause: failure })
+      }
+
+      const delayMs = Math.min(RESTART_BACKOFF_MS * 2 ** restartCount, MAX_RESTART_BACKOFF_MS)
+      restartCount += 1
+      await waitForAbort(delayMs, signal)
+    }
+  }
+}
+
+async function waitForAbort(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(finish, ms)
+    function finish(): void {
+      clearTimeout(timer)
+      signal.removeEventListener("abort", finish)
+      resolve()
+    }
+    signal.addEventListener("abort", finish, { once: true })
+  })
 }

--- a/packages/core/tests/queue-delivery.test.ts
+++ b/packages/core/tests/queue-delivery.test.ts
@@ -47,7 +47,7 @@ describe("QueueDelivery", () => {
     })
     try {
       await Bun.sleep(150)
-      await delivery.complete()
+      expect(await delivery.complete()).toBe("settled")
       expect(delivery.state).toBe("settled")
       expect(renewals).toBeGreaterThanOrEqual(2)
       expect(confirmedExpirations.length).toBeGreaterThanOrEqual(2)
@@ -86,7 +86,7 @@ describe("QueueDelivery", () => {
       await Bun.sleep(25)
       expect(delivery.state).toBe("lost")
       expect(delivery.signal.aborted).toBe(true)
-      await delivery.complete()
+      expect(await delivery.complete()).toBe("lost")
       expect(completeCalls).toBe(0)
     } finally {
       await delivery.close()
@@ -121,7 +121,7 @@ describe("QueueDelivery", () => {
       expect(delivery.state).toBe("active")
       expect(attempts).toBeGreaterThanOrEqual(2)
       expect(reportedErrors).toBe(1)
-      await delivery.complete()
+      expect(await delivery.complete()).toBe("settled")
       expect(delivery.state).toBe("settled")
     } finally {
       await delivery.close()

--- a/packages/core/tests/queue-delivery.test.ts
+++ b/packages/core/tests/queue-delivery.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test"
+import type { ClaimedQueueJob, SyncRunRequestedQueueJob } from "../src"
+import { InMemoryQueues } from "../src"
+import { createQueueDelivery } from "../src/workers/queue-delivery"
+
+const PROJECT_ID = "queue-delivery-tests"
+
+async function claimOne(
+  queues: InMemoryQueues,
+  leaseMs: number
+): Promise<ClaimedQueueJob<SyncRunRequestedQueueJob>> {
+  await queues.syncRuns.enqueue({
+    projectId: PROJECT_ID,
+    jobs: [{ type: "sync.run.requested", payload: { syncId: "sync" } }],
+  })
+  const [claimed] = await queues.syncRuns.claim({
+    projectId: PROJECT_ID,
+    workerId: "worker",
+    leaseMs,
+  })
+  if (!claimed) throw new Error("Expected a claimed queue job.")
+  return claimed
+}
+
+describe("QueueDelivery", () => {
+  test("renews ownership until a long-running delivery completes", async () => {
+    const queues = new InMemoryQueues()
+    const leaseMs = 60
+    const claimed = await claimOne(queues, leaseMs)
+    const originalRenew = queues.syncRuns.renewLease?.bind(queues.syncRuns)
+    if (!originalRenew) throw new Error("Expected queue renewal support.")
+    let renewals = 0
+    queues.syncRuns.renewLease = async (params) => {
+      renewals += 1
+      return originalRenew(params)
+    }
+
+    const delivery = createQueueDelivery({
+      queue: queues.syncRuns,
+      claimed,
+      leaseMs,
+      signal: new AbortController().signal,
+    })
+    const confirmedExpirations: string[] = []
+    const stopObserving = delivery.onLeaseRenewed((renewed) => {
+      confirmedExpirations.push(renewed.leaseExpiresAt)
+    })
+    try {
+      await Bun.sleep(150)
+      await delivery.complete()
+      expect(delivery.state).toBe("settled")
+      expect(renewals).toBeGreaterThanOrEqual(2)
+      expect(confirmedExpirations.length).toBeGreaterThanOrEqual(2)
+      expect(Date.parse(confirmedExpirations.at(-1) ?? "")).toBeGreaterThan(
+        Date.parse(claimed.leaseExpiresAt)
+      )
+    } finally {
+      stopObserving()
+      await delivery.close()
+    }
+
+    const redelivered = await queues.syncRuns.claim({
+      projectId: PROJECT_ID,
+      workerId: "observer",
+    })
+    expect(redelivered).toHaveLength(0)
+  })
+
+  test("aborts the delivery and refuses settlement after definitive lease loss", async () => {
+    const queues = new InMemoryQueues()
+    const leaseMs = 45
+    const claimed = await claimOne(queues, leaseMs)
+    let completeCalls = 0
+    queues.syncRuns.renewLease = async () => null
+    queues.syncRuns.complete = async () => {
+      completeCalls += 1
+    }
+
+    const delivery = createQueueDelivery({
+      queue: queues.syncRuns,
+      claimed,
+      leaseMs,
+      signal: new AbortController().signal,
+    })
+    try {
+      await Bun.sleep(25)
+      expect(delivery.state).toBe("lost")
+      expect(delivery.signal.aborted).toBe(true)
+      await delivery.complete()
+      expect(completeCalls).toBe(0)
+    } finally {
+      await delivery.close()
+    }
+  })
+
+  test("retries transient renewal failures while the confirmed lease is valid", async () => {
+    const queues = new InMemoryQueues()
+    const leaseMs = 90
+    const claimed = await claimOne(queues, leaseMs)
+    const originalRenew = queues.syncRuns.renewLease?.bind(queues.syncRuns)
+    if (!originalRenew) throw new Error("Expected queue renewal support.")
+    let attempts = 0
+    let reportedErrors = 0
+    queues.syncRuns.renewLease = async (params) => {
+      attempts += 1
+      if (attempts === 1) throw new Error("temporary queue outage")
+      return originalRenew(params)
+    }
+
+    const delivery = createQueueDelivery({
+      queue: queues.syncRuns,
+      claimed,
+      leaseMs,
+      signal: new AbortController().signal,
+      onRenewalError: () => {
+        reportedErrors += 1
+      },
+    })
+    try {
+      await Bun.sleep(75)
+      expect(delivery.state).toBe("active")
+      expect(attempts).toBeGreaterThanOrEqual(2)
+      expect(reportedErrors).toBe(1)
+      await delivery.complete()
+      expect(delivery.state).toBe("settled")
+    } finally {
+      await delivery.close()
+    }
+  })
+
+  test("marks the delivery lost when renewal does not finish before expiration", async () => {
+    const queues = new InMemoryQueues()
+    const leaseMs = 45
+    const claimed = await claimOne(queues, leaseMs)
+    queues.syncRuns.renewLease = () => new Promise(() => {})
+
+    const delivery = createQueueDelivery({
+      queue: queues.syncRuns,
+      claimed,
+      leaseMs,
+      signal: new AbortController().signal,
+    })
+    try {
+      await Bun.sleep(60)
+      expect(delivery.state).toBe("lost")
+      expect(delivery.signal.aborted).toBe(true)
+    } finally {
+      await delivery.close()
+    }
+  })
+})

--- a/packages/core/tests/queue-worker.test.ts
+++ b/packages/core/tests/queue-worker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import {
   type ClaimedQueueJob,
   InMemoryQueues,
@@ -157,6 +157,98 @@ describe("QueueWorker", () => {
     })
 
     await worker.stop()
+  })
+
+  test("renews leases while jobs remain in flight", async () => {
+    const queues = new InMemoryQueues()
+    const originalRenew = queues.syncRuns.renewLease?.bind(queues.syncRuns)
+    if (!originalRenew) throw new Error("Expected in-memory queue lease renewal support.")
+    let renewals = 0
+    queues.syncRuns.renewLease = async (params) => {
+      renewals += 1
+      return originalRenew(params)
+    }
+
+    const originalComplete = queues.syncRuns.complete.bind(queues.syncRuns)
+    let completed = false
+    queues.syncRuns.complete = async (params) => {
+      await originalComplete(params)
+      completed = true
+    }
+
+    class SlowWorker extends QueueWorker<SyncRunRequestedQueueJob> {
+      protected async execute(): Promise<void> {
+        await Bun.sleep(240)
+      }
+    }
+
+    const worker = new SlowWorker({
+      projectId: PROJECT_ID,
+      queue: queues.syncRuns,
+      workerId: "w",
+      leaseMs: 90,
+      idlePollMs: 10,
+    })
+
+    await queues.syncRuns.enqueue({
+      projectId: PROJECT_ID,
+      jobs: [{ type: "sync.run.requested", payload: { syncId: "slow" } }],
+    })
+
+    await worker.start()
+    try {
+      await waitFor(() => completed)
+      expect(renewals).toBeGreaterThanOrEqual(2)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("continues processing after a completion acknowledgement error", async () => {
+    const queues = new InMemoryQueues()
+    const originalComplete = queues.syncRuns.complete.bind(queues.syncRuns)
+    let completionCalls = 0
+    queues.syncRuns.complete = async (params) => {
+      await originalComplete(params)
+      completionCalls += 1
+      if (completionCalls === 1) {
+        throw new Error("connection dropped after acknowledgement")
+      }
+    }
+
+    const processed: string[] = []
+    class ResilientWorker extends QueueWorker<SyncRunRequestedQueueJob> {
+      protected async execute(claimed: ClaimedQueueJob<SyncRunRequestedQueueJob>): Promise<void> {
+        processed.push(claimed.job.payload.syncId)
+      }
+    }
+
+    const worker = new ResilientWorker({
+      projectId: PROJECT_ID,
+      queue: queues.syncRuns,
+      workerId: "w",
+      idlePollMs: 10,
+    })
+    const consoleError = spyOn(console, "error").mockImplementation(() => {})
+
+    await queues.syncRuns.enqueue({
+      projectId: PROJECT_ID,
+      jobs: [{ type: "sync.run.requested", payload: { syncId: "first" } }],
+    })
+
+    await worker.start()
+    try {
+      await waitFor(() => processed.includes("first") && completionCalls === 1)
+      await queues.syncRuns.enqueue({
+        projectId: PROJECT_ID,
+        jobs: [{ type: "sync.run.requested", payload: { syncId: "second" } }],
+      })
+      await waitFor(() => processed.includes("second"))
+      expect(consoleError).toHaveBeenCalled()
+    } finally {
+      await worker.stop()
+      consoleError.mockRestore()
+    }
   })
 
   test("claimLimit batches and executes multiple jobs concurrently", async () => {

--- a/packages/core/tests/queue-worker.test.ts
+++ b/packages/core/tests/queue-worker.test.ts
@@ -50,6 +50,41 @@ describe("QueueWorker", () => {
     expect(claimed).toHaveLength(0)
   })
 
+  test("restarts the loop after repeated queue claim failures", async () => {
+    const queues = new InMemoryQueues()
+    const originalClaim = queues.syncRuns.claim.bind(queues.syncRuns)
+    let claimCalls = 0
+    queues.syncRuns.claim = (params) => {
+      claimCalls += 1
+      if (claimCalls <= 5) return Promise.reject(new Error("queue unavailable"))
+      return originalClaim(params)
+    }
+
+    let processed = false
+    class TestWorker extends QueueWorker<SyncRunRequestedQueueJob> {
+      protected async execute(): Promise<void> {
+        processed = true
+      }
+    }
+
+    const worker = new TestWorker({
+      projectId: PROJECT_ID,
+      queue: queues.syncRuns,
+      workerId: "w",
+      idlePollMs: 1,
+    })
+    await queues.syncRuns.enqueue({
+      projectId: PROJECT_ID,
+      jobs: [{ type: "sync.run.requested", payload: { syncId: "s" } }],
+    })
+
+    await worker.start()
+    await waitFor(() => processed, 2_000)
+    await worker.stop()
+
+    expect(claimCalls).toBeGreaterThan(5)
+  })
+
   test("default policy fails jobs on execution errors", async () => {
     const queues = new InMemoryQueues()
 

--- a/packages/core/tests/worker.test.ts
+++ b/packages/core/tests/worker.test.ts
@@ -113,6 +113,9 @@ describe("Worker", () => {
     let runs = 0
 
     class TestWorker extends Worker {
+      // Skip real exponential backoffs so exhausting the 10-restart budget stays instant.
+      protected override readonly restartBackoffMs = 0
+
       protected async run(): Promise<void> {
         runs += 1
         throw new Error("persistent failure")
@@ -126,10 +129,10 @@ describe("Worker", () => {
     await expect(exit).rejects.toBeInstanceOf(WorkerUnhealthyError)
     await expect(exit).rejects.toMatchObject({
       name: "WorkerUnhealthyError",
-      restartCount: 5,
+      restartCount: 10,
       cause: expect.objectContaining({ message: "persistent failure" }),
     })
-    expect(runs).toBe(6)
+    expect(runs).toBe(11)
 
     await worker.stop()
   })

--- a/packages/core/tests/worker.test.ts
+++ b/packages/core/tests/worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Worker } from "../src"
+import { Worker, WorkerUnhealthyError } from "../src"
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
@@ -11,6 +11,14 @@ function createDeferred<T>() {
   })
 
   return { promise, resolve, reject }
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for worker state")
+    await Bun.sleep(1)
+  }
 }
 
 describe("Worker", () => {
@@ -78,6 +86,71 @@ describe("Worker", () => {
     await worker.stop()
 
     expect(runs).toBe(2)
+  })
+
+  test("restarts transient loop failures with bounded backoff", async () => {
+    let runs = 0
+
+    class TestWorker extends Worker {
+      protected async run(signal: AbortSignal): Promise<void> {
+        runs += 1
+        if (runs < 3) throw new Error(`transient ${runs}`)
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      }
+    }
+
+    const worker = new TestWorker()
+    await worker.start()
+    await waitFor(() => runs === 3)
+
+    await worker.stop()
+    expect(runs).toBe(3)
+  })
+
+  test("becomes unhealthy after exhausting the restart budget", async () => {
+    let runs = 0
+
+    class TestWorker extends Worker {
+      protected async run(): Promise<void> {
+        runs += 1
+        throw new Error("persistent failure")
+      }
+    }
+
+    const worker = new TestWorker()
+    await worker.start()
+
+    const exit = worker.wait()
+    await expect(exit).rejects.toBeInstanceOf(WorkerUnhealthyError)
+    await expect(exit).rejects.toMatchObject({
+      name: "WorkerUnhealthyError",
+      restartCount: 5,
+      cause: expect.objectContaining({ message: "persistent failure" }),
+    })
+    expect(runs).toBe(6)
+
+    await worker.stop()
+  })
+
+  test("stop cancels a pending restart", async () => {
+    let runs = 0
+
+    class TestWorker extends Worker {
+      protected async run(): Promise<void> {
+        runs += 1
+        throw new Error("restart later")
+      }
+    }
+
+    const worker = new TestWorker()
+    await worker.start()
+    await waitFor(() => runs === 1)
+    await worker.stop()
+    await Bun.sleep(300)
+
+    expect(runs).toBe(1)
   })
 
   test("stop waits for run() to complete", async () => {


### PR DESCRIPTION
## Why

An agent turn ran for about 110 seconds with a 60-second queue lease. The work was healthy, but its
lease expired before completion. The acknowledgement then failed, stopped the queue loop, and left
the process alive because `Worker.start()` had detached the rejected promise.

```text
long job -> lease expires -> acknowledgement fails -> loop stops -> idle but living process
```

This PR fixes both generic failure modes: queue ownership is managed for the full delivery, and
unexpected worker-loop failures are supervised and surfaced to the process.

## What changes

### Managed queue deliveries

Each claim now gets a `QueueDelivery` that owns renewal, lease-loss detection, abort propagation, and
settlement.

```mermaid
stateDiagram-v2
  [*] --> Active: claim
  Active --> Active: renew
  Active --> Settled: complete / retry / fail
  Active --> Lost: renewal rejected by queue or lease expires
  Lost --> [*]: abort; allow redelivery
  Settled --> [*]
```

| Situation | Behavior |
| --- | --- |
| Work exceeds the original lease | Renew around `leaseMs / 3` |
| Renewal fails transiently | Retry while the last confirmed lease remains valid |
| Renewal returns `null` or misses the deadline | Abort the delivery and refuse settlement |
| Renewal hangs | Stop waiting at the confirmed lease deadline |
| Settlement fails | Log the ambiguity and continue consuming; the job may be redelivered |
| Queue has no renewal support | Track the original deadline and prevent stale settlement |

Renewal is stopped and drained before settlement, followed by one final ownership check. A stale
worker therefore cannot acknowledge with a lease it knows it has lost.

`QueueWorker.execute` now receives the delivery in addition to its ownership-aware signal:

```ts
execute(
  claimed: ClaimedQueueJob<TJob>,
  signal: AbortSignal,
  delivery: QueueDelivery<TJob>
): Promise<void>
```

Existing subclasses that accept fewer parameters remain valid. The delivery also exposes successful
renewals for later slices that need to project queue ownership into durable execution state.

### Bounded worker supervision

Expected job and settlement failures stay inside the delivery lifecycle. Unexpected loop failures
restart with exponential backoff.

```mermaid
flowchart LR
  A[Run loop] -->|unexpected failure| B[Backoff and restart]
  B --> A
  B -->|five restarts exhausted| C[WorkerUnhealthyError]
  C --> D[worker.wait rejects]
  D --> E[CLI cleans up and exits]
```

The restart budget resets after a 60-second stable run. Five consecutive queue claim failures enter
this supervision path instead of being swallowed indefinitely. Shutdown does not consume the restart
budget.

CLI worker roles now race signal shutdown against `worker.wait()`, so an exhausted worker cannot
leave a falsely healthy process behind.

## API additions

- `QueueDelivery` and `QueueDeliveryState`
- `QueueDeliveryLeaseLostError`
- `WorkerUnhealthyError`
- `Worker.wait()`

This PR does not change queue-provider interfaces, storage schemas, server contracts, generated
clients, or UI behavior.

## Review guide

The commits separate the two concerns:

1. **`workers: manage queue delivery leases`**
   - `packages/core/src/workers/queue-delivery.ts`: delivery state machine
   - `packages/core/src/workers/queue-worker.ts`: execution and settlement integration
   - delivery and queue-worker tests: renewal, lease loss, and acknowledgement isolation

2. **`workers: supervise loop failures and propagate unhealthy exits`**
   - `packages/core/src/workers/worker.ts`: restart budget and `wait()`
   - `packages/core/src/workers/queue-worker.ts`: persistent claim failure escalation
   - `packages/cli/src/`: terminal failure propagation and cleanup

The key invariants are:

- no settlement after definitive lease loss
- renewal cannot block past the last confirmed expiration
- one settlement failure cannot stop unrelated work
- shutdown does not trigger a restart
- exhausted workers are observable by every CLI role

## Validation

```text
19 core delivery / queue-worker / worker tests passed
36 relevant CLI tests passed
bun run typecheck passed
bun run check passed
git diff --check passed
```

Tests cover long execution, transient and definitive renewal failure, hung renewal, acknowledgement
failure followed by the next job, transient loop restart, restart exhaustion, and shutdown during
backoff.

## Stack direction

This is the generic foundation for the remaining focused PRs:

```text
1. Queue delivery lifecycle and worker supervision        <- this PR
2. Agent execution-token fencing
3. Durable queued runs and idempotent dispatch
4. Durable server and client contracts
5. Chat refresh recovery and retry
```
