### PR TITLE
core: add error model foundation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -914,6 +914,9 @@
       },
     },
   },
+  "overrides": {
+    "@types/bun": "1.3.14",
+  },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.4", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.1", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-xO0e9duft/uZlnDaIeBZmzTMjfdEz1kkDzWnhQNkJZZljsKWVi6IREZW9nAa+Dx6jYJssyxSUggaFYBAV1WZpw=="],
 
@@ -2556,10 +2559,6 @@
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.6", "", { "dependencies": { "@radix-ui/react-slot": "1.3.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
-
-    "@sixb/docs/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
-
-    "@sixb/example-roku-tv/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 
     "@sixb/ui/recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
 

--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -1,0 +1,11 @@
+# Runtime error codes
+
+Sixb failures carry a stable `code` for programmatic decisions and a message for humans. Code can
+branch on `failure.code`; it must never parse `failure.message`.
+
+The catalog starts deliberately small and grows with each primitive's vertical migration. Unknown
+legacy exceptions use `internal.unexpected` until their call site receives a specific code.
+
+| Code | Retryable | What happened | What to do |
+| --- | --- | --- | --- |
+| `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect the failure and its cause chain. Do not retry automatically. |

--- a/docs/runtime/overview.md
+++ b/docs/runtime/overview.md
@@ -204,6 +204,7 @@ export const sixb = createSixb({
 ## Related
 
 - [Failed run notifications](error-handling.md) — route terminal run failures to project code
+- [Runtime error codes](error-codes.md) — branch on stable failure identities
 - [Project structure](../fundamentals/project-structure.md) — folder layout and discovery
 - [Objects](../objects/overview.md) — the typed `sixb.objects(Type)` surface
 - [Events](../events/overview.md) — domain events and `sixb.events`

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "ui:dev": "bun --filter @sixb/ui dev",
     "ui:add": "bun --filter @sixb/ui shadcn:add"
   },
+  "overrides": {
+    "@types/bun": "1.3.14"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.4.6",
     "@types/bun": "latest",

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -1,0 +1,17 @@
+interface SixbErrorDefinition {
+  readonly publicMessage: string
+  readonly retryable: boolean
+}
+
+/**
+ * Source of truth for stable Sixb error codes and their framework-level policy.
+ *
+ * Keep this catalog internal. Consumers receive the `SixbErrorCode` union and persisted
+ * `SixbFailure` values, not a mutable registry.
+ */
+export const SIXB_ERROR_DEFINITIONS = {
+  "internal.unexpected": {
+    publicMessage: "An unexpected internal error occurred.",
+    retryable: false,
+  },
+} as const satisfies Readonly<Record<string, SixbErrorDefinition>>

--- a/packages/core/src/errors/internal.ts
+++ b/packages/core/src/errors/internal.ts
@@ -1,0 +1,222 @@
+import { cloneJsonValue, type ReadonlyJsonValue } from "../json"
+import { SIXB_ERROR_DEFINITIONS } from "./catalog"
+import type { SixbErrorCode, SixbFailure } from "./types"
+
+export const SIXB_FAILURE_MAX_MESSAGE_BYTES = 4 * 1024
+export const SIXB_FAILURE_MAX_SERIALIZED_BYTES = 32 * 1024
+const TRUNCATION_SUFFIX = "… [truncated]"
+
+type SixbErrorCodeTuple = readonly [SixbErrorCode, ...SixbErrorCode[]]
+
+export interface SixbErrorOptions {
+  readonly cause?: unknown
+  readonly details?: ReadonlyJsonValue
+}
+
+/** Internal structural view returned by the factory. The implementing class stays private. */
+export interface SixbCodedError extends Error {
+  readonly code: SixbErrorCode
+  readonly retryable: boolean
+  readonly details?: ReadonlyJsonValue
+  readonly cause?: unknown
+}
+
+export interface ToSixbFailureOptions {
+  /** Timestamp for deterministic persistence. Defaults to the current time. */
+  readonly at?: Date
+}
+
+export interface ToScopedSixbFailureOptions<TCodes extends SixbErrorCodeTuple>
+  extends ToSixbFailureOptions {
+  /** Codes this boundary is allowed to expose. */
+  readonly allowedCodes: TCodes
+}
+
+export interface CaptureSixbFailureOptions<TCodes extends SixbErrorCodeTuple>
+  extends ToScopedSixbFailureOptions<TCodes> {
+  /** Code assigned when the captured value is uncoded or outside this boundary's contract. */
+  readonly defaultCode: TCodes[number]
+  /** Context attached only to the boundary error created for such a captured value. */
+  readonly details?: ReadonlyJsonValue
+}
+
+/**
+ * The canonical exception used inside Sixb.
+ *
+ * The class is deliberately not exported: repo-internal callers use the factory and consumers only
+ * ever observe serializable `SixbFailure` values.
+ */
+class SixbError extends Error implements SixbCodedError {
+  override readonly name = "SixbError"
+  readonly retryable: boolean
+  readonly details?: ReadonlyJsonValue
+
+  constructor(
+    readonly code: SixbErrorCode,
+    message: string,
+    options: SixbErrorOptions = {}
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause })
+    this.retryable = SIXB_ERROR_DEFINITIONS[code].retryable
+    if (options.details !== undefined) {
+      this.details = cloneJsonValue(options.details, "Sixb error details")
+    }
+  }
+}
+
+/** Creates a coded internal error without exposing its runtime class. */
+export function createSixbError(
+  code: SixbErrorCode,
+  message: string,
+  options: SixbErrorOptions = {}
+): SixbCodedError {
+  return new SixbError(code, message, options)
+}
+
+/**
+ * Captures an unknown terminal error as a scoped durable failure.
+ *
+ * An already-coded error is preserved only when its code belongs to this boundary. Every other
+ * value is wrapped once with the boundary's default code and context before serialization.
+ */
+export function captureSixbFailure<const TCodes extends SixbErrorCodeTuple>(
+  error: unknown,
+  options: CaptureSixbFailureOptions<TCodes>
+): SixbFailure<TCodes[number]> {
+  const allowedCodes = new Set<SixbErrorCode>(options.allowedCodes)
+  const codedError =
+    isSixbError(error) && allowedCodes.has(error.code)
+      ? error
+      : createSixbError(options.defaultCode, summarizeErrorMessage(error), {
+          cause: error,
+          ...(options.details === undefined ? {} : { details: options.details }),
+        })
+
+  return toSixbFailure(codedError, {
+    allowedCodes: options.allowedCodes,
+    ...(options.at === undefined ? {} : { at: options.at }),
+  })
+}
+
+/** Identifies errors created by Sixb without making their class part of the contract. */
+export function isSixbError(error: unknown): error is SixbCodedError {
+  return error instanceof SixbError
+}
+
+/**
+ * Takes a detached, serializable snapshot of a coded internal error.
+ *
+ * Use `captureSixbFailure()` instead when a terminal boundary receives an unknown thrown value.
+ */
+export function toSixbFailure<const TCodes extends SixbErrorCodeTuple>(
+  error: SixbCodedError,
+  options: ToScopedSixbFailureOptions<TCodes>
+): SixbFailure<TCodes[number]>
+export function toSixbFailure(error: SixbCodedError, options?: ToSixbFailureOptions): SixbFailure
+export function toSixbFailure(
+  error: SixbCodedError,
+  options: ToSixbFailureOptions | ToScopedSixbFailureOptions<SixbErrorCodeTuple> = {}
+): SixbFailure {
+  if (!isSixbError(error)) {
+    throw new Error("[Sixb] A durable failure can only be created from a coded Sixb error.")
+  }
+  const allowedCodes = "allowedCodes" in options ? new Set(options.allowedCodes) : undefined
+  if (allowedCodes && !allowedCodes.has(error.code)) {
+    throw new Error(`[Sixb] Error code '${error.code}' is not allowed by this failure contract.`)
+  }
+
+  const message = truncateUtf8(
+    SIXB_ERROR_DEFINITIONS[error.code].publicMessage,
+    SIXB_FAILURE_MAX_MESSAGE_BYTES
+  )
+  const failure: SixbFailure = {
+    code: error.code,
+    message: message.value,
+    retryable: SIXB_ERROR_DEFINITIONS[error.code].retryable,
+    at: failureTimestamp(options.at),
+    ...(error.details === undefined
+      ? {}
+      : { details: cloneJsonValue(error.details, "Sixb failure details") }),
+    ...(message.truncated ? { truncated: true } : {}),
+  }
+
+  if (serializedByteLength(failure) <= SIXB_FAILURE_MAX_SERIALIZED_BYTES) return failure
+
+  return {
+    code: failure.code,
+    message: failure.message,
+    retryable: failure.retryable,
+    at: failure.at,
+    truncated: true,
+  }
+}
+
+/**
+ * Extracts a diagnostic message for an internal error or log entry.
+ *
+ * The result can contain provider data and must not be persisted or returned by an API.
+ * `toSixbFailure()` selects the catalog-owned public message instead.
+ */
+export function summarizeErrorMessage(value: unknown, fallback?: string): string {
+  const message = readStringProperty(value, "message")
+  if (message !== undefined) return message
+  if (typeof value === "string") return value
+  return fallback ?? safeString(value)
+}
+
+function readStringProperty(value: unknown, property: "message"): string | undefined {
+  if (!isObjectLike(value)) return undefined
+  try {
+    const result = Reflect.get(value, property)
+    return typeof result === "string" ? result : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isObjectLike(value: unknown): value is object {
+  return (typeof value === "object" && value !== null) || typeof value === "function"
+}
+
+function safeString(value: unknown): string {
+  try {
+    return String(value)
+  } catch {
+    return "Unknown thrown value"
+  }
+}
+
+function failureTimestamp(at: Date | undefined): string {
+  const timestamp = at ?? new Date()
+  if (!Number.isFinite(timestamp.getTime())) {
+    throw new Error("[Sixb] Failure timestamp must be a valid Date.")
+  }
+  return timestamp.toISOString()
+}
+
+function serializedByteLength(value: SixbFailure): number {
+  return utf8ByteLength(JSON.stringify(value))
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength
+}
+
+function truncateUtf8(value: string, maxBytes: number): { value: string; truncated: boolean } {
+  if (utf8ByteLength(value) <= maxBytes) return { value, truncated: false }
+
+  const suffixBytes = utf8ByteLength(TRUNCATION_SUFFIX)
+  const characters = Array.from(value)
+  let low = 0
+  let high = characters.length
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2)
+    if (utf8ByteLength(characters.slice(0, middle).join("")) + suffixBytes <= maxBytes) {
+      low = middle
+    } else {
+      high = middle - 1
+    }
+  }
+
+  return { value: `${characters.slice(0, low).join("")}${TRUNCATION_SUFFIX}`, truncated: true }
+}

--- a/packages/core/src/errors/types.ts
+++ b/packages/core/src/errors/types.ts
@@ -1,0 +1,21 @@
+import type { ReadonlyJsonValue } from "../json"
+import type { SIXB_ERROR_DEFINITIONS } from "./catalog"
+
+/** Stable machine-readable identity for a Sixb failure. */
+export type SixbErrorCode = keyof typeof SIXB_ERROR_DEFINITIONS
+
+/**
+ * Serializable snapshot of a failure at the point where Sixb records it.
+ *
+ * Unlike the internal error object, this value can cross storage, HTTP, and process boundaries.
+ */
+export interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
+  readonly code: TCode
+  readonly message: string
+  readonly retryable: boolean
+  /** ISO-8601 UTC timestamp of the failure occurrence. */
+  readonly at: string
+  readonly details?: ReadonlyJsonValue
+  /** Present when optional context exceeded the durable failure size budget and was omitted. */
+  readonly truncated?: true
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -816,6 +816,7 @@ export type {
   SixbRuleEvaluationFailedContext,
   SixbRunFailedContext,
 } from "./error-reporting/types"
+export type { SixbErrorCode, SixbFailure } from "./errors/types"
 export type { EventsRuntime } from "./events/execution"
 export type { LogsRuntime } from "./logging/execution"
 export type {

--- a/packages/core/tests/error-model.test.ts
+++ b/packages/core/tests/error-model.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import * as publicCore from "../src"
+import { SIXB_ERROR_DEFINITIONS } from "../src/errors/catalog"
+import * as internalErrorModel from "../src/errors/internal"
+import {
+  captureSixbFailure,
+  createSixbError,
+  isSixbError,
+  SIXB_FAILURE_MAX_SERIALIZED_BYTES,
+  summarizeErrorMessage,
+  toSixbFailure,
+} from "../src/errors/internal"
+
+const AT = new Date("2026-08-05T12:00:00.000Z")
+
+describe("Sixb error model", () => {
+  test("keeps the error class private while exposing serializable contracts", () => {
+    expect(publicCore).not.toHaveProperty("SixbError")
+    expect(internalErrorModel).not.toHaveProperty("SixbError")
+  })
+
+  test("creates a coded internal error from catalog policy", () => {
+    const cause = new Error("provider offline")
+    const details = { operation: "commit", nested: { attempt: 2 } }
+    const error = createSixbError("internal.unexpected", "Commit failed", {
+      cause,
+      details,
+    })
+
+    details.nested.attempt = 3
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.name).toBe("SixbError")
+    expect(error.code).toBe("internal.unexpected")
+    expect(error.retryable).toBe(false)
+    expect(error.cause).toBe(cause)
+    expect(error.details).toEqual({ operation: "commit", nested: { attempt: 2 } })
+    expect(isSixbError(error)).toBe(true)
+    expect(isSixbError(new Error("ordinary"))).toBe(false)
+  })
+
+  test("serializes a bounded public failure without exposing native causes", () => {
+    const rootCause = new TypeError("socket closed")
+    const providerError = new Error("provider offline", { cause: rootCause })
+    const error = createSixbError("internal.unexpected", "Commit failed", {
+      cause: providerError,
+      details: { operation: "commit" },
+    })
+
+    expect(toSixbFailure(error, { at: AT })).toEqual({
+      code: "internal.unexpected",
+      message: "An unexpected internal error occurred.",
+      retryable: false,
+      at: "2026-08-05T12:00:00.000Z",
+      details: { operation: "commit" },
+    })
+    expect(error.cause).toBe(providerError)
+  })
+
+  test("captures arbitrary thrown values without exposing diagnostic data", () => {
+    const crossRealmLike = {
+      name: "ProviderError",
+      message: "offline",
+      cause: "connection refused",
+    }
+
+    expect(
+      captureSixbFailure(crossRealmLike, {
+        allowedCodes: ["internal.unexpected"],
+        defaultCode: "internal.unexpected",
+        at: AT,
+        details: { provider: "example" },
+      })
+    ).toEqual({
+      code: "internal.unexpected",
+      message: "An unexpected internal error occurred.",
+      retryable: false,
+      at: "2026-08-05T12:00:00.000Z",
+      details: { provider: "example" },
+    })
+    expect(summarizeErrorMessage(crossRealmLike, "fallback")).toBe("offline")
+    expect(summarizeErrorMessage({ reason: "offline" }, "fallback")).toBe("fallback")
+
+    expect(() =>
+      // @ts-expect-error Unknown values must go through captureSixbFailure.
+      toSixbFailure(new Error("uncoded"))
+    ).toThrow("A durable failure can only be created from a coded Sixb error")
+  })
+
+  test("bounds durable records and rejects non-serializable details", () => {
+    expect(() =>
+      createSixbError("internal.unexpected", "Invalid details", {
+        details: { invalid: undefined } as never,
+      })
+    ).toThrow("Sixb error details.invalid is undefined")
+
+    expect(() =>
+      toSixbFailure(createSixbError("internal.unexpected", "boom"), {
+        at: new Date(Number.NaN),
+      })
+    ).toThrow("[Sixb] Failure timestamp must be a valid Date.")
+
+    const oversized = toSixbFailure(
+      createSixbError("internal.unexpected", "Provider failed", {
+        cause: new Error("provider secret"),
+        details: { payload: "x".repeat(SIXB_FAILURE_MAX_SERIALIZED_BYTES) },
+      }),
+      { at: AT }
+    )
+    expect(oversized).toEqual({
+      code: "internal.unexpected",
+      message: "An unexpected internal error occurred.",
+      retryable: false,
+      at: AT.toISOString(),
+      truncated: true,
+    })
+    expect(JSON.stringify(oversized)).not.toContain("provider secret")
+  })
+
+  test("documents every catalog code exactly once", async () => {
+    const documentation = await readFile(
+      resolve(import.meta.dir, "../../../docs/runtime/error-codes.md"),
+      "utf8"
+    )
+    const documentedCodes = [...documentation.matchAll(/^\| `([^`]+)` \|/gm)].map(
+      ([, code]) => code
+    )
+
+    expect(documentedCodes.sort()).toEqual(Object.keys(SIXB_ERROR_DEFINITIONS).sort())
+  })
+})


### PR DESCRIPTION
## Summary

- add the internal coded error model without exporting its runtime class
- expose the serializable SixbErrorCode and SixbFailure contracts
- preserve JSON details and bounded causal chains when creating failure snapshots
- document the initial code catalog and enforce documentation coverage with tests

## Scope

This is the foundation slice only. It does not change runtime behavior, onError, persistence, HTTP mapping, or retry policy.

## Validation

- bun test packages/core/tests/error-model.test.ts
- bun --filter @sixb/core test
- bun run typecheck
- bun run check
- bun run test:publish
- bun --filter @sixb/core test:e2e

Refs #274