### PR TITLE
cli: isolate custom app build inputs from dev files

### DIFF
--- a/packages/cli/src/commands/build.tsx
+++ b/packages/cli/src/commands/build.tsx
@@ -1,5 +1,5 @@
 import { mkdir } from "node:fs/promises"
-import { dirname, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { createCustomApp } from "@sixb/app"
 import { buildAtlasAssets } from "@sixb/atlas"
 import { generateProjectTypes } from "../lib/typegen"
@@ -39,6 +39,10 @@ export async function runBuild(options: BuildOptions = {}) {
 
   const customApp = await createCustomApp({
     rootDir: projectRoot,
+    // Keep production build inputs separate from the files watched by `sixb dev`.
+    // Sharing `.sixb/generated` lets this command replace the dev app's injected
+    // API origin and HTML bundle, causing Bun to hot-reload a same-origin client.
+    generatedDir: join(".sixb", "build", "app"),
   })
 
   if (await customApp.hasRoutes()) {

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 
 function runBuildEntry(
   entry: string,
@@ -70,6 +70,40 @@ describe("sixb build", () => {
     const html = await readFile(join(outdir, "app", "index.html"), "utf-8")
     expect(html).toContain('<div id="root"></div>')
   })
+
+  test("does not overwrite custom app files watched by the dev server", async () => {
+    const tempDir = await mkdtemp(join(dirname(exampleEntry), ".tmp-sixb-cli-build-isolation-"))
+    tempDirs.push(tempDir)
+    const appDir = join(tempDir, "app")
+    const devGeneratedDir = join(tempDir, ".sixb", "generated")
+    const entry = join(tempDir, "sixb.config.ts")
+    const outdir = join(tempDir, "dist")
+    await mkdir(appDir, { recursive: true })
+    await mkdir(devGeneratedDir, { recursive: true })
+    await writeFile(entry, "export default {}\n")
+    await writeFile(join(appDir, "page.tsx"), "export default function Page() { return null }\n")
+
+    const devFiles = new Map([
+      ["index.html", "dev index with http://localhost:3000\n"],
+      ["index.sixb-bundle.html", "dev HTML bundle entry\n"],
+      ["main.tsx", "dev main entry\n"],
+      ["routes.ts", "dev routes\n"],
+      ["app.webmanifest", "dev manifest\n"],
+    ])
+    for (const [name, content] of devFiles) {
+      await writeFile(join(devGeneratedDir, name), content)
+    }
+
+    const result = runBuildEntry(entry, outdir)
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe("")
+    await stat(join(outdir, "app", "index.html"))
+    for (const [name, content] of devFiles) {
+      expect(await readFile(join(devGeneratedDir, name), "utf-8")).toBe(content)
+    }
+    await stat(join(tempDir, ".sixb", "build", "app", "index.html"))
+  }, 30_000)
 
   test("externalizes package dependencies when bundling runtime config", async () => {
     const repoRoot = resolve(import.meta.dir, "..", "..", "..")


### PR DESCRIPTION
## Summary

`sixb build` now stages custom-app inputs in `.sixb/build/app`, while `sixb dev` continues using `.sixb/generated`. This prevents a production build from replacing watched dev files and triggering a hot reload whose client no longer contains the dev API origin.

```text
sixb dev   ──> .sixb/generated ──> watched development app
sixb build ──> .sixb/build/app ──> production app output
```

## Behavior

The change isolates concurrent dev and build workflows without changing the production output layout.

| Concern | Before | After |
|---|---|---|
| Dev generation | `.sixb/generated` | `.sixb/generated` |
| Build generation | `.sixb/generated` | `.sixb/build/app` |
| Build during dev | Replaces watched HTML/runtime inputs | Leaves dev inputs unchanged |
| Final custom app | Written under the configured output directory | Unchanged |

## Implementation

`runBuild` configures `createCustomApp` with a build-only generation directory. The path is resolved by the existing custom-app flow relative to `projectRoot`.

```ts
const customApp = await createCustomApp({
  rootDir: projectRoot,
  generatedDir: join(".sixb", "build", "app"),
})
```

Regression coverage in `packages/cli/tests/build.test.ts` models the conflicting workflow:

- Seeds `.sixb/generated` with representative dev HTML, entry, routes, and manifest files.
- Runs a custom-app build and checks that every seeded file remains byte-for-byte unchanged.
- Confirms generation occurs at `.sixb/build/app/index.html` and the final app remains available at `dist/app/index.html`.

## Scope

This is a generation-path isolation fix rather than a change to runtime routing or authentication behavior.

- Dev-server API-origin injection and hot-reload behavior are not modified.
- Production bundling and output structure remain on the existing path.
- The build-specific files remain inside `.sixb`; no cleanup or lifecycle changes are introduced.

## Notes for reviewers

The main design decision is to prevent interference by separating mutable inputs instead of suppressing Bun reloads or reconstructing dev configuration after a build.

1. Review `packages/cli/src/commands/build.tsx` for the `generatedDir` path and its interaction with `rootDir`.
2. Review the isolation test for whether its seeded files represent the dev server’s watched surface and whether both staging and final output assertions cover the intended contract.
