### PR TITLE
Preserve exact decimal values in DuckLake

### DIFF
--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -60,7 +60,7 @@ col("raw", "json", { nullable: true })
 | `boolean` | a boolean |
 | `int64` | an integer, or an integer string |
 | `float64` | a finite number |
-| `decimal` | an exact numeric string |
+| `decimal` | an exact decimal string |
 | `date` | a `Date`, or a `YYYY-MM-DD` string |
 | `timestamp` | a `Date`, or a parseable date string |
 | `json` | any JSON value |

--- a/packages/core/src/testing/lake-storage-contract.ts
+++ b/packages/core/src/testing/lake-storage-contract.ts
@@ -42,6 +42,10 @@ const nullableWriteDataset = defineDataset("contract.writes.nullable_orders", {
   schema: [col("orderId", "string"), col("note", "string", { nullable: true })],
 })
 
+const decimalWriteDataset = defineDataset("contract.writes.decimals", {
+  schema: [col("id", "string"), col("amount", "decimal", { nullable: true })],
+})
+
 const fileRefDataset = defineDataset("contract.files.documents", {
   schema: [col("id", "string"), col("attachment", "fileRef", { nullable: true })],
 })
@@ -602,6 +606,36 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
             write.writeRows([{ orderId: "ord_1", customerName: "Ada", unexpected: true } as never])
           ).rejects.toThrow("unknown column")
           await write.abort()
+        })
+      })
+
+      test("round-trips exact decimal strings in eager and streaming reads", async () => {
+        await withStorage(async (storage) => {
+          const exact = "9007199254740993.123456789"
+          await storage.createDataset(decimalWriteDataset)
+
+          const write = await storage.beginWrite({ dataset: decimalWriteDataset, mode: "snapshot" })
+          await write.writeRows([
+            { id: "amount_1", amount: exact },
+            { id: "amount_2", amount: null },
+          ])
+          await write.commit()
+
+          await expect(
+            collectRows(storage.readRows({ datasetId: decimalWriteDataset.id }))
+          ).resolves.toEqual([
+            { id: "amount_1", amount: exact },
+            { id: "amount_2", amount: null },
+          ])
+          await expect(
+            collectRows(
+              storage.readRows({
+                datasetId: decimalWriteDataset.id,
+                columns: ["amount"],
+                limit: 1,
+              })
+            )
+          ).resolves.toEqual([{ amount: exact }])
         })
       })
 

--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -144,6 +144,8 @@ Export the definition from `datasets/` or pass it to
 `createSixb({ datasets: [rawOrdersDataset], ... })` so the runtime and worker
 use the same schema that DuckLake materializes.
 
+DuckLake stores Sixb `decimal` columns as `DECIMAL(38, 9)` and returns them as exact strings, including from SQL previews. Writes that need more than 29 integer digits or 9 fractional digits are rejected before DuckDB can round or overflow them.
+
 ## DuckLake SQL Transforms
 
 DuckLake SQL transforms let the provider run dataset-to-dataset transforms in

--- a/storage/ducklake/src/internal/duckdb-column-types.ts
+++ b/storage/ducklake/src/internal/duckdb-column-types.ts
@@ -1,0 +1,68 @@
+import type { DatasetColumnType } from "@sixb/core"
+
+interface DuckDbColumnTypeMapping {
+  readonly sql: string
+  readonly matches: (typeSql: string) => boolean
+}
+
+interface DuckDbDecimalTypeMapping extends DuckDbColumnTypeMapping {
+  readonly precision: number
+  readonly scale: number
+}
+
+function normalizeDuckDbTypeSql(typeSql: string): string {
+  return typeSql
+    .trim()
+    .toUpperCase()
+    .replace(/\s+/g, " ")
+    .replace(/\s*([(),])\s*/g, "$1")
+}
+
+function defineDuckDbColumnType<const Sql extends string>(
+  sql: Sql,
+  aliases: readonly string[] = []
+): DuckDbColumnTypeMapping & { readonly sql: Sql } {
+  const acceptedTypes = new Set([sql, ...aliases].map(normalizeDuckDbTypeSql))
+  return {
+    sql,
+    matches: (typeSql) => acceptedTypes.has(normalizeDuckDbTypeSql(typeSql)),
+  }
+}
+
+function defineDuckDbDecimalType(precision: number, scale: number): DuckDbDecimalTypeMapping {
+  return {
+    ...defineDuckDbColumnType(`DECIMAL(${precision}, ${scale})`),
+    precision,
+    scale,
+  }
+}
+
+/**
+ * DuckDB representations used for every Sixb dataset column type.
+ *
+ * Each entry owns both its CREATE TABLE representation and the metadata
+ * spellings accepted when reconstructing a Sixb dataset schema.
+ */
+export const DUCKDB_COLUMN_TYPES = {
+  string: defineDuckDbColumnType("VARCHAR"),
+  boolean: defineDuckDbColumnType("BOOLEAN"),
+  int64: defineDuckDbColumnType("BIGINT", ["INT64"]),
+  float64: defineDuckDbColumnType("DOUBLE", ["FLOAT64"]),
+  decimal: defineDuckDbDecimalType(38, 9),
+  date: defineDuckDbColumnType("DATE"),
+  timestamp: defineDuckDbColumnType("TIMESTAMPTZ", ["TIMESTAMP WITH TIME ZONE"]),
+  json: defineDuckDbColumnType("JSON"),
+  fileRef: defineDuckDbColumnType(
+    "STRUCT(blobId VARCHAR, digest VARCHAR, sizeBytes BIGINT, fileName VARCHAR, mediaType VARCHAR, logicalPath VARCHAR)"
+  ),
+} satisfies Record<DatasetColumnType, DuckDbColumnTypeMapping>
+
+export function findDatasetColumnTypeForDuckDbSql(typeSql: string): DatasetColumnType | undefined {
+  for (const type of Object.keys(DUCKDB_COLUMN_TYPES) as DatasetColumnType[]) {
+    if (DUCKDB_COLUMN_TYPES[type].matches(typeSql)) {
+      return type
+    }
+  }
+
+  return undefined
+}

--- a/storage/ducklake/src/internal/duckdb-decimal.ts
+++ b/storage/ducklake/src/internal/duckdb-decimal.ts
@@ -1,0 +1,36 @@
+import { type DecimalValue, normalizeDecimalValue } from "@sixb/core"
+import { LakeStorageError } from "@sixb/core/lake-storage"
+import { DUCKDB_COLUMN_TYPES } from "./duckdb-column-types"
+
+const decimalType = DUCKDB_COLUMN_TYPES.decimal
+const maxIntegerDigits = decimalType.precision - decimalType.scale
+
+/**
+ * Normalize a dataset decimal and reject values DuckDB would round or overflow.
+ */
+export function normalizeDuckDbDecimalValue(value: unknown, columnName: string): DecimalValue {
+  if (typeof value !== "string") {
+    throw new LakeStorageError(
+      `[SixbDuckLake] Decimal column '${columnName}' must be an exact decimal string.`
+    )
+  }
+
+  let normalized: DecimalValue
+  try {
+    normalized = normalizeDecimalValue(value)
+  } catch {
+    throw new LakeStorageError(
+      `[SixbDuckLake] Decimal column '${columnName}' must be an exact decimal string.`
+    )
+  }
+
+  const unsigned = normalized.startsWith("-") ? normalized.slice(1) : normalized
+  const [integer, fraction = ""] = unsigned.split(".")
+  if (integer.length > maxIntegerDigits || fraction.length > decimalType.scale) {
+    throw new LakeStorageError(
+      `[SixbDuckLake] Decimal column '${columnName}' cannot be represented exactly as ${decimalType.sql}; expected at most ${maxIntegerDigits} integer digits and ${decimalType.scale} fractional digits.`
+    )
+  }
+
+  return normalized
+}

--- a/storage/ducklake/src/internal/duckdb-runtime.ts
+++ b/storage/ducklake/src/internal/duckdb-runtime.ts
@@ -6,6 +6,7 @@ import {
 } from "@duckdb/node-api"
 import { LakeStorageError } from "@sixb/core/lake-storage"
 import type { DuckDbRuntimeOptions, DuckLakeStorageOptions } from "../types"
+import { sixbDuckDbValueConverter } from "./duckdb-value-converter"
 import {
   buildAttachSql,
   buildConfigurePostgresMetadataPoolSql,
@@ -102,7 +103,7 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
         sql,
         values === undefined ? undefined : [...values]
       )
-      return reader.getRowObjectsJS()
+      return reader.convertRowObjects(sixbDuckDbValueConverter)
     })
   }
 
@@ -135,7 +136,7 @@ class NodeDuckDbRuntime implements DuckDbRuntime {
         sql,
         values === undefined ? undefined : [...values]
       )
-      for await (const batch of result.yieldRowObjectJs()) {
+      for await (const batch of result.yieldConvertedRowObjects(sixbDuckDbValueConverter)) {
         for (const row of batch) {
           yield row as Record<string, unknown>
         }
@@ -231,7 +232,7 @@ class NodeDuckDbExclusiveRuntime implements DuckDbExclusiveRuntime {
       sql,
       values === undefined ? undefined : [...values]
     )
-    return reader.getRowObjectsJS()
+    return reader.convertRowObjects(sixbDuckDbValueConverter)
   }
 
   async withAppender<T>(

--- a/storage/ducklake/src/internal/duckdb-value-converter.ts
+++ b/storage/ducklake/src/internal/duckdb-value-converter.ts
@@ -1,0 +1,27 @@
+import {
+  DuckDBDecimalValue,
+  DuckDBTypeId,
+  type DuckDBValueConverter,
+  type JS,
+  JSDuckDBValueConverter,
+} from "@duckdb/node-api"
+import { LakeStorageError } from "@sixb/core/lake-storage"
+
+/**
+ * Preserve DuckDB decimals as exact strings while retaining the driver's normal
+ * JavaScript conversions for every other scalar and nested value.
+ */
+export const sixbDuckDbValueConverter: DuckDBValueConverter<JS> = (value, type, converter) => {
+  if (value === null) {
+    return null
+  }
+
+  if (type.typeId === DuckDBTypeId.DECIMAL) {
+    if (!(value instanceof DuckDBDecimalValue)) {
+      throw new LakeStorageError("[SixbDuckLake] DuckDB returned an invalid DECIMAL value.")
+    }
+    return value.toString()
+  }
+
+  return JSDuckDBValueConverter(value, type, converter)
+}

--- a/storage/ducklake/src/internal/row-appender.ts
+++ b/storage/ducklake/src/internal/row-appender.ts
@@ -1,5 +1,6 @@
 import type { DuckDBValue } from "@duckdb/node-api"
 import type { DatasetColumnDefinition, DatasetRow, DatasetSchema, FileRef } from "@sixb/core"
+import { normalizeDuckDbDecimalValue } from "./duckdb-decimal"
 import type { DuckDbAppender } from "./duckdb-runtime"
 
 /**
@@ -41,7 +42,7 @@ function appendColumnValue(
       appender.appendDouble(value as number)
       return
     case "decimal":
-      appender.appendVarchar(String(value))
+      appender.appendVarchar(normalizeDuckDbDecimalValue(value, column.name))
       return
     case "date":
       appender.appendVarchar(

--- a/storage/ducklake/src/internal/schema.ts
+++ b/storage/ducklake/src/internal/schema.ts
@@ -1,5 +1,7 @@
 import type { DatasetColumnDefinition, DatasetColumnType, DatasetSchema, FileRef } from "@sixb/core"
 import { LakeStorageError } from "@sixb/core/lake-storage"
+import { DUCKDB_COLUMN_TYPES, findDatasetColumnTypeForDuckDbSql } from "./duckdb-column-types"
+import { normalizeDuckDbDecimalValue } from "./duckdb-decimal"
 import { quoteIdentifier } from "./sql"
 
 /**
@@ -12,80 +14,24 @@ export interface DuckDbColumnMetadata {
 }
 
 /**
- * Exact DuckDB struct shape used for Sixb `fileRef` columns.
- *
- * The reverse mapper intentionally recognizes only this shape so arbitrary
- * STRUCT or JSON columns are not reconstructed as `fileRef`.
- */
-export const FILE_REF_STRUCT_SQL =
-  "STRUCT(blobId VARCHAR, digest VARCHAR, sizeBytes BIGINT, fileName VARCHAR, mediaType VARCHAR, logicalPath VARCHAR)"
-
-const DUCKDB_TYPE_BY_SIXB_TYPE: Readonly<Record<DatasetColumnType, string>> = {
-  string: "VARCHAR",
-  boolean: "BOOLEAN",
-  int64: "BIGINT",
-  float64: "DOUBLE",
-  decimal: "DECIMAL(38, 9)",
-  date: "DATE",
-  timestamp: "TIMESTAMPTZ",
-  json: "JSON",
-  fileRef: FILE_REF_STRUCT_SQL,
-}
-
-function normalizeWhitespace(typeSql: string): string {
-  return typeSql.trim().replace(/\s+/g, " ")
-}
-
-function normalizeSimpleType(typeSql: string): string {
-  const normalized = normalizeWhitespace(typeSql).toUpperCase()
-  const decimalMatch = /^DECIMAL\(\s*(\d+)\s*,\s*(\d+)\s*\)$/.exec(normalized)
-  if (decimalMatch) {
-    return `DECIMAL(${decimalMatch[1]}, ${decimalMatch[2]})`
-  }
-
-  return normalized
-}
-
-/**
  * Map a Sixb dataset column type to the DuckDB type used in CREATE TABLE.
  */
 export function datasetColumnTypeToDuckDbSql(type: DatasetColumnType): string {
-  return DUCKDB_TYPE_BY_SIXB_TYPE[type]
+  return DUCKDB_COLUMN_TYPES[type].sql
 }
 
 /**
  * Reconstruct a Sixb dataset column type from DuckDB column metadata.
  */
 export function duckDbTypeToDatasetColumnType(typeSql: string): DatasetColumnType {
-  if (normalizeWhitespace(typeSql) === FILE_REF_STRUCT_SQL) {
-    return "fileRef"
+  const type = findDatasetColumnTypeForDuckDbSql(typeSql)
+  if (type) {
+    return type
   }
 
-  switch (normalizeSimpleType(typeSql)) {
-    case "VARCHAR":
-      return "string"
-    case "BOOLEAN":
-      return "boolean"
-    case "BIGINT":
-    case "INT64":
-      return "int64"
-    case "DOUBLE":
-    case "FLOAT64":
-      return "float64"
-    case "DECIMAL(38, 9)":
-      return "decimal"
-    case "DATE":
-      return "date"
-    case "TIMESTAMPTZ":
-    case "TIMESTAMP WITH TIME ZONE":
-      return "timestamp"
-    case "JSON":
-      return "json"
-    default:
-      throw new LakeStorageError(
-        `[SixbDuckLake] DuckDB column type '${typeSql}' cannot be mapped to a Sixb dataset column type.`
-      )
-  }
+  throw new LakeStorageError(
+    `[SixbDuckLake] DuckDB column type '${typeSql}' cannot be mapped to a Sixb dataset column type.`
+  )
 }
 
 /**
@@ -134,7 +80,7 @@ export function normalizeReadValue(value: unknown, column: DatasetColumnDefiniti
     case "int64":
       return typeof value === "bigint" ? value.toString() : value
     case "decimal":
-      return typeof value === "object" && "toString" in value ? String(value) : value
+      return normalizeDuckDbDecimalValue(value, column.name)
     case "date":
       return value instanceof Date ? value.toISOString().slice(0, 10) : String(value)
     case "timestamp":

--- a/storage/ducklake/tests/duckdb-decimal.test.ts
+++ b/storage/ducklake/tests/duckdb-decimal.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { decimal } from "@sixb/core"
+import { LakeStorageError } from "@sixb/core/lake-storage"
+import { DUCKDB_COLUMN_TYPES } from "../src/internal/duckdb-column-types"
+import { normalizeDuckDbDecimalValue } from "../src/internal/duckdb-decimal"
+
+describe("DuckDB decimal values", () => {
+  test("normalizes values that fit exactly in the physical decimal type", () => {
+    expect(DUCKDB_COLUMN_TYPES.decimal.sql).toBe("DECIMAL(38, 9)")
+    expect(normalizeDuckDbDecimalValue("+0001.2300000000", "amount")).toBe(decimal("1.23"))
+    expect(normalizeDuckDbDecimalValue("99999999999999999999999999999.999999999", "amount")).toBe(
+      decimal("99999999999999999999999999999.999999999")
+    )
+    expect(normalizeDuckDbDecimalValue("-0.000000001", "amount")).toBe(decimal("-0.000000001"))
+  })
+
+  test("rejects values DuckDB would round or overflow", () => {
+    expect(() => normalizeDuckDbDecimalValue("0.1234567891", "amount")).toThrow(
+      "cannot be represented exactly as DECIMAL(38, 9)"
+    )
+    expect(() => normalizeDuckDbDecimalValue("999999999999999999999999999999", "amount")).toThrow(
+      "cannot be represented exactly as DECIMAL(38, 9)"
+    )
+  })
+
+  test("rejects invalid runtime values with a provider error", () => {
+    expect(() => normalizeDuckDbDecimalValue(1.25, "amount")).toThrow(LakeStorageError)
+    expect(() => normalizeDuckDbDecimalValue("not-a-decimal", "amount")).toThrow(
+      "must be an exact decimal string"
+    )
+  })
+})

--- a/storage/ducklake/tests/ducklake-driver.e2e.ts
+++ b/storage/ducklake/tests/ducklake-driver.e2e.ts
@@ -6,6 +6,33 @@ import { createDuckDbRuntime, setupDuckLake } from "../src/internal/duckdb-runti
 import { localDuckLakeOptions } from "./test-utils"
 
 describe("DuckLake driver e2e", () => {
+  test("preserves exact decimals across eager, exclusive, and streaming reads", async () => {
+    const runtime = await createDuckDbRuntime()
+    const sql = `
+      SELECT
+        9007199254740993.123456789::DECIMAL(38, 9) AS amount,
+        NULL::DECIMAL(38, 9) AS nullable_amount
+    `
+
+    try {
+      const expected = {
+        amount: "9007199254740993.123456789",
+        nullable_amount: null,
+      }
+
+      expect(await runtime.query(sql)).toEqual([expected])
+      expect(await runtime.withExclusive((exclusive) => exclusive.query(sql))).toEqual([expected])
+
+      const streamed = []
+      for await (const row of runtime.streamRows(sql)) {
+        streamed.push(row)
+      }
+      expect(streamed).toEqual([expected])
+    } finally {
+      await runtime.close()
+    }
+  })
+
   test("loads ducklake and attaches a local catalog", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "sixb-ducklake-e2e-"))
     const runtime = await createDuckDbRuntime()

--- a/storage/ducklake/tests/ducklake-sql-transforms.e2e.ts
+++ b/storage/ducklake/tests/ducklake-sql-transforms.e2e.ts
@@ -95,6 +95,24 @@ describe("DuckLake SQL transforms", () => {
     ])
   })
 
+  test("previews decimal expressions without converting through a JavaScript number", async () => {
+    await commitRows(storage, ordersDataset, [
+      { orderId: "ord_1", customerId: "cust_1", amount: 1 },
+    ])
+
+    await expect(
+      collectRows(
+        storage.sql.preview({
+          sources: { orders: { dataset: ordersDataset } },
+          sql: ({ orders }) => `
+            SELECT 9007199254740993.123456789::DECIMAL(38, 9) AS amount
+            FROM ${orders}
+          `,
+        })
+      )
+    ).resolves.toEqual([{ amount: "9007199254740993.123456789" }])
+  })
+
   test("pins provided source versions and resolves omitted versions to latest", async () => {
     const version1 = await commitRows(storage, ordersDataset, [
       { orderId: "ord_1", customerId: "cust_1", amount: 10 },

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -494,6 +494,36 @@ describe("DuckLakeStorage writes and latest reads", () => {
     await expect(write.writeRows([])).rejects.toThrow("already closed")
   })
 
+  test("rejects decimal writes that DuckDB cannot represent exactly", async () => {
+    const amountsDataset = defineDataset("raw.erp.amounts", {
+      schema: [col("id", "string"), col("amount", "decimal")],
+    })
+    await storage.createDataset(amountsDataset)
+
+    const exactWrite = await storage.beginWrite({ dataset: amountsDataset, mode: "snapshot" })
+    await exactWrite.writeRows([
+      { id: "amount_1", amount: "9007199254740993.123456789" },
+      { id: "amount_2", amount: "+0001.2300000000" },
+    ])
+    await exactWrite.commit()
+    await expect(collectRows(storage.readRows({ datasetId: amountsDataset.id }))).resolves.toEqual([
+      { id: "amount_1", amount: "9007199254740993.123456789" },
+      { id: "amount_2", amount: "1.23" },
+    ])
+
+    const roundedWrite = await storage.beginWrite({ dataset: amountsDataset, mode: "append" })
+    await expect(
+      roundedWrite.writeRows([{ id: "amount_3", amount: "0.1234567891" }])
+    ).rejects.toThrow("cannot be represented exactly as DECIMAL(38, 9)")
+    await roundedWrite.abort()
+
+    const overflowWrite = await storage.beginWrite({ dataset: amountsDataset, mode: "append" })
+    await expect(
+      overflowWrite.writeRows([{ id: "amount_4", amount: "999999999999999999999999999999" }])
+    ).rejects.toThrow("cannot be represented exactly as DECIMAL(38, 9)")
+    await overflowWrite.abort()
+  })
+
   test("abort closes the session without committing rows", async () => {
     const write = await storage.beginWrite({
       dataset: ordersDataset,

--- a/storage/ducklake/tests/schema.test.ts
+++ b/storage/ducklake/tests/schema.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from "bun:test"
 import { col, type DatasetColumnType } from "@sixb/core"
 import { LakeStorageError } from "@sixb/core/lake-storage"
+import { DUCKDB_COLUMN_TYPES } from "../src/internal/duckdb-column-types"
 import {
   datasetColumnToDuckDbSql,
   datasetColumnTypeToDuckDbSql,
   datasetSchemaToDuckDbColumnsSql,
   duckDbColumnsToDatasetSchema,
   duckDbTypeToDatasetColumnType,
-  FILE_REF_STRUCT_SQL,
 } from "../src/internal/schema"
+
+const fileRefSql = DUCKDB_COLUMN_TYPES.fileRef.sql
 
 describe("DuckLake schema mapping", () => {
   test("maps Sixb column types to DuckDB SQL types", () => {
@@ -21,7 +23,7 @@ describe("DuckLake schema mapping", () => {
       date: "DATE",
       timestamp: "TIMESTAMPTZ",
       json: "JSON",
-      fileRef: FILE_REF_STRUCT_SQL,
+      fileRef: fileRefSql,
     }
 
     for (const [type, sql] of Object.entries(expected)) {
@@ -32,7 +34,7 @@ describe("DuckLake schema mapping", () => {
   test("creates nullable and not-null column definitions", () => {
     expect(datasetColumnToDuckDbSql(col("orderId", "string"))).toBe('"orderId" VARCHAR NOT NULL')
     expect(datasetColumnToDuckDbSql(col("attachment", "fileRef", { nullable: true }))).toBe(
-      `"attachment" ${FILE_REF_STRUCT_SQL}`
+      `"attachment" ${fileRefSql}`
     )
   })
 
@@ -59,7 +61,7 @@ describe("DuckLake schema mapping", () => {
         { name: "orderDate", type: "DATE", nullable: false },
         { name: "createdAt", type: "TIMESTAMP WITH TIME ZONE", nullable: false },
         { name: "metadata", type: "JSON", nullable: true },
-        { name: "attachment", type: FILE_REF_STRUCT_SQL, nullable: true },
+        { name: "attachment", type: fileRefSql, nullable: true },
       ])
     ).toEqual({
       columns: [


### PR DESCRIPTION
## Context

DuckDB's default JavaScript conversion turns `DECIMAL` into a `number` before Sixb reads it, which can lose precision.

| Case | Before | After |
|---|---|---|
| Read `9007199254740993.123456789` | `number: 9007199254740992`, then rejected by the strict projection | `string: "9007199254740993.123456789"` |
| Write `0.1234567891` | DuckDB could silently round it to fit `DECIMAL(38, 9)` | Rejected before writing |

## Changes

- Preserve decimals as exact strings in eager, exclusive, streaming, and SQL preview reads.
- Canonicalize writes and enforce the physical `DECIMAL(38, 9)` limits.
- Centralize DuckDB type SQL, aliases, and decimal metadata in a typed registry.
- Add shared LakeStorage contract coverage, DuckLake E2E tests, and documentation.

## Validation

- `bun run check`
- DuckLake typecheck and build
- 9 focused unit tests
- 103 DuckLake E2E tests