### PR TITLE
projection-worker: replace permanent error class

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -40,8 +40,13 @@ Each storage and wire change remains independently reviewable even though every 
 | Code | Retryable | What happened | What to do |
 | --- | --- | --- | --- |
 | `dataset.not_found` | No | The requested dataset is not registered or is not visible to the caller. | Check the dataset ID and the caller's access. |
+| `dataset.version_incompatible` | No | The immutable dataset version does not match the dataset or schema required by the operation. | Materialize a compatible version and dispatch a new run. |
 | `dataset.version_not_found` | No | The requested dataset version does not exist, or the dataset has no committed version yet. | Check the version ID or materialize the dataset before reading rows. |
 | `dataset.version_read_inconsistent` | Yes | Read results conflict with immutable version metadata. | Retry, then inspect lake storage integrity. |
 | `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect internal logs. Do not retry automatically. |
 | `queue.enqueue_failed` | Yes | A job could not be handed to its queue. | Retry the unchanged request while the durable run remains in its enqueue phase. |
+| `projection.definition_invalid` | No | A projection definition is incompatible with its ontology or dataset mapping. | Fix the projection definition and dispatch a new run. |
+| `projection.not_found` | No | The requested projection is not registered in the current runtime. | Check the projection ID and ensure its definition is deployed. |
+| `projection.run_already_terminal` | No | A delivery targeted a projection run that had already failed or been cancelled. | Do not reuse the terminal run ID; dispatch a new semantic run if needed. |
+| `projection.run_identity_mismatch` | No | A projection run or delivery does not match its pinned semantic identity. | Discard the stale delivery and dispatch from the current projection definition. |
 | `runtime.cancelled` | No | An in-flight operation was cancelled before completion. | Confirm the cancellation was intentional before requesting another run. |

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -14,6 +14,10 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "Dataset not found.",
     retryable: false,
   },
+  "dataset.version_incompatible": {
+    publicMessage: "Dataset version is incompatible.",
+    retryable: false,
+  },
   "dataset.version_not_found": {
     publicMessage: "Dataset version not found.",
     retryable: false,
@@ -29,6 +33,22 @@ export const SIXB_ERROR_DEFINITIONS = {
   "queue.enqueue_failed": {
     publicMessage: "The job could not be enqueued.",
     retryable: true,
+  },
+  "projection.definition_invalid": {
+    publicMessage: "Projection definition is invalid.",
+    retryable: false,
+  },
+  "projection.not_found": {
+    publicMessage: "Projection not found.",
+    retryable: false,
+  },
+  "projection.run_already_terminal": {
+    publicMessage: "Projection run is already terminal.",
+    retryable: false,
+  },
+  "projection.run_identity_mismatch": {
+    publicMessage: "Projection run identity does not match the queued job.",
+    retryable: false,
   },
   "runtime.cancelled": {
     publicMessage: "Execution was cancelled.",

--- a/packages/projection-worker/src/errors.ts
+++ b/packages/projection-worker/src/errors.ts
@@ -1,9 +1,0 @@
-/**
- * A deterministic input/configuration failure that cannot succeed on queue redelivery.
- *
- * Temporary control-flow bridge: remove this class once Projection has precise non-retryable
- * error codes and its fail/retry policy can branch on those codes instead of `instanceof`.
- */
-export class ProjectionWorkerPermanentError extends Error {
-  override readonly name = "ProjectionWorkerPermanentError"
-}

--- a/packages/projection-worker/src/identity-mismatch.ts
+++ b/packages/projection-worker/src/identity-mismatch.ts
@@ -1,0 +1,12 @@
+type IdentityMismatchCandidate = {
+  readonly field: string
+  readonly expected: string
+  readonly actual: string
+}
+
+/** Keeps identity failures actionable without repeating every matching identity field. */
+export function collectIdentityMismatches(
+  candidates: readonly IdentityMismatchCandidate[]
+): readonly IdentityMismatchCandidate[] {
+  return candidates.filter(({ expected, actual }) => expected !== actual)
+}

--- a/packages/projection-worker/src/job-validation.ts
+++ b/packages/projection-worker/src/job-validation.ts
@@ -7,6 +7,7 @@ import type {
   ProjectionDefinition,
   TelemetryProjectionDefinition,
 } from "@sixb/core"
+import { createSixbError, isSixbError } from "@sixb/core/internal/errors"
 import {
   createProjectionRunId,
   getProjectionRegistry,
@@ -14,7 +15,7 @@ import {
   projectionTargetOf,
 } from "@sixb/core/internal/projections"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
-import { ProjectionWorkerPermanentError } from "./errors"
+import { collectIdentityMismatches } from "./identity-mismatch"
 import {
   assertDatasetVersionMatchesDefinition,
   assertProjectionCompatibleWithDataset,
@@ -65,14 +66,14 @@ export async function validateProjectionJob(
   job: ProjectionJob
 ): Promise<ValidatedProjectionJob> {
   const registry = getProjectionRegistry(runtime)
-  const descriptor = resolveDescriptor(registry, job.projectionId)
+  const descriptor = resolveDescriptor(registry, job)
   assertDescriptorMatchesJob(descriptor, job)
 
-  const projection = requireProjection(runtime, job.projectionId)
-  const dataset = requireDataset(runtime, job.datasetVersion.datasetId)
+  const projection = requireProjection(runtime, job)
+  const dataset = requireDataset(runtime, job)
   const version = await requirePinnedVersion(runtime, job)
 
-  validatePinnedSchema({ runtime, projection, dataset, version })
+  validatePinnedSchema({ runtime, job, projection, dataset, version })
 
   return correlateValidatedProjection({ job, projection, dataset, version })
 }
@@ -82,7 +83,9 @@ function correlateValidatedProjection(
 ): ValidatedProjectionJob {
   switch (input.projection._tag) {
     case "ObjectProjectionDefinition":
-      if (input.job.projectionKind !== "object") throw invalidProjectionKind(input.job)
+      if (input.job.projectionKind !== "object") {
+        throw invalidProjectionKind(input.job, "object")
+      }
       return {
         ...input,
         kind: "object",
@@ -91,7 +94,9 @@ function correlateValidatedProjection(
         target: projectionTargetOf(input.projection),
       }
     case "LinkProjectionDefinition":
-      if (input.job.projectionKind !== "link") throw invalidProjectionKind(input.job)
+      if (input.job.projectionKind !== "link") {
+        throw invalidProjectionKind(input.job, "link")
+      }
       return {
         ...input,
         kind: "link",
@@ -100,7 +105,9 @@ function correlateValidatedProjection(
         target: projectionTargetOf(input.projection),
       }
     case "TelemetryProjectionDefinition":
-      if (input.job.projectionKind !== "telemetry") throw invalidProjectionKind(input.job)
+      if (input.job.projectionKind !== "telemetry") {
+        throw invalidProjectionKind(input.job, "telemetry")
+      }
       return {
         ...input,
         kind: "telemetry",
@@ -111,26 +118,63 @@ function correlateValidatedProjection(
   }
 }
 
-function invalidProjectionKind(job: ProjectionJob): ProjectionWorkerPermanentError {
-  return permanent(
-    `Projection '${job.projectionId}' does not match queued kind '${job.projectionKind}'.`
+function invalidProjectionKind(
+  job: ProjectionJob,
+  expectedProjectionKind: ProjectionJob["projectionKind"]
+) {
+  return createSixbError(
+    "projection.run_identity_mismatch",
+    `[SixbProjectionWorker] Projection '${job.projectionId}' does not match queued kind '${job.projectionKind}'.`,
+    {
+      details: {
+        ...projectionRunContext(job),
+        identityMismatches: collectIdentityMismatches([
+          {
+            field: "projectionKind",
+            expected: expectedProjectionKind,
+            actual: job.projectionKind,
+          },
+        ]),
+      },
+    }
   )
 }
 
 function validatePinnedSchema(input: {
   readonly runtime: ProjectionWorkerContext
+  readonly job: ProjectionJob
   readonly projection: ProjectionDefinition
   readonly dataset: DatasetDefinition
   readonly version: DatasetVersion
 }): void {
   try {
-    assertDatasetVersionMatchesDefinition(input)
-    assertProjectionCompatibleWithDataset({ ...input, ontology: input.runtime.ontology })
+    const runId = input.job.id
+    const validationInput = {
+      projection: input.projection,
+      dataset: input.dataset,
+      version: input.version,
+      runId,
+    }
+    assertDatasetVersionMatchesDefinition(validationInput)
+    assertProjectionCompatibleWithDataset({
+      ...validationInput,
+      ontology: input.runtime.ontology,
+    })
   } catch (error) {
-    if (error instanceof ProjectionWorkerPermanentError) throw error
-    throw permanent(
-      `Projection '${input.projection.id}' is incompatible with its pinned dataset version: ${errorMessage(error)}`,
-      error
+    if (
+      isSixbError(error) &&
+      (error.code === "dataset.version_incompatible" ||
+        error.code === "projection.definition_invalid")
+    ) {
+      throw error
+    }
+    throw createSixbError(
+      "projection.definition_invalid",
+      `[SixbProjectionWorker] Projection '${input.projection.id}' is incompatible with its pinned dataset version: ${errorMessage(error)}`,
+      {
+        cause: error,
+        details: projectionJobContext(input.job),
+      }
     )
   }
 }
@@ -138,17 +182,32 @@ function validatePinnedSchema(input: {
 export function assertProjectionJobId(projectId: string, job: ProjectionJob): void {
   const expected = createProjectionRunId(projectId, job)
   if (job.id === expected) return
-  throw permanent(`Projection job id '${job.id}' does not match its pinned semantic identity.`)
+  throw createSixbError(
+    "projection.run_identity_mismatch",
+    `[SixbProjectionWorker] Projection job id '${job.id}' does not match its pinned semantic identity.`,
+    {
+      details: {
+        ...projectionRunContext(job),
+        identityMismatches: collectIdentityMismatches([
+          { field: "runId", expected, actual: job.id },
+        ]),
+      },
+    }
+  )
 }
 
 function resolveDescriptor(
   registry: ReturnType<typeof getProjectionRegistry>,
-  projectionId: string
+  job: ProjectionJob
 ): ProjectionDispatchDescriptor {
   try {
-    return registry.resolveDispatch(projectionId)
+    return registry.resolveDispatch(job.projectionId)
   } catch (error) {
-    throw permanent(`Projection '${projectionId}' is not registered.`, error)
+    throw createSixbError(
+      "projection.not_found",
+      `[SixbProjectionWorker] Projection '${job.projectionId}' is not registered.`,
+      { cause: error, details: projectionJobContext(job) }
+    )
   }
 }
 
@@ -156,31 +215,71 @@ function assertDescriptorMatchesJob(
   descriptor: ProjectionDispatchDescriptor,
   job: ProjectionJob
 ): void {
-  const matches =
-    descriptor.projectionId === job.projectionId &&
-    descriptor.projectionKind === job.projectionKind &&
-    descriptor.protocol === job.protocol &&
-    descriptor.datasetId === job.datasetVersion.datasetId &&
-    descriptor.ontologyRevision === job.ontologyRevision &&
-    descriptor.projectionRevision === job.projectionRevision &&
-    descriptor.ownershipHash === job.ownershipHash
-
-  if (matches) return
-  throw permanent(
-    `Projection '${job.projectionId}' no longer matches the queued semantic identity.`
+  const identityMismatches = collectIdentityMismatches([
+    {
+      field: "projectionId",
+      expected: job.projectionId,
+      actual: descriptor.projectionId,
+    },
+    {
+      field: "projectionKind",
+      expected: job.projectionKind,
+      actual: descriptor.projectionKind,
+    },
+    { field: "protocol", expected: job.protocol, actual: descriptor.protocol },
+    {
+      field: "datasetId",
+      expected: job.datasetVersion.datasetId,
+      actual: descriptor.datasetId,
+    },
+    {
+      field: "ontologyRevision",
+      expected: job.ontologyRevision,
+      actual: descriptor.ontologyRevision,
+    },
+    {
+      field: "projectionRevision",
+      expected: job.projectionRevision,
+      actual: descriptor.projectionRevision,
+    },
+    {
+      field: "ownershipHash",
+      expected: job.ownershipHash,
+      actual: descriptor.ownershipHash,
+    },
+  ])
+  if (identityMismatches.length === 0) return
+  throw createSixbError(
+    "projection.run_identity_mismatch",
+    `[SixbProjectionWorker] Projection '${job.projectionId}' no longer matches the queued semantic identity.`,
+    {
+      details: {
+        ...projectionRunContext(job),
+        identityMismatches,
+      },
+    }
   )
 }
 
-function requireProjection(runtime: ProjectionWorkerContext, projectionId: string) {
-  const projection = runtime.projections.getById(projectionId)
+function requireProjection(runtime: ProjectionWorkerContext, job: ProjectionJob) {
+  const projection = runtime.projections.getById(job.projectionId)
   if (projection) return projection
-  throw permanent(`Projection '${projectionId}' is not registered.`)
+  throw createSixbError(
+    "projection.not_found",
+    `[SixbProjectionWorker] Projection '${job.projectionId}' is not registered.`,
+    { details: projectionJobContext(job) }
+  )
 }
 
-function requireDataset(runtime: ProjectionWorkerContext, datasetId: string) {
+function requireDataset(runtime: ProjectionWorkerContext, job: ProjectionJob) {
+  const datasetId = job.datasetVersion.datasetId
   const dataset = runtime.datasets.getById(datasetId)
   if (dataset) return dataset
-  throw permanent(`Projection references unknown dataset '${datasetId}'.`)
+  throw createSixbError(
+    "dataset.not_found",
+    `[SixbProjectionWorker] Projection references unknown dataset '${datasetId}'.`,
+    { details: { ...projectionJobContext(job), source: "runtime" } }
+  )
 }
 
 async function requirePinnedVersion(
@@ -193,21 +292,56 @@ async function requirePinnedVersion(
     runtime.lakeStorage.getVersion(datasetId, versionId),
   ])
   if (!lakeDataset) {
-    throw permanent(`Dataset '${datasetId}' is not registered in lake storage.`)
+    throw createSixbError(
+      "dataset.not_found",
+      `[SixbProjectionWorker] Dataset '${datasetId}' is not registered in lake storage.`,
+      { details: { ...projectionJobContext(job), source: "lake-storage" } }
+    )
   }
   if (!version) {
-    throw permanent(`Dataset '${datasetId}' version '${versionId}' was not found.`)
+    throw createSixbError(
+      "dataset.version_not_found",
+      `[SixbProjectionWorker] Dataset '${datasetId}' version '${versionId}' was not found.`,
+      { details: projectionJobContext(job) }
+    )
   }
-  if (version.datasetId !== datasetId || version.createdAt.toISOString() !== createdAt) {
-    throw permanent(
-      `Dataset '${datasetId}' version '${versionId}' does not match its queued immutable metadata.`
+  const identityMismatches = collectIdentityMismatches([
+    { field: "datasetId", expected: datasetId, actual: version.datasetId },
+    {
+      field: "versionCreatedAt",
+      expected: createdAt,
+      actual: version.createdAt.toISOString(),
+    },
+  ])
+  if (identityMismatches.length > 0) {
+    throw createSixbError(
+      "projection.run_identity_mismatch",
+      `[SixbProjectionWorker] Dataset '${datasetId}' version '${versionId}' does not match its queued immutable metadata.`,
+      {
+        details: {
+          ...projectionRunContext(job),
+          identityMismatches,
+        },
+      }
     )
   }
   return version
 }
 
-function permanent(message: string, cause?: unknown): ProjectionWorkerPermanentError {
-  return new ProjectionWorkerPermanentError(`[SixbProjectionWorker] ${message}`, { cause })
+function projectionJobContext(job: ProjectionJob) {
+  return {
+    projectionId: job.projectionId,
+    runId: job.id,
+    datasetId: job.datasetVersion.datasetId,
+    versionId: job.datasetVersion.versionId,
+  }
+}
+
+function projectionRunContext(job: ProjectionJob) {
+  return {
+    projectionId: job.projectionId,
+    runId: job.id,
+  }
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/projection-worker/src/object-projection-plan.ts
+++ b/packages/projection-worker/src/object-projection-plan.ts
@@ -165,10 +165,12 @@ function buildProjectedPropertyPlans(input: {
       columnName,
       columnType: column.type,
       schema: resolveProjectionSchema(property.schema, valueTypesById, {
-        ...errorDetails,
-        objectTypeId: objectType.id,
-        propertyId,
-        columnName,
+        details: {
+          ...errorDetails,
+          objectTypeId: objectType.id,
+          propertyId,
+          columnName,
+        },
       }),
     })
   }

--- a/packages/projection-worker/src/projection-schema.ts
+++ b/packages/projection-worker/src/projection-schema.ts
@@ -1,12 +1,15 @@
-import type { Schema, ValueType } from "@sixb/core"
+import type { ReadonlyJsonValue, Schema, ValueType } from "@sixb/core"
 import { createSixbError } from "@sixb/core/internal/errors"
 
-type ProjectionSchemaErrorContext = Readonly<Record<string, string>>
+interface ProjectionSchemaErrorOptions {
+  readonly code?: "internal.unexpected" | "projection.definition_invalid"
+  readonly details?: Readonly<Record<string, ReadonlyJsonValue>>
+}
 
 export function resolveProjectionSchema(
   schema: Schema,
   valueTypesById: ReadonlyMap<string, ValueType>,
-  errorContext: ProjectionSchemaErrorContext = {},
+  options: ProjectionSchemaErrorOptions = {},
   seen = new Set<string>()
 ): Schema {
   if (typeof schema === "string") {
@@ -17,11 +20,13 @@ export function resolveProjectionSchema(
     return schema
   }
 
+  const code = options.code ?? "internal.unexpected"
+  const details = options.details ?? {}
   if (seen.has(schema.valueTypeId)) {
     throw createSixbError(
-      "internal.unexpected",
+      code,
       `[SixbProjectionWorker] Circular valueTypeRef '${schema.valueTypeId}' in projection schema.`,
-      { details: { ...errorContext, valueTypeId: schema.valueTypeId } }
+      { details: { ...details, valueTypeId: schema.valueTypeId } }
     )
   }
 
@@ -29,19 +34,19 @@ export function resolveProjectionSchema(
   nextSeen.add(schema.valueTypeId)
 
   if (schema._resolved) {
-    return resolveProjectionSchema(schema._resolved, valueTypesById, errorContext, nextSeen)
+    return resolveProjectionSchema(schema._resolved, valueTypesById, options, nextSeen)
   }
 
   const valueType = valueTypesById.get(schema.valueTypeId)
   if (!valueType) {
     throw createSixbError(
-      "internal.unexpected",
+      code,
       `[SixbProjectionWorker] Unknown valueTypeRef '${schema.valueTypeId}' in projection schema.`,
-      { details: { ...errorContext, valueTypeId: schema.valueTypeId } }
+      { details: { ...details, valueTypeId: schema.valueTypeId } }
     )
   }
 
-  return resolveProjectionSchema(valueType.schema, valueTypesById, errorContext, nextSeen)
+  return resolveProjectionSchema(valueType.schema, valueTypesById, options, nextSeen)
 }
 
 export function isIntegerEnumSchema(schema: Schema): boolean {

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -5,7 +5,7 @@ import {
   type ProjectionDefinition,
   type SixbFailure,
 } from "@sixb/core"
-import { captureSixbFailure, isSixbError } from "@sixb/core/internal/errors"
+import { captureSixbFailure, createSixbError, isSixbError } from "@sixb/core/internal/errors"
 import {
   MaterializationObjectNotFoundError,
   type ProjectionRunTerminalDecision,
@@ -16,7 +16,7 @@ import {
   type ProjectionRunFailureCode,
   type ProjectionRunRecord,
 } from "@sixb/core/storage"
-import { ProjectionWorkerPermanentError } from "./errors"
+import { collectIdentityMismatches } from "./identity-mismatch"
 import {
   assertProjectionJobId,
   type ValidatedProjectionJob,
@@ -90,8 +90,18 @@ async function findMatchingTerminalRun(
   assertRunMatchesJob(run, input.job)
   if (run.status === "running") return null
   if (run.status === "succeeded") return run
-  throw new ProjectionWorkerPermanentError(
-    `[SixbProjectionWorker] Projection run '${run.id}' is already '${run.status}'.`
+  throw createSixbError(
+    "projection.run_already_terminal",
+    `[SixbProjectionWorker] Projection run '${run.id}' is already '${run.status}'.`,
+    {
+      details: {
+        projectionId: run.identity.projectionId,
+        runId: run.id,
+        datasetId: run.identity.datasetVersion.datasetId,
+        versionId: run.identity.datasetVersion.versionId,
+        status: run.status,
+      },
+    }
   )
 }
 
@@ -254,19 +264,60 @@ async function requireRun(input: RunProjectionJobInput): Promise<ProjectionRunRe
 }
 
 function assertRunMatchesJob(run: ProjectionRunRecord, job: ProjectionJob): void {
-  const matches =
-    run.identity.projectionId === job.projectionId &&
-    run.identity.projectionKind === job.projectionKind &&
-    run.identity.protocol === job.protocol &&
-    run.identity.datasetVersion.datasetId === job.datasetVersion.datasetId &&
-    run.identity.datasetVersion.versionId === job.datasetVersion.versionId &&
-    run.identity.datasetVersion.createdAt === job.datasetVersion.createdAt &&
-    run.identity.ontologyRevision === job.ontologyRevision &&
-    run.identity.projectionRevision === job.projectionRevision &&
-    run.identity.ownershipHash === job.ownershipHash
-  if (matches) return
-  throw new ProjectionWorkerPermanentError(
-    `[SixbProjectionWorker] Projection run '${run.id}' has a different durable identity.`
+  const identityMismatches = collectIdentityMismatches([
+    {
+      field: "projectionId",
+      expected: job.projectionId,
+      actual: run.identity.projectionId,
+    },
+    {
+      field: "projectionKind",
+      expected: job.projectionKind,
+      actual: run.identity.projectionKind,
+    },
+    { field: "protocol", expected: job.protocol, actual: run.identity.protocol },
+    {
+      field: "datasetId",
+      expected: job.datasetVersion.datasetId,
+      actual: run.identity.datasetVersion.datasetId,
+    },
+    {
+      field: "versionId",
+      expected: job.datasetVersion.versionId,
+      actual: run.identity.datasetVersion.versionId,
+    },
+    {
+      field: "versionCreatedAt",
+      expected: job.datasetVersion.createdAt,
+      actual: run.identity.datasetVersion.createdAt,
+    },
+    {
+      field: "ontologyRevision",
+      expected: job.ontologyRevision,
+      actual: run.identity.ontologyRevision,
+    },
+    {
+      field: "projectionRevision",
+      expected: job.projectionRevision,
+      actual: run.identity.projectionRevision,
+    },
+    {
+      field: "ownershipHash",
+      expected: job.ownershipHash,
+      actual: run.identity.ownershipHash,
+    },
+  ])
+  if (identityMismatches.length === 0) return
+  throw createSixbError(
+    "projection.run_identity_mismatch",
+    `[SixbProjectionWorker] Projection run '${run.id}' has a different durable identity.`,
+    {
+      details: {
+        projectionId: job.projectionId,
+        runId: run.id,
+        identityMismatches,
+      },
+    }
   )
 }
 
@@ -287,10 +338,7 @@ async function isPermanentFailure(
 
 function isPermanentProjectionError(error: unknown): boolean {
   if (isSixbError(error)) return !error.retryable
-  if (
-    error instanceof ProjectionWorkerPermanentError ||
-    error instanceof MaterializationValidationError
-  ) {
+  if (error instanceof MaterializationValidationError) {
     return true
   }
   if (!isMaterializationConflictError(error)) return false

--- a/packages/projection-worker/src/run-telemetry-projection.ts
+++ b/packages/projection-worker/src/run-telemetry-projection.ts
@@ -247,10 +247,12 @@ function buildTelemetryProjectionPlan(input: {
     dataset,
     valueColumnType: valueColumn.type,
     valueSchema: resolveProjectionSchema(property.schema, runtime.ontology.getValueTypesById(), {
-      ...errorDetails,
-      objectTypeId: objectType.id,
-      propertyId: property.id,
-      columnName: valueColumn.name,
+      details: {
+        ...errorDetails,
+        objectTypeId: objectType.id,
+        propertyId: property.id,
+        columnName: valueColumn.name,
+      },
     }),
     readColumns: telemetryProjectionReadColumns(projection),
   }

--- a/packages/projection-worker/src/schema-validation.ts
+++ b/packages/projection-worker/src/schema-validation.ts
@@ -6,15 +6,24 @@ import type {
   OntologyDefinitionCatalog,
   ProjectionDefinition,
   Property,
+  ReadonlyJsonValue,
   Schema,
   ValueType,
 } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import { validateTelemetryProjectionFieldMapping } from "@sixb/core/internal/projections"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
-import { ProjectionWorkerPermanentError } from "./errors"
 import { isIntegerEnumSchema, resolveProjectionSchema } from "./projection-schema"
 
 type DatasetColumnsByName = Map<string, DatasetColumnDefinition>
+type ProjectionErrorDetails = Readonly<Record<string, ReadonlyJsonValue>>
+
+interface ProjectionValidationContext {
+  readonly projectionId: string
+  readonly datasetId: string
+  readonly versionId: string
+  readonly runId?: string
+}
 
 function columnsByName(columns: readonly DatasetColumnDefinition[]): DatasetColumnsByName {
   return new Map(columns.map((column) => [column.name, column]))
@@ -53,12 +62,15 @@ export function assertDatasetVersionMatchesDefinition(input: {
   readonly dataset: DatasetDefinition
   readonly version: DatasetVersion
   readonly projection: ProjectionDefinition
+  readonly runId?: string
 }): void {
-  const { dataset, version, projection } = input
+  const { dataset, version, projection, runId } = input
+  const context = projectionValidationContext({ projection, dataset, version, runId })
 
   if (version.datasetId !== dataset.id) {
-    throw new ProjectionWorkerPermanentError(
-      `[SixbProjectionWorker] Dataset version '${version.versionId}' belongs to dataset '${version.datasetId}', expected '${dataset.id}'.`
+    throw incompatibleDatasetVersion(
+      `[SixbProjectionWorker] Dataset version '${version.versionId}' belongs to dataset '${version.datasetId}', expected '${dataset.id}'.`,
+      { ...context, actualDatasetId: version.datasetId }
     )
   }
 
@@ -68,8 +80,14 @@ export function assertDatasetVersionMatchesDefinition(input: {
     const expected = expectedColumns.get(columnName)
     const actual = actualColumns.get(columnName)
     if (expected && actual && columnsEqual(expected, actual)) continue
-    throw new ProjectionWorkerPermanentError(
-      `[SixbProjectionWorker] Dataset '${dataset.id}' version '${version.versionId}' schema mismatch for referenced column '${columnName}'. Expected ${formatColumn(expected)}, got ${formatColumn(actual)}.`
+    throw incompatibleDatasetVersion(
+      `[SixbProjectionWorker] Dataset '${dataset.id}' version '${version.versionId}' schema mismatch for referenced column '${columnName}'. Expected ${formatColumn(expected)}, got ${formatColumn(actual)}.`,
+      {
+        ...context,
+        columnName,
+        expectedColumn: formatColumn(expected),
+        actualColumn: formatColumn(actual),
+      }
     )
   }
 }
@@ -79,17 +97,14 @@ export function assertProjectionCompatibleWithDataset(input: {
   readonly dataset: DatasetDefinition
   readonly version: DatasetVersion
   readonly ontology: OntologyDefinitionCatalog
+  readonly runId?: string
 }): void {
-  const { projection, dataset, version, ontology } = input
+  const { projection, dataset, version, ontology, runId } = input
+  const context = projectionValidationContext({ projection, dataset, version, runId })
   const columnsByName = new Map(version.schema.columns.map((column) => [column.name, column]))
 
   if (projection._tag === "ObjectProjectionDefinition") {
-    const objectType = requireObjectType(
-      ontology,
-      projection.objectTypeId,
-      projection.id,
-      "object type"
-    )
+    const objectType = requireObjectType(ontology, projection.objectTypeId, "object type", context)
 
     const propertiesById = new Map(
       objectType.properties.map((property) => [property.id, property] as const)
@@ -97,51 +112,65 @@ export function assertProjectionCompatibleWithDataset(input: {
     for (const [propertyId, columnName] of Object.entries(projection.properties)) {
       const property = propertiesById.get(propertyId)
       if (!property) {
-        throw new ProjectionWorkerPermanentError(
-          `[SixbProjectionWorker] Projection '${projection.id}' references unknown property '${propertyId}' on object type '${objectType.id}'.`
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Projection '${projection.id}' references unknown property '${propertyId}' on object type '${objectType.id}'.`,
+          { ...context, objectTypeId: objectType.id, propertyId, columnName }
         )
       }
 
-      const column = requireColumn(columnsByName, dataset.id, columnName, projection.id)
+      const column = requireColumn(columnsByName, columnName, context)
       if (
         !isDatasetColumnCompatibleWithSchema(
           column.type,
           property.schema,
           ontology.getValueTypesById(),
           {
-            projectionId: projection.id,
-            datasetId: dataset.id,
-            versionId: version.versionId,
+            ...context,
             objectTypeId: objectType.id,
             propertyId,
             columnName,
           }
         )
       ) {
-        throw new ProjectionWorkerPermanentError(
-          `[SixbProjectionWorker] Projection '${projection.id}' maps dataset column '${column.name}' (${column.type}) to incompatible property '${propertyId}'.`
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Projection '${projection.id}' maps dataset column '${column.name}' (${column.type}) to incompatible property '${propertyId}'.`,
+          {
+            ...context,
+            objectTypeId: objectType.id,
+            propertyId,
+            columnName: column.name,
+            columnType: column.type,
+          }
         )
       }
     }
 
     for (const [linkKey, descriptor] of Object.entries(projection.links)) {
       if (linkKey !== descriptor.linkId) {
-        throw new ProjectionWorkerPermanentError(
-          `[SixbProjectionWorker] Projection '${projection.id}' FK link key '${linkKey}' does not match descriptor link '${descriptor.linkId}'.`
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Projection '${projection.id}' FK link key '${linkKey}' does not match descriptor link '${descriptor.linkId}'.`,
+          { ...context, linkKey, linkId: descriptor.linkId }
         )
       }
 
-      const linkDefinition = requireLink(objectType, descriptor.linkId, projection.id)
+      const linkDefinition = requireLink(objectType, descriptor.linkId, context)
       const sourcePropertyId = descriptor.sourcePropertyId
       const sourceField = descriptor.sourceField
       if (sourcePropertyId && sourceField) {
-        throw new ProjectionWorkerPermanentError(
-          `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' must use either sourcePropertyId or sourceField, not both.`
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' must use either sourcePropertyId or sourceField, not both.`,
+          {
+            ...context,
+            linkId: descriptor.linkId,
+            propertyId: sourcePropertyId,
+            columnName: sourceField,
+          }
         )
       }
       if (!sourcePropertyId && !sourceField) {
-        throw new ProjectionWorkerPermanentError(
-          `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' must declare sourcePropertyId or sourceField.`
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' must declare sourcePropertyId or sourceField.`,
+          { ...context, linkId: descriptor.linkId }
         )
       }
 
@@ -149,22 +178,29 @@ export function assertProjectionCompatibleWithDataset(input: {
         requireProperty(
           objectType,
           sourcePropertyId,
-          projection.id,
-          `FK link '${descriptor.linkId}' source property`
+          `FK link '${descriptor.linkId}' source property`,
+          context
         )
 
         if (!(sourcePropertyId in projection.properties)) {
-          throw new ProjectionWorkerPermanentError(
-            `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' source property '${sourcePropertyId}' must be mapped as an object property.`
+          throw invalidProjectionDefinition(
+            `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' source property '${sourcePropertyId}' must be mapped as an object property.`,
+            { ...context, linkId: descriptor.linkId, propertyId: sourcePropertyId }
           )
         }
       }
 
       if (sourceField) {
-        const sourceColumn = requireColumn(columnsByName, dataset.id, sourceField, projection.id)
+        const sourceColumn = requireColumn(columnsByName, sourceField, context)
         if (sourceColumn.type !== "string") {
-          throw new ProjectionWorkerPermanentError(
-            `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' source field '${sourceField}' must be a string dataset column.`
+          throw invalidProjectionDefinition(
+            `[SixbProjectionWorker] Projection '${projection.id}' FK link '${descriptor.linkId}' source field '${sourceField}' must be a string dataset column.`,
+            {
+              ...context,
+              linkId: descriptor.linkId,
+              columnName: sourceField,
+              columnType: sourceColumn.type,
+            }
           )
         }
       }
@@ -172,12 +208,12 @@ export function assertProjectionCompatibleWithDataset(input: {
       requireObjectType(
         ontology,
         descriptor.targetObjectTypeId,
-        projection.id,
-        `FK link '${descriptor.linkId}' target type`
+        `FK link '${descriptor.linkId}' target type`,
+        context
       )
       assertLinkTargetCompatible({
         ontology,
-        projectionId: projection.id,
+        context,
         link: linkDefinition,
         actualTargetObjectTypeId: descriptor.targetObjectTypeId,
       })
@@ -186,12 +222,7 @@ export function assertProjectionCompatibleWithDataset(input: {
   }
 
   if (projection._tag === "TelemetryProjectionDefinition") {
-    const objectType = requireObjectType(
-      ontology,
-      projection.objectTypeId,
-      projection.id,
-      "object type"
-    )
+    const objectType = requireObjectType(ontology, projection.objectTypeId, "object type", context)
     // Existence + telemetry-mode + field-mapping rules are owned by core so the
     // startup and worker checks share one implementation and cannot drift. The
     // worker then layers dataset-version column type compatibility on top.
@@ -203,61 +234,69 @@ export function assertProjectionCompatibleWithDataset(input: {
       `[SixbProjectionWorker] Projection "${projection.id}"`
     )
 
-    const objectIdColumn = requireColumn(
-      columnsByName,
-      dataset.id,
-      projection.objectIdField,
-      projection.id
-    )
+    const objectIdColumn = requireColumn(columnsByName, projection.objectIdField, context)
     if (objectIdColumn.type !== "string") {
-      throw new ProjectionWorkerPermanentError(
-        `[SixbProjectionWorker] Telemetry projection '${projection.id}' objectId field '${projection.objectIdField}' must be a string dataset column.`
+      throw invalidProjectionDefinition(
+        `[SixbProjectionWorker] Telemetry projection '${projection.id}' objectId field '${projection.objectIdField}' must be a string dataset column.`,
+        {
+          ...context,
+          objectTypeId: objectType.id,
+          columnName: projection.objectIdField,
+          columnType: objectIdColumn.type,
+        }
       )
     }
 
-    const atColumn = requireColumn(columnsByName, dataset.id, projection.atField, projection.id)
+    const atColumn = requireColumn(columnsByName, projection.atField, context)
     if (!isDateLikeColumnType(atColumn.type)) {
-      throw new ProjectionWorkerPermanentError(
-        `[SixbProjectionWorker] Telemetry projection '${projection.id}' at field '${projection.atField}' must be a string, date, or timestamp dataset column.`
+      throw invalidProjectionDefinition(
+        `[SixbProjectionWorker] Telemetry projection '${projection.id}' at field '${projection.atField}' must be a string, date, or timestamp dataset column.`,
+        {
+          ...context,
+          objectTypeId: objectType.id,
+          columnName: projection.atField,
+          columnType: atColumn.type,
+        }
       )
     }
 
-    const valueColumn = requireColumn(
-      columnsByName,
-      dataset.id,
-      projection.valueField,
-      projection.id
-    )
+    const valueColumn = requireColumn(columnsByName, projection.valueField, context)
     if (
       !isDatasetColumnCompatibleWithSchema(
         valueColumn.type,
         property.schema,
         ontology.getValueTypesById(),
         {
-          projectionId: projection.id,
-          datasetId: dataset.id,
-          versionId: version.versionId,
+          ...context,
           objectTypeId: objectType.id,
           propertyId: property.id,
           columnName: valueColumn.name,
         }
       )
     ) {
-      throw new ProjectionWorkerPermanentError(
-        `[SixbProjectionWorker] Telemetry projection '${projection.id}' maps dataset column '${valueColumn.name}' (${valueColumn.type}) to incompatible property '${projection.propertyId}'.`
+      throw invalidProjectionDefinition(
+        `[SixbProjectionWorker] Telemetry projection '${projection.id}' maps dataset column '${valueColumn.name}' (${valueColumn.type}) to incompatible property '${projection.propertyId}'.`,
+        {
+          ...context,
+          objectTypeId: objectType.id,
+          propertyId: projection.propertyId,
+          columnName: valueColumn.name,
+          columnType: valueColumn.type,
+        }
       )
     }
 
     if (projection.unitField !== undefined) {
-      const unitColumn = requireColumn(
-        columnsByName,
-        dataset.id,
-        projection.unitField,
-        projection.id
-      )
+      const unitColumn = requireColumn(columnsByName, projection.unitField, context)
       if (unitColumn.type !== "string") {
-        throw new ProjectionWorkerPermanentError(
-          `[SixbProjectionWorker] Telemetry projection '${projection.id}' unit field '${projection.unitField}' must be a string dataset column.`
+        throw invalidProjectionDefinition(
+          `[SixbProjectionWorker] Telemetry projection '${projection.id}' unit field '${projection.unitField}' must be a string dataset column.`,
+          {
+            ...context,
+            objectTypeId: objectType.id,
+            columnName: projection.unitField,
+            columnType: unitColumn.type,
+          }
         )
       }
     }
@@ -268,34 +307,32 @@ export function assertProjectionCompatibleWithDataset(input: {
   const sourceObjectType = requireObjectType(
     ontology,
     projection.sourceObjectTypeId,
-    projection.id,
-    "source object type"
+    "source object type",
+    context
   )
-  requireObjectType(ontology, projection.targetObjectTypeId, projection.id, "target object type")
-  const linkDefinition = requireLink(sourceObjectType, projection.linkId, projection.id)
+  requireObjectType(ontology, projection.targetObjectTypeId, "target object type", context)
+  const linkDefinition = requireLink(sourceObjectType, projection.linkId, context)
   assertLinkTargetCompatible({
     ontology,
-    projectionId: projection.id,
+    context,
     link: linkDefinition,
     actualTargetObjectTypeId: projection.targetObjectTypeId,
   })
 
-  const sourceColumn = requireColumn(
-    columnsByName,
-    dataset.id,
-    projection.sourceField,
-    projection.id
-  )
-  const targetColumn = requireColumn(
-    columnsByName,
-    dataset.id,
-    projection.targetField,
-    projection.id
-  )
+  const sourceColumn = requireColumn(columnsByName, projection.sourceField, context)
+  const targetColumn = requireColumn(columnsByName, projection.targetField, context)
 
   if (sourceColumn.type !== "string" || targetColumn.type !== "string") {
-    throw new ProjectionWorkerPermanentError(
-      `[SixbProjectionWorker] Link projection '${projection.id}' source and target fields must be string dataset columns.`
+    throw invalidProjectionDefinition(
+      `[SixbProjectionWorker] Link projection '${projection.id}' source and target fields must be string dataset columns.`,
+      {
+        ...context,
+        linkId: projection.linkId,
+        sourceColumnName: sourceColumn.name,
+        sourceColumnType: sourceColumn.type,
+        targetColumnName: targetColumn.name,
+        targetColumnType: targetColumn.type,
+      }
     )
   }
 }
@@ -303,13 +340,14 @@ export function assertProjectionCompatibleWithDataset(input: {
 function requireObjectType(
   ontology: OntologyDefinitionCatalog,
   objectTypeId: string,
-  projectionId: string,
-  role: string
+  role: string,
+  context: ProjectionValidationContext
 ): ObjectTypeWithPropertyTokens {
   const objectType = ontology.getObjectTypeById(objectTypeId)
   if (!objectType) {
-    throw new ProjectionWorkerPermanentError(
-      `[SixbProjectionWorker] Projection '${projectionId}' references unknown ${role} '${objectTypeId}'.`
+    throw invalidProjectionDefinition(
+      `[SixbProjectionWorker] Projection '${context.projectionId}' references unknown ${role} '${objectTypeId}'.`,
+      { ...context, objectTypeId, role }
     )
   }
   return objectType
@@ -318,13 +356,14 @@ function requireObjectType(
 function requireProperty(
   objectType: ObjectTypeWithPropertyTokens,
   propertyId: string,
-  projectionId: string,
-  role: string
+  role: string,
+  context: ProjectionValidationContext
 ): Property {
   const property = objectType.properties.find((candidate) => candidate.id === propertyId)
   if (!property) {
-    throw new ProjectionWorkerPermanentError(
-      `[SixbProjectionWorker] Projection '${projectionId}' references unknown ${role} '${propertyId}' on object type '${objectType.id}'.`
+    throw invalidProjectionDefinition(
+      `[SixbProjectionWorker] Projection '${context.projectionId}' references unknown ${role} '${propertyId}' on object type '${objectType.id}'.`,
+      { ...context, objectTypeId: objectType.id, propertyId, role }
     )
   }
   return property
@@ -333,12 +372,13 @@ function requireProperty(
 function requireLink(
   objectType: ObjectTypeWithPropertyTokens,
   linkId: string,
-  projectionId: string
+  context: ProjectionValidationContext
 ): ObjectLink {
   const link = objectType.links.find((candidate) => candidate.id === linkId)
   if (!link) {
-    throw new ProjectionWorkerPermanentError(
-      `[SixbProjectionWorker] Projection '${projectionId}' references unknown link '${linkId}' on object type '${objectType.id}'.`
+    throw invalidProjectionDefinition(
+      `[SixbProjectionWorker] Projection '${context.projectionId}' references unknown link '${linkId}' on object type '${objectType.id}'.`,
+      { ...context, objectTypeId: objectType.id, linkId }
     )
   }
   return link
@@ -346,17 +386,23 @@ function requireLink(
 
 function assertLinkTargetCompatible(input: {
   readonly ontology: OntologyDefinitionCatalog
-  readonly projectionId: string
+  readonly context: ProjectionValidationContext
   readonly link: ObjectLink
   readonly actualTargetObjectTypeId: string
 }): void {
-  const { ontology, projectionId, link, actualTargetObjectTypeId } = input
+  const { ontology, context, link, actualTargetObjectTypeId } = input
   if (ontology.isValidLinkTarget(link.targetObjectTypeId, actualTargetObjectTypeId)) {
     return
   }
 
-  throw new ProjectionWorkerPermanentError(
-    `[SixbProjectionWorker] Projection '${projectionId}' link '${link.id}' target type '${actualTargetObjectTypeId}' is not compatible with declared target '${formatTarget(link.targetObjectTypeId)}'.`
+  throw invalidProjectionDefinition(
+    `[SixbProjectionWorker] Projection '${context.projectionId}' link '${link.id}' target type '${actualTargetObjectTypeId}' is not compatible with declared target '${formatTarget(link.targetObjectTypeId)}'.`,
+    {
+      ...context,
+      linkId: link.id,
+      actualTargetObjectTypeId,
+      expectedTargetObjectTypeId: formatTarget(link.targetObjectTypeId),
+    }
   )
 }
 
@@ -366,17 +412,39 @@ function formatTarget(target: string | readonly string[]): string {
 
 function requireColumn(
   columnsByName: DatasetColumnsByName,
-  datasetId: string,
   columnName: string,
-  projectionId: string
+  context: ProjectionValidationContext
 ): DatasetColumnDefinition {
   const column = columnsByName.get(columnName)
   if (!column) {
-    throw new ProjectionWorkerPermanentError(
-      `[SixbProjectionWorker] Projection '${projectionId}' references unknown dataset column '${columnName}' on dataset '${datasetId}'.`
+    throw invalidProjectionDefinition(
+      `[SixbProjectionWorker] Projection '${context.projectionId}' references unknown dataset column '${columnName}' on dataset '${context.datasetId}'.`,
+      { ...context, columnName }
     )
   }
   return column
+}
+
+function projectionValidationContext(input: {
+  readonly projection: ProjectionDefinition
+  readonly dataset: DatasetDefinition
+  readonly version: DatasetVersion
+  readonly runId?: string
+}): ProjectionValidationContext {
+  return {
+    projectionId: input.projection.id,
+    datasetId: input.dataset.id,
+    versionId: input.version.versionId,
+    ...(input.runId === undefined ? {} : { runId: input.runId }),
+  }
+}
+
+function invalidProjectionDefinition(message: string, details: ProjectionErrorDetails) {
+  return createSixbError("projection.definition_invalid", message, { details })
+}
+
+function incompatibleDatasetVersion(message: string, details: ProjectionErrorDetails) {
+  return createSixbError("dataset.version_incompatible", message, { details })
 }
 
 function isDateLikeColumnType(type: DatasetColumnDefinition["type"]): boolean {
@@ -387,9 +455,12 @@ function isDatasetColumnCompatibleWithSchema(
   columnType: DatasetColumnDefinition["type"],
   schema: Schema,
   valueTypesById: ReadonlyMap<string, ValueType>,
-  errorContext: Readonly<Record<string, string>>
+  errorContext: ProjectionErrorDetails
 ): boolean {
-  const resolved = resolveProjectionSchema(schema, valueTypesById, errorContext)
+  const resolved = resolveProjectionSchema(schema, valueTypesById, {
+    code: "projection.definition_invalid",
+    details: errorContext,
+  })
 
   switch (columnType) {
     case "string":

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -299,7 +299,8 @@ function createRuntime(
   primitive: { readonly id: string; readonly runId: string } = {
     id: host.definitions.projections.list()[0]?.id ?? "direct-projection-test",
     runId: "direct-projection-job-test",
-  }
+  },
+  catalogs: Partial<Pick<ProjectionWorkerContext, "datasets" | "projections">> = {}
 ): TestProjectionWorkerContext {
   const runtime = {
     host,
@@ -307,8 +308,8 @@ function createRuntime(
     ontology: host.definitions.ontology,
     lakeStorage: host.lakeStorage,
     projectionRunsStorage: requireProjectionRunsStorage(host),
-    datasets: host.definitions.datasets,
-    projections: host.definitions.projections,
+    datasets: catalogs.datasets ?? host.definitions.datasets,
+    projections: catalogs.projections ?? host.definitions.projections,
   } satisfies TestProjectionWorkerContext
   const execution = bindPrimitiveExecution(host, {
     primitive: { kind: "projection", ...primitive },
@@ -336,10 +337,17 @@ async function runProjectionJob(
     readonly batchSize?: number
   }
 ): Promise<ProjectionJobResult> {
-  const runtime = createRuntime(input.runtime.host, {
-    id: input.job.projectionId,
-    runId: input.job.id,
-  })
+  const runtime = createRuntime(
+    input.runtime.host,
+    {
+      id: input.job.projectionId,
+      runId: input.job.id,
+    },
+    {
+      datasets: input.runtime.datasets,
+      projections: input.runtime.projections,
+    }
+  )
   const registry = getProjectionRegistry(runtime)
   const version = await runtime.lakeStorage.getVersion(input.job.datasetId, input.job.versionId)
   let descriptor: ProjectionDispatchDescriptor
@@ -451,6 +459,11 @@ describe("runProjectionJob", () => {
         createSixbError("dataset.version_read_inconsistent", "Dataset read was incomplete.")
       )
     ).toBe(false)
+    expect(
+      isPermanentProjectionFailure(
+        createSixbError("projection.definition_invalid", "Projection definition is invalid.")
+      )
+    ).toBe(true)
     expect(
       isPermanentProjectionFailure(
         new MaterializationConflictError("projection-fence", "A newer version is active.")
@@ -893,6 +906,101 @@ describe("runProjectionJob", () => {
         replayedTerminal: true,
       }
     )
+  })
+
+  test("rejects a noncanonical run id with a coded identity error", async () => {
+    const deps = createDeps()
+    const sixb = createSixb({ datasets: [roomsDataset], projections: [roomProjection] }, deps)
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: null },
+    ])
+    const descriptor = getProjectionRegistry(sixb).resolveDispatch(roomProjection.id)
+    if (descriptor.projectionKind !== "object") throw new Error("Expected object projection.")
+    const identity = {
+      projectionId: descriptor.projectionId,
+      projectionKind: "object" as const,
+      protocol: "replacement" as const,
+      datasetVersion: {
+        datasetId: version.datasetId,
+        versionId: version.versionId,
+        createdAt: version.createdAt.toISOString(),
+      },
+      ontologyRevision: descriptor.ontologyRevision,
+      projectionRevision: descriptor.projectionRevision,
+      ownershipHash: descriptor.ownershipHash,
+    }
+    const expectedRunId = createProjectionRunId(sixb.id, identity)
+    const error = await runCanonicalProjectionJob({
+      runtime: createRuntime(sixb),
+      job: { id: "not-the-canonical-run-id", ...identity },
+    }).catch((caught: unknown) => caught)
+
+    expect(error).toMatchObject({
+      code: "projection.run_identity_mismatch",
+      retryable: false,
+      message: expect.stringContaining("does not match its pinned semantic identity"),
+      details: {
+        projectionId: roomProjection.id,
+        runId: "not-the-canonical-run-id",
+        identityMismatches: [
+          {
+            field: "runId",
+            expected: expectedRunId,
+            actual: "not-the-canonical-run-id",
+          },
+        ],
+      },
+    })
+    expect(
+      await deps.storage.projectionRuns.getById({
+        projectId: sixb.id,
+        id: expectedRunId,
+      })
+    ).toBeNull()
+  })
+
+  test("reports only projection identity fields that differ from the registry", async () => {
+    const deps = createDeps()
+    const sixb = createSixb({ datasets: [roomsDataset], projections: [roomProjection] }, deps)
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: null },
+    ])
+    const descriptor = getProjectionRegistry(sixb).resolveDispatch(roomProjection.id)
+    if (descriptor.projectionKind !== "object") throw new Error("Expected object projection.")
+    const identity = {
+      projectionId: descriptor.projectionId,
+      projectionKind: "object" as const,
+      protocol: "replacement" as const,
+      datasetVersion: {
+        datasetId: version.datasetId,
+        versionId: version.versionId,
+        createdAt: version.createdAt.toISOString(),
+      },
+      ontologyRevision: descriptor.ontologyRevision,
+      projectionRevision: "stale-projection-revision",
+      ownershipHash: descriptor.ownershipHash,
+    }
+    const runId = createProjectionRunId(sixb.id, identity)
+    const error = await runCanonicalProjectionJob({
+      runtime: createRuntime(sixb),
+      job: { id: runId, ...identity },
+    }).catch((caught: unknown) => caught)
+
+    expect(error).toMatchObject({
+      code: "projection.run_identity_mismatch",
+      retryable: false,
+      details: {
+        projectionId: roomProjection.id,
+        runId,
+        identityMismatches: [
+          {
+            field: "projectionRevision",
+            expected: "stale-projection-revision",
+            actual: descriptor.projectionRevision,
+          },
+        ],
+      },
+    })
   })
 
   test("resumes telemetry from the durable offset without an exact-multiple empty commit", async () => {
@@ -2333,18 +2441,16 @@ describe("runProjectionJob", () => {
       { device_id: "d1", device_status: "offline" },
     ])
 
-    await expect(
-      runProjectionJob({
-        runtime: createRuntime(sixb),
-        job: {
-          id: "projrun-invalid-property",
-          projectionId: "device-proj",
-          projectionKind: "object",
-          datasetId: "canonical.devices",
-          versionId: version.versionId,
-        },
-      })
-    ).rejects.toBeInstanceOf(MaterializationValidationError)
+    const job = {
+      id: "projrun-invalid-property",
+      projectionId: "device-proj",
+      projectionKind: "object" as const,
+      datasetId: "canonical.devices",
+      versionId: version.versionId,
+    }
+    await expect(runProjectionJob({ runtime: createRuntime(sixb), job })).rejects.toBeInstanceOf(
+      MaterializationValidationError
+    )
 
     const run = await deps.storage.projectionRuns.getById({
       projectId: sixb.id,
@@ -2362,6 +2468,23 @@ describe("runProjectionJob", () => {
       },
     })
     expect(run?.error?.at).toBe(run?.finishedAt?.toISOString())
+
+    const terminalError = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job,
+    }).catch((caught: unknown) => caught)
+    expect(terminalError).toMatchObject({
+      code: "projection.run_already_terminal",
+      retryable: false,
+      message: expect.stringContaining("is already 'failed'"),
+      details: {
+        projectionId: deviceProjection.id,
+        runId: canonicalRunId(job.id),
+        datasetId: devicesDataset.id,
+        versionId: version.versionId,
+        status: "failed",
+      },
+    })
   })
 
   test("normalizes int64 strings mapped to integer-like object properties", async () => {
@@ -2556,18 +2679,30 @@ describe("runProjectionJob", () => {
       deps
     )
 
-    await expect(
-      runProjectionJob({
-        runtime: createRuntime(sixb),
-        job: {
-          id: "projrun-schema-mismatch",
-          projectionId: "room-proj",
-          projectionKind: "object",
-          datasetId: "canonical.rooms",
-          versionId: version.versionId,
-        },
-      })
-    ).rejects.toThrow("schema mismatch")
+    const error = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-schema-mismatch",
+        projectionId: "room-proj",
+        projectionKind: "object",
+        datasetId: "canonical.rooms",
+        versionId: version.versionId,
+      },
+    }).catch((caught: unknown) => caught)
+    expect(error).toMatchObject({
+      code: "dataset.version_incompatible",
+      retryable: false,
+      message: expect.stringContaining("schema mismatch"),
+      details: {
+        projectionId: roomProjection.id,
+        runId: canonicalRunId("projrun-schema-mismatch"),
+        datasetId: roomsDataset.id,
+        versionId: version.versionId,
+        columnName: "room_name",
+        expectedColumn: "'room_name:string'",
+        actualColumn: "a missing column",
+      },
+    })
 
     const run = await deps.storage.projectionRuns.getById({
       projectId: sixb.id,
@@ -2589,24 +2724,121 @@ describe("runProjectionJob", () => {
       { room_id: "r1", room_name: "Kitchen", building_ref: null },
     ])
 
-    await expect(
-      runProjectionJob({
-        runtime: createRuntime(sixb),
-        job: {
-          id: "projrun-unknown",
-          projectionId: "missing-proj",
-          projectionKind: "object",
-          datasetId: "canonical.rooms",
-          versionId: version.versionId,
-        },
-      })
-    ).rejects.toThrow("not registered")
+    const error = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-unknown",
+        projectionId: "missing-proj",
+        projectionKind: "object",
+        datasetId: "canonical.rooms",
+        versionId: version.versionId,
+      },
+    }).catch((caught: unknown) => caught)
+    expect(error).toMatchObject({
+      code: "projection.not_found",
+      retryable: false,
+      message: expect.stringContaining("not registered"),
+      details: {
+        projectionId: "missing-proj",
+        runId: canonicalRunId("projrun-unknown"),
+        datasetId: roomsDataset.id,
+        versionId: version.versionId,
+      },
+    })
 
     const run = await deps.storage.projectionRuns.getById({
       projectId: sixb.id,
       id: canonicalRunId("projrun-unknown"),
     })
     expect(run).toBeNull()
+  })
+
+  test("rejects a runtime-missing dataset with the shared dataset code", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjection],
+      },
+      deps
+    )
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: null },
+    ])
+    const runtime = createRuntime(sixb, undefined, {
+      datasets: {
+        getById: () => null,
+      },
+    })
+
+    const error = await runProjectionJob({
+      runtime,
+      job: {
+        id: "projrun-unknown-dataset",
+        projectionId: roomProjection.id,
+        projectionKind: "object",
+        datasetId: roomsDataset.id,
+        versionId: version.versionId,
+      },
+    }).catch((caught: unknown) => caught)
+    expect(error).toMatchObject({
+      code: "dataset.not_found",
+      retryable: false,
+      message: expect.stringContaining("references unknown dataset"),
+      details: {
+        projectionId: roomProjection.id,
+        runId: canonicalRunId("projrun-unknown-dataset"),
+        datasetId: roomsDataset.id,
+        versionId: version.versionId,
+        source: "runtime",
+      },
+    })
+    expect(
+      await deps.storage.projectionRuns.getById({
+        projectId: sixb.id,
+        id: canonicalRunId("projrun-unknown-dataset"),
+      })
+    ).toBeNull()
+  })
+
+  test("rejects a missing pinned version with the shared version code", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjection],
+      },
+      deps
+    )
+    await deps.lakeStorage.createDataset(roomsDataset)
+
+    const error = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-unknown-version",
+        projectionId: roomProjection.id,
+        projectionKind: "object",
+        datasetId: roomsDataset.id,
+        versionId: "missing-version",
+      },
+    }).catch((caught: unknown) => caught)
+    expect(error).toMatchObject({
+      code: "dataset.version_not_found",
+      retryable: false,
+      message: expect.stringContaining("version 'missing-version' was not found"),
+      details: {
+        projectionId: roomProjection.id,
+        runId: canonicalRunId("projrun-unknown-version"),
+        datasetId: roomsDataset.id,
+        versionId: "missing-version",
+      },
+    })
+    expect(
+      await deps.storage.projectionRuns.getById({
+        projectId: sixb.id,
+        id: canonicalRunId("projrun-unknown-version"),
+      })
+    ).toBeNull()
   })
 
   test("rejects an incompatible object FK target at startup before reading rows", () => {
@@ -2973,18 +3205,30 @@ describe("runProjectionJob", () => {
       },
     ])
 
-    await expect(
-      runProjectionJob({
-        runtime: createRuntime(sixb),
-        job: {
-          id: "projrun-invalid-at",
-          projectionId: "room-invalid-at-proj",
-          projectionKind: "telemetry",
-          datasetId: roomReadingsDataset.id,
-          versionId: version.versionId,
-        },
-      })
-    ).rejects.toThrow("must be a string, date, or timestamp")
+    const error = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: "projrun-invalid-at",
+        projectionId: "room-invalid-at-proj",
+        projectionKind: "telemetry",
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+      },
+    }).catch((caught: unknown) => caught)
+    expect(error).toMatchObject({
+      code: "projection.definition_invalid",
+      retryable: false,
+      message: expect.stringContaining("must be a string, date, or timestamp"),
+      details: {
+        projectionId: "room-invalid-at-proj",
+        runId: canonicalRunId("projrun-invalid-at"),
+        datasetId: roomReadingsDataset.id,
+        versionId: version.versionId,
+        objectTypeId: Room.id,
+        columnName: "temperature",
+        columnType: "float64",
+      },
+    })
 
     const run = await deps.storage.projectionRuns.getById({
       projectId: sixb.id,


### PR DESCRIPTION
## Summary

- remove the temporary `ProjectionWorkerPermanentError` wrapper and create canonical coded errors directly
- add the public non-retryable `dataset.version_incompatible`, `projection.definition_invalid`, `projection.not_found`, `projection.run_already_terminal`, and `projection.run_identity_mismatch` codes
- reuse `dataset.not_found` and `dataset.version_not_found` for the existing Dataset taxonomy
- preserve causes and attach projection/run correlation details at error creation, reporting only identity fields that actually differ
- derive terminal versus retry behavior from catalog-owned `retryable` policy while preserving Materialization control-flow errors

## Why

The temporary permanent wrapper encoded retry policy through class identity. These failures now have stable public codes and the Projection Worker can make the same fail/retry decision from the catalog policy used by the rest of the error model.

Most validation failures happen before a run is claimed, while terminal-redelivery failures target an existing terminal run. The new codes therefore do not widen `PROJECTION_RUN_FAILURE_CODES`; persisted run failures keep their precise existing contract.

Identity failures expose only mismatched `{ field, expected, actual }` entries instead of duplicating the complete queued and durable identities.

## Validation

- `bun test packages/core/tests/error-model.test.ts packages/projection-worker/tests/` — 105 passing
- `bun --filter @sixb/projection-worker typecheck`
- `bun --filter @sixb/projection-worker build`
- `bun run typecheck`
- `bun run check`
- `git diff --check`

## Stack

Depends on #349 and continues #274.