### PR TITLE
examples: preserve exact decimals in Acme ERP syncs

### DIFF
--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -60,11 +60,16 @@ col("raw", "json", { nullable: true })
 | `boolean` | a boolean |
 | `int64` | an integer, or an integer string |
 | `float64` | a finite number |
-| `decimal` | a finite number, or a numeric string |
+| `decimal` | an exact numeric string |
 | `date` | a `Date`, or a `YYYY-MM-DD` string |
 | `timestamp` | a `Date`, or a parseable date string |
 | `json` | any JSON value |
 | `fileRef` | a [file reference](../infrastructure/overview.md) |
+
+Decimal columns reject JavaScript numbers because their exact source value may already have lost
+precision. Keep decimals as strings from the source, or construct typed values with `decimal("...")`
+or `decimal(anExactBigInt)`. Do not convert a `number` with `String(...)` and assume precision is
+restored.
 
 ## Use a dataset
 

--- a/examples/acme-corp/lib/acme-erp.ts
+++ b/examples/acme-corp/lib/acme-erp.ts
@@ -1,3 +1,5 @@
+import { type DecimalValue, decimal } from "@sixb/core"
+
 export interface ErpDepartmentRow {
   readonly dept_id: string
   readonly dept_name: string
@@ -31,7 +33,7 @@ export interface ErpProjectRow {
   readonly status: string
   readonly start_date: string
   readonly deadline: string
-  readonly budget_amount: number
+  readonly budget_amount: DecimalValue
   readonly customer_id: string
   readonly lead_emp_id: string
 }
@@ -60,7 +62,7 @@ export interface ErpDocumentRow {
 export interface ErpInvoiceRow {
   readonly id: string
   readonly number: string
-  readonly amount: number
+  readonly amount: DecimalValue
   readonly currency: string
   readonly status: string
   readonly issuedAt: string
@@ -203,7 +205,7 @@ const projects = [
     status: "active",
     start_date: "2024-01-15",
     deadline: "2024-12-31",
-    budget_amount: 250000,
+    budget_amount: decimal("250000"),
     customer_id: "cust-techstart",
     lead_emp_id: "emp-alice",
   },
@@ -214,7 +216,7 @@ const projects = [
     status: "active",
     start_date: "2024-03-01",
     deadline: "2024-09-30",
-    budget_amount: 180000,
+    budget_amount: decimal("180000"),
     customer_id: "cust-greenenergy",
     lead_emp_id: "emp-bob",
   },
@@ -225,7 +227,7 @@ const projects = [
     status: "draft",
     start_date: "2024-06-01",
     deadline: "2025-03-31",
-    budget_amount: 120000,
+    budget_amount: decimal("120000"),
     customer_id: "cust-eduplatform",
     lead_emp_id: "emp-emma",
   },
@@ -236,7 +238,7 @@ const projects = [
     status: "completed",
     start_date: "2023-06-01",
     deadline: "2024-01-31",
-    budget_amount: 320000,
+    budget_amount: decimal("320000"),
     customer_id: "cust-healthfirst",
     lead_emp_id: "emp-alice",
   },
@@ -397,7 +399,7 @@ const invoices = [
   {
     id: "inv-001",
     number: "INV-2024-001",
-    amount: 62500,
+    amount: decimal("62500"),
     currency: "EUR",
     status: "paid",
     issuedAt: "2024-04-01T00:00:00Z",
@@ -408,7 +410,7 @@ const invoices = [
   {
     id: "inv-002",
     number: "INV-2024-002",
-    amount: 45000,
+    amount: decimal("45000"),
     currency: "EUR",
     status: "sent",
     issuedAt: "2024-07-01T00:00:00Z",
@@ -419,7 +421,7 @@ const invoices = [
   {
     id: "inv-003",
     number: "INV-2024-003",
-    amount: 62500,
+    amount: decimal("62500"),
     currency: "EUR",
     status: "paid",
     issuedAt: "2024-07-01T00:00:00Z",
@@ -430,7 +432,7 @@ const invoices = [
   {
     id: "inv-004",
     number: "INV-2024-004",
-    amount: 30000,
+    amount: decimal("30000"),
     currency: "GBP",
     status: "overdue",
     issuedAt: "2024-05-01T00:00:00Z",
@@ -441,7 +443,7 @@ const invoices = [
   {
     id: "inv-005",
     number: "INV-2024-005",
-    amount: 40000,
+    amount: decimal("40000"),
     currency: "USD",
     status: "draft",
     issuedAt: "2024-08-01T00:00:00Z",

--- a/examples/acme-corp/tests/erp-dataset-contracts.test.ts
+++ b/examples/acme-corp/tests/erp-dataset-contracts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { getDatasetRowValidationError } from "@sixb/core"
+import {
+  erpCustomersDataset,
+  erpDepartmentsDataset,
+  erpDocumentsDataset,
+  erpEmployeesDataset,
+  erpInvoicesDataset,
+  erpProjectMembersDataset,
+  erpProjectProgressDataset,
+  erpProjectsDataset,
+  erpTasksDataset,
+} from "../datasets/erp"
+import { createAcmeErpClient } from "../lib/acme-erp"
+
+describe("Acme ERP dataset contracts", () => {
+  test("every source row matches its destination dataset", async () => {
+    const client = createAcmeErpClient()
+    const sources = [
+      { dataset: erpDepartmentsDataset, rows: await client.listDepartments() },
+      { dataset: erpEmployeesDataset, rows: await client.listEmployees() },
+      { dataset: erpCustomersDataset, rows: await client.listCustomers() },
+      { dataset: erpProjectsDataset, rows: await client.listProjects() },
+      { dataset: erpProjectMembersDataset, rows: await client.listProjectMembers() },
+      { dataset: erpDocumentsDataset, rows: await client.listDocuments() },
+      { dataset: erpInvoicesDataset, rows: await client.listInvoices() },
+      { dataset: erpTasksDataset, rows: await client.listTasks() },
+      { dataset: erpProjectProgressDataset, rows: await client.listProjectProgress() },
+    ]
+
+    for (const { dataset, rows } of sources) {
+      for (const [index, row] of rows.entries()) {
+        expect(
+          getDatasetRowValidationError(row, dataset),
+          `${dataset.id} row ${index + 1}`
+        ).toBeNull()
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The Acme ERP project sync returned JavaScript numbers for columns declared as `decimal`, causing runtime row validation to reject `budget_amount`. This aligns the example with Sixb's exact-decimal contract and also fixes the same latent issue in invoice amounts.

## What changed

- Model `ErpProjectRow.budget_amount` and `ErpInvoiceRow.amount` as `DecimalValue`.
- Construct all Acme budget and invoice fixtures with `decimal("...")` instead of number literals.
- Add a dataset-contract test that validates every Acme ERP source row against its destination dataset.
- Correct the dataset documentation to state that decimal columns accept exact numeric strings, not JavaScript numbers.

## Contract alignment

| Surface | Before | After |
| --- | --- | --- |
| Project budgets | JavaScript numbers | `DecimalValue` values |
| Invoice amounts | JavaScript numbers | `DecimalValue` values |
| Decimal guidance | Numbers or numeric strings | Exact numeric strings |
| Regression coverage | No source-to-dataset check | Every ERP fixture row validated |

## Tradeoffs and risk

This does not relax core validation or stringify existing numbers, because doing so cannot recover precision already lost by JavaScript. The change is scoped to example fixtures, their contract coverage, and the corresponding documentation; dataset schemas and framework APIs are unchanged.

## Validation

- `bun test examples/acme-corp/tests/` — 16 tests passed.
- `bun run build:types` — passed.
- `bun --filter @sixb/example-acme-corp typecheck` — passed.
- `bun run check` — passed.

## Review guide

1. Verify the exact-decimal fixture changes in `examples/acme-corp/lib/acme-erp.ts`.
2. Review the source-row coverage in `erp-dataset-contracts.test.ts`.
3. Confirm the accepted-type guidance in `docs/data/datasets.md`.
