### PR TITLE
Add Teamleader product actions

### DIFF
--- a/connectors/teamleader/README.md
+++ b/connectors/teamleader/README.md
@@ -9,6 +9,8 @@ V1 covers:
 - Quotations
 - Quotation actions
 - Quotation reference data
+- Products
+- Product actions
 - Contacts
 - Companies
 - Custom field definitions
@@ -77,6 +79,9 @@ client.quotations.delete(...)
 client.products.list(...)
 client.products.listAll(...)
 client.products.info(...)
+client.products.add(...)
+client.products.update(...)
+client.products.delete(...)
 
 client.productCategories.list(...)
 client.priceLists.list(...)

--- a/connectors/teamleader/src/resources/products.ts
+++ b/connectors/teamleader/src/resources/products.ts
@@ -6,6 +6,7 @@ import type {
   TeamleaderProduct,
   TeamleaderProductListItem,
   TeamleaderSingleResponse,
+  TeamleaderTypeAndId,
 } from "../types"
 
 export function createProductsResource(request: TeamleaderRequester): TeamleaderClient["products"] {
@@ -26,6 +27,19 @@ export function createProductsResource(request: TeamleaderRequester): Teamleader
         body,
         requestOptions
       )
+    },
+    add(body, requestOptions) {
+      return request<TeamleaderSingleResponse<TeamleaderTypeAndId<"product">>>(
+        "/products.add",
+        body,
+        requestOptions
+      )
+    },
+    update(body, requestOptions) {
+      return request<void>("/products.update", body, requestOptions)
+    },
+    delete(body, requestOptions) {
+      return request<void>("/products.delete", body, requestOptions)
     },
   }
 

--- a/connectors/teamleader/src/types/client.ts
+++ b/connectors/teamleader/src/types/client.ts
@@ -34,9 +34,11 @@ import type {
 } from "./deals"
 import type {
   TeamleaderProduct,
+  TeamleaderProductAddRequest,
   TeamleaderProductInfoRequest,
   TeamleaderProductListItem,
   TeamleaderProductListRequest,
+  TeamleaderProductUpdateRequest,
 } from "./products"
 import type {
   TeamleaderDocumentTemplate,
@@ -137,6 +139,15 @@ export interface TeamleaderClient {
       request: TeamleaderProductInfoRequest,
       options?: TeamleaderRequestOptions
     ): Promise<TeamleaderSingleResponse<TeamleaderProduct>>
+    add(
+      request: TeamleaderProductAddRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<TeamleaderSingleResponse<TeamleaderTypeAndId<"product">>>
+    update(
+      request: TeamleaderProductUpdateRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<void>
+    delete(request: TeamleaderInfoRequest, options?: TeamleaderRequestOptions): Promise<void>
   }
   readonly productCategories: {
     list(

--- a/connectors/teamleader/src/types/products.ts
+++ b/connectors/teamleader/src/types/products.ts
@@ -1,5 +1,5 @@
 import type { TeamleaderMoney, TeamleaderPage, TeamleaderTypeAndId } from "./common"
-import type { TeamleaderCustomField } from "./custom-fields"
+import type { TeamleaderCustomField, TeamleaderCustomFieldInput } from "./custom-fields"
 
 export interface TeamleaderProductListRequest {
   readonly filter?: {
@@ -14,6 +14,41 @@ export interface TeamleaderProductInfoRequest {
   readonly id: string
   /** Comma-separated list of optional includes. Documented value: `suppliers`. */
   readonly includes?: string
+}
+
+export type TeamleaderProductAddRequest =
+  | (TeamleaderProductAddFields & { readonly name: string; readonly code?: string })
+  | (TeamleaderProductAddFields & { readonly code: string; readonly name?: string })
+
+export interface TeamleaderProductAddFields {
+  readonly description?: string
+  readonly purchase_price?: TeamleaderMoney | null
+  readonly selling_price?: TeamleaderMoney | null
+  readonly unit_of_measure_id?: string | null
+  readonly price_list_prices?: readonly TeamleaderProductPriceListPriceInput[]
+  readonly stock?: TeamleaderProductStock
+  readonly configuration?: TeamleaderProductConfiguration | null
+  readonly department_id?: string
+  readonly product_category_id?: string
+  readonly tax_rate_id?: string
+  readonly custom_fields?: readonly TeamleaderCustomFieldInput[]
+}
+
+export interface TeamleaderProductUpdateRequest {
+  readonly id: string
+  readonly name?: string | null
+  readonly code?: string | null
+  readonly description?: string | null
+  readonly purchase_price?: TeamleaderMoney | null
+  readonly selling_price?: TeamleaderMoney | null
+  readonly unit_of_measure_id?: string | null
+  readonly price_list_prices?: readonly TeamleaderProductPriceListPriceInput[]
+  readonly stock?: TeamleaderProductStock
+  readonly configuration?: TeamleaderProductConfiguration | null
+  readonly department_id?: string
+  readonly product_category_id?: string
+  readonly tax_rate_id?: string
+  readonly custom_fields?: readonly TeamleaderCustomFieldInput[]
 }
 
 export interface TeamleaderProductListItem {
@@ -60,4 +95,9 @@ export interface TeamleaderProductSupplier {
 export interface TeamleaderProductPriceListPrice {
   readonly price_list?: TeamleaderTypeAndId<"priceList">
   readonly price?: TeamleaderMoney
+}
+
+export interface TeamleaderProductPriceListPriceInput {
+  readonly price_list_id: string
+  readonly price: TeamleaderMoney
 }

--- a/connectors/teamleader/tests/teamleader.test.ts
+++ b/connectors/teamleader/tests/teamleader.test.ts
@@ -254,6 +254,105 @@ describe("teamleader connector", () => {
     ])
   })
 
+  test("supports documented product actions", async () => {
+    const requests: CapturedRequest[] = []
+    const client = createTeamleaderClient({
+      accessToken: "test-token",
+      fetch: mockFetch((input, init) => {
+        requests.push({ input, init })
+        const path = new URL(String(input)).pathname
+
+        if (path === "/products.add") {
+          return Promise.resolve(jsonResponse({ data: { type: "product", id: "product-1" } }))
+        }
+
+        return Promise.resolve(new Response(undefined, { status: 204 }))
+      }),
+    })
+
+    const added = await client.products.add({
+      name: "Hosting",
+      code: "HOST-001",
+      description: "Product used for hosting web solutions",
+      purchase_price: { amount: 50, currency: "EUR" },
+      selling_price: { amount: 100, currency: "EUR" },
+      unit_of_measure_id: "unit-1",
+      price_list_prices: [
+        { price_list_id: "price-list-1", price: { amount: 90, currency: "EUR" } },
+      ],
+      stock: { amount: 12 },
+      configuration: { stock_threshold: { minimum: 4, action: "notify" } },
+      department_id: "department-1",
+      product_category_id: "category-1",
+      tax_rate_id: "tax-rate-1",
+      custom_fields: [{ id: "field-1", value: "external-reference" }],
+    })
+    await client.products.update({
+      id: "product-1",
+      name: "Updated hosting",
+      code: null,
+      description: null,
+      purchase_price: null,
+      selling_price: { amount: 120, currency: "EUR" },
+      unit_of_measure_id: null,
+      price_list_prices: [
+        { price_list_id: "price-list-1", price: { amount: 110, currency: "EUR" } },
+      ],
+      stock: { amount: 10 },
+      configuration: null,
+      department_id: "department-1",
+      product_category_id: "category-1",
+      tax_rate_id: "tax-rate-1",
+      custom_fields: [{ id: "field-1", value: "updated-reference" }],
+    })
+    await client.products.delete({ id: "product-1" })
+
+    expect(added.data).toEqual({ type: "product", id: "product-1" })
+    expect(requests.map((request) => new URL(String(request.input)).pathname)).toEqual([
+      "/products.add",
+      "/products.update",
+      "/products.delete",
+    ])
+    expect(requests.map((request) => JSON.parse(String(request.init?.body)))).toEqual([
+      {
+        name: "Hosting",
+        code: "HOST-001",
+        description: "Product used for hosting web solutions",
+        purchase_price: { amount: 50, currency: "EUR" },
+        selling_price: { amount: 100, currency: "EUR" },
+        unit_of_measure_id: "unit-1",
+        price_list_prices: [
+          { price_list_id: "price-list-1", price: { amount: 90, currency: "EUR" } },
+        ],
+        stock: { amount: 12 },
+        configuration: { stock_threshold: { minimum: 4, action: "notify" } },
+        department_id: "department-1",
+        product_category_id: "category-1",
+        tax_rate_id: "tax-rate-1",
+        custom_fields: [{ id: "field-1", value: "external-reference" }],
+      },
+      {
+        id: "product-1",
+        name: "Updated hosting",
+        code: null,
+        description: null,
+        purchase_price: null,
+        selling_price: { amount: 120, currency: "EUR" },
+        unit_of_measure_id: null,
+        price_list_prices: [
+          { price_list_id: "price-list-1", price: { amount: 110, currency: "EUR" } },
+        ],
+        stock: { amount: 10 },
+        configuration: null,
+        department_id: "department-1",
+        product_category_id: "category-1",
+        tax_rate_id: "tax-rate-1",
+        custom_fields: [{ id: "field-1", value: "updated-reference" }],
+      },
+      { id: "product-1" },
+    ])
+  })
+
   test("exposes quotation reference endpoints", async () => {
     const requests: CapturedRequest[] = []
     const client = createTeamleaderClient({


### PR DESCRIPTION
## Summary

- Adds Teamleader product mutation endpoints to `@sixb/connector-teamleader`.
- Exposes `products.add`, `products.update`, and `products.delete`.
- Adds documented request types for product pricing, units, categories, tax rates, stock, price lists, and custom fields.
- Covers the new methods with request/response contract tests.

## Validation

- `bun --filter @sixb/connector-teamleader typecheck`
- `bun --filter @sixb/connector-teamleader test`
- `bun --filter @sixb/connector-teamleader build`
- Real Teamleader smoke with valid credentials:
  - read-only checks passed
  - product write smoke passed for add, info, update, and delete
  - temporary smoke product was deleted successfully
