### PR TITLE
agent-ui: derive the active turn from one pure selector

### DIFF
--- a/packages/agent-ui/src/AgentChat.tsx
+++ b/packages/agent-ui/src/AgentChat.tsx
@@ -23,8 +23,9 @@ import { ConversationPanel } from "./components/ConversationPanel"
 import { installAgentResizeObserverGuard } from "./resizeObserver"
 import {
   DELAYED_WAITING_COPY_MS,
-  findPreStreamFailedRun,
   isActiveAgentRunStatus,
+  presentActiveTurn,
+  selectActiveRunId,
   shouldShowDelayedWaitingCopy,
 } from "./runPresentation"
 import type { AgentFileRef, AgentRun } from "./types"
@@ -128,11 +129,14 @@ export function AgentChat({
   // show "stopping" from the click until the cancelled run actually ends.
   const [stoppingRunId, setStoppingRunId] = useState<string | null>(null)
 
+  // The pending send's run, when it belongs to the thread being viewed.
+  const pendingRun =
+    pendingSend && threadId !== null && pendingSend.run.threadId === threadId
+      ? pendingSend.run
+      : null
   const activeRunId =
     threadId !== null
-      ? ((pendingSend?.run.threadId === threadId ? pendingSend.run.id : null) ??
-        thread?.activeRunId ??
-        (latestRun && isActiveAgentRunStatus(latestRun.status) ? latestRun.id : null))
+      ? selectActiveRunId({ pendingRun, threadActiveRunId: thread?.activeRunId ?? null, latestRun })
       : null
 
   const {
@@ -143,12 +147,6 @@ export function AgentChat({
     threadId,
     runId: activeRunId,
   })
-  const activeRun =
-    (streamRun?.id === activeRunId ? streamRun : null) ??
-    (pendingSend?.run.id === activeRunId ? pendingSend.run : null) ??
-    runs.find((run) => run.id === activeRunId) ??
-    null
-  const presentationRun = activeRun ?? latestRun
   const finalizedMessageInDurable =
     live.finalizedMessageId !== null &&
     messages.some((message) => message.id === live.finalizedMessageId)
@@ -200,36 +198,18 @@ export function AgentChat({
   const cancelRun = useMutation(cancelAgentRunMutation())
   const retryRun = useMutation(retryAgentRunMutation())
 
-  const activeRunFinished =
-    (streamRun?.id === activeRunId && !isActiveAgentRunStatus(streamRun.status)) ||
-    (live.runId === activeRunId && live.finishStatus !== null)
-  const isRunning = activeRunId !== null && !activeRunFinished
-  const failedRunFromHistory =
-    !isRunning && !messagesQuery.isLoading && presentationRun?.status === "failed"
-      ? findPreStreamFailedRun(
-          presentationRun === latestRun ? runs : [presentationRun, ...runs],
-          messages
-        )
-      : null
-  const failedRunFromEvent =
-    !isRunning &&
-    live.runId === activeRunId &&
-    live.finishStatus === "failed" &&
-    live.parts.length === 0
-      ? activeRun
-      : null
-  const failedRun = failedRunFromHistory ?? failedRunFromEvent
-  const cancelledBeforeResponse =
-    !isRunning &&
-    live.parts.length === 0 &&
-    ((presentationRun?.status === "cancelled" &&
-      !messagesQuery.isLoading &&
-      !messages.some(
-        (message) => message.role === "assistant" && message.runId === presentationRun.id
-      )) ||
-      (live.runId === activeRunId && live.finishStatus === "cancelled"))
+  const presentation = presentActiveTurn({
+    activeRunId,
+    pendingRun,
+    streamRun,
+    live,
+    runs,
+    messages,
+    messagesLoading: messagesQuery.isLoading,
+  })
+  const isRunning = presentation.kind === "responding"
   const waitingLonger = useDelayedWaitingCopy(
-    isRunning && !live.active && presentationRun?.status === "queued" ? presentationRun : null
+    presentation.kind === "responding" ? presentation.queuedRun : null
   )
 
   // Clear the stop request once the run it targeted is no longer the active one (it ended, or we
@@ -349,8 +329,8 @@ export function AgentChat({
     }
   }
 
-  const handleRetry = () => {
-    if (!failedRun || threadId === null) return
+  const handleRetry = (failedRun: AgentRun) => {
+    if (threadId === null) return
     retryRun.mutate(
       { path: { threadId, runId: failedRun.id } },
       {
@@ -402,8 +382,7 @@ export function AgentChat({
       ? pendingUser
       : null
   const anchorCurrentTurn = Boolean(
-    (pendingUser && pendingUser.threadId === threadId) ||
-      (pendingSend && pendingSend.run.threadId === threadId)
+    (pendingUser && pendingUser.threadId === threadId) || pendingRun
   )
 
   return (
@@ -432,9 +411,9 @@ export function AgentChat({
           anchorCurrentTurn={anchorCurrentTurn}
           awaitingResponse={isRunning}
           waitingLonger={waitingLonger}
-          failedBeforeResponse={failedRun !== null}
-          cancelledBeforeResponse={cancelledBeforeResponse}
-          onRetry={failedRun ? handleRetry : undefined}
+          failedBeforeResponse={presentation.kind === "failed"}
+          cancelledBeforeResponse={presentation.kind === "cancelled"}
+          onRetry={presentation.kind === "failed" ? () => handleRetry(presentation.run) : undefined}
           retrying={retryRun.isPending}
           reconnecting={reconnecting}
           sendError={sendError && sendError.threadId === threadId ? sendError.message : null}

--- a/packages/agent-ui/src/runPresentation.ts
+++ b/packages/agent-ui/src/runPresentation.ts
@@ -1,3 +1,4 @@
+import type { LiveRunState } from "./liveRun"
 import type { AgentMessage, AgentRun, AgentRunStatus } from "./types"
 
 export const DELAYED_WAITING_COPY_MS = 20_000
@@ -28,4 +29,102 @@ export function findPreStreamFailedRun(
   return messages.some((message) => message.role === "assistant" && message.runId === latest.id)
     ? null
     : latest
+}
+
+// ── Active turn presentation ─────────────────────────────────────────────────────────────────────
+
+/** Pick the run the conversation should follow: pending send, thread claim, then durable history. */
+export function selectActiveRunId(sources: {
+  readonly pendingRun: AgentRun | null
+  readonly threadActiveRunId: string | null
+  readonly latestRun: AgentRun | null
+}): string | null {
+  return (
+    sources.pendingRun?.id ??
+    sources.threadActiveRunId ??
+    (sources.latestRun && isActiveAgentRunStatus(sources.latestRun.status)
+      ? sources.latestRun.id
+      : null)
+  )
+}
+
+export interface ActiveTurnSources {
+  readonly activeRunId: string | null
+  /** The canonical run from an in-flight send, when it belongs to the current thread. */
+  readonly pendingRun: AgentRun | null
+  /** Latest durable snapshot received on the run's stream subscription. */
+  readonly streamRun: AgentRun | null
+  readonly live: LiveRunState
+  /** Durable run history, newest first. */
+  readonly runs: readonly AgentRun[]
+  readonly messages: readonly AgentMessage[]
+  /** While the transcript is loading, terminal markers are suppressed to avoid a flash. */
+  readonly messagesLoading: boolean
+}
+
+export type ActiveTurnPresentation =
+  /** Waiting or streaming. `queuedRun` is set only while the wait is queue-side, before the run
+   * announces itself on the stream — it feeds the delayed waiting copy. */
+  | { readonly kind: "responding"; readonly queuedRun: AgentRun | null }
+  /** The newest run failed before any durable assistant message; `run` feeds the retry endpoint. */
+  | { readonly kind: "failed"; readonly run: AgentRun }
+  /** The turn was stopped before it produced any content. */
+  | { readonly kind: "cancelled" }
+  | { readonly kind: "idle" }
+
+/**
+ * Reduce every run source (pending send, stream snapshot, live events, durable history and
+ * transcript) into the one state the conversation presents. The variants are mutually exclusive and
+ * ordered: an in-flight turn wins over terminal markers, and a failure wins over a cancellation —
+ * matching the transcript's render precedence.
+ */
+export function presentActiveTurn(sources: ActiveTurnSources): ActiveTurnPresentation {
+  const { activeRunId, pendingRun, streamRun, live, runs, messages, messagesLoading } = sources
+  const latestRun = runs[0] ?? null
+  const activeRun =
+    (streamRun?.id === activeRunId ? streamRun : null) ??
+    (pendingRun?.id === activeRunId ? pendingRun : null) ??
+    runs.find((run) => run.id === activeRunId) ??
+    null
+  const presentationRun = activeRun ?? latestRun
+
+  const finished =
+    (streamRun?.id === activeRunId && !isActiveAgentRunStatus(streamRun.status)) ||
+    (live.runId === activeRunId && live.finishStatus !== null)
+  if (activeRunId !== null && !finished) {
+    return {
+      kind: "responding",
+      queuedRun: !live.active && presentationRun?.status === "queued" ? presentationRun : null,
+    }
+  }
+
+  const failedFromHistory =
+    !messagesLoading && presentationRun?.status === "failed"
+      ? findPreStreamFailedRun(
+          presentationRun === latestRun ? runs : [presentationRun, ...runs],
+          messages
+        )
+      : null
+  const failedFromEvent =
+    live.runId === activeRunId && live.finishStatus === "failed" && live.parts.length === 0
+      ? activeRun
+      : null
+  const failedRun = failedFromHistory ?? failedFromEvent
+  if (failedRun) {
+    return { kind: "failed", run: failedRun }
+  }
+
+  const cancelled =
+    live.parts.length === 0 &&
+    ((presentationRun?.status === "cancelled" &&
+      !messagesLoading &&
+      !messages.some(
+        (message) => message.role === "assistant" && message.runId === presentationRun.id
+      )) ||
+      (live.runId === activeRunId && live.finishStatus === "cancelled"))
+  if (cancelled) {
+    return { kind: "cancelled" }
+  }
+
+  return { kind: "idle" }
 }

--- a/packages/agent-ui/tests/run-presentation.test.ts
+++ b/packages/agent-ui/tests/run-presentation.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test"
+import { createLiveRunState, type LiveRunState } from "../src/liveRun"
 import {
+  type ActiveTurnSources,
   DELAYED_WAITING_COPY_MS,
   findPreStreamFailedRun,
+  presentActiveTurn,
+  selectActiveRunId,
   shouldShowDelayedWaitingCopy,
 } from "../src/runPresentation"
 import type { AgentMessage, AgentRun } from "../src/types"
@@ -62,5 +66,164 @@ describe("agent run presentation", () => {
 
     const retry = run({ id: "retry", status: "succeeded" })
     expect(findPreStreamFailedRun([retry, failed], [])).toBeNull()
+  })
+
+  test("selects the active run from pending send, thread claim, then history", () => {
+    const queued = run({ id: "queued", status: "queued" })
+    const done = run({ id: "done", status: "succeeded" })
+
+    expect(
+      selectActiveRunId({ pendingRun: queued, threadActiveRunId: "claimed", latestRun: done })
+    ).toBe("queued")
+    expect(
+      selectActiveRunId({ pendingRun: null, threadActiveRunId: "claimed", latestRun: done })
+    ).toBe("claimed")
+    expect(
+      selectActiveRunId({ pendingRun: null, threadActiveRunId: null, latestRun: queued })
+    ).toBe("queued")
+    expect(selectActiveRunId({ pendingRun: null, threadActiveRunId: null, latestRun: done })).toBe(
+      null
+    )
+  })
+})
+
+function sources(overrides: Partial<ActiveTurnSources> = {}): ActiveTurnSources {
+  return {
+    activeRunId: null,
+    pendingRun: null,
+    streamRun: null,
+    live: createLiveRunState(),
+    runs: [],
+    messages: [],
+    messagesLoading: false,
+    ...overrides,
+  }
+}
+
+function liveState(overrides: Partial<LiveRunState>): LiveRunState {
+  return { ...createLiveRunState(overrides.runId ?? null), ...overrides }
+}
+
+describe("presentActiveTurn", () => {
+  test("a queued run responds with the queued run for the delayed copy", () => {
+    const queued = run({ id: "r1", status: "queued" })
+    const presentation = presentActiveTurn(
+      sources({ activeRunId: "r1", pendingRun: queued, runs: [queued] })
+    )
+    expect(presentation).toEqual({ kind: "responding", queuedRun: queued })
+  })
+
+  test("running before the first token responds without the queued run", () => {
+    const running = run({ id: "r1", status: "running" })
+    const presentation = presentActiveTurn(
+      sources({ activeRunId: "r1", streamRun: running, runs: [running] })
+    )
+    expect(presentation).toEqual({ kind: "responding", queuedRun: null })
+  })
+
+  test("an announced live stream responds without the queued run even while status lags", () => {
+    const queued = run({ id: "r1", status: "queued" })
+    const presentation = presentActiveTurn(
+      sources({
+        activeRunId: "r1",
+        runs: [queued],
+        live: liveState({ runId: "r1", active: true }),
+      })
+    )
+    expect(presentation).toEqual({ kind: "responding", queuedRun: null })
+  })
+
+  test("a terminal snapshot ends the responding state", () => {
+    const succeeded = run({ id: "r1", status: "succeeded" })
+    const presentation = presentActiveTurn(
+      sources({ activeRunId: "r1", streamRun: succeeded, runs: [succeeded] })
+    )
+    expect(presentation).toEqual({ kind: "idle" })
+  })
+
+  test("a terminal live event ends the responding state", () => {
+    const running = run({ id: "r1", status: "running" })
+    const presentation = presentActiveTurn(
+      sources({
+        activeRunId: "r1",
+        runs: [running],
+        live: liveState({
+          runId: "r1",
+          finishStatus: "succeeded",
+          parts: [{ kind: "text", text: "hi" }],
+          partKeys: ["t1"],
+        }),
+      })
+    )
+    expect(presentation).toEqual({ kind: "idle" })
+  })
+
+  test("the newest failed run without an assistant message surfaces as failed", () => {
+    const failed = run({ id: "r1", status: "failed" })
+    const presentation = presentActiveTurn(sources({ runs: [failed] }))
+    expect(presentation).toEqual({ kind: "failed", run: failed })
+  })
+
+  test("an old failure stays hidden after a successful retry", () => {
+    const failed = run({ id: "r1", status: "failed" })
+    const retried = run({ id: "r2", status: "succeeded" })
+    const presentation = presentActiveTurn(
+      sources({ runs: [retried, failed], messages: [assistantMessage("r2")] })
+    )
+    expect(presentation).toEqual({ kind: "idle" })
+  })
+
+  test("a failure known only from the live event surfaces before history refetches", () => {
+    const failed = run({ id: "r1", status: "failed" })
+    const presentation = presentActiveTurn(
+      sources({
+        activeRunId: "r1",
+        streamRun: failed,
+        live: liveState({ runId: "r1", finishStatus: "failed" }),
+      })
+    )
+    expect(presentation).toEqual({ kind: "failed", run: failed })
+  })
+
+  test("a cancellation without content surfaces from history or from the live event", () => {
+    const cancelled = run({ id: "r1", status: "cancelled" })
+    expect(presentActiveTurn(sources({ runs: [cancelled] }))).toEqual({ kind: "cancelled" })
+    expect(
+      presentActiveTurn(
+        sources({ activeRunId: "r1", live: liveState({ runId: "r1", finishStatus: "cancelled" }) })
+      )
+    ).toEqual({ kind: "cancelled" })
+    expect(
+      presentActiveTurn(sources({ runs: [cancelled], messages: [assistantMessage("r1")] }))
+    ).toEqual({ kind: "idle" })
+  })
+
+  test("terminal markers wait for the transcript to load", () => {
+    const failed = run({ id: "r1", status: "failed" })
+    const cancelled = run({ id: "r2", status: "cancelled" })
+    expect(presentActiveTurn(sources({ runs: [failed], messagesLoading: true }))).toEqual({
+      kind: "idle",
+    })
+    expect(presentActiveTurn(sources({ runs: [cancelled], messagesLoading: true }))).toEqual({
+      kind: "idle",
+    })
+  })
+
+  test("a failed run with partial live content is not a pre-stream failure", () => {
+    const failed = run({ id: "r1", status: "failed" })
+    const presentation = presentActiveTurn(
+      sources({
+        activeRunId: "r1",
+        streamRun: failed,
+        messages: [assistantMessage("r1")],
+        live: liveState({
+          runId: "r1",
+          finishStatus: "failed",
+          parts: [{ kind: "text", text: "partial" }],
+          partKeys: ["t1"],
+        }),
+      })
+    )
+    expect(presentation).toEqual({ kind: "idle" })
   })
 })


### PR DESCRIPTION
## Why

The durable chat recovery change left `AgentChat` reducing five run sources (pending send, thread claim, durable history, stream snapshot, live events) through ~40 lines of interleaved booleans. The mutual exclusivity of the resulting states was implicit, and the decision tree could not be tested without mounting the component.

## What changes

`runPresentation.ts` now owns the whole reduction:

- `selectActiveRunId()` — pending send, then thread claim, then newest active run in history
- `presentActiveTurn()` — returns a discriminated `ActiveTurnPresentation`:

```text
responding { queuedRun }   in flight; queuedRun set only while the wait is queue-side
failed { run }             newest pre-stream failure; run feeds the retry endpoint
cancelled                  stopped before any content
idle
```

Variant ordering matches the transcript's existing render precedence (in-flight > failed > cancelled). `AgentChat` keeps only the time-based delayed-copy hook and its effects, and reads `presentation.kind`.

## Behavior

Pure refactor — no visual or contract change intended. The decision table is now covered by deterministic fixture tests (12 cases), including both terminal paths (snapshot vs live event), failure resurgence after retry, the transcript-loading flash guard, and partial-content failures.

## Validation

```text
59 agent-ui tests passed (47 pre-existing unchanged + 12 new)
agent-ui build passed
bun run typecheck passed
biome check passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)