### PR TITLE
webhooks: persist portable failure records

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -29,7 +29,7 @@ interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
 }
 ```
 
-Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, pipeline step runs, workflow runs, workflow node runs, agent executions (conversation or workflow-owned), and projection runs currently declare `internal.unexpected | runtime.cancelled`.
+Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, pipeline step runs, workflow runs, workflow node runs, agent executions (conversation or workflow-owned), and projection runs currently declare `internal.unexpected | runtime.cancelled`. Webhook runs declare only `internal.unexpected`: their lifecycle has no cancellation state, while expected delivery outcomes remain represented by their HTTP status and delivery claim result.
 
 Other run primitives keep their legacy error shape until their own vertical migration. This keeps
 each storage and wire change independently reviewable.

--- a/packages/atlas/src/pages/ConnectorsPage.tsx
+++ b/packages/atlas/src/pages/ConnectorsPage.tsx
@@ -41,6 +41,7 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import {
   isUnconfiguredStorageError,
   UnrecordedHistoryState,
@@ -344,7 +345,7 @@ function WebhookRunCard({ run }: { run: WebhookRun }) {
           {formatClaimResult(run.deliveryClaimResult)} · {run.idempotencyKey}
         </p>
       )}
-      {run.error && <p className="mt-3 break-words text-xs text-destructive">{run.error}</p>}
+      {run.error && <SixbFailureSummary failure={run.error} className="mt-3 text-xs" />}
     </div>
   )
 }
@@ -393,9 +394,11 @@ function WebhookRunsList({ runs }: { runs: WebhookRun[] }) {
                       {run.id}
                     </p>
                     {run.error && (
-                      <p className="mt-1 max-w-[260px] break-words text-xs text-destructive">
-                        {run.error}
-                      </p>
+                      <SixbFailureSummary
+                        failure={run.error}
+                        className="mt-1 max-w-[260px] text-xs"
+                        truncateMessage
+                      />
                     )}
                   </div>
                 </TableCell>

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -29559,7 +29559,53 @@
                             "enum": ["claimed", "duplicate", "in_progress"]
                           },
                           "error": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                              "code": {
+                                "type": "string",
+                                "enum": ["internal.unexpected"]
+                              },
+                              "message": {
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "description": "Any JSON-compatible value.",
+                                "nullable": true,
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {}
+                                  },
+                                  {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  }
+                                ]
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
+                              }
+                            },
+                            "required": ["code", "message", "retryable", "at"],
+                            "additionalProperties": false
                           }
                         },
                         "required": [

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -10126,7 +10126,25 @@ export type ListWebhookRunsResponses = {
       responseStatus?: number
       idempotencyKey?: string
       deliveryClaimResult?: "claimed" | "duplicate" | "in_progress"
-      error?: string
+      error?: {
+        code: "internal.unexpected"
+        message: string
+        retryable: boolean
+        at: string
+        /**
+         * Any JSON-compatible value.
+         */
+        details?:
+          | string
+          | number
+          | boolean
+          | Array<unknown>
+          | {
+              [key: string]: unknown
+            }
+          | null
+        truncated?: true
+      }
     }>
     hasMore: boolean
     total: number

--- a/packages/client/tests/webhook-failure.types.ts
+++ b/packages/client/tests/webhook-failure.types.ts
@@ -1,0 +1,14 @@
+import type { ListWebhookRunsResponses } from "../src/generated/types.gen"
+
+type WebhookRun = ListWebhookRunsResponses[200]["runs"][number]
+type WebhookRunFailureCode = NonNullable<WebhookRun["error"]>["code"]
+
+const unexpected: WebhookRunFailureCode = "internal.unexpected"
+
+// Webhook runs have no cancellation state, so cancellation is not part of their failure contract.
+// @ts-expect-error the generated webhook failure contract must stay scoped to its lifecycle
+const cancelled: WebhookRunFailureCode = "runtime.cancelled"
+// @ts-expect-error HTTP route failures do not belong to persisted webhook-run failures
+const unrelated: WebhookRunFailureCode = "dataset.not_found"
+
+void [unexpected, cancelled, unrelated]

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -473,11 +473,16 @@ export type {
   ListWebhookRunsInput,
   ListWebhookRunsResult,
   StartWebhookRunInput,
+  WebhookRunFailureCode,
   WebhookRunRecord,
   WebhookRunStatus,
   WebhookRunStorage,
 } from "./webhook-runs"
-export { InMemoryWebhookRunStorage, WebhookRunError } from "./webhook-runs"
+export {
+  InMemoryWebhookRunStorage,
+  WEBHOOK_RUN_FAILURE_CODES,
+  WebhookRunError,
+} from "./webhook-runs"
 export type {
   CancelWorkflowInterventionInput,
   CreateWorkflowInterventionInput,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -223,11 +223,12 @@ export type {
   ListWebhookRunsInput,
   ListWebhookRunsResult,
   StartWebhookRunInput,
+  WebhookRunFailureCode,
   WebhookRunRecord,
   WebhookRunStatus,
   WebhookRunStorage,
 } from "./webhook-runs"
-export { WebhookRunError } from "./webhook-runs"
+export { WEBHOOK_RUN_FAILURE_CODES, WebhookRunError } from "./webhook-runs"
 export type {
   CancelWorkflowInterventionInput,
   CreateWorkflowInterventionInput,

--- a/packages/core/src/storage/webhook-runs/in-memory.ts
+++ b/packages/core/src/storage/webhook-runs/in-memory.ts
@@ -1,3 +1,4 @@
+import { parseSixbFailure } from "../../errors/internal"
 import {
   cloneRecord,
   compareStartedAt,
@@ -16,6 +17,7 @@ import type {
   WebhookRunRecord,
   WebhookRunStorage,
 } from "./types"
+import { WEBHOOK_RUN_FAILURE_CODES } from "./types"
 
 export class InMemoryWebhookRunStorage implements WebhookRunStorage {
   private readonly runs = new Map<string, WebhookRunRecord>()
@@ -64,7 +66,10 @@ export class InMemoryWebhookRunStorage implements WebhookRunStorage {
       responseStatus: input.responseStatus,
       idempotencyKey: input.idempotencyKey,
       deliveryClaimResult: input.deliveryClaimResult,
-      error: input.status === "succeeded" ? undefined : input.error,
+      error:
+        input.status === "failed"
+          ? parseSixbFailure(input.error, WEBHOOK_RUN_FAILURE_CODES)
+          : undefined,
     }
 
     this.runs.set(storageKey(input.projectId, input.id), cloneRecord(next))

--- a/packages/core/src/storage/webhook-runs/index.ts
+++ b/packages/core/src/storage/webhook-runs/index.ts
@@ -6,7 +6,9 @@ export type {
   ListWebhookRunsInput,
   ListWebhookRunsResult,
   StartWebhookRunInput,
+  WebhookRunFailureCode,
   WebhookRunRecord,
   WebhookRunStatus,
   WebhookRunStorage,
 } from "./types"
+export { WEBHOOK_RUN_FAILURE_CODES } from "./types"

--- a/packages/core/src/storage/webhook-runs/types.ts
+++ b/packages/core/src/storage/webhook-runs/types.ts
@@ -1,7 +1,16 @@
+import type { SixbErrorCode, SixbFailure } from "../../errors/types"
 import type { WebhookDeliveryClaimResult } from "../webhook-deliveries"
 
 export type WebhookRunStatus = "running" | "succeeded" | "failed" | "skipped"
 export type FinishWebhookRunStatus = Exclude<WebhookRunStatus, "running">
+
+/** Error codes a webhook run can persist and expose through its public contract. */
+export const WEBHOOK_RUN_FAILURE_CODES = ["internal.unexpected"] as const satisfies readonly [
+  SixbErrorCode,
+  ...SixbErrorCode[],
+]
+
+export type WebhookRunFailureCode = (typeof WEBHOOK_RUN_FAILURE_CODES)[number]
 
 export interface WebhookRunRecord {
   readonly id: string
@@ -17,7 +26,7 @@ export interface WebhookRunRecord {
   readonly responseStatus?: number
   readonly idempotencyKey?: string
   readonly deliveryClaimResult?: WebhookDeliveryClaimResult
-  readonly error?: string
+  readonly error?: SixbFailure<WebhookRunFailureCode>
 }
 
 export interface StartWebhookRunInput {
@@ -30,17 +39,27 @@ export interface StartWebhookRunInput {
   readonly startedAt?: Date
 }
 
-export interface FinishWebhookRunInput {
+interface FinishWebhookRunBaseInput {
   readonly id: string
   readonly projectId: string
-  readonly status: FinishWebhookRunStatus
   readonly finishedAt?: Date
   readonly requestBodyBytes?: number
   readonly responseStatus?: number
   readonly idempotencyKey?: string
   readonly deliveryClaimResult?: WebhookDeliveryClaimResult
-  readonly error?: string
 }
+
+export type FinishWebhookRunInput = FinishWebhookRunBaseInput &
+  (
+    | {
+        readonly status: "succeeded" | "skipped"
+        readonly error?: never
+      }
+    | {
+        readonly status: "failed"
+        readonly error: SixbFailure<WebhookRunFailureCode>
+      }
+  )
 
 export interface ListWebhookRunsInput {
   readonly projectId: string

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -89,6 +89,10 @@ export {
   type SandboxesContractSuiteOptions,
 } from "./sandboxes-contract"
 export {
+  runWebhookRunStorageContractSuite,
+  type WebhookRunStorageContractSuiteOptions,
+} from "./webhook-run-storage-contract"
+export {
   createTestAutomaticWorkflowExecution,
   createTestWorkflowExecution,
 } from "./workflow-execution"

--- a/packages/core/src/testing/webhook-run-storage-contract.ts
+++ b/packages/core/src/testing/webhook-run-storage-contract.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test"
+import type { SixbFailure } from "../errors/types"
+import type { WebhookRunFailureCode, WebhookRunStorage } from "../storage/webhook-runs"
+
+export interface WebhookRunStorageContractSuiteOptions<
+  TStorage extends WebhookRunStorage = WebhookRunStorage,
+> {
+  /** Factory that returns an isolated webhook-run store for each test. */
+  readonly createStorage: () => TStorage | Promise<TStorage>
+  readonly setup?: (storage: TStorage) => void | Promise<void>
+  readonly cleanup?: (storage: TStorage) => void | Promise<void>
+}
+
+const projectId = "contract-project"
+const startedAt = new Date("2026-06-01T11:59:00.000Z")
+const finishedAt = new Date("2026-06-01T12:00:00.000Z")
+
+const failure = {
+  code: "internal.unexpected",
+  message: "Webhook failed",
+  retryable: false,
+  at: finishedAt.toISOString(),
+  details: { connectorId: "github", webhookId: "events", runId: "failed-run" },
+} as const satisfies SixbFailure<WebhookRunFailureCode>
+
+/** Runs the durable webhook-run lifecycle and failure contract against a provider. */
+export function runWebhookRunStorageContractSuite<TStorage extends WebhookRunStorage>(
+  label: string,
+  options: WebhookRunStorageContractSuiteOptions<TStorage>
+): void {
+  const withStorage = async (body: (storage: TStorage) => Promise<void>): Promise<void> => {
+    const storage = await options.createStorage()
+    try {
+      await options.setup?.(storage)
+      await body(storage)
+    } finally {
+      await options.cleanup?.(storage)
+    }
+  }
+
+  describe(label, () => {
+    test("persists a validated, detached failure and exposes it through get and list", async () => {
+      await withStorage(async (storage) => {
+        await storage.start(runInput("failed-run"))
+        const mutableFailure = {
+          code: "internal.unexpected" as const,
+          message: String(failure.message),
+          retryable: false as const,
+          at: failure.at,
+          details: {
+            connectorId: String(failure.details.connectorId),
+            webhookId: String(failure.details.webhookId),
+            runId: String(failure.details.runId),
+          },
+        }
+        const finished = await storage.finish({
+          id: "failed-run",
+          projectId,
+          status: "failed",
+          finishedAt,
+          requestBodyBytes: 128,
+          responseStatus: 500,
+          idempotencyKey: "delivery-1",
+          deliveryClaimResult: "claimed",
+          error: mutableFailure,
+        })
+
+        mutableFailure.message = "mutated after write"
+        mutableFailure.details.runId = "mutated-after-write"
+
+        expect(finished).toMatchObject({
+          id: "failed-run",
+          status: "failed",
+          finishedAt,
+          requestBodyBytes: 128,
+          responseStatus: 500,
+          idempotencyKey: "delivery-1",
+          deliveryClaimResult: "claimed",
+          error: failure,
+        })
+        expect(await storage.getById({ projectId, id: "failed-run" })).toMatchObject({
+          error: failure,
+        })
+        await expect(
+          storage.list({ projectId, statuses: ["failed"], idempotencyKey: "delivery-1" })
+        ).resolves.toMatchObject({ runs: [{ id: "failed-run", error: failure }], total: 1 })
+      })
+    })
+
+    test("rejects failures outside the webhook-run code contract without finishing the run", async () => {
+      await withStorage(async (storage) => {
+        await storage.start(runInput("invalid-failure-run"))
+
+        await expect(
+          storage.finish({
+            id: "invalid-failure-run",
+            projectId,
+            status: "failed",
+            error: { ...failure, code: "runtime.cancelled" } as never,
+          })
+        ).rejects.toThrow("code is not allowed by this failure contract")
+        const unchanged = await storage.getById({ projectId, id: "invalid-failure-run" })
+        expect(unchanged?.status).toBe("running")
+        expect(unchanged?.error).toBeUndefined()
+      })
+    })
+
+    test("keeps successful and skipped runs failure-free and terminal", async () => {
+      await withStorage(async (storage) => {
+        await storage.start(runInput("succeeded-run"))
+        await storage.start(runInput("skipped-run", "stripe", "payments"))
+
+        await expect(
+          storage.finish({
+            id: "succeeded-run",
+            projectId,
+            status: "succeeded",
+            finishedAt,
+            responseStatus: 204,
+          })
+        ).resolves.toMatchObject({ status: "succeeded" })
+        await expect(
+          storage.finish({ id: "skipped-run", projectId, status: "skipped", finishedAt })
+        ).resolves.toMatchObject({ status: "skipped" })
+        expect((await storage.getById({ projectId, id: "succeeded-run" }))?.error).toBeUndefined()
+        expect((await storage.getById({ projectId, id: "skipped-run" }))?.error).toBeUndefined()
+        await expect(
+          storage.finish({
+            id: "succeeded-run",
+            projectId,
+            status: "failed",
+            error: failure,
+          })
+        ).rejects.toThrow("already terminal")
+      })
+    })
+  })
+}
+
+function runInput(id: string, connectorId = "github", webhookId = "events") {
+  return {
+    id,
+    projectId,
+    connectorId,
+    webhookId,
+    method: "POST",
+    route: `/webhooks/${connectorId}/${webhookId}`,
+    startedAt,
+  }
+}

--- a/packages/core/tests/webhook-runs.test.ts
+++ b/packages/core/tests/webhook-runs.test.ts
@@ -1,0 +1,6 @@
+import { InMemoryWebhookRunStorage } from "../src/storage"
+import { runWebhookRunStorageContractSuite } from "../src/testing"
+
+runWebhookRunStorageContractSuite("InMemoryWebhookRunStorage", {
+  createStorage: () => new InMemoryWebhookRunStorage(),
+})

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -11,12 +11,10 @@ import type {
   WebhookResponse,
 } from "@sixb/core"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
+import { captureSixbFailure } from "@sixb/core/internal/errors"
 import { bindPrimitiveExecution } from "@sixb/core/internal/primitive-execution"
-import type {
-  FinishWebhookRunStatus,
-  WebhookDeliveryClaimResult,
-  WebhookDeliveryKey,
-} from "@sixb/core/storage"
+import type { WebhookDeliveryClaimResult, WebhookDeliveryKey } from "@sixb/core/storage"
+import { WEBHOOK_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import type { Elysia } from "elysia"
 import { RequestBodyTooLargeError, readRequestBodyWithLimit } from "../utils/request-body"
 
@@ -35,16 +33,21 @@ interface DispatchWebhookOptions {
   readonly bodyLimitBytes?: number
 }
 
-interface WebhookRunFinishInput {
+interface WebhookRunFinishBaseInput {
   readonly host: SixbHostView
+  readonly registered: RegisteredWebhook
   readonly runId: string
-  readonly status: FinishWebhookRunStatus
   readonly requestBodyBytes?: number
   readonly responseStatus?: number
   readonly idempotencyKey?: string
   readonly deliveryClaimResult?: WebhookDeliveryClaimResult
-  readonly error?: string
 }
+
+type WebhookRunFinishInput = WebhookRunFinishBaseInput &
+  (
+    | { readonly status: "succeeded" | "skipped"; readonly error?: never }
+    | { readonly status: "failed"; readonly error: unknown }
+  )
 
 type DeliveryClaimResult =
   | {
@@ -121,10 +124,11 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
   } catch (error) {
     await finishWebhookRun({
       host,
+      registered,
       runId,
       status: "failed",
       responseStatus: 500,
-      error: error instanceof Error ? error.message : String(error),
+      error,
     })
     reportFailure(error)
     throw error
@@ -149,6 +153,7 @@ async function dispatchWebhookRun(
     setHeader(set, "allow", webhook.method)
     await finishWebhookRun({
       host,
+      registered,
       runId,
       status: "failed",
       responseStatus: 405,
@@ -166,10 +171,11 @@ async function dispatchWebhookRun(
     set.status = responseStatus
     await finishWebhookRun({
       host,
+      registered,
       runId,
       status: "failed",
       responseStatus,
-      error: message,
+      error,
     })
     return { error: message }
   }
@@ -193,6 +199,7 @@ async function dispatchWebhookRun(
     set.status = 401
     await finishWebhookRun({
       host,
+      registered,
       runId,
       status: "failed",
       requestBodyBytes: rawBody.byteLength,
@@ -210,11 +217,12 @@ async function dispatchWebhookRun(
     set.status = 400
     await finishWebhookRun({
       host,
+      registered,
       runId,
       status: "failed",
       requestBodyBytes: rawBody.byteLength,
       responseStatus: 400,
-      error: message,
+      error,
     })
     return { error: message }
   }
@@ -243,6 +251,7 @@ async function dispatchWebhookRun(
       const result = accepted(set)
       await finishWebhookRun({
         host,
+        registered,
         runId,
         status: "skipped",
         requestBodyBytes: rawBody.byteLength,
@@ -258,6 +267,7 @@ async function dispatchWebhookRun(
     set.status = 500
     await finishWebhookRun({
       host,
+      registered,
       runId,
       status: "failed",
       requestBodyBytes: rawBody.byteLength,
@@ -285,6 +295,7 @@ async function dispatchWebhookRun(
     set.status = 500
     await finishWebhookRun({
       host,
+      registered,
       runId,
       status: "failed",
       requestBodyBytes: rawBody.byteLength,
@@ -299,7 +310,6 @@ async function dispatchWebhookRun(
   const responseStatus = getWebhookResponseStatus(response)
   const runStatus = responseStatus >= 200 && responseStatus <= 299 ? "succeeded" : "failed"
   const failureMessage = `Webhook handler returned HTTP ${responseStatus}`
-  const responseError = runStatus === "failed" ? failureMessage : undefined
   const shouldRetryDelivery =
     runStatus === "failed" && (responseStatus < 400 || responseStatus >= 500)
 
@@ -324,6 +334,7 @@ async function dispatchWebhookRun(
     set.status = 500
     await finishWebhookRun({
       host,
+      registered,
       runId,
       status: "failed",
       requestBodyBytes: rawBody.byteLength,
@@ -338,16 +349,20 @@ async function dispatchWebhookRun(
   if (shouldRetryDelivery) {
     reportFailure(new Error(failureMessage))
   }
-  await finishWebhookRun({
+  const terminalMetadata = {
     host,
+    registered,
     runId,
-    status: runStatus,
     requestBodyBytes: rawBody.byteLength,
     responseStatus,
     idempotencyKey,
     deliveryClaimResult,
-    error: responseError,
-  })
+  }
+  await finishWebhookRun(
+    runStatus === "failed"
+      ? { ...terminalMetadata, status: "failed", error: failureMessage }
+      : { ...terminalMetadata, status: "succeeded" }
+  )
 
   return applyWebhookResponse(set, response)
 }
@@ -385,17 +400,34 @@ async function finishWebhookRun(input: WebhookRunFinishInput): Promise<void> {
   }
 
   try {
-    await storage.finish({
+    const finishedAt = new Date()
+    const terminalMetadata = {
       id: input.runId,
       projectId: input.host.id,
-      status: input.status,
-      finishedAt: new Date(),
+      finishedAt,
       requestBodyBytes: input.requestBodyBytes,
       responseStatus: input.responseStatus,
       idempotencyKey: input.idempotencyKey,
       deliveryClaimResult: input.deliveryClaimResult,
-      error: input.error,
-    })
+    }
+    await storage.finish(
+      input.status === "failed"
+        ? {
+            ...terminalMetadata,
+            status: "failed",
+            error: captureSixbFailure(input.error, {
+              allowedCodes: WEBHOOK_RUN_FAILURE_CODES,
+              defaultCode: "internal.unexpected",
+              details: {
+                connectorId: input.registered.connector.id,
+                webhookId: input.registered.webhook.id,
+                runId: input.runId,
+              },
+              at: finishedAt,
+            }),
+          }
+        : { ...terminalMetadata, status: input.status }
+    )
   } catch {
     // Webhook run history is observability-only. Do not change provider responses
     // when history storage is unavailable or temporarily failing.

--- a/packages/server/src/schemas/webhook-runs.ts
+++ b/packages/server/src/schemas/webhook-runs.ts
@@ -1,4 +1,11 @@
+import type { SixbFailure } from "@sixb/core"
+import type { WebhookRunFailureCode } from "@sixb/core/storage"
+import { WEBHOOK_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { z } from "zod"
+import { sixbFailureSchema } from "./common"
+
+const WebhookRunFailureSchema: z.ZodType<SixbFailure<WebhookRunFailureCode>> =
+  sixbFailureSchema(WEBHOOK_RUN_FAILURE_CODES)
 
 export const WebhookRunStatusSchema = z.enum(["running", "succeeded", "failed", "skipped"])
 
@@ -30,7 +37,7 @@ export const WebhookRunSchema = z.object({
   responseStatus: z.number().optional(),
   idempotencyKey: z.string().optional(),
   deliveryClaimResult: WebhookDeliveryClaimResultSchema.optional(),
-  error: z.string().optional(),
+  error: WebhookRunFailureSchema.optional(),
 })
 
 export const WebhookRunListResponseSchema = z.object({

--- a/packages/server/tests/webhooks.test.ts
+++ b/packages/server/tests/webhooks.test.ts
@@ -178,9 +178,19 @@ describe("webhook routes", () => {
       webhookId: "telemetry",
       status: "failed",
       responseStatus: 400,
-      error: "value must be a number",
+      error: {
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: {
+          connectorId: "edge",
+          webhookId: "telemetry",
+          runId: run?.id,
+        },
+      },
     })
     expect(run?.requestBodyBytes).toBe(new TextEncoder().encode(payload).byteLength)
+    expect(run?.error?.at).toBe(run?.finishedAt?.toISOString())
   })
 
   test("skips duplicate idempotent deliveries before handlers run", async () => {
@@ -386,26 +396,46 @@ describe("webhook routes", () => {
           method: "GET",
           status: "failed",
           responseStatus: 405,
-          error: "Method not allowed",
+          error: expect.objectContaining({
+            code: "internal.unexpected",
+            message: "An unexpected internal error occurred.",
+            retryable: false,
+          }),
         }),
         expect.objectContaining({
           webhookId: "events",
           method: "POST",
           status: "failed",
           responseStatus: 401,
-          error: "Webhook verification failed",
+          error: expect.objectContaining({
+            code: "internal.unexpected",
+            message: "An unexpected internal error occurred.",
+            retryable: false,
+          }),
         }),
         expect.objectContaining({
           webhookId: "failing",
           method: "POST",
           status: "failed",
           responseStatus: 500,
-          error: "Webhook handler failed",
+          error: expect.objectContaining({
+            code: "internal.unexpected",
+            message: "An unexpected internal error occurred.",
+            retryable: false,
+          }),
         }),
       ])
     )
 
     const failedRun = runs.runs.find((run) => run.webhookId === "failing")
+    expect(failedRun?.error).toMatchObject({
+      details: {
+        connectorId: "github",
+        webhookId: "failing",
+        runId: failedRun?.id,
+      },
+    })
+    expect(failedRun?.error?.at).toBe(failedRun?.finishedAt?.toISOString())
     expect(reports).toHaveLength(1)
     expect(reports[0]?.error).toBe(handlerError)
     expect(reports[0]?.context).toMatchObject({

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -38,6 +38,9 @@ import agentFailureRecordSql from "./migrations/014-agent-failure-record.sql" wi
 import projectionFailureRecordSql from "./migrations/015-projection-failure-record.sql" with {
   type: "text",
 }
+import webhookRunFailureRecordSql from "./migrations/016-webhook-run-failure-record.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -306,6 +309,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("013-workflow-failure-record", workflowFailureRecordSql),
     pgSql("014-agent-failure-record", agentFailureRecordSql),
     pgSql("015-projection-failure-record", projectionFailureRecordSql),
+    pgSql("016-webhook-run-failure-record", webhookRunFailureRecordSql),
   ],
 })
 

--- a/storage/pg/src/migrations/016-webhook-run-failure-record.sql
+++ b/storage/pg/src/migrations/016-webhook-run-failure-record.sql
@@ -1,0 +1,19 @@
+ALTER TABLE webhook_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE webhook_runs ADD COLUMN error JSONB;
+
+UPDATE webhook_runs
+SET error = jsonb_build_object(
+  'code', 'internal.unexpected',
+  'message', 'An unexpected internal error occurred.',
+  'retryable', false,
+  'at', to_char(COALESCE(finished_at, started_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'connectorId', connector_id,
+    'webhookId', webhook_id,
+    'runId', id,
+    'migratedFromLegacyError', true
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE webhook_runs DROP COLUMN legacy_error;

--- a/storage/pg/src/pg-webhook-run-storage.ts
+++ b/storage/pg/src/pg-webhook-run-storage.ts
@@ -1,3 +1,5 @@
+import type { JsonValue } from "@sixb/core"
+import { parseSixbFailure, serializeSixbFailure } from "@sixb/core/internal/errors"
 import type {
   FinishWebhookRunInput,
   ListWebhookRunsInput,
@@ -6,7 +8,7 @@ import type {
   WebhookRunRecord,
   WebhookRunStorage,
 } from "@sixb/core/storage"
-import { WebhookRunError } from "@sixb/core/storage"
+import { WEBHOOK_RUN_FAILURE_CODES, WebhookRunError } from "@sixb/core/storage"
 import type { SqlParameter } from "./pg-client"
 import { appendRunListFilters, hasEmptyStatuses, queryRunList } from "./run-list-query"
 import { isUniqueViolation } from "./storage-errors"
@@ -81,7 +83,7 @@ export class PgWebhookRunStorage implements WebhookRunStorage {
           response_status = ${input.responseStatus ?? null},
           idempotency_key = ${input.idempotencyKey ?? null},
           delivery_claim_result = ${input.deliveryClaimResult ?? null},
-          error = ${input.status === "succeeded" ? null : (input.error ?? null)}
+          error = ${input.status === "failed" ? serializeSixbFailure(input.error, WEBHOOK_RUN_FAILURE_CODES) : null}::text::jsonb
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
       `
@@ -163,7 +165,7 @@ function rowToWebhookRunRecord(row: WebhookRunDatabaseRow): WebhookRunRecord {
     responseStatus: row.response_status != null ? Number(row.response_status) : undefined,
     idempotencyKey: row.idempotency_key ?? undefined,
     deliveryClaimResult: row.delivery_claim_result ?? undefined,
-    error: row.error ?? undefined,
+    error: row.error === null ? undefined : parseSixbFailure(row.error, WEBHOOK_RUN_FAILURE_CODES),
   }
 }
 
@@ -181,5 +183,5 @@ interface WebhookRunDatabaseRow {
   readonly response_status: number | string | null
   readonly idempotency_key: string | null
   readonly delivery_claim_result: WebhookRunRecord["deliveryClaimResult"] | null
-  readonly error: string | null
+  readonly error: JsonValue | null
 }

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -51,6 +51,7 @@ describe("Postgres storage migrations", () => {
             "013-workflow-failure-record",
             "014-agent-failure-record",
             "015-projection-failure-record",
+            "016-webhook-run-failure-record",
           ],
         },
       ])
@@ -159,6 +160,13 @@ describe("Postgres storage migrations", () => {
           id: "015-projection-failure-record",
           status: "applied",
           version: 15,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "016-webhook-run-failure-record",
+          status: "applied",
+          version: 16,
         },
       ])
     })
@@ -850,6 +858,13 @@ describe("Postgres storage migrations", () => {
           id: "015-projection-failure-record",
           status: "applied",
           version: 15,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "016-webhook-run-failure-record",
+          status: "applied",
+          version: 16,
         },
       ])
     } finally {

--- a/storage/pg/tests/pg-webhook-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-webhook-run-storage.e2e.ts
@@ -1,0 +1,19 @@
+import { runWebhookRunStorageContractSuite } from "@sixb/core/testing"
+import type { PostgresStorage } from "../src"
+import { createTestStorage } from "./helpers"
+
+const contractStorageOwners = new WeakMap<PostgresStorage["webhookRuns"], PostgresStorage>()
+
+runWebhookRunStorageContractSuite("PgWebhookRunStorage contract", {
+  createStorage: async () => {
+    const { storage } = await createTestStorage()
+    contractStorageOwners.set(storage.webhookRuns, storage)
+    return storage.webhookRuns
+  },
+  cleanup: async (webhookRuns) => {
+    const owner = contractStorageOwners.get(webhookRuns)
+    if (!owner) return
+    await owner.dropSchema()
+    await owner.close()
+  },
+})

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -41,6 +41,9 @@ import agentFailureRecordSql from "./migrations/014-agent-failure-record.sql" wi
 import projectionFailureRecordSql from "./migrations/015-projection-failure-record.sql" with {
   type: "text",
 }
+import webhookRunFailureRecordSql from "./migrations/016-webhook-run-failure-record.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -76,6 +79,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("013-workflow-failure-record", workflowFailureRecordSql),
     sqliteSql("014-agent-failure-record", agentFailureRecordSql),
     sqliteSql("015-projection-failure-record", projectionFailureRecordSql),
+    sqliteSql("016-webhook-run-failure-record", webhookRunFailureRecordSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/016-webhook-run-failure-record.sql
+++ b/storage/sqlite/src/migrations/016-webhook-run-failure-record.sql
@@ -1,0 +1,19 @@
+ALTER TABLE webhook_runs RENAME COLUMN error TO legacy_error;
+ALTER TABLE webhook_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE webhook_runs
+SET error = json_object(
+  'code', 'internal.unexpected',
+  'message', 'An unexpected internal error occurred.',
+  'retryable', json('false'),
+  'at', COALESCE(finished_at, started_at),
+  'details', json_object(
+    'connectorId', connector_id,
+    'webhookId', webhook_id,
+    'runId', id,
+    'migratedFromLegacyError', json('true')
+  )
+)
+WHERE legacy_error IS NOT NULL;
+
+ALTER TABLE webhook_runs DROP COLUMN legacy_error;

--- a/storage/sqlite/src/webhook-run-storage.ts
+++ b/storage/sqlite/src/webhook-run-storage.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite"
+import { parseSixbFailure, serializeSixbFailure } from "@sixb/core/internal/errors"
 import type {
   FinishWebhookRunInput,
   ListWebhookRunsInput,
@@ -7,7 +8,7 @@ import type {
   WebhookRunRecord,
   WebhookRunStorage,
 } from "@sixb/core/storage"
-import { WebhookRunError } from "@sixb/core/storage"
+import { WEBHOOK_RUN_FAILURE_CODES, WebhookRunError } from "@sixb/core/storage"
 import { installFreshSqliteSchema } from "./migrations"
 import {
   appendRunListFilters,
@@ -131,7 +132,9 @@ export class SqliteWebhookRunStorage implements WebhookRunStorage {
           input.responseStatus ?? null,
           input.idempotencyKey ?? null,
           input.deliveryClaimResult ?? null,
-          input.status === "succeeded" ? null : (input.error ?? null),
+          input.status === "failed"
+            ? serializeSixbFailure(input.error, WEBHOOK_RUN_FAILURE_CODES)
+            : null,
           input.projectId,
           input.id
         )
@@ -218,7 +221,7 @@ function rowToWebhookRunRecord(row: WebhookRunDatabaseRow): WebhookRunRecord {
     responseStatus: row.response_status ?? undefined,
     idempotencyKey: row.idempotency_key ?? undefined,
     deliveryClaimResult: row.delivery_claim_result ?? undefined,
-    error: row.error ?? undefined,
+    error: row.error === null ? undefined : parseSixbFailure(row.error, WEBHOOK_RUN_FAILURE_CODES),
   }
 }
 

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -11,6 +11,7 @@ import {
   PIPELINE_RUN_FAILURE_CODES,
   PROJECTION_RUN_FAILURE_CODES,
   SYNC_RUN_FAILURE_CODES,
+  WEBHOOK_RUN_FAILURE_CODES,
   WORKFLOW_RUN_FAILURE_CODES,
 } from "@sixb/core/storage"
 import { SqliteStorage } from "../src"
@@ -128,6 +129,13 @@ const expectedStorageMigrationRows = [
     id: "015-projection-failure-record",
     status: "applied",
     version: 15,
+  },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "016-webhook-run-failure-record",
+    status: "applied",
+    version: 16,
   },
 ]
 
@@ -313,6 +321,15 @@ describe("SQLite storage migrations", () => {
           'failed', '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z', 1,
           'secret projection diagnostic'
         );
+
+        INSERT INTO webhook_runs (
+          project_id, id, connector_id, webhook_id, status, method, route, started_at, finished_at,
+          error
+        ) VALUES (
+          'project-a', 'webhook-legacy', 'github', 'events', 'failed', 'POST', '/hooks/github',
+          '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z',
+          'secret webhook diagnostic'
+        );
       `)
 
       for (const migration of sqliteStorageMigrations.steps.slice(10)) migration.up(db)
@@ -440,6 +457,24 @@ describe("SQLite storage migrations", () => {
         },
       })
       expect(JSON.stringify(projectionFailure)).not.toContain("secret projection diagnostic")
+
+      const webhookRow = db
+        .query("SELECT error FROM webhook_runs WHERE project_id = ? AND id = ?")
+        .get("project-a", "webhook-legacy") as { readonly error: string }
+      const webhookFailure = parseSixbFailure(webhookRow.error, WEBHOOK_RUN_FAILURE_CODES)
+      expect(webhookFailure).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: "2026-08-10T12:01:00.000Z",
+        details: {
+          connectorId: "github",
+          webhookId: "events",
+          runId: "webhook-legacy",
+          migratedFromLegacyError: true,
+        },
+      })
+      expect(JSON.stringify(webhookFailure)).not.toContain("secret webhook diagnostic")
     } finally {
       db.close()
     }

--- a/storage/sqlite/tests/sqlite-webhook-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-webhook-run-storage.test.ts
@@ -1,0 +1,9 @@
+import { runWebhookRunStorageContractSuite } from "@sixb/core/testing"
+import { SqliteWebhookRunStorage } from "../src/webhook-run-storage"
+
+runWebhookRunStorageContractSuite("SqliteWebhookRunStorage", {
+  createStorage: () => new SqliteWebhookRunStorage(),
+  cleanup(storage) {
+    storage.close()
+  },
+})


### PR DESCRIPTION
## Summary

- replace webhook run error strings with a scoped, portable SixbFailure record
- normalize failures once at the terminal history boundary while preserving provider responses and existing onError reporting
- validate and detach failures in memory, SQLite, and PostgreSQL, with validated JSON and JSONB persistence
- expose the same closed contract through OpenAPI and the generated client
- render webhook failures through the shared Atlas failure summary
- enforce identical storage behavior through a shared provider contract suite

## Design decisions

Webhook runs currently expose only internal.unexpected. Their lifecycle has no cancellation state, while expected delivery outcomes are already represented by responseStatus and deliveryClaimResult. This avoids freezing a premature webhook-specific taxonomy.

Generic verification, handler, and delivery messages remain intentionally sanitized in durable history. The underlying exception still reaches the existing error-reporting path.

webhook_deliveries.error remains a string because that table is a transport and idempotency journal with a distinct contract. This PR only migrates webhook_runs.

The finish input is a discriminated union: failed runs require a failure record, while succeeded and skipped runs cannot carry one. Storage adapters validate the record before persistence and reject codes outside the webhook contract.

## Verification

- global unit test suite
- global typecheck
- global build
- formatting and static checks
- publish smoke test across 47 packages
- shared in-memory, SQLite, and PostgreSQL webhook-run storage contract
- PostgreSQL migration tests
- webhook route tests
- generated client scope type test

Part of #274.

Stacked on #321.