### PR TITLE
atlas: support nullable action inputs

### DIFF
--- a/packages/atlas/src/components/ActionButton.tsx
+++ b/packages/atlas/src/components/ActionButton.tsx
@@ -23,6 +23,13 @@ import { Loader2 } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import {
+  type ActionParamFormValue,
+  type ActionParamFormValues,
+  actionNeedsParamDialog,
+  buildObjectActionParams,
+} from "../lib/actions/params"
+import { ActionParamNullControl } from "./ActionParamNullControl"
+import {
   FileRefUploadField,
   parseFileRefFormValue,
   stringifyFileRefFormValue,
@@ -56,7 +63,7 @@ function ActionParamsDialog({
   onSubmit,
   submitting = false,
 }: ActionParamsDialogProps) {
-  const [values, setValues] = useState<Record<string, string>>({})
+  const [values, setValues] = useState<ActionParamFormValues>({})
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [pendingFileUploads, setPendingFileUploads] = useState<ReadonlySet<string>>(() => new Set())
   const hasPendingFileUploads = pendingFileUploads.size > 0
@@ -69,7 +76,7 @@ function ActionParamsDialog({
     }
   }, [open])
 
-  function setParamValue(key: string, value: string) {
+  function setParamValue(key: string, value: ActionParamFormValue) {
     setValues((current) => ({ ...current, [key]: value }))
     setErrors(({ [key]: _removed, ...rest }) => rest)
   }
@@ -100,34 +107,11 @@ function ActionParamsDialog({
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault()
     if (hasPendingFileUploads) return
-    const params: ActionParams = {}
-    const nextErrors: Record<string, string> = {}
-    for (const [key, def] of Object.entries(action.params ?? {})) {
-      const value = values[key]?.trim() ?? ""
-      if (!value) {
-        if (def.required) nextErrors[key] = "Required."
-        continue
-      }
 
-      if (def.type === "number") {
-        params[key] = Number(value)
-      } else if (def.type === "boolean") {
-        params[key] = value === "true"
-      } else if (def.type === "fileRef") {
-        const fileRef = parseFileRefFormValue(value)
-        if (!fileRef) {
-          nextErrors[key] = "Expected an uploaded file."
-          continue
-        }
-        params[key] = fileRef
-      } else {
-        params[key] = value
-      }
-    }
-
-    setErrors(nextErrors)
-    if (Object.keys(nextErrors).length > 0) return
-    onSubmit(params)
+    const result = buildObjectActionParams(action, values)
+    setErrors(result.errors)
+    if (Object.keys(result.errors).length > 0) return
+    onSubmit(result.params)
   }
 
   return (
@@ -139,81 +123,101 @@ function ActionParamsDialog({
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          {Object.entries(action.params ?? {}).map(([key, def]: [string, ActionParam]) => (
-            <div key={key} className="space-y-1.5">
-              <div className="flex items-center gap-1.5">
-                <Label htmlFor={`action-param-${key}`} className="text-xs">
-                  {key}
-                </Label>
-                {def.required ? (
-                  <Badge variant="outline" className="h-4 px-1 py-0 text-[8px] uppercase">
-                    Required
-                  </Badge>
+          {Object.entries(action.params ?? {}).map(([key, def]: [string, ActionParam]) => {
+            const formValue = values[key]
+            const isNull = formValue === null
+            const value = typeof formValue === "string" ? formValue : ""
+            const fieldDisabled = submitting || isNull
+            const fieldRequired = Boolean(def.required && !isNull)
+
+            return (
+              <div key={key} className="space-y-1.5">
+                <div className="flex items-center gap-1.5">
+                  <Label htmlFor={`action-param-${key}`} className="text-xs">
+                    {key}
+                  </Label>
+                  {def.required ? (
+                    <Badge variant="outline" className="h-4 px-1 py-0 text-[8px] uppercase">
+                      Required
+                    </Badge>
+                  ) : null}
+                  {def.nullable ? (
+                    <ActionParamNullControl
+                      paramName={key}
+                      isNull={isNull}
+                      disabled={submitting || pendingFileUploads.has(key)}
+                      onNullChange={(nextIsNull) => setParamValue(key, nextIsNull ? null : "")}
+                    />
+                  ) : null}
+                </div>
+                {def.description ? (
+                  <p className="text-[11px] text-muted-foreground">{def.description}</p>
+                ) : null}
+                {def.enum ? (
+                  <Select
+                    value={value}
+                    onValueChange={(nextValue) => setParamValue(key, nextValue)}
+                    required={fieldRequired}
+                    disabled={fieldDisabled}
+                  >
+                    <SelectTrigger id={`action-param-${key}`} className="w-full">
+                      <SelectValue placeholder="Select..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {def.enum.map((opt) => (
+                        <SelectItem key={String(opt)} value={String(opt)}>
+                          {String(opt)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : def.type === "boolean" ? (
+                  <Select
+                    value={value}
+                    onValueChange={(nextValue) => setParamValue(key, nextValue)}
+                    required={fieldRequired}
+                    disabled={fieldDisabled}
+                  >
+                    <SelectTrigger id={`action-param-${key}`} className="w-full">
+                      <SelectValue placeholder="Select..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="true">true</SelectItem>
+                      <SelectItem value="false">false</SelectItem>
+                    </SelectContent>
+                  </Select>
+                ) : def.type === "fileRef" ? (
+                  <FileRefUploadField
+                    key={`${key}:${isNull ? "null" : "value"}`}
+                    id={`action-param-${key}`}
+                    value={parseFileRefFormValue(value)}
+                    onChange={(fileRef) =>
+                      setParamValue(key, fileRef ? stringifyFileRefFormValue(fileRef) : "")
+                    }
+                    errorId={errors[key] ? `action-param-${key}-error` : undefined}
+                    logicalPathPrefix={`actions/${actionId}/${key}`}
+                    disabled={fieldDisabled}
+                    onPendingChange={(pending) => handleFileUploadPendingChange(key, pending)}
+                  />
+                ) : (
+                  <Input
+                    id={`action-param-${key}`}
+                    type={def.type === "number" ? "number" : "text"}
+                    value={value}
+                    onChange={(event) => setParamValue(key, event.target.value)}
+                    required={fieldRequired}
+                    disabled={fieldDisabled}
+                    placeholder={`Enter ${key}...`}
+                  />
+                )}
+                {errors[key] ? (
+                  <p id={`action-param-${key}-error`} className="text-xs text-destructive">
+                    {errors[key]}
+                  </p>
                 ) : null}
               </div>
-              {def.description ? (
-                <p className="text-[11px] text-muted-foreground">{def.description}</p>
-              ) : null}
-              {def.enum ? (
-                <Select
-                  value={values[key] ?? ""}
-                  onValueChange={(value) => setParamValue(key, value)}
-                  required={def.required}
-                >
-                  <SelectTrigger id={`action-param-${key}`} className="w-full">
-                    <SelectValue placeholder="Select..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {def.enum.map((opt) => (
-                      <SelectItem key={String(opt)} value={String(opt)}>
-                        {String(opt)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : def.type === "boolean" ? (
-                <Select
-                  value={values[key] ?? ""}
-                  onValueChange={(value) => setParamValue(key, value)}
-                  required={def.required}
-                >
-                  <SelectTrigger id={`action-param-${key}`} className="w-full">
-                    <SelectValue placeholder="Select..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="true">true</SelectItem>
-                    <SelectItem value="false">false</SelectItem>
-                  </SelectContent>
-                </Select>
-              ) : def.type === "fileRef" ? (
-                <FileRefUploadField
-                  id={`action-param-${key}`}
-                  value={parseFileRefFormValue(values[key])}
-                  onChange={(fileRef) =>
-                    setParamValue(key, fileRef ? stringifyFileRefFormValue(fileRef) : "")
-                  }
-                  errorId={errors[key] ? `action-param-${key}-error` : undefined}
-                  logicalPathPrefix={`actions/${actionId}/${key}`}
-                  disabled={submitting}
-                  onPendingChange={(pending) => handleFileUploadPendingChange(key, pending)}
-                />
-              ) : (
-                <Input
-                  id={`action-param-${key}`}
-                  type={def.type === "number" ? "number" : "text"}
-                  value={values[key] ?? ""}
-                  onChange={(event) => setParamValue(key, event.target.value)}
-                  required={def.required}
-                  placeholder={`Enter ${key}...`}
-                />
-              )}
-              {errors[key] ? (
-                <p id={`action-param-${key}-error`} className="text-xs text-destructive">
-                  {errors[key]}
-                </p>
-              ) : null}
-            </div>
-          ))}
+            )
+          })}
 
           <DialogFooter>
             <Button
@@ -265,9 +269,6 @@ export function ActionButton({
     },
   })
 
-  const params = Object.values(action.params ?? {})
-  const hasRequiredParams = params.some((p: ActionParam) => p.required)
-  const hasFileParams = params.some((p: ActionParam) => p.type === "fileRef")
   const shouldConfirm = requireConfirm ?? tone === "danger"
 
   const runAction = (params?: ActionParams) => {
@@ -303,7 +304,7 @@ export function ActionButton({
   }
 
   const handleClick = () => {
-    if (hasRequiredParams || hasFileParams) {
+    if (actionNeedsParamDialog(action)) {
       setShowParams(true)
     } else {
       runAction()

--- a/packages/atlas/src/components/ActionParamNullControl.tsx
+++ b/packages/atlas/src/components/ActionParamNullControl.tsx
@@ -1,0 +1,35 @@
+import { Badge, Button } from "@sixb/ui/components"
+
+export function ActionParamNullControl({
+  paramName,
+  isNull,
+  disabled,
+  onNullChange,
+}: {
+  paramName: string
+  isNull: boolean
+  disabled?: boolean
+  onNullChange: (isNull: boolean) => void
+}) {
+  return (
+    <div className="ml-auto flex items-center gap-1.5">
+      {isNull ? (
+        <Badge variant="secondary" className="h-5 px-1.5 text-[9px] uppercase">
+          Will send null
+        </Badge>
+      ) : null}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-6 px-2 text-[11px]"
+        aria-label={`Send null for ${paramName}`}
+        aria-pressed={isNull}
+        disabled={disabled}
+        onClick={() => onNullChange(!isNull)}
+      >
+        {isNull ? "Use a value" : "Set null"}
+      </Button>
+    </div>
+  )
+}

--- a/packages/atlas/src/components/FileRefUploadField.tsx
+++ b/packages/atlas/src/components/FileRefUploadField.tsx
@@ -26,6 +26,7 @@ export function FileRefUploadField({
   const generatedId = useId()
   const inputId = id ?? generatedId
   const inputRef = useRef<HTMLInputElement>(null)
+  const activeRef = useRef(true)
   const onPendingChangeRef = useRef(onPendingChange)
   const [dragging, setDragging] = useState(false)
   const [uploadingFileName, setUploadingFileName] = useState<string | null>(null)
@@ -38,6 +39,13 @@ export function FileRefUploadField({
   useEffect(() => {
     onPendingChangeRef.current = onPendingChange
   }, [onPendingChange])
+
+  useEffect(() => {
+    activeRef.current = true
+    return () => {
+      activeRef.current = false
+    }
+  }, [])
 
   useEffect(() => {
     onPendingChangeRef.current?.(isBusy)
@@ -55,7 +63,9 @@ export function FileRefUploadField({
           ? `${logicalPathPrefix.replace(/\/$/, "")}/${file.name}`
           : file.name,
       })
-      onChange(fileRef)
+      if (activeRef.current) {
+        onChange(fileRef)
+      }
     } catch {
       // The mutation stores the error for rendering below.
     } finally {

--- a/packages/atlas/src/lib/actions/params.ts
+++ b/packages/atlas/src/lib/actions/params.ts
@@ -1,8 +1,15 @@
-import type { ListActionsResponse } from "@sixb/client"
+import type {
+  ListActionsResponse,
+  ObjectAction,
+  ActionParam as ObjectActionParam,
+} from "@sixb/client"
 import { isFileRef } from "@sixb/core/blob-storage"
 
 type ActionCatalogItem = ListActionsResponse[number]
 type ActionParam = ActionCatalogItem["params"][number]
+
+export type ActionParamFormValue = string | null
+export type ActionParamFormValues = Record<string, ActionParamFormValue | undefined>
 
 export type ActionRequestPayload = {
   path: { actionId: string }
@@ -22,12 +29,22 @@ export type ActionParamInputDescriptor =
   | { kind: "enum"; values: readonly unknown[]; valueType: "string" | "integer" }
   | { kind: "objectRef"; objectTypeId: string }
 
-export function buildActionParams(action: ActionCatalogItem, values: Record<string, string>) {
+export function buildActionParams(action: ActionCatalogItem, values: ActionParamFormValues) {
   const params: Record<string, unknown> = {}
   const errors: Record<string, string> = {}
 
   for (const param of action.params) {
-    const rawValue = values[param.id]?.trim() ?? ""
+    const formValue = values[param.id]
+    if (formValue === null) {
+      if (param.nullable) {
+        params[param.id] = null
+      } else {
+        errors[param.id] = "This parameter cannot be null."
+      }
+      continue
+    }
+
+    const rawValue = formValue?.trim() ?? ""
     if (!rawValue) {
       if (param.required) {
         errors[param.id] = "Required."
@@ -43,6 +60,43 @@ export function buildActionParams(action: ActionCatalogItem, values: Record<stri
   }
 
   return { params, errors }
+}
+
+export function buildObjectActionParams(action: ObjectAction, values: ActionParamFormValues) {
+  const params: Record<string, unknown> = {}
+  const errors: Record<string, string> = {}
+
+  for (const [paramId, param] of Object.entries(action.params ?? {})) {
+    const formValue = values[paramId]
+    if (formValue === null) {
+      if (param.nullable) {
+        params[paramId] = null
+      } else {
+        errors[paramId] = "This parameter cannot be null."
+      }
+      continue
+    }
+
+    const rawValue = formValue?.trim() ?? ""
+    if (!rawValue) {
+      if (param.required) errors[paramId] = "Required."
+      continue
+    }
+
+    try {
+      params[paramId] = parseObjectActionParamValue(param, rawValue)
+    } catch (error) {
+      errors[paramId] = error instanceof Error ? error.message : "Invalid value."
+    }
+  }
+
+  return { params, errors }
+}
+
+export function actionNeedsParamDialog(action: ObjectAction): boolean {
+  return Object.values(action.params ?? {}).some(
+    (param) => param.required || param.nullable || param.type === "fileRef"
+  )
 }
 
 export function describeActionParamInput(schema: unknown): ActionParamInputDescriptor {
@@ -77,6 +131,27 @@ export function describeActionParamInput(schema: unknown): ActionParamInputDescr
     return { kind: "json" }
   }
   return { kind: "text" }
+}
+
+function parseObjectActionParamValue(param: ObjectActionParam, rawValue: string): unknown {
+  if (param.type === "number") {
+    const value = Number(rawValue)
+    if (!Number.isFinite(value)) {
+      throw new Error("Expected a number.")
+    }
+    return value
+  }
+  if (param.type === "boolean") {
+    return rawValue === "true"
+  }
+  if (param.type === "fileRef") {
+    const fileRef = JSON.parse(rawValue) as unknown
+    if (!isFileRef(fileRef)) {
+      throw new Error("Expected an uploaded file.")
+    }
+    return fileRef
+  }
+  return rawValue
 }
 
 function parseActionParamValue(param: ActionParam, rawValue: string): unknown {

--- a/packages/atlas/src/pages/ActionsPage.tsx
+++ b/packages/atlas/src/pages/ActionsPage.tsx
@@ -51,6 +51,7 @@ import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import { AlertCircle, ArrowRight, CheckCircle2, Loader2, Play, SquareActivity } from "lucide-react"
 import { type SyntheticEvent, useCallback, useMemo, useState } from "react"
 import { Link, useNavigate, useSearchParams } from "react-router-dom"
+import { ActionParamNullControl } from "../components/ActionParamNullControl"
 import { ErrorPage, LoadingPage, PageFrame } from "../components/common"
 import {
   FileRefUploadField,
@@ -60,6 +61,8 @@ import {
 import { useActionLiveUpdates } from "../features/actions/hooks/useActionLiveUpdates"
 import { formatDate, formatRelativeTime } from "../features/workflows/utils/workflows"
 import {
+  type ActionParamFormValue,
+  type ActionParamFormValues,
   type ActionRequestPayload,
   buildActionParams,
   describeActionParamInput,
@@ -298,7 +301,7 @@ function ActionRequestDialog({
 }) {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
-  const [values, setValues] = useState<Record<string, string>>({})
+  const [values, setValues] = useState<ActionParamFormValues>({})
   const [subjectPrimaryId, setSubjectPrimaryId] = useState(subject?.primaryId ?? "")
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [pendingFileUploads, setPendingFileUploads] = useState<ReadonlySet<string>>(() => new Set())
@@ -324,7 +327,7 @@ function ActionRequestDialog({
     requestAction.reset()
   }
 
-  function handleParamChange(paramId: string, value: string) {
+  function handleParamChange(paramId: string, value: ActionParamFormValue) {
     setValues((current) => ({ ...current, [paramId]: value }))
     setFieldErrors(({ [paramId]: _param, ...rest }) => rest)
     requestAction.reset()
@@ -425,6 +428,7 @@ function ActionRequestDialog({
               action={action}
               values={values}
               errors={fieldErrors}
+              pendingFileUploads={pendingFileUploads}
               onChange={handleParamChange}
               onFileUploadPendingChange={handleFileUploadPendingChange}
             />
@@ -468,13 +472,15 @@ function ActionParamFields({
   action,
   values,
   errors,
+  pendingFileUploads,
   onChange,
   onFileUploadPendingChange,
 }: {
   action: ActionCatalogItem
-  values: Record<string, string>
+  values: ActionParamFormValues
   errors: Record<string, string>
-  onChange: (paramId: string, value: string) => void
+  pendingFileUploads: ReadonlySet<string>
+  onChange: (paramId: string, value: ActionParamFormValue) => void
   onFileUploadPendingChange?: (paramId: string, pending: boolean) => void
 }) {
   if (action.params.length === 0) {
@@ -485,8 +491,12 @@ function ActionParamFields({
     <div className="space-y-3">
       {action.params.map((param) => {
         const input = describeActionParamInput(param.schema)
-        const value = values[param.id] ?? ""
+        const formValue = values[param.id]
+        const isNull = formValue === null
+        const value = typeof formValue === "string" ? formValue : ""
         const fieldId = `action-${action.id}-${param.id}`
+        const fieldDisabled = isNull
+        const fieldRequired = Boolean(param.required && !isNull)
 
         return (
           <div key={param.id} className="space-y-1.5">
@@ -499,6 +509,14 @@ function ActionParamFields({
                   Required
                 </Badge>
               ) : null}
+              {param.nullable ? (
+                <ActionParamNullControl
+                  paramName={param.id}
+                  isNull={isNull}
+                  disabled={pendingFileUploads.has(param.id)}
+                  onNullChange={(nextIsNull) => onChange(param.id, nextIsNull ? null : "")}
+                />
+              ) : null}
             </div>
             {param.description ? (
               <p className="text-[11px] text-muted-foreground">{param.description}</p>
@@ -510,9 +528,11 @@ function ActionParamFields({
                 value={value}
                 onChange={(next) => onChange(param.id, next)}
                 fieldId={fieldId}
+                disabled={fieldDisabled}
               />
             ) : input.kind === "fileRef" ? (
               <FileRefUploadField
+                key={`${param.id}:${isNull ? "null" : "value"}`}
                 id={fieldId}
                 value={parseFileRefFormValue(value)}
                 onChange={(fileRef) =>
@@ -520,10 +540,16 @@ function ActionParamFields({
                 }
                 errorId={errors[param.id] ? `${fieldId}-error` : undefined}
                 logicalPathPrefix={`actions/${action.id}/${param.id}`}
+                disabled={fieldDisabled}
                 onPendingChange={(pending) => onFileUploadPendingChange?.(param.id, pending)}
               />
             ) : input.kind === "enum" ? (
-              <Select value={value} onValueChange={(next) => onChange(param.id, next)}>
+              <Select
+                value={value}
+                onValueChange={(next) => onChange(param.id, next)}
+                required={fieldRequired}
+                disabled={fieldDisabled}
+              >
                 <SelectTrigger id={fieldId} className="w-full">
                   <SelectValue placeholder="Select..." />
                 </SelectTrigger>
@@ -536,7 +562,12 @@ function ActionParamFields({
                 </SelectContent>
               </Select>
             ) : input.kind === "boolean" ? (
-              <Select value={value} onValueChange={(next) => onChange(param.id, next)}>
+              <Select
+                value={value}
+                onValueChange={(next) => onChange(param.id, next)}
+                required={fieldRequired}
+                disabled={fieldDisabled}
+              >
                 <SelectTrigger id={fieldId} className="w-full">
                   <SelectValue placeholder="Select..." />
                 </SelectTrigger>
@@ -550,7 +581,8 @@ function ActionParamFields({
                 id={fieldId}
                 value={value}
                 onChange={(event) => onChange(param.id, event.target.value)}
-                required={param.required}
+                required={fieldRequired}
+                disabled={fieldDisabled}
                 placeholder='{"objectTypeId":"Customer","primaryId":"cus_1"}'
                 className="min-h-24 font-mono text-xs"
               />
@@ -560,7 +592,8 @@ function ActionParamFields({
                 type={input.kind === "number" ? "number" : "text"}
                 value={value}
                 onChange={(event) => onChange(param.id, event.target.value)}
-                required={param.required}
+                required={fieldRequired}
+                disabled={fieldDisabled}
               />
             )}
 

--- a/packages/atlas/tests/action-params.test.ts
+++ b/packages/atlas/tests/action-params.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import type { ListActionsResponse } from "@sixb/client"
+import type { ListActionsResponse, ObjectAction } from "@sixb/client"
 import type { FileRef } from "@sixb/core/blob-storage"
-import { buildActionParams, describeActionParamInput } from "../src/lib/actions/params"
+import {
+  actionNeedsParamDialog,
+  buildActionParams,
+  buildObjectActionParams,
+  describeActionParamInput,
+} from "../src/lib/actions/params"
 
 const fileRef: FileRef = {
   blobId: "blob_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -21,6 +26,67 @@ function actionWithParam(param: ListActionsResponse[number]["params"][number]) {
 }
 
 describe("Atlas action params", () => {
+  test("preserves omitted, null, and concrete catalog values", () => {
+    const optional = actionWithParam({
+      id: "category",
+      name: "Category",
+      schema: { type: "enum", valueType: "string", values: ["general_services"] },
+      nullable: true,
+    })
+    const required = actionWithParam({
+      id: "category",
+      name: "Category",
+      schema: "string",
+      required: true,
+      nullable: true,
+    })
+
+    expect(buildActionParams(optional, {})).toEqual({ params: {}, errors: {} })
+    expect(buildActionParams(optional, { category: null })).toEqual({
+      params: { category: null },
+      errors: {},
+    })
+    expect(buildActionParams(optional, { category: "general_services" })).toEqual({
+      params: { category: "general_services" },
+      errors: {},
+    })
+    expect(buildActionParams(required, { category: "" }).errors).toEqual({
+      category: "Required.",
+    })
+    expect(buildActionParams(required, { category: null })).toEqual({
+      params: { category: null },
+      errors: {},
+    })
+    expect(
+      buildActionParams(actionWithParam({ id: "category", name: "Category", schema: "string" }), {
+        category: null,
+      }).errors
+    ).toEqual({ category: "This parameter cannot be null." })
+  })
+
+  test("preserves tri-state values for object action forms", () => {
+    const action: ObjectAction = {
+      id: "updateCategory",
+      params: {
+        category: { type: "string", nullable: true },
+      },
+    }
+
+    expect(buildObjectActionParams(action, {})).toEqual({ params: {}, errors: {} })
+    expect(buildObjectActionParams(action, { category: null })).toEqual({
+      params: { category: null },
+      errors: {},
+    })
+    expect(buildObjectActionParams(action, { category: "general_services" })).toEqual({
+      params: { category: "general_services" },
+      errors: {},
+    })
+    expect(actionNeedsParamDialog(action)).toBe(true)
+    expect(
+      actionNeedsParamDialog({ id: "optionalOnly", params: { note: { type: "string" } } })
+    ).toBe(false)
+  })
+
   test("recognizes fileRef params and parses uploaded FileRefs", () => {
     const action = actionWithParam({
       id: "sourcePdf",


### PR DESCRIPTION
## Summary

Completes nullable action parameter support in Atlas by giving both action forms an explicit three-state input:

- blank: omit the parameter
- **Set null**: send JSON `null`
- entered value: parse and send the value

This lets an action such as:

```ts
category: optional(param(quoteCategory, { nullable: true }))
```

represent both “leave category unchanged” and “clear category” without overloading an empty string.

## What changed

- shares a `string | null | undefined` action form model across both Atlas action entry points
- adds a parameter-specific **Set null / Use a value** control
- disables the value input while null is selected and preserves required-nullable behavior
- opens the object action dialog for optional nullable parameters instead of immediately running it
- keeps file uploads from overwriting a later null selection and clears stale upload UI on mode changes
- adds parser coverage for omitted, null, value, required, and defensive non-nullable cases

## Stack

Depends on #222, which introduces the nullable action contract and catalog metadata.

## Verification

- `bun test packages/atlas/tests/action-params.test.ts packages/atlas/tests/atlas-app.test.ts packages/atlas/tests/files.test.ts`
- `bun --filter @sixb/atlas typecheck`
- `bun run typecheck:tests`
- `bun run check`
- `bun --filter @sixb/atlas build`
