### PR TITLE
cli: add agent workers to production commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -211,6 +211,7 @@ sixb orchestrator
 sixb worker sync
 sixb worker pipeline
 sixb worker projection
+SIXB_API_PUBLIC_ORIGIN=https://api.example.com sixb worker agent
 ```
 
 **Constrained** — co-host the queue workers in one process to shrink the provider footprint
@@ -224,7 +225,8 @@ sixb worker-group sync pipeline projection
 ```
 
 `sixb worker-group` with no positional types starts every registered queue worker type in one
-process.
+process, including the agent worker when agents and agent storage are configured. Agent workers
+require the API origin through `--api-public-origin` or `SIXB_API_PUBLIC_ORIGIN`.
 
 `sixb dev` uses separated local ports by default:
 
@@ -245,5 +247,6 @@ They fail with a clear error instead of compiling assets at startup.
 `sixb worker <type>` is intended for queue backends that can be shared across processes. Each
 worker process owns exactly one queue type. `sixb worker-group [types...]` co-hosts several queue
 workers in a single process for constrained deployments; with no positional types it starts every
-registered worker type. Both reject the built-in `InMemoryQueues` — use `sixb dev`, which co-hosts
-workers in-process.
+registered worker type. Agent workers require `--api-public-origin` or
+`SIXB_API_PUBLIC_ORIGIN`. Both commands reject the built-in `InMemoryQueues` — use `sixb dev`,
+which co-hosts workers in-process.

--- a/packages/cli/src/commands/worker-group.tsx
+++ b/packages/cli/src/commands/worker-group.tsx
@@ -13,6 +13,7 @@ import { ErrorView, LoadingView, renderPersistent, renderStatic, WorkerGroupView
 export interface WorkerGroupOptions {
   entry?: string
   workerTypes?: readonly string[]
+  apiPublicOrigin?: string
 }
 
 export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
@@ -53,7 +54,11 @@ export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
       <LoadingView title="Starting sixb worker group" subtitle={entry} status="Starting workers" />
     )
 
-    workers = workerTypes.map((workerType) => createWorkerForType(sixb as LoadedSixb, workerType))
+    workers = workerTypes.map((workerType) =>
+      createWorkerForType(sixb as LoadedSixb, workerType, {
+        agentApiBaseUrl: options.apiPublicOrigin,
+      })
+    )
     await Promise.all(workers.map((worker) => worker.start()))
 
     const warnings =

--- a/packages/cli/src/commands/worker.tsx
+++ b/packages/cli/src/commands/worker.tsx
@@ -12,6 +12,7 @@ import { ErrorView, LoadingView, renderPersistent, renderStatic, WorkerView } fr
 export interface WorkerOptions {
   entry?: string
   workerType?: string
+  apiPublicOrigin?: string
 }
 
 export async function runWorker(options: WorkerOptions = {}) {
@@ -40,7 +41,9 @@ export async function runWorker(options: WorkerOptions = {}) {
       <LoadingView title="Starting sixb worker" subtitle={entry} status="Starting worker" />
     )
 
-    worker = createWorkerForType(sixb, workerType)
+    worker = createWorkerForType(sixb, workerType, {
+      agentApiBaseUrl: options.apiPublicOrigin,
+    })
     await worker.start()
 
     const workerId = `${workerType}-worker-${sixb.id}`

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -151,6 +151,7 @@ async function main(): Promise<void> {
       await runWorker({
         entry: getFlag("entry"),
         workerType: getCommandPositionals()[0],
+        apiPublicOrigin: getFlag("api-public-origin"),
       })
       break
     }
@@ -160,6 +161,7 @@ async function main(): Promise<void> {
       await runWorkerGroup({
         entry: getFlag("entry"),
         workerTypes: getCommandPositionals(),
+        apiPublicOrigin: getFlag("api-public-origin"),
       })
       break
     }

--- a/packages/cli/src/lib/worker-registry.ts
+++ b/packages/cli/src/lib/worker-registry.ts
@@ -1,4 +1,5 @@
 import { ActionWorker } from "@sixb/action-worker"
+import { AgentWorker } from "@sixb/agent-worker"
 import { InMemoryQueues, type Worker } from "@sixb/core"
 import { PipelineWorker } from "@sixb/pipeline-worker"
 import { ProjectionWorker } from "@sixb/projection-worker"
@@ -6,8 +7,12 @@ import { SyncWorker } from "@sixb/sync-worker"
 import { WorkflowWorker } from "@sixb/workflow-worker"
 import type { LoadedSixb } from "./loadSixb"
 
+export interface WorkerCreationOptions {
+  readonly agentApiBaseUrl?: string
+}
+
 interface WorkerFactory {
-  readonly create: (sixb: LoadedSixb) => Worker
+  readonly create: (sixb: LoadedSixb, options: WorkerCreationOptions) => Worker
 }
 
 const workerFactories: Record<string, WorkerFactory> = {
@@ -16,6 +21,12 @@ const workerFactories: Record<string, WorkerFactory> = {
   },
   action: {
     create: (sixb) => new ActionWorker(sixb),
+  },
+  agent: {
+    create: (sixb, options) =>
+      new AgentWorker(sixb, {
+        apiBaseUrl: resolveAgentApiBaseUrl(options.agentApiBaseUrl),
+      }),
   },
   pipeline: {
     create: (sixb) => new PipelineWorker(sixb),
@@ -28,13 +39,17 @@ const workerFactories: Record<string, WorkerFactory> = {
   },
 }
 
-export function createWorkerForType(sixb: LoadedSixb, workerType: string): Worker {
+export function createWorkerForType(
+  sixb: LoadedSixb,
+  workerType: string,
+  options: WorkerCreationOptions = {}
+): Worker {
   const factory = workerFactories[workerType]
   if (!factory) {
     throw new Error(`[SixbWorker] Unknown worker '${workerType}'. Available: ${knownWorkers()}`)
   }
 
-  return factory.create(sixb)
+  return factory.create(sixb, options)
 }
 
 export function resolveWorkerTypeToStart(requestedWorker?: string): string {
@@ -75,6 +90,10 @@ export function resolveRegisteredWorkerTypes(sixb: LoadedSixb): readonly string[
     workerTypes.push("action")
   }
 
+  if (sixb.agents.list().length > 0 && sixb.storage.agents) {
+    workerTypes.push("agent")
+  }
+
   if (sixb.workflows.list().length > 0) {
     workerTypes.push("workflow")
   }
@@ -84,6 +103,16 @@ export function resolveRegisteredWorkerTypes(sixb: LoadedSixb): readonly string[
 
 function knownWorkers(): string {
   return Object.keys(workerFactories).join(", ")
+}
+
+function resolveAgentApiBaseUrl(value: string | undefined): string {
+  const apiBaseUrl = value?.trim() || process.env.SIXB_API_PUBLIC_ORIGIN?.trim()
+  if (!apiBaseUrl) {
+    throw new Error(
+      "[SixbWorker] Agent workers require --api-public-origin or SIXB_API_PUBLIC_ORIGIN."
+    )
+  }
+  return apiBaseUrl
 }
 
 export function usesInMemoryQueues(sixb: LoadedSixb): boolean {

--- a/packages/cli/src/ui/index.tsx
+++ b/packages/cli/src/ui/index.tsx
@@ -323,7 +323,8 @@ export function HelpView({ errorMessage }: { errorMessage?: string }) {
           { label: "rules", value: "Start production rules runtime" },
           {
             label: "worker <type>",
-            value: "Start production queue worker: sync, action, pipeline, projection, workflow",
+            value:
+              "Start production queue worker: sync, action, agent, pipeline, projection, workflow",
           },
           {
             label: "worker-group [types...]",

--- a/packages/cli/tests/fixtures/worker-group/sixb.config.ts
+++ b/packages/cli/tests/fixtures/worker-group/sixb.config.ts
@@ -1,5 +1,4 @@
 import { appendFileSync } from "node:fs"
-import type { LanguageModelV4 } from "@ai-sdk/provider"
 import {
   col,
   defineAgent,
@@ -24,7 +23,7 @@ import {
 
 const assistant = defineAgent("assistant", {
   name: "Assistant",
-  model: {} as LanguageModelV4,
+  model: {} as Parameters<typeof defineAgent>[1]["model"],
   instructions: "Assist the user.",
 })
 

--- a/packages/cli/tests/fixtures/worker-group/sixb.config.ts
+++ b/packages/cli/tests/fixtures/worker-group/sixb.config.ts
@@ -1,6 +1,8 @@
 import { appendFileSync } from "node:fs"
+import type { LanguageModelV4 } from "@ai-sdk/provider"
 import {
   col,
+  defineAgent,
   defineConnector,
   defineDataset,
   defineObjectType,
@@ -15,9 +17,22 @@ import {
   InMemoryStorage,
   prop,
   type Queues,
+  type SandboxFactory,
   Sixb,
   type StorageMigrator,
 } from "@sixb/core"
+
+const assistant = defineAgent("assistant", {
+  name: "Assistant",
+  model: {} as LanguageModelV4,
+  instructions: "Assist the user.",
+})
+
+const sandboxes: SandboxFactory = {
+  async create() {
+    throw new Error("The worker-group fixture does not execute agent runs.")
+  },
+}
 
 const Order = defineObjectType({
   id: "Order",
@@ -141,4 +156,6 @@ export const sixb = new Sixb({
   syncs: [ordersSync],
   pipelines: [normalizePipeline],
   projections: [orderProjection],
+  agents: [assistant],
+  sandboxes,
 })

--- a/packages/cli/tests/worker-group.e2e.ts
+++ b/packages/cli/tests/worker-group.e2e.ts
@@ -36,7 +36,15 @@ async function startThenStop(args: readonly string[], fixture: string) {
   tempDirs.push(tempDir)
 
   return startRoleUntilReadyThenStop({
-    cmd: ["bun", cliEntry, ...args, "--entry", fixtureEntry(fixture)],
+    cmd: [
+      "bun",
+      cliEntry,
+      ...args,
+      "--entry",
+      fixtureEntry(fixture),
+      "--api-public-origin",
+      "http://localhost:3002",
+    ],
     cwd: repoRoot,
     logPath,
     graceMs: CLAIM_GRACE_MS,
@@ -60,6 +68,7 @@ describe("sixb worker-group (e2e)", () => {
       expect(claimed.has("sync")).toBe(true)
       expect(claimed.has("pipeline")).toBe(true)
       expect(claimed.has("projection")).toBe(true)
+      expect(claimed.has("agent")).toBe(true)
       // Does not migrate storage at startup.
       expect(logEntries.some((entry) => entry.type === "storage:migrate")).toBe(false)
       // Clean shutdown stops queues and lake storage.
@@ -79,6 +88,7 @@ describe("sixb worker-group (e2e)", () => {
       expect(claimed.has("sync")).toBe(true)
       expect(claimed.has("pipeline")).toBe(false)
       expect(claimed.has("projection")).toBe(false)
+      expect(claimed.has("agent")).toBe(false)
       expect(logEntries).toContainEqual({ type: "queues:close" })
       expect(logEntries).toContainEqual({ type: "lake-storage:close" })
     },

--- a/packages/cli/tests/worker.test.ts
+++ b/packages/cli/tests/worker.test.ts
@@ -96,8 +96,8 @@ describe("sixb worker", () => {
 
     expect(result.exitCode).toBe(1)
     expect(result.stdout).toContain("Unknown worker 'missing'")
-    expect(result.stdout).toContain("sync, action, pipeline")
-    expect(result.stdout).toContain("projection, workflow")
+    expect(result.stdout).toContain("sync, action, agent")
+    expect(result.stdout).toContain("pipeline, projection, workflow")
     expect(result.stdout).not.toContain("requires a queue provider")
     expect(result.stderr).toBe("")
   })
@@ -116,7 +116,8 @@ describe("sixb worker", () => {
     const result = runWorkerFixture("valid-project")
 
     expect(result.exitCode).toBe(1)
-    expect(result.stdout).toContain("Usage: sixb worker <sync|action|pipeline|projection|workflow>")
+    expect(result.stdout).toContain("Usage: sixb worker")
+    expect(result.stdout).toContain("<sync|action|agent|pipeline|projection|workflow>")
     expect(result.stderr).toBe("")
   })
 
@@ -148,8 +149,8 @@ describe("sixb worker", () => {
     expect(result.stdout).toContain("worker <type>")
     expect(result.stdout).not.toContain("--type <type>")
     expect(result.stdout).not.toContain("--worker <type>")
-    expect(result.stdout).toContain("sync, action, pipeline")
-    expect(result.stdout).toContain("workflow")
+    expect(result.stdout).toContain("sync, action, agent")
+    expect(result.stdout).toContain("pipeline, projection, workflow")
     expect(result.stderr).toBe("")
   })
 
@@ -160,7 +161,7 @@ describe("sixb worker", () => {
 
   test("rejects unknown workers with the known worker list", () => {
     expect(() => resolveWorkerTypeToStart("missing")).toThrow(
-      "Available: sync, action, pipeline, projection, workflow"
+      "Available: sync, action, agent, pipeline, projection, workflow"
     )
   })
 })

--- a/packages/client/tests/events-transport.test.ts
+++ b/packages/client/tests/events-transport.test.ts
@@ -46,16 +46,29 @@ class FakeWebSocket {
 
 const tick = (ms = 5) => new Promise((resolve) => setTimeout(resolve, ms))
 
+async function waitFor(condition: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!condition()) {
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for websocket state.")
+    }
+    await tick(1)
+  }
+}
+
 describe("createEventSocket", () => {
   let originalWebSocket: typeof WebSocket
+  let activeSocket: ReturnType<typeof createEventSocket> | null
 
   beforeEach(() => {
     originalWebSocket = globalThis.WebSocket
+    activeSocket = null
     FakeWebSocket.instances = []
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
   })
 
   afterEach(() => {
+    activeSocket?.close()
     globalThis.WebSocket = originalWebSocket
   })
 
@@ -67,6 +80,7 @@ describe("createEventSocket", () => {
       reconnectDelayMs: 1,
       onEvent: (event) => received.push(event),
     })
+    activeSocket = socket
 
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")
@@ -100,6 +114,7 @@ describe("createEventSocket", () => {
       reconnect: false,
       onEvent: () => {},
     })
+    activeSocket = socket
 
     const ws = FakeWebSocket.instances[0]
     if (!ws) throw new Error("expected a websocket")
@@ -125,6 +140,7 @@ describe("createEventSocket", () => {
       onEvent: () => {},
       onStateChange: (state) => states.push(state),
     })
+    activeSocket = socket
 
     const ws = FakeWebSocket.instances[0]
     if (!ws) throw new Error("expected a websocket")
@@ -151,15 +167,15 @@ describe("createEventSocket", () => {
       onEvent: () => {},
       onError: (message) => errors.push(message),
     })
+    activeSocket = socket
 
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")
     ws1.onopen?.()
-    await tick(15)
+    await waitFor(() => ws1.closed)
+    await waitFor(() => FakeWebSocket.instances.length === 2)
 
-    expect(ws1.closed).toBe(true)
     expect(errors).toEqual(["Event websocket handshake timed out."])
-    expect(FakeWebSocket.instances).toHaveLength(2)
 
     socket.close()
   })
@@ -168,14 +184,16 @@ describe("createEventSocket", () => {
     const socket = createEventSocket({
       topic: "telemetry",
       reconnect: false,
+      reconnectDelayMs: 1,
       onEvent: () => {},
     })
+    activeSocket = socket
 
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")
     ws1.onopen?.()
     ws1.onclose?.()
-    await tick()
+    await tick(10)
 
     expect(FakeWebSocket.instances).toHaveLength(1)
     socket.close()
@@ -188,6 +206,7 @@ describe("createEventSocket", () => {
       reconnectDelayMs: 1,
       onEvent: () => {},
     })
+    activeSocket = socket
 
     const ws1 = FakeWebSocket.instances[0]
     if (!ws1) throw new Error("expected a websocket")


### PR DESCRIPTION
## Summary

Production CLI commands previously omitted the agent worker: `sixb worker agent` was unknown, and `sixb worker-group` never selected agents when starting all registered workers. This adds agent support to both commands and requires a public API origin when an `AgentWorker` is created.

| Command | Result after this change |
|---|---|
| `sixb worker agent` | Creates and starts an `AgentWorker` |
| `sixb worker-group agent` | Starts an agent worker in the group |
| `sixb worker-group` | Includes `agent` when agents and agent storage are configured |
| Any selected agent without an API origin | Fails with a targeted configuration error |

## Scope

The change extends the existing production worker model rather than introducing a separate agent startup path.

- API origin is resolved from `--api-public-origin`, then `SIXB_API_PUBLIC_ORIGIN`; values are trimmed and the explicit flag takes precedence.
- Non-agent workers do not require this option, including explicitly constrained groups such as `sixb worker-group sync`.
- Queue-provider restrictions, storage migration behavior, shutdown handling, and `sixb dev` are unchanged.
- Help output and `packages/cli/README.md` now list `agent` and document its API-origin requirement.

```sh
sixb worker agent --api-public-origin https://api.example.com
SIXB_API_PUBLIC_ORIGIN=https://api.example.com sixb worker-group
```

## Implementation

Worker discovery and construction remain centralized in `packages/cli/src/lib/worker-registry.ts`.

- `workerFactories.agent` constructs `AgentWorker` with `apiBaseUrl` from `WorkerCreationOptions.agentApiBaseUrl`.
- `resolveRegisteredWorkerTypes()` appends `agent` only when `sixb.agents.list()` is non-empty and `sixb.storage.agents` exists.
- `resolveAgentApiBaseUrl()` emits the actionable error naming both supported configuration inputs.
- `src/index.tsx` reads `api-public-origin`; `runWorker()` and `runWorkerGroup()` pass it through `createWorkerForType()`.

## Notes for reviewers

The main compatibility effect is on no-argument worker groups: an existing deployment with configured agents and agent storage will now select the agent worker and must provide the API origin.

Review in this order:

1. Confirm the eligibility condition in `resolveRegisteredWorkerTypes()` matches when an agent worker can run.
2. Check API-origin precedence and failure behavior in `resolveAgentApiBaseUrl()`.
3. Verify both command paths propagate the option consistently.
4. Inspect the worker-group fixture and E2E assertions: the all-workers case now expects an `agent` queue claim, while an explicit `sync` group expects none.
