### PR TITLE
datasets: polish keyed merge experience

### DIFF
--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -67,8 +67,10 @@ V1 primary keys have these constraints:
 - Composite keys contain at least two unique columns. Column order is significant.
 - A key cannot be added, removed, changed, or reordered after the dataset is created.
 - Rows must be unique by key, and a row's key is immutable. Merge-capable lake providers enforce
-  uniqueness for keyed snapshots, appends, and provider-level merges. User-facing merge syncs and
-  DuckLake merge execution are delivered separately.
+  uniqueness for keyed snapshots, appends, transforms, and merges.
+
+Use a keyed dataset with a [merge sync](./syncs.md#sync-modes) when the source exposes ordered row
+changes and the dataset should stay current without replacing every row on each run.
 
 ### `col` options
 

--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -146,6 +146,21 @@ keys, ordered changes, immutable keys, and one registered writer per keyed datas
 projections evaluate the complete committed dataset; telemetry projections from merge-written
 datasets are not supported yet.
 
+### Merge source requirements
+
+Use merge only when the source provides a durable, ordered change log. Each source event needs a
+stable cursor, a complete row for an upsert or the exact key for a delete, and deterministic replay.
+Set the next checkpoint after yielding each event as shown above. Sixb stores the latest checkpoint
+only after the entire merge commits, so retrying a failed run safely replays its changes.
+
+Changing a row's key is two changes: delete the old key, then upsert the complete row under the new
+key. Do not model it as a partial update.
+
+If the source no longer recognizes the saved cursor because its retained log has a gap, stop the
+merge and rebuild from a trusted snapshot or backfill before resuming. Missing lake-side change
+history does not require source recovery: current projections evaluate the complete committed
+dataset version rather than depending on incremental row history.
+
 ## Incremental syncs with checkpoints
 
 For append sources you usually want each run to read only what is new. Call `.checkpoint<T>()` to

--- a/examples/northline/README.md
+++ b/examples/northline/README.md
@@ -111,6 +111,31 @@ actions, workflows, and the app use those clients rather than importing fixtures
 uses a local DuckDB catalog and local DuckLake storage; its pipeline transformations execute as
 DuckDB SQL rather than row-by-row TypeScript.
 
+## Keyed merge example
+
+Northline's `business.quotes` dataset is a complete worked merge sync. The dataset declares
+`quote_id` as its primary key, the file-backed business system keeps an ordered quote change log,
+and `sync-business-quotes` stores the log cursor as its checkpoint. Initial quotes and later quote
+decisions are complete-row upserts; the sync also handles exact-key deletes.
+
+Follow the implementation through
+[`datasets/business-system.ts`](./datasets/business-system.ts),
+[`syncs/business-system.ts`](./syncs/business-system.ts), and
+[`lib/sources/business-system-client.ts`](./lib/sources/business-system-client.ts).
+
+With Northline running, use the demo commands to see an update flow through the same path:
+
+```bash
+bun run demo:sync
+bun run demo:approve-quote
+bun run demo:sync
+```
+
+The second sync reads only the new source event, merges the updated quote, advances the checkpoint,
+and reevaluates the existing Quote projection against the complete dataset. Run `demo:sync` again
+without another source change and the successful no-op creates no dataset version. Atlas shows the
+dataset's primary key and `merge` versions in its dataset details.
+
 ## Read the code in this order
 
 Follow one connected path rather than browsing by feature:

--- a/examples/northline/datasets/business-system.ts
+++ b/examples/northline/datasets/business-system.ts
@@ -68,4 +68,5 @@ export const businessQuotes = defineDataset("business.quotes", {
     col("decision_at", "timestamp", { nullable: true }),
     col("updated_at", "timestamp"),
   ],
+  primaryKey: "quote_id",
 })

--- a/examples/northline/lib/scenario/create-scenario.ts
+++ b/examples/northline/lib/scenario/create-scenario.ts
@@ -22,6 +22,7 @@ export function createNorthlineScenario(
   const business: BusinessState = {
     schemaVersion: 1,
     idempotency: {},
+    quoteChanges: [],
     customers: [
       customer(
         "customer-harbor-foods",
@@ -272,6 +273,9 @@ export function createNorthlineScenario(
       },
     ],
   }
+  business.quoteChanges = business.quotes.map(
+    (row) => ({ kind: "upsert", row: structuredClone(row) }) as const
+  )
 
   const equipment = createEquipment(clock)
   const fieldService: FieldServiceState = {

--- a/examples/northline/lib/sources/business-system-client.ts
+++ b/examples/northline/lib/sources/business-system-client.ts
@@ -1,13 +1,15 @@
-import { pageRows, runIdempotently } from "./client-utils"
+import { orderedChangesSince, pageRows, runIdempotently } from "./client-utils"
 import type {
+  BusinessState,
   ContractRow,
   CustomerRow,
   FacilityRow,
+  QuoteChange,
   QuoteRow,
   SourceListInput,
   SourcePage,
 } from "./contracts"
-import { businessStore, initializeDemoSources } from "./source-state"
+import { businessStore, ensureBusinessChangeHistory, initializeDemoSources } from "./source-state"
 
 export interface CreateQuoteInput {
   readonly customerId: string
@@ -25,6 +27,7 @@ export interface BusinessSystemClient {
   listFacilities(input?: SourceListInput): Promise<SourcePage<FacilityRow>>
   listContracts(input?: SourceListInput): Promise<SourcePage<ContractRow>>
   listQuotes(input?: SourceListInput): Promise<SourcePage<QuoteRow>>
+  quoteChangesSince(cursor?: string): Promise<readonly QuoteChangeEvent[]>
   createQuote(input: CreateQuoteInput, idempotencyKey: string): Promise<QuoteRow>
   recordQuoteDecision(
     quoteId: string,
@@ -33,8 +36,16 @@ export interface BusinessSystemClient {
   ): Promise<QuoteRow>
 }
 
+export type QuoteChangeEvent = QuoteChange & { readonly cursor: string }
+
+function appendQuoteUpsert(state: BusinessState, quote: QuoteRow): void {
+  state.quoteChanges ??= []
+  state.quoteChanges.push({ kind: "upsert", row: structuredClone(quote) })
+}
+
 export async function createBusinessSystemClient(): Promise<BusinessSystemClient> {
   await initializeDemoSources()
+  await ensureBusinessChangeHistory()
 
   return {
     async listCustomers(input) {
@@ -48,6 +59,9 @@ export async function createBusinessSystemClient(): Promise<BusinessSystemClient
     },
     async listQuotes(input) {
       return pageRows((await businessStore.read()).quotes, input)
+    },
+    async quoteChangesSince(cursor) {
+      return orderedChangesSince((await businessStore.read()).quoteChanges ?? [], cursor)
     },
     async createQuote(input, idempotencyKey) {
       return businessStore.update((state) =>
@@ -78,6 +92,7 @@ export async function createBusinessSystemClient(): Promise<BusinessSystemClient
               updated_at: now,
             }
             state.quotes.push(quote)
+            appendQuoteUpsert(state, quote)
             return quote
           },
           (quote) => quote.quote_id
@@ -98,6 +113,7 @@ export async function createBusinessSystemClient(): Promise<BusinessSystemClient
             quote.status = decision
             quote.decision_at = new Date().toISOString()
             quote.updated_at = quote.decision_at
+            appendQuoteUpsert(state, quote)
             return quote
           },
           (quote) => quote.quote_id

--- a/examples/northline/lib/sources/client-utils.ts
+++ b/examples/northline/lib/sources/client-utils.ts
@@ -18,6 +18,23 @@ export function pageRows<T>(rows: readonly T[], input: SourceListInput = {}): So
   }
 }
 
+export function orderedChangesSince<T extends object>(
+  changes: readonly T[],
+  cursor?: string
+): Array<T & { readonly cursor: string }> {
+  const offset = parseCursor(cursor)
+  if (offset > changes.length) {
+    throw new Error(
+      `[NorthlineSource] Source cursor '${cursor}' is beyond the retained change history.`
+    )
+  }
+
+  return changes.slice(offset).map((change, index) => ({
+    ...structuredClone(change),
+    cursor: String(offset + index + 1),
+  }))
+}
+
 export function runIdempotently<T>(
   receipts: Record<string, Receipt>,
   key: string,

--- a/examples/northline/lib/sources/contracts.ts
+++ b/examples/northline/lib/sources/contracts.ts
@@ -80,6 +80,11 @@ export const quoteRowSchema = z.object({
   updated_at: timestamp,
 })
 
+export const quoteChangeSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("upsert"), row: quoteRowSchema }),
+  z.object({ kind: z.literal("delete"), key: z.object({ quote_id: z.string() }) }),
+])
+
 export const technicianRowSchema = z.object({
   technician_id: z.string(),
   full_name: z.string(),
@@ -203,6 +208,7 @@ export const businessStateSchema = z.object({
   facilities: z.array(facilityRowSchema),
   contracts: z.array(contractRowSchema),
   quotes: z.array(quoteRowSchema),
+  quoteChanges: z.array(quoteChangeSchema).optional(),
   idempotency: z.record(idempotencyReceipt),
 })
 
@@ -227,6 +233,7 @@ export type CustomerRow = z.infer<typeof customerRowSchema>
 export type FacilityRow = z.infer<typeof facilityRowSchema>
 export type ContractRow = z.infer<typeof contractRowSchema>
 export type QuoteRow = z.infer<typeof quoteRowSchema>
+export type QuoteChange = z.infer<typeof quoteChangeSchema>
 export type TechnicianRow = z.infer<typeof technicianRowSchema>
 export type WorkOrderRow = z.infer<typeof workOrderRowSchema>
 export type VisitRow = z.infer<typeof visitRowSchema>

--- a/examples/northline/lib/sources/source-state.ts
+++ b/examples/northline/lib/sources/source-state.ts
@@ -17,6 +17,7 @@ export const fieldServiceStore = new AtomicJsonStore(
   fieldServiceStateSchema
 )
 export const controlsStore = new AtomicJsonStore(sourcePaths.controls, controlsStateSchema)
+let businessChangeHistoryReady = false
 
 export async function initializeDemoSources(anchor = new Date()): Promise<boolean> {
   const existing = await Promise.all(Object.values(sourcePaths).map(fileExists))
@@ -37,7 +38,27 @@ export async function initializeDemoSources(anchor = new Date()): Promise<boolea
   return true
 }
 
+export async function ensureBusinessChangeHistory(): Promise<void> {
+  if (businessChangeHistoryReady) return
+
+  const current = await businessStore.read()
+  if ((current.quoteChanges?.length ?? 0) > 0 || current.quotes.length === 0) {
+    businessChangeHistoryReady = true
+    return
+  }
+
+  await businessStore.update((state) => {
+    if ((state.quoteChanges?.length ?? 0) > 0) return
+    state.quoteChanges = []
+    state.quoteChanges.push(
+      ...state.quotes.map((row) => ({ kind: "upsert" as const, row: structuredClone(row) }))
+    )
+  })
+  businessChangeHistoryReady = true
+}
+
 export async function resetDemoSources(anchor = new Date()): Promise<void> {
+  businessChangeHistoryReady = false
   await rm(sourceDirectory(), { recursive: true, force: true })
   await initializeDemoSources(anchor)
 }

--- a/examples/northline/syncs/business-system.ts
+++ b/examples/northline/syncs/business-system.ts
@@ -1,4 +1,4 @@
-import { defineSync } from "@sixb/core"
+import { change, defineSync } from "@sixb/core"
 import { businessSystemConnector } from "../connectors/business-system"
 import {
   businessContracts,
@@ -26,8 +26,14 @@ export const syncBusinessContracts = defineSync("sync-business-contracts")
   .read(async (client) => (await client.listContracts()).rows)
   .intoDataset(businessContracts)
 
-export const syncBusinessQuotes = defineSync("sync-business-quotes")
+export const syncBusinessQuotes = defineSync("sync-business-quotes", { mode: "merge" })
   .when(hourlyBusinessSync)
+  .checkpoint<{ cursor: string }>()
   .from(businessSystemConnector)
-  .read(async (client) => (await client.listQuotes()).rows)
+  .read(async function* (client, context) {
+    for (const event of await client.quoteChangesSince(context.checkpoint?.cursor)) {
+      yield event.kind === "delete" ? change.delete(event.key) : change.upsert(event.row)
+      context.setCheckpoint({ cursor: event.cursor })
+    }
+  })
   .intoDataset(businessQuotes)

--- a/examples/northline/tests/scenario.test.ts
+++ b/examples/northline/tests/scenario.test.ts
@@ -17,6 +17,10 @@ describe("Northline scenario", () => {
     expect(() => fieldServiceStateSchema.parse(scenario.fieldService)).not.toThrow()
     expect(() => controlsStateSchema.parse(scenario.controls)).not.toThrow()
     expect(scenario.business.customers).toHaveLength(5)
+    expect(scenario.business.quoteChanges).toHaveLength(scenario.business.quotes.length)
+    expect(scenario.business.quoteChanges).toEqual(
+      scenario.business.quotes.map((row) => ({ kind: "upsert", row }))
+    )
     expect(scenario.controls.equipment).toHaveLength(10)
     expect(scenario.fieldService.technicians).toHaveLength(7)
     expect(scenario.controls.readings).toHaveLength(40)

--- a/examples/northline/tests/sources.test.ts
+++ b/examples/northline/tests/sources.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { z } from "zod"
+import { orderedChangesSince } from "../lib/sources/client-utils"
 import { AtomicJsonStore } from "../lib/sources/file-store"
 
 const roots = new Set<string>()
@@ -41,5 +42,30 @@ describe("AtomicJsonStore", () => {
     const store = new AtomicJsonStore<Document>(path, documentSchema)
 
     await expect(store.read()).rejects.toThrow("[NorthlineSource] Cannot read")
+  })
+})
+
+describe("orderedChangesSince", () => {
+  const changes = [
+    { kind: "upsert" as const, row: { id: "quote-1", status: "sent" } },
+    { kind: "delete" as const, key: { id: "quote-2" } },
+  ]
+
+  test("returns ordered changes after the checkpoint with the next cursors", () => {
+    expect(orderedChangesSince(changes, "1")).toEqual([
+      { kind: "delete", key: { id: "quote-2" }, cursor: "2" },
+    ])
+    expect(orderedChangesSince(changes, "2")).toEqual([])
+  })
+
+  test("defensively clones changes and reports a source-log gap", () => {
+    const [first] = orderedChangesSince(changes)
+    expect(first?.cursor).toBe("1")
+    if (first?.kind === "upsert") first.row.status = "changed"
+    const original = changes[0]
+    if (original?.kind !== "upsert") throw new Error("Expected the first change to be an upsert")
+    expect(original.row.status).toBe("sent")
+
+    expect(() => orderedChangesSince(changes, "3")).toThrow("beyond the retained change history")
   })
 })

--- a/packages/atlas/src/features/datasets/DatasetDetails.tsx
+++ b/packages/atlas/src/features/datasets/DatasetDetails.tsx
@@ -27,6 +27,8 @@ export function DatasetDetails({
   onNavigate,
 }: DatasetDetailsProps) {
   const hasReferences = sourceCount(dataset) + consumerCount(dataset) > 0
+  const primaryKey =
+    typeof dataset.primaryKey === "string" ? [dataset.primaryKey] : (dataset.primaryKey ?? [])
   const producer = versionSummary.producer
     ? `${versionSummary.producer.kind}${
         versionSummary.producer.id ? ` · ${versionSummary.producer.id}` : ""
@@ -76,6 +78,18 @@ export function DatasetDetails({
         <Field label="Partitioned by">
           <div className="flex flex-wrap gap-1.5">
             {dataset.partitionBy.map((column) => (
+              <Badge key={column} variant="outline" className="font-mono text-[11px] font-normal">
+                {column}
+              </Badge>
+            ))}
+          </div>
+        </Field>
+      ) : null}
+
+      {primaryKey.length > 0 ? (
+        <Field label="Primary key">
+          <div className="flex flex-wrap gap-1.5">
+            {primaryKey.map((column) => (
               <Badge key={column} variant="outline" className="font-mono text-[11px] font-normal">
                 {column}
               </Badge>

--- a/packages/atlas/src/pages/DatasetsPage.tsx
+++ b/packages/atlas/src/pages/DatasetsPage.tsx
@@ -84,6 +84,7 @@ function datasetSearchText(dataset: DatasetListItem): string {
     dataset.materialized ? "materialized" : "declared",
     dataset.latestVersion?.mode,
     ...dataset.schema.columns.map((column) => column.name),
+    ...(typeof dataset.primaryKey === "string" ? [dataset.primaryKey] : (dataset.primaryKey ?? [])),
     ...(dataset.partitionBy ?? []),
     ...dataset.syncIds,
     ...dataset.sourcePipelineIds,

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -4941,6 +4941,20 @@
                       "description": {
                         "type": "string"
                       },
+                      "primaryKey": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "minItems": 2
+                          }
+                        ]
+                      },
                       "partitionBy": {
                         "type": "array",
                         "items": {
@@ -5106,6 +5120,20 @@
                     },
                     "description": {
                       "type": "string"
+                    },
+                    "primaryKey": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 2
+                        }
+                      ]
                     },
                     "partitionBy": {
                       "type": "array",
@@ -5903,6 +5931,20 @@
                               "description": {
                                 "type": "string"
                               },
+                              "primaryKey": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "minItems": 2
+                                  }
+                                ]
+                              },
                               "partitionBy": {
                                 "type": "array",
                                 "items": {
@@ -6118,6 +6160,20 @@
                             },
                             "description": {
                               "type": "string"
+                            },
+                            "primaryKey": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "minItems": 2
+                                }
+                              ]
                             },
                             "partitionBy": {
                               "type": "array",
@@ -6758,6 +6814,20 @@
                                               "description": {
                                                 "type": "string"
                                               },
+                                              "primaryKey": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "minItems": 2
+                                                  }
+                                                ]
+                                              },
                                               "partitionBy": {
                                                 "type": "array",
                                                 "items": {
@@ -6818,6 +6888,20 @@
                                         },
                                         "description": {
                                           "type": "string"
+                                        },
+                                        "primaryKey": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "minItems": 2
+                                            }
+                                          ]
                                         },
                                         "partitionBy": {
                                           "type": "array",
@@ -7060,6 +7144,20 @@
                                             "description": {
                                               "type": "string"
                                             },
+                                            "primaryKey": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "minItems": 2
+                                                }
+                                              ]
+                                            },
                                             "partitionBy": {
                                               "type": "array",
                                               "items": {
@@ -7120,6 +7218,20 @@
                                       },
                                       "description": {
                                         "type": "string"
+                                      },
+                                      "primaryKey": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "minItems": 2
+                                          }
+                                        ]
                                       },
                                       "partitionBy": {
                                         "type": "array",

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1739,6 +1739,7 @@ export type ListDatasetsResponses = {
   200: Array<{
     id: string
     description?: string
+    primaryKey?: string | Array<string>
     partitionBy?: Array<string>
     schema: {
       columns: Array<{
@@ -1807,6 +1808,7 @@ export type GetDatasetResponses = {
   200: {
     id: string
     description?: string
+    primaryKey?: string | Array<string>
     partitionBy?: Array<string>
     schema: {
       columns: Array<{
@@ -2094,6 +2096,7 @@ export type ListSyncsResponses = {
       dataset: {
         id: string
         description?: string
+        primaryKey?: string | Array<string>
         partitionBy?: Array<string>
         schema: {
           columns: Array<{
@@ -2179,6 +2182,7 @@ export type GetSyncResponses = {
       dataset: {
         id: string
         description?: string
+        primaryKey?: string | Array<string>
         partitionBy?: Array<string>
         schema: {
           columns: Array<{
@@ -2380,6 +2384,7 @@ export type ListPipelinesResponses = {
             dataset: {
               id: string
               description?: string
+              primaryKey?: string | Array<string>
               partitionBy?: Array<string>
               schema: {
                 columns: Array<{
@@ -2402,6 +2407,7 @@ export type ListPipelinesResponses = {
           output: {
             id: string
             description?: string
+            primaryKey?: string | Array<string>
             partitionBy?: Array<string>
             schema: {
               columns: Array<{
@@ -2494,6 +2500,7 @@ export type GetPipelineResponses = {
             dataset: {
               id: string
               description?: string
+              primaryKey?: string | Array<string>
               partitionBy?: Array<string>
               schema: {
                 columns: Array<{
@@ -2516,6 +2523,7 @@ export type GetPipelineResponses = {
           output: {
             id: string
             description?: string
+            primaryKey?: string | Array<string>
             partitionBy?: Array<string>
             schema: {
               columns: Array<{

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -281,12 +281,14 @@ const syncOrderEvents = defineSync("sync-order-events", { mode: "append" })
   .intoDataset(rawOrderEventsDataset)
 
 const syncInvoices = defineSync("sync-invoices", { mode: "merge" })
+  .checkpoint<{ cursor: string }>()
   .from(erpDb)
-  .read(async function* (client) {
-    for await (const event of client.invoiceChanges()) {
+  .read(async function* (client, context) {
+    for await (const event of client.invoiceChangesSince(context.checkpoint?.cursor)) {
       yield event.deleted
         ? change.delete({ invoiceId: event.invoiceId })
         : change.upsert(event.invoice)
+      context.setCheckpoint({ cursor: event.cursor })
     }
   })
   .intoDataset(rawInvoicesDataset)

--- a/packages/server/src/schemas/datasets.ts
+++ b/packages/server/src/schemas/datasets.ts
@@ -42,6 +42,7 @@ export const DatasetSchema = z.object({
 export const DatasetDefinitionSchema = z.object({
   id: z.string(),
   description: z.string().optional(),
+  primaryKey: z.union([z.string(), z.array(z.string()).min(2)]).optional(),
   partitionBy: z.array(z.string()).optional(),
   schema: DatasetSchema,
 })

--- a/packages/server/src/schemas/pipelines.ts
+++ b/packages/server/src/schemas/pipelines.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { DatasetDefinitionSchema } from "./datasets"
 
 export const PipelineParamsSchema = z.object({
   pipelineId: z.string().min(1),
@@ -23,31 +24,6 @@ export const PipelineRunsQuerySchema = z.object({
 const DatasetVersionRefSchema = z.object({
   datasetId: z.string(),
   versionId: z.string(),
-})
-
-const DatasetColumnSchema = z.object({
-  name: z.string(),
-  type: z.enum([
-    "string",
-    "boolean",
-    "int64",
-    "float64",
-    "decimal",
-    "date",
-    "timestamp",
-    "json",
-    "fileRef",
-  ]),
-  nullable: z.boolean().optional(),
-})
-
-const DatasetDefinitionSchema = z.object({
-  id: z.string(),
-  description: z.string().optional(),
-  partitionBy: z.array(z.string()).optional(),
-  schema: z.object({
-    columns: z.array(DatasetColumnSchema),
-  }),
 })
 
 const PipelineTriggerSchema = z.object({

--- a/packages/server/tests/datasets-routes.test.ts
+++ b/packages/server/tests/datasets-routes.test.ts
@@ -59,9 +59,15 @@ function createSixbStub(
   } as unknown as Sixb<readonly OntologySource[]>
 }
 
-const definitions: DatasetDefinition[] = Array.from({ length: 5 }, (_, index) =>
-  defineDataset(`raw.catalog.dataset_${index}`, { schema: [col("id", "string")] })
-)
+const definitions: DatasetDefinition[] = [
+  defineDataset("raw.catalog.dataset_0", {
+    schema: [col("source", "string"), col("id", "string")],
+    primaryKey: ["source", "id"],
+  }),
+  ...Array.from({ length: 4 }, (_, index) =>
+    defineDataset(`raw.catalog.dataset_${index + 1}`, { schema: [col("id", "string")] })
+  ),
+]
 
 const states: DatasetCatalogState[] = definitions.map((definition, index) => ({
   datasetId: definition.id,
@@ -85,11 +91,13 @@ describe("dataset catalog routes", () => {
 
     const body = (await response.json()) as Array<{
       id: string
+      primaryKey?: string | string[]
       materialized: boolean
       latestVersion: { versionId: string; mode: string; rowCount?: number } | null
     }>
 
     expect(body).toHaveLength(5)
+    expect(body[0]?.primaryKey).toEqual(["source", "id"])
     for (const item of body) {
       expect(item.materialized).toBe(true)
       expect(item.latestVersion?.mode).toBe("snapshot")
@@ -110,10 +118,12 @@ describe("dataset catalog routes", () => {
     expect(response.status).toBe(200)
 
     const item = (await response.json()) as {
+      primaryKey?: string | string[]
       materialized: boolean
       latestVersion: { mode: string } | null
     }
     expect(item.materialized).toBe(true)
+    expect(item.primaryKey).toEqual(["source", "id"])
     expect(item.latestVersion?.mode).toBe("snapshot")
 
     expect(calls()).toBe(1)

--- a/packages/server/tests/syncs-routes.test.ts
+++ b/packages/server/tests/syncs-routes.test.ts
@@ -89,6 +89,7 @@ describe("sync routes", () => {
 
     const body = (await response.json()) as Array<{
       id: string
+      target: { dataset: { primaryKey?: string | string[] } }
       latestRun: { id: string; syncId: string; status: string } | null
     }>
 
@@ -100,5 +101,8 @@ describe("sync routes", () => {
       ["sync-customers", null],
       ["sync-invoices", "run-invoices"],
     ])
+    expect(body.find((sync) => sync.id === "sync-invoices")?.target.dataset.primaryKey).toBe(
+      "invoiceId"
+    )
   })
 })

--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -180,8 +180,8 @@ change. An initial no-op returns `{ outcome: "unchanged", version: null }`; a la
 existing latest version.
 
 Snapshot, append, and SQL-transform writes to keyed datasets also enforce unique keys so a later
-merge never starts from an ambiguous baseline. Sync-level `mode: "merge"` activation will arrive
-with the follow-up sync-worker integration rather than this provider contract.
+merge never starts from an ambiguous baseline. Application authors normally use
+`defineSync(..., { mode: "merge" })`; the sync worker stages those changes through this contract.
 
 ## DuckLake SQL Transforms
 

--- a/storage/lake-local/README.md
+++ b/storage/lake-local/README.md
@@ -101,7 +101,8 @@ first. The final change for a repeated key wins. Deletes of absent keys, identic
 other changes that leave the visible rows unchanged do not create a version. An initial no-op
 returns `{ outcome: "unchanged", version: null }`.
 
-These are provider-level APIs. User-facing sync `mode: "merge"` is delivered separately.
+Application authors normally use `defineSync(..., { mode: "merge" })`; the sync worker executes the
+same provider contract and advances its source checkpoint only after commit succeeds.
 
 ## What Gets Stored On Disk
 


### PR DESCRIPTION
## Summary

Finishes the public experience for keyed merge syncs introduced in #333.

Dataset primary keys now reach the HTTP and generated-client surfaces, Atlas displays them in dataset details, and Northline includes a runnable merge-sync example backed by an ordered source change log. The user guides now explain source requirements, replay, no-op behavior, and recovery from a retained-log gap.

## What changed

- Round-trips single and composite `primaryKey` metadata through dataset, sync, and pipeline API responses.
- Reuses the shared dataset-definition schema across server surfaces and regenerates the typed client.
- Shows ordered primary-key columns in Atlas dataset details and includes them in dataset search.
- Converts Northline's `business.quotes` dataset to a checkpointed merge sync.
- Adds an immutable, ordered quote change log with cursor replay, defensive copies, and explicit gap detection.
- Documents the Northline walkthrough and removes stale notes that described merge-sync activation as future work.

```ts
export const syncBusinessQuotes = defineSync("sync-business-quotes", { mode: "merge" })
  .checkpoint<{ cursor: string }>()
  .from(businessSystemConnector)
  .read(async function* (client, context) {
    for (const event of await client.quoteChangesSince(context.checkpoint?.cursor)) {
      yield event.kind === "delete" ? change.delete(event.key) : change.upsert(event.row)
      context.setCheckpoint({ cursor: event.cursor })
    }
  })
  .intoDataset(businessQuotes)
```

```text
Ordered quote log -> checkpointed merge -> complete business.quotes dataset -> Quote projection
```

## Scope

This PR presents and demonstrates the merge contract already implemented in the preceding stack. It does not add merge pipeline outputs, multiple writers, partial patches, out-of-order reconciliation, telemetry corrections, changed-row lake history, or incremental projections.

## Verification

```text
bun run generate:client
bun run check
bun run typecheck
bun run build
bun run test:publish
bun run test:ci
git diff --check
```

Focused dataset API, sync API, Atlas type, Northline source-feed, scenario, and clean-runtime health checks also pass.

Stacked on #333.
