### PR TITLE
connector-sftp: support directory permission modes

### DIFF
--- a/connectors/sftp/README.md
+++ b/connectors/sftp/README.md
@@ -37,6 +37,28 @@ const fileRef = await blobs.put({ body, expectedSizeBytes: size, signal })
 `read(...)` returns a `Buffer` and remains useful when the complete file is intentionally needed in
 memory.
 
+### Directory permissions
+
+`mkdir(...)` and `ensureDir(...)` accept optional POSIX permission bits. `ensureDir(...)` applies
+the requested mode only to path segments created by that call and never changes existing directory
+permissions:
+
+```ts
+await client.mkdir("/exports/private", { mode: 0o700 })
+await client.ensureDir("/exports/shared/2026", { mode: 0o770 })
+```
+
+The SFTP server can restrict a requested creation mode through its umask or ACL policy. Use
+`stat(...)` when the effective mode is a required postcondition. Use `chmod(...)` only when an
+existing path must be changed explicitly:
+
+```ts
+await client.chmod("/exports/shared", 0o770)
+const effectiveMode = (await client.stat("/exports/shared")).mode & 0o7777
+```
+
+Modes must be integers between `0o0000` and `0o7777`.
+
 ### Stream read-ahead
 
 `readAheadRequests` controls how many ordered SFTP reads may be in flight for each streamed file.

--- a/connectors/sftp/src/client.ts
+++ b/connectors/sftp/src/client.ts
@@ -1,8 +1,14 @@
 import { posix } from "node:path"
 import { Readable } from "node:stream"
-import type { Callback, SFTPWrapper, ReadStream as Ssh2ReadStream } from "ssh2"
+import type { Callback, InputAttributes, SFTPWrapper, ReadStream as Ssh2ReadStream } from "ssh2"
 import { openSftpReadAheadStream } from "./read-ahead"
-import type { SftpClient, SftpOpenOptions, SftpStats, SftpWriteData } from "./types"
+import type {
+  SftpClient,
+  SftpMkdirOptions,
+  SftpOpenOptions,
+  SftpStats,
+  SftpWriteData,
+} from "./types"
 
 type SftpClientOptions = {
   readonly readAheadRequests: number
@@ -24,8 +30,8 @@ export function createSftpClient(
         sftpClient.exists(path, (exists) => resolve(exists))
       })
     },
-    ensureDir(path) {
-      return ensureSftpDirectory(sftpClient, path)
+    ensureDir(path, options) {
+      return ensureSftpDirectory(sftpClient, path, options)
     },
     open(path, openOptions) {
       return openSftpStream(sftpClient, path, clientOptions, openOptions)
@@ -42,8 +48,12 @@ export function createSftpClient(
     delete(path) {
       return callVoid((callback) => sftpClient.unlink(path, callback))
     },
-    mkdir(path) {
-      return callVoid((callback) => sftpClient.mkdir(path, callback))
+    mkdir(path, options) {
+      return createSftpDirectory(sftpClient, path, options)
+    },
+    chmod(path, mode) {
+      assertSftpMode(mode, "chmod")
+      return callVoid((callback) => sftpClient.chmod(path, mode, callback))
     },
     rmdir(path) {
       return callVoid((callback) => sftpClient.rmdir(path, callback))
@@ -139,7 +149,13 @@ function abortError(signal: AbortSignal): Error {
     : new DOMException("The operation was aborted", "AbortError")
 }
 
-async function ensureSftpDirectory(sftpClient: SFTPWrapper, path: string): Promise<void> {
+async function ensureSftpDirectory(
+  sftpClient: SFTPWrapper,
+  path: string,
+  options?: SftpMkdirOptions
+): Promise<void> {
+  const attributes = mkdirAttributes(options, "ensureDir")
+
   for (const directoryPath of directoryHierarchy(path)) {
     const exists = await new Promise<boolean>((resolve) => {
       sftpClient.exists(directoryPath, (value) => resolve(value))
@@ -151,7 +167,7 @@ async function ensureSftpDirectory(sftpClient: SFTPWrapper, path: string): Promi
     }
 
     try {
-      await callVoid((callback) => sftpClient.mkdir(directoryPath, callback))
+      await sendSftpMkdir(sftpClient, directoryPath, attributes)
     } catch (error) {
       const stats = await statIfExists(sftpClient, directoryPath)
 
@@ -167,6 +183,46 @@ async function ensureSftpDirectory(sftpClient: SFTPWrapper, path: string): Promi
 
       throw error
     }
+  }
+}
+
+function createSftpDirectory(
+  sftpClient: SFTPWrapper,
+  path: string,
+  options: SftpMkdirOptions | undefined
+): Promise<void> {
+  return sendSftpMkdir(sftpClient, path, mkdirAttributes(options, "mkdir"))
+}
+
+function sendSftpMkdir(
+  sftpClient: SFTPWrapper,
+  path: string,
+  attributes: InputAttributes | undefined
+): Promise<void> {
+  return callVoid((callback) => {
+    if (attributes) {
+      sftpClient.mkdir(path, attributes, callback)
+      return
+    }
+    sftpClient.mkdir(path, callback)
+  })
+}
+
+function mkdirAttributes(
+  options: SftpMkdirOptions | undefined,
+  operation: "mkdir" | "ensureDir"
+): InputAttributes | undefined {
+  if (options?.mode === undefined) {
+    return undefined
+  }
+
+  assertSftpMode(options.mode, operation)
+  return { mode: options.mode }
+}
+
+function assertSftpMode(mode: number, operation: "chmod" | "mkdir" | "ensureDir"): void {
+  if (!Number.isSafeInteger(mode) || mode < 0 || mode > 0o7777) {
+    throw new Error(`[SixbSftp] ${operation} mode must be an integer between 0o0000 and 0o7777.`)
   }
 }
 

--- a/connectors/sftp/src/index.ts
+++ b/connectors/sftp/src/index.ts
@@ -5,6 +5,7 @@ export type {
   SftpConnection,
   SftpConnector,
   SftpListEntry,
+  SftpMkdirOptions,
   SftpOpenOptions,
   SftpOptions,
   SftpStats,

--- a/connectors/sftp/src/types.ts
+++ b/connectors/sftp/src/types.ts
@@ -21,17 +21,29 @@ export interface SftpOpenOptions {
   readonly signal?: AbortSignal
 }
 
+export interface SftpMkdirOptions {
+  /**
+   * POSIX permission bits requested when creating a directory.
+   *
+   * The SFTP server may further restrict this mode through its umask or ACL policy. Use `stat`
+   * when the resulting permissions are a required postcondition.
+   */
+  readonly mode?: number
+}
+
 export interface SftpClient {
   list(path: string): Promise<readonly SftpListEntry[]>
   stat(path: string): Promise<SftpStats>
   exists(path: string): Promise<boolean>
-  ensureDir(path: string): Promise<void>
+  /** Creates missing path segments without changing existing directory permissions. */
+  ensureDir(path: string, options?: SftpMkdirOptions): Promise<void>
   open(path: string, options?: SftpOpenOptions): Promise<ReadableStream<Uint8Array>>
   read(path: string): Promise<Buffer>
   write(path: string, data: SftpWriteData): Promise<void>
   rename(sourcePath: string, destinationPath: string): Promise<void>
   delete(path: string): Promise<void>
-  mkdir(path: string): Promise<void>
+  mkdir(path: string, options?: SftpMkdirOptions): Promise<void>
+  chmod(path: string, mode: number): Promise<void>
   rmdir(path: string): Promise<void>
 }
 

--- a/connectors/sftp/tests/sftp.test.ts
+++ b/connectors/sftp/tests/sftp.test.ts
@@ -429,6 +429,31 @@ describe("sftp connector", () => {
     }
   })
 
+  test("requests directory modes and changes them explicitly", async () => {
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+
+    try {
+      await client.mkdir("/files/private", { mode: 0o700 })
+      expect((await client.stat("/files/private")).mode & 0o7777).toBe(0o700)
+
+      await client.chmod("/files/private", 0o770)
+      expect((await client.stat("/files/private")).mode & 0o7777).toBe(0o770)
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
   test("ensures deep directories", async () => {
     const adapter = sftp({
       host: server.host,
@@ -473,6 +498,64 @@ describe("sftp connector", () => {
 
       const stats = await client.stat("/files/archive/2026")
       expect(stats.isDirectory()).toBe(true)
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
+  test("ensureDir applies a mode only to missing segments", async () => {
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+
+    try {
+      await client.mkdir("/files/archive", { mode: 0o700 })
+      await client.ensureDir("/files/archive/2026/reports", { mode: 0o755 })
+
+      expect((await client.stat("/files/archive")).mode & 0o7777).toBe(0o700)
+      expect((await client.stat("/files/archive/2026")).mode & 0o7777).toBe(0o755)
+      expect((await client.stat("/files/archive/2026/reports")).mode & 0o7777).toBe(0o755)
+    } finally {
+      await adapter.disconnect?.(client)
+    }
+  })
+
+  test("rejects invalid directory modes before sending SFTP requests", async () => {
+    const adapter = sftp({
+      host: server.host,
+      port: server.port,
+      username: server.username,
+      password: server.password,
+    })
+
+    const client = await adapter.connect({
+      projectId: "demo",
+      connectorId: "files",
+      signal: new AbortController().signal,
+    })
+
+    try {
+      expect(() => client.mkdir("/files/negative", { mode: -1 })).toThrow(
+        "mkdir mode must be an integer between 0o0000 and 0o7777"
+      )
+      expect(() => client.ensureDir("/files/fractional", { mode: 0.5 })).toThrow(
+        "ensureDir mode must be an integer between 0o0000 and 0o7777"
+      )
+      expect(() => client.chmod("/files", 0o10000)).toThrow(
+        "chmod mode must be an integer between 0o0000 and 0o7777"
+      )
+
+      expect(await client.exists("/files/negative")).toBe(false)
+      expect(await client.exists("/files/fractional")).toBe(false)
     } finally {
       await adapter.disconnect?.(client)
     }

--- a/connectors/sftp/tests/testServer.ts
+++ b/connectors/sftp/tests/testServer.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from "node:fs"
 import {
+  chmod,
   lstat,
   mkdir,
   mkdtemp,
@@ -371,9 +372,23 @@ function bindSftpHandlers(
         sftp.status(reqid, mapErrorToStatus(error))
       }
     })
-    .on("MKDIR", async (reqid, path) => {
+    .on("SETSTAT", async (reqid, path, attrs) => {
+      if (typeof attrs.mode !== "number") {
+        sftp.status(reqid, utils.sftp.STATUS_CODE.OP_UNSUPPORTED)
+        return
+      }
+
       try {
-        await mkdir(resolveRemotePath(rootDir, path))
+        await chmod(resolveRemotePath(rootDir, path), attrs.mode)
+        sftp.status(reqid, utils.sftp.STATUS_CODE.OK)
+      } catch (error) {
+        sftp.status(reqid, mapErrorToStatus(error))
+      }
+    })
+    .on("MKDIR", async (reqid, path, attrs) => {
+      try {
+        const options = typeof attrs.mode === "number" ? { mode: attrs.mode } : undefined
+        await mkdir(resolveRemotePath(rootDir, path), options)
         sftp.status(reqid, utils.sftp.STATUS_CODE.OK)
       } catch (error) {
         sftp.status(reqid, mapErrorToStatus(error))


### PR DESCRIPTION
## Summary

- add optional POSIX modes to `mkdir` and `ensureDir`
- add an explicit `chmod` operation
- validate modes before sending SFTP requests
- keep `ensureDir` idempotent without changing existing directory permissions
- document server umask/ACL behavior and effective-mode verification
- extend the SFTP test server and integration coverage for MKDIR attributes and SETSTAT

## Why

The connector could create directories but could not request or explicitly update their permission mode. Consumers therefore had no portable connector API for enforcing shared-directory permissions when a server umask restricted newly created paths.

The connector remains infrastructure-focused: it exposes portable SFTP primitives and does not encode NAS-specific ACL policy.

## Compatibility

Existing `mkdir(path)` and `ensureDir(path)` calls keep their current behavior. The new options and `chmod` method are additive.

## Validation

- `bun --filter @sixb/connector-sftp test` — 23 passed
- `bun --filter @sixb/connector-sftp typecheck`
- `bun --filter @sixb/connector-sftp build`
- `bun run typecheck`
- `bun run check`
