### PR TITLE
pipeline: persist portable failure records

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -16,7 +16,7 @@ legacy exceptions use `internal.unexpected` until their call site receives a spe
 
 ## Failure records
 
-Persisted sync-run failures use the same portable record returned by their API:
+Persisted run failures use the same portable record returned by their API:
 
 ```ts
 interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
@@ -29,8 +29,7 @@ interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
 }
 ```
 
-Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs
-currently declare `internal.unexpected | runtime.cancelled`.
+Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, and pipeline step runs currently declare `internal.unexpected | runtime.cancelled`.
 
 Other run primitives keep their legacy error shape until their own vertical migration. This keeps
 each storage and wire change independently reviewable.

--- a/packages/atlas/src/pages/PipelinesPage.tsx
+++ b/packages/atlas/src/pages/PipelinesPage.tsx
@@ -82,6 +82,7 @@ import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPrefe
 
 type PipelineSummary = ListPipelinesResponse[number] | GetPipelineResponse
 type PipelineRun = NonNullable<PipelineSummary["latestRun"]>
+type PipelineFailure = NonNullable<PipelineRun["error"]>
 type PipelineRunStatus = PipelineRun["status"]
 type PipelineGraphNode = PipelineSummary["graph"]["nodes"][number]
 type PipelineStep = PipelineGraphNode["step"]
@@ -92,6 +93,21 @@ const pipelineListViewOptions = [
   { value: "cards", label: "Cards" },
   { value: "table", label: "Table" },
 ] as const
+
+function PipelineFailureSummary({
+  failure,
+  className,
+}: {
+  failure: PipelineFailure
+  className?: string
+}) {
+  return (
+    <div className={cn("min-w-0", className)}>
+      <p className="break-words text-destructive">{failure.message}</p>
+      <p className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">{failure.code}</p>
+    </div>
+  )
+}
 
 function pipelineName(pipeline: Pick<PipelineSummary, "id">): string {
   return humanizeIdentifier(pipeline.id)
@@ -952,10 +968,7 @@ function RunsListPanel({
                       {formatRelativeTime(run.startedAt)} · {runDuration(run)}
                     </p>
                     {run.error ? (
-                      <p className="mt-1 break-words text-[11px] text-destructive">
-                        {run.error.name ? `${run.error.name}: ` : ""}
-                        {run.error.message}
-                      </p>
+                      <PipelineFailureSummary failure={run.error} className="mt-1 text-[11px]" />
                     ) : null}
                   </div>
                   <RunStatusBadge status={run.status} />
@@ -1017,10 +1030,10 @@ function RunSummaryPanel({
             </div>
 
             {run.error ? (
-              <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
-                {run.error.name ? `${run.error.name}: ` : ""}
-                {run.error.message}
-              </div>
+              <PipelineFailureSummary
+                failure={run.error}
+                className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs"
+              />
             ) : null}
 
             {run.output ? (
@@ -1077,10 +1090,7 @@ function RunSummaryPanel({
                         </button>
                       ) : null}
                       {step.error ? (
-                        <p className="mt-2 break-words text-[11px] text-destructive">
-                          {step.error.name ? `${step.error.name}: ` : ""}
-                          {step.error.message}
-                        </p>
+                        <PipelineFailureSummary failure={step.error} className="mt-2 text-[11px]" />
                       ) : null}
                     </li>
                   ))}

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -7129,14 +7129,50 @@
                           "error": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string"
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
                               },
                               "message": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
                               }
                             },
-                            "required": ["message"],
+                            "required": ["code", "message", "retryable", "at"],
                             "additionalProperties": false
                           }
                         },
@@ -7459,14 +7495,50 @@
                         "error": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string"
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
                             },
                             "message": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
                             }
                           },
-                          "required": ["message"],
+                          "required": ["code", "message", "retryable", "at"],
                           "additionalProperties": false
                         }
                       },
@@ -7614,14 +7686,50 @@
                           "error": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string"
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
                               },
                               "message": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
                               }
                             },
-                            "required": ["message"],
+                            "required": ["code", "message", "retryable", "at"],
                             "additionalProperties": false
                           }
                         },
@@ -7741,14 +7849,50 @@
                         "error": {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string"
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
                             },
                             "message": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
                             }
                           },
-                          "required": ["message"],
+                          "required": ["code", "message", "retryable", "at"],
                           "additionalProperties": false
                         }
                       },
@@ -7827,14 +7971,50 @@
                           "error": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string"
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
                               },
                               "message": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
                               }
                             },
-                            "required": ["message"],
+                            "required": ["code", "message", "retryable", "at"],
                             "additionalProperties": false
                           }
                         },

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2502,8 +2502,23 @@ export type ListPipelinesResponses = {
         versionId: string
       }
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled"
         message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
       }
     } | null
   }>
@@ -2618,8 +2633,23 @@ export type GetPipelineResponses = {
         versionId: string
       }
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled"
         message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
       }
     } | null
   }
@@ -2676,8 +2706,23 @@ export type ListPipelineRunsResponses = {
         versionId: string
       }
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled"
         message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
       }
     }>
     hasMore: boolean
@@ -2736,8 +2781,23 @@ export type GetPipelineRunResponses = {
         versionId: string
       }
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled"
         message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
       }
     }
     steps: Array<{
@@ -2761,8 +2821,23 @@ export type GetPipelineRunResponses = {
       }
       rowsWritten?: number
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled"
         message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
       }
     }>
   }

--- a/packages/client/tests/pipeline-failure.types.ts
+++ b/packages/client/tests/pipeline-failure.types.ts
@@ -1,0 +1,36 @@
+import type {
+  GetPipelineRunResponses,
+  ListPipelineRunsResponses,
+  ListPipelinesResponses,
+} from "../src/generated/types.gen"
+
+type LatestPipelineRun = NonNullable<ListPipelinesResponses[200][number]["latestRun"]>
+type ListedPipelineRun = ListPipelineRunsResponses[200]["runs"][number]
+type PipelineStepRun = GetPipelineRunResponses[200]["steps"][number]
+
+type LatestFailureCode = NonNullable<LatestPipelineRun["error"]>["code"]
+type ListedFailureCode = NonNullable<ListedPipelineRun["error"]>["code"]
+type StepFailureCode = NonNullable<PipelineStepRun["error"]>["code"]
+
+const latestUnexpected: LatestFailureCode = "internal.unexpected"
+const latestCancelled: LatestFailureCode = "runtime.cancelled"
+const listedUnexpected: ListedFailureCode = "internal.unexpected"
+const stepCancelled: StepFailureCode = "runtime.cancelled"
+
+// Dataset lookup codes belong to HTTP route failures, not persisted pipeline failures.
+// @ts-expect-error the generated latest-run failure contract must stay scoped to its producer
+const unrelatedLatest: LatestFailureCode = "dataset.not_found"
+// @ts-expect-error the generated run-history failure contract must stay scoped to its producer
+const unrelatedListed: ListedFailureCode = "dataset.not_found"
+// @ts-expect-error the generated step-run failure contract must stay scoped to its producer
+const unrelatedStep: StepFailureCode = "dataset.not_found"
+
+void [
+  latestUnexpected,
+  latestCancelled,
+  listedUnexpected,
+  stepCancelled,
+  unrelatedLatest,
+  unrelatedListed,
+  unrelatedStep,
+]

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -369,7 +369,7 @@ export type {
   ListPipelineRunsResult,
   ListPipelineStepRunsInput,
   ListPipelineStepRunsResult,
-  PipelineRunFailure,
+  PipelineRunFailureCode,
   PipelineRunRecord,
   PipelineRunStatus,
   PipelineRunStorage,
@@ -377,7 +377,11 @@ export type {
   StartPipelineRunInput,
   StartPipelineStepRunInput,
 } from "./pipeline-runs"
-export { InMemoryPipelineRunStorage, PipelineRunError } from "./pipeline-runs"
+export {
+  InMemoryPipelineRunStorage,
+  PIPELINE_RUN_FAILURE_CODES,
+  PipelineRunError,
+} from "./pipeline-runs"
 export type {
   AdvanceProjectionTelemetryCheckpointInput,
   FinishProjectionRunInput,

--- a/packages/core/src/storage/pipeline-runs/in-memory.ts
+++ b/packages/core/src/storage/pipeline-runs/in-memory.ts
@@ -1,3 +1,5 @@
+import { parseSixbFailure } from "../../errors/internal"
+import type { SixbFailure } from "../../errors/types"
 import {
   cloneRecord,
   compareStartedAt,
@@ -18,16 +20,19 @@ import type {
   ListPipelineRunsResult,
   ListPipelineStepRunsInput,
   ListPipelineStepRunsResult,
-  PipelineRunFailure,
+  PipelineRunFailureCode,
   PipelineRunRecord,
   PipelineRunStorage,
   PipelineStepRunRecord,
   StartPipelineRunInput,
   StartPipelineStepRunInput,
 } from "./types"
+import { PIPELINE_RUN_FAILURE_CODES } from "./types"
 
-function normalizeError(error: PipelineRunFailure | undefined): PipelineRunFailure | undefined {
-  return error ? cloneRecord(error) : undefined
+function normalizeError(
+  error: SixbFailure<PipelineRunFailureCode> | undefined
+): SixbFailure<PipelineRunFailureCode> | undefined {
+  return error ? parseSixbFailure(error, PIPELINE_RUN_FAILURE_CODES) : undefined
 }
 
 function assertNonNegativeInteger(value: number | undefined, fieldName: string): void {

--- a/packages/core/src/storage/pipeline-runs/index.ts
+++ b/packages/core/src/storage/pipeline-runs/index.ts
@@ -9,7 +9,7 @@ export type {
   ListPipelineRunsResult,
   ListPipelineStepRunsInput,
   ListPipelineStepRunsResult,
-  PipelineRunFailure,
+  PipelineRunFailureCode,
   PipelineRunRecord,
   PipelineRunStatus,
   PipelineRunStorage,
@@ -17,3 +17,4 @@ export type {
   StartPipelineRunInput,
   StartPipelineStepRunInput,
 } from "./types"
+export { PIPELINE_RUN_FAILURE_CODES } from "./types"

--- a/packages/core/src/storage/pipeline-runs/types.ts
+++ b/packages/core/src/storage/pipeline-runs/types.ts
@@ -1,11 +1,15 @@
+import type { SixbErrorCode, SixbFailure } from "../../errors/types"
 import type { DatasetVersionRef, DatasetWriteMode } from "../../lake-storage"
 
 export type PipelineRunStatus = "running" | "succeeded" | "failed" | "cancelled"
 
-export interface PipelineRunFailure {
-  readonly name?: string
-  readonly message: string
-}
+/** Error codes a pipeline or pipeline-step run can persist and expose. */
+export const PIPELINE_RUN_FAILURE_CODES = [
+  "internal.unexpected",
+  "runtime.cancelled",
+] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
+
+export type PipelineRunFailureCode = (typeof PIPELINE_RUN_FAILURE_CODES)[number]
 
 export interface PipelineRunRecord {
   readonly id: string
@@ -16,7 +20,7 @@ export interface PipelineRunRecord {
   readonly finishedAt?: Date
   /** Final step output in sequential V1. */
   readonly output?: DatasetVersionRef
-  readonly error?: PipelineRunFailure
+  readonly error?: SixbFailure<PipelineRunFailureCode>
 }
 
 export interface PipelineStepRunRecord {
@@ -33,7 +37,7 @@ export interface PipelineStepRunRecord {
   readonly inputs: readonly DatasetVersionRef[]
   readonly output?: DatasetVersionRef
   readonly rowsWritten?: number
-  readonly error?: PipelineRunFailure
+  readonly error?: SixbFailure<PipelineRunFailureCode>
 }
 
 export interface StartPipelineRunInput {
@@ -56,7 +60,7 @@ export type FinishPipelineRunInput =
       readonly projectId: string
       readonly status: "failed" | "cancelled"
       readonly finishedAt?: Date
-      readonly error?: PipelineRunFailure
+      readonly error?: SixbFailure<PipelineRunFailureCode>
     }
 
 export interface StartPipelineStepRunInput {
@@ -86,7 +90,7 @@ export type FinishPipelineStepRunInput =
       readonly status: "failed" | "cancelled"
       readonly finishedAt?: Date
       readonly rowsWritten?: number
-      readonly error?: PipelineRunFailure
+      readonly error?: SixbFailure<PipelineRunFailureCode>
     }
 
 export interface ListPipelineRunsInput {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -150,7 +150,7 @@ export type {
   ListPipelineRunsResult,
   ListPipelineStepRunsInput,
   ListPipelineStepRunsResult,
-  PipelineRunFailure,
+  PipelineRunFailureCode,
   PipelineRunRecord,
   PipelineRunStatus,
   PipelineRunStorage,

--- a/packages/core/tests/pipeline-runs.test.ts
+++ b/packages/core/tests/pipeline-runs.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, test } from "bun:test"
 import { InMemoryStorage } from "../src"
+import type { PipelineRunFailureCode, SixbFailure } from "../src/storage"
 import { InMemoryPipelineRunStorage, PipelineRunError } from "../src/storage"
+
+const FAILURE: SixbFailure<PipelineRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Pipeline failed",
+  retryable: false,
+  at: "2026-05-08T10:00:01.000Z",
+  details: { pipelineId: "customers" },
+}
+
+const CANCELLED_FAILURE: SixbFailure<PipelineRunFailureCode> = {
+  ...FAILURE,
+  code: "runtime.cancelled",
+  message: "Stopped",
+}
 
 describe("InMemoryPipelineRunStorage", () => {
   test("starts and finishes a successful pipeline run", async () => {
@@ -56,10 +71,7 @@ describe("InMemoryPipelineRunStorage", () => {
       projectId: "my-app",
       status: "failed",
       finishedAt: new Date("2026-05-08T10:00:01.000Z"),
-      error: {
-        name: "Error",
-        message: "No committed source version",
-      },
+      error: { ...FAILURE, message: "No committed source version" },
     })
 
     await storage.start({
@@ -125,10 +137,7 @@ describe("InMemoryPipelineRunStorage", () => {
     })
     expect(failed?.status).toBe("failed")
     expect(failed?.output).toBeUndefined()
-    expect(failed?.error).toEqual({
-      name: "Error",
-      message: "No committed source version",
-    })
+    expect(failed?.error).toEqual({ ...FAILURE, message: "No committed source version" })
   })
 
   test("lists the latest run for multiple pipeline ids", async () => {
@@ -258,10 +267,7 @@ describe("InMemoryPipelineRunStorage", () => {
       projectId: "my-app",
       status: "failed",
       rowsWritten: 3,
-      error: {
-        name: "Error",
-        message: "Invalid row",
-      },
+      error: { ...FAILURE, message: "Invalid row" },
     })
 
     await storage.startStep({
@@ -314,10 +320,7 @@ describe("InMemoryPipelineRunStorage", () => {
       projectId: "my-app",
       statuses: ["failed"],
     })
-    expect(failedSteps.steps[0]?.error).toEqual({
-      name: "Error",
-      message: "Invalid row",
-    })
+    expect(failedSteps.steps[0]?.error).toEqual({ ...FAILURE, message: "Invalid row" })
     expect(failedSteps.steps[0]?.rowsWritten).toBe(3)
   })
 
@@ -343,9 +346,7 @@ describe("InMemoryPipelineRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "boom",
-        },
+        error: { ...FAILURE, message: "boom" },
       })
     ).rejects.toBeInstanceOf(PipelineRunError)
 
@@ -376,9 +377,7 @@ describe("InMemoryPipelineRunStorage", () => {
       id: "step_1",
       projectId: "my-app",
       status: "cancelled",
-      error: {
-        message: "Stopped",
-      },
+      error: CANCELLED_FAILURE,
     })
 
     await expect(
@@ -386,9 +385,7 @@ describe("InMemoryPipelineRunStorage", () => {
         id: "step_1",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "Too late",
-        },
+        error: { ...FAILURE, message: "Too late" },
       })
     ).rejects.toBeInstanceOf(PipelineRunError)
 
@@ -396,9 +393,7 @@ describe("InMemoryPipelineRunStorage", () => {
       id: "piperun_1",
       projectId: "my-app",
       status: "cancelled",
-      error: {
-        message: "Stopped",
-      },
+      error: CANCELLED_FAILURE,
     })
 
     await expect(
@@ -419,9 +414,7 @@ describe("InMemoryPipelineRunStorage", () => {
         id: "piperun_1",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "Too late",
-        },
+        error: { ...FAILURE, message: "Too late" },
       })
     ).rejects.toBeInstanceOf(PipelineRunError)
   })

--- a/packages/pipeline-worker/src/errors.ts
+++ b/packages/pipeline-worker/src/errors.ts
@@ -1,23 +1,10 @@
 import type { DatasetDefinition, PipelineDefinition } from "@sixb/core"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
-import type { PipelineRunFailure, PipelineRunStatus } from "@sixb/core/storage"
+import type { PipelineRunStatus } from "@sixb/core/storage"
 import type { PipelineJob } from "./types"
 
 export class PipelineWorkerError extends Error {
   readonly name = "PipelineWorkerError"
-}
-
-export function toPipelineRunFailure(error: unknown): PipelineRunFailure {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-    }
-  }
-
-  return {
-    message: String(error),
-  }
 }
 
 export function throwIfAborted(signal: AbortSignal): void {

--- a/packages/pipeline-worker/src/run-pipeline-job.ts
+++ b/packages/pipeline-worker/src/run-pipeline-job.ts
@@ -1,13 +1,13 @@
+import { captureSixbFailure } from "@sixb/core/internal/errors"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
-import type { PipelineRunRecord } from "@sixb/core/storage"
+import { PIPELINE_RUN_FAILURE_CODES, type PipelineRunRecord } from "@sixb/core/storage"
 import {
   createPipelineBookkeepingError,
   requireFinishedAt,
   requirePipeline,
   statusForFailure,
   throwIfAborted,
-  toPipelineRunFailure,
 } from "./errors"
 import { runStep } from "./run-step"
 import type { PipelineRunResult, PipelineStepRunResult, RunPipelineJobInput } from "./types"
@@ -115,7 +115,11 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
           projectId: runtime.id,
           id: job.id,
           status,
-          error: toPipelineRunFailure(error),
+          error: captureSixbFailure(error, {
+            allowedCodes: PIPELINE_RUN_FAILURE_CODES,
+            defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+            details: { pipelineId: pipeline.id, runId: job.id },
+          }),
         })
         if (status === "failed" && run.status === "failed") input.onRunFailed?.(error, run)
       } catch {

--- a/packages/pipeline-worker/src/run-step.ts
+++ b/packages/pipeline-worker/src/run-step.ts
@@ -1,12 +1,12 @@
 import type { DatasetDefinition, PipelineDefinition, PipelineStepDefinition } from "@sixb/core"
+import { captureSixbFailure } from "@sixb/core/internal/errors"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
-import type { PipelineStepRunRecord } from "@sixb/core/storage"
+import { PIPELINE_RUN_FAILURE_CODES, type PipelineStepRunRecord } from "@sixb/core/storage"
 import {
   createStepBookkeepingError,
   requireRegisteredDataset,
   statusForFailure,
   throwIfAborted,
-  toPipelineRunFailure,
 } from "./errors"
 import { executeRunStep } from "./execute-run-step"
 import { executeSqlStep } from "./execute-sql-step"
@@ -116,13 +116,23 @@ export async function runStep(input: {
     }
   } catch (error) {
     if (!committedVersion) {
+      const status = statusForFailure(signal, error)
       const failedStepRun = await runtime.pipelineRunsStorage
         .finishStep({
           projectId: runtime.id,
           id: stepRunId,
-          status: statusForFailure(signal, error),
+          status,
           rowsWritten,
-          error: toPipelineRunFailure(error),
+          error: captureSixbFailure(error, {
+            allowedCodes: PIPELINE_RUN_FAILURE_CODES,
+            defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+            details: {
+              pipelineId: pipeline.id,
+              pipelineRunId: job.id,
+              stepId: step.id,
+              stepRunId,
+            },
+          }),
         })
         .catch(() => null)
 

--- a/packages/pipeline-worker/tests/run-pipeline-job.test.ts
+++ b/packages/pipeline-worker/tests/run-pipeline-job.test.ts
@@ -172,7 +172,12 @@ describe("runPipelineJob", () => {
       id: "run_missing_input",
     })
     expect(run?.status).toBe("failed")
-    expect(run?.error?.message).toContain("has no committed version")
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      details: { pipelineId: "customers", runId: "run_missing_input" },
+    })
+    expect(run?.error?.message).toBe("An unexpected internal error occurred.")
 
     const steps = await pipelineRunsStorage.listSteps({
       projectId: runtime.id,
@@ -381,7 +386,20 @@ describe("runPipelineJob", () => {
       order: "asc",
     })
     expect(stepRuns.steps.map((step) => step.status)).toEqual(["succeeded", "failed"])
-    expect(stepRuns.steps[1]?.error?.message).toBe("stats exploded")
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      details: { pipelineId: "customers", runId: "run_failure" },
+    })
+    expect(stepRuns.steps[1]?.error).toMatchObject({
+      code: "internal.unexpected",
+      details: {
+        pipelineId: "customers",
+        pipelineRunId: "run_failure",
+        stepId: "customer-stats",
+        stepRunId: "run_failure:step:2:customer-stats",
+      },
+    })
+    expect(stepRuns.steps[1]?.error?.message).toBe("An unexpected internal error occurred.")
 
     const committedRows = await collectRows(lakeStorage.readRows({ datasetId: "customers" }))
     expect(committedRows).toEqual([{ id: "cust_1", name: "Ada" }])
@@ -532,9 +550,10 @@ describe("runPipelineJob", () => {
       stepId: "customer-stats",
       status: "failed",
       error: {
-        name: "PipelineWorkerError",
+        code: "internal.unexpected",
+        retryable: false,
       },
     })
-    expect(stepRuns.steps[0]?.error?.message).toContain("requires SQL transform support")
+    expect(stepRuns.steps[0]?.error?.message).toBe("An unexpected internal error occurred.")
   })
 })

--- a/packages/pipeline-worker/tests/worker.test.ts
+++ b/packages/pipeline-worker/tests/worker.test.ts
@@ -479,7 +479,7 @@ describe("PipelineWorker", () => {
       stepIndex: 1,
       totalSteps: 2,
       status: "failed",
-      error: "nope",
+      error: "An unexpected internal error occurred.",
     })
 
     const datasetPayload = events[3]?.payload as {
@@ -598,6 +598,25 @@ describe("PipelineWorker", () => {
       pipelineId: "customers",
       runId: "run-aborts-late",
       status: "cancelled",
+    })
+    const cancelledRun = await sixb.storage.pipelineRuns!.getById({
+      projectId: sixb.id,
+      id: "run-aborts-late",
+    })
+    const [cancelledStep] = (
+      await sixb.storage.pipelineRuns!.listSteps({
+        projectId: sixb.id,
+        pipelineRunId: "run-aborts-late",
+        statuses: ["cancelled"],
+      })
+    ).steps
+    expect(cancelledRun?.error).toMatchObject({
+      code: "runtime.cancelled",
+      retryable: false,
+    })
+    expect(cancelledStep?.error).toMatchObject({
+      code: "runtime.cancelled",
+      retryable: false,
     })
     expect(reportCount).toBe(0)
   })

--- a/packages/server/src/schemas/pipelines.ts
+++ b/packages/server/src/schemas/pipelines.ts
@@ -1,5 +1,15 @@
+import {
+  PIPELINE_RUN_FAILURE_CODES,
+  type PipelineRunFailureCode,
+  type SixbFailure,
+} from "@sixb/core/storage"
 import { z } from "zod"
+import { sixbFailureSchema } from "./common"
 import { DatasetDefinitionSchema } from "./datasets"
+
+const PipelineRunFailureSchema: z.ZodType<SixbFailure<PipelineRunFailureCode>> = sixbFailureSchema(
+  PIPELINE_RUN_FAILURE_CODES
+)
 
 export const PipelineParamsSchema = z.object({
   pipelineId: z.string().min(1),
@@ -49,12 +59,7 @@ export const PipelineRunSchema = z.object({
   startedAt: z.string(),
   finishedAt: z.string().optional(),
   output: DatasetVersionRefSchema.optional(),
-  error: z
-    .object({
-      name: z.string().optional(),
-      message: z.string(),
-    })
-    .optional(),
+  error: PipelineRunFailureSchema.optional(),
 })
 
 export const PipelineStepRunSchema = z.object({
@@ -71,12 +76,7 @@ export const PipelineStepRunSchema = z.object({
   inputs: z.array(DatasetVersionRefSchema),
   output: DatasetVersionRefSchema.optional(),
   rowsWritten: z.number().optional(),
-  error: z
-    .object({
-      name: z.string().optional(),
-      message: z.string(),
-    })
-    .optional(),
+  error: PipelineRunFailureSchema.optional(),
 })
 
 export const PipelineStepSchema = z.object({

--- a/packages/server/tests/pipelines-routes.test.ts
+++ b/packages/server/tests/pipelines-routes.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test"
+import type { SixbHostView } from "@sixb/core"
+import { col, defineDataset, definePipeline, definePipelineStep } from "@sixb/core"
+import type {
+  ListLatestPipelineRunsInput,
+  PipelineRunFailureCode,
+  PipelineRunStorage,
+  SixbFailure,
+} from "@sixb/core/storage"
+import { Elysia } from "elysia"
+import { registerPipelineRoutes } from "../src/routes/pipelines"
+
+const rawDataset = defineDataset("raw.customers", {
+  schema: [col("id", "string")],
+})
+
+const cleanDataset = defineDataset("clean.customers", {
+  schema: [col("id", "string")],
+})
+
+const cleanStep = definePipelineStep("clean-customers")
+  .inputs({ raw: rawDataset })
+  .output(cleanDataset)
+  .run(async () => {})
+
+const pipeline = definePipeline("customers").then(cleanStep)
+
+const FAILURE: SixbFailure<PipelineRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Pipeline failed",
+  retryable: false,
+  at: "2026-05-08T10:00:01.000Z",
+  details: { pipelineId: "customers" },
+}
+
+const CANCELLED_FAILURE: SixbFailure<PipelineRunFailureCode> = {
+  ...FAILURE,
+  code: "runtime.cancelled",
+  message: "Step cancelled",
+}
+
+function createSixbStub(pipelineRuns: Partial<PipelineRunStorage>): SixbHostView {
+  return {
+    id: "my-app",
+    storage: { pipelineRuns },
+    definitions: {
+      pipelines: {
+        list: () => [pipeline],
+        getById: (id: string) => (id === pipeline.id ? pipeline : null),
+      },
+    },
+  } as unknown as SixbHostView
+}
+
+function createTestApp(pipelineRuns: Partial<PipelineRunStorage>) {
+  const host = createSixbStub(pipelineRuns)
+  const sixbExecution = {
+    pipelines: {
+      list: () => host.definitions.pipelines.list(),
+      getById: (pipelineId: string) => host.definitions.pipelines.getById(pipelineId),
+      runs: {
+        async getById(runId: string) {
+          return (await pipelineRuns.getById?.({ projectId: host.id, id: runId })) ?? null
+        },
+        async listLatest(pipelineIds: readonly string[]) {
+          return (
+            (await pipelineRuns.listLatestByPipelineIds?.({
+              projectId: host.id,
+              pipelineIds,
+            })) ?? { runs: [] }
+          )
+        },
+        async listSteps(pipelineRunId: string, input: { readonly order?: "asc" | "desc" } = {}) {
+          return (
+            (await pipelineRuns.listSteps?.({
+              projectId: host.id,
+              pipelineRunId,
+              ...input,
+            })) ?? null
+          )
+        },
+      },
+    },
+  }
+  const app = new Elysia()
+  app.derive(() => ({ sixb: sixbExecution }))
+
+  return registerPipelineRoutes(app, host)
+}
+
+describe("pipeline routes", () => {
+  test("list route exposes the specialized latest-run failure", async () => {
+    let bulkCalls = 0
+    const requestedPipelineIds: string[][] = []
+    const app = createTestApp({
+      async listLatestByPipelineIds(input: ListLatestPipelineRunsInput) {
+        bulkCalls += 1
+        requestedPipelineIds.push([...input.pipelineIds])
+        return {
+          runs: [
+            {
+              id: "run-customers",
+              projectId: "my-app",
+              pipelineId: "customers",
+              status: "failed",
+              startedAt: new Date("2026-05-08T10:00:00.000Z"),
+              finishedAt: new Date("2026-05-08T10:00:01.000Z"),
+              error: FAILURE,
+            },
+          ],
+        }
+      },
+    })
+
+    const response = await app.handle(new Request("http://localhost/api/pipelines"))
+    expect(response.status).toBe(200)
+    expect(bulkCalls).toBe(1)
+    expect(requestedPipelineIds).toEqual([["customers"]])
+    expect(await response.json()).toMatchObject([
+      {
+        id: "customers",
+        latestRun: { status: "failed", error: FAILURE },
+      },
+    ])
+  })
+
+  test("detail route exposes the same failure contract for runs and steps", async () => {
+    const app = createTestApp({
+      async getById() {
+        return {
+          id: "run-customers",
+          projectId: "my-app",
+          pipelineId: "customers",
+          status: "failed",
+          startedAt: new Date("2026-05-08T10:00:00.000Z"),
+          finishedAt: new Date("2026-05-08T10:00:01.000Z"),
+          error: FAILURE,
+        }
+      },
+      async listSteps() {
+        return {
+          steps: [
+            {
+              id: "step-run-clean",
+              projectId: "my-app",
+              pipelineRunId: "run-customers",
+              pipelineId: "customers",
+              stepId: "clean-customers",
+              datasetId: "clean.customers",
+              mode: "snapshot",
+              status: "cancelled",
+              startedAt: new Date("2026-05-08T10:00:00.100Z"),
+              finishedAt: new Date("2026-05-08T10:00:00.900Z"),
+              inputs: [{ datasetId: "raw.customers", versionId: "ver-raw" }],
+              error: CANCELLED_FAILURE,
+            },
+          ],
+          hasMore: false,
+          total: 1,
+        }
+      },
+    })
+
+    const response = await app.handle(
+      new Request("http://localhost/api/pipeline-runs/run-customers")
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      run: { status: "failed", error: FAILURE },
+      steps: [{ status: "cancelled", error: CANCELLED_FAILURE }],
+    })
+  })
+})

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -28,6 +28,9 @@ import aiUsageAccountingFoundationSql from "./migrations/010-ai-usage-accounting
   type: "text",
 }
 import syncFailureRecordSql from "./migrations/011-sync-failure-record.sql" with { type: "text" }
+import pipelineFailureRecordSql from "./migrations/012-pipeline-failure-record.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -292,6 +295,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("009-agent-executions", agentExecutionsSql),
     pgSql("010-ai-usage-accounting-foundation", aiUsageAccountingFoundationSql),
     pgSql("011-sync-failure-record", syncFailureRecordSql),
+    pgSql("012-pipeline-failure-record", pipelineFailureRecordSql),
   ],
 })
 

--- a/storage/pg/src/migrations/012-pipeline-failure-record.sql
+++ b/storage/pg/src/migrations/012-pipeline-failure-record.sql
@@ -1,0 +1,47 @@
+ALTER TABLE pipeline_runs ADD COLUMN error JSONB;
+
+UPDATE pipeline_runs
+SET error = jsonb_build_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', false,
+  'at', to_char(COALESCE(finished_at, started_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'pipelineId', pipeline_id,
+    'runId', id,
+    'migratedFromLegacyError', true
+  )
+)
+WHERE error_name IS NOT NULL OR error_message IS NOT NULL;
+
+ALTER TABLE pipeline_runs
+  DROP COLUMN error_name,
+  DROP COLUMN error_message;
+
+ALTER TABLE pipeline_step_runs ADD COLUMN error JSONB;
+
+UPDATE pipeline_step_runs
+SET error = jsonb_build_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', false,
+  'at', to_char(COALESCE(finished_at, started_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'pipelineId', pipeline_id,
+    'pipelineRunId', pipeline_run_id,
+    'stepId', step_id,
+    'stepRunId', id,
+    'migratedFromLegacyError', true
+  )
+)
+WHERE error_name IS NOT NULL OR error_message IS NOT NULL;
+
+ALTER TABLE pipeline_step_runs
+  DROP COLUMN error_name,
+  DROP COLUMN error_message;

--- a/storage/pg/src/pg-pipeline-run-storage.ts
+++ b/storage/pg/src/pg-pipeline-run-storage.ts
@@ -1,3 +1,5 @@
+import type { JsonValue } from "@sixb/core"
+import { parseSixbFailure, serializeSixbFailure } from "@sixb/core/internal/errors"
 import type { DatasetVersionRef } from "@sixb/core/lake-storage"
 import type {
   FinishPipelineRunInput,
@@ -8,14 +10,13 @@ import type {
   ListPipelineRunsResult,
   ListPipelineStepRunsInput,
   ListPipelineStepRunsResult,
-  PipelineRunFailure,
   PipelineRunRecord,
   PipelineRunStorage,
   PipelineStepRunRecord,
   StartPipelineRunInput,
   StartPipelineStepRunInput,
 } from "@sixb/core/storage"
-import { PipelineRunError } from "@sixb/core/storage"
+import { PIPELINE_RUN_FAILURE_CODES, PipelineRunError } from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import type { SqlParameter } from "./pg-client"
 import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
@@ -84,8 +85,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
                 finished_at = ${input.finishedAt ?? new Date()},
                 output_dataset_id = ${input.output?.datasetId ?? null},
                 output_version_id = ${input.output?.versionId ?? null},
-                error_name = ${null},
-                error_message = ${null}
+                error = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
             `
@@ -96,8 +96,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
                 finished_at = ${input.finishedAt ?? new Date()},
                 output_dataset_id = ${null},
                 output_version_id = ${null},
-                error_name = ${input.error?.name ?? null},
-                error_message = ${input.error?.message ?? null}
+                error = ${input.error === undefined ? null : serializeSixbFailure(input.error, PIPELINE_RUN_FAILURE_CODES)}::text::jsonb
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
             `
@@ -208,8 +207,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
                 finished_at = ${input.finishedAt ?? new Date()},
                 output_version_id = ${input.output.versionId},
                 rows_written = ${input.rowsWritten ?? existing.rows_written ?? null},
-                error_name = ${null},
-                error_message = ${null}
+                error = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
             `
@@ -220,8 +218,7 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
                 finished_at = ${input.finishedAt ?? new Date()},
                 output_version_id = ${null},
                 rows_written = ${input.rowsWritten ?? existing.rows_written ?? null},
-                error_name = ${input.error?.name ?? null},
-                error_message = ${input.error?.message ?? null}
+                error = ${input.error === undefined ? null : serializeSixbFailure(input.error, PIPELINE_RUN_FAILURE_CODES)}::text::jsonb
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
             `
@@ -356,20 +353,6 @@ export class PgPipelineRunStorage implements PipelineRunStorage {
   }
 }
 
-function toFailure(row: {
-  readonly error_name: string | null
-  readonly error_message: string | null
-}): PipelineRunFailure | undefined {
-  if (!row.error_message) {
-    return undefined
-  }
-
-  return {
-    name: row.error_name ?? undefined,
-    message: row.error_message,
-  }
-}
-
 function rowToPipelineRunRecord(row: PipelineRunDatabaseRow): PipelineRunRecord {
   return {
     id: row.id,
@@ -385,7 +368,7 @@ function rowToPipelineRunRecord(row: PipelineRunDatabaseRow): PipelineRunRecord 
             versionId: row.output_version_id,
           }
         : undefined,
-    error: toFailure(row),
+    error: row.error === null ? undefined : parseSixbFailure(row.error, PIPELINE_RUN_FAILURE_CODES),
   }
 }
 
@@ -409,7 +392,7 @@ function rowToPipelineStepRunRecord(row: PipelineStepRunDatabaseRow): PipelineSt
         }
       : undefined,
     rowsWritten: row.rows_written != null ? Number(row.rows_written) : undefined,
-    error: toFailure(row),
+    error: row.error === null ? undefined : parseSixbFailure(row.error, PIPELINE_RUN_FAILURE_CODES),
   }
 }
 
@@ -434,8 +417,7 @@ interface PipelineRunDatabaseRow {
   finished_at: Date | string | null
   output_dataset_id: string | null
   output_version_id: string | null
-  error_name: string | null
-  error_message: string | null
+  error: JsonValue | null
 }
 
 interface PipelineStepRunDatabaseRow {
@@ -452,6 +434,5 @@ interface PipelineStepRunDatabaseRow {
   inputs: readonly DatasetVersionRef[] | string
   output_version_id: string | null
   rows_written: number | string | null
-  error_name: string | null
-  error_message: string | null
+  error: JsonValue | null
 }

--- a/storage/pg/tests/pg-pipeline-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-pipeline-run-storage.e2e.ts
@@ -1,8 +1,22 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { PipelineRunError } from "@sixb/core/storage"
+import { PipelineRunError, type PipelineRunFailureCode, type SixbFailure } from "@sixb/core/storage"
 import type { PostgresStorage } from "../src"
 import { PgPipelineRunStorage } from "../src/pg-pipeline-run-storage"
 import { createTestStorage } from "./helpers"
+
+const FAILURE: SixbFailure<PipelineRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Pipeline failed",
+  retryable: false,
+  at: "2026-05-08T10:00:01.000Z",
+  details: { pipelineId: "customers" },
+}
+
+const CANCELLED_FAILURE: SixbFailure<PipelineRunFailureCode> = {
+  ...FAILURE,
+  code: "runtime.cancelled",
+  message: "Stopped",
+}
 
 describe("PgPipelineRunStorage", () => {
   let storage: PostgresStorage
@@ -60,10 +74,7 @@ describe("PgPipelineRunStorage", () => {
       id: "run-1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        name: "Error",
-        message: "No committed source version",
-      },
+      error: { ...FAILURE, message: "No committed source version" },
     })
 
     await storage.pipelineRuns.start({
@@ -128,10 +139,7 @@ describe("PgPipelineRunStorage", () => {
       id: "run-1",
     })
     expect(failed?.status).toBe("failed")
-    expect(failed?.error).toEqual({
-      name: "Error",
-      message: "No committed source version",
-    })
+    expect(failed?.error).toEqual({ ...FAILURE, message: "No committed source version" })
   })
 
   test("lists the latest run for multiple pipeline ids", async () => {
@@ -252,10 +260,7 @@ describe("PgPipelineRunStorage", () => {
       projectId: "my-app",
       status: "failed",
       rowsWritten: 3,
-      error: {
-        name: "Error",
-        message: "Invalid row",
-      },
+      error: { ...FAILURE, message: "Invalid row" },
     })
 
     await storage.pipelineRuns.startStep({
@@ -308,10 +313,7 @@ describe("PgPipelineRunStorage", () => {
       projectId: "my-app",
       statuses: ["failed"],
     })
-    expect(failedSteps.steps[0]?.error).toEqual({
-      name: "Error",
-      message: "Invalid row",
-    })
+    expect(failedSteps.steps[0]?.error).toEqual({ ...FAILURE, message: "Invalid row" })
     expect(failedSteps.steps[0]?.rowsWritten).toBe(3)
   })
 
@@ -335,9 +337,7 @@ describe("PgPipelineRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "boom",
-        },
+        error: { ...FAILURE, message: "boom" },
       })
     ).rejects.toBeInstanceOf(PipelineRunError)
 
@@ -368,9 +368,7 @@ describe("PgPipelineRunStorage", () => {
       id: "step_1",
       projectId: "my-app",
       status: "cancelled",
-      error: {
-        message: "Stopped",
-      },
+      error: CANCELLED_FAILURE,
     })
 
     await expect(
@@ -378,9 +376,7 @@ describe("PgPipelineRunStorage", () => {
         id: "step_1",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "Too late",
-        },
+        error: { ...FAILURE, message: "Too late" },
       })
     ).rejects.toBeInstanceOf(PipelineRunError)
 
@@ -388,9 +384,7 @@ describe("PgPipelineRunStorage", () => {
       id: "piperun_1",
       projectId: "my-app",
       status: "cancelled",
-      error: {
-        message: "Stopped",
-      },
+      error: CANCELLED_FAILURE,
     })
 
     await expect(

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -47,6 +47,7 @@ describe("Postgres storage migrations", () => {
             "009-agent-executions",
             "010-ai-usage-accounting-foundation",
             "011-sync-failure-record",
+            "012-pipeline-failure-record",
           ],
         },
       ])
@@ -127,6 +128,13 @@ describe("Postgres storage migrations", () => {
           id: "011-sync-failure-record",
           status: "applied",
           version: 11,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "012-pipeline-failure-record",
+          status: "applied",
+          version: 12,
         },
       ])
     })
@@ -789,6 +797,13 @@ describe("Postgres storage migrations", () => {
           id: "011-sync-failure-record",
           status: "applied",
           version: 11,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "012-pipeline-failure-record",
+          status: "applied",
+          version: 12,
         },
       ])
     } finally {

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -31,6 +31,9 @@ import aiUsageAccountingFoundationSql from "./migrations/010-ai-usage-accounting
   type: "text",
 }
 import syncFailureRecordSql from "./migrations/011-sync-failure-record.sql" with { type: "text" }
+import pipelineFailureRecordSql from "./migrations/012-pipeline-failure-record.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -62,6 +65,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("009-agent-executions", agentExecutionsSql),
     sqliteSql("010-ai-usage-accounting-foundation", aiUsageAccountingFoundationSql),
     sqliteSql("011-sync-failure-record", syncFailureRecordSql),
+    sqliteSql("012-pipeline-failure-record", pipelineFailureRecordSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/012-pipeline-failure-record.sql
+++ b/storage/sqlite/src/migrations/012-pipeline-failure-record.sql
@@ -1,0 +1,45 @@
+ALTER TABLE pipeline_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE pipeline_runs
+SET error = json_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json('false'),
+  'at', COALESCE(finished_at, started_at),
+  'details', json_object(
+    'pipelineId', pipeline_id,
+    'runId', id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE error_name IS NOT NULL OR error_message IS NOT NULL;
+
+ALTER TABLE pipeline_runs DROP COLUMN error_name;
+ALTER TABLE pipeline_runs DROP COLUMN error_message;
+
+ALTER TABLE pipeline_step_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE pipeline_step_runs
+SET error = json_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json('false'),
+  'at', COALESCE(finished_at, started_at),
+  'details', json_object(
+    'pipelineId', pipeline_id,
+    'pipelineRunId', pipeline_run_id,
+    'stepId', step_id,
+    'stepRunId', id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE error_name IS NOT NULL OR error_message IS NOT NULL;
+
+ALTER TABLE pipeline_step_runs DROP COLUMN error_name;
+ALTER TABLE pipeline_step_runs DROP COLUMN error_message;

--- a/storage/sqlite/src/pipeline-run-storage.ts
+++ b/storage/sqlite/src/pipeline-run-storage.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite"
+import { parseSixbFailure, serializeSixbFailure } from "@sixb/core/internal/errors"
 import type { DatasetVersionRef } from "@sixb/core/lake-storage"
 import type {
   FinishPipelineRunInput,
@@ -9,14 +10,13 @@ import type {
   ListPipelineRunsResult,
   ListPipelineStepRunsInput,
   ListPipelineStepRunsResult,
-  PipelineRunFailure,
   PipelineRunRecord,
   PipelineRunStorage,
   PipelineStepRunRecord,
   StartPipelineRunInput,
   StartPipelineStepRunInput,
 } from "@sixb/core/storage"
-import { PipelineRunError } from "@sixb/core/storage"
+import { PIPELINE_RUN_FAILURE_CODES, PipelineRunError } from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import { installFreshSqliteSchema } from "./migrations"
 import {
@@ -116,8 +116,7 @@ export class SqlitePipelineRunStorage implements PipelineRunStorage {
             finished_at = ?,
             output_dataset_id = ?,
             output_version_id = ?,
-            error_name = ?,
-            error_message = ?
+            error = ?
           WHERE project_id = ? AND id = ?
         `
         )
@@ -126,8 +125,9 @@ export class SqlitePipelineRunStorage implements PipelineRunStorage {
           (input.finishedAt ?? new Date()).toISOString(),
           input.status === "succeeded" ? (input.output?.datasetId ?? null) : null,
           input.status === "succeeded" ? (input.output?.versionId ?? null) : null,
-          input.status === "succeeded" ? null : (input.error?.name ?? null),
-          input.status === "succeeded" ? null : (input.error?.message ?? null),
+          input.status === "succeeded" || input.error === undefined
+            ? null
+            : serializeSixbFailure(input.error, PIPELINE_RUN_FAILURE_CODES),
           input.projectId,
           input.id
         )
@@ -255,8 +255,7 @@ export class SqlitePipelineRunStorage implements PipelineRunStorage {
             finished_at = ?,
             output_version_id = ?,
             rows_written = ?,
-            error_name = ?,
-            error_message = ?
+            error = ?
           WHERE project_id = ? AND id = ?
         `
         )
@@ -265,8 +264,9 @@ export class SqlitePipelineRunStorage implements PipelineRunStorage {
           (input.finishedAt ?? new Date()).toISOString(),
           input.status === "succeeded" ? input.output.versionId : null,
           input.rowsWritten ?? existing.rows_written ?? null,
-          input.status === "succeeded" ? null : (input.error?.name ?? null),
-          input.status === "succeeded" ? null : (input.error?.message ?? null),
+          input.status === "succeeded" || input.error === undefined
+            ? null
+            : serializeSixbFailure(input.error, PIPELINE_RUN_FAILURE_CODES),
           input.projectId,
           input.id
         )
@@ -409,20 +409,6 @@ function parseDatasetVersionRefs(value: string): readonly DatasetVersionRef[] {
   return JSON.parse(value) as readonly DatasetVersionRef[]
 }
 
-function toFailure(row: {
-  readonly error_name: string | null
-  readonly error_message: string | null
-}): PipelineRunFailure | undefined {
-  if (!row.error_message) {
-    return undefined
-  }
-
-  return {
-    name: row.error_name ?? undefined,
-    message: row.error_message,
-  }
-}
-
 function rowToPipelineRunRecord(row: PipelineRunDatabaseRow): PipelineRunRecord {
   return {
     id: row.id,
@@ -438,7 +424,7 @@ function rowToPipelineRunRecord(row: PipelineRunDatabaseRow): PipelineRunRecord 
             versionId: row.output_version_id,
           }
         : undefined,
-    error: toFailure(row),
+    error: row.error === null ? undefined : parseSixbFailure(row.error, PIPELINE_RUN_FAILURE_CODES),
   }
 }
 
@@ -462,7 +448,7 @@ function rowToPipelineStepRunRecord(row: PipelineStepRunDatabaseRow): PipelineSt
         }
       : undefined,
     rowsWritten: row.rows_written ?? undefined,
-    error: toFailure(row),
+    error: row.error === null ? undefined : parseSixbFailure(row.error, PIPELINE_RUN_FAILURE_CODES),
   }
 }
 
@@ -483,8 +469,7 @@ interface PipelineRunDatabaseRow {
   finished_at: string | null
   output_dataset_id: string | null
   output_version_id: string | null
-  error_name: string | null
-  error_message: string | null
+  error: string | null
 }
 
 interface PipelineStepRunDatabaseRow {
@@ -501,6 +486,5 @@ interface PipelineStepRunDatabaseRow {
   inputs: string
   output_version_id: string | null
   rows_written: number | null
-  error_name: string | null
-  error_message: string | null
+  error: string | null
 }

--- a/storage/sqlite/tests/sqlite-pipeline-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-pipeline-run-storage.test.ts
@@ -1,7 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { PipelineRunError } from "@sixb/core/storage"
+import { PipelineRunError, type PipelineRunFailureCode, type SixbFailure } from "@sixb/core/storage"
 import { SqliteStorage } from "../src"
 import { SqlitePipelineRunStorage } from "../src/pipeline-run-storage"
+
+const FAILURE: SixbFailure<PipelineRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Pipeline failed",
+  retryable: false,
+  at: "2026-05-08T10:00:01.000Z",
+  details: { pipelineId: "customers" },
+}
+
+const CANCELLED_FAILURE: SixbFailure<PipelineRunFailureCode> = {
+  ...FAILURE,
+  code: "runtime.cancelled",
+  message: "Stopped",
+}
 
 describe("SqlitePipelineRunStorage", () => {
   let storage: SqlitePipelineRunStorage
@@ -58,10 +72,7 @@ describe("SqlitePipelineRunStorage", () => {
       id: "run-1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        name: "Error",
-        message: "No committed source version",
-      },
+      error: { ...FAILURE, message: "No committed source version" },
     })
 
     await storage.start({
@@ -126,10 +137,7 @@ describe("SqlitePipelineRunStorage", () => {
       id: "run-1",
     })
     expect(failed?.status).toBe("failed")
-    expect(failed?.error).toEqual({
-      name: "Error",
-      message: "No committed source version",
-    })
+    expect(failed?.error).toEqual({ ...FAILURE, message: "No committed source version" })
   })
 
   test("lists the latest run for multiple pipeline ids", async () => {
@@ -250,10 +258,7 @@ describe("SqlitePipelineRunStorage", () => {
       projectId: "my-app",
       status: "failed",
       rowsWritten: 3,
-      error: {
-        name: "Error",
-        message: "Invalid row",
-      },
+      error: { ...FAILURE, message: "Invalid row" },
     })
 
     await storage.startStep({
@@ -306,10 +311,7 @@ describe("SqlitePipelineRunStorage", () => {
       projectId: "my-app",
       statuses: ["failed"],
     })
-    expect(failedSteps.steps[0]?.error).toEqual({
-      name: "Error",
-      message: "Invalid row",
-    })
+    expect(failedSteps.steps[0]?.error).toEqual({ ...FAILURE, message: "Invalid row" })
     expect(failedSteps.steps[0]?.rowsWritten).toBe(3)
   })
 
@@ -333,9 +335,7 @@ describe("SqlitePipelineRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "boom",
-        },
+        error: { ...FAILURE, message: "boom" },
       })
     ).rejects.toBeInstanceOf(PipelineRunError)
 
@@ -366,9 +366,7 @@ describe("SqlitePipelineRunStorage", () => {
       id: "step_1",
       projectId: "my-app",
       status: "cancelled",
-      error: {
-        message: "Stopped",
-      },
+      error: CANCELLED_FAILURE,
     })
 
     await expect(
@@ -376,9 +374,7 @@ describe("SqlitePipelineRunStorage", () => {
         id: "step_1",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "Too late",
-        },
+        error: { ...FAILURE, message: "Too late" },
       })
     ).rejects.toBeInstanceOf(PipelineRunError)
 
@@ -386,9 +382,7 @@ describe("SqlitePipelineRunStorage", () => {
       id: "piperun_1",
       projectId: "my-app",
       status: "cancelled",
-      error: {
-        message: "Stopped",
-      },
+      error: CANCELLED_FAILURE,
     })
 
     await expect(

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { migrateStorage } from "@sixb/core"
 import { parseSixbFailure } from "@sixb/core/internal/errors"
-import { SYNC_RUN_FAILURE_CODES } from "@sixb/core/storage"
+import { PIPELINE_RUN_FAILURE_CODES, SYNC_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { SqliteStorage } from "../src"
 import {
   createSqliteStorageMigrators,
@@ -95,6 +95,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 11,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "012-pipeline-failure-record",
+    status: "applied",
+    version: 12,
+  },
 ]
 
 afterEach(async () => {
@@ -133,7 +140,7 @@ describe("SQLite storage migrations", () => {
     }
   })
 
-  test("migrates legacy failed Sync runs from the version 10 schema", () => {
+  test("migrates legacy failed run records from the version 10 schema", () => {
     const db = new Database(":memory:")
     try {
       for (const migration of sqliteStorageMigrations.steps.slice(0, 10)) migration.up(db)
@@ -155,7 +162,43 @@ describe("SQLite storage migrations", () => {
         "secret sync diagnostic"
       )
 
-      sqliteStorageMigrations.steps[10]?.up(db)
+      db.query(`
+        INSERT INTO pipeline_runs (
+          project_id, id, pipeline_id, status, started_at, finished_at, error_name, error_message
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "project-a",
+        "pipeline-legacy",
+        "orders",
+        "failed",
+        "2026-08-10T12:00:00.000Z",
+        "2026-08-10T12:01:00.000Z",
+        "PipelineError",
+        "secret pipeline diagnostic"
+      )
+
+      db.query(`
+        INSERT INTO pipeline_step_runs (
+          project_id, id, pipeline_run_id, pipeline_id, step_id, dataset_id, mode, status,
+          started_at, finished_at, inputs, error_name, error_message
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "project-a",
+        "step-legacy",
+        "pipeline-legacy",
+        "orders",
+        "extract",
+        "orders",
+        "snapshot",
+        "failed",
+        "2026-08-10T12:00:00.000Z",
+        "2026-08-10T12:01:00.000Z",
+        "{}",
+        "StepError",
+        "secret step diagnostic"
+      )
+
+      for (const migration of sqliteStorageMigrations.steps.slice(10)) migration.up(db)
 
       const row = db
         .query("SELECT error FROM sync_runs WHERE project_id = ? AND id = ?")
@@ -175,6 +218,33 @@ describe("SQLite storage migrations", () => {
         },
       })
       expect(JSON.stringify(failure)).not.toContain("secret sync diagnostic")
+
+      const pipelineRow = db
+        .query("SELECT error FROM pipeline_runs WHERE project_id = ? AND id = ?")
+        .get("project-a", "pipeline-legacy") as { readonly error: string }
+      const pipelineFailure = parseSixbFailure(pipelineRow.error, PIPELINE_RUN_FAILURE_CODES)
+      expect(pipelineFailure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        details: { pipelineId: "orders", runId: "pipeline-legacy" },
+      })
+      expect(JSON.stringify(pipelineFailure)).not.toContain("secret pipeline diagnostic")
+
+      const stepRow = db
+        .query("SELECT error FROM pipeline_step_runs WHERE project_id = ? AND id = ?")
+        .get("project-a", "step-legacy") as { readonly error: string }
+      const stepFailure = parseSixbFailure(stepRow.error, PIPELINE_RUN_FAILURE_CODES)
+      expect(stepFailure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        details: {
+          pipelineId: "orders",
+          pipelineRunId: "pipeline-legacy",
+          stepId: "extract",
+          stepRunId: "step-legacy",
+        },
+      })
+      expect(JSON.stringify(stepFailure)).not.toContain("secret step diagnostic")
     } finally {
       db.close()
     }


### PR DESCRIPTION
## Summary

- migrate pipeline runs and pipeline step runs to the scoped `SixbFailure` record
- persist validated failures as JSON in SQLite and JSONB in PostgreSQL
- convert thrown worker errors at the persistence boundary with pipeline and step context
- expose the exact `internal.unexpected | runtime.cancelled` union through HTTP, OpenAPI, and the generated client
- display the human-readable message and stable code in Atlas pipeline history

## Why

This applies the portable failure contract already established for sync runs to the next primitive without widening the refactor. Pipeline runs and step runs share the same worker and status policy, so migrating them together keeps one coherent vertical boundary while leaving every other run primitive untouched.

The runtime error class remains internal. Only the serializable `SixbFailure` record crosses storage and API boundaries.

## Decisions

- pipeline failures declare only the codes their producer can currently emit
- uncoded failures fall back to `internal.unexpected`; aborts map to `runtime.cancelled`
- storage validates the complete failure record and rejects codes outside the pipeline contract
- SQLite and PostgreSQL store one atomic failure value instead of split name/message columns
- generated type tests prevent unrelated catalog codes from leaking into pipeline responses
- no sync implementation or UI is refactored in this PR

## Stack

Stacked on #316.

## Validation

- `bun run typecheck`
- `bun run build`
- `bun run check`
- 30 targeted core, SQLite, worker, and server tests

PostgreSQL e2e was not run locally because the Docker daemon was unavailable; it remains covered by CI.