### PR TITLE
exa: add bounded web_search connector tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,18 @@
         "typescript": "^5.7.0",
       },
     },
+    "connectors/exa": {
+      "name": "@sixb/connector-exa",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sixb/connector-rest": "workspace:*",
+        "@sixb/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "connectors/github": {
       "name": "@sixb/connector-github",
       "version": "0.1.0",
@@ -391,6 +403,7 @@
       },
       "devDependencies": {
         "@ai-sdk/provider": "^4.0.0",
+        "@sixb/connector-exa": "workspace:*",
         "@types/bun": "latest",
         "typescript": "^5.7.0",
       },
@@ -1251,6 +1264,8 @@
     "@sixb/client": ["@sixb/client@workspace:packages/client"],
 
     "@sixb/connector-companycam": ["@sixb/connector-companycam@workspace:connectors/companycam"],
+
+    "@sixb/connector-exa": ["@sixb/connector-exa@workspace:connectors/exa"],
 
     "@sixb/connector-github": ["@sixb/connector-github@workspace:connectors/github"],
 

--- a/connectors/exa/LICENSE
+++ b/connectors/exa/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sixb contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/connectors/exa/README.md
+++ b/connectors/exa/README.md
@@ -1,0 +1,41 @@
+# @sixb/connector-exa
+
+Exa web search for Sixb, with a typed connector client and a bounded `web_search` agent tool.
+
+## Install
+
+```bash
+bun add @sixb/connector-exa
+```
+
+## Register the connector
+
+```ts
+import { exa } from "@sixb/connector-exa"
+import { defineConnector } from "@sixb/core"
+
+export const exaConnector = defineConnector(
+  "exa",
+  exa({ apiKey: process.env.EXA_API_KEY! })
+)
+```
+
+Pass a sync or async resolver instead when credentials rotate; resolvers run before every request.
+Search calls are single-attempt and accept a caller `AbortSignal`.
+
+## Grant web search to an agent
+
+```ts
+import { exaWebSearch } from "@sixb/connector-exa/agent-tools"
+
+const webSearch = exaWebSearch(exaConnector, {
+  maxResults: 8,
+  maxCharactersPerResult: 2_000,
+  maxTotalCharacters: 12_000,
+  timeoutMs: 20_000,
+  allowedDomains: ["docs.example.com"],
+})
+```
+
+Attach `webSearch` to an agent's `tools` array to grant that agent the capability. The model sees
+only `{ query: string }`; credentials, domain policy, timeouts, and output limits stay on the host.

--- a/connectors/exa/package.json
+++ b/connectors/exa/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "@sixb/agent-worker",
+  "name": "@sixb/connector-exa",
   "version": "0.1.0",
-  "description": "Worker that runs Sixb agent threads",
+  "description": "Exa web search connector and bounded agent tools for Sixb",
   "keywords": [
     "sixb",
     "bun",
-    "worker"
+    "connector",
+    "integration",
+    "exa",
+    "search"
   ],
   "homepage": "https://sixb.ai",
   "bugs": {
@@ -14,7 +17,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sixb-ai/sixb.git",
-    "directory": "packages/agent-worker"
+    "directory": "connectors/exa"
   },
   "author": "Sixb contributors",
   "type": "module",
@@ -26,6 +29,12 @@
       "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./agent-tools": {
+      "types": "./dist/agent-tools.d.ts",
+      "bun": "./src/agent-tools.ts",
+      "import": "./dist/agent-tools.js",
+      "default": "./dist/agent-tools.js"
     }
   },
   "scripts": {
@@ -34,21 +43,11 @@
     "test": "bun test",
     "prepack": "bun run build"
   },
-  "sixbBuild": {
-    "assets": [
-      {
-        "from": "./src/skills",
-        "to": "./dist/skills"
-      }
-    ]
-  },
   "dependencies": {
-    "@sixb/core": "workspace:*",
-    "ai": "^7.0.4"
+    "@sixb/connector-rest": "workspace:*",
+    "@sixb/core": "workspace:*"
   },
   "devDependencies": {
-    "@ai-sdk/provider": "^4.0.0",
-    "@sixb/connector-exa": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^5.7.0"
   },

--- a/connectors/exa/src/agent-tools.ts
+++ b/connectors/exa/src/agent-tools.ts
@@ -1,0 +1,229 @@
+import type { AgentToolDefinition, ConnectorDefinition } from "@sixb/core"
+import { defineAgentTool, type JsonValue } from "@sixb/core"
+import { waitForSignal } from "./signals"
+import type { ExaConnector, ExaSearchRequest, ExaSearchResponse } from "./types"
+
+const DEFAULT_MAX_RESULTS = 5
+const DEFAULT_MAX_CHARACTERS_PER_RESULT = 2_000
+const DEFAULT_MAX_TOTAL_CHARACTERS = 10_000
+const DEFAULT_TIMEOUT_MS = 20_000
+const MAX_RESULTS = 100
+const MAX_DOMAINS = 1_200
+const MAX_QUERY_CHARACTERS = 2_000
+const MAX_TITLE_CHARACTERS = 500
+const MAX_URL_CHARACTERS = 4_096
+const MAX_AUTHOR_CHARACTERS = 300
+const MAX_PUBLISHED_DATE_CHARACTERS = 100
+const MAX_REQUEST_ID_CHARACTERS = 200
+
+export interface ExaWebSearchOptions {
+  /** Maximum provider results requested and returned. Defaults to 5; Exa allows at most 100. */
+  readonly maxResults?: number
+  /** Maximum text characters returned for any one result. Defaults to 2,000. */
+  readonly maxCharactersPerResult?: number
+  /** Maximum text characters returned across all results. Defaults to 10,000. */
+  readonly maxTotalCharacters?: number
+  /** Overall connector resolution and provider-request timeout. Defaults to 20 seconds. */
+  readonly timeoutMs?: number
+  /** Exa domain or path filters to include. An explicitly empty allowlist is rejected. */
+  readonly allowedDomains?: readonly string[]
+  /** Exa domain or path filters to exclude. */
+  readonly deniedDomains?: readonly string[]
+}
+
+export interface ExaWebSearchResult {
+  readonly title: string
+  readonly url: string
+  readonly author?: string
+  readonly publishedDate?: string
+  readonly text: string
+}
+
+export interface ExaWebSearchOutput {
+  readonly results: readonly ExaWebSearchResult[]
+  readonly requestId?: string
+  readonly costDollars?: {
+    readonly total: number
+  }
+}
+
+export type ExaWebSearchTool = AgentToolDefinition<"web_search", { readonly query: "string" }>
+
+interface ResolvedExaWebSearchOptions {
+  readonly maxResults: number
+  readonly maxCharactersPerResult: number
+  readonly maxTotalCharacters: number
+  readonly timeoutMs: number
+  readonly allowedDomains?: readonly string[]
+  readonly deniedDomains?: readonly string[]
+}
+
+/** Create a provider-neutral, bounded `web_search` tool backed by an Exa connector. */
+export function exaWebSearch(
+  connectorDefinition: ConnectorDefinition<string, ExaConnector>,
+  options: ExaWebSearchOptions = {}
+): ExaWebSearchTool {
+  const limits = resolveOptions(options)
+
+  return defineAgentTool("web_search")
+    .description("Search the web and return bounded source text with URLs and metadata.")
+    .input({ query: "string" })
+    .run(async ({ input, connector, signal: runSignal }) => {
+      const query = input.query.trim()
+      if (!query) throw new Error("[SixbExa] web_search query must not be empty.")
+      if (query.length > MAX_QUERY_CHARACTERS) {
+        throw new Error(
+          `[SixbExa] web_search query must contain at most ${MAX_QUERY_CHARACTERS} characters.`
+        )
+      }
+
+      const timeoutSignal = AbortSignal.timeout(limits.timeoutMs)
+      const signal = AbortSignal.any([runSignal, timeoutSignal])
+      const request: ExaSearchRequest = {
+        query,
+        numResults: limits.maxResults,
+        contents: {
+          text: {
+            maxCharacters: Math.min(limits.maxCharactersPerResult, limits.maxTotalCharacters),
+          },
+        },
+        ...(limits.allowedDomains ? { includeDomains: limits.allowedDomains } : {}),
+        ...(limits.deniedDomains ? { excludeDomains: limits.deniedDomains } : {}),
+      }
+
+      try {
+        signal.throwIfAborted()
+        const response = await waitForSignal(
+          (async () => {
+            const client = await connector(connectorDefinition)
+            return client.search(request, { signal })
+          })(),
+          signal
+        )
+        signal.throwIfAborted()
+        return normalizeOutput(response, limits)
+      } catch (error) {
+        if (runSignal.aborted) throw runSignal.reason ?? error
+        if (timeoutSignal.aborted) {
+          throw new Error(`[SixbExa] web_search timed out after ${limits.timeoutMs}ms.`, {
+            cause: error,
+          })
+        }
+        throw error
+      }
+    })
+}
+
+function normalizeOutput(
+  response: ExaSearchResponse,
+  limits: ResolvedExaWebSearchOptions
+): JsonValue {
+  let remainingCharacters = limits.maxTotalCharacters
+  const results = response.results.slice(0, limits.maxResults).flatMap((result) => {
+    const url = normalizeResultUrl(result.url)
+    if (!url) return []
+
+    const availableCharacters = Math.min(limits.maxCharactersPerResult, remainingCharacters)
+    const text = (result.text ?? "").slice(0, availableCharacters)
+    remainingCharacters -= text.length
+    const title = truncate(result.title?.trim() || url, MAX_TITLE_CHARACTERS)
+    const author = normalizeOptionalString(result.author, MAX_AUTHOR_CHARACTERS)
+    const publishedDate = normalizeOptionalString(
+      result.publishedDate,
+      MAX_PUBLISHED_DATE_CHARACTERS
+    )
+
+    return [
+      {
+        title,
+        url,
+        ...(author ? { author } : {}),
+        ...(publishedDate ? { publishedDate } : {}),
+        text,
+      },
+    ]
+  })
+  const requestId = normalizeOptionalString(response.requestId, MAX_REQUEST_ID_CHARACTERS)
+
+  const output = {
+    results,
+    ...(requestId ? { requestId } : {}),
+    ...(response.costDollars ? { costDollars: { total: response.costDollars.total } } : {}),
+  } satisfies ExaWebSearchOutput
+  return output
+}
+
+function resolveOptions(options: ExaWebSearchOptions): ResolvedExaWebSearchOptions {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new Error("[SixbExa] web_search options must be an object.")
+  }
+
+  const maxResults = options.maxResults ?? DEFAULT_MAX_RESULTS
+  assertIntegerInRange(maxResults, "maxResults", 1, MAX_RESULTS)
+  const maxCharactersPerResult = options.maxCharactersPerResult ?? DEFAULT_MAX_CHARACTERS_PER_RESULT
+  assertPositiveSafeInteger(maxCharactersPerResult, "maxCharactersPerResult")
+  const maxTotalCharacters = options.maxTotalCharacters ?? DEFAULT_MAX_TOTAL_CHARACTERS
+  assertPositiveSafeInteger(maxTotalCharacters, "maxTotalCharacters")
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  assertPositiveSafeInteger(timeoutMs, "timeoutMs")
+
+  return {
+    maxResults,
+    maxCharactersPerResult,
+    maxTotalCharacters,
+    timeoutMs,
+    ...(options.allowedDomains !== undefined
+      ? { allowedDomains: normalizeDomains(options.allowedDomains, "allowedDomains") }
+      : {}),
+    ...(options.deniedDomains !== undefined
+      ? { deniedDomains: normalizeDomains(options.deniedDomains, "deniedDomains") }
+      : {}),
+  }
+}
+
+function normalizeDomains(domains: readonly string[], field: string): readonly string[] {
+  if (!Array.isArray(domains) || domains.length < 1 || domains.length > MAX_DOMAINS) {
+    throw new Error(`[SixbExa] ${field} must contain from 1 to ${MAX_DOMAINS} domains.`)
+  }
+  return domains.map((domain) => {
+    if (typeof domain !== "string" || !domain.trim()) {
+      throw new Error(`[SixbExa] ${field} entries must be non-empty strings.`)
+    }
+    return domain.trim()
+  })
+}
+
+function assertIntegerInRange(value: number, field: string, min: number, max: number): void {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`[SixbExa] ${field} must be an integer from ${min} to ${max}.`)
+  }
+}
+
+function assertPositiveSafeInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`[SixbExa] ${field} must be a positive safe integer.`)
+  }
+}
+
+function normalizeResultUrl(value: string): string | undefined {
+  const url = value.trim()
+  if (!url || url.length > MAX_URL_CHARACTERS) return undefined
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? url : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeOptionalString(
+  value: string | null | undefined,
+  maxCharacters: number
+): string | undefined {
+  const normalized = value?.trim()
+  return normalized ? truncate(normalized, maxCharacters) : undefined
+}
+
+function truncate(value: string, maxCharacters: number): string {
+  return value.slice(0, maxCharacters)
+}

--- a/connectors/exa/src/agent-tools.ts
+++ b/connectors/exa/src/agent-tools.ts
@@ -1,5 +1,6 @@
 import type { AgentToolDefinition, ConnectorDefinition } from "@sixb/core"
-import { defineAgentTool, type JsonValue } from "@sixb/core"
+import { AgentToolPublicError, defineAgentTool, type JsonValue } from "@sixb/core"
+import { type ExaSearchDomainPolicy, resolveExaSearchDomainPolicy } from "./search-domain-policy"
 import { waitForSignal } from "./signals"
 import type { ExaConnector, ExaSearchRequest, ExaSearchResponse } from "./types"
 
@@ -8,7 +9,6 @@ const DEFAULT_MAX_CHARACTERS_PER_RESULT = 2_000
 const DEFAULT_MAX_TOTAL_CHARACTERS = 10_000
 const DEFAULT_TIMEOUT_MS = 20_000
 const MAX_RESULTS = 100
-const MAX_DOMAINS = 1_200
 const MAX_QUERY_CHARACTERS = 2_000
 const MAX_TITLE_CHARACTERS = 500
 const MAX_URL_CHARACTERS = 4_096
@@ -54,8 +54,7 @@ interface ResolvedExaWebSearchOptions {
   readonly maxCharactersPerResult: number
   readonly maxTotalCharacters: number
   readonly timeoutMs: number
-  readonly allowedDomains?: readonly string[]
-  readonly deniedDomains?: readonly string[]
+  readonly domainPolicy: ExaSearchDomainPolicy
 }
 
 /** Create a provider-neutral, bounded `web_search` tool backed by an Exa connector. */
@@ -70,9 +69,11 @@ export function exaWebSearch(
     .input({ query: "string" })
     .run(async ({ input, connector, signal: runSignal }) => {
       const query = input.query.trim()
-      if (!query) throw new Error("[SixbExa] web_search query must not be empty.")
+      if (!query) {
+        throw new AgentToolPublicError("[SixbExa] web_search query must not be empty.")
+      }
       if (query.length > MAX_QUERY_CHARACTERS) {
-        throw new Error(
+        throw new AgentToolPublicError(
           `[SixbExa] web_search query must contain at most ${MAX_QUERY_CHARACTERS} characters.`
         )
       }
@@ -87,8 +88,12 @@ export function exaWebSearch(
             maxCharacters: Math.min(limits.maxCharactersPerResult, limits.maxTotalCharacters),
           },
         },
-        ...(limits.allowedDomains ? { includeDomains: limits.allowedDomains } : {}),
-        ...(limits.deniedDomains ? { excludeDomains: limits.deniedDomains } : {}),
+        ...(limits.domainPolicy.includeDomains
+          ? { includeDomains: limits.domainPolicy.includeDomains }
+          : {}),
+        ...(limits.domainPolicy.excludeDomains
+          ? { excludeDomains: limits.domainPolicy.excludeDomains }
+          : {}),
       }
 
       try {
@@ -105,9 +110,10 @@ export function exaWebSearch(
       } catch (error) {
         if (runSignal.aborted) throw runSignal.reason ?? error
         if (timeoutSignal.aborted) {
-          throw new Error(`[SixbExa] web_search timed out after ${limits.timeoutMs}ms.`, {
-            cause: error,
-          })
+          throw new AgentToolPublicError(
+            `[SixbExa] web_search timed out after ${limits.timeoutMs}ms.`,
+            { cause: error }
+          )
         }
         throw error
       }
@@ -120,8 +126,10 @@ function normalizeOutput(
 ): JsonValue {
   let remainingCharacters = limits.maxTotalCharacters
   const results = response.results.slice(0, limits.maxResults).flatMap((result) => {
-    const url = normalizeResultUrl(result.url)
-    if (!url) return []
+    const resultUrl = normalizeResultUrl(result.url)
+    if (!resultUrl) return []
+    limits.domainPolicy.assertAllows(resultUrl.parsed)
+    const url = resultUrl.value
 
     const availableCharacters = Math.min(limits.maxCharactersPerResult, remainingCharacters)
     const text = (result.text ?? "").slice(0, availableCharacters)
@@ -166,31 +174,18 @@ function resolveOptions(options: ExaWebSearchOptions): ResolvedExaWebSearchOptio
   assertPositiveSafeInteger(maxTotalCharacters, "maxTotalCharacters")
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   assertPositiveSafeInteger(timeoutMs, "timeoutMs")
+  const domainPolicy = resolveExaSearchDomainPolicy({
+    allowedDomains: options.allowedDomains,
+    deniedDomains: options.deniedDomains,
+  })
 
   return {
     maxResults,
     maxCharactersPerResult,
     maxTotalCharacters,
     timeoutMs,
-    ...(options.allowedDomains !== undefined
-      ? { allowedDomains: normalizeDomains(options.allowedDomains, "allowedDomains") }
-      : {}),
-    ...(options.deniedDomains !== undefined
-      ? { deniedDomains: normalizeDomains(options.deniedDomains, "deniedDomains") }
-      : {}),
+    domainPolicy,
   }
-}
-
-function normalizeDomains(domains: readonly string[], field: string): readonly string[] {
-  if (!Array.isArray(domains) || domains.length < 1 || domains.length > MAX_DOMAINS) {
-    throw new Error(`[SixbExa] ${field} must contain from 1 to ${MAX_DOMAINS} domains.`)
-  }
-  return domains.map((domain) => {
-    if (typeof domain !== "string" || !domain.trim()) {
-      throw new Error(`[SixbExa] ${field} entries must be non-empty strings.`)
-    }
-    return domain.trim()
-  })
 }
 
 function assertIntegerInRange(value: number, field: string, min: number, max: number): void {
@@ -205,12 +200,21 @@ function assertPositiveSafeInteger(value: number, field: string): void {
   }
 }
 
-function normalizeResultUrl(value: string): string | undefined {
+function normalizeResultUrl(
+  value: string
+): { readonly value: string; readonly parsed: URL } | undefined {
   const url = value.trim()
   if (!url || url.length > MAX_URL_CHARACTERS) return undefined
   try {
     const parsed = new URL(url)
-    return parsed.protocol === "http:" || parsed.protocol === "https:" ? url : undefined
+    if (
+      (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+      parsed.username ||
+      parsed.password
+    ) {
+      return undefined
+    }
+    return { value: url, parsed }
   } catch {
     return undefined
   }

--- a/connectors/exa/src/client.ts
+++ b/connectors/exa/src/client.ts
@@ -84,7 +84,9 @@ async function resolveApiKey(apiKey: ExaApiKeyResolver): Promise<string> {
   if (typeof value !== "string" || !value.trim()) {
     throw new ExaApiError("[SixbExa] Resolved apiKey must not be empty.")
   }
-  return value
+  // Headers normalize surrounding HTTP whitespace. Use that exact wire value for both the request
+  // and provider-error redaction so a padded configuration can never bypass secret scrubbing.
+  return value.trim()
 }
 
 function assertSearchRequest(request: ExaSearchRequest): void {

--- a/connectors/exa/src/client.ts
+++ b/connectors/exa/src/client.ts
@@ -1,0 +1,222 @@
+import type { RestClient } from "@sixb/connector-rest"
+import { ExaApiError } from "./errors"
+import { parseExaSearchResponse } from "./response"
+import { waitForSignal } from "./signals"
+import type {
+  ExaApiKeyResolver,
+  ExaClient,
+  ExaErrorResponse,
+  ExaRequestOptions,
+  ExaSearchRequest,
+  ExaSearchResponse,
+} from "./types"
+
+const MAX_DOMAINS = 1_200
+const MAX_RESULTS = 100
+const MAX_ERROR_MESSAGE_CHARACTERS = 500
+const MAX_ERROR_METADATA_CHARACTERS = 200
+
+export function createExaClient(
+  http: RestClient,
+  apiKey: ExaApiKeyResolver,
+  connectionSignal: AbortSignal
+): ExaClient {
+  return {
+    async search(
+      request: ExaSearchRequest,
+      options: ExaRequestOptions = {}
+    ): Promise<ExaSearchResponse> {
+      assertSearchRequest(request)
+      const signal = options.signal
+        ? AbortSignal.any([connectionSignal, options.signal])
+        : connectionSignal
+      signal.throwIfAborted()
+
+      const operation = (async (): Promise<ExaSearchResponse> => {
+        const resolvedApiKey = await resolveApiKey(apiKey)
+        signal.throwIfAborted()
+
+        let response: Response
+        try {
+          response = await http.post("search", request, {
+            headers: {
+              accept: "application/json",
+              "x-api-key": resolvedApiKey,
+            },
+            signal,
+          })
+        } catch (error) {
+          if (signal.aborted) throw signal.reason ?? error
+          throw new ExaApiError("[SixbExa] Exa search could not reach the API.", { cause: error })
+        }
+
+        if (!response.ok) {
+          throw await apiErrorFromResponse(response, resolvedApiKey)
+        }
+
+        const value = await readJson(response)
+        signal.throwIfAborted()
+        return parseExaSearchResponse(value, response.status)
+      })()
+
+      return waitForSignal(operation, signal)
+    },
+  }
+}
+
+export function assertApiKeyResolver(apiKey: ExaApiKeyResolver): void {
+  if (typeof apiKey === "string") {
+    if (!apiKey.trim()) throw new Error("[SixbExa] apiKey must not be empty.")
+    return
+  }
+  if (typeof apiKey !== "function") {
+    throw new Error("[SixbExa] apiKey must be a string or a function.")
+  }
+}
+
+async function resolveApiKey(apiKey: ExaApiKeyResolver): Promise<string> {
+  let value: string
+  try {
+    value = typeof apiKey === "function" ? await apiKey() : apiKey
+  } catch {
+    throw new ExaApiError("[SixbExa] Could not resolve apiKey.")
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    throw new ExaApiError("[SixbExa] Resolved apiKey must not be empty.")
+  }
+  return value
+}
+
+function assertSearchRequest(request: ExaSearchRequest): void {
+  if (!request || typeof request !== "object") {
+    throw new Error("[SixbExa] search request must be an object.")
+  }
+  if (typeof request.query !== "string" || !request.query.trim()) {
+    throw new Error("[SixbExa] search query must not be empty.")
+  }
+  if (request.numResults !== undefined) {
+    assertIntegerInRange(request.numResults, "numResults", 1, MAX_RESULTS)
+  }
+  assertDomains(request.includeDomains, "includeDomains")
+  assertDomains(request.excludeDomains, "excludeDomains")
+
+  if (request.contents !== undefined && !isRecord(request.contents)) {
+    throw new Error("[SixbExa] contents must be an object.")
+  }
+  const text = request.contents?.text
+  if (text !== undefined && text !== true) {
+    if (!isRecord(text)) {
+      throw new Error("[SixbExa] contents.text must be true or an options object.")
+    }
+    if (text.maxCharacters !== undefined) {
+      assertPositiveSafeInteger(text.maxCharacters, "contents.text.maxCharacters")
+    }
+    if (text.includeHtmlTags !== undefined && typeof text.includeHtmlTags !== "boolean") {
+      throw new Error("[SixbExa] contents.text.includeHtmlTags must be a boolean.")
+    }
+  }
+}
+
+function assertDomains(domains: readonly string[] | undefined, field: string): void {
+  if (domains === undefined) return
+  if (!Array.isArray(domains) || domains.length > MAX_DOMAINS) {
+    throw new Error(`[SixbExa] ${field} must contain at most ${MAX_DOMAINS} domains.`)
+  }
+  for (const domain of domains) {
+    if (typeof domain !== "string" || !domain.trim()) {
+      throw new Error(`[SixbExa] ${field} entries must be non-empty strings.`)
+    }
+  }
+}
+
+function assertIntegerInRange(value: number, field: string, min: number, max: number): void {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`[SixbExa] ${field} must be an integer from ${min} to ${max}.`)
+  }
+}
+
+function assertPositiveSafeInteger(value: unknown, field: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`[SixbExa] ${field} must be a positive safe integer.`)
+  }
+}
+
+async function apiErrorFromResponse(response: Response, apiKey: string): Promise<ExaApiError> {
+  const body = await readOptionalJson(response)
+  const error = errorResponseFrom(body)
+  const tag = sanitizeAndTruncate(error?.tag, apiKey, MAX_ERROR_METADATA_CHARACTERS)
+  const requestId = sanitizeAndTruncate(error?.requestId, apiKey, MAX_ERROR_METADATA_CHARACTERS)
+  const providerMessage = sanitizeAndTruncate(error?.error, apiKey, MAX_ERROR_MESSAGE_CHARACTERS)
+  const details = [
+    tag ? ` (${tag})` : "",
+    providerMessage ? `: ${providerMessage}` : "",
+    requestId ? ` (requestId: ${requestId})` : "",
+  ].join("")
+
+  return new ExaApiError(`[SixbExa] Exa search failed with HTTP ${response.status}${details}.`, {
+    status: response.status,
+    ...(tag ? { tag } : {}),
+    ...(requestId ? { requestId } : {}),
+  })
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  let text: string
+  try {
+    text = await response.text()
+  } catch (error) {
+    throw new ExaApiError("[SixbExa] Exa search response could not be read.", {
+      status: response.status,
+      cause: error,
+    })
+  }
+  if (!text) {
+    throw new ExaApiError("[SixbExa] Exa search returned an empty response.", {
+      status: response.status,
+    })
+  }
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw new ExaApiError("[SixbExa] Exa search returned invalid JSON.", {
+      status: response.status,
+    })
+  }
+}
+
+async function readOptionalJson(response: Response): Promise<unknown> {
+  const text = await response.text().catch(() => "")
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return undefined
+  }
+}
+
+function errorResponseFrom(value: unknown): ExaErrorResponse | undefined {
+  if (!isRecord(value)) return undefined
+  return {
+    ...(typeof value.requestId === "string" ? { requestId: value.requestId } : {}),
+    ...(typeof value.error === "string" ? { error: value.error } : {}),
+    ...(typeof value.tag === "string" ? { tag: value.tag } : {}),
+  }
+}
+
+function sanitizeAndTruncate(
+  value: string | undefined,
+  apiKey: string,
+  maxCharacters: number
+): string | undefined {
+  if (value === undefined) return undefined
+  return truncate(value.split(apiKey).join("[REDACTED]"), maxCharacters)
+}
+
+function truncate(value: string, maxCharacters: number): string {
+  const collapsed = value.replace(/\s+/g, " ").trim()
+  return collapsed.length <= maxCharacters ? collapsed : `${collapsed.slice(0, maxCharacters)}…`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/connectors/exa/src/errors.ts
+++ b/connectors/exa/src/errors.ts
@@ -1,0 +1,22 @@
+/** Raised when an Exa request fails or returns an unusable response. */
+export class ExaApiError extends Error {
+  readonly status?: number
+  readonly tag?: string
+  readonly requestId?: string
+
+  constructor(
+    message: string,
+    options: {
+      readonly status?: number
+      readonly tag?: string
+      readonly requestId?: string
+      readonly cause?: unknown
+    } = {}
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause })
+    this.name = "ExaApiError"
+    this.status = options.status
+    this.tag = options.tag
+    this.requestId = options.requestId
+  }
+}

--- a/connectors/exa/src/errors.ts
+++ b/connectors/exa/src/errors.ts
@@ -1,5 +1,8 @@
+import { AgentToolPublicError } from "@sixb/core"
+
 /** Raised when an Exa request fails or returns an unusable response. */
-export class ExaApiError extends Error {
+export class ExaApiError extends AgentToolPublicError {
+  override readonly name = "ExaApiError"
   readonly status?: number
   readonly tag?: string
   readonly requestId?: string
@@ -14,7 +17,6 @@ export class ExaApiError extends Error {
     } = {}
   ) {
     super(message, options.cause === undefined ? undefined : { cause: options.cause })
-    this.name = "ExaApiError"
     this.status = options.status
     this.tag = options.tag
     this.requestId = options.requestId

--- a/connectors/exa/src/exa.ts
+++ b/connectors/exa/src/exa.ts
@@ -1,0 +1,36 @@
+import { rest } from "@sixb/connector-rest"
+import { assertApiKeyResolver, createExaClient } from "./client"
+import type { ExaConnector, ExaConnectorOptions } from "./types"
+
+const DEFAULT_BASE_URL = "https://api.exa.ai/"
+
+/** Create a typed Exa connector backed by one-attempt REST requests. */
+export function exa(options: ExaConnectorOptions): ExaConnector {
+  if (!options || typeof options !== "object") {
+    throw new Error("[SixbExa] options must be an object.")
+  }
+  assertApiKeyResolver(options.apiKey)
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_BASE_URL)
+  const http = rest({ baseUrl })
+
+  return {
+    type: "exa",
+    async connect(context) {
+      return createExaClient(await http.connect(context), options.apiKey, context.signal)
+    },
+  }
+}
+
+function normalizeBaseUrl(value: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error("[SixbExa] baseUrl must be an absolute HTTP(S) URL.")
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("[SixbExa] baseUrl must be an absolute HTTP(S) URL.")
+  }
+  if (!url.pathname.endsWith("/")) url.pathname += "/"
+  return url.toString()
+}

--- a/connectors/exa/src/index.ts
+++ b/connectors/exa/src/index.ts
@@ -1,0 +1,18 @@
+export { ExaApiError } from "./errors"
+export { exa } from "./exa"
+export type {
+  ExaApiKeyResolver,
+  ExaClient,
+  ExaConnector,
+  ExaConnectorOptions,
+  ExaCostBreakdown,
+  ExaCostDollars,
+  ExaErrorResponse,
+  ExaRequestOptions,
+  ExaSearchContentsOptions,
+  ExaSearchRequest,
+  ExaSearchResponse,
+  ExaSearchResult,
+  ExaSearchStatus,
+  ExaTextContentsOptions,
+} from "./types"

--- a/connectors/exa/src/response.ts
+++ b/connectors/exa/src/response.ts
@@ -1,0 +1,134 @@
+import { ExaApiError } from "./errors"
+import type { ExaCostDollars, ExaSearchResponse, ExaSearchResult, ExaSearchStatus } from "./types"
+
+export function parseExaSearchResponse(value: unknown, status?: number): ExaSearchResponse {
+  if (!isRecord(value)) throw malformed("the body must be an object", status)
+  if (!Array.isArray(value.results)) throw malformed("results must be an array", status)
+
+  for (const [index, result] of value.results.entries()) {
+    assertSearchResult(result, index, status)
+  }
+  assertOptionalString(value, "requestId", status)
+  assertOptionalString(value, "searchType", status)
+  assertOptionalString(value, "resolvedSearchType", status)
+  assertOptionalFiniteNumber(value, "searchTime", status)
+
+  if (value.statuses !== undefined) {
+    if (!Array.isArray(value.statuses)) throw malformed("statuses must be an array", status)
+    for (const [index, itemStatus] of value.statuses.entries()) {
+      assertSearchStatus(itemStatus, index, status)
+    }
+  }
+
+  if (value.costDollars !== undefined) {
+    assertCostDollars(value.costDollars, status)
+  }
+
+  return value as unknown as ExaSearchResponse
+}
+
+function assertSearchResult(
+  value: unknown,
+  index: number,
+  status?: number
+): asserts value is ExaSearchResult {
+  if (!isRecord(value)) throw malformed(`results[${index}] must be an object`, status)
+  if (typeof value.id !== "string" || !value.id.trim()) {
+    throw malformed(`results[${index}].id must be a non-empty string`, status)
+  }
+  if (value.title !== null && typeof value.title !== "string") {
+    throw malformed(`results[${index}].title must be a string or null`, status)
+  }
+  if (typeof value.url !== "string" || !isHttpUrl(value.url)) {
+    throw malformed(`results[${index}].url must be an absolute HTTP(S) URL`, status)
+  }
+  assertOptionalNullableString(value, "publishedDate", `results[${index}]`, status)
+  assertOptionalNullableString(value, "author", `results[${index}]`, status)
+  assertOptionalString(value, "text", status, `results[${index}]`)
+}
+
+function assertSearchStatus(
+  value: unknown,
+  index: number,
+  status?: number
+): asserts value is ExaSearchStatus {
+  if (!isRecord(value)) throw malformed(`statuses[${index}] must be an object`, status)
+  for (const field of ["id", "status", "source"] as const) {
+    if (typeof value[field] !== "string") {
+      throw malformed(`statuses[${index}].${field} must be a string`, status)
+    }
+  }
+}
+
+function assertCostDollars(value: unknown, status?: number): asserts value is ExaCostDollars {
+  if (!isRecord(value)) throw malformed("costDollars must be an object", status)
+  if (!isNonNegativeFiniteNumber(value.total)) {
+    throw malformed("costDollars.total must be a non-negative finite number", status)
+  }
+  for (const field of ["search", "contents"] as const) {
+    const breakdown = value[field]
+    if (breakdown === undefined) continue
+    if (!isRecord(breakdown)) throw malformed(`costDollars.${field} must be an object`, status)
+    for (const amount of Object.values(breakdown)) {
+      if (!isNonNegativeFiniteNumber(amount)) {
+        throw malformed(`costDollars.${field} values must be non-negative finite numbers`, status)
+      }
+    }
+  }
+}
+
+function assertOptionalString(
+  value: Record<string, unknown>,
+  field: string,
+  status?: number,
+  prefix = "response"
+): void {
+  if (value[field] !== undefined && typeof value[field] !== "string") {
+    throw malformed(`${prefix}.${field} must be a string`, status)
+  }
+}
+
+function assertOptionalNullableString(
+  value: Record<string, unknown>,
+  field: string,
+  prefix: string,
+  status?: number
+): void {
+  const fieldValue = value[field]
+  if (fieldValue !== undefined && fieldValue !== null && typeof fieldValue !== "string") {
+    throw malformed(`${prefix}.${field} must be a string or null`, status)
+  }
+}
+
+function assertOptionalFiniteNumber(
+  value: Record<string, unknown>,
+  field: string,
+  status?: number
+): void {
+  if (value[field] !== undefined && !isNonNegativeFiniteNumber(value[field])) {
+    throw malformed(`response.${field} must be a non-negative finite number`, status)
+  }
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function malformed(detail: string, status?: number): ExaApiError {
+  return new ExaApiError(`[SixbExa] Exa search returned a malformed response: ${detail}.`, {
+    status,
+  })
+}

--- a/connectors/exa/src/search-domain-policy.ts
+++ b/connectors/exa/src/search-domain-policy.ts
@@ -1,0 +1,132 @@
+import { AgentToolPublicError } from "@sixb/core"
+
+const MAX_DOMAINS = 1_200
+const MAX_FILTER_CHARACTERS = 4_096
+
+interface ExaSearchDomainRule {
+  /** Canonical value sent to Exa. */
+  readonly value: string
+  readonly hostname: string
+  readonly wildcard: boolean
+  readonly pathPrefix?: string
+}
+
+export interface ExaSearchDomainPolicy {
+  readonly includeDomains?: readonly string[]
+  readonly excludeDomains?: readonly string[]
+  assertAllows(url: URL): void
+}
+
+/** Compile Exa's hostname, path-prefix, and wildcard syntax once when the tool is defined. */
+export function resolveExaSearchDomainPolicy(input: {
+  readonly allowedDomains?: readonly string[]
+  readonly deniedDomains?: readonly string[]
+}): ExaSearchDomainPolicy {
+  const allowedRules = normalizeRules(input.allowedDomains, "allowedDomains")
+  const deniedRules = normalizeRules(input.deniedDomains, "deniedDomains")
+
+  return {
+    ...(allowedRules ? { includeDomains: allowedRules.map((rule) => rule.value) } : {}),
+    ...(deniedRules ? { excludeDomains: deniedRules.map((rule) => rule.value) } : {}),
+    assertAllows(url) {
+      const denied = deniedRules?.some((rule) => matchesRule(url, rule)) ?? false
+      if (denied) {
+        throw new AgentToolPublicError(
+          `[SixbExa] web_search returned a URL denied by domain policy: "${url.hostname}".`
+        )
+      }
+      const allowed = allowedRules?.some((rule) => matchesRule(url, rule)) ?? true
+      if (!allowed) {
+        throw new AgentToolPublicError(
+          `[SixbExa] web_search returned a URL outside the allowed domain policy: "${url.hostname}".`
+        )
+      }
+    },
+  }
+}
+
+function normalizeRules(
+  values: readonly string[] | undefined,
+  field: string
+): readonly ExaSearchDomainRule[] | undefined {
+  if (values === undefined) return undefined
+  if (!Array.isArray(values) || values.length < 1 || values.length > MAX_DOMAINS) {
+    throw new Error(`[SixbExa] ${field} must contain from 1 to ${MAX_DOMAINS} domains.`)
+  }
+
+  const rules = new Map<string, ExaSearchDomainRule>()
+  for (const value of values) {
+    const rule = normalizeRule(value, field)
+    rules.set(rule.value, rule)
+  }
+  return [...rules.values()]
+}
+
+function normalizeRule(value: string, field: string): ExaSearchDomainRule {
+  if (typeof value !== "string") throw invalidRule(field)
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > MAX_FILTER_CHARACTERS || trimmed.includes("\\")) {
+    throw invalidRule(field)
+  }
+
+  const wildcard = trimmed.startsWith("*.")
+  const filter = wildcard ? trimmed.slice(2) : trimmed
+  const authority = filter.split("/", 1)[0] ?? ""
+  if (!authority || /[*:@?#]/.test(authority)) throw invalidRule(field)
+
+  let parsed: URL
+  try {
+    parsed = new URL(`https://${filter}`)
+  } catch {
+    throw invalidRule(field)
+  }
+  if (parsed.username || parsed.password || parsed.port || parsed.search || parsed.hash) {
+    throw invalidRule(field)
+  }
+
+  const hostname = canonicalHostname(parsed.hostname)
+  if (!isValidHostname(hostname)) throw invalidRule(field)
+  const pathPrefix = normalizePathPrefix(parsed.pathname)
+  const normalized = `${wildcard ? "*." : ""}${hostname}${pathPrefix ?? ""}`
+  if (normalized.length > MAX_FILTER_CHARACTERS) throw invalidRule(field)
+
+  return {
+    value: normalized,
+    hostname,
+    wildcard,
+    ...(pathPrefix ? { pathPrefix } : {}),
+  }
+}
+
+function matchesRule(url: URL, rule: ExaSearchDomainRule): boolean {
+  const hostname = canonicalHostname(url.hostname)
+  const hostnameMatches = rule.wildcard
+    ? hostname !== rule.hostname && hostname.endsWith(`.${rule.hostname}`)
+    : hostname === rule.hostname
+  if (!hostnameMatches) return false
+  if (!rule.pathPrefix) return true
+  return url.pathname === rule.pathPrefix || url.pathname.startsWith(`${rule.pathPrefix}/`)
+}
+
+function normalizePathPrefix(pathname: string): string | undefined {
+  const normalized = pathname.replace(/\/+$/, "")
+  return normalized || undefined
+}
+
+function canonicalHostname(value: string): string {
+  return value.toLowerCase().replace(/\.$/, "")
+}
+
+function isValidHostname(hostname: string): boolean {
+  if (!hostname || hostname.length > 253) return false
+  return hostname.split(".").every((label) => {
+    if (label.length < 1 || label.length > 63) return false
+    return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+  })
+}
+
+function invalidRule(field: string): Error {
+  return new Error(
+    `[SixbExa] ${field} entries must be Exa domain filters without schemes, credentials, ports, queries, or fragments.`
+  )
+}

--- a/connectors/exa/src/signals.ts
+++ b/connectors/exa/src/signals.ts
@@ -1,0 +1,19 @@
+/** Settle with the signal even when the underlying operation does not observe cancellation. */
+export function waitForSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason)
+
+  return new Promise((resolve, reject) => {
+    const abort = (): void => reject(signal.reason)
+    signal.addEventListener("abort", abort, { once: true })
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", abort)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener("abort", abort)
+        reject(error)
+      }
+    )
+  })
+}

--- a/connectors/exa/src/types.ts
+++ b/connectors/exa/src/types.ts
@@ -1,0 +1,80 @@
+import type { ConnectorAdapter } from "@sixb/core"
+
+export type ExaApiKeyResolver = string | (() => string | Promise<string>)
+
+export interface ExaConnectorOptions {
+  readonly apiKey: ExaApiKeyResolver
+  readonly baseUrl?: string
+}
+
+export interface ExaRequestOptions {
+  readonly signal?: AbortSignal
+}
+
+export interface ExaTextContentsOptions {
+  readonly maxCharacters?: number
+  readonly includeHtmlTags?: boolean
+}
+
+export interface ExaSearchContentsOptions {
+  readonly text?: true | ExaTextContentsOptions
+}
+
+/** The supported wire fields for one Exa `/search` request. */
+export interface ExaSearchRequest {
+  readonly query: string
+  readonly numResults?: number
+  readonly includeDomains?: readonly string[]
+  readonly excludeDomains?: readonly string[]
+  readonly contents?: ExaSearchContentsOptions
+}
+
+/** One result returned by Exa's `/search` endpoint. */
+export interface ExaSearchResult {
+  readonly id: string
+  readonly title: string | null
+  readonly url: string
+  readonly publishedDate?: string | null
+  readonly author?: string | null
+  readonly text?: string
+}
+
+/** Per-document status metadata present on some Exa responses. */
+export interface ExaSearchStatus {
+  readonly id: string
+  readonly status: string
+  readonly source: string
+}
+
+/** An endpoint-specific dollar-cost breakdown. */
+export type ExaCostBreakdown = Readonly<Record<string, number>>
+
+export interface ExaCostDollars {
+  readonly total: number
+  readonly search?: ExaCostBreakdown
+  readonly contents?: ExaCostBreakdown
+}
+
+/** The non-streaming Exa `/search` response used by this connector. */
+export interface ExaSearchResponse {
+  readonly results: readonly ExaSearchResult[]
+  readonly requestId?: string
+  readonly statuses?: readonly ExaSearchStatus[]
+  readonly costDollars?: ExaCostDollars
+  readonly searchType?: string
+  readonly resolvedSearchType?: string
+  readonly searchTime?: number
+}
+
+/** Structured fields Exa may return for a failed API request. */
+export interface ExaErrorResponse {
+  readonly requestId?: string
+  readonly error?: string
+  readonly tag?: string
+}
+
+export interface ExaClient {
+  search(request: ExaSearchRequest, options?: ExaRequestOptions): Promise<ExaSearchResponse>
+}
+
+export type ExaConnector = ConnectorAdapter<"exa", ExaClient>

--- a/connectors/exa/tests/agent-tools.test.ts
+++ b/connectors/exa/tests/agent-tools.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { type AgentToolRunContext, defineConnector, noopLogger } from "@sixb/core"
+import {
+  AgentToolPublicError,
+  type AgentToolRunContext,
+  defineConnector,
+  noopLogger,
+} from "@sixb/core"
 import type { ExaClient, ExaConnector, ExaSearchRequest, ExaSearchResponse } from "../src"
 import { type ExaWebSearchOptions, exaWebSearch } from "../src/agent-tools"
 
@@ -68,8 +73,8 @@ describe("Exa web_search agent tool", () => {
   })
 
   test("maps domain policy to Exa and snapshots developer configuration", async () => {
-    const allowedDomains = [" docs.sixb.ai "]
-    const deniedDomains = ["archive.example"]
+    const allowedDomains = [" Docs.Sixb.AI./guide/ ", "*.EXAMPLE.com/news/"]
+    const deniedDomains = [" Archive.Example. "]
     let receivedRequest: ExaSearchRequest | undefined
     const { execute } = harness(
       {
@@ -86,9 +91,47 @@ describe("Exa web_search agent tool", () => {
     await execute("domain filters")
 
     expect(receivedRequest).toMatchObject({
-      includeDomains: ["docs.sixb.ai"],
+      includeDomains: ["docs.sixb.ai/guide", "*.example.com/news"],
       excludeDomains: ["archive.example"],
     })
+  })
+
+  test("reapplies path, wildcard, allow, and deny rules to provider results", async () => {
+    const options = {
+      allowedDomains: ["example.com/docs", "*.trusted.example"],
+      deniedDomains: ["example.com/docs/private", "*.blocked.trusted.example"],
+    }
+
+    for (const url of [
+      "https://example.com/docs",
+      "https://example.com/docs/reference",
+      "https://api.trusted.example/reference",
+    ]) {
+      await expect(
+        harness({ search: async () => response([result(url, "allowed")]) }, options).execute(
+          "allowed"
+        )
+      ).resolves.toMatchObject({ results: [{ url }] })
+    }
+
+    for (const url of [
+      "https://outside.example/docs",
+      "https://example.com/docs-private",
+      "https://example.com/docs/private/credentials",
+      "https://trusted.example/reference",
+      "https://deep.blocked.trusted.example/reference",
+    ]) {
+      const error = await harness(
+        { search: async () => response([result(url, "denied")]) },
+        options
+      )
+        .execute("denied")
+        .catch((caught) => caught)
+
+      expect(error).toBeInstanceOf(AgentToolPublicError)
+      if (!(error instanceof AgentToolPublicError)) throw error
+      expect(error.message).toContain("domain policy")
+    }
   })
 
   test("normalizes metadata and includes request and cost information when available", async () => {
@@ -184,12 +227,25 @@ describe("Exa web_search agent tool", () => {
       "allowedDomains must contain from 1 to 1200 domains"
     )
     expect(() => exaWebSearch(definition, { deniedDomains: [" "] })).toThrow(
-      "deniedDomains entries must be non-empty strings"
+      "deniedDomains entries must be Exa domain filters"
     )
     for (const allowedDomains of [null, "", false]) {
       expect(() =>
         exaWebSearch(definition, { allowedDomains } as unknown as ExaWebSearchOptions)
       ).toThrow("allowedDomains must contain from 1 to 1200 domains")
+    }
+    for (const domain of [
+      "https://example.com",
+      "user@example.com",
+      "example.com:443",
+      "example.com?query=true",
+      "example.com#fragment",
+      "*.*.example.com",
+      "bad_label.example",
+    ]) {
+      expect(() => exaWebSearch(definition, { allowedDomains: [domain] })).toThrow(
+        "allowedDomains entries must be Exa domain filters"
+      )
     }
   })
 
@@ -281,8 +337,8 @@ function harness(
 
   return {
     tool,
-    execute(query: string) {
-      return tool.handler({
+    async execute(query: string) {
+      return await tool.handler({
         input: { query },
         signal,
         run: { id: "run-1", agentId: "research", threadId: "thread-1" },

--- a/connectors/exa/tests/agent-tools.test.ts
+++ b/connectors/exa/tests/agent-tools.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from "bun:test"
+import { type AgentToolRunContext, defineConnector, noopLogger } from "@sixb/core"
+import type { ExaClient, ExaConnector, ExaSearchRequest, ExaSearchResponse } from "../src"
+import { type ExaWebSearchOptions, exaWebSearch } from "../src/agent-tools"
+
+describe("Exa web_search agent tool", () => {
+  test("keeps model input narrow and applies bounded defaults", async () => {
+    let receivedRequest: ExaSearchRequest | undefined
+    let receivedSignal: AbortSignal | undefined
+    const { tool, execute } = harness({
+      async search(request, options) {
+        receivedRequest = request
+        receivedSignal = options?.signal
+        return response([result("https://sixb.ai", "current sixb information")])
+      },
+    })
+
+    const output = await execute("  current Sixb release  ")
+
+    expect(tool.name).toBe("web_search")
+    expect(tool.input).toEqual({ query: "string" })
+    expect(receivedRequest).toEqual({
+      query: "current Sixb release",
+      numResults: 5,
+      contents: { text: { maxCharacters: 2_000 } },
+    })
+    expect(receivedSignal).toBeInstanceOf(AbortSignal)
+    expect(output).toEqual({
+      results: [
+        {
+          title: "Title for https://sixb.ai",
+          url: "https://sixb.ai",
+          text: "current sixb information",
+        },
+      ],
+    })
+  })
+
+  test("reapplies result, per-result, and total text limits to provider output", async () => {
+    const { execute } = harness(
+      {
+        search: async () =>
+          response([
+            result("https://one.example", "abcdef"),
+            result("https://two.example", "uvwxyz"),
+            result("https://three.example", "ignored"),
+          ]),
+      },
+      { maxResults: 2, maxCharactersPerResult: 4, maxTotalCharacters: 6 }
+    )
+
+    const output = await execute("bounded")
+
+    expect(output).toEqual({
+      results: [
+        {
+          title: "Title for https://one.example",
+          url: "https://one.example",
+          text: "abcd",
+        },
+        {
+          title: "Title for https://two.example",
+          url: "https://two.example",
+          text: "uv",
+        },
+      ],
+    })
+  })
+
+  test("maps domain policy to Exa and snapshots developer configuration", async () => {
+    const allowedDomains = [" docs.sixb.ai "]
+    const deniedDomains = ["archive.example"]
+    let receivedRequest: ExaSearchRequest | undefined
+    const { execute } = harness(
+      {
+        async search(request) {
+          receivedRequest = request
+          return response([])
+        },
+      },
+      { allowedDomains, deniedDomains }
+    )
+    allowedDomains[0] = "changed.example"
+    deniedDomains[0] = "changed.example"
+
+    await execute("domain filters")
+
+    expect(receivedRequest).toMatchObject({
+      includeDomains: ["docs.sixb.ai"],
+      excludeDomains: ["archive.example"],
+    })
+  })
+
+  test("normalizes metadata and includes request and cost information when available", async () => {
+    const { execute } = harness({
+      search: async () => ({
+        results: [
+          {
+            id: "https://sixb.ai/docs",
+            title: null,
+            url: "https://sixb.ai/docs",
+            author: " Sixb contributors ",
+            publishedDate: " 2026-08-03 ",
+            text: "Documentation",
+          },
+        ],
+        requestId: " request-123 ",
+        costDollars: {
+          total: 0.008,
+          search: { neural: 0.007 },
+          internal: "must not reach the model",
+        },
+      }),
+    })
+
+    await expect(execute("metadata")).resolves.toEqual({
+      results: [
+        {
+          title: "https://sixb.ai/docs",
+          url: "https://sixb.ai/docs",
+          author: "Sixb contributors",
+          publishedDate: "2026-08-03",
+          text: "Documentation",
+        },
+      ],
+      requestId: "request-123",
+      costDollars: { total: 0.008 },
+    })
+  })
+
+  test("bounds provider-controlled metadata and drops overlong URLs", async () => {
+    const longUrl = `https://example.com/${"u".repeat(4_100)}`
+    const { execute } = harness(
+      {
+        search: async () => ({
+          results: [
+            result(longUrl, "ignored"),
+            {
+              id: "https://sixb.ai/docs",
+              title: ` Title ${"t".repeat(600)} `,
+              url: " https://sixb.ai/docs ",
+              author: ` Author ${"a".repeat(400)} `,
+              publishedDate: ` 2026-08-03${"d".repeat(150)} `,
+              text: "Documentation",
+            },
+          ],
+          requestId: ` request-${"r".repeat(300)} `,
+        }),
+      },
+      { maxResults: 2 }
+    )
+
+    const output = (await execute("metadata limits")) as {
+      results: Array<{ title: string; url: string; author: string; publishedDate: string }>
+      requestId: string
+    }
+
+    expect(output.results).toHaveLength(1)
+    expect(output.results[0]?.url).toBe("https://sixb.ai/docs")
+    expect(output.results[0]?.title).toHaveLength(500)
+    expect(output.results[0]?.author).toHaveLength(300)
+    expect(output.results[0]?.publishedDate).toHaveLength(100)
+    expect(output.requestId).toHaveLength(200)
+  })
+
+  test("rejects invalid limits and domain policies when the tool is defined", () => {
+    const definition = defineConnector("exa", fakeConnector({ search: async () => response([]) }))
+
+    expect(() => exaWebSearch(definition, [] as unknown as ExaWebSearchOptions)).toThrow(
+      "web_search options must be an object"
+    )
+
+    for (const options of [
+      { maxResults: 0 },
+      { maxResults: 101 },
+      { maxResults: 1.5 },
+      { maxCharactersPerResult: 0 },
+      { maxTotalCharacters: Number.POSITIVE_INFINITY },
+      { timeoutMs: 0 },
+    ]) {
+      expect(() => exaWebSearch(definition, options)).toThrow("[SixbExa]")
+    }
+    expect(() => exaWebSearch(definition, { allowedDomains: [] })).toThrow(
+      "allowedDomains must contain from 1 to 1200 domains"
+    )
+    expect(() => exaWebSearch(definition, { deniedDomains: [" "] })).toThrow(
+      "deniedDomains entries must be non-empty strings"
+    )
+    for (const allowedDomains of [null, "", false]) {
+      expect(() =>
+        exaWebSearch(definition, { allowedDomains } as unknown as ExaWebSearchOptions)
+      ).toThrow("allowedDomains must contain from 1 to 1200 domains")
+    }
+  })
+
+  test("times out a provider request that does not observe cancellation", async () => {
+    const started = Promise.withResolvers<void>()
+    let receivedSignal: AbortSignal | undefined
+    const { execute } = harness(
+      {
+        search(_request, options) {
+          receivedSignal = options?.signal
+          started.resolve()
+          return new Promise(() => {})
+        },
+      },
+      { timeoutMs: 10 }
+    )
+    const execution = execute("slow search")
+    await started.promise
+
+    await expect(execution).rejects.toThrow("web_search timed out after 10ms")
+    expect(receivedSignal?.aborted).toBe(true)
+  })
+
+  test("times out connector resolution", async () => {
+    const { execute } = harness(
+      { search: async () => response([]) },
+      { timeoutMs: 10 },
+      new AbortController().signal,
+      () => new Promise(() => {})
+    )
+
+    await expect(execute("slow connector")).rejects.toThrow("web_search timed out after 10ms")
+  })
+
+  test("passes run cancellation to a provider request that does not observe it", async () => {
+    const started = Promise.withResolvers<void>()
+    let receivedSignal: AbortSignal | undefined
+    const controller = new AbortController()
+    const cancellation = new Error("run cancelled")
+    const { execute } = harness(
+      {
+        search(_request, options) {
+          receivedSignal = options?.signal
+          started.resolve()
+          return new Promise(() => {})
+        },
+      },
+      { timeoutMs: 1_000 },
+      controller.signal
+    )
+    const execution = execute("cancel me")
+    await started.promise
+
+    controller.abort(cancellation)
+
+    await expect(execution).rejects.toBe(cancellation)
+    expect(receivedSignal?.aborted).toBe(true)
+  })
+
+  test("rejects blank and oversized queries before searching", async () => {
+    let searches = 0
+    const { execute } = harness({
+      async search() {
+        searches += 1
+        return response([])
+      },
+    })
+
+    await expect(execute("  ")).rejects.toThrow("web_search query must not be empty")
+    await expect(execute("q".repeat(2_001))).rejects.toThrow(
+      "web_search query must contain at most 2000 characters"
+    )
+    expect(searches).toBe(0)
+  })
+})
+
+function harness(
+  client: ExaClient,
+  options: Parameters<typeof exaWebSearch>[1] = {},
+  signal: AbortSignal = new AbortController().signal,
+  resolveConnector: () => Promise<ExaClient> = async () => client
+) {
+  const definition = defineConnector("exa", fakeConnector(client))
+  const tool = exaWebSearch(definition, options)
+  const connector = (async (requestedDefinition: unknown) => {
+    expect(requestedDefinition).toBe(definition)
+    return resolveConnector()
+  }) as AgentToolRunContext["connector"]
+
+  return {
+    tool,
+    execute(query: string) {
+      return tool.handler({
+        input: { query },
+        signal,
+        run: { id: "run-1", agentId: "research", threadId: "thread-1" },
+        connector,
+        logger: noopLogger,
+      })
+    },
+  }
+}
+
+function fakeConnector(client: ExaClient): ExaConnector {
+  return {
+    type: "exa",
+    connect: () => client,
+  }
+}
+
+function result(url: string, text: string) {
+  return { id: url, title: `Title for ${url}`, url, text }
+}
+
+function response(results: ExaSearchResponse["results"]): ExaSearchResponse {
+  return { results }
+}

--- a/connectors/exa/tests/exa.test.ts
+++ b/connectors/exa/tests/exa.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { ExaApiError, type ExaConnectorOptions, type ExaSearchRequest, exa } from "../src"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("Exa connector", () => {
+  test("authenticates each search and sends the typed request body", async () => {
+    let requestUrl = ""
+    let requestInit: RequestInit | undefined
+    const apiKeys: (string | null)[] = []
+    const requestBodies: unknown[] = []
+    let resolverCalls = 0
+    mockFetch((input, init) => {
+      requestUrl = String(input)
+      requestInit = init
+      apiKeys.push(new Headers(init?.headers).get("x-api-key"))
+      requestBodies.push(JSON.parse(String(init?.body)))
+      return Promise.resolve(json(searchResponse()))
+    })
+    const client = await connect({
+      apiKey: async () => {
+        resolverCalls += 1
+        return `exa-test-key-${resolverCalls}`
+      },
+      baseUrl: "https://exa.example.test/v1",
+    })
+
+    await client.search({
+      query: "sixb agents",
+      numResults: 3,
+      includeDomains: ["sixb.ai/docs"],
+      excludeDomains: ["archive.example"],
+      contents: { text: { maxCharacters: 1_500 } },
+    })
+    await client.search({ query: "rotated key" })
+
+    expect(requestUrl).toBe("https://exa.example.test/v1/search")
+    expect(requestInit?.method).toBe("POST")
+    expect(apiKeys).toEqual(["exa-test-key-1", "exa-test-key-2"])
+    expect(new Headers(requestInit?.headers).get("accept")).toBe("application/json")
+    expect(new Headers(requestInit?.headers).get("content-type")).toBe("application/json")
+    expect(requestBodies).toEqual([
+      {
+        query: "sixb agents",
+        numResults: 3,
+        includeDomains: ["sixb.ai/docs"],
+        excludeDomains: ["archive.example"],
+        contents: { text: { maxCharacters: 1_500 } },
+      },
+      { query: "rotated key" },
+    ])
+    expect(resolverCalls).toBe(2)
+  })
+
+  test("returns search result, status, request, and cost wire metadata", async () => {
+    const response = searchResponse()
+    mockFetch(() => Promise.resolve(json(response)))
+
+    await expect(
+      (await connect({ apiKey: "test-key" })).search({ query: "sixb" })
+    ).resolves.toEqual(response)
+  })
+
+  test("surfaces rate-limit and server failures after one attempt", async () => {
+    for (const status of [429, 503]) {
+      let attempts = 0
+      mockFetch(() => {
+        attempts += 1
+        return Promise.resolve(
+          json(
+            {
+              error: status === 429 ? "Rate limit exceeded" : "Service unavailable",
+              tag: status === 429 ? "RATE_LIMIT" : "INTERNAL_ERROR",
+              requestId: `request-${status}`,
+            },
+            { status }
+          )
+        )
+      })
+      const client = await connect({ apiKey: "test-key" })
+
+      const error = await client.search({ query: "sixb" }).catch((caught) => caught)
+
+      expect(error).toBeInstanceOf(ExaApiError)
+      expect(error).toMatchObject({ status, requestId: `request-${status}` })
+      expect(String(error)).toContain(`HTTP ${status}`)
+      expect(attempts).toBe(1)
+    }
+  })
+
+  test("surfaces network failures after one attempt", async () => {
+    let attempts = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.reject(new Error("socket unavailable"))
+    })
+    const client = await connect({ apiKey: "test-key" })
+
+    await expect(client.search({ query: "sixb" })).rejects.toThrow(
+      "[SixbExa] Exa search could not reach the API."
+    )
+    expect(attempts).toBe(1)
+  })
+
+  test("passes caller cancellation to the active request", async () => {
+    const started = Promise.withResolvers<void>()
+    let receivedSignal: AbortSignal | undefined
+    mockFetch((_, init) => {
+      receivedSignal = init?.signal ?? undefined
+      started.resolve()
+      return new Promise((_, reject) => {
+        const abort = (): void => reject(receivedSignal?.reason)
+        if (receivedSignal?.aborted) abort()
+        else receivedSignal?.addEventListener("abort", abort, { once: true })
+      })
+    })
+    const client = await connect({ apiKey: "test-key" })
+    const controller = new AbortController()
+    const cancellation = new Error("caller cancelled")
+    const request = client.search({ query: "sixb" }, { signal: controller.signal })
+    await started.promise
+
+    controller.abort(cancellation)
+
+    await expect(request).rejects.toBe(cancellation)
+    expect(receivedSignal?.aborted).toBe(true)
+  })
+
+  test("honors caller cancellation while resolving credentials", async () => {
+    const resolverStarted = Promise.withResolvers<void>()
+    const apiKey = Promise.withResolvers<string>()
+    let fetches = 0
+    mockFetch(() => {
+      fetches += 1
+      return Promise.resolve(json(searchResponse()))
+    })
+    const client = await connect({
+      apiKey: () => {
+        resolverStarted.resolve()
+        return apiKey.promise
+      },
+    })
+    const controller = new AbortController()
+    const cancellation = new Error("cancelled during credential resolution")
+    const request = client.search({ query: "sixb" }, { signal: controller.signal })
+    await resolverStarted.promise
+
+    controller.abort(cancellation)
+
+    await expect(request).rejects.toBe(cancellation)
+    apiKey.resolve("resolved-too-late")
+    await Bun.sleep(0)
+    expect(fetches).toBe(0)
+  })
+
+  test("does not resolve credentials or fetch for a pre-aborted request", async () => {
+    let resolverCalls = 0
+    let fetches = 0
+    mockFetch(() => {
+      fetches += 1
+      return Promise.resolve(json(searchResponse()))
+    })
+    const client = await connect({
+      apiKey: () => {
+        resolverCalls += 1
+        return "test-key"
+      },
+    })
+    const controller = new AbortController()
+    const cancellation = new Error("already cancelled")
+    controller.abort(cancellation)
+
+    await expect(client.search({ query: "sixb" }, { signal: controller.signal })).rejects.toBe(
+      cancellation
+    )
+    expect(resolverCalls).toBe(0)
+    expect(fetches).toBe(0)
+  })
+
+  test("passes connector lifecycle cancellation to the active request", async () => {
+    const started = Promise.withResolvers<void>()
+    let receivedSignal: AbortSignal | undefined
+    mockFetch((_, init) => {
+      receivedSignal = init?.signal ?? undefined
+      started.resolve()
+      return new Promise((_, reject) => {
+        const abort = (): void => reject(receivedSignal?.reason)
+        if (receivedSignal?.aborted) abort()
+        else receivedSignal?.addEventListener("abort", abort, { once: true })
+      })
+    })
+    const lifecycle = new AbortController()
+    const client = await connect({ apiKey: "test-key" }, lifecycle.signal)
+    const cancellation = new Error("connector disconnected")
+    const request = client.search({ query: "sixb" })
+    await started.promise
+
+    lifecycle.abort(cancellation)
+
+    await expect(request).rejects.toBe(cancellation)
+    expect(receivedSignal?.aborted).toBe(true)
+  })
+
+  test("handles malformed and non-JSON error responses without returning their bodies", async () => {
+    mockFetch(() =>
+      Promise.resolve(
+        new Response("<html>proxy failure with internal details</html>", { status: 502 })
+      )
+    )
+    const client = await connect({ apiKey: "test-key" })
+
+    const nonJson = await client.search({ query: "sixb" }).catch((error) => error)
+    expect(nonJson).toBeInstanceOf(ExaApiError)
+    expect(nonJson.message).toBe("[SixbExa] Exa search failed with HTTP 502.")
+    expect(nonJson.message).not.toContain("proxy failure")
+
+    mockFetch(() => Promise.resolve(json({ error: 42, requestId: {} }, { status: 400 })))
+    const malformed = await client.search({ query: "sixb" }).catch((error) => error)
+    expect(malformed).toBeInstanceOf(ExaApiError)
+    expect(malformed.message).toBe("[SixbExa] Exa search failed with HTTP 400.")
+  })
+
+  test("redacts API keys from structured provider errors", async () => {
+    const apiKey = "exa-secret-value"
+    mockFetch(() =>
+      Promise.resolve(
+        json(
+          {
+            error: `Invalid credential ${apiKey}`,
+            tag: `INVALID_${apiKey}`,
+            requestId: `request-${apiKey}`,
+          },
+          { status: 401 }
+        )
+      )
+    )
+    const client = await connect({ apiKey })
+
+    const error = await client.search({ query: "sixb" }).catch((caught) => caught)
+
+    expect(error.message).toContain("[REDACTED]")
+    expect(error.message).not.toContain(apiKey)
+    expect(error.tag).toBe("INVALID_[REDACTED]")
+    expect(error.requestId).toBe("request-[REDACTED]")
+  })
+
+  test("validates credentials, base URLs, requests, and successful response bodies", async () => {
+    expect(() => exa({ apiKey: "" })).toThrow("apiKey must not be empty")
+    expect(() => exa({ apiKey: "key", baseUrl: "relative" })).toThrow(
+      "baseUrl must be an absolute HTTP(S) URL"
+    )
+
+    const emptyResolverClient = await connect({ apiKey: () => "" })
+    await expect(emptyResolverClient.search({ query: "sixb" })).rejects.toThrow(
+      "Resolved apiKey must not be empty"
+    )
+
+    const resolverSecret = "resolver-secret"
+    const failingResolverClient = await connect({
+      apiKey: () => {
+        throw new Error(resolverSecret)
+      },
+    })
+    const resolverError = await failingResolverClient
+      .search({ query: "sixb" })
+      .catch((error) => error)
+    expect(resolverError.message).toBe("[SixbExa] Could not resolve apiKey.")
+    expect(resolverError.message).not.toContain(resolverSecret)
+    expect(resolverError.cause).toBeUndefined()
+
+    let syncResolverApiKey = ""
+    mockFetch((_, init) => {
+      syncResolverApiKey = new Headers(init?.headers).get("x-api-key") ?? ""
+      return Promise.resolve(json(searchResponse()))
+    })
+    const syncResolverClient = await connect({ apiKey: () => "sync-resolver-key" })
+    await syncResolverClient.search({ query: "sixb" })
+    expect(syncResolverApiKey).toBe("sync-resolver-key")
+
+    mockFetch(() => Promise.resolve(json({ results: {} })))
+    const client = await connect({ apiKey: "test-key" })
+    await expect(client.search({ query: "sixb" })).rejects.toThrow(
+      "malformed response: results must be an array"
+    )
+    await expect(client.search({ query: " " })).rejects.toThrow("query must not be empty")
+    await expect(client.search({ query: "sixb", numResults: 101 })).rejects.toThrow(
+      "numResults must be an integer from 1 to 100"
+    )
+    await expect(
+      client.search({ query: "sixb", contents: false } as unknown as ExaSearchRequest)
+    ).rejects.toThrow("contents must be an object")
+    await expect(
+      client.search({
+        query: "sixb",
+        contents: { text: [] },
+      } as unknown as ExaSearchRequest)
+    ).rejects.toThrow("contents.text must be true or an options object")
+  })
+})
+
+async function connect(
+  options: ExaConnectorOptions,
+  signal: AbortSignal = new AbortController().signal
+) {
+  return exa(options).connect({
+    projectId: "exa-tests",
+    connectorId: "exa",
+    signal,
+  })
+}
+
+function searchResponse() {
+  return {
+    results: [
+      {
+        id: "https://sixb.ai/docs",
+        title: "Sixb docs",
+        url: "https://sixb.ai/docs",
+        publishedDate: "2026-08-03T00:00:00.000Z",
+        author: "Sixb",
+        text: "Connector-backed agent tools",
+      },
+    ],
+    statuses: [{ id: "https://sixb.ai/docs", status: "success", source: "cached" }],
+    requestId: "request-123",
+    searchType: "auto",
+    costDollars: {
+      total: 0.008,
+      search: { neural: 0.007 },
+      contents: { text: 0.001 },
+    },
+  }
+}
+
+function json(value: unknown, init: ResponseInit = {}): Response {
+  return Response.json(value, init)
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as typeof fetch
+}

--- a/connectors/exa/tests/exa.test.ts
+++ b/connectors/exa/tests/exa.test.ts
@@ -248,6 +248,27 @@ describe("Exa connector", () => {
     expect(error.requestId).toBe("request-[REDACTED]")
   })
 
+  test("uses the canonical wire API key for requests and error redaction", async () => {
+    const apiKey = "exa-padded-secret"
+    let receivedApiKey = ""
+    mockFetch((_input, init) => {
+      receivedApiKey = new Headers(init?.headers).get("x-api-key") ?? ""
+      return Promise.resolve(
+        json({ error: `Invalid credential ${receivedApiKey}` }, { status: 401 })
+      )
+    })
+    for (const resolver of [`  ${apiKey}  `, async () => `  ${apiKey}  `]) {
+      const client = await connect({ apiKey: resolver })
+
+      const error = await client.search({ query: "sixb" }).catch((caught) => caught)
+
+      expect(receivedApiKey).toBe(apiKey)
+      expect(error).toBeInstanceOf(ExaApiError)
+      expect(error.message).toContain("[REDACTED]")
+      expect(error.message).not.toContain(apiKey)
+    }
+  })
+
   test("validates credentials, base URLs, requests, and successful response bodies", async () => {
     expect(() => exa({ apiKey: "" })).toThrow("apiKey must not be empty")
     expect(() => exa({ apiKey: "key", baseUrl: "relative" })).toThrow(

--- a/connectors/exa/tsconfig.build.json
+++ b/connectors/exa/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../packages/core/tsconfig.build.json"
+    },
+    {
+      "path": "../rest/tsconfig.build.json"
+    }
+  ]
+}

--- a/connectors/exa/tsconfig.json
+++ b/connectors/exa/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/agent-worker/src/ai-sdk-adapters.ts
+++ b/packages/agent-worker/src/ai-sdk-adapters.ts
@@ -8,6 +8,7 @@ import type {
   Logger,
   ValueType,
 } from "@sixb/core"
+import { AgentToolPublicError } from "@sixb/core"
 import {
   AgentToolResultValidationError,
   fromAiSdk,
@@ -16,7 +17,7 @@ import {
 import { schemaRecordToJsonSchema } from "@sixb/core/internal/ontology"
 import type { AgentRunUsage } from "@sixb/core/storage"
 import { jsonSchema, type LanguageModelUsage, type Tool, type ToolSet, tool } from "ai"
-import { AgentToolOutputError, AgentWorkerError } from "./errors"
+import { AgentToolExecutionError, AgentToolOutputError, AgentWorkerError } from "./errors"
 
 const NEVER_ABORTED_SIGNAL = new AbortController().signal
 
@@ -65,7 +66,8 @@ function aiSdkToolFromAgentDefinition(
         if (error instanceof AgentToolResultValidationError) {
           throw new AgentToolOutputError(definition.name, error.reason, { cause: error })
         }
-        throw error
+        if (error instanceof AgentToolPublicError) throw error
+        throw new AgentToolExecutionError(definition.name, { cause: error })
       }
       return result
     },
@@ -158,7 +160,7 @@ function indexToolOutcomes(
       toolCallId,
       part.type === "tool-result"
         ? { state: "output-available", output: part.output }
-        : { state: "output-error", errorText: errorText(part.error) }
+        : { state: "output-error", errorText: agentToolErrorText(part.error) }
     )
   }
   return outcomes
@@ -203,7 +205,7 @@ function toolCallTracePart(
     outcomes.get(toolCallId) ??
     (part.error === undefined
       ? { state: "output-error" as const, errorText: "Tool call did not produce a result." }
-      : { state: "output-error" as const, errorText: errorText(part.error) })
+      : { state: "output-error" as const, errorText: agentToolErrorText(part.error) })
 
   return {
     type: part.dynamic === true ? "dynamic-tool" : `tool-${toolName}`,
@@ -231,15 +233,9 @@ function requireNonEmptyString(value: unknown, field: string): string {
   return string
 }
 
-function errorText(error: unknown): string {
-  if (error instanceof Error) return error.message
-  if (typeof error === "string") return error
-  try {
-    const serialized = JSON.stringify(error)
-    return serialized === undefined ? String(error) : serialized
-  } catch {
-    return String(error)
-  }
+/** Expose only failures that the tool author explicitly marked as safe for the model and storage. */
+export function agentToolErrorText(error: unknown): string {
+  return error instanceof AgentToolPublicError ? error.message : "An error occurred."
 }
 
 /** Map AI SDK accounting onto Sixb's provider-independent durable usage vocabulary. */

--- a/packages/agent-worker/src/errors.ts
+++ b/packages/agent-worker/src/errors.ts
@@ -1,3 +1,5 @@
+import { AgentToolPublicError } from "@sixb/core"
+
 /** Infra-level failure in the agent worker (unknown agent, missing storage, malformed job). */
 export class AgentWorkerError extends Error {
   readonly name = "AgentWorkerError"
@@ -49,9 +51,21 @@ export class AgentTurnTimeoutError extends Error {
   }
 }
 
+/** Keep an untrusted tool failure as the cause while exposing only a generic message to AI SDK. */
+export class AgentToolExecutionError extends Error {
+  readonly name = "AgentToolExecutionError"
+
+  constructor(
+    readonly toolName: string,
+    options: ErrorOptions
+  ) {
+    super("An error occurred.", options)
+  }
+}
+
 /** A selected agent tool returned a value that cannot cross the durable JSON message boundary. */
-export class AgentToolOutputError extends Error {
-  readonly name = "AgentToolOutputError"
+export class AgentToolOutputError extends AgentToolPublicError {
+  override readonly name = "AgentToolOutputError"
   constructor(
     readonly toolName: string,
     reason: string,

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -14,9 +14,9 @@ import {
 import { isAbortError, QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { AgentRunRecord, AgentStorage } from "@sixb/core/storage"
 import { type ModelMessage, stepCountIs, streamText, toUIMessageStream } from "ai"
-import { agentRunUsageFromAiSdk } from "./ai-sdk-adapters"
+import { agentRunUsageFromAiSdk, agentToolErrorText } from "./ai-sdk-adapters"
 import { attachmentKey, modelSupportsInlineImages, prepareAgentAttachments } from "./attachments"
-import { AgentToolOutputError, AgentTurnTimeoutError, AgentWorkerError } from "./errors"
+import { AgentTurnTimeoutError, AgentWorkerError } from "./errors"
 import { appendMessageAndFinishRunOrThrow, finishRunOrThrow } from "./finalize"
 import {
   type AgentOutputAttachmentResult,
@@ -128,8 +128,7 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
   const uiStream = toUIMessageStream({
     stream: result.stream,
     tools,
-    onError: (error) =>
-      error instanceof AgentToolOutputError ? error.message : "An error occurred.",
+    onError: agentToolErrorText,
     onEnd: (event) => {
       responseMessage = event.responseMessage
       streamAborted = streamAborted || event.isAborted

--- a/packages/agent-worker/tests/ai-sdk-adapters.test.ts
+++ b/packages/agent-worker/tests/ai-sdk-adapters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  AgentToolPublicError,
   type AgentToolRunContext,
   defineAgentTool,
   defineConnector,
@@ -11,6 +12,7 @@ import {
 import type { LanguageModelUsage, ToolSet } from "ai"
 import {
   agentRunUsageFromAiSdk,
+  agentToolErrorText,
   agentTraceFromAiSdkSteps,
   aiSdkToolsFromAgentDefinitions,
 } from "../src/ai-sdk-adapters"
@@ -232,7 +234,7 @@ describe("AI SDK agent adapters", () => {
     )
   })
 
-  test("does not classify project errors by matching their message", async () => {
+  test("masks unmarked project errors without classifying them by message", async () => {
     const projectError = new Error(
       "[Sixb] Agent tool 'project_failure' result must be a JSON value; lookalike"
     )
@@ -253,12 +255,33 @@ describe("AI SDK agent adapters", () => {
       definition.name
     )
 
-    try {
-      await adapted.execute({}, {})
-      throw new Error("Expected the project error to propagate.")
-    } catch (error) {
-      expect(error).toBe(projectError)
-    }
+    const error = await adapted.execute({}, {}).catch((caught) => caught)
+
+    expect(error.message).toBe("An error occurred.")
+    expect(error.cause).toBe(projectError)
+    expect(error).not.toBe(projectError)
+  })
+
+  test("preserves tool errors explicitly marked as safe", async () => {
+    const publicError = new AgentToolPublicError("Safe project diagnostic")
+    const definition = defineAgentTool("public_failure")
+      .description("Throw a public project error.")
+      .input({})
+      .run(() => {
+        throw publicError
+      })
+    const adapted = executableTool(
+      aiSdkToolsFromAgentDefinitions({
+        definitions: [definition],
+        valueTypesById: new Map(),
+        run: { id: "run-public-error", agentId: "broken" },
+        connector: (() => Promise.reject(new Error("unused"))) as AgentToolRunContext["connector"],
+        logger: noopLogger,
+      }),
+      definition.name
+    )
+
+    await expect(adapted.execute({}, {})).rejects.toBe(publicError)
   })
 
   test("keeps prototype-like valid tool names as own properties", () => {
@@ -309,7 +332,7 @@ describe("AI SDK agent adapters", () => {
           {
             type: "tool-error",
             toolCallId: "call-2",
-            error: new Error("Not found"),
+            error: new AgentToolPublicError("Not found"),
           },
         ],
       },
@@ -337,6 +360,30 @@ describe("AI SDK agent adapters", () => {
         state: "output-error",
         errorText: "Not found",
       },
+    ])
+  })
+
+  test("exposes only tool errors explicitly marked as safe", () => {
+    const safe = new AgentToolPublicError("Safe diagnostic")
+    const internal = new Error("credential=secret")
+
+    expect(agentToolErrorText(safe)).toBe("Safe diagnostic")
+    expect(agentToolErrorText(internal)).toBe("An error occurred.")
+    expect(
+      agentTraceFromAiSdkSteps([
+        {
+          content: [
+            { type: "tool-call", toolCallId: "call-1", toolName: "safe", input: {} },
+            { type: "tool-error", toolCallId: "call-1", error: safe },
+            { type: "tool-call", toolCallId: "call-2", toolName: "internal", input: {} },
+            { type: "tool-error", toolCallId: "call-2", error: internal },
+          ],
+        },
+      ])
+    ).toMatchObject([
+      { type: "step-start" },
+      { toolName: "safe", state: "output-error", errorText: "Safe diagnostic" },
+      { toolName: "internal", state: "output-error", errorText: "An error occurred." },
     ])
   })
 

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -8,6 +8,8 @@ import type {
   LanguageModelV4StreamPart,
   LanguageModelV4Usage,
 } from "@ai-sdk/provider"
+import { exa } from "@sixb/connector-exa"
+import { exaWebSearch } from "@sixb/connector-exa/agent-tools"
 import {
   type AgentReasoningLevel,
   AgentRequestError,
@@ -117,6 +119,35 @@ function toolThenAnswerModel(captureReplay?: (prompt: string) => void): MockLang
         { type: "text-start", id: "t" },
         { type: "text-delta", id: "t", delta: "Echoed hi" },
         { type: "text-end", id: "t" },
+        finish("stop"),
+      ])
+    },
+  })
+}
+
+function webSearchThenAnswerModel(): MockLanguageModelV4 {
+  let call = 0
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    doStream: async () => {
+      call += 1
+      if (call === 1) {
+        return stream([
+          { type: "stream-start", warnings: [] },
+          {
+            type: "tool-call",
+            toolCallId: "web-search-call",
+            toolName: "web_search",
+            input: JSON.stringify({ query: "sixb connector tools" }),
+          },
+          finish("tool-calls"),
+        ])
+      }
+      return stream([
+        { type: "stream-start", warnings: [] },
+        { type: "text-start", id: "answer" },
+        { type: "text-delta", id: "answer", delta: "Search complete" },
+        { type: "text-end", id: "answer" },
         finish("stop"),
       ])
     },
@@ -1879,6 +1910,95 @@ describe("AgentWorker", () => {
       })
     } finally {
       await worker.stop()
+    }
+  })
+
+  test("runs a bounded Exa web_search through a registered connector", async () => {
+    const originalFetch = globalThis.fetch
+    let requestHeaders: Headers | undefined
+    let requestBody: unknown
+    globalThis.fetch = (async (_input, init) => {
+      requestHeaders = new Headers(init?.headers)
+      requestBody = JSON.parse(String(init?.body))
+      return Response.json({
+        results: [
+          {
+            id: "https://sixb.ai/docs",
+            title: "Sixb docs",
+            url: "https://sixb.ai/docs",
+            author: "Sixb",
+            publishedDate: "2026-08-03",
+            text: "connector-backed search content",
+          },
+        ],
+        requestId: "exa-request-1",
+        costDollars: { total: 0.008 },
+      })
+    }) as typeof fetch
+    const exaConnector = defineConnector("exa", exa({ apiKey: "exa-test-key" }))
+    const webSearch = exaWebSearch(exaConnector, {
+      maxResults: 1,
+      maxCharactersPerResult: 12,
+      maxTotalCharacters: 12,
+      timeoutMs: 1_000,
+    })
+    const sixb = buildSixb(
+      webSearchThenAnswerModel(),
+      new InMemoryBroker(),
+      new RecordingSandboxFactory(),
+      { agentTools: [webSearch], connectors: [exaConnector] }
+    )
+    const storage = agentStorageOf(sixb)
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    try {
+      await worker.start()
+      const request = await sixb.agents.request({
+        agentId: "assistant",
+        text: "search for connector tools",
+      })
+      const run = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({
+            projectId: PROJECT_ID,
+            id: request.run.id,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "Exa web_search run terminal" }
+      )
+
+      expect(run.status).toBe("succeeded")
+      expect(requestHeaders?.get("x-api-key")).toBe("exa-test-key")
+      expect(requestBody).toEqual({
+        query: "sixb connector tools",
+        numResults: 1,
+        contents: { text: { maxCharacters: 12 } },
+      })
+      const messages = await listMessages(storage, request.run.threadId)
+      expect(
+        messages
+          .find((message) => message.role === "assistant")
+          ?.parts.find((part) => part.type === "tool-call" && part.toolName === "web_search")
+      ).toMatchObject({
+        state: "output-available",
+        input: { query: "sixb connector tools" },
+        output: {
+          results: [
+            {
+              title: "Sixb docs",
+              url: "https://sixb.ai/docs",
+              author: "Sixb",
+              publishedDate: "2026-08-03",
+              text: "connector-ba",
+            },
+          ],
+          requestId: "exa-request-1",
+          costDollars: { total: 0.008 },
+        },
+      })
+    } finally {
+      await worker.stop()
+      globalThis.fetch = originalFetch
     }
   })
 

--- a/packages/core/src/agents/errors.ts
+++ b/packages/core/src/agents/errors.ts
@@ -16,6 +16,15 @@ export class AgentMessageAdapterError extends Error {
   readonly name = "AgentMessageAdapterError"
 }
 
+/**
+ * An agent-tool failure whose message is intentionally safe to expose to the model and persist in
+ * the durable trace. Tool authors must keep the message free of credentials and internal details;
+ * unknown errors remain masked by the worker.
+ */
+export class AgentToolPublicError extends Error {
+  readonly name: string = "AgentToolPublicError"
+}
+
 /** Raised when an agent tool result cannot cross the durable JSON message boundary. */
 export class AgentToolResultValidationError extends Error {
   readonly name = "AgentToolResultValidationError"

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -59,6 +59,7 @@ export {
   AgentMessageAdapterError,
   AgentRequestError,
   type AgentRequestErrorCode,
+  AgentToolPublicError,
   AgentToolResultValidationError,
 } from "./errors"
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -889,6 +889,7 @@ export {
   AGENT_REASONING_LEVELS,
   AgentDefinitionError,
   AgentRequestError,
+  AgentToolPublicError,
   agentContext,
   agentContextIdentity,
   defineAgent,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -17,6 +17,9 @@
       "path": "connectors/companycam/tsconfig.build.json"
     },
     {
+      "path": "connectors/exa/tsconfig.build.json"
+    },
+    {
       "path": "connectors/github/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,8 @@
       "@sixb/client/query": ["./packages/client/src/query.ts"],
       "create-sixb/scaffold": ["./packages/create-sixb/src/scaffold.ts"],
       "@sixb/connector-companycam": ["./connectors/companycam/src/index.ts"],
+      "@sixb/connector-exa": ["./connectors/exa/src/index.ts"],
+      "@sixb/connector-exa/agent-tools": ["./connectors/exa/src/agent-tools.ts"],
       "@sixb/connector-github": ["./connectors/github/src/index.ts"],
       "@sixb/connector-google": ["./connectors/google/src/index.ts"],
       "@sixb/connector-imap": ["./connectors/imap/src/index.ts"],


### PR DESCRIPTION
Stacked on #299.

## What changed

Adds `@sixb/connector-exa`, a typed Exa client and a prebuilt bounded `web_search` agent tool.

```ts
import { exa } from "@sixb/connector-exa"
import { exaWebSearch } from "@sixb/connector-exa/agent-tools"
import { defineConnector } from "@sixb/core"

export const exaConnector = defineConnector(
  "exa",
  exa({ apiKey: process.env.EXA_API_KEY! })
)

export const webSearch = exaWebSearch(exaConnector, {
  maxResults: 5,
  maxCharactersPerResult: 2_000,
  maxTotalCharacters: 10_000,
  timeoutMs: 20_000,
})
```

The tool can then be granted to an individual agent.

```ts
defineAgent("researcher", {
  // ...
  tools: [webSearch],
})
```

## Runtime behavior

The model controls only the search query. Credentials, domain policy, timeouts, and output limits remain on the host.

```ts
{ query: "current Sixb connector documentation" }
```

Exa calls are single-attempt and built on `@sixb/connector-rest`. Caller cancellation covers credential resolution, the provider request, and response reading. Provider responses and errors are validated and normalized before reaching the agent.

```txt
maximum results:             5 by default
maximum text per result:     2,000 characters by default
maximum text across results: 10,000 characters by default
overall timeout:             20 seconds by default
model-facing cost metadata:  total only
```

Domain allow and deny lists are developer-controlled and fail closed when malformed. API keys and raw response bodies are not included in surfaced errors.

## Validation

```txt
21 Exa connector and tool tests
52 agent-worker integration tests
bun run typecheck
bun run build
bun run check
bun run test:publish
git diff --check
```
