### PR TITLE
release: start public previews at 0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All Sixb packages ship on one version. A release publishes all of them or none.
 
-## 0.1.0
+## 0.0.1
 
-First public release.
+First public preview release. This version is published under npm's `next` tag and is not the
+recommended `latest` release.
 
 Sixb gives operational systems a shared backbone: a typed ontology, and the primitives that read and
 write it — actions, workflows, rules, events, schedules, agents, datasets, syncs, pipelines,
@@ -20,8 +21,8 @@ bun create sixb my-app
 
 ### Compatibility
 
-This is a 0.x release and carries no compatibility guarantee. Expect public API to move between
-minor versions.
+This is a 0.0.x preview and carries no compatibility guarantee. Expect public APIs and persisted
+state to change between any two preview versions.
 
 The database schema is one migration whose checksum is verified at startup. Before 1.0, a schema
 change **replaces** that migration rather than adding another, so moving between 0.x versions can

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,10 @@ Prefer targeted checks while iterating, then broader checks before review.
 Every publishable package shares one version and ships together — a release publishes all of them or
 none. `bun run test:publish` fails if they drift apart, so a version bump touches every manifest.
 
+The `0.0.x` line is for public validation. Publish those versions only under npm's `next` tag and
+increment the patch for every new artifact: npm versions are immutable. The `latest` tag is reserved
+for `0.1.0`, the first minimally stable, tested release, and later versions.
+
 Releasing is two commands. The first produces exactly what gets published and proves it; the second
 publishes, in dependency order, skipping anything already on the registry so an interrupted run can
 be re-run:
@@ -188,9 +192,14 @@ bun run release
 bun run release:publish -- --tag next
 ```
 
-Publish to a temporary tag first, verify it, then move `latest`. The publish script prints the
-`npm dist-tag` commands to do that. Note that `bun publish --dry-run` still authenticates; to
-rehearse without credentials, point `--registry` at a local registry.
+The tag changes how npm resolves an install, not the package version: consumers opt into previews
+with `bun add @sixb/core@next` or `bunx create-sixb@next my-app`. Publishing another preview moves
+`next` forward without making it the default install.
+
+For `0.1.0` and later, publish to `next` first, verify it, then move the same immutable version to
+`latest`. The publish script prints the `npm dist-tag` commands only when that promotion is allowed,
+and refuses to publish a `0.0.x` version directly to `latest`. Note that `bun publish --dry-run`
+still authenticates; to rehearse without credentials, point `--registry` at a local registry.
 
 ## The feeling we want
 

--- a/README.md
+++ b/README.md
@@ -218,8 +218,10 @@ independently against the same durable providers.
 
 ## Status
 
-Sixb is currently `0.1.0`. APIs may change between minor releases, and database upgrades may require
-manual migration before 1.0. See the [changelog](CHANGELOG.md) for compatibility notes.
+Sixb is currently in the preview `0.0.x` line, starting with `0.0.1`. Preview releases are
+published under npm's `next` tag and may change between any two versions. Version `0.1.0` will be
+the first minimally stable, tested release promoted to `latest`. See the
+[changelog](CHANGELOG.md) for compatibility notes.
 
 ## Contributing
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/docs",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/auth/magic-link/package.json
+++ b/auth/magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/auth-magic-link",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Magic-link email authentication strategy for Sixb",
   "keywords": [
     "sixb",

--- a/auth/oidc/package.json
+++ b/auth/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/auth-oidc",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "OpenID Connect authentication strategy for Sixb",
   "keywords": [
     "sixb",

--- a/broker/nats/package.json
+++ b/broker/nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/broker-nats",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "NATS-backed event broker for Sixb",
   "keywords": [
     "sixb",

--- a/broker/redis/package.json
+++ b/broker/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/broker-redis",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Redis-backed event broker for Sixb",
   "keywords": [
     "sixb",

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/docs": {
       "name": "@sixb/docs",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/ui": "workspace:*",
         "lucide-react": "^0.562.0",
@@ -33,7 +33,7 @@
     },
     "auth/magic-link": {
       "name": "@sixb/auth-magic-link",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -44,7 +44,7 @@
     },
     "auth/oidc": {
       "name": "@sixb/auth-oidc",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "openid-client": "^6.8.4",
@@ -56,7 +56,7 @@
     },
     "broker/nats": {
       "name": "@sixb/broker-nats",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@nats-io/jetstream": "^3.3.1",
         "@nats-io/nats-core": "^3.3.1",
@@ -70,7 +70,7 @@
     },
     "broker/redis": {
       "name": "@sixb/broker-redis",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -81,7 +81,7 @@
     },
     "connectors/companycam": {
       "name": "@sixb/connector-companycam",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -93,7 +93,7 @@
     },
     "connectors/github": {
       "name": "@sixb/connector-github",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@octokit/webhooks-types": "^7.6.1",
         "@sixb/connector-rest": "workspace:*",
@@ -106,7 +106,7 @@
     },
     "connectors/google": {
       "name": "@sixb/connector-google",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "connectors/imap": {
       "name": "@sixb/connector-imap",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "imapflow": "^1.4.7",
@@ -131,7 +131,7 @@
     },
     "connectors/mercury": {
       "name": "@sixb/connector-mercury",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -143,7 +143,7 @@
     },
     "connectors/meta": {
       "name": "@sixb/connector-meta",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -155,7 +155,7 @@
     },
     "connectors/pandadoc": {
       "name": "@sixb/connector-pandadoc",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -167,7 +167,7 @@
     },
     "connectors/pennylane": {
       "name": "@sixb/connector-pennylane",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -179,7 +179,7 @@
     },
     "connectors/pipedrive": {
       "name": "@sixb/connector-pipedrive",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -191,7 +191,7 @@
     },
     "connectors/rest": {
       "name": "@sixb/connector-rest",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -202,7 +202,7 @@
     },
     "connectors/sftp": {
       "name": "@sixb/connector-sftp",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "ssh2": "^1.17.0",
@@ -215,7 +215,7 @@
     },
     "connectors/sql": {
       "name": "@sixb/connector-sql",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -226,7 +226,7 @@
     },
     "connectors/teamleader": {
       "name": "@sixb/connector-teamleader",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -335,7 +335,7 @@
     },
     "loggers/pino": {
       "name": "@sixb/logger-pino",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "pino": "^9.0.0",
@@ -347,7 +347,7 @@
     },
     "packages/action-worker": {
       "name": "@sixb/action-worker",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -358,7 +358,7 @@
     },
     "packages/agent-ui": {
       "name": "@sixb/agent-ui",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/client": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -384,7 +384,7 @@
     },
     "packages/agent-worker": {
       "name": "@sixb/agent-worker",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "ai": "^7.0.4",
@@ -397,7 +397,7 @@
     },
     "packages/app": {
       "name": "@sixb/app",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/agent-ui": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -419,7 +419,7 @@
     },
     "packages/atlas": {
       "name": "@sixb/atlas",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/agent-ui": "workspace:*",
         "@sixb/app": "workspace:*",
@@ -445,7 +445,7 @@
     },
     "packages/cli": {
       "name": "@sixb/cli",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "bin": {
         "sixb": "./src/index.tsx",
       },
@@ -476,7 +476,7 @@
     },
     "packages/client": {
       "name": "@sixb/client",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -499,7 +499,7 @@
     },
     "packages/core": {
       "name": "@sixb/core",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",
       },
@@ -510,7 +510,7 @@
     },
     "packages/create-sixb": {
       "name": "create-sixb",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "bin": {
         "create-sixb": "./dist/index.js",
       },
@@ -524,7 +524,7 @@
     },
     "packages/orchestrator": {
       "name": "@sixb/orchestrator",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -535,7 +535,7 @@
     },
     "packages/pipeline-worker": {
       "name": "@sixb/pipeline-worker",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -546,7 +546,7 @@
     },
     "packages/projection-worker": {
       "name": "@sixb/projection-worker",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -557,7 +557,7 @@
     },
     "packages/rules-worker": {
       "name": "@sixb/rules-worker",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -568,7 +568,7 @@
     },
     "packages/server": {
       "name": "@sixb/server",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@elysiajs/cors": "^1.2.0",
         "@elysiajs/openapi": "^1.4.0",
@@ -587,7 +587,7 @@
     },
     "packages/sync-worker": {
       "name": "@sixb/sync-worker",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -599,7 +599,7 @@
     },
     "packages/ui": {
       "name": "@sixb/ui",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@shadcn/react": "^0.1.0",
         "@tanstack/react-table": "^8.21.3",
@@ -644,7 +644,7 @@
     },
     "packages/workflow-worker": {
       "name": "@sixb/workflow-worker",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -655,7 +655,7 @@
     },
     "queues/bullmq": {
       "name": "@sixb/queues-bullmq",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "bullmq": "^5.34.0",
@@ -668,7 +668,7 @@
     },
     "sandboxes/apple-container": {
       "name": "@sixb/sandboxes-apple-container",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -679,7 +679,7 @@
     },
     "sandboxes/local": {
       "name": "@sixb/sandboxes-local",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -690,7 +690,7 @@
     },
     "sandboxes/smolvm": {
       "name": "@sixb/sandboxes-smolvm",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "bin": {
         "sixb-agent-image": "./scripts/build-agent-image.ts",
       },
@@ -704,7 +704,7 @@
     },
     "sandboxes/vercel": {
       "name": "@sixb/sandboxes-vercel",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "@vercel/sandbox": "^2.3.0",
@@ -716,7 +716,7 @@
     },
     "storage/blob-local": {
       "name": "@sixb/blob-local",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -727,7 +727,7 @@
     },
     "storage/blob-s3": {
       "name": "@sixb/blob-s3",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1090.0",
         "@aws-sdk/s3-request-presigner": "^3.1090.0",
@@ -740,7 +740,7 @@
     },
     "storage/ducklake": {
       "name": "@sixb/ducklake",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@duckdb/node-api": "^1.5.2-r.1",
         "@sixb/core": "workspace:*",
@@ -752,7 +752,7 @@
     },
     "storage/lake-local": {
       "name": "@sixb/lake-local",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -763,7 +763,7 @@
     },
     "storage/pg": {
       "name": "@sixb/pg",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "postgres": "^3.4.5",
@@ -775,7 +775,7 @@
     },
     "storage/sqlite": {
       "name": "@sixb/sqlite",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },

--- a/connectors/companycam/package.json
+++ b/connectors/companycam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-companycam",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "CompanyCam connector for Sixb built on @sixb/connector-rest",
   "keywords": [
     "sixb",

--- a/connectors/github/package.json
+++ b/connectors/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-github",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "GitHub connector for Sixb — repositories, issues, and issue webhooks",
   "keywords": [
     "sixb",

--- a/connectors/google/package.json
+++ b/connectors/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-google",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Google Workspace connector for Sixb (Drive surface)",
   "keywords": [
     "sixb",

--- a/connectors/imap/package.json
+++ b/connectors/imap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-imap",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Read-only IMAP connector for Sixb built on ImapFlow",
   "keywords": [
     "sixb",

--- a/connectors/mercury/package.json
+++ b/connectors/mercury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-mercury",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Mercury banking API connector for Sixb",
   "keywords": [
     "sixb",

--- a/connectors/meta/package.json
+++ b/connectors/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-meta",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Meta connector for Sixb — Instagram & Facebook Page reads via the Graph API",
   "keywords": [
     "sixb",

--- a/connectors/pandadoc/package.json
+++ b/connectors/pandadoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-pandadoc",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "PandaDoc connector for Sixb built on @sixb/connector-rest",
   "keywords": [
     "sixb",

--- a/connectors/pennylane/package.json
+++ b/connectors/pennylane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-pennylane",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Pennylane Company API connector for Sixb",
   "keywords": [
     "sixb",

--- a/connectors/pipedrive/package.json
+++ b/connectors/pipedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-pipedrive",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Pipedrive connector for Sixb",
   "keywords": [
     "sixb",

--- a/connectors/rest/package.json
+++ b/connectors/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-rest",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "REST connector for Sixb built on native fetch",
   "keywords": [
     "sixb",

--- a/connectors/sftp/package.json
+++ b/connectors/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-sftp",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "SFTP connector for Sixb built on ssh2",
   "keywords": [
     "sixb",

--- a/connectors/sql/package.json
+++ b/connectors/sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-sql",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "SQL connector for Sixb built on Bun.SQL",
   "keywords": [
     "sixb",

--- a/connectors/teamleader/package.json
+++ b/connectors/teamleader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-teamleader",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Teamleader Focus connector for Sixb",
   "keywords": [
     "sixb",

--- a/docs/data/projections.md
+++ b/docs/data/projections.md
@@ -233,7 +233,7 @@ sixb worker projection
 - Object and link projections are authoritative replacements for their source. A later dataset
   version withdraws source-owned objects or links that are no longer present; managed edits remain
   separate overrides.
-- Replacement snapshots are the only V0.1.0 source materialization protocol. Activation, the
+- Replacement snapshots are the only pre-0.1 source materialization protocol. Activation, the
   durable `ontology_commits` record, and stable outbox envelopes commit atomically. Dataset CDC or
   change-stream projection is deferred.
 - An object projection requires one nonblank primary identity per dataset row and one row per object

--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -293,7 +293,7 @@ sixb worker-group   # all registered queue workers
 
 ## Scaling roles
 
-The data plane scales horizontally. The control plane does not: in 0.1.0 the
+The data plane scales horizontally. The control plane does not: in the pre-0.1 line the
 orchestrator, scheduler, and rules roles must each run as a **single process**.
 
 | Role                               | Replicas | Why                                                    |

--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -172,11 +172,11 @@ ontology transaction -> durable ontology_outbox -> immediate drain -> 60s recove
 
 Broker failure delays subscribers but never rolls back or loses the committed ontology change.
 Consumers deduplicate with stable event IDs when required. CDC/WAL change streams are not part of
-V0.1.0.
+the pre-0.1 line.
 
 An envelope that the broker repeatedly rejects remains durable and retryable; it is never silently
-dropped. After repeated failures `/api/status` stays `degraded` until delivery succeeds. V0.1.0 does
-not provide automatic quarantine or operator requeue.
+dropped. After repeated failures `/api/status` stays `degraded` until delivery succeeds. The
+pre-0.1 line does not provide automatic quarantine or operator requeue.
 
 ### HTTP: GET /api/events
 

--- a/docs/infrastructure/overview.md
+++ b/docs/infrastructure/overview.md
@@ -115,7 +115,7 @@ catches the outbox up.
 | `ontology_commits`     | **nothing** — it grows with every commit   | —       |
 
 Pending outbox rows and nonterminal sources are live data and are never purged by age.
-Size the disk with `ontology_commits` in mind: 0.1.0 has no purge for it.
+Size the disk with `ontology_commits` in mind: the pre-0.1 line has no purge for it.
 
 ```ts
 export const sixb = await createSixb({

--- a/docs/objects/crud.md
+++ b/docs/objects/crud.md
@@ -224,9 +224,9 @@ What `restore()` does depends on where the object came from:
 | Written only from code | Ceases to exist. Not reversible. | No-op — `upsert` it again instead. |
 | Also written by a projection | Stays hidden even while the projection keeps asserting it. | Reveals the projected object again. |
 
-There is no HTTP route for either yet. Write capabilities are not part of the grant model in 0.1.0,
-so a `DELETE` endpoint would expose a cascading delete to every authenticated session. An ungated
-`upsert` is recoverable; an ungated delete of a managed object is not.
+There is no HTTP route for either yet. Write capabilities are not part of the grant model before
+0.1, so a `DELETE` endpoint would expose a cascading delete to every authenticated session. An
+ungated `upsert` is recoverable; an ungated delete of a managed object is not.
 
 ## requestAction
 

--- a/docs/rules/overview.md
+++ b/docs/rules/overview.md
@@ -97,8 +97,8 @@ The event only wakes evaluation: Rules always read current committed object/link
 and periodic reconciliation repairs events missed while the worker was offline and resolves active
 state for deleted objects. Live evaluation and reconciliation share one serialized coordinator.
 
-V0.1.0 supports one active Rules worker per project. Rule notifications are at-least-once, so
-consumers must tolerate a duplicate around process failure.
+The pre-0.1 line supports one active Rules worker per project. Rule notifications are at-least-once,
+so consumers must tolerate a duplicate around process failure.
 
 ## Reacting to the signal
 

--- a/docs/server/overview.md
+++ b/docs/server/overview.md
@@ -126,7 +126,7 @@ messages — `/api/action-runs/:runId/files/content`, `/api/workflow-runs/:runId
 `.../nodes/:nodeKey/files/content`, and
 `/api/agent-threads/:threadId/messages/:messageId/files/content`.
 
-> **0.1.0 limit — upload sessions are in-memory.** Neither `@sixb/pg` nor `@sixb/sqlite`
+> **Pre-0.1 limit — upload sessions are in-memory.** Neither `@sixb/pg` nor `@sixb/sqlite`
 > implements `fileUploadSessions`, so every session opened by `POST /api/files/uploads` lives in
 > the serving process: it does not survive a restart and is not shared across replicas. Route a
 > session's requests to one instance, supply your own store on `sixb.storage.fileUploadSessions`,

--- a/loggers/pino/package.json
+++ b/loggers/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/logger-pino",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Pino output provider for Sixb handler logs",
   "keywords": [
     "sixb",

--- a/packages/action-worker/package.json
+++ b/packages/action-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/action-worker",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Worker that runs Sixb action requests",
   "keywords": [
     "sixb",

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/agent-ui",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Shared Sixb agent chat UI for Atlas and custom apps",
   "keywords": [
     "sixb",

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/agent-worker",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Worker that runs Sixb agent threads",
   "keywords": [
     "sixb",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/app",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Custom app toolkit for Sixb projects — route scanning, dev serving, and production builds",
   "keywords": [
     "sixb",

--- a/packages/atlas/package.json
+++ b/packages/atlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/atlas",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Atlas, the built-in operations UI for Sixb",
   "keywords": [
     "sixb",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/cli",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Command-line interface for Sixb projects",
   "keywords": [
     "sixb",

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -47,7 +47,7 @@ function compareVersions(left: string, right: string): number {
 }
 
 async function readPackageVersion(): Promise<string> {
-  const fallbackVersion = "0.1.0"
+  const fallbackVersion = "0.0.1"
 
   try {
     const packageJson = (await Bun.file(join(import.meta.dir, "..", "package.json")).json()) as {

--- a/packages/cli/tests/init.test.ts
+++ b/packages/cli/tests/init.test.ts
@@ -74,8 +74,8 @@ describe("sixb init", () => {
 
     expect(packageJson.name).toBe("starter")
     expect(packageJson.scripts.typecheck).toBe("sixb typegen && tsc --noEmit")
-    expect(packageJson.dependencies["@sixb/client"]).toBe("^0.1.0")
-    expect(packageJson.dependencies["@sixb/ducklake"]).toBe("^0.1.0")
+    expect(packageJson.dependencies["@sixb/client"]).toBe("^0.0.1")
+    expect(packageJson.dependencies["@sixb/ducklake"]).toBe("^0.0.1")
     expect(packageJson.dependencies["@sixb/lake-local"]).toBeUndefined()
     expect(packageJson.dependencies["@sixb/pg"]).toBeUndefined()
     expect(packageJson.dependencies["@sixb/blob-s3"]).toBeUndefined()

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Sixb API",
     "description": "Ontology-first digital twins runtime API",
-    "version": "0.1.0"
+    "version": "0.0.1"
   },
   "components": {
     "securitySchemes": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/client",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Type-safe SDK for Sixb API with TanStack Query hooks",
   "keywords": [
     "sixb",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/core",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "The ontology-first runtime for Sixb — objects, links, telemetry, actions, and provider contracts",
   "keywords": [
     "sixb",

--- a/packages/create-sixb/package.json
+++ b/packages/create-sixb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sixb",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Create a new Sixb project",
   "keywords": [
     "sixb",

--- a/packages/create-sixb/tests/create-sixb.test.ts
+++ b/packages/create-sixb/tests/create-sixb.test.ts
@@ -48,7 +48,7 @@ describe("create-sixb packed artifacts", () => {
     const cliManifest = await readPackageManifest(join(layoutRoot, "node_modules", "@sixb", "cli"))
 
     expect(createManifest.dependencies).toBeUndefined()
-    expect(cliManifest.dependencies?.["create-sixb"]).toBe("0.1.0")
+    expect(cliManifest.dependencies?.["create-sixb"]).toBe("0.0.1")
   })
 
   test("shows the bun create usage", () => {
@@ -189,7 +189,7 @@ async function assertScaffold(projectDir: string, name: string): Promise<void> {
     dependencies?: Record<string, string>
   }
   expect(packageJson.name).toBe(name)
-  expect(packageJson.dependencies?.["@sixb/cli"]).toBe("^0.1.0")
-  expect(packageJson.dependencies?.["@sixb/ducklake"]).toBe("^0.1.0")
+  expect(packageJson.dependencies?.["@sixb/cli"]).toBe("^0.0.1")
+  expect(packageJson.dependencies?.["@sixb/ducklake"]).toBe("^0.0.1")
   expect(packageJson.dependencies?.["@sixb/lake-local"]).toBeUndefined()
 }

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/orchestrator",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Bridges Sixb runtime events to queue job lanes",
   "keywords": [
     "sixb",

--- a/packages/pipeline-worker/package.json
+++ b/packages/pipeline-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/pipeline-worker",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Worker that runs Sixb pipelines",
   "keywords": [
     "sixb",

--- a/packages/projection-worker/package.json
+++ b/packages/projection-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/projection-worker",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Worker that runs Sixb projections",
   "keywords": [
     "sixb",

--- a/packages/rules-worker/package.json
+++ b/packages/rules-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/rules-worker",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Worker that evaluates Sixb rules",
   "keywords": [
     "sixb",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -69,8 +69,8 @@ origins are shown as invitation destinations and participate in `can.access(appl
 | `GET` | `/api/objects/:objectTypeId/:objectKey/files/content` | Download a `fileRef` property (`?path=/properties/scan`) |
 
 Upload sessions default to an in-memory store: neither `@sixb/pg` nor `@sixb/sqlite` implements
-`fileUploadSessions` in 0.1.0, so a session does not survive a restart and is not shared across
-replicas. Single-request `POST /api/files` is unaffected.
+`fileUploadSessions` in the pre-0.1 line, so a session does not survive a restart and is not shared
+across replicas. Single-request `POST /api/files` is unaffected.
 
 ### WebSocket
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/server",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "HTTP and WebSocket API server for Sixb",
   "keywords": [
     "sixb",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -245,7 +245,7 @@ export function createSixbApi(server: SixbServer) {
       documentation: {
         info: {
           title: "Sixb API",
-          version: "0.1.0",
+          version: "0.0.1",
           description: "Ontology-first digital twins runtime API",
         },
         components: {

--- a/packages/sync-worker/package.json
+++ b/packages/sync-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/sync-worker",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Worker that runs Sixb syncs",
   "keywords": [
     "sixb",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/ui",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Shared Sixb UI foundations and components",
   "keywords": [
     "sixb",

--- a/packages/workflow-worker/package.json
+++ b/packages/workflow-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/workflow-worker",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Worker that runs Sixb workflows",
   "keywords": [
     "sixb",

--- a/queues/bullmq/package.json
+++ b/queues/bullmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/queues-bullmq",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Redis/BullMQ-backed queue provider for Sixb",
   "keywords": [
     "sixb",

--- a/sandboxes/apple-container/package.json
+++ b/sandboxes/apple-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/sandboxes-apple-container",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Apple Container sandbox provider for Sixb agents",
   "keywords": [
     "sixb",

--- a/sandboxes/local/package.json
+++ b/sandboxes/local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/sandboxes-local",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Local process sandbox provider for Sixb agents",
   "keywords": [
     "sixb",

--- a/sandboxes/smolvm/package.json
+++ b/sandboxes/smolvm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/sandboxes-smolvm",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "smolvm microVM sandbox provider for Sixb agents",
   "keywords": [
     "sixb",

--- a/sandboxes/vercel/package.json
+++ b/sandboxes/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/sandboxes-vercel",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Vercel Sandbox provider for Sixb agents",
   "keywords": [
     "sixb",

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -3,11 +3,12 @@
  *
  *   bun scripts/publish.ts --dry-run
  *   bun scripts/publish.ts --tag next
- *   bun scripts/publish.ts --tag latest --otp 123456
- *   bun scripts/publish.ts --registry http://localhost:4873    # full rehearsal, local registry
+ *   bun scripts/publish.ts --tag next --otp 123456
+ *   bun scripts/publish.ts --tag next --registry http://localhost:4873  # local rehearsal
  *
  * Run `bun run release` first: it installs from the lockfile, rebuilds from clean, and runs the
- * publish gate. This script only publishes.
+ * publish gate. This script only publishes. Preview 0.0.x versions must use `--tag next`; `latest`
+ * starts at 0.1.0.
  *
  * Publishing 46 packages is 46 separate registry writes, so it is resumable by design: a version
  * already on the registry is skipped rather than retried, and a failure stops the run naming exactly
@@ -23,6 +24,7 @@ import {
   packageName,
   topologicalPublishOrder,
 } from "./publishable-packages"
+import { assertReleaseTagAllowed, isPreviewRelease } from "./release-policy"
 
 const root = process.cwd()
 const options = parseOptions(process.argv.slice(2))
@@ -36,6 +38,7 @@ if (versions.size !== 1) {
 }
 const [version] = [...versions]
 if (!version) throw new Error("[SixbPublish] Packages have no version.")
+assertReleaseTagAllowed(version, options.tag)
 
 console.log(
   `[SixbPublish] ${options.dryRun ? "Dry run: " : ""}publishing ${ordered.length} packages at ${version} to tag "${options.tag}".`
@@ -63,12 +66,19 @@ console.log(
   `[SixbPublish] Done. ${published.length} published, ${skipped.length} already on the registry.`
 )
 if (options.tag !== "latest" && !options.dryRun && published.length > 0) {
-  console.log(
-    `[SixbPublish] Nothing is on "latest" yet. Promote once you have verified the tag:\n` +
-      ordered
-        .map((packageInfo) => `  npm dist-tag add ${packageName(packageInfo)}@${version} latest`)
-        .join("\n")
-  )
+  if (isPreviewRelease(version)) {
+    console.log(
+      `[SixbPublish] ${version} remains on "${options.tag}". ` +
+        'The "latest" tag is reserved for 0.1.0 and later.'
+    )
+  } else {
+    console.log(
+      `[SixbPublish] Nothing is on "latest" yet. Promote once you have verified the tag:\n` +
+        ordered
+          .map((packageInfo) => `  npm dist-tag add ${packageName(packageInfo)}@${version} latest`)
+          .join("\n")
+    )
+  }
 }
 
 async function publishPackage(packageInfo: PublishablePackage, name: string): Promise<void> {

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -1,0 +1,17 @@
+/**
+ * The 0.0.x line is public for testing, but is not the default install line. Keeping this rule in
+ * the publisher ensures every preview release goes through the one documented `next` channel.
+ */
+export function isPreviewRelease(version: string): boolean {
+  const [major, minor] = version.split(".")
+  return major === "0" && minor === "0"
+}
+
+export function assertReleaseTagAllowed(version: string, tag: string): void {
+  if (!isPreviewRelease(version) || tag === "next") return
+
+  throw new Error(
+    `[SixbPublish] ${version} is a preview release and cannot be published to "${tag}". ` +
+      "Use `--tag next`; `latest` is reserved for 0.1.0 and later."
+  )
+}

--- a/scripts/tests/release-policy.test.ts
+++ b/scripts/tests/release-policy.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { assertReleaseTagAllowed, isPreviewRelease } from "../release-policy"
+
+describe("release policy", () => {
+  test("classifies the 0.0.x line as preview releases", () => {
+    expect(isPreviewRelease("0.0.1")).toBe(true)
+    expect(isPreviewRelease("0.0.2-beta.1")).toBe(true)
+    expect(isPreviewRelease("0.1.0")).toBe(false)
+    expect(isPreviewRelease("1.0.0")).toBe(false)
+  })
+
+  test("publishes preview releases only to next", () => {
+    expect(() => assertReleaseTagAllowed("0.0.1", "latest")).toThrow(/Use `--tag next`/)
+    expect(() => assertReleaseTagAllowed("0.0.1", "beta")).toThrow(/Use `--tag next`/)
+    expect(() => assertReleaseTagAllowed("0.0.1", "next")).not.toThrow()
+    expect(() => assertReleaseTagAllowed("0.1.0", "latest")).not.toThrow()
+  })
+})

--- a/storage/blob-local/package.json
+++ b/storage/blob-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/blob-local",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Local filesystem blob storage for Sixb fileRef payloads",
   "keywords": [
     "sixb",

--- a/storage/blob-s3/package.json
+++ b/storage/blob-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/blob-s3",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "S3-compatible blob storage for Sixb fileRef payloads",
   "keywords": [
     "sixb",

--- a/storage/ducklake/package.json
+++ b/storage/ducklake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/ducklake",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "DuckDB/DuckLake lake storage provider for Sixb",
   "keywords": [
     "sixb",

--- a/storage/lake-local/package.json
+++ b/storage/lake-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/lake-local",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Local filesystem lake storage provider for Sixb datasets",
   "keywords": [
     "sixb",

--- a/storage/pg/package.json
+++ b/storage/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/pg",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "PostgreSQL storage provider for Sixb",
   "keywords": [
     "sixb",

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/sqlite",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "SQLite storage provider for Sixb",
   "keywords": [
     "sixb",


### PR DESCRIPTION
## Summary

- start the public preview line at 0.0.1 across all 46 publishable packages
- require every 0.0.x release to use the npm next tag and reserve latest for 0.1.0+
- align the lockfile, CLI, scaffolder, OpenAPI metadata, changelog, and release documentation

## Verification

- `bun run release`
- `bun run typecheck`
- `bun run check`
- `bun test scripts/tests/release-policy.test.ts scripts/tests/publishable-packages.test.ts`
- `bun test packages/cli/tests/init.test.ts packages/create-sixb/tests/create-sixb.test.ts`
