### PR TITLE
datasets: add primary-key definitions

### DIFF
--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -25,6 +25,7 @@ export const rawInvoicesDataset = defineDataset("erp.invoices", {
     col("customer_id", "string"),
     col("project_id", "string"),
   ],
+  primaryKey: "id",
   description: "Raw invoice rows from the ERP.",
 })
 ```
@@ -36,8 +37,37 @@ The id `erp.invoices` is the name every other part of the project references.
 | Option | Type | Description |
 | --- | --- | --- |
 | `schema` | `col(...)[]` | Required. The ordered list of column definitions. |
+| `primaryKey` | `string \| string[]` | Optional. One key column or an ordered composite key. |
 | `partitionBy` | `string[]` | Optional. Logical partition columns; each name must exist in `schema`. |
 | `description` | `string` | Optional. Human-readable description. |
+
+### Primary keys
+
+Use one non-nullable string column for a single-column key, or two or more for a composite key:
+
+```ts
+export const invoices = defineDataset("erp.invoices", {
+  schema: [col("id", "string"), col("status", "string")],
+  primaryKey: "id",
+})
+
+export const invoiceLines = defineDataset("erp.invoice_lines", {
+  schema: [
+    col("invoiceId", "string"),
+    col("lineItemId", "string"),
+    col("description", "string"),
+  ],
+  primaryKey: ["invoiceId", "lineItemId"],
+})
+```
+
+V1 primary keys have these constraints:
+
+- Every key column must exist in the schema, have type `string`, and be non-nullable.
+- Composite keys contain at least two unique columns. Column order is significant.
+- A key cannot be added, removed, changed, or reordered after the dataset is created.
+- Rows are expected to be unique by key, and a row's key is expected to be immutable. This initial
+  contract persists key metadata but does not yet enforce row uniqueness or add keyed merge writes.
 
 ### `col` options
 
@@ -164,8 +194,12 @@ export const invoicesSummary = defineDataset("invoices.summary").derive(rawInvoi
 | --- | --- | --- |
 | `pick` | `string[]` | Keep only these parent columns. Each name must exist on the parent. |
 | `add` | `col(...)[]` | Append these columns after the kept ones. |
+| `primaryKey` | `string \| string[]` | Optional key over the resulting columns. |
 | `partitionBy` | `string[]` | Optional partition columns for the derived dataset. |
 | `description` | `string` | Optional description for the derived dataset. |
+
+Derived datasets do not inherit their parent's primary key. Declare `primaryKey` explicitly when
+the derived rows preserve the same identity contract.
 
 ## Dataset vs ontology
 

--- a/packages/core/src/datasets/builders.ts
+++ b/packages/core/src/datasets/builders.ts
@@ -4,6 +4,7 @@ import type {
   DatasetColumnNameOf,
   DatasetColumnType,
   DatasetDefinition,
+  DatasetPrimaryKey,
 } from "./types"
 import { assertDatasetColumnDefinition, assertDatasetDefinition } from "./validation"
 
@@ -13,6 +14,7 @@ type DatasetColumnOptions = {
 
 type DefineDatasetOptions = {
   readonly schema: readonly DatasetColumnDefinition[]
+  readonly primaryKey?: DatasetPrimaryKey
   readonly partitionBy?: readonly string[]
   readonly description?: string
 }
@@ -20,6 +22,7 @@ type DefineDatasetOptions = {
 type DeriveDatasetOptions<TParent extends DatasetDefinition> = {
   readonly pick?: readonly DatasetColumnNameOf<TParent>[]
   readonly add?: readonly DatasetColumnDefinition[]
+  readonly primaryKey?: DatasetPrimaryKey
   readonly partitionBy?: readonly string[]
   readonly description?: string
 }
@@ -38,6 +41,24 @@ type ColumnDefinitionOf<
   TColumns extends readonly DatasetColumnDefinition[],
   TName extends ColumnNameOf<TColumns>,
 > = Extract<TColumns[number], { readonly name: TName }>
+
+type PrimaryKeyColumnNameOf<TColumns extends readonly DatasetColumnDefinition[]> =
+  string extends ColumnNameOf<TColumns>
+    ? string
+    : {
+        [TName in ColumnNameOf<TColumns>]: ColumnDefinitionOf<
+          TColumns,
+          TName
+        >["type"] extends "string"
+          ? ColumnDefinitionOf<TColumns, TName> extends { readonly nullable: true }
+            ? never
+            : TName
+          : never
+      }[ColumnNameOf<TColumns>]
+
+type CheckedDefineDatasetOptions<TOptions extends DefineDatasetOptions> = TOptions & {
+  readonly primaryKey?: DatasetPrimaryKey<PrimaryKeyColumnNameOf<TOptions["schema"]>>
+}
 
 type PickColumns<
   TColumns extends readonly DatasetColumnDefinition[],
@@ -86,8 +107,9 @@ type DatasetColumnResult<
 
 type DatasetDefinitionResult<TId extends string, TOptions extends DefineDatasetOptions> = Omit<
   DatasetDefinition<TId, TOptions["schema"]>,
-  "partitionBy" | "description"
+  "primaryKey" | "partitionBy" | "description"
 > &
+  FieldFromOptions<TOptions, "primaryKey", DatasetPrimaryKey> &
   FieldFromOptions<TOptions, "partitionBy", readonly string[]> &
   FieldFromOptions<TOptions, "description", string>
 
@@ -95,9 +117,20 @@ type DerivedDatasetDefinitionResult<
   TId extends string,
   TParent extends DatasetDefinition,
   TOptions extends DeriveDatasetOptions<TParent> | undefined,
-> = Omit<DatasetDefinition<TId, DerivedColumns<TParent, TOptions>>, "partitionBy" | "description"> &
+> = Omit<
+  DatasetDefinition<TId, DerivedColumns<TParent, TOptions>>,
+  "primaryKey" | "partitionBy" | "description"
+> &
+  FieldFromOptions<TOptions, "primaryKey", DatasetPrimaryKey> &
   FieldFromOptions<TOptions, "partitionBy", readonly string[]> &
   FieldFromOptions<TOptions, "description", string>
+
+type CheckedDeriveDatasetOptions<
+  TParent extends DatasetDefinition,
+  TOptions extends DeriveDatasetOptions<TParent>,
+> = TOptions & {
+  readonly primaryKey?: DatasetPrimaryKey<PrimaryKeyColumnNameOf<DerivedColumns<TParent, TOptions>>>
+}
 
 export function col<const TName extends string, const TType extends DatasetColumnType>(
   name: TName,
@@ -130,12 +163,19 @@ function assertDatasetId(id: string): void {
 }
 
 function createDatasetDefinition(id: string, options: DefineDatasetOptions): DatasetDefinition {
-  const definition: DatasetDefinition = {
+  const definition: unknown = {
     kind: "dataset",
     id,
     schema: {
       columns: [...options.schema],
     },
+    ...(options.primaryKey !== undefined
+      ? {
+          primaryKey: Array.isArray(options.primaryKey)
+            ? [...options.primaryKey]
+            : options.primaryKey,
+        }
+      : {}),
     ...(options.partitionBy !== undefined ? { partitionBy: [...options.partitionBy] } : {}),
     ...(options.description !== undefined ? { description: options.description } : {}),
   }
@@ -189,6 +229,7 @@ function deriveDatasetDefinition(
 
   return createDatasetDefinition(id, {
     schema: [...pickedColumns, ...(options.add ?? [])],
+    ...(options.primaryKey !== undefined ? { primaryKey: options.primaryKey } : {}),
     ...(options.partitionBy !== undefined ? { partitionBy: options.partitionBy } : {}),
     ...(options.description !== undefined ? { description: options.description } : {}),
   })
@@ -203,7 +244,10 @@ function createDatasetDeriveBuilder<TId extends string>(id: TId) {
   function derive<
     const TParent extends DatasetDefinition,
     const TOptions extends DeriveDatasetOptions<TParent>,
-  >(parent: TParent, options: TOptions): DerivedDatasetDefinitionResult<TId, TParent, TOptions>
+  >(
+    parent: TParent,
+    options: CheckedDeriveDatasetOptions<TParent, TOptions>
+  ): DerivedDatasetDefinitionResult<TId, TParent, TOptions>
   function derive(
     parent: DatasetDefinition,
     options?: DeriveDatasetOptions<DatasetDefinition>
@@ -220,7 +264,7 @@ export function defineDataset<const TId extends string>(
 export function defineDataset<
   const TId extends string,
   const TOptions extends DefineDatasetOptions,
->(id: TId, options: TOptions): DatasetDefinitionResult<TId, TOptions>
+>(id: TId, options: CheckedDefineDatasetOptions<TOptions>): DatasetDefinitionResult<TId, TOptions>
 export function defineDataset(
   id: string,
   options?: DefineDatasetOptions

--- a/packages/core/src/datasets/index.ts
+++ b/packages/core/src/datasets/index.ts
@@ -8,6 +8,7 @@ export type {
   DatasetColumnTypeOf,
   DatasetColumnUnionOf,
   DatasetDefinition,
+  DatasetPrimaryKey,
   DatasetSchema,
 } from "./types"
 export { getDatasetRowValidationError, isDatasetDefinition } from "./validation"

--- a/packages/core/src/datasets/types.ts
+++ b/packages/core/src/datasets/types.ts
@@ -24,6 +24,10 @@ export interface DatasetSchema<
   readonly columns: TColumns
 }
 
+export type DatasetPrimaryKey<TColumnName extends string = string> =
+  | TColumnName
+  | readonly [TColumnName, TColumnName, ...TColumnName[]]
+
 export interface DatasetDefinition<
   TId extends string = string,
   TColumns extends readonly DatasetColumnDefinition[] = readonly DatasetColumnDefinition[],
@@ -31,6 +35,7 @@ export interface DatasetDefinition<
   readonly kind: "dataset"
   readonly id: TId
   readonly schema: DatasetSchema<TColumns>
+  readonly primaryKey?: DatasetPrimaryKey
   readonly partitionBy?: readonly string[]
   readonly description?: string
 }

--- a/packages/core/src/datasets/validation.ts
+++ b/packages/core/src/datasets/validation.ts
@@ -119,6 +119,53 @@ function assertDatasetSchema(
   }
 }
 
+function assertDatasetPrimaryKey(
+  primaryKey: unknown,
+  schema: DatasetSchema,
+  createError: (message: string) => Error
+): void {
+  let keyColumns: readonly unknown[]
+  if (typeof primaryKey === "string") {
+    keyColumns = [primaryKey]
+  } else if (Array.isArray(primaryKey)) {
+    if (primaryKey.length < 2) {
+      throw createError(
+        "Dataset primaryKey arrays must contain at least two column names. Use a string for a single-column key."
+      )
+    }
+    keyColumns = primaryKey
+  } else {
+    throw createError(
+      "Dataset primaryKey must be a column name or an array of at least two column names."
+    )
+  }
+
+  const columnsByName = new Map(schema.columns.map((column) => [column.name, column] as const))
+  const seenColumnNames = new Set<string>()
+
+  for (const columnName of keyColumns) {
+    if (typeof columnName !== "string" || columnName.trim().length === 0) {
+      throw createError("Dataset primaryKey columns must be non-empty strings.")
+    }
+
+    if (seenColumnNames.has(columnName)) {
+      throw createError(`Dataset primaryKey contains duplicate column '${columnName}'.`)
+    }
+    seenColumnNames.add(columnName)
+
+    const column = columnsByName.get(columnName)
+    if (column === undefined) {
+      throw createError(`Dataset primaryKey column '${columnName}' is not declared in the schema.`)
+    }
+    if (column.type !== "string") {
+      throw createError(`Dataset primaryKey column '${columnName}' must have type 'string'.`)
+    }
+    if (column.nullable === true) {
+      throw createError(`Dataset primaryKey column '${columnName}' must not be nullable.`)
+    }
+  }
+}
+
 export function assertDatasetDefinition(
   definition: unknown,
   createError: (message: string) => Error = (message) => new DatasetValidationError(message)
@@ -133,6 +180,10 @@ export function assertDatasetDefinition(
 
   assertNonEmptyString(definition.id, "Dataset id", createError)
   assertDatasetSchema(definition.schema, createError)
+
+  if (definition.primaryKey !== undefined) {
+    assertDatasetPrimaryKey(definition.primaryKey, definition.schema, createError)
+  }
 
   if (definition.partitionBy !== undefined) {
     if (!Array.isArray(definition.partitionBy)) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -140,6 +140,7 @@ export type {
   DatasetColumnTypeOf,
   DatasetColumnUnionOf,
   DatasetDefinition,
+  DatasetPrimaryKey,
   DatasetSchema,
 } from "./datasets"
 export {

--- a/packages/core/src/lake-storage/definition-updates.ts
+++ b/packages/core/src/lake-storage/definition-updates.ts
@@ -36,6 +36,7 @@ export function planDatasetDefinitionUpdate(
   requested: DatasetDefinition
 ): DatasetDefinitionUpdatePlan {
   assertSameDataset(existing, requested)
+  assertPrimaryKeyUnchanged(existing, requested)
 
   const addedColumns = getAddedColumnsAfterValidatingExistingColumns(existing, requested)
   assertAddedColumnsAreNullable(requested.id, addedColumns)
@@ -94,6 +95,24 @@ function assertSameDataset(existing: DatasetDefinition, requested: DatasetDefini
   if (existing.id !== requested.id) {
     throw new LakeStorageError(
       `[SixbLake] Cannot update dataset '${existing.id}' with definition for '${requested.id}'.`
+    )
+  }
+}
+
+function assertPrimaryKeyUnchanged(
+  existing: DatasetDefinition,
+  requested: DatasetDefinition
+): void {
+  const existingPrimaryKey = existing.primaryKey
+  const requestedPrimaryKey = requested.primaryKey
+  const unchanged =
+    existingPrimaryKey === undefined || requestedPrimaryKey === undefined
+      ? existingPrimaryKey === requestedPrimaryKey
+      : areDefinitionValuesEqual(existingPrimaryKey, requestedPrimaryKey)
+
+  if (!unchanged) {
+    throw new LakeStorageError(
+      `[SixbLake] Dataset '${requested.id}' cannot be redefined with an incompatible primaryKey. Primary keys are immutable.`
     )
   }
 }
@@ -193,6 +212,7 @@ function mergeDatasetDefinition(
   )
 
   const columns = [...cloneColumns(existing.schema.columns), ...cloneColumns(addedColumns)]
+  const primaryKey = existing.primaryKey
   const partitionBy = requested.partitionBy ?? existing.partitionBy
   const description = requested.description ?? existing.description
 
@@ -200,6 +220,7 @@ function mergeDatasetDefinition(
     kind: "dataset",
     id: requested.id,
     schema: { columns },
+    ...(primaryKey !== undefined ? { primaryKey: structuredClone(primaryKey) } : {}),
     ...(partitionBy !== undefined ? { partitionBy: [...partitionBy] } : {}),
     ...(description !== undefined ? { description } : {}),
   }

--- a/packages/core/src/lake-storage/index.ts
+++ b/packages/core/src/lake-storage/index.ts
@@ -2,6 +2,7 @@ export type {
   DatasetColumnDefinition,
   DatasetColumnType,
   DatasetDefinition,
+  DatasetPrimaryKey,
   DatasetSchema,
 } from "../datasets"
 export type { JsonValue } from "../json"

--- a/packages/core/src/testing/lake-storage-contract.ts
+++ b/packages/core/src/testing/lake-storage-contract.ts
@@ -34,6 +34,12 @@ const reorderedDefinitionDataset = defineDataset("contract.definitions.orders", 
   description: "Contract orders",
 })
 
+const keyedDefinitionDataset = defineDataset("contract.definitions.keyed_orders", {
+  schema: [col("tenantId", "string"), col("orderId", "string"), col("customerName", "string")],
+  primaryKey: ["tenantId", "orderId"],
+  description: "Contract keyed orders",
+})
+
 const writeDataset = defineDataset("contract.writes.orders", {
   schema: [col("orderId", "string"), col("customerName", "string")],
 })
@@ -98,6 +104,23 @@ export function runLakeStorageContractSuite<TStorage extends LakeStorage>(
           expect(await storage.getDataset("missing.dataset")).toBeNull()
           expect(await storage.listDatasets()).toEqual([definitionDataset])
           expect(await storage.listVersions(definitionDataset.id)).toEqual([])
+        })
+      })
+
+      test("round-trips keyed definitions through create, get, list, and reuse", async () => {
+        // Regression guard: omitting primaryKey from mergeDatasetDefinition makes reuse lose
+        // the key and fails this contract case.
+        await withStorage(async (storage) => {
+          const created = await storage.createDataset(keyedDefinitionDataset)
+          const repeated = await storage.createDataset(keyedDefinitionDataset)
+
+          expect(created).toEqual(keyedDefinitionDataset)
+          expect(repeated).toEqual(keyedDefinitionDataset)
+          expect(await storage.getDataset(keyedDefinitionDataset.id)).toEqual(
+            keyedDefinitionDataset
+          )
+          expect(await storage.listDatasets()).toEqual([keyedDefinitionDataset])
+          expect(await storage.listVersions(keyedDefinitionDataset.id)).toEqual([])
         })
       })
 

--- a/packages/core/tests/datasets.test.ts
+++ b/packages/core/tests/datasets.test.ts
@@ -39,6 +39,116 @@ const canonicalOrdersDataset = defineDataset("canonical.orders", {
 })
 
 describe("defineDataset", () => {
+  test("builds single and composite primary keys", () => {
+    const customers = defineDataset("canonical.customers", {
+      schema: [col("id", "string")],
+      primaryKey: "id",
+    })
+    const lineItems = defineDataset("canonical.line-items", {
+      schema: [col("invoiceId", "string"), col("lineItemId", "string", { nullable: false })],
+      primaryKey: ["invoiceId", "lineItemId"],
+    })
+
+    expect(customers.primaryKey).toBe("id")
+    expect(lineItems.primaryKey).toEqual(["invoiceId", "lineItemId"])
+  })
+
+  test("snapshots composite primary keys", () => {
+    // Regression guard: assigning options.primaryKey directly in createDatasetDefinition makes
+    // this test fail after the caller mutates its tuple.
+    const primaryKey: ["invoiceId", "lineItemId"] = ["invoiceId", "lineItemId"]
+    const lineItems = defineDataset("canonical.line-items", {
+      schema: [col("invoiceId", "string"), col("lineItemId", "string")],
+      primaryKey,
+    })
+
+    primaryKey.reverse()
+
+    expect(lineItems.primaryKey).toEqual(["invoiceId", "lineItemId"])
+    expect(lineItems.primaryKey).not.toBe(primaryKey)
+  })
+
+  test("validates primary-key shape", () => {
+    // Regression guard: removing assertDatasetPrimaryKey from assertDatasetDefinition makes these
+    // invalid definitions succeed.
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string")],
+        primaryKey: 42,
+      } as never)
+    ).toThrow("Dataset primaryKey must be a column name or an array of at least two column names.")
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string")],
+        primaryKey: [],
+      } as never)
+    ).toThrow(
+      "Dataset primaryKey arrays must contain at least two column names. Use a string for a single-column key."
+    )
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string")],
+        primaryKey: "",
+      } as never)
+    ).toThrow("Dataset primaryKey columns must be non-empty strings.")
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string")],
+        primaryKey: ["id"],
+      } as never)
+    ).toThrow(
+      "Dataset primaryKey arrays must contain at least two column names. Use a string for a single-column key."
+    )
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string"), col("tenantId", "string")],
+        primaryKey: ["id", ""],
+      } as never)
+    ).toThrow("Dataset primaryKey columns must be non-empty strings.")
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string"), col("tenantId", "string")],
+        primaryKey: ["id", 42],
+      } as never)
+    ).toThrow("Dataset primaryKey columns must be non-empty strings.")
+  })
+
+  test("rejects duplicate primary-key columns", () => {
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string")],
+        primaryKey: ["id", "id"],
+      } as never)
+    ).toThrow("Dataset primaryKey contains duplicate column 'id'.")
+  })
+
+  test("requires primary-key columns to exist in the schema", () => {
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string")],
+        primaryKey: "missing",
+      } as never)
+    ).toThrow("Dataset primaryKey column 'missing' is not declared in the schema.")
+  })
+
+  test("requires primary-key columns to be strings", () => {
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "int64")],
+        primaryKey: "id",
+      } as never)
+    ).toThrow("Dataset primaryKey column 'id' must have type 'string'.")
+  })
+
+  test("requires primary-key columns to be non-nullable", () => {
+    expect(() =>
+      defineDataset("canonical.invalid-key", {
+        schema: [col("id", "string", { nullable: true })],
+        primaryKey: "id",
+      } as never)
+    ).toThrow("Dataset primaryKey column 'id' must not be nullable.")
+  })
+
   test("builds a dataset definition with a wrapped schema", () => {
     expect(rawOrdersDataset).toEqual({
       kind: "dataset",
@@ -77,6 +187,7 @@ describe("defineDataset", () => {
       {
         pick: ["orderId"],
         add: [col("priority", "int64")],
+        primaryKey: "orderId",
         partitionBy: ["orderId"],
         description: "Order summaries",
       }
@@ -91,6 +202,7 @@ describe("defineDataset", () => {
           { name: "priority", type: "int64" },
         ],
       },
+      primaryKey: "orderId",
       partitionBy: ["orderId"],
       description: "Order summaries",
     })

--- a/packages/core/tests/datasets.types.ts
+++ b/packages/core/tests/datasets.types.ts
@@ -5,8 +5,11 @@ import type {
   DatasetColumnTypeOf,
   DatasetColumnUnionOf,
   DatasetDefinition,
+  DatasetPrimaryKey,
 } from "../src"
 import { col, defineDataset } from "../src"
+import type { DatasetPrimaryKey as DatasetSurfacePrimaryKey } from "../src/datasets"
+import type { DatasetPrimaryKey as LakeStorageSurfacePrimaryKey } from "../src/lake-storage"
 
 /**
  * Compile-time contract tests for dataset builder literal inference.
@@ -16,6 +19,14 @@ import { col, defineDataset } from "../src"
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
 type Expect<T extends true> = T
+
+// Regression guard: the primary-key contract must remain available from all three type surfaces.
+type _datasetSurfacePrimaryKey = Expect<
+  Equal<DatasetSurfacePrimaryKey<"id">, DatasetPrimaryKey<"id">>
+>
+type _lakeStorageSurfacePrimaryKey = Expect<
+  Equal<LakeStorageSurfacePrimaryKey<"id">, DatasetPrimaryKey<"id">>
+>
 
 const idColumn = col("customer_id", "string")
 type _columnName = Expect<Equal<typeof idColumn.name, "customer_id">>
@@ -33,17 +44,59 @@ const canonicalCustomersDataset = defineDataset("canonical.customers", {
     col("annual_revenue", "decimal"),
     col("created_at", "timestamp"),
   ],
+  primaryKey: "customer_id",
   partitionBy: ["customer_id"],
   description: "Canonical customers",
 })
 
 type _datasetId = Expect<Equal<typeof canonicalCustomersDataset.id, "canonical.customers">>
+type _primaryKey = Expect<Equal<typeof canonicalCustomersDataset.primaryKey, "customer_id">>
 type _partitionBy = Expect<
   Equal<typeof canonicalCustomersDataset.partitionBy, readonly ["customer_id"]>
 >
 type _description = Expect<
   Equal<typeof canonicalCustomersDataset.description, "Canonical customers">
 >
+
+const _broadPrimaryKey: DatasetPrimaryKey = canonicalCustomersDataset.primaryKey
+
+const customerAddressesDataset = defineDataset("canonical.customer_addresses", {
+  schema: [
+    col("customer_id", "string"),
+    col("address_id", "string", { nullable: false }),
+    col("label", "string", { nullable: true }),
+  ],
+  primaryKey: ["customer_id", "address_id"],
+})
+type _compositePrimaryKey = Expect<
+  Equal<typeof customerAddressesDataset.primaryKey, readonly ["customer_id", "address_id"]>
+>
+
+defineDataset("canonical.customers.unknown-key", {
+  // Regression guard: removing CheckedDefineDatasetOptions from the overload leaves the
+  // following expectation directive unused.
+  schema: [col("id", "string")],
+  // @ts-expect-error primary keys must reference a declared schema column
+  primaryKey: "missing",
+})
+
+defineDataset("canonical.customers.nullable-key", {
+  schema: [col("id", "string", { nullable: true })],
+  // @ts-expect-error primary-key columns must be non-nullable
+  primaryKey: "id",
+})
+
+defineDataset("canonical.customers.non-string-key", {
+  schema: [col("id", "int64")],
+  // @ts-expect-error primary-key columns must be strings
+  primaryKey: "id",
+})
+
+defineDataset("canonical.customers.single-item-composite-key", {
+  schema: [col("id", "string")],
+  // @ts-expect-error a one-column primary key uses the string shorthand
+  primaryKey: ["id"],
+})
 
 const copiedCustomersDataset = defineDataset("canonical.customers.copy").derive(
   canonicalCustomersDataset
@@ -71,6 +124,7 @@ const customerSummaryDataset = defineDataset("canonical.customer_summary").deriv
   {
     pick: ["customer_id", "created_at"],
     add: [col("score", "float64")],
+    primaryKey: "customer_id",
     partitionBy: ["customer_id"],
     description: "Customer summary",
   }
@@ -84,6 +138,7 @@ type _summarySecondColumn = Expect<
 type _summaryThirdColumn = Expect<
   Equal<(typeof customerSummaryDataset.schema.columns)[2]["name"], "score">
 >
+type _summaryPrimaryKey = Expect<Equal<typeof customerSummaryDataset.primaryKey, "customer_id">>
 type _summaryPartitionBy = Expect<
   Equal<typeof customerSummaryDataset.partitionBy, readonly ["customer_id"]>
 >
@@ -94,6 +149,12 @@ type _summaryDescription = Expect<
 defineDataset("canonical.customers.bad").derive(canonicalCustomersDataset, {
   // @ts-expect-error unknown parent column names should be rejected by derived datasets
   pick: ["missing"],
+})
+
+defineDataset("canonical.customers.bad-key").derive(canonicalCustomersDataset, {
+  pick: ["customer_id", "created_at"],
+  // @ts-expect-error derived primary keys must reference a resulting eligible column
+  primaryKey: "created_at",
 })
 
 type CustomerColumnNames = DatasetColumnNameOf<typeof canonicalCustomersDataset>
@@ -145,4 +206,5 @@ function defineDynamicDataset(datasetId: string) {
 
 void _broadColumn
 void _broadDataset
+void _broadPrimaryKey
 void defineDynamicDataset

--- a/packages/core/tests/lake-storage-definition-updates.test.ts
+++ b/packages/core/tests/lake-storage-definition-updates.test.ts
@@ -11,6 +11,7 @@ describe("dataset definition update planning", () => {
   test("returns no change for an unchanged definition", () => {
     const dataset = defineDataset("raw.erp.invoices", {
       schema: [col("invoiceId", "string"), col("total", "int64")],
+      primaryKey: "invoiceId",
     })
 
     expect(planDatasetDefinitionUpdate(dataset, dataset)).toMatchObject({
@@ -23,10 +24,12 @@ describe("dataset definition update planning", () => {
 
   test("ignores declaration reordering for existing columns", () => {
     const existing = defineDataset("raw.erp.invoices", {
-      schema: [col("invoiceId", "string"), col("total", "int64")],
+      schema: [col("invoiceId", "string"), col("tenantId", "string"), col("total", "int64")],
+      primaryKey: ["tenantId", "invoiceId"],
     })
     const requested = defineDataset("raw.erp.invoices", {
-      schema: [col("total", "int64"), col("invoiceId", "string")],
+      schema: [col("total", "int64"), col("tenantId", "string"), col("invoiceId", "string")],
+      primaryKey: ["tenantId", "invoiceId"],
     })
 
     expect(planDatasetDefinitionUpdate(existing, requested)).toMatchObject({
@@ -39,6 +42,7 @@ describe("dataset definition update planning", () => {
   test("allows adding nullable columns anywhere in the requested definition", () => {
     const existing = defineDataset("raw.erp.invoices", {
       schema: [col("invoiceId", "string"), col("total", "int64")],
+      primaryKey: "invoiceId",
     })
     const requested = defineDataset("raw.erp.invoices", {
       schema: [
@@ -47,6 +51,7 @@ describe("dataset definition update planning", () => {
         col("total", "int64"),
         col("memo", "string", { nullable: true }),
       ],
+      primaryKey: "invoiceId",
     })
 
     expect(planDatasetDefinitionUpdate(existing, requested)).toMatchObject({
@@ -57,6 +62,7 @@ describe("dataset definition update planning", () => {
           col("currency", "string", { nullable: true }),
           col("memo", "string", { nullable: true }),
         ],
+        primaryKey: "invoiceId",
       }),
       schema: {
         kind: "addNullableColumns",
@@ -67,6 +73,38 @@ describe("dataset definition update planning", () => {
       },
       changed: true,
     })
+  })
+
+  test("rejects adding, removing, changing, or reordering a primary key", () => {
+    // Regression guard: removing assertPrimaryKeyUnchanged from the planner makes these
+    // incompatible definitions succeed.
+    const schema = [col("tenantId", "string"), col("invoiceId", "string")] as const
+    const unkeyed = defineDataset("raw.erp.invoices", { schema })
+    const singleKey = defineDataset("raw.erp.invoices", {
+      schema,
+      primaryKey: "invoiceId",
+    })
+    const changedSingleKey = defineDataset("raw.erp.invoices", {
+      schema,
+      primaryKey: "tenantId",
+    })
+    const compositeKey = defineDataset("raw.erp.invoices", {
+      schema,
+      primaryKey: ["tenantId", "invoiceId"],
+    })
+    const reorderedCompositeKey = defineDataset("raw.erp.invoices", {
+      schema,
+      primaryKey: ["invoiceId", "tenantId"],
+    })
+
+    expect(() => planDatasetDefinitionUpdate(unkeyed, singleKey)).toThrow("incompatible primaryKey")
+    expect(() => planDatasetDefinitionUpdate(singleKey, unkeyed)).toThrow("incompatible primaryKey")
+    expect(() => planDatasetDefinitionUpdate(singleKey, changedSingleKey)).toThrow(
+      "incompatible primaryKey"
+    )
+    expect(() => planDatasetDefinitionUpdate(compositeKey, reorderedCompositeKey)).toThrow(
+      "incompatible primaryKey"
+    )
   })
 
   test("detects compatible metadata additions", () => {

--- a/packages/core/tests/published-artifacts.e2e.ts
+++ b/packages/core/tests/published-artifacts.e2e.ts
@@ -174,8 +174,13 @@ describe("published artifacts", () => {
     )
     await writeFile(
       join(consumerDir, "index.ts"),
-      `${subpaths.map((subpath, index) => `import * as m${index} from "${subpath}"`).join("\n")}
+      `import type { DatasetPrimaryKey as RootDatasetPrimaryKey } from "@sixb/core"
+import type { DatasetPrimaryKey as LakeDatasetPrimaryKey } from "@sixb/core/lake-storage"
+${subpaths.map((subpath, index) => `import * as m${index} from "${subpath}"`).join("\n")}
+const rootPrimaryKey: RootDatasetPrimaryKey<"tenantId" | "id"> = ["tenantId", "id"]
+const lakePrimaryKey: LakeDatasetPrimaryKey<"tenantId" | "id"> = rootPrimaryKey
 export const loaded = [${subpaths.map((_, index) => `m${index}`).join(", ")}].length
+void lakePrimaryKey
 `
     )
 

--- a/storage/ducklake/src/internal/ducklake-catalog-schema.ts
+++ b/storage/ducklake/src/internal/ducklake-catalog-schema.ts
@@ -1,4 +1,4 @@
-import type { DatasetColumnDefinition, DatasetSchema } from "@sixb/core"
+import type { DatasetColumnDefinition, DatasetPrimaryKey, DatasetSchema } from "@sixb/core"
 import { LakeStorageError } from "@sixb/core/lake-storage"
 import { duckDbTypeToDatasetColumnType } from "./schema"
 
@@ -10,7 +10,11 @@ export interface DuckLakeCatalogColumn {
   readonly columnType: string
   readonly nullsAllowed: boolean
   readonly parentColumnId?: bigint
+  readonly comment?: string
 }
+
+const SIXB_PRIMARY_KEY_COMMENT_NAMESPACE = "sixb:primary-key:"
+const SIXB_PRIMARY_KEY_COMMENT_PREFIX = `${SIXB_PRIMARY_KEY_COMMENT_NAMESPACE}v1:`
 
 const FILE_REF_STRUCT_CHILDREN = [
   { name: "blobId", type: "string" },
@@ -44,6 +48,91 @@ export function duckLakeCatalogColumnsToDatasetSchema(
       .sort(compareDuckLakeCatalogColumnOrder)
       .map((column) => duckLakeCatalogColumnToDefinition(tableName, column, childrenByParentId)),
   }
+}
+
+export function duckLakePrimaryKeyColumnComment(ordinal: number): string {
+  return `${SIXB_PRIMARY_KEY_COMMENT_PREFIX}${ordinal}`
+}
+
+export function duckLakeCatalogColumnsToDatasetPrimaryKey(
+  tableName: string,
+  rows: readonly DuckLakeCatalogColumn[]
+): DatasetPrimaryKey | undefined {
+  const keyedColumns: { readonly column: DuckLakeCatalogColumn; readonly ordinal: number }[] = []
+  const seenOrdinals = new Set<number>()
+
+  for (const column of rows) {
+    const comment = column.comment
+    if (comment === undefined || !comment.startsWith(SIXB_PRIMARY_KEY_COMMENT_NAMESPACE)) {
+      continue
+    }
+
+    if (
+      column.parentColumnId !== undefined ||
+      !comment.startsWith(SIXB_PRIMARY_KEY_COMMENT_PREFIX)
+    ) {
+      throwInvalidPrimaryKeyMetadata(tableName, column, comment)
+    }
+
+    const ordinalText = comment.slice(SIXB_PRIMARY_KEY_COMMENT_PREFIX.length)
+    if (!/^(0|[1-9]\d*)$/.test(ordinalText)) {
+      throwInvalidPrimaryKeyMetadata(tableName, column, comment)
+    }
+
+    const ordinal = Number(ordinalText)
+    if (!Number.isSafeInteger(ordinal)) {
+      throwInvalidPrimaryKeyMetadata(tableName, column, comment)
+    }
+    if (seenOrdinals.has(ordinal)) {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Dataset table '${tableName}' has duplicate primary-key ordinal '${ordinal}'.`
+      )
+    }
+    seenOrdinals.add(ordinal)
+
+    if (duckDbTypeToDatasetColumnType(column.columnType) !== "string") {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Dataset table '${tableName}' primary-key column '${column.columnName}' must map to type 'string'.`
+      )
+    }
+    if (column.nullsAllowed) {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Dataset table '${tableName}' primary-key column '${column.columnName}' must not be nullable.`
+      )
+    }
+
+    keyedColumns.push({ column, ordinal })
+  }
+
+  if (keyedColumns.length === 0) {
+    return undefined
+  }
+
+  keyedColumns.sort((left, right) => left.ordinal - right.ordinal)
+  for (const [expectedOrdinal, keyedColumn] of keyedColumns.entries()) {
+    if (keyedColumn.ordinal !== expectedOrdinal) {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Dataset table '${tableName}' primary-key ordinals must be contiguous from 0.`
+      )
+    }
+  }
+
+  const columnNames = keyedColumns.map(({ column }) => column.columnName)
+  if (columnNames.length === 1) {
+    return columnNames[0]
+  }
+
+  return columnNames as [string, string, ...string[]]
+}
+
+function throwInvalidPrimaryKeyMetadata(
+  tableName: string,
+  column: DuckLakeCatalogColumn,
+  comment: string
+): never {
+  throw new LakeStorageError(
+    `[SixbDuckLake] Dataset table '${tableName}' has malformed primary-key metadata '${comment}' on column '${column.columnName}'.`
+  )
 }
 
 function duckLakeCatalogColumnToDefinition(

--- a/storage/ducklake/src/internal/ducklake-current-dataset-definitions.ts
+++ b/storage/ducklake/src/internal/ducklake-current-dataset-definitions.ts
@@ -11,6 +11,7 @@ import {
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import {
   type DuckLakeCatalogColumn,
+  duckLakeCatalogColumnsToDatasetPrimaryKey,
   duckLakeCatalogColumnsToDatasetSchema,
 } from "./ducklake-catalog-schema"
 import { decodeDatasetTableName, encodeDatasetTableName } from "./names"
@@ -56,14 +57,14 @@ export async function readCurrentDatasetDefinitions(
   const definitions = new Map<string, DatasetDefinition>()
 
   for (const table of tables) {
+    const columns = columnsByTableName.get(table.tableName) ?? []
+    const primaryKey = duckLakeCatalogColumnsToDatasetPrimaryKey(table.tableName, columns)
     const partitionBy = partitionByTableName.get(table.tableName) ?? []
     definitions.set(table.datasetId, {
       kind: "dataset",
       id: table.datasetId,
-      schema: duckLakeCatalogColumnsToDatasetSchema(
-        table.tableName,
-        columnsByTableName.get(table.tableName) ?? []
-      ),
+      schema: duckLakeCatalogColumnsToDatasetSchema(table.tableName, columns),
+      ...(primaryKey !== undefined ? { primaryKey } : {}),
       ...(partitionBy.length > 0 ? { partitionBy } : {}),
       ...(table.comment !== undefined ? { description: table.comment } : {}),
     })
@@ -121,6 +122,7 @@ async function readCurrentDatasetColumns(
 
   const ducklakeTable = duckLakeMetadataTableName(input.options, "ducklake_table")
   const ducklakeColumn = duckLakeMetadataTableName(input.options, "ducklake_column")
+  const ducklakeColumnTag = duckLakeMetadataTableName(input.options, "ducklake_column_tag")
   const rows = await input.runtime.query(`
     SELECT
       table_meta.table_name,
@@ -129,11 +131,17 @@ async function readCurrentDatasetColumns(
       column_meta.column_name,
       column_meta.column_type,
       CAST(column_meta.nulls_allowed AS BOOLEAN) AS nulls_allowed,
-      column_meta.parent_column
+      column_meta.parent_column,
+      column_tag."value" AS comment
     FROM ${ducklakeTable} table_meta
     JOIN ${ducklakeColumn} column_meta
       ON column_meta.table_id = table_meta.table_id
       AND column_meta.end_snapshot IS NULL
+    LEFT JOIN ${ducklakeColumnTag} column_tag
+      ON column_tag.table_id = column_meta.table_id
+      AND column_tag.column_id = column_meta.column_id
+      AND column_tag."key" = 'comment'
+      AND column_tag.end_snapshot IS NULL
     WHERE table_meta.end_snapshot IS NULL
       AND table_meta.table_name IN (${quoteSqlStringList(tableNames)})
     ORDER BY table_meta.table_name, column_meta.column_order
@@ -147,6 +155,7 @@ async function readCurrentDatasetColumns(
     columnType: getString(row, "column_type"),
     nullsAllowed: getBoolean(row, "nulls_allowed"),
     parentColumnId: getOptionalBigIntLike(row, "parent_column"),
+    comment: getOptionalString(row, "comment"),
   }))
 }
 

--- a/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
+++ b/storage/ducklake/src/internal/ducklake-dataset-catalog.ts
@@ -8,6 +8,7 @@ import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import {
   type DuckLakeCatalogColumn,
   duckLakeCatalogColumnsToDatasetSchema,
+  duckLakePrimaryKeyColumnComment,
 } from "./ducklake-catalog-schema"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import { readCurrentDatasetDefinitions } from "./ducklake-current-dataset-definitions"
@@ -59,19 +60,32 @@ export class DuckLakeDatasetCatalog {
     const qualifiedName = qualifiedTableName(this.options, tableName)
 
     // Creating a dataset can be several catalog DDL statements. Keep them in
-    // one runtime slot so writes cannot observe a half-created table.
+    // one transaction and runtime slot so nothing can observe a partial definition.
     await this.connections.withExclusiveAttached(async (runtime) => {
-      await runtime.run(
-        `CREATE TABLE ${qualifiedName} (${datasetSchemaToDuckDbColumnsSql(definition.schema)})`
-      )
-
-      if (definition.description !== undefined) {
+      await runtime.run("BEGIN TRANSACTION")
+      let committed = false
+      try {
         await runtime.run(
-          `COMMENT ON TABLE ${qualifiedName} IS ${quoteSqlString(definition.description)}`
+          `CREATE TABLE ${qualifiedName} (${datasetSchemaToDuckDbColumnsSql(definition.schema)})`
         )
-      }
 
-      await this.applyPartitionBy(runtime, qualifiedName, definition)
+        if (definition.description !== undefined) {
+          await runtime.run(
+            `COMMENT ON TABLE ${qualifiedName} IS ${quoteSqlString(definition.description)}`
+          )
+        }
+
+        await this.applyPrimaryKey(runtime, qualifiedName, definition)
+        await this.applyPartitionBy(runtime, qualifiedName, definition)
+
+        await runtime.run("COMMIT")
+        committed = true
+      } catch (error) {
+        if (!committed) {
+          await this.rollbackTransaction(runtime)
+        }
+        throw error
+      }
     })
     this.connections.markLocalCatalogChanged()
 
@@ -285,6 +299,26 @@ export class DuckLakeDatasetCatalog {
       const message = error instanceof Error ? error.message : String(error)
       throw new LakeStorageError(
         `[SixbDuckLake] Dataset '${definition.id}' cannot apply partitionBy because DuckLake rejected ALTER TABLE SET PARTITIONED BY: ${message}`
+      )
+    }
+  }
+
+  private async applyPrimaryKey(
+    runtime: DuckDbQueryRuntime,
+    qualifiedName: string,
+    definition: DatasetDefinition
+  ): Promise<void> {
+    if (definition.primaryKey === undefined) {
+      return
+    }
+
+    const columnNames =
+      typeof definition.primaryKey === "string" ? [definition.primaryKey] : definition.primaryKey
+    for (const [ordinal, columnName] of columnNames.entries()) {
+      await runtime.run(
+        `COMMENT ON COLUMN ${qualifiedName}.${quoteIdentifier(columnName)} IS ${quoteSqlString(
+          duckLakePrimaryKeyColumnComment(ordinal)
+        )}`
       )
     }
   }

--- a/storage/ducklake/tests/ducklake-datasets.e2e.ts
+++ b/storage/ducklake/tests/ducklake-datasets.e2e.ts
@@ -12,6 +12,7 @@ import {
   setupDuckLake,
 } from "../src/internal/duckdb-runtime"
 import { encodeDatasetTableName } from "../src/internal/names"
+import { quoteSqlString } from "../src/internal/sql"
 import { createLocalDuckLakeStorage, localDuckLakeOptions } from "./test-utils"
 
 interface DuckLakeStorageInternals {
@@ -87,6 +88,148 @@ describe("DuckLakeStorage dataset metadata", () => {
     expect(await storage.getDataset("raw.erp.orders")).toEqual(ordersDataset)
     expect(await storage.getDataset("missing.dataset")).toBeNull()
     expect(await storage.listDatasets()).toEqual([ordersDataset])
+  })
+
+  test("persists and reconstructs ordered primary-key column comments", async () => {
+    // Regression guard: removing the column comments or their catalog join loses primaryKey on
+    // the first metadata read.
+    const dataset = defineDataset("raw.erp.keyed_invoices", {
+      schema: [col("tenantId", "string"), col("invoiceId", "string"), col("status", "string")],
+      primaryKey: ["invoiceId", "tenantId"],
+    })
+
+    await expect(storage.createDataset(dataset)).resolves.toEqual(dataset)
+    await expect(storage.getDataset(dataset.id)).resolves.toEqual(dataset)
+    await expect(storage.listDatasets()).resolves.toEqual([dataset])
+    await expect(storage.createDataset(dataset)).resolves.toEqual(dataset)
+    await expect(storage.listVersions(dataset.id)).resolves.toEqual([])
+
+    const runtime = await runtimeForStorage(storage)
+    const tableName = encodeDatasetTableName(dataset.id)
+    const comments = await runtime.query(`
+      SELECT column_name, comment
+      FROM duckdb_columns()
+      WHERE database_name = 'sixb_lake'
+        AND schema_name = 'main'
+        AND table_name = ${quoteSqlString(tableName)}
+      ORDER BY column_index
+    `)
+    expect(comments).toEqual([
+      { column_name: "tenantId", comment: "sixb:primary-key:v1:1" },
+      { column_name: "invoiceId", comment: "sixb:primary-key:v1:0" },
+      { column_name: "status", comment: null },
+    ])
+
+    await storage.close()
+    storage = createLocalDuckLakeStorage(rootDir)
+
+    await expect(storage.getDataset(dataset.id)).resolves.toEqual(dataset)
+    await expect(storage.listDatasets()).resolves.toEqual([dataset])
+    await expect(storage.createDataset(dataset)).resolves.toEqual(dataset)
+    await expect(storage.listVersions(dataset.id)).resolves.toEqual([])
+  })
+
+  test("atomically creates every part of a dataset definition", async () => {
+    // Regression guard: removing BEGIN TRANSACTION leaves the table and earlier metadata behind
+    // when the injected final partition statement fails.
+    const dataset = defineDataset("raw.erp.atomic_definition", {
+      schema: [col("tenantId", "string"), col("invoiceId", "string"), col("orderDate", "date")],
+      primaryKey: ["invoiceId", "tenantId"],
+      partitionBy: ["orderDate"],
+      description: "Atomic ERP invoices",
+    })
+    const runtime = await runtimeForStorage(storage)
+    const injected = failNextExclusiveRun(runtime, (sql) => sql.startsWith("ALTER TABLE "))
+
+    await expect(storage.createDataset(dataset)).rejects.toThrow("injected DDL failure")
+    injected.restore()
+
+    expect(injected.statements[0]).toBe("BEGIN TRANSACTION")
+    expect(injected.statements.some((sql) => sql.startsWith("CREATE TABLE "))).toBe(true)
+    expect(injected.statements.some((sql) => sql.startsWith("COMMENT ON TABLE "))).toBe(true)
+    expect(injected.statements.filter((sql) => sql.startsWith("COMMENT ON COLUMN "))).toHaveLength(
+      2
+    )
+    expect(injected.statements.some((sql) => sql.startsWith("ALTER TABLE "))).toBe(true)
+    expect(injected.statements).not.toContain("COMMIT")
+    expect(injected.statements.at(-1)).toBe("ROLLBACK")
+
+    await expect(storage.getDataset(dataset.id)).resolves.toBeNull()
+    await expect(storage.listDatasets()).resolves.toEqual([])
+    await expect(storage.listVersions(dataset.id)).resolves.toEqual([])
+
+    await expect(storage.createDataset(dataset)).resolves.toEqual(dataset)
+    await expect(storage.getDataset(dataset.id)).resolves.toEqual(dataset)
+    await expect(storage.listVersions(dataset.id)).resolves.toEqual([])
+  })
+
+  test("rejects corrupt reserved primary-key column comments", async () => {
+    const malformedId = "raw.erp.key_metadata_malformed"
+    const duplicateId = "raw.erp.key_metadata_duplicate"
+    const gapId = "raw.erp.key_metadata_gap"
+    const nullableId = "raw.erp.key_metadata_nullable"
+    const nonStringId = "raw.erp.key_metadata_non_string"
+    const runtime = await createDuckDbRuntime()
+
+    try {
+      await setupDuckLake(runtime, localDuckLakeOptions(rootDir))
+
+      const malformedTable = encodeDatasetTableName(malformedId)
+      await runtime.run(`CREATE TABLE sixb_lake.main.${malformedTable} (id VARCHAR NOT NULL)`)
+      await runtime.run(
+        `COMMENT ON COLUMN sixb_lake.main.${malformedTable}.id IS 'sixb:primary-key:v2:0'`
+      )
+
+      const duplicateTable = encodeDatasetTableName(duplicateId)
+      await runtime.run(
+        `CREATE TABLE sixb_lake.main.${duplicateTable} (tenantId VARCHAR NOT NULL, invoiceId VARCHAR NOT NULL)`
+      )
+      await runtime.run(
+        `COMMENT ON COLUMN sixb_lake.main.${duplicateTable}.tenantId IS 'sixb:primary-key:v1:0'`
+      )
+      await runtime.run(
+        `COMMENT ON COLUMN sixb_lake.main.${duplicateTable}.invoiceId IS 'sixb:primary-key:v1:0'`
+      )
+
+      const gapTable = encodeDatasetTableName(gapId)
+      await runtime.run(
+        `CREATE TABLE sixb_lake.main.${gapTable} (tenantId VARCHAR NOT NULL, invoiceId VARCHAR NOT NULL)`
+      )
+      await runtime.run(
+        `COMMENT ON COLUMN sixb_lake.main.${gapTable}.tenantId IS 'sixb:primary-key:v1:0'`
+      )
+      await runtime.run(
+        `COMMENT ON COLUMN sixb_lake.main.${gapTable}.invoiceId IS 'sixb:primary-key:v1:2'`
+      )
+
+      const nullableTable = encodeDatasetTableName(nullableId)
+      await runtime.run(`CREATE TABLE sixb_lake.main.${nullableTable} (id VARCHAR)`)
+      await runtime.run(
+        `COMMENT ON COLUMN sixb_lake.main.${nullableTable}.id IS 'sixb:primary-key:v1:0'`
+      )
+
+      const nonStringTable = encodeDatasetTableName(nonStringId)
+      await runtime.run(`CREATE TABLE sixb_lake.main.${nonStringTable} (id BIGINT NOT NULL)`)
+      await runtime.run(
+        `COMMENT ON COLUMN sixb_lake.main.${nonStringTable}.id IS 'sixb:primary-key:v1:0'`
+      )
+    } finally {
+      await runtime.close()
+    }
+
+    await expect(storage.getDataset(malformedId)).rejects.toThrow("malformed primary-key metadata")
+    await expect(storage.getDataset(duplicateId)).rejects.toThrow(
+      "duplicate primary-key ordinal '0'"
+    )
+    await expect(storage.getDataset(gapId)).rejects.toThrow(
+      "primary-key ordinals must be contiguous from 0"
+    )
+    await expect(storage.getDataset(nullableId)).rejects.toThrow(
+      "primary-key column 'id' must not be nullable"
+    )
+    await expect(storage.getDataset(nonStringId)).rejects.toThrow(
+      "primary-key column 'id' must map to type 'string'"
+    )
   })
 
   test("preserves compatible definitions and rejects incompatible definitions", async () => {
@@ -223,6 +366,7 @@ describe("DuckLakeStorage dataset metadata", () => {
           col("metadata", "json", { nullable: true }),
           col("attachment", "fileRef", { nullable: true }),
         ],
+        primaryKey: "id",
       })
       await storage.createDataset(dataset)
       definitions.push(dataset)
@@ -268,6 +412,7 @@ describe("DuckLakeStorage dataset metadata", () => {
   test("applies schema evolution and partition changes in one definition update", async () => {
     const initialDataset = defineDataset("raw.erp.schema_partition_policy", {
       schema: [col("orderId", "string"), col("orderDate", "date")],
+      primaryKey: "orderId",
     })
     const evolvedPartitionedDataset = defineDataset("raw.erp.schema_partition_policy", {
       schema: [
@@ -275,6 +420,7 @@ describe("DuckLakeStorage dataset metadata", () => {
         col("orderDate", "date"),
         col("currency", "string", { nullable: true }),
       ],
+      primaryKey: "orderId",
       partitionBy: ["orderDate"],
     })
 
@@ -445,6 +591,43 @@ function pauseAfterNextBeginTransaction(runtime: DuckDbRuntime): {
   return {
     paused: paused.promise,
     resume: () => resumed.resolve(),
+  }
+}
+
+function failNextExclusiveRun(
+  runtime: DuckDbRuntime,
+  matches: (sql: string) => boolean
+): {
+  readonly statements: string[]
+  restore(): void
+} {
+  const originalWithExclusive = runtime.withExclusive.bind(runtime)
+  const statements: string[] = []
+  let failed = false
+
+  runtime.withExclusive = (useRuntime) =>
+    originalWithExclusive((exclusiveRuntime) =>
+      useRuntime({
+        run: async (sql, values) => {
+          statements.push(sql)
+          if (!failed && matches(sql)) {
+            failed = true
+            throw new Error("injected DDL failure")
+          }
+          await exclusiveRuntime.run(sql, values)
+        },
+        runStatements: (sql) => exclusiveRuntime.runStatements(sql),
+        query: (sql, values) => exclusiveRuntime.query(sql, values),
+        withAppender: (tableName, useAppender) =>
+          exclusiveRuntime.withAppender(tableName, useAppender),
+      })
+    )
+
+  return {
+    statements,
+    restore: () => {
+      runtime.withExclusive = originalWithExclusive
+    },
   }
 }
 

--- a/storage/ducklake/tests/ducklake-remote.e2e.ts
+++ b/storage/ducklake/tests/ducklake-remote.e2e.ts
@@ -13,6 +13,7 @@ describe("DuckLakeStorage remote catalogs", () => {
     const rootDir = await mkdtemp(join(tmpdir(), "sixb-ducklake-pg-local-"))
     const dataset = defineDataset(`raw.pg.local.${randomId()}`, {
       schema: [col("orderId", "string")],
+      primaryKey: "orderId",
     })
     const storage = new DuckLakeStorage({
       catalog: postgresCatalog(),
@@ -21,6 +22,7 @@ describe("DuckLakeStorage remote catalogs", () => {
 
     try {
       await storage.createDataset(dataset)
+      await expect(storage.getDataset(dataset.id)).resolves.toEqual(dataset)
       const write = await storage.beginWrite({ dataset, mode: "snapshot" })
       await write.writeRows([{ orderId: "ord_1" }])
       await write.commit()

--- a/storage/lake-local/tests/local-lake-storage.test.ts
+++ b/storage/lake-local/tests/local-lake-storage.test.ts
@@ -23,6 +23,31 @@ runLakeStorageContractSuite("LocalLakeStorage", {
   },
 })
 
+describe("LocalLakeStorage definition persistence", () => {
+  test("round-trips a keyed definition after reopening", async () => {
+    // Regression guard: stripping primaryKey from definition.json makes the reopened reads fail.
+    const rootDir = await mkdtemp(join(tmpdir(), "sixb-lake-local-reopen-definition-"))
+    const path = join(rootDir, "lake")
+    try {
+      const dataset = defineDataset("stable.reopen-definition", {
+        schema: [col("tenantId", "string"), col("invoiceId", "string"), col("status", "string")],
+        primaryKey: ["tenantId", "invoiceId"],
+      })
+      const initial = new LocalLakeStorage({ path })
+      await initial.createDataset(dataset)
+
+      const reopened = new LocalLakeStorage({ path })
+
+      await expect(reopened.getDataset(dataset.id)).resolves.toEqual(dataset)
+      await expect(reopened.listDatasets()).resolves.toEqual([dataset])
+      await expect(reopened.createDataset(dataset)).resolves.toEqual(dataset)
+      await expect(reopened.listVersions(dataset.id)).resolves.toEqual([])
+    } finally {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+})
+
 describe("LocalLakeStorage stable pinned reads", () => {
   test("preserves physical row order and offsets after reopening", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "sixb-lake-local-reopen-order-"))


### PR DESCRIPTION
## Summary

This is the first implementation slice of #292. It adds the dataset primary-key contract that keyed merge syncs will build on.

Single-column keys use the column name:

```ts
export const invoices = defineDataset("erp.invoices", {
  schema: [
    col("id", "string"),
    col("status", "string"),
    col("customerId", "string"),
  ],
  primaryKey: "id",
})
```

Composite keys preserve their declared order:

```ts
primaryKey: ["invoiceId", "lineItemId"]
```

## In this PR

- Adds the public `DatasetPrimaryKey` type and preserves literal key inference.
- Restricts keys to declared, non-nullable string columns at compile time and runtime.
- Defensively copies composite keys and rejects malformed, duplicate, or unknown columns.
- Treats primary keys as immutable dataset identity metadata.
- Preserves keys across compatible schema additions and definition reuse.
- Round-trips keys through InMemory, LocalLake, and DuckLake storage.
- Stores ordered DuckLake key membership in reserved column comments:

```text
sixb:primary-key:v1:0
sixb:primary-key:v1:1
```

- Creates DuckLake tables, descriptions, key comments, and partition metadata atomically without creating a visible dataset version.
- Exports the type from the dataset, root, and lake-storage surfaces.
- Documents single and composite keys, derived-dataset behavior, and V1 constraints.

## Not in this PR

Primary keys are definition metadata in this slice. This PR does not yet add:

- Row uniqueness enforcement.
- `change.upsert` or `change.delete`.
- Keyed merge write sessions or optimistic merge commits.
- `mode: "merge"` sync-worker execution and checkpoint handling.
- One-writer validation.
- Full-dataset projection evaluation after merge commits.
- Incremental changed-row projections, joins, aggregations, or partial patches.

Those behaviors will follow as separate reviewable PRs built on this contract.

## Validation

```text
bun run check
bun --filter @sixb/core typecheck
bun --filter @sixb/ducklake typecheck
bun --filter @sixb/lake-local typecheck
```

Provider contract suites, DuckLake local and remote integration tests, compile-time contract tests, and the published-package consumer test also pass.
