### PR TITLE
agent-ui: restore queued and failed turns after refresh

### DIFF
--- a/docs/agents/running-and-streaming.md
+++ b/docs/agents/running-and-streaming.md
@@ -23,27 +23,36 @@ thread, post a message, follow the run — and stream the run live over a websoc
 | `GET` | `/api/agent-threads/:threadId` | Get a thread. |
 | `GET` | `/api/agent-threads/:threadId/messages` | List a thread's messages. |
 | `POST` | `/api/agent-threads/:threadId/messages` | Post a user message — **triggers a run**. |
+| `GET` | `/api/agent-threads/:threadId/runs` | List a thread's runs. |
+| `POST` | `/api/agent-threads/:threadId/runs/:runId/retry` | Retry a failed run without adding another user message. |
+| `POST` | `/api/agent-threads/:threadId/cancel` | Cancel the thread's queued or running run (`{ runId }`). |
 | `GET` | `/api/agent-runs/:runId` | Get a run's status. |
-| `POST` | `/api/agent-threads/:threadId/cancel` | Cancel the thread's active run (`{ runId }`). |
 | `GET` | `/api/agent-threads/:threadId/messages/:messageId/files/content` | Download a file attached to a message. |
 
 ## Trigger a run
 
-There is no "run" endpoint — posting a message is the trigger. The `202` response returns the ids
-you need to follow it:
+There is no separate run-trigger endpoint — posting a message is the trigger. The `202` response
+returns the canonical durable run:
 
 ```jsonc
 // POST /api/agent-threads/:threadId/messages   { "text": "Which invoices are overdue?" }
 {
-  "threadId": "thr_...",
-  "runId": "run_...",
-  "triggerMessageId": "msg_...",
-  "streamId": "agents.runs.run_...",
-  "createdThread": false
+  "run": {
+    "id": "run_...",
+    "threadId": "thr_...",
+    "agentId": "accounts",
+    "triggerMessageId": "msg_...",
+    "requestedByPrincipal": { "type": "user", "id": "usr_..." },
+    "status": "queued",
+    "attempt": 0,
+    "streamId": "agents.runs.run_...",
+    "createdAt": "2026-07-11T20:00:00.000Z"
+  }
 }
 ```
 
-The `runId` and `streamId` come back right away, so you can open the stream before the turn starts.
+The run and user message are durable before this response returns, so you can immediately read the
+run or subscribe to its stream even when queue publication is temporarily unavailable.
 A thread runs **one turn at a time** — posting while a run is active returns `409`; wait for it to
 finish first.
 
@@ -67,6 +76,7 @@ Attachments — and any files the agent produces — appear as `file` parts on t
 
 | Status | Meaning |
 | --- | --- |
+| `queued` | The request is durable and waiting to start. |
 | `running` | The turn is in progress. |
 | `succeeded` | The turn completed and the reply was persisted. |
 | `failed` | A model/tool error or the turn timeout ended it (`error` has details). |
@@ -76,8 +86,11 @@ A finished run also carries `finishReason` (`stop`, `length`, `tool-calls`, `con
 `error`, `other`, `unknown`), `usage` token counts (`inputTokens`, `outputTokens`, `totalTokens`,
 `reasoningTokens`, `cachedInputTokens`), and `modelId`.
 
-Cancel an in-flight run with `POST /api/agent-threads/:threadId/cancel` (body `{ runId }`); it ends
-as `cancelled`.
+Cancel a queued or running run with `POST /api/agent-threads/:threadId/cancel` (body `{ runId }`);
+it ends as `cancelled`.
+
+Retrying a failed run creates a new queued run that points to the failed run's existing
+`triggerMessageId`. The original user message is not appended again.
 
 ## Stream a run
 
@@ -85,17 +98,21 @@ Connect to `/ws/agents` and send JSON commands; the server replies with JSON eve
 
 | Command | Fields | Purpose |
 | --- | --- | --- |
-| `subscribe` | `runId`, `threadId?`, `afterCursor?` | Follow a run live. |
-| `replay` | `runId`, `threadId?`, `afterCursor?`, `limit?` | Read past records once. |
+| `subscribe` | `runId`, `afterCursor?` | Follow a run live. |
+| `replay` | `runId`, `afterCursor?`, `limit?` | Read past records once. |
 | `unsubscribe` | `runId?` | Stop the subscription. |
 
 ```jsonc
-// follow from the start (pass threadId so the server can authorize you before the run row exists)
-{ "type": "subscribe", "runId": "run_...", "threadId": "thr_..." }
+// follow from the start
+{ "type": "subscribe", "runId": "run_..." }
 
 // resume after a disconnect, from the last cursor you saw
 { "type": "subscribe", "runId": "run_...", "afterCursor": "..." }
 ```
+
+After replaying retained records, the server sends a `run.snapshot` frame containing the current
+durable run. A new run therefore streams `status: "queued"` before any worker lifecycle record, and
+a reconnect can recover terminal state even if no live record was observed.
 
 Each `record` frame carries an `AgentRunStreamEvent`:
 

--- a/packages/agent-ui/src/AgentChat.tsx
+++ b/packages/agent-ui/src/AgentChat.tsx
@@ -6,9 +6,12 @@ import {
   listAgentsOptions,
   listAgentThreadMessagesOptions,
   listAgentThreadMessagesQueryKey,
+  listAgentThreadRunsOptions,
+  listAgentThreadRunsQueryKey,
   listAgentThreadsOptions,
   listAgentThreadsQueryKey,
   postAgentThreadMessageMutation,
+  retryAgentRunMutation,
 } from "@sixb/client/hooks"
 import { EmptyState } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
@@ -18,12 +21,17 @@ import { useEffect, useMemo, useState } from "react"
 import { AgentsHome } from "./components/AgentsHome"
 import { ConversationPanel } from "./components/ConversationPanel"
 import { installAgentResizeObserverGuard } from "./resizeObserver"
-import type { AgentFileRef } from "./types"
+import {
+  DELAYED_WAITING_COPY_MS,
+  findPreStreamFailedRun,
+  isActiveAgentRunStatus,
+  shouldShowDelayedWaitingCopy,
+} from "./runPresentation"
+import type { AgentFileRef, AgentRun } from "./types"
 import { useThreadStream } from "./useThreadStream"
 
 interface PendingSend {
-  readonly threadId: string
-  readonly runId: string
+  readonly run: AgentRun
 }
 
 interface PendingUser {
@@ -87,6 +95,15 @@ export function AgentChat({
     enabled: threadId !== null,
   })
   const messages = useMemo(() => messagesQuery.data?.messages ?? [], [messagesQuery.data])
+  const runsQuery = useQuery({
+    ...listAgentThreadRunsOptions({
+      path: { threadId: threadId ?? "" },
+      query: { limit: "50", order: "desc" },
+    }),
+    enabled: threadId !== null,
+  })
+  const runs = useMemo(() => runsQuery.data?.runs ?? [], [runsQuery.data])
+  const latestRun = runs[0] ?? null
 
   // Live run bookkeeping.
   const [pendingSend, setPendingSend] = useState<PendingSend | null>(null)
@@ -113,12 +130,25 @@ export function AgentChat({
 
   const activeRunId =
     threadId !== null
-      ? ((pendingSend?.threadId === threadId ? pendingSend.runId : null) ??
+      ? ((pendingSend?.run.threadId === threadId ? pendingSend.run.id : null) ??
         thread?.activeRunId ??
-        null)
+        (latestRun && isActiveAgentRunStatus(latestRun.status) ? latestRun.id : null))
       : null
 
-  const { live, reconnecting } = useThreadStream({ threadId, runId: activeRunId })
+  const {
+    live,
+    run: streamRun,
+    reconnecting,
+  } = useThreadStream({
+    threadId,
+    runId: activeRunId,
+  })
+  const activeRun =
+    (streamRun?.id === activeRunId ? streamRun : null) ??
+    (pendingSend?.run.id === activeRunId ? pendingSend.run : null) ??
+    runs.find((run) => run.id === activeRunId) ??
+    null
+  const presentationRun = activeRun ?? latestRun
   const finalizedMessageInDurable =
     live.finalizedMessageId !== null &&
     messages.some((message) => message.id === live.finalizedMessageId)
@@ -128,15 +158,23 @@ export function AgentChat({
   // clear `thread.activeRunId` before the messages refetch lands, resetting `live` to null and making
   // the transcript briefly flash/reflow at the end of a response.
   useEffect(() => {
-    if (!pendingSend || live.runId !== pendingSend.runId || live.finishStatus === null) return
+    if (!pendingSend || pendingSend.run.id !== activeRunId) return
+    const terminalFromSnapshot =
+      streamRun?.id === pendingSend.run.id && !isActiveAgentRunStatus(streamRun.status)
+    const terminalFromEvent = live.runId === pendingSend.run.id && live.finishStatus !== null
+    if (!terminalFromSnapshot && !terminalFromEvent) return
     if (live.finalizedMessageId && !finalizedMessageInDurable) return
+    if (!live.finalizedMessageId && !runs.some((run) => run.id === pendingSend.run.id)) return
     setPendingSend(null)
   }, [
     pendingSend,
+    activeRunId,
+    streamRun,
     live.runId,
     live.finishStatus,
     live.finalizedMessageId,
     finalizedMessageInDurable,
+    runs,
   ])
 
   // Drop the optimistic user echo once the durable message lands (or the thread changes).
@@ -160,9 +198,39 @@ export function AgentChat({
   const createThread = useMutation(createAgentThreadMutation())
   const postMessage = useMutation(postAgentThreadMessageMutation())
   const cancelRun = useMutation(cancelAgentRunMutation())
+  const retryRun = useMutation(retryAgentRunMutation())
 
-  const isRunning =
-    activeRunId !== null && !(live.runId === activeRunId && live.finishStatus !== null)
+  const activeRunFinished =
+    (streamRun?.id === activeRunId && !isActiveAgentRunStatus(streamRun.status)) ||
+    (live.runId === activeRunId && live.finishStatus !== null)
+  const isRunning = activeRunId !== null && !activeRunFinished
+  const failedRunFromHistory =
+    !isRunning && !messagesQuery.isLoading && presentationRun?.status === "failed"
+      ? findPreStreamFailedRun(
+          presentationRun === latestRun ? runs : [presentationRun, ...runs],
+          messages
+        )
+      : null
+  const failedRunFromEvent =
+    !isRunning &&
+    live.runId === activeRunId &&
+    live.finishStatus === "failed" &&
+    live.parts.length === 0
+      ? activeRun
+      : null
+  const failedRun = failedRunFromHistory ?? failedRunFromEvent
+  const cancelledBeforeResponse =
+    !isRunning &&
+    live.parts.length === 0 &&
+    ((presentationRun?.status === "cancelled" &&
+      !messagesQuery.isLoading &&
+      !messages.some(
+        (message) => message.role === "assistant" && message.runId === presentationRun.id
+      )) ||
+      (live.runId === activeRunId && live.finishStatus === "cancelled"))
+  const waitingLonger = useDelayedWaitingCopy(
+    isRunning && !live.active && presentationRun?.status === "queued" ? presentationRun : null
+  )
 
   // Clear the stop request once the run it targeted is no longer the active one (it ended, or we
   // navigated away), so a fresh run never starts already showing "stopping".
@@ -226,7 +294,7 @@ export function AgentChat({
           path: { threadId: targetThreadId },
           body: { text, ...(attachments.length === 0 ? {} : { attachments: [...attachments] }) },
         })
-        setPendingSend({ threadId: response.run.threadId, runId: response.run.id })
+        setPendingSend({ run: response.run })
         setPendingUser((current) =>
           current && current.threadId === response.run.threadId
             ? { ...current, messageId: response.run.triggerMessageId }
@@ -253,7 +321,7 @@ export function AgentChat({
         path: { threadId: newThreadId },
         body: { text, ...(attachments.length === 0 ? {} : { attachments: [...attachments] }) },
       })
-      setPendingSend({ threadId: newThreadId, runId: response.run.id })
+      setPendingSend({ run: response.run })
       setPendingUser((current) =>
         current && current.threadId === newThreadId
           ? { ...current, messageId: response.run.triggerMessageId }
@@ -279,6 +347,27 @@ export function AgentChat({
       }
       void queryClient.invalidateQueries({ queryKey: listAgentThreadsQueryKey() })
     }
+  }
+
+  const handleRetry = () => {
+    if (!failedRun || threadId === null) return
+    retryRun.mutate(
+      { path: { threadId, runId: failedRun.id } },
+      {
+        onSuccess: (response) => {
+          setPendingSend({ run: response.run })
+          void Promise.all([
+            queryClient.invalidateQueries({
+              queryKey: listAgentThreadRunsQueryKey({ path: { threadId } }),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: getAgentThreadQueryKey({ path: { threadId } }),
+            }),
+            queryClient.invalidateQueries({ queryKey: listAgentThreadsQueryKey() }),
+          ])
+        },
+      }
+    )
   }
 
   if (agentsQuery.isLoading) {
@@ -314,7 +403,7 @@ export function AgentChat({
       : null
   const anchorCurrentTurn = Boolean(
     (pendingUser && pendingUser.threadId === threadId) ||
-      (pendingSend && pendingSend.threadId === threadId)
+      (pendingSend && pendingSend.run.threadId === threadId)
   )
 
   return (
@@ -342,6 +431,11 @@ export function AgentChat({
           pendingUserAttachments={pendingUserForThread?.attachments ?? []}
           anchorCurrentTurn={anchorCurrentTurn}
           awaitingResponse={isRunning}
+          waitingLonger={waitingLonger}
+          failedBeforeResponse={failedRun !== null}
+          cancelledBeforeResponse={cancelledBeforeResponse}
+          onRetry={failedRun ? handleRetry : undefined}
+          retrying={retryRun.isPending}
           reconnecting={reconnecting}
           sendError={sendError && sendError.threadId === threadId ? sendError.message : null}
           agents={agents}
@@ -392,4 +486,27 @@ function deriveTitle(text: string): string {
   const firstLine = text.split("\n")[0]?.trim() ?? ""
   if (firstLine.length <= 60) return firstLine
   return `${firstLine.slice(0, 57)}...`
+}
+
+function useDelayedWaitingCopy(run: Pick<AgentRun, "status" | "createdAt"> | null): boolean {
+  const [visible, setVisible] = useState(() => shouldShowDelayedWaitingCopy(run))
+
+  useEffect(() => {
+    if (!run || run.status !== "queued") {
+      setVisible(false)
+      return
+    }
+
+    const remaining = DELAYED_WAITING_COPY_MS - (Date.now() - Date.parse(run.createdAt))
+    if (remaining <= 0) {
+      setVisible(true)
+      return
+    }
+
+    setVisible(false)
+    const timer = window.setTimeout(() => setVisible(true), remaining)
+    return () => window.clearTimeout(timer)
+  }, [run])
+
+  return visible
 }

--- a/packages/agent-ui/src/components/ConversationPanel.tsx
+++ b/packages/agent-ui/src/components/ConversationPanel.tsx
@@ -37,6 +37,11 @@ export interface ConversationPanelProps {
   readonly anchorCurrentTurn?: boolean
   /** A run has been requested and we're waiting on it — show the thinking shimmer immediately. */
   readonly awaitingResponse: boolean
+  readonly waitingLonger?: boolean
+  readonly failedBeforeResponse?: boolean
+  readonly cancelledBeforeResponse?: boolean
+  readonly onRetry?: () => void
+  readonly retrying?: boolean
   /** The active run's stream dropped and is re-subscribing. */
   readonly reconnecting: boolean
   /** A failed send to surface above the composer, or null. English, user-facing. */
@@ -77,6 +82,11 @@ export function ConversationPanel({
   pendingUserAttachments = [],
   anchorCurrentTurn,
   awaitingResponse,
+  waitingLonger,
+  failedBeforeResponse,
+  cancelledBeforeResponse,
+  onRetry,
+  retrying,
   reconnecting,
   sendError,
   agents,
@@ -184,6 +194,11 @@ export function ConversationPanel({
                 pendingUserAttachments={pendingUserAttachments}
                 anchorCurrentTurn={anchorCurrentTurn}
                 awaitingResponse={awaitingResponse}
+                waitingLonger={waitingLonger}
+                failedBeforeResponse={failedBeforeResponse}
+                cancelledBeforeResponse={cancelledBeforeResponse}
+                onRetry={onRetry}
+                retrying={retrying}
                 reconnecting={reconnecting}
               />
             )}

--- a/packages/agent-ui/src/components/MessageView.tsx
+++ b/packages/agent-ui/src/components/MessageView.tsx
@@ -1,6 +1,13 @@
 import { client } from "@sixb/client"
-import { Bubble, BubbleContent, Marker, MarkerContent, MarkerIcon } from "@sixb/ui/components"
-import { AlertTriangle } from "lucide-react"
+import {
+  Bubble,
+  BubbleContent,
+  Button,
+  Marker,
+  MarkerContent,
+  MarkerIcon,
+} from "@sixb/ui/components"
+import { AlertTriangle, RotateCcw } from "lucide-react"
 import { isAwaitingFirstToken, type LiveRunState } from "../liveRun"
 import { normalizeDurableParts } from "../parts"
 import type { AgentFileRef, AgentMessage } from "../types"
@@ -81,29 +88,71 @@ function AssistantMessage({ message }: { message: AgentMessage }) {
 export function LiveAssistant({
   live,
   keepWorkOpen = false,
+  onRetry,
+  retrying = false,
 }: {
   live: LiveRunState
   keepWorkOpen?: boolean
+  onRetry?: () => void
+  retrying?: boolean
 }) {
   if (isAwaitingFirstToken(live)) {
     return <ThinkingMarker />
+  }
+  if (live.finishStatus === "failed" && live.parts.length === 0) {
+    return <RunFailureMarker onRetry={onRetry} retrying={retrying} />
+  }
+  if (live.finishStatus === "cancelled" && live.parts.length === 0) {
+    return <RunCancelledMarker />
   }
 
   return (
     <div className="flex flex-col gap-2">
       <AssistantBody parts={live.parts} live={live.active || keepWorkOpen} />
       {live.finishStatus === "failed" ? (
-        <RunErrorMarker message={live.finishError ?? "The agent run failed."} />
+        <RunErrorMarker message="I couldn’t finish that response." />
+      ) : null}
+      {live.finishStatus === "cancelled" ? <RunCancelledMarker /> : null}
+    </div>
+  )
+}
+
+export function ThinkingMarker({ takingLonger = false }: { takingLonger?: boolean }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <Marker role="status" aria-label="Agent is thinking">
+        <MarkerContent className="shimmer">Thinking…</MarkerContent>
+      </Marker>
+      {takingLonger ? (
+        <p className="pl-6 text-xs text-muted-foreground" role="status">
+          Taking a little longer than usual…
+        </p>
       ) : null}
     </div>
   )
 }
 
-export function ThinkingMarker() {
+export function RunCancelledMarker() {
+  return <p className="text-sm text-muted-foreground">Stopped.</p>
+}
+
+export function RunFailureMarker({
+  onRetry,
+  retrying = false,
+}: {
+  onRetry?: () => void
+  retrying?: boolean
+}) {
   return (
-    <Marker role="status" aria-label="Agent is thinking">
-      <MarkerContent className="shimmer">Thinking…</MarkerContent>
-    </Marker>
+    <div className="flex flex-wrap items-center gap-2" role="status">
+      <p className="text-sm text-muted-foreground">I couldn’t get a response started.</p>
+      {onRetry ? (
+        <Button variant="outline" size="sm" onClick={onRetry} disabled={retrying}>
+          <RotateCcw aria-hidden="true" />
+          {retrying ? "Retrying…" : "Retry"}
+        </Button>
+      ) : null}
+    </div>
   )
 }
 

--- a/packages/agent-ui/src/components/Transcript.tsx
+++ b/packages/agent-ui/src/components/Transcript.tsx
@@ -16,6 +16,8 @@ import {
   LiveAssistant,
   MessageView,
   ReconnectingMarker,
+  RunCancelledMarker,
+  RunFailureMarker,
   ThinkingMarker,
   UserFileAttachment,
 } from "./MessageView"
@@ -31,6 +33,13 @@ export interface TranscriptProps {
   readonly anchorCurrentTurn?: boolean
   /** A run is requested but the live stream hasn't produced content yet — show a thinking shimmer. */
   readonly awaitingResponse?: boolean
+  /** The queued run has crossed the conversational delay threshold. */
+  readonly waitingLonger?: boolean
+  /** The newest run failed before it produced a durable assistant message. */
+  readonly failedBeforeResponse?: boolean
+  readonly cancelledBeforeResponse?: boolean
+  readonly onRetry?: () => void
+  readonly retrying?: boolean
   /** The active run's stream dropped and is re-subscribing — surface a transient notice. */
   readonly reconnecting?: boolean
 }
@@ -43,6 +52,11 @@ export function Transcript({
   pendingUserAttachments = [],
   anchorCurrentTurn,
   awaitingResponse,
+  waitingLonger,
+  failedBeforeResponse,
+  cancelledBeforeResponse,
+  onRetry,
+  retrying,
   reconnecting,
 }: TranscriptProps) {
   // Keep the live row until the finalized assistant message is present in durable state, so the
@@ -138,11 +152,24 @@ export function Transcript({
               // The answer is not a turn anchor — it grows into the space below the anchored user
               // message, so streaming never yanks the reader away from where the turn started.
               <MessageScrollerItem messageId="live">
-                <LiveAssistant live={live} keepWorkOpen={handoffPending} />
+                <LiveAssistant
+                  live={live}
+                  keepWorkOpen={handoffPending}
+                  onRetry={onRetry}
+                  retrying={retrying}
+                />
               </MessageScrollerItem>
             ) : showThinking ? (
               <MessageScrollerItem messageId="thinking">
-                <ThinkingMarker />
+                <ThinkingMarker takingLonger={waitingLonger} />
+              </MessageScrollerItem>
+            ) : failedBeforeResponse ? (
+              <MessageScrollerItem messageId="run-failed">
+                <RunFailureMarker onRetry={onRetry} retrying={retrying} />
+              </MessageScrollerItem>
+            ) : cancelledBeforeResponse ? (
+              <MessageScrollerItem messageId="run-cancelled">
+                <RunCancelledMarker />
               </MessageScrollerItem>
             ) : null}
             {live.active && reconnecting ? (

--- a/packages/agent-ui/src/index.ts
+++ b/packages/agent-ui/src/index.ts
@@ -11,7 +11,9 @@ export {
   LiveAssistant,
   MessageView,
   ReconnectingMarker,
+  RunCancelledMarker,
   RunErrorMarker,
+  RunFailureMarker,
   ThinkingMarker,
 } from "./components/MessageView"
 export { Transcript, type TranscriptProps } from "./components/Transcript"
@@ -26,6 +28,12 @@ export {
 } from "./liveRun"
 export { type NormalizedPart, type NormalizedTool, normalizeDurableParts } from "./parts"
 export { installAgentResizeObserverGuard } from "./resizeObserver"
+export {
+  DELAYED_WAITING_COPY_MS,
+  findPreStreamFailedRun,
+  isActiveAgentRunStatus,
+  shouldShowDelayedWaitingCopy,
+} from "./runPresentation"
 export type {
   Agent,
   AgentMessage,

--- a/packages/agent-ui/src/runPresentation.ts
+++ b/packages/agent-ui/src/runPresentation.ts
@@ -1,0 +1,31 @@
+import type { AgentMessage, AgentRun, AgentRunStatus } from "./types"
+
+export const DELAYED_WAITING_COPY_MS = 20_000
+
+export function isActiveAgentRunStatus(status: AgentRunStatus): boolean {
+  return status === "queued" || status === "running"
+}
+
+/** The delayed copy belongs only to queue startup; running-before-content keeps the plain shimmer. */
+export function shouldShowDelayedWaitingCopy(
+  run: Pick<AgentRun, "status" | "createdAt"> | null,
+  now = Date.now()
+): boolean {
+  return run?.status === "queued" && now - Date.parse(run.createdAt) >= DELAYED_WAITING_COPY_MS
+}
+
+/**
+ * Return the newest pre-stream failure, if the newest run is failed and produced no durable
+ * assistant message. Looking only at the newest run prevents an old failed attempt from resurfacing
+ * after a successful retry.
+ */
+export function findPreStreamFailedRun(
+  runs: readonly AgentRun[],
+  messages: readonly AgentMessage[]
+): AgentRun | null {
+  const latest = runs[0]
+  if (!latest || latest.status !== "failed") return null
+  return messages.some((message) => message.role === "assistant" && message.runId === latest.id)
+    ? null
+    : latest
+}

--- a/packages/agent-ui/src/useThreadStream.ts
+++ b/packages/agent-ui/src/useThreadStream.ts
@@ -1,12 +1,14 @@
+import type { AgentRunSnapshot } from "@sixb/client"
 import {
   getAgentRunQueryKey,
   getAgentThreadQueryKey,
   listAgentThreadMessagesQueryKey,
+  listAgentThreadRunsQueryKey,
   listAgentThreadsQueryKey,
   useAgentRunStream,
 } from "@sixb/client/hooks"
 import { useQueryClient } from "@tanstack/react-query"
-import { useEffect, useReducer, useRef } from "react"
+import { useEffect, useReducer, useRef, useState } from "react"
 import { createLiveRunState, type LiveRunState, liveRunReducer } from "./liveRun"
 
 export interface UseThreadStreamOptions {
@@ -16,6 +18,8 @@ export interface UseThreadStreamOptions {
 
 export interface UseThreadStreamResult {
   readonly live: LiveRunState
+  /** Latest durable snapshot received for this subscription. */
+  readonly run: AgentRunSnapshot | null
   readonly connected: boolean
   readonly reconnecting: boolean
 }
@@ -31,19 +35,25 @@ export function useThreadStream(options: UseThreadStreamOptions): UseThreadStrea
   const { threadId, runId } = options
   const queryClient = useQueryClient()
   const [live, dispatch] = useReducer(liveRunReducer, runId, createLiveRunState)
+  const [run, setRun] = useState<AgentRunSnapshot | null>(null)
 
   // Reset the accumulator whenever we point at a different run so a new turn starts clean.
   useEffect(() => {
     dispatch({ type: "reset", runId })
+    setRun(null)
   }, [runId])
 
   // Once the run reaches a terminal status we already have all of its events; stop the subscription
   // so a server-closed socket does not reconnect on a loop to a run that is already over.
-  const runFinished = live.finishStatus !== null && live.runId === runId
+  const snapshotFinished =
+    run?.id === runId &&
+    (run.status === "succeeded" || run.status === "failed" || run.status === "cancelled")
+  const runFinished = snapshotFinished || (live.finishStatus !== null && live.runId === runId)
   const { connected, reconnecting } = useAgentRunStream({
     runId,
     enabled: Boolean(runId && threadId) && !runFinished,
     onEvent: (event) => dispatch({ type: "event", event }),
+    onRunSnapshot: setRun,
     onError: (message) => dispatch({ type: "stream-error", message }),
   })
 
@@ -74,10 +84,38 @@ export function useThreadStream(options: UseThreadStreamOptions): UseThreadStrea
             queryClient.invalidateQueries({
               queryKey: listAgentThreadMessagesQueryKey({ path: { threadId } }),
             }),
+            queryClient.invalidateQueries({
+              queryKey: listAgentThreadRunsQueryKey({ path: { threadId } }),
+            }),
           ]
         : []),
     ])
   }, [live.finishStatus, runId, threadId, queryClient])
 
-  return { live, connected, reconnecting }
+  // A durable terminal snapshot is authoritative even if the retained terminal event was pruned or
+  // arrived before this hook mounted. Refresh every durable view from it just as we do for events.
+  const snapshotHandledRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!snapshotFinished || !runId || snapshotHandledRef.current === runId) return
+    snapshotHandledRef.current = runId
+    void Promise.all([
+      queryClient.invalidateQueries({ queryKey: getAgentRunQueryKey({ path: { runId } }) }),
+      queryClient.invalidateQueries({ queryKey: listAgentThreadsQueryKey() }),
+      ...(threadId
+        ? [
+            queryClient.invalidateQueries({
+              queryKey: getAgentThreadQueryKey({ path: { threadId } }),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: listAgentThreadMessagesQueryKey({ path: { threadId } }),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: listAgentThreadRunsQueryKey({ path: { threadId } }),
+            }),
+          ]
+        : []),
+    ])
+  }, [snapshotFinished, runId, threadId, queryClient])
+
+  return { live, run: run?.id === runId ? run : null, connected, reconnecting }
 }

--- a/packages/agent-ui/tests/run-presentation.test.ts
+++ b/packages/agent-ui/tests/run-presentation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import {
+  DELAYED_WAITING_COPY_MS,
+  findPreStreamFailedRun,
+  shouldShowDelayedWaitingCopy,
+} from "../src/runPresentation"
+import type { AgentMessage, AgentRun } from "../src/types"
+
+function run(input: Partial<AgentRun> & Pick<AgentRun, "id" | "status">): AgentRun {
+  const { id, status, ...overrides } = input
+  return {
+    projectId: "project",
+    threadId: "thread",
+    agentId: "assistant",
+    triggerMessageId: "message-user",
+    requestedByPrincipal: { type: "system", id: "system" },
+    attempt: 0,
+    streamId: `agents.runs.${id}`,
+    createdAt: "2026-07-12T10:00:00.000Z",
+    ...overrides,
+    id,
+    status,
+  }
+}
+
+function assistantMessage(runId: string): AgentMessage {
+  return {
+    id: `message-${runId}`,
+    projectId: "project",
+    threadId: "thread",
+    runId,
+    role: "assistant",
+    seq: 2,
+    parts: [{ type: "text", text: "Done" }],
+    annotations: [],
+    contentVersion: 1,
+    createdAt: "2026-07-12T10:00:01.000Z",
+  }
+}
+
+describe("agent run presentation", () => {
+  test("delays extra waiting copy for queued runs only", () => {
+    const queued = run({ id: "queued", status: "queued" })
+    const createdAt = Date.parse(queued.createdAt)
+
+    expect(shouldShowDelayedWaitingCopy(queued, createdAt + DELAYED_WAITING_COPY_MS - 1)).toBe(
+      false
+    )
+    expect(shouldShowDelayedWaitingCopy(queued, createdAt + DELAYED_WAITING_COPY_MS)).toBe(true)
+    expect(
+      shouldShowDelayedWaitingCopy(
+        run({ id: "running", status: "running" }),
+        createdAt + DELAYED_WAITING_COPY_MS
+      )
+    ).toBe(false)
+  })
+
+  test("shows only the newest failed run that has no assistant message", () => {
+    const failed = run({ id: "failed", status: "failed" })
+    expect(findPreStreamFailedRun([failed], [])?.id).toBe("failed")
+    expect(findPreStreamFailedRun([failed], [assistantMessage(failed.id)])).toBeNull()
+
+    const retry = run({ id: "retry", status: "succeeded" })
+    expect(findPreStreamFailedRun([retry, failed], [])).toBeNull()
+  })
+})


### PR DESCRIPTION
## Why

PR #199 exposes durable queued and terminal run state, but the chat still relies primarily on local
`pendingSend` state and live stream events.

That works during an uninterrupted send. After refresh, a queued run can lose its thinking row, and
a pre-stream failure can disappear because it produced no assistant message and already released
`thread.activeRunId`.

This PR makes the chat presentation derive from durable runs and snapshots, so the same turn remains
visible before and after refresh.

## Recovery model

```mermaid
flowchart TD
  A[Canonical post response] --> E[Choose current run]
  B[Thread active run] --> E
  C[Thread run history] --> E
  D[WebSocket run snapshot] --> E
  E --> F[Render waiting streaming or terminal state]
```

The immediate post response still gives zero-latency feedback. Durable thread state, run history, and
stream snapshots then take over as the source of truth.

The active run is resolved from:

```text
pending canonical run
thread.activeRunId
newest active run in durable history
```

The latest run remains available for terminal presentation after the thread releases its active
slot.

## Conversation behavior

| Durable state | Chat presentation |
| --- | --- |
| `queued`, under 20 seconds | Existing thinking shimmer |
| `queued`, after 20 seconds | Shimmer plus “Taking a little longer than usual…” |
| `running`, before first token | Same thinking shimmer without announcing a state change |
| `running`, streaming | Existing live response |
| `failed`, no assistant message | “I couldn’t get a response started.” with Retry |
| `failed`, partial response | Keep the partial response and show a concise completion failure |
| `cancelled`, no assistant message | “Stopped.” |
| terminal with durable message | Existing durable transcript |

Queue, worker, dispatch, job, and lease terminology never appears in the conversation. Normal queue
delay does not create a warning toast or technical error.

Stop remains available while a run is queued or running.

## Durable failure and retry

A pre-stream failure is shown only when:

- it is the newest run
- its status is `failed`
- it produced no durable assistant message

Looking only at the newest run prevents an old failed attempt from resurfacing after a successful
retry.

Retry calls the endpoint introduced in PR #199. The new run points to the existing trigger message,
so the user text is not appended again. The button shows `Retrying…` while the mutation is active.

## Snapshot handling

`useThreadStream` now retains the latest `run.snapshot` alongside incremental stream events.

A terminal snapshot is authoritative even if the terminal event was pruned or arrived before the UI
mounted. It stops reconnecting and invalidates run, thread, message, history, and thread-list queries
so durable views converge after completion.

Pending local state is kept only through the handoff to durable state, avoiding a brief transcript
flash when `thread.activeRunId` clears before the message query refreshes.

## Presentation helpers

`runPresentation.ts` keeps state selection rules independent of React:

- active run status detection
- the 20-second queued delay threshold
- newest pre-stream failure selection

The helpers are exported for reuse and covered by deterministic tests with fixed timestamps.

## Scope

Included:

- durable run-history loading in `AgentChat`
- active and terminal run reconstruction
- snapshot-aware stream state and cache invalidation
- delayed queued copy
- friendly failure and cancellation markers
- retry without duplicate user content
- updated running and streaming documentation

No server, storage, queue, OpenAPI, or generated client changes are included.

## Review guide

| Area | Review focus |
| --- | --- |
| `packages/agent-ui/src/AgentChat.tsx` | run selection, pending-to-durable handoff, and retry |
| `packages/agent-ui/src/useThreadStream.ts` | snapshot authority and cache invalidation |
| `packages/agent-ui/src/runPresentation.ts` | deterministic presentation rules |
| `components/Transcript.tsx` | precedence between live, waiting, failed, and cancelled rows |
| `components/MessageView.tsx` | user-facing copy and retry control |
| `docs/agents/running-and-streaming.md` | final durable API and stream behavior |

Key invariants:

- refresh preserves queued, running, and pre-stream terminal turns
- queued and running-before-content share one visual waiting state
- old failed attempts do not reappear after a newer run
- retry never duplicates the user message
- infrastructure terminology stays out of the chat
- durable assistant messages replace transient rows without flicker

## Validation

```text
47 agent UI tests passed
agent UI build passed
bun run typecheck passed
bun run check passed
git diff --check passed
```

The full fast suite reached 2,544 passing and 2 skipped tests. The same unrelated Atlas development
bundler test noted on the previous PRs hit a Bun `EISDIR` error under the full parallel run and passed
when run in isolation.

## Completed stack

This PR is based on PR #199 and completes the planned stack.

```text
1. Queue delivery lifecycle and worker supervision        #196
2. Agent execution-token fencing                          #197
3. Durable queued runs and idempotent dispatch            #198
4. Durable server and client contracts                    #199
5. Chat refresh recovery and retry                        <- this PR
```
