### PR TITLE
materializer: adopt legacy effective state on edit

### DIFF
--- a/packages/core/src/materialization/index.ts
+++ b/packages/core/src/materialization/index.ts
@@ -18,6 +18,11 @@ export {
   MaterializationValidationError,
 } from "./errors"
 export type { OntologyMaterializationEvent, OntologyMaterializationEventDraft } from "./events"
+export {
+  effectiveMaterializerCommitId,
+  LEGACY_MATERIALIZER_COMMIT_ID,
+  storedMaterializerCommitId,
+} from "./legacy"
 export type {
   BaseCommitResult,
   EditCommitResult,

--- a/packages/core/src/materialization/legacy.ts
+++ b/packages/core/src/materialization/legacy.ts
@@ -1,0 +1,15 @@
+/**
+ * Revision used while adopting effective rows written before the materializer commit ledger.
+ *
+ * Providers map a missing `last_commit_id` on an existing row to this value. It is never written as
+ * a real commit id: the first materialized change replaces the legacy row with normal provenance.
+ */
+export const LEGACY_MATERIALIZER_COMMIT_ID = "__sixb_legacy_effective_state__"
+
+export function effectiveMaterializerCommitId(lastCommitId: string | null | undefined): string {
+  return lastCommitId ?? LEGACY_MATERIALIZER_COMMIT_ID
+}
+
+export function storedMaterializerCommitId(lastCommitId: string): string | null {
+  return lastCommitId === LEGACY_MATERIALIZER_COMMIT_ID ? null : lastCommitId
+}

--- a/packages/core/src/materializer/edits/load-state.ts
+++ b/packages/core/src/materializer/edits/load-state.ts
@@ -1,3 +1,4 @@
+import { LEGACY_MATERIALIZER_COMMIT_ID } from "../../materialization/legacy"
 import type { OntologyObjectRef } from "../../materialization/model"
 import { linkRefKey, objectRefKey } from "../../materialization/refs"
 import type {
@@ -51,6 +52,8 @@ export async function loadEditWorkingState(
     }
   }
 
+  adoptLegacyEditAuthority(context, state)
+
   await mergeIncidentState(
     context,
     storage,
@@ -59,7 +62,42 @@ export async function loadEditWorkingState(
     [...incidentLinks.values()],
     revivingObjects
   )
+  adoptLegacyEditAuthority(context, state)
   return state
+}
+
+function adoptLegacyEditAuthority(context: MaterializerContext, state: EditWorkingState): void {
+  for (const working of state.objects.values()) {
+    if (
+      working.before?.lastCommitId !== LEGACY_MATERIALIZER_COMMIT_ID ||
+      working.source ||
+      working.originalOverride
+    ) {
+      continue
+    }
+
+    const primaryPropertyId = context.ontology.getPrimaryPropertyId(working.ref.objectTypeId)
+    const properties = { ...working.before.properties }
+    delete properties[primaryPropertyId]
+    working.override = { kind: "create", properties }
+  }
+
+  for (const working of state.links.values()) {
+    if (
+      working.before?.lastCommitId !== LEGACY_MATERIALIZER_COMMIT_ID ||
+      working.source ||
+      working.originalOverride
+    ) {
+      continue
+    }
+
+    working.override = {
+      kind: "upsert",
+      ...(working.before.properties === undefined
+        ? {}
+        : { properties: { ...working.before.properties } }),
+    }
+  }
 }
 
 function isRevivingObjectOperation(

--- a/packages/core/src/storage/ontology/in-memory/materializations-state.ts
+++ b/packages/core/src/storage/ontology/in-memory/materializations-state.ts
@@ -1,4 +1,5 @@
 import { MaterializationConflictError } from "../../../materialization/errors"
+import { effectiveMaterializerCommitId } from "../../../materialization/legacy"
 import type {
   EffectiveLinkSnapshot,
   EffectiveObjectSnapshot,
@@ -47,27 +48,17 @@ export function uniqueBy<T>(values: readonly T[], keyOf: (value: T) => string): 
 }
 
 export function objectSnapshot(row: ObjectRow): EffectiveObjectSnapshot {
-  if (!row.lastCommitId)
-    throw new MaterializationConflictError(
-      "effective-state",
-      `Effective object ${row.objectTypeId}:${row.primaryId} lacks materializer provenance.`
-    )
   return {
     ref: { objectTypeId: row.objectTypeId, primaryId: row.primaryId },
     properties: structuredClone(row.properties) as EffectiveObjectSnapshot["properties"],
     version: row.version,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
-    lastCommitId: row.lastCommitId,
+    lastCommitId: effectiveMaterializerCommitId(row.lastCommitId),
   }
 }
 
 export function linkSnapshot(row: ObjectLinkRow): EffectiveLinkSnapshot {
-  if (!row.lastCommitId)
-    throw new MaterializationConflictError(
-      "effective-state",
-      `Effective link lacks materializer provenance.`
-    )
   return {
     ref: linkRef(row),
     ...(row.properties
@@ -75,7 +66,7 @@ export function linkSnapshot(row: ObjectLinkRow): EffectiveLinkSnapshot {
       : {}),
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
-    lastCommitId: row.lastCommitId,
+    lastCommitId: effectiveMaterializerCommitId(row.lastCommitId),
   }
 }
 
@@ -88,11 +79,6 @@ export function linkRef(row: ObjectLinkRow): OntologyLinkRef {
 }
 
 export function storedPoint(point: TimeseriesPoint): StoredTelemetryPoint {
-  if (!point.lastCommitId)
-    throw new MaterializationConflictError(
-      "timeseries-point",
-      "Telemetry point lacks materializer provenance."
-    )
   return {
     series: {
       object: { objectTypeId: point.objectTypeId, primaryId: point.objectId },
@@ -101,7 +87,7 @@ export function storedPoint(point: TimeseriesPoint): StoredTelemetryPoint {
     value: structuredClone(point.value) as StoredTelemetryPoint["value"],
     ...(point.unit !== undefined ? { unit: point.unit } : {}),
     at: point.at.toISOString(),
-    lastCommitId: point.lastCommitId,
+    lastCommitId: effectiveMaterializerCommitId(point.lastCommitId),
   }
 }
 

--- a/packages/core/src/storage/ontology/in-memory/materializations.ts
+++ b/packages/core/src/storage/ontology/in-memory/materializations.ts
@@ -3,6 +3,7 @@ import {
   MaterializationConflictError,
   MaterializationValidationError,
 } from "../../../materialization/errors"
+import { effectiveMaterializerCommitId } from "../../../materialization/legacy"
 import type {
   ExpectedLinkRevision,
   ExpectedObjectRevision,
@@ -966,7 +967,11 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
         )
       return
     }
-    if (!row || row.version !== expected.version || row.lastCommitId !== expected.lastCommitId) {
+    if (
+      !row ||
+      row.version !== expected.version ||
+      effectiveMaterializerCommitId(row.lastCommitId) !== expected.lastCommitId
+    ) {
       throw new MaterializationConflictError(
         "effective-state",
         `Expected object ${objectRefKey(expected.ref)} changed.`
@@ -994,7 +999,7 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
         )
       return
     }
-    if (!row || row.lastCommitId !== expected.lastCommitId) {
+    if (!row || effectiveMaterializerCommitId(row.lastCommitId) !== expected.lastCommitId) {
       throw new MaterializationConflictError(
         "effective-state",
         `Expected link ${linkRefKey(expected.ref)} changed.`
@@ -1008,7 +1013,9 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
       expected.series,
       expected.at
     )
-    if ((point?.lastCommitId ?? null) !== expected.lastCommitId) {
+    if (
+      (point ? effectiveMaterializerCommitId(point.lastCommitId) : null) !== expected.lastCommitId
+    ) {
       throw new MaterializationConflictError(
         "timeseries-point",
         `Telemetry point ${telemetryPointKey(expected.series, expected.at)} changed.`

--- a/packages/core/tests/runtime-materializer-adapter.test.ts
+++ b/packages/core/tests/runtime-materializer-adapter.test.ts
@@ -3,6 +3,7 @@ import {
   defineObjectType,
   InMemoryBroker,
   type InMemoryStorage,
+  type JsonValue,
   link,
   MaterializationValidationError,
   ObjectNotFoundError,
@@ -10,10 +11,15 @@ import {
   prop,
   Sixb,
 } from "../src"
-import { type EventsRuntime, OntologyOutboxDispatcher } from "../src/events"
+import {
+  type EventsRuntime,
+  OntologyOutboxDispatcher,
+  type StoredObjectMutationEvent,
+} from "../src/events"
 import { objectService } from "../src/objects"
 import { getOntologyMutationRuntime } from "../src/runtime/internal"
 import { getInMemoryOntologyStorageTestingAdapter } from "../src/storage/ontology/in-memory/testing"
+import { createStoredLinkMutationEvent, createStoredObjectMutationEvent } from "../src/testing"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
 const Sensor = defineObjectType({
@@ -71,6 +77,75 @@ async function listSensorLinks(sixb: AdapterRuntime, linkId: string) {
 }
 
 describe("runtime object writes", () => {
+  test("adopts a legacy effective object before applying a partial update", async () => {
+    const { sixb } = createRuntime()
+    const legacy = await sixb.storage.objects.applyObjectUpsert(
+      legacyObjectEvent("room", "r1", { id: "r1", name: "Kitchen" })
+    )
+    expect(legacy.lastCommitId).toBeUndefined()
+
+    await getOntologyMutationRuntime(sixb).commitEdits({
+      mode: "atomic",
+      source: { kind: "runtime", requestId: "patch-legacy-room" },
+      operations: [
+        {
+          id: "patch",
+          kind: "object.patch",
+          ref: { objectTypeId: Room.id, primaryId: "r1" },
+          set: { note: "Warm" },
+          unset: [],
+          reset: [],
+        },
+      ],
+      expectedObjects: [],
+      expectedLinks: [],
+      expectedLinkScopes: [],
+    })
+    const patched = await sixb.storage.objects.getByPrimaryId({
+      projectId: sixb.id,
+      objectTypeId: Room.id,
+      primaryId: "r1",
+    })
+
+    expect(patched?.properties).toEqual({ id: "r1", name: "Kitchen", note: "Warm" })
+    expect(patched?.version).toBe(2)
+    expect(patched?.lastCommitId).toBeString()
+  })
+
+  test("preserves legacy incident links when adopting an object", async () => {
+    const { sixb } = createRuntime()
+    await sixb.storage.objects.applyObjectUpsert(
+      legacyObjectEvent("room", "r1", { id: "r1", name: "Kitchen" })
+    )
+    await sixb.storage.objects.applyObjectUpsert(
+      legacyObjectEvent("sensor", "s1", { id: "s1", name: "Temp" })
+    )
+    await sixb.storage.objects.applyLinkUpsert(
+      createStoredLinkMutationEvent({
+        id: "legacy:room:r1:sensors:s1",
+        cursor: "2",
+        projectId: sixb.id,
+        occurredAt: "2026-07-27T08:01:00.000Z",
+        sourceTypeId: Room.id,
+        sourceId: "r1",
+        linkId: Room.l.sensors.id,
+        targetTypeId: Sensor.id,
+        targetId: "s1",
+        properties: { role: "primary" },
+      })
+    )
+
+    await sixb.upsertObject("room", { id: "r1", note: "Warm" })
+
+    const links = await listSensorLinks(sixb, Room.l.sensors.id)
+    expect(links).toHaveLength(1)
+    expect(links[0]).toMatchObject({
+      sourceId: "r1",
+      targetId: "s1",
+      properties: { role: "primary" },
+    })
+  })
+
   test("typed and dynamic mutations all commit through the materializer as runtime origins", async () => {
     const { sixb } = createRuntime()
 
@@ -248,6 +323,22 @@ describe("runtime object writes", () => {
     )
   })
 })
+
+function legacyObjectEvent(
+  objectTypeId: string,
+  primaryId: string,
+  properties: Record<string, JsonValue>
+): StoredObjectMutationEvent {
+  return createStoredObjectMutationEvent({
+    id: `legacy:${objectTypeId}:${primaryId}`,
+    cursor: "1",
+    projectId: "runtime-adapter-tests",
+    occurredAt: "2026-07-27T08:00:00.000Z",
+    objectTypeId,
+    primaryId,
+    properties,
+  })
+}
 
 describe("runtime object batches", () => {
   test("keeps local errors, item errors, and successes at their input positions", async () => {

--- a/storage/pg/src/ontology-storage/materialization-state.ts
+++ b/storage/pg/src/ontology-storage/materialization-state.ts
@@ -7,6 +7,7 @@ import type {
   TelemetrySeriesRef,
 } from "@sixb/core/internal/materialization"
 import {
+  effectiveMaterializerCommitId,
   linkRefKey,
   linkScopeSortKey,
   MaterializationConflictError,
@@ -988,29 +989,17 @@ function storedSource(row: PgOntologySourceAssertionRow): StoredSourceAssertion 
 }
 
 function effectiveObjectSnapshot(row: EffectiveObjectRow): EffectiveObjectSnapshot {
-  if (!row.last_commit_id) {
-    throw new MaterializationConflictError(
-      "effective-state",
-      `Effective object ${row.object_type_id}:${row.primary_id} lacks materializer provenance.`
-    )
-  }
   return {
     ref: objectRefFromColumns(row),
     properties: structuredClone(row.properties) as EffectiveObjectSnapshot["properties"],
     version: row.version,
     createdAt: toIsoString(row.created_at),
     updatedAt: toIsoString(row.updated_at),
-    lastCommitId: row.last_commit_id,
+    lastCommitId: effectiveMaterializerCommitId(row.last_commit_id),
   }
 }
 
 function effectiveLinkSnapshot(row: EffectiveLinkRow): EffectiveLinkSnapshot {
-  if (!row.last_commit_id) {
-    throw new MaterializationConflictError(
-      "effective-state",
-      `Effective link ${linkRefKey(linkRefFromColumns(row))} lacks materializer provenance.`
-    )
-  }
   return {
     ref: linkRefFromColumns(row),
     ...(row.properties === null
@@ -1022,24 +1011,12 @@ function effectiveLinkSnapshot(row: EffectiveLinkRow): EffectiveLinkSnapshot {
         }),
     createdAt: toIsoString(row.created_at),
     updatedAt: toIsoString(row.updated_at),
-    lastCommitId: row.last_commit_id,
+    lastCommitId: effectiveMaterializerCommitId(row.last_commit_id),
   }
 }
 
 function storedPoint(row: TelemetryRow): StoredTelemetryPoint {
   const at = toIsoString(row.at)
-  if (!row.last_commit_id) {
-    throw new MaterializationConflictError(
-      "timeseries-point",
-      `Telemetry point ${telemetryPointSortKey(
-        {
-          object: { objectTypeId: row.object_type_id, primaryId: row.object_id },
-          propertyId: row.property_id,
-        },
-        at
-      )} lacks materializer provenance.`
-    )
-  }
   return {
     series: {
       object: { objectTypeId: row.object_type_id, primaryId: row.object_id },
@@ -1048,7 +1025,7 @@ function storedPoint(row: TelemetryRow): StoredTelemetryPoint {
     value: structuredClone(row.value) as StoredTelemetryPoint["value"],
     ...(row.unit === null ? {} : { unit: row.unit }),
     at,
-    lastCommitId: row.last_commit_id,
+    lastCommitId: effectiveMaterializerCommitId(row.last_commit_id),
   }
 }
 

--- a/storage/pg/src/ontology-storage/materialization-writer.ts
+++ b/storage/pg/src/ontology-storage/materialization-writer.ts
@@ -2,6 +2,7 @@ import {
   linkRefKey,
   MaterializationConflictError,
   objectRefKey,
+  storedMaterializerCommitId,
   telemetryPointKey,
 } from "@sixb/core/internal/materialization"
 import {
@@ -111,7 +112,7 @@ export class PgMaterializationWriter {
       linkId: item.ref.linkId,
       targetTypeId: item.ref.target.objectTypeId,
       targetId: item.ref.target.primaryId,
-      expectedLastCommitId: item.expected.lastCommitId,
+      expectedLastCommitId: storedMaterializerCommitId(item.expected.lastCommitId),
     }))
     if (linkDeletes.length > 0) {
       const rows = await this.sql<{ readonly source_type_id: string }[]>`
@@ -125,7 +126,7 @@ export class PgMaterializationWriter {
           AND effective.link_id = staged.value->>'linkId'
           AND effective.target_type_id = staged.value->>'targetTypeId'
           AND effective.target_id = staged.value->>'targetId'
-          AND effective.last_commit_id = staged.value->>'expectedLastCommitId'
+          AND effective.last_commit_id IS NOT DISTINCT FROM staged.value->>'expectedLastCommitId'
         RETURNING effective.source_type_id
       `
       if (rows.length !== linkDeletes.length) throw effectiveLinkConflict(linkDeletes[0]!)
@@ -135,7 +136,7 @@ export class PgMaterializationWriter {
       objectTypeId: item.ref.objectTypeId,
       primaryId: item.ref.primaryId,
       expectedVersion: item.expected.version,
-      expectedLastCommitId: item.expected.lastCommitId,
+      expectedLastCommitId: storedMaterializerCommitId(item.expected.lastCommitId),
     }))
     if (objectDeletes.length > 0) {
       const rows = await this.sql<{ readonly object_type_id: string }[]>`
@@ -147,7 +148,7 @@ export class PgMaterializationWriter {
           AND effective.object_type_id = staged.value->>'objectTypeId'
           AND effective.primary_id = staged.value->>'primaryId'
           AND effective.version = (staged.value->>'expectedVersion')::integer
-          AND effective.last_commit_id = staged.value->>'expectedLastCommitId'
+          AND effective.last_commit_id IS NOT DISTINCT FROM staged.value->>'expectedLastCommitId'
         RETURNING effective.object_type_id
       `
       if (rows.length !== objectDeletes.length) throw effectiveObjectConflict(objectDeletes[0]!)
@@ -171,7 +172,9 @@ export class PgMaterializationWriter {
       lastCommitId: row.lastCommitId,
       expectedExists: expected.exists,
       expectedVersion: expected.exists ? expected.version : null,
-      expectedLastCommitId: expected.exists ? expected.lastCommitId : null,
+      expectedLastCommitId: expected.exists
+        ? storedMaterializerCommitId(expected.lastCommitId)
+        : null,
     }))
     const inserts = payload.filter((item) => !item.expectedExists)
     if (inserts.length > 0) {
@@ -213,7 +216,7 @@ export class PgMaterializationWriter {
           AND effective.object_type_id = staged.value->>'objectTypeId'
           AND effective.primary_id = staged.value->>'primaryId'
           AND effective.version = (staged.value->>'expectedVersion')::integer
-          AND effective.last_commit_id = staged.value->>'expectedLastCommitId'
+          AND effective.last_commit_id IS NOT DISTINCT FROM staged.value->>'expectedLastCommitId'
         RETURNING effective.object_type_id
       `
       if (rows.length !== updates.length) throw effectiveObjectConflict(updates[0]!)
@@ -235,7 +238,9 @@ export class PgMaterializationWriter {
       updatedAt: row.updatedAt,
       lastCommitId: row.lastCommitId,
       expectedExists: expected.exists,
-      expectedLastCommitId: expected.exists ? expected.lastCommitId : null,
+      expectedLastCommitId: expected.exists
+        ? storedMaterializerCommitId(expected.lastCommitId)
+        : null,
     }))
     const inserts = payload.filter((item) => !item.expectedExists)
     if (inserts.length > 0) {
@@ -282,7 +287,7 @@ export class PgMaterializationWriter {
           AND effective.link_id = staged.value->>'linkId'
           AND effective.target_type_id = staged.value->>'targetTypeId'
           AND effective.target_id = staged.value->>'targetId'
-          AND effective.last_commit_id = staged.value->>'expectedLastCommitId'
+          AND effective.last_commit_id IS NOT DISTINCT FROM staged.value->>'expectedLastCommitId'
         RETURNING effective.source_type_id
       `
       if (rows.length !== updates.length) throw effectiveLinkConflict(updates[0]!)
@@ -298,9 +303,11 @@ export class PgMaterializationWriter {
       unit: point.unit ?? null,
       at: point.at,
       lastCommitId: point.lastCommitId,
-      expectedLastCommitId: expected.lastCommitId,
+      expectedExists: expected.lastCommitId !== null,
+      expectedLastCommitId:
+        expected.lastCommitId === null ? null : storedMaterializerCommitId(expected.lastCommitId),
     }))
-    const inserts = payload.filter((item) => item.expectedLastCommitId === null)
+    const inserts = payload.filter((item) => !item.expectedExists)
     if (inserts.length > 0) {
       const rows = await this.sql<{ readonly object_type_id: string }[]>`
         WITH staged AS (
@@ -336,7 +343,7 @@ export class PgMaterializationWriter {
       if (rows.length !== inserts.length) throw pointConflict(inserts[0]!)
     }
 
-    const updates = payload.filter((item) => item.expectedLastCommitId !== null)
+    const updates = payload.filter((item) => item.expectedExists)
     if (updates.length > 0) {
       const rows = await this.sql<{ readonly object_type_id: string }[]>`
         WITH staged AS (
@@ -351,7 +358,7 @@ export class PgMaterializationWriter {
             AND points.object_id = staged.value->>'objectId'
             AND points.property_id = staged.value->>'propertyId'
             AND points.at = (staged.value->>'at')::timestamptz
-            AND points.last_commit_id = staged.value->>'expectedLastCommitId'
+            AND points.last_commit_id IS NOT DISTINCT FROM staged.value->>'expectedLastCommitId'
           RETURNING points.*
         ), latest AS (
           INSERT INTO timeseries_latest (

--- a/storage/pg/src/ontology-storage/materializations.ts
+++ b/storage/pg/src/ontology-storage/materializations.ts
@@ -5,6 +5,7 @@ import type {
 } from "@sixb/core/internal/materialization"
 import {
   assertPinnedDatasetWatermark,
+  effectiveMaterializerCommitId,
   linkRefKey,
   linkRefSortKey,
   linkScopeSortKey,
@@ -501,7 +502,11 @@ export class PgOntologyMaterializationStorage implements OntologyMaterialization
       }
       return
     }
-    if (!row || row.version !== expected.version || row.lastCommitId !== expected.lastCommitId) {
+    if (
+      !row ||
+      row.version !== expected.version ||
+      effectiveMaterializerCommitId(row.lastCommitId) !== expected.lastCommitId
+    ) {
       throw new MaterializationConflictError(
         "effective-state",
         `Expected object ${objectRefKey(expected.ref)} changed.`
@@ -522,7 +527,10 @@ export class PgOntologyMaterializationStorage implements OntologyMaterialization
       }
       return
     }
-    if (lastCommitId === undefined || lastCommitId !== expected.lastCommitId) {
+    if (
+      lastCommitId === undefined ||
+      effectiveMaterializerCommitId(lastCommitId) !== expected.lastCommitId
+    ) {
       throw new MaterializationConflictError(
         "effective-state",
         `Expected link ${linkRefKey(expected.ref)} changed.`

--- a/storage/pg/tests/pg-legacy-materializer-adoption.e2e.ts
+++ b/storage/pg/tests/pg-legacy-materializer-adoption.e2e.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import {
+  defineObjectType,
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  prop,
+  Sixb,
+} from "@sixb/core"
+import { createStoredObjectMutationEvent } from "@sixb/core/testing"
+import type { PostgresStorage } from "../src"
+import { createTestStorage } from "./helpers"
+
+const Room = defineObjectType({
+  id: "Room",
+  name: "Room",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+    prop("note", "string", { nullable: true }),
+  ],
+})
+
+describe("PostgreSQL legacy materializer adoption", () => {
+  let storage: PostgresStorage
+
+  beforeEach(async () => {
+    ;({ storage } = await createTestStorage())
+  })
+
+  afterEach(async () => {
+    await storage.dropSchema()
+    await storage.close()
+  })
+
+  test("preserves a legacy object while applying its first partial update", async () => {
+    const sixb = new Sixb({
+      id: "pg-legacy-adoption",
+      ontology: [Room],
+      storage,
+      broker: new InMemoryBroker(),
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: new InMemoryBlobStorage(),
+      queues: new InMemoryQueues(),
+    })
+    try {
+      const legacy = await storage.objects.applyObjectUpsert(
+        createStoredObjectMutationEvent({
+          id: "legacy-room",
+          cursor: "1",
+          projectId: sixb.id,
+          occurredAt: "2026-07-27T08:00:00.000Z",
+          objectTypeId: Room.id,
+          primaryId: "room-1",
+          properties: { id: "room-1", name: "Kitchen" },
+        })
+      )
+      expect(legacy.lastCommitId).toBeUndefined()
+
+      const patched = await sixb.upsertObject(Room.id, { id: "room-1", note: "Warm" })
+
+      expect(patched.properties).toEqual({ id: "room-1", name: "Kitchen", note: "Warm" })
+      expect(patched.version).toBe(2)
+      expect(patched.lastCommitId).toBeString()
+    } finally {
+      await sixb.closeBroker()
+    }
+  })
+})

--- a/storage/sqlite/src/ontology-storage/materialization-state.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-state.ts
@@ -8,6 +8,7 @@ import type {
   TelemetrySeriesRef,
 } from "@sixb/core/internal/materialization"
 import {
+  effectiveMaterializerCommitId,
   linkRefKey,
   linkScopeSortKey,
   MaterializationConflictError,
@@ -824,29 +825,17 @@ function storedSource(row: SqliteOntologySourceAssertionRow): StoredSourceAssert
 }
 
 function effectiveObjectSnapshot(row: EffectiveObjectRow): EffectiveObjectSnapshot {
-  if (!row.last_commit_id) {
-    throw new MaterializationConflictError(
-      "effective-state",
-      `Effective object ${row.object_type_id}:${row.primary_id} lacks materializer provenance.`
-    )
-  }
   return {
     ref: objectRefFromColumns(row),
     properties: parseJson<EffectiveObjectSnapshot["properties"]>(row.properties),
     version: row.version,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
-    lastCommitId: row.last_commit_id,
+    lastCommitId: effectiveMaterializerCommitId(row.last_commit_id),
   }
 }
 
 function effectiveLinkSnapshot(row: EffectiveLinkRow): EffectiveLinkSnapshot {
-  if (!row.last_commit_id) {
-    throw new MaterializationConflictError(
-      "effective-state",
-      `Effective link ${linkRefKey(linkRefFromColumns(row))} lacks materializer provenance.`
-    )
-  }
   return {
     ref: linkRefFromColumns(row),
     ...(row.properties === null
@@ -856,23 +845,11 @@ function effectiveLinkSnapshot(row: EffectiveLinkRow): EffectiveLinkSnapshot {
         }),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
-    lastCommitId: row.last_commit_id,
+    lastCommitId: effectiveMaterializerCommitId(row.last_commit_id),
   }
 }
 
 function storedPoint(row: TelemetryRow): StoredTelemetryPoint {
-  if (!row.last_commit_id) {
-    throw new MaterializationConflictError(
-      "timeseries-point",
-      `Telemetry point ${telemetryPointSortKey(
-        {
-          object: { objectTypeId: row.object_type_id, primaryId: row.object_id },
-          propertyId: row.property_id,
-        },
-        row.at
-      )} lacks materializer provenance.`
-    )
-  }
   return {
     series: {
       object: { objectTypeId: row.object_type_id, primaryId: row.object_id },
@@ -881,7 +858,7 @@ function storedPoint(row: TelemetryRow): StoredTelemetryPoint {
     value: parseJson<StoredTelemetryPoint["value"]>(row.value),
     ...(row.unit === null ? {} : { unit: row.unit }),
     at: row.at,
-    lastCommitId: row.last_commit_id,
+    lastCommitId: effectiveMaterializerCommitId(row.last_commit_id),
   }
 }
 

--- a/storage/sqlite/src/ontology-storage/materialization-writer.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-writer.ts
@@ -3,6 +3,7 @@ import {
   linkRefKey,
   MaterializationConflictError,
   objectRefKey,
+  storedMaterializerCommitId,
   telemetryPointKey,
 } from "@sixb/core/internal/materialization"
 import {
@@ -138,7 +139,7 @@ export class SqliteMaterializationWriter {
             `
               DELETE FROM links
               WHERE project_id = ? AND source_type_id = ? AND source_id = ? AND link_id = ?
-                AND target_type_id = ? AND target_id = ? AND last_commit_id = ?
+                AND target_type_id = ? AND target_id = ? AND last_commit_id IS ?
             `
           )
           .run(
@@ -148,7 +149,7 @@ export class SqliteMaterializationWriter {
             item.ref.linkId,
             item.ref.target.objectTypeId,
             item.ref.target.primaryId,
-            item.expected.lastCommitId
+            storedMaterializerCommitId(item.expected.lastCommitId)
           ).changes,
         "effective-state",
         `Expected link ${linkRefKey(item.ref)} changed.`
@@ -160,14 +161,14 @@ export class SqliteMaterializationWriter {
           .query(
             `DELETE FROM objects
              WHERE project_id = ? AND object_type_id = ? AND primary_id = ?
-               AND version = ? AND last_commit_id = ?`
+               AND version = ? AND last_commit_id IS ?`
           )
           .run(
             projectId,
             item.ref.objectTypeId,
             item.ref.primaryId,
             item.expected.version,
-            item.expected.lastCommitId
+            storedMaterializerCommitId(item.expected.lastCommitId)
           ).changes,
         "effective-state",
         `Expected object ${objectRefKey(item.ref)} changed.`
@@ -216,7 +217,7 @@ export class SqliteMaterializationWriter {
             SET properties = json(?), created_at = ?, updated_at = ?, version = ?,
               source_event_id = NULL, last_commit_id = ?
             WHERE project_id = ? AND object_type_id = ? AND primary_id = ?
-              AND version = ? AND last_commit_id = ?
+              AND version = ? AND last_commit_id IS ?
           `
         )
         .run(
@@ -229,7 +230,7 @@ export class SqliteMaterializationWriter {
           row.ref.objectTypeId,
           row.ref.primaryId,
           expected.version,
-          expected.lastCommitId
+          storedMaterializerCommitId(expected.lastCommitId)
         ).changes,
       "effective-state",
       `Expected object ${objectRefKey(row.ref)} changed.`
@@ -277,7 +278,7 @@ export class SqliteMaterializationWriter {
             SET properties = json(?), created_at = ?, updated_at = ?,
               source_event_id = NULL, last_commit_id = ?
             WHERE project_id = ? AND source_type_id = ? AND source_id = ? AND link_id = ?
-              AND target_type_id = ? AND target_id = ? AND last_commit_id = ?
+              AND target_type_id = ? AND target_id = ? AND last_commit_id IS ?
           `
         )
         .run(
@@ -291,7 +292,7 @@ export class SqliteMaterializationWriter {
           row.ref.linkId,
           row.ref.target.objectTypeId,
           row.ref.target.primaryId,
-          expected.lastCommitId
+          storedMaterializerCommitId(expected.lastCommitId)
         ).changes,
       "effective-state",
       `Expected link ${linkRefKey(row.ref)} changed.`
@@ -339,7 +340,7 @@ export class SqliteMaterializationWriter {
                 UPDATE timeseries
                 SET value = json(?), unit = ?, source_event_id = NULL, last_commit_id = ?
                 WHERE project_id = ? AND object_type_id = ? AND object_id = ?
-                  AND property_id = ? AND at = ? AND last_commit_id = ?
+                  AND property_id = ? AND at = ? AND last_commit_id IS ?
               `
             )
             .run(
@@ -351,7 +352,7 @@ export class SqliteMaterializationWriter {
               point.series.object.primaryId,
               point.series.propertyId,
               point.at,
-              expected.lastCommitId
+              storedMaterializerCommitId(expected.lastCommitId)
             ).changes,
           "timeseries-point",
           `Telemetry point ${telemetryPointKey(point.series, point.at)} changed.`

--- a/storage/sqlite/src/ontology-storage/materializations.ts
+++ b/storage/sqlite/src/ontology-storage/materializations.ts
@@ -7,6 +7,7 @@ import type {
 } from "@sixb/core/internal/materialization"
 import {
   assertPinnedDatasetWatermark,
+  effectiveMaterializerCommitId,
   linkRefKey,
   linkRefSortKey,
   linkScopeSortKey,
@@ -454,7 +455,11 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
       }
       return
     }
-    if (!row || row.version !== expected.version || row.lastCommitId !== expected.lastCommitId) {
+    if (
+      !row ||
+      row.version !== expected.version ||
+      effectiveMaterializerCommitId(row.lastCommitId) !== expected.lastCommitId
+    ) {
       throw new MaterializationConflictError(
         "effective-state",
         `Expected object ${objectRefKey(expected.ref)} changed.`
@@ -476,7 +481,10 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
       }
       return
     }
-    if (lastCommitId === undefined || lastCommitId !== expected.lastCommitId) {
+    if (
+      lastCommitId === undefined ||
+      effectiveMaterializerCommitId(lastCommitId) !== expected.lastCommitId
+    ) {
       throw new MaterializationConflictError(
         "effective-state",
         `Expected link ${linkRefKey(expected.ref)} changed.`

--- a/storage/sqlite/tests/sqlite-legacy-materializer-adoption.test.ts
+++ b/storage/sqlite/tests/sqlite-legacy-materializer-adoption.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import {
+  defineObjectType,
+  InMemoryBlobStorage,
+  InMemoryBroker,
+  InMemoryLakeStorage,
+  InMemoryQueues,
+  prop,
+  Sixb,
+} from "@sixb/core"
+import { createStoredObjectMutationEvent } from "@sixb/core/testing"
+import { SqliteStorage } from "../src"
+
+const Room = defineObjectType({
+  id: "Room",
+  name: "Room",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("name", "string", { required: true }),
+    prop("note", "string", { nullable: true }),
+  ],
+})
+
+describe("SQLite legacy materializer adoption", () => {
+  test("preserves a legacy object while applying its first partial update", async () => {
+    const storage = new SqliteStorage()
+    const sixb = new Sixb({
+      id: "sqlite-legacy-adoption",
+      ontology: [Room],
+      storage,
+      broker: new InMemoryBroker(),
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: new InMemoryBlobStorage(),
+      queues: new InMemoryQueues(),
+    })
+
+    try {
+      const legacy = await storage.objects.applyObjectUpsert(
+        createStoredObjectMutationEvent({
+          id: "legacy-room",
+          cursor: "1",
+          projectId: sixb.id,
+          occurredAt: "2026-07-27T08:00:00.000Z",
+          objectTypeId: Room.id,
+          primaryId: "room-1",
+          properties: { id: "room-1", name: "Kitchen" },
+        })
+      )
+      expect(legacy.lastCommitId).toBeUndefined()
+
+      const patched = await sixb.upsertObject(Room.id, { id: "room-1", note: "Warm" })
+
+      expect(patched.properties).toEqual({ id: "room-1", name: "Kitchen", note: "Warm" })
+      expect(patched.version).toBe(2)
+      expect(patched.lastCommitId).toBeString()
+    } finally {
+      await sixb.closeBroker()
+      storage.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- recognize effective object, link, and telemetry rows written before the materializer commit ledger
- adopt a legacy object and its incident links as managed authority on the first runtime edit
- preserve compare-and-swap checks by mapping the legacy revision back to SQL NULL at the provider boundary
- replace the legacy revision with normal commit provenance after the first effective change

## Why

After durable edits landed, Actions could read legacy rows but failed when committing an update with `lacks materializer provenance`. This affects existing production objects during an in-place upgrade.

## Validation

- `bun test packages/core/tests/runtime-materializer-adapter.test.ts storage/sqlite/tests/sqlite-legacy-materializer-adoption.test.ts`
- `bun test --preload ./tests/setup.ts ./tests/pg-legacy-materializer-adoption.e2e.ts` from `storage/pg`
- `bun run check`
- `bun run typecheck`