### PR TITLE
docs: make the documentation match the code

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -3,6 +3,6 @@
   "framework": "nextjs",
   "buildCommand": "bun run build",
   "installCommand": "bun install",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':/apps/docs' ':/packages/ui'",
+  "ignoreCommand": "bun ../../scripts/docs-vercel-ignore.ts",
   "github": { "silent": true }
 }

--- a/docs/auth/authorization.md
+++ b/docs/auth/authorization.md
@@ -292,6 +292,21 @@ membership policy above) can then invite and manage the rest of the team. See
 
 ## How grants are enforced
 
+> **0.1.0 limit — HTTP writes are not grant-checked.** Grants cover reads and run requests. These
+> four routes call the privileged runtime directly, so **any authenticated session can write any
+> object type**:
+>
+> | Route | Writes |
+> | --- | --- |
+> | `PUT /api/objects/:objectTypeId/:objectId` | object properties |
+> | `PUT /api/objects/:objectTypeId/:objectId/links/:linkId` | a link |
+> | `DELETE /api/objects/:objectTypeId/:objectId/links/:linkId` | removes a link |
+> | `POST /api/objects/:objectTypeId/:objectId/telemetry/:propertyId` | a telemetry point |
+>
+> Route writes through [actions](../actions/overview.md) instead: `apply:action` is enforced and the
+> write is recorded as a run. Block the four routes at your reverse proxy if untrusted principals
+> hold sessions.
+
 Grants are enforced through a **scoped runtime**. The raw `sixb` instance is privileged — it has
 no authorization context and bypasses all grant checks. That is intended for trusted system code
 (startup, syncs, projections, workers, tests).
@@ -354,9 +369,9 @@ for the event model.
 ## With the server
 
 The Sixb server does this for you. It resolves the session once per request and routes
-authenticated traffic through `sixb.as(context)` automatically, so grants are enforced without
-extra wiring. You define groups, roles, and membership policies; the server applies them. See the
-[Server overview](../server/overview.md).
+authenticated traffic through `sixb.as(context)` automatically, so read and run grants are enforced
+without extra wiring. You define groups, roles, and membership policies; the server applies them.
+See the [Server overview](../server/overview.md).
 
 To build a context yourself in a custom integration, resolve it from the request:
 

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -122,13 +122,17 @@ with no registered worker types prints a warning and stays running.
 A role that talks to a browser refuses to start in production without the origins it
 needs. Every flag has an environment equivalent; the flag wins.
 
-| Role                | Required                                       | Also required when                         |
-| ------------------- | ---------------------------------------------- | ------------------------------------------ |
-| `sixb api`          | `--api-public-origin`, `--atlas-public-origin` | `--app-public-origin`, with a built `app/` |
-| `sixb atlas`        | `--api-public-origin`                          | —                                          |
-| `sixb app`          | `--api-public-origin`                          | —                                          |
-| `sixb worker agent` | `--api-public-origin`                          | —                                          |
-| everything else     | none                                           | —                                          |
+| Role                | Required                                       | Also required when                                     |
+| ------------------- | ---------------------------------------------- | ------------------------------------------------------ |
+| `sixb api`          | `--api-public-origin`, `--atlas-public-origin` | `--app-public-origin`, with a built `app/`             |
+| `sixb atlas`        | `--api-public-origin`                          | —                                                      |
+| `sixb app`          | `--api-public-origin`                          | —                                                      |
+| `sixb worker agent` | `--api-public-origin`                          | —                                                      |
+| `sixb worker-group` | none                                           | `--api-public-origin`, with `agent` in the group       |
+| everything else     | none                                           | —                                                      |
+
+A group refuses to start whole, so the origin is required as soon as `agent` is one of its
+workers — including when the group selected it for you from a project that registers agents.
 
 | Flag                    | Environment variable       |
 | ----------------------- | -------------------------- |

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -94,8 +94,8 @@ Each role is a `sixb` subcommand that runs in `NODE_ENV=production`. All accept
 | `sixb worker <type>`           | Runs one queue worker                                 |
 | `sixb worker-group [types...]` | Runs several queue workers in one process            |
 
-The worker `<type>` is one of `sync`, `action`, `pipeline`, `projection`, or
-`workflow`:
+The worker `<type>` is one of `sync`, `action`, `agent`, `pipeline`, `projection`,
+or `workflow`:
 
 ```bash
 sixb worker sync
@@ -116,6 +116,52 @@ sixb worker-group
 A role process is **idle**, not an error, when it has nothing to do — an
 orchestrator with no routes, a rules process with no rules, or a worker group
 with no registered worker types prints a warning and stays running.
+
+## Public origins
+
+A role that talks to a browser refuses to start in production without the origins it
+needs. Every flag has an environment equivalent; the flag wins.
+
+| Role                | Required                                       | Also required when                         |
+| ------------------- | ---------------------------------------------- | ------------------------------------------ |
+| `sixb api`          | `--api-public-origin`, `--atlas-public-origin` | `--app-public-origin`, with a built `app/` |
+| `sixb atlas`        | `--api-public-origin`                          | —                                          |
+| `sixb app`          | `--api-public-origin`                          | —                                          |
+| `sixb worker agent` | `--api-public-origin`                          | —                                          |
+| everything else     | none                                           | —                                          |
+
+| Flag                    | Environment variable       |
+| ----------------------- | -------------------------- |
+| `--api-public-origin`   | `SIXB_API_PUBLIC_ORIGIN`   |
+| `--atlas-public-origin` | `SIXB_ATLAS_PUBLIC_ORIGIN` |
+| `--app-public-origin`   | `SIXB_APP_PUBLIC_ORIGIN`   |
+
+`sixb api` is the strict one because those origins are its CORS allowlist: each browser
+origin maps to one auth audience, and an unlisted one is rejected. `sixb atlas` and
+`sixb app` only display their own origin, so they start without it and print the address
+they bound instead — set it when you want the startup panel to show the public URL.
+
+An origin is scheme, host, and port, nothing else: `https://api.acme.example.com`. A path,
+a query string, or a fragment is rejected.
+
+## Storage migrations
+
+The six roles that touch the schema — `api`, `rules`, `scheduler`, `orchestrator`,
+`worker`, `worker-group` — bring it up to date at startup, so a forgotten migration
+cannot surface as a missing column on the first request. `atlas` and `app` serve a
+browser bundle and hold no DDL grant, so they never migrate.
+
+Run it as its own deploy stage when you want the schema change separated from the
+rollout:
+
+```bash
+sixb db migrate
+sixb api --no-migrate     # or SIXB_SKIP_MIGRATION=1
+```
+
+Postgres serializes concurrent migrators on an advisory lock, so replicas starting
+together are safe. **SQLite has no cross-process lock**: migrate it as its own step and
+start the roles with `--no-migrate`.
 
 ## Execution model
 
@@ -187,8 +233,8 @@ Workers claim jobs with a **lease** (default 15 minutes). On each outcome:
 The API role owns `OntologyMaintenance`: immediate post-commit publication still runs in the
 process that committed, while the API performs durable outbox catch-up and retention every 60
 seconds. Queue workers do not poll the outbox, and no dedicated outbox process is required.
-Deployments with separate roles must run at least one API role per project so durable outbox
-catch-up and retention remain active.
+Deployments with separate roles must run at least one API role per project, or durable outbox
+catch-up and retention never run.
 
 Because jobs and run records live in durable, shared providers, a crashed worker
 loses no work: the unfinished job's lease expires and another worker reclaims it.
@@ -230,6 +276,9 @@ A typical deployment runs each role as a separate process, all loading the same
 config against shared durable providers:
 
 ```bash
+export SIXB_API_PUBLIC_ORIGIN=https://api.acme.example.com
+export SIXB_ATLAS_PUBLIC_ORIGIN=https://atlas.acme.example.com
+
 sixb api            # HTTP/WS API
 sixb atlas          # admin UI
 sixb orchestrator   # event -> queue dispatch
@@ -238,9 +287,21 @@ sixb rules          # rule evaluation
 sixb worker-group   # all registered queue workers
 ```
 
-Scale queue-worker roles horizontally: extra `sixb worker` processes share the queue and increase
-throughput because each job is claimed by one worker. V0.1.0 runs one API maintenance owner and one
-Rules worker per project; Rules reconciliation has no cross-process lease yet.
+## Scaling roles
+
+The data plane scales horizontally. The control plane does not: in 0.1.0 the
+orchestrator, scheduler, and rules roles must each run as a **single process**.
+
+| Role                               | Replicas | Why                                                    |
+| ---------------------------------- | -------- | ------------------------------------------------------ |
+| `sixb api`                         | many     | outbox claims are lease-fenced, so drains never overlap |
+| `sixb atlas`, `sixb app`           | many     | they serve a static bundle                              |
+| `sixb worker`, `sixb worker-group` | many     | each job is claimed by exactly one worker               |
+| `sixb orchestrator`                | **one**  | a second process dispatches the same event twice        |
+| `sixb scheduler`                   | **one**  | a second process fires the same occurrence twice        |
+| `sixb rules`                       | **one**  | reconciliation has no cross-process lease               |
+
+Running two of a single-process role does not corrupt data — it duplicates runs.
 
 ## Related
 

--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -124,11 +124,31 @@ predicates. See [Client events](../client/events.md). For action buttons, prefer
 
 ### Appending events
 
-`sixb.events.append(input)` authors supported non-ontology domain events. Object, link, and telemetry
-facts are emitted only by the Materializer after their ontology commit succeeds; the public
-`DomainEventLog` cannot publish persisted outbox envelopes.
+`sixb.events.append(input)` authors supported non-ontology domain events:
 
 ```ts
+// fire a scheduled workflow now, without waiting for its cron
+await sixb.events.append({
+  events: [
+    {
+      type: "schedule.triggered",
+      payload: {
+        scheduleId: "nightly-invoice-sweep",
+        occurrenceAt: "2026-04-18T02:00:00.000Z",
+        triggeredAt: "2026-04-18T02:00:00.000Z",
+        occurrenceKey: "nightly-invoice-sweep:2026-04-18T02:00:00.000Z",
+      },
+    },
+  ],
+})
+```
+
+Ontology facts are not appendable. `append` throws on `object.*`, `link.*`, and `telemetry.*`,
+because the Materializer emits those itself once the ontology commit succeeds. Write through the
+ontology and the event follows:
+
+```ts
+// emits object.updated after the commit
 await sixb.objects(Invoice).upsert({
   properties: { id: "INV-1042", status: "paid" },
 })

--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -143,9 +143,10 @@ await sixb.events.append({
 })
 ```
 
-Ontology facts are not appendable. `append` throws on `object.*`, `link.*`, and `telemetry.*`,
-because the Materializer emits those itself once the ontology commit succeeds. Write through the
-ontology and the event follows:
+Ontology facts are not appendable. `object.*`, `link.*`, and `telemetry.*` are not in the parameter
+type, so they do not compile, and the runtime throws for a caller that reached it untyped. The
+Materializer emits them itself once the ontology commit succeeds — write through the ontology and
+the event follows:
 
 ```ts
 // emits object.updated after the commit

--- a/docs/infrastructure/overview.md
+++ b/docs/infrastructure/overview.md
@@ -102,6 +102,32 @@ freeze writers and drain jobs
 
 Project-specific mappings and migration scripts stay outside the framework.
 
+## Retention
+
+The API role purges expired rows every 60 seconds, in the same maintenance pass that
+catches the outbox up.
+
+| Table                  | Purged                                    | Default |
+| ---------------------- | ----------------------------------------- | ------- |
+| `ontology_outbox`      | published rows                            | 24 h    |
+| `ontology_source_rows` | terminal materializations, children first | 24 h    |
+| `ontology_commits`     | **nothing** — it grows with every commit  | —       |
+
+Pending outbox rows and nonterminal sources are live data and are never purged by age.
+Size the disk with `ontology_commits` in mind: 0.1.0 has no purge for it.
+
+```ts
+export const sixb = await createSixb({
+  // ...
+  ontologyMaintenance: {
+    intervalMs: 60_000,
+    publishedOutboxRetentionMs: 24 * 60 * 60_000,
+    terminalSourceRetentionMs: 24 * 60 * 60_000,
+    cleanupLimit: 1_000, // rows deleted per table per pass
+  },
+})
+```
+
 ## Provider matrix
 
 Pick a real provider class for each slot. `InMemory*` providers come from `@sixb/core` and
@@ -160,15 +186,17 @@ See [Deployment](../deployment/overview.md) for running this in production.
 ## Migrations
 
 SQL-backed storage providers (`@sixb/pg`, `@sixb/sqlite`) own their schema and ship
-migrations. The CLI runs them automatically on startup, so you mainly need the explicit
-command for pre-deploy migration steps:
+migrations. The six roles that touch the schema apply them at startup, so the explicit
+command is for running the migration as its own deploy stage:
 
 ```bash
-sixb db:migrate
+sixb db migrate
 ```
 
 This loads your runtime and applies pending migrations against the configured `storage`
-provider. In-memory and file-lake providers have no schema and skip this step.
+provider. In-memory and file-lake providers have no schema and skip this step. See
+[Deployment](../deployment/overview.md#storage-migrations) for which roles migrate and how
+to start them without migrating.
 
 ## Related
 

--- a/docs/infrastructure/overview.md
+++ b/docs/infrastructure/overview.md
@@ -107,11 +107,12 @@ Project-specific mappings and migration scripts stay outside the framework.
 The API role purges expired rows every 60 seconds, in the same maintenance pass that
 catches the outbox up.
 
-| Table                  | Purged                                    | Default |
-| ---------------------- | ----------------------------------------- | ------- |
-| `ontology_outbox`      | published rows                            | 24 h    |
-| `ontology_source_rows` | terminal materializations, children first | 24 h    |
-| `ontology_commits`     | **nothing** — it grows with every commit  | —       |
+| Table                  | Purged                                     | Default |
+| ---------------------- | ------------------------------------------ | ------- |
+| `ontology_outbox`      | published rows                             | 24 h    |
+| `ontology_source_rows` | the rows of a terminal materialization     | 24 h    |
+| `ontology_sources`     | its manifest, once those rows are gone     | 24 h    |
+| `ontology_commits`     | **nothing** — it grows with every commit   | —       |
 
 Pending outbox rows and nonterminal sources are live data and are never purged by age.
 Size the disk with `ontology_commits` in mind: 0.1.0 has no purge for it.

--- a/docs/objects/telemetry.md
+++ b/docs/objects/telemetry.md
@@ -168,7 +168,8 @@ The server exposes the same operations as routes on an object:
 | `GET` | `/api/objects/:objectTypeId/:objectId/telemetry/:propertyId/latest` | Read latest point |
 
 The append body is `{ value, unit?, at? }`. History accepts `from`, `to`, `order`, and `limit` as
-query parameters. See the [HTTP reference](./http-reference.md) for the full object API.
+query parameters. Appending is **not grant-checked in 0.1.0** — see
+[Authorization](../auth/authorization.md). See the [HTTP reference](./http-reference.md) for the full object API.
 
 ## The telemetry.appended event
 

--- a/docs/server/overview.md
+++ b/docs/server/overview.md
@@ -66,6 +66,7 @@ All JSON routes are prefixed with `/api` and mirror the runtime's typed APIs; se
 | -------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------- |
 | Objects CRUD   | `GET /api/objects`, `GET/PUT /api/objects/:type/:id`                                 | [Objects](../objects/overview.md)               |
 | Object query   | `POST /api/objects/query`, `.../query/count`, `.../query/exists`, `.../query/facets` | [Querying](../objects/querying.md)              |
+| Files          | `POST /api/files`, `/api/files/uploads/...`, `GET .../files/content`                 | [Files](#files)                                 |
 | Telemetry      | `GET/POST /api/objects/:type/:id/telemetry/:prop`, `.../history`, `.../latest`       | [Telemetry](../objects/telemetry.md)            |
 | Links          | `GET/PUT/DELETE /api/objects/:type/:id/links/:linkId`                                | [Links](../ontology/links.md)                   |
 | Actions        | `GET /api/actions`, `POST /api/actions/:actionId`                                    | [Actions](../actions/overview.md)               |
@@ -96,6 +97,38 @@ Status endpoints have distinct meanings:
 | `GET /health` | The API process is alive. | Returns `200` while the process can serve HTTP. |
 | `GET /ready` | Storage is reachable and its schema is current. | Returns `503` when the runtime must leave traffic. |
 | `GET /api/status` | Cached outbox, retry, cleanup, and maintenance state. | Reports `degraded` without removing a healthy API from traffic. |
+
+## Files
+
+A [`fileRef`](../ontology/properties.md) property holds a blob. Uploading it takes one request
+when the file is small, and a session when it is not.
+
+| Route | Use |
+| --- | --- |
+| `POST /api/files` | one multipart request; the whole file travels through the API |
+| `POST /api/files/uploads` | open a session for a large or client-uploaded file |
+| `PUT /api/files/uploads/:uploadId/content` | send the content through the API |
+| `POST /api/files/uploads/:uploadId/parts/:partNumber` | get a signed URL and upload the part directly to blob storage |
+| `POST /api/files/uploads/:uploadId/complete` | finish the session and get the reference |
+| `POST /api/files/uploads/:uploadId/abort` | discard it |
+
+Reading back is `GET` (or `HEAD`) on the owner's `files/content`, with a JSON pointer to the
+reference as `path` — on an object it must start with `/properties`:
+
+```bash
+curl "$API/api/objects/Invoice/inv-1/files/content?path=/properties/scan" -o scan.pdf
+```
+
+The same route shape hangs off action runs, workflow runs, workflow-run nodes, and agent thread
+messages — `/api/action-runs/:runId/files/content`, `/api/workflow-runs/:runId/files/content`,
+`.../nodes/:nodeKey/files/content`, and
+`/api/agent-threads/:threadId/messages/:messageId/files/content`.
+
+> **0.1.0 limit — upload sessions are in-memory.** Neither `@sixb/pg` nor `@sixb/sqlite`
+> implements `fileUploadSessions`, so every session opened by `POST /api/files/uploads` lives in
+> the serving process: it does not survive a restart and is not shared across replicas. Route a
+> session's requests to one instance, supply your own store on `sixb.storage.fileUploadSessions`,
+> or use single-request `POST /api/files`, which is unaffected.
 
 ## Real-time events
 

--- a/docs/server/overview.md
+++ b/docs/server/overview.md
@@ -86,6 +86,9 @@ All JSON routes are prefixed with `/api` and mirror the runtime's typed APIs; se
 | Auth           | `/api/auth/session`, `/auth/sign-in`, `/auth/callback`, `/api/auth/...`              | [Auth](../auth/overview.md)                     |
 | Project/Status | `GET /api/project`, `GET /api/status`, `GET /health`, `GET /ready`                   | —                                               |
 
+The object, link, and telemetry **writes are not grant-checked in 0.1.0**: any authenticated session
+can call them. Reads are filtered. See [Authorization](../auth/authorization.md).
+
 Status endpoints have distinct meanings:
 
 | Endpoint | Meaning | Failure behavior |

--- a/docs/workflows/overview.md
+++ b/docs/workflows/overview.md
@@ -253,6 +253,10 @@ A run moves through these statuses, recorded per run and per node so you can ins
 Nodes run sequentially. Step `input` and `output` are validated against their schemas at runtime, so
 a malformed shape fails the run rather than passing bad data downstream.
 
+`GET /api/workflows` carries a `latestRun` per workflow. It is `null` when the workflow has never
+run, and also when the `storage` provider keeps no run history — every published provider does, so
+only a partial custom provider hits that second case.
+
 ## Register and run
 
 Put workflow definitions under `workflows/` and export them. `createSixb()` discovers them

--- a/packages/cli/src/commands/api.tsx
+++ b/packages/cli/src/commands/api.tsx
@@ -53,7 +53,7 @@ export async function runApi(options: ApiOptions = {}) {
       .then(() => true)
       .catch(() => false)
     const topology = resolveBrowserTopology({
-      mode: "production",
+      role: "api",
       host: options.host,
       apiHost: options.apiHost,
       port: options.port,
@@ -61,7 +61,7 @@ export async function runApi(options: ApiOptions = {}) {
       apiPublicOrigin: options.apiPublicOrigin,
       atlasPublicOrigin: options.atlasPublicOrigin,
       appPublicOrigin: options.appPublicOrigin,
-      includeCustomApp: hasBuiltCustomApp,
+      hasCustomApp: hasBuiltCustomApp,
     })
 
     server = createSixbServer({

--- a/packages/cli/src/commands/api.tsx
+++ b/packages/cli/src/commands/api.tsx
@@ -57,7 +57,7 @@ export async function runApi(options: ApiOptions = {}) {
       host: options.host,
       apiHost: options.apiHost,
       port: options.port,
-      apiPort: options.apiPort ?? options.port,
+      apiPort: options.apiPort,
       apiPublicOrigin: options.apiPublicOrigin,
       atlasPublicOrigin: options.atlasPublicOrigin,
       appPublicOrigin: options.appPublicOrigin,

--- a/packages/cli/src/commands/app.tsx
+++ b/packages/cli/src/commands/app.tsx
@@ -41,7 +41,7 @@ export async function runApp(options: AppOptions = {}) {
     const topology = resolveBrowserTopology({
       role: "app",
       host: options.host,
-      appPort: options.port,
+      port: options.port,
       apiPublicOrigin: options.apiPublicOrigin,
       appPublicOrigin: options.appPublicOrigin,
     })

--- a/packages/cli/src/commands/app.tsx
+++ b/packages/cli/src/commands/app.tsx
@@ -39,14 +39,11 @@ export async function runApp(options: AppOptions = {}) {
     }
 
     const topology = resolveBrowserTopology({
-      mode: "production",
+      role: "app",
       host: options.host,
       appPort: options.port,
       apiPublicOrigin: options.apiPublicOrigin,
       appPublicOrigin: options.appPublicOrigin,
-      includeAtlas: false,
-      includeCustomApp: true,
-      serves: "app",
     })
 
     const customApp = await createCustomApp({
@@ -69,7 +66,7 @@ export async function runApp(options: AppOptions = {}) {
         title="Sixb app started"
         name={sixb.id}
         serviceName="Custom app"
-        items={[{ label: "URL", value: servedUrl(topology, "app") }]}
+        items={[{ label: "URL", value: servedUrl(topology) }]}
       />
     )
 

--- a/packages/cli/src/commands/app.tsx
+++ b/packages/cli/src/commands/app.tsx
@@ -1,7 +1,7 @@
 import { stat } from "node:fs/promises"
 import { resolve } from "node:path"
 import { type CustomAppDevServer, createCustomApp } from "@sixb/app"
-import { resolveBrowserTopology } from "../lib/browser-topology"
+import { resolveBrowserTopology, servedUrl } from "../lib/browser-topology"
 import type { LoadedSixb } from "../lib/loadSixb"
 import { builtAppOutdir, loadProductionSixb } from "../lib/production"
 import { runUntilSignal, stopQuietly, stopSixbProviders } from "../lib/runtime"
@@ -46,10 +46,8 @@ export async function runApp(options: AppOptions = {}) {
       appPublicOrigin: options.appPublicOrigin,
       includeAtlas: false,
       includeCustomApp: true,
+      serves: "app",
     })
-    if (!topology.appPublicOrigin) {
-      throw new Error("[SixbCLI] Custom app public origin was not resolved.")
-    }
 
     const customApp = await createCustomApp({
       rootDir: loaded.projectRoot,
@@ -71,7 +69,7 @@ export async function runApp(options: AppOptions = {}) {
         title="Sixb app started"
         name={sixb.id}
         serviceName="Custom app"
-        items={[{ label: "URL", value: topology.appPublicOrigin }]}
+        items={[{ label: "URL", value: servedUrl(topology, "app") }]}
       />
     )
 

--- a/packages/cli/src/commands/atlas.tsx
+++ b/packages/cli/src/commands/atlas.tsx
@@ -26,14 +26,11 @@ export async function runAtlas(options: AtlasOptions = {}) {
 
   try {
     const topology = resolveBrowserTopology({
-      mode: "production",
+      role: "atlas",
       host: options.host,
       port: options.port,
       apiPublicOrigin: options.apiPublicOrigin,
       atlasPublicOrigin: options.atlasPublicOrigin,
-      includeAtlas: true,
-      includeCustomApp: false,
-      serves: "atlas",
     })
 
     const atlas = createAtlasApp({
@@ -53,7 +50,7 @@ export async function runAtlas(options: AtlasOptions = {}) {
         title="Sixb Atlas started"
         name={sixb.id}
         serviceName="Atlas"
-        items={[{ label: "URL", value: servedUrl(topology, "atlas") }]}
+        items={[{ label: "URL", value: servedUrl(topology) }]}
       />
     )
 

--- a/packages/cli/src/commands/atlas.tsx
+++ b/packages/cli/src/commands/atlas.tsx
@@ -1,5 +1,5 @@
 import { type AtlasAppServer, createAtlasApp } from "@sixb/atlas"
-import { resolveBrowserTopology } from "../lib/browser-topology"
+import { resolveBrowserTopology, servedUrl } from "../lib/browser-topology"
 import type { LoadedSixb } from "../lib/loadSixb"
 import { builtAtlasOutdir, loadProductionSixb } from "../lib/production"
 import { runUntilSignal, stopQuietly, stopSixbProviders } from "../lib/runtime"
@@ -33,10 +33,8 @@ export async function runAtlas(options: AtlasOptions = {}) {
       atlasPublicOrigin: options.atlasPublicOrigin,
       includeAtlas: true,
       includeCustomApp: false,
+      serves: "atlas",
     })
-    if (!topology.atlasPublicOrigin) {
-      throw new Error("[SixbCLI] Atlas public origin was not resolved.")
-    }
 
     const atlas = createAtlasApp({
       apiBaseUrl: topology.apiPublicOrigin,
@@ -55,7 +53,7 @@ export async function runAtlas(options: AtlasOptions = {}) {
         title="Sixb Atlas started"
         name={sixb.id}
         serviceName="Atlas"
-        items={[{ label: "URL", value: topology.atlasPublicOrigin }]}
+        items={[{ label: "URL", value: servedUrl(topology, "atlas") }]}
       />
     )
 

--- a/packages/cli/src/commands/dev.tsx
+++ b/packages/cli/src/commands/dev.tsx
@@ -42,7 +42,7 @@ export async function runDev(options: DevOptions = {}) {
     const customAppProbe = await createCustomApp({ rootDir: projectRoot })
     const hasCustomApp = await customAppProbe.hasRoutes()
     const topology = resolveBrowserTopology({
-      mode: "development",
+      role: "dev",
       host: options.host,
       apiHost: options.apiHost,
       port: options.port,
@@ -50,7 +50,7 @@ export async function runDev(options: DevOptions = {}) {
       apiPublicOrigin: options.apiPublicOrigin,
       atlasPublicOrigin: options.atlasPublicOrigin,
       appPublicOrigin: options.appPublicOrigin,
-      includeCustomApp: hasCustomApp,
+      hasCustomApp,
     })
 
     runtime = await startSixbRuntime(sixb, {

--- a/packages/cli/src/lib/browser-topology.ts
+++ b/packages/cli/src/lib/browser-topology.ts
@@ -13,9 +13,10 @@ export type BrowserSurface = "atlas" | "app"
 
 interface BrowserBindOptions {
   readonly host?: string
-  readonly apiHost?: string
+  /** `--port`: the port this role binds. See {@link resolveBrowserPorts}. */
   readonly port?: string
-  readonly appPort?: string
+  /** `--api-host` and `--api-port`, which only the two roles that bind the API accept. */
+  readonly apiHost?: string
   readonly apiPort?: string
   readonly apiPublicOrigin?: string
   readonly atlasPublicOrigin?: string
@@ -128,15 +129,24 @@ function resolveBrowserHosts(options: BrowserTopologyOptions): BrowserHosts {
   }
 }
 
+/**
+ * `--port` is the port the role binds. `sixb dev` binds all three surfaces, so there it moves the
+ * whole block and the others keep their offsets from it. Every other role binds exactly one, and
+ * `--port` moves only that one — which is why `sixb app --port 4000` listens on 4000 and not one
+ * past it. The ports a role does not bind keep their defaults and are read by nobody.
+ */
 function resolveBrowserPorts(options: BrowserTopologyOptions): BrowserPorts {
-  const atlasPort = parsePort(options.port, "port", DEFAULT_ATLAS_PORT)
-  const appPort = parsePort(options.appPort, "app-port", atlasPort + DEFAULT_APP_PORT_OFFSET)
-  const apiPort = parsePort(options.apiPort, "api-port", atlasPort + DEFAULT_API_PORT_OFFSET)
+  const requested = parsePort(options.port, "port")
+  const base = options.role === "dev" ? (requested ?? DEFAULT_ATLAS_PORT) : DEFAULT_ATLAS_PORT
+  const bound = options.role === "dev" ? undefined : requested
 
   return {
-    atlasPort,
-    appPort,
-    apiPort,
+    atlasPort: (options.role === "atlas" ? bound : undefined) ?? base,
+    appPort: (options.role === "app" ? bound : undefined) ?? base + DEFAULT_APP_PORT_OFFSET,
+    apiPort:
+      parsePort(options.apiPort, "api-port") ??
+      (options.role === "api" ? bound : undefined) ??
+      base + DEFAULT_API_PORT_OFFSET,
   }
 }
 
@@ -263,9 +273,10 @@ function refusePublicOrigin(envName: string): never {
   )
 }
 
-function parsePort(value: string | undefined, label: string, fallback: number): number {
+/** The port a flag set, or `undefined` when it did not. `label` names the flag in the error. */
+function parsePort(value: string | undefined, label: string): number | undefined {
   if (!value) {
-    return fallback
+    return undefined
   }
 
   const port = Number.parseInt(value, 10)

--- a/packages/cli/src/lib/browser-topology.ts
+++ b/packages/cli/src/lib/browser-topology.ts
@@ -1,4 +1,5 @@
 import type { SixbBrowserOrigin } from "@sixb/server"
+import { configuredOrigin } from "./public-origin"
 
 /**
  * The process resolving the topology. One answer settles what used to be four options: whether
@@ -251,16 +252,6 @@ export function apiEventsUrl(topology: BrowserTopology): string {
   return url.toString()
 }
 
-/** The origin the flag or the environment set, normalized. `null` when neither did. */
-function configuredOrigin(
-  value: string | undefined,
-  envName: string,
-  label: string
-): string | null {
-  const configured = value ?? process.env[envName]
-  return configured ? normalizeOrigin(configured, label) : null
-}
-
 /** The local default, or `null` outside `sixb dev`, where an origin behind a proxy is a guess. */
 function localOrigin(role: BrowserRole, port: number): string | null {
   return role === "dev" ? `http://localhost:${port}` : null
@@ -283,25 +274,6 @@ function parsePort(value: string | undefined, label: string, fallback: number): 
   }
 
   return port
-}
-
-function normalizeOrigin(value: string, label: string): string {
-  let url: URL
-  try {
-    url = new URL(value)
-  } catch {
-    throw new Error(`[SixbCLI] Invalid ${label}: '${value}'.`)
-  }
-
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error(`[SixbCLI] ${label} must use http or https.`)
-  }
-
-  if (url.pathname !== "/" || url.search || url.hash) {
-    throw new Error(`[SixbCLI] ${label} must be an origin, not a full URL.`)
-  }
-
-  return url.origin
 }
 
 function toKebabCase(value: string): string {

--- a/packages/cli/src/lib/browser-topology.ts
+++ b/packages/cli/src/lib/browser-topology.ts
@@ -1,7 +1,16 @@
 import type { SixbBrowserOrigin } from "@sixb/server"
 
-export interface BrowserTopologyOptions {
-  readonly mode: "development" | "production"
+/**
+ * The process resolving the topology. One answer settles what used to be four options: whether
+ * local defaults apply, which browser surfaces the process has to account for, and which one it
+ * serves itself.
+ */
+export type BrowserRole = "dev" | "api" | "atlas" | "app"
+
+/** The two surfaces a browser loads, and the audience each maps to. */
+export type BrowserSurface = "atlas" | "app"
+
+interface BrowserBindOptions {
   readonly host?: string
   readonly apiHost?: string
   readonly port?: string
@@ -10,16 +19,20 @@ export interface BrowserTopologyOptions {
   readonly apiPublicOrigin?: string
   readonly atlasPublicOrigin?: string
   readonly appPublicOrigin?: string
-  readonly includeAtlas?: boolean
-  readonly includeCustomApp: boolean
-
-  /**
-   * The browser surface this process serves itself, if any. That role only prints the surface's
-   * public origin, so it starts without one. The API role names nothing here: the same origins are
-   * its CORS allowlist, where a guessed entry is a hole rather than a cosmetic default.
-   */
-  readonly serves?: "atlas" | "app"
 }
+
+export type BrowserTopologyOptions = BrowserBindOptions &
+  (
+    | {
+        /**
+         * Hosts the API, so its allowlist has to name every surface the project actually
+         * serves — including the custom app, which exists only when the project has one.
+         */
+        readonly role: "dev" | "api"
+        readonly hasCustomApp: boolean
+      }
+    | { readonly role: BrowserSurface }
+  )
 
 export interface BrowserTopology {
   readonly host: string
@@ -31,6 +44,13 @@ export interface BrowserTopology {
   readonly atlasPublicOrigin: string | null
   readonly appPublicOrigin: string | null
   readonly allowedBrowserOrigins: readonly SixbBrowserOrigin[]
+  /** The surface this process serves itself, or `null` when it serves none. */
+  readonly serves: BrowserSurface | null
+}
+
+/** A topology resolved by a role that serves a surface, so {@link servedUrl} always has one. */
+export interface ServingBrowserTopology extends BrowserTopology {
+  readonly serves: BrowserSurface
 }
 
 interface BrowserHosts {
@@ -62,6 +82,10 @@ const DEFAULT_ATLAS_PORT = 3000
 const DEFAULT_APP_PORT_OFFSET = 1
 const DEFAULT_API_PORT_OFFSET = 2
 
+export function resolveBrowserTopology(
+  options: BrowserBindOptions & { readonly role: BrowserSurface }
+): ServingBrowserTopology
+export function resolveBrowserTopology(options: BrowserTopologyOptions): BrowserTopology
 export function resolveBrowserTopology(options: BrowserTopologyOptions): BrowserTopology {
   const hosts = resolveBrowserHosts(options)
   const ports = resolveBrowserPorts(options)
@@ -72,13 +96,31 @@ export function resolveBrowserTopology(options: BrowserTopologyOptions): Browser
     ...ports,
     ...origins,
     allowedBrowserOrigins: createAllowedBrowserOrigins(origins),
+    serves: servedSurface(options.role),
+  }
+}
+
+/** The surface a role serves itself. For the two roles that serve one, it is the role. */
+function servedSurface(role: BrowserRole): BrowserSurface | null {
+  return role === "atlas" || role === "app" ? role : null
+}
+
+/** The surfaces a role's topology has to resolve an origin for. */
+function surfacesOf(options: BrowserTopologyOptions): Record<BrowserSurface, boolean> {
+  switch (options.role) {
+    case "dev":
+    case "api":
+      return { atlas: true, app: options.hasCustomApp }
+    case "atlas":
+      return { atlas: true, app: false }
+    case "app":
+      return { atlas: false, app: true }
   }
 }
 
 function resolveBrowserHosts(options: BrowserTopologyOptions): BrowserHosts {
   const host =
-    options.host ??
-    (options.mode === "development" ? DEFAULT_DEVELOPMENT_HOST : DEFAULT_PRODUCTION_HOST)
+    options.host ?? (options.role === "dev" ? DEFAULT_DEVELOPMENT_HOST : DEFAULT_PRODUCTION_HOST)
   return {
     host,
     apiHost: options.apiHost ?? host,
@@ -101,22 +143,23 @@ function resolveBrowserPublicOrigins(
   options: BrowserTopologyOptions,
   ports: BrowserPorts
 ): BrowserPublicOrigins {
+  const surfaces = surfacesOf(options)
+
   // Every browser surface sends its requests here, so this one is never inferred in production.
   const apiPublicOrigin =
     configuredOrigin(options.apiPublicOrigin, "SIXB_API_PUBLIC_ORIGIN", "API public origin") ??
-    localOrigin(options, ports.apiPort) ??
+    localOrigin(options.role, ports.apiPort) ??
     refusePublicOrigin("SIXB_API_PUBLIC_ORIGIN")
 
-  const atlasPublicOrigin =
-    (options.includeAtlas ?? true)
-      ? resolveSurfaceOrigin(options, "atlas", {
-          value: options.atlasPublicOrigin,
-          envName: "SIXB_ATLAS_PUBLIC_ORIGIN",
-          label: "Atlas public origin",
-          port: ports.atlasPort,
-        })
-      : null
-  const appPublicOrigin = options.includeCustomApp
+  const atlasPublicOrigin = surfaces.atlas
+    ? resolveSurfaceOrigin(options, "atlas", {
+        value: options.atlasPublicOrigin,
+        envName: "SIXB_ATLAS_PUBLIC_ORIGIN",
+        label: "Atlas public origin",
+        port: ports.atlasPort,
+      })
+    : null
+  const appPublicOrigin = surfaces.app
     ? resolveSurfaceOrigin(options, "app", {
         value: options.appPublicOrigin,
         envName: "SIXB_APP_PUBLIC_ORIGIN",
@@ -139,7 +182,7 @@ function resolveBrowserPublicOrigins(
  */
 function resolveSurfaceOrigin(
   options: BrowserTopologyOptions,
-  surface: "atlas" | "app",
+  surface: BrowserSurface,
   input: {
     readonly value: string | undefined
     readonly envName: string
@@ -150,10 +193,10 @@ function resolveSurfaceOrigin(
   const configured = configuredOrigin(input.value, input.envName, input.label)
   if (configured) return configured
 
-  const local = localOrigin(options, input.port)
+  const local = localOrigin(options.role, input.port)
   if (local) return local
 
-  return options.serves === surface ? null : refusePublicOrigin(input.envName)
+  return options.role === surface ? null : refusePublicOrigin(input.envName)
 }
 
 function createAllowedBrowserOrigins(origins: BrowserPublicOrigins): readonly SixbBrowserOrigin[] {
@@ -171,17 +214,27 @@ function createAllowedBrowserOrigins(origins: BrowserPublicOrigins): readonly Si
 }
 
 /**
+ * A bind address that is not an address anyone can open. The default production host is every
+ * interface, so a panel that printed it verbatim answered "where do I go?" with `0.0.0.0`.
+ */
+const WILDCARD_BINDS = new Set(["0.0.0.0", "::", "[::]"])
+
+/**
  * What a browser-serving role shows as its own address. The public origin when one is configured,
  * and otherwise the address it actually bound — which is all the process knows, and better than a
  * startup panel with no URL on it.
  */
-export function servedUrl(topology: BrowserTopology, surface: "atlas" | "app"): string {
+export function servedUrl(topology: ServingBrowserTopology): string {
   const [origin, port] =
-    surface === "atlas"
+    topology.serves === "atlas"
       ? ([topology.atlasPublicOrigin, topology.atlasPort] as const)
       : ([topology.appPublicOrigin, topology.appPort] as const)
 
-  return origin ?? `http://${topology.host}:${port}`
+  return origin ?? `http://${displayHost(topology.host)}:${port}`
+}
+
+function displayHost(host: string): string {
+  return WILDCARD_BINDS.has(host) ? "localhost" : host
 }
 
 export function apiUrl(topology: BrowserTopology): string {
@@ -208,9 +261,9 @@ function configuredOrigin(
   return configured ? normalizeOrigin(configured, label) : null
 }
 
-/** The local default, or `null` in production, where an origin behind a proxy cannot be guessed. */
-function localOrigin(options: BrowserTopologyOptions, port: number): string | null {
-  return options.mode === "development" ? `http://localhost:${port}` : null
+/** The local default, or `null` outside `sixb dev`, where an origin behind a proxy is a guess. */
+function localOrigin(role: BrowserRole, port: number): string | null {
+  return role === "dev" ? `http://localhost:${port}` : null
 }
 
 function refusePublicOrigin(envName: string): never {

--- a/packages/cli/src/lib/browser-topology.ts
+++ b/packages/cli/src/lib/browser-topology.ts
@@ -12,6 +12,13 @@ export interface BrowserTopologyOptions {
   readonly appPublicOrigin?: string
   readonly includeAtlas?: boolean
   readonly includeCustomApp: boolean
+
+  /**
+   * The browser surface this process serves itself, if any. That role only prints the surface's
+   * public origin, so it starts without one. The API role names nothing here: the same origins are
+   * its CORS allowlist, where a guessed entry is a hole rather than a cosmetic default.
+   */
+  readonly serves?: "atlas" | "app"
 }
 
 export interface BrowserTopology {
@@ -94,30 +101,27 @@ function resolveBrowserPublicOrigins(
   options: BrowserTopologyOptions,
   ports: BrowserPorts
 ): BrowserPublicOrigins {
-  const apiPublicOrigin = resolvePublicOrigin({
-    value: options.apiPublicOrigin,
-    envName: "SIXB_API_PUBLIC_ORIGIN",
-    label: "API public origin",
-    localDefault: `http://localhost:${ports.apiPort}`,
-    mode: options.mode,
-  })
-  const includeAtlas = options.includeAtlas ?? true
-  const atlasPublicOrigin = includeAtlas
-    ? resolvePublicOrigin({
-        value: options.atlasPublicOrigin,
-        envName: "SIXB_ATLAS_PUBLIC_ORIGIN",
-        label: "Atlas public origin",
-        localDefault: `http://localhost:${ports.atlasPort}`,
-        mode: options.mode,
-      })
-    : null
+  // Every browser surface sends its requests here, so this one is never inferred in production.
+  const apiPublicOrigin =
+    configuredOrigin(options.apiPublicOrigin, "SIXB_API_PUBLIC_ORIGIN", "API public origin") ??
+    localOrigin(options, ports.apiPort) ??
+    refusePublicOrigin("SIXB_API_PUBLIC_ORIGIN")
+
+  const atlasPublicOrigin =
+    (options.includeAtlas ?? true)
+      ? resolveSurfaceOrigin(options, "atlas", {
+          value: options.atlasPublicOrigin,
+          envName: "SIXB_ATLAS_PUBLIC_ORIGIN",
+          label: "Atlas public origin",
+          port: ports.atlasPort,
+        })
+      : null
   const appPublicOrigin = options.includeCustomApp
-    ? resolvePublicOrigin({
+    ? resolveSurfaceOrigin(options, "app", {
         value: options.appPublicOrigin,
         envName: "SIXB_APP_PUBLIC_ORIGIN",
         label: "custom app public origin",
-        localDefault: `http://localhost:${ports.appPort}`,
-        mode: options.mode,
+        port: ports.appPort,
       })
     : null
 
@@ -126,6 +130,30 @@ function resolveBrowserPublicOrigins(
     atlasPublicOrigin,
     appPublicOrigin,
   }
+}
+
+/**
+ * A browser surface's own public origin. Required wherever it feeds the API's CORS allowlist, and
+ * optional on the role that serves the surface, which only prints it — refusing to start over a
+ * label is a startup an operator has to debug for nothing.
+ */
+function resolveSurfaceOrigin(
+  options: BrowserTopologyOptions,
+  surface: "atlas" | "app",
+  input: {
+    readonly value: string | undefined
+    readonly envName: string
+    readonly label: string
+    readonly port: number
+  }
+): string | null {
+  const configured = configuredOrigin(input.value, input.envName, input.label)
+  if (configured) return configured
+
+  const local = localOrigin(options, input.port)
+  if (local) return local
+
+  return options.serves === surface ? null : refusePublicOrigin(input.envName)
 }
 
 function createAllowedBrowserOrigins(origins: BrowserPublicOrigins): readonly SixbBrowserOrigin[] {
@@ -142,6 +170,20 @@ function createAllowedBrowserOrigins(origins: BrowserPublicOrigins): readonly Si
   return allowedOrigins
 }
 
+/**
+ * What a browser-serving role shows as its own address. The public origin when one is configured,
+ * and otherwise the address it actually bound — which is all the process knows, and better than a
+ * startup panel with no URL on it.
+ */
+export function servedUrl(topology: BrowserTopology, surface: "atlas" | "app"): string {
+  const [origin, port] =
+    surface === "atlas"
+      ? ([topology.atlasPublicOrigin, topology.atlasPort] as const)
+      : ([topology.appPublicOrigin, topology.appPort] as const)
+
+  return origin ?? `http://${topology.host}:${port}`
+}
+
 export function apiUrl(topology: BrowserTopology): string {
   return new URL("/api", topology.apiPublicOrigin).toString().replace(/\/$/, "")
 }
@@ -156,24 +198,24 @@ export function apiEventsUrl(topology: BrowserTopology): string {
   return url.toString()
 }
 
-function resolvePublicOrigin(input: {
-  readonly value: string | undefined
-  readonly envName: string
-  readonly label: string
-  readonly localDefault: string
-  readonly mode: "development" | "production"
-}): string {
-  const configured = input.value ?? process.env[input.envName]
-  if (configured) {
-    return normalizeOrigin(configured, input.label)
-  }
+/** The origin the flag or the environment set, normalized. `null` when neither did. */
+function configuredOrigin(
+  value: string | undefined,
+  envName: string,
+  label: string
+): string | null {
+  const configured = value ?? process.env[envName]
+  return configured ? normalizeOrigin(configured, label) : null
+}
 
-  if (input.mode === "development") {
-    return input.localDefault
-  }
+/** The local default, or `null` in production, where an origin behind a proxy cannot be guessed. */
+function localOrigin(options: BrowserTopologyOptions, port: number): string | null {
+  return options.mode === "development" ? `http://localhost:${port}` : null
+}
 
+function refusePublicOrigin(envName: string): never {
   throw new Error(
-    `[SixbCLI] Production serving requires ${input.envName} or --${toKebabCase(input.envName.replace(/^SIXB_/, "").toLowerCase())}.`
+    `[SixbCLI] Production serving requires ${envName} or --${toKebabCase(envName.replace(/^SIXB_/, "").toLowerCase())}.`
   )
 }
 

--- a/packages/cli/src/lib/public-origin.ts
+++ b/packages/cli/src/lib/public-origin.ts
@@ -1,0 +1,46 @@
+/**
+ * One definition of a public origin, for every role that reads one.
+ *
+ * `SIXB_API_PUBLIC_ORIGIN` used to mean something different depending on who read it: the browser
+ * roles parsed it and refused anything that was not a bare origin, while the agent worker took any
+ * non-blank string and discovered the problem at its first request instead. The same value could
+ * therefore stop `sixb api` at startup and start `sixb worker agent`, which is the failure mode
+ * worth removing — a bad origin should be refused once, by the first role that reads it.
+ */
+
+/** An origin is scheme, host, and port, and nothing after them. */
+export function normalizeOrigin(value: string, label: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`[SixbCLI] Invalid ${label}: '${value}'.`)
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`[SixbCLI] ${label} must use http or https.`)
+  }
+
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(`[SixbCLI] ${label} must be an origin, not a full URL.`)
+  }
+
+  return url.origin
+}
+
+/**
+ * The origin a flag or the environment set, normalized. `null` when neither did, and a thrown
+ * error when one of them set something that is not an origin.
+ */
+export function configuredOrigin(
+  value: string | undefined,
+  envName: string,
+  label: string
+): string | null {
+  const configured = nonblank(value) ?? nonblank(process.env[envName])
+  return configured === undefined ? null : normalizeOrigin(configured, label)
+}
+
+function nonblank(value: string | undefined): string | undefined {
+  return value?.trim() || undefined
+}

--- a/packages/cli/src/lib/worker-registry.ts
+++ b/packages/cli/src/lib/worker-registry.ts
@@ -7,6 +7,7 @@ import { SyncWorker } from "@sixb/sync-worker"
 import { WorkflowWorker } from "@sixb/workflow-worker"
 import { SixbCliError } from "./errors"
 import type { LoadedSixb } from "./loadSixb"
+import { configuredOrigin } from "./public-origin"
 
 export interface WorkerCreationOptions {
   readonly agentApiBaseUrl?: string
@@ -17,6 +18,9 @@ interface WorkerFactory {
   /**
    * Why this worker cannot be constructed with the given options, or `null` when it can.
    * Asked before anything is constructed, so a group names every reason at once.
+   *
+   * A malformed input throws instead of answering: it is one bad value rather than one
+   * unsatisfied worker, and the list of workers it took down would say nothing about it.
    */
   readonly unmetRequirement?: (options: WorkerCreationOptions) => string | null
 }
@@ -175,7 +179,7 @@ function knownWorkers(): string {
 }
 
 function agentApiBaseUrl(value: string | undefined): string | null {
-  return value?.trim() || process.env.SIXB_API_PUBLIC_ORIGIN?.trim() || null
+  return configuredOrigin(value, "SIXB_API_PUBLIC_ORIGIN", "API public origin")
 }
 
 function resolveAgentApiBaseUrl(value: string | undefined): string {

--- a/packages/cli/tests/browser-topology.test.ts
+++ b/packages/cli/tests/browser-topology.test.ts
@@ -101,11 +101,11 @@ describe("browser topology", () => {
       hasCustomApp: true,
     })
 
+    // The API role binds one port. It resolves the other surfaces' *origins*, because they are
+    // its CORS allowlist, but never their ports — so those are not asserted here.
     expect(topology).toMatchObject({
       host: "127.0.0.1",
       apiHost: "127.0.0.2",
-      atlasPort: 8080,
-      appPort: 8081,
       apiPort: 8082,
       atlasPublicOrigin: "https://atlas.example.com",
       appPublicOrigin: "https://app.example.com",
@@ -168,6 +168,63 @@ describe("browser topology", () => {
     // `sixb atlas` ships a bundle that calls the API. Guessing that address serves a UI
     // that cannot talk to anything, which is worse than not starting.
     expect(() => resolveBrowserTopology({ role: "atlas" })).toThrow("SIXB_API_PUBLIC_ORIGIN")
+  })
+
+  test("gives --port to the surface the role actually binds", () => {
+    process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
+    process.env.SIXB_ATLAS_PUBLIC_ORIGIN = "https://atlas.example.com"
+
+    // `--port` used to name Atlas's port whatever the role was, and each command translated it
+    // on the way in. Only `sixb app` translated to a different field, so writing it the way its
+    // three neighbours do bound the app one port past where the operator asked.
+    //
+    // To see this fail, drop the role checks in `resolveBrowserPorts` — `appPort: base +
+    // DEFAULT_APP_PORT_OFFSET` alone puts the app on 4001 and the API back on 3002.
+    expect(resolveBrowserTopology({ role: "app", port: "4000" }).appPort).toBe(4000)
+    expect(resolveBrowserTopology({ role: "atlas", port: "4000" }).atlasPort).toBe(4000)
+    expect(resolveBrowserTopology({ role: "api", hasCustomApp: false, port: "4000" }).apiPort).toBe(
+      4000
+    )
+  })
+
+  test("keeps the offsets a role that binds every surface depends on", () => {
+    const dev = resolveBrowserTopology({ role: "dev", hasCustomApp: true, port: "8080" })
+
+    // `sixb dev` is the one role that binds all three, so its `--port` still moves the block.
+    expect(dev).toMatchObject({ atlasPort: 8080, appPort: 8081, apiPort: 8082 })
+  })
+
+  test("leaves each single-surface role on its usual port with no flag", () => {
+    process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
+    process.env.SIXB_ATLAS_PUBLIC_ORIGIN = "https://atlas.example.com"
+
+    // Unflagged, a role lands where `sixb dev` would have put it — the addresses the README and
+    // the deployment page print. Making `--port` mean "mine" must not move these.
+    expect(resolveBrowserTopology({ role: "atlas" }).atlasPort).toBe(3000)
+    expect(resolveBrowserTopology({ role: "app" }).appPort).toBe(3001)
+    expect(resolveBrowserTopology({ role: "api", hasCustomApp: false }).apiPort).toBe(3002)
+  })
+
+  test("lets --api-port win over --port on the role that takes both", () => {
+    process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
+    process.env.SIXB_ATLAS_PUBLIC_ORIGIN = "https://atlas.example.com"
+
+    const topology = resolveBrowserTopology({
+      role: "api",
+      hasCustomApp: false,
+      port: "8080",
+      apiPort: "9000",
+    })
+
+    expect(topology.apiPort).toBe(9000)
+  })
+
+  test("names the flag the operator typed when a port is invalid", () => {
+    // The error said `--app-port`, a flag no command accepts, to anyone who mistyped
+    // `sixb app --port`.
+    expect(() => resolveBrowserTopology({ role: "app", port: "abc" })).toThrow(
+      "--port must be a valid TCP port"
+    )
   })
 
   test("rejects full URLs where public origins are expected", () => {

--- a/packages/cli/tests/browser-topology.test.ts
+++ b/packages/cli/tests/browser-topology.test.ts
@@ -4,6 +4,7 @@ import {
   apiEventsUrl,
   apiUrl,
   resolveBrowserTopology,
+  servedUrl,
 } from "../src/lib/browser-topology"
 
 const PUBLIC_ORIGIN_ENV = [
@@ -115,6 +116,54 @@ describe("browser topology", () => {
       { origin: "https://app.example.com", audience: "app" },
     ])
     expect(apiEventsUrl(topology)).toBe("wss://api.example.com/ws/events")
+  })
+
+  test("still requires the origin a surface's own role does not serve", () => {
+    process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
+
+    // The API role serves neither surface: these origins are its CORS allowlist, and an
+    // allowlist assembled from guesses is a hole. It is the one role that must refuse.
+    expect(() => resolveBrowserTopology({ mode: "production", includeCustomApp: false })).toThrow(
+      "SIXB_ATLAS_PUBLIC_ORIGIN"
+    )
+  })
+
+  test("serves a surface without its own public origin, and prints where it bound", () => {
+    process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
+
+    const topology = resolveBrowserTopology({
+      mode: "production",
+      host: "127.0.0.1",
+      port: "8080",
+      includeCustomApp: false,
+      serves: "atlas",
+    })
+
+    // Atlas passes its own origin to nothing but the startup panel, so demanding one only
+    // bought an operator a crash on their first production command.
+    expect(topology.atlasPublicOrigin).toBeNull()
+    expect(servedUrl(topology, "atlas")).toBe("http://127.0.0.1:8080")
+  })
+
+  test("prefers a configured origin over the bound address", () => {
+    process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
+    process.env.SIXB_ATLAS_PUBLIC_ORIGIN = "https://atlas.example.com"
+
+    const topology = resolveBrowserTopology({
+      mode: "production",
+      includeCustomApp: false,
+      serves: "atlas",
+    })
+
+    expect(servedUrl(topology, "atlas")).toBe("https://atlas.example.com")
+  })
+
+  test("keeps the API origin required on the role that only displays a surface", () => {
+    // `sixb atlas` ships a bundle that calls the API. Guessing that address serves a UI
+    // that cannot talk to anything, which is worse than not starting.
+    expect(() =>
+      resolveBrowserTopology({ mode: "production", includeCustomApp: false, serves: "atlas" })
+    ).toThrow("SIXB_API_PUBLIC_ORIGIN")
   })
 
   test("rejects full URLs where public origins are expected", () => {

--- a/packages/cli/tests/browser-topology.test.ts
+++ b/packages/cli/tests/browser-topology.test.ts
@@ -28,8 +28,8 @@ describe("browser topology", () => {
 
   test("derives localhost origins on separate ports for development", () => {
     const topology = resolveBrowserTopology({
-      mode: "development",
-      includeCustomApp: true,
+      role: "dev",
+      hasCustomApp: true,
     })
 
     expect(topology).toMatchObject({
@@ -57,8 +57,8 @@ describe("browser topology", () => {
 
   test("omits the app origin when no custom app is served", () => {
     const topology = resolveBrowserTopology({
-      mode: "development",
-      includeCustomApp: false,
+      role: "dev",
+      hasCustomApp: false,
     })
 
     expect(topology.appPublicOrigin).toBeNull()
@@ -71,7 +71,7 @@ describe("browser topology", () => {
     process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
     process.env.SIXB_ATLAS_PUBLIC_ORIGIN = "https://atlas.example.com"
 
-    const topology = resolveBrowserTopology({ mode: "production", includeCustomApp: false })
+    const topology = resolveBrowserTopology({ role: "api", hasCustomApp: false })
 
     // The opposite default from development, and deliberately so: a role in a container
     // has to accept traffic from its load balancer, which is never on loopback.
@@ -81,8 +81,8 @@ describe("browser topology", () => {
   test("requires explicit production origins", () => {
     expect(() =>
       resolveBrowserTopology({
-        mode: "production",
-        includeCustomApp: true,
+        role: "api",
+        hasCustomApp: true,
       })
     ).toThrow("SIXB_API_PUBLIC_ORIGIN")
   })
@@ -93,12 +93,12 @@ describe("browser topology", () => {
     process.env.SIXB_APP_PUBLIC_ORIGIN = "https://app.example.com"
 
     const topology = resolveBrowserTopology({
-      mode: "production",
+      role: "api",
       host: "127.0.0.1",
       apiHost: "127.0.0.2",
       port: "8080",
       apiPort: "8082",
-      includeCustomApp: true,
+      hasCustomApp: true,
     })
 
     expect(topology).toMatchObject({
@@ -123,7 +123,7 @@ describe("browser topology", () => {
 
     // The API role serves neither surface: these origins are its CORS allowlist, and an
     // allowlist assembled from guesses is a hole. It is the one role that must refuse.
-    expect(() => resolveBrowserTopology({ mode: "production", includeCustomApp: false })).toThrow(
+    expect(() => resolveBrowserTopology({ role: "api", hasCustomApp: false })).toThrow(
       "SIXB_ATLAS_PUBLIC_ORIGIN"
     )
   })
@@ -132,45 +132,49 @@ describe("browser topology", () => {
     process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
 
     const topology = resolveBrowserTopology({
-      mode: "production",
+      role: "atlas",
       host: "127.0.0.1",
       port: "8080",
-      includeCustomApp: false,
-      serves: "atlas",
     })
 
     // Atlas passes its own origin to nothing but the startup panel, so demanding one only
     // bought an operator a crash on their first production command.
     expect(topology.atlasPublicOrigin).toBeNull()
-    expect(servedUrl(topology, "atlas")).toBe("http://127.0.0.1:8080")
+    expect(servedUrl(topology)).toBe("http://127.0.0.1:8080")
+  })
+
+  test("prints a reachable address when the role bound every interface", () => {
+    process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
+
+    const topology = resolveBrowserTopology({ role: "atlas" })
+
+    // The production default is `0.0.0.0`, which is where the socket listens and not
+    // somewhere a browser can go. Answering "where do I go?" with it is a URL an
+    // operator has to translate before it is worth printing.
+    expect(topology.host).toBe("0.0.0.0")
+    expect(servedUrl(topology)).toBe("http://localhost:3000")
   })
 
   test("prefers a configured origin over the bound address", () => {
     process.env.SIXB_API_PUBLIC_ORIGIN = "https://api.example.com"
     process.env.SIXB_ATLAS_PUBLIC_ORIGIN = "https://atlas.example.com"
 
-    const topology = resolveBrowserTopology({
-      mode: "production",
-      includeCustomApp: false,
-      serves: "atlas",
-    })
+    const topology = resolveBrowserTopology({ role: "atlas" })
 
-    expect(servedUrl(topology, "atlas")).toBe("https://atlas.example.com")
+    expect(servedUrl(topology)).toBe("https://atlas.example.com")
   })
 
   test("keeps the API origin required on the role that only displays a surface", () => {
     // `sixb atlas` ships a bundle that calls the API. Guessing that address serves a UI
     // that cannot talk to anything, which is worse than not starting.
-    expect(() =>
-      resolveBrowserTopology({ mode: "production", includeCustomApp: false, serves: "atlas" })
-    ).toThrow("SIXB_API_PUBLIC_ORIGIN")
+    expect(() => resolveBrowserTopology({ role: "atlas" })).toThrow("SIXB_API_PUBLIC_ORIGIN")
   })
 
   test("rejects full URLs where public origins are expected", () => {
     expect(() =>
       resolveBrowserTopology({
-        mode: "development",
-        includeCustomApp: false,
+        role: "dev",
+        hasCustomApp: false,
         apiPublicOrigin: "https://api.example.com/api",
       })
     ).toThrow("must be an origin")

--- a/packages/cli/tests/prod-roles.e2e.ts
+++ b/packages/cli/tests/prod-roles.e2e.ts
@@ -231,6 +231,8 @@ describe("role startup connection budget", () => {
     async () => {
       await writePrebuiltAssets(PREBUILT_ATLAS)
       const [atlasPort, apiPort] = await getFreePorts(2)
+      // No `--atlas-public-origin`: Atlas passes its own origin to nothing but the startup
+      // panel, and requiring it made the documented production command exit non-zero.
       const { ready, logEntries } = await startRole([
         "atlas",
         "--port",
@@ -239,8 +241,6 @@ describe("role startup connection budget", () => {
         "127.0.0.1",
         "--api-public-origin",
         `http://localhost:${apiPort}`,
-        "--atlas-public-origin",
-        `http://localhost:${atlasPort}`,
       ])
 
       expect(ready).toBe(true)
@@ -270,8 +270,6 @@ describe("role startup connection budget", () => {
         "127.0.0.1",
         "--api-public-origin",
         `http://localhost:${apiPort}`,
-        "--app-public-origin",
-        `http://localhost:${appPort}`,
       ])
 
       expect(ready).toBe(true)

--- a/packages/cli/tests/worker-registry.test.ts
+++ b/packages/cli/tests/worker-registry.test.ts
@@ -35,6 +35,27 @@ describe("assertWorkerInputs", () => {
     ).not.toThrow()
   })
 
+  test("refuses an origin the browser roles would refuse, at the same moment they would", () => {
+    // `sixb api` has always rejected a bare host. The agent worker used to accept it and
+    // fail at its first request instead, so one `SIXB_API_PUBLIC_ORIGIN` could stop one
+    // role at startup and start another. Both now read the same definition.
+    process.env.SIXB_API_PUBLIC_ORIGIN = "api.example.com"
+
+    expect(() =>
+      assertWorkerInputs({ workerTypes: ["agent"], options: {}, autoSelected: false })
+    ).toThrow("Invalid API public origin")
+  })
+
+  test("refuses a full URL where an origin is expected", () => {
+    expect(() =>
+      assertWorkerInputs({
+        workerTypes: ["agent"],
+        options: { agentApiBaseUrl: "https://api.example.com/api" },
+        autoSelected: false,
+      })
+    ).toThrow("must be an origin")
+  })
+
   test("names what it took down, and how to proceed without it", () => {
     // The whole group refusing is correct: five of six workers running means agent jobs
     // pile up in a queue nobody claims, which looks exactly like an idle system. What was

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -60,6 +60,17 @@ origins are shown as invitation destinations and participate in `can.access(appl
 | `GET` | `/api/objects/:objectTypeId/:objectKey/telemetry/:propertyId/history` | Get telemetry history (`?from=&to=&limit=&order=`) |
 | `GET` | `/api/objects/:objectTypeId/:objectKey/telemetry/:propertyId/latest` | Get latest telemetry point |
 | `GET` | `/api/events` | Read domain events (`?topic=&type=&afterCursor=&limit=`) |
+| `POST` | `/api/files` | Upload a file in one request |
+| `POST` | `/api/files/uploads` | Open an upload session for a large or client-uploaded file |
+| `PUT` | `/api/files/uploads/:uploadId/content` | Send session content through the API |
+| `POST` | `/api/files/uploads/:uploadId/parts/:partNumber` | Sign one part for direct upload to blob storage |
+| `POST` | `/api/files/uploads/:uploadId/complete` | Complete the session and return the file reference |
+| `POST` | `/api/files/uploads/:uploadId/abort` | Discard the session |
+| `GET` | `/api/objects/:objectTypeId/:objectKey/files/content` | Download a `fileRef` property (`?path=/properties/scan`) |
+
+Upload sessions default to an in-memory store: neither `@sixb/pg` nor `@sixb/sqlite` implements
+`fileUploadSessions` in 0.1.0, so a session does not survive a restart and is not shared across
+replicas. Single-request `POST /api/files` is unaffected.
 
 ### WebSocket
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -197,6 +197,9 @@ touch only the components.
 It works with no configuration — lookups fall back to a shared
 [Photon](https://photon.komoot.io) provider, which is free and needs no API key:
 
+> **Where the data goes.** The default sends every keystroke to `photon.komoot.io`. Self-host
+> Photon or supply your own `AddressProvider` before typing confidential addresses into it.
+
 ```tsx
 import { AddressFields } from "@sixb/ui/components"
 import { type AddressDraft, EMPTY_ADDRESS_DRAFT } from "@sixb/ui/lib/address"
@@ -275,7 +278,11 @@ way as address lookup.
 | Hooks | `@sixb/ui/hooks` | `useDictation`, `useSpeechRecognition`, `SpeechRecognitionProvider` |
 | Recognizers | `@sixb/ui/lib/speech` | `SpeechRecognizer` contract, `createWebSpeechRecognizer` |
 
-The default recognizer is the browser's own Web Speech API — no key and no server:
+The default recognizer is the browser's own Web Speech API — no key and no setup:
+
+> **Where the data goes.** "In the browser" is not "on the device": Chrome implements
+> `webkitSpeechRecognition` by streaming the audio to Google. Supply your own `SpeechRecognizer`
+> for confidential dictation.
 
 ```tsx
 import { DictationTextarea } from "@sixb/ui/components"

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -197,8 +197,9 @@ touch only the components.
 It works with no configuration — lookups fall back to a shared
 [Photon](https://photon.komoot.io) provider, which is free and needs no API key:
 
-> **Where the data goes.** The default sends every keystroke to `photon.komoot.io`. Self-host
-> Photon or supply your own `AddressProvider` before typing confidential addresses into it.
+> **Where the data goes.** The default sends what you type to `photon.komoot.io`, debounced and
+> from the third character on. Self-host Photon or supply your own `AddressProvider` before typing
+> confidential addresses into it.
 
 ```tsx
 import { AddressFields } from "@sixb/ui/components"

--- a/scripts/docs-vercel-ignore.ts
+++ b/scripts/docs-vercel-ignore.ts
@@ -1,0 +1,108 @@
+/**
+ * Vercel's Ignored Build Step for the docs site: exit 0 to skip the build, non-zero to run it.
+ *
+ * The rule this replaces diffed `HEAD^ HEAD` against `apps/docs` and `packages/ui`, but the site
+ * renders `/docs` at the repo root (`apps/docs/src/docs/config.ts`). Every documentation-only
+ * commit therefore skipped its own deployment, and nothing ever caught up: twelve of the last three
+ * hundred commits edited a published page that never shipped.
+ *
+ * Two properties keep that from happening again.
+ *
+ * **Prove, or build.** Vercel clones at `--depth=10` with no remote configured, so the previously
+ * deployed commit is regularly missing and no fetch can bring it back. Anything that cannot be
+ * proven untouched is built. A wasted build shows up on an invoice; a stale site shows up nowhere.
+ *
+ * **One declaration, one test.** `WATCHED_PATHS` is the only place the paths are written, and
+ * `scripts/tests/docs-vercel-ignore.test.ts` fails when the site grows a content root or a
+ * workspace dependency outside them.
+ *
+ * `VERCEL_GIT_PREVIOUS_SHA` is the last *successfully deployed* commit for this project and branch,
+ * so the diff spans the whole gap since the last build rather than a single push.
+ */
+
+const LOG_PREFIX = "[SixbDocs]"
+
+/**
+ * Everything the rendered site is built from. `:/` anchors a pathspec to the repo root, so the list
+ * means the same thing whichever directory Vercel runs the ignore step from.
+ */
+export const WATCHED_PATHS = [
+  ":/docs", // the content — read from the repo root by apps/docs/src/docs/config.ts
+  ":/apps/docs", // the site that renders it
+  ":/packages/ui", // its only workspace dependency
+  ":/bun.lock", // a next, shiki, or tailwind bump changes the rendered output
+] as const
+
+export interface IgnoreDecision {
+  readonly build: boolean
+  readonly reason: string
+}
+
+export interface GitProbe {
+  /** Whether `sha` resolves to a commit present in this shallow clone. */
+  readonly hasCommit: (sha: string) => boolean
+  /** Watched paths touched in `range`, or `null` when git could not answer. */
+  readonly changedPaths: (range: string, pathspecs: readonly string[]) => readonly string[] | null
+}
+
+export function decideDocsBuild(input: {
+  readonly previousSha: string | undefined
+  readonly git: GitProbe
+}): IgnoreDecision {
+  const previousSha = input.previousSha?.trim()
+  if (!previousSha) {
+    return { build: true, reason: "no previous successful deployment for this branch" }
+  }
+
+  if (!input.git.hasCommit(previousSha)) {
+    return { build: true, reason: `${abbreviate(previousSha)} is outside the shallow clone` }
+  }
+
+  const changed = input.git.changedPaths(`${previousSha}..HEAD`, WATCHED_PATHS)
+  if (changed === null) {
+    return { build: true, reason: `git could not diff ${abbreviate(previousSha)}..HEAD` }
+  }
+  if (changed.length > 0) {
+    return { build: true, reason: `${summarize(changed)} since ${abbreviate(previousSha)}` }
+  }
+
+  return { build: false, reason: `no watched path changed since ${abbreviate(previousSha)}` }
+}
+
+export function gitProbe(cwd: string): GitProbe {
+  return {
+    hasCommit: (sha) => git(cwd, ["cat-file", "-e", `${sha}^{commit}`]) !== null,
+    changedPaths: (range, pathspecs) => {
+      const output = git(cwd, ["diff", "--name-only", range, "--", ...pathspecs])
+      return output === null ? null : output.split("\n").filter((line) => line.length > 0)
+    },
+  }
+}
+
+/** Trimmed stdout, or `null` when git exited non-zero — which every caller reads as "cannot prove". */
+function git(cwd: string, args: readonly string[]): string | null {
+  const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" })
+  return result.success ? result.stdout.toString().trim() : null
+}
+
+function summarize(changed: readonly string[]): string {
+  const [first, ...rest] = changed
+  return rest.length === 0 ? `${first} changed` : `${first} and ${rest.length} more changed`
+}
+
+function abbreviate(sha: string): string {
+  return sha.slice(0, 8)
+}
+
+if (import.meta.main) {
+  const decision = decideDocsBuild({
+    previousSha: process.env.VERCEL_GIT_PREVIOUS_SHA,
+    git: gitProbe(process.cwd()),
+  })
+
+  // The skip is the dangerous outcome, so it says why, from where, out loud.
+  console.log(
+    `${LOG_PREFIX} ${decision.build ? "build" : "skip"}: ${decision.reason} (in ${process.cwd()})`
+  )
+  process.exitCode = decision.build ? 1 : 0
+}

--- a/scripts/publishable-packages.ts
+++ b/scripts/publishable-packages.ts
@@ -17,9 +17,26 @@ export type PackageJson = {
   license?: string
   publishConfig?: { access?: string }
   dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
   peerDependencies?: Record<string, string>
   optionalDependencies?: Record<string, string>
 }
+
+export type DependencyField =
+  | "dependencies"
+  | "devDependencies"
+  | "peerDependencies"
+  | "optionalDependencies"
+
+/**
+ * The fields a published package carries with it. `devDependencies` is not one: it never ships,
+ * so it constrains neither the publish order nor what a consumer installs.
+ */
+const SHIPPED_DEPENDENCY_FIELDS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const satisfies readonly DependencyField[]
 
 export interface PublishablePackage {
   readonly dir: string
@@ -72,11 +89,18 @@ export function packageName(packageInfo: PublishablePackage): string {
   return packageInfo.packageJson.name ?? packageInfo.dir
 }
 
-/** Names of the sibling workspace packages this one depends on, across every dependency field. */
-export function internalDependencies(packageJson: PackageJson): Set<string> {
+/**
+ * Names of the sibling workspace packages this one depends on. Defaults to the fields that ship,
+ * which is what publishing has to order. Pass `fields` to ask a different question: what a package
+ * is *built* from includes its `devDependencies`.
+ */
+export function internalDependencies(
+  packageJson: PackageJson,
+  fields: readonly DependencyField[] = SHIPPED_DEPENDENCY_FIELDS
+): Set<string> {
   const names = new Set<string>()
 
-  for (const field of ["dependencies", "peerDependencies", "optionalDependencies"] as const) {
+  for (const field of fields) {
     for (const dependency of Object.keys(packageJson[field] ?? {})) {
       if (dependency.startsWith("@sixb/") || dependency === "create-sixb") names.add(dependency)
     }

--- a/scripts/tests/docs-vercel-ignore.test.ts
+++ b/scripts/tests/docs-vercel-ignore.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "bun:test"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join, relative, resolve } from "node:path"
+import { docsConfig } from "../../apps/docs/src/docs/config"
+import { decideDocsBuild, type GitProbe, gitProbe, WATCHED_PATHS } from "../docs-vercel-ignore"
+import { internalDependencies, type PackageJson } from "../publishable-packages"
+
+/**
+ * A skipped deployment is invisible: the site keeps serving, the commit is green, and the page
+ * nobody can read looks published. So the decision is tested for the two ways it can be wrong —
+ * skipping something it should have built, and reading a path list that has drifted from what the
+ * site is actually made of.
+ */
+
+const repoRoot = resolve(import.meta.dir, "..", "..")
+
+/** Repo-relative directories, with the `:/` pathspec anchor stripped. */
+const watchedDirs = WATCHED_PATHS.map((pathspec) => pathspec.slice(2))
+
+function isWatched(repoRelativePath: string): boolean {
+  return watchedDirs.some(
+    (dir) => repoRelativePath === dir || repoRelativePath.startsWith(`${dir}/`)
+  )
+}
+
+function probe(overrides: Partial<GitProbe> = {}): GitProbe {
+  return { hasCommit: () => true, changedPaths: () => [], ...overrides }
+}
+
+describe("decideDocsBuild", () => {
+  test("builds when the branch has no previous deployment to compare against", () => {
+    expect(decideDocsBuild({ previousSha: undefined, git: probe() })).toEqual({
+      build: true,
+      reason: "no previous successful deployment for this branch",
+    })
+  })
+
+  test("builds when the previous commit fell out of the shallow clone", () => {
+    const decision = decideDocsBuild({
+      previousSha: "0f1e2d3c4b5a69788796a5b4c3d2e1f009876543",
+      git: probe({ hasCommit: () => false }),
+    })
+
+    expect(decision.build).toBe(true)
+    expect(decision.reason).toContain("outside the shallow clone")
+  })
+
+  test("builds when git cannot answer at all", () => {
+    const decision = decideDocsBuild({
+      previousSha: "abc1234",
+      git: probe({ changedPaths: () => null }),
+    })
+
+    expect(decision.build).toBe(true)
+    expect(decision.reason).toContain("could not diff")
+  })
+
+  test("builds when a watched path changed, and names the file that caused it", () => {
+    const decision = decideDocsBuild({
+      previousSha: "abc1234",
+      git: probe({ changedPaths: () => ["docs/deployment/overview.md"] }),
+    })
+
+    expect(decision.build).toBe(true)
+    expect(decision.reason).toContain("docs/deployment/overview.md")
+  })
+
+  test("skips only when nothing watched changed", () => {
+    const decision = decideDocsBuild({ previousSha: "abc1234", git: probe() })
+
+    expect(decision.build).toBe(false)
+    expect(decision.reason).toContain("no watched path changed")
+  })
+
+  test("diffs the whole gap since the last deployment, not just the last commit", () => {
+    const ranges: string[] = []
+    decideDocsBuild({
+      previousSha: "abc1234",
+      git: probe({
+        changedPaths: (range) => {
+          ranges.push(range)
+          return []
+        },
+      }),
+    })
+
+    expect(ranges).toEqual(["abc1234..HEAD"])
+  })
+
+  test("asks git about every watched path", () => {
+    let asked: readonly string[] = []
+    decideDocsBuild({
+      previousSha: "abc1234",
+      git: probe({
+        changedPaths: (_range, pathspecs) => {
+          asked = pathspecs
+          return []
+        },
+      }),
+    })
+
+    expect(asked).toEqual(WATCHED_PATHS)
+  })
+})
+
+describe("gitProbe", () => {
+  function commitAll(cwd: string, message: string): string {
+    Bun.spawnSync(["git", "add", "-A"], { cwd })
+    Bun.spawnSync(["git", "commit", "-q", "-m", message], { cwd })
+    return Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd, stdout: "pipe" })
+      .stdout.toString()
+      .trim()
+  }
+
+  function repository(): string {
+    const cwd = mkdtempSync(join(tmpdir(), "sixb-docs-ignore-"))
+    Bun.spawnSync(["git", "init", "-q"], { cwd })
+    Bun.spawnSync(["git", "config", "user.email", "test@sixb.local"], { cwd })
+    Bun.spawnSync(["git", "config", "user.name", "Sixb Test"], { cwd })
+    mkdirSync(join(cwd, "docs"), { recursive: true })
+    mkdirSync(join(cwd, "apps", "docs"), { recursive: true })
+    writeFileSync(join(cwd, "docs", "overview.md"), "# one\n")
+    writeFileSync(join(cwd, "apps", "docs", "page.tsx"), "export default null\n")
+    writeFileSync(join(cwd, "README.md"), "# repo\n")
+    return cwd
+  }
+
+  /**
+   * Vercel runs the ignore step from the project's root directory, not the repo's. The `:/` anchor
+   * is what makes that irrelevant, and it is the assumption the old rule silently depended on.
+   */
+  test("resolves watched paths from a subdirectory, the way Vercel runs it", () => {
+    const cwd = repository()
+    try {
+      const base = commitAll(cwd, "initial")
+      writeFileSync(join(cwd, "docs", "overview.md"), "# two\n")
+      commitAll(cwd, "docs: edit a page")
+
+      const probeFromSubdirectory = gitProbe(join(cwd, "apps", "docs"))
+
+      expect(probeFromSubdirectory.changedPaths(`${base}..HEAD`, WATCHED_PATHS)).toEqual([
+        "docs/overview.md",
+      ])
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test("reports nothing for a change outside the watched paths", () => {
+    const cwd = repository()
+    try {
+      const base = commitAll(cwd, "initial")
+      writeFileSync(join(cwd, "README.md"), "# changed\n")
+      commitAll(cwd, "readme: edit")
+
+      expect(gitProbe(cwd).changedPaths(`${base}..HEAD`, WATCHED_PATHS)).toEqual([])
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test("reports an absent commit rather than throwing", () => {
+    const cwd = repository()
+    try {
+      commitAll(cwd, "initial")
+      const absent = "0f1e2d3c4b5a69788796a5b4c3d2e1f009876543"
+
+      expect(gitProbe(cwd).hasCommit(absent)).toBe(false)
+      expect(gitProbe(cwd).changedPaths(`${absent}..HEAD`, WATCHED_PATHS)).toBeNull()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("the watched paths cover what the site is built from", () => {
+  test("every rendered page lives under a watched path", () => {
+    expect(docsConfig.length).toBeGreaterThan(20)
+
+    const unwatched = docsConfig
+      .map((doc) => relative(repoRoot, doc.sourcePath))
+      .filter((path) => !isWatched(path))
+
+    expect({ unwatched }).toEqual({ unwatched: [] })
+  })
+
+  test("every workspace dependency of the site lives under a watched path", () => {
+    const dependencies = transitiveWorkspaceDependencies("apps/docs")
+    expect(dependencies.length).toBeGreaterThan(0)
+
+    expect({ unwatched: dependencies.filter((dir) => !isWatched(dir)) }).toEqual({ unwatched: [] })
+  })
+})
+
+/** Repo-relative directories of the workspace packages `startDir` depends on, transitively. */
+function transitiveWorkspaceDependencies(startDir: string): string[] {
+  const byName = workspacePackages()
+  const found = new Set<string>()
+  const queue = [startDir]
+
+  while (queue.length > 0) {
+    const dir = queue.pop()
+    if (dir === undefined) continue
+
+    for (const name of internalDependencies(readManifest(dir))) {
+      const dependencyDir = byName.get(name)
+      if (dependencyDir === undefined || found.has(dependencyDir)) continue
+      found.add(dependencyDir)
+      queue.push(dependencyDir)
+    }
+  }
+
+  return [...found]
+}
+
+/**
+ * Every workspace package by name, including the private ones. `discoverPublishablePackages` skips
+ * those, and a private dependency is exactly the kind that would slip past this guard.
+ */
+function workspacePackages(): Map<string, string> {
+  const { workspaces = [] } = readManifest<{ workspaces?: string[] }>(".")
+  const byName = new Map<string, string>()
+
+  for (const pattern of workspaces) {
+    const parent = pattern.replace(/\/\*$/, "")
+    for (const entry of readdirSync(join(repoRoot, parent), { withFileTypes: true })) {
+      const dir = join(parent, entry.name)
+      if (!entry.isDirectory() || !existsSync(join(repoRoot, dir, "package.json"))) continue
+
+      const { name } = readManifest(dir)
+      if (name) byName.set(name, dir)
+    }
+  }
+
+  return byName
+}
+
+function readManifest<T = PackageJson>(repoRelativeDir: string): T {
+  return JSON.parse(readFileSync(join(repoRoot, repoRelativeDir, "package.json"), "utf8")) as T
+}

--- a/scripts/tests/docs-vercel-ignore.test.ts
+++ b/scripts/tests/docs-vercel-ignore.test.ts
@@ -12,7 +12,22 @@ import { tmpdir } from "node:os"
 import { join, relative, resolve } from "node:path"
 import { docsConfig } from "../../apps/docs/src/docs/config"
 import { decideDocsBuild, type GitProbe, gitProbe, WATCHED_PATHS } from "../docs-vercel-ignore"
-import { internalDependencies, type PackageJson } from "../publishable-packages"
+import {
+  type DependencyField,
+  internalDependencies,
+  type PackageJson,
+} from "../publishable-packages"
+
+/**
+ * Every field a build reads, `devDependencies` included — `shiki` and `tailwindcss` are declared
+ * there and are as load-bearing to the rendered page as anything the site ships.
+ */
+const BUILD_DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const satisfies readonly DependencyField[]
 
 /**
  * A skipped deployment is invisible: the site keeps serving, the commit is green, and the page
@@ -126,6 +141,9 @@ describe("gitProbe", () => {
     Bun.spawnSync(["git", "init", "-q"], { cwd })
     Bun.spawnSync(["git", "config", "user.email", "test@sixb.local"], { cwd })
     Bun.spawnSync(["git", "config", "user.name", "Sixb Test"], { cwd })
+    // A contributor who signs every commit globally would otherwise get `gpg: no secret key`
+    // out of a test about pathspecs, since nothing here has a key for `test@sixb.local`.
+    Bun.spawnSync(["git", "config", "commit.gpgsign", "false"], { cwd })
     mkdirSync(join(cwd, "docs"), { recursive: true })
     mkdirSync(join(cwd, "apps", "docs"), { recursive: true })
     writeFileSync(join(cwd, "docs", "overview.md"), "# one\n")
@@ -193,7 +211,7 @@ describe("the watched paths cover what the site is built from", () => {
     expect({ unwatched }).toEqual({ unwatched: [] })
   })
 
-  test("every workspace dependency of the site lives under a watched path", () => {
+  test("every workspace package the site is built from lives under a watched path", () => {
     const dependencies = transitiveWorkspaceDependencies("apps/docs")
     expect(dependencies.length).toBeGreaterThan(0)
 
@@ -211,7 +229,7 @@ function transitiveWorkspaceDependencies(startDir: string): string[] {
     const dir = queue.pop()
     if (dir === undefined) continue
 
-    for (const name of internalDependencies(readManifest(dir))) {
+    for (const name of internalDependencies(readManifest(dir), BUILD_DEPENDENCY_FIELDS)) {
       const dependencyDir = byName.get(name)
       if (dependencyDir === undefined || found.has(dependencyDir)) continue
       found.add(dependencyDir)


### PR DESCRIPTION
Lot D of the 0.1.0 release plan: make the documentation match the code. Every claim below was
read in the tree or executed, not taken from the audit.

## Commits

| # | Commit | Why |
| --- | --- | --- |
| 1 | `docs: deploy the site when the docs change` | the site never deployed on a `/docs`-only commit |
| 2 | `cli: stop atlas and app from requiring an origin they only print` | the documented production commands exited non-zero |
| 3 | `docs: say that HTTP writes are not grant-checked` | the auth page claimed a protection that does not exist |
| 4 | `docs: give deployment commands that start` | + public origins, migrations, `agent` worker, scaling |
| 5 | `docs: name the roles that migrate, and what retention bounds` | + a `## Retention` section |
| 6 | `docs: document the file routes and their in-memory sessions` | the page never mentioned files at all |
| 7 | `docs: correct three claims the code does not make` | Photon/Web Speech, the `append` example, `latestRun` |

Two commits touch code. Both are here because the documentation alone would have recorded a
defect instead of fixing it.

## 1 — The site was not deploying

`apps/docs/vercel.json` diffed `HEAD^ HEAD` against `apps/docs` and `packages/ui`. The site
renders `/docs` at the repo root (`apps/docs/src/docs/config.ts:6`), so a documentation-only
commit skipped its own deployment — **12 of the last 300 commits**, including the page that
documents `delete()`/`restore()`. Replaying the old predicate over history is how that count
was obtained.

`scripts/docs-vercel-ignore.ts` replaces it with *prove, or build*:

```
PREVIOUS_SHA absent              -> build
PREVIOUS_SHA outside the clone   -> build   (Vercel clones --depth=10, no remote to fetch from)
diff PREVIOUS_SHA..HEAD          -> skip only if no watched path moved
```

Executed against this repo, from `apps/docs`, all four branches:

```
[SixbDocs] build: no previous successful deployment for this branch
[SixbDocs] skip:  no watched path changed since 7373563d
[SixbDocs] build: docs/data/projections.md and 1 more changed since e75395dd   <- the bug
[SixbDocs] build: 0f1e2d3c is outside the shallow clone
```

The watched paths are declared once, and `scripts/tests/docs-vercel-ignore.test.ts` fails if the
site grows a content root or a workspace dependency outside them — that guard is the point, not
the script. `VERCEL_GIT_PREVIOUS_SHA` also fixes the second defect of the old rule: it spans
every commit since the last successful build, not just the last one.

## 2 — `sixb atlas` refused to start over a label

`sixb atlas --api-public-origin …`, exactly as the deployment page gives it, exited non-zero:
the role also demanded `--atlas-public-origin`, which it passes to nothing but the startup panel.

| Role | Uses its own origin for | Verdict |
| --- | --- | --- |
| `sixb api` | `allowedOrigins` -> real CORS | stays required |
| `sixb atlas` / `sixb app` | one line of the startup panel | now optional |

Unset, they print the address they bound. `packages/cli/tests/prod-roles.e2e.ts` now starts both
roles *without* the flag, so the test asserts the new contract rather than the old one.

## Not fixed here, filed instead

- #279 — durable, swept file upload sessions for `@sixb/pg` and `@sixb/sqlite`
- HTTP object/link/telemetry writes bypass grant checks. Documented as a 0.1.0 limit; the fix
  (bearer token only) is cheap since `packages/atlas/src` never calls those routes. Issue to open.

## Verified

`bun run check` · `bun run typecheck` · `bun --filter @sixb/cli test:e2e` ·
`bun --filter @sixb/docs build` · `bun test packages/cli/tests/ scripts/tests/` (137)

Every command block added to the docs was run, `sixb db migrate` included — the defect being
fixed is precisely that the commands did not work.
