### PR TITLE
agent: persist portable failure records

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -29,7 +29,7 @@ interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
 }
 ```
 
-Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, pipeline step runs, workflow runs, and workflow node runs currently declare `internal.unexpected | runtime.cancelled`.
+Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, pipeline step runs, workflow runs, workflow node runs, and agent executions (conversation or workflow-owned) currently declare `internal.unexpected | runtime.cancelled`.
 
 Other run primitives keep their legacy error shape until their own vertical migration. This keeps
 each storage and wire change independently reviewable.

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -8,11 +8,12 @@ import {
   workflowAgentNodeQueueJobId,
 } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
+import { captureSixbFailure } from "@sixb/core/internal/errors"
 import type { QueueDelivery, QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { isAbortError, QueueDeliveryLeaseLostError, QueueWorker } from "@sixb/core/internal/workers"
 import type { AgentQueueJob, ClaimedQueueJob } from "@sixb/core/queues"
 import type { AgentRunExecution, AgentRunRecord } from "@sixb/core/storage"
-import { AgentStorageError } from "@sixb/core/storage"
+import { AGENT_RUN_FAILURE_CODES, AgentStorageError } from "@sixb/core/storage"
 import { loadAgentSkills } from "./agent-skills"
 import { normalizeApiBaseUrl } from "./api-url"
 import {
@@ -180,11 +181,17 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
     if (!agent) {
       const error = new AgentWorkerError(`Unknown agent '${queuedRun.agentId}'.`)
       if (queuedRun.status === "queued") {
+        const completedAt = new Date()
         const failed = await context.storage.agents.runs.finishQueued({
           projectId: context.id,
           id: queuedRun.id,
           status: "failed",
-          error: `Agent '${queuedRun.agentId}' is not registered.`,
+          error: toAgentRunFailure(error, {
+            status: "failed",
+            at: completedAt,
+            run: queuedRun,
+          }),
+          completedAt,
         })
         this.reportFailure(error, failed, job.attempt)
         await context.streamSink.publishRunFinished(failed)
@@ -297,7 +304,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
         (signal.aborted || cancel.signal.aborted || isAbortError(error))
       const finalized = await this.recordFate(
         context,
-        run.id,
+        run,
         executionToken,
         aborted ? "cancelled" : "failed",
         error
@@ -360,11 +367,13 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
       id: runId,
     })
     if (run?.status === "queued") {
+      const completedAt = new Date()
       const failed = await this.requireContext().storage.agents.runs.finishQueued({
         projectId: this.host.id,
         id: run.id,
         status: "failed",
-        error: toErrorMessage(error),
+        error: toAgentRunFailure(error, { status: "failed", at: completedAt, run }),
+        completedAt,
       })
       this.reportFailure(error, failed, claimed.job.attempt)
       await this.requireContext().streamSink.publishRunFinished(failed)
@@ -577,18 +586,20 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
 
   private async recordFate(
     context: AgentWorkerContext,
-    runId: string,
+    run: AgentRunRecord,
     executionToken: string,
     status: "failed" | "cancelled",
     error: unknown
   ): Promise<AgentRunRecord | undefined> {
     try {
+      const completedAt = new Date()
       return await finishRunOrThrow(context.storage.agents, {
         projectId: context.id,
-        id: runId,
+        id: run.id,
         executionToken,
         status,
-        error: toErrorMessage(error),
+        error: toAgentRunFailure(error, { status, at: completedAt, run }),
+        completedAt,
       })
     } catch (finalizeError) {
       // Execution already lost / run already terminal — nothing more to record.
@@ -678,11 +689,24 @@ function aiUsageRecoveryBackoffMs(attempt: number): number {
   )
 }
 
-function toErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message
+function toAgentRunFailure(
+  error: unknown,
+  input: {
+    readonly status: "failed" | "cancelled"
+    readonly at: Date
+    readonly run: Pick<AgentRunRecord, "id" | "agentId" | "threadId">
   }
-  return String(error)
+) {
+  return captureSixbFailure(error, {
+    allowedCodes: AGENT_RUN_FAILURE_CODES,
+    defaultCode: input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+    at: input.at,
+    details: {
+      agentId: input.run.agentId,
+      runId: input.run.id,
+      threadId: input.run.threadId,
+    },
+  })
 }
 
 function normalizeRequiredString(value: string | undefined): string {

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -4,7 +4,7 @@ import {
   resolveAgentExecutionAuthorization,
 } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
-import { captureSixbFailure } from "@sixb/core/internal/errors"
+import { captureSixbFailure, createSixbError, toSixbFailure } from "@sixb/core/internal/errors"
 import type { QueueDelivery } from "@sixb/core/internal/workers"
 import { QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { WorkflowAgentNodeDefinition } from "@sixb/core/internal/workflows"
@@ -17,7 +17,7 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
-import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
+import { AGENT_RUN_FAILURE_CODES, WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { AgentUsageRecordingError, AgentWorkerError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { AiModelCallRecorder } from "./model-call-recorder"
@@ -229,12 +229,28 @@ async function loadWorkflowAgentNodeExecution(
 
   const workflowRun = await runs.getById({ projectId: context.id, id: nodeRun.workflowRunId })
   if (!workflowRun || workflowRun.status !== "waiting" || nodeRun.status !== "waiting") {
+    const completedAt = new Date()
+    const message = workflowRun
+      ? `Parent workflow run is ${workflowRun.status}.`
+      : "Parent workflow run is missing."
     await runs.agentNodes.cancel({
       projectId: context.id,
       nodeRunId: nodeRun.id,
-      error: workflowRun
-        ? `Parent workflow run is ${workflowRun.status}.`
-        : "Parent workflow run is missing.",
+      error: toSixbFailure(
+        createSixbError("runtime.cancelled", message, {
+          details: {
+            agentId: executionRecord.agentId,
+            workflowId: nodeRun.workflowId,
+            workflowRunId: nodeRun.workflowRunId,
+            nodeRunId: nodeRun.id,
+          },
+        }),
+        {
+          allowedCodes: AGENT_RUN_FAILURE_CODES,
+          at: completedAt,
+        }
+      ),
+      completedAt,
     })
     return null
   }
@@ -367,13 +383,23 @@ async function finishWorkflowAgentNodeFailed(input: {
   readonly status: "failed" | "cancelled"
   readonly error: unknown
 }): Promise<{ readonly node: WorkflowNodeRunRecord; readonly run: WorkflowRunRecord }> {
-  const message = errorMessage(input.error)
   const at = new Date()
   const failure = captureSixbFailure(input.error, {
     allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
     defaultCode: input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
     at,
     details: {
+      workflowId: input.nodeRun.workflowId,
+      workflowRunId: input.nodeRun.workflowRunId,
+      nodeRunId: input.nodeRun.id,
+    },
+  })
+  const agentFailure = captureSixbFailure(input.error, {
+    allowedCodes: AGENT_RUN_FAILURE_CODES,
+    defaultCode: input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+    at,
+    details: {
+      agentId: input.agent.id,
       workflowId: input.nodeRun.workflowId,
       workflowRunId: input.nodeRun.workflowRunId,
       nodeRunId: input.nodeRun.id,
@@ -388,19 +414,22 @@ async function finishWorkflowAgentNodeFailed(input: {
       executionToken: input.executionToken,
       status: input.status,
       modelId: input.agent.model.modelId,
-      error: message,
+      error: agentFailure,
+      completedAt: at,
     })
     const node = await runs.nodes.finish({
       projectId: input.context.id,
       id: input.nodeRun.id,
       status: input.status,
       error: failure,
+      finishedAt: at,
     })
     const run = await runs.finish({
       projectId: input.context.id,
       id: input.nodeRun.workflowRunId,
       status: input.status,
       error: failure,
+      finishedAt: at,
     })
     return { node, run }
   })
@@ -537,8 +566,4 @@ function requireFinishedAt(
     throw new AgentWorkerError(`Workflow run record '${record.id}' has no finishedAt.`)
   }
   return record.finishedAt
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
 }

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1773,7 +1773,17 @@ describe("AgentWorker", () => {
       )
 
       expect(execution.status).toBe("failed")
-      expect(execution.error).toContain("deferred to durable recovery")
+      expect(execution.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: {
+          agentId: "workflow-usage-agent",
+          workflowId: "workflow-usage-test",
+          workflowRunId: "workflow-accounting-failure",
+          nodeRunId,
+        },
+      })
       await expect(
         runs.getById({ projectId: PROJECT_ID, id: "workflow-accounting-failure" })
       ).resolves.toMatchObject({ status: "failed" })
@@ -1857,7 +1867,17 @@ describe("AgentWorker", () => {
       )
 
       expect(execution.status).toBe("failed")
-      expect(execution.error).toContain("Could not preserve AI usage")
+      expect(execution.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: {
+          agentId: "workflow-usage-agent",
+          workflowId: "workflow-usage-test",
+          workflowRunId: "workflow-final-callback-failure",
+          nodeRunId,
+        },
+      })
       expect(modelCalls).toBe(1)
       expect(appendAttempts).toBe(4)
       expect(recoveryAttempts).toBe(4)
@@ -1889,7 +1909,17 @@ describe("AgentWorker", () => {
       )
 
       expect(execution.status).toBe("failed")
-      expect(execution.error).toContain("workflow node finalization unavailable")
+      expect(execution.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: {
+          agentId: "workflow-usage-agent",
+          workflowId: "workflow-usage-test",
+          workflowRunId: "workflow-finalization-failure",
+          nodeRunId,
+        },
+      })
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,
@@ -1939,11 +1969,24 @@ describe("AgentWorker", () => {
     await worker.start()
     try {
       await toolStarted
+      const cancelledAt = new Date()
+      const agentCancellationFailure = {
+        code: "runtime.cancelled",
+        message: "Execution was cancelled.",
+        retryable: false,
+        at: cancelledAt.toISOString(),
+        details: {
+          agentId: "workflow-usage-agent",
+          workflowId: "workflow-usage-test",
+          workflowRunId: runId,
+          nodeRunId,
+        },
+      } as const
       const workflowCancellationFailure = {
         code: "runtime.cancelled",
         message: "Execution was cancelled.",
         retryable: false,
-        at: new Date().toISOString(),
+        at: cancelledAt.toISOString(),
         details: {
           workflowId: "workflow-usage-test",
           workflowRunId: runId,
@@ -1956,7 +1999,7 @@ describe("AgentWorker", () => {
         await transactionalRuns.agentNodes.cancel({
           projectId: PROJECT_ID,
           nodeRunId,
-          error: "Workflow run cancelled.",
+          error: agentCancellationFailure,
         })
         await transactionalRuns.nodes.finish({
           projectId: PROJECT_ID,
@@ -3278,7 +3321,16 @@ describe("AgentWorker", () => {
       )
 
       expect(run.status).toBe("failed")
-      expect(run.error).toContain("deferred to durable recovery")
+      expect(run.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: {
+          agentId: "assistant",
+          runId: request.run.id,
+          threadId: request.run.threadId,
+        },
+      })
       const summary = await waitFor(
         async () => {
           const value = await aiUsage.summarizeExecution({
@@ -3415,7 +3467,16 @@ describe("AgentWorker", () => {
       )
 
       expect(run.status).toBe("failed")
-      expect(run.error).toContain("Could not preserve AI usage")
+      expect(run.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: {
+          agentId: "assistant",
+          runId: request.run.id,
+          threadId: request.run.threadId,
+        },
+      })
       expect(modelCalls).toBe(1)
       expect(appendAttempts).toBe(4)
       expect(recoveryAttempts).toBe(4)
@@ -4783,7 +4844,12 @@ describe("AgentWorker", () => {
         { label: "run failed" }
       )
       expect(run.status).toBe("failed")
-      expect(run.error).toBeDefined()
+      expect(run.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        details: { agentId: "assistant", runId: run.id, threadId },
+      })
+      expect(run.error?.at).toBe(run.completedAt?.toISOString())
       await reporter.flush()
       expect(reports).toHaveLength(1)
       expect(reports[0]?.error).toBe(originalError)
@@ -4846,7 +4912,7 @@ describe("AgentWorker", () => {
         { label: "run failed" }
       )
       expect(run.status).toBe("failed")
-      expect(run.error).toContain("sandbox provisioning unavailable")
+      expect(run.error?.message).toBe("An unexpected internal error occurred.")
 
       // The turn threw before finalizing, so no assistant message was persisted.
       const messages = await listMessages(storage, threadId)
@@ -5068,7 +5134,7 @@ describe("AgentWorker", () => {
       )
 
       expect(run.status).toBe("failed")
-      expect(run.error).toContain("turn budget")
+      expect(run.error?.message).toBe("An unexpected internal error occurred.")
       expect(
         (await listRunStreamRecords(sixb.broker, run.id)).find(
           (record) => record.name === "agent.run.finished"
@@ -5148,7 +5214,7 @@ describe("AgentWorker", () => {
         { label: "missing agent run failed" }
       )
       expect(failed).toMatchObject({ status: "failed", attempt: 0 })
-      expect(failed.error).toContain("not registered")
+      expect(failed.error?.message).toBe("An unexpected internal error occurred.")
       await reporter.flush()
       expect(reports).toHaveLength(1)
       expect(reports[0]?.error).toBeInstanceOf(AgentWorkerError)

--- a/packages/atlas/src/pages/WorkflowDetailPage.tsx
+++ b/packages/atlas/src/pages/WorkflowDetailPage.tsx
@@ -1565,7 +1565,7 @@ function AgentExecutionPanel({
             </div>
           ) : null}
           {execution?.error ? (
-            <p className="break-words text-sm text-destructive">{execution.error}</p>
+            <SixbFailureSummary failure={execution.error} className="text-sm" />
           ) : null}
         </div>
       ) : loading ? (

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -11149,7 +11149,53 @@
                       "items": {}
                     },
                     "error": {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": ["internal.unexpected", "runtime.cancelled"]
+                        },
+                        "message": {
+                          "type": "string",
+                          "maxLength": 4096
+                        },
+                        "retryable": {
+                          "type": "boolean"
+                        },
+                        "at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "details": {
+                          "description": "Any JSON-compatible value.",
+                          "nullable": true,
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "array",
+                              "items": {}
+                            },
+                            {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          ]
+                        },
+                        "truncated": {
+                          "type": "boolean",
+                          "enum": [true]
+                        }
+                      },
+                      "required": ["code", "message", "retryable", "at"],
+                      "additionalProperties": false
                     },
                     "createdAt": {
                       "type": "string"
@@ -19129,7 +19175,53 @@
                           }
                         },
                         "error": {
-                          "type": "string"
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "attempt": {
                           "type": "number"
@@ -19633,7 +19725,53 @@
                           }
                         },
                         "error": {
-                          "type": "string"
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "attempt": {
                           "type": "number"
@@ -19889,7 +20027,53 @@
                           }
                         },
                         "error": {
-                          "type": "string"
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "attempt": {
                           "type": "number"
@@ -20167,7 +20351,53 @@
                             }
                           },
                           "error": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                              },
+                              "message": {
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
+                              }
+                            },
+                            "required": ["code", "message", "retryable", "at"],
+                            "additionalProperties": false
                           },
                           "attempt": {
                             "type": "number"
@@ -20396,7 +20626,53 @@
                       }
                     },
                     "error": {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "code": {
+                          "type": "string",
+                          "enum": ["internal.unexpected", "runtime.cancelled"]
+                        },
+                        "message": {
+                          "type": "string",
+                          "maxLength": 4096
+                        },
+                        "retryable": {
+                          "type": "boolean"
+                        },
+                        "at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "details": {
+                          "description": "Any JSON-compatible value.",
+                          "nullable": true,
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "array",
+                              "items": {}
+                            },
+                            {
+                              "type": "object",
+                              "additionalProperties": true
+                            }
+                          ]
+                        },
+                        "truncated": {
+                          "type": "boolean",
+                          "enum": [true]
+                        }
+                      },
+                      "required": ["code", "message", "retryable", "at"],
+                      "additionalProperties": false
                     },
                     "attempt": {
                       "type": "number"

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3958,7 +3958,25 @@ export type GetWorkflowAgentNodeExecutionResponses = {
     prompt: string
     trace?: Array<unknown>
     diagnostics?: Array<unknown>
-    error?: string
+    error?: {
+      code: "internal.unexpected" | "runtime.cancelled"
+      message: string
+      retryable: boolean
+      at: string
+      /**
+       * Any JSON-compatible value.
+       */
+      details?:
+        | string
+        | number
+        | boolean
+        | Array<unknown>
+        | {
+            [key: string]: unknown
+          }
+        | null
+      truncated?: true
+    }
     createdAt: string
   }
 }
@@ -6714,7 +6732,25 @@ export type PostAgentThreadMessageResponses = {
         path?: string
         message: string
       }>
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       attempt: number
       streamId: string
       createdAt: string
@@ -6907,7 +6943,25 @@ export type CancelAgentRunResponses = {
         path?: string
         message: string
       }>
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       attempt: number
       streamId: string
       createdAt: string
@@ -7003,7 +7057,25 @@ export type RetryAgentRunResponses = {
         path?: string
         message: string
       }>
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       attempt: number
       streamId: string
       createdAt: string
@@ -7097,7 +7169,25 @@ export type ListAgentThreadRunsResponses = {
         path?: string
         message: string
       }>
-      error?: string
+      error?: {
+        code: "internal.unexpected" | "runtime.cancelled"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
       attempt: number
       streamId: string
       createdAt: string
@@ -7188,7 +7278,25 @@ export type GetAgentRunResponses = {
       path?: string
       message: string
     }>
-    error?: string
+    error?: {
+      code: "internal.unexpected" | "runtime.cancelled"
+      message: string
+      retryable: boolean
+      at: string
+      /**
+       * Any JSON-compatible value.
+       */
+      details?:
+        | string
+        | number
+        | boolean
+        | Array<unknown>
+        | {
+            [key: string]: unknown
+          }
+        | null
+      truncated?: true
+    }
     attempt: number
     streamId: string
     createdAt: string

--- a/packages/client/tests/agent-failure.types.ts
+++ b/packages/client/tests/agent-failure.types.ts
@@ -1,0 +1,19 @@
+import type { GetAgentRunResponses, ListAgentThreadRunsResponses } from "../src/generated/types.gen"
+
+type AgentRun = GetAgentRunResponses[200]
+type ListedAgentRun = ListAgentThreadRunsResponses[200]["runs"][number]
+
+type AgentRunFailureCode = NonNullable<AgentRun["error"]>["code"]
+type ListedAgentRunFailureCode = NonNullable<ListedAgentRun["error"]>["code"]
+
+const unexpected: AgentRunFailureCode = "internal.unexpected"
+const cancelled: AgentRunFailureCode = "runtime.cancelled"
+const listedUnexpected: ListedAgentRunFailureCode = "internal.unexpected"
+
+// Dataset lookup codes belong to HTTP route failures, not persisted agent-run failures.
+// @ts-expect-error the generated agent-run failure contract must stay scoped to its producer
+const unrelatedRun: AgentRunFailureCode = "dataset.not_found"
+// @ts-expect-error the generated agent history contract must stay scoped to its producer
+const unrelatedListed: ListedAgentRunFailureCode = "dataset.not_found"
+
+void [unexpected, cancelled, listedUnexpected, unrelatedRun, unrelatedListed]

--- a/packages/client/tests/workflow-failure.types.ts
+++ b/packages/client/tests/workflow-failure.types.ts
@@ -13,12 +13,13 @@ type WorkflowAgentExecution = GetWorkflowAgentNodeExecutionResponses[200]
 type LatestFailureCode = NonNullable<LatestWorkflowRun["error"]>["code"]
 type ListedFailureCode = NonNullable<ListedWorkflowRun["error"]>["code"]
 type NodeFailureCode = NonNullable<WorkflowNodeRun["error"]>["code"]
+type AgentExecutionFailureCode = NonNullable<WorkflowAgentExecution["error"]>["code"]
 
 const latestUnexpected: LatestFailureCode = "internal.unexpected"
 const latestCancelled: LatestFailureCode = "runtime.cancelled"
 const listedUnexpected: ListedFailureCode = "internal.unexpected"
 const nodeCancelled: NodeFailureCode = "runtime.cancelled"
-const agentExecutionError: NonNullable<WorkflowAgentExecution["error"]> = "agent failed"
+const agentExecutionCancelled: AgentExecutionFailureCode = "runtime.cancelled"
 
 // Dataset lookup codes belong to HTTP route failures, not persisted workflow failures.
 // @ts-expect-error the generated latest-run failure contract must stay scoped to its producer
@@ -27,14 +28,17 @@ const unrelatedLatest: LatestFailureCode = "dataset.not_found"
 const unrelatedListed: ListedFailureCode = "dataset.not_found"
 // @ts-expect-error the generated node-run failure contract must stay scoped to its producer
 const unrelatedNode: NodeFailureCode = "dataset.not_found"
+// @ts-expect-error workflow-owned agent executions keep the scoped agent-run failure contract
+const unrelatedAgentExecution: AgentExecutionFailureCode = "dataset.not_found"
 
 void [
   latestUnexpected,
   latestCancelled,
   listedUnexpected,
   nodeCancelled,
-  agentExecutionError,
+  agentExecutionCancelled,
   unrelatedLatest,
   unrelatedListed,
   unrelatedNode,
+  unrelatedAgentExecution,
 ]

--- a/packages/core/src/agents/streams.ts
+++ b/packages/core/src/agents/streams.ts
@@ -149,7 +149,7 @@ export function agentRunFinishedEvent(
     attempt: run.attempt,
     status: run.status,
     ...(run.finishReason === undefined ? {} : { finishReason: run.finishReason }),
-    ...(run.error === undefined ? {} : { error: run.error }),
+    ...(run.error === undefined ? {} : { error: run.error.message }),
     occurredAt: occurredAt.toISOString(),
   }
 }

--- a/packages/core/src/storage/agents/in-memory.ts
+++ b/packages/core/src/storage/agents/in-memory.ts
@@ -1,12 +1,15 @@
 import { AGENT_MESSAGE_CONTENT_VERSION } from "../../agents/message"
 import { principalsEqual } from "../../auth"
 import { normalizeRequesterGroupIds } from "../../auth/attribution"
+import { parseSixbFailure } from "../../errors/internal"
+import type { SixbFailure } from "../../errors/types"
 import type { ExecutionStorage } from "../executions"
 import { AgentStorageError } from "./errors"
 import { assertAgentRunExecution } from "./provider"
 import type {
   AgentMessageRecord,
   AgentMessageStore,
+  AgentRunFailureCode,
   AgentRunRecord,
   AgentRunStore,
   AgentStorage,
@@ -27,6 +30,13 @@ import type {
   ReclaimAgentRunInput,
   StartAgentRunInput,
 } from "./types"
+import { AGENT_RUN_FAILURE_CODES } from "./types"
+
+function normalizeFailure(
+  failure: SixbFailure<AgentRunFailureCode> | undefined
+): SixbFailure<AgentRunFailureCode> | undefined {
+  return failure ? parseSixbFailure(failure, AGENT_RUN_FAILURE_CODES) : undefined
+}
 
 function key(projectId: string, id: string): string {
   return `${projectId}:${id}`
@@ -246,7 +256,7 @@ class InMemoryAgentRunStore implements AgentRunStore {
     const next: AgentRunRecord = {
       ...run,
       status: input.status,
-      ...(input.error === undefined ? {} : { error: input.error }),
+      ...(input.error === undefined ? {} : { error: normalizeFailure(input.error) }),
       completedAt,
     }
     this.state.runs.set(key(input.projectId, input.id), clone(next))
@@ -306,7 +316,9 @@ class InMemoryAgentRunStore implements AgentRunStore {
       ...(input.finishReason === undefined ? {} : { finishReason: input.finishReason }),
       ...(input.usage === undefined ? {} : { usage: clone(input.usage) }),
       ...(input.diagnostics === undefined ? {} : { diagnostics: clone(input.diagnostics) }),
-      ...(input.status === "succeeded" || input.error === undefined ? {} : { error: input.error }),
+      ...(input.status === "succeeded" || input.error === undefined
+        ? {}
+        : { error: normalizeFailure(input.error) }),
       execution: undefined,
       completedAt,
     }

--- a/packages/core/src/storage/agents/index.ts
+++ b/packages/core/src/storage/agents/index.ts
@@ -11,6 +11,7 @@ export type {
   AgentRunDiagnosticCode,
   AgentRunDiagnosticSeverity,
   AgentRunExecution,
+  AgentRunFailureCode,
   AgentRunFinishReason,
   AgentRunRecord,
   AgentRunStatus,
@@ -37,6 +38,7 @@ export type {
 } from "./types"
 export {
   AGENT_RUN_DIAGNOSTIC_CODES,
+  AGENT_RUN_FAILURE_CODES,
   AGENT_RUN_FINISH_REASONS,
   coerceAgentRunFinishReason,
 } from "./types"

--- a/packages/core/src/storage/agents/types.ts
+++ b/packages/core/src/storage/agents/types.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage, AgentMessagePart, AgentMessageRole } from "../../agents/message"
 import type { Principal } from "../../auth"
+import type { SixbErrorCode, SixbFailure } from "../../errors/types"
 import type { JsonValue } from "../../json"
 
 // ── agent_threads — one conversation with an agent ──────────────────────────────────────────────
@@ -57,6 +58,14 @@ export interface ListAgentThreadsResult {
 export type AgentExecutionStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled"
 
 export type AgentRunStatus = AgentExecutionStatus
+
+/** Error codes an agent execution can persist and expose through its public contract. */
+export const AGENT_RUN_FAILURE_CODES = [
+  "internal.unexpected",
+  "runtime.cancelled",
+] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
+
+export type AgentRunFailureCode = (typeof AGENT_RUN_FAILURE_CODES)[number]
 
 /**
  * Why a run ended — our own SDK-independent vocabulary (it mirrors the AI SDK unified finish
@@ -156,8 +165,8 @@ export interface AgentRunRecord {
   readonly usage?: AgentRunUsage
   /** Platform diagnostics are transcript annotations, never agent-authored message content. */
   readonly diagnostics?: readonly AgentRunDiagnostic[]
-  /** Failure message when the run did not succeed. */
-  readonly error?: string
+  /** Portable failure snapshot when the run did not succeed. */
+  readonly error?: SixbFailure<AgentRunFailureCode>
   /** Execution attempts: `0` while queued, `1` on first start, incremented on redelivery. */
   readonly attempt: number
   readonly execution?: AgentRunExecution
@@ -189,7 +198,7 @@ export interface FinishQueuedAgentRunInput {
   readonly id: string
   readonly projectId: string
   readonly status: "failed" | "cancelled"
-  readonly error?: string
+  readonly error?: SixbFailure<AgentRunFailureCode>
   readonly completedAt?: Date
 }
 
@@ -228,7 +237,7 @@ export type FinishAgentRunInput =
       readonly finishReason?: AgentRunFinishReason
       readonly usage?: AgentRunUsage
       readonly diagnostics?: readonly AgentRunDiagnostic[]
-      readonly error?: string
+      readonly error?: SixbFailure<AgentRunFailureCode>
       readonly completedAt?: Date
     }
 

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -54,6 +54,7 @@ export type {
   AgentRunDiagnosticCode,
   AgentRunDiagnosticSeverity,
   AgentRunExecution,
+  AgentRunFailureCode,
   AgentRunFinishReason,
   AgentRunRecord,
   AgentRunStatus,
@@ -81,6 +82,7 @@ export type {
 } from "./agents"
 export {
   AGENT_RUN_DIAGNOSTIC_CODES,
+  AGENT_RUN_FAILURE_CODES,
   AGENT_RUN_FINISH_REASONS,
   AgentStorageError,
   coerceAgentRunFinishReason,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -39,6 +39,7 @@ export { ActionRunError } from "./action-runs"
 export type {
   AgentMessageRecord,
   AgentRunExecution,
+  AgentRunFailureCode,
   AgentRunRecord,
   AgentStorage,
   AgentThreadRecord,
@@ -57,7 +58,7 @@ export type {
   ReclaimAgentRunInput,
   StartAgentRunInput,
 } from "./agents"
-export { AgentStorageError } from "./agents"
+export { AGENT_RUN_FAILURE_CODES, AgentStorageError } from "./agents"
 export type {
   AiModelCallUsage,
   AiModelCallUsageInput,

--- a/packages/core/src/storage/workflow-runs/in-memory.ts
+++ b/packages/core/src/storage/workflow-runs/in-memory.ts
@@ -1,6 +1,8 @@
 import { normalizeRequesterGroupIds } from "../../auth/attribution"
 import { parseSixbFailure } from "../../errors/internal"
 import type { SixbFailure } from "../../errors/types"
+import type { AgentRunFailureCode } from "../agents"
+import { AGENT_RUN_FAILURE_CODES } from "../agents"
 import type { ExecutionStorage } from "../executions"
 import {
   cloneRecord,
@@ -53,6 +55,12 @@ function normalizeFailure(
   failure: SixbFailure<WorkflowRunFailureCode> | undefined
 ): SixbFailure<WorkflowRunFailureCode> | undefined {
   return failure ? parseSixbFailure(failure, WORKFLOW_RUN_FAILURE_CODES) : undefined
+}
+
+function normalizeAgentFailure(
+  failure: SixbFailure<AgentRunFailureCode> | undefined
+): SixbFailure<AgentRunFailureCode> | undefined {
+  return failure ? parseSixbFailure(failure, AGENT_RUN_FAILURE_CODES) : undefined
 }
 
 function assertNonNegativeInteger(value: number, fieldName: string): void {
@@ -703,7 +711,9 @@ export class InMemoryWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRun
       ...(input.usage === undefined ? {} : { usage: cloneRecord(input.usage) }),
       ...(input.trace === undefined ? {} : { trace: cloneRecord(input.trace) }),
       ...(input.diagnostics === undefined ? {} : { diagnostics: cloneRecord(input.diagnostics) }),
-      ...(input.status === "succeeded" || input.error === undefined ? {} : { error: input.error }),
+      ...(input.status === "succeeded" || input.error === undefined
+        ? {}
+        : { error: normalizeAgentFailure(input.error) }),
       execution: undefined,
       completedAt: new Date(input.completedAt ?? new Date()),
     })
@@ -720,7 +730,7 @@ export class InMemoryWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRun
       ...run,
       status: "cancelled",
       execution: undefined,
-      error: input.error,
+      error: normalizeAgentFailure(input.error),
       completedAt: new Date(input.completedAt ?? new Date()),
     })
   }

--- a/packages/core/src/storage/workflow-runs/types.ts
+++ b/packages/core/src/storage/workflow-runs/types.ts
@@ -2,7 +2,12 @@ import type { AgentMessagePart } from "../../agents/message"
 import type { SixbErrorCode, SixbFailure } from "../../errors/types"
 import type { JsonValue } from "../../json"
 import type { WorkflowIOSnapshot } from "../../workflows/types"
-import type { AgentExecutionStatus, AgentRunFinishReason, AgentRunUsage } from "../agents"
+import type {
+  AgentExecutionStatus,
+  AgentRunFailureCode,
+  AgentRunFinishReason,
+  AgentRunUsage,
+} from "../agents"
 
 export type { WorkflowIOSnapshot } from "../../workflows/types"
 
@@ -49,7 +54,7 @@ export interface WorkflowAgentNodeRunRecord {
   readonly usage?: AgentRunUsage
   readonly trace?: readonly AgentMessagePart[]
   readonly diagnostics?: readonly JsonValue[]
-  readonly error?: string
+  readonly error?: SixbFailure<AgentRunFailureCode>
   readonly attempt: number
   readonly execution?: WorkflowAgentNodeRunExecution
   readonly createdAt: Date
@@ -87,24 +92,31 @@ export interface ConfirmWorkflowAgentNodeRunExecutionOwnershipInput {
   readonly queueLeaseExpiresAt: Date
 }
 
-export type FinishWorkflowAgentNodeRunInput = {
+interface FinishWorkflowAgentNodeRunBaseInput {
   readonly projectId: string
   readonly nodeRunId: string
   readonly executionToken: string
-  readonly status: "succeeded" | "failed" | "cancelled"
   readonly modelId?: string
   readonly finishReason?: AgentRunFinishReason
   readonly usage?: AgentRunUsage
   readonly trace?: readonly AgentMessagePart[]
   readonly diagnostics?: readonly JsonValue[]
-  readonly error?: string
   readonly completedAt?: Date
 }
+
+export type FinishWorkflowAgentNodeRunInput =
+  | (FinishWorkflowAgentNodeRunBaseInput & {
+      readonly status: "succeeded"
+    })
+  | (FinishWorkflowAgentNodeRunBaseInput & {
+      readonly status: "failed" | "cancelled"
+      readonly error?: SixbFailure<AgentRunFailureCode>
+    })
 
 export interface CancelWorkflowAgentNodeRunInput {
   readonly projectId: string
   readonly nodeRunId: string
-  readonly error?: string
+  readonly error?: SixbFailure<AgentRunFailureCode>
   readonly completedAt?: Date
 }
 

--- a/packages/core/src/testing/agent-storage-contract.ts
+++ b/packages/core/src/testing/agent-storage-contract.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test"
 import { AGENT_MESSAGE_CONTENT_VERSION } from "../agents/message"
 import type { Principal } from "../auth"
+import type { SixbFailure } from "../errors/types"
 import {
   type AgentRunExecution,
+  type AgentRunFailureCode,
   type AgentStorage,
   AgentStorageError,
   type AgentStorageErrorCode,
@@ -35,6 +37,14 @@ const owner: Principal = { type: "user", id: "usr_1" }
 const serviceAccount: Extract<Principal, { readonly type: "serviceAccount" }> = {
   type: "serviceAccount",
   id: "svc_agent_sales",
+}
+
+function failure(
+  message: string,
+  at: string,
+  code: AgentRunFailureCode = "internal.unexpected"
+): SixbFailure<AgentRunFailureCode> {
+  return { code, message, retryable: false, at }
 }
 
 function at(value: string): Date {
@@ -301,13 +311,21 @@ export function runAgentStorageContractSuite<TStorage extends AgentStorageContra
           projectId,
           id: "run_1",
           status: "cancelled",
-          error: "Cancelled before execution",
+          error: failure(
+            "Cancelled before execution",
+            "2026-06-23T10:01:00.000Z",
+            "runtime.cancelled"
+          ),
           completedAt: at("2026-06-23T10:01:00.000Z"),
         })
         expect(cancelled).toMatchObject({
           status: "cancelled",
           attempt: 0,
-          error: "Cancelled before execution",
+          error: failure(
+            "Cancelled before execution",
+            "2026-06-23T10:01:00.000Z",
+            "runtime.cancelled"
+          ),
         })
         await expect(storage.threads.getById({ projectId, id: "thr_1" })).resolves.toMatchObject({
           activeRunId: null,
@@ -327,9 +345,14 @@ export function runAgentStorageContractSuite<TStorage extends AgentStorageContra
             projectId,
             id: "run_2",
             status: "failed",
-            error: "Agent is unavailable",
+            error: failure("Agent is unavailable", "2026-06-23T10:02:00.000Z"),
+            completedAt: at("2026-06-23T10:02:00.000Z"),
           })
-        ).resolves.toMatchObject({ status: "failed", attempt: 0, error: "Agent is unavailable" })
+        ).resolves.toMatchObject({
+          status: "failed",
+          attempt: 0,
+          error: failure("Agent is unavailable", "2026-06-23T10:02:00.000Z"),
+        })
       })
     })
 
@@ -589,7 +612,7 @@ export function runAgentStorageContractSuite<TStorage extends AgentStorageContra
             id: "run_1",
             executionToken: "wrong",
             status: "failed",
-            error: "boom",
+            error: failure("boom", "2026-06-23T10:08:00.000Z"),
           }),
           "execution_lost"
         )
@@ -599,11 +622,11 @@ export function runAgentStorageContractSuite<TStorage extends AgentStorageContra
           id: "run_1",
           executionToken: "exec_1",
           status: "failed",
-          error: "ProviderError: boom",
+          error: failure("ProviderError: boom", "2026-06-23T10:08:00.000Z"),
           completedAt: at("2026-06-23T10:08:00.000Z"),
         })
         expect(failed.status).toBe("failed")
-        expect(failed.error).toBe("ProviderError: boom")
+        expect(failed.error).toEqual(failure("ProviderError: boom", "2026-06-23T10:08:00.000Z"))
 
         // Already terminal → cannot finish again.
         await expectAgentError(

--- a/packages/core/tests/agent-run-stream-records.test.ts
+++ b/packages/core/tests/agent-run-stream-records.test.ts
@@ -9,6 +9,12 @@ import {
 import type { AgentRunRecord } from "../src/storage"
 
 const OCCURRED_AT = new Date("2026-01-02T03:04:05.000Z")
+const FAILURE = {
+  code: "internal.unexpected" as const,
+  message: "boom",
+  retryable: false,
+  at: "2026-01-02T03:04:04.000Z",
+}
 
 function runRecord(overrides: Partial<AgentRunRecord> = {}): AgentRunRecord {
   return {
@@ -29,7 +35,7 @@ function runRecord(overrides: Partial<AgentRunRecord> = {}): AgentRunRecord {
 describe("agent run stream records", () => {
   test("builds the finished event from a terminal run record", () => {
     const event = agentRunFinishedEvent(
-      runRecord({ status: "failed", attempt: 2, finishReason: "error", error: "boom" }),
+      runRecord({ status: "failed", attempt: 2, finishReason: "error", error: FAILURE }),
       OCCURRED_AT
     )
 

--- a/packages/core/tests/workflow-runs.test.ts
+++ b/packages/core/tests/workflow-runs.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { InMemoryStorage } from "../src"
 import {
+  type AgentRunFailureCode,
   InMemoryWorkflowRunStorage,
   type QueueWorkflowRunInput,
   type SixbFailure,
@@ -68,6 +69,13 @@ function failure(
   message: string,
   code: WorkflowRunFailureCode = "internal.unexpected"
 ): SixbFailure<WorkflowRunFailureCode> {
+  return { code, message, retryable: false, at: FAILURE_AT }
+}
+
+function agentFailure(
+  message: string,
+  code: AgentRunFailureCode = "internal.unexpected"
+): SixbFailure<AgentRunFailureCode> {
   return { code, message, retryable: false, at: FAILURE_AT }
 }
 
@@ -856,12 +864,12 @@ describe("InMemoryWorkflowRunStorage", () => {
     const cancelled = await storage.agentNodes.cancel({
       projectId: "my-app",
       nodeRunId: execution.nodeRunId,
-      error: "Workflow cancelled.",
+      error: agentFailure("Workflow cancelled.", "runtime.cancelled"),
     })
     expect(cancelled).toMatchObject({
       status: "cancelled",
       prompt: "Resolve txn_1.",
-      error: "Workflow cancelled.",
+      error: agentFailure("Workflow cancelled.", "runtime.cancelled"),
     })
     expect(
       (await storage.nodes.getById({ projectId: "my-app", id: execution.nodeRunId }))?.input

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -19,7 +19,7 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
-import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
+import { AGENT_RUN_FAILURE_CODES, WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import type { Elysia } from "elysia"
 import { z } from "zod"
 import { bearerSecurityRequirement } from "../auth/access-token-boundary"
@@ -203,6 +203,29 @@ function toWorkflowCancellationFailure(input: {
   })
 }
 
+function toAgentCancellationFailure(input: {
+  readonly message: string
+  readonly at: Date
+  readonly agentId: string
+  readonly workflowId: string
+  readonly runId: string
+  readonly nodeRunId: string
+}) {
+  return toSixbFailure(
+    createSixbError("runtime.cancelled", input.message, {
+      details: {
+        agentId: input.agentId,
+        workflowId: input.workflowId,
+        workflowRunId: input.runId,
+        nodeRunId: input.nodeRunId,
+      },
+    }),
+    {
+      allowedCodes: AGENT_RUN_FAILURE_CODES,
+      at: input.at,
+    }
+  )
+}
 function serializeWorkflowIntervention(intervention: WorkflowInterventionRecord) {
   return {
     id: intervention.id,
@@ -1115,7 +1138,14 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
                   projectId: host.id,
                   nodeRunId: active.id,
                   completedAt: cancelledAt,
-                  error: cancellationMessage,
+                  error: toAgentCancellationFailure({
+                    message: cancellationMessage,
+                    at: cancelledAt,
+                    agentId: execution.agentId,
+                    workflowId: run.workflowId,
+                    runId: run.id,
+                    nodeRunId: active.id,
+                  }),
                 })
               }
             }

--- a/packages/server/src/schemas/agents.ts
+++ b/packages/server/src/schemas/agents.ts
@@ -1,8 +1,16 @@
 import { AGENT_REASONING_LEVELS, MAX_AGENT_CONTEXT_ENTRIES } from "@sixb/core"
-import { AGENT_RUN_DIAGNOSTIC_CODES } from "@sixb/core/storage"
+import {
+  AGENT_RUN_DIAGNOSTIC_CODES,
+  AGENT_RUN_FAILURE_CODES,
+  type AgentRunFailureCode,
+  type SixbFailure,
+} from "@sixb/core/storage"
 import { z } from "zod"
-import { JsonValueSchema } from "./common"
+import { JsonValueSchema, sixbFailureSchema } from "./common"
 import { FileRefSchema } from "./files"
+
+export const AgentRunFailureSchema: z.ZodType<SixbFailure<AgentRunFailureCode>> =
+  sixbFailureSchema(AGENT_RUN_FAILURE_CODES)
 
 export const AgentIdParamsSchema = z.object({
   agentId: z.string().min(1),
@@ -263,7 +271,7 @@ export const AgentRunSchema = z.object({
   finishReason: AgentRunFinishReasonSchema.optional(),
   usage: AgentRunUsageSchema.optional(),
   diagnostics: z.array(AgentRunDiagnosticSchema).optional(),
-  error: z.string().optional(),
+  error: AgentRunFailureSchema.optional(),
   attempt: z.number(),
   streamId: z.string(),
   createdAt: z.string(),

--- a/packages/server/src/schemas/workflows.ts
+++ b/packages/server/src/schemas/workflows.ts
@@ -4,6 +4,7 @@ import {
   type WorkflowRunFailureCode,
 } from "@sixb/core/storage"
 import { z } from "zod"
+import { AgentRunFailureSchema } from "./agents"
 import { JsonValueSchema, sixbFailureSchema } from "./common"
 
 export const WorkflowIOSnapshotSchema = z.record(JsonValueSchema)
@@ -155,7 +156,7 @@ export const WorkflowAgentNodeExecutionSchema = WorkflowAgentNodeExecutionSummar
   prompt: z.string(),
   trace: z.array(z.unknown()).optional(),
   diagnostics: z.array(z.unknown()).optional(),
-  error: z.string().optional(),
+  error: AgentRunFailureSchema.optional(),
   createdAt: z.string(),
 })
 

--- a/packages/server/tests/agents-routes.test.ts
+++ b/packages/server/tests/agents-routes.test.ts
@@ -18,7 +18,7 @@ import {
 import { agentRunControlStreamId, agentRunStreamId } from "@sixb/core/agents/streams"
 import { createAgentRunExecutionToken } from "@sixb/core/internal/agents"
 import { createSessionCredential } from "@sixb/core/internal/auth"
-import type { AgentStorage } from "@sixb/core/storage"
+import type { AgentRunFailureCode, AgentStorage, SixbFailure } from "@sixb/core/storage"
 import { createTestAgentExecution, createTestSixb } from "@sixb/core/testing"
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
@@ -30,6 +30,14 @@ const model = {
   provider: "test",
   modelId: "test-model",
 } as unknown as Parameters<typeof defineAgent>[1]["model"]
+
+const FAILURE: SixbFailure<AgentRunFailureCode> = {
+  code: "internal.unexpected",
+  message: "dispatch failed",
+  retryable: false,
+  at: "2026-06-27T10:00:02.000Z",
+  details: { agentId: "assistant" },
+}
 
 type StartedRunInput = Omit<Parameters<AgentStorage["runs"]["create"]>[0], "executionId"> &
   Omit<Parameters<AgentStorage["runs"]["start"]>[0], "id" | "projectId">
@@ -759,8 +767,17 @@ describe("agent routes", () => {
       id: request.run.id,
       projectId: sixb.id,
       status: "failed",
-      error: "dispatch failed",
+      error: FAILURE,
+      completedAt: new Date(FAILURE.at),
     })
+
+    const failedResponse = await app.fetch(
+      new Request(`http://localhost/api/agent-runs/${request.run.id}`, {
+        headers: session.headers,
+      })
+    )
+    expect(failedResponse.status).toBe(200)
+    expect(await failedResponse.json()).toMatchObject({ error: FAILURE })
 
     await storage.auth.groupMemberships.remove({
       projectId: sixb.id,

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -2000,6 +2000,29 @@ describe("SixbServer HTTP contract", () => {
           },
         ],
       })
+
+      const cancelledExecutionResponse = await fetch(
+        `${baseUrl}/api/workflow-runs/${runId}/nodes/resolveDevice/agent-execution`
+      )
+      expect(cancelledExecutionResponse.status).toBe(200)
+      const cancelledExecution = (await cancelledExecutionResponse.json()) as {
+        completedAt: string
+        error: { at: string }
+      }
+      expect(cancelledExecution).toMatchObject({
+        status: "cancelled",
+        error: {
+          code: "runtime.cancelled",
+          message: "Execution was cancelled.",
+          details: {
+            agentId: "device-resolver",
+            workflowId: "review-device-health-workflow",
+            workflowRunId: runId,
+            nodeRunId,
+          },
+        },
+      })
+      expect(cancelledExecution.error.at).toBe(cancelledExecution.completedAt)
     })
   })
 

--- a/storage/pg/src/agents/rows.ts
+++ b/storage/pg/src/agents/rows.ts
@@ -1,5 +1,7 @@
-import type { AgentMessagePart, Principal } from "@sixb/core"
+import type { AgentMessagePart, JsonValue, Principal } from "@sixb/core"
+import { parseSixbFailure } from "@sixb/core/internal/errors"
 import {
+  AGENT_RUN_FAILURE_CODES,
   type AgentMessageRecord,
   type AgentRunDiagnostic,
   type AgentRunRecord,
@@ -43,7 +45,7 @@ export interface AgentRunRow {
   usage_total_tokens: number | string | null
   usage_reasoning_tokens: number | string | null
   usage_cached_input_tokens: number | string | null
-  error: string | null
+  error: JsonValue | null
   diagnostics: AgentRunDiagnostic[] | string | null
   attempt: number | string
   execution_token: string | null
@@ -103,7 +105,7 @@ export function rowToRunRecord(row: AgentRunRow): AgentRunRecord {
     modelId: row.model_id ?? undefined,
     finishReason: coerceAgentRunFinishReason(row.finish_reason),
     usage: rowToUsage(row),
-    error: row.error ?? undefined,
+    error: row.error === null ? undefined : parseSixbFailure(row.error, AGENT_RUN_FAILURE_CODES),
     diagnostics: normalizeDiagnostics(row.diagnostics),
     attempt: Number(row.attempt),
     execution:

--- a/storage/pg/src/agents/runs.ts
+++ b/storage/pg/src/agents/runs.ts
@@ -1,6 +1,8 @@
 import { assertAgentRunExecution } from "@sixb/core/internal/agent-run-storage-provider"
 import { normalizeRequesterGroupIds } from "@sixb/core/internal/auth"
+import { serializeSixbFailure } from "@sixb/core/internal/errors"
 import {
+  AGENT_RUN_FAILURE_CODES,
   type AgentRunRecord,
   type AgentRunStore,
   AgentStorageError,
@@ -132,7 +134,10 @@ export class PgAgentRunStore implements AgentRunStore {
       const run = await this.lockStatus(tx, input.projectId, input.id, "queued")
       const [row] = await tx<AgentRunRow[]>`
         UPDATE agent_runs
-        SET status = ${input.status}, error = ${input.error ?? null}, completed_at = ${completedAt}
+        SET
+          status = ${input.status},
+          error = ${input.error === undefined ? null : serializeSixbFailure(input.error, AGENT_RUN_FAILURE_CODES)}::text::jsonb,
+          completed_at = ${completedAt}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
       `
@@ -185,7 +190,10 @@ export class PgAgentRunStore implements AgentRunStore {
 
   async finish(input: FinishAgentRunInput): Promise<AgentRunRecord> {
     const completedAt = input.completedAt ?? new Date()
-    const errorValue = input.status === "succeeded" ? null : (input.error ?? null)
+    const errorValue =
+      input.status === "succeeded" || input.error === undefined
+        ? null
+        : serializeSixbFailure(input.error, AGENT_RUN_FAILURE_CODES)
 
     return runPgTransaction(this.sql, async (tx) => {
       const run = await this.lockRunning(tx, input.projectId, input.id)
@@ -208,7 +216,7 @@ export class PgAgentRunStore implements AgentRunStore {
           usage_total_tokens = ${input.usage?.totalTokens ?? null},
           usage_reasoning_tokens = ${input.usage?.reasoningTokens ?? null},
           usage_cached_input_tokens = ${input.usage?.cachedInputTokens ?? null},
-          error = ${errorValue},
+          error = ${errorValue}::text::jsonb,
           diagnostics = ${input.diagnostics === undefined ? null : JSON.stringify(input.diagnostics)}::text::jsonb,
           execution_token = ${null},
           execution_queue_lease_expires_at = ${null},

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -34,6 +34,7 @@ import pipelineFailureRecordSql from "./migrations/012-pipeline-failure-record.s
 import workflowFailureRecordSql from "./migrations/013-workflow-failure-record.sql" with {
   type: "text",
 }
+import agentFailureRecordSql from "./migrations/014-agent-failure-record.sql" with { type: "text" }
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -300,6 +301,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("011-sync-failure-record", syncFailureRecordSql),
     pgSql("012-pipeline-failure-record", pipelineFailureRecordSql),
     pgSql("013-workflow-failure-record", workflowFailureRecordSql),
+    pgSql("014-agent-failure-record", agentFailureRecordSql),
   ],
 })
 

--- a/storage/pg/src/migrations/014-agent-failure-record.sql
+++ b/storage/pg/src/migrations/014-agent-failure-record.sql
@@ -1,0 +1,56 @@
+ALTER TABLE agent_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE agent_runs ADD COLUMN error JSONB;
+
+UPDATE agent_runs
+SET error = jsonb_build_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', false,
+  'at', to_char(COALESCE(completed_at, started_at, created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'agentId', agent_id,
+    'runId', id,
+    'threadId', thread_id,
+    'migratedFromLegacyError', true
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE agent_runs DROP COLUMN legacy_error;
+
+ALTER TABLE workflow_agent_node_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE workflow_agent_node_runs ADD COLUMN error JSONB;
+
+UPDATE workflow_agent_node_runs AS agent_node
+SET error = jsonb_build_object(
+  'code', CASE
+    WHEN agent_node.status = 'cancelled' THEN 'runtime.cancelled'
+    ELSE 'internal.unexpected'
+  END,
+  'message', CASE
+    WHEN agent_node.status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', false,
+  'at', to_char(
+    COALESCE(agent_node.completed_at, agent_node.started_at, agent_node.created_at) AT TIME ZONE 'UTC',
+    'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+  ),
+  'details', jsonb_build_object(
+    'agentId', agent_node.agent_id,
+    'workflowId', node.workflow_id,
+    'workflowRunId', node.workflow_run_id,
+    'nodeId', node.node_id,
+    'nodeRunId', agent_node.node_run_id,
+    'migratedFromLegacyError', true
+  )
+)
+FROM workflow_node_runs AS node
+WHERE node.project_id = agent_node.project_id
+  AND node.id = agent_node.node_run_id
+  AND agent_node.legacy_error IS NOT NULL;
+
+ALTER TABLE workflow_agent_node_runs DROP COLUMN legacy_error;

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -39,7 +39,11 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
-import { WORKFLOW_RUN_FAILURE_CODES, WorkflowRunError } from "@sixb/core/storage"
+import {
+  AGENT_RUN_FAILURE_CODES,
+  WORKFLOW_RUN_FAILURE_CODES,
+  WorkflowRunError,
+} from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import type { SqlParameter } from "./pg-client"
 import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
@@ -493,7 +497,7 @@ export class PgWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRunStorag
           usage = ${input.usage ? JSON.stringify(input.usage) : null}::text::jsonb,
           trace = ${input.trace ? JSON.stringify(input.trace) : null}::text::jsonb,
           diagnostics = ${input.diagnostics ? JSON.stringify(input.diagnostics) : null}::text::jsonb,
-          error = ${input.status === "succeeded" ? null : (input.error ?? null)},
+          error = ${input.status === "succeeded" || input.error === undefined ? null : serializeSixbFailure(input.error, AGENT_RUN_FAILURE_CODES)}::text::jsonb,
           execution_token = ${null},
           execution_queue_lease_expires_at = ${null},
           completed_at = ${input.completedAt ?? new Date()}
@@ -524,7 +528,7 @@ export class PgWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRunStorag
       const [updated] = await tx<WorkflowAgentNodeRunDatabaseRow[]>`
         UPDATE workflow_agent_node_runs SET
           status = ${"cancelled"},
-          error = ${input.error ?? null},
+          error = ${input.error === undefined ? null : serializeSixbFailure(input.error, AGENT_RUN_FAILURE_CODES)}::text::jsonb,
           execution_token = ${null},
           execution_queue_lease_expires_at = ${null},
           completed_at = ${input.completedAt ?? new Date()}
@@ -915,7 +919,7 @@ interface WorkflowAgentNodeRunDatabaseRow {
   usage: WorkflowAgentNodeRunRecord["usage"] | string | null
   trace: WorkflowAgentNodeRunRecord["trace"] | string | null
   diagnostics: WorkflowAgentNodeRunRecord["diagnostics"] | string | null
-  error: string | null
+  error: JsonValue | null
   attempt: number | string
   execution_token: string | null
   execution_queue_lease_expires_at: Date | string | null
@@ -974,7 +978,7 @@ function rowToWorkflowAgentNodeRunRecord(
     ...(row.usage ? { usage: parseJson(row.usage) } : {}),
     ...(row.trace ? { trace: parseJson(row.trace) } : {}),
     ...(row.diagnostics ? { diagnostics: parseJson(row.diagnostics) } : {}),
-    ...(row.error ? { error: row.error } : {}),
+    ...(row.error ? { error: parseSixbFailure(row.error, AGENT_RUN_FAILURE_CODES) } : {}),
     attempt: Number(row.attempt),
     ...(row.execution_token && row.execution_queue_lease_expires_at
       ? {

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -49,6 +49,7 @@ describe("Postgres storage migrations", () => {
             "011-sync-failure-record",
             "012-pipeline-failure-record",
             "013-workflow-failure-record",
+            "014-agent-failure-record",
           ],
         },
       ])
@@ -143,6 +144,13 @@ describe("Postgres storage migrations", () => {
           id: "013-workflow-failure-record",
           status: "applied",
           version: 13,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "014-agent-failure-record",
+          status: "applied",
+          version: 14,
         },
       ])
     })
@@ -819,6 +827,13 @@ describe("Postgres storage migrations", () => {
           id: "013-workflow-failure-record",
           status: "applied",
           version: 13,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "014-agent-failure-record",
+          status: "applied",
+          version: 14,
         },
       ])
     } finally {

--- a/storage/pg/tests/pg-workflow-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-workflow-run-storage.e2e.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import {
+  type AgentRunFailureCode,
   type QueueWorkflowRunInput,
   type SixbFailure,
   type StartWorkflowRunInput,
@@ -26,6 +27,13 @@ function failure(
     at: "2026-05-08T10:00:01.000Z",
     details: { workflowId: "reconcile-transaction" },
   }
+}
+
+function agentFailure(
+  message: string,
+  code: AgentRunFailureCode = "internal.unexpected"
+): SixbFailure<AgentRunFailureCode> {
+  return { code, message, retryable: false, at: "2026-05-08T10:00:01.000Z" }
 }
 
 describe("PgWorkflowRunStorage", () => {
@@ -695,11 +703,11 @@ describe("PgWorkflowRunStorage", () => {
     const cancelled = await storage.workflowRuns.agentNodes.cancel({
       projectId: "my-app",
       nodeRunId: running.nodeRunId,
-      error: "Workflow cancelled.",
+      error: agentFailure("Workflow cancelled.", "runtime.cancelled"),
     })
     expect(cancelled).toMatchObject({
       status: "cancelled",
-      error: "Workflow cancelled.",
+      error: agentFailure("Workflow cancelled.", "runtime.cancelled"),
       prompt: "Resolve tr_1.",
     })
     expect(cancelled.execution).toBeUndefined()

--- a/storage/sqlite/src/agents/rows.ts
+++ b/storage/sqlite/src/agents/rows.ts
@@ -1,6 +1,8 @@
 import type { Database } from "bun:sqlite"
 import type { AgentMessagePart, Principal } from "@sixb/core"
+import { parseSixbFailure } from "@sixb/core/internal/errors"
 import {
+  AGENT_RUN_FAILURE_CODES,
   type AgentMessageRecord,
   type AgentRunDiagnostic,
   type AgentRunRecord,
@@ -100,7 +102,7 @@ export function rowToRunRecord(row: AgentRunRow): AgentRunRecord {
     modelId: row.model_id ?? undefined,
     finishReason: coerceAgentRunFinishReason(row.finish_reason),
     usage: rowToUsage(row),
-    error: row.error ?? undefined,
+    error: row.error === null ? undefined : parseSixbFailure(row.error, AGENT_RUN_FAILURE_CODES),
     diagnostics:
       row.diagnostics === null ? undefined : (JSON.parse(row.diagnostics) as AgentRunDiagnostic[]),
     attempt: row.attempt,

--- a/storage/sqlite/src/agents/runs.ts
+++ b/storage/sqlite/src/agents/runs.ts
@@ -1,7 +1,9 @@
 import type { Database } from "bun:sqlite"
 import { assertAgentRunExecution } from "@sixb/core/internal/agent-run-storage-provider"
 import { normalizeRequesterGroupIds } from "@sixb/core/internal/auth"
+import { serializeSixbFailure } from "@sixb/core/internal/errors"
 import {
+  AGENT_RUN_FAILURE_CODES,
   type AgentRunRecord,
   type AgentRunStore,
   AgentStorageError,
@@ -155,7 +157,9 @@ export class SqliteAgentRunStore implements AgentRunStore {
         )
         .run(
           input.status,
-          input.error ?? null,
+          input.error === undefined
+            ? null
+            : serializeSixbFailure(input.error, AGENT_RUN_FAILURE_CODES),
           completedAt.toISOString(),
           input.projectId,
           input.id
@@ -217,7 +221,10 @@ export class SqliteAgentRunStore implements AgentRunStore {
 
   async finish(input: FinishAgentRunInput): Promise<AgentRunRecord> {
     const completedAt = input.completedAt ?? new Date()
-    const errorValue = input.status === "succeeded" ? null : (input.error ?? null)
+    const errorValue =
+      input.status === "succeeded" || input.error === undefined
+        ? null
+        : serializeSixbFailure(input.error, AGENT_RUN_FAILURE_CODES)
 
     return this.db.transaction(() => {
       const run = this.requireRunning(input.projectId, input.id)

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -37,6 +37,7 @@ import pipelineFailureRecordSql from "./migrations/012-pipeline-failure-record.s
 import workflowFailureRecordSql from "./migrations/013-workflow-failure-record.sql" with {
   type: "text",
 }
+import agentFailureRecordSql from "./migrations/014-agent-failure-record.sql" with { type: "text" }
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -70,6 +71,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("011-sync-failure-record", syncFailureRecordSql),
     sqliteSql("012-pipeline-failure-record", pipelineFailureRecordSql),
     sqliteSql("013-workflow-failure-record", workflowFailureRecordSql),
+    sqliteSql("014-agent-failure-record", agentFailureRecordSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/014-agent-failure-record.sql
+++ b/storage/sqlite/src/migrations/014-agent-failure-record.sql
@@ -1,0 +1,59 @@
+ALTER TABLE agent_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE agent_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE agent_runs
+SET error = json_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json('false'),
+  'at', COALESCE(completed_at, started_at, created_at),
+  'details', json_object(
+    'agentId', agent_id,
+    'runId', id,
+    'threadId', thread_id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE agent_runs DROP COLUMN legacy_error;
+
+ALTER TABLE workflow_agent_node_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE workflow_agent_node_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE workflow_agent_node_runs
+SET error = json_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json('false'),
+  'at', COALESCE(completed_at, started_at, created_at),
+  'details', json_object(
+    'agentId', agent_id,
+    'workflowId', (
+      SELECT workflow_id FROM workflow_node_runs AS node
+      WHERE node.project_id = workflow_agent_node_runs.project_id
+        AND node.id = workflow_agent_node_runs.node_run_id
+    ),
+    'workflowRunId', (
+      SELECT workflow_run_id FROM workflow_node_runs AS node
+      WHERE node.project_id = workflow_agent_node_runs.project_id
+        AND node.id = workflow_agent_node_runs.node_run_id
+    ),
+    'nodeId', (
+      SELECT node_id FROM workflow_node_runs AS node
+      WHERE node.project_id = workflow_agent_node_runs.project_id
+        AND node.id = workflow_agent_node_runs.node_run_id
+    ),
+    'nodeRunId', node_run_id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE workflow_agent_node_runs DROP COLUMN legacy_error;

--- a/storage/sqlite/src/workflow-run-storage.ts
+++ b/storage/sqlite/src/workflow-run-storage.ts
@@ -39,7 +39,11 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
-import { WORKFLOW_RUN_FAILURE_CODES, WorkflowRunError } from "@sixb/core/storage"
+import {
+  AGENT_RUN_FAILURE_CODES,
+  WORKFLOW_RUN_FAILURE_CODES,
+  WorkflowRunError,
+} from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import { installFreshSqliteSchema } from "./migrations"
 import {
@@ -604,7 +608,9 @@ export class SqliteWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRunSt
           input.usage ? JSON.stringify(input.usage) : null,
           input.trace ? JSON.stringify(input.trace) : null,
           input.diagnostics ? JSON.stringify(input.diagnostics) : null,
-          input.status === "succeeded" ? null : (input.error ?? null),
+          input.status === "succeeded" || input.error === undefined
+            ? null
+            : serializeSixbFailure(input.error, AGENT_RUN_FAILURE_CODES),
           (input.completedAt ?? new Date()).toISOString(),
           input.projectId,
           input.nodeRunId
@@ -629,7 +635,9 @@ export class SqliteWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRunSt
         )
         .run(
           "cancelled",
-          input.error ?? null,
+          input.error === undefined
+            ? null
+            : serializeSixbFailure(input.error, AGENT_RUN_FAILURE_CODES),
           (input.completedAt ?? new Date()).toISOString(),
           input.projectId,
           input.nodeRunId
@@ -1109,7 +1117,7 @@ function rowToWorkflowAgentNodeRunRecord(
     ...(row.usage ? { usage: JSON.parse(row.usage) } : {}),
     ...(row.trace ? { trace: JSON.parse(row.trace) } : {}),
     ...(row.diagnostics ? { diagnostics: JSON.parse(row.diagnostics) } : {}),
-    ...(row.error ? { error: row.error } : {}),
+    ...(row.error ? { error: parseSixbFailure(row.error, AGENT_RUN_FAILURE_CODES) } : {}),
     attempt: row.attempt,
     ...(row.execution_token && row.execution_queue_lease_expires_at
       ? {

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path"
 import { migrateStorage } from "@sixb/core"
 import { parseSixbFailure } from "@sixb/core/internal/errors"
 import {
+  AGENT_RUN_FAILURE_CODES,
   PIPELINE_RUN_FAILURE_CODES,
   SYNC_RUN_FAILURE_CODES,
   WORKFLOW_RUN_FAILURE_CODES,
@@ -113,6 +114,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 13,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "014-agent-failure-record",
+    status: "applied",
+    version: 14,
+  },
 ]
 
 afterEach(async () => {
@@ -210,6 +218,13 @@ describe("SQLite storage migrations", () => {
       )
 
       db.run(`
+        INSERT INTO auth_service_accounts (
+          project_id, id, name, status, created_by_principal_type, created_at, updated_at
+        ) VALUES (
+          'project-a', 'svc_agent_reviewer', 'Reviewer Agent', 'active', 'system',
+          '2026-08-10T11:00:00.000Z', '2026-08-10T11:00:00.000Z'
+        );
+
         INSERT INTO executions (
           project_id, id, executor_kind, executor_id, source_kind, source_id, correlation_id,
           authority_kind, authority_primitive_kind, authority_primitive_id, created_at
@@ -218,6 +233,32 @@ describe("SQLite storage migrations", () => {
           'event-workflow-legacy', 'correlation-workflow-legacy', 'trustedPrimitive', 'workflow',
           'orders', '2026-08-10T12:00:00.000Z'
         );
+
+        INSERT INTO executions (
+          project_id, id, executor_kind, executor_id, source_kind, source_id, correlation_id,
+          authority_kind, created_at
+        ) VALUES (
+          'project-a', 'execution-agent-parent-legacy', 'request',
+          'request-agent-parent-legacy', 'http', 'request-agent-parent-legacy',
+          'correlation-agent-legacy', 'disabled', '2026-08-10T11:59:00.000Z'
+        );
+
+        INSERT INTO executions (
+          project_id, id, executor_kind, executor_id, source_kind, source_id, correlation_id,
+          parent_execution_id, authority_kind, authority_service_account_id, created_at
+        ) VALUES
+          (
+            'project-a', 'execution-agent-legacy', 'agent', 'agent-legacy', 'execution',
+            'execution-agent-parent-legacy', 'correlation-agent-legacy',
+            'execution-agent-parent-legacy', 'principal', 'svc_agent_reviewer',
+            '2026-08-10T12:00:00.000Z'
+          ),
+          (
+            'project-a', 'execution-workflow-agent-legacy', 'agent', 'node-legacy', 'execution',
+            'execution-workflow-legacy', 'correlation-workflow-legacy',
+            'execution-workflow-legacy', 'principal', 'svc_agent_reviewer',
+            '2026-08-10T12:00:00.000Z'
+          );
 
         INSERT INTO workflow_runs (
           project_id, id, workflow_id, status, input, started_at, finished_at, error, execution_id
@@ -231,9 +272,27 @@ describe("SQLite storage migrations", () => {
           project_id, id, workflow_run_id, workflow_id, node_index, node_type, node_id, node_key,
           status, input, started_at, finished_at, error
         ) VALUES (
-          'project-a', 'node-legacy', 'workflow-legacy', 'orders', 0, 'step', 'extract', 'extract',
+          'project-a', 'node-legacy', 'workflow-legacy', 'orders', 0, 'agent', 'review', 'review',
           'failed', '{}', '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z',
           'secret workflow node diagnostic'
+        );
+
+        INSERT INTO workflow_agent_node_runs (
+          project_id, node_run_id, execution_id, agent_id, status, prompt, error, created_at,
+          completed_at
+        ) VALUES (
+          'project-a', 'node-legacy', 'execution-workflow-agent-legacy', 'reviewer', 'failed',
+          'Review this order', 'secret workflow Agent diagnostic',
+          '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z'
+        );
+
+        INSERT INTO agent_runs (
+          project_id, id, execution_id, thread_id, agent_id, trigger_message_id, status, error,
+          created_at, completed_at
+        ) VALUES (
+          'project-a', 'agent-legacy', 'execution-agent-legacy', 'thread-legacy', 'reviewer',
+          'message-legacy', 'failed', 'secret Agent diagnostic',
+          '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z'
         );
       `)
 
@@ -306,11 +365,45 @@ describe("SQLite storage migrations", () => {
         details: {
           workflowId: "orders",
           workflowRunId: "workflow-legacy",
-          nodeId: "extract",
+          nodeId: "review",
           nodeRunId: "node-legacy",
         },
       })
       expect(JSON.stringify(nodeFailure)).not.toContain("secret workflow node diagnostic")
+
+      const agentRow = db
+        .query("SELECT error FROM agent_runs WHERE project_id = ? AND id = ?")
+        .get("project-a", "agent-legacy") as { readonly error: string }
+      const agentFailure = parseSixbFailure(agentRow.error, AGENT_RUN_FAILURE_CODES)
+      expect(agentFailure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        details: {
+          agentId: "reviewer",
+          runId: "agent-legacy",
+          threadId: "thread-legacy",
+        },
+      })
+      expect(JSON.stringify(agentFailure)).not.toContain("secret Agent diagnostic")
+
+      const agentNodeRow = db
+        .query(
+          "SELECT error FROM workflow_agent_node_runs WHERE project_id = ? AND node_run_id = ?"
+        )
+        .get("project-a", "node-legacy") as { readonly error: string }
+      const agentNodeFailure = parseSixbFailure(agentNodeRow.error, AGENT_RUN_FAILURE_CODES)
+      expect(agentNodeFailure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        details: {
+          agentId: "reviewer",
+          workflowId: "orders",
+          workflowRunId: "workflow-legacy",
+          nodeId: "review",
+          nodeRunId: "node-legacy",
+        },
+      })
+      expect(JSON.stringify(agentNodeFailure)).not.toContain("secret workflow Agent diagnostic")
     } finally {
       db.close()
     }

--- a/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import {
+  type AgentRunFailureCode,
   type QueueWorkflowRunInput,
   type SixbFailure,
   type StartWorkflowRunInput,
@@ -25,6 +26,13 @@ function failure(
     at: "2026-05-08T10:00:01.000Z",
     details: { workflowId: "reconcile-transaction" },
   }
+}
+
+function agentFailure(
+  message: string,
+  code: AgentRunFailureCode = "internal.unexpected"
+): SixbFailure<AgentRunFailureCode> {
+  return { code, message, retryable: false, at: "2026-05-08T10:00:01.000Z" }
 }
 
 describe("SqliteWorkflowRunStorage", () => {
@@ -648,11 +656,11 @@ describe("SqliteWorkflowRunStorage", () => {
     const cancelled = await storage.agentNodes.cancel({
       projectId: "my-app",
       nodeRunId: running.nodeRunId,
-      error: "Workflow cancelled.",
+      error: agentFailure("Workflow cancelled.", "runtime.cancelled"),
     })
     expect(cancelled).toMatchObject({
       status: "cancelled",
-      error: "Workflow cancelled.",
+      error: agentFailure("Workflow cancelled.", "runtime.cancelled"),
       prompt: "Resolve tr_1.",
     })
     expect(cancelled.execution).toBeUndefined()


### PR DESCRIPTION
Stacked on #318.

## Summary

- migrate conversational agent runs and workflow-owned agent executions to the shared `SixbFailure` record
- scope the public contract to `internal.unexpected` and `runtime.cancelled`
- normalize failures once at the producer with stable correlation details and a shared completion timestamp
- persist validated JSON in SQLite and JSONB in PostgreSQL
- expose the precise failure shape through server schemas, OpenAPI, and the generated client
- render workflow agent diagnostics with the shared Atlas failure component

## Why

This is the next vertical slice of the error-model migration. It keeps the change reviewable by covering one primitive end to end while preserving the existing stream and domain-event string contracts.

The runtime error class remains internal. Durable and public boundaries only expose serializable `SixbFailure` values. The end-user agent UI also keeps generic failure copy; detailed diagnostics are reserved for the operator-facing Atlas surface.

`FinishWorkflowAgentNodeRunInput` is now discriminated by status so successful executions cannot carry an error.

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run generate:client`
- `bun run build`
- `bun run test:publish`
- 139 targeted agent, workflow, SQLite, server, and worker tests
- 7 HTTP contract tests
- 167 PostgreSQL end-to-end tests
