### PR TITLE
server: derive HTTP status from error codes

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -8,4 +8,5 @@ legacy exceptions use `internal.unexpected` until their call site receives a spe
 
 | Code | Retryable | What happened | What to do |
 | --- | --- | --- | --- |
+| `dataset.not_found` | No | The requested dataset is not registered or is not visible to the caller. | Check the dataset ID and the caller's access. |
 | `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect the failure and its cause chain. Do not retry automatically. |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,6 +137,12 @@
       "import": "./dist/error-reporting/internal.js",
       "default": "./dist/error-reporting/internal.js"
     },
+    "./internal/errors": {
+      "types": "./dist/errors/internal.d.ts",
+      "bun": "./src/errors/internal.ts",
+      "import": "./dist/errors/internal.js",
+      "default": "./dist/errors/internal.js"
+    },
     "./internal/events": {
       "types": "./dist/events/index.d.ts",
       "bun": "./src/events/index.ts",

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -10,6 +10,10 @@ interface SixbErrorDefinition {
  * `SixbFailure` values, not a mutable registry.
  */
 export const SIXB_ERROR_DEFINITIONS = {
+  "dataset.not_found": {
+    publicMessage: "Dataset not found.",
+    retryable: false,
+  },
   "internal.unexpected": {
     publicMessage: "An unexpected internal error occurred.",
     retryable: false,

--- a/packages/server/src/routes/datasets.ts
+++ b/packages/server/src/routes/datasets.ts
@@ -1,4 +1,5 @@
 import type { DatasetDefinition, SixbHostView } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type {
   DatasetCatalogState,
   DatasetLatestVersionSummary,
@@ -164,7 +165,9 @@ async function serializeDatasetCatalogItems(
 function requireDataset(sixb: ReturnType<typeof requireRequestSixb>, datasetId: string) {
   const dataset = sixb.datasets.getById(datasetId)
   if (!dataset) {
-    throw new Error("Dataset not found")
+    throw createSixbError("dataset.not_found", "Dataset not found", {
+      details: { datasetId },
+    })
   }
   return dataset
 }

--- a/packages/server/src/utils/http.ts
+++ b/packages/server/src/utils/http.ts
@@ -1,10 +1,21 @@
-import { AuthorizationError, OntologyNotFoundError, OntologyValidationError } from "@sixb/core"
+import {
+  AuthorizationError,
+  OntologyNotFoundError,
+  OntologyValidationError,
+  type SixbErrorCode,
+} from "@sixb/core"
+import { isSixbError } from "@sixb/core/internal/errors"
 import {
   FileUploadSessionError,
   type FileUploadSessionErrorReason,
   ObjectNotFoundError,
 } from "@sixb/core/storage"
 import { RequestBodyTooLargeError } from "./request-body"
+
+/** Explicit transport policy for coded failures that are safe to surface as non-500 responses. */
+const HTTP_STATUS_BY_ERROR_CODE: Partial<Record<SixbErrorCode, number>> = {
+  "dataset.not_found": 404,
+}
 
 export function toIsoString(value: Date): string {
   return value.toISOString()
@@ -59,6 +70,11 @@ export function handleRouteError(
 ): {
   error: string
 } {
+  if (isSixbError(error)) {
+    set.status = HTTP_STATUS_BY_ERROR_CODE[error.code] ?? 500
+    return { error: error.message }
+  }
+
   if (error instanceof AuthorizationError) {
     set.status = 403
     return { error: error.message }
@@ -86,12 +102,10 @@ export function handleRouteError(
     return { error: error.message }
   }
 
-  // The tail. Core still throws a bare `Error` for "Unknown sync 'x'" and its siblings, so the
-  // message is all a route has to go on; reading it is a guess that misfires whenever a validation
-  // message happens to contain one of these words. Every error that gains a class moves above this
-  // line and the guess covers less.
+  // Legacy uncoded errors remain bad requests until their primitive receives a vertical migration.
+  // Crucially, wording no longer changes transport semantics.
   const message = error instanceof Error ? error.message : String(error)
-  set.status = message.includes("not found") || message.includes("Unknown") ? 404 : 400
+  set.status = 400
   return { error: message }
 }
 

--- a/packages/server/tests/http-utils.test.ts
+++ b/packages/server/tests/http-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { createSixbError } from "@sixb/core/internal/errors"
+import { handleRouteError } from "../src/utils/http"
+
+describe("handleRouteError", () => {
+  test("derives coded error statuses from identity instead of message wording", () => {
+    const set: { status?: number | string } = {}
+    const response = handleRouteError(
+      createSixbError("dataset.not_found", "No dataset matches this request"),
+      set
+    )
+
+    expect(set.status).toBe(404)
+    expect(response).toEqual({ error: "No dataset matches this request" })
+  })
+
+  test("does not infer a status from legacy error messages", () => {
+    for (const message of ["Unknown property", "Resource not found"]) {
+      const set: { status?: number | string } = {}
+
+      expect(handleRouteError(new Error(message), set)).toEqual({ error: message })
+      expect(set.status).toBe(400)
+    }
+  })
+
+  test("treats uncategorized coded exceptions as internal failures", () => {
+    const set: { status?: number | string } = {}
+
+    expect(handleRouteError(createSixbError("internal.unexpected", "Commit failed"), set)).toEqual({
+      error: "Commit failed",
+    })
+    expect(set.status).toBe(500)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -60,6 +60,7 @@
       "@sixb/core/internal/bootstrap": ["./packages/core/src/bootstrap/index.ts"],
       "@sixb/core/internal/edits": ["./packages/core/src/edits/index.ts"],
       "@sixb/core/internal/error-reporting": ["./packages/core/src/error-reporting/internal.ts"],
+      "@sixb/core/internal/errors": ["./packages/core/src/errors/internal.ts"],
       "@sixb/core/internal/events": ["./packages/core/src/events/index.ts"],
       "@sixb/core/internal/http": ["./packages/core/src/http/index.ts"],
       "@sixb/core/internal/logging": ["./packages/core/src/logging/index.ts"],


### PR DESCRIPTION
## Summary

- replace message-based HTTP status inference with explicit error-code policy
- add and document `dataset.not_found` as the first vertically migrated HTTP-facing code
- preserve the dataset id in structured error details without exposing the internal error class
- keep existing typed legacy errors on their current `instanceof` mappings while their primitives migrate
- add focused tests proving that message wording can no longer change an HTTP status

## Why this shape

HTTP semantics must depend on a stable identity, not prose. A coded `dataset.not_found` failure now maps to 404 regardless of its message, while uncoded legacy errors default to 400 instead of being guessed from words such as `Unknown` or `not found`. Coded errors without an explicitly safe client status default to 500.

The internal error factory is available only through `@sixb/core/internal/errors`; the `SixbError` class remains private and is not added to any public package surface.

This PR deliberately does not add error codes to the public HTTP response schema. Doing that here would mix the transport-policy fix with a broad OpenAPI and generated-client contract change. That public contract can be introduced as a separate, reviewable slice.

## Stack

This PR is stacked on #311 (`errors/error-reporter-injection`) and should be reviewed after it. Its base branch is intentionally `errors/error-reporter-injection`, so the diff contains only the code-derived HTTP status work.

## Verification

- `bun test packages/core/tests/error-model.test.ts packages/server/tests/http-utils.test.ts packages/server/tests/httpContract.test.ts`
- `bun test packages/server/tests` — 267 passing
- `bun run test`
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test:publish` — 47 publishable packages verified

Refs #274
