### PR TITLE
orchestrator: replace intermediate error class

### DIFF
--- a/packages/orchestrator/src/compile-routes.ts
+++ b/packages/orchestrator/src/compile-routes.ts
@@ -1,6 +1,6 @@
 import type { DomainEvent, ScheduleDefinition, ScheduleReference } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import { eventScheduleSubscribedEventTypes } from "@sixb/core/internal/schedules"
-import { OrchestratorError } from "./errors"
 import { eventScheduleRouteKeyForSelector } from "./route-key"
 import type {
   CompileRoutesDiagnostic,
@@ -135,8 +135,17 @@ function addScheduleTarget(input: {
   for (const eventType of eventScheduleSubscribedEventTypes(eventSchedule)) {
     const key = eventScheduleRouteKeyForSelector(eventType, eventSchedule.trigger.source)
     if (!key) {
-      throw new OrchestratorError(
-        `Schedule '${schedule.id}' source cannot be compiled into a scoped route.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbOrchestrator] Schedule '${schedule.id}' source cannot be compiled into a scoped route.`,
+        {
+          details: {
+            scheduleId: schedule.id,
+            consumerKind: input.consumerKind,
+            consumerId: input.consumerId,
+            eventType,
+          },
+        }
       )
     }
     addCompiledEventSchedule(input.routes, { key, eventType }, eventSchedule, input.target)

--- a/packages/orchestrator/src/errors.ts
+++ b/packages/orchestrator/src/errors.ts
@@ -1,6 +1,0 @@
-export class OrchestratorError extends Error {
-  readonly name = "OrchestratorError"
-  constructor(message: string, options?: ErrorOptions) {
-    super(`[SixbOrchestrator] ${message}`, options)
-  }
-}

--- a/packages/orchestrator/src/projection-dispatch-reconciler.ts
+++ b/packages/orchestrator/src/projection-dispatch-reconciler.ts
@@ -1,8 +1,8 @@
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { ProjectionDispatchDescriptor } from "@sixb/core/internal/projections"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
 import type { ProjectionRunRequestedQueueJob, Queue } from "@sixb/core/queues"
 import type { ProjectionRunRecord } from "@sixb/core/storage"
-import { OrchestratorError } from "./errors"
 import { buildProjectionJob } from "./projection-job"
 import type { ProjectionDispatchPorts } from "./types"
 
@@ -43,7 +43,12 @@ async function reconcileProjection(
   input: ProjectionDispatchReconcilerInput,
   descriptor: ProjectionDispatchDescriptor
 ): Promise<void> {
-  const version = await findLatestDataVersion(input.lakeStorage, descriptor.datasetId)
+  const version = await findLatestDataVersion({
+    lakeStorage: input.lakeStorage,
+    projectId: input.projectId,
+    projectionId: descriptor.projectionId,
+    datasetId: descriptor.datasetId,
+  })
   if (!version) return
 
   const job = buildProjectionJob({
@@ -55,8 +60,18 @@ async function reconcileProjection(
   const run = await input.projectionRuns.getById({ projectId: input.projectId, id: job.id })
   if (run) {
     if (!runMatchesJob(run, job.payload)) {
-      throw new OrchestratorError(
-        `Projection run '${run.id}' does not match its deterministic dispatch identity.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbOrchestrator] Projection run '${run.id}' does not match its deterministic dispatch identity.`,
+        {
+          details: {
+            projectId: input.projectId,
+            projectionId: descriptor.projectionId,
+            runId: run.id,
+            datasetId: descriptor.datasetId,
+            versionId: version.versionId,
+          },
+        }
       )
     }
     return
@@ -82,29 +97,51 @@ function runMatchesJob(
   )
 }
 
-async function findLatestDataVersion(
-  lakeStorage: ProjectionDispatchPorts["lakeStorage"],
-  datasetId: string
-): Promise<DatasetVersion | null> {
-  let version = await lakeStorage.getLatestVersion(datasetId)
+async function findLatestDataVersion(input: {
+  readonly lakeStorage: ProjectionDispatchPorts["lakeStorage"]
+  readonly projectId: string
+  readonly projectionId: string
+  readonly datasetId: string
+}): Promise<DatasetVersion | null> {
+  let version = await input.lakeStorage.getLatestVersion(input.datasetId)
   const visited = new Set<string>()
 
   while (version?.mode === "schema") {
     if (!version.parentVersionId) {
-      const versions = await lakeStorage.listVersions(datasetId)
+      const versions = await input.lakeStorage.listVersions(input.datasetId)
       return versions.find((candidate) => candidate.mode !== "schema") ?? null
     }
     if (visited.has(version.versionId)) {
-      throw new OrchestratorError(
-        `Dataset '${datasetId}' version ancestry contains a cycle at '${version.versionId}'.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbOrchestrator] Dataset '${input.datasetId}' version ancestry contains a cycle at '${version.versionId}'.`,
+        {
+          details: {
+            projectId: input.projectId,
+            projectionId: input.projectionId,
+            datasetId: input.datasetId,
+            versionId: version.versionId,
+          },
+        }
       )
     }
     visited.add(version.versionId)
+    const schemaVersionId = version.versionId
     const parentVersionId = version.parentVersionId
-    version = await lakeStorage.getVersion(datasetId, parentVersionId)
+    version = await input.lakeStorage.getVersion(input.datasetId, parentVersionId)
     if (!version) {
-      throw new OrchestratorError(
-        `Dataset '${datasetId}' schema version references missing parent '${parentVersionId}'.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbOrchestrator] Dataset '${input.datasetId}' schema version references missing parent '${parentVersionId}'.`,
+        {
+          details: {
+            projectId: input.projectId,
+            projectionId: input.projectionId,
+            datasetId: input.datasetId,
+            versionId: schemaVersionId,
+            parentVersionId,
+          },
+        }
       )
     }
   }

--- a/packages/orchestrator/src/worker.ts
+++ b/packages/orchestrator/src/worker.ts
@@ -1,9 +1,9 @@
 import type { DomainEvent } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { StoredDomainEvent } from "@sixb/core/internal/events"
 import type { ProjectionDispatchDescriptor } from "@sixb/core/internal/projections"
 import { evaluateEventSchedule } from "@sixb/core/internal/schedules"
 import { Worker } from "@sixb/core/internal/workers"
-import { OrchestratorError } from "./errors"
 import { runProjectionDispatchReconciler } from "./projection-dispatch-reconciler"
 import { buildProjectionJob } from "./projection-job"
 import { routeKeysForEvent } from "./route-key"
@@ -25,17 +25,24 @@ export class OrchestratorWorker extends Worker {
 
   constructor(options: OrchestratorRuntimeOptions) {
     if (!options.projectId) {
-      throw new OrchestratorError("projectId is required.")
+      throw createSixbError("internal.unexpected", "[SixbOrchestrator] projectId is required.")
     }
     super()
     this.options = options
-    this.projectionDescriptors = projectionDescriptors(options.routes)
+    this.projectionDescriptors = projectionDescriptors(options.projectId, options.routes)
     if (this.projectionDescriptors.length > 0 && !options.projectionDispatch) {
-      throw new OrchestratorError(
-        "Projection routes require lake and projection-run storage for durable dispatch."
+      throw createSixbError(
+        "internal.unexpected",
+        "[SixbOrchestrator] Projection routes require lake and projection-run storage for durable dispatch.",
+        {
+          details: {
+            projectId: options.projectId,
+            projectionIds: this.projectionDescriptors.map((descriptor) => descriptor.projectionId),
+          },
+        }
       )
     }
-    if (hasWorkflowRoutes(options.routes)) requireDispatcher(options.dispatchers, "workflows")
+    if (hasWorkflowRoutes(options.routes)) requireDispatcher(options, "workflows")
   }
 
   protected async run(signal: AbortSignal): Promise<void> {
@@ -258,13 +265,33 @@ async function enqueueDirectJob(
       return
     case "projections": {
       if (sourceEvent.type !== "dataset.version.committed") {
-        throw new OrchestratorError(
-          `Projection jobs can only be dispatched from dataset.version.committed events, got '${sourceEvent.type}'.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbOrchestrator] Projection jobs can only be dispatched from dataset.version.committed events, got '${sourceEvent.type}'.`,
+          {
+            details: {
+              projectId: options.projectId,
+              projectionId: item.job.payload.projectionId,
+              sourceEventId: sourceEvent.id,
+              sourceEventType: sourceEvent.type,
+            },
+          }
         )
       }
       if (item.job.payload.datasetId !== sourceEvent.payload.datasetId) {
-        throw new OrchestratorError(
-          `Projection route for dataset '${item.job.payload.datasetId}' received dataset '${sourceEvent.payload.datasetId}'.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbOrchestrator] Projection route for dataset '${item.job.payload.datasetId}' received dataset '${sourceEvent.payload.datasetId}'.`,
+          {
+            details: {
+              projectId: options.projectId,
+              projectionId: item.job.payload.projectionId,
+              sourceEventId: sourceEvent.id,
+              sourceEventType: sourceEvent.type,
+              expectedDatasetId: item.job.payload.datasetId,
+              actualDatasetId: sourceEvent.payload.datasetId,
+            },
+          }
         )
       }
       const job = buildProjectionJob({
@@ -285,12 +312,21 @@ async function enqueueDirectJob(
     }
     case "workflows": {
       if (sourceEvent.type !== "schedule.triggered") {
-        throw new OrchestratorError(
-          `Direct workflow route received unsupported event '${sourceEvent.type}'.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbOrchestrator] Direct workflow route received unsupported event '${sourceEvent.type}'.`,
+          {
+            details: {
+              projectId: options.projectId,
+              workflowId: item.job.payload.workflowId,
+              sourceEventId: sourceEvent.id,
+              sourceEventType: sourceEvent.type,
+            },
+          }
         )
       }
       const scheduleId = sourceEvent.payload.scheduleId
-      await requireDispatcher(options.dispatchers, "workflows").dispatch({
+      await requireDispatcher(options, "workflows").dispatch({
         workflowId: item.job.payload.workflowId,
         runId: scheduleConsumerRunId(
           "workflow",
@@ -356,11 +392,21 @@ async function enqueueEventScheduleTarget(
     case "workflows": {
       const input = target.mapper ? target.mapper({ event } as never) : {}
       if (!isRecord(input)) {
-        throw new OrchestratorError(
-          `Workflow '${target.workflowId}' schedule mapper must return an input object.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbOrchestrator] Workflow '${target.workflowId}' schedule mapper must return an input object.`,
+          {
+            details: {
+              projectId: options.projectId,
+              workflowId: target.workflowId,
+              scheduleId,
+              sourceEventId: sourceEvent.id,
+              sourceEventType: sourceEvent.type,
+            },
+          }
         )
       }
-      await requireDispatcher(options.dispatchers, "workflows").dispatch({
+      await requireDispatcher(options, "workflows").dispatch({
         workflowId: target.workflowId,
         runId: scheduleConsumerRunId("workflow", target.workflowId, scheduleId, sourceEvent.id),
         input,
@@ -473,6 +519,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function projectionDescriptors(
+  projectId: string,
   routes: OrchestratorRoutes
 ): readonly ProjectionDispatchDescriptor[] {
   const descriptors = new Map<string, ProjectionDispatchDescriptor>()
@@ -481,8 +528,10 @@ function projectionDescriptors(
       if (item.queue !== "projections") continue
       const existing = descriptors.get(item.job.payload.projectionId)
       if (existing && !projectionDescriptorsEqual(existing, item.job.payload)) {
-        throw new OrchestratorError(
-          `Projection '${item.job.payload.projectionId}' has conflicting dispatch routes.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbOrchestrator] Projection '${item.job.payload.projectionId}' has conflicting dispatch routes.`,
+          { details: { projectId, projectionId: item.job.payload.projectionId } }
         )
       }
       descriptors.set(item.job.payload.projectionId, item.job.payload)
@@ -508,12 +557,16 @@ function hasWorkflowRoutes(routes: OrchestratorRoutes): boolean {
 }
 
 function requireDispatcher<TKey extends keyof OrchestratorDispatchers>(
-  dispatchers: OrchestratorDispatchers,
+  options: Pick<OrchestratorRuntimeOptions, "projectId" | "dispatchers">,
   key: TKey
 ): NonNullable<OrchestratorDispatchers[TKey]> {
-  const dispatcher = dispatchers[key]
+  const dispatcher = options.dispatchers[key]
   if (!dispatcher) {
-    throw new OrchestratorError(`Routes require the '${key}' dispatcher.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbOrchestrator] Routes require the '${key}' dispatcher.`,
+      { details: { projectId: options.projectId, dispatcher: key } }
+    )
   }
   return dispatcher
 }

--- a/packages/orchestrator/tests/worker.test.ts
+++ b/packages/orchestrator/tests/worker.test.ts
@@ -153,6 +153,15 @@ async function waitFor(fn: () => Promise<boolean> | boolean, timeoutMs = 2_000):
   throw new Error("Timed out waiting for condition.")
 }
 
+function thrownBy(run: () => unknown): unknown {
+  try {
+    run()
+  } catch (error) {
+    return error
+  }
+  throw new Error("Expected function to throw.")
+}
+
 const workers: OrchestratorWorker[] = []
 
 afterEach(async () => {
@@ -657,6 +666,59 @@ describe("OrchestratorWorker", () => {
     expect(claimed?.job.payload.datasetVersion.versionId).toBe(dataVersion.versionId)
   })
 
+  test("reports malformed projection version ancestry structurally", async () => {
+    const descriptor = invoiceProjectionDescriptor()
+    const schemaVersion: DatasetVersion = {
+      datasetId: rawInvoices.id,
+      versionId: "schema-cycle",
+      parentVersionId: "schema-cycle",
+      mode: "schema",
+      createdAt: new Date("2026-04-19T02:00:00.000Z"),
+      schema: rawInvoices.schema,
+    }
+    const errors: unknown[] = []
+    const originalError = console.error
+    console.error = (_message, error) => {
+      errors.push(error)
+    }
+
+    try {
+      await reconcileProjectionDispatch({
+        projectId: PROJECT_ID,
+        queue: new InMemoryQueues().projections,
+        descriptors: [descriptor],
+        lakeStorage: {
+          async listVersions() {
+            return [schemaVersion]
+          },
+          async getLatestVersion() {
+            return schemaVersion
+          },
+          async getVersion() {
+            return schemaVersion
+          },
+        },
+        projectionRuns: new InMemoryProjectionRunStorage(),
+      })
+    } finally {
+      console.error = originalError
+    }
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message:
+        "[SixbOrchestrator] Dataset 'raw.invoices' version ancestry contains a cycle at 'schema-cycle'.",
+      details: {
+        projectId: PROJECT_ID,
+        projectionId: descriptor.projectionId,
+        datasetId: rawInvoices.id,
+        versionId: schemaVersion.versionId,
+      },
+    })
+  })
+
   test("skips an existing run and redispatches after a semantic revision change", async () => {
     const descriptor = invoiceProjectionDescriptor()
     const lakeStorage = new InMemoryLakeStorage()
@@ -791,15 +853,84 @@ describe("OrchestratorWorker", () => {
 
   test("rejects an empty project id", () => {
     expect(
-      () =>
-        new OrchestratorWorker({
-          projectId: "",
-          events: createEvents(),
-          queues: new InMemoryQueues(),
-          routes: new Map(),
-          dispatchers: {},
-        })
-    ).toThrow("[SixbOrchestrator] projectId is required.")
+      thrownBy(
+        () =>
+          new OrchestratorWorker({
+            projectId: "",
+            events: createEvents(),
+            queues: new InMemoryQueues(),
+            routes: new Map(),
+            dispatchers: {},
+          })
+      )
+    ).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message: "[SixbOrchestrator] projectId is required.",
+    })
+  })
+
+  test("reports projection dispatch configuration errors structurally", () => {
+    const descriptor = invoiceProjectionDescriptor()
+    const routes = compileRoutes({
+      schedules: [],
+      syncs: [],
+      pipelines: [],
+      projections: [descriptor],
+    })
+
+    expect(
+      thrownBy(
+        () =>
+          new OrchestratorWorker({
+            projectId: PROJECT_ID,
+            events: createEvents(),
+            queues: new InMemoryQueues(),
+            routes,
+            dispatchers: {},
+          })
+      )
+    ).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message:
+        "[SixbOrchestrator] Projection routes require lake and projection-run storage for durable dispatch.",
+      details: {
+        projectId: PROJECT_ID,
+        projectionIds: [descriptor.projectionId],
+      },
+    })
+  })
+
+  test("reports conflicting projection routes with their correlation details", () => {
+    const descriptor = invoiceProjectionDescriptor()
+    const routes = compileRoutes({
+      schedules: [],
+      syncs: [],
+      pipelines: [],
+      projections: [
+        descriptor,
+        invoiceProjectionDescriptor({ projectionRevision: "projection-2" }),
+      ],
+    })
+
+    expect(
+      thrownBy(
+        () =>
+          new OrchestratorWorker({
+            projectId: PROJECT_ID,
+            events: createEvents(),
+            queues: new InMemoryQueues(),
+            routes,
+            dispatchers: {},
+          })
+      )
+    ).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message: `[SixbOrchestrator] Projection '${descriptor.projectionId}' has conflicting dispatch routes.`,
+      details: { projectId: PROJECT_ID, projectionId: descriptor.projectionId },
+    })
   })
 
   test("requires durable Core dispatch for workflow routes", () => {


### PR DESCRIPTION
## Summary

- remove the internal OrchestratorError wrapper and create canonical coded errors directly
- preserve every SixbOrchestrator message while attaching project, projection, run, dataset, version, event, workflow, and schedule identifiers where available
- keep dispatch, fan-out, retry, and reconciliation behavior unchanged
- assert the structural error contract and correlation details instead of a runtime class

## Why

OrchestratorError only supplied a name and message prefix. It had no subclasses and was never used for control flow.

This stays narrow: no public error type is exposed, no new error code is introduced, and the orchestrator's failure policies are unchanged.

## Validation

- bun test packages/orchestrator/tests/
- bun --filter @sixb/orchestrator typecheck
- bun --filter @sixb/orchestrator build
- bun run typecheck
- bun run check

## Stack

Depends on #344 and continues #274.