### PR TITLE
ace-iot: add ACE IoT Deploy API connector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,12 +91,15 @@
       "name": "@sixb/connector-ace-iot",
       "version": "0.1.0",
       "dependencies": {
-        "@sixb/connector-rest": "workspace:*",
-        "@sixb/core": "workspace:*",
+        "@sixb/connector-rest": "workspace:^",
       },
       "devDependencies": {
+        "@sixb/core": "workspace:*",
         "@types/bun": "latest",
         "typescript": "^5.7.0",
+      },
+      "peerDependencies": {
+        "@sixb/core": "workspace:^",
       },
     },
     "connectors/companycam": {

--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,18 @@
         "@sixb/core": "workspace:^",
       },
     },
+    "connectors/ace-iot": {
+      "name": "@sixb/connector-ace-iot",
+      "version": "0.1.0",
+      "dependencies": {
+        "@sixb/connector-rest": "workspace:*",
+        "@sixb/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "connectors/companycam": {
       "name": "@sixb/connector-companycam",
       "version": "0.1.1",
@@ -1343,6 +1355,8 @@
     "@sixb/cli": ["@sixb/cli@workspace:packages/cli"],
 
     "@sixb/client": ["@sixb/client@workspace:packages/client"],
+
+    "@sixb/connector-ace-iot": ["@sixb/connector-ace-iot@workspace:connectors/ace-iot"],
 
     "@sixb/connector-companycam": ["@sixb/connector-companycam@workspace:connectors/companycam"],
 

--- a/connectors/ace-iot/LICENSE
+++ b/connectors/ace-iot/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sixb contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/connectors/ace-iot/README.md
+++ b/connectors/ace-iot/README.md
@@ -1,0 +1,262 @@
+# @sixb/connector-ace-iot
+
+Typed [ACE IoT](https://aceiot.cloud) Deploy API connector for Sixb. It covers the whole published
+surface — clients, sites, points, gateways, timeseries, and weather — one method per endpoint, with
+wire-shape types taken from ACE's own schema and corrected against the live API.
+
+## Register
+
+Create an API key in ACE, then define the connector in your project's `connectors/` directory:
+
+```ts
+import { aceIot } from "@sixb/connector-ace-iot"
+import { defineConnector } from "@sixb/core"
+
+export const aceIotConnector = defineConnector(
+  "ace-iot",
+  aceIot({
+    apiKey: process.env.ACE_IOT_API_KEY!,
+  })
+)
+```
+
+`createSixb()` discovers the definition automatically. Resolve the typed client with:
+
+```ts
+const ace = await sixb.connector(aceIotConnector)
+```
+
+The key can also be an async resolver, called before every attempt, which supports rotation without
+recreating the connector.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `apiKey` | Required API key or async resolver. Sent as `Authorization: Bearer`. |
+| `baseUrl` | Defaults to `https://flightdeck.aceiot.cloud/api/`. |
+| `timeoutMs` | Optional per-attempt timeout. |
+| `minDelayMs` | Delay between request starts. Defaults to 0 — ACE publishes no rate limit. |
+| `retry` | Method-aware transient-failure policy. Defaults to two retries for reads. |
+
+Default retries cover network errors, `429`, and `5xx` responses on reads, and honor `Retry-After`.
+Writes are never replayed: `POST /points/` and `PUT /points/{name}` merge tag state, and
+`POST /gateways/{name}/token` mints a credential, so a replay would issue a second one. The one
+exception is `points.getTimeseriesForPoints`, a read that ACE exposes as a POST; it is marked
+idempotent and retried like any other read.
+
+## Timeseries
+
+The reason to reach for this connector rather than calling the endpoint directly.
+
+```ts
+for await (const sample of ace.sites.iterateTimeseries("my_site", {
+  startTime: new Date(Date.now() - 15 * 60_000),
+  endTime: new Date(),
+  pageSize: 1000,
+})) {
+  // sample.value is a string; sample.time is naive UTC.
+}
+```
+
+`iterateTimeseries` walks the window to the end and hands back every reading exactly once.
+`iterateTimeseriesPages` yields whole pages instead, and `getTimeseriesPage` returns a single page
+exactly as ACE sends it, for callers persisting cursors themselves.
+
+### ACE's cursor does not always advance
+
+`GET /sites/{site_name}/timeseries/paginated` returns a base64 cursor that decodes to
+`{"offset": N, "timestamp": "..."}`. ACE sets `offset` to the number of rows it drew from the page's
+final timestamp bucket, without adding the offset the request carried in. When a page begins and
+ends inside one bucket, the cursor it returns is the cursor it was given, and a plain
+`while (has_more)` loop re-requests the same page forever.
+
+Measured against a live site over a 15-minute window holding 3,222 readings:
+
+| `page_size` | Following ACE's cursor | `iterateTimeseries` |
+| --- | --- | --- |
+| 50 | stalls after 2 pages — 100 rows | 65 pages, 3,222 rows, no duplicates |
+| 100 | stalls after 2 pages — 200 rows | 33 pages, 3,222 rows, no duplicates |
+| 500 | stalls after 2 pages — 1,000 rows | 7 pages, 3,222 rows, no duplicates |
+| 1000 | 4 pages, 3,222 rows | 4 pages, identical result |
+
+The connector recomputes the cursor from the page it just read, which the server honors correctly.
+Large page sizes appear to work only because every page happens to cross a bucket boundary — the
+failure is silent, so lowering `page_size` loses data rather than raising an error. Where ACE's
+cursor is already right, the recomputed one is identical.
+
+A walk that returns the same page twice raises rather than looping, so an upstream change can never
+turn into an unbounded read.
+
+### Timestamps are naive but mean UTC
+
+Every ACE timestamp arrives without a zone designator — `2026-08-07T16:25:00` — so `new Date(value)`
+reads it as **local time** and shifts it silently on any host that is not on UTC. Use the exported
+parser:
+
+```ts
+import { parseAceIotTimestamp } from "@sixb/connector-ace-iot"
+
+parseAceIotTimestamp("2026-08-07T16:25:00") // 2026-08-07T16:25:00.000Z
+```
+
+It also handles the two other shapes ACE emits: microsecond precision (`…:00.627593`, truncated to
+milliseconds) and the space-separated form used by a gateway's `device_token_expires`
+(`2027-03-04 19:34:54.114795`). `normalizeAceIotTimestamp` applies the same rule and stays a string.
+
+Query bounds accept a `Date` or a string, and a naive timestamp read off a response can be passed
+straight back as a bound without shifting.
+
+### Values stay strings
+
+`point_samples[].value` is a string on the wire, including numerics like `"1.6100000143051147"`. The
+connector leaves it alone rather than introducing rounding the API never had.
+
+## Pagination
+
+List endpoints use ACE's `page`/`per_page` envelope, returned verbatim as
+`{items, page, pages, per_page, total}`. Every `list*` has a `listAll*` companion that walks it:
+
+```ts
+for await (const point of ace.sites.listAllConfiguredPoints("my_site")) {
+  // …
+}
+```
+
+`listAll*` defaults to `perPage: 1000` because ACE's own default is 10. Pass `maxPages` to bound the
+walk. `pages` comes back `null` on the gateway PCAP listing, so the walk also stops on an empty
+page, a short page, and on reaching `total`.
+
+`per_page` is a **closed enum**, not a range — `2, 10, 20, 30, 40, 50, 100, 500, 1000, 5000, 10000,
+100000`. The timeseries endpoint takes a different one for `page_size`: `3, 10, 50, 100, 500, 1000,
+5000, 10000, 50000, 100000, 300000, 500000` (it allows 3, but not 2). Both are exported as
+`ACE_IOT_PER_PAGE_VALUES` and `ACE_IOT_PAGE_SIZE_VALUES`, and both are checked locally so an
+unsupported size is a clear error instead of a 400 that names the value but not the allowed set.
+
+## Clients API
+
+| Client method | ACE endpoint |
+| --- | --- |
+| `ace.clients.list / listAll(options?)` | `GET /clients/` |
+| `ace.clients.get(name)` | `GET /clients/{client_name}` |
+| `ace.clients.create(input)` | `POST /clients/` |
+| `ace.clients.listSites / listAllSites(name, options?)` | `GET /clients/{client_name}/sites` |
+| `ace.clients.listDerEvents / listAllDerEvents(name, options?)` | `GET /clients/{client_name}/der_events` |
+| `ace.clients.createDerEvents(name, events)` | `POST /clients/{client_name}/der_events` |
+| `ace.clients.updateDerEvents(name, events)` | `PUT /clients/{client_name}/der_events` |
+| `ace.clients.listVolttronAgentPackages / listAll…(name, options?)` | `GET /clients/{client_name}/volttron_agent_package/list` |
+| `ace.clients.downloadVolttronAgentPackage(name, packageId)` | `GET /clients/{client_name}/volttron_agent_package` |
+| `ace.clients.uploadVolttronAgentPackage(name, input)` | `POST /clients/{client_name}/volttron_agent_package` |
+
+The record type is `AceIotClientAccount`, because `AceIotClient` is the connected SDK client.
+
+## Sites API
+
+| Client method | ACE endpoint |
+| --- | --- |
+| `ace.sites.list / listAll(options?)` | `GET /sites/` |
+| `ace.sites.get(name)` | `GET /sites/{site_name}` |
+| `ace.sites.create(input)` | `POST /sites/` |
+| `ace.sites.listPoints / listAllPoints(name, options?)` | `GET /sites/{site_name}/points` |
+| `ace.sites.listConfiguredPoints / listAllConfiguredPoints(name, options?)` | `GET /sites/{site_name}/configured_points` |
+| `ace.sites.getTimeseries(name, range)` | `GET /sites/{site_name}/timeseries` |
+| `ace.sites.appendTimeseries(name, samples)` | `POST /sites/{site_name}/timeseries` |
+| `ace.sites.getTimeseriesPage(name, options)` | `GET /sites/{site_name}/timeseries/paginated` |
+| `ace.sites.iterateTimeseries / iterateTimeseriesPages(name, options)` | Repaired cursor walk |
+| `ace.sites.getWeather(name)` | `GET /sites/{site_name}/weather` |
+
+`list` takes `collectEnabled` and `showArchived`; both default to false upstream and are omitted
+unless set. `getWeather` returns `null` for a site with no weather feed, which ACE reports as a 404
+carrying an all-null body.
+
+`geo_location` is a PostGIS point as a WKB hex string, not a coordinate pair — `latitude` and
+`longitude` are the readable fields.
+
+## Points API
+
+| Client method | ACE endpoint |
+| --- | --- |
+| `ace.points.list / listAll(options?)` | `GET /points/` |
+| `ace.points.get(name)` | `GET /points/{point_name}` |
+| `ace.points.create(points, options?)` | `POST /points/` |
+| `ace.points.update(name, input, options?)` | `PUT /points/{point_name}` |
+| `ace.points.getTimeseries(name, range)` | `GET /points/{point_name}/timeseries` |
+| `ace.points.getTimeseriesForPoints(names, range)` | `POST /points/get_timeseries` |
+
+Point names are slash-separated paths (`client/site/10.0.0.1-100/analogInput/1`); the connector
+percent-encodes them, which is required or the request routes elsewhere.
+
+Writes merge tags into what a point already has. Pass `overwriteMarkerTags` or `overwriteKvTags` to
+replace them instead.
+
+`bacnet_data` is typed with the 33 properties the live API returns — ACE's schema documents eleven
+and types the object as free-form — plus an index signature for vendor properties outside that set.
+A property the device did not answer for comes back as the literal string
+`"property: unknown-property"`, not `null`.
+
+## Gateways API
+
+| Client method | ACE endpoint |
+| --- | --- |
+| `ace.gateways.list / listAll(options?)` | `GET /gateways/` |
+| `ace.gateways.get(name)` | `GET /gateways/{gateway_name}` |
+| `ace.gateways.create(input)` | `POST /gateways/` |
+| `ace.gateways.update(name, input)` | `PATCH /gateways/{gateway_name}` |
+| `ace.gateways.createToken(name)` | `POST /gateways/{gateway_name}/token` |
+| `ace.gateways.listAgentConfigs / listAll…(name, options?)` | `GET /gateways/{gateway_name}/agent_configs` |
+| `ace.gateways.createAgentConfigs(name, configs, options?)` | `POST /gateways/{gateway_name}/agent_configs` |
+| `ace.gateways.listVolttronAgents / listAll…(name, options?)` | `GET /gateways/{gateway_name}/volttron_agents` |
+| `ace.gateways.createVolttronAgents(name, agents)` | `POST /gateways/{gateway_name}/volttron_agents` |
+| `ace.gateways.getVolttronAgentConfigPackage(name, identity, options?)` | `GET /gateways/{gateway_name}/volttron_agent_config_package` |
+| `ace.gateways.createVolttronAgentConfigPackage(name, input, options?)` | `POST /gateways/{gateway_name}/volttron_agent_config_package` |
+| `ace.gateways.listHawkeConfigurations / listAll…(name, options?)` | `GET /gateways/{gateway_name}/hawke_configuration` |
+| `ace.gateways.createHawkeConfigurations(name, configs, options?)` | `POST /gateways/{gateway_name}/hawke_configuration` |
+| `ace.gateways.getHawkeAgentConfiguration(name, agentId, options?)` | `GET …/hawke_configuration/{hawke_agent_id}` |
+| `ace.gateways.setHawkeAgentConfiguration(name, agentId, config, options?)` | `POST …/hawke_configuration/{hawke_agent_id}` |
+| `ace.gateways.listHawkeAgentConfigurations / listAll…(name, agentId, options?)` | `GET …/hawke_configuration/{hawke_agent_id}/list` |
+| `ace.gateways.listDerEvents / listAllDerEvents(name, options?)` | `GET /gateways/{gateway_name}/der_events` |
+| `ace.gateways.listPcapFiles / listAllPcapFiles(name, options)` | `GET /gateways/{gateway_name}/pcap/list` |
+| `ace.gateways.downloadPcap(name, fileName)` | `GET /gateways/{gateway_name}/pcap` |
+| `ace.gateways.uploadPcap(name, file, filename?)` | `POST /gateways/{gateway_name}/pcap` |
+
+`interfaces` and `deploy_config` are free-form JSON blobs ACE does not describe, so they stay
+`Record<string, unknown>`. Downloads return the raw `Response` with its body unread, so the caller
+decides whether to buffer or stream.
+
+## Errors
+
+Non-successful responses throw `AceIotApiError` with the status, parsed body, headers, and
+`retryAfterMs`. Flask-RESTX field validation is surfaced per parameter through `validationErrors`.
+
+```ts
+import { AceIotApiError } from "@sixb/connector-ace-iot"
+
+try {
+  await ace.sites.get("unknown_site")
+} catch (error) {
+  if (error instanceof AceIotApiError) {
+    console.error(error.status, error.validationErrors, error.responseBody)
+  }
+}
+```
+
+`AceIotConfigurationError` covers problems with the connector's own setup — an empty API key, an
+empty base URL. It is never retried, because it fails the same way on every attempt.
+
+Two response behaviors worth knowing, both verified against the live API and neither in ACE's
+schema:
+
+- **An invalid API key returns `500`**, carrying Flask's generic
+  `"An unhandled exception occurred."`, not a `401`. The connector appends a note saying so, because
+  that message is otherwise impossible to act on. A *missing* key does return `401`.
+- **An unknown site returns `403`** with a fully-null site body, while an unknown point — or an
+  unknown site's points — returns `404`.
+
+## Not covered
+
+ACE publishes no webhooks, no delete endpoints, and no incremental change log, so the connector
+exposes none. Every path in ACE's Swagger document is implemented.
+
+## Official documentation
+
+- [Swagger schema](https://flightdeck.aceiot.cloud/api/swagger.json) — the API's own OpenAPI 2.0 document

--- a/connectors/ace-iot/package.json
+++ b/connectors/ace-iot/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@sixb/connector-ace-iot",
+  "version": "0.1.0",
+  "description": "ACE IoT Deploy API connector for Sixb",
+  "keywords": [
+    "sixb",
+    "bun",
+    "connector",
+    "integration",
+    "ace-iot",
+    "bacnet",
+    "timeseries"
+  ],
+  "homepage": "https://sixb.ai",
+  "bugs": {
+    "url": "https://github.com/sixb-ai/sixb/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sixb-ai/sixb.git",
+    "directory": "connectors/ace-iot"
+  },
+  "author": "Sixb contributors",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun ../../scripts/build-package.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "prepack": "bun run build"
+  },
+  "dependencies": {
+    "@sixb/connector-rest": "workspace:*",
+    "@sixb/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "engines": {
+    "bun": ">=1.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/connectors/ace-iot/package.json
+++ b/connectors/ace-iot/package.json
@@ -39,10 +39,13 @@
     "prepack": "bun run build"
   },
   "dependencies": {
-    "@sixb/connector-rest": "workspace:*",
-    "@sixb/core": "workspace:*"
+    "@sixb/connector-rest": "workspace:^"
+  },
+  "peerDependencies": {
+    "@sixb/core": "workspace:^"
   },
   "devDependencies": {
+    "@sixb/core": "workspace:*",
     "@types/bun": "latest",
     "typescript": "^5.7.0"
   },

--- a/connectors/ace-iot/src/ace-iot.ts
+++ b/connectors/ace-iot/src/ace-iot.ts
@@ -1,0 +1,72 @@
+import { rest } from "@sixb/connector-rest"
+import type { ConnectorAdapter } from "@sixb/core"
+import { createAceIotClient } from "./client"
+import { AceIotConfigurationError } from "./errors"
+import { createAceIotHttp } from "./http"
+import type { AceIotApiKeyResolver, AceIotClient, AceIotConnectorOptions } from "./types"
+
+const DEFAULT_BASE_URL = "https://flightdeck.aceiot.cloud/api/"
+
+export type AceIotConnector = ConnectorAdapter<"ace-iot", AceIotClient>
+
+export function aceIot(options: AceIotConnectorOptions): AceIotConnector {
+  assertApiKeyResolver(options.apiKey)
+
+  const restAdapter = rest({
+    baseUrl: normalizeBaseUrl(options.baseUrl ?? DEFAULT_BASE_URL),
+    headers: async () => ({
+      // ACE rejects a bare token: the scheme is required even though its own spec calls this an
+      // apiKey header.
+      Authorization: `Bearer ${await resolveApiKey(options.apiKey)}`,
+      Accept: "application/json",
+    }),
+    timeoutMs: options.timeoutMs,
+    // Retries are method-aware in the ACE HTTP layer.
+    retry: { maxRetries: 0 },
+  })
+
+  return {
+    type: "ace-iot",
+    async connect(context) {
+      const restClient = await restAdapter.connect(context)
+      return createAceIotClient(
+        createAceIotHttp(restClient, {
+          minDelayMs: options.minDelayMs,
+          retry: options.retry,
+          signal: context.signal,
+        })
+      )
+    },
+  }
+}
+
+/**
+ * Every request path is relative, so the base URL has to end in a slash. Without one, `new URL()`
+ * drops the last segment and `https://host/api` would resolve `sites/` to `https://host/sites/`.
+ */
+function normalizeBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim()
+  if (!trimmed) {
+    throw new AceIotConfigurationError("[SixbAceIot] baseUrl must not be empty.")
+  }
+
+  return trimmed.endsWith("/") ? trimmed : `${trimmed}/`
+}
+
+function assertApiKeyResolver(apiKey: AceIotApiKeyResolver): void {
+  if (typeof apiKey === "string" && !apiKey.trim()) {
+    throw new AceIotConfigurationError("[SixbAceIot] apiKey must not be empty.")
+  }
+  if (typeof apiKey !== "string" && typeof apiKey !== "function") {
+    throw new AceIotConfigurationError("[SixbAceIot] apiKey must be a string or a function.")
+  }
+}
+
+async function resolveApiKey(apiKey: AceIotApiKeyResolver): Promise<string> {
+  const value = typeof apiKey === "function" ? await apiKey() : apiKey
+  if (!value.trim()) {
+    throw new AceIotConfigurationError("[SixbAceIot] apiKey must not be empty.")
+  }
+
+  return value
+}

--- a/connectors/ace-iot/src/client.ts
+++ b/connectors/ace-iot/src/client.ts
@@ -1,0 +1,15 @@
+import type { AceIotHttp } from "./http"
+import { createClientsResource } from "./resources/clients"
+import { createGatewaysResource } from "./resources/gateways"
+import { createPointsResource } from "./resources/points"
+import { createSitesResource } from "./resources/sites"
+import type { AceIotClient } from "./types"
+
+export function createAceIotClient(http: AceIotHttp): AceIotClient {
+  return {
+    clients: createClientsResource(http),
+    sites: createSitesResource(http),
+    points: createPointsResource(http),
+    gateways: createGatewaysResource(http),
+  }
+}

--- a/connectors/ace-iot/src/errors.ts
+++ b/connectors/ace-iot/src/errors.ts
@@ -1,0 +1,109 @@
+/**
+ * A problem with how the connector was configured, raised before or instead of a request.
+ *
+ * Separate from `AceIotApiError` because it is never transient: an API key resolver that returns
+ * nothing will keep returning nothing, so retrying it only delays the report. A resolver that
+ * throws for its own reasons — a token endpoint timing out, say — raises that error instead and is
+ * retried like any other read failure.
+ */
+export class AceIotConfigurationError extends Error {
+  readonly name = "AceIotConfigurationError"
+}
+
+/**
+ * A non-2xx response from the ACE API.
+ *
+ * ACE reports failures in two shapes: a bare `{"message": "..."}`, and Flask-RESTX request
+ * validation as `{"message": "Input payload validation failed", "errors": {"per_page": "..."}}`.
+ * Both are surfaced — the per-field detail through `validationErrors`.
+ */
+export class AceIotApiError extends Error {
+  readonly name = "AceIotApiError"
+  readonly headers: Headers
+  readonly retryAfterMs: number | null
+  /** Per-field validation detail from a 400, keyed by parameter name. */
+  readonly validationErrors: Readonly<Record<string, string>> | null
+
+  constructor(
+    readonly status: number,
+    readonly responseBody: unknown,
+    headers: HeadersInit = {}
+  ) {
+    super(formatAceIotApiError(status, responseBody))
+    this.headers = new Headers(headers)
+    this.retryAfterMs = parseRetryAfter(this.headers.get("retry-after"))
+    this.validationErrors = extractValidationErrors(responseBody)
+  }
+}
+
+/**
+ * ACE answers an invalid API key with a 500 carrying Flask's generic handler message, not a 401.
+ * A caller staring at "An unhandled exception occurred." has no way to guess that, so say it.
+ */
+const GENERIC_SERVER_ERROR = "An unhandled exception occurred."
+const BAD_KEY_HINT = " ACE also returns this when the API key is invalid."
+
+function formatAceIotApiError(status: number, responseBody: unknown): string {
+  const message = extractMessage(responseBody)
+  const detail = formatValidationErrors(extractValidationErrors(responseBody))
+  const hint = status === 500 && message === GENERIC_SERVER_ERROR ? BAD_KEY_HINT : ""
+
+  if (!message) {
+    return `[SixbAceIot] ACE API request failed with ${status}.${hint}`
+  }
+
+  return `[SixbAceIot] ACE API request failed with ${status}: ${message}${detail}${hint}`
+}
+
+function formatValidationErrors(errors: Readonly<Record<string, string>> | null): string {
+  if (!errors) {
+    return ""
+  }
+
+  const entries = Object.entries(errors).map(([field, detail]) => `${field}: ${detail}`)
+  return entries.length ? ` (${entries.join("; ")})` : ""
+}
+
+function extractValidationErrors(value: unknown): Readonly<Record<string, string>> | null {
+  if (!isRecord(value) || !isRecord(value.errors)) {
+    return null
+  }
+
+  const errors: Record<string, string> = {}
+  for (const [field, detail] of Object.entries(value.errors)) {
+    errors[field] = typeof detail === "string" ? detail : JSON.stringify(detail)
+  }
+
+  return Object.keys(errors).length ? errors : null
+}
+
+function extractMessage(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) {
+    return value
+  }
+
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const message = value.message
+  return typeof message === "string" && message.trim() ? message : null
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (!value) {
+    return null
+  }
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) {
+    return Math.max(seconds, 0) * 1000
+  }
+
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/connectors/ace-iot/src/http.ts
+++ b/connectors/ace-iot/src/http.ts
@@ -1,0 +1,294 @@
+import type { RestClient } from "@sixb/connector-rest"
+import { AceIotApiError, AceIotConfigurationError } from "./errors"
+import type {
+  AceIotRequestMethod,
+  AceIotRetryContext,
+  AceIotRetryPolicy,
+  QueryParams,
+  QueryValue,
+} from "./types"
+
+export interface AceIotRequestOptions {
+  /**
+   * Mark a write that cannot change server state, so the default policy may replay it.
+   * `POST /points/get_timeseries` is the one such route: it is a read that takes a body.
+   */
+  readonly idempotent?: boolean
+}
+
+export interface AceIotHttp {
+  get<T>(path: string, query?: QueryParams): Promise<T>
+  post<T>(
+    path: string,
+    body?: unknown,
+    query?: QueryParams,
+    options?: AceIotRequestOptions
+  ): Promise<T>
+  put<T>(path: string, body?: unknown, query?: QueryParams): Promise<T>
+  patch<T>(path: string, body?: unknown, query?: QueryParams): Promise<T>
+  /** A GET whose body is a file. Returns the checked `Response` with its body unread. */
+  download(path: string, query?: QueryParams): Promise<Response>
+}
+
+export interface AceIotHttpOptions {
+  readonly minDelayMs?: number
+  readonly retry?: AceIotRetryPolicy
+  readonly signal?: AbortSignal
+}
+
+const DEFAULT_MAX_RETRIES = 2
+
+export function createAceIotHttp(rest: RestClient, options: AceIotHttpOptions = {}): AceIotHttp {
+  const retryPolicy = options.retry ?? {}
+  const maxRetries = retryPolicy.maxRetries ?? DEFAULT_MAX_RETRIES
+  assertMaxRetries(maxRetries)
+  const schedule = createRequestScheduler(options.minDelayMs ?? 0)
+
+  async function send(
+    method: AceIotRequestMethod,
+    path: string,
+    body: unknown,
+    query: QueryParams | undefined,
+    idempotent: boolean
+  ): Promise<Response> {
+    const requestPath = withQuery(path, query)
+
+    for (let attempt = 0; ; attempt++) {
+      let response: Response | null = null
+      let error: unknown = null
+
+      try {
+        await schedule()
+        response = await rest.request(requestPath, createRequestInit(method, body, options.signal))
+      } catch (caughtError) {
+        error = caughtError
+      }
+
+      const context: AceIotRetryContext = { attempt, method, idempotent, response, error }
+      const shouldRetry =
+        attempt < maxRetries &&
+        (retryPolicy.shouldRetry?.(context) ?? shouldRetryByDefault(context))
+
+      if (shouldRetry) {
+        if (response?.body) {
+          await response.body.cancel().catch(() => undefined)
+        }
+        await sleep(retryPolicy.delayMs?.(context) ?? defaultRetryDelayMs(context))
+        continue
+      }
+
+      if (error) {
+        throw error
+      }
+
+      return response as Response
+    }
+  }
+
+  async function request<T>(
+    method: AceIotRequestMethod,
+    path: string,
+    body?: unknown,
+    query?: QueryParams,
+    idempotent = method === "GET"
+  ): Promise<T> {
+    return readJson<T>(await send(method, path, body, query, idempotent))
+  }
+
+  return {
+    get<T>(path: string, query?: QueryParams) {
+      return request<T>("GET", path, undefined, query)
+    },
+    post<T>(
+      path: string,
+      body?: unknown,
+      query?: QueryParams,
+      requestOptions?: AceIotRequestOptions
+    ) {
+      return request<T>("POST", path, body, query, requestOptions?.idempotent ?? false)
+    },
+    put<T>(path: string, body?: unknown, query?: QueryParams) {
+      return request<T>("PUT", path, body, query, false)
+    },
+    patch<T>(path: string, body?: unknown, query?: QueryParams) {
+      return request<T>("PATCH", path, body, query, false)
+    },
+    async download(path: string, query?: QueryParams) {
+      const response = await send("GET", path, undefined, query, true)
+      if (!response.ok) {
+        throw new AceIotApiError(
+          response.status,
+          await readResponseBody(response),
+          response.headers
+        )
+      }
+
+      return response
+    },
+  }
+}
+
+export function withQuery(path: string, query?: QueryParams): string {
+  const normalizedPath = path.startsWith("/") ? path.slice(1) : path
+  if (!query) {
+    return normalizedPath
+  }
+
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    appendQueryParam(params, key, value)
+  }
+
+  const queryString = params.toString()
+  return queryString ? `${normalizedPath}?${queryString}` : normalizedPath
+}
+
+function createRequestInit(
+  method: AceIotRequestMethod,
+  body: unknown,
+  signal: AbortSignal | undefined
+): RequestInit {
+  const headers = new Headers()
+  const init: RequestInit = { method, headers, signal }
+  const serializedBody = serializeBody(body, headers)
+
+  if (serializedBody !== undefined) {
+    init.body = serializedBody
+  }
+
+  return init
+}
+
+function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
+  if (body === undefined) {
+    return undefined
+  }
+
+  // FormData must keep the boundary fetch generates, so no content-type is set for it here.
+  if (
+    typeof body === "string" ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body) ||
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof ReadableStream
+  ) {
+    return body as BodyInit
+  }
+
+  headers.set("content-type", "application/json")
+  return JSON.stringify(body)
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const responseBody = await readResponseBody(response)
+  if (!response.ok) {
+    throw new AceIotApiError(response.status, responseBody, response.headers)
+  }
+
+  return responseBody as T
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return undefined
+  }
+
+  const text = await response.text()
+  if (!text) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+/**
+ * Replay reads only. Every ACE write changes state — `POST /points/` and `PUT /points/{name}` merge
+ * tags, and `POST /gateways/{name}/token` mints a credential — so a write is retried only when the
+ * caller marks it idempotent or supplies its own policy.
+ */
+function shouldRetryByDefault(context: AceIotRetryContext): boolean {
+  if (!(context.method === "GET" || context.idempotent) || isAbortError(context.error)) {
+    return false
+  }
+
+  // A misconfigured connector fails the same way on every attempt.
+  if (context.error instanceof AceIotConfigurationError) {
+    return false
+  }
+
+  if (context.error) {
+    return true
+  }
+
+  const status = context.response?.status
+  return status === 429 || (status !== undefined && status >= 500)
+}
+
+function defaultRetryDelayMs(context: AceIotRetryContext): number {
+  const retryAfter = parseRetryAfter(context.response?.headers.get("retry-after") ?? null)
+  return retryAfter ?? Math.min(1000 * 2 ** context.attempt, 30_000)
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (!value) {
+    return null
+  }
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) {
+    return Math.max(seconds, 0) * 1000
+  }
+
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError"
+}
+
+function appendQueryParam(params: URLSearchParams, key: string, value: QueryValue): void {
+  if (value === undefined || value === "") {
+    return
+  }
+
+  params.set(key, String(value))
+}
+
+function assertMaxRetries(maxRetries: number): void {
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error("[SixbAceIot] retry.maxRetries must be a non-negative integer.")
+  }
+}
+
+function createRequestScheduler(minDelayMs: number): () => Promise<void> {
+  if (!Number.isFinite(minDelayMs) || minDelayMs < 0) {
+    throw new Error("[SixbAceIot] minDelayMs must be a non-negative finite number.")
+  }
+
+  if (minDelayMs === 0) {
+    return () => Promise.resolve()
+  }
+
+  let nextAvailableAt = 0
+  let queue = Promise.resolve()
+
+  return () => {
+    const scheduled = queue.then(async () => {
+      await sleep(Math.max(nextAvailableAt - Date.now(), 0))
+      nextAvailableAt = Date.now() + minDelayMs
+    })
+    queue = scheduled.catch(() => undefined)
+    return scheduled
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
+}

--- a/connectors/ace-iot/src/index.ts
+++ b/connectors/ace-iot/src/index.ts
@@ -1,0 +1,16 @@
+export type { AceIotConnector } from "./ace-iot"
+export { aceIot } from "./ace-iot"
+export { createAceIotClient } from "./client"
+export { AceIotApiError, AceIotConfigurationError } from "./errors"
+export type { AceIotTimeseriesCursor } from "./pagination"
+export {
+  decodeTimeseriesCursor,
+  encodeTimeseriesCursor,
+  repairTimeseriesCursor,
+} from "./pagination"
+export type { ClientsResource } from "./resources/clients"
+export type { GatewaysResource } from "./resources/gateways"
+export type { PointsResource } from "./resources/points"
+export type { SitesResource } from "./resources/sites"
+export { normalizeAceIotTimestamp, parseAceIotTimestamp } from "./time"
+export * from "./types"

--- a/connectors/ace-iot/src/pagination.ts
+++ b/connectors/ace-iot/src/pagination.ts
@@ -1,0 +1,170 @@
+import type { AceIotListAllOptions, AceIotPage, AceIotTimeseriesPage } from "./types"
+
+/** Page size `listAll*` uses when the caller does not pick one. ACE's own default is 10. */
+export const DEFAULT_LIST_ALL_PER_PAGE = 1000
+
+type PageListMethod<TOptions, TItem> = (options: TOptions) => Promise<AceIotPage<TItem>>
+
+/**
+ * Walk ACE's `page`/`per_page` envelope.
+ *
+ * `pages` is not a reliable stop condition on its own — the gateway PCAP listing returns
+ * `"pages": null` — so the walk also stops on an empty page, on a short page, and on reaching
+ * `total`.
+ */
+export async function* listAllPages<TOptions extends AceIotListAllOptions, TItem>(
+  list: PageListMethod<TOptions, TItem>,
+  options?: TOptions
+): AsyncIterable<TItem> {
+  const perPage = options?.perPage ?? DEFAULT_LIST_ALL_PER_PAGE
+  const maxPages = options?.maxPages
+  let page = options?.page ?? 1
+  let fetchedPages = 0
+  let fetchedItems = 0
+
+  for (;;) {
+    const result = await list({ ...options, page, perPage } as TOptions)
+
+    for (const item of result.items) {
+      yield item
+    }
+
+    fetchedPages += 1
+    fetchedItems += result.items.length
+
+    if (result.items.length === 0) return
+    if (maxPages !== undefined && fetchedPages >= maxPages) return
+    if (typeof result.pages === "number" && page >= result.pages) return
+    if (typeof result.total === "number" && fetchedItems >= result.total) return
+    if (result.items.length < (result.per_page ?? perPage)) return
+
+    page += 1
+  }
+}
+
+/**
+ * The decoded form of a timeseries `next_cursor`: how many rows of the bucket at `timestamp` have
+ * already been returned.
+ */
+export interface AceIotTimeseriesCursor {
+  readonly offset: number
+  readonly timestamp: string
+}
+
+export function encodeTimeseriesCursor(cursor: AceIotTimeseriesCursor): string {
+  return btoa(JSON.stringify({ offset: cursor.offset, timestamp: cursor.timestamp }))
+}
+
+export function decodeTimeseriesCursor(cursor: string): AceIotTimeseriesCursor | null {
+  try {
+    const decoded: unknown = JSON.parse(atob(cursor))
+    if (
+      typeof decoded !== "object" ||
+      decoded === null ||
+      typeof (decoded as AceIotTimeseriesCursor).offset !== "number" ||
+      typeof (decoded as AceIotTimeseriesCursor).timestamp !== "string"
+    ) {
+      return null
+    }
+
+    const { offset, timestamp } = decoded as AceIotTimeseriesCursor
+    return Number.isInteger(offset) && offset >= 0 ? { offset, timestamp } : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Compute the cursor that actually reaches the next page.
+ *
+ * ACE sets `next_cursor.offset` to the number of rows it returned from the final timestamp bucket
+ * of the page, without adding the offset the request carried in. When a page begins and ends inside
+ * one bucket the cursor it hands back is therefore the cursor it was given, and a
+ * `while (has_more)` loop re-requests the same page forever. Measured against a live site, a
+ * 3,222-sample window walked with the server's own cursor yields 100 rows at `page_size=50` and
+ * then stalls.
+ *
+ * The correct offset is recoverable from the page itself, because the server does honor an offset
+ * it is given: carry the incoming offset when the page ended in the bucket it started in, and add
+ * the rows this page took from that final bucket. Where ACE's cursor is already right — any page
+ * that crosses into a later bucket — this returns the identical value.
+ */
+export function repairTimeseriesCursor(
+  incoming: string | null | undefined,
+  page: AceIotTimeseriesPage
+): string | null {
+  const samples = page.point_samples
+  if (!page.has_more || samples.length === 0) {
+    return null
+  }
+
+  const lastTimestamp = samples[samples.length - 1].time
+  let rowsFromLastBucket = 0
+  for (
+    let index = samples.length - 1;
+    index >= 0 && samples[index].time === lastTimestamp;
+    index--
+  ) {
+    rowsFromLastBucket += 1
+  }
+
+  const previous = incoming ? decodeTimeseriesCursor(incoming) : null
+  const carried = previous?.timestamp === lastTimestamp ? previous.offset : 0
+
+  return encodeTimeseriesCursor({ offset: carried + rowsFromLastBucket, timestamp: lastTimestamp })
+}
+
+type TimeseriesPageMethod<TOptions> = (options: TOptions) => Promise<AceIotTimeseriesPage>
+
+/**
+ * Identify a page by its size and its end rows. `(name, time)` is a reading's natural key, so two
+ * consecutive pages sharing a fingerprint hold the same rows.
+ */
+function pageFingerprint(page: AceIotTimeseriesPage): string {
+  const samples = page.point_samples
+  const first = samples[0]
+  const last = samples[samples.length - 1]
+  return `${samples.length}|${first.name}@${first.time}|${last.name}@${last.time}`
+}
+
+/**
+ * Walk `GET /sites/{site_name}/timeseries/paginated` to the end of the window, repairing ACE's
+ * cursor on every hop.
+ *
+ * A page identical to the one before it means the walk is not advancing, and is raised rather than
+ * looped on. Comparing pages rather than cursors is what makes this a real bound: the repaired
+ * cursor always advances by construction, so a cursor that never repeats proves nothing about
+ * whether the server is actually moving through the window.
+ */
+export async function* iterateTimeseriesPages<
+  TOptions extends { readonly cursor?: string; readonly maxPages?: number },
+>(getPage: TimeseriesPageMethod<TOptions>, options: TOptions): AsyncIterable<AceIotTimeseriesPage> {
+  const maxPages = options.maxPages
+  let cursor = options.cursor
+  let fetchedPages = 0
+  let previousFingerprint: string | null = null
+
+  for (;;) {
+    const page = await getPage({ ...options, cursor } as TOptions)
+
+    if (page.point_samples.length > 0) {
+      const fingerprint = pageFingerprint(page)
+      if (fingerprint === previousFingerprint) {
+        throw new Error(
+          "[SixbAceIot] Timeseries pagination returned the same page twice and would not advance."
+        )
+      }
+      previousFingerprint = fingerprint
+    }
+
+    yield page
+
+    fetchedPages += 1
+    if (maxPages !== undefined && fetchedPages >= maxPages) return
+
+    const nextCursor = repairTimeseriesCursor(cursor, page)
+    if (!nextCursor) return
+
+    cursor = nextCursor
+  }
+}

--- a/connectors/ace-iot/src/query.ts
+++ b/connectors/ace-iot/src/query.ts
@@ -1,0 +1,18 @@
+import { toAceIotQueryTime } from "./time"
+import type { AceIotPageOptions, AceIotTimeseriesRange, QueryParams } from "./types"
+
+/** ACE's `page`/`per_page` pair, shared by every list route. */
+export function pageQuery(options?: AceIotPageOptions): QueryParams {
+  return {
+    page: options?.page,
+    per_page: options?.perPage,
+  }
+}
+
+/** The required `start_time`/`end_time` pair, normalized to UTC ISO. */
+export function timeRangeQuery(range: AceIotTimeseriesRange): QueryParams {
+  return {
+    start_time: toAceIotQueryTime(range.startTime, "startTime"),
+    end_time: toAceIotQueryTime(range.endTime, "endTime"),
+  }
+}

--- a/connectors/ace-iot/src/resources/clients.ts
+++ b/connectors/ace-iot/src/resources/clients.ts
@@ -1,0 +1,151 @@
+import type { AceIotHttp } from "../http"
+import { listAllPages } from "../pagination"
+import { pageQuery } from "../query"
+import type {
+  AceIotClientAccount,
+  AceIotClientListAllOptions,
+  AceIotClientListOptions,
+  AceIotCreateClientInput,
+  AceIotCreateDerEventInput,
+  AceIotDerEvent,
+  AceIotDerEventListAllOptions,
+  AceIotDerEventListOptions,
+  AceIotPage,
+  AceIotSite,
+  AceIotSiteListAllOptions,
+  AceIotSiteListOptions,
+  AceIotUpdateDerEventInput,
+  AceIotUploadVolttronAgentPackageInput,
+  AceIotVolttronAgentPackage,
+  AceIotVolttronAgentPackageListAllOptions,
+  AceIotVolttronAgentPackageListOptions,
+} from "../types"
+import { fileUpload } from "../upload"
+import { assertMaxPages, assertPageOptions, pathSegment } from "../validation"
+
+export interface ClientsResource {
+  /** `GET /clients/` */
+  list(options?: AceIotClientListOptions): Promise<AceIotPage<AceIotClientAccount>>
+  listAll(options?: AceIotClientListAllOptions): AsyncIterable<AceIotClientAccount>
+  /** `GET /clients/{client_name}` */
+  get(clientName: string): Promise<AceIotClientAccount>
+  /** `POST /clients/` — ACE documents no response body. */
+  create(input: AceIotCreateClientInput): Promise<void>
+  /** `GET /clients/{client_name}/sites` */
+  listSites(clientName: string, options?: AceIotSiteListOptions): Promise<AceIotPage<AceIotSite>>
+  listAllSites(clientName: string, options?: AceIotSiteListAllOptions): AsyncIterable<AceIotSite>
+  /** `GET /clients/{client_name}/der_events` — active and upcoming demand-response events. */
+  listDerEvents(
+    clientName: string,
+    options?: AceIotDerEventListOptions
+  ): Promise<AceIotPage<AceIotDerEvent>>
+  listAllDerEvents(
+    clientName: string,
+    options?: AceIotDerEventListAllOptions
+  ): AsyncIterable<AceIotDerEvent>
+  /** `POST /clients/{client_name}/der_events` — ACE documents no response body. */
+  createDerEvents(clientName: string, events: readonly AceIotCreateDerEventInput[]): Promise<void>
+  /** `PUT /clients/{client_name}/der_events` — edits by id. ACE documents no response body. */
+  updateDerEvents(clientName: string, events: readonly AceIotUpdateDerEventInput[]): Promise<void>
+  /** `GET /clients/{client_name}/volttron_agent_package/list` */
+  listVolttronAgentPackages(
+    clientName: string,
+    options?: AceIotVolttronAgentPackageListOptions
+  ): Promise<AceIotPage<AceIotVolttronAgentPackage>>
+  listAllVolttronAgentPackages(
+    clientName: string,
+    options?: AceIotVolttronAgentPackageListAllOptions
+  ): AsyncIterable<AceIotVolttronAgentPackage>
+  /**
+   * `GET /clients/{client_name}/volttron_agent_package` — the package file. Returns the raw
+   * `Response` so the caller decides whether to buffer or stream it.
+   */
+  downloadVolttronAgentPackage(clientName: string, packageId: string): Promise<Response>
+  /** `POST /clients/{client_name}/volttron_agent_package` — ACE documents no response body. */
+  uploadVolttronAgentPackage(
+    clientName: string,
+    input: AceIotUploadVolttronAgentPackageInput
+  ): Promise<void>
+}
+
+export function createClientsResource(http: AceIotHttp): ClientsResource {
+  const resource: ClientsResource = {
+    list(options) {
+      assertPageOptions(options)
+      return http.get("clients/", pageQuery(options))
+    },
+    listAll(options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages((pageOptions) => resource.list(pageOptions), options)
+    },
+    get(clientName) {
+      return http.get(`clients/${pathSegment(clientName, "clientName")}`)
+    },
+    create(input) {
+      return http.post("clients/", input)
+    },
+    listSites(clientName, options) {
+      assertPageOptions(options)
+      return http.get(`clients/${pathSegment(clientName, "clientName")}/sites`, pageQuery(options))
+    },
+    listAllSites(clientName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages((pageOptions) => resource.listSites(clientName, pageOptions), options)
+    },
+    listDerEvents(clientName, options) {
+      assertPageOptions(options)
+      return http.get(`clients/${pathSegment(clientName, "clientName")}/der_events`, {
+        ...pageQuery(options),
+        get_past_events: options?.getPastEvents,
+        group_name: options?.groupName,
+      })
+    },
+    listAllDerEvents(clientName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages((pageOptions) => resource.listDerEvents(clientName, pageOptions), options)
+    },
+    createDerEvents(clientName, events) {
+      return http.post(`clients/${pathSegment(clientName, "clientName")}/der_events`, {
+        der_events: events,
+      })
+    },
+    updateDerEvents(clientName, events) {
+      return http.put(`clients/${pathSegment(clientName, "clientName")}/der_events`, {
+        der_events: events,
+      })
+    },
+    listVolttronAgentPackages(clientName, options) {
+      assertPageOptions(options)
+      return http.get(
+        `clients/${pathSegment(clientName, "clientName")}/volttron_agent_package/list`,
+        {
+          ...pageQuery(options),
+          // Upstream spells the parameter "voltron", without the first t.
+          voltron_agent_package_name: options?.packageName,
+        }
+      )
+    },
+    listAllVolttronAgentPackages(clientName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages(
+        (pageOptions) => resource.listVolttronAgentPackages(clientName, pageOptions),
+        options
+      )
+    },
+    downloadVolttronAgentPackage(clientName, packageId) {
+      return http.download(
+        `clients/${pathSegment(clientName, "clientName")}/volttron_agent_package`,
+        { volttron_agent_package_id: packageId }
+      )
+    },
+    uploadVolttronAgentPackage(clientName, input) {
+      return http.post(
+        `clients/${pathSegment(clientName, "clientName")}/volttron_agent_package`,
+        fileUpload(input.file, input.filename),
+        { package_name: input.packageName, description: input.description }
+      )
+    },
+  }
+
+  return resource
+}

--- a/connectors/ace-iot/src/resources/gateways.ts
+++ b/connectors/ace-iot/src/resources/gateways.ts
@@ -1,0 +1,326 @@
+import type { AceIotHttp } from "../http"
+import { listAllPages } from "../pagination"
+import { pageQuery, timeRangeQuery } from "../query"
+import type {
+  AceIotAgentConfig,
+  AceIotAgentConfigInput,
+  AceIotAgentConfigListAllOptions,
+  AceIotAgentConfigListOptions,
+  AceIotAgentConfigWriteOptions,
+  AceIotCreateVolttronAgentConfigPackageInput,
+  AceIotDerEvent,
+  AceIotDerEventListAllOptions,
+  AceIotDerEventListOptions,
+  AceIotGateway,
+  AceIotGatewayInput,
+  AceIotGatewayListAllOptions,
+  AceIotGatewayListOptions,
+  AceIotGatewayToken,
+  AceIotHawkeConfig,
+  AceIotHawkeConfigBaseInput,
+  AceIotHawkeConfigInput,
+  AceIotHawkeConfigListAllOptions,
+  AceIotHawkeConfigListOptions,
+  AceIotHawkeConfigOptions,
+  AceIotHawkeConfigWithIdentity,
+  AceIotHawkeConfigWriteOptions,
+  AceIotPage,
+  AceIotPcapListAllOptions,
+  AceIotPcapListOptions,
+  AceIotUpdateGatewayInput,
+  AceIotVolttronAgent,
+  AceIotVolttronAgentConfigPackage,
+  AceIotVolttronAgentConfigPackageOptions,
+  AceIotVolttronAgentInput,
+  AceIotVolttronAgentListAllOptions,
+  AceIotVolttronAgentListOptions,
+} from "../types"
+import { fileUpload } from "../upload"
+import { assertMaxPages, assertPageOptions, pathSegment } from "../validation"
+
+export interface GatewaysResource {
+  /** `GET /gateways/` */
+  list(options?: AceIotGatewayListOptions): Promise<AceIotPage<AceIotGateway>>
+  listAll(options?: AceIotGatewayListAllOptions): AsyncIterable<AceIotGateway>
+  /** `GET /gateways/{gateway_name}` */
+  get(gatewayName: string): Promise<AceIotGateway>
+  /** `POST /gateways/` — ACE documents no response body. */
+  create(input: AceIotGatewayInput): Promise<void>
+  /** `PATCH /gateways/{gateway_name}` — ACE documents no response body. */
+  update(gatewayName: string, input: AceIotUpdateGatewayInput): Promise<void>
+  /**
+   * `POST /gateways/{gateway_name}/token` — mints a new ACE Manager API token for the gateway.
+   * Never retried automatically: a replay issues a second credential.
+   */
+  createToken(gatewayName: string): Promise<AceIotGatewayToken>
+  /** `GET /gateways/{gateway_name}/agent_configs` */
+  listAgentConfigs(
+    gatewayName: string,
+    options?: AceIotAgentConfigListOptions
+  ): Promise<AceIotPage<AceIotAgentConfig>>
+  listAllAgentConfigs(
+    gatewayName: string,
+    options?: AceIotAgentConfigListAllOptions
+  ): AsyncIterable<AceIotAgentConfig>
+  /** `POST /gateways/{gateway_name}/agent_configs` — ACE documents no response body. */
+  createAgentConfigs(
+    gatewayName: string,
+    configs: readonly AceIotAgentConfigInput[],
+    options?: AceIotAgentConfigWriteOptions
+  ): Promise<void>
+  /** `GET /gateways/{gateway_name}/volttron_agents` */
+  listVolttronAgents(
+    gatewayName: string,
+    options?: AceIotVolttronAgentListOptions
+  ): Promise<AceIotPage<AceIotVolttronAgent>>
+  listAllVolttronAgents(
+    gatewayName: string,
+    options?: AceIotVolttronAgentListAllOptions
+  ): AsyncIterable<AceIotVolttronAgent>
+  /**
+   * `POST /gateways/{gateway_name}/volttron_agents` — creates agents, overwriting any that share an
+   * identity. ACE documents no response body.
+   */
+  createVolttronAgents(
+    gatewayName: string,
+    agents: readonly AceIotVolttronAgentInput[]
+  ): Promise<void>
+  /** `GET /gateways/{gateway_name}/volttron_agent_config_package` */
+  getVolttronAgentConfigPackage(
+    gatewayName: string,
+    volttronAgentIdentity: string,
+    options?: AceIotVolttronAgentConfigPackageOptions
+  ): Promise<AceIotVolttronAgentConfigPackage>
+  /** `POST /gateways/{gateway_name}/volttron_agent_config_package` — no documented response body. */
+  createVolttronAgentConfigPackage(
+    gatewayName: string,
+    input: AceIotCreateVolttronAgentConfigPackageInput,
+    options?: AceIotVolttronAgentConfigPackageOptions
+  ): Promise<void>
+  /** `GET /gateways/{gateway_name}/hawke_configuration` — latest config for every Hawke agent. */
+  listHawkeConfigurations(
+    gatewayName: string,
+    options?: AceIotHawkeConfigListOptions
+  ): Promise<AceIotPage<AceIotHawkeConfigWithIdentity>>
+  listAllHawkeConfigurations(
+    gatewayName: string,
+    options?: AceIotHawkeConfigListAllOptions
+  ): AsyncIterable<AceIotHawkeConfigWithIdentity>
+  /**
+   * `POST /gateways/{gateway_name}/hawke_configuration` — pushes configs, or activates ones that
+   * already exist. ACE documents no response body.
+   */
+  createHawkeConfigurations(
+    gatewayName: string,
+    configs: readonly AceIotHawkeConfigInput[],
+    options?: AceIotHawkeConfigWriteOptions
+  ): Promise<void>
+  /** `GET /gateways/{gateway_name}/hawke_configuration/{hawke_agent_id}` */
+  getHawkeAgentConfiguration(
+    gatewayName: string,
+    hawkeAgentId: string,
+    options?: AceIotHawkeConfigOptions
+  ): Promise<AceIotHawkeConfig>
+  /** `POST /gateways/{gateway_name}/hawke_configuration/{hawke_agent_id}` — no response body. */
+  setHawkeAgentConfiguration(
+    gatewayName: string,
+    hawkeAgentId: string,
+    config: AceIotHawkeConfigBaseInput,
+    options?: AceIotHawkeConfigWriteOptions
+  ): Promise<void>
+  /** `GET /gateways/{gateway_name}/hawke_configuration/{hawke_agent_id}/list` */
+  listHawkeAgentConfigurations(
+    gatewayName: string,
+    hawkeAgentId: string,
+    options?: AceIotHawkeConfigListOptions
+  ): Promise<AceIotPage<AceIotHawkeConfigWithIdentity>>
+  listAllHawkeAgentConfigurations(
+    gatewayName: string,
+    hawkeAgentId: string,
+    options?: AceIotHawkeConfigListAllOptions
+  ): AsyncIterable<AceIotHawkeConfigWithIdentity>
+  /** `GET /gateways/{gateway_name}/der_events` */
+  listDerEvents(
+    gatewayName: string,
+    options?: AceIotDerEventListOptions
+  ): Promise<AceIotPage<AceIotDerEvent>>
+  listAllDerEvents(
+    gatewayName: string,
+    options?: AceIotDerEventListAllOptions
+  ): AsyncIterable<AceIotDerEvent>
+  /** `GET /gateways/{gateway_name}/pcap/list` — capture file names in a time range. */
+  listPcapFiles(gatewayName: string, options: AceIotPcapListOptions): Promise<AceIotPage<string>>
+  listAllPcapFiles(gatewayName: string, options: AceIotPcapListAllOptions): AsyncIterable<string>
+  /** `GET /gateways/{gateway_name}/pcap` — one capture file, as a raw `Response`. */
+  downloadPcap(gatewayName: string, fileName: string): Promise<Response>
+  /** `POST /gateways/{gateway_name}/pcap` — ACE documents no response body. */
+  uploadPcap(gatewayName: string, file: Blob | File, filename?: string): Promise<void>
+}
+
+export function createGatewaysResource(http: AceIotHttp): GatewaysResource {
+  const gatewayPath = (gatewayName: string) => `gateways/${pathSegment(gatewayName, "gatewayName")}`
+  const hawkePath = (gatewayName: string, hawkeAgentId: string) =>
+    `${gatewayPath(gatewayName)}/hawke_configuration/${pathSegment(hawkeAgentId, "hawkeAgentId")}`
+
+  const resource: GatewaysResource = {
+    list(options) {
+      assertPageOptions(options)
+      return http.get("gateways/", {
+        ...pageQuery(options),
+        show_archived: options?.showArchived,
+      })
+    },
+    listAll(options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages((pageOptions) => resource.list(pageOptions), options)
+    },
+    get(gatewayName) {
+      return http.get(gatewayPath(gatewayName))
+    },
+    create(input) {
+      return http.post("gateways/", input)
+    },
+    update(gatewayName, input) {
+      return http.patch(gatewayPath(gatewayName), input)
+    },
+    createToken(gatewayName) {
+      return http.post(`${gatewayPath(gatewayName)}/token`)
+    },
+    listAgentConfigs(gatewayName, options) {
+      assertPageOptions(options)
+      return http.get(`${gatewayPath(gatewayName)}/agent_configs`, {
+        ...pageQuery(options),
+        agent_identity: options?.agentIdentity,
+        active: options?.active,
+        use_base64_hash: options?.useBase64Hash,
+      })
+    },
+    listAllAgentConfigs(gatewayName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages(
+        (pageOptions) => resource.listAgentConfigs(gatewayName, pageOptions),
+        options
+      )
+    },
+    createAgentConfigs(gatewayName, configs, options) {
+      return http.post(
+        `${gatewayPath(gatewayName)}/agent_configs`,
+        { agent_configs: configs },
+        { use_base64_hash: options?.useBase64Hash }
+      )
+    },
+    listVolttronAgents(gatewayName, options) {
+      assertPageOptions(options)
+      return http.get(`${gatewayPath(gatewayName)}/volttron_agents`, {
+        ...pageQuery(options),
+        volttron_agent_identity: options?.volttronAgentIdentity,
+      })
+    },
+    listAllVolttronAgents(gatewayName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages(
+        (pageOptions) => resource.listVolttronAgents(gatewayName, pageOptions),
+        options
+      )
+    },
+    createVolttronAgents(gatewayName, agents) {
+      return http.post(`${gatewayPath(gatewayName)}/volttron_agents`, { volttron_agents: agents })
+    },
+    getVolttronAgentConfigPackage(gatewayName, volttronAgentIdentity, options) {
+      return http.get(`${gatewayPath(gatewayName)}/volttron_agent_config_package`, {
+        volttron_agent_identity: volttronAgentIdentity,
+        use_agent_config_base64_hash: options?.useAgentConfigBase64Hash,
+      })
+    },
+    createVolttronAgentConfigPackage(gatewayName, input, options) {
+      return http.post(`${gatewayPath(gatewayName)}/volttron_agent_config_package`, input, {
+        use_agent_config_base64_hash: options?.useAgentConfigBase64Hash,
+      })
+    },
+    listHawkeConfigurations(gatewayName, options) {
+      assertPageOptions(options)
+      return http.get(`${gatewayPath(gatewayName)}/hawke_configuration`, {
+        ...pageQuery(options),
+        hash: options?.hash,
+        use_base64_hash: options?.useBase64Hash,
+      })
+    },
+    listAllHawkeConfigurations(gatewayName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages(
+        (pageOptions) => resource.listHawkeConfigurations(gatewayName, pageOptions),
+        options
+      )
+    },
+    createHawkeConfigurations(gatewayName, configs, options) {
+      return http.post(
+        `${gatewayPath(gatewayName)}/hawke_configuration`,
+        { hawke_agents: configs },
+        { use_base64_hash: options?.useBase64Hash }
+      )
+    },
+    getHawkeAgentConfiguration(gatewayName, hawkeAgentId, options) {
+      return http.get(hawkePath(gatewayName, hawkeAgentId), {
+        hash: options?.hash,
+        use_base64_hash: options?.useBase64Hash,
+      })
+    },
+    setHawkeAgentConfiguration(gatewayName, hawkeAgentId, config, options) {
+      return http.post(hawkePath(gatewayName, hawkeAgentId), config, {
+        use_base64_hash: options?.useBase64Hash,
+      })
+    },
+    listHawkeAgentConfigurations(gatewayName, hawkeAgentId, options) {
+      assertPageOptions(options)
+      return http.get(`${hawkePath(gatewayName, hawkeAgentId)}/list`, {
+        ...pageQuery(options),
+        use_base64_hash: options?.useBase64Hash,
+      })
+    },
+    listAllHawkeAgentConfigurations(gatewayName, hawkeAgentId, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages(
+        (pageOptions) =>
+          resource.listHawkeAgentConfigurations(gatewayName, hawkeAgentId, pageOptions),
+        options
+      )
+    },
+    listDerEvents(gatewayName, options) {
+      assertPageOptions(options)
+      return http.get(`${gatewayPath(gatewayName)}/der_events`, {
+        ...pageQuery(options),
+        get_past_events: options?.getPastEvents,
+        group_name: options?.groupName,
+      })
+    },
+    listAllDerEvents(gatewayName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages(
+        (pageOptions) => resource.listDerEvents(gatewayName, pageOptions),
+        options
+      )
+    },
+    listPcapFiles(gatewayName, options) {
+      assertPageOptions(options)
+      return http.get(`${gatewayPath(gatewayName)}/pcap/list`, {
+        ...pageQuery(options),
+        ...timeRangeQuery(options),
+      })
+    },
+    listAllPcapFiles(gatewayName, options) {
+      assertMaxPages(options.maxPages)
+      return listAllPages(
+        (pageOptions) => resource.listPcapFiles(gatewayName, pageOptions),
+        options
+      )
+    },
+    downloadPcap(gatewayName, fileName) {
+      return http.download(`${gatewayPath(gatewayName)}/pcap`, { file_name: fileName })
+    },
+    uploadPcap(gatewayName, file, filename) {
+      return http.post(`${gatewayPath(gatewayName)}/pcap`, fileUpload(file, filename))
+    },
+  }
+
+  return resource
+}

--- a/connectors/ace-iot/src/resources/points.ts
+++ b/connectors/ace-iot/src/resources/points.ts
@@ -1,0 +1,85 @@
+import type { AceIotHttp } from "../http"
+import { listAllPages } from "../pagination"
+import { pageQuery, timeRangeQuery } from "../query"
+import type {
+  AceIotPage,
+  AceIotPoint,
+  AceIotPointInput,
+  AceIotPointListAllOptions,
+  AceIotPointListOptions,
+  AceIotPointWriteOptions,
+  AceIotTimeseries,
+  AceIotTimeseriesRange,
+} from "../types"
+import { assertMaxPages, assertPageOptions, pathSegment } from "../validation"
+
+export interface PointsResource {
+  /** `GET /points/` — every point visible to the key, across all sites. */
+  list(options?: AceIotPointListOptions): Promise<AceIotPage<AceIotPoint>>
+  listAll(options?: AceIotPointListAllOptions): AsyncIterable<AceIotPoint>
+  /** `GET /points/{point_name}` */
+  get(pointName: string): Promise<AceIotPoint>
+  /** `POST /points/` — creates or updates a batch. ACE documents no response body. */
+  create(points: readonly AceIotPointInput[], options?: AceIotPointWriteOptions): Promise<void>
+  /** `PUT /points/{point_name}` — ACE documents no response body. */
+  update(
+    pointName: string,
+    input: AceIotPointInput,
+    options?: AceIotPointWriteOptions
+  ): Promise<void>
+  /** `GET /points/{point_name}/timeseries` */
+  getTimeseries(pointName: string, range: AceIotTimeseriesRange): Promise<AceIotTimeseries>
+  /**
+   * `POST /points/get_timeseries` — readings for many named points at once. A read despite the
+   * method, so it is safe to retry and is marked as such.
+   */
+  getTimeseriesForPoints(
+    pointNames: readonly string[],
+    range: AceIotTimeseriesRange
+  ): Promise<AceIotTimeseries>
+}
+
+export function createPointsResource(http: AceIotHttp): PointsResource {
+  const resource: PointsResource = {
+    list(options) {
+      assertPageOptions(options)
+      return http.get("points/", pageQuery(options))
+    },
+    listAll(options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages((pageOptions) => resource.list(pageOptions), options)
+    },
+    get(pointName) {
+      return http.get(`points/${pathSegment(pointName, "pointName")}`)
+    },
+    create(points, options) {
+      return http.post("points/", { points }, tagQuery(options))
+    },
+    update(pointName, input, options) {
+      return http.put(`points/${pathSegment(pointName, "pointName")}`, input, tagQuery(options))
+    },
+    getTimeseries(pointName, range) {
+      return http.get(
+        `points/${pathSegment(pointName, "pointName")}/timeseries`,
+        timeRangeQuery(range)
+      )
+    },
+    getTimeseriesForPoints(pointNames, range) {
+      return http.post(
+        "points/get_timeseries",
+        { points: pointNames.map((name) => ({ name })) },
+        timeRangeQuery(range),
+        { idempotent: true }
+      )
+    },
+  }
+
+  return resource
+}
+
+function tagQuery(options: AceIotPointWriteOptions | undefined) {
+  return {
+    overwrite_m_tags: options?.overwriteMarkerTags,
+    overwrite_kv_tags: options?.overwriteKvTags,
+  }
+}

--- a/connectors/ace-iot/src/resources/sites.ts
+++ b/connectors/ace-iot/src/resources/sites.ts
@@ -1,0 +1,174 @@
+import { AceIotApiError } from "../errors"
+import type { AceIotHttp } from "../http"
+import { iterateTimeseriesPages, listAllPages } from "../pagination"
+import { pageQuery, timeRangeQuery } from "../query"
+import type {
+  AceIotCreateSiteInput,
+  AceIotIterateTimeseriesOptions,
+  AceIotPage,
+  AceIotPoint,
+  AceIotPointListAllOptions,
+  AceIotPointListOptions,
+  AceIotPointSample,
+  AceIotSite,
+  AceIotSiteListAllOptions,
+  AceIotSiteListOptions,
+  AceIotTimeseries,
+  AceIotTimeseriesPage,
+  AceIotTimeseriesPageOptions,
+  AceIotTimeseriesRange,
+  AceIotWeather,
+  AceIotWeatherResponse,
+} from "../types"
+import {
+  assertMaxPages,
+  assertPageOptions,
+  assertTimeseriesPageSize,
+  pathSegment,
+} from "../validation"
+
+export interface SitesResource {
+  /** `GET /sites/` */
+  list(options?: AceIotSiteListOptions): Promise<AceIotPage<AceIotSite>>
+  listAll(options?: AceIotSiteListAllOptions): AsyncIterable<AceIotSite>
+  /** `GET /sites/{site_name}` */
+  get(siteName: string): Promise<AceIotSite>
+  /** `POST /sites/` — ACE documents no response body. */
+  create(input: AceIotCreateSiteInput): Promise<void>
+  /** `GET /sites/{site_name}/points` — every point known at the site. */
+  listPoints(siteName: string, options?: AceIotPointListOptions): Promise<AceIotPage<AceIotPoint>>
+  listAllPoints(siteName: string, options?: AceIotPointListAllOptions): AsyncIterable<AceIotPoint>
+  /** `GET /sites/{site_name}/configured_points` — only points configured for collection. */
+  listConfiguredPoints(
+    siteName: string,
+    options?: AceIotPointListOptions
+  ): Promise<AceIotPage<AceIotPoint>>
+  listAllConfiguredPoints(
+    siteName: string,
+    options?: AceIotPointListAllOptions
+  ): AsyncIterable<AceIotPoint>
+  /** `GET /sites/{site_name}/timeseries` — the whole window in one response. */
+  getTimeseries(siteName: string, range: AceIotTimeseriesRange): Promise<AceIotTimeseries>
+  /** `POST /sites/{site_name}/timeseries` — ACE documents no response body. */
+  appendTimeseries(siteName: string, samples: AceIotTimeseries): Promise<void>
+  /**
+   * `GET /sites/{site_name}/timeseries/paginated` — one page, exactly as ACE returns it.
+   *
+   * The `next_cursor` on the result is ACE's own and does not always advance; prefer
+   * `iterateTimeseries` unless you are storing cursors yourself.
+   */
+  getTimeseriesPage(
+    siteName: string,
+    options: AceIotTimeseriesPageOptions
+  ): Promise<AceIotTimeseriesPage>
+  /** Every page of the window, with ACE's cursor repaired on each hop. */
+  iterateTimeseriesPages(
+    siteName: string,
+    options: AceIotIterateTimeseriesOptions
+  ): AsyncIterable<AceIotTimeseriesPage>
+  /** Every sample in the window, with ACE's cursor repaired on each hop. */
+  iterateTimeseries(
+    siteName: string,
+    options: AceIotIterateTimeseriesOptions
+  ): AsyncIterable<AceIotPointSample>
+  /**
+   * `GET /sites/{site_name}/weather` — last known values for the site's weather points, or `null`
+   * when the site has no weather feed (ACE answers 404 with an all-null body).
+   */
+  getWeather(siteName: string): Promise<AceIotWeather | null>
+}
+
+export function createSitesResource(http: AceIotHttp): SitesResource {
+  const resource: SitesResource = {
+    list(options) {
+      assertPageOptions(options)
+      return http.get("sites/", {
+        ...pageQuery(options),
+        collect_enabled: options?.collectEnabled,
+        show_archived: options?.showArchived,
+      })
+    },
+    listAll(options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages((pageOptions) => resource.list(pageOptions), options)
+    },
+    get(siteName) {
+      return http.get(`sites/${pathSegment(siteName, "siteName")}`)
+    },
+    create(input) {
+      return http.post("sites/", input)
+    },
+    listPoints(siteName, options) {
+      assertPageOptions(options)
+      return http.get(`sites/${pathSegment(siteName, "siteName")}/points`, pageQuery(options))
+    },
+    listAllPoints(siteName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages((pageOptions) => resource.listPoints(siteName, pageOptions), options)
+    },
+    listConfiguredPoints(siteName, options) {
+      assertPageOptions(options)
+      return http.get(
+        `sites/${pathSegment(siteName, "siteName")}/configured_points`,
+        pageQuery(options)
+      )
+    },
+    listAllConfiguredPoints(siteName, options) {
+      assertMaxPages(options?.maxPages)
+      return listAllPages(
+        (pageOptions) => resource.listConfiguredPoints(siteName, pageOptions),
+        options
+      )
+    },
+    getTimeseries(siteName, range) {
+      return http.get(
+        `sites/${pathSegment(siteName, "siteName")}/timeseries`,
+        timeRangeQuery(range)
+      )
+    },
+    appendTimeseries(siteName, samples) {
+      return http.post(`sites/${pathSegment(siteName, "siteName")}/timeseries`, samples)
+    },
+    getTimeseriesPage(siteName, options) {
+      if (options.pageSize !== undefined) {
+        assertTimeseriesPageSize(options.pageSize)
+      }
+
+      return http.get(`sites/${pathSegment(siteName, "siteName")}/timeseries/paginated`, {
+        ...timeRangeQuery(options),
+        cursor: options.cursor,
+        page_size: options.pageSize,
+        raw_data: options.rawData,
+      })
+    },
+    iterateTimeseriesPages(siteName, options) {
+      assertMaxPages(options.maxPages)
+      return iterateTimeseriesPages(
+        (pageOptions) => resource.getTimeseriesPage(siteName, pageOptions),
+        options
+      )
+    },
+    async *iterateTimeseries(siteName, options) {
+      for await (const page of resource.iterateTimeseriesPages(siteName, options)) {
+        for (const sample of page.point_samples) {
+          yield sample
+        }
+      }
+    },
+    async getWeather(siteName) {
+      try {
+        const response = await http.get<AceIotWeatherResponse>(
+          `sites/${pathSegment(siteName, "siteName")}/weather`
+        )
+        return response.weather
+      } catch (error) {
+        if (error instanceof AceIotApiError && error.status === 404) {
+          return null
+        }
+        throw error
+      }
+    },
+  }
+
+  return resource
+}

--- a/connectors/ace-iot/src/time.ts
+++ b/connectors/ace-iot/src/time.ts
@@ -1,0 +1,57 @@
+import type { AceIotTimeInput, AceIotTimestamp } from "./types"
+
+/**
+ * Matches an ACE timestamp that carries no zone designator, in either shape ACE emits: the ISO
+ * `2026-08-07T16:25:00[.627593]` used by samples and `created`/`updated`, and the space-separated
+ * `2027-03-04 19:34:54.114795` used by `device_token_expires`.
+ */
+const NAIVE_TIMESTAMP = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2}(?:\.\d+)?)$/
+
+/**
+ * Parse an ACE timestamp as the UTC instant it represents.
+ *
+ * ACE returns timestamps with no zone designator even though they are UTC, so `new Date(value)`
+ * reads them as local time and shifts every sample by the host's offset — silently, and only for
+ * hosts that are not on UTC. Sub-second digits beyond milliseconds are truncated, as `Date` has no
+ * room for them.
+ *
+ * Values that already carry a zone (`Z` or `±HH:MM`) are parsed as-is.
+ */
+export function parseAceIotTimestamp(value: AceIotTimestamp): Date {
+  const parsed = new Date(normalizeAceIotTimestamp(value))
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`[SixbAceIot] Could not parse "${value}" as a timestamp.`)
+  }
+
+  return parsed
+}
+
+/** The same normalization as `parseAceIotTimestamp`, kept as a string. */
+export function normalizeAceIotTimestamp(value: AceIotTimestamp): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error("[SixbAceIot] A timestamp must be a non-empty string.")
+  }
+
+  const naive = NAIVE_TIMESTAMP.exec(value.trim())
+  return naive ? `${naive[1]}T${naive[2]}Z` : value.trim()
+}
+
+/**
+ * Serialize a `start_time`/`end_time` query value. A `Date` becomes a UTC ISO string; a string is
+ * normalized the same way responses are, so a naive timestamp read off one response can be handed
+ * straight back as a query bound without shifting by the host's offset.
+ */
+export function toAceIotQueryTime(value: AceIotTimeInput, field: string): string {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      throw new Error(`[SixbAceIot] ${field} must be a valid Date.`)
+    }
+    return value.toISOString()
+  }
+
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[SixbAceIot] ${field} must be a Date or a non-empty string.`)
+  }
+
+  return normalizeAceIotTimestamp(value)
+}

--- a/connectors/ace-iot/src/types/client.ts
+++ b/connectors/ace-iot/src/types/client.ts
@@ -1,0 +1,12 @@
+import type { ClientsResource } from "../resources/clients"
+import type { GatewaysResource } from "../resources/gateways"
+import type { PointsResource } from "../resources/points"
+import type { SitesResource } from "../resources/sites"
+
+/** The connected ACE IoT client. One property per tag in ACE's own API surface. */
+export interface AceIotClient {
+  readonly clients: ClientsResource
+  readonly sites: SitesResource
+  readonly points: PointsResource
+  readonly gateways: GatewaysResource
+}

--- a/connectors/ace-iot/src/types/clients.ts
+++ b/connectors/ace-iot/src/types/clients.ts
@@ -1,0 +1,28 @@
+import type { AceIotListAllOptions, AceIotPageOptions } from "./common"
+
+/**
+ * One record from the `/clients` resource — the tenant that owns sites, points, and gateways.
+ * Named `…ClientAccount` because `AceIotClient` is the connected SDK client.
+ */
+export interface AceIotClientAccount {
+  readonly id: number
+  /** Unique name, and the identifier every `/clients/{client_name}` route takes. */
+  readonly name: string
+  readonly nice_name: string | null
+  /** Business contact. */
+  readonly bus_contact: string | null
+  /** Technical contact. */
+  readonly tech_contact: string | null
+  readonly address: string | null
+}
+
+export interface AceIotClientListOptions extends AceIotPageOptions {}
+export interface AceIotClientListAllOptions extends AceIotListAllOptions {}
+
+export interface AceIotCreateClientInput {
+  readonly name: string
+  readonly nice_name?: string
+  readonly bus_contact?: string
+  readonly tech_contact?: string
+  readonly address?: string
+}

--- a/connectors/ace-iot/src/types/common.ts
+++ b/connectors/ace-iot/src/types/common.ts
@@ -1,0 +1,78 @@
+export type AceIotApiKeyResolver = string | (() => string | Promise<string>)
+
+export type AceIotRequestMethod = "GET" | "POST" | "PUT" | "PATCH"
+
+export interface AceIotRetryContext {
+  readonly attempt: number
+  readonly method: AceIotRequestMethod
+  /** True when replaying the request cannot change server state, so a retry is safe. */
+  readonly idempotent: boolean
+  readonly response: Response | null
+  readonly error: unknown
+}
+
+export interface AceIotRetryPolicy {
+  /** Number of retries after the initial request. Defaults to 2. */
+  readonly maxRetries?: number
+  shouldRetry?(context: AceIotRetryContext): boolean
+  delayMs?(context: AceIotRetryContext): number
+}
+
+export interface AceIotConnectorOptions {
+  /** ACE API key, or a resolver called before every attempt. Sent as `Authorization: Bearer`. */
+  readonly apiKey: AceIotApiKeyResolver
+  /** API base URL. Defaults to https://flightdeck.aceiot.cloud/api/. */
+  readonly baseUrl?: string
+  readonly timeoutMs?: number
+  /** Minimum delay between request starts. Defaults to 0 — ACE publishes no rate limit. */
+  readonly minDelayMs?: number
+  /** Method-aware retry policy. By default, only reads are retried. */
+  readonly retry?: AceIotRetryPolicy
+}
+
+export type QueryScalar = string | number | boolean
+export type QueryValue = QueryScalar | undefined
+export type QueryParams = Readonly<Record<string, QueryValue>>
+
+/**
+ * An ISO 8601 timestamp with no zone designator, as ACE returns it: `2026-08-07T16:25:00`, or
+ * `2026-08-07T16:25:00.627593` when microseconds are present. The instant is UTC, but because the
+ * string does not say so, `new Date(value)` reads it as local time. Use `parseAceIotTimestamp`.
+ */
+export type AceIotTimestamp = string
+
+/** A `Date`, or any string the ACE API accepts for `start_time`/`end_time`. */
+export type AceIotTimeInput = Date | string
+
+/**
+ * Page sizes the ACE API accepts for `per_page`. It is a closed enum, not a range: any other value
+ * is rejected with a 400, so the connector checks it before spending a request.
+ */
+export const ACE_IOT_PER_PAGE_VALUES = [
+  2, 10, 20, 30, 40, 50, 100, 500, 1000, 5000, 10000, 100000,
+] as const
+
+export type AceIotPerPage = (typeof ACE_IOT_PER_PAGE_VALUES)[number]
+
+export interface AceIotPageOptions {
+  /** 1-based page number. Defaults to 1. */
+  readonly page?: number
+  readonly perPage?: AceIotPerPage
+}
+
+export interface AceIotListAllOptions extends AceIotPageOptions {
+  /** Stop after this many pages. Unbounded by default. */
+  readonly maxPages?: number
+}
+
+/**
+ * ACE's page envelope. `pages` is `null` on some endpoints (the gateway PCAP listing returns
+ * `{"items": [], "page": 1, "pages": null, "total": 0}`), so it cannot be the sole stop condition.
+ */
+export interface AceIotPage<TItem> {
+  readonly items: readonly TItem[]
+  readonly page: number
+  readonly pages: number | null
+  readonly per_page: number
+  readonly total: number
+}

--- a/connectors/ace-iot/src/types/der-events.ts
+++ b/connectors/ace-iot/src/types/der-events.ts
@@ -1,0 +1,45 @@
+import type { AceIotListAllOptions, AceIotPageOptions, AceIotTimestamp } from "./common"
+
+/** A demand-response event scheduled against a client or gateway. */
+export interface AceIotDerEvent {
+  readonly id: string
+  readonly timezone: string | null
+  readonly event_start: AceIotTimestamp | null
+  readonly event_end: AceIotTimestamp | null
+  readonly event_type: string | null
+  readonly group_name: string | null
+  readonly client: string | null
+  readonly created_by_user: string | null
+  readonly cancelled: boolean | null
+  readonly title: string | null
+  readonly description: string | null
+  readonly updated: AceIotTimestamp | null
+  readonly created: AceIotTimestamp | null
+}
+
+/** A new event. ACE assigns the id. */
+export interface AceIotCreateDerEventInput {
+  readonly timezone?: string
+  readonly event_start?: string
+  readonly event_end?: string
+  readonly event_type?: string
+  readonly group_name?: string
+  readonly cancelled?: boolean
+  readonly title?: string
+  readonly description?: string
+}
+
+/** An edit to an existing event, matched by `id`. */
+export interface AceIotUpdateDerEventInput extends AceIotCreateDerEventInput {
+  readonly id: string
+}
+
+export interface AceIotDerEventListOptions extends AceIotPageOptions {
+  /** Also return events that ended up to 24 hours ago. Defaults to false. */
+  readonly getPastEvents?: boolean
+  readonly groupName?: string
+}
+
+export interface AceIotDerEventListAllOptions
+  extends AceIotDerEventListOptions,
+    AceIotListAllOptions {}

--- a/connectors/ace-iot/src/types/gateways.ts
+++ b/connectors/ace-iot/src/types/gateways.ts
@@ -1,0 +1,65 @@
+import type { AceIotListAllOptions, AceIotPageOptions, AceIotTimestamp } from "./common"
+
+export interface AceIotGateway {
+  /** Gateway name, and the identifier every `/gateways/{gateway_name}` route takes. */
+  readonly name: string
+  readonly site: string
+  readonly client: string
+  /** Hardware type. Read-only. */
+  readonly hw_type: string | null
+  /** Software type. Read-only. */
+  readonly software_type: string | null
+  readonly primary_mac: string | null
+  /** Overlay network IP. */
+  readonly vpn_ip: string | null
+  readonly device_token: string | null
+  /**
+   * Gateway API key expiry. Unlike every other ACE timestamp this is space-separated
+   * (`2027-03-04 19:34:54.114795`) rather than ISO. `parseAceIotTimestamp` handles both.
+   */
+  readonly device_token_expires: AceIotTimestamp | null
+  /** Free-form interface blob: netplans and discovered interfaces, keyed by name. */
+  readonly interfaces: Readonly<Record<string, unknown>>
+  /** Free-form deployment config: agent state, scan settings, collection flags. */
+  readonly deploy_config: Readonly<Record<string, unknown>>
+  readonly archived: boolean
+  readonly updated: AceIotTimestamp
+}
+
+export interface AceIotGatewayListOptions extends AceIotPageOptions {
+  /** Include archived gateways. Defaults to false. */
+  readonly showArchived?: boolean
+}
+
+export interface AceIotGatewayListAllOptions
+  extends AceIotGatewayListOptions,
+    AceIotListAllOptions {}
+
+/** Writable gateway fields. `hw_type` and `software_type` are read-only upstream. */
+export interface AceIotGatewayInput {
+  readonly name: string
+  readonly site?: string
+  readonly client?: string
+  readonly primary_mac?: string
+  readonly vpn_ip?: string
+  readonly device_token?: string
+  readonly device_token_expires?: string
+  readonly interfaces?: Readonly<Record<string, unknown>>
+  readonly deploy_config?: Readonly<Record<string, unknown>>
+  readonly archived?: boolean
+}
+
+/** The fields a PATCH may change. `name` comes from the path. */
+export type AceIotUpdateGatewayInput = Omit<AceIotGatewayInput, "name"> & { readonly name?: string }
+
+/** An authorization token used to access the ACE Manager API. */
+export interface AceIotGatewayToken {
+  readonly auth_token: string
+}
+
+export interface AceIotPcapListOptions extends AceIotPageOptions {
+  readonly startTime: Date | string
+  readonly endTime: Date | string
+}
+
+export interface AceIotPcapListAllOptions extends AceIotPcapListOptions, AceIotListAllOptions {}

--- a/connectors/ace-iot/src/types/hawke.ts
+++ b/connectors/ace-iot/src/types/hawke.ts
@@ -1,0 +1,44 @@
+import type { AceIotListAllOptions, AceIotPageOptions, AceIotTimestamp } from "./common"
+
+export interface AceIotHawkeConfig {
+  readonly content_hash: string | null
+  readonly content_blob: string | null
+  readonly updated: AceIotTimestamp | null
+  readonly created: AceIotTimestamp | null
+}
+
+/** A Hawke config as returned in a listing, which names the agent it belongs to. */
+export interface AceIotHawkeConfigWithIdentity extends AceIotHawkeConfig {
+  readonly hawke_identity: string | null
+}
+
+/** The writable fields of a Hawke config. `updated` and `created` are read-only upstream. */
+export interface AceIotHawkeConfigBaseInput {
+  readonly content_hash?: string
+  readonly content_blob?: string
+}
+
+/** A Hawke config in a batch write, which has to name the agent it belongs to. */
+export interface AceIotHawkeConfigInput extends AceIotHawkeConfigBaseInput {
+  readonly hawke_identity: string
+}
+
+export interface AceIotHawkeConfigListOptions extends AceIotPageOptions {
+  /** Retrieve one specific config by hash. */
+  readonly hash?: string
+  /** Exchange hashes as base64 rather than ASCII hex. Defaults to false. */
+  readonly useBase64Hash?: boolean
+}
+
+export interface AceIotHawkeConfigListAllOptions
+  extends AceIotHawkeConfigListOptions,
+    AceIotListAllOptions {}
+
+export interface AceIotHawkeConfigOptions {
+  readonly hash?: string
+  readonly useBase64Hash?: boolean
+}
+
+export interface AceIotHawkeConfigWriteOptions {
+  readonly useBase64Hash?: boolean
+}

--- a/connectors/ace-iot/src/types/index.ts
+++ b/connectors/ace-iot/src/types/index.ts
@@ -1,0 +1,13 @@
+// `common` and `timeseries` also export the two page-size tables, which describe the wire
+// contract and are useful to callers building their own paging.
+
+export type * from "./client"
+export type * from "./clients"
+export * from "./common"
+export type * from "./der-events"
+export type * from "./gateways"
+export type * from "./hawke"
+export type * from "./points"
+export type * from "./sites"
+export * from "./timeseries"
+export type * from "./volttron"

--- a/connectors/ace-iot/src/types/points.ts
+++ b/connectors/ace-iot/src/types/points.ts
@@ -1,0 +1,101 @@
+import type { AceIotListAllOptions, AceIotPageOptions, AceIotTimestamp } from "./common"
+
+/**
+ * BACnet metadata scraped from the device.
+ *
+ * ACE's own schema documents eleven of these properties and types the object as free-form; the
+ * live API returns all of the below. Values are strings apart from the four typed numerically or
+ * as booleans, and a property the device did not answer for comes back as the literal string
+ * `"property: unknown-property"` rather than null or an absent key.
+ *
+ * The index signature keeps vendor properties outside this list reachable without a cast.
+ */
+export interface AceIotBacnetData {
+  readonly device_address?: string
+  readonly device_id?: number
+  readonly device_name?: string
+  readonly device_description?: string
+  readonly object_type?: string
+  readonly object_index?: number
+  readonly object_name?: string
+  readonly object_description?: string
+  readonly object_units?: string
+  readonly present_value?: string
+  readonly recent_value?: string
+  readonly recent_timestamp?: string
+  readonly priority_array?: string
+  readonly scrape_interval?: number
+  readonly scrape_enabled?: boolean
+  readonly vendor_id?: string
+  readonly vendor_name?: string
+  readonly model_name?: string
+  readonly serial_number?: string
+  readonly location?: string
+  readonly firmware_revision?: string
+  readonly software_version?: string
+  readonly database_revision?: string
+  readonly protocol_version?: string
+  readonly protocol_revision?: string
+  readonly system_status?: string
+  readonly segmentation_supported?: string
+  readonly address_binding?: string
+  readonly max_apdu_length?: string
+  readonly apdu_timeout?: string
+  readonly apdu_retries?: string
+  readonly file_size?: string
+  readonly file_hash?: string
+  readonly [key: string]: string | number | boolean | null | undefined
+}
+
+export interface AceIotPoint {
+  readonly id: number
+  /** Slash-separated path, e.g. `client/site/10.0.0.1-100/analogInput/1`. */
+  readonly name: string
+  readonly client: string
+  readonly site: string
+  /** Arbitrary key/value tags. ACE stores strings only. */
+  readonly kv_tags: Readonly<Record<string, string>>
+  readonly bacnet_data: AceIotBacnetData
+  readonly marker_tags: readonly string[]
+  /** Config fragment whose shape depends on `point_type`. */
+  readonly collect_config: Readonly<Record<string, unknown>>
+  readonly point_type: string | null
+  readonly collect_enabled: boolean
+  /** Collection interval in seconds. */
+  readonly collect_interval: number | null
+  readonly updated: AceIotTimestamp
+  readonly created: AceIotTimestamp
+}
+
+export interface AceIotPointListOptions extends AceIotPageOptions {}
+export interface AceIotPointListAllOptions extends AceIotListAllOptions {}
+
+/** The writable fields of a point. `name` identifies it. */
+export interface AceIotPointInput {
+  readonly name: string
+  readonly client?: string
+  readonly site?: string
+  readonly kv_tags?: Readonly<Record<string, string>>
+  readonly bacnet_data?: AceIotBacnetData
+  readonly marker_tags?: readonly string[]
+  readonly collect_config?: Readonly<Record<string, unknown>>
+  readonly point_type?: string
+  readonly collect_enabled?: boolean
+  readonly collect_interval?: number
+}
+
+/**
+ * Tag-merge behavior for point writes. ACE merges tags into what a point already has unless told
+ * to replace them, so both default to false.
+ */
+export interface AceIotPointWriteOptions {
+  /** Replace the point's marker tags instead of merging (`overwrite_m_tags`). */
+  readonly overwriteMarkerTags?: boolean
+  /** Replace the point's key/value tags instead of merging (`overwrite_kv_tags`). */
+  readonly overwriteKvTags?: boolean
+}
+
+/** Request body for `POST /points/` and `POST /points/get_timeseries`. */
+export interface AceIotPointList {
+  readonly points: readonly AceIotPointInput[]
+}

--- a/connectors/ace-iot/src/types/sites.ts
+++ b/connectors/ace-iot/src/types/sites.ts
@@ -1,0 +1,46 @@
+import type { AceIotListAllOptions, AceIotPageOptions } from "./common"
+
+export interface AceIotSite {
+  readonly id: number
+  /** Unique path for the site, and the identifier every `/sites/{site_name}` route takes. */
+  readonly name: string
+  /** Name of the owning client. */
+  readonly client: string
+  readonly address: string | null
+  readonly nice_name: string | null
+  /** Ansible user for deploy tasks. */
+  readonly ansible_user: string | null
+  /** VOLTTRON run-as user. */
+  readonly vtron_user: string | null
+  readonly vtron_ip: string | null
+  /** PostGIS point as a WKB hex string (`0101000000…`), not a readable coordinate pair. */
+  readonly geo_location: string | null
+  readonly mqtt_prefix: string | null
+  readonly latitude: number | null
+  readonly longitude: number | null
+  readonly archived: boolean
+}
+
+export interface AceIotSiteListOptions extends AceIotPageOptions {
+  /** Only sites with at least one collect-enabled point. Defaults to false. */
+  readonly collectEnabled?: boolean
+  /** Include archived sites. Defaults to false. */
+  readonly showArchived?: boolean
+}
+
+export interface AceIotSiteListAllOptions extends AceIotSiteListOptions, AceIotListAllOptions {}
+
+export interface AceIotCreateSiteInput {
+  readonly name: string
+  readonly client?: string
+  readonly address?: string
+  readonly nice_name?: string
+  readonly ansible_user?: string
+  readonly vtron_user?: string
+  readonly vtron_ip?: string
+  readonly geo_location?: string
+  readonly mqtt_prefix?: string
+  readonly latitude?: number
+  readonly longitude?: number
+  readonly archived?: boolean
+}

--- a/connectors/ace-iot/src/types/timeseries.ts
+++ b/connectors/ace-iot/src/types/timeseries.ts
@@ -1,0 +1,85 @@
+import type { AceIotTimeInput, AceIotTimestamp } from "./common"
+
+/**
+ * Page sizes the paginated timeseries endpoint accepts. This is a different enum than `per_page`:
+ * it allows 3 but not 2, and reaches 500,000.
+ */
+export const ACE_IOT_PAGE_SIZE_VALUES = [
+  3, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 300000, 500000,
+] as const
+
+export type AceIotTimeseriesPageSize = (typeof ACE_IOT_PAGE_SIZE_VALUES)[number]
+
+/**
+ * One reading. `value` is always a string on the wire, including numerics such as
+ * `"1.6100000143051147"` — it is left alone so the connector never introduces rounding the API did
+ * not have. `time` is a naive UTC timestamp; see `parseAceIotTimestamp`.
+ */
+export interface AceIotPointSample {
+  readonly name: string
+  readonly value: string
+  readonly time: AceIotTimestamp
+}
+
+/** The unpaginated timeseries response, and the body accepted when appending samples. */
+export interface AceIotTimeseries {
+  readonly point_samples: readonly AceIotPointSample[]
+}
+
+/**
+ * One page of `GET /sites/{site_name}/timeseries/paginated`.
+ *
+ * `next_cursor` is base64 JSON, and ACE miscomputes it — see `iterateTimeseriesPages`, which
+ * repairs it. Reading `next_cursor` directly is only safe when a page ends in a later timestamp
+ * bucket than the one its request started in.
+ */
+export interface AceIotTimeseriesPage {
+  readonly point_samples: readonly AceIotPointSample[]
+  readonly next_cursor: string | null
+  readonly has_more: boolean
+}
+
+export interface AceIotTimeseriesRange {
+  readonly startTime: AceIotTimeInput
+  readonly endTime: AceIotTimeInput
+}
+
+export interface AceIotTimeseriesPageOptions extends AceIotTimeseriesRange {
+  readonly cursor?: string
+  /** Defaults to ACE's own default of 10,000. */
+  readonly pageSize?: AceIotTimeseriesPageSize
+  /** Return readings as recorded instead of ACE's 5-minute buckets. Defaults to false. */
+  readonly rawData?: boolean
+}
+
+export interface AceIotIterateTimeseriesOptions extends AceIotTimeseriesPageOptions {
+  /** Stop after this many pages. Unbounded by default. */
+  readonly maxPages?: number
+}
+
+/**
+ * A weather reading. Every field is nullable: ACE answers a site with no weather feed with a 404
+ * whose body has this shape with all-null members.
+ */
+export interface AceIotWeatherReading {
+  readonly name: string | null
+  readonly value: string | null
+  readonly time: AceIotTimestamp | null
+}
+
+/** Last known values for a site's weather trending points. */
+export interface AceIotWeather {
+  readonly temp: AceIotWeatherReading
+  readonly feels_like: AceIotWeatherReading
+  readonly pressure: AceIotWeatherReading
+  readonly humidity: AceIotWeatherReading
+  readonly dew_point: AceIotWeatherReading
+  readonly clouds: AceIotWeatherReading
+  readonly wind_speed: AceIotWeatherReading
+  readonly wind_deg: AceIotWeatherReading
+  readonly wet_bulb: AceIotWeatherReading
+}
+
+export interface AceIotWeatherResponse {
+  readonly weather: AceIotWeather
+}

--- a/connectors/ace-iot/src/types/volttron.ts
+++ b/connectors/ace-iot/src/types/volttron.ts
@@ -1,0 +1,113 @@
+import type { AceIotListAllOptions, AceIotPageOptions, AceIotTimestamp } from "./common"
+
+/** An agent wheel stored against a client. */
+export interface AceIotVolttronAgentPackage {
+  readonly id: string
+  readonly package_name: string | null
+  readonly object_hash: string | null
+  readonly object_path: string | null
+  readonly description: string | null
+  readonly created: AceIotTimestamp | null
+}
+
+export interface AceIotVolttronAgentPackageListOptions extends AceIotPageOptions {
+  /** Filter by package name (`voltron_agent_package_name`, spelled that way upstream). */
+  readonly packageName?: string
+}
+
+export interface AceIotVolttronAgentPackageListAllOptions
+  extends AceIotVolttronAgentPackageListOptions,
+    AceIotListAllOptions {}
+
+export interface AceIotUploadVolttronAgentPackageInput {
+  readonly file: Blob | File
+  readonly packageName: string
+  readonly description?: string
+  /** Filename sent with the upload. Defaults to the file's own name when it has one. */
+  readonly filename?: string
+}
+
+/** An agent configured on a gateway. */
+export interface AceIotVolttronAgent {
+  readonly id: string
+  readonly identity: string | null
+  readonly package_name: string | null
+  readonly revision: string | null
+  readonly tag: string | null
+  readonly active: boolean | null
+  readonly package_id: string | null
+  readonly updated: AceIotTimestamp | null
+  readonly created: AceIotTimestamp | null
+}
+
+export interface AceIotVolttronAgentInput {
+  readonly identity: string
+  readonly package_name?: string
+  readonly revision?: string
+  readonly tag?: string
+  readonly active?: boolean
+  readonly volttron_agent_package_id?: string
+}
+
+export interface AceIotVolttronAgentListOptions extends AceIotPageOptions {
+  readonly volttronAgentIdentity?: string
+}
+
+export interface AceIotVolttronAgentListAllOptions
+  extends AceIotVolttronAgentListOptions,
+    AceIotListAllOptions {}
+
+/** A config blob attached to an agent identity. */
+export interface AceIotAgentConfig {
+  readonly id: string
+  readonly agent_identity: string | null
+  readonly config_name: string
+  readonly config_hash: string | null
+  readonly blob: string | null
+  readonly active: boolean | null
+  readonly updated: AceIotTimestamp | null
+  readonly created: AceIotTimestamp | null
+}
+
+export interface AceIotAgentConfigInput {
+  readonly agent_identity: string
+  /** Defaults to `config` upstream. */
+  readonly config_name?: string
+  readonly config_hash?: string
+  readonly blob?: string
+  readonly active?: boolean
+}
+
+export interface AceIotAgentConfigListOptions extends AceIotPageOptions {
+  readonly agentIdentity?: string
+  /** Only active configs. Defaults to true. */
+  readonly active?: boolean
+  /** Exchange hashes as base64 rather than ASCII hex. Defaults to false. */
+  readonly useBase64Hash?: boolean
+}
+
+export interface AceIotAgentConfigListAllOptions
+  extends AceIotAgentConfigListOptions,
+    AceIotListAllOptions {}
+
+export interface AceIotAgentConfigWriteOptions {
+  /** Exchange hashes as base64 rather than ASCII hex. Defaults to false. */
+  readonly useBase64Hash?: boolean
+}
+
+/** An agent together with its active config and linked package. */
+export interface AceIotVolttronAgentConfigPackage {
+  readonly volttron_agent_package: AceIotVolttronAgentPackage
+  readonly volttron_agent: AceIotVolttronAgent
+  readonly agent_config: AceIotAgentConfig
+}
+
+export interface AceIotCreateVolttronAgentConfigPackageInput {
+  readonly volttron_agent: AceIotVolttronAgentInput
+  readonly agent_config?: AceIotAgentConfigInput
+}
+
+export interface AceIotVolttronAgentConfigPackageOptions {
+  /** Base64-encode the agent config blob (`use_agent_config_base64_hash`). Defaults to false. */
+  readonly useAgentConfigBase64Hash?: boolean
+}

--- a/connectors/ace-iot/src/upload.ts
+++ b/connectors/ace-iot/src/upload.ts
@@ -1,0 +1,17 @@
+/**
+ * Build the multipart body ACE's two upload routes expect. Both read the upload from a `file` form
+ * field. A `Blob` carries no name, so fall back to the `File` name when there is one and let
+ * `FormData` supply its default otherwise.
+ */
+export function fileUpload(file: Blob | File, filename?: string): FormData {
+  const form = new FormData()
+  const name = filename ?? ("name" in file && typeof file.name === "string" ? file.name : undefined)
+
+  if (name) {
+    form.append("file", file, name)
+  } else {
+    form.append("file", file)
+  }
+
+  return form
+}

--- a/connectors/ace-iot/src/validation.ts
+++ b/connectors/ace-iot/src/validation.ts
@@ -1,0 +1,52 @@
+import type { AceIotPageOptions } from "./types"
+import { ACE_IOT_PAGE_SIZE_VALUES, ACE_IOT_PER_PAGE_VALUES } from "./types"
+
+/**
+ * Encode one path segment. ACE point names are slash-separated
+ * (`client/site/10.0.0.1-100/analogInput/1`), so the slashes must be percent-encoded or the
+ * request lands on a different route.
+ */
+export function pathSegment(value: string, field: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`[SixbAceIot] ${field} must be a non-empty string.`)
+  }
+
+  return encodeURIComponent(value)
+}
+
+export function assertPageOptions(options: AceIotPageOptions | undefined): void {
+  if (options?.page !== undefined && (!Number.isInteger(options.page) || options.page < 1)) {
+    throw new Error("[SixbAceIot] page must be an integer greater than 0.")
+  }
+
+  if (options?.perPage !== undefined) {
+    assertPerPage(options.perPage)
+  }
+}
+
+/**
+ * ACE rejects any `per_page` outside its enum with a 400 whose message names the value but not the
+ * allowed set. Checking locally spends no request and says what to use instead.
+ */
+export function assertPerPage(perPage: number): void {
+  if (!(ACE_IOT_PER_PAGE_VALUES as readonly number[]).includes(perPage)) {
+    throw new Error(
+      `[SixbAceIot] perPage must be one of ${ACE_IOT_PER_PAGE_VALUES.join(", ")}. Received ${perPage}.`
+    )
+  }
+}
+
+/** The timeseries endpoint takes a different enum than `per_page`: it allows 3 but not 2. */
+export function assertTimeseriesPageSize(pageSize: number): void {
+  if (!(ACE_IOT_PAGE_SIZE_VALUES as readonly number[]).includes(pageSize)) {
+    throw new Error(
+      `[SixbAceIot] pageSize must be one of ${ACE_IOT_PAGE_SIZE_VALUES.join(", ")}. Received ${pageSize}.`
+    )
+  }
+}
+
+export function assertMaxPages(maxPages: number | undefined): void {
+  if (maxPages !== undefined && (!Number.isInteger(maxPages) || maxPages < 1)) {
+    throw new Error("[SixbAceIot] maxPages must be an integer greater than 0.")
+  }
+}

--- a/connectors/ace-iot/tests/ace-iot.e2e.ts
+++ b/connectors/ace-iot/tests/ace-iot.e2e.ts
@@ -1,0 +1,204 @@
+/**
+ * End-to-end check against the real ACE Deploy API.
+ *
+ * Not part of `bun test` — it needs live credentials, and it walks real timeseries pages, which is
+ * slower than a unit test may be. Run it directly:
+ *
+ *     ACE_IOT_API_KEY="…" bun connectors/ace-iot/tests/ace-iot.e2e.ts
+ *
+ * Optional: `ACE_IOT_BASE_URL` for a non-default deployment, and `ACE_IOT_TEST_SITE` to pin a site
+ * instead of taking the first one the key can see.
+ *
+ * Reads only. Nothing here creates, updates, or deletes anything, and it never mints a gateway
+ * token — the write surface is covered by the unit tests against mocks.
+ */
+import { aceIot, parseAceIotTimestamp } from "../src"
+
+const apiKey = process.env.ACE_IOT_API_KEY
+if (!apiKey) {
+  console.log("[ace-iot e2e] Skipped: set ACE_IOT_API_KEY to run.")
+  process.exit(0)
+}
+
+const ace = await aceIot({
+  apiKey,
+  baseUrl: process.env.ACE_IOT_BASE_URL,
+  timeoutMs: 60_000,
+}).connect({
+  projectId: "e2e",
+  connectorId: "ace-iot",
+  signal: new AbortController().signal,
+})
+
+let failures = 0
+
+function check(label: string, condition: boolean, detail?: unknown) {
+  if (condition) {
+    console.log(`  ✓ ${label}`)
+    return
+  }
+
+  failures += 1
+  console.log(`  ✗ ${label}${detail === undefined ? "" : ` — ${JSON.stringify(detail)}`}`)
+}
+
+console.log("\nclients")
+const clients = await ace.clients.list({ perPage: 100 })
+check("lists clients", clients.items.length > 0)
+check(
+  "page envelope is complete",
+  typeof clients.total === "number" && typeof clients.page === "number"
+)
+const clientName = clients.items[0]?.name
+if (clientName) {
+  const client = await ace.clients.get(clientName)
+  check("gets one client", client.name === clientName)
+  const clientSites = await ace.clients.listSites(clientName, { perPage: 100 })
+  check("lists the client's sites", Array.isArray(clientSites.items))
+}
+
+console.log("\nsites")
+const sites = await ace.sites.list({ perPage: 1000 })
+check("lists sites", sites.items.length > 0)
+const archived = await ace.sites.list({ perPage: 1000, showArchived: true })
+check("show_archived widens the result", archived.total >= sites.total, {
+  visible: sites.total,
+  withArchived: archived.total,
+})
+
+const siteName = process.env.ACE_IOT_TEST_SITE ?? sites.items[0]?.name
+if (!siteName) {
+  console.log("\nNo site visible to this key; stopping.")
+  process.exit(failures > 0 ? 1 : 0)
+}
+console.log(`  using site ${siteName}`)
+
+const site = await ace.sites.get(siteName)
+check("gets one site", site.name === siteName)
+check(
+  "nullable site fields are typed as returned",
+  site.address === null || typeof site.address === "string"
+)
+
+console.log("\npoints")
+const points = await ace.sites.listPoints(siteName, { perPage: 50 })
+check("lists site points", points.items.length > 0)
+const point = points.items[0]
+if (point) {
+  check("point name is the slash-separated path", point.name.includes("/"))
+  check("bacnet_data is an object", typeof point.bacnet_data === "object")
+  check("timestamps parse as UTC", !Number.isNaN(parseAceIotTimestamp(point.created).getTime()))
+
+  const fetched = await ace.points.get(point.name)
+  check("gets a point by its slash-separated name", fetched.name === point.name)
+}
+
+const configured = await ace.sites.listConfiguredPoints(siteName, { perPage: 100 })
+check("lists configured points", Array.isArray(configured.items))
+check(
+  "configured points are collect-enabled",
+  configured.items.every((candidate) => candidate.collect_enabled)
+)
+
+console.log("\ntimeseries")
+const endTime = new Date()
+const startTime = new Date(endTime.getTime() - 15 * 60 * 1000)
+
+const whole = await ace.sites.getTimeseries(siteName, { startTime, endTime })
+check("reads the window unpaginated", Array.isArray(whole.point_samples))
+const truth = new Set(whole.point_samples.map((sample) => `${sample.name}@${sample.time}`))
+console.log(`  window holds ${whole.point_samples.length} samples`)
+
+if (whole.point_samples.length > 0) {
+  const sample = whole.point_samples[0]
+  check("sample value stays a string", typeof sample.value === "string")
+  check("sample time has no zone designator", !/[Zz]|[+-]\d{2}:\d{2}$/.test(sample.time))
+  check("sample time parses as UTC", !Number.isNaN(parseAceIotTimestamp(sample.time).getTime()))
+
+  // The reason this connector exists: at a page size where ACE's own cursor stalls, the repaired
+  // walk still covers the window exactly once.
+  const collected: string[] = []
+  for await (const paged of ace.sites.iterateTimeseries(siteName, {
+    startTime,
+    endTime,
+    pageSize: 50,
+  })) {
+    collected.push(`${paged.name}@${paged.time}`)
+  }
+
+  const unique = new Set(collected)
+  check(
+    `paginated walk at page_size=50 covers all ${truth.size} samples`,
+    unique.size === truth.size,
+    {
+      paged: unique.size,
+      truth: truth.size,
+    }
+  )
+  check("paginated walk emits no duplicates", collected.length === unique.size, {
+    total: collected.length,
+    unique: unique.size,
+  })
+  check(
+    "paginated walk returns nothing outside the window",
+    [...unique].every((key) => truth.has(key))
+  )
+
+  const rawPage = await ace.sites.getTimeseriesPage(siteName, {
+    startTime,
+    endTime,
+    pageSize: 50,
+    rawData: true,
+  })
+  check("raw_data returns unbucketed samples", Array.isArray(rawPage.point_samples))
+} else {
+  console.log("  (window was empty; skipping pagination checks)")
+}
+
+const empty = await ace.sites.getTimeseriesPage(siteName, {
+  startTime: "2001-01-01T00:00:00Z",
+  endTime: "2001-01-01T01:00:00Z",
+})
+check("an empty window is a 200 with an empty page", empty.point_samples.length === 0)
+check(
+  "an empty window terminates the cursor",
+  empty.has_more === false && empty.next_cursor === null
+)
+
+console.log("\nweather")
+const weather = await ace.sites.getWeather(siteName)
+check("weather is a reading set or null", weather === null || typeof weather.temp === "object")
+
+console.log("\ngateways")
+const gateways = await ace.gateways.list({ perPage: 100 })
+check("lists gateways", Array.isArray(gateways.items))
+const gateway = gateways.items[0]
+if (gateway) {
+  const fetched = await ace.gateways.get(gateway.name)
+  check("gets one gateway", fetched.name === gateway.name)
+  check(
+    "device_token_expires parses despite its space-separated format",
+    fetched.device_token_expires === null ||
+      !Number.isNaN(parseAceIotTimestamp(fetched.device_token_expires).getTime())
+  )
+  const configs = await ace.gateways.listAgentConfigs(gateway.name, { perPage: 10 })
+  check("lists agent configs", Array.isArray(configs.items))
+  const agents = await ace.gateways.listVolttronAgents(gateway.name, { perPage: 10 })
+  check("lists volttron agents", Array.isArray(agents.items))
+  const hawke = await ace.gateways.listHawkeConfigurations(gateway.name, { perPage: 10 })
+  check("lists hawke configurations", Array.isArray(hawke.items))
+}
+
+console.log("\nlocal validation")
+try {
+  await ace.sites.list({ perPage: 25 as 20 })
+  check("an unsupported per_page is rejected locally", false)
+} catch (error) {
+  check(
+    "an unsupported per_page is rejected locally",
+    error instanceof Error && error.message.includes("perPage must be one of")
+  )
+}
+
+console.log(failures === 0 ? "\nAll checks passed.\n" : `\n${failures} check(s) failed.\n`)
+process.exit(failures > 0 ? 1 : 0)

--- a/connectors/ace-iot/tests/clients.test.ts
+++ b/connectors/ace-iot/tests/clients.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import type { AceIotClientAccount } from "../src"
+import { captureFetch, createTestClient, mockFetch, page } from "./helpers"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const CLIENT: AceIotClientAccount = {
+  id: 1,
+  name: "acme",
+  nice_name: "Acme Buildings",
+  bus_contact: "Ada Lovelace",
+  tech_contact: "Grace Hopper",
+  address: null,
+}
+
+describe("clients", () => {
+  test("list and get map to the clients collection", async () => {
+    const { urls } = captureFetch(page([CLIENT]))
+    const ace = await createTestClient()
+
+    const result = await ace.clients.list({ perPage: 100 })
+    await ace.clients.get("acme")
+
+    expect(urls[0].pathname).toBe("/api/clients/")
+    expect(urls[0].searchParams.get("per_page")).toBe("100")
+    expect(urls[1].pathname).toBe("/api/clients/acme")
+    expect(result.items[0]).toEqual(CLIENT)
+  })
+
+  test("listSites reads the client's own site collection", async () => {
+    const { urls } = captureFetch(page([]))
+    const ace = await createTestClient()
+
+    await ace.clients.listSites("acme", { perPage: 10 })
+
+    expect(urls[0].pathname).toBe("/api/clients/acme/sites")
+  })
+
+  test("der event listing forwards both filters", async () => {
+    const { urls } = captureFetch(page([]))
+    const ace = await createTestClient()
+
+    await ace.clients.listDerEvents("acme", {
+      perPage: 10,
+      getPastEvents: true,
+      groupName: "peak-shave",
+    })
+
+    expect(urls[0].pathname).toBe("/api/clients/acme/der_events")
+    expect(urls[0].searchParams.get("get_past_events")).toBe("true")
+    expect(urls[0].searchParams.get("group_name")).toBe("peak-shave")
+  })
+
+  test("creating and editing der events use the der_events envelope", async () => {
+    const { urls, inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.clients.createDerEvents("acme", [
+      {
+        title: "Peak shave",
+        event_start: "2026-08-08T18:00:00Z",
+        event_end: "2026-08-08T20:00:00Z",
+      },
+    ])
+    await ace.clients.updateDerEvents("acme", [{ id: "evt-1", cancelled: true }])
+
+    expect(inits[0].method).toBe("POST")
+    expect(JSON.parse(String(inits[0].body))).toEqual({
+      der_events: [
+        {
+          title: "Peak shave",
+          event_start: "2026-08-08T18:00:00Z",
+          event_end: "2026-08-08T20:00:00Z",
+        },
+      ],
+    })
+    expect(inits[1].method).toBe("PUT")
+    expect(JSON.parse(String(inits[1].body))).toEqual({
+      der_events: [{ id: "evt-1", cancelled: true }],
+    })
+    expect(urls[1].pathname).toBe("/api/clients/acme/der_events")
+  })
+
+  test("the package listing uses ACE's misspelled query parameter", async () => {
+    const { urls } = captureFetch(page([]))
+    const ace = await createTestClient()
+
+    await ace.clients.listVolttronAgentPackages("acme", { perPage: 10, packageName: "historian" })
+
+    expect(urls[0].pathname).toBe("/api/clients/acme/volttron_agent_package/list")
+    // Upstream spells it "voltron", and matching that is the only way the filter works.
+    expect(urls[0].searchParams.get("voltron_agent_package_name")).toBe("historian")
+  })
+
+  test("downloading a package returns the raw response with its body unread", async () => {
+    const urls: URL[] = []
+    mockFetch((input) => {
+      urls.push(new URL(String(input)))
+      return Promise.resolve(
+        new Response("wheel-bytes", { headers: { "content-type": "application/octet-stream" } })
+      )
+    })
+    const ace = await createTestClient()
+
+    const response = await ace.clients.downloadVolttronAgentPackage("acme", "pkg-1")
+
+    expect(urls[0].pathname).toBe("/api/clients/acme/volttron_agent_package")
+    expect(urls[0].searchParams.get("volttron_agent_package_id")).toBe("pkg-1")
+    expect(response.bodyUsed).toBe(false)
+    expect(await response.text()).toBe("wheel-bytes")
+  })
+
+  test("a failed download throws instead of handing back an error response", async () => {
+    mockFetch(async () => new Response("nope", { status: 404 }))
+    const ace = await createTestClient({ retry: { maxRetries: 0 } })
+
+    await expect(ace.clients.downloadVolttronAgentPackage("acme", "pkg-1")).rejects.toThrow(
+      "failed with 404"
+    )
+  })
+
+  test("uploading a package sends multipart form data and the name in the query", async () => {
+    const { urls, inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.clients.uploadVolttronAgentPackage("acme", {
+      file: new File(["wheel"], "historian-1.0.whl"),
+      packageName: "historian",
+      description: "Forward historian",
+    })
+
+    const body = inits[0].body as FormData
+    expect(body).toBeInstanceOf(FormData)
+    expect((body.get("file") as File).name).toBe("historian-1.0.whl")
+    expect(urls[0].searchParams.get("package_name")).toBe("historian")
+    expect(urls[0].searchParams.get("description")).toBe("Forward historian")
+    // fetch has to set the multipart boundary itself.
+    expect(new Headers(inits[0].headers).get("content-type")).toBeNull()
+  })
+
+  test("a Blob upload takes the explicit filename", async () => {
+    const { inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.clients.uploadVolttronAgentPackage("acme", {
+      file: new Blob(["wheel"]),
+      packageName: "historian",
+      filename: "explicit.whl",
+    })
+
+    expect(((inits[0].body as FormData).get("file") as File).name).toBe("explicit.whl")
+  })
+})

--- a/connectors/ace-iot/tests/gateways.test.ts
+++ b/connectors/ace-iot/tests/gateways.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import type { AceIotGateway } from "../src"
+import { parseAceIotTimestamp } from "../src"
+import { captureFetch, createTestClient, page } from "./helpers"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const GATEWAY: AceIotGateway = {
+  name: "acme_gw_0001",
+  site: "acme_south_campus",
+  client: "acme",
+  hw_type: null,
+  software_type: null,
+  primary_mac: "02-00-00-00-00-01",
+  vpn_ip: "100.64.0.1",
+  device_token: "example-gateway-token",
+  // Space-separated, unlike every other ACE timestamp.
+  device_token_expires: "2027-03-04 19:34:54.114795",
+  interfaces: { discovered_interfaces: { enp1s0: {} } },
+  deploy_config: { hostname: "acme-south-campus", enable_collection: true },
+  archived: false,
+  updated: "2026-07-21T12:11:27.817913",
+}
+
+describe("gateways", () => {
+  test("list forwards show_archived and returns the gateway shape", async () => {
+    const { urls } = captureFetch(page([GATEWAY], { per_page: 100, total: 5 }))
+    const ace = await createTestClient()
+
+    const result = await ace.gateways.list({ perPage: 100, showArchived: true })
+
+    expect(urls[0].pathname).toBe("/api/gateways/")
+    expect(urls[0].searchParams.get("show_archived")).toBe("true")
+    expect(result.items[0]).toEqual(GATEWAY)
+    expect(result.items[0].interfaces).toEqual({ discovered_interfaces: { enp1s0: {} } })
+  })
+
+  test("the gateway token expiry parses despite its space-separated format", () => {
+    expect(parseAceIotTimestamp(GATEWAY.device_token_expires as string).toISOString()).toBe(
+      "2027-03-04T19:34:54.114Z"
+    )
+  })
+
+  test("update uses PATCH", async () => {
+    const { urls, inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.gateways.update("gw-1", { archived: true })
+
+    expect(inits[0].method).toBe("PATCH")
+    expect(urls[0].pathname).toBe("/api/gateways/gw-1")
+    expect(JSON.parse(String(inits[0].body))).toEqual({ archived: true })
+  })
+
+  test("createToken posts to the token route", async () => {
+    const { urls, inits } = captureFetch({ auth_token: "token-value" })
+    const ace = await createTestClient()
+
+    const token = await ace.gateways.createToken("gw-1")
+
+    expect(inits[0].method).toBe("POST")
+    expect(urls[0].pathname).toBe("/api/gateways/gw-1/token")
+    expect(token.auth_token).toBe("token-value")
+  })
+
+  test("agent config listing forwards identity, active, and hash encoding", async () => {
+    const { urls } = captureFetch(page([]))
+    const ace = await createTestClient()
+
+    await ace.gateways.listAgentConfigs("gw-1", {
+      perPage: 10,
+      agentIdentity: "platform.driver",
+      active: false,
+      useBase64Hash: true,
+    })
+
+    expect(urls[0].pathname).toBe("/api/gateways/gw-1/agent_configs")
+    expect(urls[0].searchParams.get("agent_identity")).toBe("platform.driver")
+    expect(urls[0].searchParams.get("active")).toBe("false")
+    expect(urls[0].searchParams.get("use_base64_hash")).toBe("true")
+  })
+
+  test("agent configs and volttron agents post under their own envelopes", async () => {
+    const { inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.gateways.createAgentConfigs("gw-1", [
+      { agent_identity: "platform.driver", blob: "{}", active: true },
+    ])
+    await ace.gateways.createVolttronAgents("gw-1", [
+      { identity: "platform.driver", package_name: "driver", active: true },
+    ])
+
+    expect(JSON.parse(String(inits[0].body))).toEqual({
+      agent_configs: [{ agent_identity: "platform.driver", blob: "{}", active: true }],
+    })
+    expect(JSON.parse(String(inits[1].body))).toEqual({
+      volttron_agents: [{ identity: "platform.driver", package_name: "driver", active: true }],
+    })
+  })
+
+  test("hawke routes nest the agent identity in the path", async () => {
+    const { urls, inits } = captureFetch(page([]))
+    const ace = await createTestClient()
+
+    await ace.gateways.listHawkeConfigurations("gw-1", { perPage: 10, hash: "abc" })
+    await ace.gateways.getHawkeAgentConfiguration("gw-1", "hawke.one", { useBase64Hash: true })
+    await ace.gateways.listHawkeAgentConfigurations("gw-1", "hawke.one", { perPage: 10 })
+    await ace.gateways.setHawkeAgentConfiguration("gw-1", "hawke.one", { content_blob: "{}" })
+    await ace.gateways.createHawkeConfigurations("gw-1", [
+      { hawke_identity: "hawke.one", content_blob: "{}" },
+    ])
+
+    expect(urls[0].pathname).toBe("/api/gateways/gw-1/hawke_configuration")
+    expect(urls[0].searchParams.get("hash")).toBe("abc")
+    expect(urls[1].pathname).toBe("/api/gateways/gw-1/hawke_configuration/hawke.one")
+    expect(urls[1].searchParams.get("use_base64_hash")).toBe("true")
+    expect(urls[2].pathname).toBe("/api/gateways/gw-1/hawke_configuration/hawke.one/list")
+    expect(JSON.parse(String(inits[3].body))).toEqual({ content_blob: "{}" })
+    expect(JSON.parse(String(inits[4].body))).toEqual({
+      hawke_agents: [{ hawke_identity: "hawke.one", content_blob: "{}" }],
+    })
+  })
+
+  test("the combined agent/config/package route takes the identity as a query parameter", async () => {
+    const { urls, inits } = captureFetch({
+      volttron_agent_package: {},
+      volttron_agent: {},
+      agent_config: {},
+    })
+    const ace = await createTestClient()
+
+    await ace.gateways.getVolttronAgentConfigPackage("gw-1", "platform.driver", {
+      useAgentConfigBase64Hash: true,
+    })
+    await ace.gateways.createVolttronAgentConfigPackage("gw-1", {
+      volttron_agent: { identity: "platform.driver" },
+      agent_config: { agent_identity: "platform.driver", blob: "{}" },
+    })
+
+    expect(urls[0].pathname).toBe("/api/gateways/gw-1/volttron_agent_config_package")
+    expect(urls[0].searchParams.get("volttron_agent_identity")).toBe("platform.driver")
+    expect(urls[0].searchParams.get("use_agent_config_base64_hash")).toBe("true")
+    expect(JSON.parse(String(inits[1].body))).toEqual({
+      volttron_agent: { identity: "platform.driver" },
+      agent_config: { agent_identity: "platform.driver", blob: "{}" },
+    })
+  })
+
+  test("pcap listing requires a time range and returns file names", async () => {
+    const { urls } = captureFetch(page(["capture-1.pcap"], { pages: null }))
+    const ace = await createTestClient()
+
+    const result = await ace.gateways.listPcapFiles("gw-1", {
+      perPage: 10,
+      startTime: "2026-08-01T00:00:00Z",
+      endTime: "2026-08-07T00:00:00Z",
+    })
+
+    expect(urls[0].pathname).toBe("/api/gateways/gw-1/pcap/list")
+    expect(urls[0].searchParams.get("start_time")).toBe("2026-08-01T00:00:00Z")
+    expect(result.items).toEqual(["capture-1.pcap"])
+    expect(result.pages).toBeNull()
+  })
+
+  test("pcap download and upload use the file routes", async () => {
+    const { urls, inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.gateways.downloadPcap("gw-1", "capture-1.pcap")
+    await ace.gateways.uploadPcap("gw-1", new File(["bytes"], "capture-2.pcap"))
+
+    expect(urls[0].pathname).toBe("/api/gateways/gw-1/pcap")
+    expect(urls[0].searchParams.get("file_name")).toBe("capture-1.pcap")
+    expect(inits[1].method).toBe("POST")
+    expect(((inits[1].body as FormData).get("file") as File).name).toBe("capture-2.pcap")
+  })
+
+  test("gateway der events forward their filters", async () => {
+    const { urls } = captureFetch(page([]))
+    const ace = await createTestClient()
+
+    await ace.gateways.listDerEvents("gw-1", { perPage: 10, getPastEvents: true })
+
+    expect(urls[0].pathname).toBe("/api/gateways/gw-1/der_events")
+    expect(urls[0].searchParams.get("get_past_events")).toBe("true")
+  })
+})

--- a/connectors/ace-iot/tests/helpers.ts
+++ b/connectors/ace-iot/tests/helpers.ts
@@ -1,0 +1,127 @@
+import type { AceIotConnectorOptions } from "../src"
+import { aceIot } from "../src"
+
+export const CONTEXT = {
+  projectId: "demo",
+  connectorId: "ace-iot",
+  signal: new AbortController().signal,
+}
+
+export const API_KEY = "ace-test-key"
+
+export function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as typeof fetch
+}
+
+/** Records every request URL and returns the same body, for asserting query serialization. */
+export function captureFetch(
+  body: unknown,
+  init?: ResponseInit
+): { urls: URL[]; inits: RequestInit[] } {
+  const urls: URL[] = []
+  const inits: RequestInit[] = []
+  mockFetch((input, requestInit) => {
+    urls.push(new URL(String(input)))
+    inits.push(requestInit ?? {})
+    return Promise.resolve(json(body, init))
+  })
+
+  return { urls, inits }
+}
+
+export function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+export async function createTestClient(options: Partial<AceIotConnectorOptions> = {}) {
+  return aceIot({ apiKey: API_KEY, ...options }).connect(CONTEXT)
+}
+
+export async function collect<T>(items: AsyncIterable<T>): Promise<T[]> {
+  const collected: T[] = []
+  for await (const item of items) {
+    collected.push(item)
+  }
+  return collected
+}
+
+/** ACE's page envelope, so tests do not restate it on every list fixture. */
+export function page<T>(items: readonly T[], overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    items,
+    page: 1,
+    pages: 1,
+    per_page: 1000,
+    total: items.length,
+    ...overrides,
+  }
+}
+
+export interface FakeSample {
+  readonly name: string
+  readonly value: string
+  readonly time: string
+}
+
+/** Build samples laid out in 5-minute buckets, as ACE returns them: `[[timestamp, count], …]`. */
+export function buildSamples(buckets: readonly (readonly [string, number])[]): FakeSample[] {
+  const samples: FakeSample[] = []
+  for (const [time, count] of buckets) {
+    for (let index = 0; index < count; index++) {
+      samples.push({ name: `point/${index}`, value: String(index), time })
+    }
+  }
+
+  return samples
+}
+
+/**
+ * ACE's paginated timeseries endpoint, reproduced including the cursor defect.
+ *
+ * The server honors an incoming `{offset, timestamp}` correctly, but computes the outgoing offset
+ * as the number of rows it drew from the page's final bucket, without adding the offset it was
+ * given. Verified against the live API on 2026-08-07: at `page_size=50` over a 3,222-sample window
+ * the second page returns the same cursor it was handed, and the walk stops advancing.
+ */
+export function aceTimeseriesServer(samples: readonly FakeSample[]) {
+  return (url: URL) => {
+    const pageSize = Number(url.searchParams.get("page_size") ?? 10_000)
+    const cursor = url.searchParams.get("cursor")
+
+    let start = 0
+    if (cursor) {
+      const { offset, timestamp } = JSON.parse(atob(cursor)) as {
+        offset: number
+        timestamp: string
+      }
+      const bucketStart = samples.findIndex((sample) => sample.time === timestamp)
+      start = (bucketStart < 0 ? 0 : bucketStart) + offset
+    }
+
+    const pageSamples = samples.slice(start, start + pageSize)
+    const hasMore = start + pageSamples.length < samples.length
+
+    let nextCursor: string | null = null
+    if (hasMore && pageSamples.length > 0) {
+      const lastTimestamp = pageSamples[pageSamples.length - 1].time
+      let rowsFromLastBucket = 0
+      for (
+        let index = pageSamples.length - 1;
+        index >= 0 && pageSamples[index].time === lastTimestamp;
+        index--
+      ) {
+        rowsFromLastBucket += 1
+      }
+      nextCursor = btoa(JSON.stringify({ offset: rowsFromLastBucket, timestamp: lastTimestamp }))
+    }
+
+    return { point_samples: pageSamples, next_cursor: nextCursor, has_more: hasMore }
+  }
+}
+
+export const sampleKey = (sample: FakeSample) => `${sample.name}@${sample.time}`

--- a/connectors/ace-iot/tests/pagination.test.ts
+++ b/connectors/ace-iot/tests/pagination.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { decodeTimeseriesCursor, encodeTimeseriesCursor, repairTimeseriesCursor } from "../src"
+import {
+  aceTimeseriesServer,
+  buildSamples,
+  collect,
+  createTestClient,
+  json,
+  mockFetch,
+  page,
+  sampleKey,
+} from "./helpers"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const RANGE = { startTime: "2026-08-07T17:15:00Z", endTime: "2026-08-07T17:30:00Z" }
+
+/**
+ * The bucket layout measured on a live site over a 15-minute window: one full 5-minute bucket of
+ * 1,464 readings followed by two of 879. It matters that the first bucket is far larger than the
+ * page size, because that is the shape that makes ACE's cursor stall.
+ */
+const BUCKETS = [
+  ["2026-08-07T17:15:00", 1464],
+  ["2026-08-07T17:20:00", 879],
+  ["2026-08-07T17:25:00", 879],
+] as const
+
+describe("timeseries cursor repair", () => {
+  test("the fixture reproduces ACE's stall, so the repair below is not testing an already-working server", async () => {
+    // Guard proof: walking with the server's own next_cursor, which is what a plain
+    // `while (has_more)` loop does. Revert `repairTimeseriesCursor` to return `page.next_cursor`
+    // and the coverage test below fails exactly like this.
+    const samples = buildSamples(BUCKETS)
+    const server = aceTimeseriesServer(samples)
+
+    let cursor: string | null = null
+    const seen = new Set<string>()
+    const collected: string[] = []
+    let pages = 0
+    let stalled = false
+
+    for (;;) {
+      const url = new URL("https://ace.test/api/sites/s/timeseries/paginated")
+      url.searchParams.set("page_size", "50")
+      if (cursor) url.searchParams.set("cursor", cursor)
+
+      const result = server(url)
+      pages += 1
+      collected.push(...result.point_samples.map(sampleKey))
+
+      if (!result.has_more || !result.next_cursor) break
+      if (seen.has(result.next_cursor)) {
+        stalled = true
+        break
+      }
+      seen.add(result.next_cursor)
+      cursor = result.next_cursor
+    }
+
+    expect(stalled).toBe(true)
+    // The walk reaches 100 rows of 3,222 and then re-requests page 2 forever — the numbers
+    // measured against the live API.
+    expect(pages).toBe(2)
+    expect(new Set(collected).size).toBe(100)
+    expect(samples.length).toBe(3222)
+  })
+
+  test("iterateTimeseries walks the whole window at a page size that stalls ACE's own cursor", async () => {
+    const samples = buildSamples(BUCKETS)
+    const server = aceTimeseriesServer(samples)
+    let requests = 0
+    mockFetch((input) => {
+      requests += 1
+      return Promise.resolve(json(server(new URL(String(input)))))
+    })
+
+    const ace = await createTestClient()
+    const collected = await collect(
+      ace.sites.iterateTimeseries("acme_north_campus", { ...RANGE, pageSize: 50 })
+    )
+
+    expect(collected).toHaveLength(3222)
+    expect(new Set(collected.map(sampleKey)).size).toBe(3222)
+    expect(collected.map(sampleKey)).toEqual(samples.map(sampleKey))
+    expect(requests).toBe(Math.ceil(3222 / 50))
+  })
+
+  test.each([
+    3, 10, 50, 100, 500, 1000, 5000,
+  ])("page size %i yields every sample exactly once", async (pageSize) => {
+    const samples = buildSamples(BUCKETS)
+    const server = aceTimeseriesServer(samples)
+    mockFetch((input) => Promise.resolve(json(server(new URL(String(input))))))
+
+    const ace = await createTestClient()
+    const collected = await collect(
+      ace.sites.iterateTimeseries("site", {
+        ...RANGE,
+        pageSize: pageSize as 50,
+      })
+    )
+
+    expect(collected.map(sampleKey)).toEqual(samples.map(sampleKey))
+  })
+
+  test("the repair is inert when a page crosses into a later bucket, where ACE's cursor is correct", () => {
+    // Page ends 536 rows into a new bucket: ACE returns {offset: 536} and so does the repair.
+    const pageResult = {
+      point_samples: [
+        { name: "a", value: "1", time: "2026-08-07T17:15:00" },
+        { name: "b", value: "2", time: "2026-08-07T17:20:00" },
+        { name: "c", value: "3", time: "2026-08-07T17:20:00" },
+      ],
+      next_cursor: encodeTimeseriesCursor({ offset: 2, timestamp: "2026-08-07T17:20:00" }),
+      has_more: true,
+    }
+    const incoming = encodeTimeseriesCursor({ offset: 1000, timestamp: "2026-08-07T17:15:00" })
+
+    expect(decodeTimeseriesCursor(repairTimeseriesCursor(incoming, pageResult) ?? "")).toEqual({
+      offset: 2,
+      timestamp: "2026-08-07T17:20:00",
+    })
+    expect(repairTimeseriesCursor(incoming, pageResult)).toBe(pageResult.next_cursor)
+  })
+
+  test("the repair carries the incoming offset when a page stays inside one bucket", () => {
+    const pageResult = {
+      point_samples: [
+        { name: "a", value: "1", time: "2026-08-07T17:15:00" },
+        { name: "b", value: "2", time: "2026-08-07T17:15:00" },
+      ],
+      // What ACE actually sends back: the offset it was given, unchanged.
+      next_cursor: encodeTimeseriesCursor({ offset: 2, timestamp: "2026-08-07T17:15:00" }),
+      has_more: true,
+    }
+    const incoming = encodeTimeseriesCursor({ offset: 50, timestamp: "2026-08-07T17:15:00" })
+
+    expect(decodeTimeseriesCursor(repairTimeseriesCursor(incoming, pageResult) ?? "")).toEqual({
+      offset: 52,
+      timestamp: "2026-08-07T17:15:00",
+    })
+  })
+
+  test("a terminal page yields no cursor", () => {
+    const samples = [{ name: "a", value: "1", time: "2026-08-07T17:15:00" }]
+    expect(
+      repairTimeseriesCursor(null, { point_samples: samples, next_cursor: "x", has_more: false })
+    ).toBeNull()
+    expect(
+      repairTimeseriesCursor(null, { point_samples: [], next_cursor: "x", has_more: true })
+    ).toBeNull()
+  })
+
+  test("maxPages bounds the walk", async () => {
+    const samples = buildSamples(BUCKETS)
+    const server = aceTimeseriesServer(samples)
+    mockFetch((input) => Promise.resolve(json(server(new URL(String(input))))))
+
+    const ace = await createTestClient()
+    const collected = await collect(
+      ace.sites.iterateTimeseries("site", { ...RANGE, pageSize: 50, maxPages: 3 })
+    )
+
+    expect(collected).toHaveLength(150)
+  })
+
+  test("a walk that stops advancing is reported instead of looped on", async () => {
+    // A server that keeps claiming more data while ignoring the cursor entirely. Guarding on
+    // repeated cursors would not catch this: the repaired cursor advances on every hop.
+    let calls = 0
+    mockFetch(() => {
+      calls += 1
+      return Promise.resolve(
+        json({
+          point_samples: [{ name: "a", value: "1", time: "2026-08-07T17:15:00" }],
+          next_cursor: encodeTimeseriesCursor({ offset: 1, timestamp: "2026-08-07T17:15:00" }),
+          has_more: true,
+        })
+      )
+    })
+
+    const ace = await createTestClient()
+    const walk = collect(ace.sites.iterateTimeseries("site", { ...RANGE, pageSize: 3 }))
+
+    await expect(walk).rejects.toThrow(
+      "[SixbAceIot] Timeseries pagination returned the same page twice and would not advance."
+    )
+    expect(calls).toBe(2)
+  })
+
+  test("an opaque cursor that does not decode still terminates rather than looping", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls += 1
+      return Promise.resolve(
+        json({
+          point_samples:
+            calls === 1 ? [{ name: "a", value: "1", time: "2026-08-07T17:15:00" }] : [],
+          next_cursor: "not-base64-json",
+          has_more: calls === 1,
+        })
+      )
+    })
+
+    const ace = await createTestClient()
+    const collected = await collect(
+      ace.sites.iterateTimeseries("site", { ...RANGE, cursor: "garbage", pageSize: 3 })
+    )
+
+    expect(collected).toHaveLength(1)
+  })
+
+  test("cursors round-trip through base64 JSON and reject malformed input", () => {
+    const cursor = { offset: 50, timestamp: "2026-08-07T17:15:00" }
+    expect(decodeTimeseriesCursor(encodeTimeseriesCursor(cursor))).toEqual(cursor)
+    // The exact wire value ACE returns, so the encoding is pinned, not merely self-consistent.
+    expect(encodeTimeseriesCursor(cursor)).toBe(
+      "eyJvZmZzZXQiOjUwLCJ0aW1lc3RhbXAiOiIyMDI2LTA4LTA3VDE3OjE1OjAwIn0="
+    )
+    expect(
+      decodeTimeseriesCursor("eyJvZmZzZXQiOiA1MCwgInRpbWVzdGFtcCI6ICIyMDI2LTA4LTA3VDE3OjE1OjAwIn0=")
+    ).toEqual(cursor)
+    expect(decodeTimeseriesCursor("garbage")).toBeNull()
+    expect(decodeTimeseriesCursor(btoa("[]"))).toBeNull()
+    expect(decodeTimeseriesCursor(btoa(JSON.stringify({ offset: -1, timestamp: "x" })))).toBeNull()
+  })
+})
+
+describe("page walking", () => {
+  test("listAll follows page numbers and stops on the last page", async () => {
+    const urls: URL[] = []
+    mockFetch((input) => {
+      const url = new URL(String(input))
+      urls.push(url)
+      const pageNumber = Number(url.searchParams.get("page"))
+      return Promise.resolve(
+        json(
+          page([{ id: pageNumber, name: `site-${pageNumber}` }], {
+            page: pageNumber,
+            pages: 3,
+            per_page: 1,
+            total: 3,
+          })
+        )
+      )
+    })
+
+    const ace = await createTestClient()
+    const sites = await collect(ace.sites.listAll({ perPage: 2 }))
+
+    expect(sites.map((site) => site.name)).toEqual(["site-1", "site-2", "site-3"])
+    expect(urls.map((url) => url.searchParams.get("page"))).toEqual(["1", "2", "3"])
+    expect(urls[0].searchParams.get("per_page")).toBe("2")
+  })
+
+  test("listAll defaults to a page size worth walking with", async () => {
+    const urls: URL[] = []
+    mockFetch((input) => {
+      urls.push(new URL(String(input)))
+      return Promise.resolve(json(page([])))
+    })
+
+    const ace = await createTestClient()
+    await collect(ace.sites.listAll())
+
+    expect(urls[0].searchParams.get("per_page")).toBe("1000")
+  })
+
+  test("listAll stops on a null `pages`, which the PCAP listing returns", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls += 1
+      return Promise.resolve(
+        json(page(calls === 1 ? ["a.pcap", "b.pcap"] : [], { pages: null, per_page: 2, total: 4 }))
+      )
+    })
+
+    const ace = await createTestClient()
+    const files = await collect(
+      ace.gateways.listAllPcapFiles("gw", {
+        perPage: 2,
+        startTime: "2026-08-01T00:00:00Z",
+        endTime: "2026-08-07T00:00:00Z",
+      })
+    )
+
+    expect(files).toEqual(["a.pcap", "b.pcap"])
+    expect(calls).toBe(2)
+  })
+
+  test("listAll stops on a short page without spending another request", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls += 1
+      return Promise.resolve(json(page([{ id: 1 }], { pages: 9, per_page: 10, total: 90 })))
+    })
+
+    const ace = await createTestClient()
+    await collect(ace.sites.listAll({ perPage: 10 }))
+
+    expect(calls).toBe(1)
+  })
+
+  test("listAll honors maxPages", async () => {
+    mockFetch(() =>
+      Promise.resolve(json(page([{ id: 1 }, { id: 2 }], { pages: 50, per_page: 2, total: 100 })))
+    )
+
+    const ace = await createTestClient()
+    const points = await collect(ace.points.listAll({ perPage: 2, maxPages: 4 }))
+
+    expect(points).toHaveLength(8)
+  })
+})

--- a/connectors/ace-iot/tests/points.test.ts
+++ b/connectors/ace-iot/tests/points.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { captureFetch, collect, createTestClient } from "./helpers"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const POINT_NAME = "acme/acme_north_campus/10.0.0.10-100/analogInput/1"
+const RANGE = { startTime: "2026-08-07T16:00:00Z", endTime: "2026-08-07T17:00:00Z" }
+
+describe("points", () => {
+  test("get percent-encodes the slashes in a point name", async () => {
+    const { urls } = captureFetch({ id: 1, name: POINT_NAME })
+    const ace = await createTestClient()
+
+    await ace.points.get(POINT_NAME)
+
+    // Left unencoded, this would route to a different endpoint entirely.
+    expect(urls[0].pathname).toBe(
+      "/api/points/acme%2Facme_north_campus%2F10.0.0.10-100%2FanalogInput%2F1"
+    )
+  })
+
+  test("list walks the global point collection", async () => {
+    const { urls } = captureFetch({
+      items: [{ id: 1, name: POINT_NAME }],
+      page: 1,
+      pages: 8756,
+      per_page: 10,
+      total: 87559,
+    })
+    const ace = await createTestClient()
+
+    const result = await ace.points.list({ perPage: 10 })
+
+    expect(urls[0].pathname).toBe("/api/points/")
+    expect(result.total).toBe(87559)
+    expect(result.pages).toBe(8756)
+  })
+
+  test("create posts a point list and defaults to merging tags", async () => {
+    const { urls, inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.points.create([{ name: POINT_NAME, collect_enabled: true, collect_interval: 300 }])
+
+    expect(inits[0].method).toBe("POST")
+    expect(urls[0].pathname).toBe("/api/points/")
+    expect(urls[0].searchParams.get("overwrite_m_tags")).toBeNull()
+    expect(urls[0].searchParams.get("overwrite_kv_tags")).toBeNull()
+    expect(JSON.parse(String(inits[0].body))).toEqual({
+      points: [{ name: POINT_NAME, collect_enabled: true, collect_interval: 300 }],
+    })
+  })
+
+  test("tag overwrite flags map to ACE's parameter names", async () => {
+    const { urls } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.points.update(
+      POINT_NAME,
+      { name: POINT_NAME, kv_tags: { vav: "VAV2_5" }, marker_tags: ["sensor"] },
+      { overwriteMarkerTags: true, overwriteKvTags: true }
+    )
+
+    expect(urls[0].searchParams.get("overwrite_m_tags")).toBe("true")
+    expect(urls[0].searchParams.get("overwrite_kv_tags")).toBe("true")
+  })
+
+  test("update targets the named point with PUT", async () => {
+    const { urls, inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.points.update(POINT_NAME, { name: POINT_NAME, collect_enabled: false })
+
+    expect(inits[0].method).toBe("PUT")
+    expect(urls[0].pathname).toContain("/api/points/acme%2F")
+  })
+
+  test("getTimeseries reads one point's window", async () => {
+    const { urls } = captureFetch({ point_samples: [] })
+    const ace = await createTestClient()
+
+    await ace.points.getTimeseries(POINT_NAME, RANGE)
+
+    expect(urls[0].pathname).toMatch(/\/api\/points\/.+\/timeseries$/)
+    expect(urls[0].searchParams.get("start_time")).toBe("2026-08-07T16:00:00Z")
+  })
+
+  test("getTimeseriesForPoints wraps names in ACE's point-list body", async () => {
+    const { urls, inits } = captureFetch({ point_samples: [] })
+    const ace = await createTestClient()
+
+    await ace.points.getTimeseriesForPoints([POINT_NAME, "other/point"], RANGE)
+
+    expect(inits[0].method).toBe("POST")
+    expect(urls[0].pathname).toBe("/api/points/get_timeseries")
+    expect(urls[0].searchParams.get("start_time")).toBe("2026-08-07T16:00:00Z")
+    expect(urls[0].searchParams.get("end_time")).toBe("2026-08-07T17:00:00Z")
+    expect(JSON.parse(String(inits[0].body))).toEqual({
+      points: [{ name: POINT_NAME }, { name: "other/point" }],
+    })
+  })
+
+  test("listAll walks pages of the global collection", async () => {
+    let calls = 0
+    const { urls } = captureFetch(null)
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      calls += 1
+      urls.push(new URL(String(input)))
+      return new Response(
+        JSON.stringify({
+          items:
+            calls <= 2
+              ? [
+                  { id: calls, name: `p${calls}` },
+                  { id: calls, name: `q${calls}` },
+                ]
+              : [],
+          page: calls,
+          pages: 3,
+          per_page: 2,
+          total: 6,
+        }),
+        { headers: { "content-type": "application/json" } }
+      )
+    }) as typeof fetch
+
+    const ace = await createTestClient()
+    const points = await collect(ace.points.listAll({ perPage: 2 }))
+
+    expect(points).toHaveLength(4)
+    expect(calls).toBe(3)
+  })
+})

--- a/connectors/ace-iot/tests/reliability.test.ts
+++ b/connectors/ace-iot/tests/reliability.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, expect, test } from "bun:test"
+import { AceIotApiError, AceIotConfigurationError, aceIot } from "../src"
+import { API_KEY, CONTEXT, createTestClient, json, mockFetch, page } from "./helpers"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+test("the key is sent as Bearer auth, which ACE requires despite calling it an apiKey header", async () => {
+  let headers = new Headers()
+  mockFetch((_input, init) => {
+    headers = new Headers(init?.headers)
+    return Promise.resolve(json(page([])))
+  })
+
+  const ace = await createTestClient()
+  await ace.sites.list()
+
+  expect(headers.get("authorization")).toBe(`Bearer ${API_KEY}`)
+  expect(headers.get("accept")).toBe("application/json")
+})
+
+test("an async key resolver is called for every attempt, so rotation needs no reconnect", async () => {
+  const keys: string[] = []
+  let issued = 0
+  mockFetch((_input, init) => {
+    keys.push(new Headers(init?.headers).get("authorization") ?? "")
+    return Promise.resolve(json(page([])))
+  })
+
+  const ace = await aceIot({
+    apiKey: async () => `rotating-${++issued}`,
+  }).connect(CONTEXT)
+  await ace.sites.list()
+  await ace.sites.list()
+
+  expect(keys).toEqual(["Bearer rotating-1", "Bearer rotating-2"])
+})
+
+test("a failing response throws AceIotApiError carrying status and parsed body", async () => {
+  mockFetch(async () =>
+    json({ message: "A database result was required but none was found." }, { status: 404 })
+  )
+  const ace = await createTestClient()
+
+  const promise = ace.points.get("client/site/dev/analogInput/1")
+  await expect(promise).rejects.toBeInstanceOf(AceIotApiError)
+  await expect(promise).rejects.toThrow(
+    "[SixbAceIot] ACE API request failed with 404: A database result was required but none was found."
+  )
+
+  const error = (await promise.catch((caught: unknown) => caught)) as AceIotApiError
+  expect(error.status).toBe(404)
+  expect(error.responseBody).toEqual({
+    message: "A database result was required but none was found.",
+  })
+})
+
+test("Flask-RESTX field validation is surfaced through validationErrors", async () => {
+  mockFetch(async () =>
+    json(
+      {
+        errors: {
+          per_page:
+            "Results per page {error_msg} The value '7' is not a valid choice for 'per_page'.",
+        },
+        message: "Input payload validation failed",
+      },
+      { status: 400 }
+    )
+  )
+  const ace = await createTestClient()
+
+  const error = (await ace.sites.get("site").catch((caught: unknown) => caught)) as AceIotApiError
+
+  expect(error.status).toBe(400)
+  expect(error.validationErrors).toEqual({
+    per_page: "Results per page {error_msg} The value '7' is not a valid choice for 'per_page'.",
+  })
+  expect(error.message).toContain("Input payload validation failed")
+  expect(error.message).toContain("per_page:")
+})
+
+test("a 500 carrying Flask's generic message says that a bad key also produces it", async () => {
+  // Verified live: an invalid ACE key answers 500, not 401.
+  mockFetch(async () => json({ message: "An unhandled exception occurred." }, { status: 500 }))
+  const ace = await createTestClient({ retry: { maxRetries: 0 } })
+
+  const error = (await ace.sites.list().catch((caught: unknown) => caught)) as AceIotApiError
+
+  expect(error.status).toBe(500)
+  expect(error.message).toBe(
+    "[SixbAceIot] ACE API request failed with 500: An unhandled exception occurred. ACE also returns this when the API key is invalid."
+  )
+})
+
+test("a 500 on an unrelated message gets no key hint", async () => {
+  mockFetch(async () => json({ message: "Upstream timeout" }, { status: 500 }))
+  const ace = await createTestClient({ retry: { maxRetries: 0 } })
+
+  const error = (await ace.sites.list().catch((caught: unknown) => caught)) as AceIotApiError
+  expect(error.message).toBe("[SixbAceIot] ACE API request failed with 500: Upstream timeout")
+})
+
+test("retryAfterMs is parsed from the Retry-After header", async () => {
+  mockFetch(async () =>
+    json({ message: "Slow down" }, { status: 429, headers: { "retry-after": "2" } })
+  )
+  const ace = await createTestClient({ retry: { maxRetries: 0 } })
+
+  const error = (await ace.sites.list().catch((caught: unknown) => caught)) as AceIotApiError
+  expect(error.retryAfterMs).toBe(2000)
+})
+
+test("a 429 on a read is retried and honors Retry-After", async () => {
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    return attempts === 1
+      ? json({ message: "Slow down" }, { status: 429, headers: { "retry-after": "0" } })
+      : json(page([]))
+  })
+  const ace = await createTestClient()
+
+  await ace.sites.list()
+
+  expect(attempts).toBe(2)
+})
+
+test("a 5xx on a read is retried up to maxRetries and then surfaces", async () => {
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    return json({ message: "Boom" }, { status: 503 })
+  })
+  const ace = await createTestClient({ retry: { maxRetries: 2, delayMs: () => 0 } })
+
+  await expect(ace.sites.list()).rejects.toBeInstanceOf(AceIotApiError)
+  expect(attempts).toBe(3)
+})
+
+test("a network error on a read is retried", async () => {
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    if (attempts < 3) throw new TypeError("network down")
+    return json(page([]))
+  })
+  const ace = await createTestClient({ retry: { delayMs: () => 0 } })
+
+  await ace.sites.list()
+
+  expect(attempts).toBe(3)
+})
+
+test("writes are never replayed, because every ACE write changes state", async () => {
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    return json({ message: "Boom" }, { status: 503 })
+  })
+  const ace = await createTestClient({ retry: { delayMs: () => 0 } })
+
+  await expect(
+    ace.points.create([{ name: "client/site/dev/analogInput/1", collect_enabled: true }])
+  ).rejects.toBeInstanceOf(AceIotApiError)
+
+  expect(attempts).toBe(1)
+})
+
+test("minting a gateway token is never replayed", async () => {
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    return json({ message: "Boom" }, { status: 500 })
+  })
+  const ace = await createTestClient({ retry: { delayMs: () => 0 } })
+
+  await expect(ace.gateways.createToken("gw")).rejects.toBeInstanceOf(AceIotApiError)
+
+  expect(attempts).toBe(1)
+})
+
+test("the point-batch timeseries read is retried even though it is a POST", async () => {
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    return attempts < 3 ? json({ message: "Boom" }, { status: 503 }) : json({ point_samples: [] })
+  })
+  const ace = await createTestClient({ retry: { delayMs: () => 0 } })
+
+  await ace.points.getTimeseriesForPoints(["client/site/dev/analogInput/1"], {
+    startTime: "2026-08-07T17:00:00Z",
+    endTime: "2026-08-07T18:00:00Z",
+  })
+
+  expect(attempts).toBe(3)
+})
+
+test("a custom retry policy replaces the default decision", async () => {
+  const seen: Array<{ method: string; idempotent: boolean; status: number | undefined }> = []
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    return attempts === 1 ? json({ message: "Boom" }, { status: 400 }) : json({ ok: true })
+  })
+  const ace = await createTestClient({
+    retry: {
+      maxRetries: 1,
+      delayMs: () => 0,
+      shouldRetry(context) {
+        seen.push({
+          method: context.method,
+          idempotent: context.idempotent,
+          status: context.response?.status,
+        })
+        return context.response?.status === 400
+      },
+    },
+  })
+
+  await ace.gateways.update("gw", { archived: true })
+
+  expect(attempts).toBe(2)
+  expect(seen[0]).toEqual({ method: "PATCH", idempotent: false, status: 400 })
+})
+
+test("an aborted request is not retried", async () => {
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    throw new DOMException("aborted", "AbortError")
+  })
+  const ace = await createTestClient({ retry: { delayMs: () => 0 } })
+
+  await expect(ace.sites.list()).rejects.toThrow("aborted")
+  expect(attempts).toBe(1)
+})
+
+test("minDelayMs spaces request starts", async () => {
+  const starts: number[] = []
+  mockFetch(async () => {
+    starts.push(Date.now())
+    return json(page([]))
+  })
+  const ace = await createTestClient({ minDelayMs: 40 })
+
+  await Promise.all([ace.sites.list(), ace.sites.list(), ace.sites.list()])
+
+  expect(starts).toHaveLength(3)
+  expect(starts[1] - starts[0]).toBeGreaterThanOrEqual(30)
+  expect(starts[2] - starts[1]).toBeGreaterThanOrEqual(30)
+})
+
+test("an empty or non-string key is rejected before any request", () => {
+  expect(() => aceIot({ apiKey: "   " })).toThrow(AceIotConfigurationError)
+  expect(() => aceIot({ apiKey: "   " })).toThrow("[SixbAceIot] apiKey must not be empty.")
+  expect(() => aceIot({ apiKey: 42 as unknown as string })).toThrow(
+    "[SixbAceIot] apiKey must be a string or a function."
+  )
+})
+
+test("a resolver returning an empty key fails at once instead of burning retry backoff", async () => {
+  let attempts = 0
+  mockFetch(async () => {
+    attempts += 1
+    return json(page([]))
+  })
+  const ace = await aceIot({ apiKey: () => "" }).connect(CONTEXT)
+
+  const promise = ace.sites.list()
+  await expect(promise).rejects.toBeInstanceOf(AceIotConfigurationError)
+  await expect(promise).rejects.toThrow("[SixbAceIot] apiKey must not be empty.")
+  expect(attempts).toBe(0)
+})
+
+test("a resolver that fails for its own reasons is retried like any read", async () => {
+  // A token endpoint can fail transiently, so only the connector's own config checks skip retry.
+  let resolves = 0
+  mockFetch(async () => json(page([])))
+  const ace = await aceIot({
+    apiKey: () => {
+      resolves += 1
+      if (resolves < 3) throw new TypeError("token endpoint unreachable")
+      return "recovered-key"
+    },
+    retry: { delayMs: () => 0 },
+  }).connect(CONTEXT)
+
+  await ace.sites.list()
+
+  expect(resolves).toBe(3)
+})
+
+test("a base URL without a trailing slash still keeps its path prefix", async () => {
+  let requested = ""
+  mockFetch((input) => {
+    requested = String(input)
+    return Promise.resolve(json(page([])))
+  })
+
+  const ace = await aceIot({
+    apiKey: API_KEY,
+    baseUrl: "https://ace.example.com/api",
+  }).connect(CONTEXT)
+  await ace.sites.list()
+
+  expect(new URL(requested).pathname).toBe("/api/sites/")
+})
+
+test("retry.maxRetries is validated", async () => {
+  await expect(createTestClient({ retry: { maxRetries: -1 } })).rejects.toThrow(
+    "[SixbAceIot] retry.maxRetries must be a non-negative integer."
+  )
+})

--- a/connectors/ace-iot/tests/sites.test.ts
+++ b/connectors/ace-iot/tests/sites.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import type { AceIotPoint, AceIotSite } from "../src"
+import { captureFetch, collect, createTestClient, json, mockFetch, page } from "./helpers"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+/** A site exactly as the live API returns one, including the fields that come back null. */
+const SITE: AceIotSite = {
+  id: 10,
+  name: "acme_north_campus",
+  client: "acme",
+  address: null,
+  nice_name: "Acme North Campus",
+  ansible_user: null,
+  vtron_user: null,
+  vtron_ip: null,
+  geo_location: "0101000000000000000000f03f000000000000f03f",
+  mqtt_prefix: null,
+  latitude: 40.7128,
+  longitude: -74.006,
+  archived: false,
+}
+
+const POINT: AceIotPoint = {
+  id: 4001,
+  name: "acme/acme_north_campus/10.0.0.10-100/analogInput/1",
+  client: "acme",
+  site: "acme_north_campus",
+  kv_tags: { vav: "VAV2_5", type: "Room Temp" },
+  bacnet_data: {
+    device_address: "10.0.0.10",
+    device_id: 100,
+    object_type: "analogInput",
+    object_index: 1,
+    object_name: "Network.SupplyAirTemp",
+    device_name: "Controller-100",
+    object_units: "degrees-fahrenheit",
+    present_value: "38.78239822387695",
+    scrape_enabled: true,
+    scrape_interval: 300,
+    vendor_name: "ExampleVendor",
+    // A property the device did not answer for. ACE sends this literal string, not null.
+    model_name: "property: unknown-property",
+  },
+  marker_tags: [],
+  collect_config: {},
+  point_type: null,
+  collect_enabled: true,
+  collect_interval: 300,
+  updated: "2025-12-01T23:46:12.058246",
+  created: "2024-02-14T19:43:07.623281",
+}
+
+describe("sites", () => {
+  test("list sends both flags and returns ACE's page envelope untouched", async () => {
+    const { urls } = captureFetch(page([SITE], { per_page: 50, total: 3, pages: 1 }))
+    const ace = await createTestClient()
+
+    const result = await ace.sites.list({
+      page: 1,
+      perPage: 50,
+      collectEnabled: true,
+      showArchived: true,
+    })
+
+    expect(urls[0].pathname).toBe("/api/sites/")
+    expect(urls[0].searchParams.get("page")).toBe("1")
+    expect(urls[0].searchParams.get("per_page")).toBe("50")
+    expect(urls[0].searchParams.get("collect_enabled")).toBe("true")
+    expect(urls[0].searchParams.get("show_archived")).toBe("true")
+    expect(result.items[0]).toEqual(SITE)
+    expect(result.total).toBe(3)
+  })
+
+  test("omitted flags are not sent, so ACE applies its own defaults", async () => {
+    const { urls } = captureFetch(page([SITE]))
+    const ace = await createTestClient()
+
+    await ace.sites.list()
+
+    expect(urls[0].search).toBe("")
+  })
+
+  test("get encodes the site name", async () => {
+    const { urls } = captureFetch(SITE)
+    const ace = await createTestClient()
+
+    const site = await ace.sites.get("acme north/campus")
+
+    expect(urls[0].pathname).toBe("/api/sites/acme%20north%2Fcampus")
+    expect(site).toEqual(SITE)
+  })
+
+  test("listPoints and listConfiguredPoints hit their own routes", async () => {
+    const { urls } = captureFetch(page([POINT]))
+    const ace = await createTestClient()
+
+    await ace.sites.listPoints("acme_north_campus", { perPage: 1000 })
+    await ace.sites.listConfiguredPoints("acme_north_campus", { perPage: 1000 })
+
+    expect(urls[0].pathname).toBe("/api/sites/acme_north_campus/points")
+    expect(urls[1].pathname).toBe("/api/sites/acme_north_campus/configured_points")
+  })
+
+  test("a point keeps every bacnet property, including ones ACE's schema omits", async () => {
+    captureFetch(page([POINT]))
+    const ace = await createTestClient()
+
+    const result = await ace.sites.listPoints("site")
+    const point = result.items[0]
+
+    expect(point.bacnet_data.vendor_name).toBe("ExampleVendor")
+    expect(point.bacnet_data.device_id).toBe(100)
+    expect(point.bacnet_data.scrape_enabled).toBe(true)
+    expect(point.bacnet_data.model_name).toBe("property: unknown-property")
+    expect(point.kv_tags).toEqual({ vav: "VAV2_5", type: "Room Temp" })
+    expect(point.point_type).toBeNull()
+  })
+
+  test("getTimeseries returns the whole window in one response", async () => {
+    const samples = [
+      {
+        name: "acme/acme_north_campus/10.0.0.10-100/analogInput/1",
+        value: "1.6100000143051147",
+        time: "2026-08-07T16:25:00",
+      },
+    ]
+    const { urls } = captureFetch({ point_samples: samples })
+    const ace = await createTestClient()
+
+    const result = await ace.sites.getTimeseries("site", {
+      startTime: "2026-08-07T16:00:00Z",
+      endTime: "2026-08-07T17:00:00Z",
+    })
+
+    expect(urls[0].pathname).toBe("/api/sites/site/timeseries")
+    expect(result.point_samples).toEqual(samples)
+    // Numeric-looking readings stay strings, so no rounding is introduced.
+    expect(result.point_samples[0].value).toBe("1.6100000143051147")
+  })
+
+  test("getTimeseriesPage forwards cursor, page size, and raw_data", async () => {
+    const { urls } = captureFetch({ point_samples: [], next_cursor: null, has_more: false })
+    const ace = await createTestClient()
+
+    await ace.sites.getTimeseriesPage("site", {
+      startTime: "2026-08-07T16:00:00Z",
+      endTime: "2026-08-07T17:00:00Z",
+      cursor: "eyJvZmZzZXQiOiA1MH0=",
+      pageSize: 50000,
+      rawData: true,
+    })
+
+    expect(urls[0].pathname).toBe("/api/sites/site/timeseries/paginated")
+    expect(urls[0].searchParams.get("cursor")).toBe("eyJvZmZzZXQiOiA1MH0=")
+    expect(urls[0].searchParams.get("page_size")).toBe("50000")
+    expect(urls[0].searchParams.get("raw_data")).toBe("true")
+  })
+
+  test("an empty window is an empty page, not an error", async () => {
+    // ACE's schema documents 404 here; the live API answers 200 with an empty list.
+    captureFetch({ point_samples: [], next_cursor: null, has_more: false })
+    const ace = await createTestClient()
+
+    const collected = await collect(
+      ace.sites.iterateTimeseries("site", {
+        startTime: "2001-01-01T00:00:00Z",
+        endTime: "2001-01-01T01:00:00Z",
+      })
+    )
+
+    expect(collected).toEqual([])
+  })
+
+  test("appendTimeseries posts the sample list", async () => {
+    const { urls, inits } = captureFetch(undefined)
+    const ace = await createTestClient()
+
+    await ace.sites.appendTimeseries("site", {
+      point_samples: [{ name: "site/p", value: "1.5", time: "2026-08-07T16:25:00" }],
+    })
+
+    expect(inits[0].method).toBe("POST")
+    expect(urls[0].pathname).toBe("/api/sites/site/timeseries")
+    expect(JSON.parse(String(inits[0].body))).toEqual({
+      point_samples: [{ name: "site/p", value: "1.5", time: "2026-08-07T16:25:00" }],
+    })
+  })
+
+  test("getWeather unwraps the envelope", async () => {
+    const weather = {
+      temp: { name: "site/weather/temp", value: "31.29", time: "2026-08-07T17:16:34.957381" },
+      feels_like: {
+        name: "site/weather/feels_like",
+        value: "37.76",
+        time: "2026-08-07T17:16:34.957381",
+      },
+      pressure: {
+        name: "site/weather/pressure",
+        value: "1020",
+        time: "2026-08-07T17:16:34.957381",
+      },
+      humidity: { name: "site/weather/humidity", value: "62", time: "2026-08-07T17:16:34.957381" },
+      dew_point: {
+        name: "site/weather/dew_point",
+        value: "23.4",
+        time: "2026-08-07T17:16:34.957381",
+      },
+      clouds: { name: "site/weather/clouds", value: "40", time: "2026-08-07T17:16:34.957381" },
+      wind_speed: {
+        name: "site/weather/wind_speed",
+        value: "3.1",
+        time: "2026-08-07T17:16:34.957381",
+      },
+      wind_deg: { name: "site/weather/wind_deg", value: "180", time: "2026-08-07T17:16:34.957381" },
+      wet_bulb: {
+        name: "site/weather/wet_bulb",
+        value: "25.1",
+        time: "2026-08-07T17:16:34.957381",
+      },
+    }
+    const { urls } = captureFetch({ weather })
+    const ace = await createTestClient()
+
+    const result = await ace.sites.getWeather("site")
+
+    expect(urls[0].pathname).toBe("/api/sites/site/weather")
+    expect(result?.temp.value).toBe("31.29")
+  })
+
+  test("a site with no weather feed answers null rather than throwing", async () => {
+    // The live API returns 404 with an all-null body for a site that has no weather points.
+    mockFetch(async () =>
+      json({ weather: { temp: { name: null, value: null, time: null } } }, { status: 404 })
+    )
+    const ace = await createTestClient({ retry: { maxRetries: 0 } })
+
+    expect(await ace.sites.getWeather("acme_west_campus")).toBeNull()
+  })
+
+  test("a weather failure that is not a 404 still throws", async () => {
+    mockFetch(async () => json({ message: "Boom" }, { status: 500 }))
+    const ace = await createTestClient({ retry: { maxRetries: 0 } })
+
+    await expect(ace.sites.getWeather("site")).rejects.toThrow("failed with 500")
+  })
+})

--- a/connectors/ace-iot/tests/validation.test.ts
+++ b/connectors/ace-iot/tests/validation.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  ACE_IOT_PAGE_SIZE_VALUES,
+  ACE_IOT_PER_PAGE_VALUES,
+  normalizeAceIotTimestamp,
+  parseAceIotTimestamp,
+} from "../src"
+import { captureFetch, createTestClient, json, mockFetch, page } from "./helpers"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("page size enums", () => {
+  test("the two enums are what ACE accepts, and they differ", () => {
+    expect([...ACE_IOT_PER_PAGE_VALUES]).toEqual([
+      2, 10, 20, 30, 40, 50, 100, 500, 1000, 5000, 10000, 100000,
+    ])
+    expect([...ACE_IOT_PAGE_SIZE_VALUES]).toEqual([
+      3, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 300000, 500000,
+    ])
+    // The timeseries endpoint takes 3 and rejects 2; the list endpoints do the opposite.
+    expect(ACE_IOT_PER_PAGE_VALUES).toContain(2)
+    expect(ACE_IOT_PER_PAGE_VALUES).not.toContain(3)
+    expect(ACE_IOT_PAGE_SIZE_VALUES).toContain(3)
+    expect(ACE_IOT_PAGE_SIZE_VALUES).not.toContain(2)
+  })
+
+  test("an unsupported perPage is rejected locally instead of spending a 400", async () => {
+    let calls = 0
+    mockFetch(async () => {
+      calls += 1
+      return json(page([]))
+    })
+    const ace = await createTestClient()
+
+    expect(() => ace.sites.list({ perPage: 25 as 20 })).toThrow(
+      "[SixbAceIot] perPage must be one of 2, 10, 20, 30, 40, 50, 100, 500, 1000, 5000, 10000, 100000. Received 25."
+    )
+    expect(calls).toBe(0)
+  })
+
+  test("an unsupported timeseries pageSize is rejected locally", async () => {
+    const ace = await createTestClient()
+
+    expect(() =>
+      ace.sites.getTimeseriesPage("site", {
+        startTime: "2026-08-07T17:00:00Z",
+        endTime: "2026-08-07T18:00:00Z",
+        pageSize: 2 as 3,
+      })
+    ).toThrow("[SixbAceIot] pageSize must be one of 3, 10, 50")
+  })
+
+  test("page and maxPages must be positive integers", async () => {
+    const ace = await createTestClient()
+
+    expect(() => ace.sites.list({ page: 0 })).toThrow(
+      "[SixbAceIot] page must be an integer greater than 0."
+    )
+    expect(() => ace.sites.list({ page: 1.5 })).toThrow(
+      "[SixbAceIot] page must be an integer greater than 0."
+    )
+    expect(() => ace.sites.listAll({ maxPages: 0 })).toThrow(
+      "[SixbAceIot] maxPages must be an integer greater than 0."
+    )
+  })
+
+  test("an empty path identifier is rejected with the parameter name", async () => {
+    const ace = await createTestClient()
+
+    expect(() => ace.sites.get("  ")).toThrow("[SixbAceIot] siteName must be a non-empty string.")
+    expect(() => ace.points.get("")).toThrow("[SixbAceIot] pointName must be a non-empty string.")
+    expect(() => ace.gateways.get("")).toThrow(
+      "[SixbAceIot] gatewayName must be a non-empty string."
+    )
+  })
+})
+
+describe("naive UTC timestamps", () => {
+  test("a zoneless ACE timestamp parses as UTC, not as host-local time", () => {
+    // The whole point: `new Date("2026-08-07T16:25:00")` is host-local and would shift the sample.
+    expect(parseAceIotTimestamp("2026-08-07T16:25:00").toISOString()).toBe(
+      "2026-08-07T16:25:00.000Z"
+    )
+  })
+
+  test("microseconds truncate to milliseconds, which is all a Date holds", () => {
+    expect(parseAceIotTimestamp("2026-08-07T16:25:00.627593").toISOString()).toBe(
+      "2026-08-07T16:25:00.627Z"
+    )
+  })
+
+  test("the space-separated form gateways use for device_token_expires is handled", () => {
+    expect(parseAceIotTimestamp("2027-03-04 19:34:54.114795").toISOString()).toBe(
+      "2027-03-04T19:34:54.114Z"
+    )
+  })
+
+  test("a timestamp that already carries a zone is left alone", () => {
+    expect(parseAceIotTimestamp("2026-08-07T16:25:00Z").toISOString()).toBe(
+      "2026-08-07T16:25:00.000Z"
+    )
+    expect(parseAceIotTimestamp("2026-08-07T18:25:00+02:00").toISOString()).toBe(
+      "2026-08-07T16:25:00.000Z"
+    )
+  })
+
+  test("normalize exposes the same rule without building a Date", () => {
+    expect(normalizeAceIotTimestamp("2026-08-07T16:25:00")).toBe("2026-08-07T16:25:00Z")
+    expect(normalizeAceIotTimestamp("2027-03-04 19:34:54.114795")).toBe(
+      "2027-03-04T19:34:54.114795Z"
+    )
+  })
+
+  test("unparseable input is reported rather than returning an Invalid Date", () => {
+    expect(() => parseAceIotTimestamp("not a time")).toThrow(
+      '[SixbAceIot] Could not parse "not a time" as a timestamp.'
+    )
+    expect(() => parseAceIotTimestamp("")).toThrow(
+      "[SixbAceIot] A timestamp must be a non-empty string."
+    )
+  })
+})
+
+describe("time range query serialization", () => {
+  test("a Date becomes UTC ISO", async () => {
+    const { urls } = captureFetch({ point_samples: [] })
+    const ace = await createTestClient()
+
+    await ace.sites.getTimeseries("site", {
+      startTime: new Date("2026-08-07T17:00:00Z"),
+      endTime: new Date("2026-08-07T18:00:00Z"),
+    })
+
+    expect(urls[0].searchParams.get("start_time")).toBe("2026-08-07T17:00:00.000Z")
+    expect(urls[0].searchParams.get("end_time")).toBe("2026-08-07T18:00:00.000Z")
+  })
+
+  test("a naive timestamp read off a response can be handed straight back as a bound", async () => {
+    const { urls } = captureFetch({ point_samples: [] })
+    const ace = await createTestClient()
+
+    // "2026-08-07T16:25:00" is what a sample carries. It must not shift by the host offset.
+    await ace.sites.getTimeseries("site", {
+      startTime: "2026-08-07T16:25:00",
+      endTime: "2026-08-07T17:25:00",
+    })
+
+    expect(urls[0].searchParams.get("start_time")).toBe("2026-08-07T16:25:00Z")
+    expect(urls[0].searchParams.get("end_time")).toBe("2026-08-07T17:25:00Z")
+  })
+
+  test("an invalid Date is rejected before the request", async () => {
+    const ace = await createTestClient()
+
+    expect(() =>
+      ace.sites.getTimeseries("site", {
+        startTime: new Date("nonsense"),
+        endTime: new Date(),
+      })
+    ).toThrow("[SixbAceIot] startTime must be a valid Date.")
+  })
+})

--- a/connectors/ace-iot/tsconfig.build.json
+++ b/connectors/ace-iot/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../packages/core/tsconfig.build.json"
+    },
+    {
+      "path": "../rest/tsconfig.build.json"
+    }
+  ]
+}

--- a/connectors/ace-iot/tsconfig.json
+++ b/connectors/ace-iot/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -203,6 +203,7 @@ to `defineConnector`, and most ship a matching webhook helper for the [Webhooks]
 | `@sixb/connector-companycam` | `companycam(...)` | CompanyCam jobsite photos | `companyCamEventsWebhook` |
 | `@sixb/connector-pennylane` | `pennylane(...)` | Pennylane quotes, products, customers | — |
 | `@sixb/connector-mercury` | `mercury(...)` | Mercury banking, transactions, invoicing | `mercuryEventsWebhook` |
+| `@sixb/connector-ace-iot` | `aceIot(...)` | ACE IoT sites, BACnet points, gateways, timeseries | — |
 
 The pattern is the same as any adapter — `defineConnector(id, factory(options))`, then resolve it by
 name in syncs and app code:

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -184,9 +184,10 @@ describe("createCustomApp.start", () => {
 
     try {
       // Regression: an object id with percent-encoded slashes (`%2F`) and a dotted
-      // segment (the IP `10.75.35.6`) lives inside a single path segment. On a hard
+      // segment (the IP `10.0.0.10`) lives inside a single path segment. On a hard
       // refresh this must serve the SPA shell, not 404 as a "missing asset".
-      const deepRoute = "/point/point%3Asetty%3Asetty%2Fsetty%2F10.75.35.6-708112%2Fdevice%2F708112"
+      const deepRoute =
+        "/point/point%3Aacme%3Aacme%2Facme_north_campus%2F10.0.0.10-100%2Fdevice%2F100"
       const response = await fetch(`http://127.0.0.1:${port}${deepRoute}`)
       expect(response.status).toBe(200)
       expect(await response.text()).toContain('<div id="root"></div>')

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,6 +14,9 @@
       "path": "broker/redis/tsconfig.build.json"
     },
     {
+      "path": "connectors/ace-iot/tsconfig.build.json"
+    },
+    {
       "path": "connectors/companycam/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
       "@sixb/client/models": ["./packages/client/src/models.ts"],
       "@sixb/client/query": ["./packages/client/src/query.ts"],
       "create-sixb/scaffold": ["./packages/create-sixb/src/scaffold.ts"],
+      "@sixb/connector-ace-iot": ["./connectors/ace-iot/src/index.ts"],
       "@sixb/connector-companycam": ["./connectors/companycam/src/index.ts"],
       "@sixb/connector-exa": ["./connectors/exa/src/index.ts"],
       "@sixb/connector-exa/agent-tools": ["./connectors/exa/src/agent-tools.ts"],


### PR DESCRIPTION
Adds `@sixb/connector-ace-iot`, a typed connector for the [ACE IoT](https://aceiot.cloud) Deploy API — building automation sites, BACnet points, VOLTTRON gateways, and timeseries.

All 29 paths and 45 operations, one method per endpoint.

```ts
import { aceIot } from "@sixb/connector-ace-iot"
import { defineConnector } from "@sixb/core"

export const aceIotConnector = defineConnector(
  "ace-iot",
  aceIot({ apiKey: process.env.ACE_IOT_API_KEY! })
)
```

```ts
const ace = await sixb.connector(aceIotConnector)

for await (const sample of ace.sites.iterateTimeseries("my_site", {
  startTime: new Date(Date.now() - 15 * 60_000),
  endTime: new Date(),
})) {
  // sample.value is a string; sample.time is naive UTC
}
```

## Types come from the schema, corrected against the live API

ACE publishes a Swagger 2.0 document at `/api/swagger.json`. It is the starting point, not the
answer — the live API disagrees with it in several places, so every type was checked against real
responses:

| ACE's schema says | The API actually does |
| --- | --- |
| An empty timeseries window returns `404` | Returns `200` with `point_samples: []` |
| `bacnet_data` is free-form, 11 properties documented | Returns 33 typed properties |
| `pages` is always an integer | `null` on the gateway PCAP listing |
| `per_page` is an integer | A closed enum; anything else is a `400` |
| An unknown site returns `404` | Returns `403` with an all-null body |
| Auth is an `apiKey` header | Requires the `Bearer` scheme; a bare token is `401` |

A property the device did not answer for comes back as the literal string
`"property: unknown-property"`, not `null`. Sample values stay strings — including numerics like
`"1.6100000143051147"` — so the connector never introduces rounding the API did not have.

## The timeseries cursor does not always advance

This is the substance of the PR.

`GET /sites/{site_name}/timeseries/paginated` returns a base64 cursor decoding to
`{"offset": N, "timestamp": "..."}`. ACE sets `offset` to the rows drawn from the page's **final
timestamp bucket**, without adding the offset the request carried in. When a page begins and ends
inside one bucket, the cursor it returns is the cursor it was given, and `while (has_more)`
re-requests the same page forever.

Measured against a live site — a 15-minute window holding 3,222 readings:

| `page_size` | Following ACE's cursor | `iterateTimeseries` |
| --- | --- | --- |
| 50 | stalls after 2 pages — **100 rows** | 65 pages, 3,222 rows, no duplicates |
| 100 | stalls after 2 pages — 200 rows | 33 pages, 3,222 rows, no duplicates |
| 500 | stalls after 2 pages — 1,000 rows | 7 pages, 3,222 rows, no duplicates |
| 1000 | 4 pages, 3,222 rows | 4 pages, identical result |

The server *honors* an offset it is given, so the correct value is recoverable from the page itself:

```ts
nextOffset =
  (incomingCursor.timestamp === lastSampleTime ? incomingCursor.offset : 0) +
  rowsInFinalBucketOfThisPage
```

Large page sizes appear to work only because every page happens to cross a bucket boundary. The
failure is silent — lowering `page_size` loses data rather than raising — which is why this is
handled in the connector rather than left to callers. Where ACE's cursor is already right, the
recomputed one is byte-identical.

A walk that returns the same page twice raises instead of looping. That guard compares **pages, not
cursors**: the repaired cursor advances by construction, so a never-repeating cursor proves nothing
about whether the server is moving through the window.

## Timestamps are naive but mean UTC

Every ACE timestamp arrives without a zone designator, so `new Date(value)` reads it as local time
and shifts it silently on any host that is not UTC:

```ts
new Date("2026-08-07T16:25:00")            // 2026-08-07T20:25:00Z on a US/Eastern host
parseAceIotTimestamp("2026-08-07T16:25:00") // 2026-08-07T16:25:00Z
```

The parser also covers the other two shapes ACE emits: microsecond precision (`…:00.627593`) and the
space-separated form a gateway's `device_token_expires` uses (`2027-03-04 19:34:54.114795`).

## Behavior worth knowing at review time

- **`per_page` is a closed enum** — `2, 10, 20, …, 100000` — and the timeseries endpoint takes a
  *different* one for `page_size` (it allows 3, but not 2). Both are validated locally, so an
  unsupported size is a clear error rather than a `400` naming the value but not the allowed set.
- **An invalid API key returns `500`**, carrying Flask's generic `"An unhandled exception
  occurred."`, not a `401`. `AceIotApiError` appends a note saying so, because that message is
  otherwise impossible to act on.
- **Writes are never replayed.** `POST /points/` and `PUT /points/{name}` merge tag state, and
  `POST /gateways/{name}/token` mints a credential. The one exception is
  `points.getTimeseriesForPoints`, a read ACE exposes as a POST; it is marked idempotent.
- **`AceIotConfigurationError`** is separate from `AceIotApiError` and skips retry — an empty API key
  fails the same way on every attempt, and retrying it only added backoff to the report.
- `getWeather()` returns `null` for a site with no weather feed, which ACE reports as a `404`
  carrying an all-null body.

## Testing

96 unit tests, plus a live check against a real deployment.

The pagination fix is proven by reverting it, per `AGENTS.md`. The test fixture reproduces ACE's
cursor arithmetic exactly, and one test asserts the *stall* so the coverage tests are not passing
against an already-working fake:

```
# with repairTimeseriesCursor reverted to `page.next_cursor`
(fail) iterateTimeseries walks the whole window at a page size that stalls ACE's own cursor
(fail) page size 3 yields every sample exactly once
(fail) page size 10 yields every sample exactly once
(fail) page size 50 yields every sample exactly once
(fail) page size 100 yields every sample exactly once
(fail) page size 500 yields every sample exactly once
(fail) maxPages bounds the walk
 14 pass  7 fail
```

Page sizes 1000 and 5000 still pass with the fix reverted — matching the live measurement, where
those sizes work by luck.

`tests/ace-iot.e2e.ts` runs read-only against a real deployment and skips without a key. All 33
checks pass, including full-window coverage at the page size that stalls upstream:

```
ACE_IOT_API_KEY="…" bun connectors/ace-iot/tests/ace-iot.e2e.ts
```

```
timeseries
  window holds 3222 samples
  ✓ sample value stays a string
  ✓ sample time has no zone designator
  ✓ paginated walk at page_size=50 covers all 3222 samples
  ✓ paginated walk emits no duplicates
  ✓ an empty window is a 200 with an empty page
```

Following the `connectors/google` convention, the credentialed e2e has no `test:e2e` script — it is
a manual run, so CI does not gain a job that always skips.

**Write endpoints are implemented from the schema but tested against mocks only.** The available
credential points at a live production tenant with real sites and gateways; creating clients,
minting gateway tokens, or overwriting point tags there to verify a type is not a trade worth
making. The read surface is verified live end to end.

## Also in this PR

`packages/app/tests/createCustomApp.test.ts` used an object id captured from a real deployment.
Replaced with a synthetic one that keeps the four properties the test depends on — percent-encoded
slashes and colons, dots mid-path, and a decoded final segment with no dot, which is what makes
`isAssetRequest` fall through to the SPA shell instead of 404ing as a missing asset.

## Checks

`typecheck`, `check`, `build`, `test:publish` (48 packages), and `bun run test` (3,521 tests) all
pass.
