### PR TITLE
core: add logger context to webhook callbacks

### DIFF
--- a/connectors/companycam/src/events.ts
+++ b/connectors/companycam/src/events.ts
@@ -30,8 +30,8 @@ export function companyCamEventsWebhook(
       }
       verifySignature(options.secret, rawBody, request.headers.get("x-companycam-signature"))
     })
-    .handle<CompanyCamClient>(async ({ body, sixb, client }) => {
-      await options.onEvent({ event: toEvent(body), sixb, client })
+    .handle<CompanyCamClient>(async ({ body, sixb, logger, client }) => {
+      await options.onEvent({ event: toEvent(body), sixb, logger, client })
       return { status: 200 }
     })
 }

--- a/connectors/companycam/src/types/event.ts
+++ b/connectors/companycam/src/types/event.ts
@@ -1,4 +1,4 @@
-import type { OntologySource, Sixb } from "@sixb/core"
+import type { Logger, OntologySource, Sixb } from "@sixb/core"
 import type { CompanyCamClient } from "../client"
 import type { CompanyCamEventType } from "./webhook"
 
@@ -26,6 +26,7 @@ export interface CompanyCamWebhookEvent {
 export interface CompanyCamEventContext {
   readonly event: CompanyCamWebhookEvent
   readonly sixb: Sixb<readonly OntologySource[]>
+  readonly logger: Logger
   client(): Promise<CompanyCamClient>
 }
 

--- a/connectors/companycam/tests/events.test.ts
+++ b/connectors/companycam/tests/events.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createHmac } from "node:crypto"
+import { noopLogger } from "@sixb/core"
 import type { CompanyCamEventContext } from "../src"
 import { companyCamEventsWebhook, companycam } from "../src"
 
@@ -44,6 +45,7 @@ describe("companycam events webhook", () => {
       request: new Request("https://x/hook", { method: "POST" }),
       body: JSON.parse(body),
       sixb,
+      logger: noopLogger,
       client,
     } as unknown as HandleCtx)
 
@@ -54,6 +56,7 @@ describe("companycam events webhook", () => {
     expect(received[0]?.event.webhookId).toBe(7)
     expect(received[0]?.event.payload).toEqual({ id: "p1" })
     expect(received[0]?.sixb).toBe(sixb as never)
+    expect(received[0]?.logger).toBe(noopLogger)
     expect(received[0]?.client).toBe(client)
   })
 

--- a/connectors/github/src/types/webhook.ts
+++ b/connectors/github/src/types/webhook.ts
@@ -2,7 +2,7 @@ import type {
   WebhookEventMap as GitHubWebhookEventMap,
   WebhookEventName as GitHubWebhookEventName,
 } from "@octokit/webhooks-types"
-import type { OntologySource, Sixb } from "@sixb/core"
+import type { Logger, OntologySource, Sixb } from "@sixb/core"
 import type { GitHubClient } from "./client"
 
 export type { GitHubWebhookEventMap, GitHubWebhookEventName }
@@ -40,6 +40,7 @@ export type GitHubWebhookEvent<Name extends GitHubWebhookEventName = GitHubWebho
 export interface GitHubEventContext<Name extends GitHubWebhookEventName = GitHubWebhookEventName> {
   readonly event: GitHubWebhookEvent<Name>
   readonly sixb: Sixb<readonly OntologySource[]>
+  readonly logger: Logger
   client(): Promise<GitHubClient>
 }
 

--- a/connectors/github/src/webhook.ts
+++ b/connectors/github/src/webhook.ts
@@ -34,12 +34,12 @@ export function githubEventsWebhook(
       verifySignature(options.secret, rawBody, request.headers.get("x-hub-signature-256"))
     })
     .idempotencyKey(({ request }) => request.headers.get("x-github-delivery"))
-    .handle<GitHubClient>(async ({ request, body, sixb, client }) => {
+    .handle<GitHubClient>(async ({ request, body, sixb, logger, client }) => {
       const name = request.headers.get("x-github-event")
       if (!name) {
         return
       }
-      await options.onEvent({ event: toEvent(name, request, body), sixb, client })
+      await options.onEvent({ event: toEvent(name, request, body), sixb, logger, client })
     })
 }
 

--- a/connectors/github/tests/github.test.ts
+++ b/connectors/github/tests/github.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { createHmac } from "node:crypto"
+import { noopLogger } from "@sixb/core"
 import type { GitHubEventContext, GitHubEventHandler, GitHubIssueEvent } from "../src"
 import { github, githubEventsWebhook } from "../src"
 
@@ -671,6 +672,7 @@ describe("github connector", () => {
         }),
         body: JSON.parse(body),
         sixb,
+        logger: noopLogger,
         client,
       } as unknown as HandleCtx)
 
@@ -680,6 +682,7 @@ describe("github connector", () => {
       expect(received[0]?.event.deliveryId).toBe("d-1")
       // The live runtime and client resolver are passed straight through.
       expect(received[0]?.sixb).toBe(sixb as never)
+      expect(received[0]?.logger).toBe(noopLogger)
       expect(received[0]?.client).toBe(client)
     })
 

--- a/connectors/pandadoc/src/types/common.ts
+++ b/connectors/pandadoc/src/types/common.ts
@@ -1,5 +1,5 @@
 import type { RestRetryPolicy } from "@sixb/connector-rest"
-import type { OntologySource, Sixb } from "@sixb/core"
+import type { Logger, OntologySource, Sixb } from "@sixb/core"
 import type { PandaDocClient } from "./client"
 
 export type PandaDocKeyResolver = string | (() => string | Promise<string>)
@@ -101,6 +101,7 @@ export interface PandaDocWebhookEventContext {
   readonly events: readonly PandaDocWebhookEvent[]
   readonly request: Request
   readonly sixb: Sixb<readonly OntologySource[]>
+  readonly logger: Logger
   client(): Promise<PandaDocClient>
 }
 

--- a/connectors/pandadoc/src/webhooks.ts
+++ b/connectors/pandadoc/src/webhooks.ts
@@ -32,9 +32,9 @@ export function pandaDocEventsWebhook(
         new URL(request.url).searchParams.get("signature")
       )
     })
-    .handle<PandaDocClient>(async ({ body, request, sixb, client }) => {
+    .handle<PandaDocClient>(async ({ body, request, sixb, logger, client }) => {
       for (const event of body) {
-        await options.onEvent({ event, events: body, request, sixb, client })
+        await options.onEvent({ event, events: body, request, sixb, logger, client })
       }
 
       return { status: 200 }

--- a/connectors/pandadoc/tests/webhooks.test.ts
+++ b/connectors/pandadoc/tests/webhooks.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createHmac } from "node:crypto"
+import { noopLogger } from "@sixb/core"
 import type { PandaDocWebhookEventContext } from "../src"
 import { pandaDocEventsWebhook, pandadoc } from "../src"
 import { CONTEXT, collect, json, mockFetch } from "./helpers"
@@ -100,6 +101,7 @@ describe("pandadoc inbound events webhook", () => {
       request,
       body: webhook.body.parse(JSON.parse(body)),
       sixb,
+      logger: noopLogger,
       client,
     } as unknown as HandleCtx)
 
@@ -108,6 +110,7 @@ describe("pandadoc inbound events webhook", () => {
     expect(received[0]?.event.event).toBe("document_state_changed")
     expect(received[0]?.events).toHaveLength(2)
     expect(received[0]?.sixb).toBe(sixb as never)
+    expect(received[0]?.logger).toBe(noopLogger)
     expect(received[0]?.client).toBe(client)
   })
 

--- a/connectors/pipedrive/src/types/common.ts
+++ b/connectors/pipedrive/src/types/common.ts
@@ -1,5 +1,5 @@
 import type { RestRetryPolicy } from "@sixb/connector-rest"
-import type { OntologySource, Sixb } from "@sixb/core"
+import type { Logger, OntologySource, Sixb } from "@sixb/core"
 import type { PipedriveClient } from "./client"
 
 export type PipedriveTokenResolver = string | (() => string | Promise<string>)
@@ -114,6 +114,7 @@ export interface PipedriveWebhookEvent {
 export interface PipedriveEventContext {
   readonly event: PipedriveWebhookEvent
   readonly sixb: Sixb<readonly OntologySource[]>
+  readonly logger: Logger
   client(): Promise<PipedriveClient>
 }
 

--- a/connectors/pipedrive/src/webhooks.ts
+++ b/connectors/pipedrive/src/webhooks.ts
@@ -26,8 +26,8 @@ export function pipedriveEventsWebhook(
       verifyBasicAuth(options.auth, request.headers.get("authorization"))
     })
     .idempotencyKey(({ body }) => body.meta.id ?? body.meta.correlation_id)
-    .handle<PipedriveClient>(async ({ body, sixb, client }) => {
-      await options.onEvent({ event: body, sixb, client })
+    .handle<PipedriveClient>(async ({ body, sixb, logger, client }) => {
+      await options.onEvent({ event: body, sixb, logger, client })
       return { status: 200 }
     })
 }

--- a/connectors/pipedrive/tests/webhooks.test.ts
+++ b/connectors/pipedrive/tests/webhooks.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { noopLogger } from "@sixb/core"
 import type { PipedriveEventContext } from "../src"
 import { pipedrive, pipedriveEventsWebhook } from "../src"
 
@@ -49,6 +50,7 @@ describe("pipedrive events webhook", () => {
       request: new Request("https://x/hook", { method: "POST" }),
       body: webhook.body.parse(body),
       sixb,
+      logger: noopLogger,
       client,
     } as unknown as HandleCtx)
 
@@ -58,6 +60,7 @@ describe("pipedrive events webhook", () => {
     expect(received[0]?.event.meta.entity).toBe("deal")
     expect(received[0]?.event.data).toEqual({ id: 42, title: "Roof job" })
     expect(received[0]?.sixb).toBe(sixb as never)
+    expect(received[0]?.logger).toBe(noopLogger)
     expect(received[0]?.client).toBe(client)
   })
 

--- a/connectors/teamleader/tests/teamleader.test.ts
+++ b/connectors/teamleader/tests/teamleader.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { noopLogger } from "@sixb/core"
 import {
   customFieldsByDefinitionId,
   customFieldsByLabel,
@@ -583,6 +584,7 @@ describe("defineTeamleaderWebhook", () => {
       body,
       rawBody: new Uint8Array(),
       request: new Request("https://example.com"),
+      logger: noopLogger,
       sixb: {} as never,
       connector: {} as never,
       webhook: {

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -17938,7 +17938,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["sync", "pipeline", "workflow", "action"]
+              "enum": ["sync", "pipeline", "workflow", "action", "webhook"]
             }
           },
           {
@@ -18034,7 +18034,7 @@
                                 "properties": {
                                   "kind": {
                                     "type": "string",
-                                    "enum": ["sync", "pipeline", "workflow", "action"]
+                                    "enum": ["sync", "pipeline", "workflow", "action", "webhook"]
                                   },
                                   "id": {
                                     "type": "string"

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -6378,7 +6378,7 @@ export type ListLogsData = {
   body?: never
   path?: never
   query?: {
-    kind?: "sync" | "pipeline" | "workflow" | "action"
+    kind?: "sync" | "pipeline" | "workflow" | "action" | "webhook"
     runId?: string
     level?: "debug" | "info" | "warn" | "error"
     direction?: "forward" | "backward"
@@ -6421,7 +6421,7 @@ export type ListLogsResponses = {
       at: string
       context: {
         run: {
-          kind: "sync" | "pipeline" | "workflow" | "action"
+          kind: "sync" | "pipeline" | "workflow" | "action" | "webhook"
           id: string
         }
         stepId?: string

--- a/packages/client/tests/events-transport.test.ts
+++ b/packages/client/tests/events-transport.test.ts
@@ -46,16 +46,29 @@ class FakeWebSocket {
 
 const tick = (ms = 5) => new Promise((resolve) => setTimeout(resolve, ms))
 
+async function waitFor(condition: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for websocket state.")
+    }
+    await tick(1)
+  }
+}
+
 describe("createEventSocket", () => {
   let originalWebSocket: typeof WebSocket
+  let activeSocket: ReturnType<typeof createEventSocket> | null
 
   beforeEach(() => {
     originalWebSocket = globalThis.WebSocket
+    activeSocket = null
     FakeWebSocket.instances = []
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
   })
 
   afterEach(() => {
+    activeSocket?.close()
     globalThis.WebSocket = originalWebSocket
   })
 
@@ -67,6 +80,7 @@ describe("createEventSocket", () => {
       reconnectDelayMs: 1,
       onEvent: (event) => received.push(event),
     })
+    activeSocket = socket
 
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")
@@ -100,6 +114,7 @@ describe("createEventSocket", () => {
       reconnect: false,
       onEvent: () => {},
     })
+    activeSocket = socket
 
     const ws = FakeWebSocket.instances[0]
     if (!ws) throw new Error("expected a websocket")
@@ -125,6 +140,7 @@ describe("createEventSocket", () => {
       onEvent: () => {},
       onStateChange: (state) => states.push(state),
     })
+    activeSocket = socket
 
     const ws = FakeWebSocket.instances[0]
     if (!ws) throw new Error("expected a websocket")
@@ -151,15 +167,15 @@ describe("createEventSocket", () => {
       onEvent: () => {},
       onError: (message) => errors.push(message),
     })
+    activeSocket = socket
 
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")
     ws1.onopen?.()
-    await tick(15)
+    await waitFor(() => ws1.closed)
+    await waitFor(() => FakeWebSocket.instances.length === 2)
 
-    expect(ws1.closed).toBe(true)
     expect(errors).toEqual(["Event websocket handshake timed out."])
-    expect(FakeWebSocket.instances).toHaveLength(2)
 
     socket.close()
   })
@@ -168,14 +184,16 @@ describe("createEventSocket", () => {
     const socket = createEventSocket({
       topic: "telemetry",
       reconnect: false,
+      reconnectDelayMs: 1,
       onEvent: () => {},
     })
+    activeSocket = socket
 
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")
     ws1.onopen?.()
     ws1.onclose?.()
-    await tick()
+    await tick(10)
 
     expect(FakeWebSocket.instances).toHaveLength(1)
     socket.close()
@@ -188,6 +206,7 @@ describe("createEventSocket", () => {
       reconnectDelayMs: 1,
       onEvent: () => {},
     })
+    activeSocket = socket
 
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -258,7 +258,8 @@ const edgeGateway = defineConnector(
           },
         })
         .idempotencyKey(({ request }) => request.headers.get("x-delivery-id"))
-        .handle(async ({ body, sixb }) => {
+        .handle(async ({ body, sixb, logger }) => {
+          logger.info("Received device telemetry", { deviceId: body.deviceId })
           await sixb.upsertObject("Device", {
             id: body.deviceId,
             temperature: body.temperature,
@@ -269,7 +270,8 @@ const edgeGateway = defineConnector(
 )
 ```
 
-Use `.json(schema)` for JSON bodies so payloads are validated at runtime. Omit
+Use `.json(schema)` for JSON bodies so payloads are validated at runtime. The `.verify(...)`,
+`.idempotencyKey(...)`, and `.handle(...)` callbacks each receive a run-scoped `logger`. Omit
 `.idempotencyKey(...)` for deterministic upserts where duplicate provider deliveries are harmless.
 
 ## Syncs

--- a/packages/core/src/logging/types.ts
+++ b/packages/core/src/logging/types.ts
@@ -22,7 +22,7 @@ export interface Logger {
 }
 
 /** The primitive whose execution produced a log line. */
-export const LOG_RUN_KINDS = ["sync", "pipeline", "workflow", "action"] as const
+export const LOG_RUN_KINDS = ["sync", "pipeline", "workflow", "action", "webhook"] as const
 export type LogRunKind = (typeof LOG_RUN_KINDS)[number]
 
 /** Points a log line back at the run that produced it. */

--- a/packages/core/src/webhooks/types.ts
+++ b/packages/core/src/webhooks/types.ts
@@ -1,4 +1,5 @@
 import type { ConnectorDefinition } from "../connectors/types"
+import type { Logger } from "../logging"
 import type { OntologySource, Sixb } from "../runtime"
 
 export type WebhookBodyFormat = "json" | "text" | "raw"
@@ -48,6 +49,7 @@ export interface WebhookMetadata {
 
 export interface WebhookVerifyContext {
   readonly sixb: Sixb<readonly OntologySource[]>
+  readonly logger: Logger
   readonly connector: ConnectorDefinition
   readonly webhook: WebhookMetadata
   readonly request: Request

--- a/packages/core/tests/logging.test.ts
+++ b/packages/core/tests/logging.test.ts
@@ -442,7 +442,7 @@ describe("log metadata", () => {
   })
 
   test("exposes the canonical run kinds", () => {
-    expect(LOG_RUN_KINDS).toEqual(["sync", "pipeline", "workflow", "action"])
+    expect(LOG_RUN_KINDS).toEqual(["sync", "pipeline", "workflow", "action", "webhook"])
   })
 
   test("validates complete log records and stored lines", () => {

--- a/packages/core/tests/webhooks.types.ts
+++ b/packages/core/tests/webhooks.types.ts
@@ -15,7 +15,15 @@ webhookConnector({
     defineWebhook("typed")
       .post()
       .json(schema)
-      .handle(async ({ body, client }) => {
+      .verify(({ logger }) => {
+        logger.debug("verify")
+      })
+      .idempotencyKey(({ body, logger }) => {
+        logger.debug("idempotency")
+        return body.name
+      })
+      .handle(async ({ body, client, logger }) => {
+        logger.info("handle")
         const _name: string = body.name
         const connector = await client()
         const _kind: "webhook" = connector.kind

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -4,6 +4,7 @@ import type {
   ConnectorClient,
   ConnectorDefinition,
   FinishWebhookRunStatus,
+  Logger,
   OntologySource,
   RegisteredWebhook,
   Sixb,
@@ -33,7 +34,7 @@ interface DispatchWebhookOptions {
 
 interface WebhookRunFinishInput {
   readonly sixb: Sixb<readonly OntologySource[]>
-  readonly runId: string | null
+  readonly runId: string
   readonly status: FinishWebhookRunStatus
   readonly requestBodyBytes?: number
   readonly responseStatus?: number
@@ -77,9 +78,25 @@ export function registerWebhookRoutes(app: Elysia, sixb: Sixb<readonly OntologyS
 }
 
 async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown> {
+  const runId = `webhookrun_${randomUUID()}`
+  const logSession = options.sixb.logs.startExecution({ kind: "webhook", id: runId })
+
+  await startWebhookRun(options.sixb, options.registered, options.request, runId)
+
+  try {
+    return await dispatchWebhookRun(options, runId, (phase) => logSession.withContext({ phase }))
+  } finally {
+    await logSession.flush()
+  }
+}
+
+async function dispatchWebhookRun(
+  options: DispatchWebhookOptions,
+  runId: string,
+  loggerForPhase: (phase: string) => Logger
+): Promise<unknown> {
   const { sixb, registered, request, set } = options
   const { connector, webhook, route } = registered
-  const runId = await startWebhookRun(sixb, registered, request)
   const requestMethod = request.method.toUpperCase()
 
   if (requestMethod !== webhook.method) {
@@ -113,12 +130,16 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
   }
 
   const metadata = toWebhookMetadata(webhook, route)
-  const verifyContext = {
+  const baseContext = {
     sixb,
     connector,
     webhook: metadata,
     request,
     rawBody,
+  }
+  const verifyContext = {
+    ...baseContext,
+    logger: loggerForPhase("verify"),
   }
 
   try {
@@ -154,9 +175,14 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
   }
 
   const handlerContext = {
-    ...verifyContext,
+    ...baseContext,
+    logger: loggerForPhase("handle"),
     body,
     client: createClientResolver(sixb, connector),
+  }
+  const idempotencyContext = {
+    ...handlerContext,
+    logger: loggerForPhase("idempotency"),
   }
 
   // Claim before running the handler so duplicate and concurrent provider
@@ -165,7 +191,7 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
   let idempotencyKey: string | undefined
   let deliveryClaimResult: WebhookDeliveryClaimResult | undefined
   try {
-    const claim = await claimDeliveryKey(sixb, webhook, handlerContext)
+    const claim = await claimDeliveryKey(sixb, webhook, idempotencyContext)
     idempotencyKey = claim.idempotencyKey
     deliveryClaimResult = claim.claimResult
     if (claim.status === "skip") {
@@ -265,14 +291,13 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
 async function startWebhookRun(
   sixb: Sixb<readonly OntologySource[]>,
   registered: RegisteredWebhook,
-  request: Request
-): Promise<string | null> {
+  request: Request,
+  runId: string
+): Promise<void> {
   const storage = sixb.storage.webhookRuns
   if (!storage) {
-    return null
+    return
   }
-
-  const runId = `webhookrun_${randomUUID()}`
 
   try {
     await storage.start({
@@ -283,15 +308,15 @@ async function startWebhookRun(
       method: request.method.toUpperCase(),
       route: registered.route,
     })
-    return runId
   } catch {
-    return null
+    // Webhook run history is observability-only. Logging and dispatch continue
+    // even when history storage is unavailable or temporarily failing.
   }
 }
 
 async function finishWebhookRun(input: WebhookRunFinishInput): Promise<void> {
   const storage = input.sixb.storage.webhookRuns
-  if (!storage || !input.runId) {
+  if (!storage) {
     return
   }
 

--- a/packages/server/tests/webhooks.test.ts
+++ b/packages/server/tests/webhooks.test.ts
@@ -7,6 +7,8 @@ import {
   InMemoryLakeStorage,
   InMemoryQueues,
   InMemoryStorage,
+  type LogEntry,
+  type LoggerProvider,
   type OntologySource,
   Sixb,
   type SixbOptions,
@@ -29,6 +31,12 @@ describe("webhook routes", () => {
     let rawBodyText = ""
     let requestHeader = ""
     let connected = false
+    const logEntries: LogEntry[] = []
+    const logger: LoggerProvider = {
+      write(entry) {
+        logEntries.push(entry)
+      },
+    }
 
     const connector = defineConnector("github", {
       type: "test",
@@ -44,11 +52,17 @@ describe("webhook routes", () => {
               return { name: value.name }
             },
           })
-          .verify(({ request, rawBody }) => {
+          .verify(({ request, rawBody, logger }) => {
+            logger.info("verified")
             requestHeader = request.headers.get("x-provider") ?? ""
             rawBodyText = new TextDecoder().decode(rawBody)
           })
-          .handle(async ({ body, client, sixb, request, webhook }) => {
+          .idempotencyKey(({ logger }) => {
+            logger.info("resolved idempotency")
+            return null
+          })
+          .handle(async ({ body, client, sixb, request, webhook, logger }) => {
+            logger.info("handled")
             const resolved = (await client()) as { source: string }
             connected = resolved.source === "github"
 
@@ -69,7 +83,7 @@ describe("webhook routes", () => {
     })
 
     const storage = new InMemoryStorage()
-    const app = createWebhookApp([connector], storage)
+    const app = createWebhookApp([connector], storage, logger)
     const payload = JSON.stringify({ name: "issue-opened" })
     const response = await app.fetch(
       new Request("http://localhost/api/webhooks/github/events", {
@@ -107,6 +121,13 @@ describe("webhook routes", () => {
       responseStatus: 201,
     })
     expect(run?.requestBodyBytes).toBe(new TextEncoder().encode(payload).byteLength)
+    expect(logEntries.map((entry) => [entry.message, entry.context.phase])).toEqual([
+      ["verified", "verify"],
+      ["resolved idempotency", "idempotency"],
+      ["handled", "handle"],
+    ])
+    expect(new Set(logEntries.map((entry) => entry.context.run.id))).toEqual(new Set([run?.id]))
+    expect(logEntries.every((entry) => entry.context.run.kind === "webhook")).toBe(true)
   })
 
   test("returns 400 for body validation failures before handlers run", async () => {
@@ -254,6 +275,45 @@ describe("webhook routes", () => {
     })
   })
 
+  test("provides webhook logging when run history storage is not configured", async () => {
+    const logEntries: LogEntry[] = []
+    const connector = defineConnector("github", {
+      type: "test",
+      webhooks: [
+        defineWebhook("events")
+          .post()
+          .json()
+          .handle(({ logger }) => {
+            logger.info("handled without history")
+          }),
+      ],
+      connect() {
+        return {}
+      },
+    })
+    const storage = new InMemoryStorage()
+    Object.defineProperty(storage, "webhookRuns", { value: undefined })
+    const app = createWebhookApp([connector], storage, {
+      write(entry) {
+        logEntries.push(entry)
+      },
+    })
+
+    const response = await app.fetch(
+      new Request("http://localhost/api/webhooks/github/events", {
+        method: "POST",
+        body: JSON.stringify({ ok: true }),
+      })
+    )
+
+    expect(response.status).toBe(202)
+    expect(logEntries).toHaveLength(1)
+    expect(logEntries[0]).toMatchObject({
+      message: "handled without history",
+      context: { run: { kind: "webhook" }, phase: "handle" },
+    })
+  })
+
   test("maps unknown, unsupported, verification, and handler errors", async () => {
     const connector = defineConnector("github", {
       type: "test",
@@ -340,7 +400,8 @@ describe("webhook routes", () => {
 
 function createWebhookApp(
   connectors: SixbOptions<readonly OntologySource[]>["connectors"],
-  storage = new InMemoryStorage()
+  storage = new InMemoryStorage(),
+  logger?: LoggerProvider
 ) {
   const sixb = createSixbInstance<readonly OntologySource[]>({
     id: "test-project",
@@ -351,6 +412,7 @@ function createWebhookApp(
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
     connectors,
+    logger,
   })
   const server = new SixbServer({ sixb, quiet: true, browser: createTestBrowserPolicy() })
   return createSixbApi(server)


### PR DESCRIPTION
## Summary

Webhook callbacks currently cannot emit logs through the execution-scoped logging API. This change adds `ctx.logger` to verification, idempotency, handler, and built-in connector event callbacks, with all entries correlated to one webhook run ID.

| Before | After |
| --- | --- |
| No logger in webhook callback contexts | Required `Logger` in all webhook callback contexts |
| Webhooks are not a log run kind | Logs use `{ kind: "webhook", id: runId }` |
| Connector `onEvent` adapters drop logging context | Built-in adapters forward the handler logger |
| Logging depends on no webhook lifecycle | Sessions flush at the dispatch `finally` boundary |

## Behavior

Each callback receives the same run-scoped session with metadata identifying its dispatch phase. The run ID is also used for webhook history when `storage.webhookRuns` is available.

```ts
defineWebhook("events")
  .post()
  .json()
  .verify(({ logger }) => logger.debug("verify"))
  .idempotencyKey(({ logger }) => {
    logger.debug("idempotency")
    return null
  })
  .handle(({ logger }) => logger.info("handle"))
```

- Phases are `verify`, `idempotency`, and `handle`.
- Logging remains available when webhook history storage is missing or its start operation fails.
- Existing request parsing, delivery claiming, response mapping, and callback order remain in place.

## Implementation

`packages/server/src/routes/webhooks.ts` owns the logging lifecycle, keeping session creation and flushing outside individual callbacks.

```text
dispatchWebhook
  -> generate webhookrun_<uuid>
  -> startExecution({ kind: "webhook", id })
  -> optionally start history with the same id
  -> dispatchWebhookRun
       -> verify logger
       -> idempotency logger
       -> handle logger
  -> flush in finally
```

- `packages/core/src/webhooks/types.ts` adds `logger: Logger` to `WebhookVerifyContext`; derived idempotency and handler contexts inherit it.
- `packages/core/src/logging/types.ts` adds `"webhook"` to `LOG_RUN_KINDS`. OpenAPI and generated client unions are updated accordingly.
- CompanyCam, GitHub, PandaDoc, and Pipedrive add `Logger` to their event context types and forward it through `onEvent`. Teamleader uses the generic webhook context and requires only fixture updates.

## Scope

The public context types now require a logger, which is a compile-time compatibility change for code that manually constructs webhook contexts. Such callers can provide `noopLogger` when logging is intentionally disabled.

- No webhook-specific logging API or storage backend is introduced.
- Webhook history remains optional and observability-only.
- The existing webhook run ID format is reused for log/history correlation.

## Notes for reviewers

Review the server lifecycle first, then the public contracts and adapter forwarding.

- In `packages/server/src/routes/webhooks.ts`, focus on ID correlation, phase assignment, early-return behavior, and the `finally` flush boundary.
- In core and generated client types, verify that `"webhook"` is accepted everywhere log run kinds are represented.
- Connector tests assert logger identity through each adapted `onEvent` callback; server tests cover phase metadata, shared run IDs, and operation without webhook history storage.
