### PR TITLE
actions: add nullable parameter semantics

### DIFF
--- a/docs/actions/overview.md
+++ b/docs/actions/overview.md
@@ -118,14 +118,28 @@ Each entry in `.params({ ... })` is built with `param(schema, options?)`, which 
   approved: param("boolean"),                       // required
   message: param("string"),                         // required
   reviewerNote: optional(param("string")),          // optional
+  category: optional(param(stringEnum(["general", "services"]), { nullable: true })),
   currency: param(stringEnum(["EUR", "USD", "GBP"])),
   customer: param(ref(Customer)),                   // object reference param
 })
 ```
 
+Presence and nullability are independent. A required nullable param must be present but may be
+`null`; wrapping it in `optional(...)` adds the omitted state:
+
+| Declaration | Omitted / `undefined` | `null` | Value |
+| --- | --- | --- | --- |
+| `param(schema)` | rejected | rejected | validated |
+| `optional(param(schema))` | omitted | rejected | validated |
+| `param(schema, { nullable: true })` | rejected | accepted | validated |
+| `optional(param(schema, { nullable: true }))` | omitted | accepted | validated |
+
+This makes partial update actions explicit: omitted means “leave unchanged,” while `null` means
+“clear the value.”
+
 `param` schemas include the primitives `"string"`, `"uuid"`, `"boolean"`, `"integer"`,
 `"double"`, `"decimal"`, `"date"`, `"timestamp"`, plus `stringEnum([...])` and `ref(ObjectType)`.
-`param` options are `description` and `semanticType`. Handlers receive params validated and
+`param` options are `description`, `semanticType`, and `nullable`. Handlers receive params validated and
 narrowed to TypeScript types — `date`/`timestamp` arrive as `Date`, `ref(...)` as an `ObjectRef`
 (read `.primaryId` to resolve it). See [properties](../ontology/properties.md) and
 [value types](../ontology/value-types.md).

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -128,6 +128,30 @@ describe("runActionJob", () => {
     ).rejects.toBeInstanceOf(ActionWorkerError)
   })
 
+  test("passes nullable params to action handlers unchanged", async () => {
+    let received: Date | null = new Date(0)
+    const captureNullable = defineAction("captureNullable")
+      .params({ reviewedAt: param("timestamp", { nullable: true }) })
+      .writeback(({ params }) => {
+        received = params.reviewedAt
+      })
+    const sixb = createSixb([captureNullable])
+    await queueActionRun(sixb, {
+      id: "act_nullable",
+      actionId: "captureNullable",
+      subject: { kind: "none" },
+      params: { reviewedAt: null },
+    })
+
+    const result = await runActionJob({
+      runtime: createContext(sixb),
+      job: { id: "act_nullable", actionId: "captureNullable" },
+    })
+
+    expect(result.status).toBe("succeeded")
+    expect(received).toBeNull()
+  })
+
   test("commits edits and stores a succeeded run", async () => {
     const setStatus = defineAction("setStatus")
       .on(Device)

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -11227,6 +11227,9 @@
                                   "required": {
                                     "type": "boolean"
                                   },
+                                  "nullable": {
+                                    "type": "boolean"
+                                  },
                                   "semanticType": {
                                     "type": "string"
                                   },
@@ -11533,6 +11536,9 @@
                                   "type": "string"
                                 },
                                 "required": {
+                                  "type": "boolean"
+                                },
+                                "nullable": {
                                   "type": "boolean"
                                 },
                                 "semanticType": {
@@ -12482,6 +12488,9 @@
                             "required": {
                               "type": "boolean"
                             },
+                            "nullable": {
+                              "type": "boolean"
+                            },
                             "semanticType": {
                               "type": "string"
                             },
@@ -12577,6 +12586,9 @@
                             "type": "string"
                           },
                           "required": {
+                            "type": "boolean"
+                          },
+                          "nullable": {
                             "type": "boolean"
                           },
                           "semanticType": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3916,6 +3916,7 @@ export type ListObjectTypesResponses = {
         name: string
         description?: string
         required?: boolean
+        nullable?: boolean
         semanticType?: string
         schema?: unknown
       }>
@@ -4022,6 +4023,7 @@ export type GetObjectTypeResponses = {
         name: string
         description?: string
         required?: boolean
+        nullable?: boolean
         semanticType?: string
         schema?: unknown
       }>
@@ -4413,6 +4415,7 @@ export type ListActionsResponses = {
       name: string
       description?: string
       required?: boolean
+      nullable?: boolean
       semanticType?: string
       schema?: unknown
     }>
@@ -4461,6 +4464,7 @@ export type GetActionResponses = {
       name: string
       description?: string
       required?: boolean
+      nullable?: boolean
       semanticType?: string
       schema?: unknown
     }>

--- a/packages/client/src/models.ts
+++ b/packages/client/src/models.ts
@@ -27,6 +27,7 @@ export interface RelationshipEdge {
 export interface ActionParam {
   type: "string" | "number" | "boolean" | "fileRef"
   required?: boolean
+  nullable?: boolean
   description?: string
   enum?: Array<string | number | boolean>
 }
@@ -192,6 +193,7 @@ function mapActionParams(
     result[param.id] = {
       type: inferPrimitiveType(param.schema),
       required: param.required,
+      nullable: param.nullable,
       description: param.description,
       enum: enumValues,
     }

--- a/packages/client/tests/models.test.ts
+++ b/packages/client/tests/models.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import type { ListObjectsResponse, ListObjectTypesResponse } from "../src/generated/types.gen"
+import { toObjectSummary } from "../src/models"
+
+type ObjectListItem = ListObjectsResponse["objects"][number]
+type ObjectTypeDefinition = ListObjectTypesResponse[number]
+
+const object: ObjectListItem = {
+  primaryId: "quote-1",
+  objectTypeId: "Quote",
+  properties: { name: "Quote 1" },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-01T00:00:00.000Z",
+}
+
+const objectType: ObjectTypeDefinition = {
+  id: "Quote",
+  name: "Quote",
+  properties: [],
+  links: [],
+  actions: [
+    {
+      id: "updateCategory",
+      name: "updateCategory",
+      params: [
+        {
+          id: "category",
+          name: "category",
+          schema: { type: "enum", valueType: "string", values: ["general_services"] },
+          required: false,
+          nullable: true,
+        },
+      ],
+    },
+  ],
+}
+
+describe("client object models", () => {
+  test("preserves nullable action parameter metadata", () => {
+    const summary = toObjectSummary(object, objectType)
+
+    expect(summary.actions.updateCategory?.params?.category).toMatchObject({
+      required: false,
+      nullable: true,
+    })
+  })
+})

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -409,8 +409,8 @@ src/
 | Export | Description |
 |---|---|
 | `defineAction(id)` | Define a first-class phased action contract |
-| `param(schema, options?)` | Define a required action parameter inside `.params({...})` |
-| `optional(param(...))` | Mark an action parameter as optional |
+| `param(schema, options?)` | Define a required action parameter; `{ nullable: true }` accepts explicit `null` |
+| `optional(param(...))` | Mark an action parameter as optional while preserving nullable/value semantics |
 
 ### Runtime
 

--- a/packages/core/src/actions/builders/params.ts
+++ b/packages/core/src/actions/builders/params.ts
@@ -5,25 +5,37 @@ import type { ActionParamConfig } from "../types"
 type ActionParamOptions = {
   description?: string
   semanticType?: QuantitativeTypeId
+  nullable?: boolean
 }
 
-type ActionParamResult<TSchema extends SchemaOrRef, TRequired extends boolean> = {
+type FieldFromOptions<TOptions, TKey extends string, TFallback> =
+  TOptions extends Record<TKey, infer TValue>
+    ? { [K in TKey]: TValue }
+    : { [K in TKey]?: TFallback }
+
+type ActionParamResult<
+  TSchema extends SchemaOrRef,
+  TRequired extends boolean,
+  TOptions extends ActionParamOptions | undefined,
+> = {
   schema: TSchema
   required: TRequired
-  description?: string
-  semanticType?: QuantitativeTypeId
-}
+} & FieldFromOptions<TOptions, "description", string> &
+  FieldFromOptions<TOptions, "semanticType", QuantitativeTypeId> &
+  FieldFromOptions<TOptions, "nullable", boolean>
 
-export function param<const TSchema extends SchemaOrRef>(
-  schema: TSchema,
-  options?: ActionParamOptions
-): ActionParamResult<TSchema, true> {
-  return {
+export function param<
+  const TSchema extends SchemaOrRef,
+  const TOptions extends ActionParamOptions | undefined = undefined,
+>(schema: TSchema, options?: TOptions): ActionParamResult<TSchema, true, TOptions> {
+  const result: ActionParamConfig & { required: true } = {
     schema,
     required: true,
     ...(options?.description !== undefined ? { description: options.description } : {}),
     ...(options?.semanticType !== undefined ? { semanticType: options.semanticType } : {}),
+    ...(options?.nullable !== undefined ? { nullable: options.nullable } : {}),
   }
+  return result as ActionParamResult<TSchema, true, TOptions>
 }
 
 export function optional<const TParam extends ActionParamConfig>(

--- a/packages/core/src/actions/types/params.ts
+++ b/packages/core/src/actions/types/params.ts
@@ -12,6 +12,7 @@ type Simplify<T> = { [K in keyof T]: T[K] } & {}
 export interface ActionParamConfig {
   readonly schema: SchemaOrRef
   readonly required?: boolean
+  readonly nullable?: boolean
   readonly description?: string
   readonly semanticType?: QuantitativeTypeId
 }
@@ -52,12 +53,19 @@ type InferActionStructuredParamValue<
     ? ObjectRef<TObjectTypeId>
     : InferSchemaOrRef<TSchema, TValueTypes>
 
-type InferActionParamValue<
+type InferActionParamSchemaValue<
   TSchema extends SchemaOrRef,
   TValueTypes extends readonly ValueType[] = [],
 > = TSchema extends keyof ActionPrimitiveSchemaValues
   ? ActionPrimitiveSchemaValues[TSchema]
   : InferActionStructuredParamValue<TSchema, TValueTypes>
+
+type InferActionParamValue<
+  TParam extends ActionParamConfig,
+  TValueTypes extends readonly ValueType[] = [],
+> = TParam["nullable"] extends true
+  ? InferActionParamSchemaValue<TParam["schema"], TValueTypes> | null
+  : InferActionParamSchemaValue<TParam["schema"], TValueTypes>
 
 export type InferActionParams<
   TParams extends ActionParamsConfig,
@@ -66,8 +74,8 @@ export type InferActionParams<
   ? Record<string, unknown>
   : Simplify<
       {
-        [K in RequiredParamKeys<TParams>]: InferActionParamValue<TParams[K]["schema"], TValueTypes>
+        [K in RequiredParamKeys<TParams>]: InferActionParamValue<TParams[K], TValueTypes>
       } & {
-        [K in OptionalParamKeys<TParams>]?: InferActionParamValue<TParams[K]["schema"], TValueTypes>
+        [K in OptionalParamKeys<TParams>]?: InferActionParamValue<TParams[K], TValueTypes>
       }
     >

--- a/packages/core/src/actions/validation.ts
+++ b/packages/core/src/actions/validation.ts
@@ -75,6 +75,16 @@ export function normalizeActionParams(
       continue
     }
 
+    if (value === null) {
+      if (!paramDef.nullable) {
+        throw new OntologyValidationError(
+          `[Sixb] Action param ${pathPrefix}.${paramId} cannot be null`
+        )
+      }
+      normalized[paramId] = null
+      continue
+    }
+
     validateSchemaOrRefValue(
       paramDef.schema,
       value,

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -10,6 +10,7 @@ import {
   prop,
   ref,
   Sixb,
+  stringEnum,
 } from "../src"
 import { ActionRunError } from "../src/storage"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
@@ -79,6 +80,19 @@ const attachRelatedRoom = defineAction("attachRelatedRoom")
   })
   .writeback(async () => {})
 
+const updateRoomCategory = defineAction("updateRoomCategory")
+  .on(Room)
+  .params({
+    category: optional(param(stringEnum(["general_services", "construction"]), { nullable: true })),
+    relatedRoom: optional(param(ref(Room), { nullable: true })),
+    reviewedAt: optional(param("timestamp", { nullable: true })),
+  })
+  .writeback(async () => {})
+
+const recordNullableNote = defineAction("recordNullableNote")
+  .params({ note: param("string", { nullable: true }) })
+  .writeback(async () => {})
+
 function actionDefinition(action: unknown): ActionDefinition {
   return action as ActionDefinition
 }
@@ -94,6 +108,13 @@ describe("defineAction", () => {
     expect(setTemperature.phases.validate).toHaveLength(1)
     expect(typeof setTemperature.phases.writeback).toBe("function")
     expect(setTemperature.description).toBe("Set room temperature.")
+  })
+
+  test("preserves nullable action param metadata", () => {
+    expect(updateRoomCategory.params.category).toMatchObject({
+      required: false,
+      nullable: true,
+    })
   })
 
   test("builds global action definitions without a target", () => {
@@ -383,6 +404,103 @@ describe("requestAction", () => {
         params: { target: 72, bogus: "nope" },
       })
     ).rejects.toThrow("Unknown param 'bogus'")
+  })
+
+  test("preserves omitted and null params as distinct values", async () => {
+    const runtimeDeps = createTestRuntimeDeps()
+    const sixb = new Sixb({
+      id: "nullable-action-test",
+      ontology: [Room],
+      actions: [actionDefinition(updateRoomCategory)],
+      ...runtimeDeps,
+    })
+
+    const omitted = await sixb.objects(Room).requestAction({
+      id: "room:1",
+      action: updateRoomCategory,
+      params: {},
+      runId: "act_nullable_omitted",
+    })
+    const cleared = await sixb.objects(Room).requestAction({
+      id: "room:1",
+      action: updateRoomCategory,
+      params: { category: null, relatedRoom: null, reviewedAt: null },
+      runId: "act_nullable_cleared",
+    })
+
+    const omittedRun = await runtimeDeps.storage.actionRuns!.getById({
+      projectId: "nullable-action-test",
+      id: omitted.runId,
+    })
+    const clearedRun = await runtimeDeps.storage.actionRuns!.getById({
+      projectId: "nullable-action-test",
+      id: cleared.runId,
+    })
+    const events = await sixb.events.read({ types: ["action.requested"] })
+
+    expect(omittedRun?.params).toEqual({})
+    expect(clearedRun?.params).toEqual({
+      category: null,
+      relatedRoom: null,
+      reviewedAt: null,
+    })
+    await expect(
+      sixb.objects(Room).requestAction({
+        id: "room:1",
+        action: updateRoomCategory,
+        params: { category: null, relatedRoom: null, reviewedAt: null },
+        runId: cleared.runId,
+      })
+    ).resolves.toMatchObject({ created: false })
+    expect(
+      events.map((event) => (event.type === "action.requested" ? event.payload.params : null))
+    ).toEqual([{}, { category: null, relatedRoom: null, reviewedAt: null }])
+
+    await expect(
+      sixb.objects(Room).requestAction({
+        id: "room:1",
+        action: updateRoomCategory,
+        params: { category: null },
+        runId: omitted.runId,
+      })
+    ).rejects.toThrow("different request payload")
+  })
+
+  test("enforces required and nullable validation independently", async () => {
+    const sixb = new Sixb({
+      id: "nullable-action-test",
+      ontology: [Room],
+      actions: [
+        actionDefinition(setTemperature),
+        actionDefinition(updateRoomCategory),
+        actionDefinition(recordNullableNote),
+      ],
+      ...createTestRuntimeDeps(),
+    })
+
+    await expect(
+      sixb.actions.request({ actionId: "recordNullableNote", params: {} })
+    ).rejects.toThrow("Missing required param 'note'")
+
+    await expect(
+      sixb.actions.request({ actionId: "recordNullableNote", params: { note: null } })
+    ).resolves.toMatchObject({ created: true })
+
+    await expect(
+      sixb.actions.request({
+        actionId: "setTemperature",
+        subject: { kind: "object", objectTypeId: "Room", primaryId: "room:1" },
+        params: { target: null },
+      })
+    ).rejects.toThrow("Action param Room.setTemperature.target cannot be null")
+
+    await expect(
+      sixb.actions.request({
+        actionId: "updateRoomCategory",
+        subject: { kind: "object", objectTypeId: "Room", primaryId: "room:1" },
+        params: { category: "unsupported" },
+      })
+    ).rejects.toThrow("must be one of: general_services, construction")
   })
 
   test("accepts object ref params", async () => {

--- a/packages/core/tests/actions.types.ts
+++ b/packages/core/tests/actions.types.ts
@@ -12,6 +12,7 @@ import {
   prop,
   ref,
   Sixb,
+  stringEnum,
 } from "../src"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
@@ -151,6 +152,71 @@ const assignRelatedRoom = defineAction("assignRelatedRoom")
     void fallbackRoom
     void suiteRoomRef
   })
+
+const updateRoomCategory = defineAction("updateRoomCategory")
+  .on(Room)
+  .params({
+    requiredValue: param("string"),
+    optionalValue: optional(param("string")),
+    requiredNullable: param(stringEnum(["general_services", "construction"]), {
+      nullable: true,
+    }),
+    optionalNullable: optional(param("timestamp", { nullable: true })),
+    nullableRoom: optional(param(ref(Room), { nullable: true })),
+  })
+  .writeback(({ params }) => {
+    const requiredValue: string = params.requiredValue
+    const optionalValue: string | undefined = params.optionalValue
+    const requiredNullable: "general_services" | "construction" | null = params.requiredNullable
+    const optionalNullable: Date | null | undefined = params.optionalNullable
+    const nullableRoom: ObjectRef<"Room"> | null | undefined = params.nullableRoom
+
+    // @ts-expect-error non-nullable params cannot be null
+    const invalidRequiredValue: null = params.requiredValue
+
+    void requiredValue
+    void optionalValue
+    void requiredNullable
+    void optionalNullable
+    void nullableRoom
+    void invalidRequiredValue
+  })
+
+type UpdateRoomCategoryParams = InferActionParams<(typeof updateRoomCategory)["params"]>
+type _updateRoomCategoryParams = Expect<
+  Equal<
+    UpdateRoomCategoryParams,
+    {
+      requiredValue: string
+      requiredNullable: "general_services" | "construction" | null
+      optionalValue?: string
+      optionalNullable?: Date | null
+      nullableRoom?: ObjectRef<"Room"> | null
+    }
+  >
+>
+
+const maybeNullableOptions: { nullable: true } | undefined =
+  Math.random() > 0.5 ? { nullable: true } : undefined
+param("string", maybeNullableOptions)
+
+const validNullableParams: UpdateRoomCategoryParams = {
+  requiredValue: "required",
+  requiredNullable: null,
+  optionalNullable: null,
+}
+
+const missingRequiredNullable: UpdateRoomCategoryParams = {
+  requiredValue: "required",
+  // @ts-expect-error required nullable params may be null but cannot be omitted
+  requiredNullable: undefined,
+}
+
+const invalidNonNullableParam: UpdateRoomCategoryParams = {
+  // @ts-expect-error non-nullable params cannot be null
+  requiredValue: null,
+  requiredNullable: "general_services",
+}
 
 const createRoom = defineAction("createRoom")
   .params({
@@ -317,3 +383,6 @@ const invalidRequestTemperatureParams: InferActionParams<(typeof setRequestTempe
 void validAssignRelatedRoomParams
 void invalidAssignRelatedRoomParams
 void invalidRequestTemperatureParams
+void validNullableParams
+void missingRequiredNullable
+void invalidNonNullableParam

--- a/packages/server/src/routes/actions.ts
+++ b/packages/server/src/routes/actions.ts
@@ -25,6 +25,7 @@ function serializeAction(
       name: id,
       schema: config.schema,
       required: config.required ?? false,
+      nullable: config.nullable,
       description: config.description,
       semanticType: config.semanticType,
     })),

--- a/packages/server/src/routes/ontology.ts
+++ b/packages/server/src/routes/ontology.ts
@@ -77,6 +77,7 @@ function serializeObjectType(
           name: id,
           schema: config.schema,
           required: config.required ?? false,
+          nullable: config.nullable,
           description: config.description,
           semanticType: config.semanticType,
         })),

--- a/packages/server/src/schemas/ontology.ts
+++ b/packages/server/src/schemas/ontology.ts
@@ -40,6 +40,7 @@ export const ActionParamSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
   required: z.boolean().optional(),
+  nullable: z.boolean().optional(),
   semanticType: z.string().optional(),
   schema: z.unknown(),
 })

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -161,7 +161,7 @@ const reviewDeviceHealthWorkflow: WorkflowDefinition = defineWorkflow(
 
 const setSpeed = defineAction("setSpeed")
   .on(Device)
-  .params({ speed: param("double") })
+  .params({ speed: param("double", { nullable: true }) })
   .writeback(async () => {})
 
 const renameDevice = defineAction("renameDevice")
@@ -1147,10 +1147,13 @@ describe("SixbServer HTTP contract", () => {
       expect(objectTypeResponse.status).toBe(200)
       const objectType = (await objectTypeResponse.json()) as {
         id: string
-        actions: Array<{ id: string }>
+        actions: Array<{ id: string; params: Array<{ id: string; nullable?: boolean }> }>
       }
       expect(objectType.id).toBe("device")
-      expect(objectType.actions[0]?.id).toBe("setSpeed")
+      expect(objectType.actions[0]).toMatchObject({
+        id: "setSpeed",
+        params: [{ id: "speed", nullable: true }],
+      })
 
       const actionsResponse = await fetch(`${baseUrl}/api/actions`)
       expect(actionsResponse.status).toBe(200)
@@ -1165,6 +1168,7 @@ describe("SixbServer HTTP contract", () => {
               name: "speed",
               schema: "double",
               required: true,
+              nullable: true,
             },
           ],
           phases: {
@@ -1892,7 +1896,7 @@ describe("SixbServer HTTP contract", () => {
             objectTypeId: "device",
             primaryId: "fan-2",
           },
-          params: { speed: 950 },
+          params: { speed: null },
         }),
       })
       expect(requestActionResponse.status).toBe(202)
@@ -1976,7 +1980,7 @@ describe("SixbServer HTTP contract", () => {
           primaryId: "fan-2",
         },
         status: "queued",
-        params: { speed: 950 },
+        params: { speed: null },
       })
 
       const completedActionRunResponse = await fetch(
@@ -2077,7 +2081,7 @@ describe("SixbServer HTTP contract", () => {
               objectTypeId: "device",
               primaryId: "fan-2",
             },
-            params: { speed: 950 },
+            params: { speed: null },
             runId: requestActionBody.runId,
           },
         }),


### PR DESCRIPTION
## Summary

Adds first-class nullable action parameters while preserving the difference between omission and explicit clearing.

```ts
const quoteCategory = stringEnum(QUOTE_CATEGORY)

export const updateQuote = defineAction("updateQuote")
  .on(Quote)
  .params({
    category: optional(param(quoteCategory, { nullable: true })),
  })
  .edits(({ objects, params, subject }) => {
    if (params.category !== undefined) {
      objects(Quote).byId(subject.primaryId).update({ category: params.category })
    }
  })
```

`params.category` is now typed as the enum value, `null`, or `undefined`:

- omitted / `undefined`: leave the property unchanged
- `null`: explicitly clear it
- valid value: set it
- unsupported value: fail action parameter validation

## What changed

- adds `nullable` to `param(schema, options)` and action parameter inference
- validates and persists top-level `null` without weakening the underlying schema
- exposes nullable metadata through action and ontology catalogs
- regenerates the client and preserves the metadata in handwritten client models
- documents required/optional and nullable/non-nullable combinations
- adds core, worker, server, client, and type-level coverage

This intentionally follows Sixb's existing `prop(..., { nullable: true })` model rather than adding a general nullable schema wrapper.

## Verification

- `bun run typecheck`
- `bun run build`
- `bun run check`
- targeted core, action-worker, server contract, OpenAPI, and client model tests
- `bun run generate:client` with a clean generated diff
