### PR TITLE
agents: preview generated documents in app

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -454,10 +454,13 @@
         "@sixb/core": "workspace:^",
         "@sixb/ui": "workspace:^",
         "lucide-react": "^0.562.0",
+        "papaparse": "^5.5.4",
+        "parse5": "^8.0.0",
       },
       "devDependencies": {
         "@tanstack/react-query": "^5.0.0",
         "@types/bun": "latest",
+        "@types/papaparse": "^5.5.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "react": "^19.0.0",
@@ -1560,6 +1563,8 @@
 
     "@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
+    "@types/papaparse": ["@types/papaparse@5.5.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA=="],
+
     "@types/react": ["@types/react@19.2.15", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -1783,6 +1788,8 @@
     "encoding-japanese": ["encoding-japanese@2.2.0", "", {}, "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.22.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A=="],
+
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
@@ -2100,7 +2107,11 @@
 
     "os-paths": ["os-paths@4.4.0", "", {}, "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg=="],
 
+    "papaparse": ["papaparse@5.5.4", "", {}, "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 

--- a/packages/agent-ui/README.md
+++ b/packages/agent-ui/README.md
@@ -76,3 +76,23 @@ import { AgentChatPage } from "@sixb/agent-ui/react-router"
 ```
 
 `routeBase` defaults to `/agents` and must match the path you mount it on.
+
+## Document previews
+
+Durable files attached by a user or produced by an agent open directly from the conversation when
+Sixb has a viewer for their format:
+
+- Markdown uses the shared Sixb Markdown renderer.
+- HTML is a static preview in a sandboxed iframe. Scripts, forms, network subresources, nested
+  frames, app-origin access, and parent navigation are blocked; inline styles and data/blob media remain
+  available.
+- CSV and TSV render as a scrollable table. The preview is limited to 5 MB, 500 rows, and 50 columns;
+  the original file remains available through Download.
+- PDF uses the browser's native viewer and the contextual file route's range support.
+
+On a desktop `AgentChatPage`, documents open beside the conversation in a resizable, tabbed pane.
+`AgentPanel` and mobile chat use a large dialog instead. Unsupported formats keep the browser's
+existing open/download behavior.
+
+Preview tabs support Left/Right Arrow, Home, End, Delete, and Backspace. Closing the final document
+returns focus to the attachment that opened the viewer.

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -47,7 +47,9 @@
     "@sixb/client": "workspace:^",
     "@sixb/core": "workspace:^",
     "@sixb/ui": "workspace:^",
-    "lucide-react": "^0.562.0"
+    "lucide-react": "^0.562.0",
+    "papaparse": "^5.5.4",
+    "parse5": "^8.0.0"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
@@ -58,6 +60,7 @@
   "devDependencies": {
     "@tanstack/react-query": "^5.0.0",
     "@types/bun": "latest",
+    "@types/papaparse": "^5.5.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "react": "^19.0.0",

--- a/packages/agent-ui/src/AgentChat.tsx
+++ b/packages/agent-ui/src/AgentChat.tsx
@@ -4,6 +4,7 @@ import { MessagesSquare } from "lucide-react"
 import { useEffect } from "react"
 import { AgentsHome } from "./components/AgentsHome"
 import { ConversationPanel } from "./components/ConversationPanel"
+import { DocumentPreviewRoot } from "./document-preview/DocumentPreviewRoot"
 import { useAgentConversation } from "./hooks/useAgentConversation"
 import { installAgentResizeObserverGuard } from "./resizeObserver"
 import type { AgentContextInput } from "./types"
@@ -78,66 +79,70 @@ export function AgentChat({
   const presentation = conversation.presentation
 
   return (
-    <div
-      data-agent-panel={compact ? "" : undefined}
-      className={cn("relative flex h-full min-h-0 flex-col", className)}
-    >
-      {conversation.home ? (
-        <AgentsHome
-          agents={conversation.agents}
-          threads={conversation.threads}
-          agentsById={conversation.agentsById}
-          threadsError={conversation.threadsError ? "Could not load chats." : null}
-          onPickAgent={startNewChatWith}
-          onSelectThread={onNavigateThread}
-        />
-      ) : (
-        <ConversationPanel
-          agent={conversation.currentAgent}
-          threadId={threadId}
-          messages={conversation.messages}
-          live={conversation.live}
-          messagesLoading={conversation.messagesLoading}
-          messagesError={conversation.messagesError}
-          pendingUserText={pendingUser?.text ?? null}
-          pendingUserAttachments={pendingUser?.attachments ?? []}
-          pendingUserContext={pendingUser?.context ?? []}
-          anchorCurrentTurn={conversation.anchorCurrentTurn}
-          awaitingResponse={conversation.isRunning}
-          waitingLonger={conversation.waitingLonger}
-          failedBeforeResponse={presentation.kind === "failed"}
-          cancelledBeforeResponse={presentation.kind === "cancelled"}
-          onRetry={
-            presentation.kind === "failed" ? () => conversation.retry(presentation.run) : undefined
-          }
-          retrying={conversation.retrying}
-          reconnecting={conversation.reconnecting}
-          sendError={conversation.sendError}
-          agents={conversation.agents}
-          agentThreads={conversation.agentThreads}
-          canGoHome={conversation.canGoHome}
-          onSend={conversation.send}
-          onBackHome={onNavigateHome}
-          onNewChat={() => {
-            if (conversation.currentAgent) startNewChatWith(conversation.currentAgent.id)
-          }}
-          onPickAgent={startNewChatWith}
-          onSelectThread={onNavigateThread}
-          composerDisabled={conversation.isRunning}
-          composerPending={conversation.composerPending}
-          composerRunning={conversation.isRunning}
-          composerStopping={conversation.stopping}
-          onStop={conversation.stop}
-          composerPlaceholder="Ask anything"
-          composerDraft={conversation.draftReseed.text}
-          composerDraftAttachments={conversation.draftReseed.attachments}
-          composerDraftContext={conversation.draftReseed.context}
-          composerDraftNonce={conversation.draftReseed.nonce}
-          ambientContext={ambientContext}
-          compact={compact}
-        />
-      )}
-    </div>
+    <DocumentPreviewRoot compact={compact}>
+      <div
+        data-agent-panel={compact ? "" : undefined}
+        className={cn("relative flex h-full min-h-0 flex-col", className)}
+      >
+        {conversation.home ? (
+          <AgentsHome
+            agents={conversation.agents}
+            threads={conversation.threads}
+            agentsById={conversation.agentsById}
+            threadsError={conversation.threadsError ? "Could not load chats." : null}
+            onPickAgent={startNewChatWith}
+            onSelectThread={onNavigateThread}
+          />
+        ) : (
+          <ConversationPanel
+            agent={conversation.currentAgent}
+            threadId={threadId}
+            messages={conversation.messages}
+            live={conversation.live}
+            messagesLoading={conversation.messagesLoading}
+            messagesError={conversation.messagesError}
+            pendingUserText={pendingUser?.text ?? null}
+            pendingUserAttachments={pendingUser?.attachments ?? []}
+            pendingUserContext={pendingUser?.context ?? []}
+            anchorCurrentTurn={conversation.anchorCurrentTurn}
+            awaitingResponse={conversation.isRunning}
+            waitingLonger={conversation.waitingLonger}
+            failedBeforeResponse={presentation.kind === "failed"}
+            cancelledBeforeResponse={presentation.kind === "cancelled"}
+            onRetry={
+              presentation.kind === "failed"
+                ? () => conversation.retry(presentation.run)
+                : undefined
+            }
+            retrying={conversation.retrying}
+            reconnecting={conversation.reconnecting}
+            sendError={conversation.sendError}
+            agents={conversation.agents}
+            agentThreads={conversation.agentThreads}
+            canGoHome={conversation.canGoHome}
+            onSend={conversation.send}
+            onBackHome={onNavigateHome}
+            onNewChat={() => {
+              if (conversation.currentAgent) startNewChatWith(conversation.currentAgent.id)
+            }}
+            onPickAgent={startNewChatWith}
+            onSelectThread={onNavigateThread}
+            composerDisabled={conversation.isRunning}
+            composerPending={conversation.composerPending}
+            composerRunning={conversation.isRunning}
+            composerStopping={conversation.stopping}
+            onStop={conversation.stop}
+            composerPlaceholder="Ask anything"
+            composerDraft={conversation.draftReseed.text}
+            composerDraftAttachments={conversation.draftReseed.attachments}
+            composerDraftContext={conversation.draftReseed.context}
+            composerDraftNonce={conversation.draftReseed.nonce}
+            ambientContext={ambientContext}
+            compact={compact}
+          />
+        )}
+      </div>
+    </DocumentPreviewRoot>
   )
 }
 

--- a/packages/agent-ui/src/components/FileAttachmentCard.tsx
+++ b/packages/agent-ui/src/components/FileAttachmentCard.tsx
@@ -8,18 +8,23 @@ import {
 } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { File as FileIcon, FileImage, FileText, Table2 } from "lucide-react"
+import { useDocumentPreview } from "../document-preview/DocumentPreviewRoot"
+import { agentDocumentPreviewRenderer } from "../document-preview/rendering"
+import type { AgentDocumentSource } from "../document-preview/types"
 import type { AgentFileRef } from "../types"
 
 export function FileAttachmentCard({
   fileRef,
-  href,
+  document,
   className,
 }: {
   readonly fileRef: AgentFileRef
-  readonly href?: string
+  readonly document?: AgentDocumentSource
   readonly className?: string
 }) {
+  const preview = useDocumentPreview()
   const fileName = fileRef.fileName?.trim() || "File"
+  const previewable = agentDocumentPreviewRenderer(document?.kind ?? null) !== null
   const mediaLabel = fileMediaLabel(fileRef.mediaType, fileName)
   const { Icon, className: iconClassName } = fileIconPresentation(fileRef.mediaType, fileName)
 
@@ -32,9 +37,22 @@ export function FileAttachmentCard({
         className
       )}
     >
-      {href ? (
+      {document && previewable && preview ? (
         <AttachmentTrigger asChild>
-          <a href={href} target="_blank" rel="noreferrer" aria-label={`Open ${fileName}`} />
+          <button
+            type="button"
+            onClick={() => preview.openDocument(document)}
+            aria-label={`Preview ${fileName}`}
+          />
+        </AttachmentTrigger>
+      ) : document ? (
+        <AttachmentTrigger asChild>
+          <a
+            href={document.inlineUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={`Open ${fileName}`}
+          />
         </AttachmentTrigger>
       ) : null}
       <AttachmentMedia className={cn("size-9 rounded-xl bg-muted/80", iconClassName)}>

--- a/packages/agent-ui/src/components/MessageParts.tsx
+++ b/packages/agent-ui/src/components/MessageParts.tsx
@@ -73,7 +73,7 @@ function TextBlock({ text }: { text: string }) {
 }
 
 function FileBlock({ part }: { part: Extract<NormalizedPart, { kind: "file" }> }) {
-  return <FileAttachmentCard fileRef={part.fileRef} href={part.href} />
+  return <FileAttachmentCard fileRef={part.fileRef} document={part.document} />
 }
 
 /**

--- a/packages/agent-ui/src/components/MessageView.tsx
+++ b/packages/agent-ui/src/components/MessageView.tsx
@@ -1,4 +1,3 @@
-import { client } from "@sixb/client"
 import {
   Bubble,
   BubbleContent,
@@ -8,6 +7,8 @@ import {
   MarkerIcon,
 } from "@sixb/ui/components"
 import { AlertTriangle, RotateCcw } from "lucide-react"
+import { createAgentDocumentSource } from "../document-preview/source"
+import type { AgentDocumentSource } from "../document-preview/types"
 import { isAwaitingFirstToken, type LiveRunState } from "../liveRun"
 import { normalizeDurableParts } from "../parts"
 import type {
@@ -41,7 +42,7 @@ function UserMessage({ message }: { message: AgentMessage }) {
             <UserFileAttachment
               key={index}
               fileRef={part.fileRef}
-              href={agentMessageFileContentHref(message, index, "inline")}
+              document={agentMessageDocumentSource(message, index)}
             />
           ))}
         </div>
@@ -60,7 +61,7 @@ function AssistantMessage({ message }: { message: AgentMessage }) {
     <div className="flex flex-col gap-2">
       <AssistantBody
         parts={normalizeDurableParts(message.parts, {
-          fileHref: (partIndex) => agentMessageFileContentHref(message, partIndex, "inline"),
+          fileSource: (partIndex) => agentMessageDocumentSource(message, partIndex),
         })}
       />
       {message.annotations.map((annotation, index) => (
@@ -173,8 +174,14 @@ export function ReconnectingMarker() {
   )
 }
 
-export function UserFileAttachment({ fileRef, href }: { fileRef: AgentFileRef; href?: string }) {
-  return <FileAttachmentCard fileRef={fileRef} href={href} />
+export function UserFileAttachment({
+  fileRef,
+  document,
+}: {
+  fileRef: AgentFileRef
+  document?: AgentDocumentSource
+}) {
+  return <FileAttachmentCard fileRef={fileRef} document={document} />
 }
 
 export function RunErrorMarker({ message }: { message: string }) {
@@ -210,24 +217,16 @@ function contextPartsOf(message: AgentMessage): AgentContextEntryInput[] {
   )
 }
 
-function agentMessageFileContentHref(
+function agentMessageDocumentSource(
   message: AgentMessage,
-  partIndex: number,
-  disposition: "inline" | "attachment"
-): string {
-  const params = new URLSearchParams({
-    path: `/parts/${partIndex}/fileRef`,
-    disposition,
+  partIndex: number
+): AgentDocumentSource | undefined {
+  const part = message.parts[partIndex]
+  if (part?.type !== "file") return
+  return createAgentDocumentSource({
+    threadId: message.threadId,
+    messageId: message.id,
+    partIndex,
+    fileRef: part.fileRef,
   })
-  const routePath = `/api/agent-threads/${encodeURIComponent(message.threadId)}/messages/${encodeURIComponent(
-    message.id
-  )}/files/content`
-  const baseUrl = client.getConfig().baseUrl
-  if (!baseUrl && typeof window === "undefined") {
-    return `${routePath}?${params}`
-  }
-
-  const url = new URL(routePath, baseUrl ?? window.location.origin)
-  url.search = params.toString()
-  return url.toString()
 }

--- a/packages/agent-ui/src/document-preview/DocumentPreviewRoot.tsx
+++ b/packages/agent-ui/src/document-preview/DocumentPreviewRoot.tsx
@@ -1,0 +1,731 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  Markdown,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  Spinner,
+} from "@sixb/ui/components"
+import { useIsMobile } from "@sixb/ui/hooks"
+import { cn } from "@sixb/ui/lib/utils"
+import { Download, ExternalLink, FileWarning, X } from "lucide-react"
+import {
+  createContext,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useReducer,
+  useRef,
+} from "react"
+import { useDelimitedTextDocument, useHtmlDocument, useMarkdownDocument } from "./content"
+import { DelimitedTextParseError, type DelimitedTextPreview, parseDelimitedText } from "./delimited"
+import { buildSafeHtmlPreviewDocument, HTML_PREVIEW_SANDBOX } from "./html"
+import { documentPreviewPresentation } from "./presentation"
+import { agentDocumentPreviewRenderer } from "./rendering"
+import {
+  type DocumentPreviewState,
+  type DocumentTabNavigationKey,
+  documentPreviewReducer,
+  documentTabIdAfterKey,
+  EMPTY_DOCUMENT_PREVIEW_STATE,
+} from "./state"
+import type { AgentDocumentSource } from "./types"
+
+interface DocumentPreviewContextValue {
+  readonly openDocument: (document: AgentDocumentSource) => void
+}
+
+interface DocumentViewerProps {
+  readonly idPrefix: string
+  readonly state: DocumentPreviewState
+  readonly onSelect: (id: string) => void
+  readonly onClose: (id: string) => void
+  readonly onCloseAll: () => void
+}
+
+interface PreviewPanelHandle {
+  collapse(): void
+  expand(): void
+  isCollapsed(): boolean
+  resize(size: number | string): void
+}
+
+const DocumentPreviewContext = createContext<DocumentPreviewContextValue | null>(null)
+
+export function DocumentPreviewRoot({
+  children,
+  compact = false,
+}: {
+  readonly children: ReactNode
+  readonly compact?: boolean
+}) {
+  const idPrefix = useId()
+  const [state, dispatch] = useReducer(documentPreviewReducer, EMPTY_DOCUMENT_PREVIEW_STATE)
+  const [revealVersion, revealDocument] = useReducer((version: number) => version + 1, 0)
+  const openerRef = useRef<HTMLElement | null>(null)
+  const activeDocument = state.documents.find((document) => document.id === state.activeId) ?? null
+  const presentation = documentPreviewPresentation(compact, useIsMobile())
+
+  const restoreOpenerFocus = useCallback(() => {
+    const opener = openerRef.current
+    openerRef.current = null
+    if (!opener?.isConnected) return
+    queueMicrotask(() => opener.focus())
+  }, [])
+  const openDocument = useCallback(
+    (source: AgentDocumentSource) => {
+      if (state.documents.length === 0 && typeof window !== "undefined") {
+        const activeElement = window.document.activeElement
+        openerRef.current = activeElement instanceof HTMLElement ? activeElement : null
+      }
+      dispatch({ type: "open", document: source })
+      revealDocument()
+    },
+    [state.documents.length]
+  )
+  const closeDocument = useCallback(
+    (id: string) => {
+      const closesLastDocument = state.documents.length === 1 && state.documents[0]?.id === id
+      dispatch({ type: "close", id })
+      if (closesLastDocument) restoreOpenerFocus()
+    },
+    [restoreOpenerFocus, state.documents]
+  )
+  const closeAllDocuments = useCallback(() => {
+    dispatch({ type: "close-all" })
+    restoreOpenerFocus()
+  }, [restoreOpenerFocus])
+  const context = useMemo<DocumentPreviewContextValue>(() => ({ openDocument }), [openDocument])
+  const viewerProps: DocumentViewerProps = {
+    idPrefix,
+    state,
+    onSelect: (id) => dispatch({ type: "select", id }),
+    onClose: closeDocument,
+    onCloseAll: closeAllDocuments,
+  }
+
+  return (
+    <DocumentPreviewContext.Provider value={context}>
+      {presentation === "panel" ? (
+        <DocumentPreviewWorkspace
+          open={activeDocument !== null}
+          revealVersion={revealVersion}
+          viewerProps={viewerProps}
+        >
+          {children}
+        </DocumentPreviewWorkspace>
+      ) : (
+        children
+      )}
+      <DocumentPreviewDialog
+        open={presentation === "dialog" && activeDocument !== null}
+        activeDocument={activeDocument}
+        viewerProps={viewerProps}
+      />
+    </DocumentPreviewContext.Provider>
+  )
+}
+
+export function useDocumentPreview(): DocumentPreviewContextValue | null {
+  return useContext(DocumentPreviewContext)
+}
+
+function DocumentPreviewWorkspace({
+  children,
+  open,
+  revealVersion,
+  viewerProps,
+}: {
+  children: ReactNode
+  open: boolean
+  revealVersion: number
+  viewerProps: DocumentViewerProps
+}) {
+  const panelRef = useRef<PreviewPanelHandle | null>(null)
+  const openedOnceRef = useRef(false)
+
+  useEffect(() => {
+    const panel = panelRef.current
+    if (!panel) return
+
+    if (!open) {
+      panel.collapse()
+      return
+    }
+
+    if (!openedOnceRef.current) {
+      openedOnceRef.current = true
+      panel.resize("50%")
+      return
+    }
+
+    // A repeated click on an already-open document increments `revealVersion`; expand the pane
+    // again if the user previously collapsed it by dragging the separator.
+    if (panel.isCollapsed() || revealVersion > 0) panel.expand()
+  }, [open, revealVersion])
+
+  return (
+    <ResizablePanelGroup id="agent-document-workspace" orientation="horizontal" className="min-h-0">
+      <ResizablePanel id="agent-conversation" defaultSize="100%" minSize="30%">
+        <div className="h-full min-h-0 min-w-0">{children}</div>
+      </ResizablePanel>
+      <ResizableHandle
+        className={cn(
+          "bg-transparent transition-opacity before:pointer-events-none before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-border/70 before:transition-[width,background-color] before:duration-150 hover:before:w-0.5 hover:before:bg-foreground/25 focus-visible:before:w-0.5 focus-visible:before:bg-ring active:before:w-[3px] active:before:bg-foreground/35",
+          !open && "pointer-events-none invisible opacity-0"
+        )}
+      />
+      <ResizablePanel
+        id="agent-document-preview"
+        defaultSize="0%"
+        minSize="30%"
+        maxSize="70%"
+        collapsedSize="0%"
+        collapsible
+        panelRef={(panel) => {
+          panelRef.current = panel
+        }}
+      >
+        <div className="flex h-full min-h-0 min-w-0 flex-col bg-background">
+          {open ? (
+            <DocumentViewer {...viewerProps} showActionLabels={false} focusActiveTab />
+          ) : null}
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  )
+}
+
+function DocumentPreviewDialog({
+  open,
+  activeDocument,
+  viewerProps,
+}: {
+  open: boolean
+  activeDocument: AgentDocumentSource | null
+  viewerProps: DocumentViewerProps
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) viewerProps.onCloseAll()
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        className="flex h-[calc(100dvh-1rem)] max-h-none w-[calc(100vw-1rem)] max-w-none flex-col gap-0 overflow-hidden rounded-xl p-0 sm:h-[min(88vh,56rem)] sm:w-[min(92vw,72rem)] sm:max-w-[min(92vw,72rem)]"
+      >
+        <DialogTitle className="sr-only">
+          {activeDocument ? `Preview ${documentName(activeDocument)}` : "Document preview"}
+        </DialogTitle>
+        <DialogDescription className="sr-only">
+          Preview, switch between, and download documents from this conversation.
+        </DialogDescription>
+        {activeDocument ? (
+          <DocumentViewer {...viewerProps} showActionLabels focusActiveTab={false} />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DocumentViewer({
+  idPrefix,
+  state,
+  onSelect,
+  onClose,
+  onCloseAll,
+  showActionLabels,
+  focusActiveTab,
+}: DocumentViewerProps & {
+  readonly showActionLabels: boolean
+  readonly focusActiveTab: boolean
+}) {
+  const activeDocument = state.documents.find((document) => document.id === state.activeId) ?? null
+  const panelId = `${idPrefix}-document-panel`
+
+  return (
+    <>
+      <DocumentTabs
+        idPrefix={idPrefix}
+        panelId={panelId}
+        documents={state.documents}
+        activeId={state.activeId}
+        onSelect={onSelect}
+        onClose={onClose}
+        onCloseAll={onCloseAll}
+        showActionLabels={showActionLabels}
+        focusActiveTab={focusActiveTab}
+      />
+      {activeDocument ? (
+        <div
+          id={panelId}
+          role="tabpanel"
+          aria-labelledby={documentTabDomId(idPrefix, activeDocument.id)}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <DocumentContent document={activeDocument} />
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+function DocumentTabs({
+  idPrefix,
+  panelId,
+  documents,
+  activeId,
+  onSelect,
+  onClose,
+  onCloseAll,
+  showActionLabels,
+  focusActiveTab,
+}: {
+  idPrefix: string
+  panelId: string
+  documents: readonly AgentDocumentSource[]
+  activeId: string | null
+  onSelect: (id: string) => void
+  onClose: (id: string) => void
+  onCloseAll: () => void
+  showActionLabels: boolean
+  focusActiveTab: boolean
+}) {
+  const activeDocument = documents.find((document) => document.id === activeId)
+  const tabRefs = useRef(new Map<string, HTMLButtonElement>())
+
+  useEffect(() => {
+    if (!activeId) return
+    const activeTab = tabRefs.current.get(activeId)
+    activeTab?.scrollIntoView({ block: "nearest", inline: "nearest" })
+    if (focusActiveTab) activeTab?.focus()
+  }, [activeId, focusActiveTab])
+
+  const focusTab = (id: string) => {
+    onSelect(id)
+    tabRefs.current.get(id)?.focus()
+  }
+  const closeTab = (id: string) => {
+    const closedIndex = documents.findIndex((document) => document.id === id)
+    const focusId =
+      id === activeId
+        ? (documents[closedIndex + 1]?.id ?? documents[closedIndex - 1]?.id)
+        : activeId
+    onClose(id)
+    if (focusId) queueMicrotask(() => tabRefs.current.get(focusId)?.focus())
+  }
+  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>, id: string) => {
+    if (event.key === "Delete" || event.key === "Backspace") {
+      event.preventDefault()
+      closeTab(id)
+      return
+    }
+    if (!isDocumentTabNavigationKey(event.key)) return
+
+    event.preventDefault()
+    const nextId = documentTabIdAfterKey(
+      documents.map((document) => document.id),
+      id,
+      event.key
+    )
+    if (nextId) focusTab(nextId)
+  }
+
+  return (
+    <header className="flex h-11 shrink-0 items-center border-b border-border bg-muted/20">
+      <div
+        role="tablist"
+        aria-label="Open documents"
+        className="scrollbar-thin flex h-full min-w-0 flex-1 overflow-x-auto"
+      >
+        {documents.map((document) => {
+          const active = document.id === activeId
+          const name = documentName(document)
+          return (
+            <div
+              key={document.id}
+              className={cn(
+                "group/document-tab relative flex h-full max-w-64 shrink-0 items-center border-r border-border/60 transition-colors",
+                active
+                  ? "bg-background after:absolute after:inset-x-0 after:-bottom-px after:z-10 after:h-px after:bg-background"
+                  : "hover:bg-muted/60"
+              )}
+            >
+              <button
+                ref={(element) => {
+                  if (element) tabRefs.current.set(document.id, element)
+                  else tabRefs.current.delete(document.id)
+                }}
+                id={documentTabDomId(idPrefix, document.id)}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                aria-controls={panelId}
+                aria-keyshortcuts="Delete Backspace"
+                tabIndex={active ? 0 : -1}
+                onClick={() => onSelect(document.id)}
+                onKeyDown={(event) => handleTabKeyDown(event, document.id)}
+                className={cn(
+                  "h-full min-w-0 flex-1 truncate px-3 text-left text-sm font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+                  active ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+                )}
+                title={name}
+              >
+                {name}
+              </button>
+              <button
+                type="button"
+                tabIndex={-1}
+                onClick={() => closeTab(document.id)}
+                className={cn(
+                  "mr-2 flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-40 transition-[color,background-color,opacity] hover:bg-muted hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  !active && "group-hover/document-tab:opacity-70"
+                )}
+                aria-label={`Close ${name}`}
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+      <div className="flex h-full shrink-0 items-center gap-0.5 border-l border-border/60 px-1.5">
+        {activeDocument?.kind === "pdf" ? (
+          <Button variant="ghost" size="sm" asChild>
+            <a
+              href={activeDocument.inlineUrl}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`Open ${documentName(activeDocument)} in a new tab`}
+            >
+              <ExternalLink />
+              {showActionLabels ? <span className="hidden sm:inline">Open</span> : null}
+            </a>
+          </Button>
+        ) : null}
+        {activeDocument ? (
+          <Button variant="ghost" size="sm" asChild>
+            <a
+              href={activeDocument.downloadUrl}
+              download={documentName(activeDocument)}
+              aria-label={`Download ${documentName(activeDocument)}`}
+            >
+              <Download />
+              {showActionLabels ? <span className="hidden sm:inline">Download</span> : null}
+            </a>
+          </Button>
+        ) : null}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onCloseAll}
+          aria-label="Close document viewer"
+        >
+          <X />
+        </Button>
+      </div>
+    </header>
+  )
+}
+
+function DocumentContent({ document }: { document: AgentDocumentSource }) {
+  const renderer = agentDocumentPreviewRenderer(document.kind)
+  if (renderer === "markdown") return <MarkdownDocument document={document} />
+  if (renderer === "html-static") return <HtmlDocument document={document} />
+  if (renderer === "delimited-text") return <DelimitedTextDocument document={document} />
+  if (renderer === "pdf-native") return <PdfDocument document={document} />
+
+  return (
+    <DocumentNotice
+      title="Preview unavailable"
+      description="This file type is not available in the document viewer yet."
+    />
+  )
+}
+
+function HtmlDocument({ document }: { document: AgentDocumentSource }) {
+  const preview = useHtmlDocument(document)
+  const safeDocument = useMemo(
+    () => (preview.text === undefined ? null : buildSafeHtmlPreviewDocument(preview.text)),
+    [preview.text]
+  )
+
+  if (preview.tooLarge) {
+    return (
+      <DocumentNotice
+        title="Document is too large to preview"
+        description="Download the file to view the complete document."
+      />
+    )
+  }
+  if (preview.loading) return <DocumentLoading />
+  if (preview.error || safeDocument === null) {
+    return (
+      <DocumentNotice
+        title="Could not preview document"
+        description={preview.error ?? "The document did not contain readable HTML."}
+      />
+    )
+  }
+
+  const name = documentName(document)
+  return (
+    <iframe
+      srcDoc={safeDocument}
+      sandbox={HTML_PREVIEW_SANDBOX}
+      referrerPolicy="no-referrer"
+      title={name}
+      aria-label={`Preview ${name}`}
+      className="min-h-0 w-full flex-1 border-0 bg-white"
+    />
+  )
+}
+
+function DelimitedTextDocument({ document }: { document: AgentDocumentSource }) {
+  const preview = useDelimitedTextDocument(document)
+  const parsed = useMemo(
+    () => parseDelimitedPreview(preview.text, document.kind),
+    [preview.text, document.kind]
+  )
+
+  if (preview.tooLarge) {
+    return (
+      <DocumentNotice
+        title="Document is too large to preview"
+        description="Download the file to view the complete document."
+      />
+    )
+  }
+  if (preview.loading) return <DocumentLoading />
+  if (preview.error || parsed.error) {
+    return (
+      <DocumentNotice
+        title="Could not preview table"
+        description={preview.error ?? parsed.error ?? "The file could not be parsed."}
+      />
+    )
+  }
+  if (!parsed.data) {
+    return (
+      <DocumentNotice
+        title="Could not preview table"
+        description="The file did not contain readable rows."
+      />
+    )
+  }
+
+  const data = parsed.data
+  const limited = data.rowsTruncated || data.columnsTruncated
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-background">
+      {limited ? (
+        <p
+          className="shrink-0 border-b border-border bg-muted/40 px-4 py-2 text-xs text-muted-foreground"
+          role="status"
+        >
+          {delimitedLimitMessage(data)} Download the file to view all data.
+        </p>
+      ) : null}
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table
+          className="w-max min-w-full border-separate border-spacing-0 text-sm"
+          aria-label={`${documentName(document)} data preview`}
+        >
+          <thead>
+            <tr>
+              {data.headers.map((header, index) => (
+                <th
+                  key={index}
+                  scope="col"
+                  className="sticky top-0 z-10 max-w-96 min-w-32 border-r border-b border-border bg-muted/95 px-3 py-2.5 text-left text-[11px] font-semibold tracking-wide whitespace-nowrap text-muted-foreground uppercase backdrop-blur last:border-r-0"
+                >
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.rows.length > 0 ? (
+              data.rows.map((row, rowIndex) => (
+                <tr key={rowIndex} className="hover:bg-muted/40">
+                  {row.map((cell, columnIndex) => (
+                    <td
+                      key={columnIndex}
+                      className="max-w-96 min-w-32 border-r border-b border-border/70 px-3 py-2 align-top text-foreground whitespace-pre-wrap break-words last:border-r-0"
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td
+                  colSpan={Math.max(data.headers.length, 1)}
+                  className="px-4 py-12 text-center text-sm text-muted-foreground"
+                >
+                  No data rows.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function parseDelimitedPreview(
+  text: string | undefined,
+  kind: AgentDocumentSource["kind"]
+): { readonly data: DelimitedTextPreview | null; readonly error: string | null } {
+  if (text === undefined) return { data: null, error: null }
+  if (kind !== "csv" && kind !== "tsv") {
+    return { data: null, error: "The file is not CSV or TSV data." }
+  }
+
+  try {
+    return { data: parseDelimitedText(text, kind), error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error:
+        error instanceof DelimitedTextParseError
+          ? error.message
+          : "The file contains malformed delimited text.",
+    }
+  }
+}
+
+function delimitedLimitMessage(data: DelimitedTextPreview): string {
+  const limits: string[] = []
+  if (data.rowsTruncated) {
+    limits.push(
+      `the first ${data.rows.length.toLocaleString()} of ${data.totalRows.toLocaleString()} rows`
+    )
+  }
+  if (data.columnsTruncated) {
+    limits.push(
+      `the first ${data.headers.length.toLocaleString()} of ${data.totalColumns.toLocaleString()} columns`
+    )
+  }
+  return `Showing ${limits.join(" and ")}.`
+}
+
+function PdfDocument({ document }: { document: AgentDocumentSource }) {
+  const name = documentName(document)
+  return (
+    <object
+      data={document.inlineUrl}
+      type="application/pdf"
+      title={name}
+      aria-label={`Preview ${name}`}
+      className="flex min-h-0 w-full flex-1 bg-muted/20"
+    >
+      <DocumentNotice
+        title="PDF preview unavailable"
+        description="Open the PDF in your browser or download it to view the document."
+        action={
+          <div className="flex justify-center gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <a href={document.inlineUrl} target="_blank" rel="noreferrer">
+                <ExternalLink />
+                Open PDF
+              </a>
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <a href={document.downloadUrl} download={name}>
+                <Download />
+                Download
+              </a>
+            </Button>
+          </div>
+        }
+      />
+    </object>
+  )
+}
+
+function MarkdownDocument({ document }: { document: AgentDocumentSource }) {
+  const preview = useMarkdownDocument(document)
+
+  if (preview.tooLarge) {
+    return (
+      <DocumentNotice
+        title="Document is too large to preview"
+        description="Download the file to view the complete document."
+      />
+    )
+  }
+  if (preview.loading) return <DocumentLoading />
+  if (preview.error || preview.text === undefined) {
+    return (
+      <DocumentNotice
+        title="Could not preview document"
+        description={preview.error ?? "The document did not contain readable text."}
+      />
+    )
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto bg-muted/20">
+      <Markdown className="mx-auto min-h-full max-w-4xl bg-background px-6 py-8 sm:px-10 sm:py-12">
+        {preview.text}
+      </Markdown>
+    </div>
+  )
+}
+
+function DocumentLoading() {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center" aria-busy="true" role="status">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner className="size-4" />
+        Loading document…
+      </div>
+    </div>
+  )
+}
+
+function DocumentNotice({
+  title,
+  description,
+  action,
+}: {
+  title: string
+  description: string
+  action?: ReactNode
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-8 text-center">
+      <div className="max-w-sm space-y-2">
+        <FileWarning className="mx-auto size-8 text-muted-foreground" />
+        <p className="text-sm font-medium text-foreground">{title}</p>
+        <p className="text-sm text-muted-foreground">{description}</p>
+        {action ? <div className="pt-2">{action}</div> : null}
+      </div>
+    </div>
+  )
+}
+
+function isDocumentTabNavigationKey(value: string): value is DocumentTabNavigationKey {
+  return value === "ArrowLeft" || value === "ArrowRight" || value === "Home" || value === "End"
+}
+
+function documentTabDomId(idPrefix: string, documentId: string): string {
+  return `${idPrefix}-document-tab-${documentId}`
+}
+
+function documentName(document: AgentDocumentSource): string {
+  return document.fileRef.fileName?.trim() || "Document"
+}

--- a/packages/agent-ui/src/document-preview/classify.ts
+++ b/packages/agent-ui/src/document-preview/classify.ts
@@ -1,0 +1,45 @@
+import type { AgentDocumentKind } from "./types"
+
+const GENERIC_MEDIA_TYPES = new Set(["application/octet-stream", "binary/octet-stream"])
+
+/** Classify only formats the in-app viewer intentionally supports. */
+export function agentDocumentKind(
+  mediaType: string | undefined,
+  fileName: string | undefined
+): AgentDocumentKind | null {
+  const normalizedType = mediaType?.split(";", 1)[0]?.trim().toLowerCase()
+  const fromType = normalizedType ? kindFromMediaType(normalizedType) : null
+  if (fromType) return fromType
+
+  if (normalizedType && !GENERIC_MEDIA_TYPES.has(normalizedType)) return null
+  return kindFromFileName(fileName)
+}
+
+function kindFromMediaType(mediaType: string): AgentDocumentKind | null {
+  switch (mediaType) {
+    case "text/markdown":
+      return "markdown"
+    case "text/html":
+    case "application/xhtml+xml":
+      return "html"
+    case "text/csv":
+      return "csv"
+    case "text/tab-separated-values":
+      return "tsv"
+    case "application/pdf":
+      return "pdf"
+    default:
+      return null
+  }
+}
+
+function kindFromFileName(fileName: string | undefined): AgentDocumentKind | null {
+  const normalized = fileName?.trim().toLowerCase()
+  if (!normalized) return null
+  if (normalized.endsWith(".markdown") || normalized.endsWith(".md")) return "markdown"
+  if (normalized.endsWith(".html") || normalized.endsWith(".htm")) return "html"
+  if (normalized.endsWith(".csv")) return "csv"
+  if (normalized.endsWith(".tsv")) return "tsv"
+  if (normalized.endsWith(".pdf")) return "pdf"
+  return null
+}

--- a/packages/agent-ui/src/document-preview/content-policy.ts
+++ b/packages/agent-ui/src/document-preview/content-policy.ts
@@ -1,0 +1,25 @@
+/**
+ * Keep preview policy separate from React Query. Bun's test loader shares resolver state with
+ * Atlas's in-process HTML bundler, so unit tests importing the hook module can corrupt bundling.
+ */
+import { isSixbApiError } from "@sixb/client"
+import type { AgentDocumentSource } from "./types"
+
+export const MAX_TEXT_PREVIEW_BYTES = 5 * 1024 * 1024
+export const MAX_MARKDOWN_PREVIEW_BYTES = MAX_TEXT_PREVIEW_BYTES
+
+export function textPreviewTooLarge(source: AgentDocumentSource): boolean {
+  return source.fileRef.sizeBytes > MAX_TEXT_PREVIEW_BYTES
+}
+
+export function markdownPreviewTooLarge(source: AgentDocumentSource): boolean {
+  return textPreviewTooLarge(source)
+}
+
+export function documentLoadError(error: unknown): string {
+  if (isSixbApiError(error)) {
+    if (error.status === 404) return "This document is no longer available."
+    if (error.status === 501) return "Document storage is not available."
+  }
+  return "Could not load this document."
+}

--- a/packages/agent-ui/src/document-preview/content.ts
+++ b/packages/agent-ui/src/document-preview/content.ts
@@ -1,17 +1,7 @@
-import { getAgentMessageFileContent, isSixbApiError } from "@sixb/client"
+import { getAgentMessageFileContent } from "@sixb/client"
 import { useQuery } from "@tanstack/react-query"
+import { documentLoadError, textPreviewTooLarge } from "./content-policy"
 import type { AgentDocumentSource } from "./types"
-
-export const MAX_TEXT_PREVIEW_BYTES = 5 * 1024 * 1024
-export const MAX_MARKDOWN_PREVIEW_BYTES = MAX_TEXT_PREVIEW_BYTES
-
-export function textPreviewTooLarge(source: AgentDocumentSource): boolean {
-  return source.fileRef.sizeBytes > MAX_TEXT_PREVIEW_BYTES
-}
-
-export function markdownPreviewTooLarge(source: AgentDocumentSource): boolean {
-  return textPreviewTooLarge(source)
-}
 
 export function useMarkdownDocument(source: AgentDocumentSource) {
   return useTextDocument(source)
@@ -55,12 +45,4 @@ function useTextDocument(source: AgentDocumentSource) {
     error: query.error ? documentLoadError(query.error) : null,
     tooLarge,
   }
-}
-
-export function documentLoadError(error: unknown): string {
-  if (isSixbApiError(error)) {
-    if (error.status === 404) return "This document is no longer available."
-    if (error.status === 501) return "Document storage is not available."
-  }
-  return "Could not load this document."
 }

--- a/packages/agent-ui/src/document-preview/content.ts
+++ b/packages/agent-ui/src/document-preview/content.ts
@@ -1,0 +1,66 @@
+import { getAgentMessageFileContent, isSixbApiError } from "@sixb/client"
+import { useQuery } from "@tanstack/react-query"
+import type { AgentDocumentSource } from "./types"
+
+export const MAX_TEXT_PREVIEW_BYTES = 5 * 1024 * 1024
+export const MAX_MARKDOWN_PREVIEW_BYTES = MAX_TEXT_PREVIEW_BYTES
+
+export function textPreviewTooLarge(source: AgentDocumentSource): boolean {
+  return source.fileRef.sizeBytes > MAX_TEXT_PREVIEW_BYTES
+}
+
+export function markdownPreviewTooLarge(source: AgentDocumentSource): boolean {
+  return textPreviewTooLarge(source)
+}
+
+export function useMarkdownDocument(source: AgentDocumentSource) {
+  return useTextDocument(source)
+}
+
+export function useHtmlDocument(source: AgentDocumentSource) {
+  return useTextDocument(source)
+}
+
+export function useDelimitedTextDocument(source: AgentDocumentSource) {
+  return useTextDocument(source)
+}
+
+function useTextDocument(source: AgentDocumentSource) {
+  const tooLarge = textPreviewTooLarge(source)
+  const query = useQuery({
+    queryKey: [
+      "agent-document-preview",
+      source.threadId,
+      source.messageId,
+      source.partIndex,
+      source.fileRef.digest,
+    ],
+    enabled: !tooLarge,
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: async ({ signal }) => {
+      const response = await getAgentMessageFileContent({
+        path: { threadId: source.threadId, messageId: source.messageId },
+        query: { path: `/parts/${source.partIndex}/fileRef`, disposition: "inline" },
+        parseAs: "blob",
+        throwOnError: true,
+        signal,
+      })
+      return response.data.text()
+    },
+  })
+
+  return {
+    text: query.data,
+    loading: query.isLoading,
+    error: query.error ? documentLoadError(query.error) : null,
+    tooLarge,
+  }
+}
+
+export function documentLoadError(error: unknown): string {
+  if (isSixbApiError(error)) {
+    if (error.status === 404) return "This document is no longer available."
+    if (error.status === 501) return "Document storage is not available."
+  }
+  return "Could not load this document."
+}

--- a/packages/agent-ui/src/document-preview/delimited.ts
+++ b/packages/agent-ui/src/document-preview/delimited.ts
@@ -1,0 +1,109 @@
+import Papa from "papaparse"
+import type { AgentDocumentKind } from "./types"
+
+// Keep the DOM bounded; larger files remain available through the viewer's download action.
+export const MAX_DELIMITED_PREVIEW_ROWS = 500
+export const MAX_DELIMITED_PREVIEW_COLUMNS = 50
+
+export interface DelimitedTextPreview {
+  readonly headers: readonly string[]
+  readonly rows: readonly (readonly string[])[]
+  readonly totalRows: number
+  readonly totalColumns: number
+  readonly rowsTruncated: boolean
+  readonly columnsTruncated: boolean
+}
+
+export class DelimitedTextParseError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DelimitedTextParseError"
+  }
+}
+
+export function parseDelimitedText(
+  source: string,
+  kind: Extract<AgentDocumentKind, "csv" | "tsv">
+): DelimitedTextPreview {
+  const normalized = source.startsWith("\uFEFF") ? source.slice(1) : source
+  if (!normalized.trim()) {
+    throw new DelimitedTextParseError("The file is empty.")
+  }
+
+  let headerRecord: string[] | null = null
+  let pendingRecord: string[] | null = null
+  let parseError: DelimitedTextParseError | null = null
+  let totalRows = 0
+  let totalColumns = 0
+  const previewRows: string[][] = []
+
+  const retainRecord = (record: string[]) => {
+    totalRows += 1
+    totalColumns = Math.max(totalColumns, record.length)
+    if (previewRows.length < MAX_DELIMITED_PREVIEW_ROWS) {
+      previewRows.push(record.slice(0, MAX_DELIMITED_PREVIEW_COLUMNS))
+    }
+  }
+
+  Papa.parse<string[]>(normalized, {
+    delimiter: kind === "tsv" ? "\t" : ",",
+    skipEmptyLines: false,
+    step: (result, parser) => {
+      const error = result.errors[0]
+      if (error) {
+        const row = error.row === undefined ? "" : ` near row ${totalRows + 2}`
+        parseError = new DelimitedTextParseError(
+          `The file contains malformed delimited text${row}.`
+        )
+        parser.abort()
+        return
+      }
+
+      const record = result.data
+      if (headerRecord === null) {
+        headerRecord = record.slice(0, MAX_DELIMITED_PREVIEW_COLUMNS)
+        totalColumns = record.length
+        return
+      }
+
+      // Hold one row back so a parser-generated empty record from a terminal line break can be
+      // discarded without retaining every row in memory.
+      if (pendingRecord !== null) retainRecord(pendingRecord)
+      pendingRecord = record
+    },
+  })
+
+  if (parseError) throw parseError
+  if (headerRecord === null) {
+    throw new DelimitedTextParseError("The file does not contain a header row.")
+  }
+  if (pendingRecord && !(endsWithLineBreak(normalized) && isEmptyRecord(pendingRecord))) {
+    retainRecord(pendingRecord)
+  }
+
+  const renderedColumns = Math.min(totalColumns, MAX_DELIMITED_PREVIEW_COLUMNS)
+  const headers = Array.from({ length: renderedColumns }, (_, index) => {
+    const value = headerRecord?.[index]?.trim()
+    return value || `Column ${index + 1}`
+  })
+  const rows = previewRows.map((record) =>
+    Array.from({ length: renderedColumns }, (_, index) => record[index] ?? "")
+  )
+
+  return {
+    headers,
+    rows,
+    totalRows,
+    totalColumns,
+    rowsTruncated: totalRows > rows.length,
+    columnsTruncated: totalColumns > headers.length,
+  }
+}
+
+function endsWithLineBreak(value: string): boolean {
+  return value.endsWith("\n") || value.endsWith("\r")
+}
+
+function isEmptyRecord(record: readonly string[]): boolean {
+  return record.every((value) => value === "")
+}

--- a/packages/agent-ui/src/document-preview/html.ts
+++ b/packages/agent-ui/src/document-preview/html.ts
@@ -1,0 +1,67 @@
+import { type DefaultTreeAdapterTypes, parse, serialize } from "parse5"
+
+const HTML_PREVIEW_CSP = [
+  "default-src 'none'",
+  "script-src 'none'",
+  "connect-src 'none'",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "style-src 'unsafe-inline'",
+  "img-src data: blob:",
+  "font-src data:",
+  "media-src data: blob:",
+  "base-uri 'none'",
+  "form-action 'none'",
+].join("; ")
+
+const NAVIGATION_ATTRIBUTES: Readonly<Record<string, ReadonlySet<string>>> = {
+  a: new Set(["href", "target", "ping", "download"]),
+  area: new Set(["href", "target", "ping", "download"]),
+  form: new Set(["action", "target"]),
+  button: new Set(["formaction", "formtarget"]),
+  input: new Set(["formaction", "formtarget"]),
+}
+
+/** An empty capability list applies every iframe sandbox restriction. */
+export const HTML_PREVIEW_SANDBOX = ""
+
+/**
+ * Parse without a browsing context, strip user-triggered navigation, and serialize a complete
+ * document. The policy metadata precedes every untrusted token, while parse5 lets this work for
+ * both fragments and full HTML without loading resources or executing scripts during preparation.
+ */
+export function buildSafeHtmlPreviewDocument(source: string): string {
+  const policyPrefix = `<!doctype html><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${HTML_PREVIEW_CSP}">`
+  const document = parse(`${policyPrefix}${source}`)
+  neutralizeNavigation(document)
+  return serialize(document)
+}
+
+function neutralizeNavigation(parent: DefaultTreeAdapterTypes.ParentNode): void {
+  parent.childNodes = parent.childNodes.filter((node) => !isNavigationalMetadata(node))
+
+  for (const node of parent.childNodes) {
+    if (!isElement(node)) continue
+
+    const blockedAttributes = NAVIGATION_ATTRIBUTES[node.tagName]
+    if (blockedAttributes) {
+      node.attrs = node.attrs.filter((attribute) => !blockedAttributes.has(attribute.name))
+    }
+    neutralizeNavigation(node)
+    if (node.tagName === "template" && "content" in node) neutralizeNavigation(node.content)
+  }
+}
+
+function isNavigationalMetadata(node: DefaultTreeAdapterTypes.ChildNode): boolean {
+  if (!isElement(node)) return false
+  if (node.tagName === "base") return true
+  if (node.tagName !== "meta") return false
+  const httpEquiv = node.attrs.find((attribute) => attribute.name === "http-equiv")
+  return httpEquiv?.value.trim().toLowerCase() === "refresh"
+}
+
+function isElement(
+  node: DefaultTreeAdapterTypes.ChildNode
+): node is DefaultTreeAdapterTypes.Element {
+  return "tagName" in node
+}

--- a/packages/agent-ui/src/document-preview/presentation.ts
+++ b/packages/agent-ui/src/document-preview/presentation.ts
@@ -1,0 +1,8 @@
+export type DocumentPreviewPresentation = "panel" | "dialog"
+
+export function documentPreviewPresentation(
+  compact: boolean,
+  isMobile: boolean
+): DocumentPreviewPresentation {
+  return compact || isMobile ? "dialog" : "panel"
+}

--- a/packages/agent-ui/src/document-preview/rendering.ts
+++ b/packages/agent-ui/src/document-preview/rendering.ts
@@ -1,0 +1,18 @@
+import type { AgentDocumentKind } from "./types"
+
+export type AgentDocumentPreviewRenderer =
+  | "markdown"
+  | "html-static"
+  | "delimited-text"
+  | "pdf-native"
+
+/** Keep attachment click behavior and viewer dispatch on one supported-format decision. */
+export function agentDocumentPreviewRenderer(
+  kind: AgentDocumentKind | null
+): AgentDocumentPreviewRenderer | null {
+  if (kind === "markdown") return "markdown"
+  if (kind === "html") return "html-static"
+  if (kind === "csv" || kind === "tsv") return "delimited-text"
+  if (kind === "pdf") return "pdf-native"
+  return null
+}

--- a/packages/agent-ui/src/document-preview/source.ts
+++ b/packages/agent-ui/src/document-preview/source.ts
@@ -1,0 +1,50 @@
+import { client } from "@sixb/client"
+import type { AgentFileRef } from "../types"
+import { agentDocumentKind } from "./classify"
+import type { AgentDocumentSource } from "./types"
+
+export interface CreateAgentDocumentSourceInput {
+  readonly threadId: string
+  readonly messageId: string
+  readonly partIndex: number
+  readonly fileRef: AgentFileRef
+  /** Explicit base URL for pure callers and tests. Defaults to the configured Sixb client URL. */
+  readonly baseUrl?: string
+}
+
+export function createAgentDocumentSource(
+  input: CreateAgentDocumentSourceInput
+): AgentDocumentSource {
+  return {
+    id: input.fileRef.blobId,
+    kind: agentDocumentKind(input.fileRef.mediaType, input.fileRef.fileName),
+    fileRef: input.fileRef,
+    threadId: input.threadId,
+    messageId: input.messageId,
+    partIndex: input.partIndex,
+    inlineUrl: agentMessageFileContentUrl(input, "inline"),
+    downloadUrl: agentMessageFileContentUrl(input, "attachment"),
+  }
+}
+
+function agentMessageFileContentUrl(
+  input: CreateAgentDocumentSourceInput,
+  disposition: "inline" | "attachment"
+): string {
+  const routePath = `/api/agent-threads/${encodeURIComponent(input.threadId)}/messages/${encodeURIComponent(
+    input.messageId
+  )}/files/content`
+  const params = new URLSearchParams({
+    path: `/parts/${input.partIndex}/fileRef`,
+    disposition,
+  })
+  const baseUrl = input.baseUrl ?? client.getConfig().baseUrl
+
+  if (!baseUrl && typeof window === "undefined") {
+    return `${routePath}?${params}`
+  }
+
+  const url = new URL(routePath, baseUrl ?? window.location.origin)
+  url.search = params.toString()
+  return url.toString()
+}

--- a/packages/agent-ui/src/document-preview/state.ts
+++ b/packages/agent-ui/src/document-preview/state.ts
@@ -1,0 +1,71 @@
+import type { AgentDocumentSource } from "./types"
+
+export interface DocumentPreviewState {
+  readonly documents: readonly AgentDocumentSource[]
+  readonly activeId: string | null
+}
+
+export type DocumentPreviewAction =
+  | { readonly type: "open"; readonly document: AgentDocumentSource }
+  | { readonly type: "select"; readonly id: string }
+  | { readonly type: "close"; readonly id: string }
+  | { readonly type: "close-all" }
+
+export type DocumentTabNavigationKey = "ArrowLeft" | "ArrowRight" | "Home" | "End"
+
+export const EMPTY_DOCUMENT_PREVIEW_STATE: DocumentPreviewState = {
+  documents: [],
+  activeId: null,
+}
+
+export function documentPreviewReducer(
+  state: DocumentPreviewState,
+  action: DocumentPreviewAction
+): DocumentPreviewState {
+  switch (action.type) {
+    case "open": {
+      const existing = state.documents.some((document) => document.id === action.document.id)
+      return {
+        documents: existing ? state.documents : [...state.documents, action.document],
+        activeId: action.document.id,
+      }
+    }
+    case "select":
+      return state.documents.some((document) => document.id === action.id)
+        ? { ...state, activeId: action.id }
+        : state
+    case "close":
+      return closeDocument(state, action.id)
+    case "close-all":
+      return EMPTY_DOCUMENT_PREVIEW_STATE
+    default:
+      action satisfies never
+      return state
+  }
+}
+
+export function documentTabIdAfterKey(
+  ids: readonly string[],
+  currentId: string,
+  key: DocumentTabNavigationKey
+): string | null {
+  if (ids.length === 0) return null
+  if (key === "Home") return ids[0] ?? null
+  if (key === "End") return ids.at(-1) ?? null
+
+  const currentIndex = ids.indexOf(currentId)
+  if (currentIndex === -1) return ids[0] ?? null
+  const offset = key === "ArrowRight" ? 1 : -1
+  return ids[(currentIndex + offset + ids.length) % ids.length] ?? null
+}
+
+function closeDocument(state: DocumentPreviewState, id: string): DocumentPreviewState {
+  const closedIndex = state.documents.findIndex((document) => document.id === id)
+  if (closedIndex === -1) return state
+
+  const documents = state.documents.filter((document) => document.id !== id)
+  if (state.activeId !== id) return { documents, activeId: state.activeId }
+
+  const nextActive = documents[closedIndex] ?? documents[closedIndex - 1]
+  return { documents, activeId: nextActive?.id ?? null }
+}

--- a/packages/agent-ui/src/document-preview/types.ts
+++ b/packages/agent-ui/src/document-preview/types.ts
@@ -1,0 +1,15 @@
+import type { AgentFileRef } from "../types"
+
+export type AgentDocumentKind = "markdown" | "html" | "csv" | "tsv" | "pdf"
+
+/** A file part tied to the durable message route that authorizes reading its bytes. */
+export interface AgentDocumentSource {
+  readonly id: string
+  readonly kind: AgentDocumentKind | null
+  readonly fileRef: AgentFileRef
+  readonly threadId: string
+  readonly messageId: string
+  readonly partIndex: number
+  readonly inlineUrl: string
+  readonly downloadUrl: string
+}

--- a/packages/agent-ui/src/parts.ts
+++ b/packages/agent-ui/src/parts.ts
@@ -1,3 +1,4 @@
+import type { AgentDocumentSource } from "./document-preview/types"
 import type { AgentMessagePart } from "./types"
 
 // The render-ready vocabulary shared by the durable transcript and the live streaming row.
@@ -19,13 +20,13 @@ export type NormalizedPart =
   | {
       readonly kind: "file"
       readonly fileRef: Extract<AgentMessagePart, { type: "file" }>["fileRef"]
-      readonly href?: string
+      readonly document?: AgentDocumentSource
     }
   | { readonly kind: "step-start" }
 
 export function normalizeDurableParts(
   parts: readonly AgentMessagePart[],
-  options: { readonly fileHref?: (partIndex: number) => string | undefined } = {}
+  options: { readonly fileSource?: (partIndex: number) => AgentDocumentSource | undefined } = {}
 ): NormalizedPart[] {
   // Context is rendered separately with the user message. It is invalid on assistant messages,
   // but filtering keeps old or malformed durable data from turning into a fake step boundary.
@@ -60,7 +61,7 @@ export function normalizeDurableParts(
           {
             kind: "file",
             fileRef: part.fileRef,
-            ...(options.fileHref === undefined ? {} : { href: options.fileHref(index) }),
+            ...(options.fileSource === undefined ? {} : { document: options.fileSource(index) }),
           },
         ]
       case "step-start":

--- a/packages/agent-ui/tests/document-preview.test.ts
+++ b/packages/agent-ui/tests/document-preview.test.ts
@@ -5,7 +5,7 @@ import {
   documentLoadError,
   MAX_MARKDOWN_PREVIEW_BYTES,
   markdownPreviewTooLarge,
-} from "../src/document-preview/content"
+} from "../src/document-preview/content-policy"
 import {
   DelimitedTextParseError,
   MAX_DELIMITED_PREVIEW_COLUMNS,

--- a/packages/agent-ui/tests/document-preview.test.ts
+++ b/packages/agent-ui/tests/document-preview.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, test } from "bun:test"
+import { SixbApiError } from "@sixb/client"
+import { agentDocumentKind } from "../src/document-preview/classify"
+import {
+  documentLoadError,
+  MAX_MARKDOWN_PREVIEW_BYTES,
+  markdownPreviewTooLarge,
+} from "../src/document-preview/content"
+import {
+  DelimitedTextParseError,
+  MAX_DELIMITED_PREVIEW_COLUMNS,
+  MAX_DELIMITED_PREVIEW_ROWS,
+  parseDelimitedText,
+} from "../src/document-preview/delimited"
+import { buildSafeHtmlPreviewDocument, HTML_PREVIEW_SANDBOX } from "../src/document-preview/html"
+import { documentPreviewPresentation } from "../src/document-preview/presentation"
+import { agentDocumentPreviewRenderer } from "../src/document-preview/rendering"
+import { createAgentDocumentSource } from "../src/document-preview/source"
+import {
+  documentPreviewReducer,
+  documentTabIdAfterKey,
+  EMPTY_DOCUMENT_PREVIEW_STATE,
+} from "../src/document-preview/state"
+import type { AgentDocumentSource } from "../src/document-preview/types"
+import type { AgentFileRef } from "../src/types"
+
+const MARKDOWN_FILE: AgentFileRef = {
+  blobId: `blob_${"a".repeat(64)}`,
+  digest: `sha256:${"a".repeat(64)}`,
+  sizeBytes: 128,
+  fileName: "report.md",
+  mediaType: "text/markdown",
+}
+
+describe("agent document classification", () => {
+  test("recognizes supported MIME types and ignores parameters", () => {
+    expect(agentDocumentKind("text/markdown; charset=utf-8", "report.bin")).toBe("markdown")
+    expect(agentDocumentKind("text/html", "page.bin")).toBe("html")
+    expect(agentDocumentKind("text/csv", "rows.bin")).toBe("csv")
+    expect(agentDocumentKind("text/tab-separated-values", "rows.bin")).toBe("tsv")
+    expect(agentDocumentKind("application/pdf", "report.bin")).toBe("pdf")
+  })
+
+  test("uses extensions only for missing or generic media metadata", () => {
+    expect(agentDocumentKind(undefined, "REPORT.MD")).toBe("markdown")
+    expect(agentDocumentKind("application/octet-stream", "report.pdf")).toBe("pdf")
+    expect(agentDocumentKind("image/png", "not-really.md")).toBeNull()
+    expect(agentDocumentKind(undefined, "workbook.xlsx")).toBeNull()
+  })
+})
+
+describe("agent document source", () => {
+  test("builds contextual inline and attachment URLs", () => {
+    const source = createAgentDocumentSource({
+      threadId: "thread/1",
+      messageId: "message 1",
+      partIndex: 2,
+      fileRef: MARKDOWN_FILE,
+      baseUrl: "https://example.test",
+    })
+
+    expect(source.kind).toBe("markdown")
+    expect(source.id).toBe(MARKDOWN_FILE.blobId)
+    expect(source.inlineUrl).toBe(
+      "https://example.test/api/agent-threads/thread%2F1/messages/message%201/files/content?path=%2Fparts%2F2%2FfileRef&disposition=inline"
+    )
+    expect(source.downloadUrl).toContain("disposition=attachment")
+  })
+
+  test("keeps a source for unsupported files so browser fallback remains available", () => {
+    const source = createAgentDocumentSource({
+      threadId: "thread-1",
+      messageId: "message-1",
+      partIndex: 0,
+      fileRef: { ...MARKDOWN_FILE, fileName: "archive.zip", mediaType: "application/zip" },
+      baseUrl: "https://example.test",
+    })
+
+    expect(source.kind).toBeNull()
+    expect(source.inlineUrl).toContain("disposition=inline")
+  })
+})
+
+describe("document preview rendering", () => {
+  test("uses the native browser path for PDFs without selecting the text loader", () => {
+    expect(agentDocumentPreviewRenderer("markdown")).toBe("markdown")
+    expect(agentDocumentPreviewRenderer("pdf")).toBe("pdf-native")
+    expect(agentDocumentPreviewRenderer("html")).toBe("html-static")
+    expect(agentDocumentPreviewRenderer("csv")).toBe("delimited-text")
+    expect(agentDocumentPreviewRenderer("tsv")).toBe("delimited-text")
+    expect(agentDocumentPreviewRenderer(null)).toBeNull()
+  })
+})
+
+describe("delimited text preview", () => {
+  test("parses CSV quoting, escaped quotes, CRLF, multiline cells, BOM, and blank headers", () => {
+    const preview = parseDelimitedText(
+      '\uFEFFname,,note\r\nAlice,42,"hello, world"\r\nBob,,"line 1\nline 2"\r\nEve,7,"said ""hi"""\r\n',
+      "csv"
+    )
+
+    expect(preview.headers).toEqual(["name", "Column 2", "note"])
+    expect(preview.rows).toEqual([
+      ["Alice", "42", "hello, world"],
+      ["Bob", "", "line 1\nline 2"],
+      ["Eve", "7", 'said "hi"'],
+    ])
+    expect(preview.totalRows).toBe(3)
+    expect(preview.rowsTruncated).toBe(false)
+  })
+
+  test("parses TSV with an explicit tab delimiter", () => {
+    const preview = parseDelimitedText('name\tnote\nAda\t"one\ttwo"', "tsv")
+    expect(preview.headers).toEqual(["name", "note"])
+    expect(preview.rows).toEqual([["Ada", "one\ttwo"]])
+  })
+
+  test("normalizes uneven rows without dropping additional columns", () => {
+    const preview = parseDelimitedText("a,b\n1\n2,3,4", "csv")
+    expect(preview.headers).toEqual(["a", "b", "Column 3"])
+    expect(preview.rows).toEqual([
+      ["1", "", ""],
+      ["2", "3", "4"],
+    ])
+  })
+
+  test("rejects empty and malformed files", () => {
+    expect(() => parseDelimitedText("  \n", "csv")).toThrow(DelimitedTextParseError)
+    expect(() => parseDelimitedText('a,b\n"unterminated', "csv")).toThrow(
+      "malformed delimited text near row 2"
+    )
+  })
+
+  test("counts a large row stream while retaining only the bounded preview", () => {
+    const rowCount = 20_000
+    const preview = parseDelimitedText(`value\n${"x\n".repeat(rowCount)}`, "csv")
+
+    expect(preview.totalRows).toBe(rowCount)
+    expect(preview.rows).toHaveLength(MAX_DELIMITED_PREVIEW_ROWS)
+    expect(preview.rowsTruncated).toBe(true)
+  })
+
+  test("caps rendered rows and columns while retaining the source dimensions", () => {
+    const headers = Array.from(
+      { length: MAX_DELIMITED_PREVIEW_COLUMNS + 1 },
+      (_, index) => `column-${index + 1}`
+    )
+    const rows = Array.from(
+      { length: MAX_DELIMITED_PREVIEW_ROWS + 1 },
+      (_, index) => `${index},value`
+    )
+    const preview = parseDelimitedText(`${headers.join(",")}\n${rows.join("\n")}`, "csv")
+
+    expect(preview.headers).toHaveLength(MAX_DELIMITED_PREVIEW_COLUMNS)
+    expect(preview.rows).toHaveLength(MAX_DELIMITED_PREVIEW_ROWS)
+    expect(preview.totalColumns).toBe(MAX_DELIMITED_PREVIEW_COLUMNS + 1)
+    expect(preview.totalRows).toBe(MAX_DELIMITED_PREVIEW_ROWS + 1)
+    expect(preview.columnsTruncated).toBe(true)
+    expect(preview.rowsTruncated).toBe(true)
+  })
+})
+
+describe("safe HTML preview", () => {
+  test("places a restrictive CSP before untrusted document content", () => {
+    const source = '<script src="https://example.test/tracker.js"></script><h1>Report</h1>'
+    const document = buildSafeHtmlPreviewDocument(source)
+
+    expect(document.indexOf("Content-Security-Policy")).toBeLessThan(document.indexOf("<script"))
+    expect(document).toContain("<h1>Report</h1>")
+    expect(document).toContain("default-src 'none'")
+    expect(document).toContain("script-src 'none'")
+    expect(document).toContain("connect-src 'none'")
+    expect(document).toContain("base-uri 'none'")
+    expect(document).toContain("form-action 'none'")
+    expect(HTML_PREVIEW_SANDBOX).toBe("")
+  })
+
+  test("neutralizes links, image-map areas, form targets, bases, and refresh navigation", () => {
+    const document = buildSafeHtmlPreviewDocument(`
+      <base href="https://base.example/">
+      <meta http-equiv="refresh" content="0;url=https://refresh.example/">
+      <a href="https://link.example/" target="_self" ping="https://ping.example/">Leave</a>
+      <map><area href="https://area.example/" target="_top"></map>
+      <form action="https://form.example/" target="_self">
+        <button formaction="https://button.example/">Submit</button>
+      </form>
+      <svg><a xlink:href="https://svg.example/"><text>SVG link</text></a></svg>
+    `)
+
+    expect(document).not.toContain("https://base.example/")
+    expect(document).not.toContain("https://refresh.example/")
+    expect(document).not.toContain("https://link.example/")
+    expect(document).not.toContain("https://ping.example/")
+    expect(document).not.toContain("https://area.example/")
+    expect(document).not.toContain("https://form.example/")
+    expect(document).not.toContain("https://button.example/")
+    expect(document).not.toContain("https://svg.example/")
+    expect(document).toContain("<a>Leave</a>")
+    expect(document).toContain("<button>Submit</button>")
+  })
+
+  test("normalizes both fragments and full documents", () => {
+    const safeFragment = buildSafeHtmlPreviewDocument("<main>Fragment</main>")
+    const safeFullDocument = buildSafeHtmlPreviewDocument(
+      "<!doctype html><html><body>Full</body></html>"
+    )
+
+    expect(safeFragment).toContain("<body><main>Fragment</main></body>")
+    expect(safeFullDocument).toContain("<body>Full</body>")
+    expect(safeFragment.match(/Content-Security-Policy/g)).toHaveLength(1)
+    expect(safeFullDocument.match(/Content-Security-Policy/g)).toHaveLength(1)
+  })
+})
+
+describe("document preview presentation", () => {
+  test("uses the side panel only for full-page desktop chat", () => {
+    expect(documentPreviewPresentation(false, false)).toBe("panel")
+    expect(documentPreviewPresentation(false, true)).toBe("dialog")
+    expect(documentPreviewPresentation(true, false)).toBe("dialog")
+    expect(documentPreviewPresentation(true, true)).toBe("dialog")
+  })
+})
+
+describe("document preview tabs", () => {
+  test("supports wrapped arrow navigation and Home/End keys", () => {
+    const ids = ["first", "second", "third"]
+    expect(documentTabIdAfterKey(ids, "first", "ArrowRight")).toBe("second")
+    expect(documentTabIdAfterKey(ids, "third", "ArrowRight")).toBe("first")
+    expect(documentTabIdAfterKey(ids, "first", "ArrowLeft")).toBe("third")
+    expect(documentTabIdAfterKey(ids, "second", "Home")).toBe("first")
+    expect(documentTabIdAfterKey(ids, "second", "End")).toBe("third")
+    expect(documentTabIdAfterKey([], "first", "End")).toBeNull()
+  })
+
+  test("opens, selects, de-duplicates, and closes documents predictably", () => {
+    const first = document("first", "first.md")
+    const second = document("second", "second.md")
+    let state = documentPreviewReducer(EMPTY_DOCUMENT_PREVIEW_STATE, {
+      type: "open",
+      document: first,
+    })
+    state = documentPreviewReducer(state, { type: "open", document: second })
+    state = documentPreviewReducer(state, { type: "open", document: first })
+
+    expect(state.documents.map((item) => item.id)).toEqual(["first", "second"])
+    expect(state.activeId).toBe("first")
+
+    state = documentPreviewReducer(state, { type: "close", id: "first" })
+    expect(state.documents.map((item) => item.id)).toEqual(["second"])
+    expect(state.activeId).toBe("second")
+
+    state = documentPreviewReducer(state, { type: "close", id: "second" })
+    expect(state).toEqual(EMPTY_DOCUMENT_PREVIEW_STATE)
+  })
+
+  test("keeps the active tab when closing a background document", () => {
+    const first = document("first", "first.md")
+    const second = document("second", "second.md")
+    let state = documentPreviewReducer(EMPTY_DOCUMENT_PREVIEW_STATE, {
+      type: "open",
+      document: first,
+    })
+    state = documentPreviewReducer(state, { type: "open", document: second })
+    state = documentPreviewReducer(state, { type: "close", id: "first" })
+
+    expect(state.activeId).toBe("second")
+  })
+})
+
+describe("Markdown document loading policy", () => {
+  test("rejects oversized Markdown before loading it", () => {
+    expect(markdownPreviewTooLarge(document("small", "small.md"))).toBe(false)
+    expect(
+      markdownPreviewTooLarge({
+        ...document("large", "large.md"),
+        fileRef: { ...MARKDOWN_FILE, sizeBytes: MAX_MARKDOWN_PREVIEW_BYTES + 1 },
+      })
+    ).toBe(true)
+  })
+
+  test("normalizes expected API errors", () => {
+    expect(documentLoadError(new SixbApiError("missing", { status: 404 }))).toBe(
+      "This document is no longer available."
+    )
+    expect(documentLoadError(new SixbApiError("missing storage", { status: 501 }))).toBe(
+      "Document storage is not available."
+    )
+    expect(documentLoadError(new Error("network details"))).toBe("Could not load this document.")
+  })
+})
+
+function document(id: string, fileName: string): AgentDocumentSource {
+  return {
+    id,
+    kind: "markdown",
+    fileRef: { ...MARKDOWN_FILE, blobId: id, fileName },
+    threadId: "thread-1",
+    messageId: `message-${id}`,
+    partIndex: 0,
+    inlineUrl: `https://example.test/${id}`,
+    downloadUrl: `https://example.test/${id}?disposition=attachment`,
+  }
+}


### PR DESCRIPTION
## Summary

Agent conversations can produce useful documents, but file cards previously sent users to a raw browser tab or download. This adds a built-in document workspace so users can inspect generated files without leaving the conversation.

The same preview system now serves both agent UI modes:

```text
Desktop AgentChatPage:  [ conversation ] | [ resizable document workspace ]
AgentPanel / mobile:     [ conversation ] + [ responsive preview dialog ]
```

The viewer supports Markdown, HTML, CSV/TSV, and PDF. Multiple documents can remain open in tabs, and unsupported formats retain the existing browser behavior.

## Linked issue

Closes #348.

## Scope

This change is contained in `@sixb/agent-ui`. It uses the existing contextual agent-message file route and does not change server routes, OpenAPI, generated client contracts, or public agent UI props.

Durable user and assistant file parts are converted into an internal document source:

```text
message file part
  -> authorized thread/message/part content URL
  -> media type + filename classification
  -> local preview tab state
  -> format-specific renderer
```

Pending uploads and live output remain non-previewable until the durable message exists, because that message is the authorization context for reading the file.

### Viewer experience

- Desktop full-page chat opens a resizable right pane at roughly half width.
- Compact `AgentPanel` and mobile chat use a large responsive dialog.
- Tabs de-duplicate by content-addressed blob id and remain local to the mounted chat.
- The conversation subtree stays mounted while the desktop pane opens and closes, preserving transcript position, drafts, and live runs.
- The divider and tabs use quiet, integrated header styling rather than floating cards.
- Open, download, close, loading, size-limit, and parse-error states are included.

### Format behavior

```text
Markdown -> authenticated text load -> shared Sixb Markdown renderer
HTML     -> inert parse -> navigation removal -> restrictive CSP -> sandboxed srcDoc
CSV/TSV  -> authenticated text load -> streaming Papa Parse -> bounded semantic table
PDF      -> authorized inline URL -> native browser PDF viewer with range support
```

Markdown and HTML text previews are limited to 5 MB.

CSV/TSV rendering is bounded to 500 rows and 50 columns. Papa Parse uses its streaming `step` callback to count the complete input while retaining only the preview rows and one pending row, avoiding a second full in-memory copy for dense files.

HTML is parsed with `parse5` before rendering. Links, image-map areas, form targets, `<base>`, and meta-refresh navigation are neutralized. The resulting document is then rendered with:

```html
<iframe sandbox="" referrerpolicy="no-referrer" srcdoc="..." />
```

The injected CSP blocks scripts, connections, nested frames, objects, forms, base URLs, and network subresources. The iframe receives neither `allow-scripts` nor `allow-same-origin`.

### Accessibility

Document tabs implement roving keyboard focus and proper tab/tabpanel relationships.

```text
Left / Right Arrow  switch tabs
Home / End          jump to first or last tab
Delete / Backspace  close the focused tab
```

The active tab scrolls into view when many documents are open. Opening the desktop viewer moves focus to the active document tab, and closing the final document restores focus to the attachment that opened it.

## Validation

```bash
bun test packages/agent-ui/tests/
bun test packages/atlas/tests/atlas-app.test.ts
bun run typecheck
bun run build
bun run check
bun run test:publish
```

Results:

- 81 agent UI tests pass.
- Atlas integration tests pass.
- Full repository typecheck and build pass.
- Biome passes.
- Publish boundary verification passes for all 47 publishable packages.

## Notes

- `papaparse` is a runtime dependency for standards-aware CSV/TSV parsing.
- `parse5` is a runtime dependency for inert, structural HTML navigation removal.
- XLS/XLSX, images, and other unsupported formats intentionally keep their existing browser open/download behavior.
- No generated client update is required because the existing agent-message content endpoint is reused unchanged.
