### PR TITLE
workflow-worker: replace intermediate error class

### DIFF
--- a/packages/workflow-worker/src/errors.ts
+++ b/packages/workflow-worker/src/errors.ts
@@ -1,3 +1,0 @@
-export class WorkflowWorkerError extends Error {
-  readonly name = "WorkflowWorkerError"
-}

--- a/packages/workflow-worker/src/execution/workflow-node-runner.ts
+++ b/packages/workflow-worker/src/execution/workflow-node-runner.ts
@@ -1,6 +1,6 @@
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { WorkflowIOSnapshot, WorkflowNodeDefinition } from "@sixb/core/internal/workflows"
 import type { WorkflowRunRecord } from "@sixb/core/storage"
-import { WorkflowWorkerError } from "../errors"
 import { throwIfAborted } from "../normalize"
 import type { WorkflowRunRecorder } from "../recorder"
 import type {
@@ -49,8 +49,18 @@ export class WorkflowNodeRunner {
     if (outcome.status === "waiting") {
       if ("agentExecution" in outcome) {
         if (outcome.agentExecution.nodeRunId !== nodeRun.id || outcome.nodeRun.id !== nodeRun.id) {
-          throw new WorkflowWorkerError(
-            `[SixbWorkflowWorker] Workflow '${input.context.workflow.id}' agent node '${input.node.id}' parked a different node run.`
+          throw createSixbError(
+            "internal.unexpected",
+            `[SixbWorkflowWorker] Workflow '${input.context.workflow.id}' agent node '${input.node.id}' parked a different node run.`,
+            {
+              details: {
+                agentId: outcome.agentExecution.agentId,
+                workflowId: input.context.workflow.id,
+                workflowRunId: input.context.job.id,
+                nodeId: input.node.id,
+                nodeRunId: nodeRun.id,
+              },
+            }
           )
         }
         await this.dependencies.recorder.recordParkedNode({
@@ -62,8 +72,19 @@ export class WorkflowNodeRunner {
       }
 
       if (outcome.intervention.nodeRunId !== nodeRun.id) {
-        throw new WorkflowWorkerError(
-          `[SixbWorkflowWorker] Workflow '${input.context.workflow.id}' intervention node '${input.node.id}' returned an intervention for a different node run.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbWorkflowWorker] Workflow '${input.context.workflow.id}' intervention node '${input.node.id}' returned an intervention for a different node run.`,
+          {
+            details: {
+              workflowId: input.context.workflow.id,
+              workflowRunId: input.context.job.id,
+              nodeId: input.node.id,
+              nodeRunId: nodeRun.id,
+              interventionId: outcome.intervention.interventionId,
+              interventionRecordId: outcome.intervention.id,
+            },
+          }
         )
       }
 
@@ -82,14 +103,20 @@ export class WorkflowNodeRunner {
       }
     }
 
-    assertStatePatchIsPersistable(outcome.statePatch, outcome.outputSnapshot)
+    const details = {
+      workflowId: input.context.workflow.id,
+      workflowRunId: input.context.job.id,
+      nodeId: input.node.id,
+      nodeRunId: nodeRun.id,
+    }
+    assertStatePatchIsPersistable(outcome.statePatch, outcome.outputSnapshot, details)
 
     await this.dependencies.recorder.finishNodeSucceeded({
       nodeRunId: nodeRun.id,
       output: outcome.outputSnapshot,
     })
 
-    applyStatePatch(input.context.state, outcome.statePatch, outcome.outputSnapshot)
+    applyStatePatch(input.context.state, outcome.statePatch, outcome.outputSnapshot, details)
 
     return {
       status: "succeeded",
@@ -109,17 +136,19 @@ export type WorkflowNodeRunResult =
 
 function assertStatePatchIsPersistable(
   patch: WorkflowNodeStatePatch | undefined,
-  outputSnapshot: WorkflowIOSnapshot | undefined
+  outputSnapshot: WorkflowIOSnapshot | undefined,
+  details: Readonly<Record<string, string>>
 ): void {
   if (patch?.current !== undefined) {
-    requireOutputSnapshot(outputSnapshot)
+    requireOutputSnapshot(outputSnapshot, details)
   }
 }
 
 function applyStatePatch(
   state: WorkflowNodeExecutionContext["state"],
   patch: WorkflowNodeStatePatch | undefined,
-  outputSnapshot: WorkflowIOSnapshot | undefined
+  outputSnapshot: WorkflowIOSnapshot | undefined,
+  details: Readonly<Record<string, string>>
 ): void {
   if (!patch) {
     return
@@ -127,7 +156,7 @@ function applyStatePatch(
 
   if (patch.current !== undefined) {
     state.current = patch.current
-    state.currentSnapshot = requireOutputSnapshot(outputSnapshot)
+    state.currentSnapshot = requireOutputSnapshot(outputSnapshot, details)
   }
 
   if (patch.steps) {
@@ -135,10 +164,15 @@ function applyStatePatch(
   }
 }
 
-function requireOutputSnapshot(outputSnapshot: WorkflowIOSnapshot | undefined): WorkflowIOSnapshot {
+function requireOutputSnapshot(
+  outputSnapshot: WorkflowIOSnapshot | undefined,
+  details: Readonly<Record<string, string>>
+): WorkflowIOSnapshot {
   if (outputSnapshot === undefined) {
-    throw new WorkflowWorkerError(
-      "[SixbWorkflowWorker] A workflow node that advances the dataflow must persist its output snapshot."
+    throw createSixbError(
+      "internal.unexpected",
+      "[SixbWorkflowWorker] A workflow node that advances the dataflow must persist its output snapshot.",
+      { details }
     )
   }
   return outputSnapshot

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -1,5 +1,5 @@
 import type { ValueType, WorkflowDefinition } from "@sixb/core"
-import { captureSixbFailure } from "@sixb/core/internal/errors"
+import { captureSixbFailure, createSixbError } from "@sixb/core/internal/errors"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import type {
   WorkflowAgentNodeDefinition,
@@ -25,7 +25,6 @@ import type {
   WorkflowRunStorage,
 } from "@sixb/core/storage"
 import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
-import { WorkflowWorkerError } from "../errors"
 import { statusForFailure, throwIfAborted } from "../normalize"
 import { noopWorkflowRunObserver, WorkflowRunRecorder } from "../recorder"
 import type {
@@ -122,8 +121,10 @@ export class WorkflowRunSession {
   ): Promise<WorkflowRunSession> {
     const { runtime, job } = input
     if (!job.execution) {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Running workflow '${job.id}' can only be recovered by a queue-owned execution.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Running workflow '${job.id}' can only be recovered by a queue-owned execution.`,
+        { details: { workflowId: job.workflowId, runId: job.id } }
       )
     }
 
@@ -135,11 +136,14 @@ export class WorkflowRunSession {
     const run = await requireWorkflowRun({
       workflowRuns: runtime.workflowRuns,
       projectId: runtime.projectId,
+      workflowId: workflow.id,
       id: job.id,
     })
     if (run.workflowId !== workflow.id || run.status !== "running") {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow run '${job.id}' is not a running '${workflow.id}' execution.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow run '${job.id}' is not a running '${workflow.id}' execution.`,
+        { details: { workflowId: workflow.id, runId: job.id } }
       )
     }
 
@@ -148,7 +152,11 @@ export class WorkflowRunSession {
       workflowRunId: run.id,
       order: "asc",
     })
-    const recovery = analyzeRunningWorkflowHistory({ workflow, nodeRuns: listed.nodes })
+    const recovery = analyzeRunningWorkflowHistory({
+      workflow,
+      workflowRunId: run.id,
+      nodeRuns: listed.nodes,
+    })
     const state = reconstructWorkflowState({
       workflow,
       run,
@@ -209,11 +217,14 @@ export class WorkflowRunSession {
       const run = await requireWorkflowRun({
         workflowRuns: runtime.workflowRuns,
         projectId: runtime.projectId,
+        workflowId: workflow.id,
         id: job.id,
       })
       const completedNode = await requireWorkflowNodeRun({
         workflowRuns: runtime.workflowRuns,
         projectId: runtime.projectId,
+        workflowId: workflow.id,
+        workflowRunId: job.id,
         id: job.resume.nodeRunId,
       })
       const execution = await runtime.workflowRuns.agentNodes.getByNodeRunId({
@@ -227,8 +238,18 @@ export class WorkflowRunSession {
         !execution ||
         execution.nodeRunId !== completedNode.id
       ) {
-        throw new WorkflowWorkerError(
-          `[SixbWorkflowWorker] Agent node '${completedNode.id}' does not belong to workflow run '${run.id}'.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbWorkflowWorker] Agent node '${completedNode.id}' does not belong to workflow run '${run.id}'.`,
+          {
+            details: {
+              workflowId: workflow.id,
+              workflowRunId: run.id,
+              nodeId: completedNode.nodeId,
+              nodeRunId: completedNode.id,
+              ...(execution ? { agentId: execution.agentId } : {}),
+            },
+          }
         )
       }
       if (run.status === "running") {
@@ -256,13 +277,33 @@ export class WorkflowRunSession {
         }
       }
       if (run.status !== "waiting" || completedNode.status !== "succeeded") {
-        throw new WorkflowWorkerError(
-          `[SixbWorkflowWorker] Workflow run '${job.id}' and agent node '${completedNode.id}' must be waiting/succeeded to resume.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbWorkflowWorker] Workflow run '${job.id}' and agent node '${completedNode.id}' must be waiting/succeeded to resume.`,
+          {
+            details: {
+              agentId: execution.agentId,
+              workflowId: workflow.id,
+              workflowRunId: run.id,
+              nodeId: completedNode.nodeId,
+              nodeRunId: completedNode.id,
+            },
+          }
         )
       }
       if (execution.status !== "succeeded" || !completedNode.output) {
-        throw new WorkflowWorkerError(
-          `[SixbWorkflowWorker] Agent execution '${completedNode.id}' must have a validated output to resume.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbWorkflowWorker] Agent execution '${completedNode.id}' must have a validated output to resume.`,
+          {
+            details: {
+              agentId: execution.agentId,
+              workflowId: workflow.id,
+              workflowRunId: run.id,
+              nodeId: completedNode.nodeId,
+              nodeRunId: completedNode.id,
+            },
+          }
         )
       }
       const agentNode = requireAgentNode(workflow, completedNode)
@@ -325,8 +366,16 @@ export class WorkflowRunSession {
     const workflowInterventions = runtime.storage.workflowInterventions
 
     if (!workflowInterventions) {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow '${job.workflowId}' resume requires storage.workflowInterventions.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow '${job.workflowId}' resume requires storage.workflowInterventions.`,
+        {
+          details: {
+            workflowId: job.workflowId,
+            workflowRunId: job.id,
+            interventionRecordId: job.resume.interventionId,
+          },
+        }
       )
     }
 
@@ -335,16 +384,21 @@ export class WorkflowRunSession {
     const intervention = await requireInterventionRecord({
       storage: workflowInterventions,
       projectId: runtime.projectId,
+      workflowId: workflow.id,
+      workflowRunId: job.id,
       id: job.resume.interventionId,
     })
     const run = await requireWorkflowRun({
       workflowRuns: runtime.workflowRuns,
       projectId: runtime.projectId,
+      workflowId: workflow.id,
       id: job.id,
     })
     const waitingNode = await requireWorkflowNodeRun({
       workflowRuns: runtime.workflowRuns,
       projectId: runtime.projectId,
+      workflowId: workflow.id,
+      workflowRunId: job.id,
       id: intervention.nodeRunId,
     })
 
@@ -378,20 +432,52 @@ export class WorkflowRunSession {
     }
 
     if (run.status !== "waiting") {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow run '${job.id}' must be waiting to resume.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow run '${job.id}' must be waiting to resume.`,
+        {
+          details: {
+            workflowId: workflow.id,
+            workflowRunId: run.id,
+            nodeRunId: waitingNode.id,
+            interventionId: intervention.interventionId,
+            interventionRecordId: intervention.id,
+          },
+        }
       )
     }
 
     if (waitingNode.status !== "waiting") {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow node run '${waitingNode.id}' must be waiting to resume.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow node run '${waitingNode.id}' must be waiting to resume.`,
+        {
+          details: {
+            workflowId: workflow.id,
+            workflowRunId: run.id,
+            nodeId: waitingNode.nodeId,
+            nodeRunId: waitingNode.id,
+            interventionId: intervention.interventionId,
+            interventionRecordId: intervention.id,
+          },
+        }
       )
     }
 
     if (intervention.status !== "submitted" || !intervention.response) {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow intervention '${intervention.id}' must be submitted to resume.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow intervention '${intervention.id}' must be submitted to resume.`,
+        {
+          details: {
+            workflowId: workflow.id,
+            workflowRunId: run.id,
+            nodeId: waitingNode.nodeId,
+            nodeRunId: waitingNode.id,
+            interventionId: intervention.interventionId,
+            interventionRecordId: intervention.id,
+          },
+        }
       )
     }
 
@@ -628,10 +714,14 @@ export class WorkflowRunSession {
 
 function requireWorkflow(
   workflow: WorkflowDefinition | null,
-  job: { readonly workflowId: string }
+  job: { readonly id: string; readonly workflowId: string }
 ): WorkflowDefinition {
   if (!workflow) {
-    throw new WorkflowWorkerError(`[SixbWorkflowWorker] Unknown workflow '${job.workflowId}'.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Unknown workflow '${job.workflowId}'.`,
+      { details: { workflowId: job.workflowId, runId: job.id } }
+    )
   }
 
   return workflow
@@ -640,6 +730,8 @@ function requireWorkflow(
 async function requireInterventionRecord(input: {
   readonly storage: WorkflowInterventionStorage
   readonly projectId: string
+  readonly workflowId: string
+  readonly workflowRunId: string
   readonly id: string
 }): Promise<WorkflowInterventionRecord> {
   const intervention = await input.storage.getById({
@@ -648,8 +740,16 @@ async function requireInterventionRecord(input: {
   })
 
   if (!intervention) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow intervention '${input.id}' not found.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow intervention '${input.id}' not found.`,
+      {
+        details: {
+          workflowId: input.workflowId,
+          workflowRunId: input.workflowRunId,
+          interventionRecordId: input.id,
+        },
+      }
     )
   }
 
@@ -659,6 +759,7 @@ async function requireInterventionRecord(input: {
 async function requireWorkflowRun(input: {
   readonly workflowRuns: WorkflowRunStorage
   readonly projectId: string
+  readonly workflowId: string
   readonly id: string
 }): Promise<WorkflowRunRecord> {
   const run = await input.workflowRuns.getById({
@@ -667,7 +768,11 @@ async function requireWorkflowRun(input: {
   })
 
   if (!run) {
-    throw new WorkflowWorkerError(`[SixbWorkflowWorker] Workflow run '${input.id}' not found.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow run '${input.id}' not found.`,
+      { details: { workflowId: input.workflowId, runId: input.id } }
+    )
   }
 
   return run
@@ -676,6 +781,8 @@ async function requireWorkflowRun(input: {
 async function requireWorkflowNodeRun(input: {
   readonly workflowRuns: WorkflowRunStorage
   readonly projectId: string
+  readonly workflowId: string
+  readonly workflowRunId: string
   readonly id: string
 }): Promise<WorkflowNodeRunRecord> {
   const node = await input.workflowRuns.nodes.getById({
@@ -684,7 +791,17 @@ async function requireWorkflowNodeRun(input: {
   })
 
   if (!node) {
-    throw new WorkflowWorkerError(`[SixbWorkflowWorker] Workflow node run '${input.id}' not found.`)
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow node run '${input.id}' not found.`,
+      {
+        details: {
+          workflowId: input.workflowId,
+          workflowRunId: input.workflowRunId,
+          nodeRunId: input.id,
+        },
+      }
+    )
   }
 
   return node
@@ -698,8 +815,10 @@ function assertResumeMatchesRun(input: {
   readonly waitingNode: WorkflowNodeRunRecord
 }): void {
   if (input.run.workflowId !== input.workflow.id || input.job.workflowId !== input.workflow.id) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow resume job for '${input.job.workflowId}' does not match run '${input.run.workflowId}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow resume job for '${input.job.workflowId}' does not match run '${input.run.workflowId}'.`,
+      { details: { workflowId: input.job.workflowId, runId: input.job.id } }
     )
   }
 
@@ -707,8 +826,18 @@ function assertResumeMatchesRun(input: {
     input.intervention.workflowId !== input.workflow.id ||
     input.intervention.workflowRunId !== input.job.id
   ) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow intervention '${input.intervention.id}' does not match run '${input.job.id}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow intervention '${input.intervention.id}' does not match run '${input.job.id}'.`,
+      {
+        details: {
+          workflowId: input.workflow.id,
+          workflowRunId: input.job.id,
+          nodeRunId: input.intervention.nodeRunId,
+          interventionId: input.intervention.interventionId,
+          interventionRecordId: input.intervention.id,
+        },
+      }
     )
   }
 
@@ -717,8 +846,19 @@ function assertResumeMatchesRun(input: {
     input.waitingNode.workflowRunId !== input.job.id ||
     input.waitingNode.id !== input.intervention.nodeRunId
   ) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow node run '${input.waitingNode.id}' does not match intervention '${input.intervention.id}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow node run '${input.waitingNode.id}' does not match intervention '${input.intervention.id}'.`,
+      {
+        details: {
+          workflowId: input.workflow.id,
+          workflowRunId: input.job.id,
+          nodeId: input.waitingNode.nodeId,
+          nodeRunId: input.waitingNode.id,
+          interventionId: input.intervention.interventionId,
+          interventionRecordId: input.intervention.id,
+        },
+      }
     )
   }
 }
@@ -735,8 +875,19 @@ function requireInterventionNode(
     node.id !== intervention.nodeId ||
     node.key !== intervention.nodeKey
   ) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${workflow.id}' does not contain intervention node '${intervention.nodeId}' at index ${intervention.nodeIndex}.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${workflow.id}' does not contain intervention node '${intervention.nodeId}' at index ${intervention.nodeIndex}.`,
+      {
+        details: {
+          workflowId: workflow.id,
+          workflowRunId: intervention.workflowRunId,
+          nodeId: intervention.nodeId,
+          nodeRunId: intervention.nodeRunId,
+          interventionId: intervention.interventionId,
+          interventionRecordId: intervention.id,
+        },
+      }
     )
   }
 
@@ -754,8 +905,17 @@ function requireAgentNode(
     node.id !== nodeRun.nodeId ||
     node.key !== nodeRun.nodeKey
   ) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${workflow.id}' does not contain agent node '${nodeRun.nodeId}' at index ${nodeRun.nodeIndex}.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${workflow.id}' does not contain agent node '${nodeRun.nodeId}' at index ${nodeRun.nodeIndex}.`,
+      {
+        details: {
+          workflowId: workflow.id,
+          workflowRunId: nodeRun.workflowRunId,
+          nodeId: nodeRun.nodeId,
+          nodeRunId: nodeRun.id,
+        },
+      }
     )
   }
   return node
@@ -785,8 +945,16 @@ function reconstructWorkflowState(input: {
     const node = input.workflow.nodes[nodeIndex]
     const nodeRun = nodeRunsByIndex.get(nodeIndex)
     if (!node || !nodeRun) {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow run '${input.run.id}' is missing node run at index ${nodeIndex}.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow run '${input.run.id}' is missing node run at index ${nodeIndex}.`,
+        {
+          details: {
+            workflowId: input.workflow.id,
+            workflowRunId: input.run.id,
+            ...(node ? { nodeId: node.id } : {}),
+          },
+        }
       )
     }
 
@@ -810,8 +978,17 @@ function applyCompletedNodeToState(input: {
   readonly valueTypesById: ReadonlyMap<string, ValueType>
 }): void {
   if (input.nodeRun.status !== "succeeded") {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow node run '${input.nodeRun.id}' must be succeeded to reconstruct workflow state.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow node run '${input.nodeRun.id}' must be succeeded to reconstruct workflow state.`,
+      {
+        details: {
+          workflowId: input.workflowId,
+          workflowRunId: input.nodeRun.workflowRunId,
+          nodeId: input.nodeRun.nodeId,
+          nodeRunId: input.nodeRun.id,
+        },
+      }
     )
   }
 
@@ -866,6 +1043,7 @@ function restoreCompletedNodeOutput(input: {
 
 function analyzeRunningWorkflowHistory(input: {
   readonly workflow: WorkflowDefinition
+  readonly workflowRunId: string
   readonly nodeRuns: readonly WorkflowNodeRunRecord[]
 }): {
   readonly completed: readonly WorkflowNodeRunRecord[]
@@ -878,6 +1056,7 @@ function analyzeRunningWorkflowHistory(input: {
   for (let index = 0; index < input.nodeRuns.length; index++) {
     const { nodeRun } = requireWorkflowHistoryEntry({
       workflow: input.workflow,
+      workflowRunId: input.workflowRunId,
       node: input.workflow.nodes[index],
       nodeRun: input.nodeRuns[index],
       expectedIndex: index,
@@ -894,8 +1073,17 @@ function analyzeRunningWorkflowHistory(input: {
       continue
     }
 
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Running workflow '${input.workflow.id}' has an unrecoverable node '${nodeRun.id}' in status '${nodeRun.status}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Running workflow '${input.workflow.id}' has an unrecoverable node '${nodeRun.id}' in status '${nodeRun.status}'.`,
+      {
+        details: {
+          workflowId: input.workflow.id,
+          workflowRunId: input.workflowRunId,
+          nodeId: nodeRun.nodeId,
+          nodeRunId: nodeRun.id,
+        },
+      }
     )
   }
 
@@ -909,6 +1097,7 @@ function analyzeRunningWorkflowHistory(input: {
 
 function requireWorkflowHistoryEntry(input: {
   readonly workflow: WorkflowDefinition
+  readonly workflowRunId: string
   readonly node: WorkflowNodeDefinition | undefined
   readonly nodeRun: WorkflowNodeRunRecord | undefined
   readonly expectedIndex: number
@@ -916,10 +1105,19 @@ function requireWorkflowHistoryEntry(input: {
   readonly node: WorkflowNodeDefinition
   readonly nodeRun: WorkflowNodeRunRecord
 } {
-  const { workflow, node, nodeRun, expectedIndex } = input
+  const { workflow, workflowRunId, node, nodeRun, expectedIndex } = input
   if (!node || !nodeRun) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${workflow.id}' has an incomplete node history at index ${expectedIndex}.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${workflow.id}' has an incomplete node history at index ${expectedIndex}.`,
+      {
+        details: {
+          workflowId: workflow.id,
+          workflowRunId,
+          ...(node ? { nodeId: node.id } : {}),
+          ...(nodeRun ? { nodeRunId: nodeRun.id } : {}),
+        },
+      }
     )
   }
 
@@ -932,8 +1130,17 @@ function requireWorkflowHistoryEntry(input: {
   ].find(({ actual, expected }) => actual !== expected)
 
   if (mismatch) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${workflow.id}' node history has ${mismatch.field} '${mismatch.actual}' at index ${expectedIndex}; expected '${mismatch.expected}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${workflow.id}' node history has ${mismatch.field} '${mismatch.actual}' at index ${expectedIndex}; expected '${mismatch.expected}'.`,
+      {
+        details: {
+          workflowId: workflow.id,
+          workflowRunId,
+          nodeId: node.id,
+          nodeRunId: nodeRun.id,
+        },
+      }
     )
   }
 
@@ -945,8 +1152,12 @@ function createWorkflowBookkeepingError(input: {
   readonly runId: string
   readonly cause: unknown
 }): Error {
-  return new WorkflowWorkerError(
+  return createSixbError(
+    "internal.unexpected",
     `[SixbWorkflowWorker] Workflow '${input.workflowId}' executed side effects, but failed to finalize workflow run '${input.runId}'. The workflow state may need repair.`,
-    { cause: input.cause }
+    {
+      cause: input.cause,
+      details: { workflowId: input.workflowId, runId: input.runId },
+    }
   )
 }

--- a/packages/workflow-worker/src/nodes/action-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/action-node-executor.ts
@@ -9,7 +9,6 @@ import {
   type ActionRunFailure,
   type ActionRunPhase,
 } from "@sixb/core/storage"
-import { WorkflowWorkerError } from "../errors"
 import type { WorkflowNodeExecutor } from "../execution/node-executor"
 import { isRecord } from "../normalize"
 import { callWorkflowMapper } from "./mapper"
@@ -29,12 +28,14 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
         : callWorkflowMapper({
             mapper: node.mapper,
             workflowId: context.workflow.id,
+            workflowRunId: context.job.id,
             nodeId: node.id,
             workflowInput: context.state.workflowInput,
             steps: context.state.steps,
           })
     const mapperResult = normalizeActionMapperResult({
       workflowId: context.workflow.id,
+      workflowRunId: context.job.id,
       nodeId: node.id,
       action: node.action,
       value: rawMapperResult,
@@ -51,10 +52,12 @@ export const actionNodeExecutor: WorkflowNodeExecutor<WorkflowActionNodeDefiniti
     }
   },
 
-  async execute({ node, nodeIndex, prepared, context }) {
+  async execute({ node, nodeIndex, nodeRun, prepared, context }) {
     const mapperResult = normalizeActionMapperResult({
       workflowId: context.workflow.id,
+      workflowRunId: context.job.id,
       nodeId: node.id,
+      nodeRunId: nodeRun.id,
       action: node.action,
       value: prepared.input,
       mode: "mapped",
@@ -124,14 +127,18 @@ function actionRunStatusFailure(input: {
 
 function normalizeActionMapperResult(input: {
   readonly workflowId: string
+  readonly workflowRunId: string
   readonly nodeId: string
+  readonly nodeRunId?: string
   readonly action: WorkflowActionNodeDefinition["action"]
   readonly value: unknown
   readonly mode: "direct" | "mapped"
 }): ActionMapperResult {
   if (!isRecord(input.value)) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' input must be an object.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' input must be an object.`,
+      { details: actionNodeErrorDetails(input) }
     )
   }
 
@@ -146,15 +153,19 @@ function normalizeActionMapperResult(input: {
 
 function normalizeMappedActionInput(input: {
   readonly workflowId: string
+  readonly workflowRunId: string
   readonly nodeId: string
+  readonly nodeRunId?: string
   readonly action: WorkflowActionNodeDefinition["action"]
   readonly value: Readonly<Record<string, unknown>>
 }): ActionMapperResult {
   const { subject, params } = input.value
 
   if (!isRecord(params)) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must return params as an object.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must return params as an object.`,
+      { details: actionNodeErrorDetails(input) }
     )
   }
 
@@ -162,7 +173,10 @@ function normalizeMappedActionInput(input: {
     return {
       subject: normalizeObjectActionSubject({
         workflowId: input.workflowId,
+        workflowRunId: input.workflowRunId,
         nodeId: input.nodeId,
+        nodeRunId: input.nodeRunId,
+        action: input.action,
         value: subject,
       }),
       params,
@@ -170,8 +184,10 @@ function normalizeMappedActionInput(input: {
   }
 
   if (Object.hasOwn(input.value, "subject")) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must not return subject for a global action.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must not return subject for a global action.`,
+      { details: actionNodeErrorDetails(input) }
     )
   }
 
@@ -182,21 +198,28 @@ function normalizeMappedActionInput(input: {
 
 function normalizeDirectActionInput(input: {
   readonly workflowId: string
+  readonly workflowRunId: string
   readonly nodeId: string
+  readonly nodeRunId?: string
   readonly action: WorkflowActionNodeDefinition["action"]
   readonly value: Readonly<Record<string, unknown>>
 }): ActionMapperResult {
   if (isObjectActionDefinition(input.action)) {
     if (!Object.hasOwn(input.value, "subject")) {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' direct input must include subject for an object action.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' direct input must include subject for an object action.`,
+        { details: actionNodeErrorDetails(input) }
       )
     }
 
     return {
       subject: normalizeObjectActionSubject({
         workflowId: input.workflowId,
+        workflowRunId: input.workflowRunId,
         nodeId: input.nodeId,
+        nodeRunId: input.nodeRunId,
+        action: input.action,
         value: input.value.subject,
       }),
       params: pickActionParams(input.action, input.value),
@@ -204,8 +227,10 @@ function normalizeDirectActionInput(input: {
   }
 
   if (Object.hasOwn(input.value, "subject")) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' direct input must not include subject for a global action.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' direct input must not include subject for a global action.`,
+      { details: actionNodeErrorDetails(input) }
     )
   }
 
@@ -229,7 +254,10 @@ function pickActionParams(
 
 function normalizeObjectActionSubject(input: {
   readonly workflowId: string
+  readonly workflowRunId: string
   readonly nodeId: string
+  readonly nodeRunId?: string
+  readonly action: WorkflowActionNodeDefinition["action"]
   readonly value: unknown
 }): ActionSubject {
   if (isActionObjectSubject(input.value)) {
@@ -237,8 +265,10 @@ function normalizeObjectActionSubject(input: {
   }
 
   if (!isObjectRef(input.value)) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must return a valid subject object ref.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' action node '${input.nodeId}' mapper must return a valid subject object ref.`,
+      { details: actionNodeErrorDetails(input) }
     )
   }
 
@@ -263,4 +293,20 @@ function isObjectRef(value: unknown): value is { objectTypeId: string; primaryId
     typeof value.primaryId === "string" &&
     value.primaryId.trim().length > 0
   )
+}
+
+function actionNodeErrorDetails(input: {
+  readonly workflowId: string
+  readonly workflowRunId: string
+  readonly nodeId: string
+  readonly nodeRunId?: string
+  readonly action: WorkflowActionNodeDefinition["action"]
+}): Readonly<Record<string, string>> {
+  return {
+    actionId: input.action.id,
+    workflowId: input.workflowId,
+    workflowRunId: input.workflowRunId,
+    nodeId: input.nodeId,
+    ...(input.nodeRunId ? { nodeRunId: input.nodeRunId } : {}),
+  }
 }

--- a/packages/workflow-worker/src/nodes/agent-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/agent-node-executor.ts
@@ -4,12 +4,12 @@ import {
   ensureAgentExecutionIdentity,
   workflowAgentNodeQueueJobId,
 } from "@sixb/core/internal/agents"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { WorkflowAgentNodeDefinition } from "@sixb/core/internal/workflows"
 import {
   snapshotWorkflowAgentStepInput,
   validateWorkflowAgentStepInput,
 } from "@sixb/core/internal/workflows"
-import { WorkflowWorkerError } from "../errors"
 import type { WorkflowNodeExecutor } from "../execution/node-executor"
 import { throwIfAborted } from "../normalize"
 import { callWorkflowMapper, requireRecordInput } from "./mapper"
@@ -24,6 +24,7 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
         : callWorkflowMapper({
             mapper: node.mapper,
             workflowId: context.workflow.id,
+            workflowRunId: context.job.id,
             nodeId: node.id,
             workflowInput: context.state.workflowInput,
             steps: context.state.steps,
@@ -31,6 +32,7 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
     const nodeInput = requireRecordInput({
       value: rawInput,
       workflowId: context.workflow.id,
+      workflowRunId: context.job.id,
       nodeId: node.id,
     })
     const agentInput = validateWorkflowAgentStepInput({
@@ -54,12 +56,24 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
     const input = requireRecordInput({
       value: prepared.input,
       workflowId: context.workflow.id,
+      workflowRunId: context.job.id,
       nodeId: node.id,
+      nodeRunId: nodeRun.id,
     })
     const prompt = await node.agentStep.prompt({ input })
     if (typeof prompt !== "string" || !prompt.trim()) {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow '${context.workflow.id}' agent node '${node.id}' prompt must return a non-empty string.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow '${context.workflow.id}' agent node '${node.id}' prompt must return a non-empty string.`,
+        {
+          details: {
+            agentId: node.agentStep.agent.id,
+            workflowId: context.workflow.id,
+            workflowRunId: context.job.id,
+            nodeId: node.id,
+            nodeRunId: nodeRun.id,
+          },
+        }
       )
     }
     throwIfAborted(context.signal)
@@ -73,8 +87,19 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
       id: context.runtime.sixb.execution.id,
     })
     if (!parentExecution) {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow run '${context.job.id}' references missing execution '${context.runtime.sixb.execution.id}'.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow run '${context.job.id}' references missing execution '${context.runtime.sixb.execution.id}'.`,
+        {
+          details: {
+            agentId: node.agentStep.agent.id,
+            workflowId: context.workflow.id,
+            workflowRunId: context.job.id,
+            nodeId: node.id,
+            nodeRunId: nodeRun.id,
+            executionId: context.runtime.sixb.execution.id,
+          },
+        }
       )
     }
     const agentExecution = createAgentExecutionRecord({
@@ -88,8 +113,18 @@ export const agentNodeExecutor: WorkflowNodeExecutor<WorkflowAgentNodeDefinition
     const parked = await context.runtime.storage.transaction(async (tx) => {
       const workflowRuns = tx.workflowRuns
       if (!workflowRuns) {
-        throw new WorkflowWorkerError(
-          `[SixbWorkflowWorker] Workflow '${context.workflow.id}' agent node '${node.id}' requires storage.workflowRuns.`
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbWorkflowWorker] Workflow '${context.workflow.id}' agent node '${node.id}' requires storage.workflowRuns.`,
+          {
+            details: {
+              agentId: node.agentStep.agent.id,
+              workflowId: context.workflow.id,
+              workflowRunId: context.job.id,
+              nodeId: node.id,
+              nodeRunId: nodeRun.id,
+            },
+          }
         )
       }
       await tx.executions.create(agentExecution)

--- a/packages/workflow-worker/src/nodes/intervention-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/intervention-node-executor.ts
@@ -1,10 +1,10 @@
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { WorkflowInterventionNodeDefinition } from "@sixb/core/internal/workflows"
 import {
   snapshotWorkflowInterventionDefaultResponse,
   snapshotWorkflowInterventionInput,
   validateWorkflowInterventionInput,
 } from "@sixb/core/internal/workflows"
-import { WorkflowWorkerError } from "../errors"
 import type { WorkflowNodeExecutor } from "../execution/node-executor"
 import { throwIfAborted } from "../normalize"
 import { callWorkflowMapper, requireRecordInput } from "./mapper"
@@ -19,6 +19,7 @@ export const interventionNodeExecutor: WorkflowNodeExecutor<WorkflowIntervention
         : callWorkflowMapper({
             mapper: node.mapper,
             workflowId: context.workflow.id,
+            workflowRunId: context.job.id,
             nodeId: node.id,
             workflowInput: context.state.workflowInput,
             steps: context.state.steps,
@@ -26,6 +27,7 @@ export const interventionNodeExecutor: WorkflowNodeExecutor<WorkflowIntervention
     const nodeInput = requireRecordInput({
       value: rawInput,
       workflowId: context.workflow.id,
+      workflowRunId: context.job.id,
       nodeId: node.id,
     })
     const interventionInput = validateWorkflowInterventionInput({
@@ -51,7 +53,9 @@ export const interventionNodeExecutor: WorkflowNodeExecutor<WorkflowIntervention
     const interventionInput = requireRecordInput({
       value: prepared.input,
       workflowId: context.workflow.id,
+      workflowRunId: context.job.id,
       nodeId: node.id,
+      nodeRunId: nodeRun.id,
     })
     const defaultResponse = node.intervention.defaults
       ? await node.intervention.defaults({
@@ -69,16 +73,28 @@ export const interventionNodeExecutor: WorkflowNodeExecutor<WorkflowIntervention
       valueTypesById: context.valueTypesById,
     })
     const requestedAt = new Date()
+    const interventionRecordId = `${context.job.id}:intervention:${nodeIndex}`
     const workflowInterventions = context.runtime.storage.workflowInterventions
     if (!workflowInterventions) {
-      throw new WorkflowWorkerError(
-        `[SixbWorkflowWorker] Workflow '${context.workflow.id}' intervention node '${node.id}' requires storage.workflowInterventions.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow '${context.workflow.id}' intervention node '${node.id}' requires storage.workflowInterventions.`,
+        {
+          details: {
+            workflowId: context.workflow.id,
+            workflowRunId: context.job.id,
+            nodeId: node.id,
+            nodeRunId: nodeRun.id,
+            interventionId: node.intervention.id,
+            interventionRecordId,
+          },
+        }
       )
     }
 
     context.markSideEffectBoundaryPassed()
     const intervention = await workflowInterventions.create({
-      id: `${context.job.id}:intervention:${nodeIndex}`,
+      id: interventionRecordId,
       projectId: context.runtime.projectId,
       workflowId: context.workflow.id,
       workflowRunId: context.job.id,

--- a/packages/workflow-worker/src/nodes/mapper.ts
+++ b/packages/workflow-worker/src/nodes/mapper.ts
@@ -1,5 +1,5 @@
 import type { WorkflowStepOutputs } from "@sixb/core"
-import { WorkflowWorkerError } from "../errors"
+import { createSixbError } from "@sixb/core/internal/errors"
 import { isRecord } from "../normalize"
 
 type RuntimeWorkflowMapper = (context: {
@@ -10,13 +10,16 @@ type RuntimeWorkflowMapper = (context: {
 export function callWorkflowMapper(input: {
   readonly mapper: unknown
   readonly workflowId: string
+  readonly workflowRunId: string
   readonly nodeId: string
   readonly workflowInput: Readonly<Record<string, unknown>>
   readonly steps: WorkflowStepOutputs
 }): unknown {
   if (typeof input.mapper !== "function") {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' node '${input.nodeId}' mapper must be a function.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' node '${input.nodeId}' mapper must be a function.`,
+      { details: workflowNodeErrorDetails(input) }
     )
   }
 
@@ -29,13 +32,31 @@ export function callWorkflowMapper(input: {
 export function requireRecordInput(input: {
   readonly value: unknown
   readonly workflowId: string
+  readonly workflowRunId: string
   readonly nodeId: string
+  readonly nodeRunId?: string
 }): Readonly<Record<string, unknown>> {
   if (!isRecord(input.value)) {
-    throw new WorkflowWorkerError(
-      `[SixbWorkflowWorker] Workflow '${input.workflowId}' node '${input.nodeId}' input must be an object.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbWorkflowWorker] Workflow '${input.workflowId}' node '${input.nodeId}' input must be an object.`,
+      { details: workflowNodeErrorDetails(input) }
     )
   }
 
   return input.value
+}
+
+function workflowNodeErrorDetails(input: {
+  readonly workflowId: string
+  readonly workflowRunId: string
+  readonly nodeId: string
+  readonly nodeRunId?: string
+}): Readonly<Record<string, string>> {
+  return {
+    workflowId: input.workflowId,
+    workflowRunId: input.workflowRunId,
+    nodeId: input.nodeId,
+    ...(input.nodeRunId ? { nodeRunId: input.nodeRunId } : {}),
+  }
 }

--- a/packages/workflow-worker/src/nodes/step-node-executor.ts
+++ b/packages/workflow-worker/src/nodes/step-node-executor.ts
@@ -19,6 +19,7 @@ export const stepNodeExecutor: WorkflowNodeExecutor<WorkflowStepNodeDefinition> 
         : callWorkflowMapper({
             mapper: node.mapper,
             workflowId: context.workflow.id,
+            workflowRunId: context.job.id,
             nodeId: node.id,
             workflowInput: context.state.workflowInput,
             steps: context.state.steps,
@@ -26,6 +27,7 @@ export const stepNodeExecutor: WorkflowNodeExecutor<WorkflowStepNodeDefinition> 
     const nodeInput = requireRecordInput({
       value: rawInput,
       workflowId: context.workflow.id,
+      workflowRunId: context.job.id,
       nodeId: node.id,
     })
     const stepInput = validateWorkflowStepInput({
@@ -47,11 +49,13 @@ export const stepNodeExecutor: WorkflowNodeExecutor<WorkflowStepNodeDefinition> 
     }
   },
 
-  async execute({ node, prepared, context }) {
+  async execute({ node, nodeRun, prepared, context }) {
     const stepInput = requireRecordInput({
       value: prepared.input,
       workflowId: context.workflow.id,
+      workflowRunId: context.job.id,
       nodeId: node.id,
+      nodeRunId: nodeRun.id,
     })
 
     context.markSideEffectBoundaryPassed()

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -32,7 +32,6 @@ import type {
   WorkflowRunStorage,
 } from "@sixb/core/storage"
 import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
-import { WorkflowWorkerError } from "../src/errors"
 import { EventsRuntimeWorkflowRunObserver } from "../src/events"
 import { runWorkflowJob as executeWorkflowJob, runWorkflowResumeJob } from "../src/run-workflow-job"
 import type { RunWorkflowJobInput, WorkflowRunObserver, WorkflowWorkerContext } from "../src/types"
@@ -1263,6 +1262,60 @@ describe("runWorkflowJob", () => {
     expect(nodes.nodes[1]?.error?.message).toBe("An unexpected internal error occurred.")
   })
 
+  test("preserves the cause and run details when workflow finalization fails after side effects", async () => {
+    const workflow = defineWorkflow("bookkeeping-failure-workflow")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+    const sixb = createSixb({ workflows: [workflow] })
+    const runtime = createRuntime(sixb)
+    const finish = runtime.workflowRuns.finish.bind(runtime.workflowRuns)
+    const finishCause = new Error("workflow finish unavailable")
+    runtime.workflowRuns.finish = async (input) => {
+      if (input.status === "succeeded") {
+        throw finishCause
+      }
+      return finish(input)
+    }
+
+    await expect(
+      runWorkflowJob({
+        runtime,
+        job: {
+          id: "wfrun_bookkeeping_failed",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      cause: finishCause,
+      message:
+        "[SixbWorkflowWorker] Workflow 'bookkeeping-failure-workflow' executed side effects, but failed to finalize workflow run 'wfrun_bookkeeping_failed'. The workflow state may need repair.",
+      details: {
+        workflowId: workflow.id,
+        runId: "wfrun_bookkeeping_failed",
+      },
+    })
+
+    const run = await runtime.workflowRuns.getById({
+      projectId: sixb.id,
+      id: "wfrun_bookkeeping_failed",
+    })
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        runId: "wfrun_bookkeeping_failed",
+      },
+    })
+  })
+
   test("uses the workflow input as output when every node is an action", async () => {
     actionHandlerCalls = 0
     const workflow = defineWorkflow("create-invoice-only-workflow")
@@ -1468,6 +1521,62 @@ describe("runWorkflowJob", () => {
     } finally {
       unsubscribe()
     }
+  })
+
+  test("preserves action-node details without inventing a node run before preparation", async () => {
+    const workflow = defineWorkflow("invalid-global-action-input-workflow")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(prepareAttachInvoiceAction)
+      .then(createInvoice)
+    const sixb = createSixb({ actions: [createInvoice], workflows: [workflow] })
+
+    const details = {
+      actionId: createInvoice.id,
+      workflowId: workflow.id,
+      workflowRunId: "wfrun_invalid_global_action_input",
+      nodeId: "create-invoice",
+    }
+    await expect(
+      runWorkflowJob({
+        runtime: createRuntime(sixb),
+        job: {
+          id: "wfrun_invalid_global_action_input",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message:
+        "[SixbWorkflowWorker] Workflow 'invalid-global-action-input-workflow' action node 'create-invoice' direct input must not include subject for a global action.",
+      details,
+    })
+
+    const run = await sixb.storage.workflowRuns!.getById({
+      projectId: sixb.id,
+      id: "wfrun_invalid_global_action_input",
+    })
+    const nodes = await sixb.storage.workflowRuns!.nodes.list({
+      projectId: sixb.id,
+      workflowRunId: "wfrun_invalid_global_action_input",
+      order: "asc",
+    })
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message: "An unexpected internal error occurred.",
+      details,
+    })
+    expect(nodes.nodes.map((node) => node.nodeId)).toEqual([
+      "find-best-invoice",
+      "prepare-attach-invoice-action",
+    ])
   })
 
   test("picks declared params from direct global action dataflow", async () => {
@@ -1807,7 +1916,12 @@ describe("runWorkflowJob", () => {
           input: {},
         },
       })
-    ).rejects.toThrow("[SixbWorkflowWorker] Unknown workflow 'missing-workflow'.")
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message: "[SixbWorkflowWorker] Unknown workflow 'missing-workflow'.",
+      details: { workflowId: "missing-workflow", runId: "wfrun_missing" },
+    })
   })
 
   test("does not invent a node row when a mapper throws before producing input", async () => {
@@ -1817,7 +1931,7 @@ describe("runWorkflowJob", () => {
       })
       .then(findBestInvoice)
       .then(reviewInvoiceMatch, () => {
-        throw new WorkflowWorkerError("mapper exploded")
+        throw new Error("mapper exploded")
       })
     const sixb = createSixb({ workflows: [workflow] })
 


### PR DESCRIPTION
## Summary

- remove the internal WorkflowWorkerError wrapper and create canonical coded errors directly
- preserve existing messages and causes while attaching workflow, run, node, action, agent, and intervention identifiers when available
- distinguish intervention definition and persisted record identifiers in failure details
- keep workflow delivery recovery and retry policies unchanged
- assert the structural error contract, persisted correlation details, and cause chains instead of a runtime class

## Why

WorkflowWorkerError only supplied a name. It had no subclasses and was never used for control flow, while persistence deliberately preserves details already attached to coded errors rather than replacing them with fallback details later.

This stays narrow: no public error type is exposed, no new error code is introduced, and workflow retry behavior is unchanged.

## Validation

- bun test packages/workflow-worker/tests/run-workflow-job.test.ts packages/workflow-worker/tests/worker.test.ts
- bun --filter @sixb/workflow-worker typecheck
- bun --filter @sixb/workflow-worker build
- bun run typecheck
- bun run check

## Stack

Depends on #346 and continues #274.