### PR TITLE
syncs: activate keyed dataset merges

### DIFF
--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -35,15 +35,16 @@ This runs every hour, calls `listInvoices()` on the connector's client, and writ
 
 | Step | Meaning |
 | --- | --- |
-| `defineSync("sync-erp-invoices", { mode })` | Names the sync; `mode` is `"snapshot"` (default) or `"append"` |
+| `defineSync("sync-erp-invoices", { mode })` | Names the sync; `mode` is `"snapshot"` (default), `"append"`, or `"merge"` |
 | `.when(schedule)` | Declares when the sync runs; callable multiple times (OR semantics) |
 | `.checkpoint<T>()` | Opts into a typed incremental checkpoint (optional) |
 | `.from(connector)` | Chooses the source connector |
 | `.read((client, context) => ...)` | Fetches rows from the connector's client |
 | `.intoDataset(dataset)` | Chooses the target dataset |
 
-The read handler receives the `client` returned by the connector's `connect()` and a `context`. It
-may return one row, an iterable, or an async iterable.
+The read handler receives the `client` returned by the connector's `connect()` and a `context`.
+Snapshot and append handlers return rows; merge handlers return `change.upsert(...)` and
+`change.delete(...)` values. Each handler may return one value, an iterable, or an async iterable.
 
 ## Schedules
 
@@ -89,7 +90,7 @@ export const syncErpCustomers = defineSync("sync-erp-customers")
   .intoDataset(erpCustomersDataset)
 ```
 
-## Snapshot vs. append
+## Sync modes
 
 The sync mode controls how each run writes to the target dataset.
 
@@ -97,6 +98,7 @@ The sync mode controls how each run writes to the target dataset.
 | --- | --- | --- |
 | `"snapshot"` (default) | Replaces the dataset with the current full view | Current customers, open invoices, active projects |
 | `"append"` | Adds new rows to the dataset | Audit logs, webhook deliveries, invoice events |
+| `"merge"` | Upserts and deletes rows by primary key | Ordered source change logs |
 
 Snapshot is the default — omit `mode` for it. Use append when the source is event-like:
 
@@ -107,6 +109,42 @@ export const syncErpInvoiceEvents = defineSync("sync-erp-invoice-events", { mode
   .read((erp) => erp.listInvoiceEvents())
   .intoDataset(erpInvoiceEventsDataset)
 ```
+
+Use merge when the source exposes ordered row changes and the dataset should remain a current view:
+
+```ts
+import { change, col, defineDataset, defineSync } from "@sixb/core"
+
+const erpInvoicesDataset = defineDataset("erp.invoices", {
+  schema: [
+    col("invoiceId", "string"),
+    col("status", "string"),
+    col("customerId", "string"),
+  ],
+  primaryKey: "invoiceId",
+})
+
+export const syncErpInvoices = defineSync("sync-erp-invoices", { mode: "merge" })
+  .checkpoint<{ cursor: string }>()
+  .from(acmeErpConnector)
+  .read(async function* (erp, context) {
+    for await (const event of erp.changesSince(context.checkpoint?.cursor)) {
+      yield event.deleted
+        ? change.delete({ invoiceId: event.invoiceId })
+        : change.upsert(event.invoice)
+
+      context.setCheckpoint({ cursor: event.cursor })
+    }
+  })
+  .intoDataset(erpInvoicesDataset)
+```
+
+Each upsert is a complete row, not a patch. Deletes provide exactly the primary-key fields. The
+final change for a repeated key wins, identical upserts and deletes of absent keys are no-ops, and
+no dataset version is created when the visible rows do not change. V1 requires non-null string
+keys, ordered changes, immutable keys, and one registered writer per keyed dataset. Object and link
+projections evaluate the complete committed dataset; telemetry projections from merge-written
+datasets are not supported yet.
 
 ## Incremental syncs with checkpoints
 
@@ -144,6 +182,10 @@ rows.
 A first snapshot that returns no rows behaves the same way: it succeeds without creating a dataset
 version. Once a previous version exists, an empty snapshot still commits a new empty version so
 projections can withdraw source-owned objects that disappeared upstream.
+
+A merge run may also succeed and advance its checkpoint without creating a version. This happens
+when an initial run only deletes absent keys, or when every staged change leaves the current rows
+unchanged. Later no-op runs continue to reference the existing dataset version.
 
 ## Read context
 

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -5872,7 +5872,7 @@
                       },
                       "mode": {
                         "type": "string",
-                        "enum": ["snapshot", "append"]
+                        "enum": ["snapshot", "append", "merge"]
                       },
                       "connector": {
                         "type": "object",
@@ -5988,7 +5988,7 @@
                           },
                           "mode": {
                             "type": "string",
-                            "enum": ["snapshot", "append"]
+                            "enum": ["snapshot", "append", "merge"]
                           },
                           "status": {
                             "type": "string",
@@ -6088,7 +6088,7 @@
                     },
                     "mode": {
                       "type": "string",
-                      "enum": ["snapshot", "append"]
+                      "enum": ["snapshot", "append", "merge"]
                     },
                     "connector": {
                       "type": "object",
@@ -6204,7 +6204,7 @@
                         },
                         "mode": {
                           "type": "string",
-                          "enum": ["snapshot", "append"]
+                          "enum": ["snapshot", "append", "merge"]
                         },
                         "status": {
                           "type": "string",
@@ -6391,7 +6391,7 @@
                           },
                           "mode": {
                             "type": "string",
-                            "enum": ["snapshot", "append"]
+                            "enum": ["snapshot", "append", "merge"]
                           },
                           "status": {
                             "type": "string",

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2084,7 +2084,7 @@ export type ListSyncsResponses = {
    */
   200: Array<{
     id: string
-    mode: "snapshot" | "append"
+    mode: "snapshot" | "append" | "merge"
     connector: {
       id: string
       type: string
@@ -2122,7 +2122,7 @@ export type ListSyncsResponses = {
       projectId: string
       syncId: string
       datasetId: string
-      mode: "snapshot" | "append"
+      mode: "snapshot" | "append" | "merge"
       status: "running" | "succeeded" | "failed" | "cancelled"
       startedAt: string
       finishedAt?: string
@@ -2169,7 +2169,7 @@ export type GetSyncResponses = {
    */
   200: {
     id: string
-    mode: "snapshot" | "append"
+    mode: "snapshot" | "append" | "merge"
     connector: {
       id: string
       type: string
@@ -2207,7 +2207,7 @@ export type GetSyncResponses = {
       projectId: string
       syncId: string
       datasetId: string
-      mode: "snapshot" | "append"
+      mode: "snapshot" | "append" | "merge"
       status: "running" | "succeeded" | "failed" | "cancelled"
       startedAt: string
       finishedAt?: string
@@ -2271,7 +2271,7 @@ export type ListSyncRunsResponses = {
       projectId: string
       syncId: string
       datasetId: string
-      mode: "snapshot" | "append"
+      mode: "snapshot" | "append" | "merge"
       status: "running" | "succeeded" | "failed" | "cancelled"
       startedAt: string
       finishedAt?: string

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,7 +26,7 @@ bun add @sixb/core
 
 **Connectors** -- Typed external system clients that you register with the runtime and resolve lazily with `sixb.connector(...)`.
 
-**Syncs** -- Declarative batch sync definitions that read from one connector and write into one raw dataset. V1 supports `snapshot` and `append` modes with optional triggers and typed source checkpoints.
+**Syncs** -- Declarative batch sync definitions that read from one connector and write into one raw dataset. V1 supports `snapshot`, `append`, and keyed `merge` modes with optional triggers and typed source checkpoints.
 
 **Queues** -- Typed durable work lanes for executable jobs such as sync runs, pipeline runs, and projection runs. App setup passes one `Queues` provider, while workers claim from lanes like `sixb.queues.syncRuns`.
 
@@ -247,7 +247,7 @@ Use `.json(schema)` for JSON bodies so payloads are validated at runtime. The `.
 Syncs are declarative definitions in `@sixb/core` v1. They do not start background work on their own; they just declare how to read from a connector into a dataset.
 
 ```ts
-import { col, defineDataset, defineSync } from "@sixb/core"
+import { change, col, defineDataset, defineSync } from "@sixb/core"
 
 const rawOrdersDataset = defineDataset("raw.erp.orders", {
   schema: [
@@ -258,6 +258,11 @@ const rawOrdersDataset = defineDataset("raw.erp.orders", {
 
 const rawOrderEventsDataset = defineDataset("raw.erp.order-events", {
   schema: [col("eventId", "string")],
+})
+
+const rawInvoicesDataset = defineDataset("raw.erp.invoices", {
+  schema: [col("invoiceId", "string"), col("status", "string")],
+  primaryKey: "invoiceId",
 })
 
 const syncOrders = defineSync("sync-orders")
@@ -275,14 +280,25 @@ const syncOrderEvents = defineSync("sync-order-events", { mode: "append" })
   })
   .intoDataset(rawOrderEventsDataset)
 
+const syncInvoices = defineSync("sync-invoices", { mode: "merge" })
+  .from(erpDb)
+  .read(async function* (client) {
+    for await (const event of client.invoiceChanges()) {
+      yield event.deleted
+        ? change.delete({ invoiceId: event.invoiceId })
+        : change.upsert(event.invoice)
+    }
+  })
+  .intoDataset(rawInvoicesDataset)
+
 const sixb = new Sixb({
   ontology: [Room],
   broker: myBroker,
   storage: myStorage,
   queues: myQueues,
-  datasets: [rawOrdersDataset, rawOrderEventsDataset],
+  datasets: [rawOrdersDataset, rawOrderEventsDataset, rawInvoicesDataset],
   connectors: [erpDb],
-  syncs: [syncOrders, syncOrderEvents],
+  syncs: [syncOrders, syncOrderEvents, syncInvoices],
 })
 
 sixb.listSyncs()
@@ -292,6 +308,8 @@ sixb.getSyncById("sync-orders")
 Call `.checkpoint<T>()` before `.from(...)` to type `context.checkpoint` and
 `context.setCheckpoint(...)` in a sync read handler. The sync worker loads the checkpoint from the
 latest successful run and stores the next checkpoint only after the dataset commit succeeds.
+Merge syncs require a string primary key, consume complete-row upserts and exact-key deletes, and
+allow only one registered writer for their keyed dataset.
 
 ## Convention-based Setup
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -632,6 +632,7 @@ export type {
   RequestSyncRunInput,
   SyncBuilder,
   SyncDefinition,
+  SyncMode,
   SyncReadBuilder,
   SyncReadContext,
   SyncReadHandler,

--- a/packages/core/src/lake-storage/in-memory.ts
+++ b/packages/core/src/lake-storage/in-memory.ts
@@ -314,6 +314,14 @@ export class InMemoryLakeStorage implements LakeStorage {
     }
 
     const latestVersion = await this.getLatestVersion(definition.id)
+    if (
+      input.expectedLatestVersionId !== undefined &&
+      latestVersion?.versionId !== input.expectedLatestVersionId
+    ) {
+      throw new LakeStorageError(
+        `[LakeStorage] Optimistic merge start failed for dataset '${definition.id}': expected latest version '${input.expectedLatestVersionId}', found '${latestVersion?.versionId ?? "none"}'`
+      )
+    }
     return new InMemoryLakeMergeSession(
       this,
       {

--- a/packages/core/src/lake-storage/merge.ts
+++ b/packages/core/src/lake-storage/merge.ts
@@ -4,6 +4,8 @@ import type { DatasetProducer, DatasetRow, DatasetVersion, DatasetVersionRef } f
 export interface BeginDatasetMergeInput {
   /** Stored definition for the keyed dataset whose latest version is captured by `beginMerge`. */
   readonly dataset: DatasetDefinition
+  /** Optional caller guard checked against the same latest version captured by the session. */
+  readonly expectedLatestVersionId?: string
   readonly producer?: DatasetProducer
   readonly inputs?: readonly DatasetVersionRef[]
 }

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -96,6 +96,10 @@ import {
   requestSyncRun,
   type SyncRunRequestResult,
 } from "../syncs/request"
+import {
+  validateKeyedDatasetWriterTopology,
+  validateMergeSyncProjectionSafety,
+} from "../syncs/validation"
 import type { RegisteredWebhook } from "../webhooks"
 import { registerWebhooks, WebhookValidationError, webhookRoute } from "../webhooks"
 import type {
@@ -328,6 +332,12 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       this.pipelinesById.set(pipeline.id, pipeline)
     }
 
+    validateKeyedDatasetWriterTopology({
+      datasetsById: this.datasetsById,
+      syncs: [...this.syncsById.values()],
+      pipelines: [...this.pipelinesById.values()],
+    })
+
     // Rules validate against the resolved ontology so inherited properties and
     // links are available before checking predicate references.
     validateRulesAtStartup(this.rules, this.ontology)
@@ -368,6 +378,10 @@ export class Sixb<TOntologySources extends readonly OntologySource[]>
       projections: options.projections ?? [],
       ontology: this.ontology,
       datasetsById: this.datasetsById,
+    })
+    validateMergeSyncProjectionSafety({
+      syncs: [...this.syncsById.values()],
+      telemetryProjections: this.projectionRegistry.listTelemetryProjections(),
     })
     registerProjectionRegistry(this, this.projectionRegistry)
 

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -388,6 +388,7 @@ export type {
   ListSyncRunsResult,
   StartSyncRunInput,
   SyncRunFailure,
+  SyncRunMode,
   SyncRunRecord,
   SyncRunStatus,
   SyncRunStorage,

--- a/packages/core/src/storage/sync-runs/in-memory.ts
+++ b/packages/core/src/storage/sync-runs/in-memory.ts
@@ -90,9 +90,9 @@ export class InMemorySyncRunStorage implements SyncRunStorage {
           `[Sixb] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.datasetId}'.`
         )
       }
-      if (!input.output && input.rowsRead !== 0) {
+      if (!input.output && input.rowsRead !== 0 && existing.mode !== "merge") {
         throw new SyncRunError(
-          `[Sixb] Sync run '${input.id}' may omit its output only when no rows were read.`
+          `[Sixb] Sync run '${input.id}' may omit its output with rows read only for an initial merge no-op.`
         )
       }
     }

--- a/packages/core/src/storage/sync-runs/index.ts
+++ b/packages/core/src/storage/sync-runs/index.ts
@@ -8,6 +8,7 @@ export type {
   ListSyncRunsResult,
   StartSyncRunInput,
   SyncRunFailure,
+  SyncRunMode,
   SyncRunRecord,
   SyncRunStatus,
   SyncRunStorage,

--- a/packages/core/src/storage/sync-runs/types.ts
+++ b/packages/core/src/storage/sync-runs/types.ts
@@ -1,6 +1,8 @@
 import type { JsonValue } from "../../json"
 import type { DatasetVersionRef, DatasetWriteMode } from "../../lake-storage"
 
+export type SyncRunMode = DatasetWriteMode | "merge"
+
 export type SyncRunStatus = "running" | "succeeded" | "failed" | "cancelled"
 
 export interface SyncRunFailure {
@@ -13,7 +15,7 @@ export interface SyncRunRecord {
   readonly projectId: string
   readonly syncId: string
   readonly datasetId: string
-  readonly mode: DatasetWriteMode
+  readonly mode: SyncRunMode
   readonly status: SyncRunStatus
   readonly startedAt: Date
   readonly finishedAt?: Date
@@ -30,7 +32,7 @@ export interface StartSyncRunInput {
   readonly projectId: string
   readonly syncId: string
   readonly datasetId: string
-  readonly mode: DatasetWriteMode
+  readonly mode: SyncRunMode
   readonly startedAt?: Date
   readonly expectedLatestVersionId?: string
   readonly commitMessage?: string
@@ -43,7 +45,7 @@ export type FinishSyncRunInput =
       readonly status: "succeeded"
       readonly finishedAt?: Date
       readonly rowsRead: number
-      /** Absent only when a run succeeds without rows before the dataset has a version. */
+      /** Absent when a successful run has no dataset version to reference. */
       readonly output?: DatasetVersionRef
       readonly checkpoint?: JsonValue
     }

--- a/packages/core/src/storage/sync-runs/types.ts
+++ b/packages/core/src/storage/sync-runs/types.ts
@@ -19,7 +19,8 @@ export interface SyncRunRecord {
   readonly status: SyncRunStatus
   readonly startedAt: Date
   readonly finishedAt?: Date
-  readonly rowsRead?: number // Rows produced by this run, not the dataset's full visible row count.
+  /** Source items successfully consumed. Merge runs count both upserts and deletes. */
+  readonly rowsRead?: number
   readonly output?: DatasetVersionRef
   readonly expectedLatestVersionId?: string
   readonly commitMessage?: string
@@ -44,6 +45,7 @@ export type FinishSyncRunInput =
       readonly projectId: string
       readonly status: "succeeded"
       readonly finishedAt?: Date
+      /** Source items successfully consumed. Merge runs count both upserts and deletes. */
       readonly rowsRead: number
       /** Absent when a successful run has no dataset version to reference. */
       readonly output?: DatasetVersionRef
@@ -54,6 +56,7 @@ export type FinishSyncRunInput =
       readonly projectId: string
       readonly status: "failed" | "cancelled"
       readonly finishedAt?: Date
+      /** Source items successfully consumed before the failure or cancellation. */
       readonly rowsRead?: number
       readonly error?: SyncRunFailure
     }

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -172,6 +172,7 @@ export type {
   ListSyncRunsResult,
   StartSyncRunInput,
   SyncRunFailure,
+  SyncRunMode,
   SyncRunRecord,
   SyncRunStatus,
   SyncRunStorage,

--- a/packages/core/src/syncs/builders.ts
+++ b/packages/core/src/syncs/builders.ts
@@ -41,49 +41,56 @@ function normalizeBatchSyncConfig(options: BatchSyncConfig | undefined): BatchSy
   }
 }
 
+type DefaultBatchSyncConfig = Omit<BatchSyncConfig, "mode"> & { readonly mode?: undefined }
+
 /**
  * Define a batch sync that reads from one connector and writes into one dataset.
  *
  * The returned definition is inert and safe to export from `syncs/` modules.
  * Supports `snapshot`, `append`, and keyed `merge` modes with optional triggers and checkpoints.
  */
-type SyncModeFromConfig<TConfig extends BatchSyncConfig | undefined> = TConfig extends {
-  readonly mode: infer TMode extends SyncMode
-}
-  ? TMode
-  : "snapshot"
-
-export function defineSync<
-  TId extends string,
-  const TConfig extends BatchSyncConfig | undefined = undefined,
->(id: TId, options?: TConfig): SyncBuilder<TId, never, SyncModeFromConfig<TConfig>> {
+export function defineSync<TId extends string>(
+  id: TId,
+  options?: DefaultBatchSyncConfig
+): SyncBuilder<TId, never, "snapshot">
+export function defineSync<TId extends string, const TMode extends SyncMode>(
+  id: TId,
+  options: BatchSyncConfig<TMode> & { readonly mode: TMode }
+): SyncBuilder<TId, never, TMode>
+export function defineSync<TId extends string>(
+  id: TId,
+  options: BatchSyncConfig
+): SyncBuilder<TId, never, SyncMode>
+export function defineSync<TId extends string>(
+  id: TId,
+  options?: BatchSyncConfig
+): SyncBuilder<TId, never, SyncMode> {
   assertNonEmpty(id, "id")
 
-  type TMode = SyncModeFromConfig<TConfig>
-  const config = normalizeBatchSyncConfig(options) as BatchSyncDefinitionConfig<TMode>
+  const config = normalizeBatchSyncConfig(options)
   const triggers: ScheduleReference[] = []
 
-  function createBuilder<TCheckpoint>(): SyncBuilder<TId, TCheckpoint, TMode> {
-    const builder: SyncBuilder<TId, TCheckpoint, TMode> = {
-      when(schedule: ScheduleDefinition): SyncBuilder<TId, TCheckpoint, TMode> {
+  function createBuilder<TCheckpoint>(): SyncBuilder<TId, TCheckpoint, SyncMode> {
+    const builder: SyncBuilder<TId, TCheckpoint, SyncMode> = {
+      when(schedule: ScheduleDefinition): SyncBuilder<TId, TCheckpoint, SyncMode> {
         if (!isScheduleDefinition(schedule)) {
           throw new SyncValidationError("Sync .when(...) only accepts schedules.")
         }
         triggers.push({ type: "schedule", scheduleId: schedule.id })
         return builder
       },
-      checkpoint<TNextCheckpoint>(): SyncBuilder<TId, TNextCheckpoint, TMode> {
+      checkpoint<TNextCheckpoint>(): SyncBuilder<TId, TNextCheckpoint, SyncMode> {
         return createBuilder<TNextCheckpoint>()
       },
       from<TConnector extends ConnectorDefinition>(
         connector: TConnector
-      ): SyncReadBuilder<TId, TConnector, TCheckpoint, TMode> {
+      ): SyncReadBuilder<TId, TConnector, TCheckpoint, SyncMode> {
         return {
-          read(handler): SyncTargetBuilder<TId, TConnector, TCheckpoint, TMode> {
+          read(handler): SyncTargetBuilder<TId, TConnector, TCheckpoint, SyncMode> {
             return {
               intoDataset(
                 dataset: DatasetDefinition
-              ): SyncDefinition<TId, TConnector, TCheckpoint, TMode> {
+              ): SyncDefinition<TId, TConnector, TCheckpoint, SyncMode> {
                 assertDataset(dataset, config.mode)
 
                 return {

--- a/packages/core/src/syncs/builders.ts
+++ b/packages/core/src/syncs/builders.ts
@@ -8,6 +8,7 @@ import type {
   BatchSyncDefinitionConfig,
   SyncBuilder,
   SyncDefinition,
+  SyncMode,
   SyncReadBuilder,
   SyncTargetBuilder,
 } from "./types"
@@ -18,16 +19,19 @@ function assertNonEmpty(value: string, field: string): void {
   }
 }
 
-function assertDataset(dataset: DatasetDefinition): void {
+function assertDataset(dataset: DatasetDefinition, mode: SyncMode): void {
   assertNonEmpty(dataset.id, "dataset id")
+  if (mode === "merge" && dataset.primaryKey === undefined) {
+    throw new SyncValidationError(`Merge sync dataset '${dataset.id}' must define a primaryKey.`)
+  }
 }
 
 function normalizeBatchSyncConfig(options: BatchSyncConfig | undefined): BatchSyncDefinitionConfig {
   const mode = options?.mode ?? "snapshot"
 
-  if (mode !== "snapshot" && mode !== "append") {
+  if (mode !== "snapshot" && mode !== "append" && mode !== "merge") {
     throw new SyncValidationError(
-      `Invalid sync mode '${String(mode)}'. Expected 'snapshot' or 'append'.`
+      `Invalid sync mode '${String(mode)}'. Expected 'snapshot', 'append', or 'merge'.`
     )
   }
 
@@ -41,39 +45,46 @@ function normalizeBatchSyncConfig(options: BatchSyncConfig | undefined): BatchSy
  * Define a batch sync that reads from one connector and writes into one dataset.
  *
  * The returned definition is inert and safe to export from `syncs/` modules.
- * V1 supports `snapshot` and `append` modes with optional triggers and checkpoints.
+ * Supports `snapshot`, `append`, and keyed `merge` modes with optional triggers and checkpoints.
  */
-export function defineSync<TId extends string>(
-  id: TId,
-  options?: BatchSyncConfig
-): SyncBuilder<TId> {
+type SyncModeFromConfig<TConfig extends BatchSyncConfig | undefined> = TConfig extends {
+  readonly mode: infer TMode extends SyncMode
+}
+  ? TMode
+  : "snapshot"
+
+export function defineSync<
+  TId extends string,
+  const TConfig extends BatchSyncConfig | undefined = undefined,
+>(id: TId, options?: TConfig): SyncBuilder<TId, never, SyncModeFromConfig<TConfig>> {
   assertNonEmpty(id, "id")
 
-  const config = normalizeBatchSyncConfig(options)
+  type TMode = SyncModeFromConfig<TConfig>
+  const config = normalizeBatchSyncConfig(options) as BatchSyncDefinitionConfig<TMode>
   const triggers: ScheduleReference[] = []
 
-  function createBuilder<TCheckpoint>(): SyncBuilder<TId, TCheckpoint> {
-    const builder: SyncBuilder<TId, TCheckpoint> = {
-      when(schedule: ScheduleDefinition): SyncBuilder<TId, TCheckpoint> {
+  function createBuilder<TCheckpoint>(): SyncBuilder<TId, TCheckpoint, TMode> {
+    const builder: SyncBuilder<TId, TCheckpoint, TMode> = {
+      when(schedule: ScheduleDefinition): SyncBuilder<TId, TCheckpoint, TMode> {
         if (!isScheduleDefinition(schedule)) {
           throw new SyncValidationError("Sync .when(...) only accepts schedules.")
         }
         triggers.push({ type: "schedule", scheduleId: schedule.id })
         return builder
       },
-      checkpoint<TNextCheckpoint>(): SyncBuilder<TId, TNextCheckpoint> {
+      checkpoint<TNextCheckpoint>(): SyncBuilder<TId, TNextCheckpoint, TMode> {
         return createBuilder<TNextCheckpoint>()
       },
       from<TConnector extends ConnectorDefinition>(
         connector: TConnector
-      ): SyncReadBuilder<TId, TConnector, TCheckpoint> {
+      ): SyncReadBuilder<TId, TConnector, TCheckpoint, TMode> {
         return {
-          read(handler): SyncTargetBuilder<TId, TConnector, TCheckpoint> {
+          read(handler): SyncTargetBuilder<TId, TConnector, TCheckpoint, TMode> {
             return {
               intoDataset(
                 dataset: DatasetDefinition
-              ): SyncDefinition<TId, TConnector, TCheckpoint> {
-                assertDataset(dataset)
+              ): SyncDefinition<TId, TConnector, TCheckpoint, TMode> {
+                assertDataset(dataset, config.mode)
 
                 return {
                   kind: "sync",

--- a/packages/core/src/syncs/index.ts
+++ b/packages/core/src/syncs/index.ts
@@ -13,6 +13,7 @@ export type {
   SyncBlobContext,
   SyncBuilder,
   SyncDefinition,
+  SyncMode,
   SyncReadBuilder,
   SyncReadContext,
   SyncReadHandler,

--- a/packages/core/src/syncs/types.ts
+++ b/packages/core/src/syncs/types.ts
@@ -5,7 +5,7 @@ import {
   type ConnectorDefinition,
   isConnectorDefinition,
 } from "../connectors"
-import type { DatasetDefinition } from "../datasets"
+import type { DatasetDefinition, DatasetPrimaryKey, MergeChange } from "../datasets"
 import { isDatasetDefinition } from "../datasets"
 import type { Logger } from "../logging"
 import type { ScheduleDefinition, ScheduleReference } from "../schedules"
@@ -28,18 +28,27 @@ export type SyncReadContext<TCheckpoint = never> = {
       setCheckpoint(next: TCheckpoint): void
     })
 
+export type SyncMode = "snapshot" | "append" | "merge"
+
+type MergeSyncChange = MergeChange<
+  Readonly<Record<string, unknown>>,
+  Readonly<Record<string, unknown>>
+>
+
 /** A sync read handler may return one item, a sync iterable, or an async iterable. */
-export type SyncReadResult = unknown | Iterable<unknown> | AsyncIterable<unknown>
+export type SyncReadResult<TMode extends SyncMode = SyncMode> = TMode extends "merge"
+  ? MergeSyncChange | Iterable<MergeSyncChange> | AsyncIterable<MergeSyncChange>
+  : unknown | Iterable<unknown> | AsyncIterable<unknown>
 
 /** User-facing batch sync options accepted by `defineSync(...)`. */
-export interface BatchSyncConfig {
-  readonly mode?: "snapshot" | "append"
+export interface BatchSyncConfig<TMode extends SyncMode = SyncMode> {
+  readonly mode?: TMode
 }
 
 /** Normalized batch sync config stored on the final sync definition. */
-export interface BatchSyncDefinitionConfig {
+export interface BatchSyncDefinitionConfig<TMode extends SyncMode = SyncMode> {
   readonly kind: "batch"
-  readonly mode: "snapshot" | "append"
+  readonly mode: TMode
 }
 
 /** V1 syncs always target a named raw dataset. */
@@ -56,11 +65,15 @@ export interface DatasetSyncTarget {
  * builder still gives users precise `context.checkpoint` and `setCheckpoint(...)` types when
  * they author a sync.
  */
-export type SyncReadHandler<TAdapter extends ConnectorAdapter, TCheckpoint = never> = {
+export type SyncReadHandler<
+  TAdapter extends ConnectorAdapter,
+  TCheckpoint = never,
+  TMode extends SyncMode = SyncMode,
+> = {
   bivarianceHack(
     client: ConnectorClient<TAdapter>,
     context: SyncReadContext<TCheckpoint>
-  ): SyncReadResult | Promise<SyncReadResult>
+  ): SyncReadResult<TMode> | Promise<SyncReadResult<TMode>>
 }["bivarianceHack"]
 
 /**
@@ -73,13 +86,14 @@ export interface SyncDefinition<
   TId extends string = string,
   TConnector extends ConnectorDefinition = ConnectorDefinition,
   TCheckpoint = unknown,
+  TMode extends SyncMode = SyncMode,
 > {
   readonly kind: "sync"
   readonly id: TId
-  readonly config: BatchSyncDefinitionConfig
+  readonly config: BatchSyncDefinitionConfig<TMode>
   readonly triggers: readonly ScheduleReference[]
   readonly connector: TConnector
-  readonly read: SyncReadHandler<TConnector["adapter"], TCheckpoint>
+  readonly read: SyncReadHandler<TConnector["adapter"], TCheckpoint, TMode>
   readonly target: DatasetSyncTarget
 }
 
@@ -87,26 +101,36 @@ export interface SyncTargetBuilder<
   TId extends string = string,
   TConnector extends ConnectorDefinition = ConnectorDefinition,
   TCheckpoint = never,
+  TMode extends SyncMode = SyncMode,
 > {
-  intoDataset(dataset: DatasetDefinition): SyncDefinition<TId, TConnector, TCheckpoint>
+  intoDataset<TDataset extends DatasetDefinition>(
+    dataset: TMode extends "merge"
+      ? TDataset & { readonly primaryKey: DatasetPrimaryKey }
+      : TDataset
+  ): SyncDefinition<TId, TConnector, TCheckpoint, TMode>
 }
 
 export interface SyncReadBuilder<
   TId extends string = string,
   TConnector extends ConnectorDefinition = ConnectorDefinition,
   TCheckpoint = never,
+  TMode extends SyncMode = SyncMode,
 > {
   read(
-    handler: SyncReadHandler<TConnector["adapter"], TCheckpoint>
-  ): SyncTargetBuilder<TId, TConnector, TCheckpoint>
+    handler: SyncReadHandler<TConnector["adapter"], TCheckpoint, TMode>
+  ): SyncTargetBuilder<TId, TConnector, TCheckpoint, TMode>
 }
 
-export interface SyncBuilder<TId extends string = string, TCheckpoint = never> {
-  when(schedule: ScheduleDefinition): SyncBuilder<TId, TCheckpoint>
-  checkpoint<TNextCheckpoint>(): SyncBuilder<TId, TNextCheckpoint>
+export interface SyncBuilder<
+  TId extends string = string,
+  TCheckpoint = never,
+  TMode extends SyncMode = SyncMode,
+> {
+  when(schedule: ScheduleDefinition): SyncBuilder<TId, TCheckpoint, TMode>
+  checkpoint<TNextCheckpoint>(): SyncBuilder<TId, TNextCheckpoint, TMode>
   from<TConnector extends ConnectorDefinition>(
     connector: TConnector
-  ): SyncReadBuilder<TId, TConnector, TCheckpoint>
+  ): SyncReadBuilder<TId, TConnector, TCheckpoint, TMode>
 }
 
 /** Runtime type guard for values discovered from `syncs/` modules. */
@@ -120,7 +144,9 @@ export function isSyncDefinition(value: unknown): value is SyncDefinition {
     typeof value.id === "string" &&
     isRecord(value.config) &&
     value.config.kind === "batch" &&
-    (value.config.mode === "snapshot" || value.config.mode === "append") &&
+    (value.config.mode === "snapshot" ||
+      value.config.mode === "append" ||
+      value.config.mode === "merge") &&
     Array.isArray(value.triggers) &&
     (value.triggers as unknown[]).every((reference) => isScheduleReference(reference)) &&
     isConnectorDefinition(value.connector) &&

--- a/packages/core/src/syncs/validation.ts
+++ b/packages/core/src/syncs/validation.ts
@@ -1,0 +1,77 @@
+import type { DatasetDefinition } from "../datasets"
+import type { PipelineDefinition } from "../pipelines"
+import type { TelemetryProjectionDefinition } from "../projections"
+import { SyncValidationError } from "./errors"
+import type { SyncDefinition } from "./types"
+
+interface DatasetWriter {
+  readonly datasetId: string
+  readonly label: string
+}
+
+export function validateKeyedDatasetWriterTopology(input: {
+  readonly datasetsById: ReadonlyMap<string, DatasetDefinition>
+  readonly syncs: readonly SyncDefinition[]
+  readonly pipelines: readonly PipelineDefinition[]
+}): void {
+  for (const sync of input.syncs) {
+    const dataset = input.datasetsById.get(sync.target.dataset.id)
+    if (sync.config.mode === "merge" && dataset?.primaryKey === undefined) {
+      throw new SyncValidationError(
+        `[Sixb] Merge sync '${sync.id}' targets dataset '${sync.target.dataset.id}', which must define a primaryKey.`
+      )
+    }
+  }
+
+  const firstWriterByDataset = new Map<string, DatasetWriter>()
+  for (const writer of datasetWriters(input.syncs, input.pipelines)) {
+    const dataset = input.datasetsById.get(writer.datasetId)
+    if (dataset?.primaryKey === undefined) continue
+
+    const first = firstWriterByDataset.get(writer.datasetId)
+    if (!first) {
+      firstWriterByDataset.set(writer.datasetId, writer)
+      continue
+    }
+
+    throw new SyncValidationError(
+      `[Sixb] Keyed dataset '${writer.datasetId}' has multiple registered writers: ${first.label} and ${writer.label}. V1 allows one writer per keyed dataset.`
+    )
+  }
+}
+
+export function validateMergeSyncProjectionSafety(input: {
+  readonly syncs: readonly SyncDefinition[]
+  readonly telemetryProjections: readonly TelemetryProjectionDefinition[]
+}): void {
+  const mergeSyncByDataset = new Map(
+    input.syncs
+      .filter((sync) => sync.config.mode === "merge")
+      .map((sync) => [sync.target.dataset.id, sync] as const)
+  )
+
+  for (const projection of input.telemetryProjections) {
+    const sync = mergeSyncByDataset.get(projection.datasetId)
+    if (!sync) continue
+    throw new SyncValidationError(
+      `[Sixb] Telemetry projection '${projection.id}' cannot read merge-written dataset '${projection.datasetId}' from sync '${sync.id}'. V1 merge syncs support object and link replacement projections only.`
+    )
+  }
+}
+
+function* datasetWriters(
+  syncs: readonly SyncDefinition[],
+  pipelines: readonly PipelineDefinition[]
+): Iterable<DatasetWriter> {
+  for (const sync of syncs) {
+    yield { datasetId: sync.target.dataset.id, label: `sync '${sync.id}'` }
+  }
+  for (const pipeline of pipelines) {
+    for (const node of pipeline.graph.nodes) {
+      yield {
+        datasetId: node.step.output.id,
+        label: `pipeline '${pipeline.id}' step '${node.step.id}'`,
+      }
+    }
+  }
+}

--- a/packages/core/src/testing/lake-merge-storage-contract.ts
+++ b/packages/core/src/testing/lake-merge-storage-contract.ts
@@ -177,6 +177,25 @@ export function runLakeMergeStorageContractSuite<TStorage extends LakeStorage>(
       })
     })
 
+    test("checks an explicit latest-version guard against the captured merge base", async () => {
+      await withStorage(async (storage) => {
+        await storage.createDataset(invoices)
+        const seed = await storage.beginMerge({ dataset: invoices })
+        await seed.writeChanges([change.upsert({ id: "inv_1", status: "open" })])
+        const version = expectCreated(await seed.commit())
+
+        await expect(
+          storage.beginMerge({ dataset: invoices, expectedLatestVersionId: "stale-version" })
+        ).rejects.toThrow("Optimistic merge start failed")
+
+        const guarded = await storage.beginMerge({
+          dataset: invoices,
+          expectedLatestVersionId: version.versionId,
+        })
+        await guarded.abort()
+      })
+    })
+
     test("serializes concurrent commits from the same base", async () => {
       // Regression guard: bypassing a provider's per-dataset commit lock lets both commits create
       // versions from the same base and makes the fulfilled-count assertion fail.

--- a/packages/core/tests/lake-storage.types.ts
+++ b/packages/core/tests/lake-storage.types.ts
@@ -35,6 +35,7 @@ const dataset = defineDataset("contract.merge.invoices", {
 
 const beginInput: BeginDatasetMergeInput = {
   dataset,
+  expectedLatestVersionId: "ver_1",
   producer: { kind: "sync", id: "sync-invoices", runId: "run_1" },
   inputs: [{ datasetId: "source.invoices", versionId: "ver_1" }],
 }
@@ -80,8 +81,10 @@ const _requiredMerge: Promise<LakeMergeSession> = baseStorage.beginMerge(beginIn
 mergeSession.commit({ expectedLatestVersionId: "ver_1" })
 // @ts-expect-error merge is not an ordinary dataset write mode
 const _mergeWriteMode: DatasetWriteMode = "merge"
-// @ts-expect-error user-facing merge syncs are deferred to a later PR
 defineSync("sync-invoices-merge", { mode: "merge" })
+  .from({} as never)
+  .read(() => [change.delete({ id: "inv_1" })])
+  .intoDataset(dataset)
 definePipelineStep("merge-invoices").inputs({ invoices: dataset }).output(dataset, {
   // @ts-expect-error merge pipeline outputs are outside the V1 scope
   mode: "merge",

--- a/packages/core/tests/sync-runs.test.ts
+++ b/packages/core/tests/sync-runs.test.ts
@@ -95,6 +95,33 @@ describe("InMemorySyncRunStorage", () => {
     expect(finished.output).toBeUndefined()
   })
 
+  test("stores an initial merge no-op with consumed changes and no output version", async () => {
+    const storage = new InMemorySyncRunStorage()
+    const started = await storage.start({
+      id: "syncrun_merge_noop",
+      projectId: "my-app",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "merge",
+    })
+
+    const finished = await storage.finish({
+      id: started.id,
+      projectId: started.projectId,
+      status: "succeeded",
+      rowsRead: 1,
+      checkpoint: { cursor: "cursor-2" },
+    })
+
+    expect(finished).toMatchObject({
+      mode: "merge",
+      status: "succeeded",
+      rowsRead: 1,
+      checkpoint: { cursor: "cursor-2" },
+    })
+    expect(finished.output).toBeUndefined()
+  })
+
   test("stores a successful empty snapshot without an output version", async () => {
     const storage = new InMemorySyncRunStorage()
     await storage.start({

--- a/packages/core/tests/syncs.test.ts
+++ b/packages/core/tests/syncs.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import {
+  change,
   col,
   defineConnector,
   defineDataset,
   defineObjectType,
+  definePipeline,
+  definePipelineStep,
+  defineProjection,
   defineSchedule,
   defineSync,
   events,
@@ -44,6 +48,20 @@ const rawOrdersCopyDataset = defineDataset("raw.erp.orders.copy", {
   schema: [col("orderId", "string")],
 })
 
+const keyedOrdersDataset = defineDataset("raw.erp.keyed-orders", {
+  schema: [col("orderId", "string"), col("status", "string")],
+  primaryKey: "orderId",
+})
+
+const RoomReading = defineObjectType({
+  id: "RoomReading",
+  name: "Room reading",
+  properties: [
+    prop("id", "string", { required: true, primary: true }),
+    prop("temperature", "double", { mode: "telemetry" }),
+  ],
+})
+
 describe("defineSync", () => {
   test("rejects empty ids", () => {
     expect(() => defineSync("")).toThrow("Sync id must not be empty")
@@ -73,6 +91,27 @@ describe("defineSync", () => {
       .intoDataset(rawOrderEventsDataset)
 
     expect(sync.config.mode).toBe("append")
+  })
+
+  test("preserves merge mode for a keyed dataset", () => {
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [
+        change.upsert({ orderId: "ord_1", status: "open" }),
+        change.delete({ orderId: "ord_2" }),
+      ])
+      .intoDataset(keyedOrdersDataset)
+
+    expect(sync.config).toEqual({ kind: "batch", mode: "merge" })
+  })
+
+  test("rejects an unkeyed merge target defensively", () => {
+    expect(() =>
+      defineSync("sync-orders-merge", { mode: "merge" })
+        .from(erpDb)
+        .read(() => [])
+        .intoDataset(rawOrdersDataset as never)
+    ).toThrow("Merge sync dataset 'raw.erp.orders' must define a primaryKey")
   })
 
   test("attaches schedule via .when()", () => {
@@ -267,5 +306,101 @@ describe("Sixb sync registration", () => {
           ...createTestRuntimeDeps(),
         })
     ).toThrow("Sync 'sync-orders' references unknown schedule 'missing'")
+  })
+
+  test("allows only one registered writer for a keyed dataset", () => {
+    const first = defineSync("sync-keyed-orders", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(keyedOrdersDataset)
+    const second = defineSync("snapshot-keyed-orders")
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(keyedOrdersDataset)
+
+    expect(
+      () =>
+        new Sixb<readonly []>({
+          ontology: [],
+          datasets: [keyedOrdersDataset],
+          syncs: [first, second],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow(
+      "Keyed dataset 'raw.erp.keyed-orders' has multiple registered writers: sync 'sync-keyed-orders' and sync 'snapshot-keyed-orders'"
+    )
+  })
+
+  test("counts pipeline outputs as keyed dataset writers", () => {
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(keyedOrdersDataset)
+    const step = definePipelineStep("copy-keyed-orders")
+      .inputs({ orders: rawOrdersDataset })
+      .output(keyedOrdersDataset)
+      .run(() => {})
+    const pipeline = definePipeline("orders-pipeline").then(step)
+
+    expect(
+      () =>
+        new Sixb<readonly []>({
+          ontology: [],
+          datasets: [rawOrdersDataset, keyedOrdersDataset],
+          syncs: [sync],
+          pipelines: [pipeline],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow("sync 'sync-keyed-orders' and pipeline 'orders-pipeline' step 'copy-keyed-orders'")
+  })
+
+  test("validates the registered merge target instead of trusting the builder copy", () => {
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(keyedOrdersDataset)
+    const unkeyedRegisteredCopy = defineDataset(keyedOrdersDataset.id, {
+      schema: keyedOrdersDataset.schema.columns,
+    })
+
+    expect(
+      () =>
+        new Sixb<readonly []>({
+          ontology: [],
+          datasets: [unkeyedRegisteredCopy],
+          syncs: [sync],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow("Merge sync 'sync-keyed-orders' targets dataset 'raw.erp.keyed-orders'")
+  })
+
+  test("rejects telemetry projections backed by merge-written datasets", () => {
+    const readings = defineDataset("raw.room-readings", {
+      schema: [
+        col("id", "string"),
+        col("room_id", "string"),
+        col("observed_at", "timestamp"),
+        col("temperature", "float64"),
+      ],
+      primaryKey: "id",
+    })
+    const sync = defineSync("sync-room-readings", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(readings)
+    const projection = defineProjection("room-temperatures", RoomReading.p.temperature)
+      .fromDataset(readings)
+      .points({ objectId: "room_id", at: "observed_at", value: "temperature" })
+
+    expect(
+      () =>
+        new Sixb<readonly []>({
+          ontology: [RoomReading] as never,
+          datasets: [readings],
+          syncs: [sync],
+          projections: [projection],
+          ...createTestRuntimeDeps(),
+        })
+    ).toThrow("Telemetry projection 'room-temperatures' cannot read merge-written dataset")
   })
 })

--- a/packages/core/tests/syncs.types.ts
+++ b/packages/core/tests/syncs.types.ts
@@ -1,5 +1,6 @@
 import {
   type BlobInfo,
+  change,
   col,
   defineConnector,
   defineDataset,
@@ -21,6 +22,11 @@ const erpDb = defineConnector("erpDb", {
 
 const rawOrdersDataset = defineDataset("raw.erp.orders", {
   schema: [col("id", "int64")],
+})
+
+const keyedOrdersDataset = defineDataset("raw.erp.keyed-orders", {
+  schema: [col("id", "string"), col("status", "string")],
+  primaryKey: "id",
 })
 
 const syncOrders = defineSync("sync-orders")
@@ -73,10 +79,36 @@ const syncOrdersWithCheckpoint = defineSync("sync-orders-with-checkpoint")
   })
   .intoDataset(rawOrdersDataset)
 
-const _syncDefinitions: SyncDefinition[] = [syncOrders, syncOrdersWithCheckpoint]
+const mergeOrders = defineSync("merge-orders", { mode: "merge" })
+  .checkpoint<{ cursor: string }>()
+  .from(erpDb)
+  .read(async function* (_db, context) {
+    const _checkpoint: { cursor: string } | undefined = context.checkpoint
+    yield change.upsert({ id: "ord_1", status: "open" })
+    yield change.delete({ id: "ord_2" })
+    context.setCheckpoint({ cursor: "next" })
+  })
+  .intoDataset(keyedOrdersDataset)
+
+const _mergeMode: "merge" = mergeOrders.config.mode
+
+defineSync("invalid-merge-row", { mode: "merge" })
+  .from(erpDb)
+  // @ts-expect-error merge readers must return MergeChange values, not raw rows
+  .read(() => [{ id: "ord_1", status: "open" }])
+  .intoDataset(keyedOrdersDataset)
+
+defineSync("invalid-merge-target", { mode: "merge" })
+  .from(erpDb)
+  .read(() => [change.delete({ id: "ord_1" })])
+  // @ts-expect-error merge syncs require a dataset with a primary key
+  .intoDataset(rawOrdersDataset)
+
+const _syncDefinitions: SyncDefinition[] = [syncOrders, syncOrdersWithCheckpoint, mergeOrders]
 const _connector = syncOrders.connector
 const _checkpointConnector = syncOrdersWithCheckpoint.connector
 
 void _syncDefinitions
 void _connector
 void _checkpointConnector
+void _mergeMode

--- a/packages/core/tests/syncs.types.ts
+++ b/packages/core/tests/syncs.types.ts
@@ -1,4 +1,5 @@
 import {
+  type BatchSyncConfig,
   type BlobInfo,
   change,
   col,
@@ -7,6 +8,7 @@ import {
   defineSync,
   type FileRef,
   type SyncDefinition,
+  type SyncMode,
 } from "../src"
 
 const erpDb = defineConnector("erpDb", {
@@ -63,6 +65,8 @@ const syncOrders = defineSync("sync-orders")
   })
   .intoDataset(rawOrdersDataset)
 
+const _snapshotMode: "snapshot" = syncOrders.config.mode
+
 const syncOrdersWithCheckpoint = defineSync("sync-orders-with-checkpoint")
   .checkpoint<{ cursor: string }>()
   .from(erpDb)
@@ -92,6 +96,24 @@ const mergeOrders = defineSync("merge-orders", { mode: "merge" })
 
 const _mergeMode: "merge" = mergeOrders.config.mode
 
+const mergeOptions = { mode: "merge" } satisfies BatchSyncConfig
+const mergeOrdersFromSatisfiedOptions = defineSync("merge-orders-satisfied", mergeOptions)
+  .from(erpDb)
+  .read(() => [change.delete({ id: "ord_2" })])
+  .intoDataset(keyedOrdersDataset)
+const _satisfiedMergeMode: "merge" = mergeOrdersFromSatisfiedOptions.config.mode
+
+const annotatedMergeOptions: BatchSyncConfig = { mode: "merge" }
+const mergeOrdersFromAnnotatedOptions = defineSync("merge-orders-annotated", annotatedMergeOptions)
+  .from(erpDb)
+  .read(() => [change.delete({ id: "ord_2" })])
+  .intoDataset(keyedOrdersDataset)
+const _annotatedMode: SyncMode = mergeOrdersFromAnnotatedOptions.config.mode
+// Regression guard: restoring the former SyncModeFromConfig conditional makes this directive
+// unused because the annotated merge config is falsely narrowed to snapshot.
+// @ts-expect-error an annotated config must remain SyncMode, never a false snapshot literal
+const _falseSnapshotMode: "snapshot" = mergeOrdersFromAnnotatedOptions.config.mode
+
 defineSync("invalid-merge-row", { mode: "merge" })
   .from(erpDb)
   // @ts-expect-error merge readers must return MergeChange values, not raw rows
@@ -111,4 +133,8 @@ const _checkpointConnector = syncOrdersWithCheckpoint.connector
 void _syncDefinitions
 void _connector
 void _checkpointConnector
+void _snapshotMode
 void _mergeMode
+void _satisfiedMergeMode
+void _annotatedMode
+void _falseSnapshotMode

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  change,
   col,
   type DatasetDefinition,
   type DatasetRow,
@@ -19,6 +20,7 @@ import {
   MaterializationCancellationError,
   MaterializationConflictError,
   MaterializationValidationError,
+  type MergeChange,
   type ProjectionDefinition,
   prop,
   Sixb,
@@ -93,8 +95,18 @@ const roomsDataset = defineDataset("canonical.rooms", {
   ],
 })
 
+const keyedRoomsDataset = defineDataset("canonical.rooms", {
+  schema: roomsDataset.schema.columns,
+  primaryKey: "room_id",
+})
+
 const roomSensorsDataset = defineDataset("canonical.room-sensors", {
   schema: [col("room_id", "string"), col("sensor_id", "string")],
+})
+
+const keyedRoomSensorsDataset = defineDataset("canonical.room-sensors", {
+  schema: roomSensorsDataset.schema.columns,
+  primaryKey: ["room_id", "sensor_id"],
 })
 
 const roomReadingsDataset = defineDataset("canonical.room-readings", {
@@ -414,6 +426,19 @@ async function commitDatasetVersion(
   return write.commit({ commitMessage: "test projection input" })
 }
 
+async function commitDatasetMerge(
+  lakeStorage: LakeStorage,
+  dataset: DatasetDefinition,
+  changes: readonly MergeChange<DatasetRow, DatasetRow>[]
+) {
+  await lakeStorage.createDataset(dataset)
+  const merge = await lakeStorage.beginMerge({ dataset })
+  await merge.writeChanges(changes)
+  const result = await merge.commit({ commitMessage: "test merged projection input" })
+  if (!result.version) throw new Error("Expected merge changes to produce a dataset version.")
+  return result.version
+}
+
 describe("runProjectionJob", () => {
   test("classifies only terminal materialization conflicts as permanent", () => {
     expect(
@@ -475,6 +500,69 @@ describe("runProjectionJob", () => {
       primaryId: "r1",
     })
     expect(room?.properties.name).toBe("Kitchen")
+  })
+
+  test("fully replaces an object projection from each committed merge version", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [keyedRoomsDataset],
+        projections: [roomProjection],
+      },
+      deps
+    )
+    const first = await commitDatasetMerge(deps.lakeStorage, keyedRoomsDataset, [
+      change.upsert({ room_id: "r1", room_name: "Kitchen", building_ref: null }),
+      change.upsert({ room_id: "r2", room_name: "Office", building_ref: null }),
+    ])
+    await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-merge-objects-first",
+        projectionId: roomProjection.id,
+        projectionKind: "object",
+        datasetId: keyedRoomsDataset.id,
+        versionId: first.versionId,
+      },
+    })
+
+    const second = await commitDatasetMerge(deps.lakeStorage, keyedRoomsDataset, [
+      change.upsert({ room_id: "r1", room_name: "Updated kitchen", building_ref: null }),
+      change.delete({ room_id: "r2" }),
+      change.upsert({ room_id: "r3", room_name: "Studio", building_ref: null }),
+    ])
+    await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-merge-objects-second",
+        projectionId: roomProjection.id,
+        projectionKind: "object",
+        datasetId: keyedRoomsDataset.id,
+        versionId: second.versionId,
+      },
+    })
+
+    expect(
+      await deps.storage.objects.getByPrimaryId({
+        projectId: sixb.id,
+        objectTypeId: Room.id,
+        primaryId: "r1",
+      })
+    ).toMatchObject({ properties: { name: "Updated kitchen" } })
+    expect(
+      await deps.storage.objects.getByPrimaryId({
+        projectId: sixb.id,
+        objectTypeId: Room.id,
+        primaryId: "r2",
+      })
+    ).toBeNull()
+    expect(
+      await deps.storage.objects.getByPrimaryId({
+        projectId: sixb.id,
+        objectTypeId: Room.id,
+        primaryId: "r3",
+      })
+    ).toMatchObject({ properties: { name: "Studio" } })
   })
 
   test("replays an object projection without emitting no-op mutations", async () => {
@@ -1938,6 +2026,70 @@ describe("runProjectionJob", () => {
     })
     expect(links).toHaveLength(1)
     expect(links[0]?.targetId).toBe("s1")
+  })
+
+  test("fully replaces a link projection from each committed merge version", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [keyedRoomSensorsDataset],
+        projections: [roomSensorProjection],
+      },
+      deps
+    )
+    for (const roomId of ["r1", "r2"]) {
+      await sixb.upsertObject("Room", { id: roomId, name: roomId })
+    }
+    for (const sensorId of ["s1", "s2", "s3"]) {
+      await sixb.upsertObject("Sensor", { id: sensorId, name: sensorId })
+    }
+
+    const first = await commitDatasetMerge(deps.lakeStorage, keyedRoomSensorsDataset, [
+      change.upsert({ room_id: "r1", sensor_id: "s1" }),
+      change.upsert({ room_id: "r1", sensor_id: "s2" }),
+    ])
+    await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-merge-links-first",
+        projectionId: roomSensorProjection.id,
+        projectionKind: "link",
+        datasetId: keyedRoomSensorsDataset.id,
+        versionId: first.versionId,
+      },
+    })
+
+    const second = await commitDatasetMerge(deps.lakeStorage, keyedRoomSensorsDataset, [
+      change.delete({ room_id: "r1", sensor_id: "s1" }),
+      change.upsert({ room_id: "r2", sensor_id: "s3" }),
+    ])
+    await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-merge-links-second",
+        projectionId: roomSensorProjection.id,
+        projectionKind: "link",
+        datasetId: keyedRoomSensorsDataset.id,
+        versionId: second.versionId,
+      },
+    })
+
+    expect(
+      await deps.storage.objects.listLinks({
+        projectId: sixb.id,
+        objectTypeId: Room.id,
+        objectId: "r1",
+        linkId: "hasSensors",
+      })
+    ).toMatchObject([{ targetId: "s2" }])
+    expect(
+      await deps.storage.objects.listLinks({
+        projectId: sixb.id,
+        objectTypeId: Room.id,
+        objectId: "r2",
+        linkId: "hasSensors",
+      })
+    ).toMatchObject([{ targetId: "s3" }])
   })
 
   test("link projections read only source and target columns", async () => {

--- a/packages/server/src/schemas/syncs.ts
+++ b/packages/server/src/schemas/syncs.ts
@@ -6,6 +6,7 @@ export const SyncParamsSchema = z.object({
 })
 
 export const SyncRunStatusSchema = z.enum(["running", "succeeded", "failed", "cancelled"])
+const SyncModeSchema = z.enum(["snapshot", "append", "merge"])
 
 export const SyncRunsQuerySchema = z.object({
   syncId: z.string().optional(),
@@ -33,7 +34,7 @@ export const SyncRunSchema = z.object({
   projectId: z.string(),
   syncId: z.string(),
   datasetId: z.string(),
-  mode: z.enum(["snapshot", "append"]),
+  mode: SyncModeSchema,
   status: SyncRunStatusSchema,
   startedAt: z.string(),
   finishedAt: z.string().optional(),
@@ -56,7 +57,7 @@ export const SyncRunSchema = z.object({
 
 export const SyncSchema = z.object({
   id: z.string(),
-  mode: z.enum(["snapshot", "append"]),
+  mode: SyncModeSchema,
   connector: z.object({
     id: z.string(),
     type: z.string(),

--- a/packages/server/tests/syncs-routes.test.ts
+++ b/packages/server/tests/syncs-routes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { OntologySource, Sixb } from "@sixb/core"
-import { col, defineConnector, defineDataset, defineSync } from "@sixb/core"
+import { change, col, defineConnector, defineDataset, defineSync } from "@sixb/core"
 import type { ListLatestSyncRunsInput, SyncRunStorage } from "@sixb/core/storage"
 import { Elysia } from "elysia"
 import { registerSyncRoutes } from "../src/routes/syncs"
@@ -20,6 +20,11 @@ const customersDataset = defineDataset("raw.crm.customers", {
   schema: [col("customerId", "string")],
 })
 
+const invoicesDataset = defineDataset("raw.erp.invoices", {
+  schema: [col("invoiceId", "string")],
+  primaryKey: "invoiceId",
+})
+
 const syncs = [
   defineSync("sync-orders")
     .from(connector)
@@ -29,6 +34,10 @@ const syncs = [
     .from(connector)
     .read(() => [])
     .intoDataset(customersDataset),
+  defineSync("sync-invoices", { mode: "merge" })
+    .from(connector)
+    .read(() => change.delete({ invoiceId: "missing" }))
+    .intoDataset(invoicesDataset),
 ]
 
 function createSixbStub(syncRuns: Partial<SyncRunStorage>): Sixb<readonly OntologySource[]> {
@@ -61,11 +70,11 @@ describe("sync routes", () => {
           return {
             runs: [
               {
-                id: "run-customers",
+                id: "run-invoices",
                 projectId: "my-app",
-                syncId: "sync-customers",
-                datasetId: "raw.crm.customers",
-                mode: "append",
+                syncId: "sync-invoices",
+                datasetId: "raw.erp.invoices",
+                mode: "merge",
                 status: "running",
                 startedAt: new Date("2026-04-06T16:00:00.000Z"),
               },
@@ -85,10 +94,11 @@ describe("sync routes", () => {
 
     expect(bulkCalls).toBe(1)
     expect(listCalls).toBe(0)
-    expect(requestedSyncIds).toEqual([["sync-orders", "sync-customers"]])
+    expect(requestedSyncIds).toEqual([["sync-orders", "sync-customers", "sync-invoices"]])
     expect(body.map((sync) => [sync.id, sync.latestRun?.id ?? null])).toEqual([
       ["sync-orders", null],
-      ["sync-customers", "run-customers"],
+      ["sync-customers", null],
+      ["sync-invoices", "run-invoices"],
     ])
   })
 })

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -2,16 +2,21 @@ import {
   assertJsonValue,
   type BlobStorage,
   cloneJsonValue,
+  type DatasetDefinition,
+  type DatasetRow,
   type FileRef,
   getDatasetRowValidationError,
   isFileRef,
   type JsonValue,
+  type Logger,
+  type MergeChange,
+  type SyncDefinition,
 } from "@sixb/core"
 import { resolveLogsRuntime } from "@sixb/core/internal/logging"
-import type { DatasetVersion, LakeWriteSession } from "@sixb/core/lake-storage"
+import { type DatasetVersion, getDatasetMergeChangeValidationError } from "@sixb/core/lake-storage"
 import type { SyncRunFailure, SyncRunRecord } from "@sixb/core/storage"
 import { assertDatasetRow, normalizeReadResult, throwIfAborted } from "./normalize"
-import type { RunSyncJobInput, SyncRunResult } from "./types"
+import type { RunSyncJobInput, SyncRunResult, SyncWorkerContext } from "./types"
 
 export class SyncRunAlreadyStartedError extends Error {
   override readonly name = "SyncRunAlreadyStartedError"
@@ -110,12 +115,121 @@ async function verifyRowFileRefs(options: {
   }
 }
 
+function assertMergeChange(
+  value: unknown,
+  syncId: string,
+  dataset: DatasetDefinition,
+  itemIndex: number
+): MergeChange<DatasetRow, DatasetRow> {
+  const validationError = getDatasetMergeChangeValidationError(value, dataset)
+  if (validationError) {
+    throw new Error(
+      `[SixbSyncWorker] Sync '${syncId}' returned an invalid merge change at item ${itemIndex}. ${validationError}`
+    )
+  }
+  return value as MergeChange<DatasetRow, DatasetRow>
+}
+
+async function readSyncValues(options: {
+  runtime: SyncWorkerContext
+  sync: SyncDefinition
+  signal: AbortSignal
+  blobStorage: BlobStorage
+  logger: Logger
+  previousCheckpoint: JsonValue | undefined
+  setCheckpoint(next: unknown): void
+}): Promise<AsyncIterable<unknown>> {
+  const client = await options.runtime.connector(options.sync.connector)
+  const readResult = await options.sync.read(client, {
+    projectId: options.runtime.id,
+    syncId: options.sync.id,
+    signal: options.signal,
+    blobs: options.blobStorage,
+    logger: options.logger,
+    checkpoint:
+      options.previousCheckpoint !== undefined
+        ? cloneJsonValue(options.previousCheckpoint)
+        : undefined,
+    setCheckpoint: options.setCheckpoint,
+  })
+  return normalizeReadResult(readResult, options.sync.id)
+}
+
+async function* validatedDatasetRows(options: {
+  values: AsyncIterable<unknown>
+  signal: AbortSignal
+  blobStorage: BlobStorage
+  syncId: string
+  dataset: DatasetDefinition
+  onRead(): void
+}): AsyncIterable<DatasetRow> {
+  let itemIndex = 0
+  for await (const value of options.values) {
+    throwIfAborted(options.signal)
+    itemIndex += 1
+
+    const row = assertDatasetRow(value, options.syncId, itemIndex)
+    // Validate before handing rows to lake storage so sync failures include
+    // the source item index; lake storage still re-validates as the final boundary.
+    const validationError = getDatasetRowValidationError(row, options.dataset)
+    if (validationError) {
+      throw new Error(
+        `[SixbSyncWorker] Sync '${options.syncId}' returned an invalid row at item ${itemIndex}. ${validationError}`
+      )
+    }
+
+    // Lake storage validates fileRef shape; the worker owns existence checks against blob storage.
+    await verifyRowFileRefs({
+      blobStorage: options.blobStorage,
+      syncId: options.syncId,
+      dataset: options.dataset,
+      row,
+      itemIndex,
+    })
+
+    options.onRead()
+    yield row
+  }
+}
+
+async function* validatedMergeChanges(options: {
+  values: AsyncIterable<unknown>
+  signal: AbortSignal
+  blobStorage: BlobStorage
+  syncId: string
+  dataset: DatasetDefinition
+  onRead(): void
+}): AsyncIterable<MergeChange<DatasetRow, DatasetRow>> {
+  let itemIndex = 0
+  for await (const value of options.values) {
+    throwIfAborted(options.signal)
+    itemIndex += 1
+    const mergeChange = assertMergeChange(value, options.syncId, options.dataset, itemIndex)
+    if (mergeChange.kind === "upsert") {
+      await verifyRowFileRefs({
+        blobStorage: options.blobStorage,
+        syncId: options.syncId,
+        dataset: options.dataset,
+        row: mergeChange.row,
+        itemIndex,
+      })
+    }
+    options.onRead()
+    yield mergeChange
+  }
+}
+
+interface SyncCommitResult {
+  readonly outcome: "created" | "unchanged"
+  readonly version?: DatasetVersion
+}
+
 /**
  * Run one sync job end to end using a caller-supplied run id.
  *
- * The worker creates the operational sync-run record, streams rows into lake
- * storage, commits one dataset version, and then finalizes the run record with
- * the outcome. It does not own scheduling, retries, or run-id generation.
+ * The worker creates the operational sync-run record, streams source values into lake storage,
+ * commits or reuses a dataset version when one exists, and then finalizes the run record. It does
+ * not own scheduling, retries, or run-id generation.
  */
 export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult> {
   const { runtime, job } = input
@@ -161,7 +275,7 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
     id: job.id,
   })
   const logger = logSession.logger
-  let write: LakeWriteSession | undefined
+  let abortWrite: (() => Promise<void>) | undefined
   let rowsRead = 0
   let committedVersion: DatasetVersion | undefined
 
@@ -180,104 +294,125 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
     let nextCheckpoint: JsonValue | undefined =
       previousCheckpoint !== undefined ? cloneJsonValue(previousCheckpoint) : undefined
 
-    const client = await runtime.connector(sync.connector)
-    const readResult = await sync.read(client, {
-      projectId: runtime.id,
-      syncId: sync.id,
-      signal,
-      blobs: blobStorage,
-      logger,
-      checkpoint: previousCheckpoint !== undefined ? cloneJsonValue(previousCheckpoint) : undefined,
-      setCheckpoint(next: unknown) {
-        assertJsonValue(next, `Sync '${sync.id}' checkpoint`)
-        nextCheckpoint = cloneJsonValue(next)
-      },
-    })
-    const rows = normalizeReadResult(readResult, sync.id)
+    const producer = {
+      kind: "sync" as const,
+      id: sync.id,
+      runId: job.id,
+    }
+    const readValues = () =>
+      readSyncValues({
+        runtime,
+        sync,
+        signal,
+        blobStorage,
+        logger,
+        previousCheckpoint,
+        setCheckpoint(next) {
+          assertJsonValue(next, `Sync '${sync.id}' checkpoint`)
+          nextCheckpoint = cloneJsonValue(next)
+        },
+      })
+    const onRead = () => {
+      rowsRead += 1
+    }
+    const commitMessage = job.commitMessage ?? `sync ${sync.id} run ${job.id}`
+    let commitResult: SyncCommitResult
 
-    throwIfAborted(signal)
+    if (sync.config.mode === "merge") {
+      const mergeWrite = await lakeStorage.beginMerge({
+        dataset,
+        expectedLatestVersionId: job.expectedLatestVersionId,
+        producer,
+      })
+      abortWrite = () => mergeWrite.abort()
 
-    write = await lakeStorage.beginWrite({
-      dataset,
-      mode: sync.config.mode,
-      producer: {
-        kind: "sync",
-        id: sync.id,
-        runId: job.id,
-      },
-    })
+      const values = await readValues()
+      throwIfAborted(signal)
+      await mergeWrite.writeChanges(
+        validatedMergeChanges({
+          values,
+          signal,
+          blobStorage,
+          syncId: sync.id,
+          dataset,
+          onRead,
+        })
+      )
+      throwIfAborted(signal)
 
-    await write.writeRows(
-      (async function* () {
-        let itemIndex = 0
+      const commit = await mergeWrite.commit({ commitMessage })
+      abortWrite = undefined
+      commitResult = {
+        outcome: commit.outcome,
+        ...(commit.version ? { version: commit.version } : {}),
+      }
+    } else {
+      const values = await readValues()
+      throwIfAborted(signal)
 
-        for await (const value of rows) {
-          throwIfAborted(signal)
-          itemIndex += 1
+      const rowWrite = await lakeStorage.beginWrite({
+        dataset,
+        mode: sync.config.mode,
+        producer,
+      })
+      abortWrite = () => rowWrite.abort()
+      await rowWrite.writeRows(
+        validatedDatasetRows({
+          values,
+          signal,
+          blobStorage,
+          syncId: sync.id,
+          dataset,
+          onRead,
+        })
+      )
+      throwIfAborted(signal)
 
-          const row = assertDatasetRow(value, sync.id, itemIndex)
-          // Validate before handing rows to lake storage so sync failures include
-          // the source item index; lake storage still re-validates as the final boundary.
-          const validationError = getDatasetRowValidationError(row, dataset)
-          if (validationError) {
-            throw new Error(
-              `[SixbSyncWorker] Sync '${sync.id}' returned an invalid row at item ${itemIndex}. ${validationError}`
-            )
-          }
-
-          // Lake storage validates fileRef shape; the worker owns existence checks against blob storage.
-          await verifyRowFileRefs({
-            blobStorage,
-            syncId: sync.id,
-            dataset,
-            row,
-            itemIndex,
+      if (rowsRead === 0) {
+        const version = await lakeStorage.getLatestVersion(dataset.id)
+        if (sync.config.mode === "append" || !version) {
+          await rowWrite.abort()
+          abortWrite = undefined
+          const finishedRun = await syncRunsStorage.finish({
+            projectId: runtime.id,
+            id: job.id,
+            status: "succeeded",
+            rowsRead,
+            ...(version
+              ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
+              : {}),
+            checkpoint: nextCheckpoint,
           })
 
-          rowsRead += 1
-          yield row
-        }
-      })()
-    )
-
-    throwIfAborted(signal)
-
-    if (rowsRead === 0) {
-      const version = await lakeStorage.getLatestVersion(dataset.id)
-      if (sync.config.mode === "append" || !version) {
-        await write.abort()
-        write = undefined
-        const finishedRun = await syncRunsStorage.finish({
-          projectId: runtime.id,
-          id: job.id,
-          status: "succeeded",
-          rowsRead,
-          ...(version
-            ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
-            : {}),
-          checkpoint: nextCheckpoint,
-        })
-
-        return {
-          id: job.id,
-          syncId: sync.id,
-          datasetId: dataset.id,
-          mode: sync.config.mode,
-          startedAt: startedRun.startedAt,
-          finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
-          rowsRead,
-          ...(version ? { version } : {}),
-          versionCreated: false,
+          return {
+            id: job.id,
+            syncId: sync.id,
+            datasetId: dataset.id,
+            mode: sync.config.mode,
+            startedAt: startedRun.startedAt,
+            finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
+            rowsRead,
+            ...(version ? { version } : {}),
+            versionCreated: false,
+          }
         }
       }
+
+      const { outcome, ...version } = await rowWrite.commit({
+        expectedLatestVersionId: job.expectedLatestVersionId,
+        commitMessage,
+      })
+      abortWrite = undefined
+      commitResult = { outcome, version }
     }
 
-    const commit = await write.commit({
-      expectedLatestVersionId: job.expectedLatestVersionId,
-      commitMessage: job.commitMessage ?? `sync ${sync.id} run ${job.id}`,
-    })
-    const { outcome, ...version } = commit
-    committedVersion = version
+    const { outcome, version } = commitResult
+    if (outcome === "created") {
+      if (!version) {
+        throw new Error(`[SixbSyncWorker] Sync '${sync.id}' created no dataset version.`)
+      }
+      committedVersion = version
+    }
     let finishedRun: SyncRunRecord
 
     try {
@@ -286,22 +421,24 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
         id: job.id,
         status: "succeeded",
         rowsRead,
-        output: {
-          datasetId: version.datasetId,
-          versionId: version.versionId,
-        },
+        ...(version
+          ? { output: { datasetId: version.datasetId, versionId: version.versionId } }
+          : {}),
         checkpoint: nextCheckpoint,
       })
     } catch (error) {
-      throw createBookkeepingError({
-        syncId: sync.id,
-        runId: job.id,
-        version,
-        cause: error,
-      })
+      if (committedVersion) {
+        throw createBookkeepingError({
+          syncId: sync.id,
+          runId: job.id,
+          version: committedVersion,
+          cause: error,
+        })
+      }
+      throw error
     }
 
-    return {
+    const result = {
       id: job.id,
       syncId: sync.id,
       datasetId: dataset.id,
@@ -309,13 +446,14 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
       startedAt: startedRun.startedAt,
       finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
       rowsRead,
-      version,
-      versionCreated: outcome === "created",
     }
+    return version
+      ? { ...result, version, versionCreated: outcome === "created" }
+      : { ...result, versionCreated: false }
   } catch (error) {
     if (!committedVersion) {
-      // Before commit succeeds we can still best-effort clean up both the write session and run record.
-      await write?.abort().catch(() => {})
+      // Without a created commit, best-effort clean up any open session and the run record.
+      await abortWrite?.().catch(() => {})
 
       const status = signal.aborted ? "cancelled" : "failed"
       try {

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -53,6 +53,7 @@ interface SyncRunResultBase {
   readonly mode: SyncMode
   readonly startedAt: Date
   readonly finishedAt: Date
+  /** Source items successfully consumed. Merge runs count both upserts and deletes. */
   readonly rowsRead: number
 }
 

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -6,9 +6,10 @@ import type {
   DatasetDefinition,
   LakeStorage,
   SyncDefinition,
+  SyncMode,
 } from "@sixb/core"
 import type { LogsRuntime } from "@sixb/core/internal/logging"
-import type { DatasetVersion, DatasetWriteMode } from "@sixb/core/lake-storage"
+import type { DatasetVersion } from "@sixb/core/lake-storage"
 import type { SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
 
 export interface SyncWorkerContext {
@@ -49,7 +50,7 @@ interface SyncRunResultBase {
   readonly id: string
   readonly syncId: string
   readonly datasetId: string
-  readonly mode: DatasetWriteMode
+  readonly mode: SyncMode
   readonly startedAt: Date
   readonly finishedAt: Date
   readonly rowsRead: number
@@ -63,7 +64,7 @@ export type SyncRunResult = SyncRunResultBase &
         readonly versionCreated: boolean
       }
     | {
-        /** A first empty sync has no dataset version yet. */
+        /** A successful initial no-op has no dataset version yet. */
         readonly version?: undefined
         readonly versionCreated: false
       }

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -14,6 +14,7 @@ import type {
   SyncDefinition,
 } from "@sixb/core"
 import {
+  change,
   col,
   defineConnector,
   defineDataset,
@@ -69,8 +70,20 @@ const rawOrdersDataset = makeDataset("raw.erp.orders")
 const rawSingleDataset = makeDataset("raw.erp.single")
 const rawIterableDataset = makeDataset("raw.erp.iterable")
 const rawAsyncDataset = makeDataset("raw.erp.async")
+const keyedOrdersDataset = defineDataset("raw.erp.keyed-orders", {
+  schema: rawOrdersDataset.schema.columns,
+  primaryKey: "orderId",
+})
+const keyedLineItemsDataset = defineDataset("raw.erp.invoice-line-items", {
+  schema: [col("invoiceId", "string"), col("lineItemId", "string"), col("status", "string")],
+  primaryKey: ["invoiceId", "lineItemId"],
+})
 const rawDocsDataset = defineDataset("raw.docs", {
   schema: [col("id", "string"), col("attachment", "fileRef", { nullable: true })],
+})
+const keyedDocsDataset = defineDataset("raw.keyed-docs", {
+  schema: rawDocsDataset.schema.columns,
+  primaryKey: "id",
 })
 
 function createRuntime(options: {
@@ -359,6 +372,261 @@ describe("runSyncJob", () => {
     })
     expect(seenCheckpoint).toEqual({ cursor: "cursor-1" })
     expect(run?.checkpoint).toEqual({ cursor: "cursor-2" })
+  })
+
+  test("streams ordered merge changes and stores the successful checkpoint", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .checkpoint<{ cursor: string }>()
+      .from(erpDb)
+      .read(async function* (_client, context) {
+        yield change.upsert({ orderId: "ord_1", status: "open" })
+        context.setCheckpoint({ cursor: "event-1" })
+        yield change.delete({ orderId: "missing" })
+        context.setCheckpoint({ cursor: "event-2" })
+      })
+      .intoDataset(keyedOrdersDataset)
+
+    const result = await runSyncJob({
+      runtime: createRuntime({ sync, syncRunsStorage, lakeStorage }),
+      job: { id: "run_merge", syncId: sync.id },
+    })
+
+    expect(result).toMatchObject({
+      mode: "merge",
+      rowsRead: 2,
+      versionCreated: true,
+      version: {
+        mode: "merge",
+        rowCount: 1,
+        producer: { kind: "sync", id: sync.id, runId: "run_merge" },
+      },
+    })
+    expect(await collectRows(lakeStorage.readRows({ datasetId: keyedOrdersDataset.id }))).toEqual([
+      { orderId: "ord_1", status: "open" },
+    ])
+    expect(
+      await syncRunsStorage.getById({ projectId: "project-1", id: "run_merge" })
+    ).toMatchObject({
+      mode: "merge",
+      status: "succeeded",
+      rowsRead: 2,
+      checkpoint: { cursor: "event-2" },
+    })
+  })
+
+  test("passes composite-key changes through the merge worker", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    const sync = defineSync("sync-invoice-line-items", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [
+        change.upsert({ invoiceId: "inv_1", lineItemId: "line_1", status: "open" }),
+        change.delete({ invoiceId: "inv_1", lineItemId: "missing" }),
+      ])
+      .intoDataset(keyedLineItemsDataset)
+
+    const result = await runSyncJob({
+      runtime: createRuntime({ sync, lakeStorage }),
+      job: { id: "run_composite_merge", syncId: sync.id },
+    })
+
+    expect(result).toMatchObject({ rowsRead: 2, versionCreated: true })
+    expect(
+      await collectRows(lakeStorage.readRows({ datasetId: keyedLineItemsDataset.id }))
+    ).toEqual([{ invoiceId: "inv_1", lineItemId: "line_1", status: "open" }])
+  })
+
+  test("verifies file references for merge upserts but not deletes", async () => {
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    const sync = defineSync("sync-keyed-docs", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [
+        change.delete({ id: "doc_deleted" }),
+        change.upsert({
+          id: "doc_1",
+          attachment: {
+            blobId: "blob_missing",
+            digest: "sha256:missing",
+            sizeBytes: 12,
+          },
+        }),
+      ])
+      .intoDataset(keyedDocsDataset)
+
+    await expect(
+      runSyncJob({
+        runtime: createRuntime({ sync, syncRunsStorage }),
+        job: { id: "run_merge_missing_blob", syncId: sync.id },
+      })
+    ).rejects.toThrow("row 2 with dataset 'raw.keyed-docs' column 'attachment'")
+
+    expect(
+      await syncRunsStorage.getById({ projectId: "project-1", id: "run_merge_missing_blob" })
+    ).toMatchObject({ status: "failed", rowsRead: 1 })
+  })
+
+  test("advances a checkpoint for an initial merge no-op without inventing a version", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .checkpoint<{ cursor: string }>()
+      .from(erpDb)
+      .read(function* (_client, context) {
+        yield change.delete({ orderId: "missing" })
+        context.setCheckpoint({ cursor: "event-1" })
+      })
+      .intoDataset(keyedOrdersDataset)
+
+    const result = await runSyncJob({
+      runtime: createRuntime({ sync, syncRunsStorage, lakeStorage }),
+      job: { id: "run_initial_noop", syncId: sync.id },
+    })
+
+    expect(result).toMatchObject({ rowsRead: 1, versionCreated: false })
+    expect(result.version).toBeUndefined()
+    expect(await lakeStorage.listVersions(keyedOrdersDataset.id)).toEqual([])
+    expect(
+      await syncRunsStorage.getById({ projectId: "project-1", id: "run_initial_noop" })
+    ).toMatchObject({
+      status: "succeeded",
+      rowsRead: 1,
+      checkpoint: { cursor: "event-1" },
+      output: undefined,
+    })
+  })
+
+  test("reuses a later no-op version with a matching requested latest-version guard", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    await lakeStorage.createDataset(keyedOrdersDataset)
+    const seed = await lakeStorage.beginMerge({ dataset: keyedOrdersDataset })
+    await seed.writeChanges([change.upsert({ orderId: "ord_1", status: "open" })])
+    const seedResult = await seed.commit()
+    if (!seedResult.version) throw new Error("Expected a seed version")
+
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [change.upsert({ orderId: "ord_1", status: "open" })])
+      .intoDataset(keyedOrdersDataset)
+    const result = await runSyncJob({
+      runtime: createRuntime({ sync, lakeStorage }),
+      job: {
+        id: "run_later_noop",
+        syncId: sync.id,
+        expectedLatestVersionId: seedResult.version.versionId,
+      },
+    })
+
+    expect(result).toMatchObject({
+      rowsRead: 1,
+      versionCreated: false,
+      version: { versionId: seedResult.version.versionId },
+    })
+    expect(await lakeStorage.listVersions(keyedOrdersDataset.id)).toHaveLength(1)
+  })
+
+  test("rejects a stale requested merge version before connecting to the source", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    await lakeStorage.createDataset(keyedOrdersDataset)
+    const seed = await lakeStorage.beginMerge({ dataset: keyedOrdersDataset })
+    await seed.writeChanges([change.upsert({ orderId: "ord_1", status: "open" })])
+    await seed.commit()
+
+    let connectorCalls = 0
+    let readCalls = 0
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .from(erpDb)
+      .read(() => {
+        readCalls += 1
+        return [change.upsert({ orderId: "ord_2", status: "open" })]
+      })
+      .intoDataset(keyedOrdersDataset)
+
+    await expect(
+      runSyncJob({
+        runtime: createRuntime({
+          sync,
+          syncRunsStorage,
+          lakeStorage,
+          onConnect() {
+            connectorCalls += 1
+          },
+        }),
+        job: {
+          id: "run_stale_request",
+          syncId: sync.id,
+          expectedLatestVersionId: "stale-version",
+        },
+      })
+    ).rejects.toThrow("Optimistic merge start failed")
+
+    expect(connectorCalls).toBe(0)
+    expect(readCalls).toBe(0)
+    expect(
+      await syncRunsStorage.getById({ projectId: "project-1", id: "run_stale_request" })
+    ).toMatchObject({ status: "failed", rowsRead: 0 })
+    expect(await lakeStorage.listVersions(keyedOrdersDataset.id)).toHaveLength(1)
+  })
+
+  test("does not store a checkpoint when a concurrent merge makes the session stale", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .checkpoint<{ cursor: string }>()
+      .from(erpDb)
+      .read(async function* (_client, context) {
+        yield change.upsert({ orderId: "ord_worker", status: "open" })
+        context.setCheckpoint({ cursor: "event-1" })
+
+        const concurrent = await lakeStorage.beginMerge({ dataset: keyedOrdersDataset })
+        await concurrent.writeChanges([
+          change.upsert({ orderId: "ord_concurrent", status: "paid" }),
+        ])
+        await concurrent.commit()
+      })
+      .intoDataset(keyedOrdersDataset)
+
+    await expect(
+      runSyncJob({
+        runtime: createRuntime({ sync, syncRunsStorage, lakeStorage }),
+        job: { id: "run_stale", syncId: sync.id },
+      })
+    ).rejects.toThrow("Optimistic merge commit failed")
+
+    const run = await syncRunsStorage.getById({ projectId: "project-1", id: "run_stale" })
+    expect(run).toMatchObject({ status: "failed", rowsRead: 1 })
+    expect(run?.checkpoint).toBeUndefined()
+    expect(await collectRows(lakeStorage.readRows({ datasetId: keyedOrdersDataset.id }))).toEqual([
+      { orderId: "ord_concurrent", status: "paid" },
+    ])
+  })
+
+  test("cancels and discards an in-flight merge", async () => {
+    const controller = new AbortController()
+    const lakeStorage = new InMemoryLakeStorage()
+    const syncRunsStorage = new InMemorySyncRunStorage()
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .from(erpDb)
+      .read(async function* () {
+        yield change.upsert({ orderId: "ord_1", status: "open" })
+        controller.abort()
+        yield change.upsert({ orderId: "ord_2", status: "open" })
+      })
+      .intoDataset(keyedOrdersDataset)
+
+    await expect(
+      runSyncJob({
+        runtime: createRuntime({ sync, syncRunsStorage, lakeStorage }),
+        job: { id: "run_cancelled_merge", syncId: sync.id },
+        signal: controller.signal,
+      })
+    ).rejects.toMatchObject({ name: "AbortError" })
+
+    expect(
+      await syncRunsStorage.getById({ projectId: "project-1", id: "run_cancelled_merge" })
+    ).toMatchObject({ status: "cancelled", rowsRead: 1 })
+    expect(await lakeStorage.listVersions(keyedOrdersDataset.id)).toEqual([])
   })
 
   test("succeeds and advances the checkpoint for a first empty append", async () => {
@@ -1018,6 +1286,36 @@ describe("runSyncJob", () => {
     expect(rows).toEqual([
       { orderId: "ord_1", customerName: "Ada" },
       { orderId: "ord_2", customerName: "Grace" },
+    ])
+  })
+
+  test("runs a merge end-to-end against LocalLakeStorage", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "sixb-sync-worker-merge-"))
+    tempDirs.push(rootDir)
+
+    const lakeStorage = new LocalLakeStorage({ path: rootDir })
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .from(erpDb)
+      .read(() => [
+        change.upsert({ orderId: "ord_1", status: "open" }),
+        change.upsert({ orderId: "ord_2", status: "paid" }),
+        change.delete({ orderId: "ord_1" }),
+      ])
+      .intoDataset(keyedOrdersDataset)
+
+    const result = await runSyncJob({
+      runtime: createRuntime({ sync, lakeStorage }),
+      job: { id: "run_local_merge", syncId: sync.id },
+    })
+
+    expect(result).toMatchObject({
+      mode: "merge",
+      rowsRead: 3,
+      versionCreated: true,
+      version: { mode: "merge", rowCount: 1 },
+    })
+    expect(await collectRows(lakeStorage.readRows({ datasetId: keyedOrdersDataset.id }))).toEqual([
+      { orderId: "ord_2", status: "paid" },
     ])
   })
 

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  change,
   col,
   defineConnector,
   defineDataset,
@@ -463,6 +464,69 @@ describe("SyncWorker", () => {
     expect(payload.status).toBe("succeeded")
     expect(payload.datasetId).toBe("raw.erp.orders")
     expect(payload.versionId).toBe(datasetPayload.versionId)
+  })
+
+  test("emits a dataset event for a created merge but not for a later no-op", async () => {
+    const dataset = defineDataset("raw.erp.keyed-orders", {
+      schema: [col("orderId", "string"), col("status", "string")],
+      primaryKey: "orderId",
+    })
+    const sync = defineSync("sync-keyed-orders", { mode: "merge" })
+      .checkpoint<{ cursor: string }>()
+      .from(erpDb)
+      .read((_client, context) => {
+        context.setCheckpoint({ cursor: context.checkpoint ? "cursor-2" : "cursor-1" })
+        return [change.upsert({ orderId: "ord_1", status: "open" })]
+      })
+      .intoDataset(dataset)
+    const sixb = createSixbForSync(sync)
+    const worker = new SyncWorker(sixb)
+
+    await sixb.queues.syncRuns.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "sync.run.requested",
+          payload: { syncId: sync.id, runId: "run-merge-created" },
+        },
+      ],
+    })
+    await worker.start()
+    const createdRun = await waitFor(
+      () => sixb.storage.syncRuns!.getById({ projectId: sixb.id, id: "run-merge-created" }),
+      (run) => run?.status === "succeeded"
+    )
+
+    await sixb.queues.syncRuns.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "sync.run.requested",
+          payload: { syncId: sync.id, runId: "run-merge-noop" },
+        },
+      ],
+    })
+    const noOpRun = await waitFor(
+      () => sixb.storage.syncRuns!.getById({ projectId: sixb.id, id: "run-merge-noop" }),
+      (run) => run?.status === "succeeded"
+    )
+    await Bun.sleep(50)
+    await worker.stop()
+
+    expect(createdRun?.checkpoint).toEqual({ cursor: "cursor-1" })
+    expect(noOpRun?.checkpoint).toEqual({ cursor: "cursor-2" })
+    expect(noOpRun?.output?.versionId).toBe(createdRun?.output?.versionId)
+
+    const events = await sixb.events.read({
+      types: ["sync.run.started", "dataset.version.committed", "sync.run.finished"],
+    })
+    expect(events.map((event) => event.type)).toEqual([
+      "sync.run.started",
+      "dataset.version.committed",
+      "sync.run.finished",
+      "sync.run.started",
+      "sync.run.finished",
+    ])
   })
 
   test("does not emit a dataset event when storage reuses an existing version", async () => {

--- a/storage/ducklake/src/internal/ducklake-write-coordinator.ts
+++ b/storage/ducklake/src/internal/ducklake-write-coordinator.ts
@@ -122,6 +122,14 @@ export class DuckLakeWriteCoordinator {
     const latestVersion = await this.connections.withAttachedRuntime((runtime) =>
       this.snapshots.getLatestVersionForDefinition(runtime, definition)
     )
+    if (
+      input.expectedLatestVersionId !== undefined &&
+      latestVersion?.versionId !== input.expectedLatestVersionId
+    ) {
+      throw new LakeStorageError(
+        `[SixbDuckLake] Optimistic merge start failed for dataset '${definition.id}': expected latest version '${input.expectedLatestVersionId}', found '${latestVersion?.versionId ?? "none"}'.`
+      )
+    }
     const runtime = await this.connections.stagingRuntime()
     return createDuckLakeMergeSession({
       commitMerge: (options) => this.commitMerge(options),

--- a/storage/lake-local/src/local-lake-storage.ts
+++ b/storage/lake-local/src/local-lake-storage.ts
@@ -369,6 +369,14 @@ export class LocalLakeStorage implements LakeStorage {
     }
 
     const latestVersion = await this.getLatestVersion(definition.id)
+    if (
+      input.expectedLatestVersionId !== undefined &&
+      latestVersion?.versionId !== input.expectedLatestVersionId
+    ) {
+      throw new LakeStorageError(
+        `[LakeLocal] Optimistic merge start failed for dataset '${definition.id}': expected latest version '${input.expectedLatestVersionId}', found '${latestVersion?.versionId ?? "none"}'`
+      )
+    }
     await this.ensureBaseDirs()
 
     const sessionDir = join(this.tempRootPath(), `session-${randomUUID()}`)

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -15,6 +15,7 @@ import {
 } from "@sixb/core/storage"
 import initialSchemaSql from "./migrations/001-initial-schema.sql" with { type: "text" }
 import workflowRunOutputSql from "./migrations/002-workflow-run-output.sql" with { type: "text" }
+import mergeSyncRunsSql from "./migrations/003-merge-sync-runs.sql" with { type: "text" }
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -270,6 +271,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
   steps: [
     pgSql("001-initial-schema", initialSchemaSql),
     pgSql("002-workflow-run-output", workflowRunOutputSql),
+    pgSql("003-merge-sync-runs", mergeSyncRunsSql),
   ],
 })
 

--- a/storage/pg/src/migrations/003-merge-sync-runs.sql
+++ b/storage/pg/src/migrations/003-merge-sync-runs.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sync_runs
+  DROP CONSTRAINT sync_runs_mode_check,
+  ADD CONSTRAINT sync_runs_mode_check CHECK (mode IN ('snapshot', 'append', 'merge'));

--- a/storage/pg/src/pg-sync-run-storage.ts
+++ b/storage/pg/src/pg-sync-run-storage.ts
@@ -78,9 +78,9 @@ export class PgSyncRunStorage implements SyncRunStorage {
             `[SixbPg] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.dataset_id}'.`
           )
         }
-        if (!input.output && input.rowsRead !== 0) {
+        if (!input.output && input.rowsRead !== 0 && existing.mode !== "merge") {
           throw new SyncRunError(
-            `[SixbPg] Sync run '${input.id}' may omit its output only when no rows were read.`
+            `[SixbPg] Sync run '${input.id}' may omit its output with rows read only for an initial merge no-op.`
           )
         }
       }

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "bun:test"
 import { defineObjectType, migrateStorage, OntologyRegistry, prop } from "@sixb/core"
+import { defineMigrations } from "@sixb/core/storage"
 import { createMaterializerTestFixture } from "@sixb/core/testing"
 import { SQL } from "bun"
 import { PostgresStorage, type PostgresStorage as PostgresStorageType } from "../src"
 import {
+  createPostgresMigrator,
   POSTGRES_STORAGE_ADAPTER_ID,
   postgresStorageMigrations,
   quoteIdent,
 } from "../src/migrations"
+import { createPgClient } from "../src/pg-client"
 import { createTestStorage } from "./helpers"
 
 const Room = defineObjectType({
@@ -31,7 +34,11 @@ describe("Postgres storage migrations", () => {
         {
           adapterId: POSTGRES_STORAGE_ADAPTER_ID,
           status: "migrated",
-          applied: ["001-initial-schema", "002-workflow-run-output"],
+          applied: [
+            "001-initial-schema",
+            "002-workflow-run-output",
+            "003-merge-sync-runs",
+          ],
         },
       ])
       expect(await readMigrationRows(schemaName)).toEqual([
@@ -49,6 +56,13 @@ describe("Postgres storage migrations", () => {
           status: "applied",
           version: 2,
         },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "003-merge-sync-runs",
+          status: "applied",
+          version: 3,
+        },
       ])
     })
   })
@@ -57,6 +71,60 @@ describe("Postgres storage migrations", () => {
     await withStorage(false, async (storage) => {
       await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "migrated" })
       await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "current" })
+    })
+  })
+
+  test("merge sync migration preserves existing runs and admits merge mode", async () => {
+    await withStorage(false, async (storage, schemaName) => {
+      const migrationsBeforeMerge = postgresStorageMigrations.steps.slice(0, 2)
+      if (migrationsBeforeMerge.length !== 2) {
+        throw new Error("PostgreSQL migrations before merge sync support are missing.")
+      }
+      const connectionString = process.env.DATABASE_URL
+      if (!connectionString) throw new Error("[SixbPg] DATABASE_URL is required.")
+
+      const initialSql = createPgClient({ connectionString, schemaName, max: 1 })
+      try {
+        const beforeMerge = defineMigrations({
+          adapterId: POSTGRES_STORAGE_ADAPTER_ID,
+          steps: migrationsBeforeMerge,
+        })
+        await createPostgresMigrator({
+          sql: initialSql,
+          schemaName,
+          migrations: beforeMerge,
+        }).migrate()
+        await initialSql.unsafe(
+          `
+            INSERT INTO ${quoteIdent(schemaName)}.sync_runs (
+              project_id, id, sync_id, dataset_id, mode, status, started_at
+            ) VALUES ($1, $2, $3, $4, 'append', 'succeeded', $5)
+          `,
+          ["project-a", "run-append", "sync-orders", "raw.orders", "2026-08-07T12:00:00.000Z"]
+        )
+      } finally {
+        await initialSql.end()
+      }
+
+      await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "migrated" })
+
+      await withSql(async (sql) => {
+        const rows = await sql.unsafe<{ mode: string }[]>(
+          `SELECT mode FROM ${quoteIdent(schemaName)}.sync_runs WHERE project_id = $1 AND id = $2`,
+          ["project-a", "run-append"]
+        )
+        expect(rows).toEqual([{ mode: "append" }])
+        await expect(
+          sql.unsafe(
+            `
+              INSERT INTO ${quoteIdent(schemaName)}.sync_runs (
+                project_id, id, sync_id, dataset_id, mode, status, started_at
+              ) VALUES ($1, $2, $3, $4, 'merge', 'running', $5)
+            `,
+            ["project-a", "run-merge", "sync-invoices", "raw.invoices", "2026-08-07T12:01:00.000Z"]
+          )
+        ).resolves.toBeDefined()
+      })
     })
   })
 
@@ -303,7 +371,7 @@ describe("Postgres storage migrations", () => {
       expect(await migrator?.status()).toMatchObject({
         adapterId: POSTGRES_STORAGE_ADAPTER_ID,
         state: "current",
-        appliedVersion: 2,
+        appliedVersion: 3,
       })
     })
   })
@@ -339,6 +407,13 @@ describe("Postgres storage migrations", () => {
           id: "002-workflow-run-output",
           status: "applied",
           version: 2,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "003-merge-sync-runs",
+          status: "applied",
+          version: 3,
         },
       ])
     } finally {

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -34,11 +34,7 @@ describe("Postgres storage migrations", () => {
         {
           adapterId: POSTGRES_STORAGE_ADAPTER_ID,
           status: "migrated",
-          applied: [
-            "001-initial-schema",
-            "002-workflow-run-output",
-            "003-merge-sync-runs",
-          ],
+          applied: ["001-initial-schema", "002-workflow-run-output", "003-merge-sync-runs"],
         },
       ])
       expect(await readMigrationRows(schemaName)).toEqual([
@@ -83,18 +79,21 @@ describe("Postgres storage migrations", () => {
       const connectionString = process.env.DATABASE_URL
       if (!connectionString) throw new Error("[SixbPg] DATABASE_URL is required.")
 
-      const initialSql = createPgClient({ connectionString, schemaName, max: 1 })
+      // Keep the upgrade and its verification on postgres.js. Replacing the verification with
+      // two sequential Bun SQL queries at max: 1 reproduces a five-second test timeout, then
+      // leaves the test process alive because the second query is never dispatched.
+      const sql = createPgClient({ connectionString, schemaName, max: 1 })
       try {
         const beforeMerge = defineMigrations({
           adapterId: POSTGRES_STORAGE_ADAPTER_ID,
           steps: migrationsBeforeMerge,
         })
         await createPostgresMigrator({
-          sql: initialSql,
+          sql,
           schemaName,
           migrations: beforeMerge,
         }).migrate()
-        await initialSql.unsafe(
+        await sql.unsafe(
           `
             INSERT INTO ${quoteIdent(schemaName)}.sync_runs (
               project_id, id, sync_id, dataset_id, mode, status, started_at
@@ -102,29 +101,27 @@ describe("Postgres storage migrations", () => {
           `,
           ["project-a", "run-append", "sync-orders", "raw.orders", "2026-08-07T12:00:00.000Z"]
         )
-      } finally {
-        await initialSql.end()
-      }
 
-      await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "migrated" })
-
-      await withSql(async (sql) => {
-        const rows = await sql.unsafe<{ mode: string }[]>(
-          `SELECT mode FROM ${quoteIdent(schemaName)}.sync_runs WHERE project_id = $1 AND id = $2`,
-          ["project-a", "run-append"]
+        await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "migrated" })
+        await sql.unsafe(
+          `
+            INSERT INTO ${quoteIdent(schemaName)}.sync_runs (
+              project_id, id, sync_id, dataset_id, mode, status, started_at
+            ) VALUES ($1, $2, $3, $4, 'merge', 'running', $5)
+          `,
+          ["project-a", "run-merge", "sync-invoices", "raw.invoices", "2026-08-07T12:01:00.000Z"]
         )
-        expect(rows).toEqual([{ mode: "append" }])
-        await expect(
-          sql.unsafe(
-            `
-              INSERT INTO ${quoteIdent(schemaName)}.sync_runs (
-                project_id, id, sync_id, dataset_id, mode, status, started_at
-              ) VALUES ($1, $2, $3, $4, 'merge', 'running', $5)
-            `,
-            ["project-a", "run-merge", "sync-invoices", "raw.invoices", "2026-08-07T12:01:00.000Z"]
-          )
-        ).resolves.toBeDefined()
-      })
+
+        const rows = await sql.unsafe<{ id: string; mode: string }[]>(
+          `SELECT id, mode FROM ${quoteIdent(schemaName)}.sync_runs ORDER BY id`
+        )
+        expect([...rows]).toEqual([
+          { id: "run-append", mode: "append" },
+          { id: "run-merge", mode: "merge" },
+        ])
+      } finally {
+        await sql.end()
+      }
     })
   })
 

--- a/storage/pg/tests/pg-sync-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-sync-run-storage.e2e.ts
@@ -104,6 +104,27 @@ describe("PgSyncRunStorage", () => {
       rowsRead: 0,
     })
     expect(emptySnapshotFinished.output).toBeUndefined()
+
+    const mergeStarted = await storage.syncRuns.start({
+      id: "run-merge-noop",
+      projectId: "my-app",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "merge",
+    })
+    const mergeFinished = await storage.syncRuns.finish({
+      id: mergeStarted.id,
+      projectId: mergeStarted.projectId,
+      status: "succeeded",
+      rowsRead: 1,
+      checkpoint: { cursor: "cursor-merge" },
+    })
+    expect(mergeFinished).toMatchObject({
+      mode: "merge",
+      rowsRead: 1,
+      checkpoint: { cursor: "cursor-merge" },
+    })
+    expect(mergeFinished.output).toBeUndefined()
   })
 
   test("stores failures and supports filtered paging", async () => {

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -18,6 +18,7 @@ import {
 } from "@sixb/core/storage"
 import initialSchemaSql from "./migrations/001-initial-schema.sql" with { type: "text" }
 import workflowRunOutputSql from "./migrations/002-workflow-run-output.sql" with { type: "text" }
+import mergeSyncRunsSql from "./migrations/003-merge-sync-runs.sql" with { type: "text" }
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -40,6 +41,7 @@ export const sqliteStorageMigrations = defineMigrations({
   steps: [
     sqliteSql("001-initial-schema", initialSchemaSql),
     sqliteSql("002-workflow-run-output", workflowRunOutputSql),
+    sqliteSql("003-merge-sync-runs", mergeSyncRunsSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/003-merge-sync-runs.sql
+++ b/storage/sqlite/src/migrations/003-merge-sync-runs.sql
@@ -1,0 +1,71 @@
+DROP INDEX idx_sync_runs_project_started;
+DROP INDEX idx_sync_runs_project_dataset_started;
+DROP INDEX idx_sync_runs_project_sync_started;
+DROP INDEX idx_sync_runs_project_status_started;
+
+ALTER TABLE sync_runs RENAME TO sync_runs_before_merge_mode;
+
+CREATE TABLE sync_runs (
+  project_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  sync_id TEXT NOT NULL,
+  dataset_id TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('snapshot', 'append', 'merge')),
+  status TEXT NOT NULL CHECK (status IN ('running', 'succeeded', 'failed', 'cancelled')),
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  rows_read INTEGER CHECK (rows_read IS NULL OR rows_read >= 0),
+  output_version_id TEXT,
+  expected_latest_version_id TEXT,
+  commit_message TEXT,
+  error_name TEXT,
+  error_message TEXT,
+  checkpoint TEXT,
+  PRIMARY KEY (project_id, id)
+);
+
+INSERT INTO sync_runs (
+  project_id,
+  id,
+  sync_id,
+  dataset_id,
+  mode,
+  status,
+  started_at,
+  finished_at,
+  rows_read,
+  output_version_id,
+  expected_latest_version_id,
+  commit_message,
+  error_name,
+  error_message,
+  checkpoint
+)
+SELECT
+  project_id,
+  id,
+  sync_id,
+  dataset_id,
+  mode,
+  status,
+  started_at,
+  finished_at,
+  rows_read,
+  output_version_id,
+  expected_latest_version_id,
+  commit_message,
+  error_name,
+  error_message,
+  checkpoint
+FROM sync_runs_before_merge_mode;
+
+DROP TABLE sync_runs_before_merge_mode;
+
+CREATE INDEX idx_sync_runs_project_started
+  ON sync_runs(project_id, started_at DESC);
+CREATE INDEX idx_sync_runs_project_dataset_started
+  ON sync_runs(project_id, dataset_id, started_at DESC);
+CREATE INDEX idx_sync_runs_project_sync_started
+  ON sync_runs(project_id, sync_id, started_at DESC);
+CREATE INDEX idx_sync_runs_project_status_started
+  ON sync_runs(project_id, status, started_at DESC);

--- a/storage/sqlite/src/sync-run-storage.ts
+++ b/storage/sqlite/src/sync-run-storage.ts
@@ -115,9 +115,9 @@ export class SqliteSyncRunStorage implements SyncRunStorage {
             `[SixbSqlite] Sync run '${input.id}' output dataset '${input.output.datasetId}' does not match '${existing.dataset_id}'.`
           )
         }
-        if (!input.output && input.rowsRead !== 0) {
+        if (!input.output && input.rowsRead !== 0 && existing.mode !== "merge") {
           throw new SyncRunError(
-            `[SixbSqlite] Sync run '${input.id}' may omit its output only when no rows were read.`
+            `[SixbSqlite] Sync run '${input.id}' may omit its output with rows read only for an initial merge no-op.`
           )
         }
       }

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -29,6 +29,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 2,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "003-merge-sync-runs",
+    status: "applied",
+    version: 3,
+  },
 ]
 
 afterEach(async () => {
@@ -64,6 +71,68 @@ describe("SQLite storage migrations", () => {
       await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "current" })
     } finally {
       storage.close()
+    }
+  })
+
+  test("merge sync migration preserves existing runs and admits merge mode", () => {
+    const db = new Database(":memory:")
+    try {
+      sqliteStorageMigrations.steps[0]?.up(db)
+      sqliteStorageMigrations.steps[1]?.up(db)
+      db.query(`
+        INSERT INTO sync_runs (
+          project_id, id, sync_id, dataset_id, mode, status, started_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        "project-a",
+        "run-append",
+        "sync-orders",
+        "raw.orders",
+        "append",
+        "succeeded",
+        "2026-08-07T12:00:00.000Z"
+      )
+
+      expect(() =>
+        db
+          .query(`
+          INSERT INTO sync_runs (
+            project_id, id, sync_id, dataset_id, mode, status, started_at
+          ) VALUES (?, ?, ?, ?, 'merge', 'running', ?)
+        `)
+          .run(
+            "project-a",
+            "run-before-migration",
+            "sync-invoices",
+            "raw.invoices",
+            "2026-08-07T12:01:00.000Z"
+          )
+      ).toThrow()
+
+      sqliteStorageMigrations.steps[2]?.up(db)
+
+      expect(
+        db
+          .query("SELECT mode FROM sync_runs WHERE project_id = ? AND id = ?")
+          .get("project-a", "run-append")
+      ).toEqual({ mode: "append" })
+      expect(() =>
+        db
+          .query(`
+          INSERT INTO sync_runs (
+            project_id, id, sync_id, dataset_id, mode, status, started_at
+          ) VALUES (?, ?, ?, ?, 'merge', 'running', ?)
+        `)
+          .run(
+            "project-a",
+            "run-merge",
+            "sync-invoices",
+            "raw.invoices",
+            "2026-08-07T12:02:00.000Z"
+          )
+      ).not.toThrow()
+    } finally {
+      db.close()
     }
   })
 
@@ -457,7 +526,7 @@ describe("SQLite migration status is read-only", () => {
     expect(await migrator?.status()).toMatchObject({
       adapterId: SQLITE_STORAGE_ADAPTER_ID,
       state: "current",
-      appliedVersion: 2,
+      appliedVersion: 3,
     })
 
     expect(statSync(path).mtimeMs).toBe(before)

--- a/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-sync-run-storage.test.ts
@@ -102,6 +102,27 @@ describe("SqliteSyncRunStorage", () => {
       rowsRead: 0,
     })
     expect(emptySnapshotFinished.output).toBeUndefined()
+
+    const mergeStarted = await storage.start({
+      id: "run-merge-noop",
+      projectId: "my-app",
+      syncId: "sync-orders",
+      datasetId: "raw.erp.orders",
+      mode: "merge",
+    })
+    const mergeFinished = await storage.finish({
+      id: mergeStarted.id,
+      projectId: mergeStarted.projectId,
+      status: "succeeded",
+      rowsRead: 1,
+      checkpoint: { cursor: "cursor-merge" },
+    })
+    expect(mergeFinished).toMatchObject({
+      mode: "merge",
+      rowsRead: 1,
+      checkpoint: { cursor: "cursor-merge" },
+    })
+    expect(mergeFinished.output).toBeUndefined()
   })
 
   test("stores failures and supports filtered paging", async () => {


### PR DESCRIPTION
## Summary

Activates keyed dataset merges in sync definitions and the sync worker, building on the DuckLake merge storage added in #332.

Merge syncs now accept ordered `upsert` and `delete` changes, guard against stale dataset versions before reading the source, commit through the lake merge session, and advance checkpoints even when the merge produces no visible row changes.

```ts
export const syncInvoices = defineSync("sync-erp-invoices", {
  mode: "merge",
})
  .checkpoint<{ cursor: string }>()
  .from(erp)
  .read(async function* (client, context) {
    for await (const event of client.changesSince(context.checkpoint?.cursor)) {
      yield event.deleted
        ? change.delete({ id: event.id })
        : change.upsert(event.invoice)

      context.setCheckpoint({ cursor: event.cursor })
    }
  })
  .intoDataset(invoices)
```

## What changed

- Adds `"merge"` to the sync authoring contract while leaving pipeline and ordinary dataset write modes unchanged.
- Requires merge syncs to target datasets with a primary key and rejects multiple registered writers for the same keyed dataset.
- Executes ordered changes through `beginMerge()`, with validation, cancellation, cleanup, and optimistic concurrency handling in the sync worker.
- Supports created merges, later no-op merges, and initial no-op merges without inventing a visible dataset version.
- Persists successful no-op sync runs and checkpoints across in-memory, SQLite, and PostgreSQL sync-run storage.
- Emits dataset commit events only when visible rows change, while still emitting a successful sync completion event for no-op runs.
- Keeps existing object and link projections on the full-dataset replacement path after a merge commit.
- Updates sync schemas, generated client types, documentation, migrations, and contract coverage.

```text
Created merge  -> new dataset version + dataset commit event + checkpoint
Later no-op    -> existing version reused + no dataset event + checkpoint
Initial no-op  -> no dataset version + no dataset event + checkpoint
Failed/stale   -> no commit + no checkpoint advance
```

## Not in this PR

- Merge pipeline outputs
- Multiple writers for one keyed dataset
- Partial row patches or out-of-order changes
- Telemetry corrections from merge-backed datasets
- Changed-row lake history or incremental projection evaluation
- Incremental joins and aggregations
- Atlas presentation and worked examples
- Automated recovery from source-log gaps

## Verification

```text
bun run check
bun run typecheck
bun run build
bun run test:publish
bun run test:ci
bun run generate:client
git diff --check
```

Focused merge-sync, storage, worker, projection, server, SQLite, LocalLake, and DuckLake tests also pass. PostgreSQL E2E test sources compile, but the live PostgreSQL suite was not run locally because `DATABASE_URL` was unavailable.

Stacked on #332.
