### PR TITLE
objects: suppress no-op upsert events

### DIFF
--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -32,7 +32,11 @@ export {
   buildObjectDeletedEvent,
   buildObjectUpsertEvent,
 } from "./mutation-events"
-export { clearedPropertyChanges, diffPropertyChanges } from "./property-changes"
+export {
+  clearedPropertyChanges,
+  diffPropertyChanges,
+  hasPropertyChanges,
+} from "./property-changes"
 export {
   DEFAULT_EVENTS_RETENTION_MS,
   EVENTS_STREAM,

--- a/packages/core/src/events/property-changes.ts
+++ b/packages/core/src/events/property-changes.ts
@@ -9,6 +9,10 @@ export type PropertyChange =
 
 export type PropertyChangeMap = Record<string, PropertyChange>
 
+export function hasPropertyChanges(changes: PropertyChangeMap): boolean {
+  return Object.keys(changes).length > 0
+}
+
 export function diffPropertyChanges(
   before: Record<string, unknown> | undefined,
   afterPatch: Record<string, unknown> | undefined

--- a/packages/core/src/objects/link/upsert-batch.ts
+++ b/packages/core/src/objects/link/upsert-batch.ts
@@ -6,8 +6,7 @@
  */
 
 import { assertPrivileged } from "../../authorization"
-import type { EventDraft } from "../../events"
-import { buildLinkUpsertEvent } from "../../events"
+import { buildLinkUpsertEvent, hasPropertyChanges } from "../../events"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
 import { validateLinkBatch } from "../../ontology/validation"
 import type { BatchItemResult, SixbRuntimeContext } from "../../runtime/types"
@@ -77,8 +76,13 @@ export async function upsertLinkBatch(
   for (const { index, error } of validation.errors) results[index] = { ok: false, error }
   if (validation.valid.length === 0) return results
 
-  // Append events, then project the stored events into object storage.
-  const events: EventDraft[] = validation.valid.map(({ item }) => {
+  // Plan mutations and resolve unchanged items before touching the event stream.
+  const mutations: {
+    index: number
+    event: ReturnType<typeof buildLinkUpsertEvent>
+  }[] = []
+
+  for (const { index, item } of validation.valid) {
     const sameLink = (
       linksMap.get(`${item.objectType.id}:${item.sourceId}:${item.linkId}`) ?? []
     ).find(
@@ -93,7 +97,7 @@ export async function upsertLinkBatch(
           }
         : undefined
 
-    return buildLinkUpsertEvent({
+    const event = buildLinkUpsertEvent({
       sourceTypeId: item.objectType.id,
       sourceId: item.sourceId,
       linkId: item.linkId,
@@ -103,21 +107,31 @@ export async function upsertLinkBatch(
       previousProperties: sameLink?.properties,
       ...(mergedProperties !== undefined ? { properties: mergedProperties } : {}),
     })
-  })
 
-  const appended = await eventsRuntime.append({ events })
+    if (sameLink && !hasPropertyChanges(event.payload.propertyChanges)) {
+      results[index] = { ok: true, value: undefined }
+      continue
+    }
+
+    mutations.push({ index, event })
+  }
+
+  if (mutations.length === 0) return results
+
+  // Append changed events, then project the stored events into object storage.
+  const appended = await eventsRuntime.append({ events: mutations.map(({ event }) => event) })
   const linkEvents = appended.filter(
     (event): event is Extract<typeof event, { type: "link.created" | "link.updated" }> =>
       event.type === "link.created" || event.type === "link.updated"
   )
-  if (linkEvents.length !== validation.valid.length) {
+  if (linkEvents.length !== mutations.length) {
     throw new ObjectError("Failed to append link mutation event batch")
   }
 
   await storage.objects.applyLinkUpsertBatch(linkEvents)
 
-  for (const entry of validation.valid) {
-    results[entry.index] = { ok: true, value: undefined }
+  for (const { index } of mutations) {
+    results[index] = { ok: true, value: undefined }
   }
 
   return results

--- a/packages/core/src/objects/link/upsert.ts
+++ b/packages/core/src/objects/link/upsert.ts
@@ -2,7 +2,7 @@
  * Leaf operation: upsert a single link.
  */
 import { assertPrivileged } from "../../authorization"
-import { buildLinkUpsertEvent } from "../../events"
+import { buildLinkUpsertEvent, hasPropertyChanges } from "../../events"
 import { OntologyValidationError } from "../../ontology/errors"
 import { assertLinkTargetType, validateLinkProperties } from "../../ontology/validation"
 import type { ResolvedLinkContext } from "../context"
@@ -70,20 +70,22 @@ export async function upsertLink(
     }
   }
 
-  const appended = await events.append({
-    events: [
-      buildLinkUpsertEvent({
-        sourceTypeId: objectType.id,
-        sourceId,
-        linkId,
-        targetTypeId,
-        targetId,
-        operation: sameLink ? "update" : "create",
-        previousProperties: sameLink?.properties,
-        ...(mergedProperties !== undefined ? { properties: mergedProperties } : {}),
-      }),
-    ],
+  const mutationEvent = buildLinkUpsertEvent({
+    sourceTypeId: objectType.id,
+    sourceId,
+    linkId,
+    targetTypeId,
+    targetId,
+    operation: sameLink ? "update" : "create",
+    previousProperties: sameLink?.properties,
+    ...(mergedProperties !== undefined ? { properties: mergedProperties } : {}),
   })
+
+  if (sameLink && !hasPropertyChanges(mutationEvent.payload.propertyChanges)) {
+    return
+  }
+
+  const appended = await events.append({ events: [mutationEvent] })
 
   const [event] = appended
   if (!event || (event.type !== "link.created" && event.type !== "link.updated")) {

--- a/packages/core/src/objects/object/upsert-batch.ts
+++ b/packages/core/src/objects/object/upsert-batch.ts
@@ -2,8 +2,7 @@
  * Leaf operation: batch upsert objects of a single type.
  */
 import { assertPrivileged } from "../../authorization"
-import type { EventDraft } from "../../events"
-import { buildObjectUpsertEvent } from "../../events"
+import { buildObjectUpsertEvent, hasPropertyChanges } from "../../events"
 import { validateObjectBatch } from "../../ontology/validation"
 import type { BatchItemResult } from "../../runtime/types"
 import type { ObjectRow } from "../../storage"
@@ -43,35 +42,50 @@ export async function upsertObjectBatch(
   for (const { index, error } of validation.errors) results[index] = { ok: false, error }
   if (validation.valid.length === 0) return results
 
-  // Append events, then project the stored events into object storage.
-  const events: EventDraft[] = validation.valid.map(({ item }) => {
+  // Plan mutations and resolve unchanged items before touching the event stream.
+  const mutations: {
+    index: number
+    event: ReturnType<typeof buildObjectUpsertEvent>
+  }[] = []
+
+  for (const { index, item } of validation.valid) {
     const existing = existingMap.get(`${objectType.id}:${item.primaryId}`)
     const properties = {
       ...(existing?.properties ?? {}),
       ...item.properties,
     }
-    return buildObjectUpsertEvent({
+    const event = buildObjectUpsertEvent({
       objectTypeId: objectType.id,
       primaryId: item.primaryId,
       operation: existing ? "update" : "create",
       previousProperties: existing?.properties,
       properties,
     })
-  })
 
-  const appended = await eventsRuntime.append({ events })
+    if (existing && !hasPropertyChanges(event.payload.propertyChanges)) {
+      results[index] = { ok: true, value: existing }
+      continue
+    }
+
+    mutations.push({ index, event })
+  }
+
+  if (mutations.length === 0) return results
+
+  // Append changed events, then project the stored events into object storage.
+  const appended = await eventsRuntime.append({ events: mutations.map(({ event }) => event) })
   const objectEvents = appended.filter(
     (event): event is Extract<typeof event, { type: "object.created" | "object.updated" }> =>
       event.type === "object.created" || event.type === "object.updated"
   )
-  if (objectEvents.length !== validation.valid.length) {
+  if (objectEvents.length !== mutations.length) {
     throw new ObjectError("Failed to append object mutation event batch")
   }
 
   const rows = await storage.objects.applyObjectUpsertBatch(objectEvents)
 
-  for (let i = 0; i < validation.valid.length; i++) {
-    results[validation.valid[i].index] = { ok: true, value: rows[i] }
+  for (let i = 0; i < mutations.length; i++) {
+    results[mutations[i].index] = { ok: true, value: rows[i] }
   }
 
   return results

--- a/packages/core/src/objects/object/upsert.ts
+++ b/packages/core/src/objects/object/upsert.ts
@@ -3,7 +3,7 @@
  */
 
 import { assertPrivileged } from "../../authorization"
-import { buildObjectUpsertEvent } from "../../events"
+import { buildObjectUpsertEvent, hasPropertyChanges } from "../../events"
 import {
   assertKnownProperties,
   assertRequiredProperties,
@@ -47,17 +47,19 @@ export async function upsertObject(
   }
   assertRequiredProperties(objectType, mergedProperties)
 
-  const appended = await events.append({
-    events: [
-      buildObjectUpsertEvent({
-        objectTypeId: objectType.id,
-        primaryId,
-        operation: existing ? "update" : "create",
-        previousProperties: existing?.properties,
-        properties: mergedProperties,
-      }),
-    ],
+  const mutationEvent = buildObjectUpsertEvent({
+    objectTypeId: objectType.id,
+    primaryId,
+    operation: existing ? "update" : "create",
+    previousProperties: existing?.properties,
+    properties: mergedProperties,
   })
+
+  if (existing && !hasPropertyChanges(mutationEvent.payload.propertyChanges)) {
+    return existing
+  }
+
+  const appended = await events.append({ events: [mutationEvent] })
 
   const [event] = appended
   if (!event || (event.type !== "object.created" && event.type !== "object.updated")) {

--- a/packages/core/tests/upsert-noop.test.ts
+++ b/packages/core/tests/upsert-noop.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, mock, test } from "bun:test"
+import { defineObjectType, link, prop, Sixb } from "../src"
+import { createTestRuntimeDeps } from "./test-runtime-deps"
+
+const Target = defineObjectType({
+  id: "noop-target",
+  name: "No-op target",
+  properties: [prop("id", "string", { required: true, primary: true })],
+})
+
+const Source = defineObjectType({
+  id: "noop-source",
+  name: "No-op source",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+  ],
+  links: [
+    link("targets", Target, {
+      cardinality: "many",
+      properties: [prop("role", "string")],
+    }),
+  ],
+})
+
+function createRuntime() {
+  const deps = createTestRuntimeDeps()
+  const sixb = new Sixb({ ontology: [Source, Target], ...deps })
+  const originalAppend = sixb.events.append.bind(sixb.events)
+  const appendSpy = mock(originalAppend)
+  sixb.events.append = appendSpy
+  return { appendSpy, deps, sixb }
+}
+
+describe("upsert no-op suppression", () => {
+  test("a repeated object upsert preserves state and emits no update", async () => {
+    const { appendSpy, deps, sixb } = createRuntime()
+    const created = await sixb.upsertObject("noop-source", { id: "source-1", name: "Source" })
+
+    appendSpy.mockClear()
+    const replayed = await sixb.upsertObject("noop-source", {
+      id: "source-1",
+      name: "Source",
+    })
+
+    expect(appendSpy).not.toHaveBeenCalled()
+    expect(replayed).toEqual(created)
+    expect(
+      await deps.storage.objects.getByPrimaryId({
+        projectId: sixb.id,
+        objectTypeId: "noop-source",
+        primaryId: "source-1",
+      })
+    ).toEqual(created)
+    expect(await sixb.events.read({ types: ["object.updated"] })).toHaveLength(0)
+  })
+
+  test("an object batch emits only real changes and preserves result order", async () => {
+    const { appendSpy, deps, sixb } = createRuntime()
+    const source1 = await sixb.upsertObject("noop-source", { id: "source-1", name: "One" })
+    await sixb.upsertObject("noop-source", { id: "source-2", name: "Before" })
+
+    appendSpy.mockClear()
+    const results = await sixb.upsertObjectBatch("noop-source", [
+      { properties: { id: "source-1", name: "One" } },
+      { properties: { id: "source-2", name: "After" } },
+      { properties: { id: "source-3", name: "Three" } },
+    ])
+
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(appendSpy.mock.calls[0]?.[0].events).toHaveLength(2)
+    expect(results.every((result) => result.ok)).toBe(true)
+    expect(results.map((result) => (result.ok ? result.value.primaryId : undefined))).toEqual([
+      "source-1",
+      "source-2",
+      "source-3",
+    ])
+    if (results[0].ok) expect(results[0].value).toEqual(source1)
+    expect(await sixb.events.read({ types: ["object.updated"] })).toHaveLength(1)
+
+    const rowsBeforeReplay = await deps.storage.objects.getByPrimaryIdBatch({
+      projectId: sixb.id,
+      items: [
+        { objectTypeId: "noop-source", primaryId: "source-1" },
+        { objectTypeId: "noop-source", primaryId: "source-2" },
+        { objectTypeId: "noop-source", primaryId: "source-3" },
+      ],
+    })
+
+    appendSpy.mockClear()
+    const replayed = await sixb.upsertObjectBatch("noop-source", [
+      { properties: { id: "source-1", name: "One" } },
+      { properties: { id: "source-2", name: "After" } },
+      { properties: { id: "source-3", name: "Three" } },
+    ])
+
+    expect(appendSpy).not.toHaveBeenCalled()
+    expect(replayed.map((result) => result.ok)).toEqual([true, true, true])
+    for (const result of replayed) {
+      if (!result.ok) continue
+      const rowBeforeReplay = rowsBeforeReplay.get(`noop-source:${result.value.primaryId}`)
+      expect(rowBeforeReplay).toBeDefined()
+      if (rowBeforeReplay) expect(result.value).toEqual(rowBeforeReplay)
+    }
+  })
+
+  test("a repeated link upsert preserves state and emits no update", async () => {
+    const { appendSpy, deps, sixb } = createRuntime()
+    await sixb.upsertObject("noop-source", { id: "source-1", name: "Source" })
+    await sixb.upsertObject("noop-target", { id: "target-1" })
+    await sixb.upsertLink("noop-source", "source-1", "targets", {
+      targetTypeId: "noop-target",
+      targetId: "target-1",
+      properties: { role: "primary" },
+    })
+    const [created] = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "noop-source",
+      objectId: "source-1",
+      linkId: "targets",
+    })
+
+    appendSpy.mockClear()
+    await sixb.upsertLink("noop-source", "source-1", "targets", {
+      targetTypeId: "noop-target",
+      targetId: "target-1",
+      properties: { role: "primary" },
+    })
+
+    expect(appendSpy).not.toHaveBeenCalled()
+    expect(
+      await deps.storage.objects.listLinks({
+        projectId: sixb.id,
+        objectTypeId: "noop-source",
+        objectId: "source-1",
+        linkId: "targets",
+      })
+    ).toEqual([created])
+    expect(await sixb.events.read({ types: ["link.updated"] })).toHaveLength(0)
+  })
+
+  test("a link batch emits only real changes and skips an unchanged replay", async () => {
+    const { appendSpy, deps, sixb } = createRuntime()
+    await sixb.upsertObject("noop-source", { id: "source-1", name: "Source" })
+    await sixb.upsertObject("noop-target", { id: "target-1" })
+    await sixb.upsertObject("noop-target", { id: "target-2" })
+    await sixb.upsertLink("noop-source", "source-1", "targets", {
+      targetTypeId: "noop-target",
+      targetId: "target-1",
+    })
+
+    const batch = [
+      {
+        objectTypeId: "noop-source",
+        sourceId: "source-1",
+        linkId: "targets",
+        target: { targetTypeId: "noop-target", targetId: "target-1" },
+      },
+      {
+        objectTypeId: "noop-source",
+        sourceId: "source-1",
+        linkId: "targets",
+        target: { targetTypeId: "noop-target", targetId: "target-2" },
+      },
+    ] as const
+
+    appendSpy.mockClear()
+    const results = await sixb.upsertLinkBatch(batch)
+
+    expect(results.map((result) => result.ok)).toEqual([true, true])
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(appendSpy.mock.calls[0]?.[0].events).toHaveLength(1)
+    expect(await sixb.events.read({ types: ["link.updated"] })).toHaveLength(0)
+
+    const linksBeforeReplay = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "noop-source",
+      objectId: "source-1",
+      linkId: "targets",
+    })
+
+    appendSpy.mockClear()
+    expect((await sixb.upsertLinkBatch(batch)).map((result) => result.ok)).toEqual([true, true])
+    expect(appendSpy).not.toHaveBeenCalled()
+    expect(
+      await deps.storage.objects.listLinks({
+        projectId: sixb.id,
+        objectTypeId: "noop-source",
+        objectId: "source-1",
+        linkId: "targets",
+      })
+    ).toEqual(linksBeforeReplay)
+  })
+})

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -340,6 +340,58 @@ describe("runProjectionJob", () => {
     expect(room?.properties.name).toBe("Kitchen")
   })
 
+  test("replays an object projection without emitting no-op mutations", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjection],
+      },
+      deps
+    )
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: null },
+    ])
+
+    await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-object-first",
+        projectionId: "room-proj",
+        projectionKind: "object",
+        datasetId: roomsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+    const rowBeforeReplay = await deps.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: Room.id,
+      primaryId: "r1",
+    })
+
+    const replay = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-object-replay",
+        projectionId: "room-proj",
+        projectionKind: "object",
+        datasetId: roomsDataset.id,
+        versionId: version.versionId,
+      },
+    })
+
+    expect(replay.run.status).toBe("succeeded")
+    expect(
+      await deps.storage.objects.getByPrimaryId({
+        projectId: sixb.id,
+        objectTypeId: Room.id,
+        primaryId: "r1",
+      })
+    ).toEqual(rowBeforeReplay)
+    expect(await sixb.events.read({ types: ["object.created"] })).toHaveLength(1)
+    expect(await sixb.events.read({ types: ["object.updated"] })).toHaveLength(0)
+  })
+
   test("materializes a telemetry projection from the exact dataset version", async () => {
     const deps = createDeps()
     const sixb = createSixb(


### PR DESCRIPTION
Stacked on #220.

## Problem
Projection replays upsert every materialized row. Object and link upserts emitted `*.updated` events even when `propertyChanges` was empty, which also changed stored versions and mutation metadata. ADN observed 188,721 no-op events out of 201,342.

## Fix
- skip event and storage writes for unchanged object/link upserts
- filter no-ops from batches while preserving result order
- cover single, batch, and projection replay behavior

## Validation
- `bun run typecheck`
- `bun run test` — 2,649 passed, 2 skipped