### PR TITLE
syncs: persist checkpoints for empty appends

### DIFF
--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -136,6 +136,11 @@ export const syncErpInvoiceEvents = defineSync("sync-erp-invoice-events", { mode
 
 Without `.checkpoint<T>()`, `context.checkpoint` is `undefined` and there is no `setCheckpoint`.
 
+An append run that returns no rows still succeeds and stores its next checkpoint. If the dataset has
+never received a row, that run does not create a dataset version, so dataset-updated schedules do
+not fire. This lets incremental readers advance an initial cursor without inventing placeholder
+rows.
+
 ## Read context
 
 The read handler signature is `(client, context)`.

--- a/packages/core/src/storage/sync-runs/in-memory.ts
+++ b/packages/core/src/storage/sync-runs/in-memory.ts
@@ -84,10 +84,17 @@ export class InMemorySyncRunStorage implements SyncRunStorage {
       )
     }
 
-    if (input.status === "succeeded" && input.output.datasetId !== existing.datasetId) {
-      throw new SyncRunError(
-        `[Sixb] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.datasetId}'.`
-      )
+    if (input.status === "succeeded") {
+      if (input.output && input.output.datasetId !== existing.datasetId) {
+        throw new SyncRunError(
+          `[Sixb] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.datasetId}'.`
+        )
+      }
+      if (!input.output && (existing.mode !== "append" || input.rowsRead !== 0)) {
+        throw new SyncRunError(
+          `[Sixb] Sync run '${input.id}' may omit its output only for an empty append.`
+        )
+      }
     }
 
     const base: SyncRunRecord = {
@@ -101,7 +108,7 @@ export class InMemorySyncRunStorage implements SyncRunStorage {
         ? {
             ...base,
             rowsRead: input.rowsRead,
-            output: structuredClone(input.output),
+            output: input.output ? structuredClone(input.output) : undefined,
             error: undefined,
             checkpoint: normalizeCheckpoint(input.checkpoint),
           }

--- a/packages/core/src/storage/sync-runs/types.ts
+++ b/packages/core/src/storage/sync-runs/types.ts
@@ -43,7 +43,8 @@ export type FinishSyncRunInput =
       readonly status: "succeeded"
       readonly finishedAt?: Date
       readonly rowsRead: number
-      readonly output: DatasetVersionRef
+      /** Absent only when the first append run succeeds without producing any rows. */
+      readonly output?: DatasetVersionRef
       readonly checkpoint?: JsonValue
     }
   | {

--- a/packages/core/tests/sync-runs.test.ts
+++ b/packages/core/tests/sync-runs.test.ts
@@ -70,6 +70,32 @@ describe("InMemorySyncRunStorage", () => {
     })
   })
 
+  test("stores a checkpoint for a successful empty append without an output version", async () => {
+    const storage = new InMemorySyncRunStorage()
+    await storage.start({
+      id: "syncrun_empty",
+      projectId: "my-app",
+      syncId: "sync-events",
+      datasetId: "raw.erp.events",
+      mode: "append",
+    })
+
+    const finished = await storage.finish({
+      id: "syncrun_empty",
+      projectId: "my-app",
+      status: "succeeded",
+      rowsRead: 0,
+      checkpoint: { cursor: "cursor-1" },
+    })
+
+    expect(finished).toMatchObject({
+      status: "succeeded",
+      rowsRead: 0,
+      checkpoint: { cursor: "cursor-1" },
+    })
+    expect(finished.output).toBeUndefined()
+  })
+
   test("rejects duplicate starts and missing finishes", async () => {
     const storage = new InMemorySyncRunStorage()
 

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -242,6 +242,34 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
 
     throwIfAborted(signal)
 
+    if (sync.config.mode === "append" && rowsRead === 0) {
+      await write.abort()
+      write = undefined
+      const version = await lakeStorage.getLatestVersion(dataset.id)
+      const finishedRun = await syncRunsStorage.finish({
+        projectId: runtime.id,
+        id: job.id,
+        status: "succeeded",
+        rowsRead,
+        ...(version
+          ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
+          : {}),
+        checkpoint: nextCheckpoint,
+      })
+
+      return {
+        id: job.id,
+        syncId: sync.id,
+        datasetId: dataset.id,
+        mode: sync.config.mode,
+        startedAt: startedRun.startedAt,
+        finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
+        rowsRead,
+        ...(version ? { version } : {}),
+        versionCreated: false,
+      }
+    }
+
     const commit = await write.commit({
       expectedLatestVersionId: job.expectedLatestVersionId,
       commitMessage: job.commitMessage ?? `sync ${sync.id} run ${job.id}`,

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -45,7 +45,7 @@ export type SyncRunStartedHandler = (run: SyncRunRecord) => Promise<void> | void
 
 export type SyncRunFailedHandler = (error: unknown, run: SyncRunRecord) => void
 
-export interface SyncRunResult {
+interface SyncRunResultBase {
   readonly id: string
   readonly syncId: string
   readonly datasetId: string
@@ -53,7 +53,18 @@ export interface SyncRunResult {
   readonly startedAt: Date
   readonly finishedAt: Date
   readonly rowsRead: number
-  readonly version: DatasetVersion
-  /** True only when this run created the returned dataset version. */
-  readonly versionCreated: boolean
 }
+
+export type SyncRunResult = SyncRunResultBase &
+  (
+    | {
+        readonly version: DatasetVersion
+        /** True only when this run created the returned dataset version. */
+        readonly versionCreated: boolean
+      }
+    | {
+        /** A first empty append has no dataset version yet. */
+        readonly version?: undefined
+        readonly versionCreated: false
+      }
+  )

--- a/packages/sync-worker/src/worker.ts
+++ b/packages/sync-worker/src/worker.ts
@@ -163,7 +163,7 @@ async function emitSyncSucceededEvents(
             runId: job.id,
             status: "succeeded",
             datasetId: result.datasetId,
-            versionId: result.version.versionId,
+            ...(result.version ? { versionId: result.version.versionId } : {}),
           },
         },
       ],

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -192,7 +192,7 @@ describe("runSyncJob", () => {
     expect(seenContext?.syncId).toBe("sync-orders")
     expect(seenContext?.signal).toBeInstanceOf(AbortSignal)
     expect(result.rowsRead).toBe(2)
-    expect(result.version.producer).toEqual({
+    expect(result.version!.producer).toEqual({
       kind: "sync",
       id: "sync-orders",
       runId: "run_1",
@@ -212,7 +212,7 @@ describe("runSyncJob", () => {
       rowsRead: 2,
       output: {
         datasetId: "raw.erp.orders",
-        versionId: result.version.versionId,
+        versionId: result.version!.versionId,
       },
     })
 
@@ -329,6 +329,38 @@ describe("runSyncJob", () => {
     })
     expect(seenCheckpoint).toEqual({ cursor: "cursor-1" })
     expect(run?.checkpoint).toEqual({ cursor: "cursor-2" })
+  })
+
+  test("succeeds and advances the checkpoint for a first empty append", async () => {
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    const sync = defineSync("sync-orders", { mode: "append" })
+      .checkpoint<{ cursor: string }>()
+      .from(erpDb)
+      .read((_client, context) => {
+        context.setCheckpoint({ cursor: "cursor-1" })
+        return []
+      })
+      .intoDataset(rawOrdersDataset)
+    const runtime = createRuntime({ sync, syncRunsStorage })
+
+    const result = await runSyncJob({
+      runtime,
+      job: { id: "run_empty", syncId: "sync-orders" },
+    })
+
+    expect(result).toMatchObject({
+      rowsRead: 0,
+      versionCreated: false,
+    })
+    expect(result.version).toBeUndefined()
+    expect(await runtime.lakeStorage.getLatestVersion(rawOrdersDataset.id)).toBeNull()
+    expect(
+      await syncRunsStorage.getById({ projectId: "project-1", id: "run_empty" })
+    ).toMatchObject({
+      status: "succeeded",
+      rowsRead: 0,
+      checkpoint: { cursor: "cursor-1" },
+    })
   })
 
   test("does not advance checkpoints from failed runs", async () => {
@@ -732,7 +764,7 @@ describe("runSyncJob", () => {
       rowsRead: 1,
       output: {
         datasetId: "raw.docs",
-        versionId: result.version.versionId,
+        versionId: result.version!.versionId,
       },
     })
   })
@@ -806,8 +838,8 @@ describe("runSyncJob", () => {
     })
 
     expect(result.rowsRead).toBe(2)
-    expect(result.version.rowCount).toBe(3)
-    expect(result.version.parentVersionId).toBe(initialVersion.versionId)
+    expect(result.version!.rowCount).toBe(3)
+    expect(result.version!.parentVersionId).toBe(initialVersion.versionId)
   })
 
   test("surfaces bookkeeping failures after the lake commit clearly", async () => {
@@ -895,7 +927,7 @@ describe("runSyncJob", () => {
     })
 
     const rows = await collectRows(lakeStorage.readRows({ datasetId: "raw.erp.orders" }))
-    expect(result.version.rowCount).toBe(2)
+    expect(result.version!.rowCount).toBe(2)
     expect(rows).toEqual([
       { orderId: "ord_1", customerName: "Ada" },
       { orderId: "ord_2", customerName: "Grace" },
@@ -949,7 +981,7 @@ describe("runSyncJob", () => {
     const rows = await collectRows(lakeStorage.readRows({ datasetId: "raw.erp.orders" }))
 
     expect(result.rowsRead).toBe(3)
-    expect(result.version.rowCount).toBe(3)
+    expect(result.version!.rowCount).toBe(3)
     expect(rows).toEqual(expectedRows)
   })
 })

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -510,6 +510,51 @@ describe("SyncWorker", () => {
     })
   })
 
+  test("finishes a first empty append without emitting a dataset version", async () => {
+    const dataset = defineDataset("raw.erp.orders", { schema: [col("orderId", "string")] })
+    const sync = defineSync("sync-orders", { mode: "append" })
+      .checkpoint<{ cursor: string }>()
+      .from(erpDb)
+      .read((_client, context) => {
+        context.setCheckpoint({ cursor: "cursor-1" })
+        return []
+      })
+      .intoDataset(dataset)
+    const sixb = createSixbForSync(sync)
+    const worker = new SyncWorker(sixb)
+
+    await sixb.queues.syncRuns.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "sync.run.requested",
+          payload: { syncId: sync.id, runId: "run-first-empty" },
+        },
+      ],
+    })
+
+    await worker.start()
+    const run = await waitFor(
+      () => sixb.storage.syncRuns!.getById({ projectId: sixb.id, id: "run-first-empty" }),
+      (value) => value?.status === "succeeded"
+    )
+    await Bun.sleep(50)
+    await worker.stop()
+
+    expect(run?.output).toBeUndefined()
+    expect(run?.checkpoint).toEqual({ cursor: "cursor-1" })
+    const events = await sixb.events.read({
+      types: ["sync.run.started", "dataset.version.committed", "sync.run.finished"],
+    })
+    expect(events.map((event) => event.type)).toEqual(["sync.run.started", "sync.run.finished"])
+    expect(events[1]?.payload).toEqual({
+      syncId: sync.id,
+      runId: "run-first-empty",
+      status: "succeeded",
+      datasetId: dataset.id,
+    })
+  })
+
   test("does not crash when retry fails on shutdown", async () => {
     const rawOrdersDataset = makeDataset("raw.erp.orders")
     const sync = defineSync("sync-orders")

--- a/storage/pg/src/pg-sync-run-storage.ts
+++ b/storage/pg/src/pg-sync-run-storage.ts
@@ -72,10 +72,17 @@ export class PgSyncRunStorage implements SyncRunStorage {
         )
       }
 
-      if (input.status === "succeeded" && input.output.datasetId !== existing.dataset_id) {
-        throw new SyncRunError(
-          `[SixbPg] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.dataset_id}'.`
-        )
+      if (input.status === "succeeded") {
+        if (input.output && input.output.datasetId !== existing.dataset_id) {
+          throw new SyncRunError(
+            `[SixbPg] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.dataset_id}'.`
+          )
+        }
+        if (!input.output && (existing.mode !== "append" || input.rowsRead !== 0)) {
+          throw new SyncRunError(
+            `[SixbPg] Sync run '${input.id}' may omit its output only for an empty append.`
+          )
+        }
       }
 
       const [updated] =
@@ -86,7 +93,7 @@ export class PgSyncRunStorage implements SyncRunStorage {
                 status = ${input.status},
                 finished_at = ${input.finishedAt ?? new Date()},
                 rows_read = ${input.rowsRead},
-                output_version_id = ${input.output.versionId},
+                output_version_id = ${input.output?.versionId ?? null},
                 error_name = ${null},
                 error_message = ${null},
                 checkpoint = ${serializeCheckpoint(input.checkpoint)}::text::jsonb

--- a/storage/pg/tests/pg-sync-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-sync-run-storage.e2e.ts
@@ -72,6 +72,23 @@ describe("PgSyncRunStorage", () => {
     const storedNull = await storage.syncRuns.getById({ projectId: "my-app", id: "run-null" })
     expect(nullFinished.checkpoint).toBeNull()
     expect(storedNull?.checkpoint).toBeNull()
+
+    await storage.syncRuns.start({
+      id: "run-empty",
+      projectId: "my-app",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "append",
+    })
+    const emptyFinished = await storage.syncRuns.finish({
+      id: "run-empty",
+      projectId: "my-app",
+      status: "succeeded",
+      rowsRead: 0,
+      checkpoint: { cursor: "cursor-empty" },
+    })
+    expect(emptyFinished.output).toBeUndefined()
+    expect(emptyFinished.checkpoint).toEqual({ cursor: "cursor-empty" })
   })
 
   test("stores failures and supports filtered paging", async () => {

--- a/storage/sqlite/src/sync-run-storage.ts
+++ b/storage/sqlite/src/sync-run-storage.ts
@@ -109,10 +109,17 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
         )
       }
 
-      if (input.status === "succeeded" && input.output.datasetId !== existing.dataset_id) {
-        throw new SyncRunError(
-          `[SixbSqlite] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.dataset_id}'.`
-        )
+      if (input.status === "succeeded") {
+        if (input.output && input.output.datasetId !== existing.dataset_id) {
+          throw new SyncRunError(
+            `[SixbSqlite] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.dataset_id}'.`
+          )
+        }
+        if (!input.output && (existing.mode !== "append" || input.rowsRead !== 0)) {
+          throw new SyncRunError(
+            `[SixbSqlite] Sync run '${input.id}' may omit its output only for an empty append.`
+          )
+        }
       }
 
       this.db
@@ -136,7 +143,7 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
           input.status === "succeeded"
             ? input.rowsRead
             : (input.rowsRead ?? existing.rows_read ?? null),
-          input.status === "succeeded" ? input.output.versionId : null,
+          input.status === "succeeded" ? (input.output?.versionId ?? null) : null,
           input.status === "succeeded" ? null : (input.error?.name ?? null),
           input.status === "succeeded" ? null : (input.error?.message ?? null),
           input.status === "succeeded" ? serializeCheckpoint(input.checkpoint) : null,

--- a/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
@@ -70,6 +70,23 @@ describe("SqliteSyncRunStorage", () => {
     const storedNull = await storage.getById({ projectId: "my-app", id: "run-null" })
     expect(nullFinished.checkpoint).toBeNull()
     expect(storedNull?.checkpoint).toBeNull()
+
+    await storage.start({
+      id: "run-empty",
+      projectId: "my-app",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "append",
+    })
+    const emptyFinished = await storage.finish({
+      id: "run-empty",
+      projectId: "my-app",
+      status: "succeeded",
+      rowsRead: 0,
+      checkpoint: { cursor: "cursor-empty" },
+    })
+    expect(emptyFinished.output).toBeUndefined()
+    expect(emptyFinished.checkpoint).toEqual({ cursor: "cursor-empty" })
   })
 
   test("stores failures and supports filtered paging", async () => {


### PR DESCRIPTION
## Summary

- allow a successful append run to omit its dataset output when the dataset has no version and the reader returns zero rows
- persist the next incremental checkpoint for that run
- emit a successful sync lifecycle event without inventing a dataset version
- keep rejecting missing outputs for snapshots and non-empty appends across in-memory, SQLite, and PostgreSQL storage

## Why

A first incremental sync can legitimately find no rows. DuckLake has no dataset version to reuse in that case, so the run previously failed and discarded its checkpoint.

## Validation

- `bun test packages/core/tests/sync-runs.test.ts packages/sync-worker/tests/run-sync-job.test.ts storage/sqlite/tests/sqlite-sync-run-storage.test.ts`
- `bun test packages/sync-worker/tests/worker.test.ts`
- `bun test --preload ./tests/setup.ts ./tests/pg-sync-run-storage.e2e.ts` from `storage/pg`
- `bun run check`
- `bun run typecheck`