### PR TITLE
ducklake: add keyed dataset merges

### DIFF
--- a/packages/core/src/lake-storage/types.ts
+++ b/packages/core/src/lake-storage/types.ts
@@ -125,8 +125,7 @@ export interface LakeStorage {
   listVersions(datasetId: string, limit?: number): Promise<readonly DatasetVersion[]>
 
   beginWrite(input: BeginDatasetWriteInput): Promise<LakeWriteSession>
-  /** Optional until every built-in provider supports keyed merges. */
-  beginMerge?(input: BeginDatasetMergeInput): Promise<LakeMergeSession>
+  beginMerge(input: BeginDatasetMergeInput): Promise<LakeMergeSession>
 
   getLatestVersion(datasetId: string): Promise<DatasetVersion | null>
   getVersion(datasetId: string, versionId: string): Promise<DatasetVersion | null>

--- a/packages/core/src/testing/lake-merge-storage-contract.ts
+++ b/packages/core/src/testing/lake-merge-storage-contract.ts
@@ -2,10 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { change, col, defineDataset } from "../datasets"
 import type { DatasetMergeCommitResult, DatasetRow, LakeStorage } from "../lake-storage"
 
-export interface LakeMergeStorageContractSuiteOptions<
-  TStorage extends LakeStorage & Required<Pick<LakeStorage, "beginMerge">> = LakeStorage &
-    Required<Pick<LakeStorage, "beginMerge">>,
-> {
+export interface LakeMergeStorageContractSuiteOptions<TStorage extends LakeStorage = LakeStorage> {
   readonly createStorage: () => TStorage | Promise<TStorage>
   readonly teardown?: (storage: TStorage) => void | Promise<void>
 }
@@ -24,9 +21,10 @@ const unkeyed = defineDataset("contract.merges.unkeyed", {
   schema: [col("id", "string")],
 })
 
-export function runLakeMergeStorageContractSuite<
-  TStorage extends LakeStorage & Required<Pick<LakeStorage, "beginMerge">>,
->(label: string, options: LakeMergeStorageContractSuiteOptions<TStorage>): void {
+export function runLakeMergeStorageContractSuite<TStorage extends LakeStorage>(
+  label: string,
+  options: LakeMergeStorageContractSuiteOptions<TStorage>
+): void {
   const withStorage = async (body: (storage: TStorage) => Promise<void>): Promise<void> => {
     const storage = await options.createStorage()
     try {
@@ -168,13 +166,13 @@ export function runLakeMergeStorageContractSuite<
         const first = await storage.beginMerge({ dataset: invoices })
         const stale = await storage.beginMerge({ dataset: invoices })
 
-        await first.writeChanges([change.upsert({ id: "inv_1", status: "open" })])
+        await first.writeChanges([change.upsert({ id: "inv_1", status: "open", note: null })])
         await first.commit()
         await stale.writeChanges([change.upsert({ id: "inv_2", status: "open" })])
 
         await expect(stale.commit()).rejects.toThrow("Optimistic merge commit failed")
         await expect(collectRows(storage.readRows({ datasetId: invoices.id }))).resolves.toEqual([
-          { id: "inv_1", status: "open" },
+          { id: "inv_1", status: "open", note: null },
         ])
       })
     })
@@ -246,7 +244,7 @@ export function runLakeMergeStorageContractSuite<
     test("clones staged changes and enforces the session lifecycle", async () => {
       await withStorage(async (storage) => {
         await storage.createDataset(invoices)
-        const row = { id: "inv_1", status: "open" }
+        const row = { id: "inv_1", status: "open", note: null }
         const merge = await storage.beginMerge({ dataset: invoices })
         await merge.writeChanges([change.upsert(row)])
         row.status = "paid"
@@ -255,7 +253,7 @@ export function runLakeMergeStorageContractSuite<
 
         await expect(merge.writeChanges([])).rejects.toThrow("already closed")
         await expect(collectRows(storage.readRows({ datasetId: invoices.id }))).resolves.toEqual([
-          { id: "inv_1", status: "open" },
+          { id: "inv_1", status: "open", note: null },
         ])
 
         const aborted = await storage.beginMerge({ dataset: invoices })

--- a/packages/core/tests/lake-storage.types.ts
+++ b/packages/core/tests/lake-storage.types.ts
@@ -22,8 +22,7 @@ type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
 type Expect<T extends true> = T
 
-type MergeCapableLakeStorage = LakeStorage & Required<Pick<LakeStorage, "beginMerge">>
-type _baseMergeIsOptional = Expect<undefined extends LakeStorage["beginMerge"] ? true : false>
+type _baseMergeIsRequired = Expect<undefined extends LakeStorage["beginMerge"] ? false : true>
 type _writeModesRemainNarrow = Expect<Equal<DatasetWriteMode, "snapshot" | "append">>
 type _versionModesIncludeMerge = Expect<
   Equal<DatasetVersionMode, "snapshot" | "append" | "merge" | "schema">
@@ -43,7 +42,7 @@ const commitInput: CommitDatasetMergeInput = { commitMessage: "merge invoices" }
 // @ts-expect-error beginMerge selects the operation without accepting an ordinary write mode
 const _mergeInputWithMode: BeginDatasetMergeInput = { dataset, mode: "merge" }
 
-declare const mergeStorage: MergeCapableLakeStorage
+declare const mergeStorage: LakeStorage
 declare const mergeSession: LakeMergeSession
 declare const version: DatasetVersion
 
@@ -76,9 +75,7 @@ function narrowMergeResult(result: DatasetMergeCommitResult): DatasetVersion | n
 }
 
 declare const baseStorage: LakeStorage
-const _optionalMerge = baseStorage.beginMerge?.(beginInput)
-// @ts-expect-error beginMerge remains optional until DuckLake implements it in the next PR
-baseStorage.beginMerge(beginInput)
+const _requiredMerge: Promise<LakeMergeSession> = baseStorage.beginMerge(beginInput)
 // @ts-expect-error merge commits guard the version captured at beginMerge automatically
 mergeSession.commit({ expectedLatestVersionId: "ver_1" })
 // @ts-expect-error merge is not an ordinary dataset write mode
@@ -97,5 +94,5 @@ void _created
 void _initialNoOp
 void _laterNoOp
 void _mergeInputWithMode
-void _optionalMerge
+void _requiredMerge
 void narrowMergeResult

--- a/packages/core/tests/published-artifacts.e2e.ts
+++ b/packages/core/tests/published-artifacts.e2e.ts
@@ -186,7 +186,7 @@ const mergeVersionMode: DatasetVersionMode = "merge"
 declare const lakeStorage: LakeStorage
 const rootLakeStorage: RootLakeStorage = lakeStorage
 declare const beginMergeInput: BeginDatasetMergeInput
-const mergeSession = lakeStorage.beginMerge?.(beginMergeInput)
+const mergeSession = lakeStorage.beginMerge(beginMergeInput)
 export const loaded = [${subpaths.map((_, index) => `m${index}`).join(", ")}].length
 void lakePrimaryKey
 void lakeMergeChange

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -34,7 +34,11 @@ import {
 } from "@sixb/core/internal/projections"
 import { shareOntologyMutationRuntime } from "@sixb/core/internal/runtime"
 import { decorateOperationScopedMethodForTesting } from "@sixb/core/internal/storage-operation-scope"
-import type { BeginDatasetWriteInput, ReadDatasetRowsInput } from "@sixb/core/lake-storage"
+import type {
+  BeginDatasetMergeInput,
+  BeginDatasetWriteInput,
+  ReadDatasetRowsInput,
+} from "@sixb/core/lake-storage"
 import type {
   AbandonSourceMaterializationCandidateInput,
   OntologySourceRecord,
@@ -194,6 +198,10 @@ class RecordingLakeStorage implements LakeStorage {
 
   beginWrite(input: BeginDatasetWriteInput) {
     return this.delegate.beginWrite(input)
+  }
+
+  beginMerge(input: BeginDatasetMergeInput) {
+    return this.delegate.beginMerge(input)
   }
 
   getLatestVersion(datasetId: string) {

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -169,6 +169,9 @@ describe("runSyncJob", () => {
         calls.push(`begin:${input.dataset.id}`)
         return lakeStorage.beginWrite(input)
       },
+      beginMerge(input) {
+        return lakeStorage.beginMerge(input)
+      },
       getLatestVersion(datasetId) {
         return lakeStorage.getLatestVersion(datasetId)
       },
@@ -630,6 +633,9 @@ describe("runSyncJob", () => {
           },
         }
         return wrappedWrite
+      },
+      beginMerge(input) {
+        return lakeStorage.beginMerge(input)
       },
       getLatestVersion(datasetId) {
         return lakeStorage.getLatestVersion(datasetId)

--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -146,6 +146,43 @@ use the same schema that DuckLake materializes.
 
 DuckLake stores Sixb `decimal` columns as `DECIMAL(38, 9)` and returns them as exact strings, including from SQL previews. Writes that need more than 29 integer digits or 9 fractional digits are rejected before DuckDB can round or overflow them.
 
+## Keyed Merges
+
+Datasets with a primary key can apply ordered complete-row changes directly through the lake
+provider. Key columns must be non-null strings; composite key order is significant.
+
+```ts
+import { change, col, defineDataset } from "@sixb/core"
+
+const invoices = defineDataset("erp.invoices", {
+  schema: [
+    col("id", "string"),
+    col("status", "string"),
+    col("customerId", "string"),
+  ],
+  primaryKey: "id",
+})
+
+await lakeStorage.createDataset(invoices)
+
+const merge = await lakeStorage.beginMerge({ dataset: invoices })
+await merge.writeChanges([
+  change.upsert({ id: "inv_1", status: "paid", customerId: "cust_1" }),
+  change.delete({ id: "inv_2" }),
+])
+const result = await merge.commit()
+```
+
+Changes remain ordered across `writeChanges(...)` calls, and the final change for a repeated key
+wins. Upserts are complete rows rather than patches. Commit checks the dataset version captured by
+`beginMerge`, applies effective changes atomically, and creates a version only when visible rows
+change. An initial no-op returns `{ outcome: "unchanged", version: null }`; a later no-op returns the
+existing latest version.
+
+Snapshot, append, and SQL-transform writes to keyed datasets also enforce unique keys so a later
+merge never starts from an ambiguous baseline. Sync-level `mode: "merge"` activation will arrive
+with the follow-up sync-worker integration rather than this provider contract.
+
 ## DuckLake SQL Transforms
 
 DuckLake SQL transforms let the provider run dataset-to-dataset transforms in

--- a/storage/ducklake/package.json
+++ b/storage/ducklake/package.json
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:e2e": "bun run test:e2e:local && bun run test:e2e:remote",
-    "test:e2e:local": "bun test ./tests/ducklake-contract.e2e.ts ./tests/ducklake-file-refs.e2e.ts ./tests/ducklake-catalog-state.e2e.ts ./tests/ducklake-catalogs.e2e.ts ./tests/ducklake-concurrency.e2e.ts ./tests/ducklake-datasets.e2e.ts ./tests/ducklake-driver.e2e.ts ./tests/ducklake-maintenance.e2e.ts ./tests/ducklake-sql-transforms.e2e.ts ./tests/ducklake-versions.e2e.ts ./tests/ducklake-writes.e2e.ts",
+    "test:e2e:local": "bun test ./tests/ducklake-contract.e2e.ts ./tests/ducklake-file-refs.e2e.ts ./tests/ducklake-catalog-state.e2e.ts ./tests/ducklake-catalogs.e2e.ts ./tests/ducklake-concurrency.e2e.ts ./tests/ducklake-datasets.e2e.ts ./tests/ducklake-driver.e2e.ts ./tests/ducklake-maintenance.e2e.ts ./tests/ducklake-merges.e2e.ts ./tests/ducklake-sql-transforms.e2e.ts ./tests/ducklake-versions.e2e.ts ./tests/ducklake-writes.e2e.ts",
     "test:e2e:remote": "bun test --preload ./tests/setup.ts ./tests/ducklake-remote.e2e.ts",
     "prepack": "bun run build"
   },

--- a/storage/ducklake/src/ducklake-storage.ts
+++ b/storage/ducklake/src/ducklake-storage.ts
@@ -1,8 +1,10 @@
 import type { DatasetDefinition, DatasetRow, LakeStorageWithSql } from "@sixb/core"
 import type {
+  BeginDatasetMergeInput,
   BeginDatasetWriteInput,
   DatasetCatalogState,
   DatasetVersion,
+  LakeMergeSession,
   LakeWriteSession,
   ReadDatasetRowsInput,
 } from "@sixb/core/lake-storage"
@@ -102,6 +104,10 @@ export class DuckLakeStorage implements LakeStorageWithSql<"duckdb"> {
 
   async beginWrite(input: BeginDatasetWriteInput): Promise<LakeWriteSession> {
     return this.writes.beginWrite(input)
+  }
+
+  async beginMerge(input: BeginDatasetMergeInput): Promise<LakeMergeSession> {
+    return this.writes.beginMerge(input)
   }
 
   async getLatestVersion(datasetId: string): Promise<DatasetVersion | null> {

--- a/storage/ducklake/src/internal/dataset-row-commit.ts
+++ b/storage/ducklake/src/internal/dataset-row-commit.ts
@@ -1,11 +1,15 @@
 import type { DatasetDefinition } from "@sixb/core"
-import { type DatasetWriteMode, LakeStorageError } from "@sixb/core/lake-storage"
+import {
+  type DatasetWriteMode,
+  getDatasetPrimaryKeyColumns,
+  LakeStorageError,
+} from "@sixb/core/lake-storage"
 import type { DuckLakeStorageOptions } from "../types"
 import { getBigIntLike } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import { encodeDatasetTableName } from "./names"
 import { datasetSchemaColumnNamesSql } from "./schema"
-import { qualifiedTableName } from "./sql"
+import { qualifiedTableName, quoteIdentifier } from "./sql"
 
 export type CommitRowCount =
   | { readonly kind: "exact"; readonly value: number }
@@ -40,6 +44,32 @@ export async function applyDatasetRowsFromRelation(input: {
   const tableName = encodeDatasetTableName(input.dataset.id)
   const table = qualifiedTableName(input.options, tableName)
   const columnsSql = datasetSchemaColumnNamesSql(input.dataset.schema)
+  const primaryKeyColumns = getDatasetPrimaryKeyColumns(input.dataset)
+
+  if (primaryKeyColumns !== null) {
+    await inspectUniqueKeyedRelation({
+      runtime: input.runtime,
+      dataset: input.dataset,
+      relationSql: input.sourceRelationSql,
+      context: `${input.mode} source`,
+    })
+
+    if (input.mode === "append") {
+      await inspectUniqueKeyedRelation({
+        runtime: input.runtime,
+        dataset: input.dataset,
+        relationSql: table,
+        context: "current baseline",
+      })
+      await assertNoPrimaryKeyOverlap({
+        runtime: input.runtime,
+        dataset: input.dataset,
+        leftRelationSql: input.sourceRelationSql,
+        rightRelationSql: table,
+        context: "append",
+      })
+    }
+  }
 
   if (input.mode === "snapshot") {
     const source = await fingerprintRelation(input.runtime, input.sourceRelationSql, columnsSql)
@@ -77,6 +107,69 @@ export async function applyDatasetRowsFromRelation(input: {
       input.previousRowCount === undefined
         ? { kind: "unknown" }
         : { kind: "exact", value: input.previousRowCount + sourceRowCount },
+  }
+}
+
+export async function inspectUniqueKeyedRelation(input: {
+  readonly runtime: DuckDbQueryRuntime
+  readonly dataset: DatasetDefinition
+  readonly relationSql: string
+  readonly context: string
+}): Promise<number> {
+  const primaryKeyColumns = getDatasetPrimaryKeyColumns(input.dataset)
+  if (primaryKeyColumns === null) {
+    throw new LakeStorageError(
+      `[SixbDuckLake] Dataset '${input.dataset.id}' must define a primaryKey before rows can be keyed.`
+    )
+  }
+
+  const keysSql = primaryKeyColumns.map((column) => quoteIdentifier(column)).join(", ")
+  const [row] = await input.runtime.query(`
+    SELECT
+      count(*) AS row_count,
+      coalesce(max(key_count), 0) AS max_key_count
+    FROM (
+      SELECT count(*) OVER (PARTITION BY ${keysSql}) AS key_count
+      FROM ${input.relationSql}
+    ) keyed_rows
+  `)
+
+  const rowCount = row === undefined ? 0 : Number(getBigIntLike(row, "row_count"))
+  const maxKeyCount = row === undefined ? 0 : Number(getBigIntLike(row, "max_key_count"))
+  if (maxKeyCount > 1) {
+    throw new LakeStorageError(
+      `[SixbDuckLake] Dataset '${input.dataset.id}' ${input.context} contains duplicate primary key.`
+    )
+  }
+
+  return rowCount
+}
+
+async function assertNoPrimaryKeyOverlap(input: {
+  readonly runtime: DuckDbQueryRuntime
+  readonly dataset: DatasetDefinition
+  readonly leftRelationSql: string
+  readonly rightRelationSql: string
+  readonly context: string
+}): Promise<void> {
+  const primaryKeyColumns = getDatasetPrimaryKeyColumns(input.dataset)
+  if (primaryKeyColumns === null) {
+    return
+  }
+
+  const matchSql = primaryKeyColumns
+    .map((column) => `left_rows.${quoteIdentifier(column)} = right_rows.${quoteIdentifier(column)}`)
+    .join(" AND ")
+  const [collision] = await input.runtime.query(`
+    SELECT 1
+    FROM ${input.leftRelationSql} left_rows
+    JOIN ${input.rightRelationSql} right_rows ON ${matchSql}
+    LIMIT 1
+  `)
+  if (collision !== undefined) {
+    throw new LakeStorageError(
+      `[SixbDuckLake] Dataset '${input.dataset.id}' ${input.context} contains duplicate primary key.`
+    )
   }
 }
 

--- a/storage/ducklake/src/internal/dataset-row-merge.ts
+++ b/storage/ducklake/src/internal/dataset-row-merge.ts
@@ -15,6 +15,8 @@ export interface ApplyDatasetMergeFromRelationInput {
   readonly stagingTableName: string
   readonly sequenceColumnName: string
   readonly kindColumnName: string
+  readonly previousRowCount?: number
+  readonly validatedPrimaryKeyColumns?: readonly string[]
 }
 
 interface MergeEffectCounts {
@@ -36,70 +38,121 @@ export async function applyDatasetMergeFromRelation(
   const stagingTable = quoteIdentifier(input.stagingTableName)
   const targetTable = qualifiedTableName(input.options, encodeDatasetTableName(input.dataset.id))
   const sourceRowCount = await countRows(input.runtime, stagingTable)
-  const previousRowCount = await inspectUniqueKeyedRelation({
+  const previousRowCount = await currentBaselineRowCount(input, targetTable, primaryKeyColumns)
+
+  return withMaterializedFinalChanges(input, primaryKeyColumns, async (finalChanges) => {
+    const effects = await countMergeEffects(input, targetTable, finalChanges, primaryKeyColumns)
+    const effectiveChangeCount = effects.inserts + effects.updates + effects.deletes
+
+    if (effectiveChangeCount === 0) {
+      return {
+        dataChangeExpected: false,
+        sourceRowCount,
+        resultingRowCount: { kind: "exact", value: previousRowCount },
+      }
+    }
+
+    const keyMatchSql = primaryKeyMatchSql(primaryKeyColumns, "target", "source")
+    const rowDifferenceSql = datasetRowDifferenceSql(input.dataset, "target", "source")
+    const kindColumn = `source.${quoteIdentifier(input.kindColumnName)}`
+
+    await input.runtime.run(`
+      DELETE FROM ${targetTable} AS target
+      USING ${finalChanges} AS source
+      WHERE ${keyMatchSql}
+        AND (
+          ${kindColumn} = ${quoteSqlString("delete")}
+          OR (
+            ${kindColumn} = ${quoteSqlString("upsert")}
+            AND (${rowDifferenceSql})
+          )
+        )
+    `)
+
+    const columnsSql = datasetSchemaColumnNamesSql(input.dataset.schema)
+    const selectedColumnsSql = input.dataset.schema.columns
+      .map((column) => `source.${quoteIdentifier(column.name)}`)
+      .join(", ")
+    const firstSequenceColumnName = firstSequenceName(input.sequenceColumnName)
+    await input.runtime.run(`
+      INSERT INTO ${targetTable} (${columnsSql})
+      SELECT ${selectedColumnsSql}
+      FROM ${finalChanges} AS source
+      WHERE ${kindColumn} = ${quoteSqlString("upsert")}
+        AND NOT EXISTS (
+          SELECT 1
+          FROM ${targetTable} AS target
+          WHERE ${keyMatchSql}
+        )
+      ORDER BY source.${quoteIdentifier(firstSequenceColumnName)}
+    `)
+
+    return {
+      dataChangeExpected: true,
+      sourceRowCount,
+      resultingRowCount: {
+        kind: "exact",
+        value: previousRowCount + effects.inserts - effects.deletes,
+      },
+    }
+  })
+}
+
+async function currentBaselineRowCount(
+  input: ApplyDatasetMergeFromRelationInput,
+  targetTable: string,
+  primaryKeyColumns: readonly string[]
+): Promise<number> {
+  // Sixb writes mark keyed versions only after the write path has enforced uniqueness. Older or
+  // external versions carry no marker and keep the full defensive audit.
+  if (sameColumns(input.validatedPrimaryKeyColumns, primaryKeyColumns)) {
+    return input.previousRowCount ?? countRows(input.runtime, targetTable)
+  }
+
+  return inspectUniqueKeyedRelation({
     runtime: input.runtime,
     dataset: input.dataset,
     relationSql: targetTable,
     context: "current baseline",
   })
-  const finalChanges = finalChangesRelationSql(input, primaryKeyColumns)
-  const effects = await countMergeEffects(input, targetTable, finalChanges, primaryKeyColumns)
-  const effectiveChangeCount = effects.inserts + effects.updates + effects.deletes
+}
 
-  if (effectiveChangeCount === 0) {
-    return {
-      dataChangeExpected: false,
-      sourceRowCount,
-      resultingRowCount: { kind: "exact", value: previousRowCount },
+async function withMaterializedFinalChanges<T>(
+  input: ApplyDatasetMergeFromRelationInput,
+  primaryKeyColumns: readonly string[],
+  run: (finalChangesTable: string) => Promise<T>
+): Promise<T> {
+  const table = quoteIdentifier(`${input.stagingTableName}_final`)
+  await input.runtime.run(`
+    CREATE TEMP TABLE ${table} AS
+    ${finalChangesSelectSql(input, primaryKeyColumns)}
+  `)
+
+  let outcome:
+    | { readonly kind: "success"; readonly value: T }
+    | { readonly kind: "error"; readonly error: unknown }
+  try {
+    outcome = { kind: "success", value: await run(table) }
+  } catch (error) {
+    outcome = { kind: "error", error }
+  }
+
+  try {
+    await input.runtime.run(`DROP TABLE IF EXISTS ${table}`)
+  } catch (cleanupError) {
+    if (outcome.kind === "success") {
+      throw cleanupError
     }
   }
 
-  const keyMatchSql = primaryKeyMatchSql(primaryKeyColumns, "target", "source")
-  const rowDifferenceSql = datasetRowDifferenceSql(input.dataset, "target", "source")
-  const kindColumn = `source.${quoteIdentifier(input.kindColumnName)}`
-
-  await input.runtime.run(`
-    DELETE FROM ${targetTable} AS target
-    USING ${finalChanges} AS source
-    WHERE ${keyMatchSql}
-      AND (
-        ${kindColumn} = ${quoteSqlString("delete")}
-        OR (
-          ${kindColumn} = ${quoteSqlString("upsert")}
-          AND (${rowDifferenceSql})
-        )
-      )
-  `)
-
-  const columnsSql = datasetSchemaColumnNamesSql(input.dataset.schema)
-  const selectedColumnsSql = input.dataset.schema.columns
-    .map((column) => `source.${quoteIdentifier(column.name)}`)
-    .join(", ")
-  const firstSequenceColumnName = firstSequenceName(input.sequenceColumnName)
-  await input.runtime.run(`
-    INSERT INTO ${targetTable} (${columnsSql})
-    SELECT ${selectedColumnsSql}
-    FROM ${finalChanges} AS source
-    WHERE ${kindColumn} = ${quoteSqlString("upsert")}
-      AND NOT EXISTS (
-        SELECT 1
-        FROM ${targetTable} AS target
-        WHERE ${keyMatchSql}
-      )
-    ORDER BY source.${quoteIdentifier(firstSequenceColumnName)}
-  `)
-
-  return {
-    dataChangeExpected: true,
-    sourceRowCount,
-    resultingRowCount: {
-      kind: "exact",
-      value: previousRowCount + effects.inserts - effects.deletes,
-    },
+  if (outcome.kind === "error") {
+    throw outcome.error
   }
+
+  return outcome.value
 }
 
-function finalChangesRelationSql(
+function finalChangesSelectSql(
   input: ApplyDatasetMergeFromRelationInput,
   primaryKeyColumns: readonly string[]
 ): string {
@@ -108,7 +161,7 @@ function finalChangesRelationSql(
   const rankColumn = quoteIdentifier(rankName(input.sequenceColumnName))
   const firstSequenceColumn = quoteIdentifier(firstSequenceName(input.sequenceColumnName))
 
-  return `(
+  return `
     SELECT * EXCLUDE (${rankColumn})
     FROM (
       SELECT
@@ -121,7 +174,7 @@ function finalChangesRelationSql(
       FROM ${quoteIdentifier(input.stagingTableName)}
     ) ranked_changes
     WHERE ${rankColumn} = 1
-  )`
+  `
 }
 
 async function countMergeEffects(
@@ -204,4 +257,12 @@ function rankName(sequenceColumnName: string): string {
 
 function firstSequenceName(sequenceColumnName: string): string {
   return `${sequenceColumnName}_first`
+}
+
+function sameColumns(left: readonly string[] | undefined, right: readonly string[]): boolean {
+  return (
+    left !== undefined &&
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  )
 }

--- a/storage/ducklake/src/internal/dataset-row-merge.ts
+++ b/storage/ducklake/src/internal/dataset-row-merge.ts
@@ -1,0 +1,207 @@
+import type { DatasetDefinition } from "@sixb/core"
+import { getDatasetPrimaryKeyColumns, LakeStorageError } from "@sixb/core/lake-storage"
+import type { DuckLakeStorageOptions } from "../types"
+import { type ApplyDatasetRowsResult, inspectUniqueKeyedRelation } from "./dataset-row-commit"
+import { getBigIntLike } from "./duckdb-row"
+import type { DuckDbQueryRuntime } from "./duckdb-runtime"
+import { encodeDatasetTableName } from "./names"
+import { datasetSchemaColumnNamesSql } from "./schema"
+import { qualifiedTableName, quoteIdentifier, quoteSqlString } from "./sql"
+
+export interface ApplyDatasetMergeFromRelationInput {
+  readonly options: DuckLakeStorageOptions
+  readonly runtime: DuckDbQueryRuntime
+  readonly dataset: DatasetDefinition
+  readonly stagingTableName: string
+  readonly sequenceColumnName: string
+  readonly kindColumnName: string
+}
+
+interface MergeEffectCounts {
+  readonly inserts: number
+  readonly updates: number
+  readonly deletes: number
+}
+
+export async function applyDatasetMergeFromRelation(
+  input: ApplyDatasetMergeFromRelationInput
+): Promise<ApplyDatasetRowsResult> {
+  const primaryKeyColumns = getDatasetPrimaryKeyColumns(input.dataset)
+  if (primaryKeyColumns === null) {
+    throw new LakeStorageError(
+      `[SixbDuckLake] Dataset '${input.dataset.id}' must define a primaryKey before it can be merged.`
+    )
+  }
+
+  const stagingTable = quoteIdentifier(input.stagingTableName)
+  const targetTable = qualifiedTableName(input.options, encodeDatasetTableName(input.dataset.id))
+  const sourceRowCount = await countRows(input.runtime, stagingTable)
+  const previousRowCount = await inspectUniqueKeyedRelation({
+    runtime: input.runtime,
+    dataset: input.dataset,
+    relationSql: targetTable,
+    context: "current baseline",
+  })
+  const finalChanges = finalChangesRelationSql(input, primaryKeyColumns)
+  const effects = await countMergeEffects(input, targetTable, finalChanges, primaryKeyColumns)
+  const effectiveChangeCount = effects.inserts + effects.updates + effects.deletes
+
+  if (effectiveChangeCount === 0) {
+    return {
+      dataChangeExpected: false,
+      sourceRowCount,
+      resultingRowCount: { kind: "exact", value: previousRowCount },
+    }
+  }
+
+  const keyMatchSql = primaryKeyMatchSql(primaryKeyColumns, "target", "source")
+  const rowDifferenceSql = datasetRowDifferenceSql(input.dataset, "target", "source")
+  const kindColumn = `source.${quoteIdentifier(input.kindColumnName)}`
+
+  await input.runtime.run(`
+    DELETE FROM ${targetTable} AS target
+    USING ${finalChanges} AS source
+    WHERE ${keyMatchSql}
+      AND (
+        ${kindColumn} = ${quoteSqlString("delete")}
+        OR (
+          ${kindColumn} = ${quoteSqlString("upsert")}
+          AND (${rowDifferenceSql})
+        )
+      )
+  `)
+
+  const columnsSql = datasetSchemaColumnNamesSql(input.dataset.schema)
+  const selectedColumnsSql = input.dataset.schema.columns
+    .map((column) => `source.${quoteIdentifier(column.name)}`)
+    .join(", ")
+  const firstSequenceColumnName = firstSequenceName(input.sequenceColumnName)
+  await input.runtime.run(`
+    INSERT INTO ${targetTable} (${columnsSql})
+    SELECT ${selectedColumnsSql}
+    FROM ${finalChanges} AS source
+    WHERE ${kindColumn} = ${quoteSqlString("upsert")}
+      AND NOT EXISTS (
+        SELECT 1
+        FROM ${targetTable} AS target
+        WHERE ${keyMatchSql}
+      )
+    ORDER BY source.${quoteIdentifier(firstSequenceColumnName)}
+  `)
+
+  return {
+    dataChangeExpected: true,
+    sourceRowCount,
+    resultingRowCount: {
+      kind: "exact",
+      value: previousRowCount + effects.inserts - effects.deletes,
+    },
+  }
+}
+
+function finalChangesRelationSql(
+  input: ApplyDatasetMergeFromRelationInput,
+  primaryKeyColumns: readonly string[]
+): string {
+  const sequenceColumn = quoteIdentifier(input.sequenceColumnName)
+  const keyColumnsSql = primaryKeyColumns.map((column) => quoteIdentifier(column)).join(", ")
+  const rankColumn = quoteIdentifier(rankName(input.sequenceColumnName))
+  const firstSequenceColumn = quoteIdentifier(firstSequenceName(input.sequenceColumnName))
+
+  return `(
+    SELECT * EXCLUDE (${rankColumn})
+    FROM (
+      SELECT
+        *,
+        min(${sequenceColumn}) OVER (PARTITION BY ${keyColumnsSql}) AS ${firstSequenceColumn},
+        row_number() OVER (
+          PARTITION BY ${keyColumnsSql}
+          ORDER BY ${sequenceColumn} DESC
+        ) AS ${rankColumn}
+      FROM ${quoteIdentifier(input.stagingTableName)}
+    ) ranked_changes
+    WHERE ${rankColumn} = 1
+  )`
+}
+
+async function countMergeEffects(
+  input: ApplyDatasetMergeFromRelationInput,
+  targetTable: string,
+  finalChanges: string,
+  primaryKeyColumns: readonly string[]
+): Promise<MergeEffectCounts> {
+  const matchColumn = primaryKeyColumns[0]
+  if (matchColumn === undefined) {
+    throw new LakeStorageError(
+      `[SixbDuckLake] Dataset '${input.dataset.id}' primaryKey must contain at least one column.`
+    )
+  }
+
+  const keyMatchSql = primaryKeyMatchSql(primaryKeyColumns, "target", "source")
+  const targetMatch = `target.${quoteIdentifier(matchColumn)} IS NOT NULL`
+  const kindColumn = `source.${quoteIdentifier(input.kindColumnName)}`
+  const rowDifferenceSql = datasetRowDifferenceSql(input.dataset, "target", "source")
+  const [row] = await input.runtime.query(`
+    SELECT
+      count(*) FILTER (
+        WHERE ${kindColumn} = ${quoteSqlString("upsert")} AND NOT (${targetMatch})
+      ) AS insert_count,
+      count(*) FILTER (
+        WHERE ${kindColumn} = ${quoteSqlString("upsert")}
+          AND ${targetMatch}
+          AND (${rowDifferenceSql})
+      ) AS update_count,
+      count(*) FILTER (
+        WHERE ${kindColumn} = ${quoteSqlString("delete")} AND ${targetMatch}
+      ) AS delete_count
+    FROM ${finalChanges} AS source
+    LEFT JOIN ${targetTable} AS target ON ${keyMatchSql}
+  `)
+
+  return {
+    inserts: row === undefined ? 0 : Number(getBigIntLike(row, "insert_count")),
+    updates: row === undefined ? 0 : Number(getBigIntLike(row, "update_count")),
+    deletes: row === undefined ? 0 : Number(getBigIntLike(row, "delete_count")),
+  }
+}
+
+function primaryKeyMatchSql(
+  primaryKeyColumns: readonly string[],
+  leftAlias: string,
+  rightAlias: string
+): string {
+  return primaryKeyColumns
+    .map(
+      (column) =>
+        `${leftAlias}.${quoteIdentifier(column)} = ${rightAlias}.${quoteIdentifier(column)}`
+    )
+    .join(" AND ")
+}
+
+function datasetRowDifferenceSql(
+  dataset: DatasetDefinition,
+  leftAlias: string,
+  rightAlias: string
+): string {
+  return dataset.schema.columns
+    .map(
+      (column) =>
+        `${leftAlias}.${quoteIdentifier(column.name)} IS DISTINCT FROM ${rightAlias}.${quoteIdentifier(
+          column.name
+        )}`
+    )
+    .join(" OR ")
+}
+
+async function countRows(runtime: DuckDbQueryRuntime, relationSql: string): Promise<number> {
+  const [row] = await runtime.query(`SELECT count(*) AS row_count FROM ${relationSql}`)
+  return row === undefined ? 0 : Number(getBigIntLike(row, "row_count"))
+}
+
+function rankName(sequenceColumnName: string): string {
+  return `${sequenceColumnName}_rank`
+}
+
+function firstSequenceName(sequenceColumnName: string): string {
+  return `${sequenceColumnName}_first`
+}

--- a/storage/ducklake/src/internal/ducklake-merge-session.ts
+++ b/storage/ducklake/src/internal/ducklake-merge-session.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto"
+import type { DatasetRow, MergeChange } from "@sixb/core"
+import type {
+  BeginDatasetMergeInput,
+  CommitDatasetMergeInput,
+  DatasetMergeCommitResult,
+  LakeMergeSession,
+} from "@sixb/core/lake-storage"
+import {
+  cloneDatasetMergeChange,
+  getDatasetMergeChangeValidationError,
+  LakeStorageError,
+} from "@sixb/core/lake-storage"
+import type { DuckDbRuntime } from "./duckdb-runtime"
+import { appendDatasetRow } from "./row-appender"
+import { datasetSchemaToDuckDbNullableColumnsSql } from "./schema"
+import { quoteIdentifier } from "./sql"
+
+export interface DuckLakeCommitMergeInput {
+  readonly merge: BeginDatasetMergeInput
+  readonly baseVersionId: string | null
+  readonly commit?: CommitDatasetMergeInput
+  readonly stagingTableName: string
+  readonly sequenceColumnName: string
+  readonly kindColumnName: string
+  readonly changesWritten: number
+}
+
+type DuckLakeCommitMerge = (input: DuckLakeCommitMergeInput) => Promise<DatasetMergeCommitResult>
+
+const MERGE_CHANGE_BATCH_SIZE = 1000
+
+interface StagedMergeChange {
+  readonly sequence: bigint
+  readonly change: MergeChange<DatasetRow, DatasetRow>
+}
+
+interface CreateDuckLakeMergeSessionInput {
+  readonly commitMerge: DuckLakeCommitMerge
+  readonly runtime: DuckDbRuntime
+  readonly merge: BeginDatasetMergeInput
+  readonly baseVersionId: string | null
+}
+
+export async function createDuckLakeMergeSession(
+  input: CreateDuckLakeMergeSessionInput
+): Promise<LakeMergeSession> {
+  const suffix = randomUUID().replaceAll("-", "")
+  const stagingTableName = `sixb_merge_${suffix}`
+  const sequenceColumnName = `sixb_merge_sequence_${suffix}`
+  const kindColumnName = `sixb_merge_kind_${suffix}`
+
+  await input.runtime.run(`
+    CREATE TEMP TABLE ${quoteIdentifier(stagingTableName)} (
+      ${quoteIdentifier(sequenceColumnName)} UBIGINT NOT NULL,
+      ${quoteIdentifier(kindColumnName)} VARCHAR NOT NULL,
+      ${datasetSchemaToDuckDbNullableColumnsSql(input.merge.dataset.schema)}
+    )
+  `)
+
+  return new DuckLakeMergeSession(
+    input.commitMerge,
+    input.runtime,
+    input.merge,
+    input.baseVersionId,
+    stagingTableName,
+    sequenceColumnName,
+    kindColumnName
+  )
+}
+
+class DuckLakeMergeSession implements LakeMergeSession {
+  private closed = false
+  private cleanedUp = false
+  private nextSequence = 0n
+  private changesWritten = 0
+
+  constructor(
+    private readonly commitMerge: DuckLakeCommitMerge,
+    private readonly runtime: DuckDbRuntime,
+    private readonly input: BeginDatasetMergeInput,
+    private readonly baseVersionId: string | null,
+    private readonly stagingTableName: string,
+    private readonly sequenceColumnName: string,
+    private readonly kindColumnName: string
+  ) {}
+
+  async writeChanges(
+    changes:
+      | Iterable<MergeChange<DatasetRow, DatasetRow>>
+      | AsyncIterable<MergeChange<DatasetRow, DatasetRow>>
+  ): Promise<void> {
+    this.assertOpen()
+
+    let batch: StagedMergeChange[] = []
+    for await (const change of changes) {
+      const validationError = getDatasetMergeChangeValidationError(change, this.input.dataset)
+      if (validationError) {
+        throw new LakeStorageError(`[SixbDuckLake] ${validationError}`)
+      }
+
+      batch.push({
+        sequence: this.nextSequence,
+        change: cloneDatasetMergeChange(change),
+      })
+      this.nextSequence += 1n
+
+      if (batch.length >= MERGE_CHANGE_BATCH_SIZE) {
+        await this.appendBatchToStagingTable(batch)
+        batch = []
+      }
+    }
+
+    if (batch.length > 0) {
+      await this.appendBatchToStagingTable(batch)
+    }
+  }
+
+  private async appendBatchToStagingTable(batch: readonly StagedMergeChange[]): Promise<void> {
+    await this.runtime.withAppender(this.stagingTableName, (appender) => {
+      for (const staged of batch) {
+        appender.appendBigInt(staged.sequence)
+        appender.appendVarchar(staged.change.kind)
+        appendDatasetRow(
+          appender,
+          this.input.dataset.schema,
+          staged.change.kind === "upsert" ? staged.change.row : staged.change.key
+        )
+      }
+    })
+    this.changesWritten += batch.length
+  }
+
+  async commit(input?: CommitDatasetMergeInput): Promise<DatasetMergeCommitResult> {
+    this.assertOpen()
+    this.closed = true
+
+    let committed = false
+    try {
+      const result = await this.commitMerge({
+        merge: this.input,
+        baseVersionId: this.baseVersionId,
+        commit: input,
+        stagingTableName: this.stagingTableName,
+        sequenceColumnName: this.sequenceColumnName,
+        kindColumnName: this.kindColumnName,
+        changesWritten: this.changesWritten,
+      })
+      committed = true
+      await this.cleanup()
+      return result
+    } catch (error) {
+      if (!committed) {
+        await this.cleanup()
+      }
+      throw error
+    }
+  }
+
+  async abort(): Promise<void> {
+    if (this.closed) {
+      return
+    }
+
+    this.closed = true
+    await this.cleanup()
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new LakeStorageError("[SixbDuckLake] Merge session is already closed.")
+    }
+  }
+
+  private async cleanup(): Promise<void> {
+    if (this.cleanedUp) {
+      return
+    }
+
+    this.cleanedUp = true
+    try {
+      await this.runtime.run(`DROP TABLE IF EXISTS ${quoteIdentifier(this.stagingTableName)}`)
+    } catch {
+      // Preserve the commit/abort outcome. Temp tables disappear when the storage runtime closes.
+    }
+  }
+}

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -549,7 +549,10 @@ export class DuckLakeSnapshotReader {
       return null
     }
 
-    if (!options.includeParent || (row.mode !== "append" && row.mode !== "schema")) {
+    if (
+      !options.includeParent ||
+      (row.mode !== "append" && row.mode !== "merge" && row.mode !== "schema")
+    ) {
       return row
     }
 

--- a/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-snapshot-reader.ts
@@ -60,6 +60,7 @@ export interface DuckLakeVersionSummary {
   readonly datasetId: string
   readonly versionId: string
   readonly rowCount?: number
+  readonly validatedPrimaryKeyColumns?: readonly string[]
 }
 
 /** One snapshot row from the shared catalog scan, before per-dataset filtering. */
@@ -444,6 +445,9 @@ export class DuckLakeSnapshotReader {
       datasetId: tableRef.datasetId,
       versionId: toVersionId(row.snapshotId),
       ...(row.metadata?.rowCount !== undefined ? { rowCount: row.metadata.rowCount } : {}),
+      ...(row.metadata?.validatedPrimaryKeyColumns !== undefined
+        ? { validatedPrimaryKeyColumns: row.metadata.validatedPrimaryKeyColumns }
+        : {}),
     }
   }
 

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -58,6 +58,7 @@ interface DuckLakeCommitVersionOutcomeRuntimeInput extends DuckLakeCommitVersion
 
 export interface DuckLakeApplyChangesContext {
   readonly previousRowCount?: number
+  readonly validatedPrimaryKeyColumns?: readonly string[]
 }
 
 /**
@@ -177,7 +178,7 @@ export class DuckLakeWriteCoordinator {
         commitMessage: input.commit?.commitMessage ?? `merge dataset ${definition.id}`,
         producer: input.merge.producer,
         inputs: input.merge.inputs,
-        applyChanges: async (commitRuntime) => {
+        applyChanges: async (commitRuntime, context) => {
           const result = await applyDatasetMergeFromRelation({
             options: this.options,
             runtime: commitRuntime,
@@ -185,6 +186,8 @@ export class DuckLakeWriteCoordinator {
             stagingTableName: input.stagingTableName,
             sequenceColumnName: input.sequenceColumnName,
             kindColumnName: input.kindColumnName,
+            previousRowCount: context.previousRowCount,
+            validatedPrimaryKeyColumns: context.validatedPrimaryKeyColumns,
           })
           if (result.sourceRowCount !== input.changesWritten) {
             throw new LakeStorageError(
@@ -312,6 +315,7 @@ export class DuckLakeWriteCoordinator {
 
       const changeResult = await input.applyChanges(input.runtime, {
         previousRowCount: latestVersion?.rowCount,
+        validatedPrimaryKeyColumns: latestVersion?.validatedPrimaryKeyColumns,
       })
       const commitId = randomUUID()
       await this.setCommitMetadata(
@@ -442,6 +446,9 @@ export class DuckLakeWriteCoordinator {
     // transaction. Version id, timestamp, and data-change detection still come
     // from DuckLake itself. commitId is only a transaction correlation token so
     // concurrent writers do not accidentally hydrate each other's snapshots.
+    // Every keyed data path either replaces the baseline or validates its uniqueness before this
+    // marker is persisted. Merge commits can therefore avoid repeating that full-table audit.
+    const validatedPrimaryKeyColumns = getDatasetPrimaryKeyColumns(input.dataset)
     const metadata: SixbCommitMetadata = {
       kind: "datasetVersion",
       datasetId: input.dataset.id,
@@ -450,6 +457,9 @@ export class DuckLakeWriteCoordinator {
       producer: input.producer ? structuredClone(input.producer) : undefined,
       inputs: input.inputs ? structuredClone(input.inputs) : undefined,
       ...(rowCount.kind === "exact" ? { rowCount: rowCount.value } : {}),
+      ...(validatedPrimaryKeyColumns !== null
+        ? { validatedPrimaryKeyColumns: [...validatedPrimaryKeyColumns] }
+        : {}),
     }
 
     await input.runtime.run(

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -1,13 +1,16 @@
 import { randomUUID } from "node:crypto"
 import type { DatasetDefinition } from "@sixb/core"
 import type {
+  BeginDatasetMergeInput,
   BeginDatasetWriteInput,
+  DatasetMergeCommitResult,
   DatasetVersion,
   DatasetWriteCommitResult,
   DatasetWriteMode,
+  LakeMergeSession,
   LakeWriteSession,
 } from "@sixb/core/lake-storage"
-import { LakeStorageError } from "@sixb/core/lake-storage"
+import { getDatasetPrimaryKeyColumns, LakeStorageError } from "@sixb/core/lake-storage"
 import type { DuckLakeStorageOptions } from "../types"
 import { localCatalogCoordinationKey } from "./catalog-key"
 import {
@@ -16,10 +19,12 @@ import {
   assertDatasetWriteMode,
   type CommitRowCount,
 } from "./dataset-row-commit"
+import { applyDatasetMergeFromRelation } from "./dataset-row-merge"
 import { getBigIntLike } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import type { DuckLakeDatasetCatalog } from "./ducklake-dataset-catalog"
+import { createDuckLakeMergeSession, type DuckLakeCommitMergeInput } from "./ducklake-merge-session"
 import type { DuckLakeSnapshotReader, DuckLakeVersionSummary } from "./ducklake-snapshot-reader"
 import { createDuckLakeWriteSession, type DuckLakeCommitWriteInput } from "./ducklake-write-session"
 import { duckLakeAlias, duckLakeMetadataTableName, quoteIdentifier, quoteSqlString } from "./sql"
@@ -38,7 +43,16 @@ export interface DuckLakeCommitDatasetVersionInput {
   ): Promise<ApplyDatasetRowsResult>
 }
 
-interface DuckLakeCommitDatasetVersionRuntimeInput extends DuckLakeCommitDatasetVersionInput {
+interface DuckLakeCommitVersionOutcomeInput
+  extends Omit<DuckLakeCommitDatasetVersionInput, "expectedLatestVersionId" | "mode"> {
+  readonly mode: DatasetWriteMode | "merge"
+  readonly expectedLatestVersionId?: string | null
+  readonly allowInitialNoOp?: boolean
+  readonly disableRetries?: boolean
+  readonly optimisticOperation?: "commit" | "merge commit"
+}
+
+interface DuckLakeCommitVersionOutcomeRuntimeInput extends DuckLakeCommitVersionOutcomeInput {
   readonly runtime: DuckDbQueryRuntime
 }
 
@@ -90,6 +104,32 @@ export class DuckLakeWriteCoordinator {
     })
   }
 
+  async beginMerge(input: BeginDatasetMergeInput): Promise<LakeMergeSession> {
+    this.connections.assertOpen()
+
+    const definition = await this.datasets.getDataset(input.dataset.id)
+    if (!definition) {
+      throw new LakeStorageError(`[SixbDuckLake] Unknown dataset '${input.dataset.id}'.`)
+    }
+    if (getDatasetPrimaryKeyColumns(definition) === null) {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Dataset '${definition.id}' must define a primaryKey before it can be merged.`
+      )
+    }
+
+    this.datasets.assertSchema(definition)
+    const latestVersion = await this.connections.withAttachedRuntime((runtime) =>
+      this.snapshots.getLatestVersionForDefinition(runtime, definition)
+    )
+    const runtime = await this.connections.stagingRuntime()
+    return createDuckLakeMergeSession({
+      commitMerge: (options) => this.commitMerge(options),
+      runtime,
+      merge: { ...input, dataset: definition },
+      baseVersionId: latestVersion?.versionId ?? null,
+    })
+  }
+
   private async commitWrite(input: DuckLakeCommitWriteInput): Promise<DatasetWriteCommitResult> {
     const definition = await this.datasets.getDataset(input.write.dataset.id)
     if (!definition) {
@@ -115,6 +155,48 @@ export class DuckLakeWriteCoordinator {
     })
   }
 
+  private async commitMerge(input: DuckLakeCommitMergeInput): Promise<DatasetMergeCommitResult> {
+    const definition = await this.datasets.getDataset(input.merge.dataset.id)
+    if (!definition) {
+      throw new LakeStorageError(`[SixbDuckLake] Unknown dataset '${input.merge.dataset.id}'.`)
+    }
+    if (getDatasetPrimaryKeyColumns(definition) === null) {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Dataset '${definition.id}' must define a primaryKey before it can be merged.`
+      )
+    }
+
+    return this.withCommitRuntime((runtime) =>
+      this.commitVersionOutcomeOnExclusiveRuntime(runtime, {
+        dataset: definition,
+        mode: "merge",
+        expectedLatestVersionId: input.baseVersionId,
+        allowInitialNoOp: true,
+        disableRetries: true,
+        optimisticOperation: "merge commit",
+        commitMessage: input.commit?.commitMessage ?? `merge dataset ${definition.id}`,
+        producer: input.merge.producer,
+        inputs: input.merge.inputs,
+        applyChanges: async (commitRuntime) => {
+          const result = await applyDatasetMergeFromRelation({
+            options: this.options,
+            runtime: commitRuntime,
+            dataset: definition,
+            stagingTableName: input.stagingTableName,
+            sequenceColumnName: input.sequenceColumnName,
+            kindColumnName: input.kindColumnName,
+          })
+          if (result.sourceRowCount !== input.changesWritten) {
+            throw new LakeStorageError(
+              `[SixbDuckLake] Staged merge for dataset '${definition.id}' accepted ${input.changesWritten} change(s), but DuckLake saw ${result.sourceRowCount} source change(s) at commit time.`
+            )
+          }
+          return result
+        },
+      })
+    )
+  }
+
   async commitDatasetVersion(
     input: DuckLakeCommitDatasetVersionInput
   ): Promise<DatasetWriteCommitResult> {
@@ -135,6 +217,26 @@ export class DuckLakeWriteCoordinator {
     runtime: DuckDbQueryRuntime,
     input: DuckLakeCommitDatasetVersionInput
   ): Promise<DatasetWriteCommitResult> {
+    const result = await this.commitVersionOutcomeOnExclusiveRuntime(runtime, {
+      ...input,
+      // DuckLake has no primary-key constraint. Do not let its automatic retry replay a keyed
+      // append after the collision checks ran against an older transaction snapshot.
+      disableRetries:
+        input.mode === "append" && getDatasetPrimaryKeyColumns(input.dataset) !== null,
+    })
+    if (result.version === null) {
+      throw new LakeStorageError(
+        `[SixbDuckLake] No DuckLake changes were committed for dataset '${input.dataset.id}', and no previous version exists.`
+      )
+    }
+
+    return { ...result.version, outcome: result.outcome }
+  }
+
+  private async commitVersionOutcomeOnExclusiveRuntime(
+    runtime: DuckDbQueryRuntime,
+    input: DuckLakeCommitVersionOutcomeInput
+  ): Promise<DatasetMergeCommitResult> {
     const runtimeInput = { ...input, runtime }
     return this.withGuardedRetrySetting(runtimeInput, () =>
       this.commitDatasetVersionUnlocked(runtimeInput)
@@ -142,16 +244,16 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async withGuardedRetrySetting<T>(
-    input: DuckLakeCommitDatasetVersionRuntimeInput,
+    input: DuckLakeCommitVersionOutcomeRuntimeInput,
     run: () => Promise<T>
   ): Promise<T> {
-    if (input.expectedLatestVersionId === undefined) {
+    if (input.expectedLatestVersionId === undefined && !input.disableRetries) {
       return run()
     }
 
-    // DuckLake can retry transactions internally. Guarded Sixb commits need a
-    // strict compare-and-swap check, so disable retries only for this exclusive
-    // commit and always restore the runtime setting before releasing the queue.
+    // DuckLake can retry transactions internally. Optimistic guards and keyed append constraint
+    // checks must not be replayed against a different snapshot, so disable retries for this
+    // exclusive commit and restore the runtime setting before releasing the queue.
     await input.runtime.run("SET ducklake_max_retry_count = 0")
     let outcome:
       | { readonly kind: "success"; readonly value: T }
@@ -185,8 +287,8 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async commitDatasetVersionUnlocked(
-    input: DuckLakeCommitDatasetVersionRuntimeInput
-  ): Promise<DatasetWriteCommitResult> {
+    input: DuckLakeCommitVersionOutcomeRuntimeInput
+  ): Promise<DatasetMergeCommitResult> {
     // Capture the write connection's last committed DuckLake snapshot before
     // and after COMMIT. The commitId in DuckLake commit_extra_info proves
     // which snapshot belongs to this transaction.
@@ -204,6 +306,7 @@ export class DuckLakeWriteCoordinator {
           datasetId: input.dataset.id,
           expectedLatestVersionId: input.expectedLatestVersionId,
           actualLatestVersionId: latestVersion?.versionId ?? null,
+          operation: input.optimisticOperation ?? "commit",
         })
       }
 
@@ -241,13 +344,13 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async versionForCommittedWrite(
-    input: DuckLakeCommitDatasetVersionRuntimeInput & {
+    input: DuckLakeCommitVersionOutcomeRuntimeInput & {
       readonly commitId: string
       readonly previousWriteSnapshotId: string | null
       readonly committedWriteSnapshotId: string | null
       readonly changeResult: ApplyDatasetRowsResult
     }
-  ): Promise<DatasetWriteCommitResult> {
+  ): Promise<DatasetMergeCommitResult> {
     // Hydrate the committed version on the same exclusive runtime. That keeps
     // snapshot matching and row-count fallback inside the same serialized
     // connection state that just committed.
@@ -266,7 +369,7 @@ export class DuckLakeWriteCoordinator {
         ownSnapshotId
       )
       if (version) {
-        return { ...version, outcome: "created" }
+        return { outcome: "created", version }
       }
 
       throw new LakeStorageError(
@@ -275,9 +378,22 @@ export class DuckLakeWriteCoordinator {
     }
 
     if (!input.changeResult.dataChangeExpected) {
+      const version = await this.versionForNoOpCommit(
+        input.runtime,
+        input.dataset,
+        input.allowInitialNoOp ?? false
+      )
+      if (input.expectedLatestVersionId !== undefined) {
+        this.assertExpectedLatestVersion({
+          datasetId: input.dataset.id,
+          expectedLatestVersionId: input.expectedLatestVersionId,
+          actualLatestVersionId: version?.versionId ?? null,
+          operation: input.optimisticOperation ?? "commit",
+        })
+      }
       return {
-        ...(await this.versionForNoOpCommit(input.runtime, input.dataset)),
         outcome: "unchanged",
+        version,
       }
     }
 
@@ -318,7 +434,7 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async setCommitMetadata(
-    input: DuckLakeCommitDatasetVersionRuntimeInput,
+    input: DuckLakeCommitVersionOutcomeRuntimeInput,
     commitId: string,
     rowCount: CommitRowCount
   ): Promise<void> {
@@ -347,11 +463,16 @@ export class DuckLakeWriteCoordinator {
 
   private async versionForNoOpCommit(
     runtime: DuckDbQueryRuntime,
-    definition: DatasetDefinition
-  ): Promise<DatasetVersion> {
+    definition: DatasetDefinition,
+    allowInitialNoOp: boolean
+  ): Promise<DatasetVersion | null> {
     const latestVersion = await this.snapshots.getLatestVersionForDefinition(runtime, definition)
     if (latestVersion) {
       return latestVersion
+    }
+
+    if (allowInitialNoOp) {
+      return null
     }
 
     throw new LakeStorageError(
@@ -369,7 +490,7 @@ export class DuckLakeWriteCoordinator {
   }
 
   private async latestVersionForCommit(
-    input: DuckLakeCommitDatasetVersionRuntimeInput
+    input: DuckLakeCommitVersionOutcomeRuntimeInput
   ): Promise<DuckLakeVersionSummary | null> {
     if (input.expectedLatestVersionId === undefined && input.mode !== "append") {
       return null
@@ -451,8 +572,9 @@ export class DuckLakeWriteCoordinator {
 
   private assertExpectedLatestVersion(input: {
     readonly datasetId: string
-    readonly expectedLatestVersionId?: string
+    readonly expectedLatestVersionId?: string | null
     readonly actualLatestVersionId: string | null
+    readonly operation: "commit" | "merge commit"
   }): void {
     if (input.expectedLatestVersionId === undefined) {
       return
@@ -460,14 +582,14 @@ export class DuckLakeWriteCoordinator {
 
     if (input.actualLatestVersionId !== input.expectedLatestVersionId) {
       throw new LakeStorageError(
-        `[SixbDuckLake] Optimistic commit failed for dataset '${input.datasetId}': expected latest version '${input.expectedLatestVersionId}', found '${input.actualLatestVersionId ?? "none"}'.`
+        `[SixbDuckLake] Optimistic ${input.operation} failed for dataset '${input.datasetId}': expected latest version '${input.expectedLatestVersionId ?? "none"}', found '${input.actualLatestVersionId ?? "none"}'.`
       )
     }
   }
 }
 
 function commitRowCount(
-  input: Pick<DuckLakeCommitDatasetVersionInput, "expectedLatestVersionId" | "mode">,
+  input: Pick<DuckLakeCommitVersionOutcomeInput, "expectedLatestVersionId" | "mode">,
   changeResult: ApplyDatasetRowsResult,
   latestVersion: DuckLakeVersionSummary | null
 ): CommitRowCount {

--- a/storage/ducklake/src/internal/ducklake-write-session.ts
+++ b/storage/ducklake/src/internal/ducklake-write-session.ts
@@ -7,7 +7,11 @@ import type {
   DatasetWriteCommitResult,
   LakeWriteSession,
 } from "@sixb/core/lake-storage"
-import { LakeStorageError } from "@sixb/core/lake-storage"
+import {
+  encodeDatasetPrimaryKey,
+  getDatasetPrimaryKeyColumns,
+  LakeStorageError,
+} from "@sixb/core/lake-storage"
 import type { DuckDbRuntime } from "./duckdb-runtime"
 import { appendDatasetRow } from "./row-appender"
 import { datasetSchemaToDuckDbColumnsSql } from "./schema"
@@ -61,6 +65,7 @@ class DuckLakeWriteSession implements LakeWriteSession {
   private closed = false
   private cleanedUp = false
   private rowsWritten = 0
+  private readonly stagedPrimaryKeys = new Set<string>()
 
   constructor(
     private readonly commitWrite: DuckLakeCommitWrite,
@@ -76,6 +81,7 @@ class DuckLakeWriteSession implements LakeWriteSession {
     // reads (pagination, APIs, SFTP, retries) never hold a runtime slot. Only
     // appendBatchToStagingTable below briefly enters the queue.
     let batch: DatasetRow[] = []
+    let batchPrimaryKeys = new Set<string>()
     for await (const row of rows) {
       const validationError = getDatasetRowValidationError(row, this.input.dataset)
       if (validationError) {
@@ -84,20 +90,34 @@ class DuckLakeWriteSession implements LakeWriteSession {
 
       // Snapshot the validated row. Callers may reuse and mutate one row object
       // between yields, so the batch must not retain a live reference.
-      batch.push(structuredClone(row))
+      const clonedRow = structuredClone(row)
+      if (getDatasetPrimaryKeyColumns(this.input.dataset) !== null) {
+        const primaryKey = encodeDatasetPrimaryKey(this.input.dataset, clonedRow)
+        if (this.stagedPrimaryKeys.has(primaryKey) || batchPrimaryKeys.has(primaryKey)) {
+          throw new LakeStorageError(
+            `[SixbDuckLake] Dataset '${this.input.dataset.id}' ${this.input.mode ?? "snapshot"} source contains duplicate primary key.`
+          )
+        }
+        batchPrimaryKeys.add(primaryKey)
+      }
+      batch.push(clonedRow)
 
       if (batch.length >= WRITE_ROW_BATCH_SIZE) {
-        await this.appendBatchToStagingTable(batch)
+        await this.appendBatchToStagingTable(batch, batchPrimaryKeys)
         batch = []
+        batchPrimaryKeys = new Set()
       }
     }
 
     if (batch.length > 0) {
-      await this.appendBatchToStagingTable(batch)
+      await this.appendBatchToStagingTable(batch, batchPrimaryKeys)
     }
   }
 
-  private async appendBatchToStagingTable(batch: readonly DatasetRow[]): Promise<void> {
+  private async appendBatchToStagingTable(
+    batch: readonly DatasetRow[],
+    primaryKeys: ReadonlySet<string>
+  ): Promise<void> {
     // Synchronous callback: no awaits inside the queue slot. The appender
     // buffers and flushes the whole batch into the staging temp table on close.
     await this.runtime.withAppender(this.stagingTableName, (appender) => {
@@ -108,6 +128,9 @@ class DuckLakeWriteSession implements LakeWriteSession {
     // Count only rows actually appended -- commit asserts rowsWritten ===
     // sourceRowCount in the write coordinator.
     this.rowsWritten += batch.length
+    for (const primaryKey of primaryKeys) {
+      this.stagedPrimaryKeys.add(primaryKey)
+    }
   }
 
   async commit(input?: CommitDatasetWriteInput): Promise<DatasetWriteCommitResult> {

--- a/storage/ducklake/src/internal/schema.ts
+++ b/storage/ducklake/src/internal/schema.ts
@@ -49,6 +49,13 @@ export function datasetSchemaToDuckDbColumnsSql(schema: DatasetSchema): string {
   return schema.columns.map((column) => datasetColumnToDuckDbSql(column)).join(", ")
 }
 
+/** Render a dataset schema for merge staging, where delete rows leave non-key values null. */
+export function datasetSchemaToDuckDbNullableColumnsSql(schema: DatasetSchema): string {
+  return schema.columns
+    .map((column) => `${quoteIdentifier(column.name)} ${datasetColumnTypeToDuckDbSql(column.type)}`)
+    .join(", ")
+}
+
 /**
  * Render the column list used by INSERT ... SELECT operations.
  */

--- a/storage/ducklake/src/internal/versions.ts
+++ b/storage/ducklake/src/internal/versions.ts
@@ -13,6 +13,7 @@ export interface SixbCommitMetadata {
   readonly producer?: DatasetVersion["producer"]
   readonly inputs?: DatasetVersion["inputs"]
   readonly rowCount?: number
+  readonly validatedPrimaryKeyColumns?: readonly string[]
   readonly schemaChange?: SixbSchemaChangeMetadata
 }
 
@@ -57,6 +58,7 @@ export function parseCommitMetadata(value: unknown): SixbCommitMetadata | undefi
   const mode = parsed.sixb.mode
   const commitId = parsed.sixb.commitId
   const rowCount = parsed.sixb.rowCount
+  const validatedPrimaryKeyColumns = parsed.sixb.validatedPrimaryKeyColumns
 
   return {
     kind: "datasetVersion",
@@ -68,6 +70,9 @@ export function parseCommitMetadata(value: unknown): SixbCommitMetadata | undefi
     ...(isDatasetProducer(parsed.sixb.producer) ? { producer: parsed.sixb.producer } : {}),
     ...(isDatasetVersionRefs(parsed.sixb.inputs) ? { inputs: parsed.sixb.inputs } : {}),
     ...(typeof commitId === "string" && isRowCount(rowCount) ? { rowCount } : {}),
+    ...(typeof commitId === "string" && isValidatedPrimaryKeyColumns(validatedPrimaryKeyColumns)
+      ? { validatedPrimaryKeyColumns }
+      : {}),
     ...(isSchemaChangeMetadata(parsed.sixb.schemaChange)
       ? { schemaChange: parsed.sixb.schemaChange }
       : {}),
@@ -139,4 +144,13 @@ function optionalString(value: unknown): boolean {
 
 function isRowCount(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+}
+
+function isValidatedPrimaryKeyColumns(value: unknown): value is readonly string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((column) => typeof column === "string" && column.trim().length > 0) &&
+    new Set(value).size === value.length
+  )
 }

--- a/storage/ducklake/tests/ducklake-concurrency.e2e.ts
+++ b/storage/ducklake/tests/ducklake-concurrency.e2e.ts
@@ -2,12 +2,17 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { mkdir, mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { col, defineDataset } from "@sixb/core"
+import { change, col, defineDataset } from "@sixb/core"
 import { type DuckLakeStorage, DuckLakeStorage as DuckLakeStorageProvider } from "../src"
 import { collectRows, createLocalDuckLakeStorage } from "./test-utils"
 
 const ordersDataset = defineDataset("raw.erp.orders", {
   schema: [col("orderId", "string"), col("customerName", "string")],
+})
+
+const keyedOrdersDataset = defineDataset("raw.erp.keyed_orders", {
+  schema: [col("orderId", "string"), col("customerName", "string")],
+  primaryKey: "orderId",
 })
 
 describe("DuckLakeStorage optimistic concurrency", () => {
@@ -183,6 +188,26 @@ describe("DuckLakeStorage optimistic concurrency", () => {
     )
     const rows = await collectRows(storage.readRows({ datasetId: ordersDataset.id }))
     expect(rows.map((row) => row.orderId).sort()).toEqual(["ord_1", ...committedOrderIds].sort())
+  })
+
+  test("lets only one provider commit a merge from the same absent base", async () => {
+    await storage.createDataset(keyedOrdersDataset)
+    const secondStorage = createLocalDuckLakeStorage(rootDir)
+    extraStorages.push(secondStorage)
+
+    const firstMerge = await storage.beginMerge({ dataset: keyedOrdersDataset })
+    const secondMerge = await secondStorage.beginMerge({ dataset: keyedOrdersDataset })
+    await firstMerge.writeChanges([change.upsert({ orderId: "ord_1", customerName: "Ada" })])
+    await secondMerge.writeChanges([change.upsert({ orderId: "ord_2", customerName: "Grace" })])
+
+    const results = await Promise.allSettled([firstMerge.commit(), secondMerge.commit()])
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1)
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1)
+    expect(await storage.listVersions(keyedOrdersDataset.id)).toHaveLength(1)
+    expect(await collectRows(storage.readRows({ datasetId: keyedOrdersDataset.id }))).toHaveLength(
+      1
+    )
   })
 })
 

--- a/storage/ducklake/tests/ducklake-contract.e2e.ts
+++ b/storage/ducklake/tests/ducklake-contract.e2e.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { DatasetRow } from "@sixb/core"
 import { col, defineDataset } from "@sixb/core"
-import { runLakeStorageContractSuite } from "@sixb/core/testing"
+import { runLakeMergeStorageContractSuite, runLakeStorageContractSuite } from "@sixb/core/testing"
 import type { DuckLakeStorage } from "../src"
 import { createLocalDuckLakeStorage } from "./test-utils"
 
@@ -15,6 +15,23 @@ runLakeStorageContractSuite("DuckLakeStorage LakeStorage contract", {
   missingVersionId: "ducklake:999999",
   async createStorage() {
     const rootDir = await mkdtemp(join(tmpdir(), "sixb-ducklake-contract-"))
+    const storage = createLocalDuckLakeStorage(rootDir)
+    roots.set(storage, rootDir)
+    return storage
+  },
+  async teardown(storage) {
+    await storage.close()
+
+    const rootDir = roots.get(storage)
+    if (rootDir) {
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  },
+})
+
+runLakeMergeStorageContractSuite("DuckLakeStorage merge contract", {
+  async createStorage() {
+    const rootDir = await mkdtemp(join(tmpdir(), "sixb-ducklake-merge-contract-"))
     const storage = createLocalDuckLakeStorage(rootDir)
     roots.set(storage, rootDir)
     return storage

--- a/storage/ducklake/tests/ducklake-merges.e2e.ts
+++ b/storage/ducklake/tests/ducklake-merges.e2e.ts
@@ -71,7 +71,10 @@ describe("DuckLakeStorage keyed merges", () => {
       change.delete({ id: "inv_2" }),
       change.upsert({ id: "inv_3", status: "open", note: null }),
     ])
-    const result = await merge.commit({ commitMessage: "apply invoice changes" })
+    const runtime = await internals(storage).connections.runtime()
+    const { result, statements } = await captureExclusiveSql(runtime, () =>
+      merge.commit({ commitMessage: "apply invoice changes" })
+    )
 
     expect(result.outcome).toBe("created")
     if (result.outcome !== "created") {
@@ -86,6 +89,9 @@ describe("DuckLakeStorage keyed merges", () => {
     })
     expect(await snapshotCount(storage, options)).toBe(snapshotsAfterSeed + 1)
     expect(await latestCommitMessage(storage, options)).toBe("apply invoice changes")
+    expect(statements.filter((sql) => sql.includes("row_number() OVER"))).toHaveLength(1)
+    expect(statements.some((sql) => sql.includes("max_key_count"))).toBe(false)
+    expect(await temporaryMergeTableNames(storage)).toEqual([])
     await expect(
       collectRows(storage.readRows({ datasetId: invoices.id, versionId: seedVersion.versionId }))
     ).resolves.toEqual([
@@ -278,5 +284,39 @@ function wrapExclusiveRuntime(
     runStatements: (statements) => runtime.runStatements(statements),
     query: (sql, values) => runtime.query(sql, values),
     withAppender: (tableName, useAppender) => runtime.withAppender(tableName, useAppender),
+  }
+}
+
+async function captureExclusiveSql<T>(
+  runtime: DuckDbRuntime,
+  run: () => Promise<T>
+): Promise<{ readonly result: T; readonly statements: readonly string[] }> {
+  const originalWithExclusive = runtime.withExclusive.bind(runtime)
+  const statements: string[] = []
+
+  runtime.withExclusive = (useRuntime) =>
+    originalWithExclusive((exclusiveRuntime) =>
+      useRuntime({
+        run: async (sql, values) => {
+          statements.push(sql)
+          await exclusiveRuntime.run(sql, values)
+        },
+        runStatements: async (sqlStatements) => {
+          statements.push(...sqlStatements)
+          await exclusiveRuntime.runStatements(sqlStatements)
+        },
+        query: async (sql, values) => {
+          statements.push(sql)
+          return exclusiveRuntime.query(sql, values)
+        },
+        withAppender: (tableName, useAppender) =>
+          exclusiveRuntime.withAppender(tableName, useAppender),
+      })
+    )
+
+  try {
+    return { result: await run(), statements }
+  } finally {
+    runtime.withExclusive = originalWithExclusive
   }
 }

--- a/storage/ducklake/tests/ducklake-merges.e2e.ts
+++ b/storage/ducklake/tests/ducklake-merges.e2e.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { change, col, defineDataset } from "@sixb/core"
+import type { DuckLakeStorage, DuckLakeStorageOptions } from "../src"
+import type {
+  DuckDbExclusiveRuntime,
+  DuckDbQueryRuntime,
+  DuckDbRuntime,
+} from "../src/internal/duckdb-runtime"
+import { encodeDatasetTableName } from "../src/internal/names"
+import { duckLakeMetadataTableName, qualifiedTableName } from "../src/internal/sql"
+import { collectRows, createLocalDuckLakeStorage, localDuckLakeOptions } from "./test-utils"
+
+interface DuckLakeStorageInternals {
+  readonly connections: {
+    runtime(): Promise<DuckDbRuntime>
+    withAttachedRuntime<T>(run: (runtime: DuckDbQueryRuntime) => Promise<T>): Promise<T>
+  }
+}
+
+describe("DuckLakeStorage keyed merges", () => {
+  let rootDir: string
+  let options: DuckLakeStorageOptions
+  let storage: DuckLakeStorage
+
+  const invoices = defineDataset("raw.erp.merge_invoices", {
+    schema: [
+      col("id", "string"),
+      col("status", "string"),
+      col("note", "string", { nullable: true }),
+    ],
+    primaryKey: "id",
+  })
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "sixb-ducklake-merges-"))
+    options = localDuckLakeOptions(rootDir)
+    storage = createLocalDuckLakeStorage(rootDir)
+    await storage.createDataset(invoices)
+  })
+
+  afterEach(async () => {
+    await storage.close()
+    await rm(rootDir, { recursive: true, force: true })
+  })
+
+  test("commits one snapshot and reopens complete merge version metadata", async () => {
+    const snapshotsAfterCreate = await snapshotCount(storage, options)
+
+    const initialNoOp = await storage.beginMerge({ dataset: invoices })
+    expect(await initialNoOp.commit()).toEqual({ outcome: "unchanged", version: null })
+    expect(await snapshotCount(storage, options)).toBe(snapshotsAfterCreate)
+
+    const seed = await storage.beginWrite({ dataset: invoices, mode: "snapshot" })
+    await seed.writeRows([
+      { id: "inv_1", status: "open", note: null },
+      { id: "inv_2", status: "open", note: null },
+    ])
+    const seedVersion = await seed.commit()
+    const snapshotsAfterSeed = await snapshotCount(storage, options)
+
+    const merge = await storage.beginMerge({
+      dataset: invoices,
+      producer: { kind: "sync", id: "sync-invoices", runId: "run_1" },
+      inputs: [{ datasetId: "raw.erp.invoice_changes", versionId: "cursor_1" }],
+    })
+    await merge.writeChanges([
+      change.upsert({ id: "inv_1", status: "paid", note: "settled" }),
+      change.delete({ id: "inv_2" }),
+      change.upsert({ id: "inv_3", status: "open", note: null }),
+    ])
+    const result = await merge.commit({ commitMessage: "apply invoice changes" })
+
+    expect(result.outcome).toBe("created")
+    if (result.outcome !== "created") {
+      throw new Error("Expected DuckLake merge to create a version")
+    }
+    expect(result.version).toMatchObject({
+      mode: "merge",
+      parentVersionId: seedVersion.versionId,
+      rowCount: 2,
+      producer: { kind: "sync", id: "sync-invoices", runId: "run_1" },
+      inputs: [{ datasetId: "raw.erp.invoice_changes", versionId: "cursor_1" }],
+    })
+    expect(await snapshotCount(storage, options)).toBe(snapshotsAfterSeed + 1)
+    expect(await latestCommitMessage(storage, options)).toBe("apply invoice changes")
+    await expect(
+      collectRows(storage.readRows({ datasetId: invoices.id, versionId: seedVersion.versionId }))
+    ).resolves.toEqual([
+      { id: "inv_1", status: "open", note: null },
+      { id: "inv_2", status: "open", note: null },
+    ])
+
+    const noOp = await storage.beginMerge({ dataset: invoices })
+    await noOp.writeChanges([
+      change.upsert({ id: "inv_1", status: "paid", note: "settled" }),
+      change.delete({ id: "missing" }),
+    ])
+    expect(await noOp.commit()).toMatchObject({
+      outcome: "unchanged",
+      version: { versionId: result.version.versionId },
+    })
+    expect(await snapshotCount(storage, options)).toBe(snapshotsAfterSeed + 1)
+
+    await storage.close()
+    storage = createLocalDuckLakeStorage(rootDir)
+
+    await expect(storage.getLatestVersion(invoices.id)).resolves.toMatchObject({
+      versionId: result.version.versionId,
+      mode: "merge",
+      parentVersionId: seedVersion.versionId,
+      rowCount: 2,
+      producer: { kind: "sync", id: "sync-invoices", runId: "run_1" },
+      inputs: [{ datasetId: "raw.erp.invoice_changes", versionId: "cursor_1" }],
+    })
+    await expect(collectRows(storage.readRows({ datasetId: invoices.id }))).resolves.toEqual([
+      { id: "inv_1", status: "paid", note: "settled" },
+      { id: "inv_3", status: "open", note: null },
+    ])
+  })
+
+  test("rejects a corrupted duplicate baseline and cleans the staging table", async () => {
+    const seed = await storage.beginWrite({ dataset: invoices, mode: "snapshot" })
+    await seed.writeRows([{ id: "inv_1", status: "open", note: null }])
+    await seed.commit()
+
+    const table = qualifiedTableName(options, encodeDatasetTableName(invoices.id))
+    await internals(storage).connections.withAttachedRuntime((runtime) =>
+      runtime.run(`INSERT INTO ${table} VALUES ('inv_1', 'paid', NULL)`)
+    )
+    const versionsBeforeMerge = await storage.listVersions(invoices.id)
+
+    const merge = await storage.beginMerge({ dataset: invoices })
+    await merge.writeChanges([change.delete({ id: "inv_1" })])
+    await expect(merge.commit()).rejects.toThrow("current baseline contains duplicate primary key")
+
+    expect(await storage.listVersions(invoices.id)).toEqual(versionsBeforeMerge)
+    await expect(collectRows(storage.readRows({ datasetId: invoices.id }))).resolves.toEqual([
+      { id: "inv_1", status: "open", note: null },
+      { id: "inv_1", status: "paid", note: null },
+    ])
+    expect(await temporaryMergeTableNames(storage)).toEqual([])
+  })
+
+  test("rolls back deletes when the matching insert fails", async () => {
+    // Regression guard: the injected insert failure happens after merge deletes have run. Without
+    // the shared transaction, inv_1 would disappear even though commit rejects.
+    const seed = await storage.beginWrite({ dataset: invoices, mode: "snapshot" })
+    await seed.writeRows([
+      { id: "inv_1", status: "open", note: null },
+      { id: "inv_2", status: "open", note: null },
+    ])
+    const seedVersion = await seed.commit()
+
+    const merge = await storage.beginMerge({ dataset: invoices })
+    await merge.writeChanges([
+      change.upsert({ id: "inv_1", status: "paid", note: null }),
+      change.upsert({ id: "inv_3", status: "open", note: null }),
+    ])
+
+    const runtime = await internals(storage).connections.runtime()
+    const table = qualifiedTableName(options, encodeDatasetTableName(invoices.id))
+    const insertError = new Error("simulated merge insert failure")
+    const restoreRuntime = failNextInsert(runtime, table, insertError)
+    try {
+      await expect(merge.commit()).rejects.toBe(insertError)
+    } finally {
+      restoreRuntime()
+    }
+
+    expect(await storage.getLatestVersion(invoices.id)).toMatchObject({
+      versionId: seedVersion.versionId,
+    })
+    expect(await storage.listVersions(invoices.id)).toHaveLength(1)
+    await expect(collectRows(storage.readRows({ datasetId: invoices.id }))).resolves.toEqual([
+      { id: "inv_1", status: "open", note: null },
+      { id: "inv_2", status: "open", note: null },
+    ])
+    expect(await temporaryMergeTableNames(storage)).toEqual([])
+  })
+
+  test("preserves ordering across staging batches and writeChanges calls", async () => {
+    const merge = await storage.beginMerge({ dataset: invoices })
+
+    async function* changes() {
+      for (let index = 0; index < 1_001; index += 1) {
+        yield change.upsert({ id: `inv_${index}`, status: "open", note: null })
+      }
+    }
+
+    await merge.writeChanges(changes())
+    await merge.writeChanges([
+      change.upsert({ id: "inv_0", status: "paid", note: null }),
+      change.delete({ id: "inv_1000" }),
+    ])
+    const result = await merge.commit()
+
+    expect(result).toMatchObject({ outcome: "created", version: { rowCount: 1_000 } })
+    const rows = await collectRows(storage.readRows({ datasetId: invoices.id }))
+    expect(rows).toHaveLength(1_000)
+    expect(rows[0]).toEqual({ id: "inv_0", status: "paid", note: null })
+    expect(rows.at(-1)).toEqual({ id: "inv_999", status: "open", note: null })
+  })
+})
+
+function internals(storage: DuckLakeStorage): DuckLakeStorageInternals {
+  return storage as unknown as DuckLakeStorageInternals
+}
+
+async function snapshotCount(
+  storage: DuckLakeStorage,
+  options: DuckLakeStorageOptions
+): Promise<number> {
+  return internals(storage).connections.withAttachedRuntime(async (runtime) => {
+    const snapshots = duckLakeMetadataTableName(options, "ducklake_snapshot")
+    const [row] = await runtime.query(`SELECT count(*) AS snapshot_count FROM ${snapshots}`)
+    return Number(row?.snapshot_count ?? 0)
+  })
+}
+
+async function latestCommitMessage(
+  storage: DuckLakeStorage,
+  options: DuckLakeStorageOptions
+): Promise<string | null> {
+  return internals(storage).connections.withAttachedRuntime(async (runtime) => {
+    const snapshotChanges = duckLakeMetadataTableName(options, "ducklake_snapshot_changes")
+    const [row] = await runtime.query(`
+      SELECT commit_message
+      FROM ${snapshotChanges}
+      ORDER BY snapshot_id DESC
+      LIMIT 1
+    `)
+    return typeof row?.commit_message === "string" ? row.commit_message : null
+  })
+}
+
+async function temporaryMergeTableNames(storage: DuckLakeStorage): Promise<readonly string[]> {
+  const runtime = await internals(storage).connections.runtime()
+  const rows = await runtime.query(`
+    SELECT table_name
+    FROM duckdb_tables()
+    WHERE temporary AND starts_with(table_name, 'sixb_merge_')
+    ORDER BY table_name
+  `)
+  return rows.map((row) => String(row.table_name))
+}
+
+function failNextInsert(runtime: DuckDbRuntime, targetTable: string, error: Error): () => void {
+  const originalWithExclusive = runtime.withExclusive.bind(runtime)
+  let failed = false
+
+  runtime.withExclusive = (useRuntime) =>
+    originalWithExclusive((exclusiveRuntime) =>
+      useRuntime(
+        wrapExclusiveRuntime(exclusiveRuntime, async (sql, values) => {
+          if (!failed && sql.includes(`INSERT INTO ${targetTable}`)) {
+            failed = true
+            throw error
+          }
+          await exclusiveRuntime.run(sql, values)
+        })
+      )
+    )
+
+  return () => {
+    runtime.withExclusive = originalWithExclusive
+  }
+}
+
+function wrapExclusiveRuntime(
+  runtime: DuckDbExclusiveRuntime,
+  run: DuckDbExclusiveRuntime["run"]
+): DuckDbExclusiveRuntime {
+  return {
+    run,
+    runStatements: (statements) => runtime.runStatements(statements),
+    query: (sql, values) => runtime.query(sql, values),
+    withAppender: (tableName, useAppender) => runtime.withAppender(tableName, useAppender),
+  }
+}

--- a/storage/ducklake/tests/ducklake-remote.e2e.ts
+++ b/storage/ducklake/tests/ducklake-remote.e2e.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { col, defineDataset } from "@sixb/core"
+import { change, col, defineDataset } from "@sixb/core"
 import { SQL } from "bun"
 import { type DuckDbSecretOptions, DuckLakeStorage, type DuckLakeStorageOptions } from "../src"
 import { collectRows } from "./test-utils"
@@ -29,11 +29,27 @@ describe("DuckLakeStorage remote catalogs", () => {
 
       const append = await storage.beginWrite({ dataset, mode: "append" })
       await append.writeRows([{ orderId: "ord_2" }])
-      await append.commit()
+      const appendVersion = await append.commit()
+
+      const merge = await storage.beginMerge({ dataset })
+      await merge.writeChanges([
+        change.delete({ orderId: "ord_1" }),
+        change.upsert({ orderId: "ord_3" }),
+      ])
+      const mergeResult = await merge.commit()
+
+      expect(mergeResult).toMatchObject({
+        outcome: "created",
+        version: {
+          mode: "merge",
+          parentVersionId: appendVersion.versionId,
+          rowCount: 2,
+        },
+      })
 
       expect(await collectRows(storage.readRows({ datasetId: dataset.id }))).toEqual([
-        { orderId: "ord_1" },
         { orderId: "ord_2" },
+        { orderId: "ord_3" },
       ])
     } finally {
       await storage.close()

--- a/storage/ducklake/tests/ducklake-sql-transforms.e2e.ts
+++ b/storage/ducklake/tests/ducklake-sql-transforms.e2e.ts
@@ -379,6 +379,50 @@ describe("DuckLake SQL transforms", () => {
     ).rejects.toThrow("SQL transform result schema does not match target dataset")
   })
 
+  test("rejects duplicate keys from snapshot and append SQL transforms", async () => {
+    const keyedTarget = defineDataset("analytics.keyed_sql_target", {
+      schema: [col("id", "string"), col("value", "string")],
+      primaryKey: "id",
+    })
+    await storage.createDataset(keyedTarget)
+
+    await expect(
+      storage.sql.execute({
+        sources: {},
+        target: keyedTarget,
+        mode: "snapshot",
+        sql: () => `
+          SELECT *
+          FROM (VALUES ('row_1', 'first'), ('row_1', 'second')) rows(id, value)
+        `,
+      })
+    ).rejects.toThrow("snapshot source contains duplicate primary key")
+    expect(await storage.listVersions(keyedTarget.id)).toEqual([])
+
+    const seed = await storage.sql.execute({
+      sources: {},
+      target: keyedTarget,
+      mode: "snapshot",
+      sql: () => "SELECT 'row_1' AS id, 'first' AS value",
+    })
+    await expect(
+      storage.sql.execute({
+        sources: {},
+        target: keyedTarget,
+        mode: "append",
+        sql: () => "SELECT 'row_1' AS id, 'second' AS value",
+      })
+    ).rejects.toThrow("append contains duplicate primary key")
+
+    expect(await storage.listVersions(keyedTarget.id)).toHaveLength(1)
+    expect(await storage.getLatestVersion(keyedTarget.id)).toMatchObject({
+      versionId: seed.versionId,
+    })
+    await expect(collectRows(storage.readRows({ datasetId: keyedTarget.id }))).resolves.toEqual([
+      { id: "row_1", value: "first" },
+    ])
+  })
+
   test("preserves the write error when temp-table cleanup sees an aborted transaction", async () => {
     const previous = await storage.sql.execute({
       sources: {},

--- a/storage/ducklake/tests/schema.test.ts
+++ b/storage/ducklake/tests/schema.test.ts
@@ -6,6 +6,7 @@ import {
   datasetColumnToDuckDbSql,
   datasetColumnTypeToDuckDbSql,
   datasetSchemaToDuckDbColumnsSql,
+  datasetSchemaToDuckDbNullableColumnsSql,
   duckDbColumnsToDatasetSchema,
   duckDbTypeToDatasetColumnType,
 } from "../src/internal/schema"
@@ -48,6 +49,14 @@ describe("DuckLake schema mapping", () => {
         ],
       })
     ).toBe('"orderId" VARCHAR NOT NULL, "amount" DECIMAL(38, 9) NOT NULL, "metadata" JSON')
+  })
+
+  test("creates an all-nullable column list for merge staging", () => {
+    expect(
+      datasetSchemaToDuckDbNullableColumnsSql({
+        columns: [col("orderId", "string"), col("metadata", "json", { nullable: true })],
+      })
+    ).toBe('"orderId" VARCHAR, "metadata" JSON')
   })
 
   test("maps DuckDB metadata back to a Sixb schema", () => {

--- a/storage/ducklake/tests/versions.test.ts
+++ b/storage/ducklake/tests/versions.test.ts
@@ -27,6 +27,7 @@ describe("DuckLake version metadata", () => {
             producer: { kind: "sync", id: "sync-orders", runId: "run_123" },
             inputs: [{ datasetId: "raw.erp.customers", versionId: "ducklake:7" }],
             rowCount: 1250,
+            validatedPrimaryKeyColumns: ["region", "order_id"],
             schemaChange: { addColumns: ["currency"] },
           },
         })
@@ -39,6 +40,7 @@ describe("DuckLake version metadata", () => {
       producer: { kind: "sync", id: "sync-orders", runId: "run_123" },
       inputs: [{ datasetId: "raw.erp.customers", versionId: "ducklake:7" }],
       rowCount: 1250,
+      validatedPrimaryKeyColumns: ["region", "order_id"],
       schemaChange: { addColumns: ["currency"] },
     })
   })
@@ -62,6 +64,19 @@ describe("DuckLake version metadata", () => {
             inputs: [{ datasetId: "raw.erp.customers" }],
             schemaChange: { addColumns: ["currency", 42] },
             rowCount: "1250",
+            validatedPrimaryKeyColumns: ["order_id", "order_id"],
+          },
+        })
+      )
+    ).toEqual({ kind: "datasetVersion", datasetId: "raw.erp.orders" })
+
+    expect(
+      parseCommitMetadata(
+        JSON.stringify({
+          sixb: {
+            kind: "datasetVersion",
+            datasetId: "raw.erp.orders",
+            validatedPrimaryKeyColumns: ["order_id"],
           },
         })
       )


### PR DESCRIPTION
Stacked on #330. Review and merge that PR first.

## Summary

DuckLake now implements the keyed merge storage contract introduced in #330. A merge stages ordered changes, keeps the final change for each key, and commits only visible row changes.

```ts
const session = await lake.beginMerge({
  dataset: invoices,
  producer: "sync-erp-invoices",
})

await session.writeChanges([
  change.upsert({ id: "inv-1", status: "paid", customerId: "cus-1" }),
  change.delete({ id: "inv-2" }),
])

const result = await session.commit()
```

## What changed

- Adds typed, batched DuckLake merge staging for single and composite string keys.
- Collapses repeated keys in source order so the final delete or upsert wins.
- Applies effective deletes and complete-row upserts in one transaction.
- Uses the captured dataset version as an optimistic concurrency guard.
- Detects identical upserts and deletes of absent keys as no-ops, including an initial no-op.
- Enforces keyed-row uniqueness for merge baselines, snapshots, appends, and SQL transforms.
- Preserves merge metadata and parent versions when reading current or historical snapshots.
- Makes `LakeStorage.beginMerge` required now that every built-in provider implements it.

```text
changed upsert   -> delete old row + insert complete row
existing delete -> delete row
identical upsert -> no-op
missing delete   -> no-op
```

DuckLake currently permits only one update/delete action in a `MERGE INTO` statement. The implementation therefore uses targeted `DELETE` and `INSERT` statements inside the existing transaction, matching DuckLake's own delete-and-insert update model while still producing one atomic dataset version.

## Not in this PR

- `defineSync({ mode: "merge" })` and sync-worker integration
- checkpoint advancement and one-writer enforcement
- post-commit full-dataset projection evaluation
- changed-row history or incremental projections

Those remain in the next delivery slice or later optimizations.

## Validation

```text
bun run check
bun run typecheck
bun run build
bun run test:publish
bun run generate:client
```

DuckLake local and remote end-to-end suites, shared lake merge contracts, core tests, and sync/projection worker tests also pass. Transaction rollback coverage was regression-checked by removing the transaction, confirming the test failed, then restoring it and confirming it passed.