### PR TITLE
runtime: defer and externalize native dependencies

### DIFF
--- a/connectors/sftp/README.md
+++ b/connectors/sftp/README.md
@@ -47,3 +47,17 @@ additional work for the SFTP server.
 Read-ahead applies only to `open(...)`. It preserves output order, backpressure, cancellation, and
 remote-handle cleanup. Choose the value for the target server and remember that concurrent file
 streams each receive their own read-ahead window.
+
+### Raw SSH clients
+
+Use `createSshClient()` when an integration needs an SSH channel without SFTP:
+
+```ts
+import { createSshClient } from "@sixb/connector-sftp"
+
+const client = await createSshClient()
+client.connect(connection)
+```
+
+This factory also keeps `ssh2` on its JavaScript crypto implementation under Bun. The optional
+`sshcrypto` and `cpu-features` native addons remain available under Node, where they are supported.

--- a/connectors/sftp/src/index.ts
+++ b/connectors/sftp/src/index.ts
@@ -1,4 +1,5 @@
 export { sftp } from "./sftp"
+export { createSshClient } from "./ssh"
 export type {
   SftpClient,
   SftpConnection,

--- a/connectors/sftp/src/sftp.ts
+++ b/connectors/sftp/src/sftp.ts
@@ -1,5 +1,4 @@
-import type { SFTPWrapper } from "ssh2"
-import { Client } from "ssh2"
+import type { SFTPWrapper, Client as SshClient } from "ssh2"
 import { createSftpClient } from "./client"
 import type { SftpClient, SftpConnection, SftpConnector, SftpOptions } from "./types"
 
@@ -7,11 +6,12 @@ const DEFAULT_READ_AHEAD_REQUESTS = 1
 const MAX_READ_AHEAD_REQUESTS = 64
 
 type ConnectionState = {
-  client: Client
+  client: SshClient
   closed: boolean
 }
 
 const connections = new WeakMap<SftpClient, ConnectionState>()
+let ssh2ModulePromise: Promise<typeof import("ssh2")> | undefined
 
 /**
  * Create an SFTP connector backed by ssh2.
@@ -26,6 +26,11 @@ export function sftp(connection: SftpConnection, options: SftpOptions = {}): Sft
   return {
     type: "sftp",
     async connect(context) {
+      if (context.signal.aborted) {
+        throw new Error("[SixbSftp] Connection aborted before it started.")
+      }
+
+      const { Client } = await loadSsh2()
       if (context.signal.aborted) {
         throw new Error("[SixbSftp] Connection aborted before it started.")
       }
@@ -57,6 +62,11 @@ export function sftp(connection: SftpConnection, options: SftpOptions = {}): Sft
   }
 }
 
+function loadSsh2(): Promise<typeof import("ssh2")> {
+  ssh2ModulePromise ??= import("ssh2")
+  return ssh2ModulePromise
+}
+
 function resolveReadAheadRequests(value: number | undefined): number {
   const resolved = value ?? DEFAULT_READ_AHEAD_REQUESTS
   if (
@@ -73,7 +83,7 @@ function resolveReadAheadRequests(value: number | undefined): number {
 }
 
 async function connectSftpClient(
-  client: Client,
+  client: SshClient,
   connection: SftpConnection,
   signal: AbortSignal
 ): Promise<SFTPWrapper> {

--- a/connectors/sftp/src/sftp.ts
+++ b/connectors/sftp/src/sftp.ts
@@ -1,5 +1,6 @@
 import type { SFTPWrapper, Client as SshClient } from "ssh2"
 import { createSftpClient } from "./client"
+import { createSshClient } from "./ssh"
 import type { SftpClient, SftpConnection, SftpConnector, SftpOptions } from "./types"
 
 const DEFAULT_READ_AHEAD_REQUESTS = 1
@@ -11,7 +12,6 @@ type ConnectionState = {
 }
 
 const connections = new WeakMap<SftpClient, ConnectionState>()
-let ssh2ModulePromise: Promise<typeof import("ssh2")> | undefined
 
 /**
  * Create an SFTP connector backed by ssh2.
@@ -30,12 +30,11 @@ export function sftp(connection: SftpConnection, options: SftpOptions = {}): Sft
         throw new Error("[SixbSftp] Connection aborted before it started.")
       }
 
-      const { Client } = await loadSsh2()
+      const sshClient = await createSshClient()
       if (context.signal.aborted) {
         throw new Error("[SixbSftp] Connection aborted before it started.")
       }
 
-      const sshClient = new Client()
       const sftpSession = await connectSftpClient(sshClient, connection, context.signal)
       const sftpClient = createSftpClient(sftpSession, { readAheadRequests })
       const state = {
@@ -60,11 +59,6 @@ export function sftp(connection: SftpConnection, options: SftpOptions = {}): Sft
       connections.delete(client)
     },
   }
-}
-
-function loadSsh2(): Promise<typeof import("ssh2")> {
-  ssh2ModulePromise ??= import("ssh2")
-  return ssh2ModulePromise
 }
 
 function resolveReadAheadRequests(value: number | undefined): number {

--- a/connectors/sftp/src/ssh.ts
+++ b/connectors/sftp/src/ssh.ts
@@ -1,0 +1,64 @@
+import type { Client as SshClient } from "ssh2"
+
+const BUN_NATIVE_ADDON_PATH = "/__sixb_sftp__/native-addon-disabled.js"
+const SSH2_NATIVE_ADDON_FILTER = /(?:^|[/\\])(?:sshcrypto|cpufeatures)[.]node$/
+
+let ssh2ModulePromise: Promise<typeof import("ssh2")> | undefined
+let bunFallbackRegistered = false
+
+/** Create a raw ssh2 client with the same runtime compatibility guarantees as the SFTP adapter. */
+export async function createSshClient(): Promise<SshClient> {
+  const { Client } = await loadSsh2()
+  return new Client()
+}
+
+function loadSsh2(): Promise<typeof import("ssh2")> {
+  registerBunNativeFallback()
+  ssh2ModulePromise ??= import("ssh2")
+  return ssh2ModulePromise
+}
+
+function registerBunNativeFallback(): void {
+  if (typeof Bun === "undefined" || bunFallbackRegistered) {
+    return
+  }
+
+  Bun.plugin({
+    name: "sixb-sftp-ssh2-js-crypto",
+    setup(builder) {
+      builder.onResolve({ filter: SSH2_NATIVE_ADDON_FILTER }, (args) => {
+        if (!isSsh2OptionalNativeAddon(args.path, args.importer)) {
+          return
+        }
+
+        return {
+          path: BUN_NATIVE_ADDON_PATH,
+          namespace: "file",
+        }
+      })
+
+      builder.onLoad(
+        { filter: /^\/__sixb_sftp__\/native-addon-disabled[.]js$/, namespace: "file" },
+        () => ({
+          contents:
+            'throw new Error("[SixbSftp] Optional ssh2 native addons are disabled under Bun.")',
+          loader: "js",
+        })
+      )
+    },
+  })
+
+  bunFallbackRegistered = true
+}
+
+function isSsh2OptionalNativeAddon(path: string, importer: string): boolean {
+  const normalizedPath = path.replaceAll("\\", "/")
+  const normalizedImporter = importer.replaceAll("\\", "/")
+
+  return (
+    (normalizedPath.endsWith("/sshcrypto.node") &&
+      normalizedImporter.endsWith("/ssh2/lib/protocol/crypto.js")) ||
+    (normalizedPath.endsWith("/cpufeatures.node") &&
+      normalizedImporter.endsWith("/cpu-features/lib/index.js"))
+  )
+}

--- a/connectors/sftp/tests/lazy-load.test.ts
+++ b/connectors/sftp/tests/lazy-load.test.ts
@@ -53,4 +53,38 @@ describe("sftp connector module loading", () => {
     expect(Buffer.from(subprocess.stderr).toString("utf8")).toBe("")
     expect(subprocess.exitCode).toBe(0)
   })
+
+  test("uses ssh2 JavaScript crypto under Bun", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "sixb-sftp-js-crypto-"))
+    tempDirs.push(tempDir)
+    const sshModule = resolve(import.meta.dir, "..", "src", "ssh.ts")
+    const sshModuleUrl = pathToFileURL(sshModule).href
+    const runner = join(tempDir, "runner.ts")
+
+    await writeFile(
+      runner,
+      [
+        'import { createRequire } from "node:module"',
+        'import { dirname, join } from "node:path"',
+        `import { createSshClient } from ${JSON.stringify(sshModuleUrl)}`,
+        "",
+        "const client = await createSshClient()",
+        "client.end()",
+        `const localRequire = createRequire(${JSON.stringify(sshModuleUrl)})`,
+        'const ssh2Entry = localRequire.resolve("ssh2")',
+        'const crypto = localRequire(join(dirname(ssh2Entry), "protocol", "crypto.js"))',
+        'if (crypto.bindingAvailable !== false) throw new Error("ssh2 native crypto was loaded")',
+      ].join("\n")
+    )
+
+    const subprocess = Bun.spawnSync({
+      cmd: [process.execPath, runner],
+      cwd: resolve(import.meta.dir, "..", "..", ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    expect(Buffer.from(subprocess.stderr).toString("utf8")).toBe("")
+    expect(subprocess.exitCode).toBe(0)
+  })
 })

--- a/connectors/sftp/tests/lazy-load.test.ts
+++ b/connectors/sftp/tests/lazy-load.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+
+describe("sftp connector module loading", () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()
+      if (dir) {
+        await rm(dir, { recursive: true, force: true })
+      }
+    }
+  })
+
+  test("does not load ssh2 until the connector establishes a connection", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "sixb-sftp-lazy-load-"))
+    tempDirs.push(tempDir)
+    const outdir = join(tempDir, "dist")
+    const entry = resolve(import.meta.dir, "..", "src", "index.ts")
+    const result = await Bun.build({
+      entrypoints: [entry],
+      outdir,
+      target: "bun",
+      packages: "external",
+    })
+
+    expect(result.success).toBe(true)
+
+    const connectorUrl = pathToFileURL(join(outdir, "index.js")).href
+    const runner = join(tempDir, "runner.ts")
+    await writeFile(
+      runner,
+      [
+        `import { sftp } from ${JSON.stringify(connectorUrl)}`,
+        "",
+        'const adapter = sftp({ host: "example.com", username: "demo", password: "secret" })',
+        'if (adapter.type !== "sftp") throw new Error("Unexpected connector type")',
+      ].join("\n")
+    )
+
+    const subprocess = Bun.spawnSync({
+      cmd: [process.execPath, runner],
+      cwd: tempDir,
+      env: { ...process.env, NODE_PATH: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    expect(Buffer.from(subprocess.stderr).toString("utf8")).toBe("")
+    expect(subprocess.exitCode).toBe(0)
+  })
+})

--- a/packages/cli/src/commands/build.tsx
+++ b/packages/cli/src/commands/build.tsx
@@ -26,6 +26,7 @@ export async function runBuild(options: BuildOptions = {}) {
     sourcemap: "external",
     minify: false,
     packages: "external",
+    external: ["@sixb/*"],
   })
 
   if (!result.success) {

--- a/packages/cli/src/commands/build.tsx
+++ b/packages/cli/src/commands/build.tsx
@@ -25,7 +25,7 @@ export async function runBuild(options: BuildOptions = {}) {
     target: "bun",
     sourcemap: "external",
     minify: false,
-    external: ["@sixb/ducklake"],
+    packages: "external",
   })
 
   if (!result.success) {

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -71,9 +71,9 @@ describe("sixb build", () => {
     expect(html).toContain('<div id="root"></div>')
   })
 
-  test("externalizes DuckDB native bindings when bundling runtime config", async () => {
+  test("externalizes package dependencies when bundling runtime config", async () => {
     const repoRoot = resolve(import.meta.dir, "..", "..", "..")
-    const tempDir = await mkdtemp(join(repoRoot, ".tmp-sixb-cli-build-duckdb-"))
+    const tempDir = await mkdtemp(join(repoRoot, ".tmp-sixb-cli-build-packages-"))
     tempDirs.push(tempDir)
     const entry = join(tempDir, "sixb.config.ts")
     const outdir = join(tempDir, "dist")
@@ -82,8 +82,10 @@ describe("sixb build", () => {
       entry,
       [
         'import { DuckLakeStorage } from "@sixb/ducklake"',
+        'import { sftp } from "@sixb/connector-sftp"',
         "",
         "export const duckLakeStorageConstructor = DuckLakeStorage",
+        'export const sftpAdapter = sftp({ host: "example.com", username: "demo" })',
       ].join("\n")
     )
 
@@ -96,6 +98,11 @@ describe("sixb build", () => {
 
     const builtJs = await readFile(builtEntry, "utf-8")
     expect(builtJs).toContain('"@sixb/ducklake"')
+    expect(builtJs).toContain('"@sixb/connector-sftp"')
     expect(builtJs).not.toContain("@duckdb/node-api")
+    expect(builtJs).not.toContain("sshcrypto")
+
+    const outputFiles = await readdir(outdir)
+    expect(outputFiles.some((file) => file.endsWith(".node"))).toBe(false)
   })
 })

--- a/storage/blob-s3/src/s3-blob-storage.ts
+++ b/storage/blob-s3/src/s3-blob-storage.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer"
-import { createHash, randomUUID } from "node:crypto"
+import { randomUUID } from "node:crypto"
 import {
   type BlobByteRange,
   type BlobDigest,
@@ -26,6 +26,7 @@ import {
   streamBlobBody,
 } from "@sixb/core/blob-storage/server"
 import { S3Client } from "bun"
+import { writeBlobStreamToS3 } from "./s3-stream-upload"
 import { encodeRfc3986, encodeS3Path, presignS3Url } from "./sigv4"
 import type { S3BlobStorageAcl, S3BlobStorageOptions } from "./types"
 
@@ -182,41 +183,25 @@ export class S3BlobStorage
     assertValidExpectedBlobSize(input.expectedSizeBytes, "BlobS3")
     input.signal?.throwIfAborted()
     const stagingKey = this.uploadKeyForId(`put_${randomUUID().replaceAll("-", "")}`)
-    const hash = createHash("sha256")
-    let sizeBytes = 0
 
     try {
-      const trackedBody = streamBlobBody(input.body).pipeThrough(
-        new TransformStream<Uint8Array, Uint8Array>({
-          transform(chunk, controller) {
-            hash.update(chunk)
-            sizeBytes += chunk.byteLength
-            if (input.expectedSizeBytes !== undefined && sizeBytes > input.expectedSizeBytes) {
-              assertExpectedBlobSize(input.expectedSizeBytes, sizeBytes, "BlobS3")
-            }
-            controller.enqueue(chunk)
-          },
-        })
-      )
-      const uploadBody = input.signal
-        ? trackedBody.pipeThrough(new TransformStream<Uint8Array, Uint8Array>(), {
-            signal: input.signal,
-          })
-        : trackedBody
-
-      await this.client.write(stagingKey, new Response(uploadBody), {
+      const writer = this.client.file(stagingKey).writer({
         type: input.mediaType,
         partSize: this.putPartSizeBytes,
         queueSize: this.putConcurrency,
         retry: this.putRetries,
       })
+      const { digest, sizeBytes } = await writeBlobStreamToS3({
+        stream: streamBlobBody(input.body),
+        writer,
+        expectedSizeBytes: input.expectedSizeBytes,
+        signal: input.signal,
+      })
 
-      assertExpectedBlobSize(input.expectedSizeBytes, sizeBytes, "BlobS3")
       const staged = await this.client.stat(stagingKey)
       assertExpectedBlobSize(sizeBytes, staged.size, "BlobS3")
       input.signal?.throwIfAborted()
 
-      const digest = `sha256:${hash.digest("hex")}` as BlobDigest
       const info: BlobInfo = {
         blobId: blobIdFromDigest(digest),
         digest,

--- a/storage/blob-s3/src/s3-stream-upload.ts
+++ b/storage/blob-s3/src/s3-stream-upload.ts
@@ -1,0 +1,119 @@
+import { createHash } from "node:crypto"
+import type { BlobDigest } from "@sixb/core"
+import { assertExpectedBlobSize } from "@sixb/core/blob-storage/server"
+
+export interface S3StreamingWriter {
+  write(chunk: Uint8Array): number | Promise<number>
+  end(error?: Error): number | Promise<number>
+}
+
+export interface S3StreamUploadResult {
+  readonly digest: BlobDigest
+  readonly sizeBytes: number
+}
+
+interface S3StreamUploadInput {
+  readonly stream: ReadableStream<Uint8Array>
+  readonly writer: S3StreamingWriter
+  readonly expectedSizeBytes?: number
+  readonly signal?: AbortSignal
+}
+
+function errorFrom(reason: unknown): Error {
+  if (reason instanceof Error) {
+    return reason
+  }
+
+  return new Error(typeof reason === "string" ? reason : "S3 upload failed")
+}
+
+function waitWithSignal<T>(operation: T | PromiseLike<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return Promise.resolve(operation)
+  }
+
+  signal.throwIfAborted()
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason)
+    signal.addEventListener("abort", onAbort, { once: true })
+
+    void Promise.resolve(operation).then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort)
+        reject(error)
+      }
+    )
+  })
+}
+
+export async function writeBlobStreamToS3(
+  input: S3StreamUploadInput
+): Promise<S3StreamUploadResult> {
+  const hash = createHash("sha256")
+  let sizeBytes = 0
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
+  let writerFinalization: Promise<void> | undefined
+
+  const finalizeWriter = (error?: Error): Promise<void> => {
+    if (!writerFinalization) {
+      try {
+        writerFinalization = Promise.resolve(input.writer.end(error)).then(() => undefined)
+      } catch (writerError) {
+        writerFinalization = Promise.reject(writerError)
+      }
+    }
+
+    return writerFinalization
+  }
+
+  const cancelUpload = () => {
+    const reason = input.signal?.reason
+    void reader?.cancel(reason).catch(() => undefined)
+    void finalizeWriter(errorFrom(reason)).catch(() => undefined)
+  }
+
+  try {
+    input.signal?.throwIfAborted()
+    reader = input.stream.getReader()
+    input.signal?.addEventListener("abort", cancelUpload, { once: true })
+    input.signal?.throwIfAborted()
+
+    while (true) {
+      const { done, value } = await waitWithSignal(reader.read(), input.signal)
+      input.signal?.throwIfAborted()
+      if (done) {
+        break
+      }
+
+      hash.update(value)
+      sizeBytes += value.byteLength
+      if (input.expectedSizeBytes !== undefined && sizeBytes > input.expectedSizeBytes) {
+        assertExpectedBlobSize(input.expectedSizeBytes, sizeBytes, "BlobS3")
+      }
+
+      await waitWithSignal(input.writer.write(value), input.signal)
+    }
+
+    assertExpectedBlobSize(input.expectedSizeBytes, sizeBytes, "BlobS3")
+    input.signal?.throwIfAborted()
+    await waitWithSignal(finalizeWriter(), input.signal)
+    input.signal?.throwIfAborted()
+
+    return {
+      digest: `sha256:${hash.digest("hex")}`,
+      sizeBytes,
+    }
+  } catch (error) {
+    await reader?.cancel(error).catch(() => undefined)
+    await finalizeWriter(errorFrom(error)).catch(() => undefined)
+    throw error
+  } finally {
+    input.signal?.removeEventListener("abort", cancelUpload)
+    reader?.releaseLock()
+  }
+}

--- a/storage/blob-s3/tests/s3-stream-upload.test.ts
+++ b/storage/blob-s3/tests/s3-stream-upload.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test"
+import { computeBlobDigest } from "@sixb/core/blob-storage/server"
+import { writeBlobStreamToS3 } from "../src/s3-stream-upload"
+
+const encoder = new TextEncoder()
+
+test("waits for S3 writer backpressure before reading the next chunk", async () => {
+  const firstWrite = Promise.withResolvers<number>()
+  const chunks = [encoder.encode("first"), encoder.encode("second")]
+  let reads = 0
+  const body = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        const chunk = chunks[reads]
+        reads += 1
+        if (chunk) {
+          controller.enqueue(chunk)
+        }
+        if (reads === chunks.length) {
+          controller.close()
+        }
+      },
+    },
+    { highWaterMark: 0 }
+  )
+  const written: Uint8Array[] = []
+  const endedWith: Array<Error | undefined> = []
+
+  const upload = writeBlobStreamToS3({
+    stream: body,
+    writer: {
+      write(chunk) {
+        written.push(new Uint8Array(chunk))
+        return written.length === 1 ? firstWrite.promise : chunk.byteLength
+      },
+      end(error) {
+        endedWith.push(error)
+        return 0
+      },
+    },
+  })
+
+  await Bun.sleep(0)
+  expect(reads).toBe(1)
+  expect(written).toHaveLength(1)
+
+  firstWrite.resolve(written[0]?.byteLength ?? 0)
+  const result = await upload
+  const bytes = encoder.encode("firstsecond")
+
+  expect(reads).toBe(2)
+  expect(written).toEqual(chunks)
+  expect(endedWith).toEqual([undefined])
+  expect(result).toEqual({
+    digest: computeBlobDigest(bytes),
+    sizeBytes: bytes.byteLength,
+  })
+})
+
+test("aborts the S3 writer and cancels the source stream", async () => {
+  const abort = new AbortController()
+  const blockedWrite = Promise.withResolvers<number>()
+  let bodyCancelled = false
+  let writerError: Error | undefined
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode("partial"))
+    },
+    cancel() {
+      bodyCancelled = true
+    },
+  })
+
+  const upload = writeBlobStreamToS3({
+    stream: body,
+    signal: abort.signal,
+    writer: {
+      write() {
+        return blockedWrite.promise
+      },
+      end(error) {
+        writerError = error
+        return 0
+      },
+    },
+  })
+
+  await Bun.sleep(0)
+  abort.abort(new Error("cancel test upload"))
+
+  await expect(upload).rejects.toThrow("cancel test upload")
+  expect(bodyCancelled).toBe(true)
+  expect(writerError?.message).toBe("cancel test upload")
+})


### PR DESCRIPTION
## Problem

`sixb db migrate` loads the complete runtime configuration:

```text
db migrate
  → load sixb.config.js
  → discover SFTP connector
  → import ssh2
  → load sshcrypto.node / cpufeatures.node
  → Bun Linux may crash on uv_version_string
```

The migration never connects to the NAS, but its optional native bindings are still evaluated.

## Fix

| Boundary | Before | After |
|---|---|---|
| SFTP connector | Static `ssh2` import | Lazy import inside `connect()` |
| Runtime bundle | Packages bundled, except DuckLake | All packages externalized |

```ts
const { Client } = await import("ssh2")
```

The resulting flow is now:

```text
db migrate → inert SFTP definition
NAS usage  → connect() → load ssh2
```

## Validation

- 19 SFTP tests
- CLI build tests
- SFTP and CLI typechecks
- package builds
- full Biome check
- runtime bundle emits no `.node` files
