### PR TITLE
sync: handle empty initial snapshots

### DIFF
--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -141,6 +141,10 @@ never received a row, that run does not create a dataset version, so dataset-upd
 not fire. This lets incremental readers advance an initial cursor without inventing placeholder
 rows.
 
+A first snapshot that returns no rows behaves the same way: it succeeds without creating a dataset
+version. Once a previous version exists, an empty snapshot still commits a new empty version so
+projections can withdraw source-owned objects that disappeared upstream.
+
 ## Read context
 
 The read handler signature is `(client, context)`.

--- a/packages/core/src/storage/sync-runs/in-memory.ts
+++ b/packages/core/src/storage/sync-runs/in-memory.ts
@@ -90,9 +90,9 @@ export class InMemorySyncRunStorage implements SyncRunStorage {
           `[Sixb] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.datasetId}'.`
         )
       }
-      if (!input.output && (existing.mode !== "append" || input.rowsRead !== 0)) {
+      if (!input.output && input.rowsRead !== 0) {
         throw new SyncRunError(
-          `[Sixb] Sync run '${input.id}' may omit its output only for an empty append.`
+          `[Sixb] Sync run '${input.id}' may omit its output only when no rows were read.`
         )
       }
     }

--- a/packages/core/src/storage/sync-runs/types.ts
+++ b/packages/core/src/storage/sync-runs/types.ts
@@ -43,7 +43,7 @@ export type FinishSyncRunInput =
       readonly status: "succeeded"
       readonly finishedAt?: Date
       readonly rowsRead: number
-      /** Absent only when the first append run succeeds without producing any rows. */
+      /** Absent only when a run succeeds without rows before the dataset has a version. */
       readonly output?: DatasetVersionRef
       readonly checkpoint?: JsonValue
     }

--- a/packages/core/tests/sync-runs.test.ts
+++ b/packages/core/tests/sync-runs.test.ts
@@ -95,6 +95,27 @@ describe("InMemorySyncRunStorage", () => {
     expect(finished.output).toBeUndefined()
   })
 
+  test("stores a successful empty snapshot without an output version", async () => {
+    const storage = new InMemorySyncRunStorage()
+    await storage.start({
+      id: "syncrun_empty_snapshot",
+      projectId: "my-app",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "snapshot",
+    })
+
+    const finished = await storage.finish({
+      id: "syncrun_empty_snapshot",
+      projectId: "my-app",
+      status: "succeeded",
+      rowsRead: 0,
+    })
+
+    expect(finished).toMatchObject({ status: "succeeded", rowsRead: 0 })
+    expect(finished.output).toBeUndefined()
+  })
+
   test("rejects duplicate starts and missing finishes", async () => {
     const storage = new InMemorySyncRunStorage()
 

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -242,31 +242,33 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
 
     throwIfAborted(signal)
 
-    if (sync.config.mode === "append" && rowsRead === 0) {
-      await write.abort()
-      write = undefined
+    if (rowsRead === 0) {
       const version = await lakeStorage.getLatestVersion(dataset.id)
-      const finishedRun = await syncRunsStorage.finish({
-        projectId: runtime.id,
-        id: job.id,
-        status: "succeeded",
-        rowsRead,
-        ...(version
-          ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
-          : {}),
-        checkpoint: nextCheckpoint,
-      })
+      if (sync.config.mode === "append" || !version) {
+        await write.abort()
+        write = undefined
+        const finishedRun = await syncRunsStorage.finish({
+          projectId: runtime.id,
+          id: job.id,
+          status: "succeeded",
+          rowsRead,
+          ...(version
+            ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
+            : {}),
+          checkpoint: nextCheckpoint,
+        })
 
-      return {
-        id: job.id,
-        syncId: sync.id,
-        datasetId: dataset.id,
-        mode: sync.config.mode,
-        startedAt: startedRun.startedAt,
-        finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
-        rowsRead,
-        ...(version ? { version } : {}),
-        versionCreated: false,
+        return {
+          id: job.id,
+          syncId: sync.id,
+          datasetId: dataset.id,
+          mode: sync.config.mode,
+          startedAt: startedRun.startedAt,
+          finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
+          rowsRead,
+          ...(version ? { version } : {}),
+          versionCreated: false,
+        }
       }
     }
 

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -63,7 +63,7 @@ export type SyncRunResult = SyncRunResultBase &
         readonly versionCreated: boolean
       }
     | {
-        /** A first empty append has no dataset version yet. */
+        /** A first empty sync has no dataset version yet. */
         readonly version?: undefined
         readonly versionCreated: false
       }

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -22,7 +22,7 @@ import {
   InMemoryLakeStorage,
   InMemoryStorage,
 } from "@sixb/core"
-import type { LakeWriteSession } from "@sixb/core/lake-storage"
+import type { BeginDatasetWriteInput, LakeWriteSession } from "@sixb/core/lake-storage"
 import type { SyncRunStorage } from "@sixb/core/storage"
 import { InMemorySyncRunStorage } from "@sixb/core/storage"
 import { LocalLakeStorage } from "@sixb/lake-local"
@@ -112,6 +112,33 @@ async function collectRows(rows: AsyncIterable<DatasetRow>): Promise<DatasetRow[
     result.push(row)
   }
   return result
+}
+
+class RejectingFirstEmptyCommitLakeStorage extends InMemoryLakeStorage {
+  override async beginWrite(input: BeginDatasetWriteInput): Promise<LakeWriteSession> {
+    const write = await super.beginWrite(input)
+    let rowsWritten = 0
+
+    return {
+      async writeRows(rows) {
+        await write.writeRows(
+          (async function* () {
+            for await (const row of rows) {
+              rowsWritten += 1
+              yield row
+            }
+          })()
+        )
+      },
+      commit: async (commitInput) => {
+        if (rowsWritten === 0 && !(await this.getLatestVersion(input.dataset.id))) {
+          throw new Error("A first empty commit cannot create a dataset version.")
+        }
+        return write.commit(commitInput)
+      },
+      abort: () => write.abort(),
+    }
+  }
 }
 
 describe("runSyncJob", () => {
@@ -361,6 +388,60 @@ describe("runSyncJob", () => {
       rowsRead: 0,
       checkpoint: { cursor: "cursor-1" },
     })
+  })
+
+  test("succeeds without committing a first empty snapshot", async () => {
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    const lakeStorage = new RejectingFirstEmptyCommitLakeStorage()
+    const sync = defineSync("sync-empty-orders")
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(rawOrdersDataset)
+    const runtime = createRuntime({ sync, syncRunsStorage, lakeStorage })
+
+    const result = await runSyncJob({
+      runtime,
+      job: { id: "run_empty_snapshot", syncId: sync.id },
+    })
+
+    expect(result).toMatchObject({
+      mode: "snapshot",
+      rowsRead: 0,
+      versionCreated: false,
+    })
+    expect(result.version).toBeUndefined()
+    expect(await lakeStorage.getLatestVersion(rawOrdersDataset.id)).toBeNull()
+    expect(
+      await syncRunsStorage.getById({ projectId: "project-1", id: "run_empty_snapshot" })
+    ).toMatchObject({
+      status: "succeeded",
+      rowsRead: 0,
+      output: undefined,
+    })
+  })
+
+  test("commits an empty snapshot when it must clear a previous version", async () => {
+    const lakeStorage = new RejectingFirstEmptyCommitLakeStorage()
+    await lakeStorage.createDataset(rawOrdersDataset)
+    const seed = await lakeStorage.beginWrite({ dataset: rawOrdersDataset, mode: "snapshot" })
+    await seed.writeRows([{ orderId: "ord_1" }])
+    const previous = await seed.commit()
+
+    const sync = defineSync("sync-clear-orders")
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(rawOrdersDataset)
+    const runtime = createRuntime({ sync, lakeStorage })
+
+    const result = await runSyncJob({
+      runtime,
+      job: { id: "run_clear_snapshot", syncId: sync.id },
+    })
+
+    expect(result.versionCreated).toBe(true)
+    expect(result.version?.versionId).not.toBe(previous.versionId)
+    expect(result.version?.rowCount).toBe(0)
+    expect(await collectRows(lakeStorage.readRows({ datasetId: rawOrdersDataset.id }))).toEqual([])
   })
 
   test("does not advance checkpoints from failed runs", async () => {

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -555,6 +555,52 @@ describe("SyncWorker", () => {
     })
   })
 
+  test("finishes a first empty snapshot without emitting a dataset version", async () => {
+    const dataset = defineDataset("raw.erp.empty-orders", {
+      schema: [col("orderId", "string")],
+    })
+    const sync = defineSync("sync-empty-orders")
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(dataset)
+    const sixb = createSixbForSync(sync)
+    const worker = new SyncWorker(sixb)
+
+    await sixb.queues.syncRuns.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "sync.run.requested",
+          payload: { syncId: sync.id, runId: "run-first-empty-snapshot" },
+        },
+      ],
+    })
+
+    await worker.start()
+    const run = await waitFor(
+      () =>
+        sixb.storage.syncRuns!.getById({
+          projectId: sixb.id,
+          id: "run-first-empty-snapshot",
+        }),
+      (value) => value?.status === "succeeded"
+    )
+    await Bun.sleep(50)
+    await worker.stop()
+
+    expect(run?.output).toBeUndefined()
+    const events = await sixb.events.read({
+      types: ["sync.run.started", "dataset.version.committed", "sync.run.finished"],
+    })
+    expect(events.map((event) => event.type)).toEqual(["sync.run.started", "sync.run.finished"])
+    expect(events[1]?.payload).toEqual({
+      syncId: sync.id,
+      runId: "run-first-empty-snapshot",
+      status: "succeeded",
+      datasetId: dataset.id,
+    })
+  })
+
   test("does not crash when retry fails on shutdown", async () => {
     const rawOrdersDataset = makeDataset("raw.erp.orders")
     const sync = defineSync("sync-orders")

--- a/storage/pg/src/pg-sync-run-storage.ts
+++ b/storage/pg/src/pg-sync-run-storage.ts
@@ -78,9 +78,9 @@ export class PgSyncRunStorage implements SyncRunStorage {
             `[SixbPg] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.dataset_id}'.`
           )
         }
-        if (!input.output && (existing.mode !== "append" || input.rowsRead !== 0)) {
+        if (!input.output && input.rowsRead !== 0) {
           throw new SyncRunError(
-            `[SixbPg] Sync run '${input.id}' may omit its output only for an empty append.`
+            `[SixbPg] Sync run '${input.id}' may omit its output only when no rows were read.`
           )
         }
       }

--- a/storage/pg/tests/pg-sync-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-sync-run-storage.e2e.ts
@@ -89,6 +89,21 @@ describe("PgSyncRunStorage", () => {
     })
     expect(emptyFinished.output).toBeUndefined()
     expect(emptyFinished.checkpoint).toEqual({ cursor: "cursor-empty" })
+
+    await storage.syncRuns.start({
+      id: "run-empty-snapshot",
+      projectId: "my-app",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "snapshot",
+    })
+    const emptySnapshotFinished = await storage.syncRuns.finish({
+      id: "run-empty-snapshot",
+      projectId: "my-app",
+      status: "succeeded",
+      rowsRead: 0,
+    })
+    expect(emptySnapshotFinished.output).toBeUndefined()
   })
 
   test("stores failures and supports filtered paging", async () => {

--- a/storage/sqlite/src/sync-run-storage.ts
+++ b/storage/sqlite/src/sync-run-storage.ts
@@ -115,9 +115,9 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
             `[SixbSqlite] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.dataset_id}'.`
           )
         }
-        if (!input.output && (existing.mode !== "append" || input.rowsRead !== 0)) {
+        if (!input.output && input.rowsRead !== 0) {
           throw new SyncRunError(
-            `[SixbSqlite] Sync run '${input.id}' may omit its output only for an empty append.`
+            `[SixbSqlite] Sync run '${input.id}' may omit its output only when no rows were read.`
           )
         }
       }

--- a/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
@@ -87,6 +87,21 @@ describe("SqliteSyncRunStorage", () => {
     })
     expect(emptyFinished.output).toBeUndefined()
     expect(emptyFinished.checkpoint).toEqual({ cursor: "cursor-empty" })
+
+    await storage.start({
+      id: "run-empty-snapshot",
+      projectId: "my-app",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "snapshot",
+    })
+    const emptySnapshotFinished = await storage.finish({
+      id: "run-empty-snapshot",
+      projectId: "my-app",
+      status: "succeeded",
+      rowsRead: 0,
+    })
+    expect(emptySnapshotFinished.output).toBeUndefined()
   })
 
   test("stores failures and supports filtered paging", async () => {


### PR DESCRIPTION
## Problem

A sync returning no rows on its first snapshot failed because DuckLake had neither changes to commit nor a previous dataset version.

```text
Before: first empty snapshot → no version → run failed
After:  first empty snapshot → no version → run succeeded
```

## Change

| Case | Behavior |
| --- | --- |
| First empty snapshot | Succeeds without a dataset version or dataset event |
| Empty snapshot after existing data | Commits an empty version to withdraw stale rows |
| Empty append | Keeps the existing behavior |

Sync-run storage, worker events, SQLite, PostgreSQL, tests, and documentation now share this contract.

## Checks

- Typecheck and Biome
- Build and publish smoke test
- Sync-worker, core, SQLite, and PostgreSQL tests
