### PR TITLE
connector-imap: clarify downloaded charset metadata

### DIFF
--- a/connectors/imap/README.md
+++ b/connectors/imap/README.md
@@ -40,5 +40,19 @@ Requested header names are validated and deduplicated case-insensitively. Return
 lowercase and repeated fields remain separate values. Header interpretation belongs to the
 consumer; the connector only transports the requested metadata.
 
+## MIME source versus downloaded content
+
+`message.bodyStructure` describes the MIME representation declared by the source message. In
+particular, `bodyStructure.parameters.charset` and `bodyStructure.declaredCharset` are the
+charset from the original `Content-Type` header.
+
+`downloadPart()` returns the representation emitted by ImapFlow after MIME transfer decoding.
+Inline text parts with a supported non-UTF-8 charset can be transcoded to UTF-8. Decode
+`download.content` with `download.meta.contentCharset`; do not use the charset from the body
+structure to decode that stream.
+
+`meta.transferEncoding` describes the source `Content-Transfer-Encoding`; the returned stream is
+already transfer-decoded.
+
 All mailbox sessions use IMAP `EXAMINE`; the client does not expose any write or flag mutation
 method. Consume a stream returned by `downloadPart()` before the `withMailbox()` callback ends.

--- a/connectors/imap/src/client.ts
+++ b/connectors/imap/src/client.ts
@@ -349,10 +349,10 @@ class ImapMailboxSessionImpl implements ImapMailboxSession {
       meta: {
         expectedSize: downloaded.meta.expectedSize,
         contentType: downloaded.meta.contentType,
-        charset: downloaded.meta.charset ?? null,
+        contentCharset: downloaded.meta.charset ?? null,
         disposition: downloaded.meta.disposition ?? null,
         filename: downloaded.meta.filename ?? null,
-        encoding: downloaded.meta.encoding ?? null,
+        transferEncoding: downloaded.meta.encoding ?? null,
       },
       content,
     }
@@ -481,6 +481,7 @@ function normalizeBodyPart(part: MessageStructureObject): ImapBodyPart {
     part: part.part ?? null,
     type: part.type,
     parameters: { ...(part.parameters ?? {}) },
+    declaredCharset: findMimeParameter(part.parameters, "charset"),
     id: normalizeOptionalString(part.id),
     encoding: normalizeOptionalString(part.encoding),
     size: part.size ?? null,
@@ -488,6 +489,22 @@ function normalizeBodyPart(part: MessageStructureObject): ImapBodyPart {
     dispositionParameters: { ...(part.dispositionParameters ?? {}) },
     childNodes: (part.childNodes ?? []).map(normalizeBodyPart),
   }
+}
+
+function findMimeParameter(
+  parameters: Readonly<Record<string, string>> | undefined,
+  name: string
+): string | null {
+  if (!parameters) {
+    return null
+  }
+
+  for (const [parameter, value] of Object.entries(parameters)) {
+    if (parameter.toLowerCase() === name) {
+      return normalizeOptionalString(value)
+    }
+  }
+  return null
 }
 
 function normalizeDate(value: Date | string | undefined): Date | null {

--- a/connectors/imap/src/types.ts
+++ b/connectors/imap/src/types.ts
@@ -70,8 +70,17 @@ export interface ImapEnvelope {
 export interface ImapBodyPart {
   readonly part: string | null
   readonly type: string
+  /** Parameters declared in the source MIME Content-Type header. */
   readonly parameters: Readonly<Record<string, string>>
+  /**
+   * Charset declared in the source MIME Content-Type header.
+   *
+   * This describes the original message representation, not necessarily the bytes emitted by
+   * `downloadPart().content`. Use `ImapDownloadedPart.meta.contentCharset` to decode that stream.
+   */
+  readonly declaredCharset: string | null
   readonly id: string | null
+  /** Content-Transfer-Encoding declared in the source MIME part. */
   readonly encoding: string | null
   readonly size: number | null
   readonly disposition: string | null
@@ -115,10 +124,19 @@ export interface ImapDownloadedPart {
     /** ImapFlow's server-reported size; it may describe the full message, not this MIME part. */
     readonly expectedSize: number
     readonly contentType: string
-    readonly charset: string | null
+    /**
+     * Charset of the bytes emitted by `content` after ImapFlow decodes the MIME part.
+     *
+     * Use this value, rather than `ImapBodyPart.declaredCharset`, to decode the returned stream.
+     */
+    readonly contentCharset: string | null
     readonly disposition: string | null
     readonly filename: string | null
-    readonly encoding: string | null
+    /**
+     * Content-Transfer-Encoding declared in the source MIME part. The returned stream has already
+     * been transfer-decoded.
+     */
+    readonly transferEncoding: string | null
   }
   readonly content: Readable
 }

--- a/connectors/imap/tests/imap.test.ts
+++ b/connectors/imap/tests/imap.test.ts
@@ -193,6 +193,7 @@ describe("imap connector", () => {
             part: "1",
             type: "text/plain",
             parameters: { charset: "utf-8" },
+            declaredCharset: "utf-8",
           },
         ],
       },
@@ -288,6 +289,54 @@ describe("imap connector", () => {
       part: "2",
       options: { uid: true, maxBytes: 6 },
     })
+  })
+
+  test("distinguishes the source MIME charset from the downloaded content charset", async () => {
+    const fixture = clientFixture()
+    fixture.configure = (transport) => {
+      transport.searchResult = [11]
+      transport.messages = [
+        {
+          ...message(11),
+          bodyStructure: {
+            type: "multipart/alternative",
+            childNodes: [
+              { part: "1", type: "text/plain", parameters: { charset: "Windows-1252" } },
+              { part: "2", type: "text/html", parameters: { charset: "Windows-1252" } },
+            ],
+          },
+        },
+      ]
+      transport.downloadResult = {
+        meta: {
+          expectedSize: 18,
+          contentType: "text/plain",
+          charset: "utf-8",
+          encoding: "quoted-printable",
+        },
+        content: Readable.from([Buffer.from("à l’étage\nEnvoyé", "utf8")]),
+      }
+    }
+
+    const result = await fixture.client.withMailbox("INBOX", async (mailbox) => {
+      const [message] = await mailbox.listMessages({ limit: 1 })
+      const downloaded = await mailbox.downloadPart({ uid: 11, part: "1", maxBytes: 100 })
+      return {
+        bodyStructure: message?.bodyStructure,
+        meta: downloaded.meta,
+        content: await readAll(downloaded.content),
+      }
+    })
+
+    expect(result.bodyStructure?.childNodes).toMatchObject([
+      { part: "1", declaredCharset: "Windows-1252" },
+      { part: "2", declaredCharset: "Windows-1252" },
+    ])
+    expect(result.meta).toMatchObject({
+      contentCharset: "utf-8",
+      transferEncoding: "quoted-printable",
+    })
+    expect(result.content.toString("utf8")).toBe("à l’étage\nEnvoyé")
   })
 
   test("does not use the message-level expected size as the MIME part limit", async () => {


### PR DESCRIPTION
## Why

IMAP body structure reports the MIME source charset, while ImapFlow returns decoded and sometimes transcoded text. A `Windows-1252` part can therefore be returned as UTF-8; decoding it with `bodyStructure.parameters.charset` produces mojibake.

## Change

Expose `declaredCharset`, `contentCharset`, and `transferEncoding` with explicit source/output semantics.

## Checks

- `bun test connectors/imap/tests/imap.test.ts`
- `bun --filter @sixb/connector-imap typecheck`
- `bun run check -- connectors/imap/src/client.ts connectors/imap/src/types.ts connectors/imap/tests/imap.test.ts`
