### PR TITLE
actions: persist portable failure records

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -25,18 +25,22 @@ interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
   readonly retryable: boolean
   readonly at: string
   readonly details?: JsonValue
-  readonly causeChain?: readonly { readonly name: string; readonly message: string }[]
+  readonly truncated?: true
 }
 ```
 
-Each primitive specializes `TCode` to the codes it can actually persist and expose. Sync runs, pipeline runs, pipeline step runs, workflow runs, workflow node runs, agent executions (conversation or workflow-owned), and projection runs currently declare `internal.unexpected | runtime.cancelled`. Webhook runs declare only `internal.unexpected`: their lifecycle has no cancellation state, while expected delivery outcomes remain represented by their HTTP status and delivery claim result.
+Each primitive specializes `TCode` to the codes it can persist. Most migrated runs currently allow
+`internal.unexpected | runtime.cancelled`. Action failures also allow the retryable
+`queue.enqueue_failed` code and require `{ actionId, runId, phase }` in `details`.
+Webhook runs declare only `internal.unexpected`: their lifecycle has no cancellation state,
+while expected delivery outcomes remain represented by their HTTP status and delivery claim result.
 
-Other run primitives keep their legacy error shape until their own vertical migration. This keeps
-each storage and wire change independently reviewable.
+Each storage and wire change remains independently reviewable even though every migrated primitive shares the same portable base record.
 
 | Code | Retryable | What happened | What to do |
 | --- | --- | --- | --- |
 | `dataset.not_found` | No | The requested dataset is not registered or is not visible to the caller. | Check the dataset ID and the caller's access. |
 | `dataset.version_not_found` | No | The requested dataset version does not exist, or the dataset has no committed version yet. | Check the version ID or materialize the dataset before reading rows. |
-| `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect the failure and its cause chain. Do not retry automatically. |
+| `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect internal logs. Do not retry automatically. |
+| `queue.enqueue_failed` | Yes | A job could not be handed to its queue. | Retry the unchanged request while the durable run remains in its enqueue phase. |
 | `runtime.cancelled` | No | An in-flight operation was cancelled before completion. | Confirm the cancellation was intentional before requesting another run. |

--- a/examples/northline/sixb.config.ts
+++ b/examples/northline/sixb.config.ts
@@ -27,6 +27,8 @@ export const sixb = createSixb({
     let failure: string
     if (context.type === "run.failed") {
       failure = `${context.run.kind} run '${context.run.runId}' failed`
+    } else if (context.type === "action.phase.failed") {
+      failure = `action '${context.actionId}' phase '${context.phase}' failed with ${context.failure.code}`
     } else if (context.type === "event.delivery.failed") {
       failure = `event delivery failed after ${context.attempts} attempt(s)`
     } else {

--- a/packages/action-worker/src/action-execution/effects.ts
+++ b/packages/action-worker/src/action-execution/effects.ts
@@ -1,6 +1,7 @@
 import type { JsonValue } from "@sixb/core"
 import { isObjectActionDefinition } from "@sixb/core"
 import type { ActionEditCommitResult } from "@sixb/core/internal/actions"
+import { reportActionPhaseFailure } from "@sixb/core/internal/error-reporting"
 import type { ActionRunRecord } from "@sixb/core/storage"
 import { toActionRunFailure } from "../normalize"
 import { type BasePhaseContext, requireObjectSubject, toActionRuntimeFacade } from "./context"
@@ -55,14 +56,27 @@ export async function runEffectsPhase(
     input.updateActiveRun(run)
     return run
   } catch (error) {
-    const failure = toActionRunFailure(error, "effects")
+    const completedAt = new Date()
+    const failure = toActionRunFailure(error, "effects", {
+      actionId: input.action.id,
+      runId: input.run.id,
+      at: completedAt,
+    })
     run = await input.runtime.actionRunsStorage.recordEffects({
       projectId: input.runtime.id,
       id: input.run.id,
       status: "failed",
+      completedAt,
       error: failure,
     })
     input.updateActiveRun(run)
+    reportActionPhaseFailure(input.runtime.errorReporterHost, error, {
+      projectId: input.runtime.id,
+      actionId: input.action.id,
+      runId: input.run.id,
+      phase: "effects",
+      failure,
+    })
     return run
   }
 }

--- a/packages/action-worker/src/action-execution/results.ts
+++ b/packages/action-worker/src/action-execution/results.ts
@@ -3,6 +3,7 @@ import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { ActionRunFailure, ActionRunRecord } from "@sixb/core/storage"
 import { isTerminalActionRun } from "@sixb/core/storage"
 import { ActionWorkerError } from "../errors"
+import { toActionRunFailure } from "../normalize"
 import type { ActionRunResult, RunActionJobInput } from "../types"
 
 export function requireFinishedAt(runId: string, finishedAt: Date | undefined): Date {
@@ -70,12 +71,13 @@ async function resolveRunningRunUnderFence(input: RunActionJobInput, run: Action
         return { kind: "resume" as const, run: locked }
       }
 
-      const failure = redeliveryFailure(input.job.id, locked)
+      const failedAt = new Date()
+      const failure = redeliveryFailure(input.job.id, locked, failedAt)
       const finished = await storage.actionRuns.finish({
         projectId: input.runtime.id,
         id: input.job.id,
         status: "failed",
-        phase: failure.phase,
+        finishedAt: failedAt,
         error: failure,
       })
       return { kind: "failed" as const, run: finished, failure }
@@ -102,12 +104,19 @@ export function failedResult(
   }
 }
 
-function redeliveryFailure(runId: string, run: ActionRunRecord): ActionRunFailure {
-  return {
-    name: "ActionRunLeaseLostError",
-    message: `Action run '${runId}' was redelivered while already running. The previous worker may have lost its queue lease or crashed before reaching a resumable phase boundary.`,
-    phase: run.phase ?? "validation",
-  }
+function redeliveryFailure(runId: string, run: ActionRunRecord, failedAt: Date): ActionRunFailure {
+  return toActionRunFailure(
+    {
+      name: "ActionRunLeaseLostError",
+      message: `Action run '${runId}' was redelivered while already running. The previous worker may have lost its queue lease or crashed before reaching a resumable phase boundary.`,
+    },
+    run.phase ?? "validation",
+    {
+      actionId: run.actionId,
+      runId,
+      at: failedAt,
+    }
+  )
 }
 
 function reportRedeliveryFailure(input: RunActionJobInput, run: ActionRunRecord): void {

--- a/packages/action-worker/src/action-execution/writeback.ts
+++ b/packages/action-worker/src/action-execution/writeback.ts
@@ -70,11 +70,17 @@ export async function runWritebackPhase(
     input.updateActiveRun(run)
     return { run, value: result }
   } catch (error) {
-    const failure = toActionRunFailure(error, "writeback")
+    const completedAt = new Date()
+    const failure = toActionRunFailure(error, "writeback", {
+      actionId: input.action.id,
+      runId: input.run.id,
+      at: completedAt,
+    })
     run = await input.runtime.actionRunsStorage.recordWriteback({
       projectId: input.runtime.id,
       id: input.run.id,
       status: "failed",
+      completedAt,
       error: failure,
     })
     input.updateActiveRun(run)

--- a/packages/action-worker/src/normalize.ts
+++ b/packages/action-worker/src/normalize.ts
@@ -1,5 +1,16 @@
+import { parseActionRunFailure } from "@sixb/core/internal/action-run-storage"
+import {
+  createSixbError,
+  isSixbError,
+  summarizeErrorMessage,
+  toSixbFailure,
+} from "@sixb/core/internal/errors"
 import { WorkerAbortError } from "@sixb/core/internal/workers"
-import type { ActionRunFailure } from "@sixb/core/storage"
+import {
+  ACTION_RUN_FAILURE_CODES,
+  type ActionRunFailure,
+  type ActionRunPhase,
+} from "@sixb/core/storage"
 
 export function throwIfAborted(signal: AbortSignal): void {
   if (signal.aborted) {
@@ -9,20 +20,39 @@ export function throwIfAborted(signal: AbortSignal): void {
   }
 }
 
-export function toActionRunFailure(
+export function toActionRunFailure<TPhase extends ActionRunPhase>(
   error: unknown,
-  phase: ActionRunFailure["phase"]
-): ActionRunFailure {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-      phase,
+  phase: TPhase,
+  input: {
+    readonly actionId: string
+    readonly runId: string
+    readonly at: Date
+  }
+): ActionRunFailure<TPhase> {
+  const code =
+    isSixbError(error) && (ACTION_RUN_FAILURE_CODES as readonly string[]).includes(error.code)
+      ? (error.code as ActionRunFailure<TPhase>["code"])
+      : phase === "cancelled"
+        ? "runtime.cancelled"
+        : "internal.unexpected"
+  const normalized = createSixbError(
+    code,
+    summarizeErrorMessage(error, "Action execution failed."),
+    {
+      cause: error,
+      details: {
+        actionId: input.actionId,
+        runId: input.runId,
+        phase,
+      },
     }
-  }
+  )
 
-  return {
-    message: String(error),
-    phase,
-  }
+  return parseActionRunFailure(
+    toSixbFailure(normalized, {
+      allowedCodes: ACTION_RUN_FAILURE_CODES,
+      at: input.at,
+    }),
+    phase
+  )
 }

--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -41,11 +41,17 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
   const action = runtime.actions.getById(job.actionId)
   if (!action) {
     const error = new ActionWorkerError(`Unknown action '${job.actionId}'.`)
-    const failure = toActionRunFailure(error, "validation")
+    const failedAt = new Date()
+    const failure = toActionRunFailure(error, "validation", {
+      actionId: job.actionId,
+      runId: job.id,
+      at: failedAt,
+    })
     const finishedRun = await runtime.actionRunsStorage.finish({
       projectId: runtime.id,
       id: job.id,
       status: "failed",
+      finishedAt: failedAt,
       error: failure,
     })
     reportActionFailure(input, error, finishedRun)
@@ -101,16 +107,29 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
     }
   } catch (error) {
     const status = signal.aborted ? "cancelled" : "failed"
-    const failure = toActionRunFailure(
-      error,
-      status === "cancelled" ? "cancelled" : (activeRun?.phase ?? "validation")
-    )
+    const finishedAt = new Date()
+    const writebackFailure =
+      status === "failed" && activeRun?.writeback?.status === "failed"
+        ? activeRun.writeback.error
+        : undefined
+    const failure =
+      writebackFailure ??
+      toActionRunFailure(
+        error,
+        status === "cancelled" ? "cancelled" : (activeRun?.phase ?? "validation"),
+        {
+          actionId: job.actionId,
+          runId: job.id,
+          at: finishedAt,
+        }
+      )
 
     const finishedRun = await runtime.actionRunsStorage
       .finish({
         projectId: runtime.id,
         id: job.id,
         status,
+        finishedAt,
         error: failure,
       })
       .catch(() => null)

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -13,6 +13,7 @@ import {
   type OntologySource,
   param,
   prop,
+  type SixbErrorContext,
   SixbHost,
 } from "@sixb/core"
 import { findActionEditCommit } from "@sixb/core/internal/actions"
@@ -259,11 +260,13 @@ describe("runActionJob", () => {
 
     expect(result.status).toBe("failed")
     if ("error" in result) {
-      expect(result.error).toEqual({
-        name: "Error",
-        message: "external API failed",
-        phase: "writeback",
+      expect(result.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: { actionId: "failWriteback", runId: "act_1", phase: "writeback" },
       })
+      expect(result.error.at).toEqual(expect.any(String))
     }
 
     const run = await host.storage.actionRuns!.getById({ projectId: host.id, id: "act_1" })
@@ -781,8 +784,8 @@ describe("runActionJob", () => {
 
     expect(result.status).toBe("failed")
     if ("error" in result) {
-      expect(result.error.message).toBe("[SixbActionWorker] Unknown action 'missingAction'.")
-      expect(result.error.phase).toBe("validation")
+      expect(result.error.message).toBe("An unexpected internal error occurred.")
+      expect(result.error.details.phase).toBe("validation")
     }
     const run = await host.storage.actionRuns!.getById({ projectId: host.id, id: "act_1" })
     expect(run?.status).toBe("failed")
@@ -823,8 +826,9 @@ describe("runActionJob", () => {
 
     expect(result.status).toBe("failed")
     if ("error" in result) {
-      expect(result.error.name).toBe("ActionRunLeaseLostError")
-      expect(result.error.phase).toBe("validation")
+      expect(result.error.code).toBe("internal.unexpected")
+      expect(result.error.message).toBe("An unexpected internal error occurred.")
+      expect(result.error.details.phase).toBe("validation")
     }
     expect(invoked).toBe(0)
 
@@ -942,9 +946,9 @@ describe("runActionJob", () => {
       })
 
     const { host, sixb } = createSixb([setStatus])
-    let reportCount = 0
-    const reporter = attachSixbErrorReporter(sixb, () => {
-      reportCount += 1
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    const reporter = attachSixbErrorReporter(host, (error, context) => {
+      reports.push({ error, context })
     })
     await sixb.objects.upsert("Device", {
       id: "device-1",
@@ -971,13 +975,22 @@ describe("runActionJob", () => {
     expect(run?.effects).toMatchObject({
       status: "failed",
       error: {
-        name: "Error",
-        message: "notification failed",
-        phase: "effects",
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: { actionId: "setStatus", runId: "act_1", phase: "effects" },
       },
     })
     await reporter.flush()
-    expect(reportCount).toBe(0)
+    expect(reports).toHaveLength(1)
+    expect(reports[0]?.error.message).toBe("notification failed")
+    expect(reports[0]?.context).toMatchObject({
+      type: "action.phase.failed",
+      actionId: "setStatus",
+      runId: "act_1",
+      phase: "effects",
+      failure: run?.effects?.error,
+    })
   })
 
   test("does not report cancelled runs", async () => {
@@ -1022,6 +1035,14 @@ describe("runActionJob", () => {
     const result = await execution
 
     expect(result.status).toBe("cancelled")
+    if ("error" in result) {
+      expect(result.error).toMatchObject({
+        code: "runtime.cancelled",
+        message: "Execution was cancelled.",
+        retryable: false,
+        details: { actionId: "waitForCancel", runId: "act_cancelled", phase: "cancelled" },
+      })
+    }
     await reporter.flush()
     expect(reportCount).toBe(0)
   })
@@ -1057,10 +1078,8 @@ describe("runActionJob", () => {
 
     expect(result.status).toBe("failed")
     if ("error" in result) {
-      expect(result.error.message).toBe(
-        "[SixbActionWorker] Action 'setStatus' is not valid for object type 'Sensor'."
-      )
-      expect(result.error.phase).toBe("validation")
+      expect(result.error.message).toBe("An unexpected internal error occurred.")
+      expect(result.error.details.phase).toBe("validation")
     }
     expect(invoked).toBe(0)
   })

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -309,7 +309,7 @@ describe("ActionWorker", () => {
       actionId: "fail",
     })
     expect(failed.status).toBe("failed")
-    expect(failed.error?.message).toBe("writeback failed")
+    expect(failed.error?.message).toBe("An unexpected internal error occurred.")
 
     await worker.stop()
   })

--- a/packages/atlas/src/pages/ActionRunDetailPage.tsx
+++ b/packages/atlas/src/pages/ActionRunDetailPage.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@sixb/ui/components"
 import { useQuery } from "@tanstack/react-query"
 import { Navigate, useParams } from "react-router-dom"
 import { DataPanel, ErrorPage, LoadingPage, PageFrame } from "../components/common"
+import { SixbFailureSummary } from "../components/SixbFailureSummary"
 import { useActionLiveUpdates } from "../features/actions/hooks/useActionLiveUpdates"
 import { actionRunFileContentUrl } from "../lib/files"
 import { ActionRunMetaGrid, ActionRunStatusBadge, formatSubject } from "./ActionsPage"
@@ -67,7 +68,13 @@ export function ActionRunDetailPage() {
               <ActionRunStatusBadge status={run.status} />
               <span className="text-sm font-medium text-foreground">Failure</span>
             </div>
-            <DataPanel value={run.error} />
+            <SixbFailureSummary failure={run.error} />
+            <p className="mt-2 text-xs text-muted-foreground">
+              Phase <span className="font-mono text-foreground">{run.error.details.phase}</span>
+            </p>
+            <div className="mt-4">
+              <DataPanel label="Details" value={run.error.details} />
+            </div>
           </CardContent>
         </Card>
       ) : null}

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -16680,27 +16680,57 @@
                           "error": {
                             "type": "object",
                             "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "message": {
-                                "type": "string"
-                              },
-                              "phase": {
+                              "code": {
                                 "type": "string",
                                 "enum": [
-                                  "request",
-                                  "enqueue",
-                                  "validation",
-                                  "writeback",
-                                  "edits",
-                                  "commit",
-                                  "effects",
-                                  "cancelled"
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "queue.enqueue_failed"
                                 ]
+                              },
+                              "message": {
+                                "type": "string",
+                                "maxLength": 4096
+                              },
+                              "retryable": {
+                                "type": "boolean"
+                              },
+                              "at": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "details": {
+                                "type": "object",
+                                "properties": {
+                                  "actionId": {
+                                    "type": "string"
+                                  },
+                                  "runId": {
+                                    "type": "string"
+                                  },
+                                  "phase": {
+                                    "type": "string",
+                                    "enum": [
+                                      "request",
+                                      "enqueue",
+                                      "validation",
+                                      "writeback",
+                                      "edits",
+                                      "commit",
+                                      "effects",
+                                      "cancelled"
+                                    ]
+                                  }
+                                },
+                                "required": ["actionId", "runId", "phase"],
+                                "additionalProperties": false
+                              },
+                              "truncated": {
+                                "type": "boolean",
+                                "enum": [true]
                               }
                             },
-                            "required": ["message"],
+                            "required": ["code", "message", "retryable", "at", "details"],
                             "additionalProperties": false
                           }
                         },
@@ -16866,27 +16896,57 @@
                     "error": {
                       "type": "object",
                       "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "message": {
-                          "type": "string"
-                        },
-                        "phase": {
+                        "code": {
                           "type": "string",
                           "enum": [
-                            "request",
-                            "enqueue",
-                            "validation",
-                            "writeback",
-                            "edits",
-                            "commit",
-                            "effects",
-                            "cancelled"
+                            "internal.unexpected",
+                            "runtime.cancelled",
+                            "queue.enqueue_failed"
                           ]
+                        },
+                        "message": {
+                          "type": "string",
+                          "maxLength": 4096
+                        },
+                        "retryable": {
+                          "type": "boolean"
+                        },
+                        "at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "details": {
+                          "type": "object",
+                          "properties": {
+                            "actionId": {
+                              "type": "string"
+                            },
+                            "runId": {
+                              "type": "string"
+                            },
+                            "phase": {
+                              "type": "string",
+                              "enum": [
+                                "request",
+                                "enqueue",
+                                "validation",
+                                "writeback",
+                                "edits",
+                                "commit",
+                                "effects",
+                                "cancelled"
+                              ]
+                            }
+                          },
+                          "required": ["actionId", "runId", "phase"],
+                          "additionalProperties": false
+                        },
+                        "truncated": {
+                          "type": "boolean",
+                          "enum": [true]
                         }
                       },
-                      "required": ["message"],
+                      "required": ["code", "message", "retryable", "at", "details"],
                       "additionalProperties": false
                     },
                     "params": {
@@ -16894,85 +16954,185 @@
                       "additionalProperties": {}
                     },
                     "writeback": {
-                      "type": "object",
-                      "properties": {
-                        "status": {
-                          "type": "string",
-                          "enum": ["succeeded", "failed"]
-                        },
-                        "completedAt": {
-                          "type": "string"
-                        },
-                        "result": {},
-                        "error": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "message": {
-                              "type": "string"
-                            },
-                            "phase": {
+                            "status": {
                               "type": "string",
-                              "enum": [
-                                "request",
-                                "enqueue",
-                                "validation",
-                                "writeback",
-                                "edits",
-                                "commit",
-                                "effects",
-                                "cancelled"
+                              "enum": ["succeeded"]
+                            },
+                            "completedAt": {
+                              "type": "string"
+                            },
+                            "result": {
+                              "description": "Any JSON-compatible value.",
+                              "nullable": true,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {}
+                                },
+                                {
+                                  "type": "object",
+                                  "additionalProperties": true
+                                }
                               ]
                             }
                           },
-                          "required": ["message"],
+                          "required": ["status", "completedAt", "result"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "status": {
+                              "type": "string",
+                              "enum": ["failed"]
+                            },
+                            "completedAt": {
+                              "type": "string"
+                            },
+                            "error": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string",
+                                  "enum": [
+                                    "internal.unexpected",
+                                    "runtime.cancelled",
+                                    "queue.enqueue_failed"
+                                  ]
+                                },
+                                "message": {
+                                  "type": "string",
+                                  "maxLength": 4096
+                                },
+                                "retryable": {
+                                  "type": "boolean"
+                                },
+                                "at": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "details": {
+                                  "type": "object",
+                                  "properties": {
+                                    "actionId": {
+                                      "type": "string"
+                                    },
+                                    "runId": {
+                                      "type": "string"
+                                    },
+                                    "phase": {
+                                      "type": "string",
+                                      "enum": ["writeback"]
+                                    }
+                                  },
+                                  "required": ["actionId", "runId", "phase"],
+                                  "additionalProperties": false
+                                },
+                                "truncated": {
+                                  "type": "boolean",
+                                  "enum": [true]
+                                }
+                              },
+                              "required": ["code", "message", "retryable", "at", "details"],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": ["status", "completedAt", "error"],
                           "additionalProperties": false
                         }
-                      },
-                      "required": ["status", "completedAt"],
-                      "additionalProperties": false
+                      ]
                     },
                     "effects": {
-                      "type": "object",
-                      "properties": {
-                        "status": {
-                          "type": "string",
-                          "enum": ["succeeded", "failed"]
-                        },
-                        "completedAt": {
-                          "type": "string"
-                        },
-                        "error": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "message": {
-                              "type": "string"
-                            },
-                            "phase": {
+                            "status": {
                               "type": "string",
-                              "enum": [
-                                "request",
-                                "enqueue",
-                                "validation",
-                                "writeback",
-                                "edits",
-                                "commit",
-                                "effects",
-                                "cancelled"
-                              ]
+                              "enum": ["succeeded"]
+                            },
+                            "completedAt": {
+                              "type": "string"
                             }
                           },
-                          "required": ["message"],
+                          "required": ["status", "completedAt"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "status": {
+                              "type": "string",
+                              "enum": ["failed"]
+                            },
+                            "completedAt": {
+                              "type": "string"
+                            },
+                            "error": {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "string",
+                                  "enum": [
+                                    "internal.unexpected",
+                                    "runtime.cancelled",
+                                    "queue.enqueue_failed"
+                                  ]
+                                },
+                                "message": {
+                                  "type": "string",
+                                  "maxLength": 4096
+                                },
+                                "retryable": {
+                                  "type": "boolean"
+                                },
+                                "at": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "details": {
+                                  "type": "object",
+                                  "properties": {
+                                    "actionId": {
+                                      "type": "string"
+                                    },
+                                    "runId": {
+                                      "type": "string"
+                                    },
+                                    "phase": {
+                                      "type": "string",
+                                      "enum": ["effects"]
+                                    }
+                                  },
+                                  "required": ["actionId", "runId", "phase"],
+                                  "additionalProperties": false
+                                },
+                                "truncated": {
+                                  "type": "boolean",
+                                  "enum": [true]
+                                }
+                              },
+                              "required": ["code", "message", "retryable", "at", "details"],
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": ["status", "completedAt", "error"],
                           "additionalProperties": false
                         }
-                      },
-                      "required": ["status", "completedAt"],
-                      "additionalProperties": false
+                      ]
                     }
                   },
                   "required": [

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -5864,17 +5864,24 @@ export type ListActionRunsResponses = {
       startedAt?: string
       finishedAt?: string
       error?: {
-        name?: string
+        code: "internal.unexpected" | "runtime.cancelled" | "queue.enqueue_failed"
         message: string
-        phase?:
-          | "request"
-          | "enqueue"
-          | "validation"
-          | "writeback"
-          | "edits"
-          | "commit"
-          | "effects"
-          | "cancelled"
+        retryable: boolean
+        at: string
+        details: {
+          actionId: string
+          runId: string
+          phase:
+            | "request"
+            | "enqueue"
+            | "validation"
+            | "writeback"
+            | "edits"
+            | "commit"
+            | "effects"
+            | "cancelled"
+        }
+        truncated?: true
       }
     }>
     hasMore: boolean
@@ -5947,56 +5954,82 @@ export type GetActionRunResponses = {
     startedAt?: string
     finishedAt?: string
     error?: {
-      name?: string
+      code: "internal.unexpected" | "runtime.cancelled" | "queue.enqueue_failed"
       message: string
-      phase?:
-        | "request"
-        | "enqueue"
-        | "validation"
-        | "writeback"
-        | "edits"
-        | "commit"
-        | "effects"
-        | "cancelled"
+      retryable: boolean
+      at: string
+      details: {
+        actionId: string
+        runId: string
+        phase:
+          | "request"
+          | "enqueue"
+          | "validation"
+          | "writeback"
+          | "edits"
+          | "commit"
+          | "effects"
+          | "cancelled"
+      }
+      truncated?: true
     }
     params: {
       [key: string]: unknown
     }
-    writeback?: {
-      status: "succeeded" | "failed"
-      completedAt: string
-      result?: unknown
-      error?: {
-        name?: string
-        message: string
-        phase?:
-          | "request"
-          | "enqueue"
-          | "validation"
-          | "writeback"
-          | "edits"
-          | "commit"
-          | "effects"
-          | "cancelled"
-      }
-    }
-    effects?: {
-      status: "succeeded" | "failed"
-      completedAt: string
-      error?: {
-        name?: string
-        message: string
-        phase?:
-          | "request"
-          | "enqueue"
-          | "validation"
-          | "writeback"
-          | "edits"
-          | "commit"
-          | "effects"
-          | "cancelled"
-      }
-    }
+    writeback?:
+      | {
+          status: "succeeded"
+          completedAt: string
+          /**
+           * Any JSON-compatible value.
+           */
+          result:
+            | string
+            | number
+            | boolean
+            | Array<unknown>
+            | {
+                [key: string]: unknown
+              }
+            | null
+        }
+      | {
+          status: "failed"
+          completedAt: string
+          error: {
+            code: "internal.unexpected" | "runtime.cancelled" | "queue.enqueue_failed"
+            message: string
+            retryable: boolean
+            at: string
+            details: {
+              actionId: string
+              runId: string
+              phase: "writeback"
+            }
+            truncated?: true
+          }
+        }
+    effects?:
+      | {
+          status: "succeeded"
+          completedAt: string
+        }
+      | {
+          status: "failed"
+          completedAt: string
+          error: {
+            code: "internal.unexpected" | "runtime.cancelled" | "queue.enqueue_failed"
+            message: string
+            retryable: boolean
+            at: string
+            details: {
+              actionId: string
+              runId: string
+              phase: "effects"
+            }
+            truncated?: true
+          }
+        }
   }
 }
 

--- a/packages/client/tests/action-failure.types.ts
+++ b/packages/client/tests/action-failure.types.ts
@@ -1,0 +1,36 @@
+import type { GetActionRunResponses, ListActionRunsResponses } from "../src/generated/types.gen"
+
+type ListedActionRun = ListActionRunsResponses[200]["runs"][number]
+type ActionRunDetail = GetActionRunResponses[200]
+type ListedFailureCode = NonNullable<ListedActionRun["error"]>["code"]
+type DetailFailureCode = NonNullable<ActionRunDetail["error"]>["code"]
+
+const listedUnexpected: ListedFailureCode = "internal.unexpected"
+const listedCancelled: ListedFailureCode = "runtime.cancelled"
+const detailUnexpected: DetailFailureCode = "internal.unexpected"
+
+// Dataset lookup codes belong to HTTP route failures, not persisted Action failures.
+// @ts-expect-error the generated Action failure contract must stay scoped to its producer
+const unrelated: DetailFailureCode = "dataset.not_found"
+
+type FailedWriteback = Extract<NonNullable<ActionRunDetail["writeback"]>, { status: "failed" }>
+type FailedEffects = Extract<NonNullable<ActionRunDetail["effects"]>, { status: "failed" }>
+
+const writebackPhase: FailedWriteback["error"]["details"]["phase"] = "writeback"
+const effectsPhase: FailedEffects["error"]["details"]["phase"] = "effects"
+
+// @ts-expect-error a writeback record cannot carry an effects failure
+const unrelatedWritebackPhase: FailedWriteback["error"]["details"]["phase"] = "effects"
+// @ts-expect-error an effects record cannot carry a writeback failure
+const unrelatedEffectsPhase: FailedEffects["error"]["details"]["phase"] = "writeback"
+
+void [
+  listedUnexpected,
+  listedCancelled,
+  detailUnexpected,
+  unrelated,
+  writebackPhase,
+  effectsPhase,
+  unrelatedWritebackPhase,
+  unrelatedEffectsPhase,
+]

--- a/packages/client/tests/actions.test.ts
+++ b/packages/client/tests/actions.test.ts
@@ -57,6 +57,21 @@ function createActionRun(overrides: Partial<ActionRunDetail> = {}): ActionRunDet
   }
 }
 
+type ActionRunFailure = NonNullable<ActionRunDetail["error"]>
+
+function actionFailure(
+  phase: ActionRunFailure["details"]["phase"],
+  message: string
+): ActionRunFailure {
+  return {
+    code: phase === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+    message,
+    retryable: false,
+    at: "2026-06-29T12:00:02.000Z",
+    details: { actionId: "approveQuote", runId: "act_1", phase },
+  }
+}
+
 function actionEvent(type: "action.completed" | "action.failed", runId = "act_1"): SixbEvent {
   return {
     id: `evt_${type}`,
@@ -78,7 +93,7 @@ function actionEvent(type: "action.completed" | "action.failed", runId = "act_1"
             actionId: "approveQuote",
             runId,
             subject: { kind: "object", objectTypeId: "Quote", primaryId: "q_123" },
-            error: { message: "Action failed", phase: "writeback" },
+            error: actionFailure("writeback", "Action failed"),
             finishedAt: "2026-06-29T12:00:02.000Z",
           },
   } as SixbEvent
@@ -348,7 +363,7 @@ describe("action wait helpers", () => {
             status: "failed",
             phase: "writeback",
             finishedAt: "2026-06-29T12:00:02.000Z",
-            error: { name: "WritebackError", message: "Writeback failed", phase: "writeback" },
+            error: actionFailure("writeback", "Writeback failed"),
           })
         )
       }
@@ -377,7 +392,7 @@ describe("action wait helpers", () => {
             status: "cancelled",
             phase: "cancelled",
             finishedAt: "2026-06-29T12:00:02.000Z",
-            error: { message: "Action was cancelled", phase: "cancelled" },
+            error: actionFailure("cancelled", "Action was cancelled"),
           })
         )
       }
@@ -400,7 +415,7 @@ describe("action wait helpers", () => {
     const failed = createActionRun({
       status: "failed",
       finishedAt: "2026-06-29T12:00:02.000Z",
-      error: { message: "Handled manually", phase: "effects" },
+      error: actionFailure("effects", "Handled manually"),
     })
     const { client } = createTestClient((request) => {
       const url = new URL(request.url)

--- a/packages/client/tests/query-hooks.test.ts
+++ b/packages/client/tests/query-hooks.test.ts
@@ -410,7 +410,13 @@ describe("actionRunMutationOptions", () => {
     const failed = createActionRun({
       status: "failed",
       finishedAt: "2026-06-29T12:00:02.000Z",
-      error: { message: "Writeback failed", phase: "writeback" },
+      error: {
+        code: "internal.unexpected",
+        message: "Writeback failed",
+        retryable: false,
+        at: "2026-06-29T12:00:02.000Z",
+        details: { actionId: "approveQuote", runId: "act_1", phase: "writeback" },
+      },
     })
     const actionRunKey = getActionRunQueryKey({ path: { runId: "act_1" } })
     const actionRunsKey = listActionRunsQueryKey()

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,6 +95,12 @@
       "import": "./dist/storage/action-runs/provider.js",
       "default": "./dist/storage/action-runs/provider.js"
     },
+    "./internal/action-run-storage": {
+      "types": "./dist/storage/action-runs/failure.d.ts",
+      "bun": "./src/storage/action-runs/failure.ts",
+      "import": "./dist/storage/action-runs/failure.js",
+      "default": "./dist/storage/action-runs/failure.js"
+    },
     "./internal/agents": {
       "types": "./dist/agents/index.d.ts",
       "bun": "./src/agents/index.ts",

--- a/packages/core/src/actions/run-dispatch.ts
+++ b/packages/core/src/actions/run-dispatch.ts
@@ -1,9 +1,22 @@
 import { randomUUID } from "node:crypto"
 import { reportRunFailure } from "../error-reporting/capability"
+import { createSixbError, toSixbFailure } from "../errors/internal"
 import type { DomainEventLog } from "../events"
 import type { Queues } from "../queues"
-import type { ActionRunParams, ActionRunRecord, CreateExecutionInput, Storage } from "../storage"
-import { ActionRunError, actionRunParamsEqual, actionSubjectsEqual } from "../storage"
+import type {
+  ActionRunFailure,
+  ActionRunParams,
+  ActionRunRecord,
+  CreateExecutionInput,
+  Storage,
+} from "../storage"
+import {
+  ACTION_RUN_FAILURE_CODES,
+  ActionRunError,
+  actionRunParamsEqual,
+  actionSubjectsEqual,
+} from "../storage"
+import { parseActionRunFailure } from "../storage/action-runs/failure"
 import type { RequestActionResult } from "./request"
 import { createActionRunId, createActionRunIdempotencyKey } from "./run-id"
 import type { ActionSubject } from "./types"
@@ -187,12 +200,14 @@ async function failActionRunPublication(
   run: ActionRunRecord,
   error: unknown
 ): Promise<void> {
+  const failedAt = new Date()
+  const failure = toActionRunFailure(error, run, failedAt)
   const failed = await requireActionRunStorage(input.storage).finish({
     projectId: input.projectId,
     id: run.id,
     status: "failed",
-    phase: "enqueue",
-    error: toActionRunFailure(error),
+    finishedAt: failedAt,
+    error: failure,
   })
   reportRunFailure(input.errorReporterHost, error, {
     projectId: input.projectId,
@@ -224,7 +239,9 @@ function assertExistingRunMatchesRequest(
 }
 
 function isRetryableEnqueueFailure(record: ActionRunRecord): boolean {
-  return record.status === "failed" && record.phase === "enqueue"
+  return (
+    record.status === "failed" && record.phase === "enqueue" && record.error?.retryable === true
+  )
 }
 
 function existingActionRunResult(existing: ActionRunRecord): RequestActionResult {
@@ -235,9 +252,24 @@ function existingActionRunResult(existing: ActionRunRecord): RequestActionResult
   }
 }
 
-function toActionRunFailure(error: unknown): { name?: string; message: string; phase: "enqueue" } {
-  if (error instanceof Error) {
-    return { name: error.name, message: error.message, phase: "enqueue" }
-  }
-  return { message: String(error), phase: "enqueue" }
+function toActionRunFailure(
+  error: unknown,
+  run: ActionRunRecord,
+  at: Date
+): ActionRunFailure<"enqueue"> {
+  const enqueueError = createSixbError(
+    "queue.enqueue_failed",
+    `[Sixb] Could not enqueue Action run '${run.id}'.`,
+    {
+      cause: error,
+      details: { actionId: run.actionId, runId: run.id, phase: "enqueue" },
+    }
+  )
+  return parseActionRunFailure(
+    toSixbFailure(enqueueError, {
+      allowedCodes: ACTION_RUN_FAILURE_CODES,
+      at,
+    }),
+    "enqueue"
+  )
 }

--- a/packages/core/src/error-reporting/capability.ts
+++ b/packages/core/src/error-reporting/capability.ts
@@ -1,8 +1,10 @@
 import { SixbErrorReporter } from "./reporter"
 import {
+  type ReportActionPhaseFailureInput,
   type ReportEventDeliveryFailureInput,
   type ReportRuleEvaluationFailureInput,
   type ReportRunFailureInput,
+  reportActionPhaseFailure as reportActionPhaseFailureWith,
   reportEventDeliveryFailure as reportEventDeliveryFailureWith,
   reportRuleEvaluationFailure as reportRuleEvaluationFailureWith,
   reportRunFailure as reportRunFailureWith,
@@ -42,9 +44,18 @@ export function shareSixbErrorReporter(source: object, target: object): void {
 }
 
 export type {
+  ReportActionPhaseFailureInput,
   ReportEventDeliveryFailureInput,
   ReportRuleEvaluationFailureInput,
   ReportRunFailureInput,
+}
+
+export function reportActionPhaseFailure(
+  host: unknown,
+  error: unknown,
+  input: ReportActionPhaseFailureInput
+): void {
+  reportActionPhaseFailureWith(resolveSixbErrorReporter(host), error, input)
 }
 
 export function reportRunFailure(

--- a/packages/core/src/error-reporting/internal.ts
+++ b/packages/core/src/error-reporting/internal.ts
@@ -1,9 +1,11 @@
 export {
   attachSixbErrorReporter,
   flushSixbErrors,
+  type ReportActionPhaseFailureInput,
   type ReportEventDeliveryFailureInput,
   type ReportRuleEvaluationFailureInput,
   type ReportRunFailureInput,
+  reportActionPhaseFailure,
   reportEventDeliveryFailure,
   reportRuleEvaluationFailure,
   reportRunFailure,

--- a/packages/core/src/error-reporting/reports.ts
+++ b/packages/core/src/error-reporting/reports.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import type { ActionRunFailure } from "../storage/action-runs"
 import type { ErrorReporter } from "./reporter"
 import type { SixbFailedRun } from "./types"
 
@@ -27,6 +28,31 @@ export function reportRunFailure(
     occurredAt,
     ...(input.attempt === undefined ? {} : { attempt: input.attempt }),
     run: input.run,
+  })
+}
+
+export interface ReportActionPhaseFailureInput {
+  readonly projectId: string
+  readonly actionId: string
+  readonly runId: string
+  readonly phase: "effects"
+  readonly failure: ActionRunFailure<"effects">
+}
+
+export function reportActionPhaseFailure(
+  reporter: ErrorReporter,
+  error: unknown,
+  input: ReportActionPhaseFailureInput
+): void {
+  reporter.report(error, {
+    type: "action.phase.failed",
+    notificationId: `project:${input.projectId}:action:${input.actionId}:run:${input.runId}:phase:${input.phase}:failed:${input.failure.at}`,
+    projectId: input.projectId,
+    occurredAt: input.failure.at,
+    actionId: input.actionId,
+    runId: input.runId,
+    phase: input.phase,
+    failure: input.failure,
   })
 }
 

--- a/packages/core/src/error-reporting/types.ts
+++ b/packages/core/src/error-reporting/types.ts
@@ -1,3 +1,5 @@
+import type { ActionRunFailure } from "../storage/action-runs"
+
 /**
  * The failed unit of work, discriminated by primitive. Each variant carries the correlation its
  * primitive actually has, and there is exactly one variant per `SixbRunKind`.
@@ -65,6 +67,14 @@ export interface SixbRunFailedContext extends SixbFailureContext<"run.failed"> {
   readonly run: SixbFailedRun
 }
 
+/** A post-commit Action effects phase failed without changing the committed Action outcome. */
+export interface SixbActionPhaseFailedContext extends SixbFailureContext<"action.phase.failed"> {
+  readonly actionId: string
+  readonly runId: string
+  readonly phase: "effects"
+  readonly failure: ActionRunFailure<"effects">
+}
+
 /**
  * A batch of domain events never reached its subscribers.
  *
@@ -117,6 +127,7 @@ export interface SixbRuleEvaluationFailedContext
  * Failure notifications never change the outcome of the operation they observe.
  */
 export type SixbErrorContext =
+  | SixbActionPhaseFailedContext
   | SixbRunFailedContext
   | SixbEventDeliveryFailedContext
   | SixbRuleEvaluationFailedContext

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -22,6 +22,10 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "An unexpected internal error occurred.",
     retryable: false,
   },
+  "queue.enqueue_failed": {
+    publicMessage: "The job could not be enqueued.",
+    retryable: true,
+  },
   "runtime.cancelled": {
     publicMessage: "Execution was cancelled.",
     retryable: false,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -809,6 +809,7 @@ export type { BlobsRuntime } from "./blob-storage/execution"
 export type { ConnectorRuntime } from "./connectors/execution"
 export type { DatasetsRuntime } from "./datasets/execution"
 export type {
+  SixbActionPhaseFailedContext,
   SixbErrorContext,
   SixbErrorHandler,
   SixbEventDeliveryFailedContext,

--- a/packages/core/src/storage/action-runs/failure.ts
+++ b/packages/core/src/storage/action-runs/failure.ts
@@ -1,0 +1,64 @@
+import { parseSixbFailure } from "../../errors/internal"
+import { isPlainRecord } from "../../json"
+import {
+  ACTION_RUN_FAILURE_CODES,
+  ACTION_RUN_PHASES,
+  type ActionRunFailure,
+  type ActionRunFailureDetails,
+  type ActionRunPhase,
+} from "./types"
+
+/** Serializes the canonical failure plus Action's typed lifecycle extension. */
+export function serializeActionRunFailure<TPhase extends ActionRunPhase>(
+  failure: ActionRunFailure<TPhase>,
+  expectedPhase?: TPhase
+): string {
+  const parsed =
+    expectedPhase === undefined
+      ? parseActionRunFailure(failure)
+      : parseActionRunFailure(failure, expectedPhase)
+  return JSON.stringify(parsed)
+}
+
+/** Validates and detaches an Action failure read from a storage boundary. */
+export function parseActionRunFailure<TPhase extends ActionRunPhase>(
+  value: unknown,
+  expectedPhase: TPhase
+): ActionRunFailure<TPhase>
+export function parseActionRunFailure(value: unknown): ActionRunFailure
+export function parseActionRunFailure(
+  value: unknown,
+  expectedPhase?: ActionRunPhase
+): ActionRunFailure {
+  const candidate = parseStoredActionRunFailureValue(value)
+  const failure = parseSixbFailure(candidate, ACTION_RUN_FAILURE_CODES)
+  const details = failure.details
+  if (
+    !isPlainRecord(details) ||
+    typeof details.actionId !== "string" ||
+    typeof details.runId !== "string" ||
+    typeof details.phase !== "string" ||
+    !(ACTION_RUN_PHASES as readonly string[]).includes(details.phase)
+  ) {
+    throw new Error(
+      "[Sixb] Stored failure is invalid: Action details must contain actionId, runId, and a known phase."
+    )
+  }
+  if (expectedPhase !== undefined && details.phase !== expectedPhase) {
+    throw new Error(`[Sixb] Stored Action ${expectedPhase} failure has phase '${details.phase}'.`)
+  }
+
+  return {
+    ...failure,
+    details: details as unknown as ActionRunFailureDetails,
+  }
+}
+
+function parseStoredActionRunFailureValue(value: unknown): unknown {
+  if (typeof value !== "string") return value
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    throw new Error("[Sixb] Stored failure is invalid: value is not valid JSON.")
+  }
+}

--- a/packages/core/src/storage/action-runs/idempotency.ts
+++ b/packages/core/src/storage/action-runs/idempotency.ts
@@ -37,7 +37,7 @@ export function finishActionRunPhase(
     return input.phase ?? current ?? "validation"
   }
 
-  return input.phase ?? input.error?.phase ?? current ?? "validation"
+  return input.error.details.phase
 }
 
 export function canRequeueActionRunAfterEnqueueFailure(
@@ -48,6 +48,7 @@ export function canRequeueActionRunAfterEnqueueFailure(
     existing.status === "failed" &&
     existing.phase === "enqueue" &&
     existing.executionId === input.executionId &&
+    existing.error?.retryable === true &&
     existing.actionId === input.actionId &&
     existing.idempotencyKey === input.idempotencyKey &&
     actionSubjectsEqual(existing.subject, input.subject) &&

--- a/packages/core/src/storage/action-runs/in-memory.ts
+++ b/packages/core/src/storage/action-runs/in-memory.ts
@@ -1,5 +1,6 @@
 import type { ExecutionStorage } from "../executions"
 import { ActionRunError } from "./errors"
+import { parseActionRunFailure } from "./failure"
 import {
   actionRunPhaseRecordsEqual,
   actionSubjectsEqual,
@@ -11,6 +12,7 @@ import type {
   ActionRunEffectsRecord,
   ActionRunFailure,
   ActionRunParams,
+  ActionRunPhase,
   ActionRunRecord,
   ActionRunStorage,
   ActionRunWritebackRecord,
@@ -51,8 +53,13 @@ function normalizeSubject(subject: QueueActionRunInput["subject"]): QueueActionR
   return structuredClone(subject)
 }
 
-function normalizeError(error: ActionRunFailure | undefined): ActionRunFailure | undefined {
-  return error ? structuredClone(error) : undefined
+function normalizeError<TPhase extends ActionRunPhase>(
+  error: ActionRunFailure<TPhase>,
+  expectedPhase?: TPhase
+): ActionRunFailure<TPhase> {
+  return expectedPhase === undefined
+    ? (parseActionRunFailure(error) as ActionRunFailure<TPhase>)
+    : parseActionRunFailure(error, expectedPhase)
 }
 
 function normalizeWriteback(
@@ -70,7 +77,7 @@ function normalizeWriteback(
   return {
     status: "failed",
     completedAt,
-    error: normalizeError(input.error),
+    error: normalizeError(input.error, "writeback"),
   }
 }
 
@@ -88,7 +95,7 @@ function normalizeEffects(
   return {
     status: "failed",
     completedAt,
-    error: normalizeError(input.error),
+    error: normalizeError(input.error, "effects"),
   }
 }
 
@@ -312,9 +319,7 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
       }
 
       const phase =
-        input.status === "succeeded"
-          ? (input.phase ?? existing.phase)
-          : (input.phase ?? input.error?.phase ?? existing.phase)
+        input.status === "succeeded" ? (input.phase ?? existing.phase) : input.error.details.phase
 
       const base: ActionRunRecord = {
         ...existing,

--- a/packages/core/src/storage/action-runs/index.ts
+++ b/packages/core/src/storage/action-runs/index.ts
@@ -12,6 +12,8 @@ export { InMemoryActionRunStorage } from "./in-memory"
 export type {
   ActionRunEffectsRecord,
   ActionRunFailure,
+  ActionRunFailureCode,
+  ActionRunFailureDetails,
   ActionRunParams,
   ActionRunPhase,
   ActionRunPhaseStatus,
@@ -29,3 +31,4 @@ export type {
   RecordActionWritebackInput,
   StartActionRunInput,
 } from "./types"
+export { ACTION_RUN_FAILURE_CODES, ACTION_RUN_PHASES } from "./types"

--- a/packages/core/src/storage/action-runs/types.ts
+++ b/packages/core/src/storage/action-runs/types.ts
@@ -1,40 +1,72 @@
 import type { ActionSubject } from "../../actions"
+import type { SixbErrorCode, SixbFailure } from "../../errors/types"
 import type { JsonValue } from "../../json"
 
 export type ActionRunStatus = "queued" | "running" | "succeeded" | "failed" | "cancelled"
 
-export type ActionRunPhase =
-  | "request"
-  | "enqueue"
-  | "validation"
-  | "writeback"
-  | "edits"
-  | "commit"
-  | "effects"
-  | "cancelled"
+export const ACTION_RUN_PHASES = [
+  "request",
+  "enqueue",
+  "validation",
+  "writeback",
+  "edits",
+  "commit",
+  "effects",
+  "cancelled",
+] as const
+
+export type ActionRunPhase = (typeof ACTION_RUN_PHASES)[number]
 
 export type ActionRunParams = Readonly<Record<string, JsonValue>>
 
 export type ActionRunPhaseStatus = "succeeded" | "failed"
 
-export interface ActionRunFailure {
-  readonly name?: string
-  readonly message: string
-  readonly phase?: ActionRunPhase
+/** Error codes an action run or phase record can persist and expose. */
+export const ACTION_RUN_FAILURE_CODES = [
+  "internal.unexpected",
+  "runtime.cancelled",
+  "queue.enqueue_failed",
+] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
+
+export type ActionRunFailureCode = (typeof ACTION_RUN_FAILURE_CODES)[number]
+
+export interface ActionRunFailureDetails<TPhase extends ActionRunPhase = ActionRunPhase> {
+  readonly actionId: string
+  readonly runId: string
+  readonly phase: TPhase
 }
 
-export interface ActionRunWritebackRecord {
-  readonly status: ActionRunPhaseStatus
-  readonly completedAt: Date
-  readonly result?: JsonValue
-  readonly error?: ActionRunFailure
+/** Portable failure record with Action's required correlation details. */
+export interface ActionRunFailure<TPhase extends ActionRunPhase = ActionRunPhase>
+  extends Omit<SixbFailure<ActionRunFailureCode>, "details"> {
+  readonly details: ActionRunFailureDetails<TPhase>
 }
 
-export interface ActionRunEffectsRecord {
-  readonly status: ActionRunPhaseStatus
-  readonly completedAt: Date
-  readonly error?: ActionRunFailure
-}
+export type ActionRunWritebackRecord =
+  | {
+      readonly status: "succeeded"
+      readonly completedAt: Date
+      readonly result: JsonValue
+      readonly error?: never
+    }
+  | {
+      readonly status: "failed"
+      readonly completedAt: Date
+      readonly result?: never
+      readonly error: ActionRunFailure<"writeback">
+    }
+
+export type ActionRunEffectsRecord =
+  | {
+      readonly status: "succeeded"
+      readonly completedAt: Date
+      readonly error?: never
+    }
+  | {
+      readonly status: "failed"
+      readonly completedAt: Date
+      readonly error: ActionRunFailure<"effects">
+    }
 
 export interface ActionRunRecord {
   readonly id: string
@@ -94,7 +126,7 @@ export type RecordActionWritebackInput =
       readonly projectId: string
       readonly status: "failed"
       readonly completedAt?: Date
-      readonly error: ActionRunFailure
+      readonly error: ActionRunFailure<"writeback">
     }
 
 export type RecordActionEffectsInput =
@@ -109,7 +141,7 @@ export type RecordActionEffectsInput =
       readonly projectId: string
       readonly status: "failed"
       readonly completedAt?: Date
-      readonly error: ActionRunFailure
+      readonly error: ActionRunFailure<"effects">
     }
 
 export type FinishActionRunInput =
@@ -125,8 +157,7 @@ export type FinishActionRunInput =
       readonly projectId: string
       readonly status: "failed" | "cancelled"
       readonly finishedAt?: Date
-      readonly error?: ActionRunFailure
-      readonly phase?: ActionRunPhase
+      readonly error: ActionRunFailure
     }
 
 export interface ListActionRunsInput {

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -17,6 +17,7 @@ export type {
 export type {
   ActionRunEffectsRecord,
   ActionRunFailure,
+  ActionRunFailureCode,
   ActionRunParams,
   ActionRunPhase,
   ActionRunPhaseRecord,
@@ -36,6 +37,8 @@ export type {
   StartActionRunInput,
 } from "./action-runs"
 export {
+  ACTION_RUN_FAILURE_CODES,
+  ACTION_RUN_PHASES,
   ActionRunError,
   actionRunParamsEqual,
   actionRunPhaseRecordsEqual,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -23,6 +23,7 @@ export type {
 } from "../materialization/model"
 export type {
   ActionRunFailure,
+  ActionRunFailureCode,
   ActionRunParams,
   ActionRunPhase,
   ActionRunRecord,
@@ -35,7 +36,7 @@ export type {
   QueueActionRunInput,
   StartActionRunInput,
 } from "./action-runs"
-export { ActionRunError } from "./action-runs"
+export { ACTION_RUN_FAILURE_CODES, ACTION_RUN_PHASES, ActionRunError } from "./action-runs"
 export type {
   AgentMessageRecord,
   AgentRunExecution,

--- a/packages/core/tests/action-runs.test.ts
+++ b/packages/core/tests/action-runs.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, test } from "bun:test"
-import type { QueueActionRunInput } from "../src/storage"
+import type { ActionRunFailure, ActionRunPhase, QueueActionRunInput } from "../src/storage"
 import { ActionRunError, InMemoryStorage } from "../src/storage"
 import { createTestActionExecution, queueTestActionRun } from "../src/testing"
+
+const FAILURE_AT = "2026-04-29T10:00:00.000Z"
+
+function actionFailure<TPhase extends ActionRunPhase>(
+  phase: TPhase,
+  message: string
+): ActionRunFailure<TPhase> {
+  return {
+    code:
+      phase === "cancelled"
+        ? "runtime.cancelled"
+        : phase === "enqueue"
+          ? "queue.enqueue_failed"
+          : "internal.unexpected",
+    message,
+    retryable: phase === "enqueue",
+    at: FAILURE_AT,
+    details: { actionId: "sendQuote", runId: "act_1", phase },
+  }
+}
 
 function createActionRunFixture() {
   const provider = new InMemoryStorage()
@@ -163,10 +183,7 @@ describe("InMemoryActionRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "boom",
-          phase: "validation",
-        },
+        error: actionFailure("validation", "boom"),
       })
     ).rejects.toBeInstanceOf(ActionRunError)
   })
@@ -190,10 +207,7 @@ describe("InMemoryActionRunStorage", () => {
       id: "act_1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        message: "writeback failed",
-        phase: "writeback",
-      },
+      error: actionFailure("writeback", "writeback failed"),
     })
 
     await expect(
@@ -226,11 +240,7 @@ describe("InMemoryActionRunStorage", () => {
       id: "act_1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        name: "FetchError",
-        message: "TeamLeader API returned 503 Service Unavailable",
-        phase: "writeback",
-      },
+      error: actionFailure("writeback", "TeamLeader API returned 503 Service Unavailable"),
     })
 
     await queue({
@@ -279,11 +289,9 @@ describe("InMemoryActionRunStorage", () => {
       projectId: "my-app",
       id: "act_1",
     })
-    expect(failed?.error).toEqual({
-      name: "FetchError",
-      message: "TeamLeader API returned 503 Service Unavailable",
-      phase: "writeback",
-    })
+    expect(failed?.error).toEqual(
+      actionFailure("writeback", "TeamLeader API returned 503 Service Unavailable")
+    )
   })
 
   test("records V2 lifecycle records without failing committed actions on effects errors", async () => {
@@ -320,19 +328,11 @@ describe("InMemoryActionRunStorage", () => {
       id: "act_1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        name: "SlackError",
-        message: "Slack timed out",
-        phase: "effects",
-      },
+      error: actionFailure("effects", "Slack timed out"),
     })
     expect(effects.effects).toMatchObject({
       status: "failed",
-      error: {
-        name: "SlackError",
-        message: "Slack timed out",
-        phase: "effects",
-      },
+      error: actionFailure("effects", "Slack timed out"),
     })
 
     const finished = await storage.finish({

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -934,9 +934,15 @@ describe("requestAction", () => {
       status: "failed",
       phase: "enqueue",
       error: {
-        name: "Error",
-        message: "queue unavailable",
-        phase: "enqueue",
+        code: "queue.enqueue_failed",
+        message: "The job could not be enqueued.",
+        retryable: true,
+        at: failed?.finishedAt?.toISOString(),
+        details: {
+          actionId: "setTemperature",
+          runId: "act_enqueue_retry",
+          phase: "enqueue",
+        },
       },
     })
     await flushSixbErrors(sixb)

--- a/packages/core/tests/error-model.test.ts
+++ b/packages/core/tests/error-model.test.ts
@@ -14,7 +14,11 @@ import {
   summarizeErrorMessage,
   toSixbFailure,
 } from "../src/errors/internal"
-import { SYNC_RUN_FAILURE_CODES } from "../src/storage"
+import { ACTION_RUN_FAILURE_CODES, SYNC_RUN_FAILURE_CODES } from "../src/storage"
+import {
+  parseActionRunFailure,
+  serializeActionRunFailure,
+} from "../src/storage/action-runs/failure"
 
 const AT = new Date("2026-08-05T12:00:00.000Z")
 
@@ -139,6 +143,34 @@ describe("Sixb error model", () => {
     expect(parseSixbFailure(datasetFailure)).toEqual(datasetFailure)
     expect(() => parseSixbFailure(datasetFailure, SYNC_RUN_FAILURE_CODES)).toThrow(
       "code is not allowed by this failure contract"
+    )
+  })
+
+  test("round-trips the typed Action phase without weakening the base failure codec", () => {
+    const failure = parseActionRunFailure(
+      toSixbFailure(
+        createSixbError("internal.unexpected", "Writeback failed", {
+          cause: new Error("writeback failed"),
+          details: { actionId: "send-quote", runId: "act_1", phase: "writeback" },
+        }),
+        {
+          allowedCodes: ACTION_RUN_FAILURE_CODES,
+          at: AT,
+        }
+      ),
+      "writeback"
+    )
+    const serialized = serializeActionRunFailure(failure)
+
+    expect(parseActionRunFailure(serialized)).toEqual(failure)
+    expect(() =>
+      parseActionRunFailure({ ...failure, details: { ...failure.details, phase: "future" } })
+    ).toThrow("Action details must contain actionId, runId, and a known phase")
+    expect(() => parseActionRunFailure({ ...failure, code: "dataset.not_found" })).toThrow(
+      "code is not allowed by this failure contract"
+    )
+    expect(() => parseActionRunFailure(failure, "effects")).toThrow(
+      "Stored Action effects failure has phase 'writeback'"
     )
   })
 

--- a/packages/core/tests/error-reporting.types.ts
+++ b/packages/core/tests/error-reporting.types.ts
@@ -21,6 +21,9 @@ type _everyFailedRunIsIdentifiable = Expect<Equal<SixbFailedRun["runId"], string
 
 /** The error context is discriminated on `type`, and every member carries a dedup key. */
 type _errorContextIsDiscriminated = Expect<
-  Equal<SixbErrorContext["type"], "run.failed" | "event.delivery.failed" | "rule.evaluation.failed">
+  Equal<
+    SixbErrorContext["type"],
+    "action.phase.failed" | "run.failed" | "event.delivery.failed" | "rule.evaluation.failed"
+  >
 >
 type _errorContextAlwaysDeduplicable = Expect<Equal<SixbErrorContext["notificationId"], string>>

--- a/packages/server/src/routes/action-runs.ts
+++ b/packages/server/src/routes/action-runs.ts
@@ -62,19 +62,29 @@ function serializeActionRunDetail(
     ...serializeActionRunSummary(run),
     params: run.params,
     writeback: run.writeback
-      ? {
-          status: run.writeback.status,
-          completedAt: toIsoString(run.writeback.completedAt),
-          ...(run.writeback.result !== undefined ? { result: run.writeback.result } : {}),
-          error: run.writeback.error,
-        }
+      ? run.writeback.status === "succeeded"
+        ? {
+            status: "succeeded",
+            completedAt: toIsoString(run.writeback.completedAt),
+            result: run.writeback.result,
+          }
+        : {
+            status: "failed",
+            completedAt: toIsoString(run.writeback.completedAt),
+            error: run.writeback.error,
+          }
       : undefined,
     effects: run.effects
-      ? {
-          status: run.effects.status,
-          completedAt: toIsoString(run.effects.completedAt),
-          error: run.effects.error,
-        }
+      ? run.effects.status === "succeeded"
+        ? {
+            status: "succeeded",
+            completedAt: toIsoString(run.effects.completedAt),
+          }
+        : {
+            status: "failed",
+            completedAt: toIsoString(run.effects.completedAt),
+            error: run.effects.error,
+          }
       : undefined,
   })
 }

--- a/packages/server/src/schemas/actions.ts
+++ b/packages/server/src/schemas/actions.ts
@@ -1,4 +1,10 @@
+import {
+  ACTION_RUN_FAILURE_CODES,
+  ACTION_RUN_PHASES,
+  type ActionRunFailure,
+} from "@sixb/core/storage"
 import { z } from "zod"
+import { JsonValueSchema, sixbFailureSchema } from "./common"
 import { ActionParamSchema } from "./ontology"
 
 export const ActionIdParamsSchema = z.object({
@@ -55,16 +61,7 @@ export const ActionRunStatusSchema = z.enum([
   "cancelled",
 ])
 
-export const ActionRunPhaseSchema = z.enum([
-  "request",
-  "enqueue",
-  "validation",
-  "writeback",
-  "edits",
-  "commit",
-  "effects",
-  "cancelled",
-])
+export const ActionRunPhaseSchema = z.enum(ACTION_RUN_PHASES)
 
 export const ActionRunsQuerySchema = z.object({
   actionId: z.string().optional(),
@@ -78,10 +75,34 @@ export const ActionRunsQuerySchema = z.object({
   order: z.enum(["asc", "desc"]).optional(),
 })
 
-export const ActionRunFailureSchema = z.object({
-  name: z.string().optional(),
-  message: z.string(),
-  phase: ActionRunPhaseSchema.optional(),
+export const ActionRunFailureSchema: z.ZodType<ActionRunFailure> = sixbFailureSchema(
+  ACTION_RUN_FAILURE_CODES
+).extend({
+  details: z.object({
+    actionId: z.string(),
+    runId: z.string(),
+    phase: ActionRunPhaseSchema,
+  }),
+})
+
+const ActionRunWritebackFailureSchema: z.ZodType<ActionRunFailure<"writeback">> = sixbFailureSchema(
+  ACTION_RUN_FAILURE_CODES
+).extend({
+  details: z.object({
+    actionId: z.string(),
+    runId: z.string(),
+    phase: z.literal("writeback"),
+  }),
+})
+
+const ActionRunEffectsFailureSchema: z.ZodType<ActionRunFailure<"effects">> = sixbFailureSchema(
+  ACTION_RUN_FAILURE_CODES
+).extend({
+  details: z.object({
+    actionId: z.string(),
+    runId: z.string(),
+    phase: z.literal("effects"),
+  }),
 })
 
 export const ActionRunSummarySchema = z.object({
@@ -97,18 +118,30 @@ export const ActionRunSummarySchema = z.object({
   error: ActionRunFailureSchema.optional(),
 })
 
-const ActionRunWritebackRecordSchema = z.object({
-  status: z.enum(["succeeded", "failed"]),
-  completedAt: z.string(),
-  result: z.unknown().optional(),
-  error: ActionRunFailureSchema.optional(),
-})
+const ActionRunWritebackRecordSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("succeeded"),
+    completedAt: z.string(),
+    result: JsonValueSchema,
+  }),
+  z.object({
+    status: z.literal("failed"),
+    completedAt: z.string(),
+    error: ActionRunWritebackFailureSchema,
+  }),
+])
 
-const ActionRunEffectsRecordSchema = z.object({
-  status: z.enum(["succeeded", "failed"]),
-  completedAt: z.string(),
-  error: ActionRunFailureSchema.optional(),
-})
+const ActionRunEffectsRecordSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("succeeded"),
+    completedAt: z.string(),
+  }),
+  z.object({
+    status: z.literal("failed"),
+    completedAt: z.string(),
+    error: ActionRunEffectsFailureSchema,
+  }),
+])
 
 export const ActionRunDetailSchema = ActionRunSummarySchema.extend({
   params: z.record(z.unknown()),

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -551,9 +551,15 @@ describe("SixbServer HTTP contract", () => {
       status: "failed",
       completedAt: new Date("2026-02-18T09:12:04.000Z"),
       error: {
-        name: "NotificationError",
+        code: "internal.unexpected",
         message: "Notification failed",
-        phase: "effects",
+        retryable: false,
+        at: "2026-02-18T09:12:04.000Z",
+        details: {
+          actionId: "syncDeviceLabel",
+          runId: "act_audit_previous",
+          phase: "effects",
+        },
       },
     })
     await sixb.storage.actionRuns!.finish({
@@ -2171,9 +2177,15 @@ describe("SixbServer HTTP contract", () => {
           status: "failed",
           completedAt: "2026-02-18T09:12:04.000Z",
           error: {
-            name: "NotificationError",
+            code: "internal.unexpected",
             message: "Notification failed",
-            phase: "effects",
+            retryable: false,
+            at: "2026-02-18T09:12:04.000Z",
+            details: {
+              actionId: "syncDeviceLabel",
+              runId: "act_audit_previous",
+              phase: "effects",
+            },
           },
         },
       })

--- a/packages/workflow-worker/src/nodes/action-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/action-node-executor.ts
@@ -1,8 +1,14 @@
 import type { ActionSubject } from "@sixb/core"
 import { ActionRunFailedError, isObjectActionDefinition } from "@sixb/core"
+import { parseActionRunFailure } from "@sixb/core/internal/action-run-storage"
+import { createSixbError, toSixbFailure } from "@sixb/core/internal/errors"
 import type { WorkflowActionNodeDefinition } from "@sixb/core/internal/workflows"
 import { snapshotWorkflowActionInput } from "@sixb/core/internal/workflows"
-import type { ActionRunFailure } from "@sixb/core/storage"
+import {
+  ACTION_RUN_FAILURE_CODES,
+  type ActionRunFailure,
+  type ActionRunPhase,
+} from "@sixb/core/storage"
 import { WorkflowWorkerError } from "../errors"
 import type { WorkflowNodeExecutor } from "../execution/node-executor"
 import { isRecord } from "../normalize"
@@ -64,12 +70,21 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
       onRequested: () => context.markSideEffectBoundaryPassed(),
     })
     if (run.status !== "succeeded") {
+      const finishedAt = run.finishedAt ?? new Date()
       throw new ActionRunFailedError({
         runId: run.id,
         actionId: run.actionId,
         subject: run.subject,
-        error: run.error ?? actionRunStatusFailure(run.status, run.phase),
-        finishedAt: (run.finishedAt ?? new Date()).toISOString(),
+        error:
+          run.error ??
+          actionRunStatusFailure({
+            status: run.status,
+            phase: run.phase,
+            actionId: run.actionId,
+            runId: run.id,
+            at: finishedAt,
+          }),
+        finishedAt: finishedAt.toISOString(),
       })
     }
 
@@ -79,14 +94,32 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
   },
 }
 
-function actionRunStatusFailure(
-  status: "queued" | "running" | "failed" | "cancelled",
-  phase: ActionRunFailure["phase"]
-): ActionRunFailure {
-  return {
-    message: `Action run finished with status '${status}'.`,
-    phase,
-  }
+function actionRunStatusFailure(input: {
+  readonly status: "queued" | "running" | "failed" | "cancelled"
+  readonly phase?: ActionRunPhase
+  readonly actionId: string
+  readonly runId: string
+  readonly at: Date
+}): ActionRunFailure {
+  const phase = input.phase ?? (input.status === "cancelled" ? "cancelled" : "validation")
+  const error = createSixbError(
+    input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+    `Action run finished with status '${input.status}'.`,
+    {
+      details: {
+        actionId: input.actionId,
+        runId: input.runId,
+        phase,
+      },
+    }
+  )
+  return parseActionRunFailure(
+    toSixbFailure(error, {
+      allowedCodes: ACTION_RUN_FAILURE_CODES,
+      at: input.at,
+    }),
+    phase
+  )
 }
 
 function normalizeActionMapperResult(input: {

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -25,6 +25,8 @@ import {
 import { bindDurablePrimitiveExecution } from "@sixb/core/internal/primitive-execution"
 import { snapshotWorkflowInput } from "@sixb/core/internal/workflows"
 import type {
+  ActionRunFailure,
+  ActionRunPhase,
   ActionRunStorage,
   QueueWorkflowRunInput,
   WorkflowRunStorage,
@@ -35,6 +37,21 @@ import { EventsRuntimeWorkflowRunObserver } from "../src/events"
 import { runWorkflowJob as executeWorkflowJob, runWorkflowResumeJob } from "../src/run-workflow-job"
 import type { RunWorkflowJobInput, WorkflowRunObserver, WorkflowWorkerContext } from "../src/types"
 import type { WorkflowWorkerHost } from "../src/worker"
+
+const ACTION_FAILURE_AT = "2026-05-08T10:00:00.000Z"
+
+function actionFailure<TPhase extends ActionRunPhase>(
+  phase: TPhase,
+  message: string
+): ActionRunFailure<TPhase> {
+  return {
+    code: phase === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+    message,
+    retryable: false,
+    at: ACTION_FAILURE_AT,
+    details: { actionId: "sendInvoice", runId: "action-run", phase },
+  }
+}
 
 const Transaction = defineObjectType({
   id: "Transaction",
@@ -375,10 +392,7 @@ async function completeRequestedActions(
               projectId: sixb.id,
               id: event.payload.runId,
               status: "failed",
-              error: {
-                message: options.effectsErrorMessage,
-                phase: "effects",
-              },
+              error: actionFailure("effects", options.effectsErrorMessage),
             })
           }
 
@@ -395,10 +409,7 @@ async function completeRequestedActions(
                   id: event.payload.runId,
                   status: "failed",
                   finishedAt: new Date("2026-05-08T10:00:00.000Z"),
-                  error: {
-                    message: errorMessage,
-                    phase: "writeback",
-                  },
+                  error: actionFailure("writeback", errorMessage),
                 }
           )
 
@@ -420,10 +431,7 @@ async function completeRequestedActions(
                       actionId: event.payload.actionId,
                       runId: event.payload.runId,
                       subject: event.payload.subject,
-                      error: {
-                        message: errorMessage,
-                        phase: "writeback",
-                      },
+                      error: actionFailure("writeback", errorMessage),
                       finishedAt: "2026-05-08T10:00:00.000Z",
                     },
                   },
@@ -1611,7 +1619,7 @@ describe("runWorkflowJob", () => {
       expect(actionRun?.status).toBe("succeeded")
       expect(actionRun?.effects).toMatchObject({
         status: "failed",
-        error: { message: "notification failed", phase: "effects" },
+        error: { message: "notification failed", details: { phase: "effects" } },
       })
     } finally {
       unsubscribe()

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -41,6 +41,9 @@ import projectionFailureRecordSql from "./migrations/015-projection-failure-reco
 import webhookRunFailureRecordSql from "./migrations/016-webhook-run-failure-record.sql" with {
   type: "text",
 }
+import actionFailureRecordSql from "./migrations/017-action-failure-record.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -310,6 +313,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("014-agent-failure-record", agentFailureRecordSql),
     pgSql("015-projection-failure-record", projectionFailureRecordSql),
     pgSql("016-webhook-run-failure-record", webhookRunFailureRecordSql),
+    pgSql("017-action-failure-record", actionFailureRecordSql),
   ],
 })
 

--- a/storage/pg/src/migrations/017-action-failure-record.sql
+++ b/storage/pg/src/migrations/017-action-failure-record.sql
@@ -1,0 +1,57 @@
+ALTER TABLE action_runs
+  ADD COLUMN writeback_error JSONB,
+  ADD COLUMN effects_error JSONB,
+  ADD COLUMN error JSONB;
+
+UPDATE action_runs
+SET writeback_error = jsonb_build_object(
+  'code', 'internal.unexpected',
+  'message', 'An unexpected internal error occurred.',
+  'retryable', false,
+  'at', to_char(COALESCE(writeback_completed_at, finished_at, queued_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object('actionId', action_id, 'runId', id, 'phase', 'writeback')
+)
+WHERE writeback_error_name IS NOT NULL OR writeback_error_message IS NOT NULL;
+
+UPDATE action_runs
+SET effects_error = jsonb_build_object(
+  'code', 'internal.unexpected',
+  'message', 'An unexpected internal error occurred.',
+  'retryable', false,
+  'at', to_char(COALESCE(effects_completed_at, finished_at, queued_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object('actionId', action_id, 'runId', id, 'phase', 'effects')
+)
+WHERE effects_error_name IS NOT NULL OR effects_error_message IS NOT NULL;
+
+UPDATE action_runs
+SET error = jsonb_build_object(
+  'code', CASE
+    WHEN error_phase = 'enqueue' THEN 'queue.enqueue_failed'
+    WHEN error_phase = 'cancelled' OR status = 'cancelled' THEN 'runtime.cancelled'
+    ELSE 'internal.unexpected'
+  END,
+  'message', CASE
+    WHEN error_phase = 'enqueue' THEN 'The job could not be enqueued.'
+    WHEN error_phase = 'cancelled' OR status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', COALESCE(error_phase = 'enqueue', false),
+  'at', to_char(COALESCE(finished_at, queued_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+  'details', jsonb_build_object(
+    'actionId', action_id,
+    'runId', id,
+    'phase', COALESCE(error_phase, phase, 'request')
+  )
+)
+WHERE error_name IS NOT NULL OR error_message IS NOT NULL;
+
+ALTER TABLE action_runs
+  DROP COLUMN writeback_error_name,
+  DROP COLUMN writeback_error_message,
+  DROP COLUMN writeback_error_phase,
+  DROP COLUMN effects_error_name,
+  DROP COLUMN effects_error_message,
+  DROP COLUMN effects_error_phase,
+  DROP COLUMN error_name,
+  DROP COLUMN error_message,
+  DROP COLUMN error_phase;

--- a/storage/pg/src/pg-action-run-storage.ts
+++ b/storage/pg/src/pg-action-run-storage.ts
@@ -1,4 +1,8 @@
 import type { ActionSubject, JsonValue } from "@sixb/core"
+import {
+  parseActionRunFailure,
+  serializeActionRunFailure,
+} from "@sixb/core/internal/action-run-storage"
 import { assertActionRunExecution } from "@sixb/core/internal/action-run-storage-provider"
 import type {
   ActionRunEffectsRecord,
@@ -90,17 +94,11 @@ export class PgActionRunStorage implements ActionRunStorage {
           writeback_status,
           writeback_completed_at,
           writeback_result,
-          writeback_error_name,
-          writeback_error_message,
-          writeback_error_phase,
+          writeback_error,
           effects_status,
           effects_completed_at,
-          effects_error_name,
-          effects_error_message,
-          effects_error_phase,
-          error_name,
-          error_message,
-          error_phase
+          effects_error,
+          error
         ) VALUES (
           ${input.projectId},
           ${input.id},
@@ -116,12 +114,6 @@ export class PgActionRunStorage implements ActionRunStorage {
           ${null},
           ${JSON.stringify(input.params)}::text::jsonb,
           ${input.idempotencyKey},
-          ${null},
-          ${null},
-          ${null},
-          ${null},
-          ${null},
-          ${null},
           ${null},
           ${null},
           ${null},
@@ -172,17 +164,11 @@ export class PgActionRunStorage implements ActionRunStorage {
           writeback_status = ${null},
           writeback_completed_at = ${null},
           writeback_result = ${null},
-          writeback_error_name = ${null},
-          writeback_error_message = ${null},
-          writeback_error_phase = ${null},
+          writeback_error = ${null},
           effects_status = ${null},
           effects_completed_at = ${null},
-          effects_error_name = ${null},
-          effects_error_message = ${null},
-          effects_error_phase = ${null},
-          error_name = ${null},
-          error_message = ${null},
-          error_phase = ${null}
+          effects_error = ${null},
+          error = ${null}
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
       `
@@ -198,9 +184,7 @@ export class PgActionRunStorage implements ActionRunStorage {
         status = ${"running"},
         phase = ${input.phase ?? "validation"},
         started_at = ${input.startedAt ?? new Date()},
-        error_name = ${null},
-        error_message = ${null},
-        error_phase = ${null}
+        error = ${null}
       WHERE project_id = ${input.projectId}
         AND id = ${input.id}
         AND status = ${"queued"}
@@ -266,9 +250,7 @@ export class PgActionRunStorage implements ActionRunStorage {
           writeback_status = ${input.status},
           writeback_completed_at = ${nextWriteback.completedAt},
           writeback_result = ${input.status === "succeeded" ? JSON.stringify(input.result) : null}::text::jsonb,
-          writeback_error_name = ${input.status === "failed" ? (input.error.name ?? null) : null},
-          writeback_error_message = ${input.status === "failed" ? input.error.message : null},
-          writeback_error_phase = ${input.status === "failed" ? (input.error.phase ?? "writeback") : null}
+          writeback_error = ${input.status === "failed" ? serializeActionRunFailure(input.error, "writeback") : null}::text::jsonb
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
       `
@@ -299,9 +281,7 @@ export class PgActionRunStorage implements ActionRunStorage {
           phase = ${"effects"},
           effects_status = ${input.status},
           effects_completed_at = ${nextEffects.completedAt},
-          effects_error_name = ${input.status === "failed" ? (input.error.name ?? null) : null},
-          effects_error_message = ${input.status === "failed" ? input.error.message : null},
-          effects_error_phase = ${input.status === "failed" ? (input.error.phase ?? "effects") : null}
+          effects_error = ${input.status === "failed" ? serializeActionRunFailure(input.error, "effects") : null}::text::jsonb
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
       `
@@ -338,9 +318,7 @@ export class PgActionRunStorage implements ActionRunStorage {
           status = ${input.status},
           phase = ${phase},
           finished_at = ${input.finishedAt ?? new Date()},
-          error_name = ${input.status === "succeeded" ? null : (input.error?.name ?? null)},
-          error_message = ${input.status === "succeeded" ? null : (input.error?.message ?? null)},
-          error_phase = ${input.status === "succeeded" ? null : (input.error?.phase ?? phase)}
+          error = ${input.status === "succeeded" ? null : serializeActionRunFailure(input.error)}::text::jsonb
         WHERE project_id = ${input.projectId} AND id = ${input.id}
         RETURNING *
       `
@@ -499,23 +477,14 @@ export class PgActionRunStorage implements ActionRunStorage {
 }
 
 function toActionRunFailure(row: DatabaseRow): ActionRunFailure | undefined {
-  return toFailure(row.error_name, row.error_message, row.error_phase)
+  return row.error === null ? undefined : parseActionRunFailure(row.error)
 }
 
-function toFailure(
-  name: string | null,
-  message: string | null,
-  phase: ActionRunPhase | null
-): ActionRunFailure | undefined {
-  if (!message) {
-    return undefined
-  }
-
-  return {
-    name: name ?? undefined,
-    message,
-    phase: phase ?? undefined,
-  }
+function parsePhaseFailure<TPhase extends Extract<ActionRunPhase, "writeback" | "effects">>(
+  value: unknown,
+  expectedPhase: TPhase
+): ActionRunFailure<TPhase> {
+  return parseActionRunFailure(value, expectedPhase)
 }
 
 function toActionRunWritebackRecord(row: DatabaseRow): ActionRunWritebackRecord | undefined {
@@ -538,11 +507,7 @@ function toActionRunWritebackRecord(row: DatabaseRow): ActionRunWritebackRecord 
   return {
     status: "failed",
     completedAt,
-    error: toFailure(
-      row.writeback_error_name,
-      row.writeback_error_message,
-      row.writeback_error_phase
-    ),
+    error: parsePhaseFailure(row.writeback_error, "writeback"),
   }
 }
 
@@ -565,7 +530,7 @@ function toActionRunEffectsRecord(row: DatabaseRow): ActionRunEffectsRecord | un
   return {
     status: "failed",
     completedAt,
-    error: toFailure(row.effects_error_name, row.effects_error_message, row.effects_error_phase),
+    error: parsePhaseFailure(row.effects_error, "effects"),
   }
 }
 
@@ -660,15 +625,9 @@ interface DatabaseRow {
   writeback_status: ActionRunWritebackRecord["status"] | null
   writeback_completed_at: Date | string | null
   writeback_result: JsonValue | null
-  writeback_error_name: string | null
-  writeback_error_message: string | null
-  writeback_error_phase: ActionRunPhase | null
+  writeback_error: unknown | null
   effects_status: ActionRunEffectsRecord["status"] | null
   effects_completed_at: Date | string | null
-  effects_error_name: string | null
-  effects_error_message: string | null
-  effects_error_phase: ActionRunPhase | null
-  error_name: string | null
-  error_message: string | null
-  error_phase: ActionRunPhase | null
+  effects_error: unknown | null
+  error: unknown | null
 }

--- a/storage/pg/tests/pg-action-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-action-run-storage.e2e.ts
@@ -1,7 +1,28 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import type { ActionRunFailure, ActionRunPhase } from "@sixb/core/storage"
 import { queueTestActionRun } from "@sixb/core/testing"
 import type { PostgresStorage } from "../src"
 import { createTestStorage } from "./helpers"
+
+const FAILURE_AT = "2026-04-29T10:00:00.000Z"
+
+function actionFailure<TPhase extends ActionRunPhase>(
+  phase: TPhase,
+  message: string
+): ActionRunFailure<TPhase> {
+  return {
+    code:
+      phase === "cancelled"
+        ? "runtime.cancelled"
+        : phase === "enqueue"
+          ? "queue.enqueue_failed"
+          : "internal.unexpected",
+    message,
+    retryable: phase === "enqueue",
+    at: FAILURE_AT,
+    details: { actionId: "sendQuote", runId: "act_1", phase },
+  }
+}
 
 describe("PgActionRunStorage", () => {
   let storage: PostgresStorage
@@ -42,11 +63,7 @@ describe("PgActionRunStorage", () => {
       id: "act_1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        name: "SlackError",
-        message: "Slack timed out",
-        phase: "effects",
-      },
+      error: actionFailure("effects", "Slack timed out"),
     })
 
     await storage.actionRuns.finish({
@@ -70,11 +87,7 @@ describe("PgActionRunStorage", () => {
       },
       effects: {
         status: "failed",
-        error: {
-          name: "SlackError",
-          message: "Slack timed out",
-          phase: "effects",
-        },
+        error: actionFailure("effects", "Slack timed out"),
       },
     })
     const page = await storage.actionRuns.list({

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -52,6 +52,7 @@ describe("Postgres storage migrations", () => {
             "014-agent-failure-record",
             "015-projection-failure-record",
             "016-webhook-run-failure-record",
+            "017-action-failure-record",
           ],
         },
       ])
@@ -167,6 +168,13 @@ describe("Postgres storage migrations", () => {
           id: "016-webhook-run-failure-record",
           status: "applied",
           version: 16,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "017-action-failure-record",
+          status: "applied",
+          version: 17,
         },
       ])
     })
@@ -865,6 +873,13 @@ describe("Postgres storage migrations", () => {
           id: "016-webhook-run-failure-record",
           status: "applied",
           version: 16,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "017-action-failure-record",
+          status: "applied",
+          version: 17,
         },
       ])
     } finally {

--- a/storage/sqlite/src/action-run-storage.ts
+++ b/storage/sqlite/src/action-run-storage.ts
@@ -1,5 +1,9 @@
 import type { Database } from "bun:sqlite"
 import type { ActionSubject, JsonValue } from "@sixb/core"
+import {
+  parseActionRunFailure,
+  serializeActionRunFailure,
+} from "@sixb/core/internal/action-run-storage"
 import { assertActionRunExecution } from "@sixb/core/internal/action-run-storage-provider"
 import type {
   ActionRunEffectsRecord,
@@ -122,22 +126,16 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             writeback_status,
             writeback_completed_at,
             writeback_result,
-            writeback_error_name,
-            writeback_error_message,
-            writeback_error_phase,
+            writeback_error,
             effects_status,
             effects_completed_at,
-            effects_error_name,
-            effects_error_message,
-            effects_error_phase,
-            error_name,
-            error_message,
-            error_phase
+            effects_error,
+            error
           ) VALUES (
             ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?,
-            NULL, NULL, NULL, NULL, NULL, NULL,
-            NULL, NULL, NULL, NULL, NULL,
-            NULL, NULL, NULL
+            NULL, NULL, NULL, NULL,
+            NULL, NULL, NULL,
+            NULL
           )
         `
         )
@@ -204,17 +202,11 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             writeback_status = NULL,
             writeback_completed_at = NULL,
             writeback_result = NULL,
-            writeback_error_name = NULL,
-            writeback_error_message = NULL,
-            writeback_error_phase = NULL,
+            writeback_error = NULL,
             effects_status = NULL,
             effects_completed_at = NULL,
-            effects_error_name = NULL,
-            effects_error_message = NULL,
-            effects_error_phase = NULL,
-            error_name = NULL,
-            error_message = NULL,
-            error_phase = NULL
+            effects_error = NULL,
+            error = NULL
           WHERE project_id = ? AND id = ?
         `
         )
@@ -254,9 +246,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             status = ?,
             phase = ?,
             started_at = ?,
-            error_name = NULL,
-            error_message = NULL,
-            error_phase = NULL
+            error = NULL
           WHERE project_id = ? AND id = ?
         `
         )
@@ -323,9 +313,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             writeback_status = ?,
             writeback_completed_at = ?,
             writeback_result = ?,
-            writeback_error_name = ?,
-            writeback_error_message = ?,
-            writeback_error_phase = ?
+            writeback_error = ?
           WHERE project_id = ? AND id = ?
         `
         )
@@ -334,9 +322,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
           input.status,
           nextWriteback.completedAt.toISOString(),
           input.status === "succeeded" ? serializeJsonValue(input.result) : null,
-          input.status === "failed" ? (input.error.name ?? null) : null,
-          input.status === "failed" ? input.error.message : null,
-          input.status === "failed" ? (input.error.phase ?? "writeback") : null,
+          input.status === "failed" ? serializeActionRunFailure(input.error, "writeback") : null,
           input.projectId,
           input.id
         )
@@ -373,9 +359,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             phase = ?,
             effects_status = ?,
             effects_completed_at = ?,
-            effects_error_name = ?,
-            effects_error_message = ?,
-            effects_error_phase = ?
+            effects_error = ?
           WHERE project_id = ? AND id = ?
         `
         )
@@ -383,9 +367,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
           "effects",
           input.status,
           nextEffects.completedAt.toISOString(),
-          input.status === "failed" ? (input.error.name ?? null) : null,
-          input.status === "failed" ? input.error.message : null,
-          input.status === "failed" ? (input.error.phase ?? "effects") : null,
+          input.status === "failed" ? serializeActionRunFailure(input.error, "effects") : null,
           input.projectId,
           input.id
         )
@@ -426,9 +408,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             status = ?,
             phase = ?,
             finished_at = ?,
-            error_name = ?,
-            error_message = ?,
-            error_phase = ?
+            error = ?
           WHERE project_id = ? AND id = ?
         `
         )
@@ -436,9 +416,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
           input.status,
           phase,
           (input.finishedAt ?? new Date()).toISOString(),
-          input.status === "succeeded" ? null : (input.error?.name ?? null),
-          input.status === "succeeded" ? null : (input.error?.message ?? null),
-          input.status === "succeeded" ? null : (input.error?.phase ?? phase),
+          input.status === "succeeded" ? null : serializeActionRunFailure(input.error),
           input.projectId,
           input.id
         )
@@ -599,23 +577,14 @@ function serializeJsonValue(value: JsonValue): string {
 }
 
 function toActionRunFailure(row: DatabaseRow): ActionRunFailure | undefined {
-  return toFailure(row.error_name, row.error_message, row.error_phase)
+  return row.error === null ? undefined : parseActionRunFailure(row.error)
 }
 
-function toFailure(
-  name: string | null,
-  message: string | null,
-  phase: ActionRunPhase | null
-): ActionRunFailure | undefined {
-  if (!message) {
-    return undefined
-  }
-
-  return {
-    name: name ?? undefined,
-    message,
-    phase: phase ?? undefined,
-  }
+function parsePhaseFailure<TPhase extends Extract<ActionRunPhase, "writeback" | "effects">>(
+  value: string | null,
+  expectedPhase: TPhase
+): ActionRunFailure<TPhase> {
+  return parseActionRunFailure(value, expectedPhase)
 }
 
 function toActionRunWritebackRecord(row: DatabaseRow): ActionRunWritebackRecord | undefined {
@@ -639,11 +608,7 @@ function toActionRunWritebackRecord(row: DatabaseRow): ActionRunWritebackRecord 
   return {
     status: "failed",
     completedAt,
-    error: toFailure(
-      row.writeback_error_name,
-      row.writeback_error_message,
-      row.writeback_error_phase
-    ),
+    error: parsePhaseFailure(row.writeback_error, "writeback"),
   }
 }
 
@@ -666,7 +631,7 @@ function toActionRunEffectsRecord(row: DatabaseRow): ActionRunEffectsRecord | un
   return {
     status: "failed",
     completedAt,
-    error: toFailure(row.effects_error_name, row.effects_error_message, row.effects_error_phase),
+    error: parsePhaseFailure(row.effects_error, "effects"),
   }
 }
 
@@ -765,15 +730,9 @@ interface DatabaseRow {
   writeback_status: ActionRunWritebackRecord["status"] | null
   writeback_completed_at: string | null
   writeback_result: string | null
-  writeback_error_name: string | null
-  writeback_error_message: string | null
-  writeback_error_phase: ActionRunPhase | null
+  writeback_error: string | null
   effects_status: ActionRunEffectsRecord["status"] | null
   effects_completed_at: string | null
-  effects_error_name: string | null
-  effects_error_message: string | null
-  effects_error_phase: ActionRunPhase | null
-  error_name: string | null
-  error_message: string | null
-  error_phase: ActionRunPhase | null
+  effects_error: string | null
+  error: string | null
 }

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -44,6 +44,9 @@ import projectionFailureRecordSql from "./migrations/015-projection-failure-reco
 import webhookRunFailureRecordSql from "./migrations/016-webhook-run-failure-record.sql" with {
   type: "text",
 }
+import actionFailureRecordSql from "./migrations/017-action-failure-record.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -80,6 +83,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("014-agent-failure-record", agentFailureRecordSql),
     sqliteSql("015-projection-failure-record", projectionFailureRecordSql),
     sqliteSql("016-webhook-run-failure-record", webhookRunFailureRecordSql),
+    sqliteSql("017-action-failure-record", actionFailureRecordSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/017-action-failure-record.sql
+++ b/storage/sqlite/src/migrations/017-action-failure-record.sql
@@ -1,0 +1,57 @@
+ALTER TABLE action_runs ADD COLUMN writeback_error TEXT
+  CHECK (writeback_error IS NULL OR json_valid(writeback_error));
+ALTER TABLE action_runs ADD COLUMN effects_error TEXT
+  CHECK (effects_error IS NULL OR json_valid(effects_error));
+ALTER TABLE action_runs ADD COLUMN error TEXT CHECK (error IS NULL OR json_valid(error));
+
+UPDATE action_runs
+SET writeback_error = json_object(
+  'code', 'internal.unexpected',
+  'message', 'An unexpected internal error occurred.',
+  'retryable', json('false'),
+  'at', COALESCE(writeback_completed_at, finished_at, queued_at),
+  'details', json_object('actionId', action_id, 'runId', id, 'phase', 'writeback')
+)
+WHERE writeback_error_name IS NOT NULL OR writeback_error_message IS NOT NULL;
+
+UPDATE action_runs
+SET effects_error = json_object(
+  'code', 'internal.unexpected',
+  'message', 'An unexpected internal error occurred.',
+  'retryable', json('false'),
+  'at', COALESCE(effects_completed_at, finished_at, queued_at),
+  'details', json_object('actionId', action_id, 'runId', id, 'phase', 'effects')
+)
+WHERE effects_error_name IS NOT NULL OR effects_error_message IS NOT NULL;
+
+UPDATE action_runs
+SET error = json_object(
+  'code', CASE
+    WHEN error_phase = 'enqueue' THEN 'queue.enqueue_failed'
+    WHEN error_phase = 'cancelled' OR status = 'cancelled' THEN 'runtime.cancelled'
+    ELSE 'internal.unexpected'
+  END,
+  'message', CASE
+    WHEN error_phase = 'enqueue' THEN 'The job could not be enqueued.'
+    WHEN error_phase = 'cancelled' OR status = 'cancelled' THEN 'Execution was cancelled.'
+    ELSE 'An unexpected internal error occurred.'
+  END,
+  'retryable', json(CASE WHEN error_phase = 'enqueue' THEN 'true' ELSE 'false' END),
+  'at', COALESCE(finished_at, queued_at),
+  'details', json_object(
+    'actionId', action_id,
+    'runId', id,
+    'phase', COALESCE(error_phase, phase, 'request')
+  )
+)
+WHERE error_name IS NOT NULL OR error_message IS NOT NULL;
+
+ALTER TABLE action_runs DROP COLUMN writeback_error_name;
+ALTER TABLE action_runs DROP COLUMN writeback_error_message;
+ALTER TABLE action_runs DROP COLUMN writeback_error_phase;
+ALTER TABLE action_runs DROP COLUMN effects_error_name;
+ALTER TABLE action_runs DROP COLUMN effects_error_message;
+ALTER TABLE action_runs DROP COLUMN effects_error_phase;
+ALTER TABLE action_runs DROP COLUMN error_name;
+ALTER TABLE action_runs DROP COLUMN error_message;
+ALTER TABLE action_runs DROP COLUMN error_phase;

--- a/storage/sqlite/tests/sqlite-action-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-action-run-storage.test.ts
@@ -1,8 +1,28 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import type { QueueActionRunInput } from "@sixb/core/storage"
+import type { ActionRunFailure, ActionRunPhase, QueueActionRunInput } from "@sixb/core/storage"
 import { ActionRunError } from "@sixb/core/storage"
 import { queueTestActionRun } from "@sixb/core/testing"
 import { SqliteStorage } from "../src"
+
+const FAILURE_AT = "2026-04-29T10:00:00.000Z"
+
+function actionFailure<TPhase extends ActionRunPhase>(
+  phase: TPhase,
+  message: string
+): ActionRunFailure<TPhase> {
+  return {
+    code:
+      phase === "cancelled"
+        ? "runtime.cancelled"
+        : phase === "enqueue"
+          ? "queue.enqueue_failed"
+          : "internal.unexpected",
+    message,
+    retryable: phase === "enqueue",
+    at: FAILURE_AT,
+    details: { actionId: "sendQuote", runId: "act_1", phase },
+  }
+}
 
 describe("SqliteActionRunStorage", () => {
   let root: SqliteStorage
@@ -72,11 +92,7 @@ describe("SqliteActionRunStorage", () => {
       id: "act_1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        name: "FetchError",
-        message: "TeamLeader API returned 503 Service Unavailable",
-        phase: "writeback",
-      },
+      error: actionFailure("writeback", "TeamLeader API returned 503 Service Unavailable"),
     })
 
     await queue({
@@ -108,11 +124,9 @@ describe("SqliteActionRunStorage", () => {
       projectId: "my-app",
       id: "act_1",
     })
-    expect(failed?.error).toEqual({
-      name: "FetchError",
-      message: "TeamLeader API returned 503 Service Unavailable",
-      phase: "writeback",
-    })
+    expect(failed?.error).toEqual(
+      actionFailure("writeback", "TeamLeader API returned 503 Service Unavailable")
+    )
   })
 
   test("rejects duplicates and missing runs", async () => {
@@ -154,9 +168,7 @@ describe("SqliteActionRunStorage", () => {
         id: "missing",
         projectId: "my-app",
         status: "failed",
-        error: {
-          message: "boom",
-        },
+        error: actionFailure("validation", "boom"),
       })
     ).rejects.toBeInstanceOf(ActionRunError)
   })
@@ -179,10 +191,7 @@ describe("SqliteActionRunStorage", () => {
       id: "act_1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        message: "writeback failed",
-        phase: "writeback",
-      },
+      error: actionFailure("writeback", "writeback failed"),
     })
 
     await expect(
@@ -209,12 +218,8 @@ describe("SqliteActionRunStorage", () => {
       id: "act_1",
       projectId: "my-app",
       status: "failed",
-      phase: "enqueue",
       finishedAt: new Date("2026-04-29T10:00:01.000Z"),
-      error: {
-        message: "queue unavailable",
-        phase: "enqueue",
-      },
+      error: actionFailure("enqueue", "queue unavailable"),
     })
 
     const requeued = await queue({
@@ -275,11 +280,7 @@ describe("SqliteActionRunStorage", () => {
       id: "act_1",
       projectId: "my-app",
       status: "failed",
-      error: {
-        name: "SlackError",
-        message: "Slack timed out",
-        phase: "effects",
-      },
+      error: actionFailure("effects", "Slack timed out"),
     })
 
     await storage.finish({
@@ -303,11 +304,7 @@ describe("SqliteActionRunStorage", () => {
       },
       effects: {
         status: "failed",
-        error: {
-          name: "SlackError",
-          message: "Slack timed out",
-          phase: "effects",
-        },
+        error: actionFailure("effects", "Slack timed out"),
       },
     })
   })

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -5,6 +5,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { migrateStorage } from "@sixb/core"
+import { parseActionRunFailure } from "@sixb/core/internal/action-run-storage"
 import { parseSixbFailure } from "@sixb/core/internal/errors"
 import {
   AGENT_RUN_FAILURE_CODES,
@@ -137,6 +138,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 16,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "017-action-failure-record",
+    status: "applied",
+    version: 17,
+  },
 ]
 
 afterEach(async () => {
@@ -252,6 +260,15 @@ describe("SQLite storage migrations", () => {
 
         INSERT INTO executions (
           project_id, id, executor_kind, executor_id, source_kind, source_id, correlation_id,
+          authority_kind, authority_primitive_kind, authority_primitive_id, created_at
+        ) VALUES (
+          'project-a', 'execution-action-legacy', 'action', 'action-legacy', 'event',
+          'event-action-legacy', 'correlation-action-legacy', 'trustedPrimitive', 'action',
+          'approve', '2026-08-10T12:00:00.000Z'
+        );
+
+        INSERT INTO executions (
+          project_id, id, executor_kind, executor_id, source_kind, source_id, correlation_id,
           authority_kind, created_at
         ) VALUES (
           'project-a', 'execution-agent-parent-legacy', 'request',
@@ -329,6 +346,21 @@ describe("SQLite storage migrations", () => {
           'project-a', 'webhook-legacy', 'github', 'events', 'failed', 'POST', '/hooks/github',
           '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z',
           'secret webhook diagnostic'
+        );
+
+        INSERT INTO action_runs (
+          project_id, id, execution_id, action_id, subject_kind, status, phase, queued_at,
+          finished_at, params, idempotency_key, writeback_status, writeback_completed_at,
+          writeback_error_name, writeback_error_message, writeback_error_phase, effects_status,
+          effects_completed_at, effects_error_name, effects_error_message, effects_error_phase,
+          error_name, error_message, error_phase
+        ) VALUES (
+          'project-a', 'action-legacy', 'execution-action-legacy', 'approve', 'none', 'failed',
+          'effects', '2026-08-10T12:00:00.000Z', '2026-08-10T12:01:00.000Z', '{}',
+          'action-legacy', 'failed', '2026-08-10T12:00:30.000Z', 'WritebackError',
+          'secret writeback diagnostic', 'writeback', 'failed', '2026-08-10T12:00:45.000Z',
+          'EffectsError', 'secret effects diagnostic', 'effects', 'ActionError',
+          'secret Action diagnostic', 'effects'
         );
       `)
 
@@ -475,6 +507,26 @@ describe("SQLite storage migrations", () => {
         },
       })
       expect(JSON.stringify(webhookFailure)).not.toContain("secret webhook diagnostic")
+
+      const actionRow = db
+        .query("SELECT error, writeback_error, effects_error FROM action_runs WHERE id = ?")
+        .get("action-legacy") as {
+        readonly error: string
+        readonly writeback_error: string
+        readonly effects_error: string
+      }
+      expect(parseActionRunFailure(actionRow.error)).toMatchObject({
+        code: "internal.unexpected",
+        details: { actionId: "approve", runId: "action-legacy", phase: "effects" },
+      })
+      expect(parseActionRunFailure(actionRow.writeback_error, "writeback")).toMatchObject({
+        details: { actionId: "approve", runId: "action-legacy", phase: "writeback" },
+      })
+      expect(parseActionRunFailure(actionRow.effects_error, "effects")).toMatchObject({
+        details: { actionId: "approve", runId: "action-legacy", phase: "effects" },
+      })
+      expect(JSON.stringify(actionRow)).not.toContain("secret")
+      expect(readMemoryTableColumns(db, "action_runs")).not.toContain("error_phase")
     } finally {
       db.close()
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,9 @@
       "@sixb/core/broker": ["./packages/core/src/broker/index.ts"],
       "@sixb/core/events/scope": ["./packages/core/src/events/scope.ts"],
       "@sixb/core/events/selectors": ["./packages/core/src/events/selectors/index.ts"],
+      "@sixb/core/internal/action-run-storage": [
+        "./packages/core/src/storage/action-runs/failure.ts"
+      ],
       "@sixb/core/internal/actions": ["./packages/core/src/actions/index.ts"],
       "@sixb/core/internal/agents": ["./packages/core/src/agents/index.ts"],
       "@sixb/core/internal/agent-run-storage-provider": [


### PR DESCRIPTION
## Summary

- replace the legacy Action `{ name?, message, phase? }` payload with the portable failure record and a required typed lifecycle `phase`
- scope persisted Action codes to `internal.unexpected | runtime.cancelled`
- persist run, writeback, and effects failures as one validated JSON/JSONB value in SQLite and PostgreSQL
- align Action producers, storage adapters, HTTP schemas, the generated client, and Atlas on the same contract
- make writeback and effects records discriminated so failed records always contain a phase-specific failure

## Design decisions

- `phase` remains an Action-domain extension instead of weakening the shared failure model for every primitive
- the internal Action storage codec owns validation of the extension, keeping the generic error foundation independent from Action storage
- storage boundaries validate the code, retry policy, timestamp, JSON diagnostics, and expected phase at runtime rather than trusting TypeScript inputs
- a writeback failure is snapshotted once and reused as the terminal run failure, preventing timestamps or diagnostics from diverging
- no Action-specific error taxonomy is introduced yet; unknown failures remain `internal.unexpected` until a stable recovery decision requires a dedicated code
- the internal error class remains private; only serializable failure values cross storage and API boundaries

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun run test:publish` — 47 publishable packages verified
- Action, workflow integration, server contract, generated client, and SQLite tests — 129 passing
- PostgreSQL Action storage and fresh migration tests — 14 passing
- SQLite fresh migration tests — 12 passing

## Stack

- stacked on #323
- part of #274
