### PR TITLE
action-worker: replace intermediate error class

### DIFF
--- a/packages/action-worker/src/action-execution/context.ts
+++ b/packages/action-worker/src/action-execution/context.ts
@@ -9,8 +9,8 @@ import type {
 } from "@sixb/core"
 import { isObjectActionDefinition, ObjectNotFoundError } from "@sixb/core"
 import { coerceActionParamsToTyped } from "@sixb/core/internal/actions"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { ActionRunRecord } from "@sixb/core/storage"
-import { ActionWorkerError } from "../errors"
 import type { RunActionJobInput } from "../types"
 import type { LoadedObjectTarget } from "./types"
 
@@ -92,19 +92,28 @@ export async function loadObjectTarget(input: {
 }): Promise<LoadedObjectTarget | null> {
   if (!isObjectActionDefinition(input.action)) {
     if (input.run.subject.kind !== "none") {
-      throw new ActionWorkerError(`Action '${input.action.id}' does not accept a subject.`)
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbActionWorker] Action '${input.action.id}' does not accept a subject.`,
+        { details: { actionId: input.action.id, runId: input.run.id } }
+      )
     }
     return null
   }
 
-  const subject = requireObjectSubject(input.run.subject, input.action.id)
+  const subject = requireObjectSubject(input.run.subject, {
+    actionId: input.action.id,
+    runId: input.run.id,
+  })
   const subjectObjectType = input.runtime.sixb.objects.resolveType(subject.objectTypeId)
   const actionAppliesToSubject = input.runtime.sixb.actions
     .listForType(subjectObjectType)
     .some((candidate) => candidate.id === input.action.id)
   if (!actionAppliesToSubject) {
-    throw new ActionWorkerError(
-      `Action '${input.action.id}' is not valid for object type '${subjectObjectType.id}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbActionWorker] Action '${input.action.id}' is not valid for object type '${subjectObjectType.id}'.`,
+      { details: { actionId: input.action.id, runId: input.run.id } }
     )
   }
 
@@ -130,19 +139,30 @@ export async function loadObjectTarget(input: {
 
 export function requireObjectSubject<
   TObjectType extends ObjectTypeWithPropertyTokens = ObjectTypeWithPropertyTokens,
->(subject: ActionSubject, actionId: string): ActionObjectSubject<TObjectType> {
+>(
+  subject: ActionSubject,
+  input: { readonly actionId: string; readonly runId: string }
+): ActionObjectSubject<TObjectType> {
   if (subject.kind !== "object") {
-    throw new ActionWorkerError(`Action '${actionId}' requires an object subject.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbActionWorker] Action '${input.actionId}' requires an object subject.`,
+      { details: input }
+    )
   }
   return subject as ActionObjectSubject<TObjectType>
 }
 
 export function requireObjectTarget(
   target: LoadedObjectTarget | null,
-  actionId: string
+  input: { readonly actionId: string; readonly runId: string }
 ): LoadedObjectTarget {
   if (!target) {
-    throw new ActionWorkerError(`Action '${actionId}' requires an object target.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbActionWorker] Action '${input.actionId}' requires an object target.`,
+      { details: input }
+    )
   }
   return target
 }

--- a/packages/action-worker/src/action-execution/edits-commit.ts
+++ b/packages/action-worker/src/action-execution/edits-commit.ts
@@ -83,7 +83,10 @@ export async function runEditsAndCommitPhase(
       if (isObjectActionDefinition(input.action)) {
         await handler({
           ...baseContext,
-          subject: requireObjectSubject(input.run.subject, input.action.id),
+          subject: requireObjectSubject(input.run.subject, {
+            actionId: input.action.id,
+            runId: input.run.id,
+          }),
         })
         return
       }

--- a/packages/action-worker/src/action-execution/effects.ts
+++ b/packages/action-worker/src/action-execution/effects.ts
@@ -33,7 +33,10 @@ export async function runEffectsPhase(
       const effects = input.action.phases.effects
       await effects({
         ...input.baseContext,
-        subject: requireObjectSubject(input.run.subject, input.action.id),
+        subject: requireObjectSubject(input.run.subject, {
+          actionId: input.action.id,
+          runId: input.run.id,
+        }),
         sixb: toActionRuntimeFacade(input.runtime),
         writeback: input.writeback,
         commit: input.commit,

--- a/packages/action-worker/src/action-execution/results.ts
+++ b/packages/action-worker/src/action-execution/results.ts
@@ -1,17 +1,25 @@
 import { findActionEditCommit } from "@sixb/core/internal/actions"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { ActionRunFailure, ActionRunRecord } from "@sixb/core/storage"
 import { isTerminalActionRun } from "@sixb/core/storage"
-import { ActionWorkerError } from "../errors"
 import { toActionRunFailure } from "../normalize"
 import type { ActionRunResult, RunActionJobInput } from "../types"
 
-export function requireFinishedAt(runId: string, finishedAt: Date | undefined): Date {
-  if (finishedAt) {
-    return finishedAt
+export function requireFinishedAt(input: {
+  readonly actionId: string
+  readonly runId: string
+  readonly finishedAt: Date | undefined
+}): Date {
+  if (input.finishedAt) {
+    return input.finishedAt
   }
 
-  throw new ActionWorkerError(`Action run '${runId}' finished without a finishedAt timestamp.`)
+  throw createSixbError(
+    "internal.unexpected",
+    `[SixbActionWorker] Action run '${input.runId}' finished without a finishedAt timestamp.`,
+    { details: { actionId: input.actionId, runId: input.runId } }
+  )
 }
 
 /**
@@ -53,8 +61,10 @@ async function resolveRunningRunUnderFence(input: RunActionJobInput, run: Action
   return input.runtime.storage.transaction(
     async (storage) => {
       if (!storage.actionRuns) {
-        throw new ActionWorkerError(
-          "Action workers require transactional Action materialization fencing."
+        throw createSixbError(
+          "internal.unexpected",
+          "[SixbActionWorker] Action workers require transactional Action materialization fencing.",
+          { details: { actionId: input.job.actionId, runId: input.job.id } }
         )
       }
       const locked = await storage.actionRuns.lockForMaterialization({
@@ -98,7 +108,7 @@ export function failedResult(
     subject: run.subject,
     status: "failed",
     startedAt: run.startedAt ?? run.queuedAt,
-    finishedAt: requireFinishedAt(runId, run.finishedAt),
+    finishedAt: requireFinishedAt({ actionId, runId, finishedAt: run.finishedAt }),
     error: failure,
     record: run,
   }
@@ -120,8 +130,10 @@ function redeliveryFailure(runId: string, run: ActionRunRecord, failedAt: Date):
 }
 
 function reportRedeliveryFailure(input: RunActionJobInput, run: ActionRunRecord): void {
-  const error = new ActionWorkerError(
-    run.error?.message ?? `Action run '${run.id}' lost its lease.`
+  const error = createSixbError(
+    "internal.unexpected",
+    `[SixbActionWorker] ${run.error?.message ?? `Action run '${run.id}' lost its lease.`}`,
+    { details: { actionId: input.job.actionId, runId: input.job.id } }
   )
   reportRunFailure(input.runtime.errorReporterHost, error, {
     projectId: input.runtime.id,

--- a/packages/action-worker/src/action-execution/writeback.ts
+++ b/packages/action-worker/src/action-execution/writeback.ts
@@ -57,7 +57,10 @@ export async function runWritebackPhase(
           ...input.baseContext,
           sixb: toActionRuntimeFacade(input.runtime),
           read,
-          target: requireObjectTarget(input.objectTarget, input.action.id).snapshot,
+          target: requireObjectTarget(input.objectTarget, {
+            actionId: input.action.id,
+            runId: input.run.id,
+          }).snapshot,
         })
       : await handler({ ...input.baseContext, sixb: toActionRuntimeFacade(input.runtime), read })
     const result = normalizeWritebackResult(rawResult)

--- a/packages/action-worker/src/errors.ts
+++ b/packages/action-worker/src/errors.ts
@@ -1,6 +1,0 @@
-export class ActionWorkerError extends Error {
-  readonly name = "ActionWorkerError"
-  constructor(message: string, options?: ErrorOptions) {
-    super(`[SixbActionWorker] ${message}`, options)
-  }
-}

--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -1,4 +1,5 @@
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { ActionRunRecord } from "@sixb/core/storage"
 import { isTerminalActionRun } from "@sixb/core/storage"
 import { executeActionPhases } from "./action-execution/phases"
@@ -7,7 +8,6 @@ import {
   requireFinishedAt,
   resolveRedeliveredRunningRun,
 } from "./action-execution/results"
-import { ActionWorkerError } from "./errors"
 import { throwIfAborted, toActionRunFailure } from "./normalize"
 import type { ActionRunResult, RunActionJobInput } from "./types"
 
@@ -23,8 +23,18 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
     existingRun.id !== job.id ||
     existingRun.actionId !== job.actionId
   ) {
-    throw new ActionWorkerError(
-      `Action job '${job.id}' does not match durable run '${existingRun.id}' in project '${existingRun.projectId}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbActionWorker] Action job '${job.id}' does not match durable run '${existingRun.id}' in project '${existingRun.projectId}'.`,
+      {
+        details: {
+          actionId: job.actionId,
+          runId: job.id,
+          durableActionId: existingRun.actionId,
+          durableRunId: existingRun.id,
+          durableProjectId: existingRun.projectId,
+        },
+      }
     )
   }
   if (isTerminalActionRun(existingRun)) {
@@ -40,7 +50,11 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
 
   const action = runtime.actions.getById(job.actionId)
   if (!action) {
-    const error = new ActionWorkerError(`Unknown action '${job.actionId}'.`)
+    const error = createSixbError(
+      "internal.unexpected",
+      `[SixbActionWorker] Unknown action '${job.actionId}'.`,
+      { details: { actionId: job.actionId, runId: job.id } }
+    )
     const failedAt = new Date()
     const failure = toActionRunFailure(error, "validation", {
       actionId: job.actionId,
@@ -65,8 +79,10 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
     existingRun = resolution.run
   }
   if (existingRun.status !== "queued" && existingRun.status !== "running") {
-    throw new ActionWorkerError(
-      `Action run '${job.id}' cannot execute from status '${existingRun.status}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbActionWorker] Action run '${job.id}' cannot execute from status '${existingRun.status}'.`,
+      { details: { actionId: job.actionId, runId: job.id } }
     )
   }
 
@@ -102,7 +118,11 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       subject: finalRun.subject,
       status: "succeeded",
       startedAt: startedRun.startedAt ?? startedRun.queuedAt,
-      finishedAt: requireFinishedAt(job.id, finalRun.finishedAt),
+      finishedAt: requireFinishedAt({
+        actionId: job.actionId,
+        runId: job.id,
+        finishedAt: finalRun.finishedAt,
+      }),
       record: finalRun,
     }
   } catch (error) {
@@ -148,7 +168,11 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       subject: finishedRun.subject,
       status,
       startedAt,
-      finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
+      finishedAt: requireFinishedAt({
+        actionId: job.actionId,
+        runId: job.id,
+        finishedAt: finishedRun.finishedAt,
+      }),
       error: failure,
       record: finishedRun,
     }

--- a/packages/action-worker/src/worker.ts
+++ b/packages/action-worker/src/worker.ts
@@ -1,4 +1,5 @@
 import type { DomainEventLog, Queues, SixbDefinitions, Storage } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { LoggingService } from "@sixb/core/internal/logging"
 import {
   bindDurablePrimitiveExecution,
@@ -7,7 +8,6 @@ import {
 import type { QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { QueueWorker } from "@sixb/core/internal/workers"
 import type { ActionRunRequestedQueueJob, ClaimedQueueJob } from "@sixb/core/queues"
-import { ActionWorkerError } from "./errors"
 import { runActionJob } from "./run-action-job"
 import type { ActionJob, ActionRunResult, ActionWorkerContext } from "./types"
 
@@ -42,7 +42,10 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
     if (actions.length === 0) {
       console.log("[SixbActionWorker] No action definitions registered; worker will idle.")
     } else if (!host.storage.actionRuns) {
-      throw new ActionWorkerError("Action workers require storage.actionRuns support.")
+      throw createSixbError(
+        "internal.unexpected",
+        "[SixbActionWorker] Action workers require storage.actionRuns support."
+      )
     }
 
     this.host = host
@@ -69,21 +72,37 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
     signal: AbortSignal
   ): Promise<void> {
     if (this.idleWithoutDefinitions) {
-      throw new ActionWorkerError("No action definitions are registered.")
+      throw createSixbError(
+        "internal.unexpected",
+        "[SixbActionWorker] No action definitions are registered.",
+        { details: { runId: claimed.job.payload.runId } }
+      )
     }
 
     const { job } = claimed
     if (job.type !== "action.run.requested") {
-      throw new ActionWorkerError(`Unsupported action job type '${job.type}'.`)
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbActionWorker] Unsupported action job type '${job.type}'.`,
+        { details: { runId: job.payload.runId } }
+      )
     }
 
     const actionRuns = this.host.storage.actionRuns
     if (!actionRuns) {
-      throw new ActionWorkerError("Action workers require storage.actionRuns support.")
+      throw createSixbError(
+        "internal.unexpected",
+        "[SixbActionWorker] Action workers require storage.actionRuns support.",
+        { details: { runId: job.payload.runId } }
+      )
     }
     const run = await actionRuns.getById({ projectId: this.host.id, id: job.payload.runId })
     if (!run) {
-      throw new ActionWorkerError(`Action run '${job.payload.runId}' was not found.`)
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbActionWorker] Action run '${job.payload.runId}' was not found.`,
+        { details: { runId: job.payload.runId } }
+      )
     }
 
     const durableExecution = await this.host.storage.executions.getById({
@@ -91,8 +110,16 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
       id: run.executionId,
     })
     if (!durableExecution) {
-      throw new ActionWorkerError(
-        `Action run '${run.id}' references missing execution '${run.executionId}'.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbActionWorker] Action run '${run.id}' references missing execution '${run.executionId}'.`,
+        {
+          details: {
+            actionId: run.actionId,
+            runId: run.id,
+            executionId: run.executionId,
+          },
+        }
       )
     }
 
@@ -185,7 +212,10 @@ function buildActionContext(
 ): ActionWorkerContext {
   const actionRunsStorage = host.storage.actionRuns
   if (!actionRunsStorage) {
-    throw new ActionWorkerError("Action workers require storage.actionRuns support.")
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbActionWorker] Action workers require storage.actionRuns support."
+    )
   }
   const sixb = {
     objects: execution.sixb.objects,

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -21,7 +21,6 @@ import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import { bindPrimitiveExecution } from "@sixb/core/internal/primitive-execution"
 import type { ActionRunParams, ActionRunRecord } from "@sixb/core/storage"
 import { createTestSixb, queueTestActionRun } from "@sixb/core/testing"
-import { ActionWorkerError } from "../src/errors"
 import { runActionJob } from "../src/run-action-job"
 import type { ActionWorkerContext, RunActionJobInput } from "../src/types"
 import type { ActionWorkerHost } from "../src/worker"
@@ -152,7 +151,19 @@ describe("runActionJob", () => {
         },
         run,
       })
-    ).rejects.toBeInstanceOf(ActionWorkerError)
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      message:
+        "[SixbActionWorker] Action job 'act_other' does not match durable run 'act_stored' in project 'action-worker-tests'.",
+      retryable: false,
+      details: {
+        actionId: "count",
+        runId: "act_other",
+        durableActionId: "count",
+        durableRunId: "act_stored",
+        durableProjectId: "action-worker-tests",
+      },
+    })
   })
 
   test("passes nullable params to action handlers unchanged", async () => {

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -19,7 +19,6 @@ import { LOGS_STREAM } from "@sixb/core/internal/logging"
 import type { ActionRunRecord } from "@sixb/core/storage"
 import { createTestSixb } from "@sixb/core/testing"
 import { ActionWorker } from "../src"
-import { ActionWorkerError } from "../src/errors"
 import type { ActionExecutionFacade } from "../src/types"
 import { waitFor } from "./helpers"
 
@@ -68,6 +67,15 @@ function createSixb(
   return { host, sixb: createTestSixb(host) }
 }
 
+function captureThrown(callback: () => unknown): unknown {
+  try {
+    callback()
+  } catch (error) {
+    return error
+  }
+  throw new Error("Expected callback to throw")
+}
+
 describe("ActionWorker", () => {
   test("idles without action definitions or action-run storage", async () => {
     const storage = createStorageWithoutActionRuns()
@@ -77,14 +85,20 @@ describe("ActionWorker", () => {
     await worker.stop()
   })
 
-  test("throws ActionWorkerError when action-run storage is missing", () => {
+  test("throws a coded internal error when action-run storage is missing", () => {
     const noop = defineAction("noop")
       .on(Device)
       .params({})
       .writeback(() => {})
     const storage = createStorageWithoutActionRuns()
 
-    expect(() => new ActionWorker(createSixb([noop], storage).host)).toThrow(ActionWorkerError)
+    const error = captureThrown(() => new ActionWorker(createSixb([noop], storage).host))
+
+    expect(error).toMatchObject({
+      code: "internal.unexpected",
+      message: "[SixbActionWorker] Action workers require storage.actionRuns support.",
+      retryable: false,
+    })
   })
 
   test("streams a run-scoped log line to the broker", async () => {


### PR DESCRIPTION
## Summary

- remove the private ActionWorkerError wrapper
- create canonical coded errors directly through the internal error factory
- preserve existing messages while attaching actionId and runId at creation time
- update tests to assert the structural error contract instead of a runtime class

## Why

ActionWorkerError only added a name and message prefix; it carried no domain data and was not used for runtime control flow. Keeping it would preserve a second internal error model without providing behavior.

Correlation details now live on the coded error itself. This is required because normalization intentionally keeps the details of an already-coded error instead of applying fallback details.

This change stays narrow: error classes used for control flow remain untouched, and no new error taxonomy is introduced.

## Validation

- bun test packages/action-worker/tests/run-action-job.test.ts packages/action-worker/tests/worker.test.ts
- bun --filter @sixb/action-worker typecheck
- bun --filter @sixb/action-worker build
- bun run typecheck
- bun run check

## Stack

Depends on #326 and continues #274.