### PR TITLE
ui: add shared address lookup and speech dictation

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -19,8 +19,13 @@ visual language that works for dense operational tools.
   - message scrollers, bubbles, markers, attachments, and streaming status utilities
 - **Sixb components** in `src/components`
   - collection headers, card grids, empty states, theme switching, and small charts
+  - address entry in `src/components/address`
 - **Hooks and utilities** in `src/hooks` and `src/lib`
-  - `ThemeProvider`, `useTheme`, `useIsMobile`, and `cn`
+  - `ThemeProvider`, `useTheme`, `useIsMobile`, `useDebouncedValue`, and `cn`
+- **Address lookup** in `src/lib/address`
+  - the provider contract, the Photon provider, and address formatters
+- **Speech dictation** in `src/lib/speech` and `src/components/speech`
+  - the recognizer contract, the Web Speech recognizer, and microphone components
 
 ## Usage
 
@@ -178,6 +183,173 @@ apps can theme them after importing the stylesheet:
 }
 ```
 
+## Address Lookup
+
+Most Sixb apps need address entry, so the lookup lives here in three layers. Apps normally
+touch only the components.
+
+| Layer | Import | Purpose |
+| --- | --- | --- |
+| Components | `@sixb/ui/components` | `AddressAutocomplete` (one text value), `AddressFields` (structured draft) |
+| Hooks | `@sixb/ui/hooks` | `useAddressLookup`, `AddressLookupProvider`, `useAddressProvider` |
+| Providers | `@sixb/ui/lib/address` | `AddressProvider` contract, `createPhotonProvider`, formatters |
+
+It works with no configuration — lookups fall back to a shared
+[Photon](https://photon.komoot.io) provider, which is free and needs no API key:
+
+```tsx
+import { AddressFields } from "@sixb/ui/components"
+import { type AddressDraft, EMPTY_ADDRESS_DRAFT } from "@sixb/ui/lib/address"
+import { useState } from "react"
+
+export function BillingAddressForm() {
+  const [address, setAddress] = useState<AddressDraft>(EMPTY_ADDRESS_DRAFT)
+  return <AddressFields value={address} onChange={setAddress} />
+}
+```
+
+When the app stores a single formatted string instead of components, use the autocomplete
+directly:
+
+```tsx
+<AddressAutocomplete
+  value={site.address}
+  onValueChange={(next) => setSite({ ...site, address: next })}
+  onSelect={(suggestion) => setSite({ ...site, county: suggestion.county })}
+  countries={["US"]}
+/>
+```
+
+Configure the provider once at the app boundary — for example to point at a self-hosted
+Photon instance, since the public one is best-effort with no SLA:
+
+```tsx
+import { AddressLookupProvider } from "@sixb/ui/hooks"
+import { createPhotonProvider } from "@sixb/ui/lib/address"
+
+const addresses = createPhotonProvider({
+  endpoint: "https://photon.internal.example",
+  countries: ["US"],
+  proximity: { latitude: 40.7128, longitude: -74.006 },
+})
+
+export function AppRoot({ children }: { children: React.ReactNode }) {
+  return <AddressLookupProvider provider={addresses}>{children}</AddressLookupProvider>
+}
+```
+
+### Suggestions
+
+`AddressSuggestion` is a superset of what the providers return, so no app has to give up a
+field it stores. `region` keeps the provider's spelling (`"New York"`) while `regionCode`
+carries the short form (`"NY"`); `raw` is the untouched provider payload for app-specific
+enrichment. `formatAddress`, `formatAddressLine`, and `addressDraftFromSuggestion` project a
+suggestion onto whatever shape the app persists.
+
+### Adding a Provider
+
+Implement `AddressProvider`. Only `id` and `search` are required; the optional members exist
+so richer backends drop in without touching call sites:
+
+- `retrieve` — for providers whose search returns predictions rather than addresses. Google
+  Places and Mapbox both need a second details request to get components and coordinates;
+  mark those results `partial` and `useAddressLookup`'s `select` will resolve them on choice.
+- `createSession` — for providers that bill per lookup session. The hook mints one token for
+  a run of keystrokes and discards it after the details call.
+- `reverse` — coordinates to an address, for "use my location" and map-pin flows.
+
+Providers must stay free of React imports so they can also run server-side.
+
+Data licenses that require credit expose an `attribution` string, which the components
+render under the suggestion list. Photon serves OpenStreetMap data, so leave that in place
+unless the replacement provider's terms differ.
+
+## Speech Dictation
+
+Microphone-to-text for fields that are faster to speak than to type, layered the same
+way as address lookup.
+
+| Layer | Import | Purpose |
+| --- | --- | --- |
+| Components | `@sixb/ui/components` | `DictationTextarea`, `DictationButton` |
+| Hooks | `@sixb/ui/hooks` | `useDictation`, `useSpeechRecognition`, `SpeechRecognitionProvider` |
+| Recognizers | `@sixb/ui/lib/speech` | `SpeechRecognizer` contract, `createWebSpeechRecognizer` |
+
+The default recognizer is the browser's own Web Speech API — no key and no server:
+
+```tsx
+import { DictationTextarea } from "@sixb/ui/components"
+import { useState } from "react"
+
+export function ScopeOfWorkField() {
+  const [scope, setScope] = useState("")
+  return (
+    <DictationTextarea
+      label="Scope of work"
+      onChange={setScope}
+      placeholder="Describe the work, or press the microphone and say it."
+      value={scope}
+    />
+  )
+}
+```
+
+Dictation appends to whatever the field already holds, and the field goes read-only while
+listening so typed and spoken text cannot interleave.
+
+### Owning the hook
+
+Pass `dictation` when the app needs the state outside the component — most often to stop two
+microphones from running at once:
+
+```tsx
+const scope = useDictation({ value: scopeText, onChange: setScopeText })
+const notes = useDictation({ value: notesText, onChange: setNotesText })
+
+<DictationTextarea
+  busyReason={notes.isActive ? "Stop the other dictation first" : undefined}
+  dictation={scope}
+  label="Scope of work"
+  onChange={setScopeText}
+  value={scopeText}
+/>
+```
+
+For anything that is not a text field — voice commands, a transcript panel, an agent composer
+— use `useSpeechRecognition` directly and read `transcript` and `interimTranscript` yourself.
+`DictationButton` renders the microphone toggle for either hook.
+
+### Browser support
+
+The Web Speech API works in Chrome, Edge, and Safari but **not Firefox**, so `supported` is
+part of the contract: it is `null` until probed on the client, then `true` or `false`.
+`DictationButton` disables itself and `DictationTextarea` shows a "type instead" message when
+it is `false` — dictation is always an accelerator, never the only way to enter text.
+
+Two behaviors worth knowing:
+
+- Chrome stops listening after a short silence even with `continuous`, so the hook restarts
+  the session automatically (`autoRestart`, on by default) and accumulates the transcript
+  across restarts. It gives up after a few silent restarts rather than reconnecting forever.
+- Chrome streams microphone audio to Google's servers for recognition. If that is
+  unacceptable for a project, supply a different recognizer.
+
+### Adding a Recognizer
+
+Implement `SpeechRecognizer` — `id`, `isSupported()`, and `start(options, handlers)` returning
+a session with `stop()` and `abort()`. The contract is event-driven, so a
+record-then-transcribe backend (MediaRecorder plus a server call) fits by emitting one final
+result when the recording stops and never emitting interim ones. Configure it once at the app
+boundary:
+
+```tsx
+import { SpeechRecognitionProvider } from "@sixb/ui/hooks"
+
+<SpeechRecognitionProvider recognizer={whisperRecognizer}>{children}</SpeechRecognitionProvider>
+```
+
+Recognizers must stay free of React imports.
+
 ## Theming
 
 Every color, font, radius, and shadow in this package resolves through CSS variables, and
@@ -293,17 +465,33 @@ that happens, prefer copying the upstream registry component source, adapting im
 
 ```ts
 import {
+  AddressAutocomplete,
+  AddressFields,
   Attachment,
   Bubble,
   Button,
   Card,
+  DictationButton,
+  DictationTextarea,
   EmptyState,
   Marker,
   MessageScroller,
   MiniSparkline,
   ThemeSwitcher,
 } from "@sixb/ui/components"
-import { ThemeProvider, useTheme, useIsMobile } from "@sixb/ui/hooks"
+import {
+  AddressLookupProvider,
+  SpeechRecognitionProvider,
+  ThemeProvider,
+  useAddressLookup,
+  useDebouncedValue,
+  useDictation,
+  useIsMobile,
+  useSpeechRecognition,
+  useTheme,
+} from "@sixb/ui/hooks"
+import { type AddressProvider, createPhotonProvider, formatAddress } from "@sixb/ui/lib/address"
+import { createWebSpeechRecognizer, type SpeechRecognizer } from "@sixb/ui/lib/speech"
 import { cn } from "@sixb/ui/lib/utils"
 ```
 

--- a/packages/ui/dev/PreviewApp.tsx
+++ b/packages/ui/dev/PreviewApp.tsx
@@ -58,6 +58,8 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
+  AddressAutocomplete,
+  AddressFields,
   Alert,
   AlertDescription,
   AlertDialog,
@@ -150,6 +152,8 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  DictationButton,
+  DictationTextarea,
   DirectionProvider,
   Drawer,
   DrawerClose,
@@ -306,7 +310,10 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../src/components"
+import { useDictation } from "../src/hooks/use-dictation"
 import { ThemeProvider } from "../src/hooks/useTheme"
+import type { AddressDraft } from "../src/lib/address"
+import { EMPTY_ADDRESS_DRAFT } from "../src/lib/address"
 
 interface SwatchProps {
   label: string
@@ -518,6 +525,12 @@ function Showcase() {
   const [airplane, setAirplane] = useState(false)
   const [agreed, setAgreed] = useState<boolean | "indeterminate">("indeterminate")
   const [calendarDate, setCalendarDate] = useState<Date | undefined>(new Date(2026, 5, 19))
+  const [addressQuery, setAddressQuery] = useState("")
+  const [addressDraft, setAddressDraft] = useState<AddressDraft>(EMPTY_ADDRESS_DRAFT)
+  const [scopeOfWork, setScopeOfWork] = useState("")
+  const [dictationNotes, setDictationNotes] = useState("")
+  const scopeDictation = useDictation({ value: scopeOfWork, onChange: setScopeOfWork })
+  const notesDictation = useDictation({ value: dictationNotes, onChange: setDictationNotes })
   const form = useForm({
     defaultValues: {
       email: "ops@sixb.dev",
@@ -1059,6 +1072,77 @@ function Showcase() {
               </div>
             </CardContent>
           </Card>
+        </Section>
+
+        <Section
+          title="Address Lookup"
+          description="Provider-backed address entry. Defaults to Photon (free, keyless) and hits the live API — type at least three characters, then use ↑ ↓ and Enter."
+        >
+          <div className="grid gap-4 xl:grid-cols-2">
+            <Block label="Autocomplete (single string value)">
+              <div className="space-y-3">
+                <AddressAutocomplete
+                  value={addressQuery}
+                  onValueChange={setAddressQuery}
+                  aria-label="Site address"
+                />
+                <pre className="overflow-x-auto rounded-md bg-muted px-3 py-2 font-mono text-xs text-muted-foreground">
+                  {addressQuery || "—"}
+                </pre>
+              </div>
+            </Block>
+
+            <Block label="Fields (structured draft)">
+              <div className="space-y-3">
+                <AddressFields value={addressDraft} onChange={setAddressDraft} />
+                <pre className="overflow-x-auto rounded-md bg-muted px-3 py-2 font-mono text-xs text-muted-foreground">
+                  {JSON.stringify(addressDraft, null, 2)}
+                </pre>
+              </div>
+            </Block>
+          </div>
+        </Section>
+
+        <Section
+          title="Speech Dictation"
+          description="Microphone input via the browser's Web Speech API — no key, no server. Chrome, Edge, and Safari only; the button disables itself in Firefox. Two fields share the page to show that only one microphone runs at a time."
+        >
+          <div className="grid gap-4 xl:grid-cols-2">
+            <Block label="Dictation textarea">
+              <DictationTextarea
+                busyReason={notesDictation.isActive ? "Stop the other dictation first" : undefined}
+                dictation={scopeDictation}
+                label="Scope of work"
+                onChange={setScopeOfWork}
+                placeholder="Describe the work being completed, or press the microphone and say it."
+                value={scopeOfWork}
+              />
+            </Block>
+
+            <Block label="Second field + standalone button">
+              <div className="space-y-3">
+                <DictationTextarea
+                  busyReason={
+                    scopeDictation.isActive ? "Stop the other dictation first" : undefined
+                  }
+                  dictation={notesDictation}
+                  label="Internal notes"
+                  onChange={setDictationNotes}
+                  placeholder="Anything the crew should know."
+                  value={dictationNotes}
+                />
+                <div className="flex items-center gap-3">
+                  <DictationButton dictation={notesDictation} label="internal notes" />
+                  <p className="text-xs text-muted-foreground">
+                    {notesDictation.status === "idle"
+                      ? `Idle${notesDictation.supported === false ? " — unsupported browser" : ""}`
+                      : notesDictation.status}
+                    {notesDictation.isReceivingAudio ? " • audio detected" : ""}
+                  </p>
+                </div>
+              </div>
+            </Block>
+          </div>
         </Section>
 
         <Section

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,18 @@
       "import": "./dist/hooks/*.js",
       "default": "./dist/hooks/*.js"
     },
+    "./lib/address": {
+      "types": "./dist/lib/address/index.d.ts",
+      "bun": "./src/lib/address/index.ts",
+      "import": "./dist/lib/address/index.js",
+      "default": "./dist/lib/address/index.js"
+    },
+    "./lib/speech": {
+      "types": "./dist/lib/speech/index.d.ts",
+      "bun": "./src/lib/speech/index.ts",
+      "import": "./dist/lib/speech/index.js",
+      "default": "./dist/lib/speech/index.js"
+    },
     "./lib/shiki": {
       "types": "./dist/lib/shiki.d.ts",
       "bun": "./src/lib/shiki.ts",

--- a/packages/ui/src/components/address/address-autocomplete.tsx
+++ b/packages/ui/src/components/address/address-autocomplete.tsx
@@ -1,0 +1,300 @@
+"use client"
+
+import { MapPinIcon, SearchIcon } from "lucide-react"
+import type * as React from "react"
+import { useCallback, useEffect, useId, useRef, useState } from "react"
+import { useAddressLookup } from "../../hooks/use-address-lookup"
+import type { AddressCoordinates, AddressProvider, AddressSuggestion } from "../../lib/address"
+import { formatAddress } from "../../lib/address"
+import { cn } from "../../lib/utils"
+import { Input } from "../ui/input"
+import { Popover, PopoverAnchor, PopoverContent } from "../ui/popover"
+import { Spinner } from "../ui/spinner"
+
+export type AddressAutocompleteProps = {
+  /** Current text in the field. */
+  readonly value: string
+  readonly onValueChange: (value: string) => void
+  /** Fires with the completed suggestion and the text written into the field. */
+  readonly onSelect?: (suggestion: AddressSuggestion, formatted: string) => void
+  /** Fires when editing ends — on blur and after a selection. For inline editors. */
+  readonly onCommit?: (value: string) => void
+  /** Fires when the user presses Escape. Suppresses the pending `onCommit`. */
+  readonly onCancel?: () => void
+  readonly id?: string
+  readonly className?: string
+  readonly placeholder?: string
+  readonly disabled?: boolean
+  readonly autoFocus?: boolean
+  readonly "aria-label"?: string
+  readonly "aria-describedby"?: string
+  readonly provider?: AddressProvider
+  readonly minLength?: number
+  readonly debounceMs?: number
+  readonly limit?: number
+  readonly lang?: string
+  readonly countries?: readonly string[]
+  readonly proximity?: AddressCoordinates
+  readonly bbox?: readonly [number, number, number, number]
+  readonly emptyLabel?: string
+  readonly loadingLabel?: string
+  /** Text written into the field on selection. Defaults to a one-line address. */
+  readonly formatSelection?: (suggestion: AddressSuggestion) => string
+  readonly renderSuggestion?: (suggestion: AddressSuggestion) => React.ReactNode
+  readonly showAttribution?: boolean
+}
+
+/**
+ * Free-text address field with provider-backed suggestions.
+ *
+ * Implements the combobox pattern: results are a labelled listbox driven from the
+ * input with arrow keys, Enter, and Escape, and the input keeps focus throughout.
+ */
+export function AddressAutocomplete({
+  value,
+  onValueChange,
+  onSelect,
+  onCommit,
+  onCancel,
+  id,
+  className,
+  placeholder = "Search for an address…",
+  disabled = false,
+  autoFocus,
+  "aria-label": ariaLabel,
+  "aria-describedby": ariaDescribedBy,
+  provider,
+  minLength = 3,
+  debounceMs,
+  limit,
+  lang,
+  countries,
+  proximity,
+  bbox,
+  emptyLabel = "No addresses found.",
+  loadingLabel = "Searching addresses…",
+  formatSelection = (suggestion) => formatAddress(suggestion),
+  renderSuggestion,
+  showAttribution = true,
+}: AddressAutocompleteProps) {
+  const generatedId = useId()
+  const inputId = id ?? `${generatedId}-address`
+  const listboxId = `${generatedId}-listbox`
+
+  const [open, setOpen] = useState(false)
+  // Tracked by id rather than index so a new result set cannot leave the
+  // highlight pointing at a different address.
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const cancelledRef = useRef(false)
+  const selectingRef = useRef(false)
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  const eligible = !disabled && value.trim().length >= minLength
+  const lookup = useAddressLookup({
+    query: value,
+    enabled: open && !disabled,
+    provider,
+    minLength,
+    debounceMs,
+    limit,
+    lang,
+    countries,
+    proximity,
+    bbox,
+  })
+  const { suggestions, loading, error, attribution, select } = lookup
+  const showList = open && eligible
+
+  const activeIndex = activeId === null ? -1 : suggestions.findIndex((s) => s.id === activeId)
+  const activeSuggestion = activeIndex >= 0 ? suggestions[activeIndex] : undefined
+
+  // Matching on the data attribute rather than a selector avoids escaping
+  // provider ids, which contain colons and commas.
+  useEffect(() => {
+    if (!activeId) return
+    const rows = listRef.current?.querySelectorAll<HTMLElement>("[data-suggestion-id]")
+    rows?.forEach((row) => {
+      if (row.dataset.suggestionId === activeId) row.scrollIntoView({ block: "nearest" })
+    })
+  }, [activeId])
+
+  const choose = useCallback(
+    async (suggestion: AddressSuggestion) => {
+      if (selectingRef.current) return
+      selectingRef.current = true
+      setOpen(false)
+      setActiveId(null)
+      try {
+        const resolved = await select(suggestion)
+        const formatted = formatSelection(resolved)
+        onValueChange(formatted)
+        onSelect?.(resolved, formatted)
+        onCommit?.(formatted)
+      } finally {
+        selectingRef.current = false
+      }
+    },
+    [select, formatSelection, onValueChange, onSelect, onCommit]
+  )
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      if (!open && !onCancel) return
+      event.preventDefault()
+      setOpen(false)
+      setActiveId(null)
+      if (onCancel) {
+        cancelledRef.current = true
+        onCancel()
+      }
+      return
+    }
+
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      if (!eligible) return
+      event.preventDefault()
+      if (!open) {
+        setOpen(true)
+        return
+      }
+      if (suggestions.length === 0) return
+      const step = event.key === "ArrowDown" ? 1 : -1
+      const next =
+        activeIndex < 0
+          ? step === 1
+            ? 0
+            : suggestions.length - 1
+          : (activeIndex + step + suggestions.length) % suggestions.length
+      setActiveId(suggestions[next]?.id ?? null)
+      return
+    }
+
+    if (event.key === "Enter") {
+      if (!showList || !activeSuggestion) return
+      event.preventDefault()
+      void choose(activeSuggestion)
+      return
+    }
+
+    if (event.key === "Tab" && open) {
+      setOpen(false)
+      setActiveId(null)
+    }
+  }
+
+  const activeOptionId = activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined
+
+  return (
+    <Popover open={showList} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div className={cn("relative min-w-0", className)}>
+          <SearchIcon
+            aria-hidden="true"
+            className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            id={inputId}
+            value={value}
+            onChange={(event) => {
+              onValueChange(event.target.value)
+              if (!disabled) setOpen(true)
+            }}
+            onFocus={() => {
+              cancelledRef.current = false
+              if (!disabled) setOpen(true)
+            }}
+            onBlur={() => {
+              setOpen(false)
+              setActiveId(null)
+              if (cancelledRef.current) {
+                cancelledRef.current = false
+                return
+              }
+              onCommit?.(value)
+            }}
+            onKeyDown={onKeyDown}
+            placeholder={placeholder}
+            disabled={disabled}
+            autoFocus={autoFocus}
+            autoComplete="off"
+            spellCheck={false}
+            className="min-w-0 pr-9 pl-9"
+            aria-label={ariaLabel}
+            aria-describedby={ariaDescribedBy}
+            role="combobox"
+            aria-expanded={showList}
+            aria-controls={showList ? listboxId : undefined}
+            aria-autocomplete="list"
+            aria-activedescendant={activeOptionId}
+          />
+          {loading ? (
+            <Spinner className="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground" />
+          ) : null}
+        </div>
+      </PopoverAnchor>
+
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        // The input owns focus and keyboard handling; the popover must not take it.
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        className="w-[var(--radix-popover-trigger-width,var(--radix-popper-anchor-width))] overflow-hidden p-0"
+      >
+        <div ref={listRef} id={listboxId} role="listbox" aria-label="Address suggestions">
+          {suggestions.length > 0 ? (
+            <div className="max-h-72 overflow-y-auto p-1">
+              {suggestions.map((suggestion, index) => (
+                <button
+                  key={suggestion.id}
+                  id={`${listboxId}-option-${index}`}
+                  type="button"
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  data-suggestion-id={suggestion.id}
+                  // Keeps focus in the input so blur-commit does not race the click.
+                  onMouseDown={(event) => event.preventDefault()}
+                  onMouseEnter={() => setActiveId(suggestion.id)}
+                  onClick={() => void choose(suggestion)}
+                  className={cn(
+                    "flex w-full items-start gap-2.5 rounded-md px-2.5 py-2 text-left text-sm transition-colors",
+                    index === activeIndex ? "bg-accent text-accent-foreground" : "hover:bg-muted"
+                  )}
+                >
+                  {renderSuggestion ? (
+                    renderSuggestion(suggestion)
+                  ) : (
+                    <>
+                      <MapPinIcon
+                        aria-hidden="true"
+                        className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+                      />
+                      <span className="grid min-w-0 gap-0.5">
+                        <span className="truncate font-medium leading-5">{suggestion.label}</span>
+                        {suggestion.description ? (
+                          <span className="truncate text-xs text-muted-foreground">
+                            {suggestion.description}
+                          </span>
+                        ) : null}
+                      </span>
+                    </>
+                  )}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="px-3 py-2.5 text-sm text-muted-foreground">
+              {loading ? loadingLabel : (error ?? emptyLabel)}
+            </p>
+          )}
+
+          {showAttribution && attribution ? (
+            <p className="border-t border-border/70 px-3 py-1.5 text-[10px] text-muted-foreground">
+              {attribution}
+            </p>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/ui/src/components/address/address-fields.tsx
+++ b/packages/ui/src/components/address/address-fields.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import { useId, useState } from "react"
+import type {
+  AddressCoordinates,
+  AddressDraft,
+  AddressProvider,
+  AddressSuggestion,
+} from "../../lib/address"
+import { addressDraftFromSuggestion } from "../../lib/address"
+import { cn } from "../../lib/utils"
+import { Field, FieldLabel } from "../ui/field"
+import { Input } from "../ui/input"
+import { AddressAutocomplete } from "./address-autocomplete"
+
+type AddressField = keyof AddressDraft
+
+export type AddressFieldsProps = {
+  readonly value: AddressDraft
+  readonly onChange: (value: AddressDraft) => void
+  readonly onSelect?: (suggestion: AddressSuggestion) => void
+  readonly disabled?: boolean
+  readonly className?: string
+  readonly idPrefix?: string
+  /** Which fields are marked required. Presentation only — validation stays with the form. */
+  readonly required?: readonly AddressField[]
+  /** Store the provider's region spelling ("New York") or its code ("NY"). */
+  readonly regionFormat?: "name" | "code"
+  readonly labels?: Partial<Record<AddressField | "search", string>>
+  readonly searchPlaceholder?: string
+  readonly showAttribution?: boolean
+  readonly provider?: AddressProvider
+  readonly minLength?: number
+  readonly debounceMs?: number
+  readonly limit?: number
+  readonly lang?: string
+  readonly countries?: readonly string[]
+  readonly proximity?: AddressCoordinates
+  readonly bbox?: readonly [number, number, number, number]
+}
+
+const DEFAULT_LABELS: Record<AddressField | "search", string> = {
+  search: "Search address",
+  line1: "Address line 1",
+  line2: "Address line 2",
+  city: "City",
+  region: "State / region",
+  postalCode: "Postal code",
+  countryCode: "Country code",
+}
+
+const DEFAULT_REQUIRED: readonly AddressField[] = ["line1", "city", "postalCode", "countryCode"]
+
+/**
+ * Full address entry: provider-backed lookup that fills the structured fields
+ * below, which stay editable so an address that no geocoder knows can still be
+ * typed in.
+ */
+export function AddressFields({
+  value,
+  onChange,
+  onSelect,
+  disabled,
+  className,
+  idPrefix,
+  required = DEFAULT_REQUIRED,
+  regionFormat = "name",
+  labels,
+  searchPlaceholder,
+  showAttribution,
+  provider,
+  minLength,
+  debounceMs,
+  limit,
+  lang,
+  countries,
+  proximity,
+  bbox,
+}: AddressFieldsProps) {
+  const generatedId = useId()
+  const prefix = idPrefix ?? generatedId
+  const [query, setQuery] = useState("")
+  const text = { ...DEFAULT_LABELS, ...labels }
+
+  function patch(field: AddressField, next: string) {
+    onChange({
+      ...value,
+      [field]: field === "countryCode" ? next.slice(0, 2).toUpperCase() : next,
+    })
+  }
+
+  return (
+    <div className={cn("grid gap-3", className)}>
+      <Field>
+        <FieldLabel htmlFor={fieldId(prefix, "search")}>{text.search}</FieldLabel>
+        <AddressAutocomplete
+          id={fieldId(prefix, "search")}
+          value={query}
+          onValueChange={setQuery}
+          onSelect={(suggestion) => {
+            onChange(
+              addressDraftFromSuggestion(suggestion, { previous: value, region: regionFormat })
+            )
+            onSelect?.(suggestion)
+          }}
+          disabled={disabled}
+          placeholder={searchPlaceholder}
+          showAttribution={showAttribution}
+          provider={provider}
+          minLength={minLength}
+          debounceMs={debounceMs}
+          limit={limit}
+          lang={lang}
+          countries={countries}
+          proximity={proximity}
+          bbox={bbox}
+        />
+      </Field>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {(["line1", "line2"] as const).map((field) => (
+          <AddressInput
+            key={field}
+            className="sm:col-span-2"
+            disabled={disabled}
+            id={fieldId(prefix, field)}
+            label={text[field]}
+            onChange={(next) => patch(field, next)}
+            required={required.includes(field)}
+            value={value[field]}
+          />
+        ))}
+        <AddressInput
+          disabled={disabled}
+          id={fieldId(prefix, "city")}
+          label={text.city}
+          onChange={(next) => patch("city", next)}
+          required={required.includes("city")}
+          value={value.city}
+        />
+        <AddressInput
+          disabled={disabled}
+          id={fieldId(prefix, "region")}
+          label={text.region}
+          onChange={(next) => patch("region", next)}
+          required={required.includes("region")}
+          value={value.region}
+        />
+        <AddressInput
+          disabled={disabled}
+          id={fieldId(prefix, "postalCode")}
+          label={text.postalCode}
+          onChange={(next) => patch("postalCode", next)}
+          required={required.includes("postalCode")}
+          value={value.postalCode}
+        />
+        <AddressInput
+          disabled={disabled}
+          id={fieldId(prefix, "countryCode")}
+          label={text.countryCode}
+          onChange={(next) => patch("countryCode", next)}
+          placeholder="US"
+          required={required.includes("countryCode")}
+          value={value.countryCode}
+        />
+      </div>
+    </div>
+  )
+}
+
+function AddressInput({
+  className,
+  disabled,
+  id,
+  label,
+  onChange,
+  placeholder,
+  required,
+  value,
+}: {
+  readonly className?: string
+  readonly disabled?: boolean
+  readonly id: string
+  readonly label: string
+  readonly onChange: (value: string) => void
+  readonly placeholder?: string
+  readonly required?: boolean
+  readonly value: string
+}) {
+  return (
+    <Field className={className}>
+      <FieldLabel htmlFor={id}>
+        {label}
+        {required ? <span aria-hidden="true">*</span> : null}
+      </FieldLabel>
+      <Input
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+        required={required}
+      />
+    </Field>
+  )
+}
+
+function fieldId(prefix: string, field: string): string {
+  return `${prefix}-${field}`
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,6 +1,12 @@
 // shadcn primitives
 
 export { toast } from "sonner"
+// Sixb address lookup
+export {
+  AddressAutocomplete,
+  type AddressAutocompleteProps,
+} from "./address/address-autocomplete"
+export { AddressFields, type AddressFieldsProps } from "./address/address-fields"
 // Sixb data-viz primitives
 export { MiniSparkline } from "./charts/MiniSparkline"
 export {
@@ -16,6 +22,9 @@ export {
   type SidebarUser,
   SidebarUserMenu,
 } from "./sidebar-user-menu"
+// Sixb speech dictation
+export { DictationButton, type DictationButtonProps } from "./speech/dictation-button"
+export { DictationTextarea, type DictationTextareaProps } from "./speech/dictation-textarea"
 export { ThemeSwitcher } from "./theme-switcher"
 export { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./ui/accordion"
 export { Alert, AlertDescription, AlertTitle } from "./ui/alert"

--- a/packages/ui/src/components/speech/dictation-button.tsx
+++ b/packages/ui/src/components/speech/dictation-button.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { MicIcon } from "lucide-react"
+import type { SpeechRecognitionState } from "../../hooks/use-speech-recognition"
+import { cn } from "../../lib/utils"
+import { Button } from "../ui/button"
+import { Spinner } from "../ui/spinner"
+
+export type DictationButtonProps = {
+  /** State from `useSpeechRecognition` or `useDictation`. */
+  readonly dictation: SpeechRecognitionState
+  /**
+   * What is being dictated, used in the accessible label — e.g. "scope of work"
+   * becomes "Start scope of work dictation".
+   */
+  readonly label?: string
+  readonly disabled?: boolean
+  /**
+   * Blocks starting while another dictation owns the microphone, without making
+   * the control look broken.
+   */
+  readonly busyReason?: string
+  readonly className?: string
+  readonly size?: React.ComponentProps<typeof Button>["size"]
+  readonly variant?: React.ComponentProps<typeof Button>["variant"]
+}
+
+/**
+ * Microphone toggle for a dictation session.
+ *
+ * Reflects the four states the recognizer reports: a spinner while starting or
+ * stopping, a pulsing icon while audio is actually arriving, and a disabled
+ * control when the browser cannot recognize speech at all.
+ */
+export function DictationButton({
+  dictation,
+  label,
+  disabled,
+  busyReason,
+  className,
+  size = "icon",
+  variant = "outline",
+}: DictationButtonProps) {
+  const { isActive, isReceivingAudio, status, supported, start, stop } = dictation
+  const transitioning = status === "starting" || status === "stopping"
+  const subject = label ? `${label.toLowerCase()} ` : ""
+
+  return (
+    <Button
+      type="button"
+      size={size}
+      variant={variant}
+      aria-label={isActive ? `Stop ${subject}dictation` : `Start ${subject}dictation`}
+      aria-pressed={isActive}
+      disabled={disabled || Boolean(busyReason) || supported !== true || transitioning}
+      onClick={isActive ? stop : start}
+      title={
+        isActive
+          ? "Stop dictation"
+          : (busyReason ??
+            (supported === false ? "Dictation isn't supported in this browser" : "Start dictation"))
+      }
+      className={cn(
+        "rounded-full bg-card shadow-sm",
+        status === "listening" &&
+          "border-destructive/35 bg-destructive/10 text-destructive hover:bg-destructive/15 hover:text-destructive dark:bg-destructive/15 dark:hover:bg-destructive/20",
+        className
+      )}
+    >
+      {transitioning ? (
+        <Spinner className="size-4" />
+      ) : (
+        <MicIcon
+          aria-hidden="true"
+          className={cn("size-4", isReceivingAudio && "dictation-mic-receiving")}
+        />
+      )}
+    </Button>
+  )
+}

--- a/packages/ui/src/components/speech/dictation-textarea.tsx
+++ b/packages/ui/src/components/speech/dictation-textarea.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useId } from "react"
+import { useDictation } from "../../hooks/use-dictation"
+import type { SpeechRecognitionState } from "../../hooks/use-speech-recognition"
+import type { SpeechRecognizer } from "../../lib/speech"
+import { appendDictationText } from "../../lib/speech"
+import { cn } from "../../lib/utils"
+import { Field, FieldLabel } from "../ui/field"
+import { Textarea } from "../ui/textarea"
+import { DictationButton } from "./dictation-button"
+
+export type DictationTextareaProps = {
+  readonly value: string
+  readonly onChange: (value: string) => void
+  readonly label?: string
+  readonly placeholder?: string
+  readonly disabled?: boolean
+  readonly id?: string
+  readonly className?: string
+  readonly textareaClassName?: string
+  readonly rows?: number
+  /**
+   * Supply the state when the app needs the hook outside this component — for
+   * example to keep two microphones from running at once. Omit it and the
+   * component manages its own dictation.
+   */
+  readonly dictation?: SpeechRecognitionState
+  readonly recognizer?: SpeechRecognizer
+  readonly lang?: string
+  /** Reason the microphone is unavailable right now; shown in the button title. */
+  readonly busyReason?: string
+  /** Prevents typing over text that dictation is still appending to. */
+  readonly readOnlyWhileListening?: boolean
+  /** Show in-progress speech in the field before the recognizer finalizes it. */
+  readonly showInterim?: boolean
+  readonly unsupportedMessage?: string
+}
+
+/**
+ * Textarea with a built-in microphone, for free-text fields that are quicker to
+ * speak than to type.
+ *
+ * Dictation appends to whatever the field already holds, and the field goes
+ * read-only while listening so typed and spoken text cannot interleave.
+ */
+export function DictationTextarea({
+  value,
+  onChange,
+  label,
+  placeholder,
+  disabled,
+  id,
+  className,
+  textareaClassName,
+  rows = 5,
+  dictation,
+  recognizer,
+  lang,
+  busyReason,
+  readOnlyWhileListening = true,
+  showInterim = true,
+  unsupportedMessage = "Voice dictation isn't supported in this browser. You can still type instead.",
+}: DictationTextareaProps) {
+  const generatedId = useId()
+  const fieldId = id ?? `${generatedId}-dictation`
+  const statusId = `${generatedId}-status`
+
+  // Always called so the hook order is stable; ignored when the caller owns the state.
+  const ownDictation = useDictation({ value, onChange, disabled, recognizer, lang })
+  const state = dictation ?? ownDictation
+
+  const statusMessage =
+    state.status === "starting"
+      ? "Waiting for microphone permission…"
+      : state.status === "listening"
+        ? "Listening… Press stop when you're finished."
+        : state.status === "stopping"
+          ? "Finishing dictation…"
+          : state.supported === false
+            ? unsupportedMessage
+            : null
+
+  const displayValue =
+    showInterim && state.interimTranscript
+      ? appendDictationText(value, state.interimTranscript)
+      : value
+
+  return (
+    <Field className={cn("min-w-0", className)}>
+      {label ? <FieldLabel htmlFor={fieldId}>{label}</FieldLabel> : null}
+
+      {state.error || statusMessage ? (
+        <div id={statusId}>
+          {state.error ? (
+            <p className="text-xs font-medium text-destructive" role="alert">
+              {state.error}
+            </p>
+          ) : (
+            <p
+              // Transient progress is for screen readers only; a browser that
+              // cannot dictate at all needs the message on screen.
+              className={state.supported === false ? "text-xs text-muted-foreground" : "sr-only"}
+              role="status"
+            >
+              {statusMessage}
+            </p>
+          )}
+        </div>
+      ) : null}
+
+      <div className="relative min-w-0">
+        <Textarea
+          id={fieldId}
+          value={displayValue}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          readOnly={readOnlyWhileListening && state.isActive}
+          rows={rows}
+          aria-describedby={state.error || statusMessage ? statusId : undefined}
+          className={cn("resize-none pr-14 pb-14 text-base leading-6", textareaClassName)}
+        />
+        <DictationButton
+          busyReason={busyReason}
+          className="absolute right-3 bottom-3"
+          dictation={state}
+          disabled={disabled}
+          label={label}
+        />
+      </div>
+    </Field>
+  )
+}

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,2 +1,19 @@
+export {
+  AddressLookupProvider,
+  type UseAddressLookupOptions,
+  type UseAddressLookupResult,
+  useAddressLookup,
+  useAddressProvider,
+} from "./use-address-lookup"
+export { useDebouncedValue } from "./use-debounced-value"
+export { type UseDictationOptions, useDictation } from "./use-dictation"
 export { useIsMobile } from "./use-mobile"
+export {
+  SpeechRecognitionProvider,
+  type SpeechRecognitionState,
+  type SpeechStatus,
+  type UseSpeechRecognitionOptions,
+  useSpeechRecognition,
+  useSpeechRecognizer,
+} from "./use-speech-recognition"
 export { ThemeProvider, useTheme } from "./useTheme"

--- a/packages/ui/src/hooks/use-address-lookup.tsx
+++ b/packages/ui/src/hooks/use-address-lookup.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import type * as React from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
+import type {
+  AddressCoordinates,
+  AddressProvider,
+  AddressSearchOptions,
+  AddressSuggestion,
+} from "../lib/address"
+import { createPhotonProvider } from "../lib/address"
+import { useDebouncedValue } from "./use-debounced-value"
+
+const DEFAULT_MIN_LENGTH = 3
+const DEFAULT_DEBOUNCE_MS = 300
+const DEFAULT_ERROR_MESSAGE = "Address lookup is unavailable right now."
+
+const AddressProviderContext = createContext<AddressProvider | null>(null)
+
+let sharedPhotonProvider: AddressProvider | null = null
+
+/** Keyless Photon provider used when an app has not configured one. */
+function defaultAddressProvider(): AddressProvider {
+  sharedPhotonProvider ??= createPhotonProvider()
+  return sharedPhotonProvider
+}
+
+/**
+ * Configures the address provider for a subtree. Optional — without it, lookups
+ * fall back to a shared Photon provider.
+ */
+export function AddressLookupProvider({
+  provider,
+  children,
+}: {
+  provider?: AddressProvider
+  children: React.ReactNode
+}) {
+  const value = useMemo(() => provider ?? defaultAddressProvider(), [provider])
+  return <AddressProviderContext.Provider value={value}>{children}</AddressProviderContext.Provider>
+}
+
+/** Resolves the provider to use: an explicit override, the context one, or the default. */
+export function useAddressProvider(override?: AddressProvider): AddressProvider {
+  const fromContext = useContext(AddressProviderContext)
+  return override ?? fromContext ?? defaultAddressProvider()
+}
+
+export type UseAddressLookupOptions = {
+  readonly query: string
+  /** Set false to suspend lookups, e.g. while a field is closed or disabled. */
+  readonly enabled?: boolean
+  /** Overrides the provider from context. */
+  readonly provider?: AddressProvider
+  readonly minLength?: number
+  readonly debounceMs?: number
+  readonly limit?: number
+  readonly lang?: string
+  readonly countries?: readonly string[]
+  readonly proximity?: AddressCoordinates
+  readonly bbox?: readonly [number, number, number, number]
+  readonly errorMessage?: string
+}
+
+export type UseAddressLookupResult = {
+  readonly suggestions: readonly AddressSuggestion[]
+  readonly loading: boolean
+  /** Set only for real failures; an empty result is not an error. */
+  readonly error: string | null
+  /** Required credit for the provider's data, when it has one. */
+  readonly attribution: string | null
+  /**
+   * Finalizes a choice. For providers with a two-phase flow this performs the
+   * follow-up details request and returns the completed suggestion; otherwise it
+   * returns the suggestion unchanged.
+   */
+  readonly select: (suggestion: AddressSuggestion) => Promise<AddressSuggestion>
+  readonly reset: () => void
+}
+
+/**
+ * Debounced, abortable address search over any {@link AddressProvider}.
+ *
+ * Keeps the provider's two-phase and per-session details out of call sites, so
+ * swapping Photon for a keyed provider later is a configuration change.
+ */
+export function useAddressLookup(options: UseAddressLookupOptions): UseAddressLookupResult {
+  const {
+    query,
+    enabled = true,
+    minLength = DEFAULT_MIN_LENGTH,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    errorMessage = DEFAULT_ERROR_MESSAGE,
+    lang,
+  } = options
+
+  const provider = useAddressProvider(options.provider)
+  const [suggestions, setSuggestions] = useState<readonly AddressSuggestion[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const trimmedQuery = query.trim()
+  const debouncedQuery = useDebouncedValue(trimmedQuery, debounceMs)
+  const active = enabled && trimmedQuery.length >= minLength
+
+  // Object and array options would break effect identity every render, so the
+  // effect reads them through a ref and re-runs on their serialized value.
+  const searchOptions: AddressSearchOptions = {
+    limit: options.limit,
+    lang,
+    countries: options.countries,
+    proximity: options.proximity,
+    bbox: options.bbox,
+  }
+  const searchOptionsKey = JSON.stringify(searchOptions)
+  const searchOptionsRef = useRef(searchOptions)
+  searchOptionsRef.current = searchOptions
+
+  const sessionRef = useRef<string | null>(null)
+  const ensureSession = useCallback((): string | undefined => {
+    if (!provider.createSession) return undefined
+    sessionRef.current ??= provider.createSession()
+    return sessionRef.current
+  }, [provider])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: searchOptionsKey re-runs the search when the option objects change by value, not because the body reads it
+  useEffect(() => {
+    if (!active) {
+      setSuggestions([])
+      setLoading(false)
+      setError(null)
+      return
+    }
+
+    // Show progress from the first keystroke rather than after the debounce.
+    if (debouncedQuery !== trimmedQuery) {
+      setLoading(true)
+      return
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    provider
+      .search(debouncedQuery, {
+        ...searchOptionsRef.current,
+        signal: controller.signal,
+        sessionToken: ensureSession(),
+      })
+      .then((next) => {
+        if (controller.signal.aborted) return
+        setSuggestions(next)
+        setLoading(false)
+      })
+      .catch((searchError: unknown) => {
+        if (controller.signal.aborted || isAbortError(searchError)) return
+        setSuggestions([])
+        setError(errorMessage)
+        setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [
+    active,
+    debouncedQuery,
+    trimmedQuery,
+    provider,
+    ensureSession,
+    errorMessage,
+    searchOptionsKey,
+  ])
+
+  const select = useCallback(
+    async (suggestion: AddressSuggestion): Promise<AddressSuggestion> => {
+      if (!provider.retrieve) {
+        sessionRef.current = null
+        return suggestion
+      }
+
+      try {
+        return await provider.retrieve(suggestion, {
+          lang,
+          sessionToken: sessionRef.current ?? undefined,
+        })
+      } catch (retrieveError: unknown) {
+        if (isAbortError(retrieveError)) throw retrieveError
+        // Keep the partial suggestion: losing the user's choice is worse than
+        // filling in fewer fields, and the error surfaces alongside it.
+        setError(errorMessage)
+        return suggestion
+      } finally {
+        // A lookup session ends with its details request.
+        sessionRef.current = null
+      }
+    },
+    [provider, lang, errorMessage]
+  )
+
+  const reset = useCallback(() => {
+    sessionRef.current = null
+    setSuggestions([])
+    setLoading(false)
+    setError(null)
+  }, [])
+
+  return {
+    suggestions,
+    loading,
+    error,
+    attribution: provider.attribution ?? null,
+    select,
+    reset,
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError"
+}

--- a/packages/ui/src/hooks/use-debounced-value.ts
+++ b/packages/ui/src/hooks/use-debounced-value.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react"
+
+/** Returns `value` after it has stopped changing for `delayMs`. */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    if (delayMs <= 0) {
+      setDebounced(value)
+      return
+    }
+    const timer = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return delayMs <= 0 ? value : debounced
+}

--- a/packages/ui/src/hooks/use-dictation.ts
+++ b/packages/ui/src/hooks/use-dictation.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef } from "react"
+import { appendDictationText } from "../lib/speech"
+import type { SpeechRecognitionState, UseSpeechRecognitionOptions } from "./use-speech-recognition"
+import { useSpeechRecognition } from "./use-speech-recognition"
+
+export type UseDictationOptions = Omit<UseSpeechRecognitionOptions, "onResult"> & {
+  /** Current field text. Dictation is appended to whatever it holds when `start` is called. */
+  readonly value: string
+  readonly onChange: (value: string) => void
+}
+
+/**
+ * Dictation wired to a text field: speech is appended to the existing value
+ * instead of being handed back as a bare transcript.
+ *
+ * The text present when `start` is called becomes the base, and each final result
+ * is appended to it — so the field should not be edited while dictation runs
+ * (`DictationTextarea` makes it read-only for exactly this reason). For anything
+ * that is not a field, use {@link useSpeechRecognition} directly.
+ */
+export function useDictation({
+  value,
+  onChange,
+  ...recognitionOptions
+}: UseDictationOptions): SpeechRecognitionState {
+  const valueRef = useRef(value)
+  const onChangeRef = useRef(onChange)
+  const baseTextRef = useRef("")
+  const dictatedRef = useRef("")
+
+  useEffect(() => {
+    valueRef.current = value
+  }, [value])
+
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  const state = useSpeechRecognition({
+    ...recognitionOptions,
+    onResult: (result) => {
+      if (!result.isFinal) return
+      dictatedRef.current = appendDictationText(dictatedRef.current, result.transcript)
+      onChangeRef.current(appendDictationText(baseTextRef.current, dictatedRef.current))
+    },
+  })
+
+  const { isActive, start: startRecognition } = state
+
+  const start = useCallback(() => {
+    // Re-anchoring mid-session would replay the whole transcript onto the field.
+    if (isActive) return
+    baseTextRef.current = valueRef.current
+    dictatedRef.current = ""
+    startRecognition()
+  }, [isActive, startRecognition])
+
+  return { ...state, start }
+}

--- a/packages/ui/src/hooks/use-speech-recognition.tsx
+++ b/packages/ui/src/hooks/use-speech-recognition.tsx
@@ -1,0 +1,310 @@
+"use client"
+
+import type * as React from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
+import type { SpeechErrorCode, SpeechRecognizer, SpeechResult, SpeechSession } from "../lib/speech"
+import { appendDictationText, createWebSpeechRecognizer, speechErrorMessage } from "../lib/speech"
+
+const DEFAULT_LANG = "en-US"
+
+/**
+ * How many times in a row the session may restart without producing speech
+ * before giving up, so a microphone left open does not reconnect forever.
+ */
+const MAX_SILENT_RESTARTS = 3
+
+const SpeechRecognizerContext = createContext<SpeechRecognizer | null>(null)
+
+let sharedWebSpeechRecognizer: SpeechRecognizer | null = null
+
+/** Web Speech recognizer used when an app has not configured one. */
+function defaultSpeechRecognizer(): SpeechRecognizer {
+  sharedWebSpeechRecognizer ??= createWebSpeechRecognizer()
+  return sharedWebSpeechRecognizer
+}
+
+/**
+ * Configures the speech recognizer for a subtree. Optional — without it,
+ * dictation uses the browser's Web Speech API.
+ */
+export function SpeechRecognitionProvider({
+  recognizer,
+  children,
+}: {
+  recognizer?: SpeechRecognizer
+  children: React.ReactNode
+}) {
+  const value = useMemo(() => recognizer ?? defaultSpeechRecognizer(), [recognizer])
+  return (
+    <SpeechRecognizerContext.Provider value={value}>{children}</SpeechRecognizerContext.Provider>
+  )
+}
+
+/** Resolves the recognizer to use: an explicit override, the context one, or the default. */
+export function useSpeechRecognizer(override?: SpeechRecognizer): SpeechRecognizer {
+  const fromContext = useContext(SpeechRecognizerContext)
+  return override ?? fromContext ?? defaultSpeechRecognizer()
+}
+
+export type SpeechStatus = "idle" | "starting" | "listening" | "stopping"
+
+export type UseSpeechRecognitionOptions = {
+  /** Overrides the recognizer from context. */
+  readonly recognizer?: SpeechRecognizer
+  /** BCP 47 tag. Applies to the next session, not the running one. */
+  readonly lang?: string
+  readonly continuous?: boolean
+  readonly interimResults?: boolean
+  readonly maxAlternatives?: number
+  /** Stops any running session and blocks new ones. */
+  readonly disabled?: boolean
+  /**
+   * Restart when the browser ends a session on its own. Chrome stops listening
+   * after a short silence even with `continuous`, so this is on by default;
+   * without it long dictation appears to die mid-sentence.
+   */
+  readonly autoRestart?: boolean
+  /** Called for every result, interim and final, before state updates land. */
+  readonly onResult?: (result: SpeechResult) => void
+}
+
+export type SpeechRecognitionState = {
+  /** Null until support has been probed on the client (it cannot be known during SSR). */
+  readonly supported: boolean | null
+  readonly status: SpeechStatus
+  readonly isActive: boolean
+  readonly isReceivingAudio: boolean
+  /** Final text accumulated during the current session. Cleared by `start` and `reset`. */
+  readonly transcript: string
+  /** In-progress text the recognizer may still revise. Empty unless `interimResults`. */
+  readonly interimTranscript: string
+  /** Human-readable message, or null. Intentional stops never set this. */
+  readonly error: string | null
+  readonly errorCode: SpeechErrorCode | null
+  readonly start: () => void
+  readonly stop: () => void
+  readonly abort: () => void
+  readonly reset: () => void
+}
+
+/**
+ * Microphone speech recognition over any {@link SpeechRecognizer}.
+ *
+ * Owns the parts that are easy to get wrong: ignoring events from superseded
+ * sessions, accumulating final text across browser-initiated restarts, tracking
+ * whether audio is actually arriving, and tearing the microphone down on unmount.
+ */
+export function useSpeechRecognition(
+  options: UseSpeechRecognitionOptions = {}
+): SpeechRecognitionState {
+  const {
+    lang = DEFAULT_LANG,
+    continuous = true,
+    interimResults = true,
+    maxAlternatives = 1,
+    disabled = false,
+    autoRestart = true,
+    onResult,
+  } = options
+
+  const recognizer = useSpeechRecognizer(options.recognizer)
+  const [supported, setSupported] = useState<boolean | null>(null)
+  const [status, setStatus] = useState<SpeechStatus>("idle")
+  const [error, setError] = useState<string | null>(null)
+  const [errorCode, setErrorCode] = useState<SpeechErrorCode | null>(null)
+  const [isReceivingAudio, setIsReceivingAudio] = useState(false)
+  const [transcript, setTranscript] = useState("")
+  const [interimTranscript, setInterimTranscript] = useState("")
+
+  // Monotonic session id: every event handler checks it, so results from a
+  // session that has been stopped or superseded are dropped.
+  const sessionRef = useRef(0)
+  const handleRef = useRef<SpeechSession | null>(null)
+  const stopRequestedRef = useRef(false)
+  const lastErrorCodeRef = useRef<SpeechErrorCode | null>(null)
+  const silentRestartsRef = useRef(0)
+  const beginSessionRef = useRef<() => void>(() => {})
+
+  const onResultRef = useRef(onResult)
+  useEffect(() => {
+    onResultRef.current = onResult
+  }, [onResult])
+
+  // Read inside the session callbacks so changing an option never restarts a
+  // running session or invalidates the callbacks below.
+  const configRef = useRef({ lang, continuous, interimResults, maxAlternatives, autoRestart })
+  useEffect(() => {
+    configRef.current = { lang, continuous, interimResults, maxAlternatives, autoRestart }
+  }, [lang, continuous, interimResults, maxAlternatives, autoRestart])
+
+  useEffect(() => {
+    setSupported(recognizer.isSupported())
+  }, [recognizer])
+
+  const beginSession = useCallback(() => {
+    const session = sessionRef.current + 1
+    sessionRef.current = session
+    const config = configRef.current
+
+    setStatus("starting")
+    setIsReceivingAudio(false)
+    setInterimTranscript("")
+
+    try {
+      handleRef.current = recognizer.start(
+        {
+          lang: config.lang,
+          continuous: config.continuous,
+          interimResults: config.interimResults,
+          maxAlternatives: config.maxAlternatives,
+        },
+        {
+          onStart: () => {
+            if (sessionRef.current === session) setStatus("listening")
+          },
+          onAudioActivity: (active) => {
+            if (sessionRef.current === session) setIsReceivingAudio(active)
+          },
+          onResult: (result) => {
+            if (sessionRef.current !== session) return
+            if (result.isFinal) {
+              silentRestartsRef.current = 0
+              setInterimTranscript("")
+              setTranscript((current) => appendDictationText(current, result.transcript))
+            } else {
+              setInterimTranscript(result.transcript)
+            }
+            onResultRef.current?.(result)
+          },
+          onError: (code) => {
+            if (sessionRef.current !== session) return
+            lastErrorCodeRef.current = code
+            setIsReceivingAudio(false)
+            const message = speechErrorMessage(code)
+            if (message) {
+              setError(message)
+              setErrorCode(code)
+            }
+          },
+          onEnd: () => {
+            if (sessionRef.current !== session) return
+            handleRef.current = null
+            setIsReceivingAudio(false)
+            setInterimTranscript("")
+
+            // Only a clean end or a silence timeout is worth retrying; a denied
+            // microphone or a network failure would loop forever.
+            const lastError = lastErrorCodeRef.current
+            const retryable = lastError === null || lastError === "no-speech"
+            if (
+              configRef.current.autoRestart &&
+              !stopRequestedRef.current &&
+              retryable &&
+              silentRestartsRef.current < MAX_SILENT_RESTARTS
+            ) {
+              silentRestartsRef.current += 1
+              lastErrorCodeRef.current = null
+              beginSessionRef.current()
+              return
+            }
+
+            setStatus("idle")
+          },
+        }
+      )
+    } catch {
+      if (sessionRef.current !== session) return
+      handleRef.current = null
+      setIsReceivingAudio(false)
+      setStatus("idle")
+      setError(speechErrorMessage("unknown"))
+      setErrorCode("unknown")
+    }
+  }, [recognizer])
+
+  useEffect(() => {
+    beginSessionRef.current = beginSession
+  }, [beginSession])
+
+  const abortSession = useCallback((updateState: boolean) => {
+    sessionRef.current += 1
+    stopRequestedRef.current = true
+    const handle = handleRef.current
+    handleRef.current = null
+    if (handle) {
+      try {
+        handle.abort()
+      } catch {
+        // The session may have already ended on its own.
+      }
+    }
+    if (updateState) {
+      setIsReceivingAudio(false)
+      setInterimTranscript("")
+      setStatus("idle")
+    }
+  }, [])
+
+  useEffect(() => {
+    if (disabled) abortSession(true)
+  }, [abortSession, disabled])
+
+  useEffect(() => () => abortSession(false), [abortSession])
+
+  const start = useCallback(() => {
+    if (disabled || status !== "idle") return
+    if (!recognizer.isSupported()) {
+      setSupported(false)
+      return
+    }
+
+    stopRequestedRef.current = false
+    lastErrorCodeRef.current = null
+    silentRestartsRef.current = 0
+    setError(null)
+    setErrorCode(null)
+    setTranscript("")
+    beginSessionRef.current()
+  }, [disabled, recognizer, status])
+
+  const stop = useCallback(() => {
+    stopRequestedRef.current = true
+    const handle = handleRef.current
+    if (!handle) return
+
+    setStatus("stopping")
+    setIsReceivingAudio(false)
+    try {
+      handle.stop()
+    } catch {
+      handleRef.current = null
+      setStatus("idle")
+      setError(speechErrorMessage("unknown"))
+      setErrorCode("unknown")
+    }
+  }, [])
+
+  const abort = useCallback(() => abortSession(true), [abortSession])
+
+  const reset = useCallback(() => {
+    setTranscript("")
+    setInterimTranscript("")
+    setError(null)
+    setErrorCode(null)
+  }, [])
+
+  return {
+    supported,
+    status,
+    isActive: status !== "idle",
+    isReceivingAudio,
+    transcript,
+    interimTranscript,
+    error,
+    errorCode,
+    start,
+    stop,
+    abort,
+    reset,
+  }
+}

--- a/packages/ui/src/lib/address/format.ts
+++ b/packages/ui/src/lib/address/format.ts
@@ -1,0 +1,86 @@
+import type { AddressDraft, AddressSuggestion } from "./types"
+
+/** Trims a possibly-unknown value into a non-empty string, or null. */
+export function addressText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+/** Joins parts with a single space, dropping blanks. */
+export function joinSpace(...values: Array<string | null | undefined>): string | null {
+  const parts = values.map((value) => value?.trim()).filter((value): value is string => !!value)
+  return parts.length ? parts.join(" ") : null
+}
+
+/** Joins parts with `separator`, dropping blanks. */
+export function joinParts(
+  separator: string,
+  ...values: Array<string | null | undefined>
+): string | null {
+  const parts = values.map((value) => value?.trim()).filter((value): value is string => !!value)
+  return parts.length ? parts.join(separator) : null
+}
+
+/** The street line to put in an address form's first field. */
+export function formatAddressLine(suggestion: AddressSuggestion): string {
+  return suggestion.line1 ?? suggestion.name ?? ""
+}
+
+/**
+ * Renders a suggestion as a single-line address, e.g.
+ * `"123 Main Street, Brooklyn NY 11201"`.
+ */
+export function formatAddress(
+  suggestion: AddressSuggestion,
+  options: { readonly includeCountry?: boolean } = {}
+): string {
+  const locality = joinSpace(
+    suggestion.city,
+    suggestion.regionCode ?? suggestion.region,
+    suggestion.postalCode
+  )
+  return (
+    joinParts(
+      ", ",
+      formatAddressLine(suggestion),
+      locality,
+      options.includeCountry ? suggestion.country : null
+    ) ?? ""
+  )
+}
+
+export const EMPTY_ADDRESS_DRAFT: AddressDraft = {
+  line1: "",
+  line2: "",
+  city: "",
+  region: "",
+  postalCode: "",
+  countryCode: "",
+}
+
+/**
+ * Projects a suggestion onto address form state.
+ *
+ * Fields the suggestion does not carry fall back to `previous` rather than being
+ * blanked, and `line2` is always preserved because no geocoder returns it.
+ * Pass `region: "code"` to store short region codes ("NY") instead of the
+ * provider's spelling ("New York").
+ */
+export function addressDraftFromSuggestion(
+  suggestion: AddressSuggestion,
+  options: { readonly previous?: AddressDraft; readonly region?: "name" | "code" } = {}
+): AddressDraft {
+  const previous = options.previous ?? EMPTY_ADDRESS_DRAFT
+  const region =
+    options.region === "code"
+      ? (suggestion.regionCode ?? suggestion.region)
+      : (suggestion.region ?? suggestion.regionCode)
+
+  return {
+    line1: suggestion.line1 ?? suggestion.name ?? previous.line1,
+    line2: previous.line2,
+    city: suggestion.city ?? previous.city,
+    region: region ?? previous.region,
+    postalCode: suggestion.postalCode ?? previous.postalCode,
+    countryCode: suggestion.countryCode ?? previous.countryCode,
+  }
+}

--- a/packages/ui/src/lib/address/index.ts
+++ b/packages/ui/src/lib/address/index.ts
@@ -1,0 +1,21 @@
+export {
+  addressDraftFromSuggestion,
+  EMPTY_ADDRESS_DRAFT,
+  formatAddress,
+  formatAddressLine,
+} from "./format"
+export {
+  createPhotonProvider,
+  PHOTON_ATTRIBUTION,
+  type PhotonProviderOptions,
+  photonFeatureToSuggestion,
+} from "./photon"
+export type {
+  AddressCoordinates,
+  AddressDraft,
+  AddressProvider,
+  AddressRetrieveOptions,
+  AddressReverseOptions,
+  AddressSearchOptions,
+  AddressSuggestion,
+} from "./types"

--- a/packages/ui/src/lib/address/photon.ts
+++ b/packages/ui/src/lib/address/photon.ts
@@ -1,0 +1,329 @@
+import { addressText, joinParts, joinSpace } from "./format"
+import type {
+  AddressCoordinates,
+  AddressProvider,
+  AddressReverseOptions,
+  AddressSearchOptions,
+  AddressSuggestion,
+} from "./types"
+
+const PHOTON_PROVIDER_ID = "photon"
+
+/** Photon serves OpenStreetMap data, which is ODbL-licensed and requires credit. */
+export const PHOTON_ATTRIBUTION = "Address data © OpenStreetMap contributors"
+
+const DEFAULT_ENDPOINT = "https://photon.komoot.io"
+const DEFAULT_LIMIT = 5
+const DEFAULT_LANG = "en"
+const DEFAULT_TIMEOUT_MS = 6_000
+const DEFAULT_CACHE_TTL_MS = 60 * 60 * 1000
+
+export type PhotonProviderOptions = {
+  /**
+   * Base URL of a Photon instance; `/api` and `/reverse` are appended.
+   * Point this at a self-hosted instance — the public one is best-effort with no SLA.
+   */
+  readonly endpoint?: string
+  readonly limit?: number
+  readonly lang?: string
+  readonly countries?: readonly string[]
+  readonly proximity?: AddressCoordinates
+  readonly bbox?: readonly [number, number, number, number]
+  readonly timeoutMs?: number
+  /** Set to 0 to disable response caching. */
+  readonly cacheTtlMs?: number
+  readonly fetchImpl?: typeof fetch
+}
+
+/**
+ * Photon address provider — free, keyless, and self-hostable.
+ *
+ * Photon returns complete addresses from a single request, so this provider has
+ * no `retrieve` or `createSession`.
+ */
+export function createPhotonProvider(options: PhotonProviderOptions = {}): AddressProvider {
+  const endpoint = (options.endpoint ?? DEFAULT_ENDPOINT).replace(/\/+$/, "")
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+  const fetchImpl = options.fetchImpl ?? fetch
+
+  const cache = new Map<string, { at: number; suggestions: readonly AddressSuggestion[] }>()
+  const inflight = new Map<string, Promise<readonly AddressSuggestion[]>>()
+
+  async function request(url: URL): Promise<readonly AddressSuggestion[]> {
+    const response = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) })
+    if (!response.ok) {
+      throw new Error(`[SixbUI] Photon address lookup failed (${response.status}).`)
+    }
+    const payload: unknown = await response.json()
+    const features = record(payload)?.features
+    if (!Array.isArray(features)) return []
+    return features
+      .map(photonFeatureToSuggestion)
+      .filter((suggestion): suggestion is AddressSuggestion => suggestion !== null)
+  }
+
+  /**
+   * Shares one network request between concurrent callers and caches the result.
+   * The caller's signal is applied to their own promise rather than the shared
+   * request, so one caller aborting (a keystroke superseding another) neither
+   * fails the others nor discards a response that is about to be cached.
+   */
+  async function cachedRequest(
+    key: string,
+    url: URL,
+    signal: AbortSignal | undefined
+  ): Promise<readonly AddressSuggestion[]> {
+    if (signal?.aborted) throw abortError()
+
+    const cached = cacheTtlMs > 0 ? cache.get(key) : undefined
+    if (cached && Date.now() - cached.at < cacheTtlMs) return cached.suggestions
+
+    let pending = inflight.get(key)
+    if (!pending) {
+      pending = request(url).then((suggestions) => {
+        if (cacheTtlMs > 0) cache.set(key, { at: Date.now(), suggestions })
+        return suggestions
+      })
+      inflight.set(key, pending)
+      const settled = pending
+      void settled
+        .catch(() => {})
+        .then(() => {
+          if (inflight.get(key) === settled) inflight.delete(key)
+        })
+    }
+
+    return withAbort(pending, signal)
+  }
+
+  return {
+    id: PHOTON_PROVIDER_ID,
+    attribution: PHOTON_ATTRIBUTION,
+
+    async search(query, searchOptions: AddressSearchOptions = {}) {
+      const trimmed = query.trim()
+      if (!trimmed) return []
+
+      const limit = searchOptions.limit ?? options.limit ?? DEFAULT_LIMIT
+      const lang = searchOptions.lang ?? options.lang ?? DEFAULT_LANG
+      const proximity = searchOptions.proximity ?? options.proximity
+      const bbox = searchOptions.bbox ?? options.bbox
+
+      const url = new URL(`${endpoint}/api`)
+      url.searchParams.set("q", trimmed)
+      url.searchParams.set("limit", String(limit))
+      url.searchParams.set("lang", lang)
+      if (proximity) {
+        url.searchParams.set("lat", String(proximity.latitude))
+        url.searchParams.set("lon", String(proximity.longitude))
+      }
+      if (bbox) url.searchParams.set("bbox", bbox.join(","))
+
+      // Photon has no country parameter, so the restriction is applied to results.
+      // The cache key omits it, letting differently-restricted callers share a request.
+      const suggestions = await cachedRequest(
+        `search:${trimmed.toLowerCase()}:${url.search}`,
+        url,
+        searchOptions.signal
+      )
+      return filterByCountry(suggestions, searchOptions.countries ?? options.countries)
+    },
+
+    async reverse(coordinates, reverseOptions: AddressReverseOptions = {}) {
+      const url = new URL(`${endpoint}/reverse`)
+      url.searchParams.set("lat", String(coordinates.latitude))
+      url.searchParams.set("lon", String(coordinates.longitude))
+      url.searchParams.set("lang", reverseOptions.lang ?? options.lang ?? DEFAULT_LANG)
+      url.searchParams.set("limit", "1")
+
+      const suggestions = await cachedRequest(`reverse:${url.search}`, url, reverseOptions.signal)
+      return suggestions[0] ?? null
+    },
+  }
+}
+
+/**
+ * Maps one Photon GeoJSON feature onto the canonical suggestion shape.
+ *
+ * Returns null for features with no addressable line (a bare city or country),
+ * which are noise in an address field.
+ */
+export function photonFeatureToSuggestion(feature: unknown): AddressSuggestion | null {
+  const properties = record(record(feature)?.properties)
+  if (!properties) return null
+
+  const name = addressText(properties.name)
+  const street = joinSpace(addressText(properties.housenumber), addressText(properties.street))
+  const line1 = street ?? name
+  if (!line1) return null
+
+  const city =
+    addressText(properties.city) ??
+    addressText(properties.town) ??
+    addressText(properties.village) ??
+    addressText(properties.locality) ??
+    addressText(properties.municipality) ??
+    addressText(properties.district)
+  const region = addressText(properties.state)
+  const regionCode = toRegionCode(region)
+  const county = stripCountySuffix(addressText(properties.county))
+  const postalCode = addressText(properties.postcode)
+  const country = addressText(properties.country)
+  const countryCode = addressText(properties.countrycode)?.toUpperCase() ?? null
+
+  const coordinates = record(record(feature)?.geometry)?.coordinates
+  const longitude = Array.isArray(coordinates) ? numeric(coordinates[0]) : null
+  const latitude = Array.isArray(coordinates) ? numeric(coordinates[1]) : null
+
+  const displayName = name && name !== line1 ? name : null
+  const label = joinParts(", ", displayName, line1) ?? line1
+  const description = joinParts(
+    " • ",
+    joinSpace(city, regionCode ?? region, postalCode),
+    // Photon spells US counties with the suffix; other countries use their own term.
+    county && countryCode === "US" ? `${county} County` : county,
+    country
+  )
+
+  const osmType = addressText(properties.osm_type)
+  const osmId = numeric(properties.osm_id)
+  const identity =
+    osmType && osmId !== null
+      ? `${osmType}:${osmId}`
+      : `${longitude ?? "x"},${latitude ?? "y"}:${label}`
+
+  return {
+    id: `${PHOTON_PROVIDER_ID}:${identity}`,
+    label,
+    description,
+    name: displayName,
+    line1,
+    city,
+    region,
+    regionCode,
+    county,
+    postalCode,
+    country,
+    countryCode,
+    latitude,
+    longitude,
+    provider: PHOTON_PROVIDER_ID,
+    raw: feature,
+  }
+}
+
+function filterByCountry(
+  suggestions: readonly AddressSuggestion[],
+  countries: readonly string[] | undefined
+): readonly AddressSuggestion[] {
+  if (!countries?.length) return suggestions
+  const allowed = new Set(countries.map((code) => code.trim().toUpperCase()))
+  return suggestions.filter(
+    (suggestion) => suggestion.countryCode !== null && allowed.has(suggestion.countryCode)
+  )
+}
+
+/** Rejects as soon as `signal` aborts, without disturbing the shared request. */
+function withAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return promise
+  if (signal.aborted) return Promise.reject(abortError())
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError())
+    signal.addEventListener("abort", onAbort, { once: true })
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort))
+  })
+}
+
+function abortError(): DOMException {
+  return new DOMException("The address lookup was aborted.", "AbortError")
+}
+
+/**
+ * Derives a short region code from Photon's region name.
+ *
+ * Photon reports US states as full names ("New York") and exposes no ISO 3166-2
+ * code, so the mapping lives here rather than in the shared formatters. Keyed
+ * providers return codes directly — Google Places as
+ * `administrative_area_level_1.short_name`, Mapbox as `short_code` — and should
+ * use those instead of this table.
+ *
+ * Returns null when the value cannot be mapped, so callers never mistake a full
+ * region name for a code; the raw value stays on `AddressSuggestion.region`.
+ */
+function toRegionCode(value: string | null | undefined): string | null {
+  const region = value?.trim()
+  if (!region) return null
+  if (/^[a-z]{2}$/i.test(region)) return region.toUpperCase()
+  return US_STATE_CODES[region.toLowerCase()] ?? null
+}
+
+function stripCountySuffix(value: string | null): string | null {
+  return value?.replace(/\s+county$/i, "").trim() || null
+}
+
+function numeric(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+const US_STATE_CODES: Record<string, string> = {
+  alabama: "AL",
+  alaska: "AK",
+  arizona: "AZ",
+  arkansas: "AR",
+  california: "CA",
+  colorado: "CO",
+  connecticut: "CT",
+  delaware: "DE",
+  "district of columbia": "DC",
+  florida: "FL",
+  georgia: "GA",
+  hawaii: "HI",
+  idaho: "ID",
+  illinois: "IL",
+  indiana: "IN",
+  iowa: "IA",
+  kansas: "KS",
+  kentucky: "KY",
+  louisiana: "LA",
+  maine: "ME",
+  maryland: "MD",
+  massachusetts: "MA",
+  michigan: "MI",
+  minnesota: "MN",
+  mississippi: "MS",
+  missouri: "MO",
+  montana: "MT",
+  nebraska: "NE",
+  nevada: "NV",
+  "new hampshire": "NH",
+  "new jersey": "NJ",
+  "new mexico": "NM",
+  "new york": "NY",
+  "north carolina": "NC",
+  "north dakota": "ND",
+  ohio: "OH",
+  oklahoma: "OK",
+  oregon: "OR",
+  pennsylvania: "PA",
+  "puerto rico": "PR",
+  "rhode island": "RI",
+  "south carolina": "SC",
+  "south dakota": "SD",
+  tennessee: "TN",
+  texas: "TX",
+  utah: "UT",
+  vermont: "VT",
+  virginia: "VA",
+  washington: "WA",
+  "west virginia": "WV",
+  wisconsin: "WI",
+  wyoming: "WY",
+}

--- a/packages/ui/src/lib/address/types.ts
+++ b/packages/ui/src/lib/address/types.ts
@@ -1,0 +1,123 @@
+/**
+ * Provider-agnostic address lookup contract.
+ *
+ * Deliberately free of React and DOM-framework imports so the same providers can
+ * be reused outside the browser (server-side geocoding, scripts, tests).
+ */
+
+export type AddressCoordinates = {
+  readonly latitude: number
+  readonly longitude: number
+}
+
+/**
+ * A single address candidate, normalized across providers.
+ *
+ * The shape is a superset on purpose: `region` keeps the provider's spelling
+ * ("New York") while `regionCode` carries the short form ("NY"), so apps that
+ * store either one never lose information.
+ */
+export type AddressSuggestion = {
+  /** Stable within a provider; prefixed with the provider id to stay unique across them. */
+  readonly id: string
+  /** Primary display line — the "what" (place name and/or street address). */
+  readonly label: string
+  /** Secondary display line — the "where" (city, region, postal code, country). */
+  readonly description: string | null
+  /** Place or business name, only when it differs from `line1`. */
+  readonly name: string | null
+  /** Street address: house number and street, or the place name when there is no street. */
+  readonly line1: string | null
+  readonly city: string | null
+  /** Region as the provider spells it, e.g. "New York". */
+  readonly region: string | null
+  /** Short region code when it can be derived, e.g. "NY". */
+  readonly regionCode: string | null
+  readonly county: string | null
+  readonly postalCode: string | null
+  readonly country: string | null
+  /** ISO 3166-1 alpha-2, uppercased. */
+  readonly countryCode: string | null
+  readonly latitude: number | null
+  readonly longitude: number | null
+  /** Id of the provider that produced this suggestion. */
+  readonly provider: string
+  /** Untouched provider payload, for app-specific enrichment. */
+  readonly raw: unknown
+  /**
+   * Set when the provider returned a prediction that still needs
+   * {@link AddressProvider.retrieve} to fill in components and coordinates
+   * (Google Places and Mapbox work this way; Photon does not).
+   */
+  readonly partial?: boolean
+}
+
+export type AddressSearchOptions = {
+  readonly signal?: AbortSignal
+  readonly limit?: number
+  /** Preferred language for returned names, e.g. "en". */
+  readonly lang?: string
+  /** Restrict results to these ISO 3166-1 alpha-2 country codes. */
+  readonly countries?: readonly string[]
+  /** Bias results toward a point. */
+  readonly proximity?: AddressCoordinates
+  /** Bias/restrict results to a bounding box: [minLon, minLat, maxLon, maxLat]. */
+  readonly bbox?: readonly [number, number, number, number]
+  /**
+   * Groups the keystrokes of one lookup with the follow-up `retrieve` call.
+   * Providers that bill per session (Google Places, Mapbox) need this; others ignore it.
+   */
+  readonly sessionToken?: string
+}
+
+export type AddressRetrieveOptions = {
+  readonly signal?: AbortSignal
+  readonly lang?: string
+  readonly sessionToken?: string
+}
+
+export type AddressReverseOptions = {
+  readonly signal?: AbortSignal
+  readonly lang?: string
+}
+
+/**
+ * Implemented once per geocoding backend. Only `id` and `search` are required;
+ * the optional members exist so providers with richer flows (a details call, a
+ * billing session, reverse geocoding) can be added without changing call sites.
+ */
+export type AddressProvider = {
+  readonly id: string
+  /** Rendered next to results when the data license requires credit. */
+  readonly attribution?: string
+  /** Text query to address candidates. */
+  search(query: string, options?: AddressSearchOptions): Promise<readonly AddressSuggestion[]>
+  /**
+   * Resolves a `partial` suggestion into a complete one. Providers whose search
+   * already returns full addresses omit this.
+   */
+  retrieve?(
+    suggestion: AddressSuggestion,
+    options?: AddressRetrieveOptions
+  ): Promise<AddressSuggestion>
+  /** Coordinates to the address at that point. */
+  reverse?(
+    coordinates: AddressCoordinates,
+    options?: AddressReverseOptions
+  ): Promise<AddressSuggestion | null>
+  /** Mints a session token for providers that bill per lookup session. */
+  createSession?(): string
+}
+
+/**
+ * Editable address form state. `line2` is never returned by geocoders — it is
+ * always user-entered — so it lives here rather than on {@link AddressSuggestion}.
+ */
+export type AddressDraft = {
+  line1: string
+  line2: string
+  city: string
+  region: string
+  postalCode: string
+  countryCode: string
+}

--- a/packages/ui/src/lib/speech/index.ts
+++ b/packages/ui/src/lib/speech/index.ts
@@ -1,0 +1,14 @@
+export { appendDictationText, speechErrorMessage, toSpeechErrorCode } from "./messages"
+export type {
+  SpeechErrorCode,
+  SpeechRecognizer,
+  SpeechRecognizerHandlers,
+  SpeechRecognizerStartOptions,
+  SpeechResult,
+  SpeechSession,
+} from "./types"
+export {
+  createWebSpeechRecognizer,
+  type SpeechRecognitionConstructor,
+  type WebSpeechRecognizerOptions,
+} from "./web-speech"

--- a/packages/ui/src/lib/speech/messages.ts
+++ b/packages/ui/src/lib/speech/messages.ts
@@ -1,0 +1,57 @@
+import type { SpeechErrorCode } from "./types"
+
+/**
+ * Appends dictated text to existing text with exactly one separating space.
+ *
+ * Returns the original text unchanged when the transcript is blank, so a silent
+ * result never rewrites what the user already typed.
+ */
+export function appendDictationText(existingText: string, dictatedText: string): string {
+  const transcript = dictatedText.trim()
+  if (!transcript) return existingText
+
+  const existing = existingText.trimEnd()
+  return existing ? `${existing} ${transcript}` : transcript
+}
+
+/**
+ * Maps an error code to a message that tells the user what to do about it.
+ *
+ * Returns null for `"aborted"`, which is what the browser reports when dictation
+ * is stopped on purpose — surfacing that as an error would be wrong.
+ */
+export function speechErrorMessage(code: SpeechErrorCode): string | null {
+  switch (code) {
+    case "aborted":
+      return null
+    case "not-allowed":
+    case "service-not-allowed":
+      return "Microphone access was denied. Allow microphone access in your browser settings and try again."
+    case "audio-capture":
+      return "No microphone is available. Connect or enable a microphone and try again."
+    case "no-speech":
+      return "No speech was detected. Try again when you're ready."
+    case "network":
+      return "Voice dictation couldn't connect. Check your connection or type instead."
+    case "language-not-supported":
+      return "Voice dictation isn't available for this language. Type instead."
+    default:
+      return "Voice dictation couldn't start. Try again or type instead."
+  }
+}
+
+/** Normalizes an arbitrary error name from the browser onto {@link SpeechErrorCode}. */
+export function toSpeechErrorCode(value: unknown): SpeechErrorCode {
+  switch (value) {
+    case "aborted":
+    case "audio-capture":
+    case "language-not-supported":
+    case "network":
+    case "no-speech":
+    case "not-allowed":
+    case "service-not-allowed":
+      return value
+    default:
+      return "unknown"
+  }
+}

--- a/packages/ui/src/lib/speech/types.ts
+++ b/packages/ui/src/lib/speech/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Provider-agnostic speech recognition contract.
+ *
+ * Deliberately free of React imports. The shape is event-driven so it fits both
+ * streaming recognizers (the browser's Web Speech API) and record-then-transcribe
+ * backends (MediaRecorder plus a server transcription call), which emit a single
+ * final result when the recording stops.
+ */
+
+/** Web Speech API error names, plus a catch-all for anything else. */
+export type SpeechErrorCode =
+  | "aborted"
+  | "audio-capture"
+  | "language-not-supported"
+  | "network"
+  | "no-speech"
+  | "not-allowed"
+  | "service-not-allowed"
+  | "unknown"
+
+export type SpeechResult = {
+  readonly transcript: string
+  /**
+   * False for in-progress text the recognizer may still revise. Only final
+   * results are accumulated; interim text is replaced on each update.
+   */
+  readonly isFinal: boolean
+}
+
+export type SpeechRecognizerStartOptions = {
+  /** BCP 47 tag, e.g. "en-US". */
+  readonly lang?: string
+  /** Keep recognizing across pauses rather than stopping at the first result. */
+  readonly continuous?: boolean
+  /** Emit in-progress results, not just final ones. */
+  readonly interimResults?: boolean
+  readonly maxAlternatives?: number
+}
+
+export type SpeechRecognizerHandlers = {
+  /** The recognizer is live and capturing audio. */
+  onStart?(): void
+  onResult?(result: SpeechResult): void
+  /** Whether sound or speech is currently reaching the microphone. */
+  onAudioActivity?(active: boolean): void
+  onError?(code: SpeechErrorCode): void
+  /** The session finished, whether by `stop`, `abort`, an error, or the browser. */
+  onEnd?(): void
+}
+
+export type SpeechSession = {
+  /** Finish gracefully, delivering any pending final result. */
+  stop(): void
+  /** Finish immediately and discard pending results. */
+  abort(): void
+}
+
+/**
+ * Implemented once per speech backend. `start` may throw synchronously if the
+ * session cannot be created; callers are expected to treat that as an
+ * `"unknown"` error.
+ */
+export type SpeechRecognizer = {
+  readonly id: string
+  /** False when the environment cannot recognize speech at all (e.g. Firefox). */
+  isSupported(): boolean
+  start(options: SpeechRecognizerStartOptions, handlers: SpeechRecognizerHandlers): SpeechSession
+}

--- a/packages/ui/src/lib/speech/web-speech.ts
+++ b/packages/ui/src/lib/speech/web-speech.ts
@@ -1,0 +1,177 @@
+import { toSpeechErrorCode } from "./messages"
+import type {
+  SpeechRecognizer,
+  SpeechRecognizerHandlers,
+  SpeechRecognizerStartOptions,
+  SpeechSession,
+} from "./types"
+
+const WEB_SPEECH_RECOGNIZER_ID = "web-speech"
+
+/**
+ * Minimal structural types for the Web Speech API.
+ *
+ * Declared here rather than taken from `lib.dom.d.ts`, whose speech definitions
+ * vary by TypeScript version and are still prefixed in some browsers.
+ */
+type BrowserSpeechAlternative = { readonly transcript?: string }
+
+type BrowserSpeechResult = {
+  readonly isFinal: boolean
+  readonly length: number
+  readonly [index: number]: BrowserSpeechAlternative | undefined
+}
+
+type BrowserSpeechResultList = {
+  readonly length: number
+  readonly [index: number]: BrowserSpeechResult | undefined
+}
+
+type BrowserSpeechResultEvent = {
+  readonly resultIndex: number
+  readonly results: BrowserSpeechResultList
+}
+
+type BrowserSpeechErrorEvent = { readonly error: unknown }
+
+type BrowserSpeechRecognition = {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  maxAlternatives: number
+  onend: ((event: unknown) => void) | null
+  onerror: ((event: BrowserSpeechErrorEvent) => void) | null
+  onresult: ((event: BrowserSpeechResultEvent) => void) | null
+  onsoundend: ((event: unknown) => void) | null
+  onsoundstart: ((event: unknown) => void) | null
+  onspeechend: ((event: unknown) => void) | null
+  onspeechstart: ((event: unknown) => void) | null
+  onstart: ((event: unknown) => void) | null
+  abort(): void
+  start(): void
+  stop(): void
+}
+
+export type SpeechRecognitionConstructor = new () => BrowserSpeechRecognition
+
+type SpeechRecognitionWindow = Window & {
+  SpeechRecognition?: SpeechRecognitionConstructor
+  webkitSpeechRecognition?: SpeechRecognitionConstructor
+}
+
+export type WebSpeechRecognizerOptions = {
+  /** Overrides the constructor looked up on `window`. Primarily for tests. */
+  readonly implementation?: SpeechRecognitionConstructor
+}
+
+/**
+ * Recognizer backed by the browser's built-in Web Speech API — no key, no server.
+ *
+ * Supported in Chrome, Edge, and Safari (behind the `webkit` prefix) but not
+ * Firefox, so always branch on `isSupported()`. Note that Chrome streams audio to
+ * Google's servers for recognition; if that is unacceptable for a project, supply
+ * a different {@link SpeechRecognizer} instead.
+ */
+export function createWebSpeechRecognizer(
+  options: WebSpeechRecognizerOptions = {}
+): SpeechRecognizer {
+  function resolveConstructor(): SpeechRecognitionConstructor | null {
+    if (options.implementation) return options.implementation
+    if (typeof window === "undefined") return null
+    const browserWindow = window as SpeechRecognitionWindow
+    return browserWindow.SpeechRecognition ?? browserWindow.webkitSpeechRecognition ?? null
+  }
+
+  return {
+    id: WEB_SPEECH_RECOGNIZER_ID,
+
+    isSupported() {
+      return resolveConstructor() !== null
+    },
+
+    start(
+      startOptions: SpeechRecognizerStartOptions,
+      handlers: SpeechRecognizerHandlers
+    ): SpeechSession {
+      const Recognition = resolveConstructor()
+      if (!Recognition) throw new Error("[SixbUI] Speech recognition is unavailable.")
+
+      const recognition = new Recognition()
+      recognition.continuous = startOptions.continuous ?? true
+      recognition.interimResults = startOptions.interimResults ?? true
+      recognition.lang = startOptions.lang ?? "en-US"
+      recognition.maxAlternatives = startOptions.maxAlternatives ?? 1
+
+      // The API reports sound and speech separately; either one means the
+      // microphone is picking something up.
+      let soundDetected = false
+      let speechDetected = false
+      const reportAudioActivity = () => {
+        handlers.onAudioActivity?.(soundDetected || speechDetected)
+      }
+
+      recognition.onstart = () => handlers.onStart?.()
+      recognition.onsoundstart = () => {
+        soundDetected = true
+        reportAudioActivity()
+      }
+      recognition.onsoundend = () => {
+        soundDetected = false
+        reportAudioActivity()
+      }
+      recognition.onspeechstart = () => {
+        speechDetected = true
+        reportAudioActivity()
+      }
+      recognition.onspeechend = () => {
+        speechDetected = false
+        reportAudioActivity()
+      }
+
+      recognition.onresult = (event) => {
+        const finals: string[] = []
+        const interims: string[] = []
+
+        for (let index = event.resultIndex; index < event.results.length; index += 1) {
+          const result = event.results[index]
+          const transcript = result?.[0]?.transcript
+          if (!result || !transcript) continue
+          if (result.isFinal) finals.push(transcript)
+          else interims.push(transcript)
+        }
+
+        // Interim text is reported first so a final result overwrites it rather
+        // than the other way round.
+        if (interims.length) {
+          handlers.onResult?.({ transcript: interims.join(" "), isFinal: false })
+        }
+        if (finals.length) {
+          handlers.onResult?.({ transcript: finals.join(" "), isFinal: true })
+        }
+      }
+
+      recognition.onerror = (event) => {
+        soundDetected = false
+        speechDetected = false
+        handlers.onError?.(toSpeechErrorCode(event.error))
+      }
+
+      recognition.onend = () => {
+        soundDetected = false
+        speechDetected = false
+        handlers.onEnd?.()
+      }
+
+      recognition.start()
+
+      return {
+        stop() {
+          recognition.stop()
+        },
+        abort() {
+          recognition.abort()
+        },
+      }
+    },
+  }
+}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -236,6 +236,32 @@
   }
 }
 
+/* Pulses a microphone icon while audio is reaching it (DictationButton). */
+@keyframes dictation-mic-receiving {
+  0%,
+  100% {
+    opacity: 0.75;
+    transform: scale(0.92);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
+.dictation-mic-receiving {
+  animation: dictation-mic-receiving 720ms ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dictation-mic-receiving {
+    animation: none;
+    opacity: 1;
+    transform: scale(1.04);
+  }
+}
+
 @custom-variant data-autoscrolling {
   &:where([data-autoscrolling]) {
     @slot;

--- a/packages/ui/tests/address.test.ts
+++ b/packages/ui/tests/address.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, test } from "bun:test"
+import {
+  addressDraftFromSuggestion,
+  createPhotonProvider,
+  EMPTY_ADDRESS_DRAFT,
+  formatAddress,
+  formatAddressLine,
+  PHOTON_ATTRIBUTION,
+  photonFeatureToSuggestion,
+} from "@sixb/ui/lib/address"
+
+const OFFICE_FEATURE = {
+  geometry: { coordinates: [-73.9442, 40.6782] },
+  properties: {
+    osm_type: "W",
+    osm_id: 42,
+    name: "Sixb office",
+    housenumber: "123",
+    street: "Main Street",
+    city: "New York",
+    county: "Kings County",
+    state: "New York",
+    postcode: "10001",
+    country: "United States",
+    countrycode: "us",
+  },
+}
+
+describe("photonFeatureToSuggestion", () => {
+  test("maps a complete feature onto the canonical shape", () => {
+    expect(photonFeatureToSuggestion(OFFICE_FEATURE)).toEqual({
+      id: "photon:W:42",
+      label: "Sixb office, 123 Main Street",
+      description: "New York NY 10001 • Kings County • United States",
+      name: "Sixb office",
+      line1: "123 Main Street",
+      city: "New York",
+      region: "New York",
+      regionCode: "NY",
+      county: "Kings",
+      postalCode: "10001",
+      country: "United States",
+      countryCode: "US",
+      latitude: 40.6782,
+      longitude: -73.9442,
+      provider: "photon",
+      raw: OFFICE_FEATURE,
+    })
+  })
+
+  test("falls back to the feature name and locality when there is no street", () => {
+    const suggestion = photonFeatureToSuggestion({
+      properties: { name: "Market Square", locality: "Cambridge", countrycode: "GB" },
+    })
+
+    expect(suggestion?.line1).toBe("Market Square")
+    expect(suggestion?.label).toBe("Market Square")
+    // The name is not repeated once it has become the address line.
+    expect(suggestion?.name).toBeNull()
+    expect(suggestion?.city).toBe("Cambridge")
+    expect(suggestion?.countryCode).toBe("GB")
+    expect(suggestion?.regionCode).toBeNull()
+  })
+
+  test("ignores features that cannot provide an address line", () => {
+    expect(photonFeatureToSuggestion({ properties: { city: "Berlin" } })).toBeNull()
+    expect(photonFeatureToSuggestion({})).toBeNull()
+    expect(photonFeatureToSuggestion(null)).toBeNull()
+  })
+
+  test("keeps a county name without its suffix and only re-labels US counties", () => {
+    const us = photonFeatureToSuggestion(OFFICE_FEATURE)
+    expect(us?.county).toBe("Kings")
+    expect(us?.description).toContain("Kings County")
+
+    const nonUs = photonFeatureToSuggestion({
+      properties: { street: "Hauptstraße", county: "Landkreis Rosenheim", countrycode: "de" },
+    })
+    expect(nonUs?.county).toBe("Landkreis Rosenheim")
+    expect(nonUs?.description).toBe("Landkreis Rosenheim")
+  })
+
+  test("falls back to coordinates for the id when OSM identifiers are absent", () => {
+    const suggestion = photonFeatureToSuggestion({
+      geometry: { coordinates: [-0.1276, 51.5072] },
+      properties: { name: "Market Square" },
+    })
+    expect(suggestion?.id).toBe("photon:-0.1276,51.5072:Market Square")
+  })
+})
+
+describe("region codes", () => {
+  function suggestionForState(state: string | undefined) {
+    return photonFeatureToSuggestion({ properties: { street: "Main Street", state } })
+  }
+
+  test("derives US state codes, passes existing codes through, and rejects the rest", () => {
+    expect(suggestionForState("New York")?.regionCode).toBe("NY")
+    expect(suggestionForState("district of columbia")?.regionCode).toBe("DC")
+    expect(suggestionForState("ny")?.regionCode).toBe("NY")
+    expect(suggestionForState("Bavaria")?.regionCode).toBeNull()
+    expect(suggestionForState("")?.regionCode).toBeNull()
+    expect(suggestionForState(undefined)?.regionCode).toBeNull()
+  })
+
+  test("keeps the provider spelling on region even when no code can be derived", () => {
+    const suggestion = suggestionForState("Bavaria")
+    expect(suggestion?.region).toBe("Bavaria")
+    expect(suggestion?.regionCode).toBeNull()
+  })
+})
+
+describe("formatters", () => {
+  const suggestion = photonFeatureToSuggestion(OFFICE_FEATURE)
+
+  test("formats a one-line address using the region code", () => {
+    expect(formatAddressLine(suggestion!)).toBe("123 Main Street")
+    expect(formatAddress(suggestion!)).toBe("123 Main Street, New York NY 10001")
+    expect(formatAddress(suggestion!, { includeCountry: true })).toBe(
+      "123 Main Street, New York NY 10001, United States"
+    )
+  })
+})
+
+describe("addressDraftFromSuggestion", () => {
+  const suggestion = photonFeatureToSuggestion(OFFICE_FEATURE)
+
+  test("stores the region name by default and the code on request", () => {
+    expect(addressDraftFromSuggestion(suggestion!).region).toBe("New York")
+    expect(addressDraftFromSuggestion(suggestion!, { region: "code" }).region).toBe("NY")
+  })
+
+  test("preserves line2 and falls back to previous values", () => {
+    const previous = { ...EMPTY_ADDRESS_DRAFT, line2: "Suite 5", city: "Kept", countryCode: "US" }
+    const sparse = photonFeatureToSuggestion({ properties: { name: "Market Square" } })
+
+    expect(addressDraftFromSuggestion(sparse!, { previous })).toEqual({
+      line1: "Market Square",
+      line2: "Suite 5",
+      city: "Kept",
+      region: "",
+      postalCode: "",
+      countryCode: "US",
+    })
+  })
+})
+
+describe("createPhotonProvider", () => {
+  test("requests the configured endpoint and maps results", async () => {
+    const { fetchImpl, urls } = stubFetch({ features: [OFFICE_FEATURE] })
+    const provider = createPhotonProvider({ endpoint: "https://photon.internal/", fetchImpl })
+
+    const results = await provider.search("123 main")
+
+    expect(provider.id).toBe("photon")
+    expect(provider.attribution).toBe(PHOTON_ATTRIBUTION)
+    expect(results).toHaveLength(1)
+    expect(results[0]?.line1).toBe("123 Main Street")
+    expect(urls).toHaveLength(1)
+    expect(urls[0]).toStartWith("https://photon.internal/api?")
+    expect(urls[0]).toContain("q=123+main")
+    expect(urls[0]).toContain("limit=5")
+    expect(urls[0]).toContain("lang=en")
+  })
+
+  test("passes proximity, bbox, and limit through to Photon", async () => {
+    const { fetchImpl, urls } = stubFetch({ features: [] })
+    const provider = createPhotonProvider({ fetchImpl })
+
+    await provider.search("main", {
+      limit: 8,
+      lang: "de",
+      proximity: { latitude: 40.1, longitude: -73.2 },
+      bbox: [-74, 40, -73, 41],
+    })
+
+    expect(urls[0]).toContain("limit=8")
+    expect(urls[0]).toContain("lang=de")
+    expect(urls[0]).toContain("lat=40.1")
+    expect(urls[0]).toContain("lon=-73.2")
+    expect(urls[0]).toContain("bbox=-74%2C40%2C-73%2C41")
+  })
+
+  test("returns no results for a blank query without calling the network", async () => {
+    const { fetchImpl, urls } = stubFetch({ features: [OFFICE_FEATURE] })
+    const provider = createPhotonProvider({ fetchImpl })
+
+    expect(await provider.search("   ")).toEqual([])
+    expect(urls).toHaveLength(0)
+  })
+
+  test("caches repeated queries", async () => {
+    const { fetchImpl, urls } = stubFetch({ features: [OFFICE_FEATURE] })
+    const provider = createPhotonProvider({ fetchImpl })
+
+    await provider.search("123 main")
+    await provider.search("123 main")
+
+    expect(urls).toHaveLength(1)
+  })
+
+  test("honours a disabled cache", async () => {
+    const { fetchImpl, urls } = stubFetch({ features: [OFFICE_FEATURE] })
+    const provider = createPhotonProvider({ fetchImpl, cacheTtlMs: 0 })
+
+    await provider.search("123 main")
+    await provider.search("123 main")
+
+    expect(urls).toHaveLength(2)
+  })
+
+  test("coalesces concurrent identical queries into one request", async () => {
+    const { fetchImpl, urls, release } = stubFetch({ features: [OFFICE_FEATURE] }, { defer: true })
+    const provider = createPhotonProvider({ fetchImpl })
+
+    const both = Promise.all([provider.search("123 main"), provider.search("123 main")])
+    release()
+    const [first, second] = await both
+
+    expect(urls).toHaveLength(1)
+    expect(first).toEqual(second)
+  })
+
+  test("filters results to the requested countries", async () => {
+    const { fetchImpl } = stubFetch({ features: [OFFICE_FEATURE] })
+    const provider = createPhotonProvider({ fetchImpl })
+
+    expect(await provider.search("123 main", { countries: ["GB"] })).toEqual([])
+    expect(await provider.search("123 main", { countries: ["us"] })).toHaveLength(1)
+  })
+
+  test("rejects an aborted caller without discarding the shared response", async () => {
+    const { fetchImpl, urls, release } = stubFetch({ features: [OFFICE_FEATURE] }, { defer: true })
+    const provider = createPhotonProvider({ fetchImpl })
+    const controller = new AbortController()
+
+    const aborted = provider.search("123 main", { signal: controller.signal })
+    controller.abort()
+    release()
+
+    expect(await abortNameOf(aborted)).toBe("AbortError")
+
+    // The in-flight request still completed and populated the cache.
+    await Bun.sleep(20)
+    expect(await provider.search("123 main")).toHaveLength(1)
+    expect(urls).toHaveLength(1)
+  })
+
+  test("rejects without a request when the signal is already aborted", async () => {
+    const { fetchImpl, urls } = stubFetch({ features: [OFFICE_FEATURE] })
+    const provider = createPhotonProvider({ fetchImpl })
+
+    const aborted = provider.search("123 main", { signal: AbortSignal.abort() })
+
+    expect(await abortNameOf(aborted)).toBe("AbortError")
+    expect(urls).toHaveLength(0)
+  })
+
+  test("throws a package-prefixed error for a failed response", async () => {
+    const fetchImpl = (async () => new Response("nope", { status: 503 })) as unknown as typeof fetch
+    const provider = createPhotonProvider({ fetchImpl })
+
+    await expect(provider.search("123 main")).rejects.toThrow(
+      "[SixbUI] Photon address lookup failed (503)."
+    )
+  })
+
+  test("reverse geocodes coordinates to a single suggestion", async () => {
+    const { fetchImpl, urls } = stubFetch({ features: [OFFICE_FEATURE] })
+    const provider = createPhotonProvider({ fetchImpl })
+
+    const suggestion = await provider.reverse?.({ latitude: 40.6782, longitude: -73.9442 })
+
+    expect(suggestion?.line1).toBe("123 Main Street")
+    expect(urls[0]).toStartWith("https://photon.komoot.io/reverse?")
+    expect(urls[0]).toContain("lat=40.6782")
+    expect(urls[0]).toContain("lon=-73.9442")
+  })
+
+  test("reverse returns null when Photon has no match", async () => {
+    const { fetchImpl } = stubFetch({ features: [] })
+    const provider = createPhotonProvider({ fetchImpl })
+
+    expect(await provider.reverse?.({ latitude: 0, longitude: 0 })).toBeNull()
+  })
+
+  test("has no retrieve or session step", () => {
+    const provider = createPhotonProvider()
+    expect(provider.retrieve).toBeUndefined()
+    expect(provider.createSession).toBeUndefined()
+  })
+})
+
+/** Resolves to the rejection's `name`, so DOMException identity is asserted directly. */
+async function abortNameOf(promise: Promise<unknown>): Promise<string | null> {
+  try {
+    await promise
+    return null
+  } catch (error) {
+    return error instanceof DOMException ? error.name : null
+  }
+}
+
+/** Records requested URLs and returns a fixed payload, optionally on demand. */
+function stubFetch(
+  payload: unknown,
+  options: { readonly defer?: boolean } = {}
+): { fetchImpl: typeof fetch; urls: string[]; release: () => void } {
+  const urls: string[] = []
+  let release = () => {}
+  const gate = options.defer
+    ? new Promise<void>((resolve) => {
+        release = resolve
+      })
+    : Promise.resolve()
+
+  const fetchImpl = (async (input: URL | RequestInfo) => {
+    urls.push(String(input))
+    await gate
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }) as unknown as typeof fetch
+
+  return { fetchImpl, urls, release: () => release() }
+}

--- a/packages/ui/tests/speech.test.ts
+++ b/packages/ui/tests/speech.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import {
+  appendDictationText,
+  createWebSpeechRecognizer,
+  type SpeechErrorCode,
+  type SpeechRecognitionConstructor,
+  type SpeechResult,
+  speechErrorMessage,
+  toSpeechErrorCode,
+} from "@sixb/ui/lib/speech"
+
+describe("appendDictationText", () => {
+  test("uses the dictated text when the field is empty", () => {
+    expect(appendDictationText("", "  Remove the damaged tree.  ")).toBe("Remove the damaged tree.")
+  })
+
+  test("appends to existing text with one separator", () => {
+    expect(appendDictationText("Prune the trees.   ", "  Remove all debris.")).toBe(
+      "Prune the trees. Remove all debris."
+    )
+  })
+
+  test("leaves the field untouched for a blank transcript", () => {
+    expect(appendDictationText("Existing scope  ", "   ")).toBe("Existing scope  ")
+  })
+})
+
+describe("speechErrorMessage", () => {
+  test("maps permission denial to an actionable message", () => {
+    expect(speechErrorMessage("not-allowed")).toContain("Microphone access was denied")
+    expect(speechErrorMessage("service-not-allowed")).toContain("Microphone access was denied")
+  })
+
+  test("does not surface intentional aborts as errors", () => {
+    expect(speechErrorMessage("aborted")).toBeNull()
+  })
+
+  test("has a message for every other code", () => {
+    const codes: SpeechErrorCode[] = [
+      "audio-capture",
+      "language-not-supported",
+      "network",
+      "no-speech",
+      "unknown",
+    ]
+    for (const code of codes) expect(speechErrorMessage(code)).toBeTruthy()
+  })
+})
+
+describe("toSpeechErrorCode", () => {
+  test("passes known codes through and funnels the rest to unknown", () => {
+    expect(toSpeechErrorCode("no-speech")).toBe("no-speech")
+    expect(toSpeechErrorCode("audio-capture")).toBe("audio-capture")
+    expect(toSpeechErrorCode("something-new")).toBe("unknown")
+    expect(toSpeechErrorCode(undefined)).toBe("unknown")
+  })
+})
+
+describe("createWebSpeechRecognizer", () => {
+  beforeEach(() => {
+    FakeRecognition.last = null
+  })
+
+  test("reports no support without a browser implementation", () => {
+    expect(createWebSpeechRecognizer().isSupported()).toBe(false)
+    expect(createWebSpeechRecognizer({ implementation: fakeConstructor() }).isSupported()).toBe(
+      true
+    )
+  })
+
+  test("throws when started with no implementation available", () => {
+    expect(() => createWebSpeechRecognizer().start({}, {})).toThrow(
+      "[SixbUI] Speech recognition is unavailable."
+    )
+  })
+
+  test("applies start options and defaults to continuous dictation", () => {
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    recognizer.start({ lang: "es-ES", maxAlternatives: 3 }, {})
+    const instance = lastInstance()
+
+    expect(instance.lang).toBe("es-ES")
+    expect(instance.maxAlternatives).toBe(3)
+    expect(instance.continuous).toBe(true)
+    expect(instance.interimResults).toBe(true)
+    expect(instance.started).toBe(1)
+  })
+
+  test("honours explicitly disabled continuous and interim results", () => {
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    recognizer.start({ continuous: false, interimResults: false }, {})
+    const instance = lastInstance()
+
+    expect(instance.continuous).toBe(false)
+    expect(instance.interimResults).toBe(false)
+  })
+
+  test("reports interim text before the final result that replaces it", () => {
+    const results: SpeechResult[] = []
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    recognizer.start({}, { onResult: (result) => results.push(result) })
+    call(lastInstance().onresult, {
+      resultIndex: 0,
+      results: [
+        { isFinal: true, 0: { transcript: "Remove the tree." } },
+        { isFinal: false, 0: { transcript: "and haul away" } },
+      ],
+    })
+
+    expect(results).toEqual([
+      { transcript: "and haul away", isFinal: false },
+      { transcript: "Remove the tree.", isFinal: true },
+    ])
+  })
+
+  test("reads only from resultIndex onward and skips empty alternatives", () => {
+    const results: SpeechResult[] = []
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    recognizer.start({}, { onResult: (result) => results.push(result) })
+    call(lastInstance().onresult, {
+      resultIndex: 1,
+      results: [
+        { isFinal: true, 0: { transcript: "already delivered" } },
+        { isFinal: true, 0: { transcript: "" } },
+        { isFinal: true, 0: undefined },
+        { isFinal: true, 0: { transcript: "second chunk" } },
+      ],
+    })
+
+    expect(results).toEqual([{ transcript: "second chunk", isFinal: true }])
+  })
+
+  test("joins multiple final chunks from one event", () => {
+    const results: SpeechResult[] = []
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    recognizer.start({}, { onResult: (result) => results.push(result) })
+    call(lastInstance().onresult, {
+      resultIndex: 0,
+      results: [
+        { isFinal: true, 0: { transcript: "first" } },
+        { isFinal: true, 0: { transcript: "second" } },
+      ],
+    })
+
+    expect(results).toEqual([{ transcript: "first second", isFinal: true }])
+  })
+
+  test("treats either sound or speech as incoming audio", () => {
+    const activity: boolean[] = []
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    recognizer.start({}, { onAudioActivity: (active) => activity.push(active) })
+    const instance = lastInstance()
+
+    call(instance.onsoundstart, {})
+    call(instance.onspeechstart, {})
+    // Sound ends but speech is still detected, so audio is still arriving.
+    call(instance.onsoundend, {})
+    call(instance.onspeechend, {})
+
+    expect(activity).toEqual([true, true, true, false])
+  })
+
+  test("normalizes error names and forwards lifecycle events", () => {
+    const codes: SpeechErrorCode[] = []
+    let started = 0
+    let ended = 0
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    recognizer.start(
+      {},
+      {
+        onStart: () => {
+          started += 1
+        },
+        onEnd: () => {
+          ended += 1
+        },
+        onError: (code) => codes.push(code),
+      }
+    )
+    const instance = lastInstance()
+
+    call(instance.onstart, {})
+    call(instance.onerror, { error: "not-allowed" })
+    call(instance.onerror, { error: "totally-new" })
+    call(instance.onend, {})
+
+    expect(started).toBe(1)
+    expect(ended).toBe(1)
+    expect(codes).toEqual(["not-allowed", "unknown"])
+  })
+
+  test("clears audio activity when a session errors or ends", () => {
+    const activity: boolean[] = []
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    recognizer.start({}, { onAudioActivity: (active) => activity.push(active) })
+    const instance = lastInstance()
+
+    call(instance.onsoundstart, {})
+    call(instance.onend, {})
+    // A fresh sound event after the reset still reports activity.
+    call(instance.onsoundstart, {})
+
+    expect(activity).toEqual([true, true])
+  })
+
+  test("delegates stop and abort to the browser session", () => {
+    const recognizer = createWebSpeechRecognizer({ implementation: fakeConstructor() })
+
+    const session = recognizer.start({}, {})
+    const instance = lastInstance()
+
+    session.stop()
+    session.abort()
+
+    expect(instance.stopped).toBe(1)
+    expect(instance.aborted).toBe(1)
+  })
+})
+
+/**
+ * Stand-in for the browser's SpeechRecognition. Handler fields are `unknown`
+ * because the recognizer assigns differently-shaped event callbacks to each;
+ * tests invoke them through {@link call}.
+ */
+class FakeRecognition {
+  static last: FakeRecognition | null = null
+
+  continuous = false
+  interimResults = false
+  lang = ""
+  maxAlternatives = 0
+  onend: unknown = null
+  onerror: unknown = null
+  onresult: unknown = null
+  onsoundend: unknown = null
+  onsoundstart: unknown = null
+  onspeechend: unknown = null
+  onspeechstart: unknown = null
+  onstart: unknown = null
+  started = 0
+  stopped = 0
+  aborted = 0
+
+  constructor() {
+    FakeRecognition.last = this
+  }
+
+  start() {
+    this.started += 1
+  }
+
+  stop() {
+    this.stopped += 1
+  }
+
+  abort() {
+    this.aborted += 1
+  }
+}
+
+function fakeConstructor(): SpeechRecognitionConstructor {
+  return FakeRecognition as unknown as SpeechRecognitionConstructor
+}
+
+function lastInstance(): FakeRecognition {
+  const instance = FakeRecognition.last
+  if (!instance) throw new Error("No recognition instance was constructed.")
+  return instance
+}
+
+/** Invokes a handler the recognizer installed, with the event shape it expects. */
+function call<T>(handler: unknown, event: T): void {
+  ;(handler as ((event: T) => void) | null)?.(event)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,7 +93,9 @@
       "@sixb/ui/hooks/*": ["./packages/ui/src/hooks/*.ts", "./packages/ui/src/hooks/*.tsx"],
       "@sixb/ui/hooks/*.ts": ["./packages/ui/src/hooks/*.ts"],
       "@sixb/ui/hooks/*.tsx": ["./packages/ui/src/hooks/*.tsx"],
+      "@sixb/ui/lib/address": ["./packages/ui/src/lib/address/index.ts"],
       "@sixb/ui/lib/shiki": ["./packages/ui/src/lib/shiki.ts"],
+      "@sixb/ui/lib/speech": ["./packages/ui/src/lib/speech/index.ts"],
       "@sixb/ui/lib/utils": ["./packages/ui/src/lib/utils.ts"],
       "@sixb/workflow-worker": ["./packages/workflow-worker/src/index.ts"]
     }


### PR DESCRIPTION
Address lookup and microphone dictation were rebuilt per app. This moves both into `@sixb/ui` so the next project imports them instead.

Both are additive. No existing app changes in this PR.

## Why now

Address lookup existed twice and had drifted apart:

| | `internal` | `eastcoast-inc` |
| --- | --- | --- |
| Region | `"New York"` | `"NY"` (51-entry map) |
| Coordinates | dropped | kept |
| Caching | 60-min TTL | none |
| Attribution | rendered | missing |

Dictation existed once, in eastcoast's quote intake. Neither had keyboard navigation, request coalescing, or a way to swap the backend.

## Layers

Same shape for both, so learning one teaches the other.

| Layer | Import | Address | Speech |
| --- | --- | --- | --- |
| Components | `@sixb/ui/components` | `AddressAutocomplete`, `AddressFields` | `DictationTextarea`, `DictationButton` |
| Hooks | `@sixb/ui/hooks` | `useAddressLookup` | `useSpeechRecognition`, `useDictation` |
| Providers | `@sixb/ui/lib/address`, `@sixb/ui/lib/speech` | `createPhotonProvider` | `createWebSpeechRecognizer` |

Both work with no configuration. Photon and the Web Speech API are free and keyless.

```tsx
<AddressFields value={address} onChange={setAddress} />
<DictationTextarea label="Scope of work" value={scope} onChange={setScope} />
```

## Provider contracts

The point of the seam is that swapping the backend is configuration, not a rewrite.

```tsx
<AddressLookupProvider provider={createPhotonProvider({ endpoint: "https://photon.internal" })}>
```

Two details had to exist up front or adding a provider later would be a breaking change.

**Address — a details call.** Google Places and Mapbox return predictions with no components or coordinates; you need a second request, tied to the first by a billing session token. So `search` is joined by optional `retrieve` and `createSession`, and the hook's `select()` performs the round-trip. Photon needs neither.

```ts
type AddressProvider = {
  search(query, options?): Promise<readonly AddressSuggestion[]>
  retrieve?(suggestion, options?): Promise<AddressSuggestion>   // Google, Mapbox
  reverse?(coordinates, options?): Promise<AddressSuggestion | null>
  createSession?(): string
}
```

**Speech — events, not promises.** A record-then-transcribe backend (MediaRecorder plus a server call) has to fit alongside a streaming one, so the recognizer reports through handlers and emits a single final result if that is all it has.

```ts
type SpeechRecognizer = {
  isSupported(): boolean
  start(options, handlers): SpeechSession   // onStart / onResult / onAudioActivity / onError / onEnd
}
```

Only the free providers are implemented. The contracts are shaped for the others.

## Suggestions keep both spellings

`internal` stores `"New York"`, eastcoast stores `"NY"`. Rather than pick, `AddressSuggestion` carries `region` and `regionCode`, plus `county`, coordinates, and `raw` for app-specific enrichment. Formatters project it onto whatever an app persists, so neither storage shape has to change.

## Fixed along the way

**Suggestion lists were mouse-only.** Both apps rendered a plain `<div>` of buttons. `AddressAutocomplete` implements the combobox pattern — arrow keys, Enter, Escape, `aria-activedescendant` — on Radix `Popover`, so it also positions correctly inside dialogs. The highlight is tracked by suggestion id, not index, so arriving results cannot leave it pointing at a different address.

**Chrome stops listening after a few seconds of silence**, even with `continuous = true`. Dictation died mid-sentence with no error. The hook restarts and accumulates the transcript across restarts, but only after a clean end or `no-speech` — never after a denied microphone — and gives up after three silent restarts.

**No interim results.** Speech only appeared once a phrase finalized. Now on by default.

Also: request coalescing and a TTL cache in the Photon provider, and OpenStreetMap attribution rendered by the component rather than remembered per app.

## Behavior changes when apps migrate

Two dictation defaults differ from eastcoast's current behavior: `interimResults` and `autoRestart` are both on. Neither changes what gets stored, but the migration is not purely mechanical.

Suggestion `label` is now the concise primary line with location in `description`, replacing `internal`'s single long label. The shared component renders both lines.

## Note on Chrome and audio

The Web Speech API streams microphone audio to Google's servers in Chrome. That is inherent to the browser API, not added here, and it is documented in the README and on the recognizer. Any project that cannot send audio off-network is the case for a second recognizer, which the contract accepts.

## Verification

```bash
bun run test        # 3067 pass, 0 fail
bun run typecheck   # includes examples and docs
bun run build
bun run check       # 2000 files
```

41 tests in `packages/ui/tests/` — the first tests in this package. Pure mappers and formatters are covered directly; the Photon provider runs against an injected `fetch` and the recognizer against a fake `SpeechRecognition`, so caching, coalescing, abort handling, and event wiring are all tested without a network or a browser.

No route, schema, or client contract changed, so `generate:client` was not needed.

## Review notes

Not shared on purpose: eastcoast's FCC/Census county enrichment for sales tax (US-tax-specific; `raw` and coordinates keep it possible) and the address value type, since apps store addresses differently.

Two follow-ups, happy to file as issues:

1. Migrate `internal` and `eastcoast-inc` onto this and delete their copies. Until then the repo has three address implementations, not two.
2. Worth eyeballing in a browser: the suggestion dropdown width uses `--radix-popover-trigger-width` with `--radix-popper-anchor-width` as a fallback, because the trigger is a `PopoverAnchor`. If it sizes to content instead of matching the input, that fallback chain is why.

The preview (`bun run ui:dev`) has an **Address Lookup** section and a **Speech Dictation** section with two fields that show mutual exclusion.

This is two independent slices in one PR. Say the word and I will split it.
