### PR TITLE
agent-worker: replace intermediate error class

### DIFF
--- a/packages/agent-worker/src/ai-sdk-adapters.ts
+++ b/packages/agent-worker/src/ai-sdk-adapters.ts
@@ -14,12 +14,23 @@ import {
   fromAiSdk,
   validateAndNormalizeAgentToolInput,
 } from "@sixb/core/internal/agents"
+import { createSixbError } from "@sixb/core/internal/errors"
 import { schemaRecordToJsonSchema } from "@sixb/core/internal/ontology"
 import type { AgentRunUsage, AiModelCallUsageInput } from "@sixb/core/storage"
 import { jsonSchema, type LanguageModelUsage, type Tool, type ToolSet, tool } from "ai"
-import { AgentToolExecutionError, AgentToolOutputError, AgentWorkerError } from "./errors"
+import { AgentToolExecutionError, AgentToolOutputError } from "./errors"
 
 const NEVER_ABORTED_SIGNAL = new AbortController().signal
+
+type AgentErrorDetails =
+  | { readonly agentId: string; readonly runId: string }
+  | { readonly agentId: string; readonly nodeRunId: string }
+  | {
+      readonly agentId: string
+      readonly workflowId: string
+      readonly workflowRunId: string
+      readonly nodeRunId: string
+    }
 
 interface AiSdkToolsFromAgentDefinitionsInput {
   readonly definitions: readonly AgentToolDefinition[]
@@ -27,6 +38,7 @@ interface AiSdkToolsFromAgentDefinitionsInput {
   readonly run: AgentToolRunInfo
   readonly connector: AgentToolRunContext["connector"]
   readonly logger: Logger
+  readonly errorDetails?: AgentErrorDetails
 }
 
 /** Adapt one agent's explicitly selected Sixb definitions to executable AI SDK tools. */
@@ -36,8 +48,15 @@ export function aiSdkToolsFromAgentDefinitions(
   const tools = emptyToolSet()
   for (const definition of input.definitions) {
     if (Object.hasOwn(tools, definition.name)) {
-      throw new AgentWorkerError(
-        `Agent '${input.run.agentId}' has duplicate selected tool name '${definition.name}'.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] Agent '${input.run.agentId}' has duplicate selected tool name '${definition.name}'.`,
+        {
+          details: input.errorDetails ?? {
+            agentId: input.run.agentId,
+            runId: input.run.id,
+          },
+        }
       )
     }
     tools[definition.name] = aiSdkToolFromAgentDefinition(definition, input)
@@ -51,7 +70,11 @@ function aiSdkToolFromAgentDefinition(
 ): Tool<Record<string, unknown>, JsonValue> {
   return tool({
     description: definition.description,
-    inputSchema: aiSdkInputSchemaFromAgentDefinition(definition, context.valueTypesById),
+    inputSchema: aiSdkInputSchemaFromAgentDefinition(
+      definition,
+      context.valueTypesById,
+      context.errorDetails ?? { agentId: context.run.agentId, runId: context.run.id }
+    ),
     async execute(input, { abortSignal }) {
       let result: JsonValue
       try {
@@ -76,7 +99,8 @@ function aiSdkToolFromAgentDefinition(
 
 function aiSdkInputSchemaFromAgentDefinition(
   definition: AgentToolDefinition,
-  valueTypesById: ReadonlyMap<string, ValueType>
+  valueTypesById: ReadonlyMap<string, ValueType>,
+  errorDetails: AgentErrorDetails
 ) {
   const inputSchema = schemaRecordToJsonSchema({ shape: definition.input, valueTypesById })
   return jsonSchema<Record<string, unknown>>(inputSchema as Parameters<typeof jsonSchema>[0], {
@@ -97,9 +121,14 @@ function aiSdkInputSchemaFromAgentDefinition(
           error:
             error instanceof Error
               ? error
-              : new AgentWorkerError(`Agent tool '${definition.name}' input validation failed.`, {
-                  cause: error,
-                }),
+              : createSixbError(
+                  "internal.unexpected",
+                  `[SixbAgentWorker] Agent tool '${definition.name}' input validation failed.`,
+                  {
+                    cause: error,
+                    details: errorDetails,
+                  }
+                ),
         }
       }
     },
@@ -135,27 +164,38 @@ type ToolOutcome =
 
 /** Convert final AI SDK steps into Sixb's durable, JSON-validated trace contract. */
 export function agentTraceFromAiSdkSteps(
-  steps: readonly AiSdkTraceStep[]
+  steps: readonly AiSdkTraceStep[],
+  errorDetails?: AgentErrorDetails
 ): readonly AgentMessagePart[] {
-  const parts = steps.flatMap(agentTracePartsFromAiSdkStep)
+  const parts = steps.flatMap((step) => agentTracePartsFromAiSdkStep(step, errorDetails))
   return fromAiSdk({ role: "assistant", parts }).parts
 }
 
-function agentTracePartsFromAiSdkStep(step: AiSdkTraceStep): AgentInboundUiMessagePart[] {
-  const toolOutcomes = indexToolOutcomes(step.content)
+function agentTracePartsFromAiSdkStep(
+  step: AiSdkTraceStep,
+  errorDetails?: AgentErrorDetails
+): AgentInboundUiMessagePart[] {
+  const toolOutcomes = indexToolOutcomes(step.content, errorDetails)
   return [
     { type: "step-start" },
-    ...step.content.flatMap((part) => agentTracePartsFromAiSdkContent(part, toolOutcomes)),
+    ...step.content.flatMap((part) =>
+      agentTracePartsFromAiSdkContent(part, toolOutcomes, errorDetails)
+    ),
   ]
 }
 
 function indexToolOutcomes(
-  content: readonly AiSdkTraceContentPart[]
+  content: readonly AiSdkTraceContentPart[],
+  errorDetails?: AgentErrorDetails
 ): ReadonlyMap<string, ToolOutcome> {
   const outcomes = new Map<string, ToolOutcome>()
   for (const part of content) {
     if (part.type !== "tool-result" && part.type !== "tool-error") continue
-    const toolCallId = requireNonEmptyString(part.toolCallId, `${part.type}.toolCallId`)
+    const toolCallId = requireNonEmptyString(
+      part.toolCallId,
+      `${part.type}.toolCallId`,
+      errorDetails
+    )
     outcomes.set(
       toolCallId,
       part.type === "tool-result"
@@ -168,7 +208,8 @@ function indexToolOutcomes(
 
 function agentTracePartsFromAiSdkContent(
   part: AiSdkTraceContentPart,
-  toolOutcomes: ReadonlyMap<string, ToolOutcome>
+  toolOutcomes: ReadonlyMap<string, ToolOutcome>,
+  errorDetails?: AgentErrorDetails
 ): AgentInboundUiMessagePart[] {
   switch (part.type) {
     case "text":
@@ -176,31 +217,34 @@ function agentTracePartsFromAiSdkContent(
       return [
         {
           type: part.type,
-          text: requireString(part.text, `${part.type}.text`),
+          text: requireString(part.text, `${part.type}.text`, errorDetails),
           ...(part.providerMetadata === undefined
             ? {}
             : { providerMetadata: part.providerMetadata }),
         },
       ]
     case "tool-call":
-      return [toolCallTracePart(part, toolOutcomes)]
+      return [toolCallTracePart(part, toolOutcomes, errorDetails)]
     case "tool-result":
     case "tool-error":
       // Results are folded into their tool-call part, which is Sixb's durable representation.
       return []
     default:
-      throw new AgentWorkerError(
-        `AI SDK trace content '${part.type}' is not supported by the durable agent trace contract.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] AI SDK trace content '${part.type}' is not supported by the durable agent trace contract.`,
+        errorDetails === undefined ? undefined : { details: errorDetails }
       )
   }
 }
 
 function toolCallTracePart(
   part: AiSdkTraceContentPart,
-  outcomes: ReadonlyMap<string, ToolOutcome>
+  outcomes: ReadonlyMap<string, ToolOutcome>,
+  errorDetails?: AgentErrorDetails
 ): AgentInboundUiMessagePart {
-  const toolCallId = requireNonEmptyString(part.toolCallId, "tool-call.toolCallId")
-  const toolName = requireNonEmptyString(part.toolName, "tool-call.toolName")
+  const toolCallId = requireNonEmptyString(part.toolCallId, "tool-call.toolCallId", errorDetails)
+  const toolName = requireNonEmptyString(part.toolName, "tool-call.toolName", errorDetails)
   const outcome =
     outcomes.get(toolCallId) ??
     (part.error === undefined
@@ -218,17 +262,29 @@ function toolCallTracePart(
   }
 }
 
-function requireString(value: unknown, field: string): string {
+function requireString(value: unknown, field: string, errorDetails?: AgentErrorDetails): string {
   if (typeof value !== "string") {
-    throw new AgentWorkerError(`AI SDK trace ${field} must be a string.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] AI SDK trace ${field} must be a string.`,
+      errorDetails === undefined ? undefined : { details: errorDetails }
+    )
   }
   return value
 }
 
-function requireNonEmptyString(value: unknown, field: string): string {
-  const string = requireString(value, field)
+function requireNonEmptyString(
+  value: unknown,
+  field: string,
+  errorDetails?: AgentErrorDetails
+): string {
+  const string = requireString(value, field, errorDetails)
   if (!string) {
-    throw new AgentWorkerError(`AI SDK trace ${field} must not be empty.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] AI SDK trace ${field} must not be empty.`,
+      errorDetails === undefined ? undefined : { details: errorDetails }
+    )
   }
   return string
 }

--- a/packages/agent-worker/src/errors.ts
+++ b/packages/agent-worker/src/errors.ts
@@ -1,16 +1,8 @@
 import { AgentToolPublicError } from "@sixb/core"
 
-/** Infra-level failure in the agent worker (unknown agent, missing storage, malformed job). */
-export class AgentWorkerError extends Error {
-  readonly name: string = "AgentWorkerError"
-  constructor(message: string, options?: ErrorOptions) {
-    super(`[SixbAgentWorker] ${message}`, options)
-  }
-}
-
 /** A completed provider call was not recorded synchronously, so this turn must stop. */
-export class AgentUsageRecordingError extends AgentWorkerError {
-  override readonly name = "AgentUsageRecordingError"
+export class AgentUsageRecordingError extends Error {
+  readonly name = "AgentUsageRecordingError"
 
   constructor(
     readonly runId: string,
@@ -20,14 +12,14 @@ export class AgentUsageRecordingError extends AgentWorkerError {
   ) {
     super(
       recoveryScheduled
-        ? `AI usage for call '${callId}' in agent execution '${runId}' was deferred to durable recovery.`
-        : `Could not preserve AI usage for call '${callId}' in agent execution '${runId}'.`,
+        ? `[SixbAgentWorker] AI usage for call '${callId}' in agent execution '${runId}' was deferred to durable recovery.`
+        : `[SixbAgentWorker] Could not preserve AI usage for call '${callId}' in agent execution '${runId}'.`,
       options
     )
   }
 }
 
-/** This delivery's execution token is stale, so it must make no further run or message writes. */
+/** This delivery's execution token is stale, so it must make no further durable writes. */
 export class AgentExecutionLostError extends Error {
   readonly name = "AgentExecutionLostError"
   constructor(readonly runId: string) {

--- a/packages/agent-worker/src/model-call-recovery.ts
+++ b/packages/agent-worker/src/model-call-recovery.ts
@@ -1,3 +1,4 @@
+import { createSixbError } from "@sixb/core/internal/errors"
 import type {
   AgentAiUsageRecordPayload,
   AgentAiUsageRecordRequestedQueueJob,
@@ -11,11 +12,16 @@ import type {
   RecordAiModelCallResult,
 } from "@sixb/core/storage"
 import { AiUsageStorageError, normalizeAiModelCallRecord } from "@sixb/core/storage"
-import { AgentWorkerError } from "./errors"
 
 const AGENT_AI_USAGE_RECOVERY_JOB_PREFIX = "agt_usage_job_"
 
-class InvalidAiUsageRecoveryJobError extends AgentWorkerError {}
+class InvalidAiUsageRecoveryJobError extends Error {
+  readonly name = "InvalidAiUsageRecoveryJobError"
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(`[SixbAgentWorker] ${message}`, options)
+  }
+}
 
 /** Stable queue identity: a lost enqueue response can safely retry the same accounting handoff. */
 export function agentAiUsageRecoveryJobId(recordId: string): string {
@@ -41,7 +47,11 @@ export async function enqueueAiModelCallRecovery(
   })
 
   if (job?.id !== jobId || job.type !== "agent.ai-usage.record.requested") {
-    throw new AgentWorkerError(`Agent queue did not confirm AI usage recovery job '${jobId}'.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Agent queue did not confirm AI usage recovery job '${jobId}'.`,
+      { details: { jobId } }
+    )
   }
 }
 

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -11,12 +11,13 @@ import {
   fromAiSdk,
   toModelMessages,
 } from "@sixb/core/internal/agents"
+import { createSixbError } from "@sixb/core/internal/errors"
 import { isAbortError, QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { AgentRunRecord, AgentStorage } from "@sixb/core/storage"
 import { type ModelMessage, stepCountIs, streamText, toUIMessageStream } from "ai"
 import { agentRunUsageFromAiSdk, agentToolErrorText } from "./ai-sdk-adapters"
 import { attachmentKey, modelSupportsInlineImages, prepareAgentAttachments } from "./attachments"
-import { AgentTurnTimeoutError, AgentWorkerError } from "./errors"
+import { AgentTurnTimeoutError } from "./errors"
 import { appendMessageAndFinishRunOrThrow, finishRunOrThrow } from "./finalize"
 import { AiModelCallRecorder } from "./model-call-recorder"
 import {
@@ -54,7 +55,11 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
   const runId = run.id
   const executionToken = run.execution?.token
   if (!executionToken) {
-    throw new AgentWorkerError(`Agent run '${runId}' has no execution token.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Agent run '${runId}' has no execution token.`,
+      { details: { agentId: run.agentId, runId } }
+    )
   }
   const agents = storage.agents
 
@@ -213,7 +218,11 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
       throw drainError
     }
     if (!responseMessage) {
-      throw new AgentWorkerError(`Agent run '${runId}' produced no response message.`)
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] Agent run '${runId}' produced no response message.`,
+        { details: { agentId: run.agentId, runId } }
+      )
     }
 
     const finishReason = await result.finishReason

--- a/packages/agent-worker/src/run-environment.ts
+++ b/packages/agent-worker/src/run-environment.ts
@@ -149,6 +149,10 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
     run: { id: runId, agentId: agent.id, ...(threadId ? { threadId } : {}) },
     connector: context.connector,
     logger,
+    errorDetails:
+      mode === "conversation"
+        ? { agentId: agent.id, runId }
+        : { agentId: agent.id, nodeRunId: runId },
   })
 
   let sandboxWasUsed = false

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -19,6 +19,8 @@ export interface RunWorkflowAgentNodeInput {
   readonly agent: AgentDefinition
   readonly agentStep: AgentStepDefinition
   readonly workflowId: string
+  readonly workflowRunId: string
+  readonly nodeRunId: string
   readonly prompt: string
   readonly valueTypesById: ReadonlyMap<string, ValueType>
   readonly usageRecorder: AiModelCallRecorder
@@ -100,7 +102,12 @@ export async function runWorkflowAgentNode(
       modelId: input.agent.model.modelId,
       finishReason: coerceAgentRunFinishReason(result.finishReason) ?? "unknown",
       ...(usage ? { usage } : {}),
-      trace: agentTraceFromAiSdkSteps(result.steps),
+      trace: agentTraceFromAiSdkSteps(result.steps, {
+        agentId: input.agent.id,
+        workflowId: input.workflowId,
+        workflowRunId: input.workflowRunId,
+        nodeRunId: input.nodeRunId,
+      }),
     }
   } finally {
     clearTimeout(timer)

--- a/packages/agent-worker/src/stream-sink.ts
+++ b/packages/agent-worker/src/stream-sink.ts
@@ -7,8 +7,8 @@ import {
   agentRunStreamId,
   agentRunStreamIdempotencyKey,
 } from "@sixb/core/agents/streams"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { AgentRunRecord } from "@sixb/core/storage"
-import { AgentWorkerError } from "./errors"
 
 /** Receives live and lifecycle records for one agent run stream. */
 export interface StreamSink {
@@ -87,7 +87,10 @@ class BrokerStreamSink implements StreamSink {
   }): Promise<void> {
     let chunk: JsonValue
     try {
-      chunk = toBrokerJson(input.chunk, "Agent stream chunk")
+      chunk = toBrokerJson(input.chunk, "Agent stream chunk", {
+        agentId: input.run.agentId,
+        runId: input.run.id,
+      })
     } catch (error) {
       console.error("[SixbAgentWorker] Agent run stream chunk encoding failed:", error)
       return
@@ -150,7 +153,10 @@ class BrokerStreamSink implements StreamSink {
     // already JSON, so it is forwarded as-is instead of being serialized a second time.
     const payload = options.prevalidated
       ? (event as unknown as JsonValue)
-      : toBrokerJson(event, "Agent stream event")
+      : toBrokerJson(event, "Agent stream event", {
+          agentId: event.agentId,
+          runId: event.runId,
+        })
     await this.broker.append({
       projectId: this.projectId,
       streamId: agentRunStreamId(event.runId),
@@ -190,17 +196,29 @@ async function isolateStreamSinkCall(
   }
 }
 
-function toBrokerJson(value: unknown, label: string): JsonValue {
+function toBrokerJson(
+  value: unknown,
+  label: string,
+  details: { readonly agentId: string; readonly runId: string }
+): JsonValue {
   try {
     const serialized = JSON.stringify(value)
     if (serialized === undefined) {
-      throw new AgentWorkerError(`${label} serialized to undefined.`)
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] ${label} serialized to undefined.`,
+        { details }
+      )
     }
     // The stringify/parse round-trip already yields a pure JSON value (functions/symbols/undefined
     // are dropped or throw above, NaN/Infinity become null), so no further validation is needed —
     // the broker append boundary re-checks the payload anyway.
     return JSON.parse(serialized) as JsonValue
   } catch (error) {
-    throw new AgentWorkerError(`${label} could not be JSON encoded.`, { cause: error })
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] ${label} could not be JSON encoded.`,
+      { cause: error, details }
+    )
   }
 }

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -8,7 +8,7 @@ import {
   workflowAgentNodeQueueJobId,
 } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
-import { captureSixbFailure } from "@sixb/core/internal/errors"
+import { captureSixbFailure, createSixbError, isSixbError } from "@sixb/core/internal/errors"
 import type { QueueDelivery, QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { isAbortError, QueueDeliveryLeaseLostError, QueueWorker } from "@sixb/core/internal/workers"
 import type { AgentQueueJob, ClaimedQueueJob } from "@sixb/core/queues"
@@ -16,12 +16,7 @@ import type { AgentRunExecution, AgentRunRecord } from "@sixb/core/storage"
 import { AGENT_RUN_FAILURE_CODES, AgentStorageError } from "@sixb/core/storage"
 import { loadAgentSkills } from "./agent-skills"
 import { normalizeApiBaseUrl } from "./api-url"
-import {
-  AgentExecutionLostError,
-  AgentFinalizationError,
-  AgentUsageRecordingError,
-  AgentWorkerError,
-} from "./errors"
+import { AgentExecutionLostError, AgentFinalizationError, AgentUsageRecordingError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { finishRunOrThrow } from "./finalize"
 import {
@@ -172,25 +167,36 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
       id: runId,
     })
     if (!queuedRun) {
-      throw new AgentWorkerError(`Queued agent run '${runId}' was not found.`)
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] Queued agent run '${runId}' was not found.`,
+        { details: { runId } }
+      )
     }
     if (queuedRun.status !== "queued" && queuedRun.status !== "running") {
       return
     }
     const agent = this.host.definitions.agents.getById(queuedRun.agentId)
     if (!agent) {
-      const error = new AgentWorkerError(`Unknown agent '${queuedRun.agentId}'.`)
+      const error = createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] Unknown agent '${queuedRun.agentId}'.`,
+        { details: { agentId: queuedRun.agentId, runId } }
+      )
       if (queuedRun.status === "queued") {
         const completedAt = new Date()
         const failed = await context.storage.agents.runs.finishQueued({
           projectId: context.id,
           id: queuedRun.id,
           status: "failed",
-          error: toAgentRunFailure(error, {
-            status: "failed",
-            at: completedAt,
-            run: queuedRun,
-          }),
+          error: toAgentRunFailure(
+            createSixbError(
+              "internal.unexpected",
+              `[SixbAgentWorker] Agent '${queuedRun.agentId}' is not registered.`,
+              { details: { agentId: queuedRun.agentId, runId } }
+            ),
+            { status: "failed", at: completedAt, run: queuedRun }
+          ),
           completedAt,
         })
         this.reportFailure(error, failed, job.attempt)
@@ -205,8 +211,16 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
       id: queuedRun.executionId,
     })
     if (!durableExecution) {
-      throw new AgentWorkerError(
-        `Agent run '${runId}' references missing execution '${queuedRun.executionId}'.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] Agent run '${runId}' references missing execution '${queuedRun.executionId}'.`,
+        {
+          details: {
+            agentId: queuedRun.agentId,
+            runId,
+            executionId: queuedRun.executionId,
+          },
+        }
       )
     }
     const resolved = await resolveAgentExecutionAuthorization({
@@ -237,7 +251,11 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
     const run = reservation.run
     const executionToken = run.execution?.token
     if (!executionToken) {
-      throw new AgentWorkerError(`Agent run '${run.id}' has no execution token.`)
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbAgentWorker] Agent run '${run.id}' has no execution token.`,
+        { details: { agentId: run.agentId, runId: run.id } }
+      )
     }
     let environment: AgentExecutionEnvironment | null = null
     let stopOwnershipProjection: (() => void) | undefined
@@ -347,7 +365,9 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
       }
       return { kind: "fail" }
     }
-    if (error instanceof AgentWorkerError) {
+    // Known deterministic failures honor the catalog policy; uncoded dependency failures retain
+    // the worker's bounded pre-start retry path below.
+    if (isSixbError(error) && !error.retryable) {
       return { kind: "fail" }
     }
 
@@ -491,7 +511,10 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
 
   private requireContext(): AgentWorkerContext {
     if (!this.context) {
-      throw new AgentWorkerError("Agent worker has no agent storage configured.")
+      throw createSixbError(
+        "internal.unexpected",
+        "[SixbAgentWorker] Agent worker has no agent storage configured."
+      )
     }
     return this.context
   }
@@ -616,8 +639,9 @@ function buildAgentContext(host: AgentWorkerHost, options: AgentWorkerOptions): 
   const storage = host.storage
   assertAgentWorkerStorage(storage)
   if (!host.sandboxes) {
-    throw new AgentWorkerError(
-      "Agent workers require createSixb({ sandboxes }) for the built-in bash tool."
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Agent workers require createSixb({ sandboxes }) for the built-in bash tool."
     )
   }
   const agentSkills = loadAgentSkills({
@@ -651,13 +675,22 @@ function assertAgentWorkerStorage(
   storage: AgentWorkerHost["storage"]
 ): asserts storage is AgentWorkerStorage {
   if (!storage.agents) {
-    throw new AgentWorkerError("Agent workers require storage.agents support.")
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Agent workers require storage.agents support."
+    )
   }
   if (!storage.auth) {
-    throw new AgentWorkerError("Agent workers require storage.auth support.")
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Agent workers require storage.auth support."
+    )
   }
   if (!storage.aiUsage) {
-    throw new AgentWorkerError("Agent workers require storage.aiUsage support.")
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Agent workers require storage.aiUsage support."
+    )
   }
 }
 
@@ -712,7 +745,10 @@ function toAgentRunFailure(
 function normalizeRequiredString(value: string | undefined): string {
   const trimmed = value?.trim()
   if (!trimmed) {
-    throw new AgentWorkerError("Agent workers require options.apiBaseUrl.")
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Agent workers require options.apiBaseUrl."
+    )
   }
   return trimmed
 }
@@ -735,7 +771,10 @@ function normalizeConcurrency(value: number | undefined): number {
     return DEFAULT_AGENT_CONCURRENCY
   }
   if (!Number.isFinite(value) || value < 1) {
-    throw new AgentWorkerError("Agent worker concurrency must be at least 1.")
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Agent worker concurrency must be at least 1."
+    )
   }
   return Math.floor(value)
 }

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -18,7 +18,7 @@ import type {
   WorkflowRunStorage,
 } from "@sixb/core/storage"
 import { AGENT_RUN_FAILURE_CODES, WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
-import { AgentUsageRecordingError, AgentWorkerError } from "./errors"
+import { AgentUsageRecordingError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { AiModelCallRecorder } from "./model-call-recorder"
 import {
@@ -96,7 +96,11 @@ export async function executeWorkflowAgentNode(
   })
   const executionToken = reserved.execution?.token
   if (!executionToken) {
-    throw new AgentWorkerError(`Agent workflow node '${nodeRun.id}' has no execution token.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Agent workflow node '${nodeRun.id}' has no execution token.`,
+      { details: workflowAgentErrorDetails(agent.id, nodeRun) }
+    )
   }
   const usageRecorder = new AiModelCallRecorder({
     storage: context.storage.aiUsage,
@@ -138,6 +142,8 @@ export async function executeWorkflowAgentNode(
       agent,
       agentStep: node.agentStep,
       workflowId: workflow.id,
+      workflowRunId: nodeRun.workflowRunId,
+      nodeRunId: nodeRun.id,
       prompt: reserved.prompt,
       valueTypesById,
       usageRecorder,
@@ -146,6 +152,7 @@ export async function executeWorkflowAgentNode(
     const completedNode = await finishWorkflowAgentNodeSucceeded({
       context,
       nodeRun,
+      agentId: agent.id,
       executionToken,
       result,
     })
@@ -213,7 +220,13 @@ async function loadWorkflowAgentNodeExecution(
 ): Promise<WorkflowAgentNodeExecutionContext | null> {
   const { context, host, job } = input
   const runs = context.storage.workflowRuns
-  if (!runs) throw new AgentWorkerError("Workflow agent nodes require workflow storage.")
+  if (!runs) {
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbAgentWorker] Workflow agent nodes require workflow storage.",
+      { details: { nodeRunId: job.payload.nodeRunId } }
+    )
+  }
 
   const [executionRecord, nodeRun] = await Promise.all([
     runs.agentNodes.getByNodeRunId({
@@ -223,7 +236,11 @@ async function loadWorkflowAgentNodeExecution(
     runs.nodes.getById({ projectId: context.id, id: job.payload.nodeRunId }),
   ])
   if (!executionRecord || !nodeRun || nodeRun.nodeType !== "agent") {
-    throw new AgentWorkerError(`Agent workflow node '${job.payload.nodeRunId}' was not found.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Agent workflow node '${job.payload.nodeRunId}' was not found.`,
+      { details: { nodeRunId: job.payload.nodeRunId } }
+    )
   }
   if (executionRecord.status !== "queued" && executionRecord.status !== "running") return null
 
@@ -260,26 +277,46 @@ async function loadWorkflowAgentNodeExecution(
     id: executionRecord.executionId,
   })
   if (!durableExecution) {
-    throw new AgentWorkerError(
-      `Agent workflow node '${nodeRun.id}' references missing execution '${executionRecord.executionId}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Agent workflow node '${nodeRun.id}' references missing execution '${executionRecord.executionId}'.`,
+      {
+        details: {
+          ...workflowAgentErrorDetails(executionRecord.agentId, nodeRun),
+          executionId: executionRecord.executionId,
+        },
+      }
     )
   }
   if (durableExecution.parentExecutionId !== workflowRun.executionId) {
-    throw new AgentWorkerError(
-      `Agent workflow node '${nodeRun.id}' execution is not linked to workflow run '${workflowRun.id}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Agent workflow node '${nodeRun.id}' execution is not linked to workflow run '${workflowRun.id}'.`,
+      {
+        details: {
+          ...workflowAgentErrorDetails(executionRecord.agentId, nodeRun),
+          executionId: executionRecord.executionId,
+        },
+      }
     )
   }
 
   const workflow = host.definitions.workflows.getById(nodeRun.workflowId)
   const node = workflow?.nodes[nodeRun.nodeIndex]
   if (!workflow || !node || node.type !== "agent" || node.id !== nodeRun.nodeId) {
-    throw new AgentWorkerError(
-      `Workflow definition for agent node '${job.payload.nodeRunId}' is no longer available.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Workflow definition for agent node '${job.payload.nodeRunId}' is no longer available.`,
+      { details: workflowAgentErrorDetails(executionRecord.agentId, nodeRun) }
     )
   }
   const agent = host.definitions.agents.getById(executionRecord.agentId)
   if (!agent || agent.id !== node.agentStep.agent.id) {
-    throw new AgentWorkerError(`Unknown agent '${executionRecord.agentId}'.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Unknown agent '${executionRecord.agentId}'.`,
+      { details: workflowAgentErrorDetails(executionRecord.agentId, nodeRun) }
+    )
   }
 
   return {
@@ -350,12 +387,19 @@ function confirmQueueOwnership(input: {
 async function finishWorkflowAgentNodeSucceeded(input: {
   readonly context: AgentWorkerContext
   readonly nodeRun: WorkflowNodeRunRecord
+  readonly agentId: string
   readonly executionToken: string
   readonly result: Awaited<ReturnType<typeof runWorkflowAgentNode>>
 }): Promise<WorkflowNodeRunRecord> {
   return input.context.storage.transaction(async (tx) => {
     const runs = tx.workflowRuns
-    if (!runs) throw new AgentWorkerError("Workflow storage disappeared during finalization.")
+    if (!runs) {
+      throw createSixbError(
+        "internal.unexpected",
+        "[SixbAgentWorker] Workflow storage disappeared during finalization.",
+        { details: workflowAgentErrorDetails(input.agentId, input.nodeRun) }
+      )
+    }
     await runs.agentNodes.finish({
       projectId: input.context.id,
       nodeRunId: input.nodeRun.id,
@@ -407,7 +451,13 @@ async function finishWorkflowAgentNodeFailed(input: {
   })
   return input.context.storage.transaction(async (tx) => {
     const runs = tx.workflowRuns
-    if (!runs) throw new AgentWorkerError("Workflow storage disappeared during finalization.")
+    if (!runs) {
+      throw createSixbError(
+        "internal.unexpected",
+        "[SixbAgentWorker] Workflow storage disappeared during finalization.",
+        { details: workflowAgentErrorDetails(input.agent.id, input.nodeRun) }
+      )
+    }
     await runs.agentNodes.finish({
       projectId: input.context.id,
       nodeRunId: input.nodeRun.id,
@@ -563,7 +613,31 @@ function requireFinishedAt(
   record: WorkflowNodeRunRecord | WorkflowRunRecord
 ): NonNullable<typeof record.finishedAt> {
   if (!record.finishedAt) {
-    throw new AgentWorkerError(`Workflow run record '${record.id}' has no finishedAt.`)
+    const details: Readonly<Record<string, string>> =
+      "workflowRunId" in record
+        ? {
+            workflowId: record.workflowId,
+            workflowRunId: record.workflowRunId,
+            nodeRunId: record.id,
+          }
+        : { workflowId: record.workflowId, workflowRunId: record.id }
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbAgentWorker] Workflow run record '${record.id}' has no finishedAt.`,
+      { details }
+    )
   }
   return record.finishedAt
+}
+
+function workflowAgentErrorDetails(
+  agentId: string,
+  nodeRun: Pick<WorkflowNodeRunRecord, "id" | "workflowId" | "workflowRunId">
+): Readonly<Record<string, string>> {
+  return {
+    agentId,
+    workflowId: nodeRun.workflowId,
+    workflowRunId: nodeRun.workflowRunId,
+    nodeRunId: nodeRun.id,
+  }
 }

--- a/packages/agent-worker/tests/ai-sdk-adapters.test.ts
+++ b/packages/agent-worker/tests/ai-sdk-adapters.test.ts
@@ -18,6 +18,15 @@ import {
   aiSdkToolsFromAgentDefinitions,
 } from "../src/ai-sdk-adapters"
 
+function captureThrown(callback: () => unknown): unknown {
+  try {
+    callback()
+  } catch (error) {
+    return error
+  }
+  throw new Error("Expected callback to throw")
+}
+
 describe("AI SDK agent adapters", () => {
   test("converts Sixb tool definitions and supplies the narrow run-scoped context", async () => {
     const connectorDefinition = defineConnector("knowledge", {
@@ -389,9 +398,26 @@ describe("AI SDK agent adapters", () => {
   })
 
   test("rejects unsupported or non-JSON trace content instead of silently losing fidelity", () => {
-    expect(() => agentTraceFromAiSdkSteps([{ content: [{ type: "source" }] }])).toThrow(
-      "trace content 'source' is not supported"
+    const error = captureThrown(() =>
+      agentTraceFromAiSdkSteps([{ content: [{ type: "source" }] }], {
+        agentId: "workflow-agent",
+        workflowId: "review",
+        workflowRunId: "workflow-run-1",
+        nodeRunId: "node-run-1",
+      })
     )
+    expect(error).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message:
+        "[SixbAgentWorker] AI SDK trace content 'source' is not supported by the durable agent trace contract.",
+      details: {
+        agentId: "workflow-agent",
+        workflowId: "review",
+        workflowRunId: "workflow-run-1",
+        nodeRunId: "node-run-1",
+      },
+    })
 
     expect(() =>
       agentTraceFromAiSdkSteps([

--- a/packages/agent-worker/tests/model-call-recovery.test.ts
+++ b/packages/agent-worker/tests/model-call-recovery.test.ts
@@ -3,7 +3,6 @@ import { InMemoryQueues, InMemoryStorage, type ReadonlyJsonValue } from "@sixb/c
 import type { AgentAiUsageRecordRequestedQueueJob } from "@sixb/core/queues"
 import { AiUsageStorageError, type RecordAiModelCallInput } from "@sixb/core/storage"
 import { createTestAgentExecution } from "@sixb/core/testing"
-import { AgentWorkerError } from "../src/errors"
 import {
   agentAiUsageRecoveryJobId,
   enqueueAiModelCallRecovery,
@@ -100,18 +99,21 @@ describe("AI usage recovery", () => {
     }
 
     const storage = new InMemoryStorage()
-    await expect(recordRecoveredAiModelCall(storage.aiUsage, job)).rejects.toBeInstanceOf(
-      AgentWorkerError
+    const invalidJobError = await recordRecoveredAiModelCall(storage.aiUsage, job).catch(
+      (error: unknown) => error
     )
+    expect(invalidJobError).toMatchObject({
+      name: "InvalidAiUsageRecoveryJobError",
+      message:
+        "[SixbAgentWorker] AI usage recovery job 'agt_usage_job_usage_1' has an invalid occurredAt timestamp.",
+    })
+    expect(isPermanentAiUsageRecoveryError(invalidJobError)).toBe(true)
     expect(isPermanentAiUsageRecoveryError(new TypeError("invalid"))).toBe(true)
     expect(
       isPermanentAiUsageRecoveryError(
         new AiUsageStorageError("missing_execution", "missing execution")
       )
     ).toBe(true)
-    expect(isPermanentAiUsageRecoveryError(new AgentWorkerError("queue response mismatch"))).toBe(
-      false
-    )
     expect(isPermanentAiUsageRecoveryError(new Error("storage unavailable"))).toBe(false)
   })
 })

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -50,6 +50,8 @@ import {
   resolveAgentExecutionAuthorization,
 } from "@sixb/core/internal/agents"
 import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
+import { createSixbError } from "@sixb/core/internal/errors"
+import type { AgentQueueJob, ClaimedQueueJob } from "@sixb/core/queues"
 import {
   type AgentStorage,
   AgentStorageError,
@@ -69,7 +71,7 @@ import { AgentWorker, type AgentWorkerOptions } from "../src"
 import { loadAgentSkills } from "../src/agent-skills"
 import { normalizeApiBaseUrl } from "../src/api-url"
 import { prepareAgentAttachments } from "../src/attachments"
-import { AgentExecutionLostError, AgentFinalizationError, AgentWorkerError } from "../src/errors"
+import { AgentExecutionLostError, AgentFinalizationError } from "../src/errors"
 import { finishRunOrThrow } from "../src/finalize"
 import { enqueueAiModelCallRecovery } from "../src/model-call-recovery"
 import { runAgentTurn } from "../src/run-agent-turn"
@@ -621,6 +623,12 @@ const echoAgentTool = defineAgentTool("echo")
   .run(({ input }) => ({ echoed: input.value }))
 
 type TestSixb = AgentWorkerHost & { readonly blobStorage: BlobStorage }
+
+class InspectableAgentWorker extends AgentWorker {
+  decideExecutionError(claimed: ClaimedQueueJob<AgentQueueJob>, error: unknown) {
+    return this.onExecutionError(claimed, error)
+  }
+}
 
 function workerOptions(
   options: Omit<AgentWorkerOptions, "apiBaseUrl"> & { readonly apiBaseUrl?: string } = {}
@@ -1409,6 +1417,39 @@ describe("AgentWorker", () => {
     } finally {
       await worker.stop()
     }
+  })
+
+  test("fails coded non-retryable errors and retries unknown infrastructure failures", async () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+    const worker = new InspectableAgentWorker(sixb, workerOptions({ skillsDir: false }))
+    const now = new Date().toISOString()
+    const claimed: ClaimedQueueJob<AgentQueueJob> = {
+      leaseId: "lease-1",
+      claimedAt: now,
+      leaseExpiresAt: now,
+      job: {
+        id: "job-1",
+        projectId: PROJECT_ID,
+        createdAt: now,
+        availableAt: now,
+        attempt: 1,
+        type: "agent.run.requested",
+        payload: { runId: "run-1" },
+      },
+    }
+
+    await expect(
+      worker.decideExecutionError(
+        claimed,
+        createSixbError("internal.unexpected", "[SixbAgentWorker] Deterministic worker failure.", {
+          details: { agentId: "assistant", runId: "run-1" },
+        })
+      )
+    ).resolves.toEqual({ kind: "fail" })
+
+    await expect(
+      worker.decideExecutionError(claimed, new Error("storage unavailable"))
+    ).resolves.toMatchObject({ kind: "retry", availableAt: expect.any(String) })
   })
 
   test("executes a headless workflow agent node and publishes its resume", async () => {
@@ -5213,11 +5254,24 @@ describe("AgentWorker", () => {
         },
         { label: "missing agent run failed" }
       )
-      expect(failed).toMatchObject({ status: "failed", attempt: 0 })
-      expect(failed.error?.message).toBe("An unexpected internal error occurred.")
+      expect(failed).toMatchObject({
+        status: "failed",
+        attempt: 0,
+        error: {
+          code: "internal.unexpected",
+          retryable: false,
+          message: "An unexpected internal error occurred.",
+          details: { agentId: "removed-agent", runId },
+        },
+      })
       await reporter.flush()
       expect(reports).toHaveLength(1)
-      expect(reports[0]?.error).toBeInstanceOf(AgentWorkerError)
+      expect(reports[0]?.error).toMatchObject({
+        code: "internal.unexpected",
+        retryable: false,
+        message: "[SixbAgentWorker] Unknown agent 'removed-agent'.",
+        details: { agentId: "removed-agent", runId },
+      })
       expect(reports[0]?.context).toMatchObject({
         projectId: PROJECT_ID,
         attempt: 1,


### PR DESCRIPTION
## Summary

- remove the internal AgentWorkerError wrapper and create canonical coded errors directly
- preserve existing messages and causes while attaching agent, run, workflow, and node identifiers at creation time
- route known non-retryable Sixb errors to fail while retaining bounded retries for unknown infrastructure failures
- assert the structural error contract and fail/retry policy instead of a runtime class

## Why

AgentWorkerError only supplied a name and message prefix. It carried no control-flow semantics, unlike the execution-loss, finalization, timeout, tool-sanitization, and tool-output errors that remain in place.

Correlation details now travel with the coded error through tool adaptation, trace conversion, stream encoding, conversation runs, and workflow agent nodes. This matters because persistence deliberately preserves the details of an already-coded error rather than applying fallback details later.

This stays narrow: no public error class is exposed, no new error code is introduced, and the remaining Agent Worker error classes are unchanged.

## Validation

- bun test packages/agent-worker/tests/
- bun --filter @sixb/agent-worker typecheck
- bun --filter @sixb/agent-worker build
- bun run typecheck
- bun run check

## Stack

Depends on #327 and continues #274.