### PR TITLE
google: support Application Default Credentials

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
+        "google-auth-library": "^10.9.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -1416,6 +1417,8 @@
 
     "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.14", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.4.1", "libqp": "2.1.1" } }, "sha512-rz0FQOhN3Vq1XrSeSSa9+dPcaFbBxmQPjiZm6zS9oxdVHV7rOWIAYX3yP2YAUf0qBncY8CI+NogzPCmMVrMXcw=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ai": ["ai@7.0.4", "", { "dependencies": { "@ai-sdk/gateway": "4.0.4", "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-mZub080RWRxpWg8OY56KVnI3AoMVniccSWG+dwVb3nH81+GiNMDYBIdP41RLUivLpmU49pB7ssD7tvfIUaSaCA=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
@@ -1444,11 +1447,17 @@
 
     "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.43", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ=="],
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
@@ -1554,6 +1563,8 @@
 
     "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
     "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -1585,6 +1596,8 @@
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
 
@@ -1626,13 +1639,25 @@
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
     "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.3.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
+
+    "google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -1645,6 +1670,8 @@
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
@@ -1702,9 +1729,15 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "libbase64": ["libbase64@1.3.0", "", {}, "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="],
 
@@ -1862,6 +1895,10 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
@@ -2004,6 +2041,8 @@
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -2127,6 +2166,8 @@
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 

--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -20,7 +20,7 @@ export const googleConnector = defineConnector(
   "google",
   google({
     auth: {
-      serviceAccountKey: process.env.GOOGLE_SA_KEY!, // parsed object or its JSON string
+      applicationDefault: true,
       scopes: ["https://www.googleapis.com/auth/drive.readonly"],
     },
   })
@@ -133,7 +133,15 @@ resource shapes — the connector relays them without interpretation.
 
 ## Auth
 
-Two modes (a discriminated union):
+Three explicit modes (a discriminated union):
+
+- **Application Default Credentials (recommended)** — `{ applicationDefault: true, scopes }`.
+  The official `google-auth-library` discovers credentials from the environment and owns token
+  refresh. This supports local ADC created by `gcloud`, `GOOGLE_APPLICATION_CREDENTIALS`
+  (including Workload Identity Federation configurations), and service accounts attached to
+  Google Cloud workloads. Discovery is lazy: constructing the connector does not read credentials
+  or contact a metadata server. Credential-specific request metadata, such as a quota project
+  header, is preserved.
 
 - **Service account** — `{ serviceAccountKey, scopes, subject? }`. The connector mints and
   refreshes OAuth tokens (JWT-bearer, signed with the SA key via Web Crypto). Tokens are cached,
@@ -144,7 +152,32 @@ Two modes (a discriminated union):
   OAuth, a vault, another service) and own scopes + refresh; the connector just calls it.
 
 A missing scope surfaces as Google's `403` (`GoogleApiError`); it does not churn the token. A
-`401` invalidates the cached token and retries once with a fresh one.
+`401` invalidates the cached token and retries once with a fresh one. ADC is never selected
+implicitly, so a process cannot silently pick up a developer's ambient Google identity.
+
+### Application Default Credentials
+
+For local development, create user ADC with the scopes your connector needs:
+
+```bash
+gcloud auth application-default login \
+  --client-id-file=/path/to/oauth-client.json \
+  --scopes=https://www.googleapis.com/auth/drive.readonly
+```
+
+Google APIs outside Google Cloud, including Drive and Calendar, require a custom OAuth client ID
+when adding their scopes to local ADC. The resulting credential contains a refresh token; do not
+copy a short-lived access token into project configuration.
+
+In production on Google Cloud, attach a least-privileged user-managed service account to the
+workload. Outside Google Cloud, point `GOOGLE_APPLICATION_CREDENTIALS` at a Workload Identity
+Federation credential configuration that impersonates the service account used for Workspace
+access. Downloadable service-account keys are supported for compatibility, but should be a last
+resort.
+
+ADC authenticates an identity; it does not grant that identity access to Workspace data. Share the
+target Drive resources with the resolved identity and request the required OAuth scopes. Domain-wide
+delegation through `subject` remains available only in service-account-key mode.
 
 ## Reading Google Meet transcripts via Drive
 

--- a/connectors/google/package.json
+++ b/connectors/google/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@sixb/connector-rest": "workspace:*",
-    "@sixb/core": "workspace:*"
+    "@sixb/core": "workspace:*",
+    "google-auth-library": "^10.9.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/connectors/google/src/auth/application-default.ts
+++ b/connectors/google/src/auth/application-default.ts
@@ -1,0 +1,94 @@
+import { GoogleAuth } from "google-auth-library"
+import { GoogleAuthError } from "../errors"
+import type { TokenSource } from "./types"
+
+export interface ApplicationDefaultClient {
+  readonly credentials: {
+    access_token?: string | null
+    expiry_date?: number | null
+  }
+  getRequestHeaders(): Promise<Headers>
+}
+
+export type ApplicationDefaultClientLoader = (
+  scopes: readonly string[]
+) => Promise<ApplicationDefaultClient>
+
+export function createApplicationDefaultTokenSource(
+  scopes: readonly string[],
+  loadClient: ApplicationDefaultClientLoader = loadApplicationDefaultClient
+): TokenSource {
+  let clientPromise: Promise<ApplicationDefaultClient> | null = null
+  let inflightHeaders: Promise<Headers> | null = null
+  let invalidated = false
+
+  const client = (): Promise<ApplicationDefaultClient> => {
+    clientPromise ??= Promise.resolve()
+      .then(() => loadClient(scopes))
+      .catch((error: unknown) => {
+        clientPromise = null
+        throw wrapAuthError("could not load Application Default Credentials", error)
+      })
+    return clientPromise
+  }
+
+  const resolveHeaders = async (): Promise<Headers> => {
+    const authClient = await client()
+    if (invalidated) {
+      // Preserve refresh credentials while forcing the official client to mint a new access token.
+      authClient.credentials.access_token = null
+      authClient.credentials.expiry_date = 0
+      invalidated = false
+    }
+
+    try {
+      return await authClient.getRequestHeaders()
+    } catch (error) {
+      throw wrapAuthError("could not obtain ADC request headers", error)
+    }
+  }
+
+  const requestHeaders = (): Promise<Headers> => {
+    inflightHeaders ??= resolveHeaders().finally(() => {
+      inflightHeaders = null
+    })
+    return inflightHeaders
+  }
+
+  return {
+    async get() {
+      return extractBearerToken(await requestHeaders())
+    },
+    getRequestHeaders: requestHeaders,
+    invalidate() {
+      invalidated = true
+    },
+  }
+}
+
+function extractBearerToken(headers: Headers): string {
+  const authorization = headers.get("authorization")
+  const match = authorization?.match(/^Bearer\s+(.+)$/i)
+  const token = match?.[1]
+  if (!token?.trim()) {
+    throw new GoogleAuthError(
+      "Application Default Credentials did not return a bearer Authorization header."
+    )
+  }
+  return token
+}
+
+async function loadApplicationDefaultClient(
+  scopes: readonly string[]
+): Promise<ApplicationDefaultClient> {
+  const auth = new GoogleAuth({ scopes: [...scopes] })
+  return auth.getClient()
+}
+
+function wrapAuthError(message: string, cause: unknown): GoogleAuthError {
+  if (cause instanceof GoogleAuthError) {
+    return cause
+  }
+  const detail = cause instanceof Error ? cause.message : String(cause)
+  return new GoogleAuthError(`${message}: ${detail}`, { cause })
+}

--- a/connectors/google/src/auth/index.ts
+++ b/connectors/google/src/auth/index.ts
@@ -1,0 +1,54 @@
+import { GoogleAuthError } from "../errors"
+import {
+  type ApplicationDefaultClientLoader,
+  createApplicationDefaultTokenSource,
+} from "./application-default"
+import {
+  createServiceAccountTokenSource,
+  type ServiceAccountTokenSourceDeps,
+} from "./service-account"
+import type { GoogleAuthOptions, TokenSource } from "./types"
+
+export type { GoogleAuthOptions, ServiceAccountKey, TokenSource } from "./types"
+
+/** Test seams for credential discovery, time, and token exchange. */
+interface TokenSourceDeps extends ServiceAccountTokenSourceDeps {
+  readonly loadApplicationDefaultClient?: ApplicationDefaultClientLoader
+}
+
+export function createTokenSource(
+  auth: GoogleAuthOptions,
+  deps: TokenSourceDeps = {}
+): TokenSource {
+  if ("token" in auth) {
+    return createResolverTokenSource(auth.token)
+  }
+
+  if ("applicationDefault" in auth) {
+    if (auth.applicationDefault !== true) {
+      throw new GoogleAuthError("applicationDefault must be true when ADC auth is selected.")
+    }
+    validateScopes(auth.scopes, "application-default")
+    return createApplicationDefaultTokenSource(auth.scopes, deps.loadApplicationDefaultClient)
+  }
+
+  validateScopes(auth.scopes, "service-account")
+  return createServiceAccountTokenSource(auth.serviceAccountKey, auth.scopes, auth.subject, deps)
+}
+
+function createResolverTokenSource(resolve: () => string | Promise<string>): TokenSource {
+  const get = (): Promise<string> => Promise.resolve(resolve())
+  return {
+    get,
+    async getRequestHeaders() {
+      return new Headers({ Authorization: `Bearer ${await get()}` })
+    },
+    invalidate() {},
+  }
+}
+
+function validateScopes(scopes: readonly string[], mode: string): void {
+  if (scopes.length === 0 || scopes.some((scope) => !scope.trim())) {
+    throw new GoogleAuthError(`at least one non-empty scope is required for ${mode} auth.`)
+  }
+}

--- a/connectors/google/src/auth/service-account.ts
+++ b/connectors/google/src/auth/service-account.ts
@@ -1,4 +1,5 @@
-import { GoogleAuthError, isRecord } from "./errors"
+import { GoogleAuthError, isRecord } from "../errors"
+import type { ServiceAccountKey, TokenSource } from "./types"
 
 const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer"
@@ -8,70 +9,39 @@ const EXPIRY_MARGIN_MS = 60_000
 /** Attempts for the token exchange itself (network / 429 / 5xx), independent of API retries. */
 const EXCHANGE_MAX_ATTEMPTS = 3
 
-/** A Google service-account key, as found in the JSON key file. */
-export interface ServiceAccountKey {
-  readonly client_email: string
-  /** PEM-encoded PKCS#8 private key (`-----BEGIN PRIVATE KEY-----`). */
-  readonly private_key: string
-  /** Token endpoint override; defaults to Google's global endpoint. */
-  readonly token_uri?: string
-}
-
-export type GoogleAuthOptions =
-  | {
-      /** Service-account key (parsed object or its JSON string). Connector mints tokens. */
-      readonly serviceAccountKey: string | ServiceAccountKey
-      /** OAuth scopes to request; the union across every surface you call. */
-      readonly scopes: readonly string[]
-      /** Impersonate ONE fixed user (domain-wide delegation). See the package README. */
-      readonly subject?: string
-    }
-  | {
-      /** Caller mints tokens elsewhere and owns scopes + refresh. */
-      readonly token: () => string | Promise<string>
-    }
-
-export interface TokenSource {
-  /** Cached, single-flight, refreshed on an expiry margin. */
-  get(): Promise<string>
-  /** Drop the cached token; called by the REST adapter's `onUnauthorized` on a 401. */
-  invalidate(): void
-}
-
-/** Test seams: injectable clock and token-exchange. Not part of the public surface. */
-export interface TokenSourceDeps {
-  readonly now?: () => number
-  readonly exchange?: (nowMs: number) => Promise<TokenExchangeResult>
-}
-
 interface TokenExchangeResult {
   readonly accessToken: string
   readonly expiresInSec: number
 }
 
-export function createTokenSource(
-  auth: GoogleAuthOptions,
-  deps: TokenSourceDeps = {}
+export interface ServiceAccountTokenSourceDeps {
+  readonly now?: () => number
+  readonly exchange?: (nowMs: number) => Promise<TokenExchangeResult>
+}
+
+export function createServiceAccountTokenSource(
+  keyInput: string | ServiceAccountKey,
+  scopes: readonly string[],
+  subject: string | undefined,
+  deps: ServiceAccountTokenSourceDeps = {}
 ): TokenSource {
-  if ("token" in auth) {
-    return {
-      get: () => Promise.resolve(auth.token()),
-      invalidate() {},
-    }
-  }
-
-  const key = normalizeKey(auth.serviceAccountKey)
-  const scopes = auth.scopes
-  if (scopes.length === 0) {
-    throw new GoogleAuthError("at least one scope is required for service-account auth.")
-  }
-
+  const key = normalizeKey(keyInput)
   const now = deps.now ?? (() => Date.now())
-  const exchange =
-    deps.exchange ?? ((nowMs: number) => exchangeToken(key, scopes, auth.subject, nowMs))
+  const exchange = deps.exchange ?? ((nowMs: number) => exchangeToken(key, scopes, subject, nowMs))
 
   let cached: { token: string; expEpochMs: number } | null = null
   let inflight: Promise<string> | null = null
+
+  const get = (): Promise<string> => {
+    if (cached && cached.expEpochMs - EXPIRY_MARGIN_MS > now()) {
+      return Promise.resolve(cached.token)
+    }
+    // Coalesce concurrent refreshes: N callers with an expired token trigger ONE exchange.
+    inflight ??= refresh().finally(() => {
+      inflight = null
+    })
+    return inflight
+  }
 
   const refresh = async (): Promise<string> => {
     const { accessToken, expiresInSec } = await exchange(now())
@@ -80,15 +50,9 @@ export function createTokenSource(
   }
 
   return {
-    get() {
-      if (cached && cached.expEpochMs - EXPIRY_MARGIN_MS > now()) {
-        return Promise.resolve(cached.token)
-      }
-      // Coalesce concurrent refreshes: N callers with an expired token trigger ONE exchange.
-      inflight ??= refresh().finally(() => {
-        inflight = null
-      })
-      return inflight
+    get,
+    async getRequestHeaders() {
+      return new Headers({ Authorization: `Bearer ${await get()}` })
     },
     invalidate() {
       cached = null

--- a/connectors/google/src/auth/types.ts
+++ b/connectors/google/src/auth/types.ts
@@ -1,0 +1,37 @@
+/** A Google service-account key, as found in the JSON key file. */
+export interface ServiceAccountKey {
+  readonly client_email: string
+  /** PEM-encoded PKCS#8 private key (`-----BEGIN PRIVATE KEY-----`). */
+  readonly private_key: string
+  /** Token endpoint override; defaults to Google's global endpoint. */
+  readonly token_uri?: string
+}
+
+export type GoogleAuthOptions =
+  | {
+      /** Discover credentials from the runtime environment through Google's ADC strategy. */
+      readonly applicationDefault: true
+      /** OAuth scopes to request; the union across every surface you call. */
+      readonly scopes: readonly string[]
+    }
+  | {
+      /** Service-account key (parsed object or its JSON string). Connector mints tokens. */
+      readonly serviceAccountKey: string | ServiceAccountKey
+      /** OAuth scopes to request; the union across every surface you call. */
+      readonly scopes: readonly string[]
+      /** Impersonate ONE fixed user (domain-wide delegation). See the package README. */
+      readonly subject?: string
+    }
+  | {
+      /** Caller mints tokens elsewhere and owns scopes + refresh. */
+      readonly token: () => string | Promise<string>
+    }
+
+export interface TokenSource {
+  /** Resolve a bearer access token, refreshing it when the auth mode supports refresh. */
+  get(): Promise<string>
+  /** Resolve every required auth header. Optional for compatibility with custom token sources. */
+  getRequestHeaders?(): Promise<Headers>
+  /** Invalidate the current token; called by the REST adapter's auth retry on a 401. */
+  invalidate(): void
+}

--- a/connectors/google/src/errors.ts
+++ b/connectors/google/src/errors.ts
@@ -14,12 +14,12 @@ export class GoogleApiError extends Error {
   }
 }
 
-/** Raised when minting or exchanging a service-account token fails. */
+/** Raised when resolving or refreshing Google authentication credentials fails. */
 export class GoogleAuthError extends Error {
   readonly name = "GoogleAuthError"
 
-  constructor(message: string) {
-    super(`[SixbGoogle] ${message}`)
+  constructor(message: string, options?: ErrorOptions) {
+    super(`[SixbGoogle] ${message}`, options)
   }
 }
 

--- a/connectors/google/src/google.ts
+++ b/connectors/google/src/google.ts
@@ -29,7 +29,9 @@ export function google(options: GoogleConnectorOptions): GoogleConnector {
   const token = createTokenSource(options.auth)
 
   const common = {
-    headers: async () => ({ Authorization: `Bearer ${await token.get()}` }),
+    headers: () =>
+      token.getRequestHeaders?.() ??
+      token.get().then((accessToken) => new Headers({ Authorization: `Bearer ${accessToken}` })),
     // The REST adapter fires this on a 401 only, so a stale token is dropped and
     // the request is retried once with a fresh one. 403 (scope) does not churn it.
     onUnauthorized: () => token.invalidate(),

--- a/connectors/google/tests/auth.test.ts
+++ b/connectors/google/tests/auth.test.ts
@@ -16,9 +16,181 @@ describe("createTokenSource — resolver mode", () => {
   test("delegates to the caller's token function", async () => {
     const source = createTokenSource({ token: () => "caller-token" })
     expect(await source.get()).toBe("caller-token")
+    expect((await source.getRequestHeaders?.())?.get("authorization")).toBe("Bearer caller-token")
     // invalidate is a no-op for resolver mode
     source.invalidate()
     expect(await source.get()).toBe("caller-token")
+  })
+})
+
+describe("createTokenSource — Application Default Credentials mode", () => {
+  test("validates scopes before attempting credential discovery", () => {
+    expect(() => createTokenSource({ applicationDefault: true, scopes: [] })).toThrow(
+      /non-empty scope/
+    )
+    expect(() => createTokenSource({ applicationDefault: true, scopes: ["   "] })).toThrow(
+      /non-empty scope/
+    )
+  })
+
+  test("discovers credentials lazily and single-flights concurrent token requests", async () => {
+    let loads = 0
+    let headerRequests = 0
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const credentials = { access_token: "adc-token", expiry_date: Date.now() + 3600_000 }
+    const source = createTokenSource(
+      { applicationDefault: true, scopes: ["scope-a", "scope-b"] },
+      {
+        loadApplicationDefaultClient: async (scopes) => {
+          loads++
+          expect(scopes).toEqual(["scope-a", "scope-b"])
+          await gate
+          return {
+            credentials,
+            async getRequestHeaders() {
+              headerRequests++
+              return new Headers({
+                Authorization: `Bearer ${credentials.access_token}`,
+                "x-goog-user-project": "quota-project",
+              })
+            },
+          }
+        },
+      }
+    )
+
+    expect(loads).toBe(0)
+    const tokens = Promise.all([source.get(), source.get(), source.get()])
+    await Promise.resolve()
+    expect(loads).toBe(1)
+    release()
+
+    expect(await tokens).toEqual(["adc-token", "adc-token", "adc-token"])
+    expect(loads).toBe(1)
+    expect(headerRequests).toBe(1)
+
+    const headers = await source.getRequestHeaders?.()
+    expect(headers?.get("authorization")).toBe("Bearer adc-token")
+    expect(headers?.get("x-goog-user-project")).toBe("quota-project")
+    expect(loads).toBe(1)
+    expect(headerRequests).toBe(2)
+  })
+
+  test("invalidates only the access token and refreshes it on the next request", async () => {
+    let refreshes = 0
+    const credentials = {
+      access_token: null as string | null,
+      expiry_date: null as number | null,
+      refresh_token: "preserve-me",
+    }
+    const source = createTokenSource(
+      { applicationDefault: true, scopes: ["scope"] },
+      {
+        loadApplicationDefaultClient: async () => ({
+          credentials,
+          async getRequestHeaders() {
+            if (!credentials.access_token) {
+              refreshes++
+              credentials.access_token = `adc-token-${refreshes}`
+              credentials.expiry_date = Date.now() + 3600_000
+            }
+            return new Headers({ Authorization: `Bearer ${credentials.access_token}` })
+          },
+        }),
+      }
+    )
+
+    expect(await source.get()).toBe("adc-token-1")
+    expect(await source.get()).toBe("adc-token-1")
+    expect(refreshes).toBe(1)
+
+    source.invalidate()
+    expect(await source.get()).toBe("adc-token-2")
+    expect(refreshes).toBe(2)
+    expect(credentials.refresh_token).toBe("preserve-me")
+  })
+
+  test("retries discovery after a failure and preserves the original cause", async () => {
+    const discoveryError = new Error("ADC is not configured")
+    let attempts = 0
+    const source = createTokenSource(
+      { applicationDefault: true, scopes: ["scope"] },
+      {
+        loadApplicationDefaultClient: () => {
+          attempts++
+          if (attempts === 1) {
+            throw discoveryError
+          }
+          return Promise.resolve({
+            credentials: {},
+            getRequestHeaders: async () => new Headers({ Authorization: "Bearer recovered" }),
+          })
+        },
+      }
+    )
+
+    try {
+      await source.get()
+      throw new Error("expected ADC discovery to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(GoogleAuthError)
+      expect((error as GoogleAuthError).message).toContain(
+        "could not load Application Default Credentials"
+      )
+      expect((error as GoogleAuthError).cause).toBe(discoveryError)
+    }
+
+    expect(await source.get()).toBe("recovered")
+    expect(attempts).toBe(2)
+  })
+
+  test("wraps token refresh failures and allows the next request to retry", async () => {
+    const refreshError = new Error("refresh unavailable")
+    let refreshes = 0
+    const source = createTokenSource(
+      { applicationDefault: true, scopes: ["scope"] },
+      {
+        loadApplicationDefaultClient: async () => ({
+          credentials: {},
+          async getRequestHeaders() {
+            refreshes++
+            if (refreshes === 1) {
+              throw refreshError
+            }
+            return new Headers({ Authorization: "Bearer refreshed" })
+          },
+        }),
+      }
+    )
+
+    try {
+      await source.get()
+      throw new Error("expected ADC token refresh to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(GoogleAuthError)
+      expect((error as GoogleAuthError).message).toContain("could not obtain ADC request headers")
+      expect((error as GoogleAuthError).cause).toBe(refreshError)
+    }
+
+    expect(await source.get()).toBe("refreshed")
+    expect(refreshes).toBe(2)
+  })
+
+  test("rejects missing bearer authorization headers", async () => {
+    const source = createTokenSource(
+      { applicationDefault: true, scopes: ["scope"] },
+      {
+        loadApplicationDefaultClient: async () => ({
+          credentials: {},
+          getRequestHeaders: async () => new Headers(),
+        }),
+      }
+    )
+
+    await expect(source.get()).rejects.toThrow(/bearer Authorization header/)
   })
 })
 

--- a/connectors/google/tests/calendar.e2e.ts
+++ b/connectors/google/tests/calendar.e2e.ts
@@ -1,23 +1,28 @@
 /**
  * End-to-end smoke test against the real Google Calendar API.
  *
- * Not part of `bun test` (it needs live credentials). Two ways to authenticate:
+ * Not part of `bun test` (it needs live credentials). Three ways to authenticate:
  *
- * A) Keyless (recommended) — mint a short-lived token via SA impersonation, no
- *    key, no org-policy change. Read-only scope is enough for the default run:
+ * A) Application Default Credentials (recommended). For local Calendar scopes, first run
+ *    `gcloud auth application-default login` with a custom OAuth client and `--scopes`:
+ *
+ *      GOOGLE_ADC=1 bun connectors/google/tests/calendar.e2e.ts
+ *
+ * B) Pre-minted short-lived token via SA impersonation. Read-only scope is enough for the
+ *    default run:
  *
  *      GOOGLE_ACCESS_TOKEN="$(gcloud auth print-access-token \
  *        --impersonate-service-account=SA@PROJECT.iam.gserviceaccount.com \
  *        --scopes=https://www.googleapis.com/auth/calendar.readonly)" \
  *      bun connectors/google/tests/calendar.e2e.ts
  *
- * B) Service-account key (if key creation is allowed):
+ * C) Service-account key (if key creation is allowed):
  *
  *      GOOGLE_SA_KEY="$(cat service-account.json)" \
  *      GOOGLE_SCOPE="https://www.googleapis.com/auth/calendar.readonly" \
  *      bun connectors/google/tests/calendar.e2e.ts
  *
- *    Optional (mode B): GOOGLE_SUBJECT="user@customer.com" to impersonate one user (DWD).
+ *    Optional (mode C): GOOGLE_SUBJECT="user@customer.com" to impersonate one user (DWD).
  *
  * Optional env for either mode:
  *   - GOOGLE_CALENDAR_ID   a calendar to read events / free-busy from (default: "primary")
@@ -35,26 +40,30 @@ import type { GoogleAuthOptions } from "../src/index"
 
 const accessToken = process.env.GOOGLE_ACCESS_TOKEN
 const key = process.env.GOOGLE_SA_KEY
+const useApplicationDefault = process.env.GOOGLE_ADC === "1"
 const scope = process.env.GOOGLE_SCOPE ?? "https://www.googleapis.com/auth/calendar.readonly"
 const subject = process.env.GOOGLE_SUBJECT
 const calendarId = process.env.GOOGLE_CALENDAR_ID ?? "primary"
 const runWrite = process.env.GOOGLE_CALENDAR_WRITE === "1"
 
-if (!accessToken && !key) {
+if (!useApplicationDefault && !accessToken && !key) {
   console.error(
     "Missing env. Set one of:\n" +
-      "  - GOOGLE_ACCESS_TOKEN  (keyless, recommended)\n" +
+      "  - GOOGLE_ADC=1         (Application Default Credentials, recommended)\n" +
+      "  - GOOGLE_ACCESS_TOKEN  (pre-minted short-lived token)\n" +
       "  - GOOGLE_SA_KEY        (service-account JSON)\n" +
       "See the header of this file for full commands."
   )
   process.exit(1)
 }
 
-const auth: GoogleAuthOptions = accessToken
-  ? { token: () => accessToken }
-  : subject
-    ? { serviceAccountKey: key as string, scopes: [scope], subject }
-    : { serviceAccountKey: key as string, scopes: [scope] }
+const auth: GoogleAuthOptions = useApplicationDefault
+  ? { applicationDefault: true, scopes: [scope] }
+  : accessToken
+    ? { token: () => accessToken }
+    : subject
+      ? { serviceAccountKey: key as string, scopes: [scope], subject }
+      : { serviceAccountKey: key as string, scopes: [scope] }
 
 const client = await google({ auth }).connect({
   projectId: "e2e",

--- a/connectors/google/tests/drive.e2e.ts
+++ b/connectors/google/tests/drive.e2e.ts
@@ -1,10 +1,16 @@
 /**
  * End-to-end smoke test against the real Google Drive API.
  *
- * Not part of `bun test` (it needs live credentials). Two ways to authenticate:
+ * Not part of `bun test` (it needs live credentials). Three ways to authenticate:
  *
- * A) Keyless (recommended) — mint a short-lived token via SA impersonation, no
- *    key, no org-policy change:
+ * A) Application Default Credentials (recommended). For local Drive scopes, first run
+ *    `gcloud auth application-default login` with a custom OAuth client and `--scopes`:
+ *
+ *      GOOGLE_ADC=1 \
+ *      GOOGLE_TEST_FOLDER_ID="1AbC...xyz" \
+ *      bun connectors/google/tests/drive.e2e.ts
+ *
+ * B) Pre-minted short-lived token via SA impersonation:
  *
  *      GOOGLE_ACCESS_TOKEN="$(gcloud auth print-access-token \
  *        --impersonate-service-account=SA@PROJECT.iam.gserviceaccount.com \
@@ -12,14 +18,14 @@
  *      GOOGLE_TEST_FOLDER_ID="1AbC...xyz" \
  *      bun connectors/google/tests/drive.e2e.ts
  *
- * B) Service-account key (if key creation is allowed):
+ * C) Service-account key (if key creation is allowed):
  *
  *      GOOGLE_SA_KEY="$(cat service-account.json)" \
  *      GOOGLE_TEST_FOLDER_ID="1AbC...xyz" \
  *      GOOGLE_SCOPE="https://www.googleapis.com/auth/drive.readonly" \
  *      bun connectors/google/tests/drive.e2e.ts
  *
- *    Optional (mode B): GOOGLE_SUBJECT="user@customer.com" to impersonate one user (DWD).
+ *    Optional (mode C): GOOGLE_SUBJECT="user@customer.com" to impersonate one user (DWD).
  *
  * Write pass (opt-in): set GOOGLE_E2E_WRITE=1 and a write-capable scope
  * (GOOGLE_SCOPE="https://www.googleapis.com/auth/drive.file" is enough — the
@@ -31,25 +37,29 @@ import type { GoogleAuthOptions } from "../src/index"
 
 const accessToken = process.env.GOOGLE_ACCESS_TOKEN
 const key = process.env.GOOGLE_SA_KEY
+const useApplicationDefault = process.env.GOOGLE_ADC === "1"
 const folderId = process.env.GOOGLE_TEST_FOLDER_ID
 const scope = process.env.GOOGLE_SCOPE ?? "https://www.googleapis.com/auth/drive.readonly"
 const subject = process.env.GOOGLE_SUBJECT
 
-if (!folderId || (!accessToken && !key)) {
+if (!folderId || (!useApplicationDefault && !accessToken && !key)) {
   console.error(
     "Missing env. Set GOOGLE_TEST_FOLDER_ID plus one of:\n" +
-      "  - GOOGLE_ACCESS_TOKEN  (keyless, recommended)\n" +
+      "  - GOOGLE_ADC=1         (Application Default Credentials, recommended)\n" +
+      "  - GOOGLE_ACCESS_TOKEN  (pre-minted short-lived token)\n" +
       "  - GOOGLE_SA_KEY        (service-account JSON)\n" +
       "See the header of this file for full commands."
   )
   process.exit(1)
 }
 
-const auth: GoogleAuthOptions = accessToken
-  ? { token: () => accessToken }
-  : subject
-    ? { serviceAccountKey: key as string, scopes: [scope], subject }
-    : { serviceAccountKey: key as string, scopes: [scope] }
+const auth: GoogleAuthOptions = useApplicationDefault
+  ? { applicationDefault: true, scopes: [scope] }
+  : accessToken
+    ? { token: () => accessToken }
+    : subject
+      ? { serviceAccountKey: key as string, scopes: [scope], subject }
+      : { serviceAccountKey: key as string, scopes: [scope] }
 
 const connector = google({ auth })
 


### PR DESCRIPTION
## Pourquoi

Permettre au connecteur Google de s’authentifier sans clé de service account JSON, notamment lorsque leur création est bloquée par une Organization Policy.

## Changement

```diff
 auth: {
-  serviceAccountKey: process.env.GOOGLE_SERVICE_ACCOUNT_KEY!,
+  applicationDefault: true,
   scopes: ["https://www.googleapis.com/auth/drive.readonly"],
 }
```

- utilise `google-auth-library` pour découvrir et rafraîchir les ADC ;
- conserve les headers associés aux credentials et renouvelle le token après un `401` ;
- préserve les modes existants par clé de service account et token personnalisé ;
- regroupe les implémentations dans `src/auth/`.

## Validation

- 75 tests du connecteur
- `bun run typecheck`
- `bun run check`
- `bun run test:publish`