### PR TITLE
core: inject internal error reporter

### DIFF
--- a/docs/runtime/error-handling.md
+++ b/docs/runtime/error-handling.md
@@ -24,6 +24,9 @@ export const sixb = await createSixb({
 })
 ```
 
+When `onError` is omitted, Sixb reports the same failures to `console.error`; they are never silently dropped.
+Configuring `onError` replaces that default console destination, so each failure is reported once.
+
 The callback covers failed action, agent, pipeline, projection, sync, workflow, and webhook runs,
 plus failed ontology-outbox publication attempts and Rules evaluation passes.
 It does not run for successes, cancellations, retries that remain recoverable, workflow nodes or

--- a/packages/core/src/error-reporting/capability.ts
+++ b/packages/core/src/error-reporting/capability.ts
@@ -1,13 +1,16 @@
-import { randomUUID } from "node:crypto"
 import { SixbErrorReporter } from "./reporter"
-import type { SixbErrorHandler, SixbFailedRun } from "./types"
-
-function resolveOccurredAt(occurredAt?: Date | string): string {
-  if (occurredAt instanceof Date) return occurredAt.toISOString()
-  return occurredAt ?? new Date().toISOString()
-}
+import {
+  type ReportEventDeliveryFailureInput,
+  type ReportRuleEvaluationFailureInput,
+  type ReportRunFailureInput,
+  reportEventDeliveryFailure as reportEventDeliveryFailureWith,
+  reportRuleEvaluationFailure as reportRuleEvaluationFailureWith,
+  reportRunFailure as reportRunFailureWith,
+} from "./reports"
+import type { SixbErrorHandler } from "./types"
 
 const ERROR_REPORTER = Symbol("sixb.error-reporter")
+const FALLBACK_REPORTER = new SixbErrorReporter()
 
 type ErrorReporterHost = {
   [ERROR_REPORTER]?: SixbErrorReporter
@@ -18,6 +21,10 @@ function asHost(value: unknown): ErrorReporterHost | null {
     return null
   }
   return value as ErrorReporterHost
+}
+
+function resolveSixbErrorReporter(host: unknown): SixbErrorReporter {
+  return asHost(host)?.[ERROR_REPORTER] ?? FALLBACK_REPORTER
 }
 
 export function attachSixbErrorReporter(
@@ -34,11 +41,10 @@ export function shareSixbErrorReporter(source: object, target: object): void {
   if (reporter) (target as ErrorReporterHost)[ERROR_REPORTER] = reporter
 }
 
-export interface ReportRunFailureInput {
-  readonly projectId: string
-  readonly run: SixbFailedRun
-  readonly occurredAt?: Date | string
-  readonly attempt?: number
+export type {
+  ReportEventDeliveryFailureInput,
+  ReportRuleEvaluationFailureInput,
+  ReportRunFailureInput,
 }
 
 export function reportRunFailure(
@@ -46,85 +52,15 @@ export function reportRunFailure(
   error: unknown,
   input: ReportRunFailureInput
 ): void {
-  const reporter = asHost(host)?.[ERROR_REPORTER]
-  if (!reporter) return
-
-  const occurredAt = resolveOccurredAt(input.occurredAt)
-  reporter.report(error, {
-    type: "run.failed",
-    notificationId: `project:${input.projectId}:run:${input.run.kind}:${input.run.runId}:failed:${occurredAt}`,
-    projectId: input.projectId,
-    occurredAt,
-    ...(input.attempt === undefined ? {} : { attempt: input.attempt }),
-    run: input.run,
-  })
+  reportRunFailureWith(resolveSixbErrorReporter(host), error, input)
 }
 
-export interface ReportEventDeliveryFailureInput {
-  readonly projectId: string
-  /** Event types that never reached subscribers. Payloads must not be passed in. */
-  readonly eventTypes: readonly string[]
-  readonly occurredAt?: Date | string
-  /** Delivery attempts so far. Defaults to 1, which is right for a rejected emit. */
-  readonly attempts?: number
-  /** Envelope ids, when the events were persisted before delivery failed. */
-  readonly eventIds?: readonly string[]
-  /**
-   * Identity of this loss, used only when nothing was persisted. Defaults to a fresh id; pass one to
-   * make a report reproducible in a test.
-   */
-  readonly occurrenceId?: string
-}
-
-/**
- * Report that domain events were lost.
- *
- * Both delivery paths land here: the outbox dispatcher, which has persisted envelope ids and retries,
- * and a rejected `events.emit()`, which has only the types. Reporting must work for both — an earlier
- * version returned early on an empty `eventIds`, which silently dropped exactly the case this exists
- * to surface.
- *
- * Each path keys on the strongest identity it has. The outbox persisted its envelopes, so the ids plus
- * the attempt number name the loss exactly and stay stable if one report is delivered twice. A rejected
- * emit persisted nothing and is always terminal at attempt 1, so the type list alone was its whole
- * correlation — and two schedules losing `schedule.triggered` in the same broker outage are dispatched
- * concurrently, land in the same millisecond, and were therefore one notification. A timestamp does not
- * fix that; an identity does.
- */
 export function reportEventDeliveryFailure(
   host: unknown,
   error: unknown,
   input: ReportEventDeliveryFailureInput
 ): void {
-  const reporter = asHost(host)?.[ERROR_REPORTER]
-  if (!reporter) return
-
-  const occurredAt = resolveOccurredAt(input.occurredAt)
-  const attempts = input.attempts ?? 1
-  const eventIds = input.eventIds === undefined ? undefined : [...input.eventIds].sort()
-  const firstEventId = eventIds?.[0]
-  const occurrence = firstEventId
-    ? `events:${firstEventId}:attempt:${attempts}`
-    : `emit:${input.occurrenceId ?? randomUUID()}`
-  reporter.report(error, {
-    type: "event.delivery.failed",
-    notificationId: `project:${input.projectId}:event-delivery:${occurrence}`,
-    projectId: input.projectId,
-    occurredAt,
-    attempts,
-    eventTypes: input.eventTypes,
-    ...(eventIds === undefined ? {} : { eventIds }),
-  })
-}
-
-export interface ReportRuleEvaluationFailureInput {
-  readonly projectId: string
-  readonly source: "live" | "reconciliation"
-  readonly eventIds?: readonly string[]
-  readonly occurredAt?: Date | string
-  /** Set when the failure could be attributed to one rule/subject candidate. */
-  readonly ruleId?: string
-  readonly subject?: { readonly objectTypeId: string; readonly primaryId: string }
+  reportEventDeliveryFailureWith(resolveSixbErrorReporter(host), error, input)
 }
 
 export function reportRuleEvaluationFailure(
@@ -132,29 +68,9 @@ export function reportRuleEvaluationFailure(
   error: unknown,
   input: ReportRuleEvaluationFailureInput
 ): void {
-  const reporter = asHost(host)?.[ERROR_REPORTER]
-  if (!reporter) return
-
-  const occurredAt = resolveOccurredAt(input.occurredAt)
-  const eventIds = [...(input.eventIds ?? [])].sort()
-  // A candidate-level failure keys on the candidate, so two rules failing over the same batch stay
-  // two notifications rather than collapsing into one.
-  const occurrence =
-    input.ruleId && input.subject
-      ? `${input.ruleId}:${input.subject.objectTypeId}:${input.subject.primaryId}`
-      : (eventIds[0] ?? "current-state")
-  reporter.report(error, {
-    type: "rule.evaluation.failed",
-    notificationId: `project:${input.projectId}:rule-evaluation:${input.source}:${occurrence}:failed:${occurredAt}`,
-    projectId: input.projectId,
-    occurredAt,
-    source: input.source,
-    eventIds,
-    ...(input.ruleId === undefined ? {} : { ruleId: input.ruleId }),
-    ...(input.subject === undefined ? {} : { subject: input.subject }),
-  })
+  reportRuleEvaluationFailureWith(resolveSixbErrorReporter(host), error, input)
 }
 
 export async function flushSixbErrors(host: unknown, timeoutMs?: number): Promise<void> {
-  await asHost(host)?.[ERROR_REPORTER]?.flush(timeoutMs)
+  await resolveSixbErrorReporter(host).flush(timeoutMs)
 }

--- a/packages/core/src/error-reporting/internal.ts
+++ b/packages/core/src/error-reporting/internal.ts
@@ -10,4 +10,4 @@ export {
   shareSixbErrorReporter,
 } from "./capability"
 export { normalizeReportedError } from "./normalize"
-export { SixbErrorReporter } from "./reporter"
+export { type ErrorReporter, SixbErrorReporter } from "./reporter"

--- a/packages/core/src/error-reporting/reporter.ts
+++ b/packages/core/src/error-reporting/reporter.ts
@@ -3,17 +3,25 @@ import type { SixbErrorContext, SixbErrorHandler } from "./types"
 
 const DEFAULT_FLUSH_TIMEOUT_MS = 5_000
 
+export interface ErrorReporter {
+  report(error: unknown, context: SixbErrorContext): void
+}
+
 /** Failure-isolated, non-blocking adapter around the configured callback. */
-export class SixbErrorReporter {
+export class SixbErrorReporter implements ErrorReporter {
   private readonly pending = new Set<Promise<void>>()
 
   constructor(private readonly handler?: SixbErrorHandler) {}
 
   report(error: unknown, context: SixbErrorContext): void {
-    if (!this.handler) return
+    const normalizedError = normalizeReportedError(error)
+    if (!this.handler) {
+      reportToConsole(normalizedError, context)
+      return
+    }
 
     const invocation = Promise.resolve()
-      .then(() => this.handler?.(normalizeReportedError(error), context))
+      .then(() => this.handler?.(normalizedError, context))
       .then(() => undefined)
       .catch((handlerError) => {
         try {
@@ -44,6 +52,14 @@ export class SixbErrorReporter {
         return
       }
     }
+  }
+}
+
+function reportToConsole(error: Error, context: SixbErrorContext): void {
+  try {
+    console.error(`[Sixb] Unhandled ${context.type}:`, error, context)
+  } catch {
+    // Error reporting must never escape back into framework execution.
   }
 }
 

--- a/packages/core/src/error-reporting/reports.ts
+++ b/packages/core/src/error-reporting/reports.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from "node:crypto"
+import type { ErrorReporter } from "./reporter"
+import type { SixbFailedRun } from "./types"
+
+function resolveOccurredAt(occurredAt?: Date | string): string {
+  if (occurredAt instanceof Date) return occurredAt.toISOString()
+  return occurredAt ?? new Date().toISOString()
+}
+
+export interface ReportRunFailureInput {
+  readonly projectId: string
+  readonly run: SixbFailedRun
+  readonly occurredAt?: Date | string
+  readonly attempt?: number
+}
+
+export function reportRunFailure(
+  reporter: ErrorReporter,
+  error: unknown,
+  input: ReportRunFailureInput
+): void {
+  const occurredAt = resolveOccurredAt(input.occurredAt)
+  reporter.report(error, {
+    type: "run.failed",
+    notificationId: `project:${input.projectId}:run:${input.run.kind}:${input.run.runId}:failed:${occurredAt}`,
+    projectId: input.projectId,
+    occurredAt,
+    ...(input.attempt === undefined ? {} : { attempt: input.attempt }),
+    run: input.run,
+  })
+}
+
+export interface ReportEventDeliveryFailureInput {
+  readonly projectId: string
+  /** Event types that never reached subscribers. Payloads must not be passed in. */
+  readonly eventTypes: readonly string[]
+  readonly occurredAt?: Date | string
+  /** Delivery attempts so far. Defaults to 1, which is right for a rejected emit. */
+  readonly attempts?: number
+  /** Envelope ids, when the events were persisted before delivery failed. */
+  readonly eventIds?: readonly string[]
+  /**
+   * Identity of this loss, used only when nothing was persisted. Defaults to a fresh id; pass one to
+   * make a report reproducible in a test.
+   */
+  readonly occurrenceId?: string
+}
+
+/**
+ * Report that domain events were lost.
+ *
+ * Both delivery paths land here: the outbox dispatcher, which has persisted envelope ids and retries,
+ * and a rejected `events.emit()`, which has only the types. Reporting must work for both — an earlier
+ * version returned early on an empty `eventIds`, which silently dropped exactly the case this exists
+ * to surface.
+ *
+ * Each path keys on the strongest identity it has. The outbox persisted its envelopes, so the ids plus
+ * the attempt number name the loss exactly and stay stable if one report is delivered twice. A rejected
+ * emit persisted nothing and is always terminal at attempt 1, so the type list alone was its whole
+ * correlation — and two schedules losing `schedule.triggered` in the same broker outage are dispatched
+ * concurrently, land in the same millisecond, and were therefore one notification. A timestamp does not
+ * fix that; an identity does.
+ */
+export function reportEventDeliveryFailure(
+  reporter: ErrorReporter,
+  error: unknown,
+  input: ReportEventDeliveryFailureInput
+): void {
+  const occurredAt = resolveOccurredAt(input.occurredAt)
+  const attempts = input.attempts ?? 1
+  const eventIds = input.eventIds === undefined ? undefined : [...input.eventIds].sort()
+  const firstEventId = eventIds?.[0]
+  const occurrence = firstEventId
+    ? `events:${firstEventId}:attempt:${attempts}`
+    : `emit:${input.occurrenceId ?? randomUUID()}`
+  reporter.report(error, {
+    type: "event.delivery.failed",
+    notificationId: `project:${input.projectId}:event-delivery:${occurrence}`,
+    projectId: input.projectId,
+    occurredAt,
+    attempts,
+    eventTypes: input.eventTypes,
+    ...(eventIds === undefined ? {} : { eventIds }),
+  })
+}
+
+export interface ReportRuleEvaluationFailureInput {
+  readonly projectId: string
+  readonly source: "live" | "reconciliation"
+  readonly eventIds?: readonly string[]
+  readonly occurredAt?: Date | string
+  /** Set when the failure could be attributed to one rule/subject candidate. */
+  readonly ruleId?: string
+  readonly subject?: { readonly objectTypeId: string; readonly primaryId: string }
+}
+
+export function reportRuleEvaluationFailure(
+  reporter: ErrorReporter,
+  error: unknown,
+  input: ReportRuleEvaluationFailureInput
+): void {
+  const occurredAt = resolveOccurredAt(input.occurredAt)
+  const eventIds = [...(input.eventIds ?? [])].sort()
+  // A candidate-level failure keys on the candidate, so two rules failing over the same batch stay
+  // two notifications rather than collapsing into one.
+  const occurrence =
+    input.ruleId && input.subject
+      ? `${input.ruleId}:${input.subject.objectTypeId}:${input.subject.primaryId}`
+      : (eventIds[0] ?? "current-state")
+  reporter.report(error, {
+    type: "rule.evaluation.failed",
+    notificationId: `project:${input.projectId}:rule-evaluation:${input.source}:${occurrence}:failed:${occurredAt}`,
+    projectId: input.projectId,
+    occurredAt,
+    source: input.source,
+    eventIds,
+    ...(input.ruleId === undefined ? {} : { ruleId: input.ruleId }),
+    ...(input.subject === undefined ? {} : { subject: input.subject }),
+  })
+}

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,3 +1,4 @@
+export type { ErrorReporter } from "../error-reporting/reporter"
 export type { EventDefinition, EventDefinitionGroup, EventDefinitionMap } from "./definitions"
 export {
   ACTION_EVENT_DEFINITIONS,

--- a/packages/core/src/events/service.ts
+++ b/packages/core/src/events/service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import type { Broker, BrokerCursor, BrokerRecord, BrokerStreamDefinition } from "../broker"
-import { reportEventDeliveryFailure } from "../error-reporting/capability"
+import { type ErrorReporter, SixbErrorReporter } from "../error-reporting/reporter"
+import { reportEventDeliveryFailure } from "../error-reporting/reports"
 import { getInvalidJsonValueReason, type JsonValue } from "../json"
 import type { OntologyMaterializationEvent } from "../materialization/events"
 import {
@@ -31,11 +32,8 @@ export interface DomainEventServiceOptions {
   readonly projectId: string
   readonly broker: Broker
   readonly stream?: BrokerStreamDefinition
-  /**
-   * The `Sixb` instance — or anything sharing its error reporter — that owns this service. Only `emit`
-   * needs it, to escalate a lost batch. Absent means a lost batch is logged and nothing more.
-   */
-  readonly host?: object
+  /** Internal failure reporter. Defaults to the console when this runtime is used standalone. */
+  readonly errorReporter?: ErrorReporter
 }
 
 export interface EventsAppendInput {
@@ -46,7 +44,7 @@ export interface EventsAppendInput {
 }
 
 export interface EventsEmitOptions {
-  /** Package prefix for the console line, such as `SixbPipelineWorker`. */
+  /** Framework component that initiated the emission, such as `SixbPipelineWorker`. */
   readonly source: string
 }
 
@@ -95,14 +93,14 @@ export class DomainEventService implements DomainEventLog, StableEventPublisher 
   private readonly projectId: string
   private readonly broker: Broker
   private readonly stream: BrokerStreamDefinition
-  private readonly host: object | undefined
+  private readonly errorReporter: ErrorReporter
   private readonly ensureStreamPromises = new Map<string, Promise<void>>()
 
   constructor(options: DomainEventServiceOptions) {
     this.projectId = options.projectId
     this.broker = options.broker
     this.stream = options.stream ?? EVENTS_STREAM
-    this.host = options.host
+    this.errorReporter = options.errorReporter ?? new SixbErrorReporter()
   }
 
   /**
@@ -112,29 +110,23 @@ export class DomainEventService implements DomainEventLog, StableEventPublisher 
    * turn a successful run into a failed one. It is not a swallow either — every event Sixb publishes is
    * a potential trigger edge (a rule's `.when()`, an event schedule, a workflow's wait node), so a lost
    * batch is a handler that silently never runs. The loss is escalated to `onError` as
-   * `event.delivery.failed`; the console line is there for local debugging.
+   * `event.delivery.failed`, or to the default console reporter when no handler was configured.
    *
    * Framework emit sites want this. Application code wants `append`, which reports failure to the
    * caller and returns the stored envelopes.
    */
-  async emit(input: EventsAppendInput, options: EventsEmitOptions): Promise<void> {
+  async emit(input: EventsAppendInput, _options: EventsEmitOptions): Promise<void> {
     try {
       await this.append(input)
     } catch (error) {
       try {
         const eventTypes = input.events.map((event) => event.type)
-        // Escalate before logging. `console` is replaceable and `onError` is the contract, so a
-        // replacement that throws must not be what loses the report.
-        reportEventDeliveryFailure(this.host, error, {
+        reportEventDeliveryFailure(this.errorReporter, error, {
           projectId: this.projectId,
           eventTypes,
         })
-        console.error(`[${options.source}] Failed to emit ${eventTypes.join(", ")}:`, error)
       } catch {
-        // The contract above is absolute, so escalation cannot be the thing that breaks it: a replaced
-        // `console` that throws would turn a run that already succeeded into a failed one. The loss is
-        // already unreported at this point — rejecting on top of it helps nobody. `SixbErrorReporter`
-        // guards its own console line the same way.
+        // The contract above is absolute, so escalation cannot be the thing that breaks it.
       }
     }
   }

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -20,11 +20,8 @@ import type { Broker } from "../broker"
 import { ConnectorService } from "../connectors/service"
 import type { ConnectorDefinition } from "../connectors/types"
 import type { DatasetDefinition } from "../datasets/types"
-import {
-  attachSixbErrorReporter,
-  reportEventDeliveryFailure,
-  shareSixbErrorReporter,
-} from "../error-reporting/capability"
+import { attachSixbErrorReporter, shareSixbErrorReporter } from "../error-reporting/capability"
+import { reportEventDeliveryFailure } from "../error-reporting/reports"
 import type { SixbErrorHandler } from "../error-reporting/types"
 import {
   createDomainEventService,
@@ -136,14 +133,13 @@ export class SixbHost<
   readonly auth: AuthRuntime
 
   constructor(options: SixbHostOptions<TOntologySources>) {
-    attachSixbErrorReporter(this, options.onError)
+    const errorReporter = attachSixbErrorReporter(this, options.onError)
     this.projectId = options.id ?? "default"
     this.broker = options.broker
-    // `host: this` is how `events.emit()` reaches the reporter attached at the top of this constructor.
     this.eventService = createDomainEventService({
       projectId: this.projectId,
       broker: this.broker,
-      host: this,
+      errorReporter,
     })
     this.events = this.eventService
     this.logging = new LoggingService({
@@ -187,7 +183,7 @@ export class SixbHost<
       storage: this.storage,
       events: this.eventService,
       onDeliveryFailure: (error, failure) =>
-        reportEventDeliveryFailure(this, error, {
+        reportEventDeliveryFailure(errorReporter, error, {
           projectId: this.projectId,
           ...failure,
         }),

--- a/packages/core/tests/error-reporting.test.ts
+++ b/packages/core/tests/error-reporting.test.ts
@@ -3,11 +3,13 @@ import type { SixbErrorContext } from "../src"
 import type { Broker } from "../src/broker"
 import {
   attachSixbErrorReporter,
+  type ErrorReporter,
   flushSixbErrors,
   normalizeReportedError,
   reportEventDeliveryFailure,
   reportRuleEvaluationFailure,
   reportRunFailure,
+  SixbErrorReporter,
 } from "../src/error-reporting/internal"
 import { DomainEventService } from "../src/events"
 
@@ -230,13 +232,45 @@ describe("Sixb error reporting", () => {
     consoleError.mockRestore()
   })
 
-  test("is a no-op when no reporter is attached", async () => {
-    const host = {}
-    reportRunFailure(host, new Error("ignored"), {
-      projectId: PROJECT_ID,
-      run: { kind: "workflow", runId: "workflow-run-1", workflowId: "approval" },
+  test("falls back to the console when no reporter is attached", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {})
+    try {
+      const host = {}
+      const error = new Error("workflow failed")
+      reportRunFailure(host, error, {
+        projectId: PROJECT_ID,
+        run: { kind: "workflow", runId: "workflow-run-1", workflowId: "approval" },
+      })
+      await flushSixbErrors(host)
+
+      expect(consoleError).toHaveBeenCalledWith(
+        "[Sixb] Unhandled run.failed:",
+        error,
+        expect.objectContaining({
+          type: "run.failed",
+          projectId: PROJECT_ID,
+          run: { kind: "workflow", runId: "workflow-run-1", workflowId: "approval" },
+        })
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  test("isolates the console fallback from framework execution", () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {
+      throw new Error("console is broken")
     })
-    await expect(flushSixbErrors(host)).resolves.toBeUndefined()
+    try {
+      expect(() =>
+        reportRunFailure({}, new Error("run failed"), {
+          projectId: PROJECT_ID,
+          run: { kind: "sync", runId: "sync-run-1", syncId: "customers" },
+        })
+      ).not.toThrow()
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
   test("a rule failure is correlated by candidate, since it has no run id", async () => {
@@ -287,11 +321,11 @@ describe("Sixb error reporting", () => {
     try {
       const host = {}
       const reports: Array<{ error: Error; context: SixbErrorContext }> = []
-      attachSixbErrorReporter(host, (error, context) => {
+      const reporter = attachSixbErrorReporter(host, (error, context) => {
         reports.push({ error, context })
       })
       const appendFailure = new Error("broker unavailable")
-      const events = eventServiceFor(host)
+      const events = eventServiceFor(reporter)
       spyOn(events, "append").mockImplementation(() => Promise.reject(appendFailure))
 
       await events.emit(
@@ -313,55 +347,79 @@ describe("Sixb error reporting", () => {
       if (context?.type !== "event.delivery.failed") throw new Error("expected a delivery failure")
       expect(context.eventTypes).toEqual(["sync.run.finished"])
       expect(context.notificationId).toStartWith(`project:${PROJECT_ID}:event-delivery:emit:`)
-      // The console line stays for local debugging; the report is what makes it visible in prod.
-      expect(consoleError).toHaveBeenCalledWith(
-        "[SixbTestWorker] Failed to emit sync.run.finished:",
-        appendFailure
-      )
+      expect(consoleError).not.toHaveBeenCalled()
     } finally {
       consoleError.mockRestore()
     }
   })
 
-  test("emit still resolves when escalation itself throws", async () => {
+  test("emit still resolves when its injected reporter throws", async () => {
     // `emit` promises never to reject, and that promise cannot depend on the escalation path working:
-    // an app that replaced `console` with something that throws would otherwise turn a run that had
-    // already succeeded into a failed one. The batch is lost either way — rejecting on top helps nobody.
-    const consoleError = spyOn(console, "error").mockImplementation(() => {
-      throw new Error("console is broken")
+    // a broken adapter must not turn a run that already succeeded into a failed one. The batch is lost
+    // either way — rejecting on top helps nobody.
+    const events = eventServiceFor({
+      report() {
+        throw new Error("reporter is broken")
+      },
     })
+    spyOn(events, "append").mockImplementation(() =>
+      Promise.reject(new Error("broker unavailable"))
+    )
+
+    await expect(
+      events.emit(
+        {
+          events: [
+            {
+              type: "sync.run.finished",
+              payload: { syncId: "nightly", runId: "sync-run-1", status: "failed" },
+            },
+          ],
+        },
+        { source: "SixbTestWorker" }
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  test("a failed standalone emit falls back to the console", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {})
     try {
-      const host = {}
-      const events = eventServiceFor(host)
-      spyOn(events, "append").mockImplementation(() =>
-        Promise.reject(new Error("broker unavailable"))
+      const appendFailure = new Error("broker unavailable")
+      const events = eventServiceFor()
+      spyOn(events, "append").mockImplementation(() => Promise.reject(appendFailure))
+
+      await events.emit(
+        {
+          events: [
+            {
+              type: "sync.run.finished",
+              payload: { syncId: "nightly", runId: "sync-run-1", status: "failed" },
+            },
+          ],
+        },
+        { source: "SixbTestWorker" }
       )
 
-      await expect(
-        events.emit(
-          {
-            events: [
-              {
-                type: "sync.run.finished",
-                payload: { syncId: "nightly", runId: "sync-run-1", status: "failed" },
-              },
-            ],
-          },
-          { source: "SixbTestWorker" }
-        )
-      ).resolves.toBeUndefined()
+      expect(consoleError).toHaveBeenCalledTimes(1)
+      expect(consoleError).toHaveBeenCalledWith(
+        "[Sixb] Unhandled event.delivery.failed:",
+        appendFailure,
+        expect.objectContaining({
+          type: "event.delivery.failed",
+          eventTypes: ["sync.run.finished"],
+        })
+      )
     } finally {
       consoleError.mockRestore()
     }
   })
 
   test("an emit that reaches the broker reports nothing", async () => {
-    const host = {}
     const reports: SixbErrorContext[] = []
-    attachSixbErrorReporter(host, (_error, context) => {
+    const reporter = new SixbErrorReporter((_error, context) => {
       reports.push(context)
     })
-    const events = eventServiceFor(host)
+    const events = eventServiceFor(reporter)
     spyOn(events, "append").mockImplementation(() => Promise.resolve([]))
 
     await events.emit(
@@ -375,13 +433,13 @@ describe("Sixb error reporting", () => {
       },
       { source: "SixbTestWorker" }
     )
-    await flushSixbErrors(host)
+    await reporter.flush()
 
     expect(reports).toEqual([])
   })
 })
 
 // The broker is never reached: every test here spies on `append`, which is the seam `emit` wraps.
-function eventServiceFor(host: object): DomainEventService {
-  return new DomainEventService({ projectId: PROJECT_ID, broker: {} as Broker, host })
+function eventServiceFor(errorReporter?: ErrorReporter): DomainEventService {
+  return new DomainEventService({ projectId: PROJECT_ID, broker: {} as Broker, errorReporter })
 }

--- a/packages/core/tests/scheduler-runtime.test.ts
+++ b/packages/core/tests/scheduler-runtime.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test"
 import type { SixbErrorContext } from "../src"
 import { InMemoryBroker } from "../src"
-import { attachSixbErrorReporter, flushSixbErrors } from "../src/error-reporting/internal"
+import {
+  attachSixbErrorReporter,
+  type ErrorReporter,
+  flushSixbErrors,
+} from "../src/error-reporting/internal"
 import type { StoredScheduleTriggeredEvent } from "../src/events"
 import { DomainEventService } from "../src/events"
 import { SchedulerRuntime, SchedulerValidationError } from "../src/scheduler"
@@ -9,8 +13,8 @@ import { defineSchedule } from "../src/schedules"
 
 const PROJECT = "test"
 
-function createEvents(host?: object) {
-  return new DomainEventService({ projectId: PROJECT, broker: new InMemoryBroker(), host })
+function createEvents(errorReporter?: ErrorReporter) {
+  return new DomainEventService({ projectId: PROJECT, broker: new InMemoryBroker(), errorReporter })
 }
 
 function createTestClock(initial: Date) {
@@ -296,12 +300,11 @@ describe("SchedulerRuntime", () => {
     try {
       const reports: { error: Error; context: SixbErrorContext }[] = []
       const host = {}
-      attachSixbErrorReporter(host, (error, context) => {
+      const errorReporter = attachSixbErrorReporter(host, (error, context) => {
         reports.push({ error, context })
       })
 
-      // The scheduler reports lost triggers through its events runtime, so the host is attached there.
-      const eventsRuntime = createEvents(host)
+      const eventsRuntime = createEvents(errorReporter)
       const appendFailure = new Error("broker unavailable")
       eventsRuntime.append = () => Promise.reject(appendFailure)
 


### PR DESCRIPTION
## Summary

- create one internal error reporter in `Sixb` and inject its narrow `report(...)` port directly into `EventsRuntime` and the ontology outbox
- separate failure-context construction from the boundary capability, so internally owned components depend on the reporter instead of an arbitrary host object
- keep the private symbol capability only where runtime contexts and public worker facades already cross package boundaries
- fall back to `console.error` whenever no `onError` handler or attached capability exists, while preserving handler isolation and graceful `flush()` semantics
- remove the duplicate event-delivery console line when `onError` is configured, so each failure has one destination

## Why this shape

`onError` remains the only public configuration surface. Exposing the reporter on `Sixb` would leak an internal concern, while requiring it in every public worker constructor would create a breaking and noisy API change.

The hybrid design keeps dependencies explicit for components the runtime owns and limits the private symbol to genuine boundaries where explicit injection is not possible without changing public APIs. A minimal internal `ErrorReporter` port also prevents `EventsRuntime` from depending on callback buffering or shutdown details it does not use.

The console fallback closes the previous silent-failure path: a missing capability can no longer discard a terminal failure. Both custom handlers and the fallback are isolated, so reporting can never alter queue settlement, run status, HTTP responses, or the non-rejecting `events.emit()` contract.

No internal error class or reporter is added to the public `@sixb/core` surface.

## Stack

This PR is stacked on #309 (`errors/error-model-foundation`) and should be reviewed after it. Its base branch is intentionally `errors/error-model-foundation` so the diff contains only the error-reporting refactor.

## Verification

- `bun test packages/core/tests/error-reporting.test.ts packages/core/tests/scheduler-runtime.test.ts`
- `bun test packages/core/tests` — 1,447 passing
- `bun run test`
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test:publish` — 47 publishable packages verified
