### PR TITLE
workflows: emit waiting lifecycle events for agent nodes

### DIFF
--- a/packages/core/src/events/types/workflows.ts
+++ b/packages/core/src/events/types/workflows.ts
@@ -63,7 +63,7 @@ export interface WorkflowRunNodeWaitingEvent extends EventEnvelope {
     nodeRunId: string
     nodeIndex: number
     totalNodes: number
-    nodeType: "intervention"
+    nodeType: "intervention" | "agent"
     nodeId: string
     nodeKey: string
     waitingAt: string

--- a/packages/workflow-worker/src/events.ts
+++ b/packages/workflow-worker/src/events.ts
@@ -77,9 +77,9 @@ export class EventsRuntimeWorkflowRunObserver implements WorkflowRunObserver {
     node: WorkflowNodeRunRecord,
     context: WorkflowNodeLifecycleContext & WorkflowWaitingLifecycleContext
   ): Promise<void> {
-    if (node.nodeType !== "intervention") {
+    if (node.nodeType !== "intervention" && node.nodeType !== "agent") {
       throw new Error(
-        `[SixbWorkflowWorker] Workflow node run '${node.id}' is waiting, but is not an intervention node.`
+        `[SixbWorkflowWorker] Workflow node run '${node.id}' is waiting, but is not a waitable node.`
       )
     }
 

--- a/packages/workflow-worker/src/recorder.ts
+++ b/packages/workflow-worker/src/recorder.ts
@@ -157,6 +157,8 @@ export class WorkflowRunRecorder {
         ...this.nodeContext(),
         waitingAt: params.waitingAt,
       })
+    })
+    await this.notify(async () => {
       await this.dependencies.observer.onRunWaiting?.(params.run, {
         waitingAt: params.waitingAt,
       })

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -760,6 +760,7 @@ describe("runWorkflowJob", () => {
           transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
         },
       },
+      observer: new EventsRuntimeWorkflowRunObserver(sixb.events),
     })
 
     expect(waiting.status).toBe("waiting")
@@ -773,6 +774,19 @@ describe("runWorkflowJob", () => {
       agentId: invoiceResolverAgent.id,
       status: "queued",
       prompt: "Resolve transaction 'txn_1'.",
+    })
+    const waitingEvents = await sixb.events.read({ topics: ["workflows"] })
+    expect(waitingEvents.map((event) => event.type)).toEqual([
+      "workflow.run.started",
+      "workflow.run.node.started",
+      "workflow.run.node.waiting",
+      "workflow.run.waiting",
+    ])
+    expect(waitingEvents[2]?.payload).toMatchObject({
+      workflowId: workflow.id,
+      runId: waiting.id,
+      nodeRunId: node!.id,
+      nodeType: "agent",
     })
     const [queuedAgentJob] = await sixb.queues.agents.claim({
       projectId: sixb.id,
@@ -822,6 +836,47 @@ describe("runWorkflowJob", () => {
     })
     expect(resumed.status).toBe("succeeded")
     expect(resumed.steps.resolveInvoiceWithAgent).toEqual(output)
+  })
+
+  test("notifies run waiting when a parked node notification fails", async () => {
+    const workflow = defineWorkflow("agent-waiting-observer-fails")
+      .input({ transaction: ref(Transaction) })
+      .then(resolveInvoiceWithAgent)
+    const sixb = createSixb({ workflows: [workflow], agents: [invoiceResolverAgent] })
+    let runWaitingNotified = false
+    const observer: WorkflowRunObserver = {
+      onRunStarted: async () => undefined,
+      onNodeStarted: async () => undefined,
+      async onNodeWaiting() {
+        throw new Error("node waiting observer failed")
+      },
+      async onRunWaiting() {
+        runWaitingNotified = true
+      },
+      onNodeFinished: async () => undefined,
+      onRunFinished: async () => undefined,
+    }
+
+    const originalConsoleError = console.error
+    console.error = () => undefined
+    try {
+      const result = await runWorkflowJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "wfrun_agent_waiting_observer_fails",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+        observer,
+      })
+
+      expect(result.status).toBe("waiting")
+      expect(runWaitingNotified).toBe(true)
+    } finally {
+      console.error = originalConsoleError
+    }
   })
 
   test("resumes submitted interventions and continues workflow dataflow", async () => {


### PR DESCRIPTION
## Summary

- allow agent nodes in `workflow.run.node.waiting` lifecycle events
- emit `workflow.run.waiting` independently when node lifecycle notification fails
- cover agent parking and observer failure with regression tests

## Root cause

Structured agent steps park their workflow node and run while the agent worker executes. The waiting event contract and observer still restricted `workflow.run.node.waiting` to intervention nodes. That observer error was swallowed as intended, but both waiting notifications shared one callback, so it also prevented `workflow.run.waiting` from being emitted.

## Impact

Agent workflows now emit the same coherent waiting lifecycle as intervention workflows without allowing observer failures to interrupt workflow execution.

## Validation

- `bun test packages/workflow-worker/tests/run-workflow-job.test.ts`
- `bun test packages/core/tests/workflow-events.test.ts packages/workflow-worker/tests/worker.test.ts`
- `bun run generate:client`
- `bun run check`
- `bun run typecheck`