### PR TITLE
projection-worker: assign cardinality-one FK links

### DIFF
--- a/docs/data/projections.md
+++ b/docs/data/projections.md
@@ -231,6 +231,8 @@ sixb worker projection
 - `.properties(...)` checks that mapped properties and columns exist and that their types are
   compatible. The primary property must be mapped.
 - Projections are set-only: missing rows do not delete existing objects or links.
+- A nonblank FK assigns a cardinality-one link, replacing a different current target atomically.
+  Blank FKs are no-ops; cardinality-many FK links remain additive.
 - Link projections require string source and target fields.
 - For an FK descriptor, `target` must be the link's declared target type or a subtype (via
   `extends`).

--- a/packages/core/src/actions/commit-edit-batch.ts
+++ b/packages/core/src/actions/commit-edit-batch.ts
@@ -1,33 +1,14 @@
-import type { EditBatchInput, EditCommitDiff } from "../edits"
-import { planEditBatch } from "../edits"
+import type { EditBatchInput, EditCommitDiff, SerializationRetryOptions } from "../edits"
+import { planEditBatch, runWithStorageSerializationRetry } from "../edits"
 import { buildEditCommitPlanEvents, type EventDraft } from "../events"
 import type { OntologyRegistry } from "../ontology/registry"
 import type { ActionRunRecord, ActionRunStorage } from "../storage/action-runs"
 import { actionSubjectsEqual } from "../storage/action-runs"
-import { isStorageSerializationFailure } from "../storage/errors"
 import type { Storage } from "../storage/types"
 import { ActionEditCommitError } from "./errors"
 import type { ActionSubject } from "./types"
 
-const DEFAULT_MAX_SERIALIZATION_ATTEMPTS = 3
-const SERIALIZATION_BASE_DELAY_MS = 10
-const SERIALIZATION_MAX_DELAY_MS = 200
-
-/**
- * Tunes the serialization-failure retry. Both fields are optional and injectable so tests stay
- * deterministic: a no-op `sleep` removes wall-clock delay.
- */
-export interface SerializationRetryOptions {
-  /** Total attempts, including the first. Defaults to 3; values below 1 are clamped to 1. */
-  readonly maxAttempts?: number
-  /** Awaited before each retry. Defaults to a real timer. */
-  readonly sleep?: (ms: number) => Promise<void>
-}
-
-interface ResolvedSerializationRetryPolicy {
-  readonly maxAttempts: number
-  readonly sleep: (ms: number) => Promise<void>
-}
+export type { SerializationRetryOptions } from "../edits"
 
 export interface CommitActionEditBatchInput {
   readonly storage: Storage
@@ -86,54 +67,10 @@ export async function commitActionEditBatch(
   input: CommitActionEditBatchInput
 ): Promise<CommitActionEditBatchResult> {
   const committedAt = input.committedAt ?? new Date()
-  const policy = resolveSerializationRetryPolicy(input.serializationRetry)
-  return commitActionEditBatchWithSerializationRetry(input, committedAt, policy)
-}
-
-async function commitActionEditBatchWithSerializationRetry(
-  input: CommitActionEditBatchInput,
-  committedAt: Date,
-  policy: ResolvedSerializationRetryPolicy
-): Promise<CommitActionEditBatchResult> {
-  for (let failures = 0; ; failures++) {
-    try {
-      return await commitActionEditBatchOnce(input, committedAt)
-    } catch (error) {
-      const attempted = failures + 1
-      if (!isStorageSerializationFailure(error) || attempted >= policy.maxAttempts) {
-        throw error
-      }
-
-      await policy.sleep(serializationBackoffMs(attempted))
-    }
-  }
-}
-
-function resolveSerializationRetryPolicy(
-  options: SerializationRetryOptions = {}
-): ResolvedSerializationRetryPolicy {
-  return {
-    maxAttempts: Math.max(1, Math.trunc(options.maxAttempts ?? DEFAULT_MAX_SERIALIZATION_ATTEMPTS)),
-    sleep: options.sleep ?? defaultSerializationSleep,
-  }
-}
-
-/**
- * Full-jitter exponential backoff (AWS "Exponential Backoff And Jitter"): a uniformly random delay
- * in `[0, cap]` where `cap = min(SERIALIZATION_MAX_DELAY_MS, SERIALIZATION_BASE_DELAY_MS * 2 ** (failures - 1))`.
- * Full jitter de-synchronizes a thundering herd better than fixed or equal-jittered backoff.
- * `failures` is the number of attempts that have already failed (≥ 1).
- */
-function serializationBackoffMs(failures: number): number {
-  const cap = Math.min(
-    SERIALIZATION_MAX_DELAY_MS,
-    SERIALIZATION_BASE_DELAY_MS * 2 ** (failures - 1)
+  return runWithStorageSerializationRetry(
+    () => commitActionEditBatchOnce(input, committedAt),
+    input.serializationRetry
   )
-  return Math.random() * cap
-}
-
-function defaultSerializationSleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 async function commitActionEditBatchOnce(

--- a/packages/core/src/edits/commit.ts
+++ b/packages/core/src/edits/commit.ts
@@ -1,0 +1,111 @@
+import { buildEditCommitPlanEvents, type EventDraft } from "../events"
+import type { OntologyRegistry } from "../ontology/registry"
+import { isStorageSerializationFailure } from "../storage/errors"
+import type { Storage } from "../storage/types"
+import type { EditBatchInput, EditCommitDiff } from "./types"
+import { planEditBatch } from "./validation"
+
+const DEFAULT_MAX_SERIALIZATION_ATTEMPTS = 3
+const SERIALIZATION_BASE_DELAY_MS = 10
+const SERIALIZATION_MAX_DELAY_MS = 200
+
+/** Tunes serializable-transaction retries. Both fields are injectable for deterministic tests. */
+export interface SerializationRetryOptions {
+  /** Total attempts, including the first. Defaults to 3; values below 1 are clamped to 1. */
+  readonly maxAttempts?: number
+  /** Awaited before each retry. Defaults to a real timer. */
+  readonly sleep?: (ms: number) => Promise<void>
+}
+
+interface ResolvedSerializationRetryPolicy {
+  readonly maxAttempts: number
+  readonly sleep: (ms: number) => Promise<void>
+}
+
+interface ApplyEditBatchCommitInput {
+  readonly storage: Pick<Storage, "objects">
+  readonly projectId: string
+  readonly ontology: Pick<
+    OntologyRegistry,
+    "resolveObjectType" | "getPrimaryPropertyId" | "getValueTypesById" | "isValidLinkTarget"
+  >
+  readonly batch: EditBatchInput
+  readonly committedAt: Date
+  readonly idempotencyKeyPrefix?: string
+}
+
+export interface CommitEditBatchResult {
+  readonly diff: EditCommitDiff
+  readonly events: readonly EventDraft[]
+  readonly committedAt: Date
+}
+
+/** Plans and applies an EditBatch using the caller's active transaction. */
+export async function applyEditBatchCommit(
+  input: ApplyEditBatchCommitInput
+): Promise<CommitEditBatchResult> {
+  const plan = await planEditBatch({
+    projectId: input.projectId,
+    ontology: input.ontology,
+    storage: input.storage,
+    batch: input.batch,
+  })
+
+  await input.storage.objects.applyEditCommitPlan({
+    projectId: input.projectId,
+    plan,
+    committedAt: input.committedAt,
+  })
+
+  return {
+    diff: plan.diff,
+    events: buildEditCommitPlanEvents({
+      plan,
+      idempotencyKeyPrefix: input.idempotencyKeyPrefix,
+    }),
+    committedAt: input.committedAt,
+  }
+}
+
+/** Runs a deterministic storage callback with bounded retries for serialization failures. */
+export async function runWithStorageSerializationRetry<T>(
+  run: () => Promise<T>,
+  options: SerializationRetryOptions = {}
+): Promise<T> {
+  const policy = resolveSerializationRetryPolicy(options)
+
+  for (let failures = 0; ; failures++) {
+    try {
+      return await run()
+    } catch (error) {
+      const attempted = failures + 1
+      if (!isStorageSerializationFailure(error) || attempted >= policy.maxAttempts) {
+        throw error
+      }
+
+      await policy.sleep(serializationBackoffMs(attempted))
+    }
+  }
+}
+
+function resolveSerializationRetryPolicy(
+  options: SerializationRetryOptions
+): ResolvedSerializationRetryPolicy {
+  return {
+    maxAttempts: Math.max(1, Math.trunc(options.maxAttempts ?? DEFAULT_MAX_SERIALIZATION_ATTEMPTS)),
+    sleep: options.sleep ?? defaultSerializationSleep,
+  }
+}
+
+/** Full-jitter exponential backoff, capped to keep worker retries responsive. */
+function serializationBackoffMs(failures: number): number {
+  const cap = Math.min(
+    SERIALIZATION_MAX_DELAY_MS,
+    SERIALIZATION_BASE_DELAY_MS * 2 ** (failures - 1)
+  )
+  return Math.random() * cap
+}
+
+function defaultSerializationSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/core/src/edits/index.ts
+++ b/packages/core/src/edits/index.ts
@@ -1,3 +1,5 @@
+export type { SerializationRetryOptions } from "./commit"
+export { runWithStorageSerializationRetry } from "./commit"
 export { EditBatchError } from "./errors"
 export { normalizeEditBatch, normalizeEditOperationInput } from "./normalize"
 export type {

--- a/packages/core/src/events/mutation-events.ts
+++ b/packages/core/src/events/mutation-events.ts
@@ -232,5 +232,14 @@ function linkEventKey(input: {
   readonly targetTypeId: string
   readonly targetId: string
 }): string {
-  return `${input.sourceTypeId}:${input.sourceId}:${input.linkId}:${input.targetTypeId}:${input.targetId}`
+  // Idempotency keys are compared as opaque strings. Delimiter joining is ambiguous when IDs
+  // contain that delimiter: ["a", "b:c"] and ["a:b", "c"] both become "a:b:c". JSON preserves
+  // each field's boundary, so different links cannot accidentally produce the same key.
+  return JSON.stringify([
+    input.sourceTypeId,
+    input.sourceId,
+    input.linkId,
+    input.targetTypeId,
+    input.targetId,
+  ])
 }

--- a/packages/core/src/objects/index.ts
+++ b/packages/core/src/objects/index.ts
@@ -16,7 +16,8 @@ export type {
 } from "./context"
 export { requireLinkDefinition, resolveLinkContext, resolveObjectContext } from "./context"
 export { ObjectError } from "./errors"
-export { removeLink, upsertLink, upsertLinkBatch } from "./link"
+export type { SetLinkBatchOptions } from "./link"
+export { removeLink, setLinkBatch, upsertLink, upsertLinkBatch } from "./link"
 export { upsertObject, upsertObjectBatch } from "./object"
 // SDK adapters (typed ObjectSet / ObjectByIdHandle)
 export { createObjectSet } from "./sdk"

--- a/packages/core/src/objects/link/index.ts
+++ b/packages/core/src/objects/link/index.ts
@@ -1,3 +1,5 @@
 export { removeLink } from "./remove"
+export type { SetLinkBatchOptions } from "./set-batch"
+export { setLinkBatch } from "./set-batch"
 export { upsertLink } from "./upsert"
 export { upsertLinkBatch } from "./upsert-batch"

--- a/packages/core/src/objects/link/set-batch.ts
+++ b/packages/core/src/objects/link/set-batch.ts
@@ -1,0 +1,186 @@
+/**
+ * Leaf operation: assign cardinality-one links in a serializable EditBatch.
+ *
+ * Assignment differs from an edge upsert: a different current target is deleted before the desired
+ * target is created. Existence filtering and EditBatch planning share one transaction so a missing
+ * target remains a per-item no-op even when objects change concurrently.
+ */
+
+import { assertPrivileged } from "../../authorization"
+import { applyEditBatchCommit, runWithStorageSerializationRetry } from "../../edits/commit"
+import type { EventDraft } from "../../events"
+import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
+import type { BatchItemResult, SixbRuntimeContext } from "../../runtime/types"
+import { ObjectNotFoundError } from "../../storage/errors"
+import type { ResolvedLinkBatchItem } from "../context"
+import { ObjectError } from "../errors"
+
+export interface SetLinkBatchOptions {
+  readonly idempotencyKeyPrefix?: string
+}
+
+type ResolvedLinkSetBatchItem = Omit<ResolvedLinkBatchItem, "properties">
+
+interface IndexedLinkSetItem {
+  readonly index: number
+  readonly item: ResolvedLinkSetBatchItem
+}
+
+interface MissingLinkSetItem {
+  readonly index: number
+  readonly error: ObjectNotFoundError
+}
+
+export async function setLinkBatch(
+  ctx: SixbRuntimeContext,
+  items: readonly ResolvedLinkSetBatchItem[],
+  options: SetLinkBatchOptions = {}
+): Promise<readonly BatchItemResult<void>[]> {
+  assertPrivileged(ctx, "setLinkBatch")
+  const { events, storage, projectId, ontology } = ctx
+
+  if (items.length === 0) return []
+
+  for (const item of items) {
+    if (item.linkDefinition.cardinality !== "one") {
+      throw new ObjectError(
+        `setLinkBatch requires cardinality 'one' link '${item.objectType.id}.${item.linkId}'`
+      )
+    }
+  }
+
+  const indexed: readonly IndexedLinkSetItem[] = items.map((item, index) => ({ index, item }))
+  const committedAt = new Date()
+
+  let committed: {
+    readonly events: readonly EventDraft[]
+    readonly assignedIndices: readonly number[]
+    readonly missingItems: readonly MissingLinkSetItem[]
+  }
+  try {
+    committed = await runWithStorageSerializationRetry(() =>
+      storage.transaction(
+        async (tx) => {
+          const existingMap = await tx.objects.getByPrimaryIdBatch({
+            projectId,
+            items: collectExistenceLookups(indexed),
+          })
+          const assignedItems: IndexedLinkSetItem[] = []
+          const missingItems: MissingLinkSetItem[] = []
+
+          for (const entry of indexed) {
+            const { item } = entry
+            const sourceKey = `${item.objectType.id}:${item.sourceId}`
+            if (!existingMap.has(sourceKey)) {
+              missingItems.push({
+                index: entry.index,
+                error: new ObjectNotFoundError(
+                  item.objectType.id,
+                  item.sourceId,
+                  "Source object not found"
+                ),
+              })
+              continue
+            }
+
+            const targetKey = `${item.targetTypeId}:${item.targetId}`
+            if (!existingMap.has(targetKey)) {
+              missingItems.push({
+                index: entry.index,
+                error: new ObjectNotFoundError(
+                  item.targetTypeId,
+                  item.targetId,
+                  "Target object not found"
+                ),
+              })
+              continue
+            }
+
+            assignedItems.push(entry)
+          }
+
+          if (assignedItems.length === 0) {
+            return { events: [], assignedIndices: [], missingItems }
+          }
+
+          const editCommit = await applyEditBatchCommit({
+            storage: tx,
+            projectId,
+            ontology,
+            batch: {
+              version: 1,
+              operations: assignedItems.map(({ item }) => ({
+                kind: "link.set" as const,
+                source: { objectTypeId: item.objectType.id, primaryId: item.sourceId },
+                linkId: item.linkId,
+                target: { objectTypeId: item.targetTypeId, primaryId: item.targetId },
+              })),
+            },
+            committedAt,
+            ...(options.idempotencyKeyPrefix !== undefined
+              ? { idempotencyKeyPrefix: options.idempotencyKeyPrefix }
+              : {}),
+          })
+
+          return {
+            events: editCommit.events,
+            assignedIndices: assignedItems.map(({ index }) => index),
+            missingItems,
+          }
+        },
+        { isolation: "serializable" }
+      )
+    )
+  } catch (error) {
+    const normalized = error instanceof Error ? error : new Error(String(error))
+    return items.map(() => ({ ok: false, error: normalized }))
+  }
+
+  // Match action commits: storage state is atomic, while mutation-event delivery is best effort.
+  if (committed.events.length > 0) {
+    try {
+      await events.append({ events: committed.events })
+    } catch (error) {
+      console.error("[Sixb] Failed to emit cardinality-one link assignment events:", error)
+    }
+  }
+
+  const results: BatchItemResult<void>[] = new Array(items.length)
+  for (const { index, error } of committed.missingItems) {
+    results[index] = { ok: false, error }
+  }
+  for (const index of committed.assignedIndices) {
+    results[index] = { ok: true, value: undefined }
+  }
+  return results
+}
+
+function collectExistenceLookups(
+  items: readonly {
+    item: {
+      objectType: ObjectTypeWithPropertyTokens
+      sourceId: string
+      targetTypeId: string
+      targetId: string
+    }
+  }[]
+): { objectTypeId: string; primaryId: string }[] {
+  const lookups: { objectTypeId: string; primaryId: string }[] = []
+  const keys = new Set<string>()
+
+  for (const { item } of items) {
+    const sourceKey = `${item.objectType.id}:${item.sourceId}`
+    if (!keys.has(sourceKey)) {
+      keys.add(sourceKey)
+      lookups.push({ objectTypeId: item.objectType.id, primaryId: item.sourceId })
+    }
+
+    const targetKey = `${item.targetTypeId}:${item.targetId}`
+    if (!keys.has(targetKey)) {
+      keys.add(targetKey)
+      lookups.push({ objectTypeId: item.targetTypeId, primaryId: item.targetId })
+    }
+  }
+
+  return lookups
+}

--- a/packages/core/src/objects/service/index.ts
+++ b/packages/core/src/objects/service/index.ts
@@ -1,5 +1,5 @@
 export { requestAction, requestActionAndWait } from "./action-service"
-export { removeLink, upsertLink, upsertLinkBatch } from "./link-service"
+export { removeLink, setLinkBatch, upsertLink, upsertLinkBatch } from "./link-service"
 export type { ListObjectsParams } from "./list-service"
 export { listObjects } from "./list-service"
 export { upsertObject, upsertObjectBatch } from "./object-service"

--- a/packages/core/src/objects/service/link-service.ts
+++ b/packages/core/src/objects/service/link-service.ts
@@ -8,6 +8,8 @@ import type { ResolvedLinkBatchItem } from "../context"
 import { requireLinkDefinition, resolveLinkContext, resolveObjectContext } from "../context"
 import {
   removeLink as removeLinkLeaf,
+  type SetLinkBatchOptions,
+  setLinkBatch as setLinkBatchLeaf,
   upsertLinkBatch as upsertLinkBatchLeaf,
   upsertLink as upsertLinkLeaf,
 } from "../link"
@@ -54,6 +56,32 @@ export async function upsertLinkBatch(
   })
 
   return upsertLinkBatchLeaf(runtime, resolvedItems)
+}
+
+export async function setLinkBatch(
+  runtime: SixbRuntimeContext,
+  items: readonly {
+    objectTypeId: string
+    sourceId: string
+    linkId: string
+    target: { targetTypeId: string; targetId: string }
+  }[],
+  options: SetLinkBatchOptions = {}
+): Promise<readonly BatchItemResult<void>[]> {
+  const resolvedItems: ResolvedLinkBatchItem[] = items.map((item) => {
+    const objectType = runtime.ontology.resolveObjectType(item.objectTypeId)
+    const linkDefinition = requireLinkDefinition(objectType, item.linkId)
+    return {
+      objectType,
+      linkDefinition,
+      sourceId: item.sourceId,
+      linkId: item.linkId,
+      targetTypeId: item.target.targetTypeId,
+      targetId: item.target.targetId,
+    }
+  })
+
+  return setLinkBatchLeaf(runtime, resolvedItems, options)
 }
 
 export async function removeLink(

--- a/packages/core/tests/batch-upsert.test.ts
+++ b/packages/core/tests/batch-upsert.test.ts
@@ -3,10 +3,15 @@ import {
   defineObjectType,
   link,
   ObjectNotFoundError,
+  type OntologyRegistry,
   OntologyValidationError,
   prop,
   Sixb,
+  type Storage,
 } from "../src"
+import { applyEditBatchCommit } from "../src/edits/commit"
+import { objectService } from "../src/objects"
+import { StorageTransactionError } from "../src/storage"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
 // ── Test fixtures ────────────────────────────────────────────
@@ -304,5 +309,235 @@ describe("upsertLinkBatch", () => {
 
     // Should be exactly 1 events.append call for all links
     expect(appendSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── setLinkBatch ─────────────────────────────────────────────
+
+describe("setLinkBatch", () => {
+  test("atomically replaces a cardinality-one target", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({ ontology: [Building, Room, Sensor], ...deps })
+
+    await sixb.upsertObject("building", { id: "b1", name: "HQ" })
+    await sixb.upsertObject("building", { id: "b2", name: "Branch" })
+    await sixb.upsertObject("room", { id: "r1", name: "Room 1" })
+    await sixb.upsertLink("room", "r1", "inBuilding", {
+      targetTypeId: "building",
+      targetId: "b1",
+    })
+    const appendSpy = mock(sixb.events.append.bind(sixb.events))
+    sixb.events.append = appendSpy
+
+    const results = await objectService.setLinkBatch(sixb, [
+      {
+        objectTypeId: "room",
+        sourceId: "r1",
+        linkId: "inBuilding",
+        target: { targetTypeId: "building", targetId: "b2" },
+      },
+    ])
+
+    expect(results).toEqual([{ ok: true, value: undefined }])
+    const links = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "room",
+      objectId: "r1",
+      linkId: "inBuilding",
+    })
+    expect(links).toHaveLength(1)
+    expect(links[0]?.targetId).toBe("b2")
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(appendSpy.mock.calls[0]?.[0].events.map((event) => event.type)).toEqual([
+      "link.deleted",
+      "link.created",
+    ])
+  })
+
+  test("preserves the current target when the desired target is missing", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({ ontology: [Building, Room, Sensor], ...deps })
+
+    await sixb.upsertObject("building", { id: "b1", name: "HQ" })
+    await sixb.upsertObject("room", { id: "r1", name: "Room 1" })
+    await sixb.upsertLink("room", "r1", "inBuilding", {
+      targetTypeId: "building",
+      targetId: "b1",
+    })
+
+    const results = await objectService.setLinkBatch(sixb, [
+      {
+        objectTypeId: "room",
+        sourceId: "r1",
+        linkId: "inBuilding",
+        target: { targetTypeId: "building", targetId: "missing-building" },
+      },
+    ])
+
+    expect(results).toHaveLength(1)
+    expect(results[0]?.ok).toBe(false)
+    if (!results[0]?.ok) {
+      expect(results[0].error).toBeInstanceOf(ObjectNotFoundError)
+    }
+    const links = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "room",
+      objectId: "r1",
+      linkId: "inBuilding",
+    })
+    expect(links).toHaveLength(1)
+    expect(links[0]?.targetId).toBe("b1")
+  })
+
+  test("rechecks missing targets after a serialization retry", async () => {
+    const deps = createTestRuntimeDeps()
+    const backingStorage = deps.storage
+    let projectId = ""
+    let ontology!: OntologyRegistry
+    let transactionAttempts = 0
+    const racingStorage: Storage = {
+      objects: backingStorage.objects,
+      timeseries: backingStorage.timeseries,
+      async transaction(run, options) {
+        transactionAttempts += 1
+        if (transactionAttempts === 1) {
+          const conflict = new StorageTransactionError("retry assignment", {
+            code: "serialization_failure",
+          })
+          try {
+            await backingStorage.transaction(async (tx) => {
+              await run(tx)
+              throw conflict
+            }, options)
+          } catch (error) {
+            await backingStorage.transaction(
+              (tx) =>
+                applyEditBatchCommit({
+                  storage: tx,
+                  projectId,
+                  ontology,
+                  batch: {
+                    version: 1,
+                    operations: [
+                      { kind: "object.delete", objectTypeId: "building", primaryId: "b2" },
+                    ],
+                  },
+                  committedAt: new Date(),
+                }),
+              { isolation: "serializable" }
+            )
+            throw error
+          }
+        }
+        return backingStorage.transaction(run, options)
+      },
+    }
+    const sixb = new Sixb({
+      ontology: [Building, Room, Sensor],
+      ...deps,
+      storage: racingStorage,
+    })
+    projectId = sixb.id
+    ontology = sixb.ontology
+
+    for (const [id, name] of [
+      ["b1", "Current"],
+      ["b2", "Deleted before retry"],
+      ["b3", "Valid replacement"],
+    ] as const) {
+      await sixb.upsertObject("building", { id, name })
+    }
+    for (const roomId of ["r1", "r2"]) {
+      await sixb.upsertObject("room", { id: roomId, name: roomId })
+      await sixb.upsertLink("room", roomId, "inBuilding", {
+        targetTypeId: "building",
+        targetId: "b1",
+      })
+    }
+
+    const results = await objectService.setLinkBatch(sixb, [
+      {
+        objectTypeId: "room",
+        sourceId: "r1",
+        linkId: "inBuilding",
+        target: { targetTypeId: "building", targetId: "b2" },
+      },
+      {
+        objectTypeId: "room",
+        sourceId: "r2",
+        linkId: "inBuilding",
+        target: { targetTypeId: "building", targetId: "b3" },
+      },
+    ])
+
+    expect(transactionAttempts).toBe(2)
+    expect(results[0]?.ok).toBe(false)
+    if (!results[0]?.ok) expect(results[0].error).toBeInstanceOf(ObjectNotFoundError)
+    expect(results[1]).toEqual({ ok: true, value: undefined })
+
+    const [r1Links, r2Links] = await Promise.all(
+      ["r1", "r2"].map((objectId) =>
+        backingStorage.objects.listLinks({
+          projectId: sixb.id,
+          objectTypeId: "room",
+          objectId,
+          linkId: "inBuilding",
+        })
+      )
+    )
+    expect(r1Links.map((link) => link.targetId)).toEqual(["b1"])
+    expect(r2Links.map((link) => link.targetId)).toEqual(["b3"])
+  })
+
+  test("serializes concurrent assignments without cardinality violations", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({ ontology: [Building, Room, Sensor], ...deps })
+
+    for (const buildingId of ["b1", "b2"]) {
+      await sixb.upsertObject("building", { id: buildingId, name: buildingId })
+    }
+    await sixb.upsertObject("room", { id: "r1", name: "Room 1" })
+
+    const results = await Promise.all(
+      ["b1", "b2"].map((targetId) =>
+        objectService.setLinkBatch(sixb, [
+          {
+            objectTypeId: "room",
+            sourceId: "r1",
+            linkId: "inBuilding",
+            target: { targetTypeId: "building", targetId },
+          },
+        ])
+      )
+    )
+
+    expect(results.flat().every((result) => result.ok)).toBe(true)
+    const links = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "room",
+      objectId: "r1",
+      linkId: "inBuilding",
+    })
+    expect(links).toHaveLength(1)
+    expect(["b1", "b2"]).toContain(links[0]?.targetId)
+  })
+
+  test("rejects assignment semantics for cardinality-many links", async () => {
+    const deps = createTestRuntimeDeps()
+    const sixb = new Sixb({ ontology: [Building, Room, Sensor], ...deps })
+
+    await sixb.upsertObject("room", { id: "r1", name: "Room 1" })
+    await sixb.upsertObject("sensor", { id: "s1", name: "Temp" })
+
+    await expect(
+      objectService.setLinkBatch(sixb, [
+        {
+          objectTypeId: "room",
+          sourceId: "r1",
+          linkId: "hasSensors",
+          target: { targetTypeId: "sensor", targetId: "s1" },
+        },
+      ])
+    ).rejects.toThrow("setLinkBatch requires cardinality 'one' link 'room.hasSensors'")
   })
 })

--- a/packages/core/tests/edits.test.ts
+++ b/packages/core/tests/edits.test.ts
@@ -21,6 +21,7 @@ import {
   planEditBatch,
   validateEditBatch,
 } from "../src/edits"
+import { buildLinkUpsertEvent } from "../src/events"
 import { type ActionRunStorage, ObjectStorageError, StorageTransactionError } from "../src/storage"
 
 const Customer = defineObjectType({
@@ -1009,6 +1010,24 @@ describe("EditBatch staged object upsert", () => {
 })
 
 describe("EditBatch cardinality-one link assignment", () => {
+  test("builds unambiguous event keys for primary IDs containing delimiters", () => {
+    const event = (sourceId: string, targetId: string) =>
+      buildLinkUpsertEvent({
+        sourceTypeId: "Invoice",
+        sourceId,
+        linkId: "customer",
+        targetTypeId: "Customer",
+        targetId,
+        operation: "create",
+        idempotencyKeyPrefix: "commit",
+      })
+    const delimiter = ":customer:Customer:"
+
+    expect(event("inv", `cus${delimiter}1`).idempotencyKey).not.toBe(
+      event(`inv${delimiter}cus`, "1").idempotencyKey
+    )
+  })
+
   test("records set and clear intent without reading the current target", async () => {
     const batch = await recordRuntimeEdits({ runId: "act_assign_link" }, ({ objects }) => {
       const invoice = objects(Invoice).byId("inv_1")

--- a/packages/projection-worker/README.md
+++ b/packages/projection-worker/README.md
@@ -48,6 +48,8 @@ await runProjectionJob({
 
 - The worker executes the projection named by the job. It does not resolve projection dependencies.
 - V1 materialization is set-only: projected rows upsert state, missing rows do not delete state.
+- A nonblank FK assigns a cardinality-one link, atomically replacing a different current target.
+  Blank FKs remain no-ops; cardinality-many FK links remain additive.
 - V1 traceability lives in dataset versions and projection run records; object writes do not carry
   projection-specific metadata.
 

--- a/packages/projection-worker/src/run-object-projection.ts
+++ b/packages/projection-worker/src/run-object-projection.ts
@@ -21,6 +21,7 @@ interface RunObjectProjectionInput {
   readonly runtime: ProjectionWorkerContext
   readonly projection: ObjectProjectionDefinition
   readonly dataset: DatasetDefinition
+  readonly runId: string
   readonly versionId: string
   readonly signal: AbortSignal
   readonly batchSize: number
@@ -40,7 +41,7 @@ interface ForeignKeyLinkItem {
 export async function runObjectProjection(
   input: RunObjectProjectionInput
 ): Promise<ProjectionExecutionResult> {
-  const { runtime, projection, dataset, versionId, signal, batchSize, onProgress } = input
+  const { runtime, projection, dataset, runId, versionId, signal, batchSize, onProgress } = input
   const primaryPropertyId = runtime.ontology.getPrimaryPropertyId(projection.objectTypeId)
   const projectionPlan = buildObjectProjectionPlan({
     ontology: runtime.ontology,
@@ -48,6 +49,7 @@ export async function runObjectProjection(
     dataset,
     primaryPropertyId,
   })
+  let flushIndex = 0
 
   return runStreamingProjection<ProjectedObjectRow>({
     runtime,
@@ -68,7 +70,17 @@ export async function runObjectProjection(
         }
         return { status: "item", item: projected.row }
       },
-      flushBatch: (rows, ctx) => flushObjectBatch({ runtime, projection, rows, ctx }),
+      flushBatch(rows, ctx) {
+        const currentFlushIndex = flushIndex
+        flushIndex += 1
+        return flushObjectBatch({
+          runtime,
+          projection,
+          eventIdempotencyKeyPrefix: `projection.commit:${runId}:batch:${currentFlushIndex}`,
+          rows,
+          ctx,
+        })
+      },
     },
   })
 }
@@ -76,10 +88,11 @@ export async function runObjectProjection(
 async function flushObjectBatch(input: {
   readonly runtime: ProjectionWorkerContext
   readonly projection: ObjectProjectionDefinition
+  readonly eventIdempotencyKeyPrefix: string
   readonly rows: readonly ProjectedObjectRow[]
   readonly ctx: FlushContext
 }): Promise<void> {
-  const { runtime, projection, rows, ctx } = input
+  const { runtime, projection, eventIdempotencyKeyPrefix, rows, ctx } = input
   const { counters, rememberError } = ctx
 
   const batchResults = await objectService.upsertObjectBatch(
@@ -104,9 +117,10 @@ async function flushObjectBatch(input: {
     )
   }
 
-  await upsertForeignKeyLinks({
+  await materializeForeignKeyLinks({
     runtime,
     projection,
+    eventIdempotencyKeyPrefix,
     rows: succeededRows,
     counters,
     rememberError,
@@ -120,22 +134,27 @@ function objectProjectionReadColumns(projection: ObjectProjectionDefinition): re
   return [...new Set([...Object.values(projection.properties), ...linkSourceFields])]
 }
 
-async function upsertForeignKeyLinks(input: {
+async function materializeForeignKeyLinks(input: {
   readonly runtime: ProjectionWorkerContext
   readonly projection: ObjectProjectionDefinition
+  readonly eventIdempotencyKeyPrefix: string
   readonly rows: readonly ProjectedObjectRow[]
   readonly counters: {
     linksUpserted: number
   }
   readonly rememberError: (message: string) => void
 }): Promise<void> {
-  const { runtime, projection, rows, counters, rememberError } = input
+  const { runtime, projection, eventIdempotencyKeyPrefix, rows, counters, rememberError } = input
   const descriptors = Object.values(projection.links)
   if (descriptors.length === 0 || rows.length === 0) {
     return
   }
 
-  const linkItems: ForeignKeyLinkItem[] = []
+  const objectType = runtime.ontology.resolveObjectType(projection.objectTypeId)
+  const linksById = new Map(objectType.links.map((link) => [link.id, link]))
+  const assignmentItems: ForeignKeyLinkItem[] = []
+  const additiveItems: ForeignKeyLinkItem[] = []
+
   for (const row of rows) {
     for (const descriptor of descriptors) {
       const fkValue = row.foreignKeyValues[descriptor.linkId]
@@ -143,7 +162,7 @@ async function upsertForeignKeyLinks(input: {
         continue
       }
 
-      linkItems.push({
+      const item: ForeignKeyLinkItem = {
         objectTypeId: projection.objectTypeId,
         sourceId: String(row.primaryValue),
         linkId: descriptor.linkId,
@@ -151,21 +170,41 @@ async function upsertForeignKeyLinks(input: {
           targetTypeId: descriptor.targetObjectTypeId,
           targetId: String(fkValue),
         },
-      })
+      }
+      const linkDefinition = linksById.get(descriptor.linkId)
+      if (!linkDefinition) {
+        throw new Error(
+          `[SixbProjectionWorker] Projection '${projection.id}' references unknown link '${descriptor.linkId}' on object type '${projection.objectTypeId}'.`
+        )
+      }
+
+      if (linkDefinition.cardinality === "one") {
+        assignmentItems.push(item)
+      } else {
+        additiveItems.push(item)
+      }
     }
   }
 
-  if (linkItems.length === 0) {
-    return
-  }
+  const assignmentResults = await objectService.setLinkBatch(runtime, assignmentItems, {
+    idempotencyKeyPrefix: eventIdempotencyKeyPrefix,
+  })
+  recordLinkResults(assignmentResults, counters, rememberError)
 
-  const linkResults = await objectService.upsertLinkBatch(runtime, linkItems)
-  for (let index = 0; index < linkResults.length; index += 1) {
-    const result = linkResults[index]
-    if (result?.ok) {
+  const additiveResults = await objectService.upsertLinkBatch(runtime, additiveItems)
+  recordLinkResults(additiveResults, counters, rememberError)
+}
+
+function recordLinkResults(
+  results: readonly { readonly ok: boolean; readonly error?: Error }[],
+  counters: { linksUpserted: number },
+  rememberError: (message: string) => void
+): void {
+  for (const result of results) {
+    if (result.ok) {
       counters.linksUpserted += 1
-    } else if (!(result?.error instanceof ObjectNotFoundError)) {
-      rememberError(errorMessage(result?.error))
+    } else if (!(result.error instanceof ObjectNotFoundError)) {
+      rememberError(errorMessage(result.error))
     }
   }
 }

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -156,6 +156,7 @@ async function executeProjection(input: {
       runtime,
       projection,
       dataset,
+      runId: job.id,
       versionId: job.versionId,
       signal,
       batchSize,

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -92,6 +92,14 @@ const roomProjectionWithFk = roomProjection.withLinks({
   }),
 })
 
+const roomProjectionWithManyFk = roomProjection.withLinks({
+  hasSensors: fromForeignKey({
+    link: Room.l.hasSensors,
+    sourceField: "building_ref",
+    target: Sensor,
+  }),
+})
+
 const roomProjectionWithDatasetFieldFk = defineProjection("room-dataset-field-fk-proj", Room)
   .fromDataset(roomsDataset)
   .properties({ id: "room_id", name: "room_name" })
@@ -958,6 +966,220 @@ describe("runProjectionJob", () => {
     })
     expect(links).toHaveLength(1)
     expect(links[0]?.targetId).toBe("b1")
+  })
+
+  test("atomically reassigns cardinality-one FK links", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjectionWithFk],
+      },
+      deps
+    )
+    await sixb.upsertObject("Building", { id: "b1", name: "Old HQ" })
+    await sixb.upsertObject("Building", { id: "b2", name: "New HQ" })
+    await sixb.upsertObject("Room", { id: "r1", name: "Kitchen", buildingRef: "b1" })
+    await sixb.upsertLink("Room", "r1", "inBuilding", {
+      targetTypeId: "Building",
+      targetId: "b1",
+    })
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: "b2" },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-reassign-fk",
+        projectionId: "room-proj",
+        projectionKind: "object",
+        datasetId: "canonical.rooms",
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.run.status).toBe("succeeded")
+    expect(result.linksUpserted).toBe(1)
+
+    const links = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      linkId: "inBuilding",
+    })
+    expect(links).toHaveLength(1)
+    expect(links[0]?.targetId).toBe("b2")
+
+    const repeated = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-reassign-fk-repeated",
+        projectionId: "room-proj",
+        projectionKind: "object",
+        datasetId: "canonical.rooms",
+        versionId: version.versionId,
+      },
+    })
+    expect(repeated.run.status).toBe("succeeded")
+    expect(repeated.linksUpserted).toBe(1)
+    expect(
+      await deps.storage.objects.listLinks({
+        projectId: sixb.id,
+        objectTypeId: "Room",
+        objectId: "r1",
+        linkId: "inBuilding",
+      })
+    ).toHaveLength(1)
+  })
+
+  test("keeps cardinality-many FK links additive", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjectionWithManyFk],
+      },
+      deps
+    )
+    for (const sensorId of ["s1", "s2"]) {
+      await sixb.upsertObject("Sensor", { id: sensorId, name: sensorId })
+    }
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: "s1" },
+      { room_id: "r1", room_name: "Kitchen", building_ref: "s2" },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-many-fk",
+        projectionId: "room-proj",
+        projectionKind: "object",
+        datasetId: "canonical.rooms",
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.run.status).toBe("succeeded")
+    expect(result.linksUpserted).toBe(2)
+    const links = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      linkId: "hasSensors",
+    })
+    expect(links.map((link) => link.targetId).sort()).toEqual(["s1", "s2"])
+  })
+
+  test("uses flush-scoped idempotency keys for repeated FK edges", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjectionWithFk],
+      },
+      deps
+    )
+    for (const buildingId of ["b1", "b2"]) {
+      await sixb.upsertObject("Building", { id: buildingId, name: buildingId })
+    }
+
+    const originalAppend = sixb.events.append.bind(sixb.events)
+    const seenKeys = new Set<string>()
+    const publishedB1Creates: string[] = []
+    sixb.events.append = async (params) => {
+      const uniqueEvents = params.events.filter((event) => {
+        const key = event.idempotencyKey
+        if (key === undefined) return true
+        if (seenKeys.has(key)) return false
+        seenKeys.add(key)
+        return true
+      })
+      for (const event of uniqueEvents) {
+        if (event.type === "link.created" && event.payload.targetId === "b1") {
+          publishedB1Creates.push(event.idempotencyKey ?? "")
+        }
+      }
+      return originalAppend({ events: uniqueEvents })
+    }
+
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: "b1" },
+      { room_id: "r1", room_name: "Kitchen", building_ref: "b2" },
+      { room_id: "r1", room_name: "Kitchen", building_ref: "b1" },
+    ])
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-repeated-edge",
+        projectionId: "room-proj",
+        projectionKind: "object",
+        datasetId: "canonical.rooms",
+        versionId: version.versionId,
+      },
+      batchSize: 1,
+    })
+
+    expect(result.run.status).toBe("succeeded")
+    expect(result.linksUpserted).toBe(3)
+    expect(publishedB1Creates).toHaveLength(2)
+    expect(new Set(publishedB1Creates).size).toBe(2)
+
+    const links = await deps.storage.objects.listLinks({
+      projectId: sixb.id,
+      objectTypeId: "Room",
+      objectId: "r1",
+      linkId: "inBuilding",
+    })
+    expect(links.map((link) => link.targetId)).toEqual(["b1"])
+  })
+
+  test("preserves cardinality-one links for blank or missing FK targets", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjectionWithFk],
+      },
+      deps
+    )
+    await sixb.upsertObject("Building", { id: "b1", name: "HQ" })
+    for (const roomId of ["r1", "r2"]) {
+      await sixb.upsertObject("Room", { id: roomId, name: roomId, buildingRef: "b1" })
+      await sixb.upsertLink("Room", roomId, "inBuilding", {
+        targetTypeId: "Building",
+        targetId: "b1",
+      })
+    }
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: null },
+      { room_id: "r2", room_name: "Office", building_ref: "missing-building" },
+    ])
+
+    const result = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-preserve-fk",
+        projectionId: "room-proj",
+        projectionKind: "object",
+        datasetId: "canonical.rooms",
+        versionId: version.versionId,
+      },
+    })
+
+    expect(result.run.status).toBe("succeeded")
+    expect(result.linksUpserted).toBe(0)
+    for (const roomId of ["r1", "r2"]) {
+      const links = await deps.storage.objects.listLinks({
+        projectId: sixb.id,
+        objectTypeId: "Room",
+        objectId: roomId,
+        linkId: "inBuilding",
+      })
+      expect(links).toHaveLength(1)
+      expect(links[0]?.targetId).toBe("b1")
+    }
   })
 
   test("materializes FK links from dataset fields without storing FK properties", async () => {


### PR DESCRIPTION
## Summary

East Coast's production `canonical.contacts` projection failed when a contact's Pipedrive organization changed from RD Management (`organization:pipedrive:386`) to Brixmor (`organization:pipedrive:326`). Canonical data correctly contained the new FK, but the materialized `Contact.organization` link still pointed at the old organization, so the worker failed with:

```text
[Sixb] Link Contact.organization has cardinality 'one' and already points to Organization:organization:pipedrive:386
```

This was the only mismatch among 980 expected organization links: 979 already matched canonical data, while one legitimate parent reassignment prevented the projection run from succeeding. This is a normal FK synchronization case—a source record moves from one parent to another—but object projections currently send every nonblank FK through additive `upsertLinkBatch`, which cannot replace a cardinality-one edge.

This PR treats cardinality-one projected FKs as assignments using the `link.set` semantics introduced by #225. The projection can now atomically replace the stale target with the current canonical target without a manual unlink/relink repair.

## Resulting behavior

| Projected FK | Result |
| --- | --- |
| Cardinality one, no current target | Create the edge |
| Cardinality one, same target | Keep the edge idempotently |
| Cardinality one, different target | Atomically replace the old edge |
| Blank or missing target | Preserve the current edge |
| Cardinality many | Continue additive upsert behavior |

Replacements continue to emit the existing `link.deleted` and `link.created` event types; no new mutation event contract is introduced.

## Implementation

- Adds privileged internal `setLinkBatch`, which filters missing objects and plans `link.set` operations inside the same serializable transaction. Serialization conflicts use the shared bounded retry path.
- Partitions object-projection FK links by ontology cardinality: cardinality one uses assignment, while cardinality many stays on `upsertLinkBatch`.
- Uses projection-run and flush-scoped event idempotency prefixes so retries remain stable without suppressing legitimate repeated edges across batches.
- Encodes link event identities as JSON tuples, preserving field boundaries when primary IDs contain delimiters.

## Scope

- Projection semantics remain set-only: a blank FK does not clear an existing link.
- Missing targets remain per-item no-ops and do not remove the current target.
- `upsertLinkBatch` remains additive and continues rejecting destructive cardinality-one conflicts.
- No storage migration or provider-specific write path is required.

## Validation

- `bun test packages/core/tests/batch-upsert.test.ts`
- `bun test packages/core/tests/edits.test.ts packages/action-worker/tests packages/projection-worker/tests/run-projection-job.test.ts`
- `bun --filter @sixb/core typecheck`
- `bun --filter @sixb/action-worker typecheck`
- `bun --filter @sixb/projection-worker typecheck`
- `bun run typecheck:tests`
- `bun --filter @sixb/core build`
- `bun --filter @sixb/projection-worker build`
- `bun run check`

## Stack and review guidance

This PR is stacked on #225, which is itself stacked on #224. Review the internal transactional assignment path first, then the projection-worker routing and regression coverage.
