### PR TITLE
agent-worker: run tools selected by each agent

### DIFF
--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -13,7 +13,6 @@ import { AgentWorker } from "@sixb/agent-worker"
 
 const worker = new AgentWorker(sixb, {
   apiBaseUrl: "http://localhost:3002",
-  tools,
 })
 
 await worker.start()
@@ -66,7 +65,6 @@ The terminal run state is stored on the run record:
 
 ## Options
 
-- `tools`: additional AI SDK tools exposed to the model alongside the built-in `bash` tool.
 - `apiBaseUrl`: required Sixb server origin that hosts the agent API gateway. The worker injects a
   run-scoped gateway URL into sandboxes as `SIXB_API_BASE_URL`, writes Agent Skills into
   `SIXB_SKILLS_DIR`, and creates the sandbox with a restricted network policy allowing the server

--- a/packages/agent-worker/src/ai-sdk-adapters.ts
+++ b/packages/agent-worker/src/ai-sdk-adapters.ts
@@ -1,8 +1,99 @@
-import type { AgentInboundUiMessagePart, AgentMessagePart } from "@sixb/core"
+import {
+  type AgentInboundUiMessagePart,
+  type AgentMessagePart,
+  type AgentToolDefinition,
+  type AgentToolRunContext,
+  type AgentToolRunInfo,
+  getInvalidJsonValueReason,
+  type JsonValue,
+  type Logger,
+  type ValueType,
+} from "@sixb/core"
 import { fromAiSdk } from "@sixb/core/internal/agents"
+import { schemaRecordToJsonSchema } from "@sixb/core/internal/ontology"
 import type { AgentRunUsage } from "@sixb/core/storage"
-import type { LanguageModelUsage } from "ai"
-import { AgentWorkerError } from "./errors"
+import { jsonSchema, type LanguageModelUsage, type Tool, type ToolSet, tool } from "ai"
+import { AgentToolOutputError, AgentWorkerError } from "./errors"
+
+const NEVER_ABORTED_SIGNAL = new AbortController().signal
+
+interface AiSdkToolsFromAgentDefinitionsInput {
+  readonly definitions: readonly AgentToolDefinition[]
+  readonly valueTypesById: ReadonlyMap<string, ValueType>
+  readonly run: AgentToolRunInfo
+  readonly connector: AgentToolRunContext["connector"]
+  readonly logger: Logger
+}
+
+/** Adapt one agent's explicitly selected Sixb definitions to executable AI SDK tools. */
+export function aiSdkToolsFromAgentDefinitions(
+  input: AiSdkToolsFromAgentDefinitionsInput
+): ToolSet {
+  const tools = emptyToolSet()
+  for (const definition of input.definitions) {
+    if (Object.hasOwn(tools, definition.name)) {
+      throw new AgentWorkerError(
+        `Agent '${input.run.agentId}' has duplicate selected tool name '${definition.name}'.`
+      )
+    }
+    tools[definition.name] = aiSdkToolFromAgentDefinition(definition, input)
+  }
+  return tools
+}
+
+function aiSdkToolFromAgentDefinition(
+  definition: AgentToolDefinition,
+  context: Omit<AiSdkToolsFromAgentDefinitionsInput, "definitions">
+): Tool<Record<string, unknown>, JsonValue> {
+  const inputSchema = schemaRecordToJsonSchema({
+    shape: definition.input,
+    valueTypesById: context.valueTypesById,
+  })
+
+  return tool({
+    description: definition.description,
+    inputSchema: jsonSchema<Record<string, unknown>>(
+      inputSchema as Parameters<typeof jsonSchema>[0]
+    ),
+    async execute(input, { abortSignal }) {
+      let result: JsonValue
+      try {
+        result = await definition.handler({
+          input,
+          signal: abortSignal ?? NEVER_ABORTED_SIGNAL,
+          run: context.run,
+          connector: context.connector,
+          logger: context.logger,
+        })
+      } catch (error) {
+        const reason = coreResultValidationReason(error, definition.name)
+        if (reason) {
+          throw new AgentToolOutputError(definition.name, reason, { cause: error })
+        }
+        throw error
+      }
+      const reason = getInvalidJsonValueReason(result, "result")
+      if (reason) {
+        throw new AgentToolOutputError(definition.name, reason)
+      }
+      return result
+    },
+  })
+}
+
+function coreResultValidationReason(error: unknown, toolName: string): string | null {
+  if (!(error instanceof Error)) return null
+  const prefix = `[Sixb] Agent tool '${toolName}' result must be a JSON value; `
+  if (!error.message.startsWith(prefix)) return null
+  const reason = error.message.slice(prefix.length)
+  const resultLabel = `Agent tool '${toolName}' `
+  return reason.startsWith(resultLabel) ? reason.slice(resultLabel.length) : reason
+}
+
+function emptyToolSet(): ToolSet {
+  // Tool names may legally be `__proto__`; a null prototype keeps every valid name an own property.
+  return Object.create(null) as ToolSet
+}
 
 /** Minimal structural boundary implemented by AI SDK StepResult content. */
 export interface AiSdkTraceStep {

--- a/packages/agent-worker/src/ai-sdk-adapters.ts
+++ b/packages/agent-worker/src/ai-sdk-adapters.ts
@@ -1,15 +1,18 @@
-import {
-  type AgentInboundUiMessagePart,
-  type AgentMessagePart,
-  type AgentToolDefinition,
-  type AgentToolRunContext,
-  type AgentToolRunInfo,
-  getInvalidJsonValueReason,
-  type JsonValue,
-  type Logger,
-  type ValueType,
+import type {
+  AgentInboundUiMessagePart,
+  AgentMessagePart,
+  AgentToolDefinition,
+  AgentToolRunContext,
+  AgentToolRunInfo,
+  JsonValue,
+  Logger,
+  ValueType,
 } from "@sixb/core"
-import { fromAiSdk } from "@sixb/core/internal/agents"
+import {
+  AgentToolResultValidationError,
+  fromAiSdk,
+  validateAndNormalizeAgentToolInput,
+} from "@sixb/core/internal/agents"
 import { schemaRecordToJsonSchema } from "@sixb/core/internal/ontology"
 import type { AgentRunUsage } from "@sixb/core/storage"
 import { jsonSchema, type LanguageModelUsage, type Tool, type ToolSet, tool } from "ai"
@@ -45,16 +48,9 @@ function aiSdkToolFromAgentDefinition(
   definition: AgentToolDefinition,
   context: Omit<AiSdkToolsFromAgentDefinitionsInput, "definitions">
 ): Tool<Record<string, unknown>, JsonValue> {
-  const inputSchema = schemaRecordToJsonSchema({
-    shape: definition.input,
-    valueTypesById: context.valueTypesById,
-  })
-
   return tool({
     description: definition.description,
-    inputSchema: jsonSchema<Record<string, unknown>>(
-      inputSchema as Parameters<typeof jsonSchema>[0]
-    ),
+    inputSchema: aiSdkInputSchemaFromAgentDefinition(definition, context.valueTypesById),
     async execute(input, { abortSignal }) {
       let result: JsonValue
       try {
@@ -66,28 +62,46 @@ function aiSdkToolFromAgentDefinition(
           logger: context.logger,
         })
       } catch (error) {
-        const reason = coreResultValidationReason(error, definition.name)
-        if (reason) {
-          throw new AgentToolOutputError(definition.name, reason, { cause: error })
+        if (error instanceof AgentToolResultValidationError) {
+          throw new AgentToolOutputError(definition.name, error.reason, { cause: error })
         }
         throw error
-      }
-      const reason = getInvalidJsonValueReason(result, "result")
-      if (reason) {
-        throw new AgentToolOutputError(definition.name, reason)
       }
       return result
     },
   })
 }
 
-function coreResultValidationReason(error: unknown, toolName: string): string | null {
-  if (!(error instanceof Error)) return null
-  const prefix = `[Sixb] Agent tool '${toolName}' result must be a JSON value; `
-  if (!error.message.startsWith(prefix)) return null
-  const reason = error.message.slice(prefix.length)
-  const resultLabel = `Agent tool '${toolName}' `
-  return reason.startsWith(resultLabel) ? reason.slice(resultLabel.length) : reason
+function aiSdkInputSchemaFromAgentDefinition(
+  definition: AgentToolDefinition,
+  valueTypesById: ReadonlyMap<string, ValueType>
+) {
+  const inputSchema = schemaRecordToJsonSchema({ shape: definition.input, valueTypesById })
+  return jsonSchema<Record<string, unknown>>(inputSchema as Parameters<typeof jsonSchema>[0], {
+    validate(value) {
+      try {
+        return {
+          success: true,
+          value: validateAndNormalizeAgentToolInput(
+            definition.name,
+            definition.input,
+            value,
+            valueTypesById
+          ),
+        }
+      } catch (error) {
+        return {
+          success: false,
+          error:
+            error instanceof Error
+              ? error
+              : new AgentWorkerError(`Agent tool '${definition.name}' input validation failed.`, {
+                  cause: error,
+                }),
+        }
+      }
+    },
+  })
 }
 
 function emptyToolSet(): ToolSet {

--- a/packages/agent-worker/src/errors.ts
+++ b/packages/agent-worker/src/errors.ts
@@ -48,3 +48,18 @@ export class AgentTurnTimeoutError extends Error {
     super(`[SixbAgentWorker] Agent run '${runId}' exceeded its ${timeoutMs}ms turn budget.`)
   }
 }
+
+/** A selected agent tool returned a value that cannot cross the durable JSON message boundary. */
+export class AgentToolOutputError extends Error {
+  readonly name = "AgentToolOutputError"
+  constructor(
+    readonly toolName: string,
+    reason: string,
+    options?: ErrorOptions
+  ) {
+    super(
+      `[SixbAgentWorker] Agent tool '${toolName}' returned a non-JSON result; ${reason}.`,
+      options
+    )
+  }
+}

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -16,7 +16,7 @@ import type { AgentRunRecord, AgentStorage } from "@sixb/core/storage"
 import { type ModelMessage, stepCountIs, streamText, toUIMessageStream } from "ai"
 import { agentRunUsageFromAiSdk } from "./ai-sdk-adapters"
 import { attachmentKey, modelSupportsInlineImages, prepareAgentAttachments } from "./attachments"
-import { AgentTurnTimeoutError, AgentWorkerError } from "./errors"
+import { AgentToolOutputError, AgentTurnTimeoutError, AgentWorkerError } from "./errors"
 import { appendMessageAndFinishRunOrThrow, finishRunOrThrow } from "./finalize"
 import {
   type AgentOutputAttachmentResult,
@@ -128,6 +128,8 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
   const uiStream = toUIMessageStream({
     stream: result.stream,
     tools,
+    onError: (error) =>
+      error instanceof AgentToolOutputError ? error.message : "An error occurred.",
     onEnd: (event) => {
       responseMessage = event.responseMessage
       streamAborted = streamAborted || event.isAborted

--- a/packages/agent-worker/src/run-environment.ts
+++ b/packages/agent-worker/src/run-environment.ts
@@ -1,7 +1,9 @@
 import type { AgentDefinition, Sandbox } from "@sixb/core"
+import { resolveLogsRuntime } from "@sixb/core/internal/logging"
 import type { WorkflowIOSnapshot } from "@sixb/core/internal/workflows"
 import type { AgentRunRecord, WorkflowAgentNodeRunRecord } from "@sixb/core/storage"
 import { renderAgentSkillCatalog } from "./agent-skills"
+import { aiSdkToolsFromAgentDefinitions } from "./ai-sdk-adapters"
 import { createAgentApiGatewayBaseUrl } from "./api-url"
 import {
   modelSupportsInlineImages,
@@ -130,7 +132,30 @@ interface AgentEnvironmentSetup extends CreateAgentEnvironmentInput {
 function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvironment {
   const { context, agent, runId, threadId, apiBaseUrl, attachmentContext, skills } = input
 
-  const ready = provisionSandbox({
+  const logSession = resolveLogsRuntime(context.id, context.logs).startExecution({
+    kind: "agent",
+    id: runId,
+  })
+  const logger = logSession.logger.child({
+    agentId: agent.id,
+    ...(threadId ? { threadId } : {}),
+  })
+  const tools = aiSdkToolsFromAgentDefinitions({
+    definitions: agent.tools,
+    valueTypesById: context.valueTypesById,
+    run: { id: runId, agentId: agent.id, ...(threadId ? { threadId } : {}) },
+    connector: context.connector,
+    logger,
+  })
+
+  let sandboxWasUsed = false
+  let ready: Promise<BashSandboxHandle>
+  tools.bash = createBashTool(() => {
+    sandboxWasUsed = true
+    return ready
+  })
+
+  ready = provisionSandbox({
     context,
     agent,
     run: { id: runId, ...(threadId ? { threadId } : {}) },
@@ -139,7 +164,6 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
     attachmentContext,
     skills,
   })
-  let sandboxWasUsed = false
   // Creation failure is surfaced where it is awaited (turn / bash tool / dispose); attach a no-op
   // catch so a rejection observed by none of them is not reported as unhandled.
   ready.catch(() => {})
@@ -157,13 +181,7 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
       blobStorage: context.blobStorage,
       apiBaseUrl,
       attachmentContext,
-      tools: {
-        ...context.baseTools,
-        bash: createBashTool(() => {
-          sandboxWasUsed = true
-          return ready
-        }),
-      },
+      tools,
       systemAddendum: renderAgentSkillCatalog(skills),
       sandboxReady: ready,
       sandboxWasUsed: () => sandboxWasUsed,
@@ -171,7 +189,12 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
       defaultMaxSteps: context.defaultMaxSteps,
       turnTimeoutMs: context.turnTimeoutMs,
     },
-    dispose: () => disposeEnvironment(ready, () => settled, input.onDetachedTeardown),
+    async dispose() {
+      await Promise.all([
+        disposeEnvironment(ready, () => settled, input.onDetachedTeardown),
+        logSession.flush(),
+      ])
+    },
   }
 }
 

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -1,13 +1,19 @@
 import type {
+  AgentToolRunContext,
   BlobStorage,
   Broker,
+  ConnectorAdapter,
+  ConnectorClient,
+  ConnectorDefinition,
   DomainEventLog,
   Queues,
   SandboxFactory,
   SixbRuntimeContext,
   Storage,
+  ValueType,
 } from "@sixb/core"
 import type { AgentsRuntime } from "@sixb/core/internal/agents"
+import type { LogsRuntime } from "@sixb/core/internal/logging"
 import type { WorkflowsRuntime } from "@sixb/core/internal/workflows"
 import type { AgentStorage, AuthStorage } from "@sixb/core/storage"
 import type { ToolSet } from "ai"
@@ -39,6 +45,10 @@ export interface AgentWorkerSixb {
   readonly blobStorage: BlobStorage
   readonly sandboxes?: SandboxFactory
   readonly projectRoot?: string
+  readonly logs?: LogsRuntime
+  connector<TAdapter extends ConnectorAdapter>(
+    definition: ConnectorDefinition<string, TAdapter>
+  ): Promise<ConnectorClient<TAdapter>>
 }
 
 /**
@@ -51,7 +61,9 @@ export interface AgentWorkerContext {
   readonly storage: AgentWorkerStorage
   readonly blobStorage: BlobStorage
   readonly sandboxes: SandboxFactory
-  readonly baseTools: ToolSet
+  readonly connector: AgentToolRunContext["connector"]
+  readonly logs?: LogsRuntime
+  readonly valueTypesById: ReadonlyMap<string, ValueType>
   readonly apiBaseUrl: string
   readonly streamSink: StreamSink
   readonly agentSkills: Promise<readonly AgentSkill[]>
@@ -89,8 +101,6 @@ export interface AgentWorkerOptions {
    * The sandbox receives a run-scoped gateway URL under this origin.
    */
   readonly apiBaseUrl: string
-  /** Tools exposed to the model in addition to the built-in `bash` tool. */
-  readonly tools?: ToolSet
   /** Project Agent Skills directory. Defaults to `<projectRoot>/skills`; `false` disables project skills. */
   readonly skillsDir?: string | false
   /** Maximum number of agent run jobs this worker claims and executes at once. Defaults to 4. */

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -600,7 +600,9 @@ function buildAgentContext(sixb: AgentWorkerSixb, options: AgentWorkerOptions): 
     storage: storage as AgentWorkerStorage,
     blobStorage: sixb.blobStorage,
     sandboxes: sixb.sandboxes,
-    baseTools: options.tools ?? {},
+    connector: (definition) => sixb.connector(definition),
+    logs: sixb.logs,
+    valueTypesById: sixb.ontology?.getValueTypesById() ?? new Map(),
     // Normalize the server base URL once here, at the boundary. Everything downstream (the gateway
     // URL builder, the sandbox run context) consumes it verbatim.
     apiBaseUrl: normalizeApiBaseUrl(normalizeRequiredString(options.apiBaseUrl)),

--- a/packages/agent-worker/tests/ai-sdk-adapters.test.ts
+++ b/packages/agent-worker/tests/ai-sdk-adapters.test.ts
@@ -117,6 +117,103 @@ describe("AI SDK agent adapters", () => {
     expect(receivedSignal).toBe(abort.signal)
   })
 
+  test("validates, normalizes, and freezes model input before execution", async () => {
+    let receivedInput: Readonly<Record<string, unknown>> | undefined
+    const definition = defineAgentTool("create_quote")
+      .description("Create a normalized quote.")
+      .input({
+        customer: "string",
+        quantity: "integer",
+        amount: "decimal",
+        details: {
+          type: "object",
+          properties: {
+            tags: {
+              required: true,
+              schema: { type: "array", items: "string" },
+            },
+          },
+        },
+      })
+      .run(({ input }) => {
+        receivedInput = input
+        return { amount: input.amount }
+      })
+    const adapted = executableTool(
+      aiSdkToolsFromAgentDefinitions({
+        definitions: [definition],
+        valueTypesById: new Map(),
+        run: { id: "run-input", agentId: "quotes" },
+        connector: (() => Promise.reject(new Error("unused"))) as AgentToolRunContext["connector"],
+        logger: noopLogger,
+      }),
+      definition.name
+    )
+
+    expect(await toolJsonSchema(adapted)).toMatchObject({
+      properties: {
+        amount: { type: "string", pattern: "^[+-]?\\d+(?:\\.\\d+)?$" },
+      },
+    })
+
+    const invalidInputs = [
+      { customer: "Acme", amount: "1.20", details: { tags: ["priority"] } },
+      {
+        customer: "Acme",
+        quantity: "2",
+        amount: "1.20",
+        details: { tags: ["priority"] },
+      },
+      {
+        customer: "Acme",
+        quantity: 2,
+        amount: 1.2,
+        details: { tags: ["priority"] },
+      },
+      {
+        customer: "Acme",
+        quantity: 2,
+        amount: "1.20",
+        details: { tags: ["priority"], unexpected: true },
+      },
+      {
+        customer: "Acme",
+        quantity: 2,
+        amount: "1.20",
+        details: { tags: ["priority"] },
+        unexpected: true,
+      },
+    ]
+    for (const input of invalidInputs) {
+      expect(await validateToolInput(adapted, input)).toMatchObject({ success: false })
+    }
+
+    const rawInput = {
+      customer: "Acme",
+      quantity: 2,
+      amount: "+001.2300",
+      details: { tags: ["priority"] },
+    }
+    const validation = await validateToolInput(adapted, rawInput)
+    if (!validation.success) throw validation.error
+    const normalizedInput = validation.value as typeof rawInput
+
+    expect(normalizedInput).toEqual({
+      customer: "Acme",
+      quantity: 2,
+      amount: "1.23",
+      details: { tags: ["priority"] },
+    })
+    expect(Object.isFrozen(normalizedInput)).toBe(true)
+    expect(Object.isFrozen(normalizedInput.details)).toBe(true)
+    expect(Object.isFrozen(normalizedInput.details.tags)).toBe(true)
+
+    rawInput.details.tags.push("mutated")
+    expect(normalizedInput.details.tags).toEqual(["priority"])
+    await expect(adapted.execute(normalizedInput, {})).resolves.toEqual({ amount: "1.23" })
+    expect(receivedInput).toBe(normalizedInput)
+  })
+
   test("rejects a non-JSON Sixb tool result at the AI SDK boundary", async () => {
     const definition = defineAgentTool("invalid_result")
       .description("Return an invalid result.")
@@ -133,6 +230,35 @@ describe("AI SDK agent adapters", () => {
     await expect(executableTool(tools, definition.name).execute({}, {})).rejects.toThrow(
       "[SixbAgentWorker] Agent tool 'invalid_result' returned a non-JSON result; result.value is undefined."
     )
+  })
+
+  test("does not classify project errors by matching their message", async () => {
+    const projectError = new Error(
+      "[Sixb] Agent tool 'project_failure' result must be a JSON value; lookalike"
+    )
+    const definition = defineAgentTool("project_failure")
+      .description("Throw a project error.")
+      .input({})
+      .run(() => {
+        throw projectError
+      })
+    const adapted = executableTool(
+      aiSdkToolsFromAgentDefinitions({
+        definitions: [definition],
+        valueTypesById: new Map(),
+        run: { id: "run-project-error", agentId: "broken" },
+        connector: (() => Promise.reject(new Error("unused"))) as AgentToolRunContext["connector"],
+        logger: noopLogger,
+      }),
+      definition.name
+    )
+
+    try {
+      await adapted.execute({}, {})
+      throw new Error("Expected the project error to propagate.")
+    } catch (error) {
+      expect(error).toBe(projectError)
+    }
   })
 
   test("keeps prototype-like valid tool names as own properties", () => {
@@ -277,8 +403,30 @@ function executableTool(
 }
 
 async function toolJsonSchema(toolDefinition: { readonly inputSchema: unknown }): Promise<unknown> {
-  const schema = toolDefinition.inputSchema as { readonly jsonSchema: unknown }
+  const schema = toolDefinition.inputSchema as ToolInputSchema
   return Promise.resolve(schema.jsonSchema)
+}
+
+type ToolInputValidationResult =
+  | { readonly success: true; readonly value: Record<string, unknown> }
+  | { readonly success: false; readonly error: Error }
+
+interface ToolInputSchema {
+  readonly jsonSchema: unknown
+  readonly validate?: (
+    value: unknown
+  ) => ToolInputValidationResult | PromiseLike<ToolInputValidationResult>
+}
+
+async function validateToolInput(
+  toolDefinition: { readonly inputSchema: unknown },
+  input: unknown
+): Promise<ToolInputValidationResult> {
+  const schema = toolDefinition.inputSchema as ToolInputSchema
+  if (!schema.validate) {
+    throw new Error("Expected the adapted tool input schema to validate values.")
+  }
+  return schema.validate(input)
 }
 
 function recordingLogger(

--- a/packages/agent-worker/tests/ai-sdk-adapters.test.ts
+++ b/packages/agent-worker/tests/ai-sdk-adapters.test.ts
@@ -1,8 +1,157 @@
 import { describe, expect, test } from "bun:test"
-import type { LanguageModelUsage } from "ai"
-import { agentRunUsageFromAiSdk, agentTraceFromAiSdkSteps } from "../src/ai-sdk-adapters"
+import {
+  type AgentToolRunContext,
+  defineAgentTool,
+  defineConnector,
+  type JsonValue,
+  type Logger,
+  noopLogger,
+  stringEnum,
+} from "@sixb/core"
+import type { LanguageModelUsage, ToolSet } from "ai"
+import {
+  agentRunUsageFromAiSdk,
+  agentTraceFromAiSdkSteps,
+  aiSdkToolsFromAgentDefinitions,
+} from "../src/ai-sdk-adapters"
 
 describe("AI SDK agent adapters", () => {
+  test("converts Sixb tool definitions and supplies the narrow run-scoped context", async () => {
+    const connectorDefinition = defineConnector("knowledge", {
+      type: "knowledge",
+      connect() {
+        return { search: (query: string) => [`found:${query}`] }
+      },
+    })
+    const client = await connectorDefinition.adapter.connect()
+    let resolvedDefinition: unknown
+    const connector = (async (definition: unknown) => {
+      resolvedDefinition = definition
+      return client
+    }) as AgentToolRunContext["connector"]
+    const logEntries: Array<{ readonly message: string; readonly fields?: object }> = []
+    const logger = recordingLogger(logEntries)
+    const definition = defineAgentTool("search_knowledge")
+      .description("Search project knowledge.")
+      .input({
+        query: "string",
+        limit: "integer",
+        mode: stringEnum(["quick", "deep"]),
+      })
+      .run(async ({ input, signal, run, connector: resolve, logger: runLogger }) => {
+        const knowledge = await resolve(connectorDefinition)
+        runLogger.info("searching", { query: input.query })
+        return {
+          results: knowledge.search(input.query),
+          limit: input.limit,
+          mode: input.mode,
+          aborted: signal.aborted,
+          run: { id: run.id, agentId: run.agentId, threadId: run.threadId ?? null },
+        }
+      })
+    const run = { id: "run-1", agentId: "research", threadId: "thread-1" }
+    const tools = aiSdkToolsFromAgentDefinitions({
+      definitions: [definition],
+      valueTypesById: new Map(),
+      run: { id: run.id, agentId: run.agentId, threadId: run.threadId },
+      connector,
+      logger,
+    })
+    const adapted = executableTool(tools, definition.name)
+    const schema = await toolJsonSchema(adapted)
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "integer" },
+        mode: { enum: ["quick", "deep"] },
+      },
+      required: ["query", "limit", "mode"],
+      additionalProperties: false,
+    })
+
+    const abort = new AbortController()
+    await expect(
+      adapted.execute({ query: "sixb", limit: 2, mode: "quick" }, { abortSignal: abort.signal })
+    ).resolves.toEqual({
+      results: ["found:sixb"],
+      limit: 2,
+      mode: "quick",
+      aborted: false,
+      run,
+    })
+    expect(resolvedDefinition).toBe(connectorDefinition)
+    expect(logEntries).toEqual([{ message: "searching", fields: { query: "sixb" } }])
+  })
+
+  test("passes cancellation to an executing Sixb tool definition", async () => {
+    let receivedSignal: AbortSignal | undefined
+    const started = Promise.withResolvers<void>()
+    const definition = defineAgentTool("wait")
+      .description("Wait until cancelled.")
+      .input({})
+      .run(async ({ signal }) => {
+        receivedSignal = signal
+        started.resolve()
+        await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve()))
+        return { cancelled: signal.aborted }
+      })
+    const tools = aiSdkToolsFromAgentDefinitions({
+      definitions: [definition],
+      valueTypesById: new Map(),
+      run: { id: "run-2", agentId: "waiter" },
+      connector: (() => Promise.reject(new Error("unused"))) as AgentToolRunContext["connector"],
+      logger: noopLogger,
+    })
+    const abort = new AbortController()
+    const execution = executableTool(tools, definition.name).execute(
+      {},
+      { abortSignal: abort.signal }
+    )
+
+    await started.promise
+    abort.abort()
+
+    await expect(execution).resolves.toEqual({ cancelled: true })
+    expect(receivedSignal).toBe(abort.signal)
+  })
+
+  test("rejects a non-JSON Sixb tool result at the AI SDK boundary", async () => {
+    const definition = defineAgentTool("invalid_result")
+      .description("Return an invalid result.")
+      .input({})
+      .run((() => ({ value: undefined })) as never)
+    const tools = aiSdkToolsFromAgentDefinitions({
+      definitions: [definition],
+      valueTypesById: new Map(),
+      run: { id: "run-3", agentId: "broken" },
+      connector: (() => Promise.reject(new Error("unused"))) as AgentToolRunContext["connector"],
+      logger: noopLogger,
+    })
+
+    await expect(executableTool(tools, definition.name).execute({}, {})).rejects.toThrow(
+      "[SixbAgentWorker] Agent tool 'invalid_result' returned a non-JSON result; result.value is undefined."
+    )
+  })
+
+  test("keeps prototype-like valid tool names as own properties", () => {
+    const definition = defineAgentTool("__proto__")
+      .description("Return a safe result.")
+      .input({})
+      .run(() => null)
+    const tools = aiSdkToolsFromAgentDefinitions({
+      definitions: [definition],
+      valueTypesById: new Map(),
+      run: { id: "run-4", agentId: "prototype" },
+      connector: (() => Promise.reject(new Error("unused"))) as AgentToolRunContext["connector"],
+      logger: noopLogger,
+    })
+
+    expect(Object.hasOwn(tools, definition.name)).toBe(true)
+    expect(typeof tools[definition.name]?.execute).toBe("function")
+  })
+
   test("converts ordered step content into the durable Sixb trace", () => {
     const trace = agentTraceFromAiSdkSteps([
       {
@@ -109,6 +258,48 @@ describe("AI SDK agent adapters", () => {
     expect(agentRunUsageFromAiSdk(usage({}))).toBeUndefined()
   })
 })
+
+function executableTool(
+  tools: ToolSet,
+  name: string
+): {
+  readonly inputSchema: unknown
+  execute(
+    input: Record<string, unknown>,
+    options: { readonly abortSignal?: AbortSignal }
+  ): Promise<JsonValue>
+} {
+  const adapted = tools[name]
+  if (!adapted || typeof adapted.execute !== "function") {
+    throw new Error(`Expected executable tool '${name}'.`)
+  }
+  return adapted as never
+}
+
+async function toolJsonSchema(toolDefinition: { readonly inputSchema: unknown }): Promise<unknown> {
+  const schema = toolDefinition.inputSchema as { readonly jsonSchema: unknown }
+  return Promise.resolve(schema.jsonSchema)
+}
+
+function recordingLogger(
+  entries: Array<{ readonly message: string; readonly fields?: object }>,
+  bindings: Readonly<Record<string, JsonValue>> = {}
+): Logger {
+  const write = (message: string, fields?: Readonly<Record<string, JsonValue>>): void => {
+    entries.push({ message, fields: { ...bindings, ...fields } })
+  }
+  return {
+    debug: write,
+    info: write,
+    warn: write,
+    error(message, fields) {
+      write(message instanceof Error ? message.message : message, fields)
+    },
+    child(childBindings) {
+      return recordingLogger(entries, { ...bindings, ...childBindings })
+    },
+  }
+}
 
 function usage(input: {
   readonly inputTokens?: number

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -11,12 +11,16 @@ import type {
 import {
   type AgentReasoningLevel,
   AgentRequestError,
+  type AgentToolDefinition,
   type BlobStorage,
   type Broker,
   type CommandResult,
+  type ConnectorDefinition,
   type CreateSandboxOptions,
   defineAgent,
   defineAgentStep,
+  defineAgentTool,
+  defineConnector,
   defineGroup,
   defineWorkflow,
   InMemoryBlobStorage,
@@ -59,7 +63,7 @@ import { reconcileAgentExecutionIdentity } from "../src/identity"
 import { runAgentTurn } from "../src/run-agent-turn"
 import { createConversationAgentEnvironment } from "../src/run-environment"
 import { createBrokerStreamSink, NOOP_STREAM_SINK } from "../src/stream-sink"
-import type { AgentWorkerContext, AgentWorkerStorage } from "../src/types"
+import type { AgentWorkerContext, AgentWorkerSixb, AgentWorkerStorage } from "../src/types"
 import { waitFor, writeProjectSkill } from "./helpers"
 
 const PROJECT_ID = "agent-worker-tests"
@@ -84,11 +88,11 @@ function finish(unified: "stop" | "tool-calls"): LanguageModelV4StreamPart {
  * A model that, on its first call, calls the `echo` tool, then on its second call answers with
  * reasoning + text. A stateful `doStream` (not the array form) guarantees per-call ordering.
  */
-function toolThenAnswerModel(): MockLanguageModelV4 {
+function toolThenAnswerModel(captureReplay?: (prompt: string) => void): MockLanguageModelV4 {
   let call = 0
   return new MockLanguageModelV4({
     modelId: "mock-model",
-    doStream: async () => {
+    doStream: async (options) => {
       call += 1
       if (call === 1) {
         return stream([
@@ -102,6 +106,9 @@ function toolThenAnswerModel(): MockLanguageModelV4 {
           finish("tool-calls"),
         ])
       }
+      if (call === 3) {
+        captureReplay?.(JSON.stringify(options.prompt))
+      }
       return stream([
         { type: "stream-start", warnings: [] },
         { type: "reasoning-start", id: "r" },
@@ -110,6 +117,54 @@ function toolThenAnswerModel(): MockLanguageModelV4 {
         { type: "text-start", id: "t" },
         { type: "text-delta", id: "t", delta: "Echoed hi" },
         { type: "text-end", id: "t" },
+        finish("stop"),
+      ])
+    },
+  })
+}
+
+function answerModel(captureTools?: (names: readonly string[]) => void): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    doStream: async (options) => {
+      captureTools?.((options.tools ?? []).map((tool) => tool.name))
+      return stream([
+        { type: "stream-start", warnings: [] },
+        { type: "text-start", id: "answer" },
+        { type: "text-delta", id: "answer", delta: "Done" },
+        { type: "text-end", id: "answer" },
+        finish("stop"),
+      ])
+    },
+  })
+}
+
+function failingToolThenAnswerModel(captureReplay: (prompt: string) => void): MockLanguageModelV4 {
+  let call = 0
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    doStream: async (options) => {
+      call += 1
+      if (call === 1) {
+        return stream([
+          { type: "stream-start", warnings: [] },
+          {
+            type: "tool-call",
+            toolCallId: "invalid-result-call",
+            toolName: "invalid_result",
+            input: JSON.stringify({}),
+          },
+          finish("tool-calls"),
+        ])
+      }
+      if (call === 3) {
+        captureReplay(JSON.stringify(options.prompt))
+      }
+      return stream([
+        { type: "stream-start", warnings: [] },
+        { type: "text-start", id: `answer-${call}` },
+        { type: "text-delta", id: `answer-${call}`, delta: "Recovered" },
+        { type: "text-end", id: `answer-${call}` },
         finish("stop"),
       ])
     },
@@ -154,13 +209,30 @@ function toolOnlyModel(): MockLanguageModelV4 {
   })
 }
 
-function structuredAnswerModel(
+function structuredToolThenAnswerModel(
   captureSystem?: (system: string | undefined) => void
 ): MockLanguageModelV4 {
+  let call = 0
   return new MockLanguageModelV4({
     modelId: "mock-model",
     doGenerate: async (options) => {
       captureSystem?.(options.prompt.find((message) => message.role === "system")?.content)
+      call += 1
+      if (call === 1) {
+        return {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "workflow-lookup",
+              toolName: "lookup_project",
+              input: JSON.stringify({ query: "alpha" }),
+            },
+          ],
+          finishReason: { unified: "tool-calls", raw: "tool-calls" },
+          usage: USAGE,
+          warnings: [],
+        }
+      }
       return {
         content: [
           {
@@ -393,6 +465,11 @@ const echoTool: ToolSet = {
   }),
 }
 
+const echoAgentTool = defineAgentTool("echo")
+  .description("Echo a value back.")
+  .input({ value: "string" })
+  .run(({ input }) => ({ echoed: input.value }))
+
 // Sixb's generics overflow TS2589 when instantiated with an empty ontology in a test; we only need a
 // structural `AgentWorkerSixb`, so we construct through a narrowed constructor cast (as the
 // action-worker tests do).
@@ -406,6 +483,9 @@ interface TestSixb {
   readonly agents: AgentsRuntime
   readonly blobStorage: BlobStorage
   readonly sandboxes?: SandboxFactory
+  readonly logs: NonNullable<AgentWorkerSixb["logs"]>
+  readonly ontology: NonNullable<AgentWorkerSixb["ontology"]>
+  readonly connector: AgentWorkerSixb["connector"]
 }
 
 const SixbCtor = Sixb as unknown as new (options: Record<string, unknown>) => TestSixb
@@ -641,6 +721,8 @@ function buildSixb(
     readonly reasoning?: AgentReasoningLevel
     readonly providerOptions?: LanguageModelV4CallOptions["providerOptions"]
     readonly projectRoot?: string
+    readonly agentTools?: readonly AgentToolDefinition[]
+    readonly connectors?: readonly ConnectorDefinition[]
   } = {}
 ): TestSixb {
   const agent = defineAgent("assistant", {
@@ -650,12 +732,14 @@ function buildSixb(
     ...(options.providerOptions === undefined ? {} : { providerOptions: options.providerOptions }),
     instructions: "You are a helpful test assistant.",
     groups: [AGENT_RUNTIME_GROUP],
+    ...(options.agentTools === undefined ? {} : { tools: options.agentTools }),
     loop: { stopWhen: { maxSteps: 4 } },
   })
   return new SixbCtor({
     id: PROJECT_ID,
     ontology: [],
     agents: [agent],
+    ...(options.connectors === undefined ? {} : { connectors: options.connectors }),
     groups: [AGENT_RUNTIME_GROUP],
     broker,
     storage: new InMemoryStorage(),
@@ -665,6 +749,14 @@ function buildSixb(
     sandboxes,
     ...(options.projectRoot === undefined ? {} : { projectRoot: options.projectRoot }),
   })
+}
+
+function buildSixbWithEchoTool(
+  model: LanguageModelV4,
+  broker: Broker = new InMemoryBroker(),
+  sandboxes: SandboxFactory = new RecordingSandboxFactory()
+): TestSixb {
+  return buildSixb(model, broker, sandboxes, { agentTools: [echoAgentTool] })
 }
 
 class FailingRunStreamBroker extends InMemoryBroker {
@@ -706,7 +798,7 @@ function workerStorageOf(storage: Storage): AgentWorkerStorage {
 
 function buildAgentWorkerContext(
   sixb: TestSixb,
-  input: { readonly apiBaseUrl?: string; readonly baseTools?: ToolSet } = {}
+  input: { readonly apiBaseUrl?: string } = {}
 ): AgentWorkerContext {
   if (!sixb.sandboxes) {
     throw new Error("expected sandbox factory")
@@ -716,7 +808,9 @@ function buildAgentWorkerContext(
     storage: workerStorageOf(sixb.storage),
     blobStorage: sixb.blobStorage,
     sandboxes: sixb.sandboxes,
-    baseTools: input.baseTools ?? {},
+    connector: (definition) => sixb.connector(definition),
+    logs: sixb.logs,
+    valueTypesById: sixb.ontology.getValueTypesById(),
     // Mirror the production boundary (worker.ts buildAgentContext): normalize the server base once.
     apiBaseUrl: normalizeApiBaseUrl(input.apiBaseUrl ?? TEST_AGENT_API_BASE_URL),
     streamSink: NOOP_STREAM_SINK,
@@ -936,14 +1030,23 @@ describe("AgentWorker", () => {
 
   test("executes a headless workflow agent node and publishes its resume", async () => {
     let capturedSystem: string | undefined
-    const model = structuredAnswerModel((system) => {
+    const model = structuredToolThenAnswerModel((system) => {
       capturedSystem = system
     })
+    let lookupCalls = 0
+    const lookupProject = defineAgentTool("lookup_project")
+      .description("Look up a project.")
+      .input({ query: "string" })
+      .run(({ input, run }) => {
+        lookupCalls += 1
+        return { project: "Project Alpha", query: input.query, runId: run.id }
+      })
     const agent = defineAgent("workflow-resolver", {
       name: "Workflow resolver",
       model,
       instructions: "Resolve the best project.",
       groups: [AGENT_RUNTIME_GROUP],
+      tools: [lookupProject],
     })
     const agentStep = defineAgentStep("resolve-project", agent)
       .input({ query: "string" })
@@ -1026,6 +1129,19 @@ describe("AgentWorker", () => {
       })
       expect(execution.execution).toBeUndefined()
       expect(execution.trace).toBeArray()
+      expect(lookupCalls).toBe(1)
+      expect(execution.trace).toContainEqual(
+        expect.objectContaining({
+          type: "tool-call",
+          toolName: lookupProject.name,
+          state: "output-available",
+          output: {
+            project: "Project Alpha",
+            query: "alpha",
+            runId: nodeRunId,
+          },
+        })
+      )
       expect(capturedSystem).toContain("headless Sixb workflow agent")
       expect(capturedSystem).toContain("Do not ask a user follow-up question")
       expect(await runs.nodes.getById({ projectId: PROJECT_ID, id: nodeRunId })).toMatchObject({
@@ -1581,7 +1697,7 @@ describe("AgentWorker", () => {
   })
 
   test("dispatches a durable queued run after the request-time enqueue fails", async () => {
-    const sixb = buildSixb(toolThenAnswerModel())
+    const sixb = buildSixbWithEchoTool(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
     const queue = sixb.queues.agents
     const originalEnqueue = queue.enqueue.bind(queue)
@@ -1602,7 +1718,7 @@ describe("AgentWorker", () => {
     }
     expect(request.jobId).toBeUndefined()
 
-    const worker = new AgentWorker(sixb, workerOptions({ tools: echoTool }))
+    const worker = new AgentWorker(sixb, workerOptions())
     await worker.start()
     try {
       const run = await waitFor(
@@ -1619,17 +1735,222 @@ describe("AgentWorker", () => {
     }
   })
 
+  test("runs only the current agent's selected tools with connector, metadata, and logs", async () => {
+    let connectorCalls = 0
+    const knowledge = defineConnector("knowledge", {
+      type: "knowledge",
+      connect() {
+        connectorCalls += 1
+        return { echo: (value: string) => `connected:${value}` }
+      },
+    })
+    let handlerContext:
+      | { readonly runId: string; readonly agentId: string; readonly threadId?: string }
+      | undefined
+    let handlerSignal: AbortSignal | undefined
+    let selectedCalls = 0
+    let successfulReplay = ""
+    const selectedEcho = defineAgentTool("echo")
+      .description("Echo through the registered knowledge connector.")
+      .input({ value: "string" })
+      .run(async ({ input, run, signal, connector, logger }) => {
+        selectedCalls += 1
+        handlerContext = { runId: run.id, agentId: run.agentId, threadId: run.threadId }
+        handlerSignal = signal
+        const client = await connector(knowledge)
+        logger.info("selected tool called", { value: input.value })
+        return { echoed: client.echo(input.value) }
+      })
+    const research = defineAgent("research", {
+      name: "Research",
+      model: toolThenAnswerModel((prompt) => {
+        successfulReplay = prompt
+      }),
+      instructions: "Research with selected tools.",
+      groups: [AGENT_RUNTIME_GROUP],
+      tools: [selectedEcho],
+    })
+    let unselectedToolNames: readonly string[] = []
+    const plain = defineAgent("plain", {
+      name: "Plain",
+      model: answerModel((names) => {
+        unselectedToolNames = names
+      }),
+      instructions: "Answer without the research tool.",
+      groups: [AGENT_RUNTIME_GROUP],
+    })
+    const sixb = new SixbCtor({
+      id: PROJECT_ID,
+      ontology: [],
+      agents: [research, plain],
+      connectors: [knowledge],
+      groups: [AGENT_RUNTIME_GROUP],
+      broker: new InMemoryBroker(),
+      storage: new InMemoryStorage(),
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: new InMemoryBlobStorage(),
+      queues: new InMemoryQueues(),
+      sandboxes: new RecordingSandboxFactory(),
+    })
+    const storage = agentStorageOf(sixb)
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    await worker.start()
+    try {
+      const selectedRequest = await sixb.agents.request({ agentId: research.id, text: "echo hi" })
+      const selectedRun = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({
+            projectId: PROJECT_ID,
+            id: selectedRequest.run.id,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "selected tool run terminal" }
+      )
+      const plainRequest = await sixb.agents.request({ agentId: plain.id, text: "answer" })
+      await waitFor(
+        async () => {
+          const record = await storage.runs.getById({
+            projectId: PROJECT_ID,
+            id: plainRequest.run.id,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "unselected agent run terminal" }
+      )
+
+      expect(selectedRun.status).toBe("succeeded")
+      expect(selectedCalls).toBe(1)
+      expect(connectorCalls).toBe(1)
+      expect(handlerSignal).toBeInstanceOf(AbortSignal)
+      expect(handlerContext).toEqual({
+        runId: selectedRequest.run.id,
+        agentId: research.id,
+        threadId: selectedRequest.run.threadId,
+      })
+      expect(unselectedToolNames).toContain("bash")
+      expect(unselectedToolNames).not.toContain(selectedEcho.name)
+
+      const messages = await listMessages(storage, selectedRequest.run.threadId)
+      expect(
+        messages
+          .find((message) => message.role === "assistant")
+          ?.parts.find((part) => part.type === "tool-call" && part.toolName === selectedEcho.name)
+      ).toMatchObject({
+        state: "output-available",
+        input: { value: "hi" },
+        output: { echoed: "connected:hi" },
+      })
+
+      const followUp = await sixb.agents.request({
+        agentId: research.id,
+        threadId: selectedRequest.run.threadId,
+        text: "continue",
+      })
+      await waitFor(
+        async () => {
+          const record = await storage.runs.getById({ projectId: PROJECT_ID, id: followUp.run.id })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "successful selected tool replay terminal" }
+      )
+      expect(successfulReplay).toContain(selectedEcho.name)
+      expect(successfulReplay).toContain("connected:hi")
+
+      const logs = await waitFor(
+        async () => {
+          const page = await sixb.logs.read({
+            run: { kind: "agent", id: selectedRequest.run.id },
+          })
+          return page.lines.length > 0 ? page.lines : null
+        },
+        { label: "selected tool logs flushed" }
+      )
+      expect(logs).toHaveLength(1)
+      expect(logs[0]).toMatchObject({
+        level: "info",
+        message: "selected tool called",
+        fields: {
+          agentId: research.id,
+          threadId: selectedRequest.run.threadId,
+          value: "hi",
+        },
+        context: { run: { kind: "agent", id: selectedRequest.run.id } },
+      })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("persists and replays selected tool failures with clear non-JSON diagnostics", async () => {
+    let replayedPrompt = ""
+    const invalidResult = {
+      kind: "agentTool",
+      name: "invalid_result",
+      description: "Return an invalid result.",
+      input: {},
+      handler: async () => ({ invalid: undefined }),
+    } as unknown as AgentToolDefinition
+    const sixb = buildSixb(
+      failingToolThenAnswerModel((prompt) => {
+        replayedPrompt = prompt
+      }),
+      new InMemoryBroker(),
+      new RecordingSandboxFactory(),
+      { agentTools: [invalidResult] }
+    )
+    const storage = agentStorageOf(sixb)
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    await worker.start()
+    try {
+      const first = await sixb.agents.request({ agentId: "assistant", text: "run the tool" })
+      const firstRun = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({ projectId: PROJECT_ID, id: first.run.id })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "invalid selected tool run terminal" }
+      )
+      expect(firstRun.status).toBe("succeeded")
+
+      const firstAssistant = (await listMessages(storage, first.run.threadId)).find(
+        (message) => message.role === "assistant"
+      )
+      expect(
+        firstAssistant?.parts.find(
+          (part) => part.type === "tool-call" && part.toolName === invalidResult.name
+        )
+      ).toMatchObject({
+        state: "output-error",
+        errorText:
+          "[SixbAgentWorker] Agent tool 'invalid_result' returned a non-JSON result; result.invalid is undefined.",
+      })
+
+      const second = await sixb.agents.request({
+        agentId: "assistant",
+        threadId: first.run.threadId,
+        text: "continue",
+      })
+      await waitFor(
+        async () => {
+          const record = await storage.runs.getById({ projectId: PROJECT_ID, id: second.run.id })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "tool failure replay run terminal" }
+      )
+      expect(replayedPrompt).toContain("invalid_result")
+      expect(replayedPrompt).toContain("returned a non-JSON result")
+    } finally {
+      await worker.stop()
+    }
+  })
+
   test("runs a full multi-step turn: starts, persists the assistant message, finalizes with usage", async () => {
-    const sixb = buildSixb(toolThenAnswerModel())
+    const sixb = buildSixbWithEchoTool(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
     const auth = authStorageOf(sixb)
 
-    const worker = new AgentWorker(
-      sixb,
-      workerOptions({
-        tools: echoTool,
-      })
-    )
+    const worker = new AgentWorker(sixb, workerOptions())
     await worker.start()
     try {
       const {
@@ -1856,15 +2177,10 @@ describe("AgentWorker", () => {
   })
 
   test("adds visible guidance when the step limit is reached before an answer", async () => {
-    const sixb = buildSixb(toolOnlyModel())
+    const sixb = buildSixbWithEchoTool(toolOnlyModel())
     const storage = agentStorageOf(sixb)
 
-    const worker = new AgentWorker(
-      sixb,
-      workerOptions({
-        tools: echoTool,
-      })
-    )
+    const worker = new AgentWorker(sixb, workerOptions())
     await worker.start()
     try {
       const {
@@ -2403,10 +2719,7 @@ describe("AgentWorker", () => {
 
     const firstRequest = await sixb.agents.request({ agentId: "assistant", text: "first" })
 
-    const worker = new AgentWorker(
-      sixb,
-      workerOptions({ concurrency: 2, idlePollMs: 10, tools: echoTool })
-    )
+    const worker = new AgentWorker(sixb, workerOptions({ concurrency: 2, idlePollMs: 10 }))
     await worker.start()
     try {
       await waitFor(() => (controlled.startedCount() >= 1 ? true : null), {
@@ -2502,7 +2815,7 @@ describe("AgentWorker", () => {
 
     const request = await sixb.agents.request({ agentId: "assistant", text: "go" })
 
-    const worker = new AgentWorker(sixb, workerOptions({ idlePollMs: 10, tools: echoTool }))
+    const worker = new AgentWorker(sixb, workerOptions({ idlePollMs: 10 }))
     await worker.start()
     try {
       await waitFor(() => (controlled.startedCount() >= 1 ? true : null), {
@@ -2543,6 +2856,55 @@ describe("AgentWorker", () => {
     }
   })
 
+  test("propagates run cancellation to an active selected tool handler", async () => {
+    const started = Promise.withResolvers<void>()
+    let handlerWasCancelled = false
+    const blockingEcho = defineAgentTool("echo")
+      .description("Wait for cancellation.")
+      .input({ value: "string" })
+      .run(async ({ signal }) => {
+        started.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+        handlerWasCancelled = signal.aborted
+        return { cancelled: signal.aborted }
+      })
+    const sixb = buildSixb(
+      toolThenAnswerModel(),
+      new InMemoryBroker(),
+      new RecordingSandboxFactory(),
+      { agentTools: [blockingEcho] }
+    )
+    const storage = agentStorageOf(sixb)
+    const request = await sixb.agents.request({ agentId: "assistant", text: "wait" })
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    await worker.start()
+    try {
+      await started.promise
+      await publishAgentRunCancel(sixb.broker, {
+        projectId: PROJECT_ID,
+        runId: request.run.id,
+      })
+
+      const run = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({ projectId: PROJECT_ID, id: request.run.id })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "selected tool run terminal after cancel" }
+      )
+      expect(run.status).toBe("cancelled")
+      expect(handlerWasCancelled).toBe(true)
+    } finally {
+      await worker.stop()
+    }
+  })
+
   test("persists the partial assistant message when a mid-response run is cancelled", async () => {
     const partial = "Let me start by checking the pipeline logs"
     const controlled = partialTextThenBlockingModel(partial)
@@ -2551,7 +2913,7 @@ describe("AgentWorker", () => {
 
     const request = await sixb.agents.request({ agentId: "assistant", text: "go" })
 
-    const worker = new AgentWorker(sixb, workerOptions({ idlePollMs: 10, tools: echoTool }))
+    const worker = new AgentWorker(sixb, workerOptions({ idlePollMs: 10 }))
     await worker.start()
     try {
       await controlled.waitForStarted()
@@ -2598,7 +2960,7 @@ describe("AgentWorker", () => {
   })
 
   test("publishes UI chunks before appending the finalized assistant message", async () => {
-    const sixb = buildSixb(toolThenAnswerModel())
+    const sixb = buildSixbWithEchoTool(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
     let chunksBeforeAssistantAppend = 0
     let finalizedBeforeAssistantAppend = false
@@ -2624,9 +2986,12 @@ describe("AgentWorker", () => {
       agents: sixb.agents,
       blobStorage: sixb.blobStorage,
       sandboxes: sixb.sandboxes,
+      logs: sixb.logs,
+      ontology: sixb.ontology,
+      connector: sixb.connector.bind(sixb),
     }
 
-    const worker = new AgentWorker(workerSixb, workerOptions({ tools: echoTool }))
+    const worker = new AgentWorker(workerSixb, workerOptions())
     await worker.start()
     try {
       const {
@@ -2649,7 +3014,7 @@ describe("AgentWorker", () => {
   })
 
   test("does not report broker run stream publication failures", async () => {
-    const sixb = buildSixb(toolThenAnswerModel(), new FailingRunStreamBroker())
+    const sixb = buildSixbWithEchoTool(toolThenAnswerModel(), new FailingRunStreamBroker())
     const storage = agentStorageOf(sixb)
     let reportCount = 0
     const reporter = attachSixbErrorReporter(sixb, () => {
@@ -2658,7 +3023,7 @@ describe("AgentWorker", () => {
     const originalConsoleError = console.error
     console.error = () => {}
 
-    const worker = new AgentWorker(sixb, workerOptions({ tools: echoTool }))
+    const worker = new AgentWorker(sixb, workerOptions())
     try {
       await worker.start()
       const {
@@ -2687,7 +3052,7 @@ describe("AgentWorker", () => {
   })
 
   test("continues the turn when a custom stream sink fails", async () => {
-    const sixb = buildSixb(toolThenAnswerModel())
+    const sixb = buildSixbWithEchoTool(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
     const originalConsoleError = console.error
     console.error = () => {}
@@ -2695,7 +3060,6 @@ describe("AgentWorker", () => {
     const worker = new AgentWorker(
       sixb,
       workerOptions({
-        tools: echoTool,
         streamSink: {
           async publishStarted() {
             throw new Error("sink down")
@@ -2795,7 +3159,7 @@ describe("AgentWorker", () => {
   })
 
   test("reclaims a crashed run on redelivery and completes it (attempt++)", async () => {
-    const sixb = buildSixb(toolThenAnswerModel())
+    const sixb = buildSixbWithEchoTool(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
 
     // Trigger normally, then simulate a worker that crashed after starting the durable run. The
@@ -2813,7 +3177,7 @@ describe("AgentWorker", () => {
       execution: freshTestExecution(),
     })
 
-    const worker = new AgentWorker(sixb, workerOptions({ tools: echoTool }))
+    const worker = new AgentWorker(sixb, workerOptions())
     await worker.start()
     try {
       const reclaimed = await waitFor(
@@ -3153,7 +3517,7 @@ describe("AgentWorker", () => {
   })
 
   test("absorbs a transient finalize blip in place: one run, one message, no lock", async () => {
-    const sixb = buildSixb(toolThenAnswerModel())
+    const sixb = buildSixbWithEchoTool(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
     // The worker sees a storage whose `finish` fails twice before succeeding; the trigger keeps using
     // the real storage (both delegate to the same underlying state).
@@ -3166,9 +3530,12 @@ describe("AgentWorker", () => {
       agents: sixb.agents,
       blobStorage: sixb.blobStorage,
       sandboxes: sixb.sandboxes,
+      logs: sixb.logs,
+      ontology: sixb.ontology,
+      connector: sixb.connector.bind(sixb),
     }
 
-    const worker = new AgentWorker(workerSixb, workerOptions({ tools: echoTool }))
+    const worker = new AgentWorker(workerSixb, workerOptions())
     await worker.start()
     try {
       const {
@@ -3453,7 +3820,7 @@ describe("AgentWorker", () => {
       ],
     })
 
-    const worker = new AgentWorker(sixb, workerOptions({ tools: echoTool }))
+    const worker = new AgentWorker(sixb, workerOptions())
     await worker.start()
     try {
       // Let the worker reject the orphan job. The active run must be untouched: not reclaimed, no

--- a/packages/core/src/agents/errors.ts
+++ b/packages/core/src/agents/errors.ts
@@ -16,6 +16,19 @@ export class AgentMessageAdapterError extends Error {
   readonly name = "AgentMessageAdapterError"
 }
 
+/** Raised when an agent tool result cannot cross the durable JSON message boundary. */
+export class AgentToolResultValidationError extends Error {
+  readonly name = "AgentToolResultValidationError"
+
+  constructor(
+    readonly toolName: string,
+    readonly reason: string,
+    options?: ErrorOptions
+  ) {
+    super(`[Sixb] Agent tool '${toolName}' result must be a JSON value; ${reason}.`, options)
+  }
+}
+
 export type AgentRequestErrorCode =
   | "agent_not_found"
   | "thread_not_found"

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -59,6 +59,7 @@ export {
   AgentMessageAdapterError,
   AgentRequestError,
   type AgentRequestErrorCode,
+  AgentToolResultValidationError,
 } from "./errors"
 export {
   createAgentMessageId,
@@ -136,4 +137,5 @@ export {
   isAgentToolDefinition,
   validateAgentGroupReferences,
   validateAgentToolsAtStartup,
+  validateAndNormalizeAgentToolInput,
 } from "./validation"

--- a/packages/core/src/agents/tool-definition.ts
+++ b/packages/core/src/agents/tool-definition.ts
@@ -1,5 +1,5 @@
-import { cloneJsonValue } from "../json"
-import { AgentDefinitionError } from "./errors"
+import { cloneJsonValue, getInvalidJsonValueReason } from "../json"
+import { AgentDefinitionError, AgentToolResultValidationError } from "./errors"
 import type {
   AgentToolDefinition,
   AgentToolHandler,
@@ -41,7 +41,15 @@ export function createAgentToolDefinition<
     input,
     handler: async (context) => {
       const result = await definition.handler(context)
-      return cloneJsonValue(result, `Agent tool '${definition.name}' result`)
+      try {
+        return cloneJsonValue(result, "result")
+      } catch (cause) {
+        throw new AgentToolResultValidationError(
+          definition.name,
+          getInvalidJsonValueReason(result, "result") ?? "result could not be cloned safely",
+          { cause }
+        )
+      }
     },
   }
 

--- a/packages/core/src/agents/validation.ts
+++ b/packages/core/src/agents/validation.ts
@@ -1,4 +1,11 @@
-import { getInvalidJsonValueReason, isPlainRecord } from "../json"
+import { getInvalidJsonValueReason, isPlainRecord, type JsonValue } from "../json"
+import {
+  normalizeSchemaValue,
+  type ObjectSchema,
+  OntologyValidationError,
+  type ValueType,
+  validateSchemaValue,
+} from "../ontology"
 import type { GroupDefinition, SecurityRegistry } from "../security"
 import { AgentDefinitionError } from "./errors"
 import {
@@ -101,6 +108,38 @@ export function validateAndSnapshotAgentToolInput<TInput extends AgentToolInputS
       `[Sixb] Agent tool '${toolName}' input must be safely snapshot-compatible.`
     )
   }
+}
+
+/** Validate model input against a tool schema, normalize it to JSON, and lock the snapshot. */
+export function validateAndNormalizeAgentToolInput(
+  toolName: string,
+  shape: AgentToolInputSchema,
+  value: unknown,
+  valueTypesById: ReadonlyMap<string, ValueType>
+): Record<string, JsonValue> {
+  const label = `Agent tool '${toolName}' input`
+  if (!isPlainRecord(value)) {
+    throw new OntologyValidationError(`[Sixb] ${label} must be a JSON object.`)
+  }
+
+  const reason = getInvalidJsonValueReason(value, label)
+  if (reason) {
+    throw new OntologyValidationError(`[Sixb] ${label} must be JSON-compatible; ${reason}.`)
+  }
+
+  const schema: ObjectSchema = {
+    type: "object",
+    properties: Object.fromEntries(
+      Object.entries(shape).map(([field, fieldSchema]) => [
+        field,
+        { schema: fieldSchema, required: true },
+      ])
+    ),
+  }
+  validateSchemaValue(schema, value, label, valueTypesById)
+  return deepFreeze(
+    normalizeSchemaValue(schema, value, label, valueTypesById) as Record<string, JsonValue>
+  )
 }
 
 /** Revalidate and lock tool definitions supplied directly to the runtime. */

--- a/packages/core/src/ontology/json-schema.ts
+++ b/packages/core/src/ontology/json-schema.ts
@@ -53,8 +53,9 @@ function schemaJsonSchema(
       case "integer":
         return { type: "integer" }
       case "double":
-      case "decimal":
         return { type: "number" }
+      case "decimal":
+        return { type: "string", pattern: "^[+-]?\\d+(?:\\.\\d+)?$" }
       case "boolean":
         return { type: "boolean" }
       case "date":

--- a/packages/core/src/ontology/validation/normalize.ts
+++ b/packages/core/src/ontology/validation/normalize.ts
@@ -84,20 +84,18 @@ export function normalizeSchemaValue(
 
   const fields = schema.properties
   const record = assertPlainRecord(value, path)
-  const output: Record<string, JsonValue> = {}
+  const entries: Array<[string, JsonValue]> = []
   for (const [fieldId, field] of Object.entries(fields)) {
     const fieldValue = record[fieldId]
     if (fieldValue === undefined) {
       continue
     }
-    output[fieldId] = normalizeObjectFieldValue(
-      field,
-      fieldValue,
-      `${path}.${fieldId}`,
-      valueTypesById
-    )
+    entries.push([
+      fieldId,
+      normalizeObjectFieldValue(field, fieldValue, `${path}.${fieldId}`, valueTypesById),
+    ])
   }
-  return output
+  return Object.fromEntries(entries)
 }
 
 function normalizeObjectFieldValue(

--- a/packages/core/tests/agents.test.ts
+++ b/packages/core/tests/agents.test.ts
@@ -17,6 +17,7 @@ import {
   prop,
   RuntimeError,
 } from "../src"
+import { AgentToolResultValidationError } from "../src/agents/errors"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
 const coreModuleUrl = pathToFileURL(resolve(import.meta.dir, "..", "src", "index.ts")).href
@@ -123,9 +124,12 @@ describe("defineAgentTool", () => {
       .input({})
       .run((() => ({ value: undefined })) as never)
 
-    await expect(invalidResult.handler({ input: {} } as never)).rejects.toThrow(
-      "Agent tool 'invalid_result' result must be a JSON value"
-    )
+    const invalidResultPromise = invalidResult.handler({ input: {} } as never)
+    await expect(invalidResultPromise).rejects.toBeInstanceOf(AgentToolResultValidationError)
+    await expect(invalidResultPromise).rejects.toMatchObject({
+      toolName: "invalid_result",
+      reason: "result.value is undefined",
+    })
   })
 
   test("deeply snapshots and freezes nested input schemas", () => {

--- a/packages/core/tests/workflows.test.ts
+++ b/packages/core/tests/workflows.test.ts
@@ -194,6 +194,7 @@ describe("schemaRecordToJsonSchema", () => {
           project: ref(Invoice),
           evidence: valueTypeRef(MatchEvidence.id),
           scores: { type: "map", keySchema: "string", valueSchema: "double" },
+          amount: "decimal",
           attachment: "fileRef",
         },
         valueTypesById: new Map([[MatchEvidence.id, MatchEvidence]]),
@@ -220,6 +221,7 @@ describe("schemaRecordToJsonSchema", () => {
           additionalProperties: false,
         },
         scores: { type: "object", additionalProperties: { type: "number" } },
+        amount: { type: "string", pattern: "^[+-]?\\d+(?:\\.\\d+)?$" },
         attachment: {
           type: "object",
           properties: {
@@ -234,7 +236,7 @@ describe("schemaRecordToJsonSchema", () => {
           additionalProperties: false,
         },
       },
-      required: ["project", "evidence", "scores", "attachment"],
+      required: ["project", "evidence", "scores", "amount", "attachment"],
       additionalProperties: false,
     })
   })


### PR DESCRIPTION
## Stack

Stacked on #298, which introduces reusable, inert agent tool definitions. This PR executes those definitions inside the agent worker.

```text
#298     agents: define reusable agent tools
  ↓
This PR  agent-worker: run tools selected by each agent
```

## What changed

Each run now exposes only the tools selected by its agent, plus framework-provided sandboxed `bash`.

```text
Effective tools = agent.tools + bash
```

The worker adapts Sixb definitions to AI SDK tools and supplies a narrow, run-scoped execution context.

```ts
.run(async ({ input, signal, run, connector, logger }) => {
  const client = await connector(knowledge)
  logger.info("Searching", { query: input.query })

  return client.search(input.query, { signal })
})
```

The adapter:

- Converts Sixb input schemas to AI SDK JSON schemas.
- Passes cancellation, run metadata, connector resolution, and scoped logging.
- Validates tool output before returning it to the AI SDK.
- Persists successful and failed results for replay.
- Supports conversational and workflow agent runs.
- Does not expose the raw Sixb runtime to handlers.

The unused deployment-wide `AgentWorkerOptions.tools` path was removed. All non-`bash` capabilities must be granted explicitly through `agent.tools`.

```text
Storage migrations: none
API/OpenAPI changes: none
Generated client changes: none
```

## Verification

```bash
bun test packages/agent-worker/tests/
bun --filter @sixb/agent-worker build
bun --filter @sixb/agent-worker typecheck
bun run typecheck
bun run check
```

```text
68 tests passed
0 tests failed
```