### PR TITLE
Add Teamleader contact actions

### DIFF
--- a/connectors/teamleader/README.md
+++ b/connectors/teamleader/README.md
@@ -12,6 +12,7 @@ V1 covers:
 - Products
 - Product actions
 - Contacts
+- Contact actions
 - Companies
 - Custom field definitions
 
@@ -96,6 +97,15 @@ client.documentTemplates.list(...)
 client.contacts.list(...)
 client.contacts.listAll(...)
 client.contacts.info(...)
+client.contacts.add(...)
+client.contacts.update(...)
+client.contacts.delete(...)
+client.contacts.tag(...)
+client.contacts.untag(...)
+client.contacts.linkToCompany(...)
+client.contacts.unlinkFromCompany(...)
+client.contacts.updateCompanyLink(...)
+client.contacts.uploadAvatar(...)
 
 client.companies.list(...)
 client.companies.listAll(...)

--- a/connectors/teamleader/src/errors.ts
+++ b/connectors/teamleader/src/errors.ts
@@ -16,8 +16,18 @@ function formatTeamleaderApiError(
   status: number,
   errors: readonly TeamleaderApiErrorItem[]
 ): string {
-  const title = errors.find((error) => error.title)?.title
-  return title
-    ? `[SixbTeamleader] API request failed with ${status}: ${title}`
+  const details = errors.map(formatTeamleaderApiErrorItem).filter(Boolean)
+  return details.length > 0
+    ? `[SixbTeamleader] API request failed with ${status}: ${details.join("; ")}`
     : `[SixbTeamleader] API request failed with ${status}.`
+}
+
+function formatTeamleaderApiErrorItem(error: TeamleaderApiErrorItem): string {
+  const message = error.title ?? error.detail ?? error.key ?? error.code
+  if (!message) {
+    return ""
+  }
+
+  const field = error.meta?.field
+  return field ? `${field}: ${message}` : message
 }

--- a/connectors/teamleader/src/resources/contacts.ts
+++ b/connectors/teamleader/src/resources/contacts.ts
@@ -6,6 +6,7 @@ import type {
   TeamleaderContactListItem,
   TeamleaderListResponse,
   TeamleaderSingleResponse,
+  TeamleaderTypeAndId,
 } from "../types"
 
 export function createContactsResource(request: TeamleaderRequester): TeamleaderClient["contacts"] {
@@ -26,6 +27,37 @@ export function createContactsResource(request: TeamleaderRequester): Teamleader
         body,
         requestOptions
       )
+    },
+    add(body, requestOptions) {
+      return request<TeamleaderSingleResponse<TeamleaderTypeAndId<"contact">>>(
+        "/contacts.add",
+        body,
+        requestOptions
+      )
+    },
+    update(body, requestOptions) {
+      return request<void>("/contacts.update", body, requestOptions)
+    },
+    delete(body, requestOptions) {
+      return request<void>("/contacts.delete", body, requestOptions)
+    },
+    tag(body, requestOptions) {
+      return request<void>("/contacts.tag", body, requestOptions)
+    },
+    untag(body, requestOptions) {
+      return request<void>("/contacts.untag", body, requestOptions)
+    },
+    linkToCompany(body, requestOptions) {
+      return request<void>("/contacts.linkToCompany", body, requestOptions)
+    },
+    unlinkFromCompany(body, requestOptions) {
+      return request<void>("/contacts.unlinkFromCompany", body, requestOptions)
+    },
+    updateCompanyLink(body, requestOptions) {
+      return request<void>("/contacts.updateCompanyLink", body, requestOptions)
+    },
+    uploadAvatar(body, requestOptions) {
+      return request<void>("/contacts.uploadAvatar", body, requestOptions)
     },
   }
 

--- a/connectors/teamleader/src/types/client.ts
+++ b/connectors/teamleader/src/types/client.ts
@@ -16,8 +16,15 @@ import type {
 } from "./companies"
 import type {
   TeamleaderContact,
+  TeamleaderContactAddRequest,
+  TeamleaderContactLinkToCompanyRequest,
   TeamleaderContactListItem,
   TeamleaderContactListRequest,
+  TeamleaderContactTagRequest,
+  TeamleaderContactUnlinkFromCompanyRequest,
+  TeamleaderContactUpdateCompanyLinkRequest,
+  TeamleaderContactUpdateRequest,
+  TeamleaderContactUploadAvatarRequest,
 } from "./contacts"
 import type {
   TeamleaderCustomFieldDefinition,
@@ -210,6 +217,33 @@ export interface TeamleaderClient {
       request: TeamleaderInfoRequest,
       options?: TeamleaderRequestOptions
     ): Promise<TeamleaderSingleResponse<TeamleaderContact>>
+    add(
+      request: TeamleaderContactAddRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<TeamleaderSingleResponse<TeamleaderTypeAndId<"contact">>>
+    update(
+      request: TeamleaderContactUpdateRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<void>
+    delete(request: TeamleaderInfoRequest, options?: TeamleaderRequestOptions): Promise<void>
+    tag(request: TeamleaderContactTagRequest, options?: TeamleaderRequestOptions): Promise<void>
+    untag(request: TeamleaderContactTagRequest, options?: TeamleaderRequestOptions): Promise<void>
+    linkToCompany(
+      request: TeamleaderContactLinkToCompanyRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<void>
+    unlinkFromCompany(
+      request: TeamleaderContactUnlinkFromCompanyRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<void>
+    updateCompanyLink(
+      request: TeamleaderContactUpdateCompanyLinkRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<void>
+    uploadAvatar(
+      request: TeamleaderContactUploadAvatarRequest,
+      options?: TeamleaderRequestOptions
+    ): Promise<void>
   }
   readonly companies: {
     list(

--- a/connectors/teamleader/src/types/common.ts
+++ b/connectors/teamleader/src/types/common.ts
@@ -130,8 +130,15 @@ export interface TeamleaderAddress {
 
 export interface TeamleaderApiErrorItem {
   readonly title?: string
+  readonly key?: string
   readonly code?: string
   readonly status?: string
   readonly detail?: string
+  readonly meta?: TeamleaderApiErrorMeta
   readonly source?: TeamleaderJsonObject
+}
+
+export interface TeamleaderApiErrorMeta {
+  readonly field?: string
+  readonly [key: string]: TeamleaderJsonValue | undefined
 }

--- a/connectors/teamleader/src/types/contacts.ts
+++ b/connectors/teamleader/src/types/contacts.ts
@@ -1,14 +1,56 @@
 import type {
-  TeamleaderAddress,
-  TeamleaderEmail,
-  TeamleaderJsonObject,
   TeamleaderPage,
   TeamleaderPrimaryEmailFilter,
   TeamleaderSort,
-  TeamleaderTelephone,
   TeamleaderTypeAndId,
 } from "./common"
-import type { TeamleaderCustomField } from "./custom-fields"
+import type { TeamleaderCustomField, TeamleaderCustomFieldInput } from "./custom-fields"
+
+export type TeamleaderContactStatus = "active" | "deactivated"
+
+export type TeamleaderContactGender =
+  | "female"
+  | "male"
+  | "non_binary"
+  | "prefers_not_to_say"
+  | "unknown"
+
+export type TeamleaderContactTelephoneType = "phone" | "mobile" | "fax"
+
+export type TeamleaderContactAddressType = "primary" | "invoicing" | "delivery" | "visiting"
+
+export interface TeamleaderContactEmail {
+  readonly type?: "primary"
+  readonly email?: string
+}
+
+export interface TeamleaderContactTelephone {
+  readonly type?: TeamleaderContactTelephoneType
+  readonly number?: string
+}
+
+export interface TeamleaderContactAddressValue {
+  readonly addressee?: string
+  readonly line_1?: string | null
+  readonly postal_code?: string | null
+  readonly city?: string | null
+  readonly country?: string
+  readonly area_level_two?: TeamleaderTypeAndId<"area_level_two"> | null
+}
+
+export interface TeamleaderContactAddress {
+  readonly type?: TeamleaderContactAddressType
+  readonly address?: TeamleaderContactAddressValue
+}
+
+export interface TeamleaderContactPaymentTerm {
+  readonly type?: "cash" | "end_of_month" | "after_invoice_date"
+  readonly days?: number
+}
+
+export interface TeamleaderContactInvoicingPreferences {
+  readonly electronic_invoicing_address?: string | null
+}
 
 export interface TeamleaderContactListRequest {
   readonly filter?: {
@@ -18,7 +60,7 @@ export interface TeamleaderContactListRequest {
     readonly term?: string
     readonly updated_since?: string
     readonly tags?: readonly string[]
-    readonly status?: "active" | "deactivated"
+    readonly status?: TeamleaderContactStatus
     readonly marketing_mails_consent?: boolean
   }
   readonly page?: TeamleaderPage
@@ -31,20 +73,20 @@ export interface TeamleaderContactListItem {
   readonly id: string
   readonly first_name?: string
   readonly last_name?: string
-  readonly status?: "active" | "deactivated"
+  readonly status?: TeamleaderContactStatus
   readonly salutation?: string
-  readonly emails?: readonly TeamleaderEmail[]
-  readonly telephones?: readonly TeamleaderTelephone[]
+  readonly emails?: readonly TeamleaderContactEmail[]
+  readonly telephones?: readonly TeamleaderContactTelephone[]
   readonly website?: string
-  readonly primary_address?: TeamleaderAddress
-  readonly gender?: string
+  readonly primary_address?: TeamleaderContactAddressValue
+  readonly gender?: TeamleaderContactGender | null
   readonly birthdate?: string
   readonly iban?: string
   readonly bic?: string
   readonly national_identification_number?: string
   readonly language?: string
-  readonly payment_term?: TeamleaderTypeAndId<"paymentTerm">
-  readonly invoicing_preferences?: TeamleaderJsonObject
+  readonly payment_term?: TeamleaderContactPaymentTerm | null
+  readonly invoicing_preferences?: TeamleaderContactInvoicingPreferences
   readonly tags?: readonly string[]
   readonly added_at?: string
   readonly updated_at?: string
@@ -55,14 +97,114 @@ export interface TeamleaderContactListItem {
 }
 
 export interface TeamleaderContact extends Omit<TeamleaderContactListItem, "primary_address"> {
-  readonly vat_number?: string
-  readonly addresses?: readonly TeamleaderAddress[]
-  readonly companies?: readonly {
-    readonly position?: string
-    readonly secondary_position?: string
-    readonly division?: string
-    readonly decision_maker?: boolean
-    readonly company?: TeamleaderTypeAndId<"company">
-  }[]
+  readonly vat_number?: string | null
+  readonly addresses?: readonly TeamleaderContactAddress[]
+  readonly companies?: readonly TeamleaderContactCompanyLink[]
   readonly remarks?: string
+}
+
+export interface TeamleaderContactCompanyLink {
+  readonly position?: string
+  readonly secondary_position?: string
+  readonly division?: string
+  readonly decision_maker?: boolean
+  readonly company?: TeamleaderTypeAndId<"company">
+}
+
+export interface TeamleaderContactEmailInput {
+  readonly type: "primary"
+  readonly email: string
+}
+
+export interface TeamleaderContactEmailUpdateInput {
+  readonly type: "primary"
+  readonly email: string | null
+}
+
+export interface TeamleaderContactTelephoneInput {
+  readonly type: TeamleaderContactTelephoneType
+  readonly number: string
+}
+
+export interface TeamleaderContactAddressInput {
+  readonly type: TeamleaderContactAddressType
+  readonly address: {
+    readonly addressee?: string
+    readonly line_1: string | null
+    readonly postal_code: string | null
+    readonly city: string | null
+    readonly country: string
+    readonly area_level_two_id?: string
+  }
+}
+
+export interface TeamleaderContactAddRequest {
+  readonly first_name?: string
+  readonly last_name: string
+  readonly emails?: readonly TeamleaderContactEmailInput[]
+  readonly salutation?: string
+  readonly telephones?: readonly TeamleaderContactTelephoneInput[]
+  readonly website?: string
+  readonly addresses?: readonly TeamleaderContactAddressInput[]
+  readonly language?: string
+  readonly gender?: TeamleaderContactGender | null
+  readonly birthdate?: string
+  readonly iban?: string
+  readonly bic?: string
+  readonly national_identification_number?: string
+  readonly remarks?: string
+  readonly tags?: readonly string[]
+  readonly custom_fields?: readonly TeamleaderCustomFieldInput[]
+  readonly marketing_mails_consent?: boolean
+}
+
+export interface TeamleaderContactUpdateRequest {
+  readonly id: string
+  readonly first_name?: string | null
+  readonly last_name?: string
+  readonly salutation?: string | null
+  readonly emails?: readonly TeamleaderContactEmailUpdateInput[]
+  readonly telephones?: readonly TeamleaderContactTelephoneInput[] | null
+  readonly website?: string | null
+  readonly addresses?: readonly TeamleaderContactAddressInput[]
+  readonly language?: string
+  readonly gender?: TeamleaderContactGender | null
+  readonly birthdate?: string | null
+  readonly iban?: string | null
+  readonly bic?: string | null
+  readonly national_identification_number?: string
+  readonly remarks?: string | null
+  /** Replaces all existing tags. Use `tag` or `untag` for incremental changes. */
+  readonly tags?: readonly string[]
+  readonly custom_fields?: readonly TeamleaderCustomFieldInput[]
+  /** Updates only the supplied custom fields instead of replacing the collection. */
+  readonly custom_fields_update_strategy?: "partial"
+  readonly marketing_mails_consent?: boolean
+}
+
+export interface TeamleaderContactTagRequest {
+  readonly id: string
+  readonly tags: readonly string[]
+}
+
+export interface TeamleaderContactCompanyLinkRequest {
+  readonly id: string
+  readonly company_id: string
+  readonly position?: string
+  readonly decision_maker?: boolean
+}
+
+export type TeamleaderContactLinkToCompanyRequest = TeamleaderContactCompanyLinkRequest
+
+export type TeamleaderContactUpdateCompanyLinkRequest = TeamleaderContactCompanyLinkRequest
+
+export interface TeamleaderContactUnlinkFromCompanyRequest {
+  readonly id: string
+  readonly company_id: string
+}
+
+export interface TeamleaderContactUploadAvatarRequest {
+  readonly id: string
+  /** A data URL, or `null` to remove the current avatar. */
+  readonly image: string | null
 }

--- a/connectors/teamleader/src/types/contacts.ts
+++ b/connectors/teamleader/src/types/contacts.ts
@@ -19,6 +19,8 @@ export type TeamleaderContactTelephoneType = "phone" | "mobile" | "fax"
 
 export type TeamleaderContactAddressType = "primary" | "invoicing" | "delivery" | "visiting"
 
+export type TeamleaderContactAddressInputType = Exclude<TeamleaderContactAddressType, "primary">
+
 export interface TeamleaderContactEmail {
   readonly type?: "primary"
   readonly email?: string
@@ -127,9 +129,11 @@ export interface TeamleaderContactTelephoneInput {
 }
 
 export interface TeamleaderContactAddressInput {
-  readonly type: TeamleaderContactAddressType
+  readonly type: TeamleaderContactAddressInputType
   readonly address: {
     readonly addressee?: string
+    /** Teamleader rejects this generic field; use the structured address fields below. */
+    readonly address?: never
     readonly line_1: string | null
     readonly postal_code: string | null
     readonly city: string | null

--- a/connectors/teamleader/tests/teamleader.test.ts
+++ b/connectors/teamleader/tests/teamleader.test.ts
@@ -353,6 +353,148 @@ describe("teamleader connector", () => {
     ])
   })
 
+  test("supports every documented contact endpoint", async () => {
+    const requests: CapturedRequest[] = []
+    const client = createTeamleaderClient({
+      accessToken: "test-token",
+      fetch: mockFetch((input, init) => {
+        requests.push({ input, init })
+        const path = new URL(String(input)).pathname
+
+        if (path === "/contacts.list") {
+          return Promise.resolve(jsonResponse({ data: [] }))
+        }
+
+        if (path === "/contacts.info") {
+          return Promise.resolve(jsonResponse({ data: { id: "contact-1" } }))
+        }
+
+        if (path === "/contacts.add") {
+          return Promise.resolve(
+            jsonResponse({ data: { type: "contact", id: "contact-1" } }, { status: 201 })
+          )
+        }
+
+        return Promise.resolve(new Response(undefined, { status: 204 }))
+      }),
+    })
+
+    const addRequest = {
+      first_name: "John",
+      last_name: "Smith",
+      emails: [{ type: "primary", email: "john@example.com" }],
+      salutation: "Mr",
+      telephones: [{ type: "mobile", number: "+32470000000" }],
+      website: "https://example.com",
+      addresses: [
+        {
+          type: "invoicing",
+          address: {
+            addressee: "John Smith",
+            line_1: "Dok Noord 3A 101",
+            postal_code: "9000",
+            city: "Ghent",
+            country: "BE",
+            area_level_two_id: "area-1",
+          },
+        },
+      ],
+      language: "en",
+      gender: "prefers_not_to_say",
+      birthdate: "1989-08-19",
+      iban: "BE12123412341234",
+      bic: "BICBANK",
+      national_identification_number: "01234567-X",
+      remarks: "Met at expo",
+      tags: ["prospect", "expo"],
+      custom_fields: [{ id: "field-1", value: "external-reference" }],
+      marketing_mails_consent: false,
+    } as const
+    const updateRequest = {
+      id: "contact-1",
+      first_name: null,
+      last_name: "Jones",
+      salutation: null,
+      emails: [{ type: "primary", email: null }],
+      telephones: null,
+      website: null,
+      addresses: [],
+      language: "fr",
+      gender: null,
+      birthdate: null,
+      iban: null,
+      bic: null,
+      national_identification_number: "19346758-T",
+      remarks: null,
+      tags: [],
+      custom_fields: [{ id: "field-1", value: "updated-reference" }],
+      custom_fields_update_strategy: "partial",
+      marketing_mails_consent: true,
+    } as const
+    const tagRequest = { id: "contact-1", tags: ["customer", "newsletter"] } as const
+    const untagRequest = { id: "contact-1", tags: ["prospect"] } as const
+    const linkRequest = {
+      id: "contact-1",
+      company_id: "company-1",
+      position: "CEO",
+      decision_maker: true,
+    } as const
+    const unlinkRequest = { id: "contact-1", company_id: "company-1" } as const
+    const updateLinkRequest = {
+      id: "contact-1",
+      company_id: "company-1",
+      position: "CTO",
+      decision_maker: false,
+    } as const
+    const uploadAvatarRequest = { id: "contact-1", image: null } as const
+
+    await client.contacts.list({
+      filter: { status: "active", marketing_mails_consent: true },
+      includes: "custom_fields,price_list",
+    })
+    await client.contacts.info({ id: "contact-1" })
+    const added = await client.contacts.add(addRequest)
+    await client.contacts.update(updateRequest)
+    await client.contacts.delete({ id: "contact-1" })
+    await client.contacts.tag(tagRequest)
+    await client.contacts.untag(untagRequest)
+    await client.contacts.linkToCompany(linkRequest)
+    await client.contacts.unlinkFromCompany(unlinkRequest)
+    await client.contacts.updateCompanyLink(updateLinkRequest)
+    await client.contacts.uploadAvatar(uploadAvatarRequest)
+
+    expect(added.data).toEqual({ type: "contact", id: "contact-1" })
+    expect(requests.map((request) => new URL(String(request.input)).pathname)).toEqual([
+      "/contacts.list",
+      "/contacts.info",
+      "/contacts.add",
+      "/contacts.update",
+      "/contacts.delete",
+      "/contacts.tag",
+      "/contacts.untag",
+      "/contacts.linkToCompany",
+      "/contacts.unlinkFromCompany",
+      "/contacts.updateCompanyLink",
+      "/contacts.uploadAvatar",
+    ])
+    expect(requests.map((request) => JSON.parse(String(request.init?.body)))).toEqual([
+      {
+        filter: { status: "active", marketing_mails_consent: true },
+        includes: "custom_fields,price_list",
+      },
+      { id: "contact-1" },
+      addRequest,
+      updateRequest,
+      { id: "contact-1" },
+      tagRequest,
+      untagRequest,
+      linkRequest,
+      unlinkRequest,
+      updateLinkRequest,
+      uploadAvatarRequest,
+    ])
+  })
+
   test("exposes quotation reference endpoints", async () => {
     const requests: CapturedRequest[] = []
     const client = createTeamleaderClient({

--- a/connectors/teamleader/tests/teamleader.test.ts
+++ b/connectors/teamleader/tests/teamleader.test.ts
@@ -7,7 +7,26 @@ import {
   teamleader,
 } from "../src"
 import { createTeamleaderClient } from "../src/client"
-import type { TeamleaderCustomField, TeamleaderCustomFieldDefinition } from "../src/types"
+import type {
+  TeamleaderContactAddressInput,
+  TeamleaderCustomField,
+  TeamleaderCustomFieldDefinition,
+} from "../src/types"
+
+type IsExact<TActual, TExpected> = [TActual] extends [TExpected]
+  ? [TExpected] extends [TActual]
+    ? true
+    : false
+  : false
+
+const contactAddressInputTypesAreExact: IsExact<
+  TeamleaderContactAddressInput["type"],
+  "invoicing" | "delivery" | "visiting"
+> = true
+const genericContactAddressFieldIsForbidden: IsExact<
+  TeamleaderContactAddressInput["address"]["address"],
+  undefined
+> = true
 
 type CapturedRequest = {
   readonly input: RequestInfo | URL
@@ -354,6 +373,9 @@ describe("teamleader connector", () => {
   })
 
   test("supports every documented contact endpoint", async () => {
+    expect(contactAddressInputTypesAreExact).toBe(true)
+    expect(genericContactAddressFieldIsForbidden).toBe(true)
+
     const requests: CapturedRequest[] = []
     const client = createTeamleaderClient({
       accessToken: "test-token",
@@ -598,29 +620,36 @@ describe("teamleader connector", () => {
     expect(contacts.map((contact) => contact.id)).toEqual(["contact-1", "contact-2", "contact-3"])
   })
 
-  test("throws TeamleaderApiError for API errors", async () => {
+  test("preserves and formats every Teamleader API error", async () => {
+    const errors = [
+      {
+        title: "address must not be present",
+        key: "validation_error",
+        meta: { field: "addresses[0].address.address" },
+      },
+      {
+        title: 'type must be in { "invoicing", "delivery", "visiting" }',
+        key: "validation_error",
+        meta: { field: "addresses[0].type" },
+      },
+    ]
     const client = createTeamleaderClient({
       accessToken: "test-token",
-      fetch: mockFetch(() =>
-        Promise.resolve(
-          jsonResponse(
-            {
-              errors: [{ title: "Deal not found" }],
-            },
-            { status: 404 }
-          )
-        )
-      ),
+      fetch: mockFetch(() => Promise.resolve(jsonResponse({ errors }, { status: 400 }))),
     })
 
     try {
-      await client.deals.info({ id: "missing" })
+      await client.contacts.add({ last_name: "Smith" })
       throw new Error("Expected request to fail")
     } catch (error) {
       expect(error).toBeInstanceOf(TeamleaderApiError)
-      expect((error as TeamleaderApiError).status).toBe(404)
-      expect((error as TeamleaderApiError).errors).toEqual([{ title: "Deal not found" }])
-      expect((error as Error).message).toContain("Deal not found")
+      expect((error as TeamleaderApiError).status).toBe(400)
+      expect((error as TeamleaderApiError).errors).toEqual(errors)
+      expect((error as Error).message).toBe(
+        "[SixbTeamleader] API request failed with 400: " +
+          "addresses[0].address.address: address must not be present; " +
+          'addresses[0].type: type must be in { "invoicing", "delivery", "visiting" }'
+      )
     }
   })
 


### PR DESCRIPTION
## Summary

- add every documented Teamleader Contacts endpoint
- type contact create/update payloads, company links, tags, avatars, and nullable fields
- align contact response types with the official API schemas
- document the expanded client API

## Validation

- `bun --filter @sixb/connector-teamleader test`
- `bun --filter @sixb/connector-teamleader typecheck`
- `bun --filter @sixb/connector-teamleader build`
- `bun run typecheck`
- `bun run check`