### PR TITLE
workflow: persist portable failure records

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -29,7 +29,7 @@ interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
 }
 ```
 
-Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, and pipeline step runs currently declare `internal.unexpected | runtime.cancelled`.
+Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, pipeline step runs, workflow runs, and workflow node runs currently declare `internal.unexpected | runtime.cancelled`.
 
 Other run primitives keep their legacy error shape until their own vertical migration. This keeps
 each storage and wire change independently reviewable.

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -4,6 +4,7 @@ import {
   resolveAgentExecutionAuthorization,
 } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
+import { captureSixbFailure } from "@sixb/core/internal/errors"
 import type { QueueDelivery } from "@sixb/core/internal/workers"
 import { QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { WorkflowAgentNodeDefinition } from "@sixb/core/internal/workflows"
@@ -16,6 +17,7 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
+import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { AgentUsageRecordingError, AgentWorkerError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { AiModelCallRecorder } from "./model-call-recorder"
@@ -366,6 +368,17 @@ async function finishWorkflowAgentNodeFailed(input: {
   readonly error: unknown
 }): Promise<{ readonly node: WorkflowNodeRunRecord; readonly run: WorkflowRunRecord }> {
   const message = errorMessage(input.error)
+  const at = new Date()
+  const failure = captureSixbFailure(input.error, {
+    allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
+    defaultCode: input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+    at,
+    details: {
+      workflowId: input.nodeRun.workflowId,
+      workflowRunId: input.nodeRun.workflowRunId,
+      nodeRunId: input.nodeRun.id,
+    },
+  })
   return input.context.storage.transaction(async (tx) => {
     const runs = tx.workflowRuns
     if (!runs) throw new AgentWorkerError("Workflow storage disappeared during finalization.")
@@ -381,13 +394,13 @@ async function finishWorkflowAgentNodeFailed(input: {
       projectId: input.context.id,
       id: input.nodeRun.id,
       status: input.status,
-      error: message,
+      error: failure,
     })
     const run = await runs.finish({
       projectId: input.context.id,
       id: input.nodeRun.workflowRunId,
       status: input.status,
-      error: message,
+      error: failure,
     })
     return { node, run }
   })
@@ -448,7 +461,7 @@ async function emitNodeAndRunFailed(
             nodeKey: failed.node.nodeKey,
             status,
             finishedAt: requireFinishedAt(failed.node).toISOString(),
-            ...(failed.node.error ? { error: failed.node.error } : {}),
+            ...(failed.node.error ? { error: failed.node.error.message } : {}),
           },
         },
         {
@@ -458,7 +471,7 @@ async function emitNodeAndRunFailed(
             runId: failed.run.id,
             status,
             finishedAt: requireFinishedAt(failed.run).toISOString(),
-            ...(failed.run.error ? { error: failed.run.error } : {}),
+            ...(failed.run.error ? { error: failed.run.error.message } : {}),
           },
         },
       ],

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1939,6 +1939,17 @@ describe("AgentWorker", () => {
     await worker.start()
     try {
       await toolStarted
+      const workflowCancellationFailure = {
+        code: "runtime.cancelled",
+        message: "Execution was cancelled.",
+        retryable: false,
+        at: new Date().toISOString(),
+        details: {
+          workflowId: "workflow-usage-test",
+          workflowRunId: runId,
+          nodeRunId,
+        },
+      } as const
       await sixb.storage.transaction(async (tx) => {
         const transactionalRuns = tx.workflowRuns
         if (!transactionalRuns) throw new Error("expected transactional workflow storage")
@@ -1951,13 +1962,13 @@ describe("AgentWorker", () => {
           projectId: PROJECT_ID,
           id: nodeRunId,
           status: "cancelled",
-          error: "Workflow run cancelled.",
+          error: workflowCancellationFailure,
         })
         await transactionalRuns.finish({
           projectId: PROJECT_ID,
           id: runId,
           status: "cancelled",
-          error: "Workflow run cancelled.",
+          error: workflowCancellationFailure,
         })
       })
       await publishAgentRunCancel(sixb.broker, { projectId: PROJECT_ID, runId: nodeRunId })

--- a/packages/atlas/src/components/SixbFailureSummary.tsx
+++ b/packages/atlas/src/components/SixbFailureSummary.tsx
@@ -1,0 +1,24 @@
+import type { SixbFailure } from "@sixb/core"
+import { cn } from "@sixb/ui/lib/utils"
+
+export function SixbFailureSummary({
+  failure,
+  className,
+  truncateMessage = false,
+}: {
+  failure: Pick<SixbFailure, "code" | "message">
+  className?: string
+  truncateMessage?: boolean
+}) {
+  return (
+    <div className={cn("min-w-0", className)}>
+      <p
+        className={cn("text-destructive", truncateMessage ? "truncate" : "break-words")}
+        title={truncateMessage ? failure.message : undefined}
+      >
+        {failure.message}
+      </p>
+      <p className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">{failure.code}</p>
+    </div>
+  )
+}

--- a/packages/atlas/src/features/workflows/components/runs/RunHistoryTable.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/RunHistoryTable.tsx
@@ -9,6 +9,7 @@ import {
 } from "@sixb/ui/components"
 import { ArrowRight } from "lucide-react"
 import { Link } from "react-router-dom"
+import { SixbFailureSummary } from "../../../../components/SixbFailureSummary"
 import {
   formatDate,
   formatRunDuration,
@@ -100,7 +101,7 @@ function RunHistoryCard({ run }: { run: WorkflowRunSummary }) {
         <RunMetric label="Duration" value={formatRunDuration(run)} />
         <RunMetric label="Status" value={run.status} />
       </div>
-      {run.error ? <p className="mt-3 break-words text-xs text-destructive">{run.error}</p> : null}
+      {run.error ? <SixbFailureSummary failure={run.error} className="mt-3 text-xs" /> : null}
     </article>
   )
 }
@@ -149,9 +150,7 @@ function RunHistoryTableRow({ run }: { run: WorkflowRunSummary }) {
       </TableCell>
       <TableCell className="max-w-[16rem]">
         {run.error ? (
-          <p className="truncate text-xs text-destructive" title={run.error}>
-            {run.error}
-          </p>
+          <SixbFailureSummary failure={run.error} className="text-xs" truncateMessage />
         ) : (
           <span className="text-xs text-muted-foreground">—</span>
         )}

--- a/packages/atlas/src/features/workflows/components/runs/RunListItem.tsx
+++ b/packages/atlas/src/features/workflows/components/runs/RunListItem.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom"
+import { SixbFailureSummary } from "../../../../components/SixbFailureSummary"
 import {
   formatDate,
   formatRunDuration,
@@ -44,7 +45,7 @@ export function RunListItem({
               {formatDate(run.queuedAt ?? run.startedAt)}
             </p>
           ) : null}
-          {run.error ? <p className="break-words text-xs text-destructive">{run.error}</p> : null}
+          {run.error ? <SixbFailureSummary failure={run.error} className="text-xs" /> : null}
         </div>
         <StatusBadge status={run.status} />
       </div>

--- a/packages/atlas/src/pages/PipelinesPage.tsx
+++ b/packages/atlas/src/pages/PipelinesPage.tsx
@@ -69,6 +69,7 @@ import {
 } from "lucide-react"
 import { type ReactNode, useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import {
   isUnconfiguredStorageError,
   UnrecordedHistoryState,
@@ -82,7 +83,6 @@ import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPrefe
 
 type PipelineSummary = ListPipelinesResponse[number] | GetPipelineResponse
 type PipelineRun = NonNullable<PipelineSummary["latestRun"]>
-type PipelineFailure = NonNullable<PipelineRun["error"]>
 type PipelineRunStatus = PipelineRun["status"]
 type PipelineGraphNode = PipelineSummary["graph"]["nodes"][number]
 type PipelineStep = PipelineGraphNode["step"]
@@ -93,21 +93,6 @@ const pipelineListViewOptions = [
   { value: "cards", label: "Cards" },
   { value: "table", label: "Table" },
 ] as const
-
-function PipelineFailureSummary({
-  failure,
-  className,
-}: {
-  failure: PipelineFailure
-  className?: string
-}) {
-  return (
-    <div className={cn("min-w-0", className)}>
-      <p className="break-words text-destructive">{failure.message}</p>
-      <p className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">{failure.code}</p>
-    </div>
-  )
-}
 
 function pipelineName(pipeline: Pick<PipelineSummary, "id">): string {
   return humanizeIdentifier(pipeline.id)
@@ -968,7 +953,7 @@ function RunsListPanel({
                       {formatRelativeTime(run.startedAt)} · {runDuration(run)}
                     </p>
                     {run.error ? (
-                      <PipelineFailureSummary failure={run.error} className="mt-1 text-[11px]" />
+                      <SixbFailureSummary failure={run.error} className="mt-1 text-[11px]" />
                     ) : null}
                   </div>
                   <RunStatusBadge status={run.status} />
@@ -1030,7 +1015,7 @@ function RunSummaryPanel({
             </div>
 
             {run.error ? (
-              <PipelineFailureSummary
+              <SixbFailureSummary
                 failure={run.error}
                 className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs"
               />
@@ -1090,7 +1075,7 @@ function RunSummaryPanel({
                         </button>
                       ) : null}
                       {step.error ? (
-                        <PipelineFailureSummary failure={step.error} className="mt-2 text-[11px]" />
+                        <SixbFailureSummary failure={step.error} className="mt-2 text-[11px]" />
                       ) : null}
                     </li>
                   ))}

--- a/packages/atlas/src/pages/SyncsPage.tsx
+++ b/packages/atlas/src/pages/SyncsPage.tsx
@@ -40,6 +40,7 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import {
   isUnconfiguredStorageError,
   UnrecordedHistoryState,
@@ -446,14 +447,7 @@ function SyncRunCard({ run }: { run: DisplayRun }) {
           <p className="mt-0.5 truncate text-foreground">{run.rowsRead ?? 0}</p>
         </div>
       </div>
-      {run.error && (
-        <div className="mt-3 min-w-0">
-          <p className="break-words text-xs text-destructive">{run.error.message}</p>
-          <p className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
-            {run.error.code}
-          </p>
-        </div>
-      )}
+      {run.error && <SixbFailureSummary failure={run.error} className="mt-3 text-xs" />}
     </div>
   )
 }
@@ -522,14 +516,7 @@ function SyncRunList({ runs, queuedRun }: { runs: SyncRun[]; queuedRun: QueuedRu
                       {run.output.versionId}
                     </p>
                   )}
-                  {run.error && (
-                    <div className="mt-1 min-w-0">
-                      <p className="text-xs text-destructive">{run.error.message}</p>
-                      <p className="truncate font-mono text-[10px] text-muted-foreground">
-                        {run.error.code}
-                      </p>
-                    </div>
-                  )}
+                  {run.error && <SixbFailureSummary failure={run.error} className="mt-1 text-xs" />}
                 </td>
                 <td className="px-3 py-3">
                   <RunStatusBadge status={run.status} />

--- a/packages/atlas/src/pages/WorkflowDetailPage.tsx
+++ b/packages/atlas/src/pages/WorkflowDetailPage.tsx
@@ -47,6 +47,7 @@ import {
 } from "lucide-react"
 import { type ReactNode, useEffect, useMemo, useState } from "react"
 import { Navigate, useNavigate, useParams, useSearchParams } from "react-router-dom"
+import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import { StructuredValue } from "../components/StructuredValue"
 import {
   isUnconfiguredStorageError,
@@ -1266,7 +1267,7 @@ function RunsListPanel({
                       {runTimeLabel(run)} · {formatRunDuration(run)}
                     </p>
                     {run.error ? (
-                      <p className="mt-1 break-words text-[11px] text-destructive">{run.error}</p>
+                      <SixbFailureSummary failure={run.error} className="mt-1 text-[11px]" />
                     ) : null}
                   </div>
                   <StatusBadge status={run.status} />
@@ -1320,9 +1321,10 @@ function RunSummaryPanel({
         <RunProgress status={run.status} nodes={nodes} totalSteps={totalSteps} />
 
         {run.error ? (
-          <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
-            {run.error}
-          </div>
+          <SixbFailureSummary
+            failure={run.error}
+            className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs"
+          />
         ) : null}
 
         <p className="rounded-lg bg-muted/30 p-3 text-xs text-muted-foreground">
@@ -1488,7 +1490,7 @@ function RunNodePanel({
 
             {runNode.error ? (
               <PanelBlock label="Error" icon={<X className={cn(SECTION_ICON, "text-red-500")} />}>
-                <p className="break-words text-sm text-destructive">{runNode.error}</p>
+                <SixbFailureSummary failure={runNode.error} className="text-sm" />
               </PanelBlock>
             ) : (
               <PanelBlock

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -8561,7 +8561,53 @@
                             "type": "string"
                           },
                           "error": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                              },
+                              "message": {
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
+                              }
+                            },
+                            "required": ["code", "message", "retryable", "at"],
+                            "additionalProperties": false
                           },
                           "requestedBy": {
                             "type": "object",
@@ -8975,7 +9021,53 @@
                           "type": "string"
                         },
                         "error": {
-                          "type": "string"
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "requestedBy": {
                           "type": "object",
@@ -10410,7 +10502,53 @@
                             "type": "string"
                           },
                           "error": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                              },
+                              "message": {
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
+                              }
+                            },
+                            "required": ["code", "message", "retryable", "at"],
+                            "additionalProperties": false
                           },
                           "requestedBy": {
                             "type": "object",
@@ -10551,7 +10689,53 @@
                           "type": "string"
                         },
                         "error": {
-                          "type": "string"
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "requestedBy": {
                           "type": "object",
@@ -10725,7 +10909,53 @@
                             }
                           },
                           "error": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                              },
+                              "message": {
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
+                              }
+                            },
+                            "required": ["code", "message", "retryable", "at"],
+                            "additionalProperties": false
                           },
                           "agentExecution": {
                             "type": "object",
@@ -11079,7 +11309,53 @@
                           "type": "string"
                         },
                         "error": {
-                          "type": "string"
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "requestedBy": {
                           "type": "object",
@@ -11253,7 +11529,53 @@
                             }
                           },
                           "error": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                              },
+                              "message": {
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
+                              }
+                            },
+                            "required": ["code", "message", "retryable", "at"],
+                            "additionalProperties": false
                           },
                           "agentExecution": {
                             "type": "object",

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3030,7 +3030,25 @@ export type ListWorkflowsResponses = {
       queuedAt?: string
       startedAt: string
       finishedAt?: string
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       requestedBy: {
         principalType: "user" | "serviceAccount" | "system"
         principalId: string
@@ -3192,7 +3210,25 @@ export type GetWorkflowResponses = {
       queuedAt?: string
       startedAt: string
       finishedAt?: string
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       requestedBy: {
         principalType: "user" | "serviceAccount" | "system"
         principalId: string
@@ -3676,7 +3712,25 @@ export type ListWorkflowRunsResponses = {
       queuedAt?: string
       startedAt: string
       finishedAt?: string
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       requestedBy: {
         principalType: "user" | "serviceAccount" | "system"
         principalId: string
@@ -3734,7 +3788,25 @@ export type GetWorkflowRunResponses = {
       queuedAt?: string
       startedAt: string
       finishedAt?: string
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       requestedBy: {
         principalType: "user" | "serviceAccount" | "system"
         principalId: string
@@ -3796,7 +3868,25 @@ export type GetWorkflowRunResponses = {
             }
           | null
       }
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       agentExecution?: {
         agentId: string
         status: "queued" | "running" | "succeeded" | "failed" | "cancelled"
@@ -3923,7 +4013,25 @@ export type CancelWorkflowRunResponses = {
       queuedAt?: string
       startedAt: string
       finishedAt?: string
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       requestedBy: {
         principalType: "user" | "serviceAccount" | "system"
         principalId: string
@@ -3985,7 +4093,25 @@ export type CancelWorkflowRunResponses = {
             }
           | null
       }
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       agentExecution?: {
         agentId: string
         status: "queued" | "running" | "succeeded" | "failed" | "cancelled"

--- a/packages/client/tests/workflow-failure.types.ts
+++ b/packages/client/tests/workflow-failure.types.ts
@@ -1,0 +1,40 @@
+import type {
+  GetWorkflowAgentNodeExecutionResponses,
+  GetWorkflowRunResponses,
+  ListWorkflowRunsResponses,
+  ListWorkflowsResponses,
+} from "../src/generated/types.gen"
+
+type LatestWorkflowRun = NonNullable<ListWorkflowsResponses[200][number]["latestRun"]>
+type ListedWorkflowRun = ListWorkflowRunsResponses[200]["runs"][number]
+type WorkflowNodeRun = GetWorkflowRunResponses[200]["nodes"][number]
+type WorkflowAgentExecution = GetWorkflowAgentNodeExecutionResponses[200]
+
+type LatestFailureCode = NonNullable<LatestWorkflowRun["error"]>["code"]
+type ListedFailureCode = NonNullable<ListedWorkflowRun["error"]>["code"]
+type NodeFailureCode = NonNullable<WorkflowNodeRun["error"]>["code"]
+
+const latestUnexpected: LatestFailureCode = "internal.unexpected"
+const latestCancelled: LatestFailureCode = "runtime.cancelled"
+const listedUnexpected: ListedFailureCode = "internal.unexpected"
+const nodeCancelled: NodeFailureCode = "runtime.cancelled"
+const agentExecutionError: NonNullable<WorkflowAgentExecution["error"]> = "agent failed"
+
+// Dataset lookup codes belong to HTTP route failures, not persisted workflow failures.
+// @ts-expect-error the generated latest-run failure contract must stay scoped to its producer
+const unrelatedLatest: LatestFailureCode = "dataset.not_found"
+// @ts-expect-error the generated run-history failure contract must stay scoped to its producer
+const unrelatedListed: ListedFailureCode = "dataset.not_found"
+// @ts-expect-error the generated node-run failure contract must stay scoped to its producer
+const unrelatedNode: NodeFailureCode = "dataset.not_found"
+
+void [
+  latestUnexpected,
+  latestCancelled,
+  listedUnexpected,
+  nodeCancelled,
+  agentExecutionError,
+  unrelatedLatest,
+  unrelatedListed,
+  unrelatedNode,
+]

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -525,6 +525,7 @@ export type {
   WorkflowNodeRunStorage,
   WorkflowNodeRunType,
   WorkflowRunExecution,
+  WorkflowRunFailureCode,
   WorkflowRunRecord,
   WorkflowRunStatus,
   WorkflowRunStorage,
@@ -533,5 +534,6 @@ export {
   InMemoryWorkflowAgentNodeRunStorage,
   InMemoryWorkflowNodeRunStorage,
   InMemoryWorkflowRunStorage,
+  WORKFLOW_RUN_FAILURE_CODES,
   WorkflowRunError,
 } from "./workflow-runs"

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -272,11 +272,12 @@ export type {
   WorkflowNodeRunStorage,
   WorkflowNodeRunType,
   WorkflowRunExecution,
+  WorkflowRunFailureCode,
   WorkflowRunRecord,
   WorkflowRunStatus,
   WorkflowRunStorage,
 } from "./workflow-runs"
-export { WorkflowRunError } from "./workflow-runs"
+export { WORKFLOW_RUN_FAILURE_CODES, WorkflowRunError } from "./workflow-runs"
 
 export interface StorageTransactionOptions {
   readonly isolation?: "default" | "serializable"

--- a/packages/core/src/storage/workflow-runs/in-memory.ts
+++ b/packages/core/src/storage/workflow-runs/in-memory.ts
@@ -1,4 +1,6 @@
 import { normalizeRequesterGroupIds } from "../../auth/attribution"
+import { parseSixbFailure } from "../../errors/internal"
+import type { SixbFailure } from "../../errors/types"
 import type { ExecutionStorage } from "../executions"
 import {
   cloneRecord,
@@ -41,9 +43,17 @@ import type {
   WorkflowAgentNodeRunStorage,
   WorkflowNodeRunRecord,
   WorkflowNodeRunStorage,
+  WorkflowRunFailureCode,
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "./types"
+import { WORKFLOW_RUN_FAILURE_CODES } from "./types"
+
+function normalizeFailure(
+  failure: SixbFailure<WorkflowRunFailureCode> | undefined
+): SixbFailure<WorkflowRunFailureCode> | undefined {
+  return failure ? parseSixbFailure(failure, WORKFLOW_RUN_FAILURE_CODES) : undefined
+}
 
 function assertNonNegativeInteger(value: number, fieldName: string): void {
   if (!Number.isInteger(value) || value < 0) {
@@ -177,7 +187,7 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
         : {
             ...base,
             output: undefined,
-            error: input.error,
+            error: normalizeFailure(input.error),
           }
 
     this.runs.set(storageKey(input.projectId, input.id), cloneRecord(next))
@@ -463,7 +473,7 @@ export class InMemoryWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
         : {
             ...base,
             output: undefined,
-            error: input.error,
+            error: normalizeFailure(input.error),
           }
 
     this.nodes.set(storageKey(input.projectId, input.id), cloneRecord(next))

--- a/packages/core/src/storage/workflow-runs/index.ts
+++ b/packages/core/src/storage/workflow-runs/index.ts
@@ -39,7 +39,9 @@ export type {
   WorkflowNodeRunStorage,
   WorkflowNodeRunType,
   WorkflowRunExecution,
+  WorkflowRunFailureCode,
   WorkflowRunRecord,
   WorkflowRunStatus,
   WorkflowRunStorage,
 } from "./types"
+export { WORKFLOW_RUN_FAILURE_CODES } from "./types"

--- a/packages/core/src/storage/workflow-runs/types.ts
+++ b/packages/core/src/storage/workflow-runs/types.ts
@@ -1,4 +1,5 @@
 import type { AgentMessagePart } from "../../agents/message"
+import type { SixbErrorCode, SixbFailure } from "../../errors/types"
 import type { JsonValue } from "../../json"
 import type { WorkflowIOSnapshot } from "../../workflows/types"
 import type { AgentExecutionStatus, AgentRunFinishReason, AgentRunUsage } from "../agents"
@@ -14,6 +15,14 @@ export type WorkflowRunStatus =
   | "cancelled"
 export type WorkflowNodeRunStatus = Exclude<WorkflowRunStatus, "queued">
 export type WorkflowNodeRunType = "step" | "action" | "intervention" | "agent"
+
+/** Error codes a workflow or workflow-node run can persist and expose. */
+export const WORKFLOW_RUN_FAILURE_CODES = [
+  "internal.unexpected",
+  "runtime.cancelled",
+] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
+
+export type WorkflowRunFailureCode = (typeof WORKFLOW_RUN_FAILURE_CODES)[number]
 
 export interface WorkflowRunExecution {
   readonly token: string
@@ -125,7 +134,7 @@ export interface WorkflowRunRecord {
   readonly queuedAt?: Date
   readonly startedAt: Date
   readonly finishedAt?: Date
-  readonly error?: string
+  readonly error?: SixbFailure<WorkflowRunFailureCode>
   /** Durable group memberships snapshotted when the workflow run was admitted. */
   readonly requesterGroupIds: readonly string[]
   readonly attempt: number
@@ -146,7 +155,7 @@ export interface WorkflowNodeRunRecord {
   readonly startedAt: Date
   readonly finishedAt?: Date
   readonly output?: WorkflowIOSnapshot
-  readonly error?: string
+  readonly error?: SixbFailure<WorkflowRunFailureCode>
 }
 
 export interface StartWorkflowRunInput {
@@ -207,7 +216,7 @@ export type FinishWorkflowRunInput =
       readonly projectId: string
       readonly status: "failed" | "cancelled"
       readonly finishedAt?: Date
-      readonly error?: string
+      readonly error?: SixbFailure<WorkflowRunFailureCode>
       readonly executionToken?: string
     }
 
@@ -246,7 +255,7 @@ export type FinishWorkflowNodeRunInput =
       readonly projectId: string
       readonly status: "failed" | "cancelled"
       readonly finishedAt?: Date
-      readonly error?: string
+      readonly error?: SixbFailure<WorkflowRunFailureCode>
       readonly executionToken?: string
     }
 

--- a/packages/core/src/workflows/run-dispatch.ts
+++ b/packages/core/src/workflows/run-dispatch.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto"
 import { isDeepStrictEqual } from "node:util"
 import { SYSTEM_PRINCIPAL } from "../auth"
 import { reportRunFailure } from "../error-reporting/capability"
+import { captureSixbFailure } from "../errors/internal"
 import type { DomainEventLog } from "../events"
 import type { RunDispatcher } from "../execution/dispatch"
 import { createPrimitiveExecutionRecord } from "../execution/durable"
@@ -9,7 +10,7 @@ import type { ValueType } from "../ontology"
 import type { Queues } from "../queues"
 import type { SixbDefinitions } from "../runtime/definitions"
 import type { CreateExecutionInput, Storage, WorkflowRunRecord } from "../storage"
-import { WorkflowRunError } from "../storage"
+import { WORKFLOW_RUN_FAILURE_CODES, WorkflowRunError } from "../storage"
 import { WorkflowValidationError } from "./errors"
 import type { WorkflowRunRequestResult } from "./request"
 import { snapshotWorkflowInput } from "./snapshot"
@@ -273,7 +274,11 @@ async function failWorkflowRunPublication(
     projectId: input.projectId,
     id: run.id,
     status: "failed",
-    error: error instanceof Error ? error.message : String(error),
+    error: captureSixbFailure(error, {
+      allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
+      defaultCode: "internal.unexpected",
+      details: { workflowId: run.workflowId, runId: run.id },
+    }),
   })
   reportRunFailure(input.errorReporterHost, error, {
     projectId: input.projectId,

--- a/packages/core/tests/workflow-request.test.ts
+++ b/packages/core/tests/workflow-request.test.ts
@@ -141,7 +141,15 @@ describe("sixb.workflows.request", () => {
       projectId: sixb.execution.projectId,
       id: "run_enqueue_failure",
     })
-    expect(run).toMatchObject({ status: "failed", error: "workflow queue unavailable" })
+    expect(run).toMatchObject({
+      status: "failed",
+      error: {
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: { workflowId: draftInvoice.id, runId: "run_enqueue_failure" },
+      },
+    })
     await flushSixbErrors(host)
     expect(reports).toEqual([
       `project:workflow-enqueue-failure:run:workflow:run_enqueue_failure:failed:${run?.finishedAt?.toISOString()}:workflow queue unavailable`,

--- a/packages/core/tests/workflow-runs.test.ts
+++ b/packages/core/tests/workflow-runs.test.ts
@@ -3,8 +3,10 @@ import { InMemoryStorage } from "../src"
 import {
   InMemoryWorkflowRunStorage,
   type QueueWorkflowRunInput,
+  type SixbFailure,
   type StartWorkflowRunInput,
   WorkflowRunError,
+  type WorkflowRunFailureCode,
 } from "../src/storage"
 import {
   createTestAgentExecution,
@@ -58,6 +60,15 @@ function createWorkflowRunStorage() {
       })
     },
   })
+}
+
+const FAILURE_AT = "2026-05-08T10:00:00.000Z"
+
+function failure(
+  message: string,
+  code: WorkflowRunFailureCode = "internal.unexpected"
+): SixbFailure<WorkflowRunFailureCode> {
+  return { code, message, retryable: false, at: FAILURE_AT }
 }
 
 describe("InMemoryWorkflowRunStorage", () => {
@@ -241,10 +252,10 @@ describe("InMemoryWorkflowRunStorage", () => {
       id: "wf-run-failed-before-start",
       projectId: "my-app",
       status: "failed",
-      error: "queue dispatch failed",
+      error: failure("queue dispatch failed"),
     })
     expect(finished.status).toBe("failed")
-    expect(finished.error).toBe("queue dispatch failed")
+    expect(finished.error).toEqual(failure("queue dispatch failed"))
   })
 
   test("waits and resumes workflow and node runs", async () => {
@@ -324,7 +335,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       id: "wf-run-cancelled-while-waiting",
       projectId: "my-app",
       status: "cancelled",
-      error: "Reviewer cancelled",
+      error: failure("Reviewer cancelled", "runtime.cancelled"),
     })
     expect(cancelled.status).toBe("cancelled")
   })
@@ -343,7 +354,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       id: "run-1",
       projectId: "my-app",
       status: "failed",
-      error: "No invoice candidate",
+      error: failure("No invoice candidate"),
     })
 
     await storage.start({
@@ -396,7 +407,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       id: "run-1",
     })
     expect(failed?.status).toBe("failed")
-    expect(failed?.error).toBe("No invoice candidate")
+    expect(failed?.error).toEqual(failure("No invoice candidate"))
   })
 
   test("lists the latest run for multiple workflow ids", async () => {
@@ -520,7 +531,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       id: "node-1",
       projectId: "my-app",
       status: "failed",
-      error: "No match",
+      error: failure("No match"),
     })
 
     await storage.nodes.start({
@@ -573,7 +584,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       statuses: ["failed"],
     })
     expect(failedNodes.nodes[0]?.output).toBeUndefined()
-    expect(failedNodes.nodes[0]?.error).toBe("No match")
+    expect(failedNodes.nodes[0]?.error).toEqual(failure("No match"))
   })
 
   test("rejects invalid workflow and node run lifecycle transitions", async () => {
@@ -600,7 +611,7 @@ describe("InMemoryWorkflowRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: "boom",
+        error: failure("boom"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -676,7 +687,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       id: "node-1",
       projectId: "my-app",
       status: "cancelled",
-      error: "Stopped",
+      error: failure("Stopped", "runtime.cancelled"),
     })
 
     await expect(
@@ -684,7 +695,7 @@ describe("InMemoryWorkflowRunStorage", () => {
         id: "node-1",
         projectId: "my-app",
         status: "failed",
-        error: "Too late",
+        error: failure("Too late"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -692,7 +703,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       id: "wf-run-1",
       projectId: "my-app",
       status: "cancelled",
-      error: "Stopped",
+      error: failure("Stopped", "runtime.cancelled"),
     })
 
     await expect(
@@ -714,7 +725,7 @@ describe("InMemoryWorkflowRunStorage", () => {
         id: "wf-run-1",
         projectId: "my-app",
         status: "failed",
-        error: "Too late",
+        error: failure("Too late"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
   })

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -6,6 +6,7 @@ import {
   type WorkflowDefinition,
 } from "@sixb/core"
 import { publishAgentRunCancel } from "@sixb/core/internal/agents"
+import { createSixbError, toSixbFailure } from "@sixb/core/internal/errors"
 import type { Sixb, WorkflowRunView } from "@sixb/core/internal/request-execution"
 import {
   snapshotWorkflowInterventionResponse,
@@ -18,6 +19,7 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
+import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import type { Elysia } from "elysia"
 import { z } from "zod"
 import { bearerSecurityRequirement } from "../auth/access-token-boundary"
@@ -179,6 +181,26 @@ async function serializeWorkflowNodeWithExecution(
 
 function principalForExecution(sixb: Sixb<readonly OntologySource[]>): Principal {
   return sixb.execution.requestedBy ?? SYSTEM_PRINCIPAL
+}
+
+function toWorkflowCancellationFailure(input: {
+  readonly message: string
+  readonly at: Date
+  readonly workflowId: string
+  readonly runId: string
+  readonly nodeRunId?: string
+}) {
+  const details: Readonly<Record<string, string>> = input.nodeRunId
+    ? {
+        workflowId: input.workflowId,
+        workflowRunId: input.runId,
+        nodeRunId: input.nodeRunId,
+      }
+    : { workflowId: input.workflowId, workflowRunId: input.runId }
+  return toSixbFailure(createSixbError("runtime.cancelled", input.message, { details }), {
+    allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
+    at: input.at,
+  })
 }
 
 function serializeWorkflowIntervention(intervention: WorkflowInterventionRecord) {
@@ -456,7 +478,7 @@ async function emitWorkflowInterventionCancelled(input: {
           nodeKey: node.nodeKey,
           status: "cancelled",
           finishedAt: node.finishedAt.toISOString(),
-          ...(node.error ? { error: node.error } : {}),
+          ...(node.error ? { error: node.error.message } : {}),
         },
       },
       {
@@ -466,7 +488,7 @@ async function emitWorkflowInterventionCancelled(input: {
           runId: run.id,
           status: "cancelled",
           finishedAt: run.finishedAt.toISOString(),
-          ...(run.error ? { error: run.error } : {}),
+          ...(run.error ? { error: run.error.message } : {}),
         },
       },
     ],
@@ -500,7 +522,7 @@ async function emitWorkflowRunCancelled(input: {
                 nodeKey: node.nodeKey,
                 status: "cancelled" as const,
                 finishedAt: node.finishedAt.toISOString(),
-                ...(node.error ? { error: node.error } : {}),
+                ...(node.error ? { error: node.error.message } : {}),
               },
             },
           ]
@@ -512,7 +534,7 @@ async function emitWorkflowRunCancelled(input: {
           runId: run.id,
           status: "cancelled",
           finishedAt: run.finishedAt.toISOString(),
-          ...(run.error ? { error: run.error } : {}),
+          ...(run.error ? { error: run.error.message } : {}),
         },
       },
     ],
@@ -796,6 +818,7 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
 
           CancelWorkflowInterventionBodySchema.parse(body ?? {})
           const cancelledAt = new Date()
+          const cancellationMessage = "Workflow intervention cancelled."
           const { cancelled, cancelledNode, cancelledRun } = await host.storage.transaction(
             async (tx) => {
               if (!tx.workflowInterventions || !tx.workflowRuns) {
@@ -812,14 +835,25 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
                 id: intervention.nodeRunId,
                 status: "cancelled",
                 finishedAt: cancelledAt,
-                error: "Workflow intervention cancelled.",
+                error: toWorkflowCancellationFailure({
+                  message: cancellationMessage,
+                  at: cancelledAt,
+                  workflowId: intervention.workflowId,
+                  runId: intervention.workflowRunId,
+                  nodeRunId: intervention.nodeRunId,
+                }),
               })
               const cancelledRun = await tx.workflowRuns.finish({
                 projectId: host.id,
                 id: intervention.workflowRunId,
                 status: "cancelled",
                 finishedAt: cancelledAt,
-                error: "Workflow intervention cancelled.",
+                error: toWorkflowCancellationFailure({
+                  message: cancellationMessage,
+                  at: cancelledAt,
+                  workflowId: intervention.workflowId,
+                  runId: intervention.workflowRunId,
+                }),
               })
               return { cancelled, cancelledNode, cancelledRun }
             }
@@ -1057,7 +1091,7 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
           }
 
           const cancelledAt = new Date()
-          const cancellationError = "Workflow run cancelled."
+          const cancellationMessage = "Workflow run cancelled."
           const result = await host.storage.transaction(async (tx) => {
             const runs = tx.workflowRuns
             if (!runs) {
@@ -1081,7 +1115,7 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
                   projectId: host.id,
                   nodeRunId: active.id,
                   completedAt: cancelledAt,
-                  error: cancellationError,
+                  error: cancellationMessage,
                 })
               }
             }
@@ -1109,7 +1143,13 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
                 id: active.id,
                 status: "cancelled",
                 finishedAt: cancelledAt,
-                error: cancellationError,
+                error: toWorkflowCancellationFailure({
+                  message: cancellationMessage,
+                  at: cancelledAt,
+                  workflowId: run.workflowId,
+                  runId: run.id,
+                  nodeRunId: active.id,
+                }),
                 executionToken: run.execution?.token,
               })
             }
@@ -1118,7 +1158,12 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
               id: run.id,
               status: "cancelled",
               finishedAt: cancelledAt,
-              error: cancellationError,
+              error: toWorkflowCancellationFailure({
+                message: cancellationMessage,
+                at: cancelledAt,
+                workflowId: run.workflowId,
+                runId: run.id,
+              }),
               executionToken: run.execution?.token,
             })
             return { run: cancelledRun, node: cancelledNode }

--- a/packages/server/src/schemas/workflows.ts
+++ b/packages/server/src/schemas/workflows.ts
@@ -1,7 +1,16 @@
+import {
+  type SixbFailure,
+  WORKFLOW_RUN_FAILURE_CODES,
+  type WorkflowRunFailureCode,
+} from "@sixb/core/storage"
 import { z } from "zod"
-import { JsonValueSchema } from "./common"
+import { JsonValueSchema, sixbFailureSchema } from "./common"
 
 export const WorkflowIOSnapshotSchema = z.record(JsonValueSchema)
+
+const WorkflowRunFailureSchema: z.ZodType<SixbFailure<WorkflowRunFailureCode>> = sixbFailureSchema(
+  WORKFLOW_RUN_FAILURE_CODES
+)
 
 export const WorkflowParamsSchema = z.object({
   workflowId: z.string().min(1),
@@ -121,7 +130,7 @@ export const WorkflowRunSummarySchema = z.object({
   queuedAt: z.string().optional(),
   startedAt: z.string(),
   finishedAt: z.string().optional(),
-  error: z.string().optional(),
+  error: WorkflowRunFailureSchema.optional(),
   requestedBy: WorkflowInterventionActorSchema,
 })
 
@@ -164,7 +173,7 @@ export const WorkflowNodeRunSchema = z.object({
   startedAt: z.string(),
   finishedAt: z.string().optional(),
   output: WorkflowIOSnapshotSchema.optional(),
-  error: z.string().optional(),
+  error: WorkflowRunFailureSchema.optional(),
   agentExecution: WorkflowAgentNodeExecutionSummarySchema.optional(),
 })
 

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -1860,7 +1860,15 @@ describe("SixbServer HTTP contract", () => {
       expect(cancelledRun).toMatchObject({
         id: pending.workflowRunId,
         status: "cancelled",
-        error: "Workflow intervention cancelled.",
+        error: {
+          code: "runtime.cancelled",
+          message: "Execution was cancelled.",
+          retryable: false,
+          details: {
+            workflowId: "review-device-health-workflow",
+            workflowRunId: pending.workflowRunId,
+          },
+        },
       })
 
       const cancelledNode = await sixb.storage.workflowRuns!.nodes.getById({
@@ -1870,7 +1878,16 @@ describe("SixbServer HTTP contract", () => {
       expect(cancelledNode).toMatchObject({
         id: pending.nodeRunId,
         status: "cancelled",
-        error: "Workflow intervention cancelled.",
+        error: {
+          code: "runtime.cancelled",
+          message: "Execution was cancelled.",
+          retryable: false,
+          details: {
+            workflowId: "review-device-health-workflow",
+            workflowRunId: pending.workflowRunId,
+            nodeRunId: pending.nodeRunId,
+          },
+        },
       })
 
       const workflowEvents = await events.read({

--- a/packages/server/tests/workflows-routes.test.ts
+++ b/packages/server/tests/workflows-routes.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test"
+import type { SixbHostView } from "@sixb/core"
+import { defineWorkflow, defineWorkflowStep } from "@sixb/core"
+import type {
+  ListLatestWorkflowRunsInput,
+  SixbFailure,
+  WorkflowNodeRunStorage,
+  WorkflowRunFailureCode,
+  WorkflowRunStorage,
+} from "@sixb/core/storage"
+import { Elysia } from "elysia"
+import { registerWorkflowRoutes } from "../src/routes/workflows"
+
+const step = defineWorkflowStep("review")
+  .input({})
+  .output({})
+  .run(() => ({}))
+
+const workflow = defineWorkflow("review-request").input({}).then(step)
+
+const FAILURE: SixbFailure<WorkflowRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "Workflow failed",
+  retryable: false,
+  at: "2026-05-08T10:00:01.000Z",
+  details: { workflowId: workflow.id, runId: "run-review" },
+}
+
+const CANCELLED_FAILURE: SixbFailure<WorkflowRunFailureCode> = {
+  ...FAILURE,
+  code: "runtime.cancelled",
+  message: "Node cancelled",
+  details: {
+    workflowId: workflow.id,
+    workflowRunId: "run-review",
+    nodeRunId: "run-review:node:0",
+  },
+}
+
+type WorkflowRunStorageStub = Partial<Omit<WorkflowRunStorage, "nodes">> & {
+  readonly nodes?: Partial<WorkflowNodeRunStorage>
+}
+
+function createSixbStub(workflowRuns: WorkflowRunStorageStub): SixbHostView {
+  return {
+    id: "my-app",
+    storage: { workflowRuns },
+    definitions: {
+      workflows: {
+        list: () => [workflow],
+        getById: (id: string) => (id === workflow.id ? workflow : null),
+      },
+    },
+  } as unknown as SixbHostView
+}
+
+function createTestApp(workflowRuns: WorkflowRunStorageStub) {
+  const host = createSixbStub(workflowRuns)
+  const sixbExecution = {
+    workflows: {
+      list: () => host.definitions.workflows.list(),
+      getById: (workflowId: string) => host.definitions.workflows.getById(workflowId),
+      runs: {
+        async getById(runId: string) {
+          return (await workflowRuns.getById?.({ projectId: host.id, id: runId })) ?? null
+        },
+        async listLatest(workflowIds: readonly string[]) {
+          return (
+            (await workflowRuns.listLatestByWorkflowIds?.({
+              projectId: host.id,
+              workflowIds,
+            })) ?? { runs: [] }
+          )
+        },
+      },
+    },
+  }
+  const app = new Elysia()
+  app.derive(() => ({ sixb: sixbExecution }))
+
+  return registerWorkflowRoutes(app, host)
+}
+
+describe("workflow routes", () => {
+  test("list route exposes the specialized latest-run failure", async () => {
+    let bulkCalls = 0
+    const app = createTestApp({
+      async listLatestByWorkflowIds(input: ListLatestWorkflowRunsInput) {
+        bulkCalls += 1
+        expect(input.workflowIds).toEqual([workflow.id])
+        return {
+          runs: [
+            {
+              id: "run-review",
+              projectId: "my-app",
+              executionId: "exec-review",
+              workflowId: workflow.id,
+              status: "failed",
+              input: {},
+              requesterGroupIds: [],
+              startedAt: new Date("2026-05-08T10:00:00.000Z"),
+              finishedAt: new Date("2026-05-08T10:00:01.000Z"),
+              error: FAILURE,
+              attempt: 1,
+            },
+          ],
+        }
+      },
+    })
+
+    const response = await app.handle(new Request("http://localhost/api/workflows"))
+    expect(response.status).toBe(200)
+    expect(bulkCalls).toBe(1)
+    expect(await response.json()).toMatchObject([
+      { id: workflow.id, latestRun: { status: "failed", error: FAILURE } },
+    ])
+  })
+
+  test("detail route exposes the same failure contract for runs and nodes", async () => {
+    const app = createTestApp({
+      async getById() {
+        return {
+          id: "run-review",
+          projectId: "my-app",
+          executionId: "exec-review",
+          workflowId: workflow.id,
+          status: "failed",
+          input: {},
+          requesterGroupIds: [],
+          startedAt: new Date("2026-05-08T10:00:00.000Z"),
+          finishedAt: new Date("2026-05-08T10:00:01.000Z"),
+          error: FAILURE,
+          attempt: 1,
+        }
+      },
+      nodes: {
+        async list() {
+          return {
+            nodes: [
+              {
+                id: "run-review:node:0",
+                projectId: "my-app",
+                workflowRunId: "run-review",
+                workflowId: workflow.id,
+                nodeIndex: 0,
+                nodeType: "step",
+                nodeId: step.id,
+                nodeKey: step.id,
+                status: "cancelled",
+                input: {},
+                startedAt: new Date("2026-05-08T10:00:00.100Z"),
+                finishedAt: new Date("2026-05-08T10:00:00.900Z"),
+                error: CANCELLED_FAILURE,
+              },
+            ],
+            hasMore: false,
+            total: 1,
+          }
+        },
+      },
+    })
+
+    const response = await app.handle(new Request("http://localhost/api/workflow-runs/run-review"))
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      run: { status: "failed", error: FAILURE },
+      nodes: [{ status: "cancelled", error: CANCELLED_FAILURE }],
+    })
+  })
+})

--- a/packages/workflow-worker/src/events.ts
+++ b/packages/workflow-worker/src/events.ts
@@ -144,7 +144,7 @@ export class EventsRuntimeWorkflowRunObserver implements WorkflowRunObserver {
           nodeKey: node.nodeKey,
           status: requireTerminalStatus(node.status, `Workflow node run '${node.id}'`),
           finishedAt: node.finishedAt.toISOString(),
-          ...(node.error ? { error: node.error } : {}),
+          ...(node.error ? { error: node.error.message } : {}),
         },
       },
     ])
@@ -163,7 +163,7 @@ export class EventsRuntimeWorkflowRunObserver implements WorkflowRunObserver {
           runId: run.id,
           status: requireTerminalStatus(run.status, `Workflow run '${run.id}'`),
           finishedAt: run.finishedAt.toISOString(),
-          ...(run.error ? { error: run.error } : {}),
+          ...(run.error ? { error: run.error.message } : {}),
         },
       },
     ])

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -1,4 +1,5 @@
 import type { ValueType, WorkflowDefinition } from "@sixb/core"
+import { captureSixbFailure } from "@sixb/core/internal/errors"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import type {
   WorkflowAgentNodeDefinition,
@@ -15,14 +16,17 @@ import {
   validateWorkflowStepOutput,
 } from "@sixb/core/internal/workflows"
 import type {
+  SixbFailure,
   WorkflowInterventionRecord,
   WorkflowInterventionStorage,
   WorkflowNodeRunRecord,
+  WorkflowRunFailureCode,
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
+import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { WorkflowWorkerError } from "../errors"
-import { statusForFailure, throwIfAborted, toWorkflowRunError } from "../normalize"
+import { statusForFailure, throwIfAborted } from "../normalize"
 import { noopWorkflowRunObserver, WorkflowRunRecorder } from "../recorder"
 import type {
   RunWorkflowJobInput,
@@ -550,12 +554,24 @@ export class WorkflowRunSession {
       return
     }
 
+    const at = new Date()
+    const activeNodeRunId = this.dependencies.recorder.activeNodeId
+    const failure = captureSixbFailure(error, {
+      allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
+      defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+      details: {
+        workflowId: this.dependencies.workflow.id,
+        workflowRunId: this.dependencies.job.id,
+        ...(activeNodeRunId ? { nodeRunId: activeNodeRunId } : {}),
+      },
+      at,
+    })
     await this.dependencies.recorder.finishActiveNodeAfterError({
       status,
-      error: toWorkflowRunError(error),
+      error: failure,
     })
 
-    await this.finishWorkflowRunAfterError({ error, status })
+    await this.finishWorkflowRunAfterError({ error, failure, status })
   }
 
   flushLogs(): Promise<void> {
@@ -585,12 +601,13 @@ export class WorkflowRunSession {
 
   private async finishWorkflowRunAfterError(input: {
     readonly error: unknown
+    readonly failure: SixbFailure<WorkflowRunFailureCode>
     readonly status: "failed" | "cancelled"
   }): Promise<void> {
     const finishError = await this.dependencies.recorder
       .finishRunAfterError({
         status: input.status,
-        error: toWorkflowRunError(input.error),
+        error: input.failure,
         onTransition:
           input.status === "failed"
             ? (run) => this.dependencies.onRunFailed?.(input.error, run)

--- a/packages/workflow-worker/src/normalize.ts
+++ b/packages/workflow-worker/src/normalize.ts
@@ -23,14 +23,6 @@ export function statusForFailure(
   return signal.aborted || isAbortError(error) ? "cancelled" : "failed"
 }
 
-export function toWorkflowRunError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message
-  }
-
-  return String(error)
-}
-
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }

--- a/packages/workflow-worker/src/recorder.ts
+++ b/packages/workflow-worker/src/recorder.ts
@@ -2,9 +2,11 @@ import { isDeepStrictEqual } from "node:util"
 import type { WorkflowDefinition } from "@sixb/core"
 import type { WorkflowIOSnapshot } from "@sixb/core/internal/workflows"
 import type {
+  SixbFailure,
   WorkflowInterventionRecord,
   WorkflowNodeRunRecord,
   WorkflowRunExecution,
+  WorkflowRunFailureCode,
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
@@ -178,7 +180,7 @@ export class WorkflowRunRecorder {
 
   async finishActiveNodeAfterError(params: {
     readonly status: "failed" | "cancelled"
-    readonly error: string
+    readonly error: SixbFailure<WorkflowRunFailureCode>
   }): Promise<void> {
     if (!this.activeNodeRunId) {
       return
@@ -238,7 +240,7 @@ export class WorkflowRunRecorder {
 
   async finishRunAfterError(params: {
     readonly status: "failed" | "cancelled"
-    readonly error: string
+    readonly error: SixbFailure<WorkflowRunFailureCode>
     readonly onTransition?: (run: WorkflowRunRecord) => void
   }): Promise<WorkflowRunRecord> {
     const run = await this.dependencies.workflowRuns.finish({

--- a/packages/workflow-worker/src/run-workflow-job.ts
+++ b/packages/workflow-worker/src/run-workflow-job.ts
@@ -1,6 +1,8 @@
+import { captureSixbFailure } from "@sixb/core/internal/errors"
+import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { workflowNodeExecutors } from "./execution/node-executors"
 import { WorkflowRunSession } from "./execution/workflow-run-session"
-import { statusForFailure, toWorkflowRunError } from "./normalize"
+import { statusForFailure } from "./normalize"
 import type { RunWorkflowJobInput, RunWorkflowResumeJobInput, WorkflowRunResult } from "./types"
 
 export async function runWorkflowJob(input: RunWorkflowJobInput): Promise<WorkflowRunResult> {
@@ -117,11 +119,16 @@ async function failQueuedRun(input: RunWorkflowJobInput, error: unknown): Promis
     return
   }
 
+  const status = statusForFailure(input.signal ?? new AbortController().signal, error)
   const failed = await input.runtime.workflowRuns.finish({
     projectId: input.runtime.projectId,
     id: input.job.id,
-    status: statusForFailure(input.signal ?? new AbortController().signal, error),
-    error: toWorkflowRunError(error),
+    status,
+    error: captureSixbFailure(error, {
+      allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
+      defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+      details: { workflowId: input.job.workflowId, runId: input.job.id },
+    }),
   })
 
   if (failed.status === "failed") {

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -1149,7 +1149,7 @@ describe("runWorkflowJob", () => {
           onNodeStarted: async () => undefined,
           onNodeFinished: async () => undefined,
           onRunFinished: async (run) => {
-            observerCalls.push(`${run.status}:${run.error}`)
+            observerCalls.push(`${run.status}:${run.error?.message}`)
           },
         },
       })
@@ -1161,8 +1161,7 @@ describe("runWorkflowJob", () => {
     })
     expect(run?.status).toBe("failed")
     expect(observerCalls).toHaveLength(1)
-    expect(observerCalls[0]).toContain("failed:[Sixb] Missing required field")
-    expect(observerCalls[0]).toContain('Workflow "queued-invalid-input" input.transaction')
+    expect(observerCalls[0]).toBe("failed:An unexpected internal error occurred.")
   })
 
   test("marks the active step and workflow failed when step output validation fails", async () => {
@@ -1197,9 +1196,7 @@ describe("runWorkflowJob", () => {
     expect(run?.status).toBe("failed")
     expect(nodes.nodes).toHaveLength(1)
     expect(nodes.nodes[0]?.status).toBe("failed")
-    expect(nodes.nodes[0]?.error).toContain(
-      'Workflow "invalid-output-workflow" step "invalid-output" output.invoice'
-    )
+    expect(nodes.nodes[0]?.error?.message).toBe("An unexpected internal error occurred.")
   })
 
   test("marks the active step and workflow failed when a step handler throws", async () => {
@@ -1237,7 +1234,25 @@ describe("runWorkflowJob", () => {
     })
     expect(run?.status).toBe("failed")
     expect(nodes.nodes.map((node) => node.status)).toEqual(["succeeded", "failed"])
-    expect(nodes.nodes[1]?.error).toBe("step exploded")
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_step_failed",
+        nodeRunId: "wfrun_step_failed:node:1",
+      },
+    })
+    expect(nodes.nodes[1]?.error).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_step_failed",
+        nodeRunId: "wfrun_step_failed:node:1",
+      },
+    })
+    expect(nodes.nodes[1]?.error?.message).toBe("An unexpected internal error occurred.")
   })
 
   test("uses the workflow input as output when every node is an action", async () => {
@@ -1716,7 +1731,7 @@ describe("runWorkflowJob", () => {
     })
     expect(run?.status).toBe("failed")
     expect(nodes.nodes.map((node) => node.status)).toEqual(["succeeded", "failed"])
-    expect(nodes.nodes[1]?.error).toBe("attach failed")
+    expect(nodes.nodes[1]?.error?.message).toBe("An unexpected internal error occurred.")
   })
 
   test("marks action node and workflow failed when the action run fails after request", async () => {

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -391,7 +391,16 @@ describe("WorkflowWorker", () => {
         }),
       (value) => value?.status === "failed"
     )
-    expect(run?.error).toBe("workflow exploded")
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      message: "An unexpected internal error occurred.",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_worker_failed",
+        nodeRunId: "wfrun_worker_failed:node:0",
+      },
+    })
 
     const reported = await waitFor(
       async () => reports,
@@ -434,14 +443,14 @@ describe("WorkflowWorker", () => {
       runId: "wfrun_worker_failed",
       nodeRunId: "wfrun_worker_failed:node:0",
       status: "failed",
-      error: "workflow exploded",
+      error: "An unexpected internal error occurred.",
     })
     expect(events[3]?.payload).toMatchObject({
       workflowId: workflow.id,
       runId: "wfrun_worker_failed",
       status: "failed",
       finishedAt: expect.any(String),
-      error: "workflow exploded",
+      error: "An unexpected internal error occurred.",
     })
 
     await Bun.sleep(50)
@@ -769,7 +778,16 @@ describe("WorkflowWorker", () => {
       (value) => value.length === 1
     )
 
-    expect(run?.error).toBe(resumeError.message)
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      message: "An unexpected internal error occurred.",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_worker_resume_failed",
+        nodeRunId: "wfrun_worker_resume_failed:node:2",
+      },
+    })
     expect(reported[0]?.error).toBe(resumeError)
     expect(reported[0]?.context).toMatchObject({
       attempt: 1,

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -31,6 +31,9 @@ import syncFailureRecordSql from "./migrations/011-sync-failure-record.sql" with
 import pipelineFailureRecordSql from "./migrations/012-pipeline-failure-record.sql" with {
   type: "text",
 }
+import workflowFailureRecordSql from "./migrations/013-workflow-failure-record.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -296,6 +299,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("010-ai-usage-accounting-foundation", aiUsageAccountingFoundationSql),
     pgSql("011-sync-failure-record", syncFailureRecordSql),
     pgSql("012-pipeline-failure-record", pipelineFailureRecordSql),
+    pgSql("013-workflow-failure-record", workflowFailureRecordSql),
   ],
 })
 

--- a/storage/pg/src/migrations/013-workflow-failure-record.sql
+++ b/storage/pg/src/migrations/013-workflow-failure-record.sql
@@ -1,0 +1,45 @@
+ALTER TABLE workflow_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE workflow_runs ADD COLUMN error JSONB;
+
+UPDATE workflow_runs
+SET error = jsonb_build_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', false,
+  'at', to_char(COALESCE(finished_at, started_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'workflowId', workflow_id,
+    'workflowRunId', id,
+    'migratedFromLegacyError', true
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE workflow_runs DROP COLUMN legacy_error;
+
+ALTER TABLE workflow_node_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE workflow_node_runs ADD COLUMN error JSONB;
+
+UPDATE workflow_node_runs
+SET error = jsonb_build_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', false,
+  'at', to_char(COALESCE(finished_at, started_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'workflowId', workflow_id,
+    'workflowRunId', workflow_run_id,
+    'nodeId', node_id,
+    'nodeRunId', id,
+    'migratedFromLegacyError', true
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE workflow_node_runs DROP COLUMN legacy_error;

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -1,4 +1,6 @@
+import type { JsonValue } from "@sixb/core"
 import { normalizeRequesterGroupIds } from "@sixb/core/internal/auth"
+import { parseSixbFailure, serializeSixbFailure } from "@sixb/core/internal/errors"
 import {
   assertWorkflowAgentNodeRunExecution,
   assertWorkflowRunExecution,
@@ -37,7 +39,7 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
-import { WorkflowRunError } from "@sixb/core/storage"
+import { WORKFLOW_RUN_FAILURE_CODES, WorkflowRunError } from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import type { SqlParameter } from "./pg-client"
 import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
@@ -217,7 +219,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
                 status = ${input.status},
                 finished_at = ${input.finishedAt ?? new Date()},
                 output = ${null},
-                error = ${input.error ?? null},
+                error = ${input.error === undefined ? null : serializeSixbFailure(input.error, WORKFLOW_RUN_FAILURE_CODES)}::text::jsonb,
                 execution_token = ${null},
                 execution_queue_lease_expires_at = ${null}
               WHERE project_id = ${input.projectId} AND id = ${input.id}
@@ -682,7 +684,7 @@ export class PgWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
                 status = ${input.status},
                 finished_at = ${input.finishedAt ?? new Date()},
                 output = ${null},
-                error = ${input.error ?? null}
+                error = ${input.error === undefined ? null : serializeSixbFailure(input.error, WORKFLOW_RUN_FAILURE_CODES)}::text::jsonb
               WHERE project_id = ${input.projectId} AND id = ${input.id}
               RETURNING *
             `
@@ -816,7 +818,7 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
     queuedAt: row.queued_at ? new Date(row.queued_at) : undefined,
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
-    error: row.error ?? undefined,
+    error: row.error === null ? undefined : parseSixbFailure(row.error, WORKFLOW_RUN_FAILURE_CODES),
     requesterGroupIds: parseJson(row.requester_group_ids),
     attempt: Number(row.attempt),
     ...(row.execution_token && row.execution_queue_lease_expires_at
@@ -845,7 +847,7 @@ function rowToWorkflowNodeRunRecord(row: WorkflowNodeRunDatabaseRow): WorkflowNo
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     output: row.output ? parseRecord(row.output) : undefined,
-    error: row.error ?? undefined,
+    error: row.error === null ? undefined : parseSixbFailure(row.error, WORKFLOW_RUN_FAILURE_CODES),
   }
 }
 
@@ -877,7 +879,7 @@ interface WorkflowRunDatabaseRow {
   queued_at: Date | string | null
   started_at: Date | string
   finished_at: Date | string | null
-  error: string | null
+  error: JsonValue | null
   requester_group_ids: string[] | string
   attempt: number | string
   execution_token: string | null
@@ -898,7 +900,7 @@ interface WorkflowNodeRunDatabaseRow {
   started_at: Date | string
   finished_at: Date | string | null
   output: WorkflowIOSnapshot | string | null
-  error: string | null
+  error: JsonValue | null
 }
 
 interface WorkflowAgentNodeRunDatabaseRow {

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -48,6 +48,7 @@ describe("Postgres storage migrations", () => {
             "010-ai-usage-accounting-foundation",
             "011-sync-failure-record",
             "012-pipeline-failure-record",
+            "013-workflow-failure-record",
           ],
         },
       ])
@@ -135,6 +136,13 @@ describe("Postgres storage migrations", () => {
           id: "012-pipeline-failure-record",
           status: "applied",
           version: 12,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "013-workflow-failure-record",
+          status: "applied",
+          version: 13,
         },
       ])
     })
@@ -804,6 +812,13 @@ describe("Postgres storage migrations", () => {
           id: "012-pipeline-failure-record",
           status: "applied",
           version: 12,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "013-workflow-failure-record",
+          status: "applied",
+          version: 13,
         },
       ])
     } finally {

--- a/storage/pg/tests/pg-workflow-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-workflow-run-storage.e2e.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import {
   type QueueWorkflowRunInput,
+  type SixbFailure,
   type StartWorkflowRunInput,
   WorkflowRunError,
+  type WorkflowRunFailureCode,
 } from "@sixb/core/storage"
 import {
   createTestAgentExecution,
@@ -12,6 +14,19 @@ import {
 import type { PostgresStorage } from "../src"
 import { PgWorkflowRunStorage } from "../src/pg-workflow-run-storage"
 import { createTestStorage } from "./helpers"
+
+function failure(
+  message: string,
+  code: WorkflowRunFailureCode = "internal.unexpected"
+): SixbFailure<WorkflowRunFailureCode> {
+  return {
+    code,
+    message,
+    retryable: false,
+    at: "2026-05-08T10:00:01.000Z",
+    details: { workflowId: "reconcile-transaction" },
+  }
+}
 
 describe("PgWorkflowRunStorage", () => {
   let root: PostgresStorage
@@ -204,7 +219,7 @@ describe("PgWorkflowRunStorage", () => {
       id: "run-1",
       projectId: "my-app",
       status: "failed",
-      error: "No invoice candidate",
+      error: failure("No invoice candidate"),
     })
 
     await storage.workflowRuns.start({
@@ -256,7 +271,7 @@ describe("PgWorkflowRunStorage", () => {
       projectId: "my-app",
       id: "run-1",
     })
-    expect(failed?.error).toBe("No invoice candidate")
+    expect(failed?.error).toEqual(failure("No invoice candidate"))
   })
 
   test("lists the latest run for multiple workflow ids", async () => {
@@ -372,7 +387,7 @@ describe("PgWorkflowRunStorage", () => {
       id: "node-1",
       projectId: "my-app",
       status: "failed",
-      error: "No match",
+      error: failure("No match"),
     })
 
     await storage.workflowRuns.nodes.start({
@@ -425,7 +440,7 @@ describe("PgWorkflowRunStorage", () => {
       statuses: ["failed"],
     })
     expect(failedNodes.nodes[0]?.output).toBeUndefined()
-    expect(failedNodes.nodes[0]?.error).toBe("No match")
+    expect(failedNodes.nodes[0]?.error).toEqual(failure("No match"))
   })
 
   test("rejects invalid workflow and node run lifecycle transitions", async () => {
@@ -450,7 +465,7 @@ describe("PgWorkflowRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: "boom",
+        error: failure("boom"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -512,7 +527,7 @@ describe("PgWorkflowRunStorage", () => {
       id: "node-1",
       projectId: "my-app",
       status: "cancelled",
-      error: "Stopped",
+      error: failure("Stopped", "runtime.cancelled"),
     })
 
     await expect(
@@ -520,7 +535,7 @@ describe("PgWorkflowRunStorage", () => {
         id: "node-1",
         projectId: "my-app",
         status: "failed",
-        error: "Too late",
+        error: failure("Too late"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -528,7 +543,7 @@ describe("PgWorkflowRunStorage", () => {
       id: "wf-run-1",
       projectId: "my-app",
       status: "cancelled",
-      error: "Stopped",
+      error: failure("Stopped", "runtime.cancelled"),
     })
 
     await expect(
@@ -550,7 +565,7 @@ describe("PgWorkflowRunStorage", () => {
         id: "wf-run-1",
         projectId: "my-app",
         status: "failed",
-        error: "Too late",
+        error: failure("Too late"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
   })

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -34,6 +34,9 @@ import syncFailureRecordSql from "./migrations/011-sync-failure-record.sql" with
 import pipelineFailureRecordSql from "./migrations/012-pipeline-failure-record.sql" with {
   type: "text",
 }
+import workflowFailureRecordSql from "./migrations/013-workflow-failure-record.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -66,6 +69,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("010-ai-usage-accounting-foundation", aiUsageAccountingFoundationSql),
     sqliteSql("011-sync-failure-record", syncFailureRecordSql),
     sqliteSql("012-pipeline-failure-record", pipelineFailureRecordSql),
+    sqliteSql("013-workflow-failure-record", workflowFailureRecordSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/013-workflow-failure-record.sql
+++ b/storage/sqlite/src/migrations/013-workflow-failure-record.sql
@@ -1,0 +1,45 @@
+ALTER TABLE workflow_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE workflow_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE workflow_runs
+SET error = json_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json('false'),
+  'at', COALESCE(finished_at, started_at),
+  'details', json_object(
+    'workflowId', workflow_id,
+    'workflowRunId', id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE workflow_runs DROP COLUMN legacy_error;
+
+ALTER TABLE workflow_node_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE workflow_node_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE workflow_node_runs
+SET error = json_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json('false'),
+  'at', COALESCE(finished_at, started_at),
+  'details', json_object(
+    'workflowId', workflow_id,
+    'workflowRunId', workflow_run_id,
+    'nodeId', node_id,
+    'nodeRunId', id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE workflow_node_runs DROP COLUMN legacy_error;

--- a/storage/sqlite/src/workflow-run-storage.ts
+++ b/storage/sqlite/src/workflow-run-storage.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite"
 import { normalizeRequesterGroupIds } from "@sixb/core/internal/auth"
+import { parseSixbFailure, serializeSixbFailure } from "@sixb/core/internal/errors"
 import {
   assertWorkflowAgentNodeRunExecution,
   assertWorkflowRunExecution,
@@ -38,7 +39,7 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
-import { WorkflowRunError } from "@sixb/core/storage"
+import { WORKFLOW_RUN_FAILURE_CODES, WorkflowRunError } from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import { installFreshSqliteSchema } from "./migrations"
 import {
@@ -259,7 +260,9 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
           input.status,
           (input.finishedAt ?? new Date()).toISOString(),
           input.status === "succeeded" ? serializeRecord(input.output) : null,
-          input.status === "succeeded" ? null : (input.error ?? null),
+          input.status === "succeeded" || input.error === undefined
+            ? null
+            : serializeSixbFailure(input.error, WORKFLOW_RUN_FAILURE_CODES),
           input.projectId,
           input.id
         )
@@ -823,7 +826,9 @@ export class SqliteWorkflowNodeRunStorage implements WorkflowNodeRunStorage {
           input.status,
           (input.finishedAt ?? new Date()).toISOString(),
           input.status === "succeeded" && input.output ? serializeRecord(input.output) : null,
-          input.status === "succeeded" ? null : (input.error ?? null),
+          input.status === "succeeded" || input.error === undefined
+            ? null
+            : serializeSixbFailure(input.error, WORKFLOW_RUN_FAILURE_CODES),
           input.projectId,
           input.id
         )
@@ -970,7 +975,7 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
     queuedAt: row.queued_at ? new Date(row.queued_at) : undefined,
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
-    error: row.error ?? undefined,
+    error: row.error === null ? undefined : parseSixbFailure(row.error, WORKFLOW_RUN_FAILURE_CODES),
     requesterGroupIds: JSON.parse(row.requester_group_ids) as string[],
     attempt: row.attempt,
     ...(row.execution_token && row.execution_queue_lease_expires_at
@@ -999,7 +1004,7 @@ function rowToWorkflowNodeRunRecord(row: WorkflowNodeRunDatabaseRow): WorkflowNo
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     output: row.output ? parseRecord(row.output) : undefined,
-    error: row.error ?? undefined,
+    error: row.error === null ? undefined : parseSixbFailure(row.error, WORKFLOW_RUN_FAILURE_CODES),
   }
 }
 

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -6,7 +6,11 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { migrateStorage } from "@sixb/core"
 import { parseSixbFailure } from "@sixb/core/internal/errors"
-import { PIPELINE_RUN_FAILURE_CODES, SYNC_RUN_FAILURE_CODES } from "@sixb/core/storage"
+import {
+  PIPELINE_RUN_FAILURE_CODES,
+  SYNC_RUN_FAILURE_CODES,
+  WORKFLOW_RUN_FAILURE_CODES,
+} from "@sixb/core/storage"
 import { SqliteStorage } from "../src"
 import {
   createSqliteStorageMigrators,
@@ -101,6 +105,13 @@ const expectedStorageMigrationRows = [
     id: "012-pipeline-failure-record",
     status: "applied",
     version: 12,
+  },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "013-workflow-failure-record",
+    status: "applied",
+    version: 13,
   },
 ]
 
@@ -198,6 +209,34 @@ describe("SQLite storage migrations", () => {
         "secret step diagnostic"
       )
 
+      db.run(`
+        INSERT INTO executions (
+          project_id, id, executor_kind, executor_id, source_kind, source_id, correlation_id,
+          authority_kind, authority_primitive_kind, authority_primitive_id, created_at
+        ) VALUES (
+          'project-a', 'execution-workflow-legacy', 'workflow', 'workflow-legacy', 'event',
+          'event-workflow-legacy', 'correlation-workflow-legacy', 'trustedPrimitive', 'workflow',
+          'orders', '2026-08-10T12:00:00.000Z'
+        );
+
+        INSERT INTO workflow_runs (
+          project_id, id, workflow_id, status, input, started_at, finished_at, error, execution_id
+        ) VALUES (
+          'project-a', 'workflow-legacy', 'orders', 'failed', '{}',
+          '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z',
+          'secret workflow diagnostic', 'execution-workflow-legacy'
+        );
+
+        INSERT INTO workflow_node_runs (
+          project_id, id, workflow_run_id, workflow_id, node_index, node_type, node_id, node_key,
+          status, input, started_at, finished_at, error
+        ) VALUES (
+          'project-a', 'node-legacy', 'workflow-legacy', 'orders', 0, 'step', 'extract', 'extract',
+          'failed', '{}', '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z',
+          'secret workflow node diagnostic'
+        );
+      `)
+
       for (const migration of sqliteStorageMigrations.steps.slice(10)) migration.up(db)
 
       const row = db
@@ -245,6 +284,33 @@ describe("SQLite storage migrations", () => {
         },
       })
       expect(JSON.stringify(stepFailure)).not.toContain("secret step diagnostic")
+
+      const workflowRow = db
+        .query("SELECT error FROM workflow_runs WHERE project_id = ? AND id = ?")
+        .get("project-a", "workflow-legacy") as { readonly error: string }
+      const workflowFailure = parseSixbFailure(workflowRow.error, WORKFLOW_RUN_FAILURE_CODES)
+      expect(workflowFailure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        details: { workflowId: "orders", workflowRunId: "workflow-legacy" },
+      })
+      expect(JSON.stringify(workflowFailure)).not.toContain("secret workflow diagnostic")
+
+      const nodeRow = db
+        .query("SELECT error FROM workflow_node_runs WHERE project_id = ? AND id = ?")
+        .get("project-a", "node-legacy") as { readonly error: string }
+      const nodeFailure = parseSixbFailure(nodeRow.error, WORKFLOW_RUN_FAILURE_CODES)
+      expect(nodeFailure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        details: {
+          workflowId: "orders",
+          workflowRunId: "workflow-legacy",
+          nodeId: "extract",
+          nodeRunId: "node-legacy",
+        },
+      })
+      expect(JSON.stringify(nodeFailure)).not.toContain("secret workflow node diagnostic")
     } finally {
       db.close()
     }

--- a/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import {
   type QueueWorkflowRunInput,
+  type SixbFailure,
   type StartWorkflowRunInput,
   WorkflowRunError,
+  type WorkflowRunFailureCode,
 } from "@sixb/core/storage"
 import {
   createTestAgentExecution,
@@ -11,6 +13,19 @@ import {
 } from "@sixb/core/testing"
 import { SqliteStorage } from "../src"
 import { SqliteWorkflowRunStorage } from "../src/workflow-run-storage"
+
+function failure(
+  message: string,
+  code: WorkflowRunFailureCode = "internal.unexpected"
+): SixbFailure<WorkflowRunFailureCode> {
+  return {
+    code,
+    message,
+    retryable: false,
+    at: "2026-05-08T10:00:01.000Z",
+    details: { workflowId: "reconcile-transaction" },
+  }
+}
 
 describe("SqliteWorkflowRunStorage", () => {
   let root: SqliteStorage
@@ -202,7 +217,7 @@ describe("SqliteWorkflowRunStorage", () => {
       id: "run-1",
       projectId: "my-app",
       status: "failed",
-      error: "No invoice candidate",
+      error: failure("No invoice candidate"),
     })
 
     await storage.start({
@@ -254,7 +269,7 @@ describe("SqliteWorkflowRunStorage", () => {
       projectId: "my-app",
       id: "run-1",
     })
-    expect(failed?.error).toBe("No invoice candidate")
+    expect(failed?.error).toEqual(failure("No invoice candidate"))
   })
 
   test("lists the latest run for multiple workflow ids", async () => {
@@ -370,7 +385,7 @@ describe("SqliteWorkflowRunStorage", () => {
       id: "node-1",
       projectId: "my-app",
       status: "failed",
-      error: "No match",
+      error: failure("No match"),
     })
 
     await storage.nodes.start({
@@ -423,7 +438,7 @@ describe("SqliteWorkflowRunStorage", () => {
       statuses: ["failed"],
     })
     expect(failedNodes.nodes[0]?.output).toBeUndefined()
-    expect(failedNodes.nodes[0]?.error).toBe("No match")
+    expect(failedNodes.nodes[0]?.error).toEqual(failure("No match"))
   })
 
   test("rejects invalid workflow and node run lifecycle transitions", async () => {
@@ -448,7 +463,7 @@ describe("SqliteWorkflowRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: "boom",
+        error: failure("boom"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -510,7 +525,7 @@ describe("SqliteWorkflowRunStorage", () => {
       id: "node-1",
       projectId: "my-app",
       status: "cancelled",
-      error: "Stopped",
+      error: failure("Stopped", "runtime.cancelled"),
     })
 
     await expect(
@@ -518,7 +533,7 @@ describe("SqliteWorkflowRunStorage", () => {
         id: "node-1",
         projectId: "my-app",
         status: "failed",
-        error: "Too late",
+        error: failure("Too late"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -526,7 +541,7 @@ describe("SqliteWorkflowRunStorage", () => {
       id: "wf-run-1",
       projectId: "my-app",
       status: "cancelled",
-      error: "Stopped",
+      error: failure("Stopped", "runtime.cancelled"),
     })
 
     await expect(
@@ -548,7 +563,7 @@ describe("SqliteWorkflowRunStorage", () => {
         id: "wf-run-1",
         projectId: "my-app",
         status: "failed",
-        error: "Too late",
+        error: failure("Too late"),
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
   })


### PR DESCRIPTION
## Summary

- replace workflow-run and workflow-node `error?: string` values with the portable `SixbFailure` record
- normalize every workflow failure producer, including request dispatch, workflow execution, agent-node execution, and server-side cancellation
- validate and detach failures in memory, serialize them in SQLite, and store them as JSONB in PostgreSQL
- expose the specialized failure contract through OpenAPI and the generated client
- render failures consistently in Atlas through a shared `SixbFailureSummary` used by sync, pipeline, and workflow views

## Decisions

- workflow failures are intentionally scoped to `internal.unexpected | runtime.cancelled`; unrelated catalog codes cannot leak into the generated contract
- the internal runtime error class remains private; storage and APIs only expose serializable failure values
- `WorkflowAgentNodeRunRecord.error` stays a string because it belongs to the agent-execution lifecycle and will migrate with agent runs
- workflow event payloads keep their existing string contract by publishing `failure.message`; changing event schemas is a separate concern
- run and node failures created from the same occurrence share a timestamp while retaining boundary-specific details

## Stack

This PR is stacked on #317 and only contains the workflow vertical slice.

## Validation

- `bun run check`
- `bun run typecheck`
- targeted core, workflow-worker, agent-worker, server, SQLite, and workflow-event tests
- PostgreSQL workflow-run storage e2e tests
