### PR TITLE
examples: forward Northline dev arguments

### DIFF
--- a/examples/northline/scripts/dev.ts
+++ b/examples/northline/scripts/dev.ts
@@ -3,20 +3,26 @@ import { initializeDemoSources } from "../lib/sources/source-state"
 import { apiBaseUrl, apiRequest, isRecord, waitUntil } from "./api"
 import { synchronizeDemo } from "./sync-demo"
 
+export function createRuntimeCommand(args: readonly string[]): string[] {
+  return [
+    process.execPath,
+    resolve(import.meta.dir, "../../../packages/cli/src/index.tsx"),
+    "dev",
+    ...args,
+  ]
+}
+
 async function main(): Promise<void> {
   const initialized = await initializeDemoSources()
   if (initialized) console.log("[Northline] Initialized deterministic demo sources.")
 
-  const child = Bun.spawn(
-    [process.execPath, resolve(import.meta.dir, "../../../packages/cli/src/index.tsx"), "dev"],
-    {
-      cwd: resolve(import.meta.dir, ".."),
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-      env: process.env,
-    }
-  )
+  const child = Bun.spawn(createRuntimeCommand(process.argv.slice(2)), {
+    cwd: resolve(import.meta.dir, ".."),
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+    env: process.env,
+  })
 
   const stop = () => child.kill("SIGTERM")
   process.once("SIGINT", stop)
@@ -66,7 +72,9 @@ async function main(): Promise<void> {
   process.exitCode = exitCode
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error))
-  process.exit(1)
-})
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/examples/northline/tests/dev-script.test.ts
+++ b/examples/northline/tests/dev-script.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { createRuntimeCommand } from "../scripts/dev"
+
+describe("Northline development script", () => {
+  test("forwards its arguments to the Sixb dev command", () => {
+    const command = createRuntimeCommand([
+      "--port",
+      "4100",
+      "--api-port=4102",
+      "--host",
+      "127.0.0.1",
+    ])
+
+    expect(command.slice(2)).toEqual([
+      "dev",
+      "--port",
+      "4100",
+      "--api-port=4102",
+      "--host",
+      "127.0.0.1",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- forward arguments supplied to the Northline development wrapper into `sixb dev`
- make the spawned command independently testable without starting the development runtime
- add regression coverage for spaced and equals-style CLI options

## Why

The Northline wrapper constructed a hard-coded `sixb dev` command, so options passed through `bun --filter @sixb/example-northline dev` were silently discarded. Forwarding the wrapper's arguments restores the normal CLI behavior, including custom ports and hosts.

## Validation

- `bun test examples/northline/tests/`
- `bun --filter @sixb/example-northline typecheck`
- `bunx biome check examples/northline/scripts/dev.ts examples/northline/tests/dev-script.test.ts`