### PR TITLE
projection: persist portable failure records

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -29,7 +29,7 @@ interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
 }
 ```
 
-Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, pipeline step runs, workflow runs, workflow node runs, and agent executions (conversation or workflow-owned) currently declare `internal.unexpected | runtime.cancelled`.
+Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, pipeline step runs, workflow runs, workflow node runs, agent executions (conversation or workflow-owned), and projection runs currently declare `internal.unexpected | runtime.cancelled`.
 
 Other run primitives keep their legacy error shape until their own vertical migration. This keeps
 each storage and wire change independently reviewable.

--- a/packages/atlas/src/pages/ProjectionsPage.tsx
+++ b/packages/atlas/src/pages/ProjectionsPage.tsx
@@ -43,6 +43,7 @@ import {
 } from "lucide-react"
 import { useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import { humanizeIdentifier } from "../lib/labels"
 import { formatRelativeTime } from "../lib/time"
 import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
@@ -475,9 +476,7 @@ function ProjectionRunList({ runs }: { runs: ProjectionRun[] }) {
                   >
                     {run.identity.datasetVersion.versionId}
                   </p>
-                  {run.errorMessage && (
-                    <p className="mt-1 break-words text-xs text-destructive">{run.errorMessage}</p>
-                  )}
+                  {run.error && <SixbFailureSummary failure={run.error} className="mt-1 text-xs" />}
                 </td>
                 <td className="whitespace-nowrap px-3 py-3 text-muted-foreground">
                   {formatRelativeTime(run.startedAt)}
@@ -527,9 +526,7 @@ function ProjectionRunList({ runs }: { runs: ProjectionRun[] }) {
                 </span>
               ))}
             </div>
-            {run.errorMessage && (
-              <p className="mt-2 break-words text-xs text-destructive">{run.errorMessage}</p>
-            )}
+            {run.error && <SixbFailureSummary failure={run.error} className="mt-2 text-xs" />}
           </div>
         ))}
       </div>

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -25070,8 +25070,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -25182,8 +25228,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -25297,8 +25389,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -25457,8 +25595,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -25569,8 +25753,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -25684,8 +25914,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -25849,8 +26125,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -25961,8 +26283,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -26076,8 +26444,54 @@
                                   "finishedAt": {
                                     "type": "string"
                                   },
-                                  "errorMessage": {
-                                    "type": "string"
+                                  "error": {
+                                    "type": "object",
+                                    "properties": {
+                                      "code": {
+                                        "type": "string",
+                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      },
+                                      "message": {
+                                        "type": "string",
+                                        "maxLength": 4096
+                                      },
+                                      "retryable": {
+                                        "type": "boolean"
+                                      },
+                                      "at": {
+                                        "type": "string",
+                                        "format": "date-time"
+                                      },
+                                      "details": {
+                                        "description": "Any JSON-compatible value.",
+                                        "nullable": true,
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {}
+                                          },
+                                          {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                          }
+                                        ]
+                                      },
+                                      "truncated": {
+                                        "type": "boolean",
+                                        "enum": [true]
+                                      }
+                                    },
+                                    "required": ["code", "message", "retryable", "at"],
+                                    "additionalProperties": false
                                   },
                                   "identity": {
                                     "type": "object",
@@ -26285,8 +26699,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -26397,8 +26857,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -26512,8 +27018,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -26669,8 +27221,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -26781,8 +27379,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -26896,8 +27540,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -27058,8 +27748,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -27170,8 +27906,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -27285,8 +28067,54 @@
                                 "finishedAt": {
                                   "type": "string"
                                 },
-                                "errorMessage": {
-                                  "type": "string"
+                                "error": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string",
+                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "maxLength": 4096
+                                    },
+                                    "retryable": {
+                                      "type": "boolean"
+                                    },
+                                    "at": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "details": {
+                                      "description": "Any JSON-compatible value.",
+                                      "nullable": true,
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {}
+                                        },
+                                        {
+                                          "type": "object",
+                                          "additionalProperties": true
+                                        }
+                                      ]
+                                    },
+                                    "truncated": {
+                                      "type": "boolean",
+                                      "enum": [true]
+                                    }
+                                  },
+                                  "required": ["code", "message", "retryable", "at"],
+                                  "additionalProperties": false
                                 },
                                 "identity": {
                                   "type": "object",
@@ -27541,8 +28369,54 @@
                               "finishedAt": {
                                 "type": "string"
                               },
-                              "errorMessage": {
-                                "type": "string"
+                              "error": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string",
+                                    "enum": ["internal.unexpected", "runtime.cancelled"]
+                                  },
+                                  "message": {
+                                    "type": "string",
+                                    "maxLength": 4096
+                                  },
+                                  "retryable": {
+                                    "type": "boolean"
+                                  },
+                                  "at": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "details": {
+                                    "description": "Any JSON-compatible value.",
+                                    "nullable": true,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {}
+                                      },
+                                      {
+                                        "type": "object",
+                                        "additionalProperties": true
+                                      }
+                                    ]
+                                  },
+                                  "truncated": {
+                                    "type": "boolean",
+                                    "enum": [true]
+                                  }
+                                },
+                                "required": ["code", "message", "retryable", "at"],
+                                "additionalProperties": false
                               },
                               "identity": {
                                 "type": "object",
@@ -27653,8 +28527,54 @@
                               "finishedAt": {
                                 "type": "string"
                               },
-                              "errorMessage": {
-                                "type": "string"
+                              "error": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string",
+                                    "enum": ["internal.unexpected", "runtime.cancelled"]
+                                  },
+                                  "message": {
+                                    "type": "string",
+                                    "maxLength": 4096
+                                  },
+                                  "retryable": {
+                                    "type": "boolean"
+                                  },
+                                  "at": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "details": {
+                                    "description": "Any JSON-compatible value.",
+                                    "nullable": true,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {}
+                                      },
+                                      {
+                                        "type": "object",
+                                        "additionalProperties": true
+                                      }
+                                    ]
+                                  },
+                                  "truncated": {
+                                    "type": "boolean",
+                                    "enum": [true]
+                                  }
+                                },
+                                "required": ["code", "message", "retryable", "at"],
+                                "additionalProperties": false
                               },
                               "identity": {
                                 "type": "object",
@@ -27768,8 +28688,54 @@
                               "finishedAt": {
                                 "type": "string"
                               },
-                              "errorMessage": {
-                                "type": "string"
+                              "error": {
+                                "type": "object",
+                                "properties": {
+                                  "code": {
+                                    "type": "string",
+                                    "enum": ["internal.unexpected", "runtime.cancelled"]
+                                  },
+                                  "message": {
+                                    "type": "string",
+                                    "maxLength": 4096
+                                  },
+                                  "retryable": {
+                                    "type": "boolean"
+                                  },
+                                  "at": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "details": {
+                                    "description": "Any JSON-compatible value.",
+                                    "nullable": true,
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {}
+                                      },
+                                      {
+                                        "type": "object",
+                                        "additionalProperties": true
+                                      }
+                                    ]
+                                  },
+                                  "truncated": {
+                                    "type": "boolean",
+                                    "enum": [true]
+                                  }
+                                },
+                                "required": ["code", "message", "retryable", "at"],
+                                "additionalProperties": false
                               },
                               "identity": {
                                 "type": "object",
@@ -27956,8 +28922,54 @@
                         "finishedAt": {
                           "type": "string"
                         },
-                        "errorMessage": {
-                          "type": "string"
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "identity": {
                           "type": "object",
@@ -28068,8 +29080,54 @@
                         "finishedAt": {
                           "type": "string"
                         },
-                        "errorMessage": {
-                          "type": "string"
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "identity": {
                           "type": "object",
@@ -28183,8 +29241,54 @@
                         "finishedAt": {
                           "type": "string"
                         },
-                        "errorMessage": {
-                          "type": "string"
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                            },
+                            "message": {
+                              "type": "string",
+                              "maxLength": 4096
+                            },
+                            "retryable": {
+                              "type": "boolean"
+                            },
+                            "at": {
+                              "type": "string",
+                              "format": "date-time"
+                            },
+                            "details": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
+                              ]
+                            },
+                            "truncated": {
+                              "type": "boolean",
+                              "enum": [true]
+                            }
+                          },
+                          "required": ["code", "message", "retryable", "at"],
+                          "additionalProperties": false
                         },
                         "identity": {
                           "type": "object",

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -8752,7 +8752,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -8781,7 +8799,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -8811,7 +8847,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -8852,7 +8906,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -8881,7 +8953,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -8911,7 +9001,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -8953,7 +9061,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -8982,7 +9108,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -9012,7 +9156,25 @@ export type ListProjectionsResponses = {
             }
             startedAt: string
             finishedAt?: string
-            errorMessage?: string
+            error?: {
+              code: "internal.unexpected" | "runtime.cancelled"
+              message: string
+              retryable: boolean
+              at: string
+              /**
+               * Any JSON-compatible value.
+               */
+              details?:
+                | string
+                | number
+                | boolean
+                | Array<unknown>
+                | {
+                    [key: string]: unknown
+                  }
+                | null
+              truncated?: true
+            }
             identity: {
               projectionId: string
               datasetVersion: {
@@ -9090,7 +9252,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9119,7 +9299,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9149,7 +9347,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9190,7 +9406,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9219,7 +9453,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9249,7 +9501,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9291,7 +9561,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9320,7 +9608,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9350,7 +9656,25 @@ export type GetProjectionResponses = {
               }
               startedAt: string
               finishedAt?: string
-              errorMessage?: string
+              error?: {
+                code: "internal.unexpected" | "runtime.cancelled"
+                message: string
+                retryable: boolean
+                at: string
+                /**
+                 * Any JSON-compatible value.
+                 */
+                details?:
+                  | string
+                  | number
+                  | boolean
+                  | Array<unknown>
+                  | {
+                      [key: string]: unknown
+                    }
+                  | null
+                truncated?: true
+              }
               identity: {
                 projectionId: string
                 datasetVersion: {
@@ -9426,7 +9750,25 @@ export type ListProjectionRunsResponses = {
           }
           startedAt: string
           finishedAt?: string
-          errorMessage?: string
+          error?: {
+            code: "internal.unexpected" | "runtime.cancelled"
+            message: string
+            retryable: boolean
+            at: string
+            /**
+             * Any JSON-compatible value.
+             */
+            details?:
+              | string
+              | number
+              | boolean
+              | Array<unknown>
+              | {
+                  [key: string]: unknown
+                }
+              | null
+            truncated?: true
+          }
           identity: {
             projectionId: string
             datasetVersion: {
@@ -9455,7 +9797,25 @@ export type ListProjectionRunsResponses = {
           }
           startedAt: string
           finishedAt?: string
-          errorMessage?: string
+          error?: {
+            code: "internal.unexpected" | "runtime.cancelled"
+            message: string
+            retryable: boolean
+            at: string
+            /**
+             * Any JSON-compatible value.
+             */
+            details?:
+              | string
+              | number
+              | boolean
+              | Array<unknown>
+              | {
+                  [key: string]: unknown
+                }
+              | null
+            truncated?: true
+          }
           identity: {
             projectionId: string
             datasetVersion: {
@@ -9485,7 +9845,25 @@ export type ListProjectionRunsResponses = {
           }
           startedAt: string
           finishedAt?: string
-          errorMessage?: string
+          error?: {
+            code: "internal.unexpected" | "runtime.cancelled"
+            message: string
+            retryable: boolean
+            at: string
+            /**
+             * Any JSON-compatible value.
+             */
+            details?:
+              | string
+              | number
+              | boolean
+              | Array<unknown>
+              | {
+                  [key: string]: unknown
+                }
+              | null
+            truncated?: true
+          }
           identity: {
             projectionId: string
             datasetVersion: {
@@ -9560,7 +9938,25 @@ export type GetProjectionRunResponses = {
         }
         startedAt: string
         finishedAt?: string
-        errorMessage?: string
+        error?: {
+          code: "internal.unexpected" | "runtime.cancelled"
+          message: string
+          retryable: boolean
+          at: string
+          /**
+           * Any JSON-compatible value.
+           */
+          details?:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+          truncated?: true
+        }
         identity: {
           projectionId: string
           datasetVersion: {
@@ -9589,7 +9985,25 @@ export type GetProjectionRunResponses = {
         }
         startedAt: string
         finishedAt?: string
-        errorMessage?: string
+        error?: {
+          code: "internal.unexpected" | "runtime.cancelled"
+          message: string
+          retryable: boolean
+          at: string
+          /**
+           * Any JSON-compatible value.
+           */
+          details?:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+          truncated?: true
+        }
         identity: {
           projectionId: string
           datasetVersion: {
@@ -9619,7 +10033,25 @@ export type GetProjectionRunResponses = {
         }
         startedAt: string
         finishedAt?: string
-        errorMessage?: string
+        error?: {
+          code: "internal.unexpected" | "runtime.cancelled"
+          message: string
+          retryable: boolean
+          at: string
+          /**
+           * Any JSON-compatible value.
+           */
+          details?:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+          truncated?: true
+        }
         identity: {
           projectionId: string
           datasetVersion: {

--- a/packages/client/tests/projection-failure.types.ts
+++ b/packages/client/tests/projection-failure.types.ts
@@ -1,0 +1,38 @@
+import type {
+  GetProjectionResponses,
+  GetProjectionRunResponses,
+  ListProjectionRunsResponses,
+  ListProjectionsResponses,
+} from "../src/generated/types.gen"
+
+type LatestRun = NonNullable<
+  ListProjectionsResponses[200]["objectProjections"][number]["latestRun"]
+>
+type ProjectionLatestRun = NonNullable<GetProjectionResponses[200]["latestRun"]>
+type ListedRun = ListProjectionRunsResponses[200]["runs"][number]
+type DetailedRun = GetProjectionRunResponses[200]
+
+type LatestFailureCode = NonNullable<LatestRun["error"]>["code"]
+type ProjectionFailureCode = NonNullable<ProjectionLatestRun["error"]>["code"]
+type ListedFailureCode = NonNullable<ListedRun["error"]>["code"]
+type DetailedFailureCode = NonNullable<DetailedRun["error"]>["code"]
+
+const latestUnexpected: LatestFailureCode = "internal.unexpected"
+const projectionCancelled: ProjectionFailureCode = "runtime.cancelled"
+const listedUnexpected: ListedFailureCode = "internal.unexpected"
+const detailedCancelled: DetailedFailureCode = "runtime.cancelled"
+
+// Dataset lookup codes belong to HTTP route failures, not persisted projection-run failures.
+// @ts-expect-error the generated projection failure contract must stay scoped to its producer
+const unrelatedLatest: LatestFailureCode = "dataset.not_found"
+// @ts-expect-error projection run detail must expose the same closed failure scope
+const unrelatedDetailed: DetailedFailureCode = "dataset.not_found"
+
+void [
+  latestUnexpected,
+  projectionCancelled,
+  listedUnexpected,
+  detailedCancelled,
+  unrelatedLatest,
+  unrelatedDetailed,
+]

--- a/packages/core/src/materialization/model.ts
+++ b/packages/core/src/materialization/model.ts
@@ -1,7 +1,8 @@
+import type { SixbFailure } from "../errors/types"
 import type { EventActor, EventOrigin } from "../events/envelope"
 import type { PropertyChange, PropertyChangeMap } from "../events/property-changes"
 import type { JsonValue } from "../json"
-import type { ProjectionProtocolIdentity } from "../projections/types"
+import type { ProjectionProtocolIdentity, ProjectionRunFailureCode } from "../projections/types"
 
 export type { ProjectionProtocolIdentity } from "../projections/types"
 
@@ -177,6 +178,7 @@ interface ProjectionRunFinishBase {
   readonly source: ProjectionSourceRef
   readonly datasetVersion: PinnedDatasetVersion
   readonly execution: ProjectionExecution
+  readonly finishedAt?: Date
 }
 
 export type ProjectionRunTerminalDecision =
@@ -194,7 +196,7 @@ export type ProjectionRunTerminalDecision =
   | {
       readonly protocol: ProjectionProtocolIdentity["protocol"]
       readonly status: "failed" | "cancelled"
-      readonly errorMessage?: string
+      readonly error?: SixbFailure<ProjectionRunFailureCode>
       readonly inputExhausted?: never
     }
 

--- a/packages/core/src/materializer/projections/finish-run.ts
+++ b/packages/core/src/materializer/projections/finish-run.ts
@@ -67,7 +67,7 @@ function prepareProjectionRunFinish(
     input: { ...raw, source, datasetVersion, execution },
     identity,
     resolved,
-    finishedAt: context.clock(),
+    finishedAt: new Date(raw.finishedAt ?? context.clock()),
   }
 }
 
@@ -123,7 +123,7 @@ function terminalDecision(input: ProjectionRunFinishInput): ProjectionRunTermina
     return {
       protocol: input.protocol,
       status: input.status,
-      ...(input.errorMessage === undefined ? {} : { errorMessage: input.errorMessage }),
+      ...(input.error === undefined ? {} : { error: input.error }),
     }
   }
   if (input.protocol === "telemetry") {

--- a/packages/core/src/projections/types.ts
+++ b/packages/core/src/projections/types.ts
@@ -1,3 +1,13 @@
+import type { SixbErrorCode } from "../errors/types"
+
+/** Error codes a projection run can persist and expose through its public contract. */
+export const PROJECTION_RUN_FAILURE_CODES = [
+  "internal.unexpected",
+  "runtime.cancelled",
+] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
+
+export type ProjectionRunFailureCode = (typeof PROJECTION_RUN_FAILURE_CODES)[number]
+
 /**
  * Lowered, serializable definition interfaces for projection DSL.
  *

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -399,6 +399,7 @@ export type {
   ProjectionKind,
   ProjectionMissingTarget,
   ProjectionRunClaim,
+  ProjectionRunFailureCode,
   ProjectionRunProgress,
   ProjectionRunRecord,
   ProjectionRunStatus,
@@ -412,6 +413,7 @@ export type {
 } from "./projection-runs"
 export {
   InMemoryProjectionRunStorage,
+  PROJECTION_RUN_FAILURE_CODES,
   PROJECTION_RUN_PROGRESS_KEYS,
   ProjectionRunError,
   projectionRunObjectTypesVisible,

--- a/packages/core/src/storage/projection-runs/index.ts
+++ b/packages/core/src/storage/projection-runs/index.ts
@@ -18,6 +18,7 @@ export type {
   ProjectionMaterializationIdentity,
   ProjectionMissingTarget,
   ProjectionRunClaim,
+  ProjectionRunFailureCode,
   ProjectionRunProgress,
   ProjectionRunRecord,
   ProjectionRunStatus,
@@ -30,6 +31,7 @@ export type {
   UpdateProjectionRunInput,
 } from "./types"
 export {
+  PROJECTION_RUN_FAILURE_CODES,
   PROJECTION_RUN_PROGRESS_KEYS,
   projectionRunObjectTypesVisible,
   zeroProjectionRunProgress,

--- a/packages/core/src/storage/projection-runs/lifecycle.ts
+++ b/packages/core/src/storage/projection-runs/lifecycle.ts
@@ -1,8 +1,15 @@
+import { parseSixbFailure } from "../../errors/internal"
+import type { SixbFailure } from "../../errors/types"
 import type {
   ProjectionMaterializationIdentity,
   ProjectionRunTerminalDecision,
 } from "../../materialization/model"
-import type { ProjectionKind, ProjectionTarget } from "../../projections/types"
+import type {
+  ProjectionKind,
+  ProjectionRunFailureCode,
+  ProjectionTarget,
+} from "../../projections/types"
+import { PROJECTION_RUN_FAILURE_CODES } from "../../projections/types"
 import { ProjectionRunError } from "./errors"
 import type {
   AdvanceProjectionTelemetryCheckpointInput,
@@ -51,7 +58,7 @@ export interface PersistedProjectionRunRecord {
   readonly missingTargetBatchOrdinal?: number
   readonly missingTargetFirstSeenAt?: Date
   readonly progress: ProjectionRunProgress
-  readonly errorMessage?: string
+  readonly error?: unknown
 }
 
 export interface ProjectionTelemetryAdvance {
@@ -64,7 +71,7 @@ export interface ProjectionRunFinishPlan {
   readonly finishedAt: Date
   readonly progress: ProjectionRunProgress
   readonly inputExhausted?: true
-  readonly errorMessage?: string
+  readonly error?: SixbFailure<ProjectionRunFailureCode>
 }
 
 // ── Scalar and identity validation ──────────────────────────
@@ -353,9 +360,9 @@ export function planProjectionRunFinish(
     ...(input.status === "succeeded" && input.protocol === "telemetry"
       ? { inputExhausted: true as const }
       : {}),
-    ...(input.status === "succeeded" || input.errorMessage === undefined
+    ...(input.status === "succeeded" || input.error === undefined
       ? {}
-      : { errorMessage: input.errorMessage }),
+      : { error: parseSixbFailure(input.error, PROJECTION_RUN_FAILURE_CODES) }),
   }
 }
 
@@ -370,7 +377,7 @@ export function finishProjectionRunRecord(
     status: plan.status,
     finishedAt: plan.finishedAt,
     progress: plan.progress,
-    errorMessage: plan.errorMessage,
+    error: plan.error,
   }
   if (plan.inputExhausted) {
     const telemetry = requireTelemetryProjectionRun(record)
@@ -412,7 +419,10 @@ export function restoreProjectionRun(row: PersistedProjectionRunRecord): StoredP
     finishedAt: row.finishedAt ? new Date(row.finishedAt) : undefined,
     attempt: row.attempt,
     progress: { ...row.progress },
-    errorMessage: row.errorMessage,
+    error:
+      row.error === undefined
+        ? undefined
+        : parseSixbFailure(row.error, PROJECTION_RUN_FAILURE_CODES),
     executionToken: row.executionToken,
   }
 

--- a/packages/core/src/storage/projection-runs/types.ts
+++ b/packages/core/src/storage/projection-runs/types.ts
@@ -1,3 +1,4 @@
+import type { SixbFailure } from "../../errors/types"
 import type {
   PinnedDatasetVersion,
   ProjectionExecution,
@@ -8,8 +9,12 @@ import type {
   LinkProjectionTarget,
   ObjectProjectionTarget,
   ProjectionKind,
+  ProjectionRunFailureCode,
   ProjectionTarget,
 } from "../../projections/types"
+
+export type { ProjectionRunFailureCode } from "../../projections/types"
+export { PROJECTION_RUN_FAILURE_CODES } from "../../projections/types"
 
 export type ProjectionRunStatus = "running" | "succeeded" | "failed" | "cancelled"
 
@@ -68,7 +73,7 @@ interface ProjectionRunRecordBase {
   readonly progress: ProjectionRunProgress
   readonly startedAt: Date
   readonly finishedAt?: Date
-  readonly errorMessage?: string
+  readonly error?: SixbFailure<ProjectionRunFailureCode>
 }
 
 type ProjectionIdentity<TKind extends ProjectionKind> = Extract<

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -172,6 +172,7 @@ export type {
   ObjectProjectionTarget,
   ProjectionKind,
   ProjectionRunClaim,
+  ProjectionRunFailureCode,
   ProjectionRunProgress,
   ProjectionRunRecord,
   ProjectionRunStatus,
@@ -182,7 +183,7 @@ export type {
   TelemetryProjectionRunRecord,
   UpdateProjectionRunInput,
 } from "./projection-runs"
-export { ProjectionRunError } from "./projection-runs"
+export { PROJECTION_RUN_FAILURE_CODES, ProjectionRunError } from "./projection-runs"
 export type {
   ListActiveRuleStatesInput,
   ListActiveRuleStatesResult,

--- a/packages/core/src/testing/projection-run-storage-contract.ts
+++ b/packages/core/src/testing/projection-run-storage-contract.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
+import type { SixbFailure } from "../errors/types"
 import type { ProjectionMaterializationIdentity } from "../materialization/model"
-import type { ProjectionRunClaim, ProjectionRunStorage } from "../storage/projection-runs"
+import type {
+  ProjectionRunClaim,
+  ProjectionRunFailureCode,
+  ProjectionRunStorage,
+} from "../storage/projection-runs"
 
 export interface ProjectionRunStorageContractSuiteOptions<
   TStorage extends ProjectionRunStorage = ProjectionRunStorage,
@@ -13,6 +18,15 @@ export interface ProjectionRunStorageContractSuiteOptions<
 
 const projectId = "contract-project"
 const objectTarget = { objectTypeId: "Device" } as const
+
+const failure = {
+  code: "internal.unexpected",
+  message: "Projection failed",
+  retryable: false,
+  at: "2026-06-01T12:00:00.000Z",
+  details: { projectionId: "contract.devices", runId: "failed-run" },
+  causeChain: [{ name: "Error", message: "Source failure" }],
+} as const satisfies SixbFailure<ProjectionRunFailureCode>
 
 const replacementIdentity = {
   projectionId: "contract.devices",
@@ -342,6 +356,39 @@ export function runProjectionRunStorageContractSuite<TStorage extends Projection
         await expect(storage.lockForMaterialization(executionInput(claim))).rejects.toThrow(
           "already terminal"
         )
+      })
+    })
+
+    test("validates, detaches, and persists scoped failures", async () => {
+      await withStorage(async (storage) => {
+        const claim = await storage.startOrReclaim(replacementInput("failed-run"))
+        const finished = await storage.finish({
+          ...executionInput(claim),
+          protocol: "replacement",
+          status: "failed",
+          finishedAt: new Date(failure.at),
+          error: failure,
+        })
+
+        expect(finished).toMatchObject({
+          status: "failed",
+          finishedAt: new Date(failure.at),
+          error: failure,
+        })
+        expect(finished.error).not.toBe(failure)
+        await expect(storage.getById({ projectId, id: "failed-run" })).resolves.toMatchObject({
+          error: failure,
+        })
+
+        const invalid = await storage.startOrReclaim(replacementInput("invalid-failure-run"))
+        await expect(
+          storage.finish({
+            ...executionInput(invalid),
+            protocol: "replacement",
+            status: "failed",
+            error: { ...failure, code: "dataset.not_found" } as never,
+          })
+        ).rejects.toThrow("code is not allowed by this failure contract")
       })
     })
 

--- a/packages/core/src/testing/projection-run-storage-contract.ts
+++ b/packages/core/src/testing/projection-run-storage-contract.ts
@@ -25,7 +25,6 @@ const failure = {
   retryable: false,
   at: "2026-06-01T12:00:00.000Z",
   details: { projectionId: "contract.devices", runId: "failed-run" },
-  causeChain: [{ name: "Error", message: "Source failure" }],
 } as const satisfies SixbFailure<ProjectionRunFailureCode>
 
 const replacementIdentity = {

--- a/packages/create-sixb/template/app/page.tsx
+++ b/packages/create-sixb/template/app/page.tsx
@@ -162,7 +162,7 @@ export default function HomePage() {
   const epoch = satellite ? new Date(satellite.properties.elementEpoch) : null
   const stale = epoch ? now.getTime() - epoch.getTime() > 48 * 60 * 60 * 1_000 : false
   const error = failed
-    ? (projection?.errorMessage ??
+    ? (projection?.error?.message ??
       run?.error?.message ??
       (timedOut
         ? "The refresh did not finish within 30 seconds."

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -4,12 +4,13 @@ import {
   MaterializationValidationError,
   type ProjectionDefinition,
 } from "@sixb/core"
+import { toSixbFailure } from "@sixb/core/internal/errors"
 import {
   MaterializationObjectNotFoundError,
   type ProjectionRunTerminalDecision,
 } from "@sixb/core/internal/materialization"
 import { getOntologyMutationRuntime } from "@sixb/core/internal/runtime"
-import type { ProjectionRunRecord } from "@sixb/core/storage"
+import { PROJECTION_RUN_FAILURE_CODES, type ProjectionRunRecord } from "@sixb/core/storage"
 import { ProjectionWorkerPermanentError } from "./errors"
 import {
   assertProjectionJobId,
@@ -45,19 +46,11 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
     if (succeeded) return terminalResult(succeeded)
 
     if (isExplicitCancellation(error)) {
-      await finishProjection(input, execution, {
-        protocol: input.job.protocol,
-        status: "cancelled",
-        errorMessage: error.message,
-      })
+      await finishProjection(input, execution, projectionFailure(input, error, "cancelled"))
       throw error
     }
     if ((await isPermanentFailure(input, execution, error)) && !signal.aborted) {
-      await finishProjection(input, execution, {
-        protocol: input.job.protocol,
-        status: "failed",
-        errorMessage: errorMessage(error),
-      })
+      await finishProjection(input, execution, projectionFailure(input, error, "failed"))
       const run = await requireRun(input)
       input.onRunFailed?.(error, run)
     }
@@ -194,7 +187,7 @@ function replacementEntries(
 async function finishProjection(
   input: RunProjectionJobInput,
   execution: ClaimedProjectionExecution,
-  decision: ProjectionRunTerminalDecision
+  decision: ProjectionRunTerminalDecision & { readonly finishedAt?: Date }
 ): Promise<void> {
   const common = {
     source: { projectionId: input.job.projectionId },
@@ -205,6 +198,25 @@ async function finishProjection(
     ...common,
     ...decision,
   })
+}
+
+function projectionFailure(
+  input: RunProjectionJobInput,
+  error: unknown,
+  status: "failed" | "cancelled"
+): ProjectionRunTerminalDecision & { readonly finishedAt: Date } {
+  const finishedAt = new Date(input.now?.() ?? Date.now())
+  return {
+    protocol: input.job.protocol,
+    status,
+    finishedAt,
+    error: toSixbFailure(error, {
+      allowedCodes: PROJECTION_RUN_FAILURE_CODES,
+      fallbackCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+      at: finishedAt,
+      fallbackDetails: { projectionId: input.job.projectionId, runId: input.job.id },
+    }),
+  }
 }
 
 type ProjectionSuccessfulCompletion =
@@ -281,10 +293,6 @@ function isPermanentSyncFailure(error: unknown): boolean {
 
 function isExplicitCancellation(error: unknown): error is MaterializationCancellationError {
   return error instanceof MaterializationCancellationError
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
 }
 
 /**

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -3,14 +3,19 @@ import {
   MaterializationCancellationError,
   MaterializationValidationError,
   type ProjectionDefinition,
+  type SixbFailure,
 } from "@sixb/core"
-import { toSixbFailure } from "@sixb/core/internal/errors"
+import { captureSixbFailure } from "@sixb/core/internal/errors"
 import {
   MaterializationObjectNotFoundError,
   type ProjectionRunTerminalDecision,
 } from "@sixb/core/internal/materialization"
 import { getOntologyMutationRuntime } from "@sixb/core/internal/runtime"
-import { PROJECTION_RUN_FAILURE_CODES, type ProjectionRunRecord } from "@sixb/core/storage"
+import {
+  PROJECTION_RUN_FAILURE_CODES,
+  type ProjectionRunFailureCode,
+  type ProjectionRunRecord,
+} from "@sixb/core/storage"
 import { ProjectionWorkerPermanentError } from "./errors"
 import {
   assertProjectionJobId,
@@ -204,17 +209,21 @@ function projectionFailure(
   input: RunProjectionJobInput,
   error: unknown,
   status: "failed" | "cancelled"
-): ProjectionRunTerminalDecision & { readonly finishedAt: Date } {
+): ProjectionRunTerminalDecision & {
+  readonly status: "failed" | "cancelled"
+  readonly finishedAt: Date
+  readonly error: SixbFailure<ProjectionRunFailureCode>
+} {
   const finishedAt = new Date(input.now?.() ?? Date.now())
   return {
     protocol: input.job.protocol,
     status,
     finishedAt,
-    error: toSixbFailure(error, {
+    error: captureSixbFailure(error, {
       allowedCodes: PROJECTION_RUN_FAILURE_CODES,
-      fallbackCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+      defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+      details: { projectionId: input.job.projectionId, runId: input.job.id },
       at: finishedAt,
-      fallbackDetails: { projectionId: input.job.projectionId, runId: input.job.id },
     }),
   }
 }

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -2314,7 +2314,15 @@ describe("runProjectionJob", () => {
     expect(run?.status).toBe("failed")
     expect(run?.progress.sourceRowsRead).toBe(1)
     expect(run?.progress.sourceRowsSkipped).toBe(0)
-    expect(run?.errorMessage).toContain("must be one of")
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      message: expect.stringContaining("must be one of"),
+      details: {
+        projectionId: "device-proj",
+        runId: canonicalRunId("projrun-invalid-property"),
+      },
+    })
+    expect(run?.error?.at).toBe(run?.finishedAt?.toISOString())
   })
 
   test("normalizes int64 strings mapped to integer-like object properties", async () => {
@@ -2434,7 +2442,10 @@ describe("runProjectionJob", () => {
     expect(run?.status).toBe("failed")
     expect(run?.progress.sourceRowsRead).toBe(1)
     expect(run?.progress.sourceRowsSkipped).toBe(0)
-    expect(run?.errorMessage).toContain("cannot safely coerce")
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      message: expect.stringContaining("cannot safely coerce"),
+    })
   })
 
   test("materializes fileRef object properties from fileRef dataset columns", async () => {
@@ -2693,12 +2704,24 @@ describe("runProjectionJob", () => {
     ).rejects.toBe(cancellation)
 
     expect(failuresReported).toBe(0)
-    expect(
-      await deps.storage.projectionRuns.getById({
-        projectId: sixb.id,
-        id: canonicalRunId("projrun-explicit-cancellation"),
-      })
-    ).toMatchObject({ status: "cancelled", progress: { sourceRowsRead: 0 } })
+    const cancelledRun = await deps.storage.projectionRuns.getById({
+      projectId: sixb.id,
+      id: canonicalRunId("projrun-explicit-cancellation"),
+    })
+    expect(cancelledRun).toMatchObject({
+      status: "cancelled",
+      progress: { sourceRowsRead: 0 },
+      error: {
+        code: "runtime.cancelled",
+        message: expect.stringContaining("Cancelled by test."),
+        retryable: false,
+        details: {
+          projectionId: "room-proj",
+          runId: canonicalRunId("projrun-explicit-cancellation"),
+        },
+      },
+    })
+    expect(cancelledRun?.error?.at).toBe(cancelledRun?.finishedAt?.toISOString())
     expect(
       await deps.storage.ontology.commits.getByOrigin({
         projectId: sixb.id,
@@ -2867,7 +2890,10 @@ describe("runProjectionJob", () => {
     })
     expect(run?.status).toBe("failed")
     expect(run?.progress.sourceRowsRead).toBe(0)
-    expect(run?.errorMessage).toContain("Invalid unit")
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      message: expect.stringContaining("Invalid unit"),
+    })
 
     // The fixed physical batch is atomic: no prefix of it is committed.
     const history = await deps.storage.timeseries.getHistory({

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -2316,7 +2316,7 @@ describe("runProjectionJob", () => {
     expect(run?.progress.sourceRowsSkipped).toBe(0)
     expect(run?.error).toMatchObject({
       code: "internal.unexpected",
-      message: expect.stringContaining("must be one of"),
+      message: "An unexpected internal error occurred.",
       details: {
         projectionId: "device-proj",
         runId: canonicalRunId("projrun-invalid-property"),
@@ -2444,7 +2444,7 @@ describe("runProjectionJob", () => {
     expect(run?.progress.sourceRowsSkipped).toBe(0)
     expect(run?.error).toMatchObject({
       code: "internal.unexpected",
-      message: expect.stringContaining("cannot safely coerce"),
+      message: "An unexpected internal error occurred.",
     })
   })
 
@@ -2713,7 +2713,7 @@ describe("runProjectionJob", () => {
       progress: { sourceRowsRead: 0 },
       error: {
         code: "runtime.cancelled",
-        message: expect.stringContaining("Cancelled by test."),
+        message: "Execution was cancelled.",
         retryable: false,
         details: {
           projectionId: "room-proj",
@@ -2892,7 +2892,7 @@ describe("runProjectionJob", () => {
     expect(run?.progress.sourceRowsRead).toBe(0)
     expect(run?.error).toMatchObject({
       code: "internal.unexpected",
-      message: expect.stringContaining("Invalid unit"),
+      message: "An unexpected internal error occurred.",
     })
 
     // The fixed physical batch is atomic: no prefix of it is committed.

--- a/packages/projection-worker/tests/worker.test.ts
+++ b/packages/projection-worker/tests/worker.test.ts
@@ -220,7 +220,7 @@ describe("ProjectionWorker", () => {
       )
       expect(run?.error).toMatchObject({
         code: "internal.unexpected",
-        message: expect.stringContaining("room_id"),
+        message: "An unexpected internal error occurred.",
       })
 
       await waitFor(

--- a/packages/projection-worker/tests/worker.test.ts
+++ b/packages/projection-worker/tests/worker.test.ts
@@ -218,7 +218,10 @@ describe("ProjectionWorker", () => {
         () => projectionRunsStorage.getById({ projectId: sixb.id, id: runId }),
         (value) => value?.status === "failed"
       )
-      expect(run?.errorMessage).toContain("room_id")
+      expect(run?.error).toMatchObject({
+        code: "internal.unexpected",
+        message: expect.stringContaining("room_id"),
+      })
 
       await waitFor(
         async () => reports.length,

--- a/packages/server/src/routes/projections.ts
+++ b/packages/server/src/routes/projections.ts
@@ -38,7 +38,7 @@ function serializeProjectionRun(run: ProjectionRunRecord) {
     progress: run.progress,
     startedAt: toIsoString(run.startedAt),
     finishedAt: run.finishedAt ? toIsoString(run.finishedAt) : undefined,
-    errorMessage: run.errorMessage,
+    error: run.error,
   })
 }
 

--- a/packages/server/src/schemas/projections.ts
+++ b/packages/server/src/schemas/projections.ts
@@ -1,4 +1,10 @@
+import type { SixbFailure } from "@sixb/core"
+import { PROJECTION_RUN_FAILURE_CODES, type ProjectionRunFailureCode } from "@sixb/core/storage"
 import { z } from "zod"
+import { sixbFailureSchema } from "./common"
+
+const ProjectionRunFailureSchema: z.ZodType<SixbFailure<ProjectionRunFailureCode>> =
+  sixbFailureSchema(PROJECTION_RUN_FAILURE_CODES)
 
 export const ProjectionKindSchema = z.enum(["object", "link", "telemetry"])
 export const ProjectionRunStatusSchema = z.enum(["running", "succeeded", "failed", "cancelled"])
@@ -26,7 +32,7 @@ const ProjectionRunBaseSchema = z.object({
   }),
   startedAt: z.string(),
   finishedAt: z.string().optional(),
-  errorMessage: z.string().optional(),
+  error: ProjectionRunFailureSchema.optional(),
 })
 
 const ObjectProjectionRunSchema = ProjectionRunBaseSchema.extend({

--- a/packages/server/tests/projections-routes.test.ts
+++ b/packages/server/tests/projections-routes.test.ts
@@ -38,6 +38,14 @@ const sensorsProjection: ObjectProjectionDefinition = {
   links: {},
 }
 
+const projectionFailure = {
+  code: "internal.unexpected",
+  message: "Projection failed",
+  retryable: false,
+  at: "2026-05-04T09:01:00.000Z",
+  details: { projectionId: "rooms", runId: "run-1" },
+} as const
+
 function makeRun(
   input: {
     readonly run?: Partial<ObjectProjectionRunRecord>
@@ -157,7 +165,11 @@ describe("projection routes", () => {
     const sixb = createSixbStub({
       async list(input: ListProjectionRunsInput) {
         captured = input
-        return { runs: [makeRun()], hasMore: false, total: 1 }
+        return {
+          runs: [makeRun({ run: { status: "failed", error: projectionFailure } })],
+          hasMore: false,
+          total: 1,
+        }
       },
     })
 
@@ -169,9 +181,13 @@ describe("projection routes", () => {
     expect(captured?.objectTypeIds).toEqual(["room"])
     expect(captured?.projectionId).toBe("rooms")
 
-    const body = (await response.json()) as { runs: { id: string }[]; total: number }
+    const body = (await response.json()) as {
+      runs: { id: string; error?: typeof projectionFailure }[]
+      total: number
+    }
     expect(body.total).toBe(1)
     expect(body.runs[0]?.id).toBe("run-1")
+    expect(body.runs[0]?.error).toEqual(projectionFailure)
   })
 
   test("serializes only the public run schema even if a provider returns internal fields", async () => {

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -35,6 +35,9 @@ import workflowFailureRecordSql from "./migrations/013-workflow-failure-record.s
   type: "text",
 }
 import agentFailureRecordSql from "./migrations/014-agent-failure-record.sql" with { type: "text" }
+import projectionFailureRecordSql from "./migrations/015-projection-failure-record.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -302,6 +305,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("012-pipeline-failure-record", pipelineFailureRecordSql),
     pgSql("013-workflow-failure-record", workflowFailureRecordSql),
     pgSql("014-agent-failure-record", agentFailureRecordSql),
+    pgSql("015-projection-failure-record", projectionFailureRecordSql),
   ],
 })
 

--- a/storage/pg/src/migrations/001-initial-schema.sql
+++ b/storage/pg/src/migrations/001-initial-schema.sql
@@ -170,7 +170,7 @@ CREATE TABLE projection_runs (
   missing_target_first_seen_at TIMESTAMPTZ,
   source_rows_read BIGINT NOT NULL DEFAULT 0 CHECK (source_rows_read >= 0),
   source_rows_skipped BIGINT NOT NULL DEFAULT 0 CHECK (source_rows_skipped >= 0),
-  error JSONB,
+  error_message TEXT,
   PRIMARY KEY (project_id, id),
   CHECK (source_rows_skipped <= source_rows_read),
   CHECK ((status = 'running') = (finished_at IS NULL)),

--- a/storage/pg/src/migrations/001-initial-schema.sql
+++ b/storage/pg/src/migrations/001-initial-schema.sql
@@ -170,7 +170,7 @@ CREATE TABLE projection_runs (
   missing_target_first_seen_at TIMESTAMPTZ,
   source_rows_read BIGINT NOT NULL DEFAULT 0 CHECK (source_rows_read >= 0),
   source_rows_skipped BIGINT NOT NULL DEFAULT 0 CHECK (source_rows_skipped >= 0),
-  error_message TEXT,
+  error JSONB,
   PRIMARY KEY (project_id, id),
   CHECK (source_rows_skipped <= source_rows_read),
   CHECK ((status = 'running') = (finished_at IS NULL)),

--- a/storage/pg/src/migrations/015-projection-failure-record.sql
+++ b/storage/pg/src/migrations/015-projection-failure-record.sql
@@ -1,0 +1,20 @@
+ALTER TABLE projection_runs ADD COLUMN error JSONB;
+
+UPDATE projection_runs
+SET error = jsonb_build_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', false,
+  'at', to_char(COALESCE(finished_at, started_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'projectionId', projection_id,
+    'runId', id,
+    'migratedFromLegacyError', true
+  )
+)
+WHERE error_message IS NOT NULL;
+
+ALTER TABLE projection_runs DROP COLUMN error_message;

--- a/storage/pg/src/pg-projection-run-storage.ts
+++ b/storage/pg/src/pg-projection-run-storage.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto"
+import type { JsonValue } from "@sixb/core"
+import { serializeSixbFailure } from "@sixb/core/internal/errors"
 import {
   advanceProjectionTelemetry,
   assertGenericProgressDoesNotAdvanceTelemetry,
@@ -40,7 +42,7 @@ import type {
   TelemetryProjectionRunRecord,
   UpdateProjectionRunInput,
 } from "@sixb/core/storage"
-import { ProjectionRunError } from "@sixb/core/storage"
+import { PROJECTION_RUN_FAILURE_CODES, ProjectionRunError } from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import type { SQLClient, SqlParameter } from "./pg-client"
 import { lockAdvisoryKeys, type PgStoreClient, runPgTransaction } from "./transactions"
@@ -200,7 +202,7 @@ export class PgProjectionRunStorage implements ProjectionRunStorage {
           source_rows_read = ${plan.progress.sourceRowsRead},
           source_rows_skipped = ${plan.progress.sourceRowsSkipped},
           input_exhausted = ${plan.inputExhausted ?? existingRow.input_exhausted},
-          error_message = ${plan.errorMessage ?? null}
+          error = ${plan.error === undefined ? null : serializeSixbFailure(plan.error, PROJECTION_RUN_FAILURE_CODES)}::text::jsonb
         WHERE project_id = ${input.projectId}
           AND id = ${input.id}
           AND status = ${"running"}
@@ -470,7 +472,7 @@ function restoreProjectionRunRow(row: DatabaseRow): StoredProjectionRunRecord {
       sourceRowsRead: databaseSafeInteger(row.source_rows_read, "sourceRowsRead"),
       sourceRowsSkipped: databaseSafeInteger(row.source_rows_skipped, "sourceRowsSkipped"),
     },
-    errorMessage: row.error_message ?? undefined,
+    error: row.error ?? undefined,
   }
   return restoreProjectionRun(persisted)
 }
@@ -522,5 +524,5 @@ interface DatabaseRow {
   missing_target_first_seen_at: Date | string | null
   source_rows_read: number | string
   source_rows_skipped: number | string
-  error_message: string | null
+  error: JsonValue | null
 }

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -50,6 +50,7 @@ describe("Postgres storage migrations", () => {
             "012-pipeline-failure-record",
             "013-workflow-failure-record",
             "014-agent-failure-record",
+            "015-projection-failure-record",
           ],
         },
       ])
@@ -151,6 +152,13 @@ describe("Postgres storage migrations", () => {
           id: "014-agent-failure-record",
           status: "applied",
           version: 14,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "015-projection-failure-record",
+          status: "applied",
+          version: 15,
         },
       ])
     })
@@ -835,6 +843,13 @@ describe("Postgres storage migrations", () => {
           id: "014-agent-failure-record",
           status: "applied",
           version: 14,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "015-projection-failure-record",
+          status: "applied",
+          version: 15,
         },
       ])
     } finally {

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -385,6 +385,7 @@ describe("Postgres storage migrations", () => {
           "next_batch_ordinal",
           "next_row_offset",
           "input_exhausted",
+          "error",
         ])
       )
       expect(await readTableColumns(schemaName, "workflow_runs")).toEqual(

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -38,6 +38,9 @@ import workflowFailureRecordSql from "./migrations/013-workflow-failure-record.s
   type: "text",
 }
 import agentFailureRecordSql from "./migrations/014-agent-failure-record.sql" with { type: "text" }
+import projectionFailureRecordSql from "./migrations/015-projection-failure-record.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -72,6 +75,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("012-pipeline-failure-record", pipelineFailureRecordSql),
     sqliteSql("013-workflow-failure-record", workflowFailureRecordSql),
     sqliteSql("014-agent-failure-record", agentFailureRecordSql),
+    sqliteSql("015-projection-failure-record", projectionFailureRecordSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/001-initial-schema.sql
+++ b/storage/sqlite/src/migrations/001-initial-schema.sql
@@ -113,7 +113,7 @@ CREATE TABLE projection_runs (
   missing_target_first_seen_at TEXT,
   source_rows_read INTEGER NOT NULL DEFAULT 0 CHECK (source_rows_read >= 0),
   source_rows_skipped INTEGER NOT NULL DEFAULT 0 CHECK (source_rows_skipped >= 0),
-  error TEXT CHECK (error IS NULL OR json_valid(error)),
+  error_message TEXT,
   PRIMARY KEY (project_id, id),
   CHECK (source_rows_skipped <= source_rows_read),
   CHECK ((status = 'running') = (finished_at IS NULL)),

--- a/storage/sqlite/src/migrations/001-initial-schema.sql
+++ b/storage/sqlite/src/migrations/001-initial-schema.sql
@@ -113,7 +113,7 @@ CREATE TABLE projection_runs (
   missing_target_first_seen_at TEXT,
   source_rows_read INTEGER NOT NULL DEFAULT 0 CHECK (source_rows_read >= 0),
   source_rows_skipped INTEGER NOT NULL DEFAULT 0 CHECK (source_rows_skipped >= 0),
-  error_message TEXT,
+  error TEXT CHECK (error IS NULL OR json_valid(error)),
   PRIMARY KEY (project_id, id),
   CHECK (source_rows_skipped <= source_rows_read),
   CHECK ((status = 'running') = (finished_at IS NULL)),

--- a/storage/sqlite/src/migrations/015-projection-failure-record.sql
+++ b/storage/sqlite/src/migrations/015-projection-failure-record.sql
@@ -1,0 +1,20 @@
+ALTER TABLE projection_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE projection_runs
+SET error = json_object(
+  'code', CASE WHEN status = 'cancelled' THEN 'runtime.cancelled' ELSE 'internal.unexpected' END,
+  'message', CASE
+    WHEN status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json('false'),
+  'at', COALESCE(finished_at, started_at),
+  'details', json_object(
+    'projectionId', projection_id,
+    'runId', id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE error_message IS NOT NULL;
+
+ALTER TABLE projection_runs DROP COLUMN error_message;

--- a/storage/sqlite/src/projection-run-storage.ts
+++ b/storage/sqlite/src/projection-run-storage.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite"
 import { randomUUID } from "node:crypto"
+import { serializeSixbFailure } from "@sixb/core/internal/errors"
 import {
   advanceProjectionTelemetry,
   assertGenericProgressDoesNotAdvanceTelemetry,
@@ -41,7 +42,7 @@ import type {
   TelemetryProjectionRunRecord,
   UpdateProjectionRunInput,
 } from "@sixb/core/storage"
-import { ProjectionRunError } from "@sixb/core/storage"
+import { PROJECTION_RUN_FAILURE_CODES, ProjectionRunError } from "@sixb/core/storage"
 import { queryLatestRunsByOwnerId } from "./latest-run-query"
 import { installFreshSqliteSchema } from "./migrations"
 import {
@@ -221,7 +222,7 @@ export class SqliteProjectionRunStorage implements ProjectionRunStorage {
             source_rows_read = ?,
             source_rows_skipped = ?,
             input_exhausted = ?,
-            error_message = ?
+            error = ?
           WHERE project_id = ? AND id = ? AND status = 'running' AND execution_token = ?
         `
         )
@@ -231,7 +232,9 @@ export class SqliteProjectionRunStorage implements ProjectionRunStorage {
           plan.progress.sourceRowsRead,
           plan.progress.sourceRowsSkipped,
           plan.inputExhausted ? 1 : existingRow.input_exhausted,
-          plan.errorMessage ?? null,
+          plan.error === undefined
+            ? null
+            : serializeSixbFailure(plan.error, PROJECTION_RUN_FAILURE_CODES),
           input.projectId,
           input.id,
           input.executionToken
@@ -528,7 +531,7 @@ function restoreProjectionRunRow(row: DatabaseRow): StoredProjectionRunRecord {
       sourceRowsRead: databaseSafeInteger(row.source_rows_read, "sourceRowsRead"),
       sourceRowsSkipped: databaseSafeInteger(row.source_rows_skipped, "sourceRowsSkipped"),
     },
-    errorMessage: row.error_message ?? undefined,
+    error: row.error ?? undefined,
   }
   return restoreProjectionRun(persisted)
 }
@@ -588,5 +591,5 @@ interface DatabaseRow {
   missing_target_first_seen_at: string | null
   source_rows_read: number
   source_rows_skipped: number
-  error_message: string | null
+  error: string | null
 }

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -9,6 +9,7 @@ import { parseSixbFailure } from "@sixb/core/internal/errors"
 import {
   AGENT_RUN_FAILURE_CODES,
   PIPELINE_RUN_FAILURE_CODES,
+  PROJECTION_RUN_FAILURE_CODES,
   SYNC_RUN_FAILURE_CODES,
   WORKFLOW_RUN_FAILURE_CODES,
 } from "@sixb/core/storage"
@@ -120,6 +121,13 @@ const expectedStorageMigrationRows = [
     id: "014-agent-failure-record",
     status: "applied",
     version: 14,
+  },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "015-projection-failure-record",
+    status: "applied",
+    version: 15,
   },
 ]
 
@@ -294,6 +302,17 @@ describe("SQLite storage migrations", () => {
           'message-legacy', 'failed', 'secret Agent diagnostic',
           '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z'
         );
+
+        INSERT INTO projection_runs (
+          project_id, id, projection_id, projection_kind, materialization_protocol, dataset_id,
+          dataset_version_id, dataset_version_created_at, ontology_revision, projection_revision,
+          ownership_hash, object_type_id, status, started_at, finished_at, attempt, error_message
+        ) VALUES (
+          'project-a', 'projection-legacy', 'orders', 'object', 'replacement', 'orders', 'version-1',
+          '2026-08-10T11:00:00.000Z', 'ontology-1', 'projection-1', 'ownership-1', 'Order',
+          'failed', '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z', 1,
+          'secret projection diagnostic'
+        );
       `)
 
       for (const migration of sqliteStorageMigrations.steps.slice(10)) migration.up(db)
@@ -404,6 +423,23 @@ describe("SQLite storage migrations", () => {
         },
       })
       expect(JSON.stringify(agentNodeFailure)).not.toContain("secret workflow Agent diagnostic")
+
+      const projectionRow = db
+        .query("SELECT error FROM projection_runs WHERE project_id = ? AND id = ?")
+        .get("project-a", "projection-legacy") as { readonly error: string }
+      const projectionFailure = parseSixbFailure(projectionRow.error, PROJECTION_RUN_FAILURE_CODES)
+      expect(projectionFailure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: "2026-08-10T12:01:00.000Z",
+        details: {
+          projectionId: "orders",
+          runId: "projection-legacy",
+          migratedFromLegacyError: true,
+        },
+      })
+      expect(JSON.stringify(projectionFailure)).not.toContain("secret projection diagnostic")
     } finally {
       db.close()
     }

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -716,6 +716,7 @@ describe("SQLite storage migrations", () => {
           "next_batch_ordinal",
           "next_row_offset",
           "input_exhausted",
+          "error",
         ])
       )
     } finally {


### PR DESCRIPTION
## Summary

- replace projection run errorMessage strings with a scoped, portable SixbFailure record
- normalize worker failures once with internal.unexpected or runtime.cancelled while preserving onRunFailed behavior
- validate and detach failures at storage boundaries, persist them as validated JSON in SQLite and JSONB in PostgreSQL
- expose the same closed contract through OpenAPI and the generated client
- render projection failures through the shared Atlas failure summary

## Design decisions

The projection failure scope lives in the projection contract shared by materialization and storage. This keeps the type precise without introducing a materialization/storage dependency cycle or a new abstraction just for two codes.

The worker records one timestamp for both the failure occurrence and terminal run completion. Storage providers validate the full snapshot before persistence, including the code policy and serialized details.

The internal projection worker error classes remain control-flow implementation details. Only the serializable failure record crosses storage and HTTP boundaries.

## Verification

- global typecheck
- global build
- formatting and static checks
- publish smoke test across 47 packages
- projection Core and worker tests
- server projection route tests
- SQLite projection storage contract and migrations
- PostgreSQL projection storage contract and migrations
- generated client scope type tests

Part of #274.

Stacked on #320.