### PR TITLE
create-sixb: use DuckLake in starter template

### DIFF
--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -60,7 +60,10 @@ describe("sixb init", () => {
     const configSource = await readFile(join(targetDir, "sixb.config.ts"), "utf-8")
     expect(configSource).toContain('const projectId = "starter"')
     expect(configSource).toContain('new SqliteStorage({ path: ".sixb" })')
-    expect(configSource).toContain('new LocalLakeStorage({ path: ".sixb/lake" })')
+    expect(configSource).toContain("new DuckLakeStorage({")
+    expect(configSource).toContain('path: ".sixb/lake/metadata.ducklake"')
+    expect(configSource).toContain('dataPath: ".sixb/lake/data"')
+    expect(configSource).not.toContain("LocalLakeStorage")
     expect(configSource).not.toContain("isProduction")
 
     const packageJson = JSON.parse(await readFile(join(targetDir, "package.json"), "utf-8")) as {
@@ -72,8 +75,8 @@ describe("sixb init", () => {
     expect(packageJson.name).toBe("starter")
     expect(packageJson.scripts.typecheck).toBe("sixb typegen && tsc --noEmit")
     expect(packageJson.dependencies["@sixb/client"]).toBe("^0.1.0")
-    expect(packageJson.dependencies["@sixb/lake-local"]).toBe("^0.1.0")
-    expect(packageJson.dependencies["@sixb/ducklake"]).toBeUndefined()
+    expect(packageJson.dependencies["@sixb/ducklake"]).toBe("^0.1.0")
+    expect(packageJson.dependencies["@sixb/lake-local"]).toBeUndefined()
     expect(packageJson.dependencies["@sixb/pg"]).toBeUndefined()
     expect(packageJson.dependencies["@sixb/blob-s3"]).toBeUndefined()
     expect(packageJson.dependencies.react).toBe("^19.0.0")

--- a/packages/create-sixb/template/package.json
+++ b/packages/create-sixb/template/package.json
@@ -14,7 +14,7 @@
     "@sixb/cli": "__SIXB_VERSION__",
     "@sixb/client": "__SIXB_VERSION__",
     "@sixb/core": "__SIXB_VERSION__",
-    "@sixb/lake-local": "__SIXB_VERSION__",
+    "@sixb/ducklake": "__SIXB_VERSION__",
     "@sixb/sqlite": "__SIXB_VERSION__",
     "@sixb/ui": "__SIXB_VERSION__",
     "@tailwindcss/cli": "^4.2.2",

--- a/packages/create-sixb/template/sixb.config.ts
+++ b/packages/create-sixb/template/sixb.config.ts
@@ -1,6 +1,6 @@
 import { LocalBlobStorage } from "@sixb/blob-local"
 import { createSixb, InMemoryBroker, InMemoryQueues } from "@sixb/core"
-import { LocalLakeStorage } from "@sixb/lake-local"
+import { DuckLakeStorage } from "@sixb/ducklake"
 import { SqliteStorage } from "@sixb/sqlite"
 
 const projectId = "sixb-app"
@@ -9,7 +9,13 @@ export const sixb = createSixb({
   id: projectId,
   broker: new InMemoryBroker(),
   storage: new SqliteStorage({ path: ".sixb" }),
-  lakeStorage: new LocalLakeStorage({ path: ".sixb/lake" }),
+  lakeStorage: new DuckLakeStorage({
+    catalog: {
+      type: "duckdb",
+      path: ".sixb/lake/metadata.ducklake",
+    },
+    dataPath: ".sixb/lake/data",
+  }),
   blobStorage: new LocalBlobStorage({ basePath: ".sixb/blobs" }),
   queues: new InMemoryQueues(),
 })

--- a/packages/create-sixb/tests/create-sixb.test.ts
+++ b/packages/create-sixb/tests/create-sixb.test.ts
@@ -174,8 +174,10 @@ async function assertScaffold(projectDir: string, name: string): Promise<void> {
   const configSource = await readFile(join(projectDir, "sixb.config.ts"), "utf8")
   expect(configSource).toContain(`const projectId = "${name}"`)
   expect(configSource).toContain('new SqliteStorage({ path: ".sixb" })')
-  expect(configSource).toContain('new LocalLakeStorage({ path: ".sixb/lake" })')
-  expect(configSource).not.toContain("DuckLakeStorage")
+  expect(configSource).toContain("new DuckLakeStorage({")
+  expect(configSource).toContain('path: ".sixb/lake/metadata.ducklake"')
+  expect(configSource).toContain('dataPath: ".sixb/lake/data"')
+  expect(configSource).not.toContain("LocalLakeStorage")
   expect(configSource).not.toContain("isProduction")
 
   const incrementAction = await readFile(join(projectDir, "actions", "increment.ts"), "utf8")
@@ -188,6 +190,6 @@ async function assertScaffold(projectDir: string, name: string): Promise<void> {
   }
   expect(packageJson.name).toBe(name)
   expect(packageJson.dependencies?.["@sixb/cli"]).toBe("^0.1.0")
-  expect(packageJson.dependencies?.["@sixb/lake-local"]).toBe("^0.1.0")
-  expect(packageJson.dependencies?.["@sixb/ducklake"]).toBeUndefined()
+  expect(packageJson.dependencies?.["@sixb/ducklake"]).toBe("^0.1.0")
+  expect(packageJson.dependencies?.["@sixb/lake-local"]).toBeUndefined()
 }


### PR DESCRIPTION
Use DuckLake in the template example so SQL pipelines work out of the gate.

## Testing

- `bun run typecheck:template`
- `bun test packages/create-sixb/tests/create-sixb.test.ts packages/cli/tests/init.test.ts`