### PR TITLE
release: publish packages independently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-All Sixb packages ship on one version. A release publishes all of them or none.
+Sixb packages are versioned independently. Each release entry names the packages that shipped.
+
+## 2026-08-05
+
+### 0.1.1
+
+- `@sixb/core` and `@sixb/agent-worker`: define reusable agent tools and run the tools selected by
+  each agent.
+- `@sixb/connector-github`: add users, memberships, members, invitations, and outside collaborators.
+- `@sixb/sync-worker`, `@sixb/pg`, and `@sixb/sqlite`: handle empty initial snapshots without
+  creating an unusable dataset version.
+
+### `@sixb/connector-exa` 0.1.0
+
+Add bounded web search and fetch tools as a new connector package.
+
+### `@sixb/connector-google` 0.1.1
+
+Add the complete typed Gmail v1 surface.
 
 ## 0.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,18 +185,21 @@ Prefer targeted checks while iterating, then broader checks before review.
 
 ## Versioning
 
-Every publishable package shares one version and ships together — a release publishes all of them or
-none. `bun run test:publish` fails if they drift apart, so a version bump touches every manifest.
+Publishable packages are versioned independently. A package manifest is its release intent: bump the
+packages that should ship and leave unrelated manifests alone. The publisher reads registry state
+before its first write, publishes only local versions that do not exist yet, and keeps dependency
+order across that smaller plan.
 
 The `0.0.x` line is for public validation. Publish those versions only under npm's `next` tag and
 increment the patch for every new artifact: npm versions are immutable. The `latest` tag is reserved
 for `0.1.0`, the first minimally stable, tested release, and later versions.
 
-Releasing is two commands. The first produces exactly what gets published and proves it; the second
-publishes, in dependency order, skipping anything already on the registry so an interrupted run can
-be re-run:
+Preview the selective plan first. Releasing itself remains two commands: the first produces and
+verifies every package artifact; the second publishes the plan in dependency order. Existing package
+versions are skipped so an interrupted run can be re-run:
 
 ```bash
+bun run release:plan -- --tag next
 bun run release
 bun run release:publish -- --tag next
 ```
@@ -205,10 +208,11 @@ The tag changes how npm resolves an install, not the package version: consumers 
 with `bun add @sixb/core@next` or `bunx create-sixb@next my-app`. Publishing another preview moves
 `next` forward without making it the default install.
 
-For `0.1.0` and later, publish to `next` first, verify it, then move the same immutable version to
-`latest`. The publish script prints the `npm dist-tag` commands only when that promotion is allowed,
-and refuses to publish a `0.0.x` version directly to `latest`. Note that `bun publish --dry-run`
-still authenticates; to rehearse without credentials, point `--registry` at a local registry.
+For `0.1.0` and later, publish to `next` first, verify it, then move those immutable package versions
+to `latest`. The publish script prints promotion commands only for packages in the release, including
+packages staged by an interrupted earlier run, and refuses to publish a `0.0.x` version directly to
+`latest`. Note that `bun publish --dry-run` still authenticates; to rehearse without credentials,
+point `--registry` at a local registry.
 
 ## The feeling we want
 

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ independently against the same durable providers.
 
 ## Status
 
-Sixb is currently `0.1.0`, the first minimally stable and tested release promoted to npm's
-`latest` tag. APIs may change between minor releases, and database upgrades may require manual
+Sixb core is currently `0.1.1`. Packages are versioned independently and publish only when they
+change. APIs may change between minor releases, and database upgrades may require manual
 migration before 1.0. See the [changelog](CHANGELOG.md) for compatibility notes.
 
 ## Contributing

--- a/bun.lock
+++ b/bun.lock
@@ -105,7 +105,7 @@
     },
     "connectors/github": {
       "name": "@sixb/connector-github",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@octokit/webhooks-types": "^7.6.1",
         "@sixb/connector-rest": "workspace:*",
@@ -118,7 +118,7 @@
     },
     "connectors/google": {
       "name": "@sixb/connector-google",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@sixb/connector-rest": "workspace:*",
         "@sixb/core": "workspace:*",
@@ -396,7 +396,7 @@
     },
     "packages/agent-worker": {
       "name": "@sixb/agent-worker",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "ai": "^7.0.4",
@@ -512,7 +512,7 @@
     },
     "packages/core": {
       "name": "@sixb/core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",
       },
@@ -602,7 +602,7 @@
     },
     "packages/sync-worker": {
       "name": "@sixb/sync-worker",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },
@@ -778,7 +778,7 @@
     },
     "storage/pg": {
       "name": "@sixb/pg",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
         "postgres": "^3.4.5",
@@ -790,7 +790,7 @@
     },
     "storage/sqlite": {
       "name": "@sixb/sqlite",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@sixb/core": "workspace:*",
       },

--- a/connectors/github/package.json
+++ b/connectors/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-github",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "GitHub connector for Sixb — repositories, issues, people, and webhooks",
   "keywords": [
     "sixb",

--- a/connectors/google/package.json
+++ b/connectors/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/connector-google",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Typed Google Workspace connector for Sixb (Drive, Calendar, and Gmail)",
   "keywords": [
     "sixb",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:js": "bun --filter './packages/*' --filter './auth/*' --filter './connectors/*' --filter './broker/*' --filter './loggers/*' --filter './queues/*' --filter './sandboxes/*' --filter './storage/*' build",
     "build:clean": "rm -rf {packages,auth,connectors,broker,queues,sandboxes,storage,loggers}/*/{dist,.tsbuild} examples/*/.sixb",
     "release": "bun install --frozen-lockfile && bun run build && bun run test:publish",
+    "release:plan": "bun scripts/publish.ts --plan",
     "release:publish": "bun scripts/publish.ts",
     "dev": "bun sixb dev",
     "test": "bun test --parallel=2",

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/agent-worker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Worker that runs Sixb agent threads",
   "keywords": [
     "sixb",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The ontology-first runtime for Sixb — objects, links, telemetry, actions, and provider contracts",
   "keywords": [
     "sixb",

--- a/packages/sync-worker/package.json
+++ b/packages/sync-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/sync-worker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Worker that runs Sixb syncs",
   "keywords": [
     "sixb",

--- a/scripts/pack-smoke.ts
+++ b/scripts/pack-smoke.ts
@@ -19,7 +19,6 @@ import {
 const root = process.cwd()
 const packages = await discoverPublishablePackages(root)
 
-assertLockstepVersions(packages)
 await assertSourceAliasesMirrorExports(packages)
 
 // A cycle makes the release unpublishable, because a package cannot go to the registry before
@@ -33,29 +32,6 @@ for (const packageInfo of packages) {
 }
 
 console.log(`[SixbPublish] Verified ${packages.length} publishable packages.`)
-
-/**
- * Every package ships on one train. A stray version means a `workspace:*` dependency resolves to
- * a version its sibling never published, which only shows up as an install failure downstream.
- */
-function assertLockstepVersions(all: PublishablePackage[]): void {
-  const byVersion = new Map<string, string[]>()
-  for (const packageInfo of all) {
-    const version = packageInfo.packageJson.version
-    if (!version) {
-      throw new Error(`[SixbPublish] ${packageName(packageInfo)} has no version.`)
-    }
-    byVersion.set(version, [...(byVersion.get(version) ?? []), packageName(packageInfo)])
-  }
-
-  if (byVersion.size <= 1) return
-
-  const detail = [...byVersion.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([version, names]) => `  ${version}: ${names.join(", ")}`)
-    .join("\n")
-  throw new Error(`[SixbPublish] Publishable packages must share one version.\n${detail}`)
-}
 
 /**
  * The root `paths` map and `exports.bun` must name the same file for every source-first subpath.
@@ -91,6 +67,10 @@ async function assertSourceAliasesMirrorExports(all: PublishablePackage[]): Prom
 function validatePackage(packageInfo: PublishablePackage): void {
   const name = packageName(packageInfo)
   const { packageJson } = packageInfo
+
+  if (!packageJson.version?.trim()) {
+    throw new Error(`[SixbPublish] ${name} has no version.`)
+  }
 
   // Command packages can expose supported utility subpaths without exposing an
   // importable package root. They do not need root main/types entries.

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,6 +1,7 @@
 /**
- * Publish every Sixb package to npm, in dependency order.
+ * Publish every locally-versioned Sixb package that is not yet on npm, in dependency order.
  *
+ *   bun scripts/publish.ts --plan
  *   bun scripts/publish.ts --dry-run
  *   bun scripts/publish.ts --tag next
  *   bun scripts/publish.ts --tag next --otp 123456
@@ -10,9 +11,9 @@
  * publish gate. This script only publishes. Preview 0.0.x versions must use `--tag next`; `latest`
  * starts at 0.1.0.
  *
- * Publishing 46 packages is 46 separate registry writes, so it is resumable by design: a version
- * already on the registry is skipped rather than retried, and a failure stops the run naming exactly
- * what got through. Re-running after fixing the cause continues where it stopped.
+ * A package manifest is its release intent: bump the packages that should ship and leave every other
+ * manifest alone. Registry state is read for the whole workspace before the first write, and an
+ * existing package version is skipped so an interrupted run can resume safely.
  *
  * Note that `bun publish --dry-run` still authenticates, so a dry run needs a token. To rehearse the
  * whole thing with no credentials and no public side effects, point `--registry` at a local registry.
@@ -20,75 +21,86 @@
 import { join } from "node:path"
 import {
   discoverPublishablePackages,
-  type PublishablePackage,
   packageName,
   topologicalPublishOrder,
 } from "./publishable-packages"
+import {
+  createPackageReleasePlan,
+  type PackageRegistryState,
+  type PlannedPackageRelease,
+  packageReleaseId,
+} from "./release-plan"
 import { assertReleaseTagAllowed, isPreviewRelease } from "./release-policy"
 
 const root = process.cwd()
 const options = parseOptions(process.argv.slice(2))
 const ordered = topologicalPublishOrder(await discoverPublishablePackages(root))
-
-const versions = new Set(ordered.map((packageInfo) => packageInfo.packageJson.version))
-if (versions.size !== 1) {
-  throw new Error(
-    `[SixbPublish] Packages are not on one version (${[...versions].join(", ")}). Run \`bun run test:publish\`.`
+const registryByName = new Map(
+  await Promise.all(
+    ordered.map(async (packageInfo) => {
+      const name = packageName(packageInfo)
+      return [name, await readRegistryState(name)] as const
+    })
   )
+)
+const plan = createPackageReleasePlan(ordered, registryByName, options.tag)
+
+for (const release of plan.publish) {
+  assertReleaseTagAllowed(release.version, options.tag)
 }
-const [version] = [...versions]
-if (!version) throw new Error("[SixbPublish] Packages have no version.")
-assertReleaseTagAllowed(version, options.tag)
 
 console.log(
-  `[SixbPublish] ${options.dryRun ? "Dry run: " : ""}publishing ${ordered.length} packages at ${version} to tag "${options.tag}".`
+  `[SixbPublish] ${options.planOnly ? "Plan: " : options.dryRun ? "Dry run: " : ""}` +
+    `${plan.publish.length} to publish, ` +
+    `${plan.alreadyPublished} already on the registry, tag "${options.tag}".`
 )
+for (const release of plan.publish) console.log(`  ${packageReleaseId(release)}`)
 
-const skipped: string[] = []
 const published: string[] = []
 
-for (const [index, packageInfo] of ordered.entries()) {
-  const name = packageName(packageInfo)
-  const position = `${String(index + 1).padStart(2, " ")}/${ordered.length}`
-
-  if (await isAlreadyPublished(name, version)) {
-    skipped.push(name)
-    console.log(`[SixbPublish] ${position} ${name}@${version} already on the registry, skipping.`)
-    continue
-  }
-
-  console.log(`[SixbPublish] ${position} ${name}`)
-  await publishPackage(packageInfo, name)
-  published.push(name)
+for (const [index, release] of (options.planOnly ? [] : plan.publish).entries()) {
+  const position = `${String(index + 1).padStart(2, " ")}/${plan.publish.length}`
+  const id = packageReleaseId(release)
+  console.log(`[SixbPublish] ${position} ${id}`)
+  await publishPackage(release)
+  published.push(id)
 }
 
 console.log(
-  `[SixbPublish] Done. ${published.length} published, ${skipped.length} already on the registry.`
+  options.planOnly
+    ? "[SixbPublish] Plan complete. Nothing was published."
+    : options.dryRun
+      ? `[SixbPublish] Dry run complete. ${published.length} validated.`
+      : `[SixbPublish] Done. ${published.length} published.`
 )
-if (options.tag !== "latest" && !options.dryRun && published.length > 0) {
-  if (isPreviewRelease(version)) {
+
+if (options.tag !== "latest" && !options.dryRun && !options.planOnly) {
+  const promotion = uniqueReleases([...plan.stagedForPromotion, ...plan.publish])
+  const previews = promotion.filter((release) => isPreviewRelease(release.version))
+  const stable = promotion.filter((release) => !isPreviewRelease(release.version))
+
+  if (previews.length > 0) {
     console.log(
-      `[SixbPublish] ${version} remains on "${options.tag}". ` +
+      `[SixbPublish] ${previews.map(packageReleaseId).join(", ")} remain on "${options.tag}". ` +
         'The "latest" tag is reserved for 0.1.0 and later.'
     )
-  } else {
+  }
+  if (stable.length > 0) {
     console.log(
-      `[SixbPublish] Nothing is on "latest" yet. Promote once you have verified the tag:\n` +
-        ordered
-          .map((packageInfo) => `  npm dist-tag add ${packageName(packageInfo)}@${version} latest`)
-          .join("\n")
+      `[SixbPublish] Promote once you have verified the tag:\n` +
+        stable.map((release) => `  npm dist-tag add ${packageReleaseId(release)} latest`).join("\n")
     )
   }
 }
 
-async function publishPackage(packageInfo: PublishablePackage, name: string): Promise<void> {
+async function publishPackage(release: PlannedPackageRelease): Promise<void> {
   const args = [process.execPath, "publish", "--tag", options.tag]
   if (options.dryRun) args.push("--dry-run")
   if (options.otp) args.push("--otp", options.otp)
   if (options.registry) args.push("--registry", options.registry)
 
   const proc = Bun.spawn(args, {
-    cwd: join(root, packageInfo.dir),
+    cwd: join(root, release.packageInfo.dir),
     stdout: "pipe",
     stderr: "pipe",
   })
@@ -110,7 +122,7 @@ async function publishPackage(packageInfo: PublishablePackage, name: string): Pr
     .join("\n")
 
   throw new Error(
-    `[SixbPublish] Failed to publish ${name}.\n${reason}\n\n` +
+    `[SixbPublish] Failed to publish ${packageReleaseId(release)}.\n${reason}\n\n` +
       (output.includes("missing authentication")
         ? "Run `bunx npm login` first — `bun publish` authenticates even for --dry-run.\n"
         : "") +
@@ -120,26 +132,37 @@ async function publishPackage(packageInfo: PublishablePackage, name: string): Pr
 }
 
 /**
- * Ask the registry directly rather than trusting a local marker, so a run interrupted anywhere —
- * including between the registry write and this process exiting — resumes correctly.
+ * Read registry state before any write so a network or authentication-adjacent lookup failure
+ * cannot leave a release half-published. A 404 is a new package with no versions or tags yet.
  */
-async function isAlreadyPublished(name: string, target: string): Promise<boolean> {
+async function readRegistryState(name: string): Promise<PackageRegistryState> {
   const registry = (options.registry ?? "https://registry.npmjs.org").replace(/\/+$/, "")
   const response = await fetch(`${registry}/${encodeURIComponent(name)}`, {
     headers: { accept: "application/vnd.npm.install-v1+json" },
   })
 
-  if (response.status === 404) return false
+  if (response.status === 404) return { versions: new Set(), tags: {} }
   if (!response.ok) {
     throw new Error(`[SixbPublish] Could not query the registry for ${name}: ${response.status}`)
   }
 
-  const body = (await response.json()) as { versions?: Record<string, unknown> }
-  return Boolean(body.versions?.[target])
+  const body = (await response.json()) as {
+    versions?: Record<string, unknown>
+    "dist-tags"?: Record<string, string>
+  }
+  return {
+    versions: new Set(Object.keys(body.versions ?? {})),
+    tags: body["dist-tags"] ?? {},
+  }
+}
+
+function uniqueReleases(releases: readonly PlannedPackageRelease[]): PlannedPackageRelease[] {
+  return [...new Map(releases.map((release) => [packageReleaseId(release), release])).values()]
 }
 
 interface PublishOptions {
   readonly dryRun: boolean
+  readonly planOnly: boolean
   readonly tag: string
   readonly otp?: string
   readonly registry?: string
@@ -148,11 +171,16 @@ interface PublishOptions {
 function parseOptions(argv: string[]): PublishOptions {
   const values = new Map<string, string>()
   let dryRun = false
+  let planOnly = false
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index]
     if (arg === "--dry-run") {
       dryRun = true
+      continue
+    }
+    if (arg === "--plan") {
+      planOnly = true
       continue
     }
     if (arg === "--tag" || arg === "--otp" || arg === "--registry") {
@@ -166,7 +194,7 @@ function parseOptions(argv: string[]): PublishOptions {
     }
     throw new Error(
       `[SixbPublish] Unknown argument ${arg}. Usage: bun scripts/publish.ts ` +
-        "[--dry-run] [--tag <tag>] [--otp <code>] [--registry <url>]"
+        "[--plan] [--dry-run] [--tag <tag>] [--otp <code>] [--registry <url>]"
     )
   }
 
@@ -174,6 +202,7 @@ function parseOptions(argv: string[]): PublishOptions {
   const registry = values.get("--registry")
   return {
     dryRun,
+    planOnly,
     tag: values.get("--tag") ?? "latest",
     ...(otp ? { otp } : {}),
     ...(registry ? { registry } : {}),

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -1,0 +1,108 @@
+import type { PublishablePackage } from "./publishable-packages"
+import { internalDependencies, packageName } from "./publishable-packages"
+
+export interface PackageRegistryState {
+  readonly versions: ReadonlySet<string>
+  readonly tags: Readonly<Record<string, string>>
+}
+
+export interface PlannedPackageRelease {
+  readonly packageInfo: PublishablePackage
+  readonly name: string
+  readonly version: string
+}
+
+export interface PackageReleasePlan {
+  readonly publish: readonly PlannedPackageRelease[]
+  readonly stagedForPromotion: readonly PlannedPackageRelease[]
+  readonly alreadyPublished: number
+}
+
+/**
+ * A manifest version is the package's release intent. Missing registry versions are published;
+ * versions already present are left alone so unrelated packages can stay on their current line.
+ */
+export function createPackageReleasePlan(
+  ordered: readonly PublishablePackage[],
+  registryByName: ReadonlyMap<string, PackageRegistryState>,
+  tag: string
+): PackageReleasePlan {
+  const publish: PlannedPackageRelease[] = []
+  const stagedForPromotion: PlannedPackageRelease[] = []
+
+  for (const packageInfo of ordered) {
+    const name = packageName(packageInfo)
+    const version = packageInfo.packageJson.version
+    if (!version?.trim()) {
+      throw new Error(`[SixbPublish] ${name} has no version.`)
+    }
+
+    const registry = registryByName.get(name)
+    if (!registry) {
+      throw new Error(`[SixbPublish] Registry state is missing for ${name}.`)
+    }
+
+    const release = { packageInfo, name, version }
+    if (!registry.versions.has(version)) {
+      publish.push(release)
+      continue
+    }
+
+    if (tag !== "latest" && registry.tags[tag] === version && registry.tags.latest !== version) {
+      stagedForPromotion.push(release)
+    }
+  }
+
+  assertInternalDependenciesAvailable(ordered, publish, registryByName)
+
+  return {
+    publish,
+    stagedForPromotion,
+    alreadyPublished: ordered.length - publish.length,
+  }
+}
+
+export function packageReleaseId(release: PlannedPackageRelease): string {
+  return `${release.name}@${release.version}`
+}
+
+function assertInternalDependenciesAvailable(
+  ordered: readonly PublishablePackage[],
+  publish: readonly PlannedPackageRelease[],
+  registryByName: ReadonlyMap<string, PackageRegistryState>
+): void {
+  const byName = new Map(ordered.map((packageInfo) => [packageName(packageInfo), packageInfo]))
+  const available = new Set<string>()
+
+  for (const packageInfo of ordered) {
+    const name = packageName(packageInfo)
+    const version = packageInfo.packageJson.version
+    if (version && registryByName.get(name)?.versions.has(version)) {
+      available.add(`${name}@${version}`)
+    }
+  }
+
+  for (const release of publish) {
+    for (const dependencyName of internalDependencies(release.packageInfo.packageJson)) {
+      const dependency = byName.get(dependencyName)
+      if (!dependency) {
+        throw new Error(
+          `[SixbPublish] ${packageReleaseId(release)} depends on unpublished workspace package ${dependencyName}.`
+        )
+      }
+
+      const dependencyVersion = dependency.packageJson.version
+      if (!dependencyVersion?.trim()) {
+        throw new Error(`[SixbPublish] ${dependencyName} has no version.`)
+      }
+
+      const dependencyId = `${dependencyName}@${dependencyVersion}`
+      if (!available.has(dependencyId)) {
+        throw new Error(
+          `[SixbPublish] ${packageReleaseId(release)} requires ${dependencyId} before it can publish.`
+        )
+      }
+    }
+    available.add(packageReleaseId(release))
+  }
+}

--- a/scripts/tests/release-plan.test.ts
+++ b/scripts/tests/release-plan.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test"
+import type { PublishablePackage } from "../publishable-packages"
+import {
+  createPackageReleasePlan,
+  type PackageRegistryState,
+  packageReleaseId,
+} from "../release-plan"
+
+function stub(
+  name: string,
+  version: string | undefined,
+  dependencies: readonly string[] = []
+): PublishablePackage {
+  return {
+    dir: `packages/${name.replace("@sixb/", "")}`,
+    packageJson: {
+      name,
+      version,
+      dependencies: Object.fromEntries(
+        dependencies.map((dependency) => [dependency, "workspace:*"])
+      ),
+    },
+  }
+}
+
+function registry(
+  versions: readonly string[],
+  tags: Readonly<Record<string, string>> = {}
+): PackageRegistryState {
+  return { versions: new Set(versions), tags }
+}
+
+describe("createPackageReleasePlan", () => {
+  test("publishes only local versions missing from the registry", () => {
+    const core = stub("@sixb/core", "0.1.2")
+    const connector = stub("@sixb/connector-example", "0.1.2", ["@sixb/core"])
+    const ui = stub("@sixb/ui", "0.1.0")
+
+    const plan = createPackageReleasePlan(
+      [core, connector, ui],
+      new Map([
+        ["@sixb/core", registry(["0.1.0"])],
+        ["@sixb/connector-example", registry(["0.1.0"])],
+        ["@sixb/ui", registry(["0.1.0"], { latest: "0.1.0", next: "0.1.0" })],
+      ]),
+      "next"
+    )
+
+    expect(plan.publish.map(packageReleaseId)).toEqual([
+      "@sixb/core@0.1.2",
+      "@sixb/connector-example@0.1.2",
+    ])
+    expect(plan.alreadyPublished).toBe(1)
+  })
+
+  test("accepts an already-published internal dependency on its own version", () => {
+    const rest = stub("@sixb/connector-rest", "0.1.0")
+    const github = stub("@sixb/connector-github", "0.1.2", ["@sixb/connector-rest"])
+
+    const plan = createPackageReleasePlan(
+      [rest, github],
+      new Map([
+        ["@sixb/connector-rest", registry(["0.1.0"])],
+        ["@sixb/connector-github", registry(["0.1.0"])],
+      ]),
+      "next"
+    )
+
+    expect(plan.publish.map(packageReleaseId)).toEqual(["@sixb/connector-github@0.1.2"])
+  })
+
+  test("rejects a plan that puts an unpublished dependency after its dependent", () => {
+    const core = stub("@sixb/core", "0.1.2")
+    const worker = stub("@sixb/worker", "0.1.2", ["@sixb/core"])
+    const states = new Map([
+      ["@sixb/core", registry(["0.1.0"])],
+      ["@sixb/worker", registry(["0.1.0"])],
+    ])
+
+    expect(() => createPackageReleasePlan([worker, core], states, "next")).toThrow(
+      /requires @sixb\/core@0\.1\.2 before it can publish/
+    )
+  })
+
+  test("remembers an already-staged version for promotion after a resumed run", () => {
+    const google = stub("@sixb/connector-google", "0.1.1")
+    const plan = createPackageReleasePlan(
+      [google],
+      new Map([
+        [
+          "@sixb/connector-google",
+          registry(["0.1.0", "0.1.1"], { latest: "0.1.0", next: "0.1.1" }),
+        ],
+      ]),
+      "next"
+    )
+
+    expect(plan.publish).toEqual([])
+    expect(plan.stagedForPromotion.map(packageReleaseId)).toEqual(["@sixb/connector-google@0.1.1"])
+  })
+
+  test("requires every package to declare a version", () => {
+    const core = stub("@sixb/core", undefined)
+
+    expect(() =>
+      createPackageReleasePlan([core], new Map([["@sixb/core", registry(["0.1.0"])]]), "next")
+    ).toThrow(/@sixb\/core has no version/)
+  })
+})

--- a/storage/pg/package.json
+++ b/storage/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/pg",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PostgreSQL storage provider for Sixb",
   "keywords": [
     "sixb",

--- a/storage/sqlite/package.json
+++ b/storage/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/sqlite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SQLite storage provider for Sixb",
   "keywords": [
     "sixb",


### PR DESCRIPTION
## Summary

- replace the repository-wide lockstep version with explicit, per-package release intent
- add a registry-backed `release:plan` command that shows exactly which local versions are missing
- publish only those versions, while preserving the existing dependency order, artifact gate, resumability, and preview-tag policy
- prepare the packages changed since `0.1.0` for their next release

## Why

The existing release script required every publishable workspace to share one version. With 47 packages at different stages, releasing one connector or worker therefore meant bumping and republishing unrelated packages.

This keeps the current lightweight Bun-based release flow, but makes each package manifest authoritative for that package. Before the first registry write, the publisher reads registry state for the entire workspace, removes versions that already exist, and verifies that every internal dependency version is already available or appears earlier in the publish plan.

That gives us selective releases without introducing a larger release-management system.

## Release behavior

The release flow is now:

```bash
bun run release:plan -- --tag next
bun run release
bun run release:publish -- --tag next
```

- `release:plan` is read-only and prints the exact package/version set.
- `release` still performs the clean build and validates every publishable artifact.
- `release:publish` publishes only missing versions in topological order.
- Re-running an interrupted release skips immutable versions already on the registry.
- Promotion commands include only packages from the selective release, including packages staged during an earlier partial run.
- `0.0.x` releases remain restricted to the `next` tag.

The publish gate no longer enforces a shared version, but it still requires every package to declare a version and retains all existing package-boundary, export, tarball, and dependency-cycle checks.

## Prepared package versions

| Package | Version | Reason |
| --- | ---: | --- |
| `@sixb/core` | `0.1.1` | reusable agent tool definitions |
| `@sixb/agent-worker` | `0.1.1` | execute tools selected by an agent |
| `@sixb/connector-github` | `0.1.1` | expanded people and membership APIs |
| `@sixb/sync-worker` | `0.1.1` | handle empty initial snapshots |
| `@sixb/pg` | `0.1.1` | handle empty initial snapshots |
| `@sixb/sqlite` | `0.1.1` | handle empty initial snapshots |
| `@sixb/connector-exa` | `0.1.0` | first publication |
| `@sixb/connector-google` | `0.1.1` | align the manifest and changelog with the already-published Gmail release |

The current registry-backed plan selects seven packages. Google and the other 39 current versions are already on the registry and are skipped.

## Validation

- `bun test scripts/tests/` — 55 passed
- `bun run typecheck`
- `bun run check`
- `bun run release` — clean build and publish-artifact validation for all 47 packages
- `bun run release:plan -- --tag next` — seven packages selected; nothing published
- `git diff --check`

No packages were published while preparing or validating this change.