### PR TITLE
sync: persist canonical failure records

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -14,8 +14,30 @@ if (isSixbApiError(error) && error.code === "dataset.not_found") {
 The catalog starts deliberately small and grows with each primitive's vertical migration. Unknown
 legacy exceptions use `internal.unexpected` until their call site receives a specific code.
 
+## Failure records
+
+Persisted sync-run failures use the same portable record returned by their API:
+
+```ts
+interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
+  readonly code: TCode
+  readonly message: string
+  readonly retryable: boolean
+  readonly at: string
+  readonly details?: JsonValue
+  readonly causeChain?: readonly { readonly name: string; readonly message: string }[]
+}
+```
+
+Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs
+currently declare `internal.unexpected | runtime.cancelled`.
+
+Other run primitives keep their legacy error shape until their own vertical migration. This keeps
+each storage and wire change independently reviewable.
+
 | Code | Retryable | What happened | What to do |
 | --- | --- | --- | --- |
 | `dataset.not_found` | No | The requested dataset is not registered or is not visible to the caller. | Check the dataset ID and the caller's access. |
 | `dataset.version_not_found` | No | The requested dataset version does not exist, or the dataset has no committed version yet. | Check the version ID or materialize the dataset before reading rows. |
 | `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect the failure and its cause chain. Do not retry automatically. |
+| `runtime.cancelled` | No | An in-flight operation was cancelled before completion. | Confirm the cancellation was intentional before requesting another run. |

--- a/packages/atlas/src/pages/SyncsPage.tsx
+++ b/packages/atlas/src/pages/SyncsPage.tsx
@@ -447,10 +447,12 @@ function SyncRunCard({ run }: { run: DisplayRun }) {
         </div>
       </div>
       {run.error && (
-        <p className="mt-3 break-words text-xs text-destructive">
-          {run.error.name ? `${run.error.name}: ` : ""}
-          {run.error.message}
-        </p>
+        <div className="mt-3 min-w-0">
+          <p className="break-words text-xs text-destructive">{run.error.message}</p>
+          <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+            {run.error.code}
+          </p>
+        </div>
       )}
     </div>
   )
@@ -521,10 +523,12 @@ function SyncRunList({ runs, queuedRun }: { runs: SyncRun[]; queuedRun: QueuedRu
                     </p>
                   )}
                   {run.error && (
-                    <p className="mt-1 text-xs text-destructive">
-                      {run.error.name ? `${run.error.name}: ` : ""}
-                      {run.error.message}
-                    </p>
+                    <div className="mt-1 min-w-0">
+                      <p className="text-xs text-destructive">{run.error.message}</p>
+                      <p className="truncate font-mono text-[10px] text-muted-foreground">
+                        {run.error.code}
+                      </p>
+                    </div>
                   )}
                 </td>
                 <td className="px-3 py-3">

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -6087,14 +6087,50 @@
                           "error": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string"
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
                               },
                               "message": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
                               }
                             },
-                            "required": ["message"],
+                            "required": ["code", "message", "retryable", "at"],
                             "additionalProperties": false
                           }
                         },
@@ -6317,14 +6353,50 @@
                         "error": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string"
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
                             },
                             "message": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
                             }
                           },
-                          "required": ["message"],
+                          "required": ["code", "message", "retryable", "at"],
                           "additionalProperties": false
                         }
                       },
@@ -6504,14 +6576,50 @@
                           "error": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string"
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
                               },
                               "message": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
                               }
                             },
-                            "required": ["message"],
+                            "required": ["code", "message", "retryable", "at"],
                             "additionalProperties": false
                           }
                         },

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2153,8 +2153,23 @@ export type ListSyncsResponses = {
       expectedLatestVersionId?: string
       commitMessage?: string
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled"
         message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
       }
     } | null
   }>
@@ -2239,8 +2254,23 @@ export type GetSyncResponses = {
       expectedLatestVersionId?: string
       commitMessage?: string
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled"
         message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
       }
     } | null
   }
@@ -2303,8 +2333,23 @@ export type ListSyncRunsResponses = {
       expectedLatestVersionId?: string
       commitMessage?: string
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled"
         message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
       }
     }>
     hasMore: boolean

--- a/packages/client/tests/sync-failure.types.ts
+++ b/packages/client/tests/sync-failure.types.ts
@@ -1,0 +1,13 @@
+import type { ListSyncsResponses } from "../src/generated/types.gen"
+
+type LatestSyncRun = NonNullable<ListSyncsResponses[200][number]["latestRun"]>
+type SyncFailureCode = NonNullable<LatestSyncRun["error"]>["code"]
+
+const unexpected: SyncFailureCode = "internal.unexpected"
+const cancelled: SyncFailureCode = "runtime.cancelled"
+
+// Dataset lookup codes belong to HTTP route failures, not persisted sync-run failures.
+// @ts-expect-error the generated sync failure contract must stay scoped to its producer
+const unrelated: SyncFailureCode = "dataset.not_found"
+
+void [unexpected, cancelled, unrelated]

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -22,4 +22,16 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "An unexpected internal error occurred.",
     retryable: false,
   },
+  "runtime.cancelled": {
+    publicMessage: "Execution was cancelled.",
+    retryable: false,
+  },
 } as const satisfies Readonly<Record<string, SixbErrorDefinition>>
+
+type CatalogErrorCode = keyof typeof SIXB_ERROR_DEFINITIONS
+
+/** Runtime counterpart of `SixbErrorCode` for internal schema boundaries. */
+export const SIXB_ERROR_CODES = Object.freeze(Object.keys(SIXB_ERROR_DEFINITIONS)) as readonly [
+  CatalogErrorCode,
+  ...CatalogErrorCode[],
+]

--- a/packages/core/src/errors/internal.ts
+++ b/packages/core/src/errors/internal.ts
@@ -1,12 +1,15 @@
-import { cloneJsonValue, type ReadonlyJsonValue } from "../json"
-import { SIXB_ERROR_DEFINITIONS } from "./catalog"
+import { cloneJsonValue, isJsonValue, isPlainRecord, type ReadonlyJsonValue } from "../json"
+import { SIXB_ERROR_CODES, SIXB_ERROR_DEFINITIONS } from "./catalog"
 import type { SixbErrorCode, SixbFailure } from "./types"
 
 export const SIXB_FAILURE_MAX_MESSAGE_BYTES = 4 * 1024
 export const SIXB_FAILURE_MAX_SERIALIZED_BYTES = 32 * 1024
 const TRUNCATION_SUFFIX = "… [truncated]"
+const SIXB_ERROR_CODE_SET: ReadonlySet<string> = new Set(SIXB_ERROR_CODES)
 
 type SixbErrorCodeTuple = readonly [SixbErrorCode, ...SixbErrorCode[]]
+
+export { SIXB_ERROR_CODES }
 
 export interface SixbErrorOptions {
   readonly cause?: unknown
@@ -124,19 +127,18 @@ export function toSixbFailure(
   if (allowedCodes && !allowedCodes.has(error.code)) {
     throw new Error(`[Sixb] Error code '${error.code}' is not allowed by this failure contract.`)
   }
-
+  const code = error.code
+  const details = error.details
   const message = truncateUtf8(
-    SIXB_ERROR_DEFINITIONS[error.code].publicMessage,
+    SIXB_ERROR_DEFINITIONS[code].publicMessage,
     SIXB_FAILURE_MAX_MESSAGE_BYTES
   )
   const failure: SixbFailure = {
-    code: error.code,
+    code,
     message: message.value,
-    retryable: SIXB_ERROR_DEFINITIONS[error.code].retryable,
+    retryable: SIXB_ERROR_DEFINITIONS[code].retryable,
     at: failureTimestamp(options.at),
-    ...(error.details === undefined
-      ? {}
-      : { details: cloneJsonValue(error.details, "Sixb failure details") }),
+    ...(details === undefined ? {} : { details: cloneJsonValue(details, "Sixb failure details") }),
     ...(message.truncated ? { truncated: true } : {}),
   }
 
@@ -149,6 +151,104 @@ export function toSixbFailure(
     at: failure.at,
     truncated: true,
   }
+}
+
+/** Serializes a validated failure for durable storage. */
+export function serializeSixbFailure<const TCodes extends SixbErrorCodeTuple>(
+  failure: SixbFailure<TCodes[number]>,
+  allowedCodes: TCodes
+): string
+export function serializeSixbFailure(failure: SixbFailure): string
+export function serializeSixbFailure(
+  failure: SixbFailure,
+  allowedCodes?: SixbErrorCodeTuple
+): string {
+  const parsed = allowedCodes ? parseSixbFailure(failure, allowedCodes) : parseSixbFailure(failure)
+  return JSON.stringify(parsed)
+}
+
+/**
+ * Validates and detaches a failure read from a storage boundary.
+ *
+ * Strings are accepted for SQLite; PostgreSQL adapters can pass their decoded JSON value directly.
+ */
+export function parseSixbFailure<const TCodes extends SixbErrorCodeTuple>(
+  value: unknown,
+  allowedCodes: TCodes
+): SixbFailure<TCodes[number]>
+export function parseSixbFailure(value: unknown): SixbFailure
+export function parseSixbFailure(
+  value: unknown,
+  allowedCodes: SixbErrorCodeTuple = SIXB_ERROR_CODES
+): SixbFailure {
+  const candidate = parseStoredFailureValue(value)
+  if (!isPlainRecord(candidate)) {
+    throw invalidStoredFailure("expected a JSON object")
+  }
+
+  const { code, message, retryable, at, details, truncated } = candidate
+  if (typeof code !== "string" || !SIXB_ERROR_CODE_SET.has(code)) {
+    throw invalidStoredFailure("code is not a known Sixb error code")
+  }
+  if (!(allowedCodes as readonly string[]).includes(code)) {
+    throw invalidStoredFailure("code is not allowed by this failure contract")
+  }
+  if (typeof message !== "string") {
+    throw invalidStoredFailure("message is not a string")
+  }
+  if (utf8ByteLength(message) > SIXB_FAILURE_MAX_MESSAGE_BYTES) {
+    throw invalidStoredFailure(`message exceeds ${SIXB_FAILURE_MAX_MESSAGE_BYTES} UTF-8 bytes`)
+  }
+  if (typeof retryable !== "boolean") {
+    throw invalidStoredFailure("retryable is not a boolean")
+  }
+  if (retryable !== SIXB_ERROR_DEFINITIONS[code as SixbErrorCode].retryable) {
+    throw invalidStoredFailure("retryable does not match the error code policy")
+  }
+  if (typeof at !== "string" || !isCanonicalIsoTimestamp(at)) {
+    throw invalidStoredFailure("at is not a canonical ISO-8601 timestamp")
+  }
+  if (details !== undefined && !isJsonValue(details)) {
+    throw invalidStoredFailure("details is not a JSON value")
+  }
+  if (truncated !== undefined && truncated !== true) {
+    throw invalidStoredFailure("truncated must be true when present")
+  }
+
+  const failure: SixbFailure = {
+    code: code as SixbErrorCode,
+    message,
+    retryable,
+    at,
+    ...(details === undefined
+      ? {}
+      : { details: cloneJsonValue(details, "Stored Sixb failure details") }),
+    ...(truncated === true ? { truncated: true } : {}),
+  }
+  if (serializedByteLength(failure) > SIXB_FAILURE_MAX_SERIALIZED_BYTES) {
+    throw invalidStoredFailure(
+      `record exceeds ${SIXB_FAILURE_MAX_SERIALIZED_BYTES} serialized UTF-8 bytes`
+    )
+  }
+  return failure
+}
+
+function parseStoredFailureValue(value: unknown): unknown {
+  if (typeof value !== "string") return value
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    throw invalidStoredFailure("value is not valid JSON")
+  }
+}
+
+function isCanonicalIsoTimestamp(value: string): boolean {
+  const timestamp = new Date(value)
+  return Number.isFinite(timestamp.getTime()) && timestamp.toISOString() === value
+}
+
+function invalidStoredFailure(reason: string): Error {
+  return new Error(`[Sixb] Stored failure is invalid: ${reason}.`)
 }
 
 /**

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -5,6 +5,7 @@
  * the interface cannot be implemented from outside the package.
  */
 export type { Principal } from "../auth"
+export type { SixbFailure } from "../errors/types"
 export type { StoredRuleResolvedEvent, StoredRuleTriggeredEvent } from "../events"
 export type { ReadonlyJsonObject } from "../json"
 export { stableJsonStringify } from "../json"
@@ -429,13 +430,13 @@ export type {
   ListSyncRunsInput,
   ListSyncRunsResult,
   StartSyncRunInput,
-  SyncRunFailure,
+  SyncRunFailureCode,
   SyncRunMode,
   SyncRunRecord,
   SyncRunStatus,
   SyncRunStorage,
 } from "./sync-runs"
-export { InMemorySyncRunStorage, SyncRunError } from "./sync-runs"
+export { InMemorySyncRunStorage, SYNC_RUN_FAILURE_CODES, SyncRunError } from "./sync-runs"
 export type {
   TimeseriesHistoryBatchInput,
   TimeseriesHistoryBatchResult,

--- a/packages/core/src/storage/sync-runs/in-memory.ts
+++ b/packages/core/src/storage/sync-runs/in-memory.ts
@@ -1,3 +1,5 @@
+import { parseSixbFailure } from "../../errors/internal"
+import type { SixbFailure } from "../../errors/types"
 import { cloneJsonValue, type JsonValue } from "../../json"
 import {
   compareStartedAt,
@@ -15,10 +17,11 @@ import type {
   ListSyncRunsInput,
   ListSyncRunsResult,
   StartSyncRunInput,
-  SyncRunFailure,
+  SyncRunFailureCode,
   SyncRunRecord,
   SyncRunStorage,
 } from "./types"
+import { SYNC_RUN_FAILURE_CODES } from "./types"
 
 function syncRunKey(projectId: string, id: string): string {
   return `${projectId}:${id}`
@@ -32,8 +35,10 @@ function normalizeCheckpoint(checkpoint: JsonValue | undefined): JsonValue | und
   return checkpoint !== undefined ? cloneJsonValue(checkpoint) : undefined
 }
 
-function normalizeError(error: SyncRunFailure | undefined): SyncRunFailure | undefined {
-  return error ? structuredClone(error) : undefined
+function normalizeError(
+  error: SixbFailure<SyncRunFailureCode> | undefined
+): SixbFailure<SyncRunFailureCode> | undefined {
+  return error ? parseSixbFailure(error, SYNC_RUN_FAILURE_CODES) : undefined
 }
 
 export class InMemorySyncRunStorage implements SyncRunStorage {

--- a/packages/core/src/storage/sync-runs/index.ts
+++ b/packages/core/src/storage/sync-runs/index.ts
@@ -7,9 +7,10 @@ export type {
   ListSyncRunsInput,
   ListSyncRunsResult,
   StartSyncRunInput,
-  SyncRunFailure,
+  SyncRunFailureCode,
   SyncRunMode,
   SyncRunRecord,
   SyncRunStatus,
   SyncRunStorage,
 } from "./types"
+export { SYNC_RUN_FAILURE_CODES } from "./types"

--- a/packages/core/src/storage/sync-runs/types.ts
+++ b/packages/core/src/storage/sync-runs/types.ts
@@ -1,3 +1,4 @@
+import type { SixbErrorCode, SixbFailure } from "../../errors/types"
 import type { JsonValue } from "../../json"
 import type { DatasetVersionRef, DatasetWriteMode } from "../../lake-storage"
 
@@ -5,10 +6,13 @@ export type SyncRunMode = DatasetWriteMode | "merge"
 
 export type SyncRunStatus = "running" | "succeeded" | "failed" | "cancelled"
 
-export interface SyncRunFailure {
-  readonly name?: string // Example: "AbortError"
-  readonly message: string // Example: "Sync cancelled by request"
-}
+/** Error codes a sync run can persist and expose through its public contract. */
+export const SYNC_RUN_FAILURE_CODES = [
+  "internal.unexpected",
+  "runtime.cancelled",
+] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
+
+export type SyncRunFailureCode = (typeof SYNC_RUN_FAILURE_CODES)[number]
 
 export interface SyncRunRecord {
   readonly id: string
@@ -24,7 +28,7 @@ export interface SyncRunRecord {
   readonly output?: DatasetVersionRef
   readonly expectedLatestVersionId?: string
   readonly commitMessage?: string
-  readonly error?: SyncRunFailure
+  readonly error?: SixbFailure<SyncRunFailureCode>
   readonly checkpoint?: JsonValue
 }
 
@@ -58,7 +62,7 @@ export type FinishSyncRunInput =
       readonly finishedAt?: Date
       /** Source items successfully consumed before the failure or cancellation. */
       readonly rowsRead?: number
-      readonly error?: SyncRunFailure
+      readonly error?: SixbFailure<SyncRunFailureCode>
     }
 
 export interface ListSyncRunsInput {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -193,7 +193,7 @@ export type {
   ListSyncRunsInput,
   ListSyncRunsResult,
   StartSyncRunInput,
-  SyncRunFailure,
+  SyncRunFailureCode,
   SyncRunMode,
   SyncRunRecord,
   SyncRunStatus,

--- a/packages/core/tests/error-model.test.ts
+++ b/packages/core/tests/error-model.test.ts
@@ -8,10 +8,13 @@ import {
   captureSixbFailure,
   createSixbError,
   isSixbError,
+  parseSixbFailure,
   SIXB_FAILURE_MAX_SERIALIZED_BYTES,
+  serializeSixbFailure,
   summarizeErrorMessage,
   toSixbFailure,
 } from "../src/errors/internal"
+import { SYNC_RUN_FAILURE_CODES } from "../src/storage"
 
 const AT = new Date("2026-08-05T12:00:00.000Z")
 
@@ -87,6 +90,56 @@ describe("Sixb error model", () => {
       // @ts-expect-error Unknown values must go through captureSixbFailure.
       toSixbFailure(new Error("uncoded"))
     ).toThrow("A durable failure can only be created from a coded Sixb error")
+  })
+
+  test("round-trips and validates failure records at storage boundaries", () => {
+    const failure = captureSixbFailure(new Error("provider offline"), {
+      allowedCodes: SYNC_RUN_FAILURE_CODES,
+      defaultCode: "internal.unexpected",
+      at: AT,
+      details: { syncId: "sync-1", runId: "run-1" },
+    })
+    const serialized = serializeSixbFailure(failure)
+
+    expect(parseSixbFailure(serialized)).toEqual(failure)
+    expect(parseSixbFailure(JSON.parse(serialized))).toEqual(failure)
+    expect(() => parseSixbFailure({ ...failure, code: "future.unknown" })).toThrow(
+      "code is not a known Sixb error code"
+    )
+    expect(() => parseSixbFailure({ ...failure, retryable: true })).toThrow(
+      "retryable does not match the error code policy"
+    )
+    expect(() => parseSixbFailure({ ...failure, at: "2026-08-05" })).toThrow(
+      "at is not a canonical ISO-8601 timestamp"
+    )
+  })
+
+  test("constrains a failure to the codes declared by its boundary", () => {
+    const datasetError = createSixbError("dataset.not_found", "Dataset is missing", {
+      details: { datasetId: "foreign" },
+    })
+
+    expect(() =>
+      toSixbFailure(datasetError, {
+        allowedCodes: SYNC_RUN_FAILURE_CODES,
+        at: AT,
+      })
+    ).toThrow("Error code 'dataset.not_found' is not allowed by this failure contract")
+
+    const scopedFailure = captureSixbFailure(datasetError, {
+      allowedCodes: SYNC_RUN_FAILURE_CODES,
+      defaultCode: "internal.unexpected",
+      details: { syncId: "sync-1", runId: "run-1" },
+      at: AT,
+    })
+    expect(scopedFailure.code).toBe("internal.unexpected")
+    expect(scopedFailure.details).toEqual({ syncId: "sync-1", runId: "run-1" })
+
+    const datasetFailure = toSixbFailure(datasetError, { at: AT })
+    expect(parseSixbFailure(datasetFailure)).toEqual(datasetFailure)
+    expect(() => parseSixbFailure(datasetFailure, SYNC_RUN_FAILURE_CODES)).toThrow(
+      "code is not allowed by this failure contract"
+    )
   })
 
   test("bounds durable records and rejects non-serializable details", () => {

--- a/packages/core/tests/sync-runs.test.ts
+++ b/packages/core/tests/sync-runs.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test"
+import type { SixbFailure, SyncRunFailureCode } from "../src/storage"
 import { InMemorySyncRunStorage, SyncRunError } from "../src/storage"
+
+const FAILURE: SixbFailure<SyncRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Database connection lost",
+  retryable: false,
+  at: "2026-04-06T15:00:00.420Z",
+  details: { provider: "erp" },
+}
 
 describe("InMemorySyncRunStorage", () => {
   test("starts and finishes a successful run with a checkpoint", async () => {
@@ -169,9 +178,7 @@ describe("InMemorySyncRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "boom",
-        },
+        error: { ...FAILURE, message: "boom" },
       })
     ).rejects.toBeInstanceOf(SyncRunError)
   })
@@ -193,10 +200,7 @@ describe("InMemorySyncRunStorage", () => {
       status: "failed",
       finishedAt: new Date("2026-04-06T15:00:00.420Z"),
       rowsRead: 23,
-      error: {
-        name: "Error",
-        message: "Database connection lost",
-      },
+      error: FAILURE,
     })
 
     await storage.start({
@@ -259,10 +263,7 @@ describe("InMemorySyncRunStorage", () => {
 
     expect(failed?.status).toBe("failed")
     expect(failed?.rowsRead).toBe(23)
-    expect(failed?.error).toEqual({
-      name: "Error",
-      message: "Database connection lost",
-    })
+    expect(failed?.error).toEqual(FAILURE)
   })
 
   test("lists the latest run for multiple sync ids", async () => {

--- a/packages/server/src/schemas/common.ts
+++ b/packages/server/src/schemas/common.ts
@@ -1,4 +1,5 @@
 import type { SixbErrorCode } from "@sixb/core"
+import { SIXB_FAILURE_MAX_MESSAGE_BYTES } from "@sixb/core/internal/errors"
 import { z } from "zod"
 import { ignoreOverride, type JsonSchema7Type, type OverrideCallback } from "zod-to-json-schema"
 
@@ -35,6 +36,20 @@ export const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
 
 /** A JSON null with an explicit runtime and generated-client type. */
 export const JsonNullSchema = JsonValueSchema.refine((value): value is null => value === null)
+
+/** Creates a portable failure record constrained to one boundary's declared codes. */
+export function sixbFailureSchema<
+  const TCodes extends readonly [SixbErrorCode, ...SixbErrorCode[]],
+>(codes: TCodes) {
+  return z.object({
+    code: z.enum(codes),
+    message: z.string().max(SIXB_FAILURE_MAX_MESSAGE_BYTES),
+    retryable: z.boolean(),
+    at: z.string().datetime(),
+    details: JsonValueSchema.optional(),
+    truncated: z.literal(true).optional(),
+  })
+}
 
 const JsonValueOpenApiSchema = {
   description: "Any JSON-compatible value.",

--- a/packages/server/src/schemas/syncs.ts
+++ b/packages/server/src/schemas/syncs.ts
@@ -1,5 +1,14 @@
+import {
+  type SixbFailure,
+  SYNC_RUN_FAILURE_CODES,
+  type SyncRunFailureCode,
+} from "@sixb/core/storage"
 import { z } from "zod"
+import { sixbFailureSchema } from "./common"
 import { DatasetDefinitionSchema } from "./datasets"
+
+const SyncRunFailureSchema: z.ZodType<SixbFailure<SyncRunFailureCode>> =
+  sixbFailureSchema(SYNC_RUN_FAILURE_CODES)
 
 export const SyncParamsSchema = z.object({
   syncId: z.string().min(1),
@@ -47,12 +56,7 @@ export const SyncRunSchema = z.object({
     .optional(),
   expectedLatestVersionId: z.string().optional(),
   commitMessage: z.string().optional(),
-  error: z
-    .object({
-      name: z.string().optional(),
-      message: z.string(),
-    })
-    .optional(),
+  error: SyncRunFailureSchema.optional(),
 })
 
 export const SyncSchema = z.object({

--- a/packages/server/tests/syncs-routes.test.ts
+++ b/packages/server/tests/syncs-routes.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import type { SixbHostView } from "@sixb/core"
 import { change, col, defineConnector, defineDataset, defineSync } from "@sixb/core"
-import type { ListLatestSyncRunsInput, SyncRunStorage } from "@sixb/core/storage"
+import type {
+  ListLatestSyncRunsInput,
+  SixbFailure,
+  SyncRunFailureCode,
+  SyncRunStorage,
+} from "@sixb/core/storage"
 import { Elysia } from "elysia"
 import { registerSyncRoutes } from "../src/routes/syncs"
 
@@ -39,6 +44,14 @@ const syncs = [
     .read(() => change.delete({ invoiceId: "missing" }))
     .intoDataset(invoicesDataset),
 ]
+
+const FAILURE: SixbFailure<SyncRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Provider offline",
+  retryable: false,
+  at: "2026-04-06T16:00:01.000Z",
+  details: { provider: "erp" },
+}
 
 function createSixbStub(syncRuns: Partial<SyncRunStorage>): SixbHostView {
   return {
@@ -90,6 +103,17 @@ describe("sync routes", () => {
         return {
           runs: [
             {
+              id: "run-customers",
+              projectId: "my-app",
+              syncId: "sync-customers",
+              datasetId: "raw.crm.customers",
+              mode: "append",
+              status: "failed",
+              startedAt: new Date("2026-04-06T16:00:00.000Z"),
+              finishedAt: new Date("2026-04-06T16:00:01.000Z"),
+              error: FAILURE,
+            },
+            {
               id: "run-invoices",
               projectId: "my-app",
               syncId: "sync-invoices",
@@ -109,7 +133,12 @@ describe("sync routes", () => {
     const body = (await response.json()) as Array<{
       id: string
       target: { dataset: { primaryKey?: string | string[] } }
-      latestRun: { id: string; syncId: string; status: string } | null
+      latestRun: {
+        id: string
+        syncId: string
+        status: string
+        error?: SixbFailure<SyncRunFailureCode>
+      } | null
     }>
 
     expect(bulkCalls).toBe(1)
@@ -117,11 +146,15 @@ describe("sync routes", () => {
     expect(requestedSyncIds).toEqual([["sync-orders", "sync-customers", "sync-invoices"]])
     expect(body.map((sync) => [sync.id, sync.latestRun?.id ?? null])).toEqual([
       ["sync-orders", null],
-      ["sync-customers", null],
+      ["sync-customers", "run-customers"],
       ["sync-invoices", "run-invoices"],
     ])
     expect(body.find((sync) => sync.id === "sync-invoices")?.target.dataset.primaryKey).toBe(
       "invoiceId"
     )
+    expect(body.find((sync) => sync.id === "sync-customers")?.latestRun).toMatchObject({
+      status: "failed",
+      error: FAILURE,
+    })
   })
 })

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -12,9 +12,10 @@ import {
   type MergeChange,
   type SyncDefinition,
 } from "@sixb/core"
+import { captureSixbFailure } from "@sixb/core/internal/errors"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import { type DatasetVersion, getDatasetMergeChangeValidationError } from "@sixb/core/lake-storage"
-import type { SyncRunFailure, SyncRunRecord } from "@sixb/core/storage"
+import { SYNC_RUN_FAILURE_CODES, type SyncRunRecord } from "@sixb/core/storage"
 import { assertDatasetRow, normalizeReadResult, throwIfAborted } from "./normalize"
 import type { RunSyncJobInput, SyncRunResult, SyncWorkerContext } from "./types"
 
@@ -23,19 +24,6 @@ export class SyncRunAlreadyStartedError extends Error {
 
   constructor(readonly run: SyncRunRecord) {
     super(`[SixbSyncWorker] Sync run '${run.id}' has already started.`)
-  }
-}
-
-function toSyncRunFailure(error: unknown): SyncRunFailure {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-    }
-  }
-
-  return {
-    message: String(error),
   }
 }
 
@@ -462,7 +450,11 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
           id: job.id,
           status,
           rowsRead,
-          error: toSyncRunFailure(error),
+          error: captureSixbFailure(error, {
+            allowedCodes: SYNC_RUN_FAILURE_CODES,
+            defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+            details: { syncId: sync.id, runId: job.id },
+          }),
         })
         if (status === "failed" && run.status === "failed") input.onRunFailed?.(error, run)
       } catch {

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -949,8 +949,11 @@ describe("runSyncJob", () => {
       status: "failed",
       rowsRead: 1,
       error: {
-        message:
-          "[SixbSyncWorker] Sync 'sync-orders' returned an invalid row at item 2. Dataset rows must be plain objects.",
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: expect.any(String),
+        details: { syncId: "sync-orders", runId: "run_1" },
       },
     })
   })
@@ -983,8 +986,11 @@ describe("runSyncJob", () => {
       status: "failed",
       rowsRead: 0,
       error: {
-        message:
-          "[SixbSyncWorker] Sync 'sync-orders' returned an unsupported read result. Expected a row object, iterable, or async iterable.",
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: expect.any(String),
+        details: { syncId: "sync-orders", runId: "run_1" },
       },
     })
   })
@@ -1017,8 +1023,11 @@ describe("runSyncJob", () => {
       status: "failed",
       rowsRead: 0,
       error: {
-        message:
-          "[SixbSyncWorker] Sync 'sync-orders' returned an invalid row at item 1. Dataset 'raw.erp.orders' row contains unknown column 'unexpected'.",
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: expect.any(String),
+        details: { syncId: "sync-orders", runId: "run_schema_error" },
       },
     })
   })
@@ -1060,8 +1069,11 @@ describe("runSyncJob", () => {
       status: "failed",
       rowsRead: 0,
       error: {
-        message:
-          "[SixbSyncWorker] Sync 'sync-docs' returned row 1 with dataset 'raw.docs' column 'attachment' referencing unknown blob 'blob_missing'.",
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: expect.any(String),
+        details: { syncId: "sync-docs", runId: "run_missing_blob" },
       },
     })
   })
@@ -1163,7 +1175,10 @@ describe("runSyncJob", () => {
       status: "cancelled",
       rowsRead: 1,
       error: {
-        name: "AbortError",
+        code: "runtime.cancelled",
+        retryable: false,
+        at: expect.any(String),
+        details: { syncId: "sync-orders", runId: "run_1" },
       },
     })
   })

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -27,6 +27,7 @@ import agentExecutionsSql from "./migrations/009-agent-executions.sql" with { ty
 import aiUsageAccountingFoundationSql from "./migrations/010-ai-usage-accounting-foundation.sql" with {
   type: "text",
 }
+import syncFailureRecordSql from "./migrations/011-sync-failure-record.sql" with { type: "text" }
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -290,6 +291,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("008-action-executions", actionExecutionsSql),
     pgSql("009-agent-executions", agentExecutionsSql),
     pgSql("010-ai-usage-accounting-foundation", aiUsageAccountingFoundationSql),
+    pgSql("011-sync-failure-record", syncFailureRecordSql),
   ],
 })
 

--- a/storage/pg/src/migrations/011-sync-failure-record.sql
+++ b/storage/pg/src/migrations/011-sync-failure-record.sql
@@ -1,0 +1,23 @@
+ALTER TABLE sync_runs ADD COLUMN error JSONB;
+
+UPDATE sync_runs
+SET error = jsonb_build_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', false,
+  'at', to_char(COALESCE(finished_at, started_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'syncId', sync_id,
+    'runId', id,
+    'datasetId', dataset_id,
+    'migratedFromLegacyError', true
+  )
+)
+WHERE error_name IS NOT NULL OR error_message IS NOT NULL;
+
+ALTER TABLE sync_runs
+  DROP COLUMN error_name,
+  DROP COLUMN error_message;

--- a/storage/pg/src/pg-sync-run-storage.ts
+++ b/storage/pg/src/pg-sync-run-storage.ts
@@ -1,4 +1,5 @@
 import type { JsonValue } from "@sixb/core"
+import { parseSixbFailure, serializeSixbFailure } from "@sixb/core/internal/errors"
 import type {
   FinishSyncRunInput,
   ListLatestSyncRunsInput,
@@ -6,11 +7,10 @@ import type {
   ListSyncRunsInput,
   ListSyncRunsResult,
   StartSyncRunInput,
-  SyncRunFailure,
   SyncRunRecord,
   SyncRunStorage,
 } from "@sixb/core/storage"
-import { SyncRunError } from "@sixb/core/storage"
+import { SYNC_RUN_FAILURE_CODES, SyncRunError } from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import type { SqlParameter } from "./pg-client"
 import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
@@ -94,8 +94,7 @@ export class PgSyncRunStorage implements SyncRunStorage {
                 finished_at = ${input.finishedAt ?? new Date()},
                 rows_read = ${input.rowsRead},
                 output_version_id = ${input.output?.versionId ?? null},
-                error_name = ${null},
-                error_message = ${null},
+                error = ${null},
                 checkpoint = ${serializeCheckpoint(input.checkpoint)}::text::jsonb
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *, checkpoint IS NOT NULL AS checkpoint_present
@@ -107,8 +106,7 @@ export class PgSyncRunStorage implements SyncRunStorage {
                 finished_at = ${input.finishedAt ?? new Date()},
                 rows_read = ${input.rowsRead ?? existing.rows_read ?? null},
                 output_version_id = ${null},
-                error_name = ${input.error?.name ?? null},
-                error_message = ${input.error?.message ?? null},
+                error = ${input.error === undefined ? null : serializeSixbFailure(input.error, SYNC_RUN_FAILURE_CODES)}::text::jsonb,
                 checkpoint = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *, checkpoint IS NOT NULL AS checkpoint_present
@@ -198,17 +196,6 @@ function serializeCheckpoint(checkpoint: JsonValue | undefined): string | null {
   return checkpoint !== undefined ? JSON.stringify(checkpoint) : null
 }
 
-function toSyncRunFailure(row: DatabaseRow): SyncRunFailure | undefined {
-  if (!row.error_message) {
-    return undefined
-  }
-
-  return {
-    name: row.error_name ?? undefined,
-    message: row.error_message,
-  }
-}
-
 function rowToSyncRunRecord(row: DatabaseRow): SyncRunRecord {
   return {
     id: row.id,
@@ -228,7 +215,7 @@ function rowToSyncRunRecord(row: DatabaseRow): SyncRunRecord {
       : undefined,
     expectedLatestVersionId: row.expected_latest_version_id ?? undefined,
     commitMessage: row.commit_message ?? undefined,
-    error: toSyncRunFailure(row),
+    error: row.error === null ? undefined : parseSixbFailure(row.error, SYNC_RUN_FAILURE_CODES),
     checkpoint: hasCheckpoint(row) ? row.checkpoint : undefined,
   }
 }
@@ -256,8 +243,7 @@ interface DatabaseRow {
   output_version_id: string | null
   expected_latest_version_id: string | null
   commit_message: string | null
-  error_name: string | null
-  error_message: string | null
+  error: JsonValue | null
   checkpoint: JsonValue | null
   checkpoint_present: boolean | number | string
 }

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -46,6 +46,7 @@ describe("Postgres storage migrations", () => {
             "008-action-executions",
             "009-agent-executions",
             "010-ai-usage-accounting-foundation",
+            "011-sync-failure-record",
           ],
         },
       ])
@@ -119,6 +120,13 @@ describe("Postgres storage migrations", () => {
           id: "010-ai-usage-accounting-foundation",
           status: "applied",
           version: 10,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "011-sync-failure-record",
+          status: "applied",
+          version: 11,
         },
       ])
     })
@@ -774,6 +782,13 @@ describe("Postgres storage migrations", () => {
           id: "010-ai-usage-accounting-foundation",
           status: "applied",
           version: 10,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "011-sync-failure-record",
+          status: "applied",
+          version: 11,
         },
       ])
     } finally {

--- a/storage/pg/tests/pg-sync-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-sync-run-storage.e2e.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { SyncRunError } from "@sixb/core/storage"
+import { type SixbFailure, SyncRunError, type SyncRunFailureCode } from "@sixb/core/storage"
 import type { PostgresStorage } from "../src"
 import { createTestStorage } from "./helpers"
+
+const FAILURE: SixbFailure<SyncRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Database connection lost",
+  retryable: false,
+  at: "2026-04-06T15:00:00.420Z",
+  details: { provider: "erp" },
+}
 
 describe("PgSyncRunStorage", () => {
   let storage: PostgresStorage
@@ -141,10 +149,7 @@ describe("PgSyncRunStorage", () => {
       projectId: "my-app",
       status: "failed",
       rowsRead: 23,
-      error: {
-        name: "Error",
-        message: "Database connection lost",
-      },
+      error: FAILURE,
     })
 
     await storage.syncRuns.start({
@@ -192,7 +197,7 @@ describe("PgSyncRunStorage", () => {
       projectId: "my-app",
       id: "run-1",
     })
-    expect(failed?.error?.message).toBe("Database connection lost")
+    expect(failed?.error).toEqual(FAILURE)
     expect(failed?.rowsRead).toBe(23)
   })
 
@@ -262,9 +267,7 @@ describe("PgSyncRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "boom",
-        },
+        error: { ...FAILURE, message: "boom" },
       })
     ).rejects.toBeInstanceOf(SyncRunError)
 

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -30,6 +30,7 @@ import agentExecutionsSql from "./migrations/009-agent-executions.sql" with { ty
 import aiUsageAccountingFoundationSql from "./migrations/010-ai-usage-accounting-foundation.sql" with {
   type: "text",
 }
+import syncFailureRecordSql from "./migrations/011-sync-failure-record.sql" with { type: "text" }
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -60,6 +61,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("008-action-executions", actionExecutionsSql),
     sqliteSql("009-agent-executions", agentExecutionsSql),
     sqliteSql("010-ai-usage-accounting-foundation", aiUsageAccountingFoundationSql),
+    sqliteSql("011-sync-failure-record", syncFailureRecordSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/011-sync-failure-record.sql
+++ b/storage/sqlite/src/migrations/011-sync-failure-record.sql
@@ -1,0 +1,22 @@
+ALTER TABLE sync_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE sync_runs
+SET error = json_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json('false'),
+  'at', COALESCE(finished_at, started_at),
+  'details', json_object(
+    'syncId', sync_id,
+    'runId', id,
+    'datasetId', dataset_id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE error_name IS NOT NULL OR error_message IS NOT NULL;
+
+ALTER TABLE sync_runs DROP COLUMN error_name;
+ALTER TABLE sync_runs DROP COLUMN error_message;

--- a/storage/sqlite/src/sync-run-storage.ts
+++ b/storage/sqlite/src/sync-run-storage.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite"
 import type { JsonValue } from "@sixb/core"
+import { parseSixbFailure, serializeSixbFailure } from "@sixb/core/internal/errors"
 import type {
   FinishSyncRunInput,
   ListLatestSyncRunsInput,
@@ -7,11 +8,10 @@ import type {
   ListSyncRunsInput,
   ListSyncRunsResult,
   StartSyncRunInput,
-  SyncRunFailure,
   SyncRunRecord,
   SyncRunStorage,
 } from "@sixb/core/storage"
-import { SyncRunError } from "@sixb/core/storage"
+import { SYNC_RUN_FAILURE_CODES, SyncRunError } from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import { installFreshSqliteSchema } from "./migrations"
 import {
@@ -131,8 +131,7 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
             finished_at = ?,
             rows_read = ?,
             output_version_id = ?,
-            error_name = ?,
-            error_message = ?,
+            error = ?,
             checkpoint = ?
           WHERE project_id = ? AND id = ?
         `
@@ -144,8 +143,9 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
             ? input.rowsRead
             : (input.rowsRead ?? existing.rows_read ?? null),
           input.status === "succeeded" ? (input.output?.versionId ?? null) : null,
-          input.status === "succeeded" ? null : (input.error?.name ?? null),
-          input.status === "succeeded" ? null : (input.error?.message ?? null),
+          input.status === "succeeded" || input.error === undefined
+            ? null
+            : serializeSixbFailure(input.error, SYNC_RUN_FAILURE_CODES),
           input.status === "succeeded" ? serializeCheckpoint(input.checkpoint) : null,
           input.projectId,
           input.id
@@ -241,17 +241,6 @@ function parseCheckpoint(value: string | null | undefined): JsonValue | undefine
   return value != null ? (JSON.parse(value) as JsonValue) : undefined
 }
 
-function toSyncRunFailure(row: DatabaseRow): SyncRunFailure | undefined {
-  if (!row.error_message) {
-    return undefined
-  }
-
-  return {
-    name: row.error_name ?? undefined,
-    message: row.error_message,
-  }
-}
-
 function rowToSyncRunRecord(row: DatabaseRow): SyncRunRecord {
   return {
     id: row.id,
@@ -271,7 +260,7 @@ function rowToSyncRunRecord(row: DatabaseRow): SyncRunRecord {
       : undefined,
     expectedLatestVersionId: row.expected_latest_version_id ?? undefined,
     commitMessage: row.commit_message ?? undefined,
-    error: toSyncRunFailure(row),
+    error: row.error === null ? undefined : parseSixbFailure(row.error, SYNC_RUN_FAILURE_CODES),
     checkpoint: parseCheckpoint(row.checkpoint),
   }
 }
@@ -293,7 +282,6 @@ interface DatabaseRow {
   output_version_id: string | null
   expected_latest_version_id: string | null
   commit_message: string | null
-  error_name: string | null
-  error_message: string | null
+  error: string | null
   checkpoint: string | null
 }

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -5,6 +5,8 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { migrateStorage } from "@sixb/core"
+import { parseSixbFailure } from "@sixb/core/internal/errors"
+import { SYNC_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { SqliteStorage } from "../src"
 import {
   createSqliteStorageMigrators,
@@ -86,6 +88,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 10,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "011-sync-failure-record",
+    status: "applied",
+    version: 11,
+  },
 ]
 
 afterEach(async () => {
@@ -121,6 +130,53 @@ describe("SQLite storage migrations", () => {
       await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "current" })
     } finally {
       storage.close()
+    }
+  })
+
+  test("migrates legacy failed Sync runs from the version 10 schema", () => {
+    const db = new Database(":memory:")
+    try {
+      for (const migration of sqliteStorageMigrations.steps.slice(0, 10)) migration.up(db)
+      db.query(`
+        INSERT INTO sync_runs (
+          project_id, id, sync_id, dataset_id, mode, status, started_at, finished_at,
+          error_name, error_message
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "project-a",
+        "sync-legacy",
+        "sync.orders",
+        "orders",
+        "snapshot",
+        "failed",
+        "2026-08-10T12:00:00.000Z",
+        "2026-08-10T12:01:00.000Z",
+        "ProviderError",
+        "secret sync diagnostic"
+      )
+
+      sqliteStorageMigrations.steps[10]?.up(db)
+
+      const row = db
+        .query("SELECT error FROM sync_runs WHERE project_id = ? AND id = ?")
+        .get("project-a", "sync-legacy") as { readonly error: string }
+      const failure = parseSixbFailure(row.error, SYNC_RUN_FAILURE_CODES)
+
+      expect(failure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: "2026-08-10T12:01:00.000Z",
+        details: {
+          syncId: "sync.orders",
+          runId: "sync-legacy",
+          datasetId: "orders",
+          migratedFromLegacyError: true,
+        },
+      })
+      expect(JSON.stringify(failure)).not.toContain("secret sync diagnostic")
+    } finally {
+      db.close()
     }
   })
 

--- a/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { SyncRunError } from "@sixb/core/storage"
+import { type SixbFailure, SyncRunError, type SyncRunFailureCode } from "@sixb/core/storage"
 import { SqliteSyncRunStorage } from "../src/sync-run-storage"
+
+const FAILURE: SixbFailure<SyncRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Database connection lost",
+  retryable: false,
+  at: "2026-04-06T15:00:00.420Z",
+  details: { provider: "erp" },
+}
 
 describe("SqliteSyncRunStorage", () => {
   let storage: SqliteSyncRunStorage
@@ -139,10 +147,7 @@ describe("SqliteSyncRunStorage", () => {
       projectId: "my-app",
       status: "failed",
       rowsRead: 23,
-      error: {
-        name: "Error",
-        message: "Database connection lost",
-      },
+      error: FAILURE,
     })
 
     await storage.start({
@@ -190,7 +195,7 @@ describe("SqliteSyncRunStorage", () => {
       projectId: "my-app",
       id: "run-1",
     })
-    expect(failed?.error?.message).toBe("Database connection lost")
+    expect(failed?.error).toEqual(FAILURE)
     expect(failed?.rowsRead).toBe(23)
   })
 
@@ -260,9 +265,7 @@ describe("SqliteSyncRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "boom",
-        },
+        error: { ...FAILURE, message: "boom" },
       })
     ).rejects.toBeInstanceOf(SyncRunError)
 


### PR DESCRIPTION
## Summary

- replace the legacy sync-run `{ name?, message }` failure shape with the canonical serializable `SixbFailure` record
- normalize worker exceptions into stable codes, including `runtime.cancelled`, without exposing the internal error class
- persist and validate the full record in memory, SQLite JSON, and PostgreSQL JSONB
- expose the same contract through sync HTTP responses, generated client types, and Atlas
- constrain sync-run failures to `internal.unexpected | runtime.cancelled` across every boundary

## Design decisions

- `SixbError` remains internal. Storage and transport only receive detached `SixbFailure` values.
- `SixbFailure` is generic over its code, so primitives can specialize one canonical record instead of recreating primitive-specific shapes.
- `SYNC_RUN_FAILURE_CODES` is the single runtime and type-level source for the worker, storage adapters, HTTP schema, and generated client.
- A globally valid code outside the sync-run contract is normalized to `internal.unexpected` at the worker boundary and rejected by sync storage validation.
- The migration is intentionally limited to sync runs. Other run primitives keep their legacy shapes until their own vertical migration.
- The pre-1.0 SQLite and PostgreSQL baseline migrations are updated in place; existing development databases using the old baseline need to be recreated.

## Verification

- `bun test packages/core/tests/error-model.test.ts packages/core/tests/sync-runs.test.ts packages/sync-worker/tests/run-sync-job.test.ts storage/sqlite/tests/sqlite-sync-run-storage.test.ts packages/server/tests/syncs-routes.test.ts` — 39 passed
- `bun run generate:client`
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test:publish` — 47 publishable packages verified
- `git diff --check`

PostgreSQL E2E could not run locally because the Docker daemon was unavailable; the updated test is included for CI.

## Stack

- Builds on #314
- Part of #274
