### PR TITLE
github: add people APIs

### DIFF
--- a/connectors/github/README.md
+++ b/connectors/github/README.md
@@ -4,6 +4,7 @@ A small GitHub connector for Sixb, built on `@sixb/connector-rest`.
 
 - **Repositories** — list authenticated-user/org repositories, get a repository
 - **Issues** — list authenticated-user/org/repository issues, get/create/update repository issues
+- **People** — query users, organization members, memberships, outside collaborators, and invitations
 - **Webhooks** — receive GitHub events through one inbound route
 
 ## Register
@@ -29,7 +30,10 @@ export const githubConnector = defineConnector(
 | `webhookSecret` | Secret used to verify inbound webhooks. See [Webhooks](#webhooks).       |
 | `onEvent`       | Handler for inbound webhook events. See [Webhooks](#webhooks).           |
 
-**Token permissions** (fine-grained PAT): `Metadata: read` and `Issues: read & write`.
+**Token permissions** (fine-grained PAT): `Metadata: read` and `Issues: read & write` for
+repository and issue APIs. Organization people APIs require `Members: read`. Public user profiles
+and public organization membership can be queried without that organization permission, but private
+membership visibility depends on the authenticated user's organization access.
 
 ## Client API
 
@@ -55,6 +59,19 @@ The client is scoped by GitHub resource:
 | `gh.repo({ owner, repo }).issues.comments.delete()` | `DELETE /repos/{owner}/{repo}/issues/comments/{id}` |
 | `gh.org(org).repos.list()`               | `GET /orgs/{org}/repos`                       |
 | `gh.org(org).issues.listForAuthenticatedUser()` | `GET /orgs/{org}/issues`              |
+| `gh.users.getAuthenticated()`             | `GET /user`                                      |
+| `gh.users.get(username)`                  | `GET /users/{username}`                          |
+| `gh.users.getById(accountId)`             | `GET /user/{account_id}`                         |
+| `gh.users.list()`                         | `GET /users`                                     |
+| `gh.memberships.list()`                   | `GET /user/memberships/orgs`                     |
+| `gh.memberships.get(org)`                 | `GET /user/memberships/orgs/{org}`               |
+| `gh.org(org).members.list()`              | `GET /orgs/{org}/members`                        |
+| `gh.org(org).members.listPublic()`        | `GET /orgs/{org}/public_members`                 |
+| `gh.org(org).members.check(username)`     | `GET /orgs/{org}/members/{username}`             |
+| `gh.org(org).members.checkPublic(username)` | `GET /orgs/{org}/public_members/{username}`    |
+| `gh.org(org).members.getMembership(username)` | `GET /orgs/{org}/memberships/{username}`     |
+| `gh.org(org).outsideCollaborators.list()` | `GET /orgs/{org}/outside_collaborators`          |
+| `gh.org(org).invitations.list()`          | `GET /orgs/{org}/invitations`                    |
 
 ```ts
 const userRepos = await gh.repos.listForAuthenticatedUser({
@@ -68,6 +85,10 @@ const orgRepos = await gh.org("acme").repos.list({
   type: "sources",
   pageSize: 100,
 })
+
+const members = await gh.org("acme").members.list({ role: "member", pageSize: 100 })
+const profile = await gh.users.get(members.items[0]!.login)
+const membership = await gh.org("acme").members.getMembership(profile.login)
 
 const repo = gh.repo({ owner: "acme", repo: "web" })
 const issue = await repo.issues.create({ title: "Bug", labels: ["triage"] })

--- a/connectors/github/package.json
+++ b/connectors/github/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sixb/connector-github",
   "version": "0.1.0",
-  "description": "GitHub connector for Sixb — repositories, issues, and issue webhooks",
+  "description": "GitHub connector for Sixb — repositories, issues, people, and webhooks",
   "keywords": [
     "sixb",
     "bun",

--- a/connectors/github/src/client.ts
+++ b/connectors/github/src/client.ts
@@ -5,10 +5,17 @@ import {
   createRepositoryIssuesApi,
 } from "./resources/issues"
 import {
+  createAuthenticatedUserOrganizationMembershipsApi,
+  createOrganizationInvitationsApi,
+  createOrganizationMembersApi,
+  createOrganizationOutsideCollaboratorsApi,
+} from "./resources/members"
+import {
   createAuthenticatedUserRepositoriesApi,
   createOrganizationRepositoriesApi,
   createRepositoryApi,
 } from "./resources/repos"
+import { createGitHubUsersApi } from "./resources/users"
 import type { GitHubClient } from "./types/client"
 
 export function createGitHubClient(http: RestClient, apiBaseUrl: URL): GitHubClient {
@@ -16,6 +23,8 @@ export function createGitHubClient(http: RestClient, apiBaseUrl: URL): GitHubCli
   return {
     repos: createAuthenticatedUserRepositoriesApi(context),
     issues: createAuthenticatedUserIssuesApi(context),
+    users: createGitHubUsersApi(context),
+    memberships: createAuthenticatedUserOrganizationMembershipsApi(context),
     repo: (target) => ({
       ...createRepositoryApi(context, target),
       issues: createRepositoryIssuesApi(context, target),
@@ -23,6 +32,9 @@ export function createGitHubClient(http: RestClient, apiBaseUrl: URL): GitHubCli
     org: (org) => ({
       repos: createOrganizationRepositoriesApi(context, org),
       issues: createOrganizationIssuesApi(context, org),
+      members: createOrganizationMembersApi(context, org),
+      outsideCollaborators: createOrganizationOutsideCollaboratorsApi(context, org),
+      invitations: createOrganizationInvitationsApi(context, org),
     }),
   }
 }

--- a/connectors/github/src/http.ts
+++ b/connectors/github/src/http.ts
@@ -43,6 +43,13 @@ export async function readNoContent(response: Response): Promise<void> {
   }
 }
 
+/** Read GitHub's 204/404 membership-check response as a boolean. */
+export async function readPresence(response: Response): Promise<boolean> {
+  if (response.status === 204) return true
+  if (response.status === 404) return false
+  throw new GitHubApiError(response.status, await response.text().catch(() => ""))
+}
+
 export async function readPage<T>(response: Response, apiBaseUrl: URL): Promise<GitHubPage<T>> {
   const items = await readJson<T[]>(response)
   const links = parseLinkHeader(response.headers.get("link"))

--- a/connectors/github/src/resources/members.ts
+++ b/connectors/github/src/resources/members.ts
@@ -1,0 +1,134 @@
+import type { GitHubHttpContext } from "../http"
+import {
+  applyPaging,
+  pathPart,
+  readJson,
+  readPage,
+  readPresence,
+  resolvePagePath,
+  withQuery,
+} from "../http"
+import type { GitHubPage, GitHubUser } from "../types/common"
+import type {
+  AuthenticatedUserOrganizationMembershipsApi,
+  GitHubOrganizationInvitation,
+  GitHubOrganizationMembership,
+  ListAuthenticatedUserOrganizationMembershipsOptions,
+  ListOrganizationInvitationsOptions,
+  ListOrganizationMembersOptions,
+  ListOutsideCollaboratorsOptions,
+  OrganizationInvitationsApi,
+  OrganizationMembersApi,
+  OrganizationOutsideCollaboratorsApi,
+} from "../types/members"
+
+export function createAuthenticatedUserOrganizationMembershipsApi(
+  context: GitHubHttpContext
+): AuthenticatedUserOrganizationMembershipsApi {
+  return {
+    async list(
+      options?: ListAuthenticatedUserOrganizationMembershipsOptions
+    ): Promise<GitHubPage<GitHubOrganizationMembership>> {
+      const params = new URLSearchParams()
+      applyPaging(params, options)
+      if (options?.state) params.set("state", options.state)
+      const path = withQuery("/user/memberships/orgs", params)
+      return readPage<GitHubOrganizationMembership>(
+        await context.http.get(resolvePagePath(path, options)),
+        context.apiBaseUrl
+      )
+    },
+
+    async get(org: string): Promise<GitHubOrganizationMembership> {
+      return readJson<GitHubOrganizationMembership>(
+        await context.http.get(`/user/memberships/orgs/${pathPart(org, "org")}`)
+      )
+    },
+  }
+}
+
+export function createOrganizationMembersApi(
+  context: GitHubHttpContext,
+  org: string
+): OrganizationMembersApi {
+  const orgPath = `/orgs/${pathPart(org, "org")}`
+  return {
+    async list(options?: ListOrganizationMembersOptions): Promise<GitHubPage<GitHubUser>> {
+      const params = new URLSearchParams()
+      applyPaging(params, options)
+      if (options?.filter) params.set("filter", options.filter)
+      if (options?.role) params.set("role", options.role)
+      return readUserPage(context, withQuery(`${orgPath}/members`, params), options)
+    },
+
+    async listPublic(options): Promise<GitHubPage<GitHubUser>> {
+      const params = new URLSearchParams()
+      applyPaging(params, options)
+      return readUserPage(context, withQuery(`${orgPath}/public_members`, params), options)
+    },
+
+    async check(username: string): Promise<boolean> {
+      return readPresence(
+        await context.http.get(`${orgPath}/members/${pathPart(username, "username")}`)
+      )
+    },
+
+    async checkPublic(username: string): Promise<boolean> {
+      return readPresence(
+        await context.http.get(`${orgPath}/public_members/${pathPart(username, "username")}`)
+      )
+    },
+
+    async getMembership(username: string): Promise<GitHubOrganizationMembership> {
+      return readJson<GitHubOrganizationMembership>(
+        await context.http.get(`${orgPath}/memberships/${pathPart(username, "username")}`)
+      )
+    },
+  }
+}
+
+export function createOrganizationOutsideCollaboratorsApi(
+  context: GitHubHttpContext,
+  org: string
+): OrganizationOutsideCollaboratorsApi {
+  const path = `/orgs/${pathPart(org, "org")}/outside_collaborators`
+  return {
+    async list(options?: ListOutsideCollaboratorsOptions): Promise<GitHubPage<GitHubUser>> {
+      const params = new URLSearchParams()
+      applyPaging(params, options)
+      if (options?.filter) params.set("filter", options.filter)
+      return readUserPage(context, withQuery(path, params), options)
+    },
+  }
+}
+
+export function createOrganizationInvitationsApi(
+  context: GitHubHttpContext,
+  org: string
+): OrganizationInvitationsApi {
+  const path = `/orgs/${pathPart(org, "org")}/invitations`
+  return {
+    async list(
+      options?: ListOrganizationInvitationsOptions
+    ): Promise<GitHubPage<GitHubOrganizationInvitation>> {
+      const params = new URLSearchParams()
+      applyPaging(params, options)
+      if (options?.role) params.set("role", options.role)
+      if (options?.invitationSource) params.set("invitation_source", options.invitationSource)
+      return readPage<GitHubOrganizationInvitation>(
+        await context.http.get(resolvePagePath(withQuery(path, params), options)),
+        context.apiBaseUrl
+      )
+    },
+  }
+}
+
+function readUserPage(
+  context: GitHubHttpContext,
+  path: string,
+  options?: { readonly pageToken?: string }
+): Promise<GitHubPage<GitHubUser>> {
+  return context.http
+    .get(resolvePagePath(path, options))
+    .then((response) => readPage<GitHubUser>(response, context.apiBaseUrl))
+}

--- a/connectors/github/src/resources/users.ts
+++ b/connectors/github/src/resources/users.ts
@@ -1,0 +1,50 @@
+import type { GitHubHttpContext } from "../http"
+import {
+  applyPaging,
+  pathId,
+  pathPart,
+  readJson,
+  readPage,
+  resolvePagePath,
+  withQuery,
+} from "../http"
+import type { GitHubUser } from "../types/common"
+import type { GitHubUserProfile, GitHubUsersApi, ListUsersOptions } from "../types/users"
+
+export function createGitHubUsersApi(context: GitHubHttpContext): GitHubUsersApi {
+  return {
+    async getAuthenticated(): Promise<GitHubUserProfile> {
+      return readJson<GitHubUserProfile>(await context.http.get("/user"))
+    },
+
+    async get(username: string): Promise<GitHubUserProfile> {
+      return readJson<GitHubUserProfile>(
+        await context.http.get(`/users/${pathPart(username, "username")}`)
+      )
+    },
+
+    async getById(accountId: number): Promise<GitHubUserProfile> {
+      return readJson<GitHubUserProfile>(
+        await context.http.get(`/user/${pathId(accountId, "accountId")}`)
+      )
+    },
+
+    async list(options?: ListUsersOptions) {
+      const params = new URLSearchParams()
+      applyPaging(params, options)
+      if (options?.since !== undefined) params.set("since", String(assertSince(options.since)))
+      const path = withQuery("/users", params)
+      return readPage<GitHubUser>(
+        await context.http.get(resolvePagePath(path, options)),
+        context.apiBaseUrl
+      )
+    },
+  }
+}
+
+function assertSince(since: number): number {
+  if (!Number.isSafeInteger(since) || since < 0) {
+    throw new Error("[SixbGitHub] since must be a non-negative safe integer.")
+  }
+  return since
+}

--- a/connectors/github/src/types/client.ts
+++ b/connectors/github/src/types/client.ts
@@ -5,14 +5,23 @@ import type {
   RepositoryIssuesApi,
 } from "./issues"
 import type {
+  AuthenticatedUserOrganizationMembershipsApi,
+  OrganizationInvitationsApi,
+  OrganizationMembersApi,
+  OrganizationOutsideCollaboratorsApi,
+} from "./members"
+import type {
   AuthenticatedUserRepositoriesApi,
   GitHubRepository,
   OrganizationRepositoriesApi,
 } from "./repos"
+import type { GitHubUsersApi } from "./users"
 
 export interface GitHubClient {
   readonly repos: AuthenticatedUserRepositoriesApi
   readonly issues: AuthenticatedUserIssuesApi
+  readonly users: GitHubUsersApi
+  readonly memberships: AuthenticatedUserOrganizationMembershipsApi
   repo(target: GitHubRepositoryTarget): GitHubRepositoryScope
   org(org: string): GitHubOrganizationScope
 }
@@ -25,4 +34,7 @@ export interface GitHubRepositoryScope {
 export interface GitHubOrganizationScope {
   readonly repos: OrganizationRepositoriesApi
   readonly issues: OrganizationIssuesApi
+  readonly members: OrganizationMembersApi
+  readonly outsideCollaborators: OrganizationOutsideCollaboratorsApi
+  readonly invitations: OrganizationInvitationsApi
 }

--- a/connectors/github/src/types/common.ts
+++ b/connectors/github/src/types/common.ts
@@ -17,11 +17,29 @@ export interface GitHubPage<T> {
   readonly previousPageToken?: string
 }
 
+/** GitHub's `simple-user` representation embedded in lists and other resources. */
 export interface GitHubUser {
+  /** Included by a few user endpoints in addition to the normal simple-user fields. */
+  readonly name?: string | null
+  readonly email?: string | null
   readonly login: string
   readonly id: number
   readonly node_id: string
-  readonly type: string
-  readonly html_url: string
+  readonly avatar_url: string
+  readonly gravatar_id: string | null
   readonly url: string
+  readonly html_url: string
+  readonly followers_url: string
+  readonly following_url: string
+  readonly gists_url: string
+  readonly starred_url: string
+  readonly subscriptions_url: string
+  readonly organizations_url: string
+  readonly repos_url: string
+  readonly events_url: string
+  readonly received_events_url: string
+  readonly type: string
+  readonly site_admin: boolean
+  readonly starred_at?: string
+  readonly user_view_type?: string
 }

--- a/connectors/github/src/types/index.ts
+++ b/connectors/github/src/types/index.ts
@@ -31,6 +31,25 @@ export type {
   RepositoryIssuesApi,
   UpdateIssueInput,
 } from "./issues"
+export type {
+  AuthenticatedUserOrganizationMembershipsApi,
+  GitHubOrganizationInvitation,
+  GitHubOrganizationInvitationRole,
+  GitHubOrganizationInvitationSource,
+  GitHubOrganizationMemberFilter,
+  GitHubOrganizationMemberRole,
+  GitHubOrganizationMembership,
+  GitHubOrganizationMembershipRole,
+  GitHubOrganizationMembershipState,
+  GitHubOrganizationSummary,
+  ListAuthenticatedUserOrganizationMembershipsOptions,
+  ListOrganizationInvitationsOptions,
+  ListOrganizationMembersOptions,
+  ListOutsideCollaboratorsOptions,
+  OrganizationInvitationsApi,
+  OrganizationMembersApi,
+  OrganizationOutsideCollaboratorsApi,
+} from "./members"
 export type { GitHubConnectorOptions } from "./options"
 export type {
   AuthenticatedUserRepositoriesApi,
@@ -47,6 +66,12 @@ export type {
   OrganizationRepositoriesApi,
   RepositoryApi,
 } from "./repos"
+export type {
+  GitHubUserPlan,
+  GitHubUserProfile,
+  GitHubUsersApi,
+  ListUsersOptions,
+} from "./users"
 export type {
   GitHubEventContext,
   GitHubEventHandler,

--- a/connectors/github/src/types/members.ts
+++ b/connectors/github/src/types/members.ts
@@ -1,0 +1,110 @@
+import type { GitHubPage, GitHubPaginationOptions, GitHubUser } from "./common"
+
+export type GitHubOrganizationMemberFilter = "all" | "2fa_disabled" | "2fa_insecure"
+export type GitHubOrganizationMemberRole = "all" | "admin" | "member"
+export type GitHubOrganizationMembershipRole = "admin" | "member" | "billing_manager"
+export type GitHubOrganizationMembershipState = "active" | "pending"
+
+export interface ListOrganizationMembersOptions extends GitHubPaginationOptions {
+  readonly filter?: GitHubOrganizationMemberFilter
+  readonly role?: GitHubOrganizationMemberRole
+}
+
+export interface GitHubOrganizationSummary {
+  readonly login: string
+  readonly id: number
+  readonly node_id: string
+  readonly url: string
+  readonly repos_url: string
+  readonly events_url: string
+  readonly hooks_url: string
+  readonly issues_url: string
+  readonly members_url: string
+  readonly public_members_url: string
+  readonly avatar_url: string
+  readonly description: string | null
+}
+
+export interface GitHubOrganizationMembership {
+  readonly url: string
+  readonly state: GitHubOrganizationMembershipState
+  readonly role: GitHubOrganizationMembershipRole
+  readonly organization_url: string
+  readonly direct_membership?: boolean
+  readonly enterprise_teams_providing_indirect_membership?: readonly string[]
+  readonly permissions?: {
+    readonly can_create_repository: boolean
+  }
+  readonly organization: GitHubOrganizationSummary
+  readonly user: GitHubUser | null
+}
+
+export interface ListAuthenticatedUserOrganizationMembershipsOptions
+  extends GitHubPaginationOptions {
+  readonly state?: GitHubOrganizationMembershipState
+}
+
+export interface AuthenticatedUserOrganizationMembershipsApi {
+  /** List one page of organization memberships for the authenticated user. */
+  list(
+    options?: ListAuthenticatedUserOrganizationMembershipsOptions
+  ): Promise<GitHubPage<GitHubOrganizationMembership>>
+  /** Get the authenticated user's membership in an organization. */
+  get(org: string): Promise<GitHubOrganizationMembership>
+}
+
+export interface OrganizationMembersApi {
+  /** List one page of members. Private members are included when GitHub permits it. */
+  list(options?: ListOrganizationMembersOptions): Promise<GitHubPage<GitHubUser>>
+  /** List one page of members who have publicized their organization membership. */
+  listPublic(options?: GitHubPaginationOptions): Promise<GitHubPage<GitHubUser>>
+  /** Check public or private organization membership without turning a 404 into an error. */
+  check(username: string): Promise<boolean>
+  /** Check whether a user has publicized their organization membership. */
+  checkPublic(username: string): Promise<boolean>
+  /** Get a user's detailed organization membership. */
+  getMembership(username: string): Promise<GitHubOrganizationMembership>
+}
+
+export interface ListOutsideCollaboratorsOptions extends GitHubPaginationOptions {
+  readonly filter?: GitHubOrganizationMemberFilter
+}
+
+export interface OrganizationOutsideCollaboratorsApi {
+  /** List one page of users who collaborate on organization repositories without membership. */
+  list(options?: ListOutsideCollaboratorsOptions): Promise<GitHubPage<GitHubUser>>
+}
+
+export type GitHubOrganizationInvitationRole =
+  | "direct_member"
+  | "admin"
+  | "billing_manager"
+  | "hiring_manager"
+export type GitHubOrganizationInvitationSource = "member" | "scim"
+
+export interface ListOrganizationInvitationsOptions extends GitHubPaginationOptions {
+  readonly role?: "all" | GitHubOrganizationInvitationRole
+  readonly invitationSource?: "all" | GitHubOrganizationInvitationSource
+}
+
+export interface GitHubOrganizationInvitation {
+  readonly id: number
+  readonly login: string | null
+  readonly node_id: string
+  readonly email: string | null
+  readonly role: GitHubOrganizationInvitationRole
+  readonly created_at: string
+  readonly inviter: GitHubUser
+  readonly team_count: number
+  readonly invitation_teams_url: string
+  readonly invitation_source?: GitHubOrganizationInvitationSource
+  readonly failed_at?: string | null
+  readonly failed_reason?: string | null
+}
+
+export interface OrganizationInvitationsApi {
+  /** List one page of pending organization invitations. */
+  list(
+    options?: ListOrganizationInvitationsOptions
+  ): Promise<GitHubPage<GitHubOrganizationInvitation>>
+}

--- a/connectors/github/src/types/users.ts
+++ b/connectors/github/src/types/users.ts
@@ -1,0 +1,53 @@
+import type { GitHubPage, GitHubPaginationOptions, GitHubUser } from "./common"
+
+export interface ListUsersOptions extends GitHubPaginationOptions {
+  /** Only return users whose numeric ID is greater than this value. */
+  readonly since?: number
+}
+
+export interface GitHubUserPlan {
+  readonly name: string
+  readonly space: number
+  readonly private_repos: number
+  readonly collaborators: number
+}
+
+/** A full GitHub user profile returned by `GET /user` or `GET /users/{username}`. */
+export interface GitHubUserProfile extends GitHubUser {
+  readonly name: string | null
+  readonly company: string | null
+  readonly blog: string | null
+  readonly location: string | null
+  readonly email: string | null
+  readonly notification_email?: string | null
+  readonly hireable: boolean | null
+  readonly bio: string | null
+  readonly twitter_username?: string | null
+  readonly public_repos: number
+  readonly public_gists: number
+  readonly followers: number
+  readonly following: number
+  readonly created_at: string
+  readonly updated_at: string
+  /** Private fields are present only when the token can view them. */
+  readonly private_gists?: number
+  readonly total_private_repos?: number
+  readonly owned_private_repos?: number
+  readonly disk_usage?: number
+  readonly collaborators?: number
+  readonly two_factor_authentication?: boolean
+  readonly plan?: GitHubUserPlan
+  readonly business_plus?: boolean
+  readonly ldap_dn?: string
+}
+
+export interface GitHubUsersApi {
+  /** Get the authenticated user's profile, including private fields when GitHub returns them. */
+  getAuthenticated(): Promise<GitHubUserProfile>
+  /** Get a user by login. */
+  get(username: string): Promise<GitHubUserProfile>
+  /** Get a user by their durable numeric account ID. */
+  getById(accountId: number): Promise<GitHubUserProfile>
+  /** List one page of all GitHub users, ordered by signup ID. */
+  list(options?: ListUsersOptions): Promise<GitHubPage<GitHubUser>>
+}

--- a/connectors/github/tests/people.test.ts
+++ b/connectors/github/tests/people.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import type { GitHubOrganizationInvitation, GitHubUsersApi } from "../src"
+import { github } from "../src"
+
+type IsOptional<T, K extends keyof T> = object extends Pick<T, K> ? true : false
+
+const CONTEXT = {
+  projectId: "demo",
+  connectorId: "github",
+  signal: new AbortController().signal,
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as unknown as typeof fetch
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+describe("github people APIs", () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("response contracts keep conditionally returned fields optional", () => {
+    type AuthenticatedProfile = Awaited<ReturnType<GitHubUsersApi["getAuthenticated"]>>
+
+    // Type-check guard: making either field required turns its assertion into a compile error.
+    const privateGistsOptional = true satisfies IsOptional<AuthenticatedProfile, "private_gists">
+    const invitationSourceOptional = true satisfies IsOptional<
+      GitHubOrganizationInvitation,
+      "invitation_source"
+    >
+
+    expect(privateGistsOptional).toBe(true)
+    expect(invitationSourceOptional).toBe(true)
+  })
+
+  test("org().members.list maps member filters and pagination", async () => {
+    let requested = ""
+    mockFetch((input) => {
+      requested = String(input)
+      return Promise.resolve(json([{ login: "octocat", id: 1 }]))
+    })
+
+    const client = await github({ token: "t" }).connect(CONTEXT)
+    const page = await client.org("acme").members.list({
+      filter: "2fa_disabled",
+      role: "admin",
+      pageSize: 100,
+    })
+
+    const url = new URL(requested)
+    expect(url.pathname).toBe("/orgs/acme/members")
+    expect(url.searchParams.get("filter")).toBe("2fa_disabled")
+    expect(url.searchParams.get("role")).toBe("admin")
+    expect(url.searchParams.get("per_page")).toBe("100")
+    expect(page.items[0]?.login).toBe("octocat")
+  })
+
+  test("org member checks map GitHub's 204 and 404 responses to booleans", async () => {
+    mockFetch((input) => {
+      const pathname = new URL(String(input)).pathname
+      return Promise.resolve(
+        new Response(null, { status: pathname.endsWith("/octocat") ? 204 : 404 })
+      )
+    })
+
+    const members = (await github({ token: "t" }).connect(CONTEXT)).org("acme").members
+
+    expect(await members.check("octocat")).toBe(true)
+    expect(await members.check("hubot")).toBe(false)
+  })
+
+  test("org member APIs query public members and detailed membership", async () => {
+    const calls: string[] = []
+    mockFetch((input) => {
+      const url = String(input)
+      calls.push(url)
+      return Promise.resolve(
+        url.includes("/memberships/")
+          ? json({ state: "active", role: "member", user: { login: "octocat" } })
+          : json([{ login: "octocat", id: 1 }])
+      )
+    })
+
+    const members = (await github({ token: "t" }).connect(CONTEXT)).org("acme").members
+    await members.listPublic({ pageSize: 50 })
+    const membership = await members.getMembership("octocat")
+
+    expect(new URL(calls[0] ?? "").pathname).toBe("/orgs/acme/public_members")
+    expect(new URL(calls[0] ?? "").searchParams.get("per_page")).toBe("50")
+    expect(new URL(calls[1] ?? "").pathname).toBe("/orgs/acme/memberships/octocat")
+    expect(membership.state).toBe("active")
+  })
+
+  test("org people APIs query outside collaborators and pending invitations", async () => {
+    const calls: string[] = []
+    mockFetch((input) => {
+      calls.push(String(input))
+      return Promise.resolve(json([]))
+    })
+
+    const org = (await github({ token: "t" }).connect(CONTEXT)).org("acme")
+    await org.outsideCollaborators.list({ filter: "2fa_insecure", pageSize: 25 })
+    await org.invitations.list({
+      role: "direct_member",
+      invitationSource: "scim",
+      pageSize: 10,
+    })
+
+    const outside = new URL(calls[0] ?? "")
+    expect(outside.pathname).toBe("/orgs/acme/outside_collaborators")
+    expect(outside.searchParams.get("filter")).toBe("2fa_insecure")
+    expect(outside.searchParams.get("per_page")).toBe("25")
+
+    const invitations = new URL(calls[1] ?? "")
+    expect(invitations.pathname).toBe("/orgs/acme/invitations")
+    expect(invitations.searchParams.get("role")).toBe("direct_member")
+    expect(invitations.searchParams.get("invitation_source")).toBe("scim")
+    expect(invitations.searchParams.get("per_page")).toBe("10")
+  })
+
+  test("users API gets profiles by authentication, login, and durable ID", async () => {
+    const calls: string[] = []
+    mockFetch((input) => {
+      calls.push(String(input))
+      return Promise.resolve(json({ login: "octocat", id: 1 }))
+    })
+
+    const users = (await github({ token: "t" }).connect(CONTEXT)).users
+    await users.getAuthenticated()
+    await users.get("octo/cat")
+    await users.getById(42)
+    await users.list({ since: 10, pageSize: 20 })
+
+    expect(new URL(calls[0] ?? "").pathname).toBe("/user")
+    expect(new URL(calls[1] ?? "").pathname).toBe("/users/octo%2Fcat")
+    expect(new URL(calls[2] ?? "").pathname).toBe("/user/42")
+    expect(new URL(calls[3] ?? "").pathname).toBe("/users")
+    expect(new URL(calls[3] ?? "").searchParams.get("since")).toBe("10")
+    expect(new URL(calls[3] ?? "").searchParams.get("per_page")).toBe("20")
+  })
+
+  test("authenticated-user memberships can be listed and fetched", async () => {
+    const calls: string[] = []
+    mockFetch((input) => {
+      calls.push(String(input))
+      return Promise.resolve(calls.length === 1 ? json([]) : json({ state: "pending" }))
+    })
+
+    const memberships = (await github({ token: "t" }).connect(CONTEXT)).memberships
+    await memberships.list({ state: "pending", pageSize: 30 })
+    const membership = await memberships.get("acme")
+
+    const list = new URL(calls[0] ?? "")
+    expect(list.pathname).toBe("/user/memberships/orgs")
+    expect(list.searchParams.get("state")).toBe("pending")
+    expect(list.searchParams.get("per_page")).toBe("30")
+    expect(new URL(calls[1] ?? "").pathname).toBe("/user/memberships/orgs/acme")
+    expect(membership.state).toBe("pending")
+  })
+})


### PR DESCRIPTION
## What this adds

The GitHub connector already supports repositories, issues, and webhooks. This PR adds the people side of the GitHub API: user profiles, organization memberships, members, outside collaborators, and pending invitations.

The new APIs follow the connector's existing scoped client style:

```ts
const gh = await github({ token }).connect(context)

const me = await gh.users.getAuthenticated()
const octocat = await gh.users.get("octocat")
const users = await gh.users.list({ since: 1000, pageSize: 50 })

const memberships = await gh.memberships.list({ state: "active" })
const acmeMembership = await gh.memberships.get("acme")
```

Organization-specific operations live under `gh.org(org)`, beside the existing repository and issue APIs:

```ts
const acme = gh.org("acme")

const members = await acme.members.list({
  role: "member",
  pageSize: 100,
})

const publicMembers = await acme.members.listPublic()
const membership = await acme.members.getMembership("octocat")
const outsideCollaborators = await acme.outsideCollaborators.list()
const invitations = await acme.invitations.list({
  role: "direct_member",
  invitationSource: "scim",
})
```

## Membership checks

GitHub represents a successful membership check with `204 No Content` and a missing membership with `404 Not Found`. The connector turns those responses into booleans, while other error statuses still throw `GitHubApiError`.

```ts
const isMember = await acme.members.check("octocat")
const isPublicMember = await acme.members.checkPublic("octocat")

// true for GitHub 204
// false for GitHub 404
```

## Response contracts

The new public types model GitHub's wire responses and are exported from `@sixb/connector-github`.

Authenticated profile fields remain optional because GitHub omits private data when the token does not have permission to read it. Organization invitation responses may also omit `invitation_source`.

```ts
const profile = await gh.users.getAuthenticated()

profile.private_gists // number | undefined
profile.two_factor_authentication // boolean | undefined

const invitation = invitations.items[0]
invitation?.invitation_source // "member" | "scim" | undefined
```

This keeps the types sound for OAuth tokens and classic PATs without the `user` scope instead of promising fields that may be absent at runtime.

## Pagination and validation

Every new list operation uses the connector's existing `GitHubPage<T>` contract and Link-header page tokens. User IDs, usernames, organization names, filters, roles, and page options are mapped through the same validation and URL-encoding helpers as the existing resources.

```ts
const firstPage = await gh.users.list({ pageSize: 100 })

const secondPage = firstPage.nextPageToken
  ? await gh.users.list({ pageToken: firstPage.nextPageToken })
  : undefined
```

## Permissions

Public user profiles and public organization membership follow GitHub's normal visibility rules. Reading private organization people data generally requires a fine-grained PAT with `Members: read`; the exact fields returned still depend on the authenticated user's organization access.

## Validation

- [x] `bun test connectors/github/tests/` — 43 tests pass
- [x] `bun --filter @sixb/connector-github build`
- [x] `bun run typecheck`
- [x] `bun run check`
- [x] `git diff --check`
