### PR TITLE
sqlite: keep materialization batch lookups indexed

### DIFF
--- a/storage/sqlite/src/ontology-storage/materialization-state.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-state.ts
@@ -142,33 +142,44 @@ export class SqliteMaterializationStateReader {
         json_extract(value, '$.primaryId') AS primary_id
       FROM json_each(?)
     `
+    // Keep the JSON request set on the outer side of each lookup. SQLite cannot estimate the
+    // cardinality of json_each() and otherwise scans every project row once per requested key.
+    // CROSS JOIN deliberately fixes the loop order so the existing composite indexes are used.
     const effectiveRows = this.db
       .query(
         `WITH requested AS (${requestedObjects})
-         SELECT objects.* FROM objects
-         JOIN requested USING (object_type_id, primary_id)
-         WHERE objects.project_id = ?`
+         SELECT objects.* FROM requested
+         CROSS JOIN objects
+           ON objects.project_id = ?
+          AND objects.object_type_id = requested.object_type_id
+          AND objects.primary_id = requested.primary_id`
       )
       .all(requested, this.projectId) as EffectiveObjectRow[]
     const sourceRows = this.db
       .query(
         `WITH requested AS (${requestedObjects})
-         SELECT rows.* FROM ontology_source_rows AS rows
-         JOIN requested USING (object_type_id, primary_id)
+         SELECT rows.* FROM requested
+         CROSS JOIN ontology_source_rows AS rows
+           ON rows.project_id = ?
+          AND rows.entity_kind = 'object'
+          AND rows.object_type_id = requested.object_type_id
+          AND rows.primary_id = requested.primary_id
          JOIN ontology_sources AS sources
            ON sources.project_id = rows.project_id
           AND sources.source_id = rows.source_id
           AND sources.materialization_id = rows.materialization_id
-         WHERE rows.project_id = ? AND rows.entity_kind = 'object'
-           AND sources.status = 'active'`
+         WHERE sources.status = 'active'`
       )
       .all(requested, this.projectId) as SqliteOntologySourceAssertionRow[]
     const overrideRows = this.db
       .query(
         `WITH requested AS (${requestedObjects})
-         SELECT overrides.* FROM ontology_overrides AS overrides
-         JOIN requested USING (object_type_id, primary_id)
-         WHERE overrides.project_id = ? AND overrides.entity_kind = 'object'`
+         SELECT overrides.* FROM requested
+         CROSS JOIN ontology_overrides AS overrides
+           ON overrides.project_id = ?
+          AND overrides.entity_kind = 'object'
+          AND overrides.object_type_id = requested.object_type_id
+          AND overrides.primary_id = requested.primary_id`
       )
       .all(requested, this.projectId) as ObjectOverrideRow[]
     const telemetryRows = this.db
@@ -180,11 +191,11 @@ export class SqliteMaterializationStateReader {
                  timeseries.property_id
                ORDER BY timeseries.at DESC
              ) AS rank
-           FROM timeseries
-           JOIN requested
-             ON requested.object_type_id = timeseries.object_type_id
-            AND requested.primary_id = timeseries.object_id
-           WHERE timeseries.project_id = ?
+           FROM requested
+           CROSS JOIN timeseries
+             ON timeseries.project_id = ?
+            AND timeseries.object_type_id = requested.object_type_id
+            AND timeseries.object_id = requested.primary_id
          )
          SELECT * FROM ranked WHERE rank = 1`
       )
@@ -261,34 +272,47 @@ export class SqliteMaterializationStateReader {
     const effectiveRows = this.db
       .query(
         `WITH requested AS (${effectiveRequest})
-         SELECT links.* FROM links
-         JOIN requested USING (source_type_id, source_id, link_id, target_type_id, target_id)
-         WHERE links.project_id = ?`
+         SELECT links.* FROM requested
+         CROSS JOIN links
+           ON links.project_id = ?
+          AND links.source_type_id = requested.source_type_id
+          AND links.source_id = requested.source_id
+          AND links.link_id = requested.link_id
+          AND links.target_type_id = requested.target_type_id
+          AND links.target_id = requested.target_id`
       )
       .all(requested, this.projectId) as EffectiveLinkRow[]
     const sourceRows = this.db
       .query(
         `WITH requested AS (${sourceRequest})
-         SELECT rows.* FROM ontology_source_rows AS rows
-         JOIN requested USING (
-           source_type_id, source_primary_id, link_id, target_type_id, target_primary_id
-         )
+         SELECT rows.* FROM requested
+         CROSS JOIN ontology_source_rows AS rows
+           ON rows.project_id = ?
+          AND rows.entity_kind = 'link'
+          AND rows.source_type_id = requested.source_type_id
+          AND rows.source_primary_id = requested.source_primary_id
+          AND rows.link_id = requested.link_id
+          AND rows.target_type_id = requested.target_type_id
+          AND rows.target_primary_id = requested.target_primary_id
          JOIN ontology_sources AS sources
            ON sources.project_id = rows.project_id
           AND sources.source_id = rows.source_id
           AND sources.materialization_id = rows.materialization_id
-         WHERE rows.project_id = ? AND rows.entity_kind = 'link'
-           AND sources.status = 'active'`
+         WHERE sources.status = 'active'`
       )
       .all(requested, this.projectId) as SqliteOntologySourceAssertionRow[]
     const overrideRows = this.db
       .query(
         `WITH requested AS (${sourceRequest})
-         SELECT overrides.* FROM ontology_overrides AS overrides
-         JOIN requested USING (
-           source_type_id, source_primary_id, link_id, target_type_id, target_primary_id
-         )
-         WHERE overrides.project_id = ? AND overrides.entity_kind = 'link'`
+         SELECT overrides.* FROM requested
+         CROSS JOIN ontology_overrides AS overrides
+           ON overrides.project_id = ?
+          AND overrides.entity_kind = 'link'
+          AND overrides.source_type_id = requested.source_type_id
+          AND overrides.source_primary_id = requested.source_primary_id
+          AND overrides.link_id = requested.link_id
+          AND overrides.target_type_id = requested.target_type_id
+          AND overrides.target_primary_id = requested.target_primary_id`
       )
       .all(requested, this.projectId) as LinkOverrideRow[]
     const effective = new Map(
@@ -337,9 +361,13 @@ export class SqliteMaterializationStateReader {
              json_extract(value, '$.at') AS at
            FROM json_each(?)
          )
-         SELECT timeseries.* FROM timeseries
-         JOIN requested USING (object_type_id, object_id, property_id, at)
-         WHERE timeseries.project_id = ?`
+         SELECT timeseries.* FROM requested
+         CROSS JOIN timeseries
+           ON timeseries.project_id = ?
+          AND timeseries.object_type_id = requested.object_type_id
+          AND timeseries.object_id = requested.object_id
+          AND timeseries.property_id = requested.property_id
+          AND timeseries.at = requested.at`
       )
       .all(requested, this.projectId) as TelemetryRow[]
     const found = new Map(
@@ -382,9 +410,12 @@ export class SqliteMaterializationStateReader {
             FROM json_each(?)
           )
           SELECT requested.scope_sort_key, links.*
-          FROM links
-          JOIN requested USING (source_type_id, source_id, link_id)
-          WHERE links.project_id = ?
+          FROM requested
+          CROSS JOIN links
+            ON links.project_id = ?
+           AND links.source_type_id = requested.source_type_id
+           AND links.source_id = requested.source_id
+           AND links.link_id = requested.link_id
           ORDER BY requested.scope_sort_key, ${linkSortExpression("links")}
         `
       )
@@ -610,22 +641,30 @@ export class SqliteMaterializationStateReader {
     if (materializationIds.length === 0 || refs.length === 0) {
       return { owned: new Set(), byMaterialization: new Map() }
     }
-    const requestedKeys = canonicalJson(refs.map((ref) => projectionEntityKey(ref)))
+    const requestedEntities = canonicalJson(
+      refs.map((ref) => ({ entityKind: ref.kind, entityKey: projectionEntityKey(ref) }))
+    )
     const requestedMaterializations = canonicalJson([...new Set(materializationIds)])
     const rows = this.db
       .query(
         `WITH requested_entities AS (
-           SELECT value AS entity_key FROM json_each(?)
+           SELECT DISTINCT json_extract(value, '$.entityKind') AS entity_kind,
+             json_extract(value, '$.entityKey') AS entity_key
+           FROM json_each(?)
          ), requested_materializations AS (
            SELECT value AS materialization_id FROM json_each(?)
          )
-         SELECT rows.* FROM ontology_source_rows AS rows
-         JOIN requested_entities USING (entity_key)
-         JOIN requested_materializations USING (materialization_id)
-         WHERE rows.project_id = ? AND rows.source_id = ?`
+         SELECT rows.* FROM requested_materializations
+         CROSS JOIN requested_entities
+         CROSS JOIN ontology_source_rows AS rows
+           ON rows.project_id = ?
+          AND rows.source_id = ?
+          AND rows.materialization_id = requested_materializations.materialization_id
+          AND rows.entity_kind = requested_entities.entity_kind
+          AND rows.entity_key = requested_entities.entity_key`
       )
       .all(
-        requestedKeys,
+        requestedEntities,
         requestedMaterializations,
         this.projectId,
         sourceId

--- a/storage/sqlite/tests/sqlite-materialization-query-plan.test.ts
+++ b/storage/sqlite/tests/sqlite-materialization-query-plan.test.ts
@@ -1,0 +1,221 @@
+import { Database, type SQLQueryBindings } from "bun:sqlite"
+import { describe, expect, test } from "bun:test"
+import type { OntologyLinkRef, OntologyObjectRef } from "@sixb/core/internal/materialization"
+import { installFreshSqliteSchema } from "../src/migrations"
+import { SqliteMaterializationStateReader } from "../src/ontology-storage/materialization-state"
+
+interface RecordedQuery {
+  readonly sql: string
+  readonly bindings: readonly SQLQueryBindings[]
+}
+
+interface QueryPlanRow {
+  readonly detail: string
+}
+
+const projectId = "query-plan-project"
+const objectRef: OntologyObjectRef = { objectTypeId: "Employee", primaryId: "employee-1" }
+const linkRef: OntologyLinkRef = {
+  source: objectRef,
+  linkId: "timecards",
+  target: { objectTypeId: "Timecard", primaryId: "timecard-1" },
+}
+
+describe("SQLite materialization query plans", () => {
+  // Regression proof: replacing the requested-first CROSS JOINs with reorderable JOINs makes
+  // SQLite search the project tables on project_id alone, and these assertions fail.
+  test("object state batches drive indexed lookups from the requested objects", () => {
+    withRecordedReader(({ db, reader, recorded }) => {
+      reader.objectStates([objectRef])
+
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "SELECT objects.* FROM requested"),
+        "SEARCH objects",
+        ["project_id=?", "object_type_id=?", "primary_id=?"]
+      )
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "CROSS JOIN ontology_source_rows AS rows", "'object'"),
+        "SEARCH rows",
+        ["project_id=?", "object_type_id=?", "primary_id=?"]
+      )
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "SELECT overrides.* FROM requested", "'object'"),
+        "SEARCH overrides",
+        ["project_id=?", "object_type_id=?", "primary_id=?"]
+      )
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "ROW_NUMBER() OVER", "CROSS JOIN timeseries"),
+        "SEARCH timeseries",
+        ["project_id=?", "object_type_id=?", "object_id=?"]
+      )
+    })
+  })
+
+  test("link state batches drive indexed lookups from the requested links", () => {
+    withRecordedReader(({ db, reader, recorded }) => {
+      reader.linkStates([linkRef])
+
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "SELECT links.* FROM requested"),
+        "SEARCH links",
+        [
+          "project_id=?",
+          "source_type_id=?",
+          "source_id=?",
+          "link_id=?",
+          "target_type_id=?",
+          "target_id=?",
+        ]
+      )
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "CROSS JOIN ontology_source_rows AS rows", "'link'"),
+        "SEARCH rows",
+        [
+          "project_id=?",
+          "source_type_id=?",
+          "source_primary_id=?",
+          "link_id=?",
+          "target_type_id=?",
+          "target_primary_id=?",
+        ]
+      )
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "SELECT overrides.* FROM requested", "'link'"),
+        "SEARCH overrides",
+        [
+          "project_id=?",
+          "source_type_id=?",
+          "source_primary_id=?",
+          "link_id=?",
+          "target_type_id=?",
+          "target_primary_id=?",
+        ]
+      )
+    })
+  })
+
+  test("point and link-scope batches use their complete lookup keys", () => {
+    withRecordedReader(({ db, reader, recorded }) => {
+      reader.exactPoints([
+        {
+          series: { object: objectRef, propertyId: "workedMinutes" },
+          at: "2026-08-06T00:00:00.000Z",
+        },
+      ])
+      reader.linkScopes([{ source: objectRef, linkId: "timecards" }])
+
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "SELECT timeseries.* FROM requested"),
+        "SEARCH timeseries",
+        ["project_id=?", "object_type_id=?", "object_id=?", "property_id=?", "at=?"]
+      )
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "SELECT requested.scope_sort_key, links.*"),
+        "SEARCH links",
+        ["project_id=?", "source_type_id=?", "source_id=?", "link_id=?"]
+      )
+    })
+  })
+
+  test("replacement source batches use entity kind and the full primary key", () => {
+    withRecordedReader(({ db, reader, recorded }) => {
+      reader.replacementObjectStates("employees", "materialization-1", [objectRef])
+
+      expectRequestedFirstLookup(
+        db,
+        findRecorded(recorded, "requested_materializations", "SELECT rows.*"),
+        "SEARCH rows",
+        ["project_id=?", "source_id=?", "materialization_id=?", "entity_kind=?", "entity_key=?"]
+      )
+    })
+  })
+})
+
+function withRecordedReader(
+  run: (input: {
+    readonly db: Database
+    readonly reader: SqliteMaterializationStateReader
+    readonly recorded: readonly RecordedQuery[]
+  }) => void
+): void {
+  const db = new Database(":memory:")
+  installFreshSqliteSchema(db)
+  const recorded: RecordedQuery[] = []
+  const reader = new SqliteMaterializationStateReader(recordingDatabase(db, recorded), projectId)
+  try {
+    run({ db, reader, recorded })
+  } finally {
+    db.close()
+  }
+}
+
+function recordingDatabase(db: Database, recorded: RecordedQuery[]): Database {
+  return new Proxy(db, {
+    get(target, property) {
+      if (property === "query") {
+        return (sql: string) => {
+          const statement = target.query(sql)
+          return new Proxy(statement, {
+            get(statementTarget, statementProperty) {
+              if (statementProperty === "all") {
+                return (...bindings: SQLQueryBindings[]) => {
+                  recorded.push({ sql, bindings })
+                  return statementTarget.all(...bindings)
+                }
+              }
+              if (statementProperty === "iterate") {
+                return (...bindings: SQLQueryBindings[]) => {
+                  recorded.push({ sql, bindings })
+                  return statementTarget.iterate(...bindings)
+                }
+              }
+              const value = Reflect.get(statementTarget, statementProperty, statementTarget)
+              return typeof value === "function" ? value.bind(statementTarget) : value
+            },
+          })
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === "function" ? value.bind(target) : value
+    },
+  })
+}
+
+function findRecorded(
+  recorded: readonly RecordedQuery[],
+  ...fragments: readonly string[]
+): RecordedQuery {
+  const match = recorded.find(({ sql }) => fragments.every((fragment) => sql.includes(fragment)))
+  expect(match).toBeDefined()
+  return match!
+}
+
+function expectRequestedFirstLookup(
+  db: Database,
+  query: RecordedQuery,
+  searchPrefix: string,
+  keyFragments: readonly string[]
+): void {
+  const plan = db
+    .query<QueryPlanRow, SQLQueryBindings[]>(`EXPLAIN QUERY PLAN ${query.sql}`)
+    .all(...query.bindings)
+  const lookupIndex = plan.findIndex(({ detail }) => detail.startsWith(searchPrefix))
+  const requestedIndex = plan.findIndex(
+    ({ detail }) => detail === "SCAN requested" || detail.startsWith("SCAN json_each")
+  )
+
+  expect(requestedIndex).toBeGreaterThanOrEqual(0)
+  expect(lookupIndex).toBeGreaterThan(requestedIndex)
+  for (const fragment of keyFragments) {
+    expect(plan[lookupIndex]?.detail).toContain(fragment)
+  }
+}


### PR DESCRIPTION
## Why

Large SQLite ontology projections become CPU-bound because SQLite may reorder joins against `json_each()` and scan project rows before filtering requested keys. On a 3,274-row workload, link batches took about 12 seconds and the materialization about 70 seconds.

## What changed

- Keep requested keys as the outer loop with SQLite `CROSS JOIN`.
- Apply the indexed lookup shape to objects, links, provenance, overrides, telemetry, and link scopes.
- Include `entity_kind` in replacement-source lookups to use the full primary key.
- Add `EXPLAIN QUERY PLAN` regression tests.

No schema migration or API change.

## Result

| Reader batch | Before | After |
|---|---:|---:|
| 1,000 objects | 3.7–4.2 s | 11–80 ms |
| 1,000 links | 11.6–12.1 s | 13–70 ms |

Measured against a production-shaped SQLite database in read-only mode.

## Validation

- `bun --filter @sixb/sqlite test` — 187 passed
- `bun run check`
