### PR TITLE
pipeline-worker: replace intermediate error class

### DIFF
--- a/packages/pipeline-worker/src/errors.ts
+++ b/packages/pipeline-worker/src/errors.ts
@@ -1,11 +1,8 @@
 import type { DatasetDefinition, PipelineDefinition } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
 import type { PipelineRunStatus } from "@sixb/core/storage"
 import type { PipelineJob } from "./types"
-
-export class PipelineWorkerError extends Error {
-  readonly name = "PipelineWorkerError"
-}
 
 export function throwIfAborted(signal: AbortSignal): void {
   if (signal.aborted) {
@@ -20,27 +17,45 @@ export function statusForFailure(
   return signal.aborted || isAbortError(error) ? "cancelled" : "failed"
 }
 
-export function requireFinishedAt(runId: string, finishedAt: Date | undefined): Date {
-  if (finishedAt) {
-    return finishedAt
+export function requireFinishedAt(input: {
+  readonly pipelineId: string
+  readonly runId: string
+  readonly finishedAt: Date | undefined
+}): Date {
+  if (input.finishedAt) {
+    return input.finishedAt
   }
 
-  throw new PipelineWorkerError(
-    `[SixbPipelineWorker] Pipeline run '${runId}' finished without a finishedAt timestamp.`
+  throw createSixbError(
+    "internal.unexpected",
+    `[SixbPipelineWorker] Pipeline run '${input.runId}' finished without a finishedAt timestamp.`,
+    { details: { pipelineId: input.pipelineId, runId: input.runId } }
   )
 }
 
 export function createStepBookkeepingError(options: {
   readonly pipelineId: string
+  readonly pipelineRunId: string
   readonly stepId: string
-  readonly runId: string
+  readonly stepRunId: string
   readonly version: DatasetVersion
   readonly cause: unknown
 }): Error {
   // The dataset version is already durable; retrying the whole pipeline could duplicate appends.
-  return new PipelineWorkerError(
-    `[SixbPipelineWorker] Pipeline '${options.pipelineId}' step '${options.stepId}' committed dataset version '${options.version.versionId}', but failed to finalize step run '${options.runId}'. The dataset commit may already have succeeded and the step run record may need repair.`,
-    { cause: options.cause }
+  return createSixbError(
+    "internal.unexpected",
+    `[SixbPipelineWorker] Pipeline '${options.pipelineId}' step '${options.stepId}' committed dataset version '${options.version.versionId}', but failed to finalize step run '${options.stepRunId}'. The dataset commit may already have succeeded and the step run record may need repair.`,
+    {
+      cause: options.cause,
+      details: {
+        pipelineId: options.pipelineId,
+        pipelineRunId: options.pipelineRunId,
+        stepId: options.stepId,
+        stepRunId: options.stepRunId,
+        datasetId: options.version.datasetId,
+        versionId: options.version.versionId,
+      },
+    }
   )
 }
 
@@ -50,9 +65,18 @@ export function createPipelineBookkeepingError(options: {
   readonly version: DatasetVersion
   readonly cause: unknown
 }): Error {
-  return new PipelineWorkerError(
+  return createSixbError(
+    "internal.unexpected",
     `[SixbPipelineWorker] Pipeline '${options.pipelineId}' committed final dataset version '${options.version.versionId}', but failed to finalize pipeline run '${options.runId}'. The dataset commit may already have succeeded and the pipeline run record may need repair.`,
-    { cause: options.cause }
+    {
+      cause: options.cause,
+      details: {
+        pipelineId: options.pipelineId,
+        runId: options.runId,
+        datasetId: options.version.datasetId,
+        versionId: options.version.versionId,
+      },
+    }
   )
 }
 
@@ -61,7 +85,11 @@ export function requirePipeline(
   job: PipelineJob
 ): PipelineDefinition {
   if (!pipeline) {
-    throw new PipelineWorkerError(`[SixbPipelineWorker] Unknown pipeline '${job.pipelineId}'.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbPipelineWorker] Unknown pipeline '${job.pipelineId}'.`,
+      { details: { pipelineId: job.pipelineId, runId: job.id } }
+    )
   }
 
   return pipeline
@@ -70,6 +98,7 @@ export function requirePipeline(
 export function requireRegisteredDataset(options: {
   readonly dataset: DatasetDefinition | null
   readonly pipelineId: string
+  readonly pipelineRunId: string
   readonly stepId: string
   readonly role: "input" | "output"
   readonly name?: string
@@ -81,8 +110,17 @@ export function requireRegisteredDataset(options: {
 
   const namedRole = options.role === "input" ? `input '${options.name ?? "unknown"}'` : "output"
 
-  throw new PipelineWorkerError(
-    `[SixbPipelineWorker] Pipeline '${options.pipelineId}' step '${options.stepId}' ${namedRole} references unknown dataset '${options.datasetId}'.`
+  throw createSixbError(
+    "internal.unexpected",
+    `[SixbPipelineWorker] Pipeline '${options.pipelineId}' step '${options.stepId}' ${namedRole} references unknown dataset '${options.datasetId}'.`,
+    {
+      details: {
+        pipelineId: options.pipelineId,
+        pipelineRunId: options.pipelineRunId,
+        stepId: options.stepId,
+        datasetId: options.datasetId,
+      },
+    }
   )
 }
 

--- a/packages/pipeline-worker/src/execute-run-step.ts
+++ b/packages/pipeline-worker/src/execute-run-step.ts
@@ -5,8 +5,9 @@ import type {
   PipelineStepDefinition,
   PipelineStepRunContext,
 } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
-import { PipelineWorkerError, throwIfAborted } from "./errors"
+import { throwIfAborted } from "./errors"
 import { createStepInputs, type ResolvedStepInput } from "./step-inputs"
 import type { PipelineJob, PipelineLogSession, PipelineWorkerContext } from "./types"
 
@@ -27,8 +28,17 @@ export async function executeRunStep(input: {
   const { runtime, pipeline, step, job, signal, outputDataset, resolvedInputs } = input
 
   if (step.executor.kind !== "run") {
-    throw new PipelineWorkerError(
-      `[SixbPipelineWorker] Pipeline '${pipeline.id}' step '${step.id}' uses SQL execution, which is not supported by the run step executor.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbPipelineWorker] Pipeline '${pipeline.id}' step '${step.id}' uses SQL execution, which is not supported by the run step executor.`,
+      {
+        details: {
+          pipelineId: pipeline.id,
+          pipelineRunId: job.id,
+          stepId: step.id,
+          datasetId: outputDataset.id,
+        },
+      }
     )
   }
 

--- a/packages/pipeline-worker/src/execute-sql-step.ts
+++ b/packages/pipeline-worker/src/execute-sql-step.ts
@@ -5,12 +5,13 @@ import type {
   PipelineDefinition,
   PipelineStepDefinition,
 } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type {
   DatasetVersion,
   DatasetWriteMode,
   LakeSqlTransformCapabilities,
 } from "@sixb/core/lake-storage"
-import { PipelineWorkerError, throwIfAborted } from "./errors"
+import { throwIfAborted } from "./errors"
 import type { ResolvedStepInput } from "./step-inputs"
 import type { PipelineJob, PipelineWorkerContext } from "./types"
 
@@ -27,7 +28,9 @@ function assertSqlModeSupported(input: {
   readonly dialect: string
   readonly mode: DatasetWriteMode
   readonly pipelineId: string
+  readonly pipelineRunId: string
   readonly stepId: string
+  readonly datasetId: string
 }): void {
   const supported =
     input.mode === "append"
@@ -35,9 +38,18 @@ function assertSqlModeSupported(input: {
       : input.capabilities.supportsSnapshot
   if (supported) return
 
-  throw new PipelineWorkerError(
+  throw createSixbError(
+    "internal.unexpected",
     `[SixbPipelineWorker] Pipeline '${input.pipelineId}' step '${input.stepId}' writes in ` +
-      `'${input.mode}' mode, which the ${input.dialect} SQL executor does not support.`
+      `'${input.mode}' mode, which the ${input.dialect} SQL executor does not support.`,
+    {
+      details: {
+        pipelineId: input.pipelineId,
+        pipelineRunId: input.pipelineRunId,
+        stepId: input.stepId,
+        datasetId: input.datasetId,
+      },
+    }
   )
 }
 
@@ -57,14 +69,32 @@ export async function executeSqlStep(input: {
   const { runtime, pipeline, step, job, signal, outputDataset, resolvedInputs } = input
 
   if (step.executor.kind !== "sql") {
-    throw new PipelineWorkerError(
-      `[SixbPipelineWorker] Pipeline '${pipeline.id}' step '${step.id}' uses run execution, which is not supported by the SQL step executor.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbPipelineWorker] Pipeline '${pipeline.id}' step '${step.id}' uses run execution, which is not supported by the SQL step executor.`,
+      {
+        details: {
+          pipelineId: pipeline.id,
+          pipelineRunId: job.id,
+          stepId: step.id,
+          datasetId: outputDataset.id,
+        },
+      }
     )
   }
 
   if (!hasSqlExecutor(runtime.lakeStorage)) {
-    throw new PipelineWorkerError(
-      `[SixbPipelineWorker] Pipeline '${pipeline.id}' step '${step.id}' requires SQL transform support, but lake storage does not provide lakeStorage.sql.execute(...).`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbPipelineWorker] Pipeline '${pipeline.id}' step '${step.id}' requires SQL transform support, but lake storage does not provide lakeStorage.sql.execute(...).`,
+      {
+        details: {
+          pipelineId: pipeline.id,
+          pipelineRunId: job.id,
+          stepId: step.id,
+          datasetId: outputDataset.id,
+        },
+      }
     )
   }
 
@@ -77,7 +107,9 @@ export async function executeSqlStep(input: {
     dialect: runtime.lakeStorage.sql.dialect,
     mode: step.mode,
     pipelineId: pipeline.id,
+    pipelineRunId: job.id,
     stepId: step.id,
+    datasetId: outputDataset.id,
   })
 
   throwIfAborted(signal)

--- a/packages/pipeline-worker/src/run-pipeline-job.ts
+++ b/packages/pipeline-worker/src/run-pipeline-job.ts
@@ -102,7 +102,11 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
     return {
       run: {
         ...run,
-        finishedAt: requireFinishedAt(job.id, run.finishedAt),
+        finishedAt: requireFinishedAt({
+          pipelineId: pipeline.id,
+          runId: job.id,
+          finishedAt: run.finishedAt,
+        }),
       },
       steps,
       version: finalVersion,

--- a/packages/pipeline-worker/src/run-step.ts
+++ b/packages/pipeline-worker/src/run-step.ts
@@ -44,11 +44,17 @@ export async function runStep(input: {
   }
 
   throwIfAborted(signal)
-  const resolvedInputs = await resolveStepInputs({ runtime, pipeline, step })
+  const resolvedInputs = await resolveStepInputs({
+    runtime,
+    pipeline,
+    step,
+    pipelineRunId: job.id,
+  })
   const inputRefs = resolvedInputs.map((resolved) => resolved.ref)
   const outputDataset = requireRegisteredDataset({
     dataset: runtime.datasets.getById(step.output.id),
     pipelineId: pipeline.id,
+    pipelineRunId: job.id,
     stepId: step.id,
     role: "output",
     datasetId: step.output.id,
@@ -101,8 +107,9 @@ export async function runStep(input: {
     } catch (error) {
       throw createStepBookkeepingError({
         pipelineId: pipeline.id,
+        pipelineRunId: job.id,
         stepId: step.id,
-        runId: stepRunId,
+        stepRunId,
         version: committedVersion,
         cause: error,
       })

--- a/packages/pipeline-worker/src/step-inputs.ts
+++ b/packages/pipeline-worker/src/step-inputs.ts
@@ -5,12 +5,13 @@ import type {
   PipelineStepInput,
   PipelineStepRunContext,
 } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type {
   DatasetVersion,
   DatasetVersionRef,
   ReadDatasetRowsInput,
 } from "@sixb/core/lake-storage"
-import { PipelineWorkerError, requireRegisteredDataset } from "./errors"
+import { requireRegisteredDataset } from "./errors"
 import type { PipelineWorkerContext } from "./types"
 
 export interface ResolvedStepInput {
@@ -24,14 +25,16 @@ export async function resolveStepInputs(input: {
   readonly runtime: PipelineWorkerContext
   readonly pipeline: PipelineDefinition
   readonly step: PipelineStepDefinition
+  readonly pipelineRunId: string
 }): Promise<readonly ResolvedStepInput[]> {
-  const { runtime, pipeline, step } = input
+  const { runtime, pipeline, step, pipelineRunId } = input
   const resolved: ResolvedStepInput[] = []
 
   for (const [name, declaredDataset] of Object.entries(step.inputs)) {
     const dataset = requireRegisteredDataset({
       dataset: runtime.datasets.getById(declaredDataset.id),
       pipelineId: pipeline.id,
+      pipelineRunId,
       stepId: step.id,
       role: "input",
       name,
@@ -40,8 +43,17 @@ export async function resolveStepInputs(input: {
 
     const version = await runtime.lakeStorage.getLatestVersion(dataset.id)
     if (!version) {
-      throw new PipelineWorkerError(
-        `[SixbPipelineWorker] Pipeline '${pipeline.id}' step '${step.id}' input '${name}' dataset '${dataset.id}' has no committed version.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbPipelineWorker] Pipeline '${pipeline.id}' step '${step.id}' input '${name}' dataset '${dataset.id}' has no committed version.`,
+        {
+          details: {
+            pipelineId: pipeline.id,
+            pipelineRunId,
+            stepId: step.id,
+            datasetId: dataset.id,
+          },
+        }
       )
     }
 

--- a/packages/pipeline-worker/tests/run-pipeline-job.test.ts
+++ b/packages/pipeline-worker/tests/run-pipeline-job.test.ts
@@ -20,6 +20,7 @@ import type {
 } from "@sixb/core/lake-storage"
 import type { PipelineRunStorage } from "@sixb/core/storage"
 import { InMemoryPipelineRunStorage } from "@sixb/core/storage"
+import { createPipelineBookkeepingError, createStepBookkeepingError } from "../src/errors"
 import { runPipelineJob } from "../src/run-pipeline-job"
 import type { PipelineWorkerContext } from "../src/types"
 
@@ -139,7 +140,63 @@ describe("runPipelineJob", () => {
           pipelineId: "missing",
         },
       })
-    ).rejects.toThrow("[SixbPipelineWorker] Unknown pipeline 'missing'.")
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message: "[SixbPipelineWorker] Unknown pipeline 'missing'.",
+      details: { pipelineId: "missing", runId: "run_1" },
+    })
+  })
+
+  test("preserves causes and correlation details for post-commit bookkeeping failures", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    const { outcome: _outcome, ...version } = await seedDatasetVersion(
+      lakeStorage,
+      customersDataset,
+      [{ id: "cust_1", name: "Ada" }]
+    )
+    const stepCause = new Error("step finish unavailable")
+    const stepError = createStepBookkeepingError({
+      pipelineId: "customers",
+      pipelineRunId: "run_1",
+      stepId: "clean-customers",
+      stepRunId: "run_1:step:1:clean-customers",
+      version,
+      cause: stepCause,
+    })
+
+    expect(stepError).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      cause: stepCause,
+      details: {
+        pipelineId: "customers",
+        pipelineRunId: "run_1",
+        stepId: "clean-customers",
+        stepRunId: "run_1:step:1:clean-customers",
+        datasetId: "customers",
+        versionId: version.versionId,
+      },
+    })
+
+    const runCause = new Error("pipeline finish unavailable")
+    const runError = createPipelineBookkeepingError({
+      pipelineId: "customers",
+      runId: "run_1",
+      version,
+      cause: runCause,
+    })
+    expect(runError).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      cause: runCause,
+      details: {
+        pipelineId: "customers",
+        runId: "run_1",
+        datasetId: "customers",
+        versionId: version.versionId,
+      },
+    })
   })
 
   test("fails clearly when an input has no committed version", async () => {
@@ -163,9 +220,18 @@ describe("runPipelineJob", () => {
           pipelineId: "customers",
         },
       })
-    ).rejects.toThrow(
-      "[SixbPipelineWorker] Pipeline 'customers' step 'clean-customers' input 'rawCustomers' dataset 'raw.customers' has no committed version."
-    )
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message:
+        "[SixbPipelineWorker] Pipeline 'customers' step 'clean-customers' input 'rawCustomers' dataset 'raw.customers' has no committed version.",
+      details: {
+        pipelineId: "customers",
+        pipelineRunId: "run_missing_input",
+        stepId: "clean-customers",
+        datasetId: "raw.customers",
+      },
+    })
 
     const run = await pipelineRunsStorage.getById({
       projectId: runtime.id,
@@ -175,7 +241,12 @@ describe("runPipelineJob", () => {
     expect(run?.error).toMatchObject({
       code: "internal.unexpected",
       retryable: false,
-      details: { pipelineId: "customers", runId: "run_missing_input" },
+      details: {
+        pipelineId: "customers",
+        pipelineRunId: "run_missing_input",
+        stepId: "clean-customers",
+        datasetId: "raw.customers",
+      },
     })
     expect(run?.error?.message).toBe("An unexpected internal error occurred.")
 
@@ -429,7 +500,18 @@ describe("runPipelineJob", () => {
 
     await expect(
       runPipelineJob({ runtime, job: { id: "run_sql", pipelineId: "customers" } })
-    ).rejects.toThrow("writes in 'append' mode, which the duckdb SQL executor does not support")
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message:
+        "[SixbPipelineWorker] Pipeline 'customers' step 'customer-stats' writes in 'append' mode, which the duckdb SQL executor does not support.",
+      details: {
+        pipelineId: "customers",
+        pipelineRunId: "run_sql",
+        stepId: "customer-stats",
+        datasetId: "customer_stats",
+      },
+    })
     // Refused before the provider was asked to do it, so nothing was written or committed.
     expect(lakeStorage.executeCalls).toHaveLength(0)
   })
@@ -532,9 +614,18 @@ describe("runPipelineJob", () => {
           pipelineId: "customers",
         },
       })
-    ).rejects.toThrow(
-      "[SixbPipelineWorker] Pipeline 'customers' step 'customer-stats' requires SQL transform support, but lake storage does not provide lakeStorage.sql.execute(...)."
-    )
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message:
+        "[SixbPipelineWorker] Pipeline 'customers' step 'customer-stats' requires SQL transform support, but lake storage does not provide lakeStorage.sql.execute(...).",
+      details: {
+        pipelineId: "customers",
+        pipelineRunId: "run_sql_no_support",
+        stepId: "customer-stats",
+        datasetId: "customer_stats",
+      },
+    })
 
     const run = await pipelineRunsStorage.getById({
       projectId: runtime.id,
@@ -552,6 +643,12 @@ describe("runPipelineJob", () => {
       error: {
         code: "internal.unexpected",
         retryable: false,
+        details: {
+          pipelineId: "customers",
+          pipelineRunId: "run_sql_no_support",
+          stepId: "customer-stats",
+          datasetId: "customer_stats",
+        },
       },
     })
     expect(stepRuns.steps[0]?.error?.message).toBe("An unexpected internal error occurred.")


### PR DESCRIPTION
## Summary

- remove the internal PipelineWorkerError wrapper and create canonical coded errors directly
- preserve existing messages and causes while attaching pipeline, run, step, dataset, and version identifiers at creation time
- keep PipelineRunAlreadyStartedError because it still drives queue acknowledgement control flow
- assert the structural error contract and persisted correlation details instead of a runtime class

## Why

PipelineWorkerError only supplied a name and message prefix. It carried no control-flow semantics, while persistence deliberately preserves details already attached to coded errors rather than replacing them with fallback details later.

This stays narrow: no public error type is exposed, no new error code is introduced, and the remaining control-flow error is unchanged.

## Validation

- bun test packages/pipeline-worker/tests/run-pipeline-job.test.ts packages/pipeline-worker/tests/worker.test.ts
- bun --filter @sixb/pipeline-worker typecheck
- bun --filter @sixb/pipeline-worker build
- bun run typecheck
- bun run check

## Stack

Depends on #339 and continues #274.