### PR TITLE
projection-worker: replace intermediate error class

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -41,6 +41,7 @@ Each storage and wire change remains independently reviewable even though every 
 | --- | --- | --- | --- |
 | `dataset.not_found` | No | The requested dataset is not registered or is not visible to the caller. | Check the dataset ID and the caller's access. |
 | `dataset.version_not_found` | No | The requested dataset version does not exist, or the dataset has no committed version yet. | Check the version ID or materialize the dataset before reading rows. |
+| `dataset.version_read_inconsistent` | Yes | Read results conflict with immutable version metadata. | Retry, then inspect lake storage integrity. |
 | `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect internal logs. Do not retry automatically. |
 | `queue.enqueue_failed` | Yes | A job could not be handed to its queue. | Retry the unchanged request while the durable run remains in its enqueue phase. |
 | `runtime.cancelled` | No | An in-flight operation was cancelled before completion. | Confirm the cancellation was intentional before requesting another run. |

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -18,6 +18,10 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "Dataset version not found.",
     retryable: false,
   },
+  "dataset.version_read_inconsistent": {
+    publicMessage: "Dataset version could not be read consistently.",
+    retryable: true,
+  },
   "internal.unexpected": {
     publicMessage: "An unexpected internal error occurred.",
     retryable: false,

--- a/packages/projection-worker/src/errors.ts
+++ b/packages/projection-worker/src/errors.ts
@@ -1,8 +1,9 @@
-export class ProjectionWorkerError extends Error {
-  override readonly name: string = "ProjectionWorkerError"
-}
-
-/** A deterministic input/configuration failure that cannot succeed on queue redelivery. */
-export class ProjectionWorkerPermanentError extends ProjectionWorkerError {
+/**
+ * A deterministic input/configuration failure that cannot succeed on queue redelivery.
+ *
+ * Temporary control-flow bridge: remove this class once Projection has precise non-retryable
+ * error codes and its fail/retry policy can branch on those codes instead of `instanceof`.
+ */
+export class ProjectionWorkerPermanentError extends Error {
   override readonly name = "ProjectionWorkerPermanentError"
 }

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -7,7 +7,7 @@ import {
   type OntologyDefinitionCatalog,
   type Schema,
 } from "@sixb/core"
-import { ProjectionWorkerError } from "./errors"
+import { createSixbError } from "@sixb/core/internal/errors"
 import { resolveProjectionSchema } from "./projection-schema"
 import { normalizeProjectedValue } from "./projection-value-coercion"
 import { isPlainObject } from "./utils"
@@ -57,14 +57,23 @@ export function buildObjectProjectionPlan(input: {
   readonly projection: ObjectProjectionDefinition
   readonly dataset: DatasetDefinition
   readonly primaryPropertyId: string
+  readonly correlation?: {
+    readonly runId: string
+    readonly versionId: string
+  }
 }): ObjectProjectionPlan {
-  const { ontology, projection, dataset, primaryPropertyId } = input
+  const { ontology, projection, dataset, primaryPropertyId, correlation } = input
 
   return {
     projection,
     dataset,
     primaryPropertyId,
-    propertyPlans: buildProjectedPropertyPlans({ ontology, projection, dataset }),
+    propertyPlans: buildProjectedPropertyPlans({
+      ontology,
+      projection,
+      dataset,
+      correlation,
+    }),
   }
 }
 
@@ -104,12 +113,19 @@ function buildProjectedPropertyPlans(input: {
   readonly ontology: OntologyDefinitionCatalog
   readonly projection: ObjectProjectionDefinition
   readonly dataset: DatasetDefinition
+  readonly correlation?: {
+    readonly runId: string
+    readonly versionId: string
+  }
 }): ReadonlyMap<string, ProjectedPropertyPlan> {
-  const { ontology, projection, dataset } = input
+  const { ontology, projection, dataset, correlation } = input
+  const errorDetails = projectionPlanErrorDetails({ projection, dataset, correlation })
   const objectType = ontology.getObjectTypeById(projection.objectTypeId)
   if (!objectType) {
-    throw new ProjectionWorkerError(
-      `[SixbProjectionWorker] Projection '${projection.id}' references unknown object type '${projection.objectTypeId}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbProjectionWorker] Projection '${projection.id}' references unknown object type '${projection.objectTypeId}'.`,
+      { details: { ...errorDetails, objectTypeId: projection.objectTypeId } }
     )
   }
 
@@ -121,15 +137,26 @@ function buildProjectedPropertyPlans(input: {
   for (const [propertyId, columnName] of Object.entries(projection.properties)) {
     const property = propertiesById.get(propertyId)
     if (!property) {
-      throw new ProjectionWorkerError(
-        `[SixbProjectionWorker] Projection '${projection.id}' references unknown property '${propertyId}' on object type '${objectType.id}'.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbProjectionWorker] Projection '${projection.id}' references unknown property '${propertyId}' on object type '${objectType.id}'.`,
+        { details: { ...errorDetails, objectTypeId: objectType.id, propertyId } }
       )
     }
 
     const column = columnsByName.get(columnName)
     if (!column) {
-      throw new ProjectionWorkerError(
-        `[SixbProjectionWorker] Projection '${projection.id}' references unknown dataset column '${columnName}' on dataset '${dataset.id}'.`
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbProjectionWorker] Projection '${projection.id}' references unknown dataset column '${columnName}' on dataset '${dataset.id}'.`,
+        {
+          details: {
+            ...errorDetails,
+            objectTypeId: objectType.id,
+            propertyId,
+            columnName,
+          },
+        }
       )
     }
 
@@ -137,11 +164,31 @@ function buildProjectedPropertyPlans(input: {
       propertyId,
       columnName,
       columnType: column.type,
-      schema: resolveProjectionSchema(property.schema, valueTypesById),
+      schema: resolveProjectionSchema(property.schema, valueTypesById, {
+        ...errorDetails,
+        objectTypeId: objectType.id,
+        propertyId,
+        columnName,
+      }),
     })
   }
 
   return propertyPlans
+}
+
+function projectionPlanErrorDetails(input: {
+  readonly projection: ObjectProjectionDefinition
+  readonly dataset: DatasetDefinition
+  readonly correlation?: {
+    readonly runId: string
+    readonly versionId: string
+  }
+}) {
+  return {
+    projectionId: input.projection.id,
+    datasetId: input.dataset.id,
+    ...(input.correlation ?? {}),
+  }
 }
 
 function collectProperties(

--- a/packages/projection-worker/src/projection-schema.ts
+++ b/packages/projection-worker/src/projection-schema.ts
@@ -1,9 +1,12 @@
 import type { Schema, ValueType } from "@sixb/core"
-import { ProjectionWorkerError } from "./errors"
+import { createSixbError } from "@sixb/core/internal/errors"
+
+type ProjectionSchemaErrorContext = Readonly<Record<string, string>>
 
 export function resolveProjectionSchema(
   schema: Schema,
   valueTypesById: ReadonlyMap<string, ValueType>,
+  errorContext: ProjectionSchemaErrorContext = {},
   seen = new Set<string>()
 ): Schema {
   if (typeof schema === "string") {
@@ -15,8 +18,10 @@ export function resolveProjectionSchema(
   }
 
   if (seen.has(schema.valueTypeId)) {
-    throw new ProjectionWorkerError(
-      `[SixbProjectionWorker] Circular valueTypeRef '${schema.valueTypeId}' in projection schema.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbProjectionWorker] Circular valueTypeRef '${schema.valueTypeId}' in projection schema.`,
+      { details: { ...errorContext, valueTypeId: schema.valueTypeId } }
     )
   }
 
@@ -24,17 +29,19 @@ export function resolveProjectionSchema(
   nextSeen.add(schema.valueTypeId)
 
   if (schema._resolved) {
-    return resolveProjectionSchema(schema._resolved, valueTypesById, nextSeen)
+    return resolveProjectionSchema(schema._resolved, valueTypesById, errorContext, nextSeen)
   }
 
   const valueType = valueTypesById.get(schema.valueTypeId)
   if (!valueType) {
-    throw new ProjectionWorkerError(
-      `[SixbProjectionWorker] Unknown valueTypeRef '${schema.valueTypeId}' in projection schema.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbProjectionWorker] Unknown valueTypeRef '${schema.valueTypeId}' in projection schema.`,
+      { details: { ...errorContext, valueTypeId: schema.valueTypeId } }
     )
   }
 
-  return resolveProjectionSchema(valueType.schema, valueTypesById, nextSeen)
+  return resolveProjectionSchema(valueType.schema, valueTypesById, errorContext, nextSeen)
 }
 
 export function isIntegerEnumSchema(schema: Schema): boolean {

--- a/packages/projection-worker/src/replacement-progress.ts
+++ b/packages/projection-worker/src/replacement-progress.ts
@@ -1,6 +1,6 @@
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { ProjectionMaterializationIdentity } from "@sixb/core/internal/materialization"
 import type { ProjectionRunStorage } from "@sixb/core/storage"
-import { ProjectionWorkerError } from "./errors"
 
 const DEFAULT_PROGRESS_FLUSH_INTERVAL = 500
 
@@ -57,14 +57,41 @@ export class ReplacementProgress {
 
   assertComplete(): void {
     if (this.input.expectedRows !== undefined && this.sourceRowsRead !== this.input.expectedRows) {
-      throw new ProjectionWorkerError(
-        `[SixbProjectionWorker] Projection run '${this.input.projectionRunId}' reached EOF after ${this.sourceRowsRead} of ${this.input.expectedRows} pinned rows.`
+      throw createSixbError(
+        "dataset.version_read_inconsistent",
+        `[SixbProjectionWorker] Projection run '${this.input.projectionRunId}' reached EOF after ${this.sourceRowsRead} of ${this.input.expectedRows} pinned rows.`,
+        {
+          details: {
+            ...this.versionDetails(),
+            expectedRows: this.input.expectedRows,
+            rowsRead: this.sourceRowsRead,
+          },
+        }
       )
     }
     if (this.hasReachedPersistedFloor()) return
-    throw new ProjectionWorkerError(
-      `[SixbProjectionWorker] Projection run '${this.input.projectionRunId}' reached EOF before its persisted progress floor (${this.sourceRowsRead}/${this.input.persistedRowsRead} rows, ${this.sourceRowsSkipped}/${this.input.persistedRowsSkipped} skipped).`
+    throw createSixbError(
+      "dataset.version_read_inconsistent",
+      `[SixbProjectionWorker] Projection run '${this.input.projectionRunId}' reached EOF before its persisted progress floor (${this.sourceRowsRead}/${this.input.persistedRowsRead} rows, ${this.sourceRowsSkipped}/${this.input.persistedRowsSkipped} skipped).`,
+      {
+        details: {
+          ...this.versionDetails(),
+          persistedRowsRead: this.input.persistedRowsRead,
+          persistedRowsSkipped: this.input.persistedRowsSkipped,
+          rowsRead: this.sourceRowsRead,
+          rowsSkipped: this.sourceRowsSkipped,
+        },
+      }
     )
+  }
+
+  private versionDetails() {
+    return {
+      projectionId: this.input.identity.projectionId,
+      runId: this.input.projectionRunId,
+      datasetId: this.input.identity.datasetVersion.datasetId,
+      versionId: this.input.identity.datasetVersion.versionId,
+    }
   }
 
   private shouldFlush(): boolean {

--- a/packages/projection-worker/src/run-object-projection.ts
+++ b/packages/projection-worker/src/run-object-projection.ts
@@ -28,6 +28,10 @@ export function mapObjectProjectionEntries(input: {
     projection,
     dataset,
     primaryPropertyId: runtime.ontology.getPrimaryPropertyId(projection.objectTypeId),
+    correlation: {
+      runId: execution.run.id,
+      versionId: execution.run.identity.datasetVersion.versionId,
+    },
   })
   const progress = createProgress(runtime, execution, expectedRows)
 

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -5,7 +5,7 @@ import {
   type ProjectionDefinition,
   type SixbFailure,
 } from "@sixb/core"
-import { captureSixbFailure } from "@sixb/core/internal/errors"
+import { captureSixbFailure, isSixbError } from "@sixb/core/internal/errors"
 import {
   MaterializationObjectNotFoundError,
   type ProjectionRunTerminalDecision,
@@ -282,10 +282,11 @@ async function isPermanentFailure(
   if (error instanceof MaterializationObjectNotFoundError) {
     return missingTargetWaitedLongEnough(input, execution, error)
   }
-  return isPermanentSyncFailure(error)
+  return isPermanentProjectionError(error)
 }
 
-function isPermanentSyncFailure(error: unknown): boolean {
+function isPermanentProjectionError(error: unknown): boolean {
+  if (isSixbError(error)) return !error.retryable
   if (
     error instanceof ProjectionWorkerPermanentError ||
     error instanceof MaterializationValidationError
@@ -311,7 +312,7 @@ function isExplicitCancellation(error: unknown): error is MaterializationCancell
  */
 export function isPermanentProjectionFailure(error: unknown): boolean {
   return (
-    (!(error instanceof MaterializationObjectNotFoundError) && isPermanentSyncFailure(error)) ||
+    (!(error instanceof MaterializationObjectNotFoundError) && isPermanentProjectionError(error)) ||
     isExplicitCancellation(error)
   )
 }

--- a/packages/projection-worker/src/run-telemetry-projection.ts
+++ b/packages/projection-worker/src/run-telemetry-projection.ts
@@ -7,10 +7,10 @@ import {
   type Schema,
   type TelemetryProjectionDefinition,
 } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { TelemetryPointWrite } from "@sixb/core/internal/materialization"
 import { getOntologyMutationRuntime } from "@sixb/core/internal/runtime"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
-import { ProjectionWorkerError } from "./errors"
 import { resolveProjectionSchema } from "./projection-schema"
 import { normalizeProjectedValue } from "./projection-value-coercion"
 import type { ClaimedProjectionExecution, ProjectionWorkerContext } from "./types"
@@ -46,15 +46,23 @@ export async function runTelemetryProjection(input: {
   readonly signal: AbortSignal
 }): Promise<{ readonly protocol: "telemetry"; readonly inputExhausted: true }> {
   const { runtime, projection, dataset, version, execution, signal } = input
+  const errorDetails = {
+    projectionId: projection.id,
+    runId: execution.run.id,
+    datasetId: execution.run.identity.datasetVersion.datasetId,
+    versionId: execution.run.identity.datasetVersion.versionId,
+  }
   const checkpoint = execution.run.telemetryCheckpoint
   if (!checkpoint) {
-    throw new ProjectionWorkerError(
-      `[SixbProjectionWorker] Telemetry projection run '${execution.run.id}' has no checkpoint.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbProjectionWorker] Telemetry projection run '${execution.run.id}' has no checkpoint.`,
+      { details: errorDetails }
     )
   }
   if (checkpoint.inputExhausted) return telemetryInputExhausted()
 
-  const plan = buildTelemetryProjectionPlan({ runtime, projection, dataset })
+  const plan = buildTelemetryProjectionPlan({ runtime, projection, dataset, errorDetails })
   const batch: unknown[] = []
   let batchOrdinal = checkpoint.nextBatchOrdinal
   let attemptRowsRead = 0
@@ -68,7 +76,7 @@ export async function runTelemetryProjection(input: {
     throwIfAborted(signal)
     attemptRowsRead += 1
     assertWithinPinnedInput({
-      projectionRunId: execution.run.id,
+      ...errorDetails,
       expectedRows: version.rowCount,
       rowsRead: checkpoint.nextRowOffset + attemptRowsRead,
     })
@@ -89,7 +97,7 @@ export async function runTelemetryProjection(input: {
 
   throwIfAborted(signal)
   assertCompletePinnedInput({
-    projectionRunId: execution.run.id,
+    ...errorDetails,
     expectedRows: version.rowCount,
     rowsRead: checkpoint.nextRowOffset + attemptRowsRead,
   })
@@ -112,24 +120,52 @@ function telemetryInputExhausted() {
 }
 
 function assertWithinPinnedInput(input: {
-  readonly projectionRunId: string
+  readonly projectionId: string
+  readonly runId: string
+  readonly datasetId: string
+  readonly versionId: string
   readonly expectedRows: number | undefined
   readonly rowsRead: number
 }): void {
   if (input.expectedRows === undefined || input.rowsRead <= input.expectedRows) return
-  throw new ProjectionWorkerError(
-    `[SixbProjectionWorker] Telemetry projection run '${input.projectionRunId}' read more than its ${input.expectedRows} pinned rows.`
+  throw createSixbError(
+    "dataset.version_read_inconsistent",
+    `[SixbProjectionWorker] Telemetry projection run '${input.runId}' read more than its ${input.expectedRows} pinned rows.`,
+    {
+      details: {
+        projectionId: input.projectionId,
+        runId: input.runId,
+        datasetId: input.datasetId,
+        versionId: input.versionId,
+        expectedRows: input.expectedRows,
+        rowsRead: input.rowsRead,
+      },
+    }
   )
 }
 
 function assertCompletePinnedInput(input: {
-  readonly projectionRunId: string
+  readonly projectionId: string
+  readonly runId: string
+  readonly datasetId: string
+  readonly versionId: string
   readonly expectedRows: number | undefined
   readonly rowsRead: number
 }): void {
   if (input.expectedRows === undefined || input.rowsRead === input.expectedRows) return
-  throw new ProjectionWorkerError(
-    `[SixbProjectionWorker] Telemetry projection run '${input.projectionRunId}' reached EOF after ${input.rowsRead} of ${input.expectedRows} pinned rows.`
+  throw createSixbError(
+    "dataset.version_read_inconsistent",
+    `[SixbProjectionWorker] Telemetry projection run '${input.runId}' reached EOF after ${input.rowsRead} of ${input.expectedRows} pinned rows.`,
+    {
+      details: {
+        projectionId: input.projectionId,
+        runId: input.runId,
+        datasetId: input.datasetId,
+        versionId: input.versionId,
+        expectedRows: input.expectedRows,
+        rowsRead: input.rowsRead,
+      },
+    }
   )
 }
 
@@ -183,16 +219,26 @@ function buildTelemetryProjectionPlan(input: {
   readonly runtime: ProjectionWorkerContext
   readonly projection: TelemetryProjectionDefinition
   readonly dataset: DatasetDefinition
+  readonly errorDetails: Readonly<Record<string, string>>
 }): TelemetryProjectionPlan {
-  const { runtime, projection, dataset } = input
+  const { runtime, projection, dataset, errorDetails } = input
   const objectType = runtime.ontology.getObjectTypeById(projection.objectTypeId)
   const property = objectType?.properties.find(
     (candidate) => candidate.id === projection.propertyId
   )
   const valueColumn = dataset.schema.columns.find((column) => column.name === projection.valueField)
   if (!objectType || !property || !valueColumn) {
-    throw new ProjectionWorkerError(
-      `[SixbProjectionWorker] Telemetry projection '${projection.id}' was not validated before execution.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[SixbProjectionWorker] Telemetry projection '${projection.id}' was not validated before execution.`,
+      {
+        details: {
+          ...errorDetails,
+          objectTypeId: projection.objectTypeId,
+          propertyId: projection.propertyId,
+          columnName: projection.valueField,
+        },
+      }
     )
   }
 
@@ -200,7 +246,12 @@ function buildTelemetryProjectionPlan(input: {
     projection,
     dataset,
     valueColumnType: valueColumn.type,
-    valueSchema: resolveProjectionSchema(property.schema, runtime.ontology.getValueTypesById()),
+    valueSchema: resolveProjectionSchema(property.schema, runtime.ontology.getValueTypesById(), {
+      ...errorDetails,
+      objectTypeId: objectType.id,
+      propertyId: property.id,
+      columnName: valueColumn.name,
+    }),
     readColumns: telemetryProjectionReadColumns(projection),
   }
 }

--- a/packages/projection-worker/src/schema-validation.ts
+++ b/packages/projection-worker/src/schema-validation.ts
@@ -107,7 +107,15 @@ export function assertProjectionCompatibleWithDataset(input: {
         !isDatasetColumnCompatibleWithSchema(
           column.type,
           property.schema,
-          ontology.getValueTypesById()
+          ontology.getValueTypesById(),
+          {
+            projectionId: projection.id,
+            datasetId: dataset.id,
+            versionId: version.versionId,
+            objectTypeId: objectType.id,
+            propertyId,
+            columnName,
+          }
         )
       ) {
         throw new ProjectionWorkerPermanentError(
@@ -224,7 +232,15 @@ export function assertProjectionCompatibleWithDataset(input: {
       !isDatasetColumnCompatibleWithSchema(
         valueColumn.type,
         property.schema,
-        ontology.getValueTypesById()
+        ontology.getValueTypesById(),
+        {
+          projectionId: projection.id,
+          datasetId: dataset.id,
+          versionId: version.versionId,
+          objectTypeId: objectType.id,
+          propertyId: property.id,
+          columnName: valueColumn.name,
+        }
       )
     ) {
       throw new ProjectionWorkerPermanentError(
@@ -370,9 +386,10 @@ function isDateLikeColumnType(type: DatasetColumnDefinition["type"]): boolean {
 function isDatasetColumnCompatibleWithSchema(
   columnType: DatasetColumnDefinition["type"],
   schema: Schema,
-  valueTypesById: ReadonlyMap<string, ValueType>
+  valueTypesById: ReadonlyMap<string, ValueType>,
+  errorContext: Readonly<Record<string, string>>
 ): boolean {
-  const resolved = resolveProjectionSchema(schema, valueTypesById)
+  const resolved = resolveProjectionSchema(schema, valueTypesById, errorContext)
 
   switch (columnType) {
     case "string":

--- a/packages/projection-worker/tests/object-projection-plan.test.ts
+++ b/packages/projection-worker/tests/object-projection-plan.test.ts
@@ -74,4 +74,44 @@ describe("object projection plan", () => {
         "Dataset 'canonical.meter-readings' column 'reading' must match type 'float64'.",
     })
   })
+
+  test("codes an execution plan invariant with its projection correlation", () => {
+    const Account = defineObjectType({
+      id: "Account",
+      name: "Account",
+      properties: [prop("id", "string", { required: true, primary: true })],
+    })
+    const accounts = defineDataset("canonical.accounts", {
+      schema: [col("account_id", "string")],
+    })
+    const projection = defineProjection("account-projection", Account)
+      .fromDataset(accounts)
+      .properties({ id: "account_id" })
+
+    let caught: unknown
+    try {
+      buildObjectProjectionPlan({
+        ontology: new OntologyRegistry({ sources: [] }),
+        projection,
+        dataset: accounts,
+        primaryPropertyId: "id",
+        correlation: { runId: "projection-run-1", versionId: "version-1" },
+      })
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      message: expect.stringContaining("references unknown object type 'Account'"),
+      details: {
+        projectionId: projection.id,
+        runId: "projection-run-1",
+        datasetId: accounts.id,
+        versionId: "version-1",
+        objectTypeId: Account.id,
+      },
+    })
+  })
 })

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -27,6 +27,7 @@ import {
   stringEnum,
   valueTypeRef,
 } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import type { DomainEventService } from "@sixb/core/internal/events"
 import { bindPrimitiveExecution } from "@sixb/core/internal/primitive-execution"
 import {
@@ -439,7 +440,17 @@ async function commitDatasetMerge(
 }
 
 describe("runProjectionJob", () => {
-  test("classifies only terminal materialization conflicts as permanent", () => {
+  test("classifies catalog policy and only terminal materialization conflicts as permanent", () => {
+    expect(
+      isPermanentProjectionFailure(
+        createSixbError("internal.unexpected", "Projection invariant failed.")
+      )
+    ).toBe(true)
+    expect(
+      isPermanentProjectionFailure(
+        createSixbError("dataset.version_read_inconsistent", "Dataset read was incomplete.")
+      )
+    ).toBe(false)
     expect(
       isPermanentProjectionFailure(
         new MaterializationConflictError("projection-fence", "A newer version is active.")
@@ -993,7 +1004,20 @@ describe("runProjectionJob", () => {
     }
 
     lakeStorage.stopAfterRows = 2
-    await expect(runProjectionJob(input)).rejects.toThrow("reached EOF after 2 of 3 pinned rows")
+    const readError = await runProjectionJob(input).catch((error: unknown) => error)
+    expect(readError).toMatchObject({
+      code: "dataset.version_read_inconsistent",
+      retryable: true,
+      message: expect.stringContaining("reached EOF after 2 of 3 pinned rows"),
+      details: {
+        projectionId: roomTemperatureProjection.id,
+        runId: canonicalRunId(input.job.id),
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+        expectedRows: 3,
+        rowsRead: 2,
+      },
+    })
     expect(
       await deps.storage.projectionRuns.getById({
         projectId: sixb.id,
@@ -1770,7 +1794,22 @@ describe("runProjectionJob", () => {
 
     lakeStorage.failAfterRows = undefined
     lakeStorage.stopAfterRows = 1
-    await expect(runProjectionJob(input)).rejects.toThrow("persisted progress floor")
+    const readError = await runProjectionJob(input).catch((error: unknown) => error)
+    expect(readError).toMatchObject({
+      code: "dataset.version_read_inconsistent",
+      retryable: true,
+      message: expect.stringContaining("persisted progress floor"),
+      details: {
+        projectionId: roomProjection.id,
+        runId: canonicalRunId(input.job.id),
+        datasetId: roomsDataset.id,
+        versionId: nextVersion.versionId,
+        persistedRowsRead: 2,
+        persistedRowsSkipped: 0,
+        rowsRead: 1,
+        rowsSkipped: 0,
+      },
+    })
     expect(
       await deps.storage.projectionRuns.getById({
         projectId: sixb.id,


### PR DESCRIPTION
## Summary

- remove the nominal `ProjectionWorkerError` wrapper and create canonical coded errors directly
- add the public `dataset.version_read_inconsistent` code with catalog-owned retry policy
- preserve recovery from short, overlong, or regressed immutable-version reads while treating coded non-retryable invariants as terminal
- attach projection, run, dataset, version, schema, and progress correlation details at error creation
- keep `ProjectionWorkerPermanentError` temporarily for deterministic control flow, with its removal condition documented above the class
- assert the structural error contract and both terminal/retry decisions instead of the removed runtime class

## Why

The generic wrapper mixed two different policies. Projection plan invariants cannot succeed on redelivery, while an immutable-version read can temporarily return fewer rows and existing tests prove that a later delivery can complete successfully. Mapping both cases to `internal.unexpected` would mark recoverable reads as `retryable: false` while the worker continued retrying them.

`dataset.version_read_inconsistent` gives that recovery path a stable identity and a catalog-owned `retryable: true` policy. Other coded invariants use `internal.unexpected` and now terminate according to the same catalog policy.

`ProjectionWorkerPermanentError` remains only as a temporary control-flow bridge for the existing deterministic validation taxonomy. It should be removed once Projection has precise non-retryable codes and fail/retry can branch on those codes instead of `instanceof`.

## Validation

- `bun test packages/core/tests/error-model.test.ts packages/projection-worker/tests/` — 101 passing
- `bun --filter @sixb/projection-worker typecheck`
- `bun --filter @sixb/projection-worker build`
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `git diff --check`

## Stack

Depends on #347 and continues #274.