### PR TITLE
runtime: notify projects when runs fail

### DIFF
--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -63,11 +63,12 @@ export const sixb = createSixb({
 })
 ```
 
-Two demo scripts seed the system from the mock ERP and replay events:
+Two demo scripts seed the system from the mock ERP and replay events. With the default development
+topology they call the Sixb API on port `3002`:
 
 ```bash
 bun run sync:erp       # pull ERP rows into datasets, then project them into objects
-bun run webhooks:demo  # send sample webhook events at the running app
+bun run webhooks:demo  # send sample webhook events to the running API
 ```
 
 The ERP document sync stores a sample PDF and PNG through Sixb blob storage, writes them as

--- a/docs/runtime/error-handling.md
+++ b/docs/runtime/error-handling.md
@@ -1,0 +1,73 @@
+# Failed run notifications
+
+Sixb can notify project code when background runs reach a terminal `failed` state. Configure an
+`onError` callback on `createSixb()` and route the notification to the service your project uses.
+
+```ts
+import { createSixb } from "@sixb/core"
+
+export const sixb = await createSixb({
+  // providers and definitions...
+  async onError(error, context) {
+    await sendToSlack({
+      deduplicationKey: context.notificationId,
+      message: `${context.run.kind} run ${context.run.runId} failed: ${error.message}`,
+    })
+  },
+})
+```
+
+The callback covers failed action, agent, pipeline, projection, sync, workflow, and webhook runs.
+It does not run for successes, cancellations, retries that remain recoverable, workflow nodes or
+pipeline steps separately, or routine webhook 4xx rejections.
+
+## Context
+
+The second argument is a discriminated `SixbErrorContext`. Its current type is
+`SixbRunFailedContext`:
+
+```ts
+interface SixbRunFailedContext {
+  readonly type: "run.failed"
+  readonly notificationId: string
+  readonly projectId: string
+  readonly occurredAt: string
+  readonly attempt?: number
+  readonly run: SixbFailedRun
+}
+```
+
+Narrow `context.run.kind` to access the definition identifier for that run:
+
+```ts
+onError(error, context) {
+  if (context.run.kind === "projection") {
+    console.error(`Projection ${context.run.projectionId} failed`, error)
+  }
+
+  if (context.run.kind === "workflow") {
+    console.error(`Workflow ${context.run.workflowId} failed`, error)
+  }
+}
+```
+
+`notificationId` is stable for one failed-state transition and includes the project, run identity,
+and failure timestamp. Use it as an idempotency or deduplication key at the notification
+destination. If a supported retry reopens and later fails the same run again, that new transition
+receives a different identifier.
+
+## Delivery semantics
+
+`onError` is an in-process, best-effort observer rather than a broker event. Sixb isolates the
+handler from execution: a synchronous throw or rejected promise from `onError` cannot change run
+status, queue settlement, retries, or HTTP responses. Handler failures fall back to
+`console.error`.
+
+Sixb tracks pending asynchronous handlers and gives them up to five seconds to drain during
+graceful CLI shutdown. A process crash can still happen between persisting a failed run and
+delivering its notification, so this API does not provide exactly-once delivery. Integrations
+should use `notificationId` to tolerate possible duplicate delivery.
+
+The original `Error` is preserved when one exists. Sixb safely wraps non-`Error` thrown values. The
+context contains identifiers only; it does not include action parameters, webhook bodies,
+credentials, or queue payloads.

--- a/docs/runtime/overview.md
+++ b/docs/runtime/overview.md
@@ -50,9 +50,10 @@ local for dev, hosted backends for production).
 
 Optional: `id` (project id), `auth` (a `SixbAuthConfig`, see
 [Authentication](../auth/authentication.md)), `sandboxes` (a `SandboxFactory`), `logger` (a
-`LoggerProvider` for process-level log output) and `observability` (broker log-capture controls) —
-both covered in [Logging](../logging/overview.md) — and `projectRoot` (discovery root, defaults to
-`process.cwd()`).
+`LoggerProvider` for process-level log output), `observability` (broker log-capture controls),
+`onError` (terminal [failed run notifications](error-handling.md)), and `projectRoot` (discovery
+root, defaults to `process.cwd()`). Logging options are covered in
+[Logging](../logging/overview.md).
 
 ## The Sixb instance
 
@@ -188,6 +189,7 @@ export const sixb = await createSixb({
 
 ## Related
 
+- [Failed run notifications](error-handling.md) — route terminal run failures to project code
 - [Project structure](../fundamentals/project-structure.md) — folder layout and discovery
 - [Objects](../objects/overview.md) — the typed `sixb.objects(Type)` surface
 - [Events](../events/overview.md) — domain events and `sixb.events`

--- a/examples/acme-corp/scripts/send-webhooks.ts
+++ b/examples/acme-corp/scripts/send-webhooks.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_URL = "http://localhost:3000/api"
+const DEFAULT_API_URL = "http://localhost:3002/api"
 const WEBHOOK_PATH = "/webhooks/acme-erp/invoice-events"
 const LOCAL_WEBHOOK_SIGNATURE = "acme-local-secret"
 

--- a/examples/acme-corp/scripts/sync-erp.ts
+++ b/examples/acme-corp/scripts/sync-erp.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_URL = "http://localhost:3000/api"
+const DEFAULT_API_URL = "http://localhost:3002/api"
 const ROOT_SYNC_ID = "sync-erp-departments"
 
 interface RequestSyncRunResponse {

--- a/examples/acme-corp/sixb.config.ts
+++ b/examples/acme-corp/sixb.config.ts
@@ -11,6 +11,13 @@ export const sixb = createSixb({
   lakeStorage: new LocalLakeStorage({ path: ".sixb/lake" }),
   blobStorage: new LocalBlobStorage({ basePath: ".sixb" }),
   queues: new InMemoryQueues(),
+  // `bun run webhooks:demo` includes a deliberate handler failure that exercises this hook.
+  onError(error, context) {
+    console.error(
+      `[Sixb onError Callback] [AcmeCorp] ${context.run.kind} run '${context.run.runId}' failed (${context.notificationId}):`,
+      error
+    )
+  },
   sandboxes: new LocalSandboxFactory({
     timeout: 30_000,
     env: {

--- a/packages/action-worker/src/action-execution/results.ts
+++ b/packages/action-worker/src/action-execution/results.ts
@@ -1,3 +1,4 @@
+import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { ActionRunFailure, ActionRunRecord } from "@sixb/core/storage"
 import { isTerminalActionRun } from "@sixb/core/storage"
 import { ActionWorkerError } from "../errors"
@@ -47,6 +48,7 @@ export async function failRedeliveredRunningRun(
     phase: existingRun.phase ?? "validation",
   }
 
+  let transitioned = false
   const finishedRun = await runtime.actionRunsStorage
     .finish({
       projectId: runtime.id,
@@ -55,7 +57,11 @@ export async function failRedeliveredRunningRun(
       phase: failure.phase,
       error: failure,
     })
-    .catch(async (error) => {
+    .then((run) => {
+      transitioned = true
+      return run
+    })
+    .catch(async (finishError) => {
       const latest = await runtime.actionRunsStorage.getById({
         projectId: runtime.id,
         id: job.id,
@@ -65,7 +71,7 @@ export async function failRedeliveredRunningRun(
         return latest
       }
 
-      throw error
+      throw finishError
     })
 
   if (finishedRun.status !== "failed") {
@@ -77,6 +83,19 @@ export async function failRedeliveredRunningRun(
       skipped: true,
       record: finishedRun,
     }
+  }
+
+  if (transitioned) {
+    reportRunFailure(runtime.sixb, error, {
+      projectId: runtime.id,
+      occurredAt: finishedRun.finishedAt,
+      attempt: input.attempt,
+      run: {
+        kind: "action",
+        runId: job.id,
+        actionId: job.actionId,
+      },
+    })
   }
 
   return {

--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -1,3 +1,4 @@
+import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { ActionRunRecord } from "@sixb/core/storage"
 import { isTerminalActionRun } from "@sixb/core/storage"
 import { executeActionPhases } from "./action-execution/phases"
@@ -42,16 +43,15 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
 
   const action = runtime.getActionById(job.actionId)
   if (!action) {
-    const failure = toActionRunFailure(
-      new ActionWorkerError(`Unknown action '${job.actionId}'.`),
-      "validation"
-    )
+    const error = new ActionWorkerError(`Unknown action '${job.actionId}'.`)
+    const failure = toActionRunFailure(error, "validation")
     const finishedRun = await runtime.actionRunsStorage.finish({
       projectId: runtime.id,
       id: job.id,
       status: "failed",
       error: failure,
     })
+    reportActionFailure(input, error, finishedRun)
 
     return failedResult(job.id, job.actionId, finishedRun, failure)
   }
@@ -119,6 +119,9 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
     if (!finishedRun) {
       throw error
     }
+    if (status === "failed" && finishedRun.status === "failed") {
+      reportActionFailure(input, error, finishedRun)
+    }
 
     const startedAt = startedRun?.startedAt ?? finishedRun.startedAt ?? finishedRun.queuedAt
     return {
@@ -132,4 +135,17 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       record: finishedRun,
     }
   }
+}
+
+function reportActionFailure(input: RunActionJobInput, error: unknown, run: ActionRunRecord): void {
+  reportRunFailure(input.runtime.sixb, error, {
+    projectId: input.runtime.id,
+    occurredAt: run.finishedAt,
+    attempt: input.attempt,
+    run: {
+      kind: "action",
+      runId: input.job.id,
+      actionId: input.job.actionId,
+    },
+  })
 }

--- a/packages/action-worker/src/types.ts
+++ b/packages/action-worker/src/types.ts
@@ -48,6 +48,8 @@ export interface RunActionJobInput {
   readonly runtime: ActionWorkerContext
   readonly job: ActionJob
   readonly signal?: AbortSignal
+  /** Queue delivery attempt, when invoked by ActionWorker. */
+  readonly attempt?: number
 }
 
 export type ActionRunResult =

--- a/packages/action-worker/src/worker.ts
+++ b/packages/action-worker/src/worker.ts
@@ -91,6 +91,7 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
       runtime: context,
       job: actionJob,
       signal,
+      attempt: job.attempt,
     })
 
     if ("skipped" in result) {

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -14,6 +14,7 @@ import {
   prop,
   Sixb,
 } from "@sixb/core"
+import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import type { EventsRuntime } from "@sixb/core/internal/events"
 import type { ActionRunParams, ObjectRow } from "@sixb/core/storage"
 import { ActionWorkerError } from "../src/errors"
@@ -681,7 +682,7 @@ describe("runActionJob", () => {
     expect(run?.phase).toBe("validation")
   })
 
-  test("marks redelivered running runs failed before a resumable boundary", async () => {
+  test("reports a lease-loss failure once and not on terminal redelivery", async () => {
     let invoked = 0
     const count = defineAction("count")
       .params({})
@@ -690,6 +691,10 @@ describe("runActionJob", () => {
       })
 
     const sixb = createSixb([count])
+    let reportCount = 0
+    const reporter = attachSixbErrorReporter(sixb, () => {
+      reportCount += 1
+    })
     await queueActionRun(sixb, {
       id: "act_1",
       actionId: "count",
@@ -720,6 +725,15 @@ describe("runActionJob", () => {
     expect(run?.status).toBe("failed")
     expect(run?.phase).toBe("validation")
     expect(run?.finishedAt).toBeInstanceOf(Date)
+
+    const redelivered = await runActionJob({
+      runtime: createContext(sixb),
+      job: { id: "act_1", actionId: "count" },
+      attempt: 2,
+    })
+    expect("skipped" in redelivered && redelivered.skipped).toBe(true)
+    await reporter.flush()
+    expect(reportCount).toBe(1)
   })
 
   test("resumes from a persisted successful writeback without replaying it", async () => {
@@ -780,6 +794,10 @@ describe("runActionJob", () => {
       })
 
     const sixb = createSixb([setStatus])
+    let reportCount = 0
+    const reporter = attachSixbErrorReporter(sixb, () => {
+      reportCount += 1
+    })
     await sixb.upsertObject("Device", {
       id: "device-1",
       name: "Device 1",
@@ -810,6 +828,54 @@ describe("runActionJob", () => {
         phase: "effects",
       },
     })
+    await reporter.flush()
+    expect(reportCount).toBe(0)
+  })
+
+  test("does not report cancelled runs", async () => {
+    let enteredWriteback: (() => void) | undefined
+    const entered = new Promise<void>((resolve) => {
+      enteredWriteback = resolve
+    })
+    const waitForCancel = defineAction("waitForCancel")
+      .params({})
+      .writeback(
+        ({ signal }) =>
+          new Promise((_resolve, reject) => {
+            enteredWriteback?.()
+            signal.addEventListener(
+              "abort",
+              () => reject(signal.reason ?? new DOMException("Aborted", "AbortError")),
+              { once: true }
+            )
+          })
+      )
+    const sixb = createSixb([waitForCancel])
+    let reportCount = 0
+    const reporter = attachSixbErrorReporter(sixb, () => {
+      reportCount += 1
+    })
+    await queueActionRun(sixb, {
+      id: "act_cancelled",
+      actionId: "waitForCancel",
+      subject: { kind: "none" },
+      params: {},
+    })
+    const controller = new AbortController()
+
+    const execution = runActionJob({
+      runtime: createContext(sixb),
+      job: { id: "act_cancelled", actionId: "waitForCancel" },
+      signal: controller.signal,
+      attempt: 1,
+    })
+    await entered
+    controller.abort(new Error("worker stopping"))
+    const result = await execution
+
+    expect(result.status).toBe("cancelled")
+    await reporter.flush()
+    expect(reportCount).toBe(0)
   })
 
   test("rejects forged object subjects outside the action target hierarchy", async () => {

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -12,8 +12,10 @@ import {
   param,
   prop,
   Sixb,
+  type SixbErrorContext,
   type Storage,
 } from "@sixb/core"
+import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import { EventsRuntime } from "@sixb/core/internal/events"
 import { LOGS_STREAM } from "@sixb/core/internal/logging"
 import type { ActionRunRecord, ObjectRow } from "@sixb/core/storage"
@@ -269,6 +271,47 @@ describe("ActionWorker", () => {
     })
 
     await worker.stop()
+  })
+
+  test("reports a terminal action failure exactly once with the original error", async () => {
+    const originalError = new Error("writeback failed")
+    const fail = defineAction("fail")
+      .on(Device)
+      .params({})
+      .writeback(() => {
+        throw originalError
+      })
+    const sixb = createSixb([fail])
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    const reporter = attachSixbErrorReporter(sixb, (error, context) => {
+      reports.push({ error, context })
+    })
+    const worker = new ActionWorker(sixb)
+    await sixb.upsertObject("Device", { id: "device-1", name: "Device 1" })
+
+    await worker.start()
+    const failed = await deviceObjects(sixb).requestActionAndWait({
+      id: "device-1",
+      actionId: "fail",
+    })
+    await worker.stop()
+    await reporter.flush()
+
+    expect(failed.status).toBe("failed")
+    expect(reports).toHaveLength(1)
+    expect(reports[0]?.error).toBe(originalError)
+    expect(reports[0]?.context).toMatchObject({
+      type: "run.failed",
+      notificationId: `project:${sixb.id}:run:action:${failed.id}:failed:${failed.finishedAt?.toISOString()}`,
+      projectId: sixb.id,
+      attempt: 1,
+      run: {
+        kind: "action",
+        runId: failed.id,
+        actionId: "fail",
+      },
+    })
+    expect(reports[0]?.context.occurredAt).toBe(failed.finishedAt?.toISOString() ?? "")
   })
 
   test("requestActionAndWait resolves with the terminal action run", async () => {

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -5,6 +5,7 @@ import {
   dispatchQueuedAgentRuns,
   subscribeAgentRunCancel,
 } from "@sixb/core/internal/agents"
+import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { QueueDelivery, QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { isAbortError, QueueDeliveryLeaseLostError, QueueWorker } from "@sixb/core/internal/workers"
 import type { AgentRunRequestedQueueJob, ClaimedQueueJob } from "@sixb/core/queues"
@@ -150,6 +151,7 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
     const { agentId, threadId, runId, triggerMessageId } = job.payload
     const agent = this.sixb.agents.getById(agentId)
     if (!agent) {
+      const error = new AgentWorkerError(`Unknown agent '${agentId}'.`)
       const run = await context.storage.agents.runs.getById({ projectId: context.id, id: runId })
       if (
         run?.status === "queued" &&
@@ -163,10 +165,11 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
           status: "failed",
           error: `Agent '${agentId}' is not registered.`,
         })
+        this.reportFailure(error, failed, job.attempt)
         await context.streamSink.publishRunFinished(failed)
         return
       }
-      throw new AgentWorkerError(`Unknown agent '${agentId}'.`)
+      throw error
     }
     const identity = await reconcileAgentExecutionIdentity(context.storage, context.id, agent)
 
@@ -256,6 +259,9 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
         error
       )
       if (finalized) {
+        if (finalized.status === "failed") {
+          this.reportFailure(error, finalized, job.attempt)
+        }
         await context.streamSink.publishRunFinished(finalized)
       }
       // Shutdown abort: rethrow so `onAbortError` releases the job for another process. A user cancel
@@ -308,6 +314,7 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
         status: "failed",
         error: toErrorMessage(error),
       })
+      this.reportFailure(error, failed, claimed.job.attempt)
       await this.requireContext().streamSink.publishRunFinished(failed)
     }
     return { kind: "fail" }
@@ -457,6 +464,19 @@ export class AgentWorker extends QueueWorker<AgentRunRequestedQueueJob> {
       id: runId,
       executionToken,
       queueLeaseExpiresAt: new Date(queueLeaseExpiresAt),
+    })
+  }
+
+  private reportFailure(error: unknown, run: AgentRunRecord, attempt: number): void {
+    reportRunFailure(this.sixb, error, {
+      projectId: this.sixb.id,
+      occurredAt: run.completedAt,
+      attempt,
+      run: {
+        kind: "agent",
+        runId: run.id,
+        agentId: run.agentId,
+      },
     })
   }
 

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -28,6 +28,7 @@ import {
   type SandboxFactory,
   type SandboxFileRecord,
   Sixb,
+  type SixbErrorContext,
   type Storage,
 } from "@sixb/core"
 import { type AgentRunStreamEvent, agentRunStreamId } from "@sixb/core/agents/streams"
@@ -37,6 +38,7 @@ import {
   createAgentRunId,
   publishAgentRunCancel,
 } from "@sixb/core/internal/agents"
+import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import type { EventsRuntime } from "@sixb/core/internal/events"
 import {
   type AgentStorage,
@@ -49,7 +51,7 @@ import { AgentWorker, type AgentWorkerOptions } from "../src"
 import { loadAgentSkills } from "../src/agent-skills"
 import { normalizeApiBaseUrl } from "../src/api-url"
 import { prepareAgentAttachments } from "../src/attachments"
-import { AgentExecutionLostError, AgentFinalizationError } from "../src/errors"
+import { AgentExecutionLostError, AgentFinalizationError, AgentWorkerError } from "../src/errors"
 import { finishRunOrThrow } from "../src/finalize"
 import { reconcileAgentExecutionIdentity } from "../src/identity"
 import { runAgentTurn } from "../src/run-agent-turn"
@@ -1669,9 +1671,13 @@ describe("AgentWorker", () => {
     }
   })
 
-  test("redelivers with a fresh execution token after queue ownership is lost", async () => {
+  test("redelivers without reporting when queue ownership is lost", async () => {
     const sixb = buildSixb(slowAnswerModel(120))
     const storage = agentStorageOf(sixb)
+    let reportCount = 0
+    const reporter = attachSixbErrorReporter(sixb, () => {
+      reportCount += 1
+    })
     const queue = sixb.queues.agents
     const originalRenew = queue.renewLease?.bind(queue)
     if (!originalRenew) throw new Error("expected queue lease renewal")
@@ -1702,6 +1708,8 @@ describe("AgentWorker", () => {
         (message) => message.role === "assistant"
       )
       expect(assistants).toHaveLength(1)
+      await reporter.flush()
+      expect(reportCount).toBe(0)
     } finally {
       await worker.stop()
       console.error = originalConsoleError
@@ -2344,10 +2352,14 @@ describe("AgentWorker", () => {
     }
   })
 
-  test("cancels an in-flight run, records it cancelled, and frees the thread", async () => {
+  test("cancels an in-flight run without reporting a failure", async () => {
     const controlled = controlledBlockingAnswerModel()
     const sixb = buildSixb(controlled.model, new InMemoryBroker(), new RecordingSandboxFactory())
     const storage = agentStorageOf(sixb)
+    let reportCount = 0
+    const reporter = attachSixbErrorReporter(sixb, () => {
+      reportCount += 1
+    })
 
     const request = await sixb.agents.request({ agentId: "assistant", text: "go" })
 
@@ -2385,6 +2397,8 @@ describe("AgentWorker", () => {
       const records = await listRunStreamRecords(sixb.broker, request.run.id)
       const finished = records.find((record) => record.name === "agent.run.finished")
       expect((finished?.payload as { status?: string } | undefined)?.status).toBe("cancelled")
+      await reporter.flush()
+      expect(reportCount).toBe(0)
     } finally {
       await worker.stop()
     }
@@ -2495,9 +2509,13 @@ describe("AgentWorker", () => {
     }
   })
 
-  test("continues the turn when broker run stream publishing fails", async () => {
+  test("does not report broker run stream publication failures", async () => {
     const sixb = buildSixb(toolThenAnswerModel(), new FailingRunStreamBroker())
     const storage = agentStorageOf(sixb)
+    let reportCount = 0
+    const reporter = attachSixbErrorReporter(sixb, () => {
+      reportCount += 1
+    })
     const originalConsoleError = console.error
     console.error = () => {}
 
@@ -2521,6 +2539,8 @@ describe("AgentWorker", () => {
         (message) => message.role === "assistant"
       )
       expect(assistants).toHaveLength(1)
+      await reporter.flush()
+      expect(reportCount).toBe(0)
     } finally {
       await worker.stop()
       console.error = originalConsoleError
@@ -2827,19 +2847,24 @@ describe("AgentWorker", () => {
     expect(capturedProviderOptions).toEqual({ openai: { reasoningSummary: "detailed" } })
   })
 
-  test("records a run-level failure on the record (model error)", async () => {
+  test("reports a terminal model failure exactly once with the original error", async () => {
+    const originalError = new Error("provider boom")
     const failingModel = new MockLanguageModelV4({
       modelId: "mock-model",
       doStream: async () => ({
         stream: new ReadableStream<LanguageModelV4StreamPart>({
           start(controller) {
             controller.enqueue({ type: "stream-start", warnings: [] })
-            controller.error(new Error("provider boom"))
+            controller.error(originalError)
           },
         }),
       }),
     })
     const sixb = buildSixb(failingModel)
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    const reporter = attachSixbErrorReporter(sixb, (error, context) => {
+      reports.push({ error, context })
+    })
     const storage = agentStorageOf(sixb)
 
     const worker = new AgentWorker(sixb, workerOptions())
@@ -2858,6 +2883,17 @@ describe("AgentWorker", () => {
       )
       expect(run.status).toBe("failed")
       expect(run.error).toBeDefined()
+      await reporter.flush()
+      expect(reports).toHaveLength(1)
+      expect(reports[0]?.error).toBe(originalError)
+      expect(reports[0]?.context).toMatchObject({
+        type: "run.failed",
+        notificationId: `project:${PROJECT_ID}:run:agent:${run.id}:failed:${run.completedAt?.toISOString()}`,
+        projectId: PROJECT_ID,
+        attempt: 1,
+        run: { kind: "agent", runId: run.id, agentId: "assistant" },
+      })
+      expect(reports[0]?.context.occurredAt).toBe(run.completedAt?.toISOString() ?? "")
       expect(
         (await listRunStreamRecords(sixb.broker, run.id)).find(
           (record) => record.name === "agent.run.finished"
@@ -3157,9 +3193,13 @@ describe("AgentWorker", () => {
     }
   })
 
-  test("records a durable failure when the queued agent is no longer registered", async () => {
+  test("reports a queued run failed when its agent is no longer registered", async () => {
     const sixb = buildSixb(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    const reporter = attachSixbErrorReporter(sixb, (error, context) => {
+      reports.push({ error, context })
+    })
     const threadId = "thread-missing-agent"
     const runId = createAgentRunId()
     const triggerMessageId = "message-missing-agent"
@@ -3207,6 +3247,14 @@ describe("AgentWorker", () => {
       )
       expect(failed).toMatchObject({ status: "failed", attempt: 0 })
       expect(failed.error).toContain("not registered")
+      await reporter.flush()
+      expect(reports).toHaveLength(1)
+      expect(reports[0]?.error).toBeInstanceOf(AgentWorkerError)
+      expect(reports[0]?.context).toMatchObject({
+        projectId: PROJECT_ID,
+        attempt: 1,
+        run: { kind: "agent", runId, agentId: "removed-agent" },
+      })
       await expect(
         storage.threads.getById({ projectId: PROJECT_ID, id: threadId })
       ).resolves.toMatchObject({

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -2,6 +2,7 @@ import { appendFileSync } from "node:fs"
 import { ActionWorker } from "@sixb/action-worker"
 import { AgentWorker } from "@sixb/agent-worker"
 import { migrateStorage } from "@sixb/core"
+import { flushSixbErrors } from "@sixb/core/internal/error-reporting"
 import type { Worker } from "@sixb/core/internal/workers"
 import { assertLakeDatasetDefinitionsCompatible } from "@sixb/core/lake-storage"
 import {
@@ -83,6 +84,7 @@ export async function checkRuntimeLakeDefinitions(sixb: LoadedSixb): Promise<voi
 }
 
 export async function stopSixbProviders(sixb: LoadedSixb): Promise<void> {
+  await stopQuietly(() => flushSixbErrors(sixb))
   await stopQuietly(() => sixb.disconnectConnectors())
   await stopQuietly(() => closeProvider(sixb.queues))
   await stopQuietly(() => closeProvider(sixb.storage))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -103,6 +103,12 @@
       "import": "./dist/events/index.js",
       "default": "./dist/events/index.js"
     },
+    "./internal/error-reporting": {
+      "types": "./dist/error-reporting/internal.d.ts",
+      "bun": "./src/error-reporting/internal.ts",
+      "import": "./dist/error-reporting/internal.js",
+      "default": "./dist/error-reporting/internal.js"
+    },
     "./internal/http": {
       "types": "./dist/http/index.d.ts",
       "bun": "./src/http/index.ts",

--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -1,4 +1,5 @@
 import { assertAuthorized } from "../authorization"
+import { reportRunFailure } from "../error-reporting/capability"
 import { ActionRunTimeoutError } from "../objects/action/errors"
 import { OntologyValidationError } from "../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
@@ -190,12 +191,21 @@ async function enqueueActionRunJob(
     })
     jobId = job?.id
   } catch (error) {
-    await params.actionRuns.finish({
+    const failed = await params.actionRuns.finish({
       projectId: runtime.projectId,
       id: params.runId,
       status: "failed",
       phase: "enqueue",
       error: toActionRunFailure(error, "enqueue"),
+    })
+    reportRunFailure(runtime, error, {
+      projectId: runtime.projectId,
+      occurredAt: failed.finishedAt,
+      run: {
+        kind: "action",
+        runId: params.runId,
+        actionId: params.actionId,
+      },
     })
     throw error
   }

--- a/packages/core/src/error-reporting/capability.ts
+++ b/packages/core/src/error-reporting/capability.ts
@@ -1,0 +1,62 @@
+import { SixbErrorReporter } from "./reporter"
+import type { SixbErrorHandler, SixbFailedRun } from "./types"
+
+const ERROR_REPORTER = Symbol("sixb.error-reporter")
+
+type ErrorReporterHost = {
+  [ERROR_REPORTER]?: SixbErrorReporter
+}
+
+function asHost(value: unknown): ErrorReporterHost | null {
+  if ((typeof value !== "object" && typeof value !== "function") || value === null) {
+    return null
+  }
+  return value as ErrorReporterHost
+}
+
+export function attachSixbErrorReporter(
+  host: object,
+  handler?: SixbErrorHandler
+): SixbErrorReporter {
+  const reporter = new SixbErrorReporter(handler)
+  ;(host as ErrorReporterHost)[ERROR_REPORTER] = reporter
+  return reporter
+}
+
+export function shareSixbErrorReporter(source: object, target: object): void {
+  const reporter = (source as ErrorReporterHost)[ERROR_REPORTER]
+  if (reporter) (target as ErrorReporterHost)[ERROR_REPORTER] = reporter
+}
+
+export interface ReportRunFailureInput {
+  readonly projectId: string
+  readonly run: SixbFailedRun
+  readonly occurredAt?: Date | string
+  readonly attempt?: number
+}
+
+export function reportRunFailure(
+  host: unknown,
+  error: unknown,
+  input: ReportRunFailureInput
+): void {
+  const reporter = asHost(host)?.[ERROR_REPORTER]
+  if (!reporter) return
+
+  const occurredAt =
+    input.occurredAt instanceof Date
+      ? input.occurredAt.toISOString()
+      : (input.occurredAt ?? new Date().toISOString())
+  reporter.report(error, {
+    type: "run.failed",
+    notificationId: `project:${input.projectId}:run:${input.run.kind}:${input.run.runId}:failed:${occurredAt}`,
+    projectId: input.projectId,
+    occurredAt,
+    ...(input.attempt === undefined ? {} : { attempt: input.attempt }),
+    run: input.run,
+  })
+}
+
+export async function flushSixbErrors(host: unknown, timeoutMs?: number): Promise<void> {
+  await asHost(host)?.[ERROR_REPORTER]?.flush(timeoutMs)
+}

--- a/packages/core/src/error-reporting/internal.ts
+++ b/packages/core/src/error-reporting/internal.ts
@@ -1,0 +1,9 @@
+export {
+  attachSixbErrorReporter,
+  flushSixbErrors,
+  type ReportRunFailureInput,
+  reportRunFailure,
+  shareSixbErrorReporter,
+} from "./capability"
+export { normalizeReportedError } from "./normalize"
+export { SixbErrorReporter } from "./reporter"

--- a/packages/core/src/error-reporting/normalize.ts
+++ b/packages/core/src/error-reporting/normalize.ts
@@ -1,0 +1,35 @@
+function safeString(value: unknown): string {
+  try {
+    return String(value)
+  } catch {
+    return "Unknown thrown value"
+  }
+}
+
+/** Preserve native errors and safely wrap arbitrary thrown values. */
+export function normalizeReportedError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value
+  }
+
+  if (typeof value === "object" && value !== null) {
+    let message: unknown
+    let name: unknown
+    try {
+      message = Reflect.get(value, "message")
+      name = Reflect.get(value, "name")
+    } catch {
+      return new Error("Unknown thrown value")
+    }
+
+    if (typeof message === "string") {
+      const error = new Error(message)
+      if (typeof name === "string" && name.trim()) {
+        error.name = name
+      }
+      return error
+    }
+  }
+
+  return new Error(safeString(value))
+}

--- a/packages/core/src/error-reporting/reporter.ts
+++ b/packages/core/src/error-reporting/reporter.ts
@@ -1,0 +1,65 @@
+import { normalizeReportedError } from "./normalize"
+import type { SixbErrorContext, SixbErrorHandler } from "./types"
+
+const DEFAULT_FLUSH_TIMEOUT_MS = 5_000
+
+/** Failure-isolated, non-blocking adapter around the configured callback. */
+export class SixbErrorReporter {
+  private readonly pending = new Set<Promise<void>>()
+
+  constructor(private readonly handler?: SixbErrorHandler) {}
+
+  report(error: unknown, context: SixbErrorContext): void {
+    if (!this.handler) return
+
+    const invocation = Promise.resolve()
+      .then(() => this.handler?.(normalizeReportedError(error), context))
+      .then(() => undefined)
+      .catch((handlerError) => {
+        try {
+          console.error("[Sixb] onError handler failed:", handlerError)
+        } catch {
+          // Error reporting must never escape back into framework execution.
+        }
+      })
+
+    const tracked = invocation.finally(() => {
+      this.pending.delete(tracked)
+    })
+    this.pending.add(tracked)
+  }
+
+  async flush(timeoutMs = DEFAULT_FLUSH_TIMEOUT_MS): Promise<void> {
+    const deadline = Date.now() + Math.max(0, timeoutMs)
+    while (this.pending.size > 0) {
+      const remainingMs = deadline - Date.now()
+      if (remainingMs <= 0 || !(await settleWithin([...this.pending], remainingMs))) {
+        try {
+          console.error(
+            `[Sixb] Timed out after ${timeoutMs}ms waiting for ${this.pending.size} onError handler(s).`
+          )
+        } catch {
+          // Error reporting must never escape back into framework shutdown.
+        }
+        return
+      }
+    }
+  }
+}
+
+async function settleWithin(
+  promises: readonly Promise<void>[],
+  timeoutMs: number
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      Promise.allSettled(promises).then(() => true),
+      new Promise<false>((resolve) => {
+        timeout = setTimeout(() => resolve(false), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}

--- a/packages/core/src/error-reporting/types.ts
+++ b/packages/core/src/error-reporting/types.ts
@@ -1,0 +1,55 @@
+export type SixbFailedRun =
+  | {
+      readonly kind: "action"
+      readonly runId: string
+      readonly actionId: string
+    }
+  | {
+      readonly kind: "agent"
+      readonly runId: string
+      readonly agentId: string
+    }
+  | {
+      readonly kind: "pipeline"
+      readonly runId: string
+      readonly pipelineId: string
+    }
+  | {
+      readonly kind: "projection"
+      readonly runId: string
+      readonly projectionId: string
+      readonly projectionKind: "object" | "link" | "telemetry"
+    }
+  | {
+      readonly kind: "sync"
+      readonly runId: string
+      readonly syncId: string
+    }
+  | {
+      readonly kind: "workflow"
+      readonly runId: string
+      readonly workflowId: string
+    }
+  | {
+      readonly kind: "webhook"
+      readonly runId: string
+      readonly connectorId: string
+      readonly webhookId: string
+    }
+
+export interface SixbRunFailedContext {
+  readonly type: "run.failed"
+  /** Stable key consumers can use to deduplicate this failure occurrence. */
+  readonly notificationId: string
+  readonly projectId: string
+  readonly occurredAt: string
+  /** Queue delivery attempt, when the run was executed through a queue. */
+  readonly attempt?: number
+  readonly run: SixbFailedRun
+}
+
+/** Context supplied to the global Sixb error handler. */
+export type SixbErrorContext = SixbRunFailedContext
+
+/** Observes terminal failed runs without changing their outcome. */
+export type SixbErrorHandler = (error: Error, context: SixbErrorContext) => void | Promise<void>

--- a/packages/core/src/error-reporting/types.ts
+++ b/packages/core/src/error-reporting/types.ts
@@ -48,7 +48,12 @@ export interface SixbRunFailedContext {
   readonly run: SixbFailedRun
 }
 
-/** Context supplied to the global Sixb error handler. */
+/**
+ * Context supplied to the global Sixb error handler.
+ *
+ * V1 emits terminal `run.failed` notifications only. Additional error context types may be added
+ * later.
+ */
 export type SixbErrorContext = SixbRunFailedContext
 
 /** Observes terminal failed runs without changing their outcome. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -733,6 +733,12 @@ export {
 // ── Runtime ─────────────────────────────────────────────────
 
 export type {
+  SixbErrorContext,
+  SixbErrorHandler,
+  SixbFailedRun,
+  SixbRunFailedContext,
+} from "./error-reporting/types"
+export type {
   BatchItemResult,
   CreateSixbOptions,
   ListResult,

--- a/packages/core/src/objects/sdk/object-set.ts
+++ b/packages/core/src/objects/sdk/object-set.ts
@@ -7,6 +7,7 @@
 import type { ActionDefinition } from "../../actions"
 import type { AuthorizationContext } from "../../authorization"
 import { assertAuthorized } from "../../authorization"
+import { shareSixbErrorReporter } from "../../error-reporting/capability"
 import type { ValueType } from "../../ontology"
 import { OntologyValidationError } from "../../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
@@ -72,6 +73,7 @@ export function createObjectSet<
     objectType,
     primaryPropertyId,
   }
+  shareSixbErrorReporter(params, resolvedCtx)
 
   const objectSet = {
     get: async (id: string) => {

--- a/packages/core/src/runtime/create.ts
+++ b/packages/core/src/runtime/create.ts
@@ -23,6 +23,7 @@ import {
 import type { Broker } from "../broker"
 import type { ConnectorDefinition } from "../connectors/types"
 import type { DatasetDefinition } from "../datasets"
+import type { SixbErrorHandler } from "../error-reporting/types"
 import type { FunctionDefinition } from "../functions/types"
 import type { LakeStorage } from "../lake-storage"
 import type { LoggerProvider, ObservabilityOptions } from "../logging"
@@ -52,6 +53,8 @@ export interface CreateSixbOptions {
   logger?: LoggerProvider
   /** Broker capture controls, independent from the output provider. */
   observability?: ObservabilityOptions
+  /** Observes terminal failed runs without changing their outcome. */
+  onError?: SixbErrorHandler
   ontologies?: readonly OntologySource[]
   actions?: readonly ActionDefinition[]
   /** Agent definitions to register in addition to auto-discovered `agents/` exports. */
@@ -140,6 +143,7 @@ export async function createSixb(
     sandboxes: options.sandboxes,
     logger: options.logger,
     observability: options.observability,
+    onError: options.onError,
     projectRoot,
     actions,
     datasets: [...(options.datasets ?? []), ...datasets],

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -25,6 +25,8 @@ import { ConnectorRuntime } from "../connectors/runtime"
 import type { ConnectorAdapter, ConnectorClient, ConnectorDefinition } from "../connectors/types"
 import type { DatasetDefinition } from "../datasets/types"
 import { assertDatasetDefinition } from "../datasets/validation"
+import { attachSixbErrorReporter, shareSixbErrorReporter } from "../error-reporting/capability"
+import type { SixbErrorHandler } from "../error-reporting/types"
 import { EventsRuntime } from "../events"
 import { FunctionRuntime } from "../functions/runtime"
 import type { FunctionDefinition } from "../functions/types"
@@ -93,6 +95,8 @@ export interface SixbOptions<TOntologySources extends readonly OntologySource[]>
   logger?: LoggerProvider
   /** Broker capture controls, independent from the output provider. */
   observability?: ObservabilityOptions
+  /** Observes terminal failed runs without changing their outcome. */
+  onError?: SixbErrorHandler
   projectRoot?: string
   actions?: readonly ActionDefinition[]
   datasets?: readonly DatasetDefinition[]
@@ -152,6 +156,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
   private schedulerRuntime: SchedulerRuntime | null = null
 
   constructor(options: SixbOptions<TOntologySources>) {
+    attachSixbErrorReporter(this, options.onError)
     this.projectId = options.id ?? "default"
     this.ontologySources = options.ontology
     this.functions = options.functions ?? []
@@ -322,6 +327,7 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       sandboxes: this.sandboxes,
       rules: this.rules,
     }
+    shareSixbErrorReporter(this, this.runtimeContext)
     this.actions = new ActionsRuntime(this.runtimeContext)
     this.workflows = new WorkflowsRuntime(this.runtimeContext, workflows)
 

--- a/packages/core/src/workflows/request.ts
+++ b/packages/core/src/workflows/request.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto"
 import { assertAuthorized } from "../authorization"
+import { reportRunFailure } from "../error-reporting/capability"
 import type { SixbRuntimeContext } from "../runtime/types"
 import { WorkflowValidationError } from "./errors"
 import { snapshotWorkflowInput } from "./snapshot"
@@ -85,15 +86,35 @@ export async function requestWorkflowRun(
     source: options.source,
   })
 
-  const [job] = await queue.enqueue({
-    projectId: runtime.projectId,
-    jobs: [
-      {
-        type: "workflow.run.requested",
-        payload: { workflowId: workflow.id, runId, input: value },
+  let job: Awaited<ReturnType<typeof queue.enqueue>>[number] | undefined
+  try {
+    ;[job] = await queue.enqueue({
+      projectId: runtime.projectId,
+      jobs: [
+        {
+          type: "workflow.run.requested",
+          payload: { workflowId: workflow.id, runId, input: value },
+        },
+      ],
+    })
+  } catch (error) {
+    const failed = await storage.finish({
+      projectId: runtime.projectId,
+      id: runId,
+      status: "failed",
+      error: error instanceof Error ? error.message : String(error),
+    })
+    reportRunFailure(runtime, error, {
+      projectId: runtime.projectId,
+      occurredAt: failed.finishedAt,
+      run: {
+        kind: "workflow",
+        runId,
+        workflowId: workflow.id,
       },
-    ],
-  })
+    })
+    throw error
+  }
 
   await runtime.events.append({
     events: [

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -12,6 +12,7 @@ import {
   Sixb,
   stringEnum,
 } from "../src"
+import { flushSixbErrors } from "../src/error-reporting/internal"
 import { ActionRunError } from "../src/storage"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
@@ -795,6 +796,7 @@ describe("requestAction", () => {
 
   test("retries enqueue failures for the same run id and payload", async () => {
     const runtimeDeps = createTestRuntimeDeps()
+    const reports: string[] = []
     const enqueue = runtimeDeps.queues.actions.enqueue.bind(runtimeDeps.queues.actions)
     let shouldFailEnqueue = true
     runtimeDeps.queues.actions.enqueue = async (input) => {
@@ -810,6 +812,9 @@ describe("requestAction", () => {
       id: "action-enqueue-retry-test",
       ontology: [Room],
       actions: [actionDefinition(setTemperature)],
+      onError(error, context) {
+        reports.push(`${context.notificationId}:${error.message}`)
+      },
       ...runtimeDeps,
     })
 
@@ -839,6 +844,10 @@ describe("requestAction", () => {
         phase: "enqueue",
       },
     })
+    await flushSixbErrors(sixb)
+    expect(reports).toEqual([
+      `project:action-enqueue-retry-test:run:action:act_enqueue_retry:failed:${failed?.finishedAt?.toISOString()}:queue unavailable`,
+    ])
 
     const retry = await sixb.objects(Room).requestAction({
       id: "room:1",

--- a/packages/core/tests/error-reporting.test.ts
+++ b/packages/core/tests/error-reporting.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import type { SixbErrorContext } from "../src"
+import {
+  attachSixbErrorReporter,
+  flushSixbErrors,
+  normalizeReportedError,
+  reportRunFailure,
+} from "../src/error-reporting/internal"
+
+const PROJECT_ID = "error-reporting-tests"
+
+describe("Sixb error reporting", () => {
+  test("reports a normalized terminal run failure with stable context", async () => {
+    const host = {}
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    attachSixbErrorReporter(host, (error, context) => {
+      reports.push({ error, context })
+    })
+
+    reportRunFailure(host, "projection exploded", {
+      projectId: PROJECT_ID,
+      occurredAt: "2026-01-02T03:04:05.000Z",
+      attempt: 2,
+      run: {
+        kind: "projection",
+        runId: "projection-run-1",
+        projectionId: "rooms",
+        projectionKind: "object",
+      },
+    })
+    await flushSixbErrors(host)
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]?.error).toBeInstanceOf(Error)
+    expect(reports[0]?.error.message).toBe("projection exploded")
+    expect(reports[0]?.context).toEqual({
+      type: "run.failed",
+      notificationId:
+        "project:error-reporting-tests:run:projection:projection-run-1:failed:2026-01-02T03:04:05.000Z",
+      projectId: PROJECT_ID,
+      occurredAt: "2026-01-02T03:04:05.000Z",
+      attempt: 2,
+      run: {
+        kind: "projection",
+        runId: "projection-run-1",
+        projectionId: "rooms",
+        projectionKind: "object",
+      },
+    })
+  })
+
+  test("preserves Error identity", () => {
+    const original = new Error("boom")
+    expect(normalizeReportedError(original)).toBe(original)
+  })
+
+  test("normalizes cross-realm-like errors and hostile thrown values", () => {
+    const errorLike = normalizeReportedError({ name: "ProviderError", message: "offline" })
+    expect(errorLike.name).toBe("ProviderError")
+    expect(errorLike.message).toBe("offline")
+
+    const hostile = Object.create(null) as Record<string, unknown>
+    Object.defineProperty(hostile, "message", {
+      get() {
+        throw new Error("getter failed")
+      },
+    })
+    expect(normalizeReportedError(hostile).message).toBe("Unknown thrown value")
+  })
+
+  test("isolates callback rejection from framework execution", async () => {
+    const host = {}
+    const consoleError = spyOn(console, "error").mockImplementation(() => {})
+    attachSixbErrorReporter(host, async () => {
+      throw new Error("notification unavailable")
+    })
+
+    expect(() =>
+      reportRunFailure(host, new Error("run failed"), {
+        projectId: PROJECT_ID,
+        run: { kind: "sync", runId: "sync-run-1", syncId: "customers" },
+      })
+    ).not.toThrow()
+    await flushSixbErrors(host)
+
+    expect(consoleError).toHaveBeenCalledTimes(1)
+    consoleError.mockRestore()
+  })
+
+  test("flush drains reports added while a handler is running", async () => {
+    const host = {}
+    const messages: string[] = []
+    attachSixbErrorReporter(host, (error) => {
+      messages.push(error.message)
+      if (error.message === "first") {
+        reportRunFailure(host, new Error("second"), {
+          projectId: PROJECT_ID,
+          run: { kind: "sync", runId: "sync-run-2", syncId: "customers" },
+        })
+      }
+    })
+
+    reportRunFailure(host, new Error("first"), {
+      projectId: PROJECT_ID,
+      run: { kind: "sync", runId: "sync-run-1", syncId: "customers" },
+    })
+    await flushSixbErrors(host)
+
+    expect(messages).toEqual(["first", "second"])
+  })
+
+  test("flush stops waiting after its timeout", async () => {
+    const host = {}
+    const consoleError = spyOn(console, "error").mockImplementation(() => {})
+    attachSixbErrorReporter(host, () => new Promise<void>(() => {}))
+    reportRunFailure(host, new Error("run failed"), {
+      projectId: PROJECT_ID,
+      run: { kind: "agent", runId: "agent-run-1", agentId: "assistant" },
+    })
+
+    await flushSixbErrors(host, 5)
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[Sixb] Timed out after 5ms waiting for 1 onError handler(s)."
+    )
+    consoleError.mockRestore()
+  })
+
+  test("is a no-op when no reporter is attached", async () => {
+    const host = {}
+    reportRunFailure(host, new Error("ignored"), {
+      projectId: PROJECT_ID,
+      run: { kind: "workflow", runId: "workflow-run-1", workflowId: "approval" },
+    })
+    await expect(flushSixbErrors(host)).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/tests/workflow-request.test.ts
+++ b/packages/core/tests/workflow-request.test.ts
@@ -13,6 +13,7 @@ import {
   type WorkflowDefinition,
   WorkflowValidationError,
 } from "../src"
+import { flushSixbErrors } from "../src/error-reporting/internal"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
 const Transaction = defineObjectType({
@@ -93,6 +94,40 @@ describe("sixb.workflows.request", () => {
       queuedAt: result.queuedAt,
       jobId: result.jobId,
     })
+  })
+
+  test("marks and reports a run failed when queue dispatch fails", async () => {
+    const runtimeDeps = createTestRuntimeDeps()
+    runtimeDeps.queues.workflows.enqueue = async () => {
+      throw new Error("workflow queue unavailable")
+    }
+    const reports: string[] = []
+    const sixb = new Sixb({
+      id: "workflow-enqueue-failure",
+      ontology: [Transaction, Invoice],
+      workflows: [draftInvoice],
+      onError(error, context) {
+        reports.push(`${context.notificationId}:${error.message}`)
+      },
+      ...runtimeDeps,
+    })
+
+    await expect(
+      sixb.workflows.request(draftInvoice, {
+        runId: "run_enqueue_failure",
+        input: validInput(),
+      })
+    ).rejects.toThrow("workflow queue unavailable")
+
+    const run = await sixb.storage.workflowRuns?.getById({
+      projectId: sixb.id,
+      id: "run_enqueue_failure",
+    })
+    expect(run).toMatchObject({ status: "failed", error: "workflow queue unavailable" })
+    await flushSixbErrors(sixb)
+    expect(reports).toEqual([
+      `project:workflow-enqueue-failure:run:workflow:run_enqueue_failure:failed:${run?.finishedAt?.toISOString()}:workflow queue unavailable`,
+    ])
   })
 
   test("requestById rejects unknown input fields at runtime", async () => {

--- a/packages/pipeline-worker/src/run-pipeline-job.ts
+++ b/packages/pipeline-worker/src/run-pipeline-job.ts
@@ -109,14 +109,18 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
     }
   } catch (error) {
     if (startedRun && !finished) {
-      await runtime.pipelineRunsStorage
-        .finish({
+      const status = statusForFailure(signal, error)
+      try {
+        const run = await runtime.pipelineRunsStorage.finish({
           projectId: runtime.id,
           id: job.id,
-          status: statusForFailure(signal, error),
+          status,
           error: toPipelineRunFailure(error),
         })
-        .catch(() => {})
+        if (status === "failed" && run.status === "failed") input.onRunFailed?.(error, run)
+      } catch {
+        // The run did not transition to the requested terminal status.
+      }
     }
 
     throw error

--- a/packages/pipeline-worker/src/types.ts
+++ b/packages/pipeline-worker/src/types.ts
@@ -47,6 +47,7 @@ export interface RunPipelineJobInput {
   readonly job: PipelineJob
   readonly signal?: AbortSignal
   readonly onRunStarted?: PipelineRunStartedHandler
+  readonly onRunFailed?: PipelineRunFailedHandler
   readonly onStepStarted?: PipelineStepStartedHandler
   readonly onStepFinished?: PipelineStepFinishedHandler
   readonly onStepCommitted?: PipelineStepCommittedHandler
@@ -55,6 +56,8 @@ export interface RunPipelineJobInput {
 export type PipelineStepCommittedHandler = (result: PipelineStepRunResult) => Promise<void> | void
 
 export type PipelineRunStartedHandler = (run: PipelineRunRecord) => Promise<void> | void
+
+export type PipelineRunFailedHandler = (error: unknown, run: PipelineRunRecord) => void
 
 export interface PipelineStepLifecycleContext {
   readonly stepIndex: number

--- a/packages/pipeline-worker/src/worker.ts
+++ b/packages/pipeline-worker/src/worker.ts
@@ -1,3 +1,4 @@
+import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { QueueWorker } from "@sixb/core/internal/workers"
 import type { ClaimedQueueJob, PipelineRunRequestedQueueJob } from "@sixb/core/queues"
@@ -58,6 +59,18 @@ export class PipelineWorker extends QueueWorker<PipelineRunRequestedQueueJob> {
         job: pipelineJob,
         signal,
         onRunStarted: (run) => emitPipelineRunStarted(this.sixb.events, run),
+        onRunFailed: (error, run) => {
+          reportRunFailure(this.sixb, error, {
+            projectId: this.sixb.id,
+            occurredAt: run.finishedAt,
+            attempt: job.attempt,
+            run: {
+              kind: "pipeline",
+              runId: run.id,
+              pipelineId: run.pipelineId,
+            },
+          })
+        },
         onStepStarted: (step, context) =>
           emitPipelineRunStepStarted(this.sixb.events, step, context),
         onStepFinished: (step, context) =>

--- a/packages/pipeline-worker/tests/worker.test.ts
+++ b/packages/pipeline-worker/tests/worker.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import type { DatasetDefinition, DatasetRow, PipelineDefinition } from "@sixb/core"
+import type {
+  DatasetDefinition,
+  DatasetRow,
+  PipelineDefinition,
+  SixbErrorContext,
+  SixbErrorHandler,
+} from "@sixb/core"
 import {
   col,
   defineDataset,
@@ -55,6 +61,7 @@ function createSixbForPipeline(options: {
   readonly pipeline: PipelineDefinition
   readonly datasets: readonly DatasetDefinition[]
   readonly lakeStorage?: InMemoryLakeStorage
+  readonly onError?: SixbErrorHandler
 }) {
   return new Sixb({
     id: "pipeline-worker-tests",
@@ -66,6 +73,7 @@ function createSixbForPipeline(options: {
     queues: new InMemoryQueues(),
     datasets: options.datasets,
     pipelines: [options.pipeline],
+    onError: options.onError,
   })
 }
 
@@ -374,7 +382,9 @@ describe("PipelineWorker", () => {
     })
   })
 
-  test("emits committed step events before failing a later step", async () => {
+  test("emits committed step events and reports once before failing a later step", async () => {
+    const reports: { error: Error; context: SixbErrorContext }[] = []
+    const originalError = new Error("nope")
     const cleanStep = definePipelineStep("clean-customers")
       .inputs({ rawCustomers: rawCustomersDataset })
       .output(customersDataset)
@@ -385,12 +395,15 @@ describe("PipelineWorker", () => {
       .inputs({ customers: customersDataset })
       .output(defineDataset("failed_output", { schema: [col("id", "string")] }))
       .run(() => {
-        throw new Error("nope")
+        throw originalError
       })
     const pipeline = definePipeline("customers").then(cleanStep).then(failingStep)
     const sixb = createSixbForPipeline({
       pipeline,
       datasets: [rawCustomersDataset, customersDataset, failingStep.output],
+      onError(error, context) {
+        reports.push({ error, context })
+      },
     })
     await seedDatasetVersion(sixb.lakeStorage as InMemoryLakeStorage, rawCustomersDataset, [
       { id: "cust_1", name: "Ada" },
@@ -413,10 +426,28 @@ describe("PipelineWorker", () => {
     await worker.start()
 
     try {
-      await waitFor(
+      const run = await waitFor(
         () => sixb.storage.pipelineRuns!.getById({ projectId: sixb.id, id: "run-fails-late" }),
         (value) => value?.status === "failed"
       )
+      await waitFor(
+        async () => reports.length,
+        (count) => count === 1
+      )
+      expect(reports).toHaveLength(1)
+      expect(reports[0]?.error).toBe(originalError)
+      expect(reports[0]?.context).toEqual({
+        type: "run.failed",
+        notificationId: `project:${sixb.id}:run:pipeline:run-fails-late:failed:${run!.finishedAt!.toISOString()}`,
+        projectId: sixb.id,
+        occurredAt: run!.finishedAt!.toISOString(),
+        attempt: 1,
+        run: {
+          kind: "pipeline",
+          runId: "run-fails-late",
+          pipelineId: pipeline.id,
+        },
+      })
 
       const claimed = await sixb.queues.pipelines.claim({
         projectId: sixb.id,
@@ -486,7 +517,8 @@ describe("PipelineWorker", () => {
     expect(finishedPayload.versionId).toBeUndefined()
   })
 
-  test("fails an aborted queue job after a step has committed", async () => {
+  test("fails an aborted queue job after a step has committed without reporting it", async () => {
+    let reportCount = 0
     const firstStep = definePipelineStep("clean-customers")
       .inputs({ rawCustomers: rawCustomersDataset })
       .output(customersDataset)
@@ -505,6 +537,9 @@ describe("PipelineWorker", () => {
     const sixb = createSixbForPipeline({
       pipeline,
       datasets: [rawCustomersDataset, customersDataset, abortingStep.output],
+      onError() {
+        reportCount += 1
+      },
     })
     await seedDatasetVersion(sixb.lakeStorage as InMemoryLakeStorage, rawCustomersDataset, [
       { id: "cust_1", name: "Ada" },
@@ -571,5 +606,6 @@ describe("PipelineWorker", () => {
       runId: "run-aborts-late",
       status: "cancelled",
     })
+    expect(reportCount).toBe(0)
   })
 })

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -91,6 +91,9 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
     materialized = hasMaterialized(counters)
 
     if (execution.firstErrorMessage) {
+      const error = new ProjectionWorkerError(
+        `[SixbProjectionWorker] Projection run '${job.id}' failed. ${execution.firstErrorMessage}`
+      )
       runFinishAttempted = true
       const run = await finishRun({
         runtime,
@@ -101,9 +104,8 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
         materialized,
       })
       finished = true
-      throw new ProjectionWorkerError(
-        `[SixbProjectionWorker] Projection run '${run.id}' failed. ${execution.firstErrorMessage}`
-      )
+      if (run.status === "failed") input.onRunFailed?.(error, run)
+      throw error
     }
 
     runFinishAttempted = true
@@ -134,6 +136,7 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
         error,
         materialized,
         signal,
+        onRunFailed: input.onRunFailed,
       })
     }
 
@@ -292,18 +295,20 @@ async function finishAfterError(input: {
   readonly error: unknown
   readonly materialized: boolean
   readonly signal: AbortSignal
+  readonly onRunFailed: RunProjectionJobInput["onRunFailed"]
 }): Promise<void> {
   const status = input.signal.aborted || isAbortError(input.error) ? "cancelled" : "failed"
   const error = status === "cancelled" ? createAbortError() : input.error
 
   try {
-    await input.runtime.projectionRunsStorage.finish({
+    const run = await input.runtime.projectionRunsStorage.finish({
       projectId: input.runtime.projectId,
       id: input.job.id,
       status,
       errorMessage: errorMessage(error),
       ...input.counters,
     })
+    if (status === "failed" && run.status === "failed") input.onRunFailed?.(input.error, run)
   } catch (finishError) {
     if (input.materialized) {
       throw createBookkeepingError({

--- a/packages/projection-worker/src/types.ts
+++ b/packages/projection-worker/src/types.ts
@@ -42,7 +42,10 @@ export interface RunProjectionJobInput {
   readonly job: ProjectionJob
   readonly signal?: AbortSignal
   readonly batchSize?: number
+  readonly onRunFailed?: ProjectionRunFailedHandler
 }
+
+export type ProjectionRunFailedHandler = (error: unknown, run: ProjectionRunRecord) => void
 
 export interface ProjectionJobResult extends ProjectionRunCounters {
   readonly id: string

--- a/packages/projection-worker/src/worker.ts
+++ b/packages/projection-worker/src/worker.ts
@@ -1,3 +1,4 @@
+import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import { QueueWorker } from "@sixb/core/internal/workers"
 import type { ClaimedQueueJob, ProjectionRunRequestedQueueJob } from "@sixb/core/queues"
 import type { ProjectionRunStorage } from "@sixb/core/storage"
@@ -6,6 +7,7 @@ import type { ProjectionWorkerContext, ProjectionWorkerSixb } from "./types"
 
 export class ProjectionWorker extends QueueWorker<ProjectionRunRequestedQueueJob> {
   private readonly context: ProjectionWorkerContext
+  private readonly sixb: ProjectionWorkerSixb
 
   constructor(sixb: ProjectionWorkerSixb) {
     const projectionCount =
@@ -28,6 +30,7 @@ export class ProjectionWorker extends QueueWorker<ProjectionRunRequestedQueueJob
     })
 
     this.context = buildProjectionContext(sixb, projectionRunsStorage)
+    this.sixb = sixb
   }
 
   protected async execute(
@@ -46,6 +49,19 @@ export class ProjectionWorker extends QueueWorker<ProjectionRunRequestedQueueJob
         queueJobId: job.id,
       },
       signal,
+      onRunFailed: (error, run) => {
+        reportRunFailure(this.sixb, error, {
+          projectId: this.sixb.projectId,
+          occurredAt: run.finishedAt,
+          attempt: job.attempt,
+          run: {
+            kind: "projection",
+            runId: run.id,
+            projectionId: run.projectionId,
+            projectionKind: run.projectionKind,
+          },
+        })
+      },
     })
   }
 }

--- a/packages/projection-worker/tests/worker.test.ts
+++ b/packages/projection-worker/tests/worker.test.ts
@@ -15,6 +15,8 @@ import {
   type ProjectionDefinition,
   prop,
   Sixb,
+  type SixbErrorContext,
+  type SixbErrorHandler,
 } from "@sixb/core"
 import type { ProjectionRunStorage } from "@sixb/core/storage"
 import { ProjectionWorker } from "../src"
@@ -46,6 +48,7 @@ function createDeps() {
 function createSixb(options: {
   datasets?: readonly DatasetDefinition[]
   projections?: readonly ProjectionDefinition[]
+  onError?: SixbErrorHandler
 }) {
   const deps = createDeps()
   return new Sixb({
@@ -54,6 +57,7 @@ function createSixb(options: {
     ...deps,
     datasets: options.datasets ?? [],
     projections: options.projections ?? [],
+    onError: options.onError,
   })
 }
 
@@ -153,10 +157,14 @@ describe("ProjectionWorker", () => {
     }
   })
 
-  test("fails the queue job and run when execution fails", async () => {
+  test("reports once when execution transitions the run to failed", async () => {
+    const reports: { error: Error; context: SixbErrorContext }[] = []
     const sixb = createSixb({
       datasets: [roomsDataset],
       projections: [roomProjection],
+      onError(error, context) {
+        reports.push({ error, context })
+      },
     })
     await sixb.lakeStorage.createDataset(roomsDataset)
     const [queued] = await sixb.queues.projections.enqueue({
@@ -185,6 +193,26 @@ describe("ProjectionWorker", () => {
         (value) => value?.status === "failed"
       )
       expect(run?.errorMessage).toContain("was not found")
+
+      await waitFor(
+        async () => reports.length,
+        (count) => count === 1
+      )
+      expect(reports).toHaveLength(1)
+      expect(reports[0]?.error.message).toContain("was not found")
+      expect(reports[0]?.context).toEqual({
+        type: "run.failed",
+        notificationId: `project:${sixb.id}:run:projection:${runId}:failed:${run!.finishedAt!.toISOString()}`,
+        projectId: sixb.id,
+        occurredAt: run!.finishedAt!.toISOString(),
+        attempt: 1,
+        run: {
+          kind: "projection",
+          runId,
+          projectionId: roomProjection.id,
+          projectionKind: "object",
+        },
+      })
 
       const claimed = await sixb.queues.projections.claim({
         projectId: sixb.id,

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -286,13 +286,28 @@ async function dispatchWebhookRun(
     return { error: "Webhook handler failed" }
   }
 
+  const responseStatus = getWebhookResponseStatus(response)
+  const runStatus = responseStatus >= 200 && responseStatus <= 299 ? "succeeded" : "failed"
+  const failureMessage = `Webhook handler returned HTTP ${responseStatus}`
+  const responseError = runStatus === "failed" ? failureMessage : undefined
+  const shouldRetryDelivery =
+    runStatus === "failed" && (responseStatus < 400 || responseStatus >= 500)
+
   try {
     if (deliveryKey) {
-      // Mark completion only after the synchronous handler has succeeded.
-      await sixb.storage.webhookDeliveries?.complete({
-        ...deliveryKey,
-        completedAt: new Date().toISOString(),
-      })
+      const finalizedAt = new Date().toISOString()
+      if (shouldRetryDelivery) {
+        await sixb.storage.webhookDeliveries?.fail({
+          ...deliveryKey,
+          failedAt: finalizedAt,
+          error: failureMessage,
+        })
+      } else {
+        await sixb.storage.webhookDeliveries?.complete({
+          ...deliveryKey,
+          completedAt: finalizedAt,
+        })
+      }
     }
   } catch (error) {
     reportFailure(error)
@@ -310,10 +325,8 @@ async function dispatchWebhookRun(
     return { error: "Webhook delivery completion failed" }
   }
 
-  const responseStatus = getWebhookResponseStatus(response)
-  const runStatus = responseStatus >= 200 && responseStatus <= 299 ? "succeeded" : "failed"
-  if (runStatus === "failed" && (responseStatus < 400 || responseStatus >= 500)) {
-    reportFailure(new Error(`Webhook handler returned HTTP ${responseStatus}`))
+  if (shouldRetryDelivery) {
+    reportFailure(new Error(failureMessage))
   }
   await finishWebhookRun({
     sixb,
@@ -323,7 +336,7 @@ async function dispatchWebhookRun(
     responseStatus,
     idempotencyKey,
     deliveryClaimResult,
-    error: runStatus === "failed" ? `Webhook handler returned HTTP ${responseStatus}` : undefined,
+    error: responseError,
   })
 
   return applyWebhookResponse(set, response)

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -11,6 +11,7 @@ import type {
   WebhookMetadata,
   WebhookResponse,
 } from "@sixb/core"
+import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type {
   FinishWebhookRunStatus,
   WebhookDeliveryClaimResult,
@@ -81,12 +82,43 @@ export function registerWebhookRoutes(app: Elysia, sixb: Sixb<readonly OntologyS
 
 async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown> {
   const runId = `webhookrun_${randomUUID()}`
-  const logSession = options.sixb.logs.startExecution({ kind: "webhook", id: runId })
+  const { sixb, registered } = options
+  const logSession = sixb.logs.startExecution({ kind: "webhook", id: runId })
+  let failureReported = false
+  const reportFailure = (error: unknown) => {
+    if (failureReported) return
 
-  await startWebhookRun(options.sixb, options.registered, options.request, runId)
+    failureReported = true
+    reportRunFailure(sixb, error, {
+      projectId: sixb.id,
+      run: {
+        kind: "webhook",
+        runId,
+        connectorId: registered.connector.id,
+        webhookId: registered.webhook.id,
+      },
+    })
+  }
+
+  await startWebhookRun(sixb, registered, options.request, runId)
 
   try {
-    return await dispatchWebhookRun(options, runId, (phase) => logSession.withContext({ phase }))
+    return await dispatchWebhookRun(
+      options,
+      runId,
+      (phase) => logSession.withContext({ phase }),
+      reportFailure
+    )
+  } catch (error) {
+    await finishWebhookRun({
+      sixb,
+      runId,
+      status: "failed",
+      responseStatus: 500,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    reportFailure(error)
+    throw error
   } finally {
     await logSession.flush()
   }
@@ -95,7 +127,8 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
 async function dispatchWebhookRun(
   options: DispatchWebhookOptions,
   runId: string,
-  loggerForPhase: (phase: string) => Logger
+  loggerForPhase: (phase: string) => Logger,
+  reportFailure: (error: unknown) => void
 ): Promise<unknown> {
   const { sixb, registered, request, set } = options
   const { connector, webhook, route } = registered
@@ -210,7 +243,8 @@ async function dispatchWebhookRun(
       return result
     }
     deliveryKey = claim.key
-  } catch {
+  } catch (error) {
+    reportFailure(error)
     set.status = 500
     await finishWebhookRun({
       sixb,
@@ -227,6 +261,7 @@ async function dispatchWebhookRun(
   try {
     response = await webhook.handle(handlerContext as never)
   } catch (error) {
+    reportFailure(error)
     // Handler failures mark the key failed so the provider's next retry can
     // attempt the delivery again.
     if (deliveryKey) {
@@ -259,7 +294,8 @@ async function dispatchWebhookRun(
         completedAt: new Date().toISOString(),
       })
     }
-  } catch {
+  } catch (error) {
+    reportFailure(error)
     set.status = 500
     await finishWebhookRun({
       sixb,
@@ -276,6 +312,9 @@ async function dispatchWebhookRun(
 
   const responseStatus = getWebhookResponseStatus(response)
   const runStatus = responseStatus >= 200 && responseStatus <= 299 ? "succeeded" : "failed"
+  if (runStatus === "failed" && (responseStatus < 400 || responseStatus >= 500)) {
+    reportFailure(new Error(`Webhook handler returned HTTP ${responseStatus}`))
+  }
   await finishWebhookRun({
     sixb,
     runId,

--- a/packages/server/tests/webhooks.test.ts
+++ b/packages/server/tests/webhooks.test.ts
@@ -11,8 +11,11 @@ import {
   type LoggerProvider,
   type OntologySource,
   Sixb,
+  type SixbErrorContext,
+  type SixbErrorHandler,
   type SixbOptions,
 } from "@sixb/core"
+import { flushSixbErrors } from "@sixb/core/internal/error-reporting"
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
 
@@ -315,6 +318,8 @@ describe("webhook routes", () => {
   })
 
   test("maps unknown, unsupported, verification, and handler errors", async () => {
+    const handlerError = new Error("boom")
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
     const connector = defineConnector("github", {
       type: "test",
       webhooks: [
@@ -331,7 +336,7 @@ describe("webhook routes", () => {
           .post()
           .text()
           .handle(() => {
-            throw new Error("boom")
+            throw handlerError
           }),
       ],
       connect() {
@@ -340,7 +345,14 @@ describe("webhook routes", () => {
     })
 
     const storage = new InMemoryStorage()
-    const app = createWebhookApp([connector], storage)
+    const { app, sixb } = createWebhookRuntime(
+      [connector],
+      storage,
+      undefined,
+      (error, context) => {
+        reports.push({ error, context })
+      }
+    )
 
     const unknown = await app.fetch(
       new Request("http://localhost/api/webhooks/github/missing", { method: "POST" })
@@ -360,6 +372,7 @@ describe("webhook routes", () => {
         body: "hello",
       })
     )
+    await flushSixbErrors(sixb)
 
     expect(unknown.status).toBe(404)
     expect(unsupported.status).toBe(405)
@@ -395,6 +408,153 @@ describe("webhook routes", () => {
         }),
       ])
     )
+
+    const failedRun = runs.runs.find((run) => run.webhookId === "failing")
+    expect(reports).toHaveLength(1)
+    expect(reports[0]?.error).toBe(handlerError)
+    expect(reports[0]?.context).toMatchObject({
+      type: "run.failed",
+      notificationId: `project:test-project:run:webhook:${failedRun?.id}:failed:${reports[0]?.context.occurredAt}`,
+      projectId: "test-project",
+      run: {
+        kind: "webhook",
+        runId: failedRun?.id,
+        connectorId: "github",
+        webhookId: "failing",
+      },
+    })
+  })
+
+  test("reports delivery infrastructure and returned non-4xx failures exactly once", async () => {
+    const claimError = new Error("claim storage unavailable")
+    const completionError = new Error("completion storage unavailable")
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    const connector = defineConnector("github", {
+      type: "test",
+      webhooks: [
+        defineWebhook("claim-failure")
+          .post()
+          .json()
+          .idempotencyKey(() => "claim-delivery")
+          .handle(() => undefined),
+        defineWebhook("completion-failure")
+          .post()
+          .json()
+          .idempotencyKey(() => "completion-delivery")
+          .handle(() => undefined),
+        defineWebhook("unavailable")
+          .post()
+          .json()
+          .handle(() => ({ status: 503, body: { error: "Retry later" } })),
+        defineWebhook("redirected")
+          .post()
+          .json()
+          .handle(() => ({ status: 302, body: { location: "elsewhere" } })),
+        defineWebhook("client-rejection")
+          .post()
+          .json()
+          .handle(() => ({ status: 422, body: { error: "Invalid event" } })),
+        defineWebhook("success")
+          .post()
+          .json()
+          .handle(() => undefined),
+      ],
+      connect() {
+        return {}
+      },
+    })
+
+    const storage = new InMemoryStorage()
+    const deliveries = storage.webhookDeliveries
+    const claim = deliveries.claim.bind(deliveries)
+    const complete = deliveries.complete.bind(deliveries)
+    deliveries.claim = async (input) => {
+      if (input.webhookId === "claim-failure") {
+        throw claimError
+      }
+      return claim(input)
+    }
+    deliveries.complete = async (input) => {
+      if (input.webhookId === "completion-failure") {
+        throw completionError
+      }
+      return complete(input)
+    }
+    storage.webhookRuns.finish = async () => {
+      throw new Error("run history unavailable")
+    }
+
+    const { app, sixb } = createWebhookRuntime(
+      [connector],
+      storage,
+      undefined,
+      (error, context) => {
+        reports.push({ error, context })
+      }
+    )
+    const dispatch = (webhookId: string) =>
+      app.fetch(
+        new Request(`http://localhost/api/webhooks/github/${webhookId}`, {
+          method: "POST",
+          body: JSON.stringify({ ok: true }),
+        })
+      )
+
+    const claimFailure = await dispatch("claim-failure")
+    const completionFailure = await dispatch("completion-failure")
+    const skippedRetry = await dispatch("completion-failure")
+    const unavailable = await dispatch("unavailable")
+    const redirected = await dispatch("redirected")
+    const clientRejection = await dispatch("client-rejection")
+    const success = await dispatch("success")
+    await flushSixbErrors(sixb)
+
+    expect(claimFailure.status).toBe(500)
+    expect(completionFailure.status).toBe(500)
+    expect(skippedRetry.status).toBe(202)
+    expect(unavailable.status).toBe(503)
+    expect(await unavailable.json()).toEqual({ error: "Retry later" })
+    expect(redirected.status).toBe(302)
+    expect(clientRejection.status).toBe(422)
+    expect(success.status).toBe(202)
+
+    expect(reports).toHaveLength(4)
+    expect(reports.map((report) => report.error)).toEqual([
+      claimError,
+      completionError,
+      expect.any(Error),
+      expect.any(Error),
+    ])
+    expect(reports[2]?.error.message).toBe("Webhook handler returned HTTP 503")
+    expect(reports[3]?.error.message).toBe("Webhook handler returned HTTP 302")
+    expect(reports.map((report) => report.context.run)).toEqual([
+      {
+        kind: "webhook",
+        runId: expect.stringMatching(/^webhookrun_/),
+        connectorId: "github",
+        webhookId: "claim-failure",
+      },
+      {
+        kind: "webhook",
+        runId: expect.stringMatching(/^webhookrun_/),
+        connectorId: "github",
+        webhookId: "completion-failure",
+      },
+      {
+        kind: "webhook",
+        runId: expect.stringMatching(/^webhookrun_/),
+        connectorId: "github",
+        webhookId: "unavailable",
+      },
+      {
+        kind: "webhook",
+        runId: expect.stringMatching(/^webhookrun_/),
+        connectorId: "github",
+        webhookId: "redirected",
+      },
+    ])
+    expect(reports.every((report) => report.context.projectId === "test-project")).toBe(true)
+    expect(new Set(reports.map((report) => report.context.run.runId)).size).toBe(4)
   })
 })
 
@@ -402,6 +562,15 @@ function createWebhookApp(
   connectors: SixbOptions<readonly OntologySource[]>["connectors"],
   storage = new InMemoryStorage(),
   logger?: LoggerProvider
+) {
+  return createWebhookRuntime(connectors, storage, logger).app
+}
+
+function createWebhookRuntime(
+  connectors: SixbOptions<readonly OntologySource[]>["connectors"],
+  storage = new InMemoryStorage(),
+  logger?: LoggerProvider,
+  onError?: SixbErrorHandler
 ) {
   const sixb = createSixbInstance<readonly OntologySource[]>({
     id: "test-project",
@@ -413,9 +582,10 @@ function createWebhookApp(
     queues: new InMemoryQueues(),
     connectors,
     logger,
+    onError,
   })
   const server = new SixbServer({ sixb, quiet: true, browser: createTestBrowserPolicy() })
-  return createSixbApi(server)
+  return { app: createSixbApi(server), sixb }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/server/tests/webhooks.test.ts
+++ b/packages/server/tests/webhooks.test.ts
@@ -556,6 +556,41 @@ describe("webhook routes", () => {
     expect(reports.every((report) => report.context.projectId === "test-project")).toBe(true)
     expect(new Set(reports.map((report) => report.context.run.runId)).size).toBe(4)
   })
+
+  test("retries idempotent deliveries after a returned server failure", async () => {
+    let invocations = 0
+    const connector = defineConnector("github", {
+      type: "test",
+      webhooks: [
+        defineWebhook("retryable")
+          .post()
+          .json()
+          .idempotencyKey(() => "delivery-1")
+          .handle(() => {
+            invocations += 1
+            return { status: 503, body: { error: "Retry later" } }
+          }),
+      ],
+      connect() {
+        return {}
+      },
+    })
+    const app = createWebhookApp([connector])
+    const dispatch = () =>
+      app.fetch(
+        new Request("http://localhost/api/webhooks/github/retryable", {
+          method: "POST",
+          body: JSON.stringify({ ok: true }),
+        })
+      )
+
+    const first = await dispatch()
+    const retry = await dispatch()
+
+    expect(first.status).toBe(503)
+    expect(retry.status).toBe(503)
+    expect(invocations).toBe(2)
+  })
 })
 
 function createWebhookApp(

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -287,15 +287,19 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
       // Before commit succeeds we can still best-effort clean up both the write session and run record.
       await write?.abort().catch(() => {})
 
-      await syncRunsStorage
-        .finish({
+      const status = signal.aborted ? "cancelled" : "failed"
+      try {
+        const run = await syncRunsStorage.finish({
           projectId: runtime.id,
           id: job.id,
-          status: signal.aborted ? "cancelled" : "failed",
+          status,
           rowsRead,
           error: toSyncRunFailure(error),
         })
-        .catch(() => {})
+        if (status === "failed" && run.status === "failed") input.onRunFailed?.(error, run)
+      } catch {
+        // The run did not transition to the requested terminal status.
+      }
     }
 
     throw error

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -38,9 +38,12 @@ export interface RunSyncJobInput {
   readonly job: SyncJob
   readonly signal?: AbortSignal
   readonly onRunStarted?: SyncRunStartedHandler
+  readonly onRunFailed?: SyncRunFailedHandler
 }
 
 export type SyncRunStartedHandler = (run: SyncRunRecord) => Promise<void> | void
+
+export type SyncRunFailedHandler = (error: unknown, run: SyncRunRecord) => void
 
 export interface SyncRunResult {
   readonly id: string

--- a/packages/sync-worker/src/worker.ts
+++ b/packages/sync-worker/src/worker.ts
@@ -9,6 +9,7 @@ import type {
   Storage,
   SyncDefinition,
 } from "@sixb/core"
+import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { EventsRuntime } from "@sixb/core/internal/events"
 import type { LogsRuntime } from "@sixb/core/internal/logging"
 import type { QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
@@ -72,6 +73,18 @@ export class SyncWorker extends QueueWorker<SyncRunRequestedQueueJob> {
         job: syncJob,
         signal,
         onRunStarted: (run) => emitSyncRunStarted(this.sixb, run),
+        onRunFailed: (error, run) => {
+          reportRunFailure(this.sixb, error, {
+            projectId: this.sixb.id,
+            occurredAt: run.finishedAt,
+            attempt: job.attempt,
+            run: {
+              kind: "sync",
+              runId: run.id,
+              syncId: run.syncId,
+            },
+          })
+        },
       })
     } catch (error) {
       if (error instanceof SyncRunAlreadyStartedError) return

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -12,6 +12,8 @@ import {
   InMemoryStorage,
   prop,
   Sixb,
+  type SixbErrorContext,
+  type SixbErrorHandler,
   type SyncDefinition,
 } from "@sixb/core"
 import { LOGS_STREAM } from "@sixb/core/internal/logging"
@@ -83,7 +85,8 @@ class ReusingVersionLakeStorage extends InMemoryLakeStorage {
 
 function createSixbForSync(
   sync: SyncDefinition,
-  lakeStorage: InMemoryLakeStorage = new InMemoryLakeStorage()
+  lakeStorage: InMemoryLakeStorage = new InMemoryLakeStorage(),
+  onError?: SixbErrorHandler
 ) {
   const storage = new InMemoryStorage()
 
@@ -98,6 +101,7 @@ function createSixbForSync(
     queues: new InMemoryQueues(),
     datasets: [sync.target.dataset],
     syncs: [sync],
+    onError,
   })
 }
 
@@ -142,6 +146,67 @@ describe("SyncWorker", () => {
     expect(claimed).toHaveLength(0)
 
     await worker.stop()
+  })
+
+  test("reports once when execution transitions the run to failed", async () => {
+    const reports: { error: Error; context: SixbErrorContext }[] = []
+    const originalError = new Error("sync source failed")
+    const dataset = makeDataset("raw.erp.failed-orders")
+    const sync = defineSync("sync-failed-orders")
+      .from(erpDb)
+      .read(() => {
+        throw originalError
+      })
+      .intoDataset(dataset)
+    const sixb = createSixbForSync(sync, undefined, (error, context) => {
+      reports.push({ error, context })
+    })
+    const worker = new SyncWorker(sixb)
+
+    await sixb.queues.syncRuns.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "sync.run.requested",
+          payload: { syncId: sync.id, runId: "run-failed" },
+        },
+      ],
+    })
+
+    await worker.start()
+    try {
+      const run = await waitFor(
+        () => sixb.storage.syncRuns!.getById({ projectId: sixb.id, id: "run-failed" }),
+        (value) => value?.status === "failed"
+      )
+      await waitFor(
+        async () => reports.length,
+        (count) => count === 1
+      )
+
+      expect(reports).toHaveLength(1)
+      expect(reports[0]?.error).toBe(originalError)
+      expect(reports[0]?.context).toEqual({
+        type: "run.failed",
+        notificationId: `project:${sixb.id}:run:sync:run-failed:failed:${run!.finishedAt!.toISOString()}`,
+        projectId: sixb.id,
+        occurredAt: run!.finishedAt!.toISOString(),
+        attempt: 1,
+        run: {
+          kind: "sync",
+          runId: "run-failed",
+          syncId: sync.id,
+        },
+      })
+
+      const claimed = await sixb.queues.syncRuns.claim({
+        projectId: sixb.id,
+        workerId: "observer",
+      })
+      expect(claimed).toHaveLength(0)
+    } finally {
+      await worker.stop()
+    }
   })
 
   test("streams a run-scoped log line to the broker", async () => {
@@ -221,7 +286,8 @@ describe("SyncWorker", () => {
     await worker.stop()
   })
 
-  test("retries the queue job when shutdown aborts an in-flight sync", async () => {
+  test("retries an aborted in-flight sync without reporting it", async () => {
+    let reportCount = 0
     const rawOrdersDataset = makeDataset("raw.erp.orders")
     const sync = defineSync("sync-orders")
       .from(erpDb)
@@ -240,7 +306,9 @@ describe("SyncWorker", () => {
         return []
       })
       .intoDataset(rawOrdersDataset)
-    const sixb = createSixbForSync(sync)
+    const sixb = createSixbForSync(sync, undefined, () => {
+      reportCount += 1
+    })
     const worker = new SyncWorker(sixb)
 
     const [queued] = await sixb.queues.syncRuns.enqueue({
@@ -279,6 +347,7 @@ describe("SyncWorker", () => {
 
     expect(retried?.job.id).toBe(queued?.id)
     expect(retried?.job.attempt).toBe(2)
+    expect(reportCount).toBe(0)
   })
 
   test("survives a transient claim error and keeps polling", async () => {

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -47,6 +47,7 @@ export class WorkflowRunSession {
       readonly state: WorkflowExecutionState
       readonly recorder: WorkflowRunRecorder
       readonly runner: WorkflowNodeRunner
+      readonly onRunFailed?: RunWorkflowJobInput["onRunFailed"]
     }
   ) {}
 
@@ -102,6 +103,7 @@ export class WorkflowRunSession {
         recorder,
         executors: options.executors,
       }),
+      onRunFailed: input.onRunFailed,
     })
   }
 
@@ -232,6 +234,7 @@ export class WorkflowRunSession {
         recorder,
         executors: options.executors,
       }),
+      onRunFailed: input.onRunFailed,
     })
 
     await runtime.workflowRuns.resume({
@@ -376,6 +379,10 @@ export class WorkflowRunSession {
       .finishRunAfterError({
         status: input.status,
         error: toWorkflowRunError(input.error),
+        onTransition:
+          input.status === "failed"
+            ? (run) => this.dependencies.onRunFailed?.(input.error, run)
+            : undefined,
       })
       .then(() => null)
       .catch((error: unknown) => error)

--- a/packages/workflow-worker/src/recorder.ts
+++ b/packages/workflow-worker/src/recorder.ts
@@ -193,6 +193,7 @@ export class WorkflowRunRecorder {
   async finishRunAfterError(params: {
     readonly status: "failed" | "cancelled"
     readonly error: string
+    readonly onTransition?: (run: WorkflowRunRecord) => void
   }): Promise<WorkflowRunRecord> {
     const run = await this.dependencies.workflowRuns.finish({
       projectId: this.dependencies.projectId,
@@ -201,6 +202,7 @@ export class WorkflowRunRecorder {
       error: params.error,
     })
     this.finished = true
+    params.onTransition?.(run)
     await this.notify(() => this.dependencies.observer.onRunFinished(run))
     return run
   }

--- a/packages/workflow-worker/src/run-workflow-job.ts
+++ b/packages/workflow-worker/src/run-workflow-job.ts
@@ -109,6 +109,10 @@ async function failQueuedRun(input: RunWorkflowJobInput, error: unknown): Promis
     error: toWorkflowRunError(error),
   })
 
+  if (failed.status === "failed") {
+    input.onRunFailed?.(error, failed)
+  }
+
   try {
     await input.observer?.onRunFinished(failed)
   } catch (observerError) {

--- a/packages/workflow-worker/src/types.ts
+++ b/packages/workflow-worker/src/types.ts
@@ -43,11 +43,14 @@ export interface WorkflowResumeJob {
   readonly pendingInterventionId: string
 }
 
+export type WorkflowRunFailureReporter = (error: unknown, run: WorkflowRunRecord) => void
+
 export interface RunWorkflowJobInput {
   readonly runtime: WorkflowWorkerContext
   readonly job: WorkflowJob
   readonly signal?: AbortSignal
   readonly observer?: WorkflowRunObserver
+  readonly onRunFailed?: WorkflowRunFailureReporter
 }
 
 export interface RunWorkflowResumeJobInput {
@@ -55,6 +58,7 @@ export interface RunWorkflowResumeJobInput {
   readonly job: WorkflowResumeJob
   readonly signal?: AbortSignal
   readonly observer?: WorkflowRunObserver
+  readonly onRunFailed?: WorkflowRunFailureReporter
 }
 
 export interface WorkflowRunResult {

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -1,7 +1,8 @@
+import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { QueueWorker } from "@sixb/core/internal/workers"
 import type { ClaimedQueueJob, WorkflowQueueJob } from "@sixb/core/queues"
-import type { WorkflowRunStorage } from "@sixb/core/storage"
+import type { WorkflowRunRecord, WorkflowRunStorage } from "@sixb/core/storage"
 import { EventsRuntimeWorkflowRunObserver } from "./events"
 import { runWorkflowJob, runWorkflowResumeJob } from "./run-workflow-job"
 import type {
@@ -15,6 +16,7 @@ import type {
 export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
   private readonly context: WorkflowWorkerContext
   private readonly observer: WorkflowRunObserver
+  private readonly sixb: WorkflowWorkerSixb
 
   constructor(sixb: WorkflowWorkerSixb) {
     if (sixb.workflows.list().length === 0) {
@@ -40,6 +42,7 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
 
     this.context = buildWorkflowContext(sixb, workflowRuns)
     this.observer = new EventsRuntimeWorkflowRunObserver(sixb.events)
+    this.sixb = sixb
   }
 
   protected async execute(
@@ -52,6 +55,7 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
         job: workflowResumeJobFromClaimed(claimed),
         signal,
         observer: this.observer,
+        onRunFailed: (error, run) => this.reportFailedRun(claimed, error, run),
       })
       return
     }
@@ -63,6 +67,24 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
       job: workflowJob,
       signal,
       observer: this.observer,
+      onRunFailed: (error, run) => this.reportFailedRun(claimed, error, run),
+    })
+  }
+
+  private reportFailedRun(
+    claimed: ClaimedQueueJob<WorkflowQueueJob>,
+    error: unknown,
+    run: WorkflowRunRecord
+  ): void {
+    reportRunFailure(this.sixb, error, {
+      projectId: this.sixb.projectId,
+      occurredAt: run.finishedAt,
+      attempt: claimed.job.attempt,
+      run: {
+        kind: "workflow",
+        runId: run.id,
+        workflowId: run.workflowId,
+      },
     })
   }
 

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -491,6 +491,7 @@ describe("runWorkflowJob", () => {
       })
       .then(findBestInvoice)
     const sixb = createSixb({ workflows: [workflow] })
+    const reportedFailures: unknown[] = []
     const observer: WorkflowRunObserver = {
       async onRunStarted() {
         throw new Error("observer failed")
@@ -513,9 +514,11 @@ describe("runWorkflowJob", () => {
           },
         },
         observer,
+        onRunFailed: (error) => reportedFailures.push(error),
       })
 
       expect(result.run.status).toBe("succeeded")
+      expect(reportedFailures).toHaveLength(0)
     } finally {
       console.error = originalConsoleError
     }

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -13,6 +13,8 @@ import {
   prop,
   ref,
   Sixb,
+  type SixbErrorContext,
+  type SixbErrorHandler,
   type WorkflowDefinition,
 } from "@sixb/core"
 import { LOGS_STREAM } from "@sixb/core/internal/logging"
@@ -49,6 +51,7 @@ const slowStep = defineWorkflowStep("slow-step")
     return {}
   })
 
+const workflowExplosion = new Error("workflow exploded")
 const failingStep = defineWorkflowStep("explode")
   .input({
     transaction: ref(Transaction),
@@ -57,7 +60,7 @@ const failingStep = defineWorkflowStep("explode")
     invoice: ref(Invoice),
   })
   .run(() => {
-    throw new Error("workflow exploded")
+    throw workflowExplosion
   })
 
 const reviewInvoice = defineIntervention("review-invoice")
@@ -91,6 +94,7 @@ afterEach(async () => {
 function createSixb(options: {
   readonly workflows?: readonly WorkflowDefinition[]
   readonly actions?: readonly ActionDefinition[]
+  readonly onError?: SixbErrorHandler
 }) {
   return new Sixb({
     id: "workflow-worker-tests",
@@ -100,6 +104,7 @@ function createSixb(options: {
     lakeStorage: new InMemoryLakeStorage(),
     blobStorage: new InMemoryBlobStorage(),
     queues: new InMemoryQueues(),
+    onError: options.onError,
     actions: options.actions ?? [],
     workflows: options.workflows ?? [],
   })
@@ -320,16 +325,32 @@ describe("WorkflowWorker", () => {
     expect(claimed).toHaveLength(0)
   })
 
-  test("fails the queue job and emits failed workflow lifecycle events", async () => {
+  test("reports a terminal failed workflow once with the original error", async () => {
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
     const workflow = defineWorkflow("failing-workflow")
       .input({
         transaction: ref(Transaction),
       })
       .then(failingStep)
-    const sixb = createSixb({ workflows: [workflow] })
+    const sixb = createSixb({
+      workflows: [workflow],
+      onError: (error, context) => {
+        reports.push({ error, context })
+      },
+    })
     await sixb.queues.workflows.enqueue({
       projectId: sixb.id,
       jobs: [
+        {
+          type: "workflow.run.requested",
+          payload: {
+            workflowId: workflow.id,
+            runId: "wfrun_worker_failed",
+            input: {
+              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+            },
+          },
+        },
         {
           type: "workflow.run.requested",
           payload: {
@@ -356,6 +377,24 @@ describe("WorkflowWorker", () => {
       (value) => value?.status === "failed"
     )
     expect(run?.error).toBe("workflow exploded")
+
+    const reported = await waitFor(
+      async () => reports,
+      (value) => value.length === 1
+    )
+    expect(reported[0]?.error).toBe(workflowExplosion)
+    expect(reported[0]?.context).toMatchObject({
+      type: "run.failed",
+      notificationId: `project:${sixb.id}:run:workflow:wfrun_worker_failed:failed:${run?.finishedAt?.toISOString()}`,
+      projectId: sixb.id,
+      attempt: 1,
+      run: {
+        kind: "workflow",
+        runId: "wfrun_worker_failed",
+        workflowId: workflow.id,
+      },
+    })
+    expect(reported[0]?.context.occurredAt).toBe(run?.finishedAt?.toISOString() ?? "")
 
     const events = await waitFor(
       () =>
@@ -390,11 +429,79 @@ describe("WorkflowWorker", () => {
       error: "workflow exploded",
     })
 
+    await Bun.sleep(50)
+    expect(reports).toHaveLength(1)
+
     const claimed = await sixb.queues.workflows.claim({
       projectId: sixb.id,
       workerId: "observer",
     })
     expect(claimed).toHaveLength(0)
+  })
+
+  test("reports a queued run that fails before workflow start", async () => {
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    const workflow = defineWorkflow("queued-invalid-workflow")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+    const sixb = createSixb({
+      workflows: [workflow],
+      onError: (error, context) => {
+        reports.push({ error, context })
+      },
+    })
+
+    await sixb.storage.workflowRuns!.queue({
+      projectId: sixb.id,
+      id: "wfrun_queued_invalid",
+      workflowId: workflow.id,
+      input: {},
+    })
+    await sixb.queues.workflows.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "workflow.run.requested",
+          payload: {
+            workflowId: workflow.id,
+            runId: "wfrun_queued_invalid",
+            input: {},
+          },
+        },
+      ],
+    })
+
+    const worker = new WorkflowWorker(sixb)
+    workers.push(worker)
+    await worker.start()
+
+    const run = await waitFor(
+      () =>
+        sixb.storage.workflowRuns!.getById({
+          projectId: sixb.id,
+          id: "wfrun_queued_invalid",
+        }),
+      (value) => value?.status === "failed"
+    )
+    const reported = await waitFor(
+      async () => reports,
+      (value) => value.length === 1
+    )
+
+    expect(reported[0]?.error.message).toContain("Missing required field")
+    expect(reported[0]?.context).toMatchObject({
+      type: "run.failed",
+      notificationId: `project:${sixb.id}:run:workflow:wfrun_queued_invalid:failed:${run?.finishedAt?.toISOString()}`,
+      attempt: 1,
+      run: {
+        kind: "workflow",
+        runId: "wfrun_queued_invalid",
+        workflowId: workflow.id,
+      },
+    })
+    expect(reported[0]?.context.occurredAt).toBe(run?.finishedAt?.toISOString() ?? "")
   })
 
   test("completes queue jobs when workflow runs suspend at intervention nodes", async () => {
@@ -591,9 +698,112 @@ describe("WorkflowWorker", () => {
     expect(claimed).toHaveLength(0)
   })
 
-  test("cancels the run and fails the queue job on worker shutdown", async () => {
+  test("reports a resumed workflow only when it transitions to failed", async () => {
+    const resumeError = new Error("resumed workflow exploded")
+    const failAfterResume = defineWorkflowStep("fail-after-resume")
+      .input({ approvedInvoice: ref(Invoice) })
+      .output({ invoice: ref(Invoice) })
+      .run(() => {
+        throw resumeError
+      })
+    const workflow = defineWorkflow("failing-resumed-workflow")
+      .input({ transaction: ref(Transaction) })
+      .then(findBestInvoice)
+      .then(reviewInvoice, ({ steps }) => ({
+        invoice: steps.findBestInvoice.invoice,
+      }))
+      .then(failAfterResume)
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    const sixb = createSixb({
+      workflows: [workflow],
+      onError: (error, context) => {
+        reports.push({ error, context })
+      },
+    })
+
+    await sixb.queues.workflows.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "workflow.run.requested",
+          payload: {
+            workflowId: workflow.id,
+            runId: "wfrun_worker_resume_failed",
+            input: {
+              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+            },
+          },
+        },
+      ],
+    })
+
+    const worker = new WorkflowWorker(sixb)
+    workers.push(worker)
+    await worker.start()
+
+    await waitFor(
+      () =>
+        sixb.storage.workflowRuns!.getById({
+          projectId: sixb.id,
+          id: "wfrun_worker_resume_failed",
+        }),
+      (value) => value?.status === "waiting"
+    )
+    await sixb.storage.workflowInterventions!.submit({
+      projectId: sixb.id,
+      id: "wfrun_worker_resume_failed:intervention:1",
+      response: {
+        approvedInvoice: { objectTypeId: "Invoice", primaryId: "inv_reviewed" },
+      },
+    })
+    await sixb.queues.workflows.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "workflow.run.resume.requested",
+          payload: {
+            workflowId: workflow.id,
+            runId: "wfrun_worker_resume_failed",
+            pendingInterventionId: "wfrun_worker_resume_failed:intervention:1",
+          },
+        },
+      ],
+    })
+
+    const run = await waitFor(
+      () =>
+        sixb.storage.workflowRuns!.getById({
+          projectId: sixb.id,
+          id: "wfrun_worker_resume_failed",
+        }),
+      (value) => value?.status === "failed"
+    )
+    const reported = await waitFor(
+      async () => reports,
+      (value) => value.length === 1
+    )
+
+    expect(run?.error).toBe(resumeError.message)
+    expect(reported[0]?.error).toBe(resumeError)
+    expect(reported[0]?.context).toMatchObject({
+      attempt: 1,
+      run: {
+        kind: "workflow",
+        runId: "wfrun_worker_resume_failed",
+        workflowId: workflow.id,
+      },
+    })
+  })
+
+  test("cancels the run without reporting a failure on worker shutdown", async () => {
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
     const workflow = defineWorkflow("cancel-workflow").input({}).then(slowStep)
-    const sixb = createSixb({ workflows: [workflow] })
+    const sixb = createSixb({
+      workflows: [workflow],
+      onError: (error, context) => {
+        reports.push({ error, context })
+      },
+    })
     await sixb.queues.workflows.enqueue({
       projectId: sixb.id,
       jobs: [
@@ -628,6 +838,8 @@ describe("WorkflowWorker", () => {
       id: "wfrun_worker_cancelled",
     })
     expect(run?.status).toBe("cancelled")
+    await Bun.sleep(0)
+    expect(reports).toHaveLength(0)
 
     const events = await sixb.events.read({
       types: [


### PR DESCRIPTION
## Summary

Adds a top-level `onError` callback to `createSixb()` so projects can route terminal run failures to email, Slack, Discord, Sentry, or another notification destination. The callback receives the original normalized `Error` plus typed run context for actions, agents, pipelines, projections, syncs, workflows, and webhooks.

Reporting is observational and process-local: callback failures cannot alter run status, queue settlement, retries, or HTTP responses.

## Linked issue

Closes #226.

## Resulting API

```ts
export const sixb = await createSixb({
  // providers...
  async onError(error, context) {
    await sendNotification({
      id: context.notificationId,
      message: `${context.run.kind} ${context.run.runId}: ${error.message}`,
    })
  },
})
```

`context.run.kind` is a discriminated union that exposes the relevant action, agent, pipeline, projection, sync, workflow, or webhook identifier. Each failed-state transition receives a project-scoped `notificationId` for downstream deduplication.

## Implementation

```text
run execution
    │
    ├── success / cancellation / recoverable retry ──> no notification
    │
    └── durable terminal failure
            └── reportRunFailure(error, run context)
                    └── isolated onError callback
                            └── bounded drain during shutdown
```

- Core owns normalization, callback isolation, pending-handler tracking, and the private reporter capability shared by derived runtime contexts.
- Workers report only top-level failed transitions; workflow nodes and pipeline steps do not produce duplicate notifications.
- Webhooks report handler and infrastructure failures while excluding routine 4xx rejection paths.
- The Acme example logs failed runs and includes a deliberate webhook failure in `bun run webhooks:demo`; its demo scripts now target the default API port `3002`.

## Scope

This PR intentionally does not add a `SixbError` base hierarchy, broker error event, storage migration, or generated client contract. Function, scheduler, rules, orchestrator, and worker-health diagnostics remain outside this failed-run-focused slice.

Delivery is best effort rather than exactly once. Sixb gives pending async handlers up to five seconds to drain during graceful CLI shutdown, while integrations can use `notificationId` to tolerate duplicate delivery after process failure.

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test` — 2,704 passed, 2 skipped
- `bun --filter @sixb/example-acme-corp typecheck`

## Notes for reviewers

The highest-value review areas are the per-worker terminal transition boundaries, reporter failure isolation and shutdown behavior, and the webhook distinction between actionable failures and routine request rejection.
