### PR TITLE
app: bound the Tailwind CSS build

### DIFF
--- a/packages/app/src/tailwind.ts
+++ b/packages/app/src/tailwind.ts
@@ -25,6 +25,17 @@ export interface TailwindCssCompilerOptions {
   minify?: boolean
   /** Debounce for `schedule()` rebuilds, in milliseconds. */
   debounceMs?: number
+  /**
+   * How long one Tailwind CLI run may take before it is killed and the build
+   * reported as failed. Defaults to two minutes, generous enough for a cold
+   * build on a loaded CI runner.
+   *
+   * A bound is not optional here: the CLI runs as a child process, and a child
+   * that never exits makes `compile()` hang forever — outside any test runner's
+   * per-test timeout, so the whole job dies at its wall clock with no failing
+   * test named, leaving orphaned `bun` processes behind.
+   */
+  timeoutMs?: number
   /** Called when a `schedule()`d rebuild fails. Defaults to `console.error`. */
   onError?: (error: Error) => void
 }
@@ -71,6 +82,7 @@ export function createTailwindCssCompiler(
   const resolveFrom = options.resolveFrom ?? cwd
   const label = options.label ?? "[SixbTailwind]"
   const debounceMs = options.debounceMs ?? 50
+  const timeoutMs = options.timeoutMs ?? 120_000
   const onError = options.onError ?? ((error: Error) => console.error(`${label} ${error.message}`))
 
   let chain: Promise<void> = Promise.resolve()
@@ -98,10 +110,33 @@ export function createTailwindCssCompiler(
       stderr: "pipe",
     })
 
-    const exitCode = await proc.exited
-    if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text()
-      throw new Error(`${label} Tailwind CSS build failed: ${stderr.trim()}`)
+    // Read stderr *while* the child runs. Waiting for `exited` first leaves the pipe
+    // unread, and a child that fills its ~64 KB buffer blocks on write forever — a
+    // deadlock rather than a slow build.
+    const stderrText = new Response(proc.stderr).text()
+
+    // `proc.kill()` matters as much as the timer: without it the child outlives this
+    // function and the CI runner has to reap it as an orphan.
+    let timedOut = false
+    const killTimer = setTimeout(() => {
+      timedOut = true
+      proc.kill()
+    }, timeoutMs)
+
+    try {
+      const exitCode = await proc.exited
+      if (timedOut) {
+        throw new Error(
+          `${label} Tailwind CSS build did not finish within ${timeoutMs}ms and was stopped. Check that '${options.inputPath}' compiles, or raise 'timeoutMs'.`
+        )
+      }
+      if (exitCode !== 0) {
+        throw new Error(`${label} Tailwind CSS build failed: ${(await stderrText).trim()}`)
+      }
+    } finally {
+      clearTimeout(killTimer)
+      // Settle the read either way so a killed child leaves nothing pending.
+      await stderrText.catch(() => "")
     }
   }
 

--- a/packages/app/tests/styles.test.ts
+++ b/packages/app/tests/styles.test.ts
@@ -164,6 +164,32 @@ describe("createTailwindCssCompiler", () => {
       await compiler.stop()
     }
   })
+
+  test("a CLI that never exits fails the build instead of hanging forever", async () => {
+    // `await proc.exited` used to be unbounded. A child that never exits then hung
+    // `compile()` outside any test runner's per-test timeout, so CI died at the job's
+    // wall clock with no failing test named and orphaned children to reap.
+    const inputPath = join(tempRoot, "app.css")
+    await writeFile(inputPath, ".initial { color: red; }\n")
+    await installFakeTailwindCli(tempRoot, ["await new Promise(() => {})"])
+
+    const compiler = createTailwindCssCompiler({
+      inputPath,
+      outputPath: join(tempRoot, "dist", "app.css"),
+      cwd: tempRoot,
+      resolveFrom: tempRoot,
+      timeoutMs: 200,
+      label: "[SixbTest]",
+    })
+
+    try {
+      await expect(compiler.compile()).rejects.toThrow(
+        "[SixbTest] Tailwind CSS build did not finish within 200ms and was stopped."
+      )
+    } finally {
+      await compiler.stop()
+    }
+  })
 })
 
 describe("custom app Tailwind build (e2e)", () => {
@@ -315,7 +341,10 @@ async function getFreePort(): Promise<number> {
   return port
 }
 
-async function installFakeTailwindCli(projectRoot: string): Promise<void> {
+async function installFakeTailwindCli(
+  projectRoot: string,
+  body?: readonly string[]
+): Promise<void> {
   const cliRoot = join(projectRoot, "node_modules", "@tailwindcss", "cli")
   await mkdir(join(cliRoot, "dist"), { recursive: true })
   await writeFile(
@@ -325,9 +354,11 @@ async function installFakeTailwindCli(projectRoot: string): Promise<void> {
   await writeFile(
     join(cliRoot, "dist", "index.mjs"),
     [
-      'const input = process.argv[process.argv.indexOf("-i") + 1]',
-      'const output = process.argv[process.argv.indexOf("-o") + 1]',
-      "await Bun.write(output, await Bun.file(input).text())",
+      ...(body ?? [
+        'const input = process.argv[process.argv.indexOf("-i") + 1]',
+        'const output = process.argv[process.argv.indexOf("-o") + 1]',
+        "await Bun.write(output, await Bun.file(input).text())",
+      ]),
       "",
     ].join("\n")
   )


### PR DESCRIPTION
`runCompile()` spawned the Tailwind CLI, then `await proc.exited` — no bound, no kill, and stderr
read only after the wait.

```ts
const proc = Bun.spawn(args, { cwd, stdout: "ignore", stderr: "pipe" })
const exitCode = await proc.exited          // waits forever if the child never exits
```

## Three defects in two lines

| | Effect |
|---|---|
| No bound | `compile()` hangs forever. `sixb dev` never becomes ready; a CI job dies at its own wall clock with no failing test named |
| No `kill()` | the child outlives the function — the runner reaps it as an orphan, which is how these hangs are recognizable after the fact |
| stderr read after `exited` | a child that fills the ~64 KB pipe blocks on write while the parent waits for the exit that write is blocking. **Deadlock, not a slow build** |

The third one is latent rather than active: measured **36 bytes** of stderr on the Atlas stylesheet
today. The ordering is wrong regardless, and it costs nothing to read concurrently.

## The change

`timeoutMs`, default **two minutes** — generous for a cold build on a loaded runner, and an option
because a large app may legitimately need longer. The error names the input, the bound, and the knob:

```
[SixbAtlas] Tailwind CSS build did not finish within 120000ms and was stopped.
Check that '…/index.css' compiles, or raise 'timeoutMs'.
```

## What this does not claim

It is **not** proven to fix the `Unit tests` job that has been dying at its 15-minute timeout inside
`packages/atlas/tests/atlas-app.test.ts`. Evidence against that reading, produced while teeth-testing
this change: with the kill removed, the new test fails at **5.05 s** via Bun's per-test timeout rather
than hanging. So Bun *can* interrupt a stuck `await proc.exited` — which means the job that runs 15
minutes without any per-test timeout firing is stuck somewhere else. The remaining suspect on that path
is `ensureBuiltInUiDevBundle()`'s `await import(htmlPath)`, Bun's in-process HTML bundler.

This lands on its own merits: an unbounded wait on a child process, an unreaped child, and a pipe read
in the wrong order are defects whether or not they are today's outage.

## Verification

- `bun --filter @sixb/app typecheck` · `bun run build:types` · `bun run check`
- `bun test packages/app/tests/` — 37 pass / 1 fail, and that one failure is **pre-existing on `main`**
  (36 pass / 1 fail there; this change adds the passing test)
- Teeth: with `proc.kill()` removed the new test fails instead of passing
