### PR TITLE
build: preserve workspace package boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,8 @@ repo's `typecheck` chain reads source.
 - A type that appears in a public interface signature must be exported from the same subpath as the interface, or the interface cannot be implemented from outside.
 - `@sixb/core/internal/*` is for this repo's packages only — no compatibility promise. Nothing in `docs/`, `examples/`, `templates/`, or `apps/` may import from it.
 - Export types freely (users need them to annotate their own code); keep runtime values minimal. Connectors export all their wire types on purpose.
-- A package may import a sibling; it must never absorb one. Every bare specifier in `src` or `dist` has to be a declared `dependencies`/`peerDependencies`/`optionalDependencies` entry — `test:publish` rejects the rest, in both directions. `tsc` cannot: the root `paths` map resolves an undeclared `@sixb/*` import to source, so it type-checks and then the bundler inlines it. `scripts/package-boundaries.ts` holds the rule and explains the failure.
+- A package may import a sibling; it must never absorb one. Every bare specifier its JavaScript and TypeScript import — in `src` and in `dist` — has to be a declared `dependencies`/`peerDependencies`/`optionalDependencies` entry, and `test:publish` rejects the rest in both directions. `tsc` cannot: the root `paths` map resolves an undeclared `@sixb/*` import to source, so it type-checks and then the bundler inlines it. `scripts/package-boundaries.ts` holds the rule and explains the failure.
+- Stylesheets served from `src` sit outside that check and stay a manual call. A bare `@import` in CSS is resolved by the consumer's Tailwind — relative to the stylesheet, then up through `node_modules` — not by the module resolver. `@sixb/ui` takes `tailwindcss` as an optional peer for exactly that reason: `@sixb/ui/globals.css` opens with `@import "tailwindcss"`, and only the consumer can satisfy it.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ repo's `typecheck` chain reads source.
 - A type that appears in a public interface signature must be exported from the same subpath as the interface, or the interface cannot be implemented from outside.
 - `@sixb/core/internal/*` is for this repo's packages only — no compatibility promise. Nothing in `docs/`, `examples/`, `templates/`, or `apps/` may import from it.
 - Export types freely (users need them to annotate their own code); keep runtime values minimal. Connectors export all their wire types on purpose.
+- A package may import a sibling; it must never absorb one. Every bare specifier in `src` or `dist` has to be a declared `dependencies`/`peerDependencies`/`optionalDependencies` entry — `test:publish` rejects the rest, in both directions. `tsc` cannot: the root `paths` map resolves an undeclared `@sixb/*` import to source, so it type-checks and then the bundler inlines it. `scripts/package-boundaries.ts` holds the rule and explains the failure.
 
 ## Code Style
 
@@ -138,6 +139,10 @@ repo's `typecheck` chain reads source.
   `packages/core/tests/published-artifacts.e2e.ts` shows the shape. The one in-process exception is
   `atlas-app.test.ts`, which imports Bun's HTML entry because that import *is* the behavior under
   test — it is why `test:ci` runs behind a guard at all.
+- A guard is proven by removing it. Before landing a test that locks in a fix, revert the fix and
+  watch the test fail — a test that passes either way locks in nothing, and reads for years as if
+  it did. Say in the test how to reproduce that check, and say it there when a toolchain version
+  is what makes the failure reachable.
 - Run targeted tests first, then broader checks when shared behavior changes.
 
 ## Contribution Flow

--- a/bun.lock
+++ b/bun.lock
@@ -248,6 +248,27 @@
         "typescript": "^5.7.0",
       },
     },
+    "examples/auth": {
+      "name": "@sixb/example-auth",
+      "dependencies": {
+        "@sixb/app": "workspace:*",
+        "@sixb/auth-magic-link": "workspace:*",
+        "@sixb/auth-oidc": "workspace:*",
+        "@sixb/client": "workspace:*",
+        "@sixb/core": "workspace:*",
+        "@sixb/sqlite": "workspace:*",
+        "@tanstack/react-query": "^5.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.13.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^22.15.30",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+      },
+    },
     "examples/northline": {
       "name": "@sixb/example-northline",
       "dependencies": {
@@ -271,27 +292,6 @@
       },
       "devDependencies": {
         "@sixb/server": "workspace:*",
-        "@types/bun": "latest",
-        "@types/node": "^22.15.30",
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
-      },
-    },
-    "examples/auth": {
-      "name": "@sixb/example-auth",
-      "dependencies": {
-        "@sixb/app": "workspace:*",
-        "@sixb/auth-magic-link": "workspace:*",
-        "@sixb/auth-oidc": "workspace:*",
-        "@sixb/client": "workspace:*",
-        "@sixb/core": "workspace:*",
-        "@sixb/sqlite": "workspace:*",
-        "@tanstack/react-query": "^5.0.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "react-router-dom": "^7.13.0",
-      },
-      "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^22.15.30",
         "@types/react": "^19.0.0",
@@ -648,7 +648,11 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "tailwindcss": "^4.0.0",
       },
+      "optionalPeers": [
+        "tailwindcss",
+      ],
     },
     "packages/workflow-worker": {
       "name": "@sixb/workflow-worker",
@@ -1290,9 +1294,9 @@
 
     "@sixb/ducklake": ["@sixb/ducklake@workspace:storage/ducklake"],
 
-    "@sixb/example-northline": ["@sixb/example-northline@workspace:examples/northline"],
-
     "@sixb/example-auth": ["@sixb/example-auth@workspace:examples/auth"],
+
+    "@sixb/example-northline": ["@sixb/example-northline@workspace:examples/northline"],
 
     "@sixb/example-panasonic-ac": ["@sixb/example-panasonic-ac@workspace:examples/panasonic-ac"],
 
@@ -2421,8 +2425,6 @@
     "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "@sixb/docs/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
-
-    "@sixb/example-acme-corp/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 
     "@sixb/example-roku-tv/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 

--- a/packages/app/tests/package-build.test.ts
+++ b/packages/app/tests/package-build.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dir, "../../..")
+const buildPackageScript = join(repoRoot, "scripts", "build-package.ts")
+
+describe("package build workspace boundaries", () => {
+  let fixtureRoot = ""
+
+  afterEach(async () => {
+    if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true })
+  })
+
+  test("keeps workspace dependencies and their subpaths external", async () => {
+    fixtureRoot = await mkdtemp(join(tmpdir(), "sixb-package-build-"))
+    const consumerRoot = join(fixtureRoot, "packages", "consumer")
+    const dependencyRoot = join(fixtureRoot, "packages", "dependency")
+
+    await mkdir(join(consumerRoot, "src"), { recursive: true })
+    await mkdir(join(dependencyRoot, "src"), { recursive: true })
+    await writeJson(join(fixtureRoot, "package.json"), {
+      private: true,
+      workspaces: ["packages/*"],
+    })
+    await writeJson(join(consumerRoot, "package.json"), {
+      name: "@sixb/fixture-consumer",
+      type: "module",
+      exports: {
+        ".": {
+          bun: "./src/index.ts",
+          import: "./dist/index.js",
+        },
+      },
+      dependencies: {
+        "@sixb/fixture-dependency": "workspace:*",
+      },
+    })
+    await writeJson(join(consumerRoot, "tsconfig.json"), {
+      compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "bundler",
+        target: "ES2022",
+      },
+    })
+    await writeFile(
+      join(consumerRoot, "src", "index.ts"),
+      [
+        'export { rootValue } from "@sixb/fixture-dependency"',
+        'export { subpathValue } from "@sixb/fixture-dependency/subpath"',
+        "",
+      ].join("\n")
+    )
+    await writeJson(join(dependencyRoot, "package.json"), {
+      name: "@sixb/fixture-dependency",
+      type: "module",
+      exports: {
+        ".": {
+          bun: "./src/index.ts",
+          import: "./dist/index.js",
+        },
+        "./subpath": {
+          bun: "./src/subpath.ts",
+          import: "./dist/subpath.js",
+        },
+      },
+    })
+    await writeFile(
+      join(dependencyRoot, "src", "index.ts"),
+      'export { rootValue } from "./value"\n'
+    )
+    await writeFile(
+      join(dependencyRoot, "src", "value.ts"),
+      [
+        'import { thirdPartyValue } from "fixture-third-party"',
+        "export const rootValue = thirdPartyValue",
+        "",
+      ].join("\n")
+    )
+    await writeFile(
+      join(dependencyRoot, "src", "subpath.ts"),
+      'export const subpathValue = "subpath"\n'
+    )
+
+    await runBounded([process.execPath, "install"], fixtureRoot)
+    const thirdPartyRoot = join(dependencyRoot, "node_modules", "fixture-third-party")
+    await mkdir(thirdPartyRoot, { recursive: true })
+    await writeJson(join(thirdPartyRoot, "package.json"), {
+      name: "fixture-third-party",
+      type: "module",
+      exports: "./index.js",
+    })
+    await writeFile(join(thirdPartyRoot, "index.js"), 'export const thirdPartyValue = "root"\n')
+    await runBounded([process.execPath, "run", buildPackageScript], consumerRoot)
+
+    const output = await readFile(join(consumerRoot, "dist", "index.js"), "utf-8")
+    expect(output).toContain('from "@sixb/fixture-dependency"')
+    expect(output).toContain('from "@sixb/fixture-dependency/subpath"')
+    expect(output).not.toContain('from "fixture-third-party"')
+    expect(output).not.toContain('subpathValue = "subpath"')
+  }, 20_000)
+})
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+async function runBounded(command: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(command, {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const timer = setTimeout(() => proc.kill("SIGKILL"), 15_000)
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  clearTimeout(timer)
+
+  if (exitCode !== 0) {
+    throw new Error(`Command failed (${command.join(" ")}):\n${stdout}${stderr}`.trim())
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -98,7 +98,13 @@
   },
   "peerDependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwindcss": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@shadcn/react": "^0.1.0",

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -6,6 +6,9 @@ type PackageJson = {
   name?: string
   types?: string
   exports?: ExportsMap
+  dependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
   sixbBuild?: {
     entrypoints?: string[]
     assets?: Array<{
@@ -36,6 +39,7 @@ const buildConfigDir = join(packageRoot, ".tsbuild")
 
 const packageJson = (await Bun.file(packageJsonPath).json()) as PackageJson
 const packageName = packageJson.name ?? relative(process.cwd(), packageRoot)
+const workspaceExternals = resolveWorkspaceExternals(packageJson)
 
 // Root builds remove dist before TypeScript emits declarations. Package-scoped builds and
 // prepack runs preserve those declarations but remove every runtime artifact so stale chunks,
@@ -60,6 +64,11 @@ if (entrypoints.length > 0) {
     target: "bun",
     format: "esm",
     packages: "external",
+    // `packages: "external"` still follows Bun workspace links resolved through the `bun`
+    // export condition. Preserve every workspace package boundary explicitly: a package artifact
+    // may import a sibling, but it must never absorb that sibling's source and orphan its
+    // third-party imports under the wrong node_modules owner.
+    ...(workspaceExternals.length > 0 ? { external: workspaceExternals } : {}),
     sourcemap: "external",
     // Share modules between entrypoints via chunks. Without splitting, each
     // subpath entry bundles its own copy of shared modules, so stateful
@@ -221,6 +230,26 @@ async function writeBundleTsconfig(): Promise<string> {
     )}\n`
   )
   return bundleTsconfigPath
+}
+
+function resolveWorkspaceExternals(manifest: PackageJson): string[] {
+  const patterns = new Set<string>()
+  for (const field of [
+    manifest.dependencies,
+    manifest.peerDependencies,
+    manifest.optionalDependencies,
+  ]) {
+    for (const [dependency, range] of Object.entries(field ?? {})) {
+      if (!range.startsWith("workspace:")) continue
+
+      // The trailing wildcard covers the package root and every subpath with one pattern.
+      // Separate exact-root and `/*` patterns let Bun inline re-export barrels despite marking
+      // ordinary imports external.
+      patterns.add(`${dependency}*`)
+    }
+  }
+
+  return [...patterns].sort((a, b) => a.localeCompare(b))
 }
 
 async function resolveEntrypoints(

--- a/scripts/build-package.ts
+++ b/scripts/build-package.ts
@@ -1,6 +1,7 @@
 import type { Dirent } from "node:fs"
-import { cp, mkdir, readdir, rm, writeFile } from "node:fs/promises"
+import { cp, mkdir, readdir, rm } from "node:fs/promises"
 import { extname, join, relative, resolve } from "node:path"
+import { workspaceBoundaryPlugins } from "./package-boundaries"
 
 type PackageJson = {
   name?: string
@@ -35,18 +36,15 @@ const packageRoot = process.cwd()
 const srcRoot = join(packageRoot, "src")
 const distRoot = join(packageRoot, "dist")
 const packageJsonPath = join(packageRoot, "package.json")
-const buildConfigDir = join(packageRoot, ".tsbuild")
 
 const packageJson = (await Bun.file(packageJsonPath).json()) as PackageJson
 const packageName = packageJson.name ?? relative(process.cwd(), packageRoot)
-const workspaceExternals = resolveWorkspaceExternals(packageJson)
 
 // Root builds remove dist before TypeScript emits declarations. Package-scoped builds and
 // prepack runs preserve those declarations but remove every runtime artifact so stale chunks,
 // styles, and copied assets cannot leak into a later tarball.
 await cleanRuntimeOutputs(distRoot)
 await mkdir(distRoot, { recursive: true })
-await mkdir(buildConfigDir, { recursive: true })
 
 await ensureDeclarations()
 
@@ -56,7 +54,6 @@ const entrypoints = await resolveEntrypoints(
 )
 
 if (entrypoints.length > 0) {
-  const bundleTsconfigPath = await writeBundleTsconfig()
   const result = await Bun.build({
     entrypoints,
     outdir: distRoot,
@@ -64,11 +61,11 @@ if (entrypoints.length > 0) {
     target: "bun",
     format: "esm",
     packages: "external",
-    // `packages: "external"` still follows Bun workspace links resolved through the `bun`
-    // export condition. Preserve every workspace package boundary explicitly: a package artifact
-    // may import a sibling, but it must never absorb that sibling's source and orphan its
-    // third-party imports under the wrong node_modules owner.
-    ...(workspaceExternals.length > 0 ? { external: workspaceExternals } : {}),
+    // `packages: "external"` judges the resolved path, so it stops applying the moment something
+    // resolves a sibling to a file instead of a package — which the root `tsconfig.json` `paths`
+    // map does whenever `node_modules` has no entry for the specifier. This settles every sibling
+    // on the specifier itself, before resolution can blur it. See `package-boundaries.ts`.
+    plugins: workspaceBoundaryPlugins(packageJson),
     sourcemap: "external",
     // Share modules between entrypoints via chunks. Without splitting, each
     // subpath entry bundles its own copy of shared modules, so stateful
@@ -86,7 +83,6 @@ if (entrypoints.length > 0) {
     // so this pins the value rather than introducing the fold — and
     // `"production"` is the honest value for a published artifact.
     define: { "process.env.NODE_ENV": '"production"' },
-    tsconfig: bundleTsconfigPath,
   })
 
   if (!result.success) {
@@ -212,44 +208,6 @@ async function cleanRuntimeOutputs(directory: string): Promise<void> {
 
 function isMissingPathError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error && error.code === "ENOENT"
-}
-
-async function writeBundleTsconfig(): Promise<string> {
-  const bundleTsconfigPath = join(buildConfigDir, "tsconfig.bundle.json")
-  await writeFile(
-    bundleTsconfigPath,
-    `${JSON.stringify(
-      {
-        extends: "../tsconfig.json",
-        compilerOptions: {
-          paths: {},
-        },
-      },
-      null,
-      2
-    )}\n`
-  )
-  return bundleTsconfigPath
-}
-
-function resolveWorkspaceExternals(manifest: PackageJson): string[] {
-  const patterns = new Set<string>()
-  for (const field of [
-    manifest.dependencies,
-    manifest.peerDependencies,
-    manifest.optionalDependencies,
-  ]) {
-    for (const [dependency, range] of Object.entries(field ?? {})) {
-      if (!range.startsWith("workspace:")) continue
-
-      // The trailing wildcard covers the package root and every subpath with one pattern.
-      // Separate exact-root and `/*` patterns let Bun inline re-export barrels despite marking
-      // ordinary imports external.
-      patterns.add(`${dependency}*`)
-    }
-  }
-
-  return [...patterns].sort((a, b) => a.localeCompare(b))
 }
 
 async function resolveEntrypoints(

--- a/scripts/pack-smoke.ts
+++ b/scripts/pack-smoke.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path"
+import { artifactScope, findUndeclaredImports, sourceScope } from "./package-boundaries"
 import {
   discoverPublishablePackages,
   type ExportTarget,
@@ -19,6 +20,7 @@ topologicalPublishOrder(packages)
 
 for (const packageInfo of packages) {
   validatePackage(packageInfo)
+  await assertImportsAreDeclared(packageInfo)
   await dryRunPack(packageInfo)
 }
 
@@ -174,6 +176,37 @@ function hasRootExport(exports: unknown): boolean {
 
   const keys = Object.keys(exports)
   return keys.includes(".") || keys.every((key) => !key.startsWith("."))
+}
+
+/**
+ * A package may only import what it declares.
+ *
+ * This is the assertion that does not depend on how the build happens to resolve things. A bundler
+ * that absorbs a sibling instead of leaving it external emits that sibling's third-party imports
+ * from the wrong package, and they show up here as names this manifest never promised — which is
+ * also how a plainly forgotten dependency shows up. `tsc` cannot see either one: the root
+ * `tsconfig.json` maps every `@sixb/*` specifier to source, so an undeclared sibling type-checks.
+ *
+ * Both directions matter. `dist` is what non-Bun consumers load; `src` ships in the tarball and
+ * `exports.bun` points Bun consumers straight at it.
+ */
+async function assertImportsAreDeclared(packageInfo: PublishablePackage): Promise<void> {
+  const name = packageName(packageInfo)
+  const packageRoot = join(root, packageInfo.dir)
+
+  for (const scope of [sourceScope, artifactScope]) {
+    const undeclared = await findUndeclaredImports(packageRoot, packageInfo.packageJson, scope)
+    if (undeclared.length === 0) continue
+
+    const detail = undeclared
+      .map(({ specifier, file }) => `  ${specifier} (${scope.directory}/${file})`)
+      .join("\n")
+    throw new Error(
+      `[SixbPublish] ${name} imports packages it does not declare:\n${detail}\n` +
+        "Declare them, or — when they belong to a sibling — check that the sibling is a declared " +
+        "workspace dependency so the build keeps it external instead of absorbing its source."
+    )
+  }
 }
 
 async function dryRunPack(packageInfo: PublishablePackage): Promise<void> {

--- a/scripts/package-boundaries.ts
+++ b/scripts/package-boundaries.ts
@@ -20,6 +20,10 @@ import { internalDependencies } from "./publishable-packages"
  * So the boundary is asserted twice, from one derivation so the two can never drift:
  * `build-package.ts` resolves every sibling as external before the bundler can decide, and
  * `pack-smoke.ts` rejects any package whose imports outrun what its manifest declares.
+ *
+ * Stylesheets are out of scope. A bare `@import` in CSS is resolved by the consumer's Tailwind —
+ * relative to the stylesheet, then up through `node_modules` — not by the module resolver, so
+ * what a published stylesheet needs is declared by hand. `AGENTS.md` says so next to this rule.
  */
 
 /**
@@ -48,11 +52,14 @@ export interface UndeclaredImport {
 /**
  * `src` ships in the tarball and `exports.bun` points Bun consumers straight at it, so a source
  * import is a runtime import on someone else's machine — a devDependency there fails for them,
- * never for us.
+ * never for us. Every module extension, not only the TypeScript ones the repo happens to use.
  */
-export const sourceScope: ImportScope = { directory: "src", glob: "**/*.{ts,tsx}" }
+export const sourceScope: ImportScope = {
+  directory: "src",
+  glob: "**/*.{ts,tsx,js,jsx,mjs,cjs}",
+}
 
-/** What every non-Bun consumer loads. */
+/** What every non-Bun consumer loads. `Bun.build` emits `.js` and nothing else. */
 export const artifactScope: ImportScope = { directory: "dist", glob: "**/*.js" }
 
 /**

--- a/scripts/package-boundaries.ts
+++ b/scripts/package-boundaries.ts
@@ -1,0 +1,204 @@
+import { isBuiltin } from "node:module"
+import { join } from "node:path"
+import { type BunPlugin, Glob } from "bun"
+import { internalDependencies } from "./publishable-packages"
+
+/**
+ * The manifest is the package boundary.
+ *
+ * A package artifact may import a sibling; it must never absorb one. When it does, the sibling's
+ * third-party imports are emitted from a directory that cannot resolve them, and every module
+ * identity inside the absorbed copy splits in two — the same failure `splitting: true` already
+ * guards against within a single package, now across a package boundary.
+ *
+ * Nothing in the resolver enforces that. Bun's `packages: "external"` decides from the *resolved
+ * path*, so any alias that turns `@sixb/ui` into `packages/ui/src/index.ts` makes a sibling look
+ * like local source — and the root `tsconfig.json` `paths` map does exactly that whenever
+ * `node_modules` has no entry for the specifier. The build cannot opt out of the map either: Bun
+ * reads the `tsconfig.json` next to the source file, not the one handed to `Bun.build`.
+ *
+ * So the boundary is asserted twice, from one derivation so the two can never drift:
+ * `build-package.ts` resolves every sibling as external before the bundler can decide, and
+ * `pack-smoke.ts` rejects any package whose imports outrun what its manifest declares.
+ */
+
+/**
+ * The manifest fields that say what a package may import at runtime.
+ *
+ * Structural on purpose: the build script and the release gate each carry their own, wider
+ * `PackageJson`, and only these fields matter here.
+ */
+export interface ManifestDependencies {
+  readonly name?: string
+  readonly dependencies?: Record<string, string>
+  readonly peerDependencies?: Record<string, string>
+  readonly optionalDependencies?: Record<string, string>
+}
+
+export interface ImportScope {
+  readonly directory: string
+  readonly glob: string
+}
+
+export interface UndeclaredImport {
+  readonly specifier: string
+  readonly file: string
+}
+
+/**
+ * `src` ships in the tarball and `exports.bun` points Bun consumers straight at it, so a source
+ * import is a runtime import on someone else's machine — a devDependency there fails for them,
+ * never for us.
+ */
+export const sourceScope: ImportScope = { directory: "src", glob: "**/*.{ts,tsx}" }
+
+/** What every non-Bun consumer loads. */
+export const artifactScope: ImportScope = { directory: "dist", glob: "**/*.js" }
+
+/**
+ * Matches this package's siblings, and only its siblings: each declared name, either whole or
+ * followed by a subpath. `null` when the package has none.
+ *
+ * Siblings come from `internalDependencies` so the build and the release gate share one answer to
+ * "what is a sibling". `pack-smoke.ts` already enforces that the two ways of asking — a `@sixb/*`
+ * name and a `workspace:` range — always agree.
+ */
+export function siblingSpecifierPattern(manifest: ManifestDependencies): RegExp | null {
+  const siblings = [...internalDependencies(manifest)].sort((a, b) => a.localeCompare(b))
+  if (siblings.length === 0) return null
+
+  return new RegExp(`^(?:${siblings.map(escapeRegExp).join("|")})(?:$|/)`)
+}
+
+/**
+ * Resolves every sibling as a package, whatever else would have resolved it.
+ *
+ * This runs on the specifier as written, before the resolution `packages: "external"` judges and
+ * before any alias can rewrite it — which is the only place the boundary can be settled.
+ *
+ * `external` patterns are the obvious alternative and cannot express this: measured against Bun
+ * 1.3.14, an exact `"@sixb/ui"` loses to a `paths` alias and only a wildcard pre-empts it, so the
+ * boundary would have to be written `"@sixb/ui*"` — which also captures `@sixb/ui-anything` and
+ * would externalize a package the manifest never declared.
+ */
+export function workspaceBoundaryPlugins(manifest: ManifestDependencies): BunPlugin[] {
+  const filter = siblingSpecifierPattern(manifest)
+  if (!filter) return []
+
+  return [
+    {
+      name: "sixb:workspace-boundary",
+      setup(build) {
+        build.onResolve({ filter }, ({ path }) => ({ path, external: true }))
+      },
+    },
+  ]
+}
+
+/**
+ * Bare specifiers under `scope` that the manifest does not declare, with the first file importing
+ * each one.
+ *
+ * Bun's transpiler is the parser on purpose. Type-only imports have to erase — they resolve
+ * against devDependencies legitimately — and `@sixb/app` emits real `import` lines inside a
+ * template literal (the generated custom-app entry) that a regex reads as its own imports.
+ */
+export async function findUndeclaredImports(
+  packageRoot: string,
+  manifest: ManifestDependencies,
+  scope: ImportScope
+): Promise<UndeclaredImport[]> {
+  const declared = declaredDependencies(manifest)
+  const directory = join(packageRoot, scope.directory)
+  const offenders = new Map<string, string>()
+
+  for await (const file of scanFiles(directory, scope.glob)) {
+    const contents = stripShebang(await Bun.file(join(directory, file)).text())
+
+    for (const specifier of importedSpecifiers(contents, file)) {
+      const owner = packageOwner(specifier)
+      // A package may reference itself through its own `exports`; that resolves for consumers.
+      if (!owner || owner === manifest.name || declared.has(owner) || offenders.has(owner)) continue
+      offenders.set(owner, file)
+    }
+  }
+
+  return [...offenders]
+    .map(([specifier, file]) => ({ specifier, file }))
+    .sort((a, b) => a.specifier.localeCompare(b.specifier))
+}
+
+/** Every package name this manifest promises will be installed alongside it. */
+function declaredDependencies(manifest: ManifestDependencies): Set<string> {
+  return new Set([
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}),
+    ...Object.keys(manifest.optionalDependencies ?? {}),
+  ])
+}
+
+/**
+ * A parse failure is a real finding, not something to step over: the gate cannot vouch for a file
+ * it never read.
+ */
+function importedSpecifiers(contents: string, file: string): string[] {
+  try {
+    return transpilerFor(loaderFor(file))
+      .scanImports(contents)
+      .map(({ path }) => path)
+  } catch (error) {
+    throw new Error(`[SixbPublish] Could not parse ${file}: ${(error as Error).message}`)
+  }
+}
+
+/** TypeScript generics and JSX are ambiguous, so the loader has to follow the extension. */
+function loaderFor(file: string): SourceLoader {
+  if (file.endsWith(".tsx")) return "tsx"
+  if (file.endsWith(".ts")) return "ts"
+  if (file.endsWith(".jsx")) return "jsx"
+  return "js"
+}
+
+type SourceLoader = "ts" | "tsx" | "js" | "jsx"
+
+const transpilers = new Map<SourceLoader, Bun.Transpiler>()
+
+function transpilerFor(loader: SourceLoader): Bun.Transpiler {
+  const existing = transpilers.get(loader)
+  if (existing) return existing
+
+  const created = new Bun.Transpiler({ loader })
+  transpilers.set(loader, created)
+  return created
+}
+
+/** `Glob.scan` throws on a missing root; a package without the directory has nothing to check. */
+async function* scanFiles(directory: string, glob: string): AsyncGenerator<string> {
+  try {
+    yield* new Glob(glob).scan({ cwd: directory })
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return
+    throw error
+  }
+}
+
+/** The package a bare specifier installs from, or `null` when nothing has to be installed. */
+function packageOwner(specifier: string): string | null {
+  if (specifier.startsWith(".") || specifier.startsWith("/")) return null
+  if (specifier === "bun" || specifier.startsWith("bun:")) return null
+  if (isBuiltin(specifier)) return null
+
+  const segments = specifier.split("/")
+  return specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0]
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+/** `@sixb/cli` ships a bin with a shebang, which the transpiler refuses to parse. */
+function stripShebang(contents: string): string {
+  if (!contents.startsWith("#!")) return contents
+  const newline = contents.indexOf("\n")
+  return newline === -1 ? "" : contents.slice(newline + 1)
+}

--- a/scripts/tests/build-package.test.ts
+++ b/scripts/tests/build-package.test.ts
@@ -1,47 +1,68 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { join } from "node:path"
 
-const repoRoot = resolve(import.meta.dir, "../../..")
-const buildPackageScript = join(repoRoot, "scripts", "build-package.ts")
+/**
+ * The one thing `package-boundaries.test.ts` cannot check: that the bundler is actually handed
+ * the patterns, and that they hold against a real resolution.
+ *
+ * The fixture reproduces the trigger rather than the incident. A sibling only gets absorbed when
+ * something resolves its specifier to a file, which here — as in the repo — is a `tsconfig.json`
+ * `paths` entry pointing at the sibling's source. Drop the `paths` block and the build is correct
+ * either way; that is the control, and it is why the block is not incidental setup.
+ *
+ * To confirm this test still has teeth: delete `external:` from `build-package.ts` and run it.
+ * It must fail. Bun 1.3.14 (`.bun-version`) is where the trigger is live — 1.3.8 resolved through
+ * `packages: "external"` first and never consulted `paths`, so on an older Bun this passes either
+ * way. That drift is the reason the release gate asserts on the artifact and does not rely on
+ * this test alone.
+ */
 
-describe("package build workspace boundaries", () => {
-  let fixtureRoot = ""
+const buildPackageScript = join(import.meta.dir, "..", "build-package.ts")
+const fixtureRoots: string[] = []
 
-  afterEach(async () => {
+afterEach(async () => {
+  while (fixtureRoots.length > 0) {
+    const fixtureRoot = fixtureRoots.pop()
     if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true })
-  })
+  }
+})
 
-  test("keeps workspace dependencies and their subpaths external", async () => {
-    fixtureRoot = await mkdtemp(join(tmpdir(), "sixb-package-build-"))
+describe("build-package", () => {
+  test("keeps a sibling external even when an alias resolves it to source", async () => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), "sixb-package-build-"))
+    fixtureRoots.push(fixtureRoot)
+
     const consumerRoot = join(fixtureRoot, "packages", "consumer")
     const dependencyRoot = join(fixtureRoot, "packages", "dependency")
-
     await mkdir(join(consumerRoot, "src"), { recursive: true })
     await mkdir(join(dependencyRoot, "src"), { recursive: true })
+
     await writeJson(join(fixtureRoot, "package.json"), {
       private: true,
       workspaces: ["packages/*"],
     })
+
     await writeJson(join(consumerRoot, "package.json"), {
       name: "@sixb/fixture-consumer",
       type: "module",
       exports: {
-        ".": {
-          bun: "./src/index.ts",
-          import: "./dist/index.js",
-        },
+        ".": { bun: "./src/index.ts", import: "./dist/index.js" },
       },
-      dependencies: {
-        "@sixb/fixture-dependency": "workspace:*",
-      },
+      dependencies: { "@sixb/fixture-dependency": "workspace:*" },
     })
     await writeJson(join(consumerRoot, "tsconfig.json"), {
       compilerOptions: {
         module: "ESNext",
         moduleResolution: "bundler",
         target: "ES2022",
+        // The trigger. Bun reads the tsconfig next to the source file, so the build cannot opt out
+        // of this map — only naming the sibling in `external` keeps the boundary.
+        paths: {
+          "@sixb/fixture-dependency": ["../dependency/src/index.ts"],
+          "@sixb/fixture-dependency/subpath": ["../dependency/src/subpath.ts"],
+        },
       },
     })
     await writeFile(
@@ -52,18 +73,13 @@ describe("package build workspace boundaries", () => {
         "",
       ].join("\n")
     )
+
     await writeJson(join(dependencyRoot, "package.json"), {
       name: "@sixb/fixture-dependency",
       type: "module",
       exports: {
-        ".": {
-          bun: "./src/index.ts",
-          import: "./dist/index.js",
-        },
-        "./subpath": {
-          bun: "./src/subpath.ts",
-          import: "./dist/subpath.js",
-        },
+        ".": { bun: "./src/index.ts", import: "./dist/index.js" },
+        "./subpath": { bun: "./src/subpath.ts", import: "./dist/subpath.js" },
       },
     })
     await writeFile(
@@ -84,6 +100,9 @@ describe("package build workspace boundaries", () => {
     )
 
     await runBounded([process.execPath, "install"], fixtureRoot)
+
+    // Only the dependency can resolve this, which is the whole point: absorbed source keeps the
+    // import and loses the node_modules that satisfies it.
     const thirdPartyRoot = join(dependencyRoot, "node_modules", "fixture-third-party")
     await mkdir(thirdPartyRoot, { recursive: true })
     await writeJson(join(thirdPartyRoot, "package.json"), {
@@ -92,6 +111,7 @@ describe("package build workspace boundaries", () => {
       exports: "./index.js",
     })
     await writeFile(join(thirdPartyRoot, "index.js"), 'export const thirdPartyValue = "root"\n')
+
     await runBounded([process.execPath, "run", buildPackageScript], consumerRoot)
 
     const output = await readFile(join(consumerRoot, "dist", "index.js"), "utf-8")
@@ -106,13 +126,18 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`)
 }
 
+/**
+ * The unit suite fails at 60 seconds of silence and cannot tell a wedged child from a slow one,
+ * so the child gets a bound of its own and says which it was.
+ */
 async function runBounded(command: string[], cwd: string): Promise<void> {
-  const proc = Bun.spawn(command, {
-    cwd,
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-  const timer = setTimeout(() => proc.kill("SIGKILL"), 15_000)
+  const proc = Bun.spawn(command, { cwd, stdout: "pipe", stderr: "pipe" })
+  let timedOut = false
+  const timer = setTimeout(() => {
+    timedOut = true
+    proc.kill("SIGKILL")
+  }, 15_000)
+
   const [exitCode, stdout, stderr] = await Promise.all([
     proc.exited,
     new Response(proc.stdout).text(),
@@ -120,6 +145,7 @@ async function runBounded(command: string[], cwd: string): Promise<void> {
   ])
   clearTimeout(timer)
 
+  if (timedOut) throw new Error(`Command timed out after 15s: ${command.join(" ")}`)
   if (exitCode !== 0) {
     throw new Error(`Command failed (${command.join(" ")}):\n${stdout}${stderr}`.trim())
   }

--- a/scripts/tests/package-boundaries.test.ts
+++ b/scripts/tests/package-boundaries.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import {
+  artifactScope,
+  findUndeclaredImports,
+  type ManifestDependencies,
+  siblingSpecifierPattern,
+  sourceScope,
+  workspaceBoundaryPlugins,
+} from "../package-boundaries"
+
+/**
+ * These cover the rule itself. `build-package.test.ts` covers the wiring — that the bundler is
+ * actually handed the patterns computed here.
+ */
+
+const fixtureRoots: string[] = []
+
+afterEach(async () => {
+  while (fixtureRoots.length > 0) {
+    const fixtureRoot = fixtureRoots.pop()
+    if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true })
+  }
+})
+
+describe("siblingSpecifierPattern", () => {
+  test("matches a sibling whole and at every subpath", () => {
+    const pattern = patternFor({ dependencies: { "@sixb/ui": "workspace:*" } })
+
+    expect(pattern.test("@sixb/ui")).toBe(true)
+    expect(pattern.test("@sixb/ui/button")).toBe(true)
+    expect(pattern.test("@sixb/ui/components/ui/chart")).toBe(true)
+  })
+
+  test("never matches a package whose name merely starts the same", () => {
+    // The reason this is a regexp and not an `external: ["@sixb/cli*"]` pattern: that glob also
+    // catches `@sixb/client`, and externalizing a package this one does not depend on emits an
+    // import nothing installs.
+    const pattern = patternFor({ dependencies: { "@sixb/cli": "workspace:*" } })
+
+    expect(pattern.test("@sixb/cli")).toBe(true)
+    expect(pattern.test("@sixb/client")).toBe(false)
+    expect(pattern.test("@sixb/client/browser")).toBe(false)
+  })
+
+  test("covers every dependency field and leaves third-party packages alone", () => {
+    const pattern = patternFor({
+      dependencies: { "@sixb/core": "workspace:*", tailwindcss: "^4.1.18" },
+      peerDependencies: { "@sixb/client": "workspace:*", react: "^19.0.0" },
+      optionalDependencies: { "create-sixb": "workspace:*" },
+    })
+
+    expect(pattern.test("@sixb/core/agents/context")).toBe(true)
+    expect(pattern.test("@sixb/client/browser")).toBe(true)
+    expect(pattern.test("create-sixb/scaffold")).toBe(true)
+    expect(pattern.test("tailwindcss")).toBe(false)
+    expect(pattern.test("react")).toBe(false)
+  })
+
+  test("is null when a package has no siblings, so nothing is intercepted", () => {
+    expect(siblingSpecifierPattern({ dependencies: { react: "^19.0.0" } })).toBeNull()
+    expect(siblingSpecifierPattern({})).toBeNull()
+  })
+})
+
+describe("workspaceBoundaryPlugins", () => {
+  test("installs one resolver, and none at all without siblings", () => {
+    expect(workspaceBoundaryPlugins({ dependencies: { "@sixb/ui": "workspace:*" } })).toHaveLength(
+      1
+    )
+    expect(workspaceBoundaryPlugins({ dependencies: { react: "^19.0.0" } })).toEqual([])
+  })
+})
+
+describe("findUndeclaredImports", () => {
+  test("reports a bare import the manifest never declared", async () => {
+    const { packageRoot, manifest } = await packageWith(
+      { name: "@sixb/example", dependencies: { "@sixb/core": "workspace:*" } },
+      {
+        "src/index.ts": 'import { thing } from "@sixb/core"\nimport { other } from "recharts"\n',
+      }
+    )
+
+    expect(await findUndeclaredImports(packageRoot, manifest, sourceScope)).toEqual([
+      { specifier: "recharts", file: "index.ts" },
+    ])
+  })
+
+  test("accepts declared packages, their subpaths, relative paths, builtins, and self-reference", async () => {
+    const { packageRoot, manifest } = await packageWith(
+      {
+        name: "@sixb/example",
+        dependencies: { "@sixb/core": "workspace:*" },
+        peerDependencies: { react: "^19.0.0" },
+      },
+      {
+        "src/index.ts": [
+          'import { readFile } from "node:fs/promises"',
+          'import { Glob } from "bun"',
+          'import { createElement } from "react"',
+          'import { context } from "@sixb/core/agents/context"',
+          'import { helper } from "@sixb/example/helper"',
+          'import { local } from "./local"',
+          "",
+        ].join("\n"),
+        "src/local.ts": "export const local = 1\n",
+      }
+    )
+
+    expect(await findUndeclaredImports(packageRoot, manifest, sourceScope)).toEqual([])
+  })
+
+  test("ignores type-only imports, which resolve against devDependencies legitimately", async () => {
+    const { packageRoot, manifest } = await packageWith(
+      { name: "@sixb/example" },
+      {
+        "src/index.ts": [
+          'import type { Database } from "@sixb/sqlite"',
+          'export type { Row } from "@sixb/sqlite"',
+          "export type Alias = Database",
+          "",
+        ].join("\n"),
+      }
+    )
+
+    expect(await findUndeclaredImports(packageRoot, manifest, sourceScope)).toEqual([])
+  })
+
+  test("does not read import statements out of a template literal", async () => {
+    // `@sixb/app` generates a custom-app entry as source text. A regex reads those lines as this
+    // package's own imports; a parser does not.
+    const { packageRoot, manifest } = await packageWith(
+      { name: "@sixb/example" },
+      {
+        "src/index.ts": [
+          "export const generated = `",
+          'import { signOut } from "@sixb/client"',
+          "`",
+          "",
+        ].join("\n"),
+      }
+    )
+
+    expect(await findUndeclaredImports(packageRoot, manifest, sourceScope)).toEqual([])
+  })
+
+  test("parses an artifact behind a shebang", async () => {
+    const { packageRoot, manifest } = await packageWith(
+      { name: "@sixb/example" },
+      { "dist/cli.js": '#!/usr/bin/env bun\nimport { render } from "ink"\n' }
+    )
+
+    expect(await findUndeclaredImports(packageRoot, manifest, artifactScope)).toEqual([
+      { specifier: "ink", file: "cli.js" },
+    ])
+  })
+
+  test("reports each package once, at the first file that imports it", async () => {
+    const { packageRoot, manifest } = await packageWith(
+      { name: "@sixb/example" },
+      {
+        "dist/a.js": 'import { a } from "cmdk/one"\n',
+        "dist/b.js": 'import { b } from "cmdk/two"\nimport { c } from "shiki"\n',
+      }
+    )
+
+    expect(await findUndeclaredImports(packageRoot, manifest, artifactScope)).toEqual([
+      { specifier: "cmdk", file: "a.js" },
+      { specifier: "shiki", file: "b.js" },
+    ])
+  })
+
+  test("says nothing about a package that has no such directory", async () => {
+    const { packageRoot, manifest } = await packageWith({ name: "@sixb/example" }, {})
+
+    expect(await findUndeclaredImports(packageRoot, manifest, artifactScope)).toEqual([])
+  })
+})
+
+function patternFor(manifest: ManifestDependencies): RegExp {
+  const pattern = siblingSpecifierPattern(manifest)
+  if (!pattern) throw new Error("Expected the manifest to declare at least one sibling")
+  return pattern
+}
+
+interface Fixture {
+  readonly packageRoot: string
+  readonly manifest: ManifestDependencies
+}
+
+async function packageWith(
+  manifest: ManifestDependencies,
+  files: Record<string, string>
+): Promise<Fixture> {
+  const packageRoot = await mkdtemp(join(tmpdir(), "sixb-boundaries-"))
+  fixtureRoots.push(packageRoot)
+
+  for (const [path, contents] of Object.entries(files)) {
+    const target = join(packageRoot, path)
+    await mkdir(dirname(target), { recursive: true })
+    await writeFile(target, contents)
+  }
+
+  return { packageRoot, manifest }
+}


### PR DESCRIPTION
The Northline example failed when its first custom-app request loaded the built agent routes.

The dependencies were installed correctly. The problem was that our package build crossed a workspace package boundary.

## What was wrong

When Bun built `@sixb/app`, it followed the source exports for `@sixb/agent-ui` and `@sixb/ui`. Their source code was copied into `packages/app/dist/agents.js`, while their third-party dependencies remained external:

```ts
// packages/app/dist/agents.js
import * as RechartsPrimitive from "recharts"
import { Command as CommandPrimitive } from "cmdk"
import { codeToHtml } from "shiki"
```

Those dependencies belong to `@sixb/ui`, so Bun's isolated install correctly placed them under that package. Once the UI source had been copied into `@sixb/app`, module resolution started from the wrong package and could not find them.

The recent agent-route export exposed this existing build bug by pulling more of the UI graph through `@sixb/app/agents`.

## How it is fixed

The shared package builder now treats every declared `workspace:*` dependency as an explicit external, including all of its subpaths:

```ts
for (const [dependency, range] of Object.entries(field ?? {})) {
  if (range.startsWith("workspace:")) {
    patterns.add(`${dependency}*`)
  }
}
```

The resulting app artifact keeps the real package boundary:

```ts
// packages/app/dist/agents.js
import { AgentChatPage } from "@sixb/agent-ui/react-router"
import { createAgentRoutes } from "@sixb/agent-ui"
```

Now `@sixb/agent-ui` and `@sixb/ui` resolve their own dependencies from their own package locations.

This is enforced centrally in the package builder. Packages do not need a `sixbBuild.externalWorkspaceDependencies` allowlist, and new workspace dependencies receive the same behavior automatically.

## Regression coverage

The new test creates an isolated workspace where one package:

- imports both the root and a subpath of another workspace package
- depends on a third-party module available only to that dependency
- is built through the real package build script

It verifies that the output preserves both workspace imports and does not absorb either the dependency source or its third-party import.

```text
bun test packages/app/tests/package-build.test.ts
1 pass, 0 fail

bun run build
all package builds passed

bun --filter @sixb/example-northline build
built successfully

bun run test:publish
verified 46 publishable packages
```
