### PR TITLE
app: support TLS-terminating proxies in custom app dev

### DIFF
--- a/packages/app/src/createCustomApp.ts
+++ b/packages/app/src/createCustomApp.ts
@@ -254,6 +254,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
       let htmlImportVersion = 0
       let htmlBundle = await importHtmlBundle(htmlPath, htmlImportVersion)
       const publicRoutes = (await pathExists(publicDir)) ? await createPublicRoutes(publicDir) : {}
+      let internalOrigin = ""
       const serveOptions = (bundle: Bun.HTMLBundle) =>
         ({
           port,
@@ -264,11 +265,12 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
             ...reservedSixbRoutes(),
             [customAppManifestRoute]: manifestRoute(manifestPath),
             [internalAppShellRoute]: htmlBundleRoute(bundle),
-            "/": spaHtmlRoute(),
-            "/*": spaHtmlRoute(),
+            "/": spaHtmlRoute(() => internalOrigin),
+            "/*": spaHtmlRoute(() => internalOrigin),
           },
         }) as Parameters<typeof Bun.serve>[0]
       const server = Bun.serve(serveOptions(htmlBundle))
+      internalOrigin = devServerInternalOrigin(host, server.port ?? port)
 
       // .ts/.tsx edits can change Tailwind's scanned classes and .css edits
       // change the stylesheet source, so both regenerate the entry and
@@ -703,32 +705,55 @@ function manifestRoute(manifestPath: string): BunServeRoute {
   )
 }
 
-function spaHtmlRoute(): BunServeRoute {
+function devServerInternalOrigin(host: string, port: number): string {
+  if (host === "0.0.0.0") {
+    return `http://127.0.0.1:${port}`
+  }
+  if (host === "::" || host === "[::]") {
+    return `http://[::1]:${port}`
+  }
+
+  const urlHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
+  return `http://${urlHost}:${port}`
+}
+
+function spaHtmlRoute(internalOrigin: () => string): BunServeRoute {
   return getHeadRoute(async (request) => {
-    const url = new URL(request.url)
-    if (url.pathname !== "/" && isAssetRequest(url.pathname)) {
+    const publicUrl = new URL(request.url)
+    if (publicUrl.pathname !== "/" && isAssetRequest(publicUrl.pathname)) {
       return notFoundResponse()
     }
 
-    url.pathname = internalAppShellRoute
+    const url = new URL(internalAppShellRoute, internalOrigin())
+    url.search = publicUrl.search
+    const requestHeaders = new Headers(request.headers)
+    for (const header of [
+      "forwarded",
+      "host",
+      "x-forwarded-host",
+      "x-forwarded-port",
+      "x-forwarded-proto",
+    ]) {
+      requestHeaders.delete(header)
+    }
     const bundleResponse = await fetch(
-      new Request(url, { method: request.method, headers: request.headers })
+      new Request(url, { method: request.method, headers: requestHeaders })
     )
-    const headers = new Headers(bundleResponse.headers)
-    headers.delete("content-length")
-    headers.delete("etag")
+    const responseHeaders = new Headers(bundleResponse.headers)
+    responseHeaders.delete("content-length")
+    responseHeaders.delete("etag")
     if (request.method === "HEAD") {
       return new Response(null, {
         status: bundleResponse.status,
         statusText: bundleResponse.statusText,
-        headers,
+        headers: responseHeaders,
       })
     }
 
     return new Response(restoreAppStaticUrls(await bundleResponse.text()), {
       status: bundleResponse.status,
       statusText: bundleResponse.statusText,
-      headers,
+      headers: responseHeaders,
     })
   })
 }

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -1,10 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { generateAppEntry, generateRouteManifest } from "../src/codegen"
 import { createCustomApp } from "../src/createCustomApp"
+
+async function linkDependencies(projectRoot: string, packages: readonly string[]): Promise<void> {
+  const atlasRoot = resolve(import.meta.dir, "..", "..", "atlas")
+
+  for (const name of packages) {
+    const packageDir = dirname(Bun.resolveSync(`${name}/package.json`, atlasRoot))
+    const target = join(projectRoot, "node_modules", ...name.split("/"))
+    await mkdir(dirname(target), { recursive: true })
+    await symlink(packageDir, target)
+  }
+}
 
 async function getFreePort(): Promise<number> {
   return await new Promise<number>((resolvePromise, reject) => {
@@ -260,6 +271,49 @@ describe("createCustomApp.dev", () => {
       expect((await fetch(`http://127.0.0.1:${port}/other.webmanifest`)).status).toBe(404)
     } finally {
       await server.stop()
+    }
+  })
+
+  test("serves the app shell behind a TLS-terminating reverse proxy", async () => {
+    const workspaceTempDir = resolve(import.meta.dir, "../../..", ".local", "test-tmp")
+    await mkdir(workspaceTempDir, { recursive: true })
+    const proxyRoot = await mkdtemp(join(workspaceTempDir, "sixb-app-proxy-"))
+    await mkdir(join(proxyRoot, "app"), { recursive: true })
+    await writeFile(
+      join(proxyRoot, "app", "page.tsx"),
+      "export default function Page() { return null }\n"
+    )
+    await linkDependencies(proxyRoot, [
+      "@sixb/client",
+      "@tanstack/react-query",
+      "react",
+      "react-dom",
+      "react-router-dom",
+    ])
+
+    const port = await getFreePort()
+    const app = await createCustomApp({
+      rootDir: proxyRoot,
+      authEnabled: false,
+      agentRoutes: false,
+    })
+    const server = await app.dev({ host: "127.0.0.1", port })
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/dashboard`, {
+        headers: {
+          host: "app.example.test",
+          "x-forwarded-host": "app.example.test",
+          "x-forwarded-port": "443",
+          "x-forwarded-proto": "https",
+        },
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('<div id="root"></div>')
+    } finally {
+      await server.stop()
+      await rm(proxyRoot, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
## Summary

Custom app development currently derives its internal app-shell request from the browser-facing request URL. Behind a TLS-terminating reverse proxy, this sends the self-request back through the public HTTPS origin and can fail before the app shell renders. This change separates the public request URL from the local Bun server origin.

## Scope

- Build the internal app-shell URL from the bound development host and actual server port.
- Map wildcard IPv4 and IPv6 bind addresses to their corresponding loopback addresses.
- Remove `Forwarded`, `Host`, and `X-Forwarded-*` routing headers from the internal request.
- Preserve the public request query string and existing response-header handling.
- Add a regression test that sends proxy headers and verifies a deep SPA route renders successfully.

## Request flow

The app shell now stays on the local transport while the browser continues using the public origin:

```text
Browser
  └─ HTTPS reverse proxy
       └─ Sixb custom app dev server
            └─ HTTP local app-shell request
```

## Tradeoffs and risk

The change only affects the private app-shell self-request used by the development server; production serving is unchanged. Proxy routing headers are intentionally discarded for that internal hop because they describe the browser-to-proxy request, not the local server-to-server request.

Host normalization explicitly handles `0.0.0.0`, `::`, bracketed IPv6, and concrete bind addresses. The regression fixture runs inside the workspace so Bun can resolve the same dependencies available to a real Sixb project.

## Validation

- `bun test packages/app/tests/` — 37 tests passed.
- `bun --filter @sixb/app typecheck` — passed.
- `bun --filter @sixb/app build` — passed.
- `bunx biome check packages/app/src/createCustomApp.ts packages/app/tests/createCustomApp.test.ts` — passed.
- Live Tailscale Serve smoke test returned the custom app shell with HTTP 200.

## Review guide

1. Review `devServerInternalOrigin` and `spaHtmlRoute` in `packages/app/src/createCustomApp.ts`.
2. Confirm the forwarded-header boundary matches the intended internal request semantics.
3. Review the TLS-terminating proxy regression in `packages/app/tests/createCustomApp.test.ts`.
