### PR TITLE
http: expose typed error codes

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -3,10 +3,19 @@
 Sixb failures carry a stable `code` for programmatic decisions and a message for humans. Code can
 branch on `failure.code`; it must never parse `failure.message`.
 
+HTTP error responses expose the same identity as an optional `code` while endpoints migrate. The Sixb client copies it to `SixbApiError.code`; clients should handle unknown strings so an older client remains compatible with codes introduced by a newer server.
+
+```ts
+if (isSixbApiError(error) && error.code === "dataset.not_found") {
+  // Recover without depending on the human-readable message.
+}
+```
+
 The catalog starts deliberately small and grows with each primitive's vertical migration. Unknown
 legacy exceptions use `internal.unexpected` until their call site receives a specific code.
 
 | Code | Retryable | What happened | What to do |
 | --- | --- | --- | --- |
 | `dataset.not_found` | No | The requested dataset is not registered or is not visible to the caller. | Check the dataset ID and the caller's access. |
+| `dataset.version_not_found` | No | The requested dataset version does not exist, or the dataset has no committed version yet. | Check the version ID or materialize the dataset before reading rows. |
 | `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect the failure and its cause chain. Do not retry automatically. |

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -5276,9 +5276,14 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["dataset.not_found"],
+                      "description": "Stable machine-readable failure code for programmatic handling."
                     }
                   },
-                  "required": ["error"],
+                  "required": ["error", "code"],
                   "additionalProperties": false
                 }
               }
@@ -5457,9 +5462,14 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["dataset.not_found"],
+                      "description": "Stable machine-readable failure code for programmatic handling."
                     }
                   },
-                  "required": ["error"],
+                  "required": ["error", "code"],
                   "additionalProperties": false
                 }
               }
@@ -5626,9 +5636,14 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["dataset.not_found", "dataset.version_not_found"],
+                      "description": "Stable machine-readable failure code for programmatic handling."
                     }
                   },
-                  "required": ["error"],
+                  "required": ["error", "code"],
                   "additionalProperties": false
                 }
               }
@@ -5869,9 +5884,14 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": ["dataset.not_found", "dataset.version_not_found"],
+                      "description": "Stable machine-readable failure code for programmatic handling."
                     }
                   },
-                  "required": ["error"],
+                  "required": ["error", "code"],
                   "additionalProperties": false
                 }
               }

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -1,3 +1,4 @@
+import type { SixbErrorCode } from "@sixb/core"
 import { type Auth, type Client, type Config, createClient, createConfig } from "./generated/client"
 
 export const SIXB_CSRF_HEADER_NAME = "x-sixb-csrf"
@@ -34,13 +35,16 @@ export interface SixbApiErrorInit {
   readonly body?: unknown
 }
 
+/** Known Sixb codes with a forward-compatible escape hatch for newer servers. */
+export type SixbApiErrorCode = SixbErrorCode | (string & Record<never, never>)
+
 /**
  * A structured HTTP error thrown by the Sixb client. The raw generated client
  * throws the bare response body (a string, or parsed JSON) with no status code
  * or identity, which makes failures impossible to branch on and prints as
  * cryptic quoted text in dev tooling. `SixbApiError` carries the status, the
- * parsed `body`, and a readable `message`, so callers and error boundaries can
- * tell a `404` apart from a `500` instead of catching a stringy blob.
+ * parsed `body`, an optional stable `code`, and a readable `message`, so callers
+ * and error boundaries can branch without parsing prose.
  */
 export class SixbApiError extends Error {
   readonly status: number
@@ -48,6 +52,7 @@ export class SixbApiError extends Error {
   readonly url: string
   readonly method: string
   readonly body: unknown
+  readonly code?: SixbApiErrorCode
 
   constructor(message: string, init: SixbApiErrorInit) {
     super(message)
@@ -57,6 +62,7 @@ export class SixbApiError extends Error {
     this.url = init.url ?? ""
     this.method = init.method ?? ""
     this.body = init.body
+    this.code = extractErrorCode(init.body)
   }
 }
 
@@ -212,6 +218,19 @@ function extractErrorDetail(body: unknown): string | undefined {
     }
   }
   return undefined
+}
+
+function extractErrorCode(body: unknown): SixbApiErrorCode | undefined {
+  if (!body || typeof body !== "object") {
+    return undefined
+  }
+
+  try {
+    const code = Reflect.get(body, "code")
+    return typeof code === "string" && code.trim() === code && code.length > 0 ? code : undefined
+  } catch {
+    return undefined
+  }
 }
 
 function safeRequestPath(url: string): string {

--- a/packages/client/src/browser.ts
+++ b/packages/client/src/browser.ts
@@ -6,7 +6,7 @@ import {
 } from "./api"
 import { client } from "./generated/client.gen"
 
-export type { SixbApiErrorInit } from "./api"
+export type { SixbApiErrorCode, SixbApiErrorInit } from "./api"
 export { isSixbApiError, SixbApiError } from "./api"
 
 import { getAuthSession } from "./generated/sdk.gen"

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1796,6 +1796,10 @@ export type GetDatasetErrors = {
    */
   404: {
     error: string
+    /**
+     * Stable machine-readable failure code for programmatic handling.
+     */
+    code: "dataset.not_found"
   }
 }
 
@@ -1867,6 +1871,10 @@ export type ListDatasetVersionsErrors = {
    */
   404: {
     error: string
+    /**
+     * Stable machine-readable failure code for programmatic handling.
+     */
+    code: "dataset.not_found"
   }
 }
 
@@ -1940,6 +1948,10 @@ export type GetDatasetVersionErrors = {
    */
   404: {
     error: string
+    /**
+     * Stable machine-readable failure code for programmatic handling.
+     */
+    code: "dataset.not_found" | "dataset.version_not_found"
   }
 }
 
@@ -2013,6 +2025,10 @@ export type ListDatasetRowsErrors = {
    */
   404: {
     error: string
+    /**
+     * Stable machine-readable failure code for programmatic handling.
+     */
+    code: "dataset.not_found" | "dataset.version_not_found"
   }
 }
 

--- a/packages/client/tests/api.test.ts
+++ b/packages/client/tests/api.test.ts
@@ -126,6 +126,7 @@ describe("SixbApiError", () => {
 
     const error = (await promise.catch((caught) => caught)) as SixbApiError
     expect(error.status).toBe(404)
+    expect(error.code).toBeUndefined()
     expect(error.body).toBe("Not Found")
     expect(error.method).toBe("GET")
     expect(error.url).toContain("/api/auth/access-tokens")
@@ -135,12 +136,12 @@ describe("SixbApiError", () => {
     expect(isSixbApiError(error)).toBe(true)
   })
 
-  test("keeps the parsed JSON body and folds its error string into the message", async () => {
+  test("surfaces a stable code from a structured error response", async () => {
     const client = createSixbClient({
       baseUrl: "http://localhost:3002",
       fetch: createRespondingFetch(
         () =>
-          new Response(JSON.stringify({ error: "Object not found" }), {
+          new Response(JSON.stringify({ error: "Dataset not found", code: "dataset.not_found" }), {
             status: 404,
             headers: { "Content-Type": "application/json" },
           })
@@ -151,8 +152,27 @@ describe("SixbApiError", () => {
       (caught) => caught
     )) as SixbApiError
     expect(error.status).toBe(404)
-    expect(error.body).toEqual({ error: "Object not found" })
-    expect(error.message).toContain("Object not found")
+    expect(error.code).toBe("dataset.not_found")
+    expect(error.body).toEqual({ error: "Dataset not found", code: "dataset.not_found" })
+    expect(error.message).toContain("Dataset not found")
+  })
+
+  test("preserves codes introduced by a newer server", async () => {
+    const client = createSixbClient({
+      baseUrl: "http://localhost:3002",
+      fetch: createRespondingFetch(
+        () =>
+          new Response(JSON.stringify({ error: "Future failure", code: "future.new_code" }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          })
+      ),
+    })
+
+    const error = (await listAuthAccessTokens({ client, throwOnError: true }).catch(
+      (caught) => caught
+    )) as SixbApiError
+    expect(error.code).toBe("future.new_code")
   })
 
   test("surfaces the structured error on the non-throwing result path too", async () => {

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -14,6 +14,10 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "Dataset not found.",
     retryable: false,
   },
+  "dataset.version_not_found": {
+    publicMessage: "Dataset version not found.",
+    retryable: false,
+  },
   "internal.unexpected": {
     publicMessage: "An unexpected internal error occurred.",
     retryable: false,

--- a/packages/server/src/routes/datasets.ts
+++ b/packages/server/src/routes/datasets.ts
@@ -8,7 +8,7 @@ import type {
 import type { Elysia } from "elysia"
 import { requireRequestSixb } from "../auth/scope"
 import { OPENAPI_TAGS } from "../openapi/tags"
-import { ErrorResponseSchema } from "../schemas/common"
+import { codedErrorResponseSchema, ErrorResponseSchema } from "../schemas/common"
 import {
   DatasetCatalogItemSchema,
   DatasetParamsSchema,
@@ -25,6 +25,12 @@ const DEFAULT_VERSION_LIMIT = 20
 const MAX_VERSION_LIMIT = 100
 const DEFAULT_ROW_LIMIT = 100
 const MAX_ROW_LIMIT = 1_000
+
+const DatasetNotFoundErrorResponseSchema = codedErrorResponseSchema(["dataset.not_found"])
+const DatasetVersionNotFoundErrorResponseSchema = codedErrorResponseSchema([
+  "dataset.not_found",
+  "dataset.version_not_found",
+])
 
 function parseLimit(value: string | undefined, fallback: number, max: number): number {
   const parsed = parseOptionalInt(value) ?? fallback
@@ -172,6 +178,12 @@ function requireDataset(sixb: ReturnType<typeof requireRequestSixb>, datasetId: 
   return dataset
 }
 
+function datasetVersionNotFound(datasetId: string, versionId?: string) {
+  return createSixbError("dataset.version_not_found", "Dataset version not found", {
+    details: { datasetId, ...(versionId === undefined ? {} : { versionId }) },
+  })
+}
+
 function parseColumns(value: string | undefined): readonly string[] | undefined {
   if (!value) return undefined
 
@@ -249,7 +261,7 @@ export function registerDatasetRoutes(app: Elysia, host: SixbHostView) {
         response: {
           200: DatasetCatalogItemSchema,
           400: ErrorResponseSchema,
-          404: ErrorResponseSchema,
+          404: DatasetNotFoundErrorResponseSchema,
         },
         detail: {
           summary: "Get dataset metadata",
@@ -283,7 +295,7 @@ export function registerDatasetRoutes(app: Elysia, host: SixbHostView) {
         response: {
           200: DatasetVersionListResponseSchema,
           400: ErrorResponseSchema,
-          404: ErrorResponseSchema,
+          404: DatasetNotFoundErrorResponseSchema,
         },
         detail: {
           summary: "List dataset versions",
@@ -301,8 +313,7 @@ export function registerDatasetRoutes(app: Elysia, host: SixbHostView) {
           requireDataset(sixb, params.datasetId)
           const version = await host.lakeStorage.getVersion(params.datasetId, params.versionId)
           if (!version) {
-            set.status = 404
-            return { error: "Dataset version not found" }
+            throw datasetVersionNotFound(params.datasetId, params.versionId)
           }
 
           return serializeDatasetVersion(version)
@@ -315,7 +326,7 @@ export function registerDatasetRoutes(app: Elysia, host: SixbHostView) {
         response: {
           200: DatasetVersionSchema,
           400: ErrorResponseSchema,
-          404: ErrorResponseSchema,
+          404: DatasetVersionNotFoundErrorResponseSchema,
         },
         detail: {
           summary: "Get dataset version",
@@ -339,8 +350,7 @@ export function registerDatasetRoutes(app: Elysia, host: SixbHostView) {
             : await host.lakeStorage.getLatestVersion(params.datasetId)
 
           if (!version) {
-            set.status = 404
-            return { error: "Dataset version not found" }
+            throw datasetVersionNotFound(params.datasetId, parsed.versionId)
           }
 
           const requestedColumns = parseColumns(parsed.columns)
@@ -381,7 +391,7 @@ export function registerDatasetRoutes(app: Elysia, host: SixbHostView) {
         response: {
           200: DatasetRowsResponseSchema,
           400: ErrorResponseSchema,
-          404: ErrorResponseSchema,
+          404: DatasetVersionNotFoundErrorResponseSchema,
         },
         detail: {
           summary: "Preview dataset rows",

--- a/packages/server/src/schemas/common.ts
+++ b/packages/server/src/schemas/common.ts
@@ -1,7 +1,16 @@
+import type { SixbErrorCode } from "@sixb/core"
 import { z } from "zod"
 import { ignoreOverride, type JsonSchema7Type, type OverrideCallback } from "zod-to-json-schema"
 
 export const ErrorResponseSchema = z.object({ error: z.string() })
+
+export function codedErrorResponseSchema<
+  const TCodes extends readonly [SixbErrorCode, ...SixbErrorCode[]],
+>(codes: TCodes) {
+  return ErrorResponseSchema.extend({
+    code: z.enum(codes).describe("Stable machine-readable failure code for programmatic handling."),
+  })
+}
 
 export const SuccessResponseSchema = z.object({ success: z.boolean() })
 

--- a/packages/server/src/utils/http.ts
+++ b/packages/server/src/utils/http.ts
@@ -15,6 +15,7 @@ import { RequestBodyTooLargeError } from "./request-body"
 /** Explicit transport policy for coded failures that are safe to surface as non-500 responses. */
 const HTTP_STATUS_BY_ERROR_CODE: Partial<Record<SixbErrorCode, number>> = {
   "dataset.not_found": 404,
+  "dataset.version_not_found": 404,
 }
 
 export function toIsoString(value: Date): string {
@@ -69,10 +70,11 @@ export function handleRouteError(
   set: { status?: number | string }
 ): {
   error: string
+  code?: SixbErrorCode
 } {
   if (isSixbError(error)) {
     set.status = HTTP_STATUS_BY_ERROR_CODE[error.code] ?? 500
-    return { error: error.message }
+    return { error: error.message, code: error.code }
   }
 
   if (error instanceof AuthorizationError) {

--- a/packages/server/tests/http-utils.test.ts
+++ b/packages/server/tests/http-utils.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, test } from "bun:test"
 import { createSixbError } from "@sixb/core/internal/errors"
+import { codedErrorResponseSchema } from "../src/schemas/common"
 import { handleRouteError } from "../src/utils/http"
 
 describe("handleRouteError", () => {
+  test("constrains coded response schemas to their declared codes", () => {
+    const schema = codedErrorResponseSchema(["dataset.not_found"])
+
+    expect(schema.parse({ error: "Missing", code: "dataset.not_found" })).toEqual({
+      error: "Missing",
+      code: "dataset.not_found",
+    })
+    expect(() =>
+      schema.parse({ error: "Missing version", code: "dataset.version_not_found" })
+    ).toThrow()
+  })
+
   test("derives coded error statuses from identity instead of message wording", () => {
     const set: { status?: number | string } = {}
     const response = handleRouteError(
@@ -11,7 +24,10 @@ describe("handleRouteError", () => {
     )
 
     expect(set.status).toBe(404)
-    expect(response).toEqual({ error: "No dataset matches this request" })
+    expect(response).toEqual({
+      error: "No dataset matches this request",
+      code: "dataset.not_found",
+    })
   })
 
   test("does not infer a status from legacy error messages", () => {
@@ -28,6 +44,7 @@ describe("handleRouteError", () => {
 
     expect(handleRouteError(createSixbError("internal.unexpected", "Commit failed"), set)).toEqual({
       error: "Commit failed",
+      code: "internal.unexpected",
     })
     expect(set.status).toBe(500)
   })

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -728,7 +728,10 @@ describe("SixbServer HTTP contract", () => {
 
       const missingDatasetResponse = await fetch(`${baseUrl}/api/datasets/missing`)
       expect(missingDatasetResponse.status).toBe(404)
-      expect(await missingDatasetResponse.json()).toEqual({ error: "Dataset not found" })
+      expect(await missingDatasetResponse.json()).toEqual({
+        error: "Dataset not found",
+        code: "dataset.not_found",
+      })
 
       const versionsResponse = await fetch(
         `${baseUrl}/api/datasets/raw.github.events/versions?limit=5`
@@ -777,6 +780,7 @@ describe("SixbServer HTTP contract", () => {
       expect(uncommittedRowsResponse.status).toBe(404)
       expect(await uncommittedRowsResponse.json()).toEqual({
         error: "Dataset version not found",
+        code: "dataset.version_not_found",
       })
 
       const invalidRowsResponse = await fetch(


### PR DESCRIPTION
## Summary

- Expose a stable error code alongside the human-readable message when the HTTP boundary receives an internal coded failure.
- Add a coded response schema factory constrained to SixbErrorCode and declare the exact allowed codes per migrated endpoint.
- Migrate dataset and dataset-version 404 responses, including the new dataset.version_not_found identity.
- Regenerate OpenAPI and client types, and surface the code on SixbApiError.

## Design decisions

- SixbError remains internal. The HTTP contract exposes only its serializable identity and message.
- The legacy ErrorResponseSchema stays unchanged so unmigrated endpoints do not claim to return a code.
- Migrated endpoint schemas use closed code enums, which produces precise literal unions in the generated SDK.
- SixbApiError.code keeps an unknown-string escape hatch so older clients remain compatible with codes introduced by newer servers.

## Verification

- bun test packages/server/tests/http-utils.test.ts packages/server/tests/httpContract.test.ts packages/client/tests/api.test.ts packages/core/tests/error-model.test.ts: 27 passed
- bun run typecheck
- bun run check
- bun run generate:client
- git diff --check
- Full workspace run: 3381 tests passed; the aggregate run reported a transient Atlas development-bundle failure. Its test file passes independently: 5 passed.

## Stack

- Builds on #313
- Part of #274