### PR TITLE
google: add Drive file downloads

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -33,12 +33,18 @@ const client = await googleConnector.adapter.connect(ctx)
 await client.drive.files.list({ q: "'FOLDER_ID' in parents and trashed = false" })
 for await (const file of client.drive.files.listAll({ q })) { /* ... */ }
 await client.drive.files.get(fileId, { fields: "id, name, modifiedTime" })
-const bytes = await client.drive.files.export(fileId, "text/plain")
+const storedBytes = await client.drive.files.download(fileId, { supportsAllDrives: true })
+const nativeBytes = await client.drive.files.export(fileId, "text/plain")
 
 // Incremental change feed — the caller persists the page token as its checkpoint.
 const { startPageToken } = await client.drive.changes.getStartPageToken()
 for await (const change of client.drive.changes.listAll({ pageToken: startPageToken })) { /* ... */ }
 ```
+
+Use `files.download()` for stored files such as CSV, XLSX, PDF, and images. It returns the file's
+raw bytes and supports Shared Drive files with `{ supportsAllDrives: true }` (plus
+`acknowledgeAbuse` when needed). Use `files.export()` instead for native Google Docs, Sheets, and
+Slides, choosing the desired export MIME type.
 
 ### Writing files
 

--- a/connectors/google/src/http.ts
+++ b/connectors/google/src/http.ts
@@ -53,7 +53,10 @@ export interface GoogleHttp {
     path: string,
     options?: GoogleRequestOptions
   ): Promise<T>
-  /** Raw bytes (e.g. Drive `files.export`); throws `GoogleApiError` on non-2xx. */
+  /**
+   * Raw bytes (e.g. Drive `files.download`/`files.export`); throws
+   * `GoogleApiError` on non-2xx.
+   */
   media(
     surface: GoogleSurface,
     path: string,

--- a/connectors/google/src/surfaces/drive/files.ts
+++ b/connectors/google/src/surfaces/drive/files.ts
@@ -8,6 +8,7 @@ import type {
   DriveFileCopyInput,
   DriveFileCreateInput,
   DriveFileDeleteOptions,
+  DriveFileDownloadOptions,
   DriveFileGetOptions,
   DriveFileList,
   DriveFilesListOptions,
@@ -21,6 +22,11 @@ export interface DriveFilesResource {
   listAll(options?: DriveFilesListOptions): AsyncIterable<DriveFile>
   /** `GET /files/{fileId}` — metadata only. */
   get(fileId: string, options?: DriveFileGetOptions): Promise<DriveFile>
+  /**
+   * `GET /files/{fileId}?alt=media` — download the raw bytes of a stored file
+   * such as a CSV, XLSX, PDF, or image. Use `export` for Google-native files.
+   */
+  download(fileId: string, options?: DriveFileDownloadOptions): Promise<Uint8Array>
   /**
    * `GET /files/{fileId}/export` — export a Google-native doc (e.g. a Meet
    * transcript Doc) to `text/plain`, `text/markdown`, `application/pdf`, …
@@ -61,6 +67,15 @@ export function driveFilesResource(http: GoogleHttp): DriveFilesResource {
     get(fileId, options) {
       return http.json<DriveFile>("drive", "GET", `files/${pathSegment(fileId, "fileId")}`, {
         query: options,
+      })
+    },
+    download(fileId, options) {
+      return http.media("drive", `files/${pathSegment(fileId, "fileId")}`, {
+        query: {
+          alt: "media",
+          supportsAllDrives: options?.supportsAllDrives,
+          acknowledgeAbuse: options?.acknowledgeAbuse,
+        },
       })
     },
     export(fileId, mimeType) {

--- a/connectors/google/src/types/drive.ts
+++ b/connectors/google/src/types/drive.ts
@@ -57,6 +57,13 @@ export type DriveFileGetOptions = QueryParams & {
   readonly acknowledgeAbuse?: boolean
 }
 
+export type DriveFileDownloadOptions = QueryParams & {
+  /** Required for files in Shared Drives. */
+  readonly supportsAllDrives?: boolean
+  /** Acknowledge the risk of downloading a file flagged as abusive. */
+  readonly acknowledgeAbuse?: boolean
+}
+
 export interface DriveChange {
   readonly fileId?: string
   readonly file?: DriveFile

--- a/connectors/google/tests/drive.test.ts
+++ b/connectors/google/tests/drive.test.ts
@@ -72,6 +72,41 @@ describe("drive.files", () => {
     expect(requests[0]?.url).toBe("https://www.googleapis.com/drive/v3/files/abc?fields=id%2C+name")
   })
 
+  test("download requests alt=media and returns raw file bytes", async () => {
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return new Response(Uint8Array.from([0, 127, 255]), {
+        headers: { "content-type": "application/octet-stream" },
+      })
+    })
+
+    const client = await connect()
+    const bytes = await client.drive.files.download("stored/file")
+
+    expect(Array.from(bytes)).toEqual([0, 127, 255])
+    expect(requests[0]?.url).toBe(
+      "https://www.googleapis.com/drive/v3/files/stored%2Ffile?alt=media"
+    )
+  })
+
+  test("download supports Shared Drive files and abuse acknowledgement", async () => {
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return new Response("file contents")
+    })
+
+    const client = await connect()
+    await client.drive.files.download("shared-file", {
+      supportsAllDrives: true,
+      acknowledgeAbuse: true,
+    })
+
+    expect(requests[0]?.url).toBe(
+      "https://www.googleapis.com/drive/v3/files/shared-file" +
+        "?alt=media&supportsAllDrives=true&acknowledgeAbuse=true"
+    )
+  })
+
   test("export returns raw bytes from the export endpoint", async () => {
     mockFetch(async (input, init) => {
       record(input, init)
@@ -89,7 +124,7 @@ describe("drive.files", () => {
     )
   })
 
-  test("maps a Google error envelope to GoogleApiError", async () => {
+  test("download maps a Google error envelope to GoogleApiError", async () => {
     mockFetch(async () =>
       json(
         { error: { code: 403, message: "Insufficient Permission", status: "PERMISSION_DENIED" } },
@@ -98,7 +133,7 @@ describe("drive.files", () => {
     )
 
     const client = await connect()
-    const error = (await client.drive.files.list().catch((e) => e)) as GoogleApiError
+    const error = (await client.drive.files.download("blocked").catch((e) => e)) as GoogleApiError
     expect(error).toBeInstanceOf(GoogleApiError)
     expect(error.status).toBe(403)
     expect(error.message).toContain("Insufficient Permission")


### PR DESCRIPTION
## Summary

Adds `drive.files.download()` for stored Drive files such as CSV, XLSX, PDF, and images. It returns the raw response bytes through the existing media helper.

```ts
const bytes = await client.drive.files.download(fileId)
```

Supports files in Shared Drives and optional acknowledgement for files Google has flagged as abusive.

```ts
const bytes = await client.drive.files.download(fileId, {
  supportsAllDrives: true,
  acknowledgeAbuse: true,
})
```

Keeps `drive.files.export()` as the path for native Google Docs, Sheets, and Slides.

```ts
const bytes = await client.drive.files.export(fileId, "application/pdf")
```

## Testing

- Covers the request path and `alt=media` query
- Verifies raw binary responses
- Covers Shared Drive and abuse acknowledgement options
- Verifies Google API error handling

```sh
bun test connectors/google/tests
bun --filter @sixb/connector-google typecheck
bun --filter @sixb/connector-google build
bun run check -- connectors/google/src/surfaces/drive/files.ts connectors/google/src/types/drive.ts connectors/google/src/http.ts connectors/google/tests/drive.test.ts
```
