### PR TITLE
core: define AI model-call usage accounting

### DIFF
--- a/packages/core/src/storage/ai-usage/errors.ts
+++ b/packages/core/src/storage/ai-usage/errors.ts
@@ -1,0 +1,13 @@
+export type AiUsageStorageErrorCode = "duplicate_id"
+
+/** Storage failure specific to the AI model-call usage ledger. */
+export class AiUsageStorageError extends Error {
+  readonly name = "AiUsageStorageError"
+
+  constructor(
+    readonly code: AiUsageStorageErrorCode,
+    message: string
+  ) {
+    super(message)
+  }
+}

--- a/packages/core/src/storage/ai-usage/in-memory.ts
+++ b/packages/core/src/storage/ai-usage/in-memory.ts
@@ -1,0 +1,151 @@
+import { AiUsageStorageError } from "./errors"
+import { assertAiUsageExecution, normalizeAiModelCallRecord } from "./record"
+import type {
+  AiModelCallUsageRecord,
+  AiUsageExecutionIdentity,
+  AiUsageStorage,
+  RecordAiModelCallInput,
+  RecordAiModelCallResult,
+  SummarizeAiUsageExecutionInput,
+  SummarizeAiUsageExecutionsInput,
+} from "./types"
+import { aggregateAiModelCallUsage } from "./usage"
+
+export interface InMemoryAiUsageGroupRow {
+  readonly projectId: string
+  readonly usageRecordId: string
+  readonly groupId: string
+  readonly occurredAt: Date
+}
+
+export interface InMemoryAiUsageStorageSnapshot {
+  readonly records: Map<string, AiModelCallUsageRecord>
+  readonly recordKeysByIdempotencyKey: Map<string, string>
+  readonly groupRows: Map<string, InMemoryAiUsageGroupRow>
+}
+
+/** In-memory model-call ledger used by development runtimes and storage contract tests. */
+export class InMemoryAiUsageStorage implements AiUsageStorage {
+  private readonly records = new Map<string, AiModelCallUsageRecord>()
+  private readonly recordKeysByIdempotencyKey = new Map<string, string>()
+  private readonly groupRows = new Map<string, InMemoryAiUsageGroupRow>()
+
+  async recordModelCall(input: RecordAiModelCallInput): Promise<RecordAiModelCallResult> {
+    const record = normalizeAiModelCallRecord(input)
+    const idempotencyKey = modelCallIdempotencyKey(record)
+    const existingRecordKey = this.recordKeysByIdempotencyKey.get(idempotencyKey)
+    if (existingRecordKey !== undefined) {
+      const existing = this.records.get(existingRecordKey)
+      if (!existing) {
+        throw new Error("[Sixb] In-memory AI usage idempotency index is inconsistent.")
+      }
+      return { record: structuredClone(existing), created: false }
+    }
+
+    const recordKey = modelCallRecordKey(record.projectId, record.id)
+    if (this.records.has(recordKey)) {
+      throw new AiUsageStorageError(
+        "duplicate_id",
+        `[Sixb] AI usage record '${record.id}' already exists for project '${record.projectId}'.`
+      )
+    }
+
+    this.records.set(recordKey, structuredClone(record))
+    this.recordKeysByIdempotencyKey.set(idempotencyKey, recordKey)
+    for (const groupId of record.requesterGroupIds) {
+      const row: InMemoryAiUsageGroupRow = {
+        projectId: record.projectId,
+        usageRecordId: record.id,
+        groupId,
+        occurredAt: record.occurredAt,
+      }
+      this.groupRows.set(groupRowKey(row), row)
+    }
+
+    return { record: structuredClone(record), created: true }
+  }
+
+  async summarizeExecution(input: SummarizeAiUsageExecutionInput) {
+    const [summary] = await this.summarizeExecutions({
+      projectId: input.projectId,
+      executions: [input.execution],
+    })
+    return summary!
+  }
+
+  async summarizeExecutions(input: SummarizeAiUsageExecutionsInput) {
+    if (typeof input.projectId !== "string" || input.projectId.trim().length === 0) {
+      throw new TypeError("[Sixb] AI usage projectId must be nonblank.")
+    }
+
+    const usageByExecution = new Map<string, AiModelCallUsageRecord["usage"][]>()
+    for (const execution of input.executions) {
+      assertAiUsageExecution(execution)
+      usageByExecution.set(executionKey(execution), [])
+    }
+    if (usageByExecution.size === 0) return []
+
+    for (const record of this.records.values()) {
+      if (record.projectId !== input.projectId) continue
+      usageByExecution.get(executionKey(record.execution))?.push(record.usage)
+    }
+
+    return input.executions.map((execution) =>
+      aggregateAiModelCallUsage(usageByExecution.get(executionKey(execution)) ?? [])
+    )
+  }
+
+  snapshot(): InMemoryAiUsageStorageSnapshot {
+    return structuredClone({
+      records: this.records,
+      recordKeysByIdempotencyKey: this.recordKeysByIdempotencyKey,
+      groupRows: this.groupRows,
+    })
+  }
+
+  restore(snapshot: InMemoryAiUsageStorageSnapshot): void {
+    replaceMap(this.records, snapshot.records)
+    replaceMap(this.recordKeysByIdempotencyKey, snapshot.recordKeysByIdempotencyKey)
+    replaceMap(this.groupRows, snapshot.groupRows)
+  }
+}
+
+function modelCallRecordKey(projectId: string, id: string): string {
+  return JSON.stringify([projectId, id])
+}
+
+function modelCallIdempotencyKey(
+  record: Pick<
+    AiModelCallUsageRecord,
+    "projectId" | "execution" | "attempt" | "callId" | "responseId"
+  >
+): string {
+  return JSON.stringify([
+    record.projectId,
+    ...executionKeyParts(record.execution),
+    record.attempt,
+    record.callId,
+    record.responseId,
+  ])
+}
+
+function executionKeyParts(execution: AiUsageExecutionIdentity): readonly string[] {
+  return execution.kind === "agentRun"
+    ? [execution.kind, execution.runId]
+    : [execution.kind, execution.workflowRunId, execution.nodeRunId]
+}
+
+function executionKey(execution: AiUsageExecutionIdentity): string {
+  return JSON.stringify(executionKeyParts(execution))
+}
+
+function groupRowKey(row: InMemoryAiUsageGroupRow): string {
+  return JSON.stringify([row.projectId, row.usageRecordId, row.groupId])
+}
+
+function replaceMap<TKey, TValue>(target: Map<TKey, TValue>, source: Map<TKey, TValue>): void {
+  target.clear()
+  for (const [key, value] of structuredClone(source)) {
+    target.set(key, value)
+  }
+}

--- a/packages/core/src/storage/ai-usage/in-memory.ts
+++ b/packages/core/src/storage/ai-usage/in-memory.ts
@@ -3,6 +3,7 @@ import { assertAiUsageExecution, normalizeAiModelCallRecord } from "./record"
 import type {
   AiModelCallUsageRecord,
   AiUsageExecutionIdentity,
+  AiUsageExecutionSummary,
   AiUsageStorage,
   RecordAiModelCallInput,
   RecordAiModelCallResult,
@@ -65,7 +66,9 @@ export class InMemoryAiUsageStorage implements AiUsageStorage {
     return { record: structuredClone(record), created: true }
   }
 
-  async summarizeExecution(input: SummarizeAiUsageExecutionInput) {
+  async summarizeExecution(
+    input: SummarizeAiUsageExecutionInput
+  ): Promise<AiUsageExecutionSummary> {
     const [summary] = await this.summarizeExecutions({
       projectId: input.projectId,
       executions: [input.execution],
@@ -73,7 +76,9 @@ export class InMemoryAiUsageStorage implements AiUsageStorage {
     return summary!
   }
 
-  async summarizeExecutions(input: SummarizeAiUsageExecutionsInput) {
+  async summarizeExecutions(
+    input: SummarizeAiUsageExecutionsInput
+  ): Promise<readonly AiUsageExecutionSummary[]> {
     if (typeof input.projectId !== "string" || input.projectId.trim().length === 0) {
       throw new TypeError("[Sixb] AI usage projectId must be nonblank.")
     }
@@ -90,9 +95,13 @@ export class InMemoryAiUsageStorage implements AiUsageStorage {
       usageByExecution.get(executionKey(record.execution))?.push(record.usage)
     }
 
-    return input.executions.map((execution) =>
-      aggregateAiModelCallUsage(usageByExecution.get(executionKey(execution)) ?? [])
-    )
+    return input.executions.map((execution) => {
+      const usages = usageByExecution.get(executionKey(execution)) ?? []
+      return {
+        modelCallCount: usages.length,
+        usage: aggregateAiModelCallUsage(usages),
+      }
+    })
   }
 
   snapshot(): InMemoryAiUsageStorageSnapshot {

--- a/packages/core/src/storage/ai-usage/index.ts
+++ b/packages/core/src/storage/ai-usage/index.ts
@@ -1,0 +1,21 @@
+export type { AiUsageStorageErrorCode } from "./errors"
+export { AiUsageStorageError } from "./errors"
+export type {
+  InMemoryAiUsageGroupRow,
+  InMemoryAiUsageStorageSnapshot,
+} from "./in-memory"
+export { InMemoryAiUsageStorage } from "./in-memory"
+export { assertAiUsageExecution, normalizeAiModelCallRecord } from "./record"
+export type {
+  AiModelCallUsage,
+  AiModelCallUsageInput,
+  AiModelCallUsageRecord,
+  AiUsageExecutionIdentity,
+  AiUsageReportingStatus,
+  AiUsageStorage,
+  RecordAiModelCallInput,
+  RecordAiModelCallResult,
+  SummarizeAiUsageExecutionInput,
+  SummarizeAiUsageExecutionsInput,
+} from "./types"
+export { aggregateAiModelCallUsage, normalizeAiModelCallUsage } from "./usage"

--- a/packages/core/src/storage/ai-usage/index.ts
+++ b/packages/core/src/storage/ai-usage/index.ts
@@ -11,6 +11,7 @@ export type {
   AiModelCallUsageInput,
   AiModelCallUsageRecord,
   AiUsageExecutionIdentity,
+  AiUsageExecutionSummary,
   AiUsageReportingStatus,
   AiUsageStorage,
   RecordAiModelCallInput,

--- a/packages/core/src/storage/ai-usage/record.ts
+++ b/packages/core/src/storage/ai-usage/record.ts
@@ -1,0 +1,108 @@
+import { assertJsonValue, compareStrings, isPlainRecord } from "../../json"
+import type {
+  AiModelCallUsageRecord,
+  AiUsageExecutionIdentity,
+  RecordAiModelCallInput,
+} from "./types"
+import { normalizeAiModelCallUsage } from "./usage"
+
+/** Validate and defensively snapshot one provider-neutral model-call ledger input. */
+export function normalizeAiModelCallRecord(input: RecordAiModelCallInput): AiModelCallUsageRecord {
+  assertNonBlank(input.id, "id")
+  assertNonBlank(input.projectId, "projectId")
+  assertAiUsageExecution(input.execution)
+  assertPositiveSafeInteger(input.attempt, "attempt")
+  assertNonBlank(input.callId, "callId")
+  assertPrincipal(input.requesterPrincipal)
+  assertNonBlank(input.providerId, "providerId")
+  assertNonBlank(input.requestedModelId, "requestedModelId")
+  if (input.responseModelId !== undefined) {
+    assertNonBlank(input.responseModelId, "responseModelId")
+  }
+  assertNonBlank(input.responseId, "responseId")
+
+  const occurredAt = cloneValidDate(input.occurredAt, "occurredAt")
+  const recordedAt = cloneValidDate(input.recordedAt ?? new Date(), "recordedAt")
+  const requesterGroupIds = normalizeGroupIds(input.requesterGroupIds)
+  const rawUsage = cloneRawUsage(input.rawUsage)
+
+  return {
+    id: input.id,
+    projectId: input.projectId,
+    execution: structuredClone(input.execution),
+    attempt: input.attempt,
+    callId: input.callId,
+    requesterPrincipal: structuredClone(input.requesterPrincipal),
+    requesterGroupIds,
+    providerId: input.providerId,
+    requestedModelId: input.requestedModelId,
+    ...(input.responseModelId === undefined ? {} : { responseModelId: input.responseModelId }),
+    responseId: input.responseId,
+    usage: normalizeAiModelCallUsage(input.usage),
+    ...(rawUsage === undefined ? {} : { rawUsage }),
+    occurredAt,
+    recordedAt,
+  }
+}
+
+/** Validate a durable execution identity at storage and query boundaries. */
+export function assertAiUsageExecution(execution: AiUsageExecutionIdentity): void {
+  if (execution.kind === "agentRun") {
+    assertNonBlank(execution.runId, "execution.runId")
+    return
+  }
+  if (execution.kind === "workflowAgentNode") {
+    assertNonBlank(execution.workflowRunId, "execution.workflowRunId")
+    assertNonBlank(execution.nodeRunId, "execution.nodeRunId")
+    return
+  }
+  throw new TypeError("[Sixb] AI usage execution kind is invalid.")
+}
+
+function normalizeGroupIds(groupIds: readonly string[]): readonly string[] {
+  const unique = new Set<string>()
+  for (const groupId of groupIds) {
+    assertNonBlank(groupId, "requesterGroupIds[]")
+    unique.add(groupId)
+  }
+  return [...unique].sort(compareStrings)
+}
+
+function cloneRawUsage(rawUsage: RecordAiModelCallInput["rawUsage"]) {
+  if (rawUsage === undefined) return undefined
+  if (!isPlainRecord(rawUsage)) {
+    throw new TypeError("[Sixb] AI usage rawUsage must be a JSON object.")
+  }
+  assertJsonValue(rawUsage, "AI usage rawUsage")
+  return structuredClone(rawUsage)
+}
+
+function assertPrincipal(principal: RecordAiModelCallInput["requesterPrincipal"]): void {
+  if (
+    principal.type !== "user" &&
+    principal.type !== "serviceAccount" &&
+    principal.type !== "system"
+  ) {
+    throw new TypeError("[Sixb] AI usage requesterPrincipal.type is invalid.")
+  }
+  assertNonBlank(principal.id, "requesterPrincipal.id")
+}
+
+function assertNonBlank(value: string, field: string): void {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`[Sixb] AI usage ${field} must be nonblank.`)
+  }
+}
+
+function assertPositiveSafeInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`[Sixb] AI usage ${field} must be a positive safe integer.`)
+  }
+}
+
+function cloneValidDate(value: Date, field: string): Date {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new TypeError(`[Sixb] AI usage ${field} must be a valid Date.`)
+  }
+  return new Date(value)
+}

--- a/packages/core/src/storage/ai-usage/types.ts
+++ b/packages/core/src/storage/ai-usage/types.ts
@@ -1,0 +1,101 @@
+import type { Principal } from "../../auth"
+import type { ReadonlyJsonObject } from "../../json"
+
+/** How much normalized token usage a provider reported for one model call. */
+export type AiUsageReportingStatus = "complete" | "partial" | "unavailable"
+
+/** Provider-neutral token counts accepted at the model-call boundary. */
+export interface AiModelCallUsageInput {
+  readonly inputTokens?: number
+  readonly outputTokens?: number
+  readonly uncachedInputTokens?: number
+  readonly cacheReadInputTokens?: number
+  readonly cacheWriteInputTokens?: number
+  readonly textOutputTokens?: number
+  readonly reasoningOutputTokens?: number
+}
+
+/** Normalized token counts for one completed model call. Details overlap their input/output totals. */
+export interface AiModelCallUsage extends AiModelCallUsageInput {
+  /** Present only when both input and output totals are known. */
+  readonly totalTokens?: number
+  readonly reportingStatus: AiUsageReportingStatus
+}
+
+/** The durable execution that owns a model call. */
+export type AiUsageExecutionIdentity =
+  | {
+      readonly kind: "agentRun"
+      readonly runId: string
+    }
+  | {
+      readonly kind: "workflowAgentNode"
+      readonly workflowRunId: string
+      readonly nodeRunId: string
+    }
+
+/** Input for an idempotent model-call ledger append. */
+export interface RecordAiModelCallInput {
+  readonly id: string
+  readonly projectId: string
+  readonly execution: AiUsageExecutionIdentity
+  /** Queue delivery attempt that made the provider call. */
+  readonly attempt: number
+  /** AI SDK generation ID. Tool-loop model calls share it and are distinguished by responseId. */
+  readonly callId: string
+  readonly requesterPrincipal: Principal
+  /** Durable group memberships snapshotted when the parent run was admitted. */
+  readonly requesterGroupIds: readonly string[]
+  /** AI SDK provider that handled the call, such as `openai`, `anthropic`, or `gateway`. */
+  readonly providerId: string
+  readonly requestedModelId: string
+  /** Provider-returned model identity when the capture path exposes it. */
+  readonly responseModelId?: string
+  /** Provider-returned response ID used for later usage and cost reconciliation. */
+  readonly responseId: string
+  readonly usage: AiModelCallUsageInput
+  readonly rawUsage?: ReadonlyJsonObject
+  /** When the provider call completed, used for historical pricing and accounting periods. */
+  readonly occurredAt: Date
+  readonly recordedAt?: Date
+}
+
+/** Immutable accounting record for one completed provider model call. */
+export interface AiModelCallUsageRecord extends RecordAiModelCallInput {
+  readonly usage: AiModelCallUsage
+  readonly recordedAt: Date
+}
+
+export interface RecordAiModelCallResult {
+  readonly record: AiModelCallUsageRecord
+  /** False when the idempotency key already existed and its record was returned. */
+  readonly created: boolean
+}
+
+export interface SummarizeAiUsageExecutionInput {
+  readonly projectId: string
+  readonly execution: AiUsageExecutionIdentity
+}
+
+export interface SummarizeAiUsageExecutionsInput {
+  readonly projectId: string
+  readonly executions: readonly AiUsageExecutionIdentity[]
+}
+
+/** Durable, provider-neutral accounting for completed language-model calls. */
+export interface AiUsageStorage {
+  /**
+   * Append one model-call record idempotently. The identity is project, execution, attempt, call
+   * ID, and response ID; retrying that identity returns the existing record with `created: false`.
+   */
+  recordModelCall(input: RecordAiModelCallInput): Promise<RecordAiModelCallResult>
+
+  /** Aggregate normalized usage across every attempt of one execution. */
+  summarizeExecution(input: SummarizeAiUsageExecutionInput): Promise<AiModelCallUsage>
+
+  /**
+   * Aggregate multiple executions in one storage read. Results have the same length and order as
+   * `executions`, including an unavailable result for executions without ledger records.
+   */
+  summarizeExecutions(input: SummarizeAiUsageExecutionsInput): Promise<readonly AiModelCallUsage[]>
+}

--- a/packages/core/src/storage/ai-usage/types.ts
+++ b/packages/core/src/storage/ai-usage/types.ts
@@ -22,6 +22,14 @@ export interface AiModelCallUsage extends AiModelCallUsageInput {
   readonly reportingStatus: AiUsageReportingStatus
 }
 
+/** Aggregated usage and call presence for one durable execution. */
+export interface AiUsageExecutionSummary {
+  /** Number of idempotent model-call ledger records included across every delivery attempt. */
+  readonly modelCallCount: number
+  /** Unavailable with a positive call count means the provider reported no normalized counts. */
+  readonly usage: AiModelCallUsage
+}
+
 /** The durable execution that owns a model call. */
 export type AiUsageExecutionIdentity =
   | {
@@ -90,12 +98,15 @@ export interface AiUsageStorage {
    */
   recordModelCall(input: RecordAiModelCallInput): Promise<RecordAiModelCallResult>
 
-  /** Aggregate normalized usage across every attempt of one execution. */
-  summarizeExecution(input: SummarizeAiUsageExecutionInput): Promise<AiModelCallUsage>
+  /** Aggregate normalized usage and call presence across every attempt of one execution. */
+  summarizeExecution(input: SummarizeAiUsageExecutionInput): Promise<AiUsageExecutionSummary>
 
   /**
    * Aggregate multiple executions in one storage read. Results have the same length and order as
-   * `executions`, including an unavailable result for executions without ledger records.
+   * `executions`. Executions without ledger records have a zero model-call count and unavailable
+   * usage.
    */
-  summarizeExecutions(input: SummarizeAiUsageExecutionsInput): Promise<readonly AiModelCallUsage[]>
+  summarizeExecutions(
+    input: SummarizeAiUsageExecutionsInput
+  ): Promise<readonly AiUsageExecutionSummary[]>
 }

--- a/packages/core/src/storage/ai-usage/usage.ts
+++ b/packages/core/src/storage/ai-usage/usage.ts
@@ -1,0 +1,104 @@
+import type { AiModelCallUsage, AiModelCallUsageInput } from "./types"
+
+const USAGE_FIELDS = [
+  "inputTokens",
+  "outputTokens",
+  "uncachedInputTokens",
+  "cacheReadInputTokens",
+  "cacheWriteInputTokens",
+  "textOutputTokens",
+  "reasoningOutputTokens",
+] as const
+
+type AiUsageField = (typeof USAGE_FIELDS)[number]
+
+/** Validate provider-neutral counts and derive total/reporting fields without inventing zeroes. */
+export function normalizeAiModelCallUsage(input: AiModelCallUsageInput): AiModelCallUsage {
+  for (const field of USAGE_FIELDS) {
+    assertUsageCount(input[field], field)
+  }
+
+  const totalTokens =
+    input.inputTokens === undefined || input.outputTokens === undefined
+      ? undefined
+      : addUsageCounts(input.inputTokens, input.outputTokens, "totalTokens")
+  const reportingStatus =
+    input.inputTokens !== undefined && input.outputTokens !== undefined
+      ? "complete"
+      : USAGE_FIELDS.some((field) => input[field] !== undefined)
+        ? "partial"
+        : "unavailable"
+
+  return {
+    ...(input.inputTokens === undefined ? {} : { inputTokens: input.inputTokens }),
+    ...(input.outputTokens === undefined ? {} : { outputTokens: input.outputTokens }),
+    ...(totalTokens === undefined ? {} : { totalTokens }),
+    ...(input.uncachedInputTokens === undefined
+      ? {}
+      : { uncachedInputTokens: input.uncachedInputTokens }),
+    ...(input.cacheReadInputTokens === undefined
+      ? {}
+      : { cacheReadInputTokens: input.cacheReadInputTokens }),
+    ...(input.cacheWriteInputTokens === undefined
+      ? {}
+      : { cacheWriteInputTokens: input.cacheWriteInputTokens }),
+    ...(input.textOutputTokens === undefined ? {} : { textOutputTokens: input.textOutputTokens }),
+    ...(input.reasoningOutputTokens === undefined
+      ? {}
+      : { reasoningOutputTokens: input.reasoningOutputTokens }),
+    reportingStatus,
+  }
+}
+
+/**
+ * Aggregate model-call usage without treating a missing count as zero.
+ *
+ * A field is present only when every call reported it. This prevents a partial provider response
+ * from becoming an apparently complete execution total. Zero remains a reported value.
+ */
+export function aggregateAiModelCallUsage(
+  usages: Iterable<AiModelCallUsageInput>
+): AiModelCallUsage {
+  const normalized = Array.from(usages, normalizeAiModelCallUsage)
+  const fields = Object.fromEntries(
+    USAGE_FIELDS.map((field) => [field, sumUsageField(normalized, field)])
+  ) as Record<AiUsageField, number | undefined>
+  const aggregate = normalizeAiModelCallUsage(fields)
+
+  if (
+    aggregate.reportingStatus === "unavailable" &&
+    normalized.some((usage) => usage.reportingStatus !== "unavailable")
+  ) {
+    return { ...aggregate, reportingStatus: "partial" }
+  }
+  return aggregate
+}
+
+function sumUsageField(
+  usages: readonly AiModelCallUsage[],
+  field: AiUsageField
+): number | undefined {
+  if (usages.length === 0) return undefined
+
+  let total = 0
+  for (const usage of usages) {
+    const value = usage[field]
+    if (value === undefined) return undefined
+    total = addUsageCounts(total, value, `aggregate ${field}`)
+  }
+  return total
+}
+
+function assertUsageCount(value: number | undefined, field: AiUsageField): void {
+  if (value !== undefined && (!Number.isSafeInteger(value) || value < 0)) {
+    throw new TypeError(`[Sixb] AI model-call usage ${field} must be a non-negative safe integer.`)
+  }
+}
+
+function addUsageCounts(left: number, right: number, field: string): number {
+  const result = left + right
+  if (!Number.isSafeInteger(result)) {
+    throw new TypeError(`[Sixb] AI model-call usage ${field} exceeds the safe integer range.`)
+  }
+  return result
+}

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -4,7 +4,9 @@
  * A type in a public interface signature must be exported from the same subpath as the interface, or
  * the interface cannot be implemented from outside the package.
  */
+export type { Principal } from "../auth"
 export type { StoredRuleResolvedEvent, StoredRuleTriggeredEvent } from "../events"
+export type { ReadonlyJsonObject } from "../json"
 export { stableJsonStringify } from "../json"
 export type {
   PinnedDatasetVersion,
@@ -83,6 +85,29 @@ export {
   coerceAgentRunFinishReason,
   InMemoryAgentStorage,
 } from "./agents"
+export type {
+  AiModelCallUsage,
+  AiModelCallUsageInput,
+  AiModelCallUsageRecord,
+  AiUsageExecutionIdentity,
+  AiUsageReportingStatus,
+  AiUsageStorage,
+  AiUsageStorageErrorCode,
+  InMemoryAiUsageGroupRow,
+  InMemoryAiUsageStorageSnapshot,
+  RecordAiModelCallInput,
+  RecordAiModelCallResult,
+  SummarizeAiUsageExecutionInput,
+  SummarizeAiUsageExecutionsInput,
+} from "./ai-usage"
+export {
+  AiUsageStorageError,
+  aggregateAiModelCallUsage,
+  assertAiUsageExecution,
+  InMemoryAiUsageStorage,
+  normalizeAiModelCallRecord,
+  normalizeAiModelCallUsage,
+} from "./ai-usage"
 export type {
   AccessTokenRecord,
   AccessTokenSubjectType,

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -90,6 +90,7 @@ export type {
   AiModelCallUsageInput,
   AiModelCallUsageRecord,
   AiUsageExecutionIdentity,
+  AiUsageExecutionSummary,
   AiUsageReportingStatus,
   AiUsageStorage,
   AiUsageStorageErrorCode,

--- a/packages/core/src/testing/ai-usage-storage-contract.ts
+++ b/packages/core/src/testing/ai-usage-storage-contract.ts
@@ -129,15 +129,18 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(
           storage.summarizeExecution({ projectId, execution: agentExecution })
         ).resolves.toEqual({
-          inputTokens: 16,
-          outputTokens: 14,
-          totalTokens: 30,
-          uncachedInputTokens: 13,
-          cacheReadInputTokens: 3,
-          cacheWriteInputTokens: 3,
-          textOutputTokens: 11,
-          reasoningOutputTokens: 3,
-          reportingStatus: "complete",
+          modelCallCount: 2,
+          usage: {
+            inputTokens: 16,
+            outputTokens: 14,
+            totalTokens: 30,
+            uncachedInputTokens: 13,
+            cacheReadInputTokens: 3,
+            cacheWriteInputTokens: 3,
+            textOutputTokens: 11,
+            reasoningOutputTokens: 3,
+            reportingStatus: "complete",
+          },
         })
       })
     })
@@ -166,15 +169,18 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(
           storage.summarizeExecution({ projectId, execution: agentExecution })
         ).resolves.toEqual({
-          inputTokens: 16,
-          outputTokens: 14,
-          totalTokens: 30,
-          uncachedInputTokens: 13,
-          cacheReadInputTokens: 3,
-          cacheWriteInputTokens: 3,
-          textOutputTokens: 11,
-          reasoningOutputTokens: 3,
-          reportingStatus: "complete",
+          modelCallCount: 2,
+          usage: {
+            inputTokens: 16,
+            outputTokens: 14,
+            totalTokens: 30,
+            uncachedInputTokens: 13,
+            cacheReadInputTokens: 3,
+            cacheWriteInputTokens: 3,
+            textOutputTokens: 11,
+            reasoningOutputTokens: 3,
+            reportingStatus: "complete",
+          },
         })
       })
     })
@@ -189,7 +195,20 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         expect(results.map((result) => result.created).sort()).toEqual([false, true])
         await expect(
           storage.summarizeExecution({ projectId, execution: agentExecution })
-        ).resolves.toMatchObject({ inputTokens: 12, outputTokens: 8, totalTokens: 20 })
+        ).resolves.toEqual({
+          modelCallCount: 1,
+          usage: {
+            inputTokens: 12,
+            outputTokens: 8,
+            totalTokens: 20,
+            uncachedInputTokens: 9,
+            cacheReadInputTokens: 3,
+            cacheWriteInputTokens: 1,
+            textOutputTokens: 6,
+            reasoningOutputTokens: 2,
+            reportingStatus: "complete",
+          },
+        })
       })
     })
 
@@ -219,24 +238,33 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(
           storage.summarizeExecution({ projectId, execution: workflowExecution })
         ).resolves.toEqual({
-          inputTokens: 5,
-          outputTokens: 3,
-          totalTokens: 8,
-          reportingStatus: "complete",
+          modelCallCount: 1,
+          usage: {
+            inputTokens: 5,
+            outputTokens: 3,
+            totalTokens: 8,
+            reportingStatus: "complete",
+          },
         })
         await expect(
           storage.summarizeExecution({ projectId, execution: agentExecution })
-        ).resolves.toEqual({ reportingStatus: "unavailable" })
+        ).resolves.toEqual({
+          modelCallCount: 0,
+          usage: { reportingStatus: "unavailable" },
+        })
         await expect(
           storage.summarizeExecution({
             projectId,
             execution: { ...workflowExecution, workflowRunId: "workflow_run_2" },
           })
-        ).resolves.toEqual({ reportingStatus: "unavailable" })
+        ).resolves.toEqual({
+          modelCallCount: 0,
+          usage: { reportingStatus: "unavailable" },
+        })
       })
     })
 
-    test("summarizes multiple executions in input order with one unavailable entry per miss", async () => {
+    test("summarizes multiple executions in input order with one zero-call entry per miss", async () => {
       await withStorage(async (storage) => {
         await expect(storage.summarizeExecutions({ projectId, executions: [] })).resolves.toEqual(
           []
@@ -280,29 +308,63 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
             ],
           })
         ).resolves.toEqual([
-          { inputTokens: 4, outputTokens: 6, totalTokens: 10, reportingStatus: "complete" },
-          { reportingStatus: "unavailable" },
-          { inputTokens: 5, outputTokens: 3, totalTokens: 8, reportingStatus: "complete" },
           {
-            inputTokens: 12,
-            outputTokens: 8,
-            totalTokens: 20,
-            uncachedInputTokens: 9,
-            cacheReadInputTokens: 3,
-            cacheWriteInputTokens: 1,
-            textOutputTokens: 6,
-            reasoningOutputTokens: 2,
-            reportingStatus: "complete",
+            modelCallCount: 1,
+            usage: {
+              inputTokens: 4,
+              outputTokens: 6,
+              totalTokens: 10,
+              reportingStatus: "complete",
+            },
           },
-          { inputTokens: 4, outputTokens: 6, totalTokens: 10, reportingStatus: "complete" },
+          { modelCallCount: 0, usage: { reportingStatus: "unavailable" } },
+          {
+            modelCallCount: 1,
+            usage: {
+              inputTokens: 5,
+              outputTokens: 3,
+              totalTokens: 8,
+              reportingStatus: "complete",
+            },
+          },
+          {
+            modelCallCount: 1,
+            usage: {
+              inputTokens: 12,
+              outputTokens: 8,
+              totalTokens: 20,
+              uncachedInputTokens: 9,
+              cacheReadInputTokens: 3,
+              cacheWriteInputTokens: 1,
+              textOutputTokens: 6,
+              reasoningOutputTokens: 2,
+              reportingStatus: "complete",
+            },
+          },
+          {
+            modelCallCount: 1,
+            usage: {
+              inputTokens: 4,
+              outputTokens: 6,
+              totalTokens: 10,
+              reportingStatus: "complete",
+            },
+          },
         ])
       })
     })
 
-    test("preserves completely missing provider usage instead of inventing zeroes", async () => {
+    test("distinguishes no model calls from a call without reported usage", async () => {
       // Regression guard: coerce nullable SQL token columns with `Number(null)` and this becomes a
       // complete zero-token report instead of an unavailable one.
       await withStorage(async (storage) => {
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toEqual({
+          modelCallCount: 0,
+          usage: { reportingStatus: "unavailable" },
+        })
+
         const result = await storage.recordModelCall(
           modelCallInput({ usage: {}, rawUsage: undefined })
         )
@@ -311,7 +373,10 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         expect(result.record.rawUsage).toBeUndefined()
         await expect(
           storage.summarizeExecution({ projectId, execution: agentExecution })
-        ).resolves.toEqual({ reportingStatus: "unavailable" })
+        ).resolves.toEqual({
+          modelCallCount: 1,
+          usage: { reportingStatus: "unavailable" },
+        })
       })
     })
 
@@ -348,8 +413,11 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(
           storage.summarizeExecution({ projectId, execution: agentExecution })
         ).resolves.toEqual({
-          inputTokens: 10,
-          reportingStatus: "partial",
+          modelCallCount: 2,
+          usage: {
+            inputTokens: 10,
+            reportingStatus: "partial",
+          },
         })
       })
     })
@@ -390,7 +458,10 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(error).rejects.toMatchObject({ code: "duplicate_id" })
         await expect(
           storage.summarizeExecution({ projectId, execution: agentExecution })
-        ).resolves.toMatchObject({ inputTokens: 12, outputTokens: 8, totalTokens: 20 })
+        ).resolves.toMatchObject({
+          modelCallCount: 1,
+          usage: { inputTokens: 12, outputTokens: 8, totalTokens: 20 },
+        })
       })
     })
 
@@ -417,7 +488,10 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         ).rejects.toThrow()
         await expect(
           storage.summarizeExecution({ projectId, execution: agentExecution })
-        ).resolves.toEqual({ reportingStatus: "unavailable" })
+        ).resolves.toEqual({
+          modelCallCount: 0,
+          usage: { reportingStatus: "unavailable" },
+        })
       })
     })
   })

--- a/packages/core/src/testing/ai-usage-storage-contract.ts
+++ b/packages/core/src/testing/ai-usage-storage-contract.ts
@@ -1,0 +1,424 @@
+import { describe, expect, test } from "bun:test"
+import type { Principal } from "../auth"
+import {
+  type AiUsageStorage,
+  AiUsageStorageError,
+  type RecordAiModelCallInput,
+} from "../storage/ai-usage"
+
+export interface AiUsageStorageContractSuiteOptions<
+  TStorage extends AiUsageStorage = AiUsageStorage,
+> {
+  /** Factory that returns an isolated AI usage store for each test. */
+  readonly createStorage: () => TStorage | Promise<TStorage>
+  readonly setup?: (storage: TStorage) => void | Promise<void>
+  readonly cleanup?: (storage: TStorage) => void | Promise<void>
+}
+
+const projectId = "contract-project"
+const requester: Principal = { type: "user", id: "usr_1" }
+const agentExecution = { kind: "agentRun", runId: "run_1" } as const
+
+function at(value: string): Date {
+  return new Date(value)
+}
+
+function modelCallInput(overrides: Partial<RecordAiModelCallInput> = {}): RecordAiModelCallInput {
+  return {
+    id: "usage_1",
+    projectId,
+    execution: agentExecution,
+    attempt: 1,
+    callId: "call_1",
+    requesterPrincipal: requester,
+    requesterGroupIds: ["support", "engineering"],
+    providerId: "gateway",
+    requestedModelId: "openai/gpt-5",
+    responseModelId: "gpt-5-2026-06-01",
+    responseId: "response_1",
+    usage: {
+      inputTokens: 12,
+      outputTokens: 8,
+      uncachedInputTokens: 9,
+      cacheReadInputTokens: 3,
+      cacheWriteInputTokens: 1,
+      textOutputTokens: 6,
+      reasoningOutputTokens: 2,
+    },
+    rawUsage: { input_tokens: 12, output_tokens: 8 },
+    occurredAt: at("2026-06-23T10:00:00.000Z"),
+    recordedAt: at("2026-06-23T10:00:01.000Z"),
+    ...overrides,
+  }
+}
+
+/** Runs the provider-neutral model-call ledger contract against one storage implementation. */
+export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
+  label: string,
+  options: AiUsageStorageContractSuiteOptions<TStorage>
+): void {
+  const withStorage = async (body: (storage: TStorage) => Promise<void>): Promise<void> => {
+    const storage = await options.createStorage()
+    try {
+      await options.setup?.(storage)
+      await body(storage)
+    } finally {
+      await options.cleanup?.(storage)
+    }
+  }
+
+  describe(label, () => {
+    test("records normalized usage and one canonical row per requester group", async () => {
+      await withStorage(async (storage) => {
+        const result = await storage.recordModelCall(
+          modelCallInput({
+            requesterGroupIds: ["support", "engineering", "support"],
+          })
+        )
+
+        expect(result.created).toBe(true)
+        expect(result.record).toEqual({
+          ...modelCallInput(),
+          requesterGroupIds: ["engineering", "support"],
+          usage: {
+            ...modelCallInput().usage,
+            totalTokens: 20,
+            reportingStatus: "complete",
+          },
+          recordedAt: at("2026-06-23T10:00:01.000Z"),
+        })
+      })
+    })
+
+    test("returns the existing record when the idempotency key is replayed", async () => {
+      await withStorage(async (storage) => {
+        const first = await storage.recordModelCall(modelCallInput())
+        const replay = await storage.recordModelCall(
+          modelCallInput({
+            id: "ignored_retry_id",
+            requesterGroupIds: ["different-group"],
+            usage: { inputTokens: 999, outputTokens: 1 },
+          })
+        )
+
+        expect(first.created).toBe(true)
+        expect(replay.created).toBe(false)
+        expect(replay.record).toEqual(first.record)
+      })
+    })
+
+    test("allows one generation call id to contain multiple billable responses", async () => {
+      await withStorage(async (storage) => {
+        await storage.recordModelCall(modelCallInput())
+        await storage.recordModelCall(
+          modelCallInput({
+            id: "usage_2",
+            responseId: "response_2",
+            usage: {
+              inputTokens: 4,
+              outputTokens: 6,
+              uncachedInputTokens: 4,
+              cacheReadInputTokens: 0,
+              cacheWriteInputTokens: 2,
+              textOutputTokens: 5,
+              reasoningOutputTokens: 1,
+            },
+          })
+        )
+
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toEqual({
+          inputTokens: 16,
+          outputTokens: 14,
+          totalTokens: 30,
+          uncachedInputTokens: 13,
+          cacheReadInputTokens: 3,
+          cacheWriteInputTokens: 3,
+          textOutputTokens: 11,
+          reasoningOutputTokens: 3,
+          reportingStatus: "complete",
+        })
+      })
+    })
+
+    test("bills the same call and response IDs again on a later delivery attempt", async () => {
+      // Regression guard: remove `attempt` from a provider's idempotency key/query/index and the
+      // second append collapses into the first, making the aggregate assertions fail.
+      await withStorage(async (storage) => {
+        await storage.recordModelCall(modelCallInput())
+        await storage.recordModelCall(
+          modelCallInput({
+            id: "usage_2",
+            attempt: 2,
+            usage: {
+              inputTokens: 4,
+              outputTokens: 6,
+              uncachedInputTokens: 4,
+              cacheReadInputTokens: 0,
+              cacheWriteInputTokens: 2,
+              textOutputTokens: 5,
+              reasoningOutputTokens: 1,
+            },
+          })
+        )
+
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toEqual({
+          inputTokens: 16,
+          outputTokens: 14,
+          totalTokens: 30,
+          uncachedInputTokens: 13,
+          cacheReadInputTokens: 3,
+          cacheWriteInputTokens: 3,
+          textOutputTokens: 11,
+          reasoningOutputTokens: 3,
+          reportingStatus: "complete",
+        })
+      })
+    })
+
+    test("does not count concurrent idempotent appends twice", async () => {
+      await withStorage(async (storage) => {
+        const results = await Promise.all([
+          storage.recordModelCall(modelCallInput()),
+          storage.recordModelCall(modelCallInput({ id: "usage_retry" })),
+        ])
+
+        expect(results.map((result) => result.created).sort()).toEqual([false, true])
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toMatchObject({ inputTokens: 12, outputTokens: 8, totalTokens: 20 })
+      })
+    })
+
+    test("keeps projects and workflow executions isolated", async () => {
+      await withStorage(async (storage) => {
+        const workflowExecution = {
+          kind: "workflowAgentNode",
+          workflowRunId: "workflow_run_1",
+          nodeRunId: "node_run_1",
+        } as const
+        await storage.recordModelCall(
+          modelCallInput({
+            id: "usage_workflow",
+            execution: workflowExecution,
+            usage: { inputTokens: 5, outputTokens: 3 },
+          })
+        )
+        await storage.recordModelCall(
+          modelCallInput({
+            id: "usage_other_project",
+            projectId: "other-project",
+            execution: workflowExecution,
+            usage: { inputTokens: 100, outputTokens: 100 },
+          })
+        )
+
+        await expect(
+          storage.summarizeExecution({ projectId, execution: workflowExecution })
+        ).resolves.toEqual({
+          inputTokens: 5,
+          outputTokens: 3,
+          totalTokens: 8,
+          reportingStatus: "complete",
+        })
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toEqual({ reportingStatus: "unavailable" })
+        await expect(
+          storage.summarizeExecution({
+            projectId,
+            execution: { ...workflowExecution, workflowRunId: "workflow_run_2" },
+          })
+        ).resolves.toEqual({ reportingStatus: "unavailable" })
+      })
+    })
+
+    test("summarizes multiple executions in input order with one unavailable entry per miss", async () => {
+      await withStorage(async (storage) => {
+        await expect(storage.summarizeExecutions({ projectId, executions: [] })).resolves.toEqual(
+          []
+        )
+
+        const otherAgentExecution = { kind: "agentRun", runId: "run_2" } as const
+        const workflowExecution = {
+          kind: "workflowAgentNode",
+          workflowRunId: "workflow_run_1",
+          nodeRunId: "node_run_1",
+        } as const
+        await storage.recordModelCall(modelCallInput())
+        await storage.recordModelCall(
+          modelCallInput({
+            id: "usage_agent_2",
+            execution: otherAgentExecution,
+            callId: "call_agent_2",
+            responseId: "response_agent_2",
+            usage: { inputTokens: 4, outputTokens: 6 },
+          })
+        )
+        await storage.recordModelCall(
+          modelCallInput({
+            id: "usage_workflow",
+            execution: workflowExecution,
+            callId: "call_workflow",
+            responseId: "response_workflow",
+            usage: { inputTokens: 5, outputTokens: 3 },
+          })
+        )
+
+        await expect(
+          storage.summarizeExecutions({
+            projectId,
+            executions: [
+              otherAgentExecution,
+              { kind: "agentRun", runId: "missing" },
+              workflowExecution,
+              agentExecution,
+              otherAgentExecution,
+            ],
+          })
+        ).resolves.toEqual([
+          { inputTokens: 4, outputTokens: 6, totalTokens: 10, reportingStatus: "complete" },
+          { reportingStatus: "unavailable" },
+          { inputTokens: 5, outputTokens: 3, totalTokens: 8, reportingStatus: "complete" },
+          {
+            inputTokens: 12,
+            outputTokens: 8,
+            totalTokens: 20,
+            uncachedInputTokens: 9,
+            cacheReadInputTokens: 3,
+            cacheWriteInputTokens: 1,
+            textOutputTokens: 6,
+            reasoningOutputTokens: 2,
+            reportingStatus: "complete",
+          },
+          { inputTokens: 4, outputTokens: 6, totalTokens: 10, reportingStatus: "complete" },
+        ])
+      })
+    })
+
+    test("preserves completely missing provider usage instead of inventing zeroes", async () => {
+      // Regression guard: coerce nullable SQL token columns with `Number(null)` and this becomes a
+      // complete zero-token report instead of an unavailable one.
+      await withStorage(async (storage) => {
+        const result = await storage.recordModelCall(
+          modelCallInput({ usage: {}, rawUsage: undefined })
+        )
+
+        expect(result.record.usage).toEqual({ reportingStatus: "unavailable" })
+        expect(result.record.rawUsage).toBeUndefined()
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toEqual({ reportingStatus: "unavailable" })
+      })
+    })
+
+    test("normalizes offset timestamps to the same UTC instants", async () => {
+      // Regression guard: persist a timezone-naive SQL timestamp and these offset-derived instants
+      // shift when read under a different database or process timezone.
+      await withStorage(async (storage) => {
+        const result = await storage.recordModelCall(
+          modelCallInput({
+            occurredAt: at("2026-06-23T03:04:05.678-07:00"),
+            recordedAt: at("2026-06-23T03:04:06.789-07:00"),
+          })
+        )
+
+        expect(result.record.occurredAt.toISOString()).toBe("2026-06-23T10:04:05.678Z")
+        expect(result.record.recordedAt.toISOString()).toBe("2026-06-23T10:04:06.789Z")
+      })
+    })
+
+    test("keeps incomplete execution totals partial instead of inventing zeroes", async () => {
+      await withStorage(async (storage) => {
+        await storage.recordModelCall(
+          modelCallInput({ usage: { inputTokens: 10, outputTokens: 5 } })
+        )
+        await storage.recordModelCall(
+          modelCallInput({
+            id: "usage_2",
+            callId: "call_2",
+            responseId: "response_2",
+            usage: { inputTokens: 0 },
+          })
+        )
+
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toEqual({
+          inputTokens: 10,
+          reportingStatus: "partial",
+        })
+      })
+    })
+
+    test("defensively snapshots inputs and returned records", async () => {
+      await withStorage(async (storage) => {
+        const requesterGroupIds = ["support"]
+        const rawUsage = { nested: { cached: 3 } }
+        const occurredAt = at("2026-06-23T10:00:00.000Z")
+        const input = modelCallInput({ requesterGroupIds, rawUsage, occurredAt })
+        const first = await storage.recordModelCall(input)
+
+        requesterGroupIds.push("mutated-input")
+        rawUsage.nested.cached = 999
+        occurredAt.setTime(0)
+
+        const returnedGroups = first.record.requesterGroupIds as string[]
+        returnedGroups.push("mutated-output")
+        const returnedRaw = first.record.rawUsage as { nested: { cached: number } }
+        returnedRaw.nested.cached = 888
+        first.record.occurredAt.setTime(1)
+
+        const replay = await storage.recordModelCall(modelCallInput())
+        expect(replay.record.requesterGroupIds).toEqual(["support"])
+        expect(replay.record.rawUsage).toEqual({ nested: { cached: 3 } })
+        expect(replay.record.occurredAt.toISOString()).toBe("2026-06-23T10:00:00.000Z")
+      })
+    })
+
+    test("rejects a reused record id with a different model-call identity", async () => {
+      await withStorage(async (storage) => {
+        await storage.recordModelCall(modelCallInput())
+
+        const error = storage.recordModelCall(
+          modelCallInput({ callId: "call_2", responseId: "response_2" })
+        )
+        await expect(error).rejects.toBeInstanceOf(AiUsageStorageError)
+        await expect(error).rejects.toMatchObject({ code: "duplicate_id" })
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toMatchObject({ inputTokens: 12, outputTokens: 8, totalTokens: 20 })
+      })
+    })
+
+    test("rejects invalid identity, usage, dates, groups, and raw JSON", async () => {
+      await withStorage(async (storage) => {
+        const invalidInputs: RecordAiModelCallInput[] = [
+          modelCallInput({ attempt: 0 }),
+          modelCallInput({ providerId: " " }),
+          modelCallInput({ requesterGroupIds: [""] }),
+          modelCallInput({ usage: { inputTokens: -1 } }),
+          modelCallInput({ occurredAt: new Date(Number.NaN) }),
+          modelCallInput({ rawUsage: { invalid: undefined } as never }),
+          modelCallInput({ execution: { kind: "agentRun", runId: "" } }),
+        ]
+
+        for (const input of invalidInputs) {
+          await expect(storage.recordModelCall(input)).rejects.toThrow()
+        }
+        await expect(
+          storage.summarizeExecutions({
+            projectId,
+            executions: [{ kind: "agentRun", runId: "" }],
+          })
+        ).rejects.toThrow()
+        await expect(
+          storage.summarizeExecution({ projectId, execution: agentExecution })
+        ).resolves.toEqual({ reportingStatus: "unavailable" })
+      })
+    })
+  })
+}

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -3,6 +3,10 @@ export {
   runAgentStorageContractSuite,
 } from "./agent-storage-contract"
 export {
+  type AiUsageStorageContractSuiteOptions,
+  runAiUsageStorageContractSuite,
+} from "./ai-usage-storage-contract"
+export {
   type AuthStorageContractSuiteOptions,
   runAuthStorageContractSuite,
 } from "./auth-storage-contract"

--- a/packages/core/tests/ai-usage-storage.test.ts
+++ b/packages/core/tests/ai-usage-storage.test.ts
@@ -32,7 +32,8 @@ describe("InMemoryAiUsageStorage", () => {
 
     storage.restore(empty)
     await expect(storage.summarizeExecution(executionSummaryInput())).resolves.toEqual({
-      reportingStatus: "unavailable",
+      modelCallCount: 0,
+      usage: { reportingStatus: "unavailable" },
     })
     await expect(storage.recordModelCall(modelCallInput())).resolves.toMatchObject({
       created: true,

--- a/packages/core/tests/ai-usage-storage.test.ts
+++ b/packages/core/tests/ai-usage-storage.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { InMemoryAiUsageStorage, type RecordAiModelCallInput } from "../src/storage"
+import { runAiUsageStorageContractSuite } from "../src/testing"
+
+runAiUsageStorageContractSuite("InMemoryAiUsageStorage", {
+  createStorage: () => new InMemoryAiUsageStorage(),
+})
+
+describe("InMemoryAiUsageStorage", () => {
+  test("snapshots model-call records, idempotency keys, and group rows", async () => {
+    const storage = new InMemoryAiUsageStorage()
+    const empty = storage.snapshot()
+
+    await storage.recordModelCall(modelCallInput())
+    const populated = storage.snapshot()
+    expect(populated.records.size).toBe(1)
+    expect(populated.recordKeysByIdempotencyKey.size).toBe(1)
+    expect([...populated.groupRows.values()]).toEqual([
+      {
+        projectId: "project_1",
+        usageRecordId: "usage_1",
+        groupId: "engineering",
+        occurredAt: new Date("2026-06-23T10:00:00.000Z"),
+      },
+      {
+        projectId: "project_1",
+        usageRecordId: "usage_1",
+        groupId: "support",
+        occurredAt: new Date("2026-06-23T10:00:00.000Z"),
+      },
+    ])
+
+    storage.restore(empty)
+    await expect(storage.summarizeExecution(executionSummaryInput())).resolves.toEqual({
+      reportingStatus: "unavailable",
+    })
+    await expect(storage.recordModelCall(modelCallInput())).resolves.toMatchObject({
+      created: true,
+    })
+  })
+})
+
+function modelCallInput(): RecordAiModelCallInput {
+  return {
+    id: "usage_1",
+    projectId: "project_1",
+    execution: { kind: "agentRun", runId: "run_1" },
+    attempt: 1,
+    callId: "call_1",
+    requesterPrincipal: { type: "user", id: "usr_1" },
+    requesterGroupIds: ["support", "engineering", "support"],
+    providerId: "gateway",
+    requestedModelId: "openai/gpt-5",
+    responseId: "response_1",
+    usage: { inputTokens: 12, outputTokens: 8 },
+    rawUsage: { input_tokens: 12, output_tokens: 8 },
+    occurredAt: new Date("2026-06-23T10:00:00.000Z"),
+    recordedAt: new Date("2026-06-23T10:00:01.000Z"),
+  }
+}
+
+function executionSummaryInput() {
+  return {
+    projectId: "project_1",
+    execution: { kind: "agentRun", runId: "run_1" },
+  } as const
+}

--- a/packages/core/tests/ai-usage.test.ts
+++ b/packages/core/tests/ai-usage.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test"
+import { aggregateAiModelCallUsage, normalizeAiModelCallUsage } from "../src/storage"
+
+describe("AI model-call usage vocabulary", () => {
+  test("normalizes a complete provider report without double-counting details", () => {
+    expect(
+      normalizeAiModelCallUsage({
+        inputTokens: 12,
+        outputTokens: 8,
+        uncachedInputTokens: 9,
+        cacheReadInputTokens: 3,
+        cacheWriteInputTokens: 2,
+        textOutputTokens: 6,
+        reasoningOutputTokens: 2,
+      })
+    ).toEqual({
+      inputTokens: 12,
+      outputTokens: 8,
+      totalTokens: 20,
+      uncachedInputTokens: 9,
+      cacheReadInputTokens: 3,
+      cacheWriteInputTokens: 2,
+      textOutputTokens: 6,
+      reasoningOutputTokens: 2,
+      reportingStatus: "complete",
+    })
+  })
+
+  test("preserves reported zeroes and keeps missing counts unknown", () => {
+    expect(
+      normalizeAiModelCallUsage({
+        inputTokens: 0,
+        outputTokens: 0,
+        uncachedInputTokens: 0,
+        cacheReadInputTokens: 0,
+        cacheWriteInputTokens: 0,
+        textOutputTokens: 0,
+        reasoningOutputTokens: 0,
+      })
+    ).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      uncachedInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      textOutputTokens: 0,
+      reasoningOutputTokens: 0,
+      reportingStatus: "complete",
+    })
+
+    expect(normalizeAiModelCallUsage({})).toEqual({
+      reportingStatus: "unavailable",
+    })
+    expect(normalizeAiModelCallUsage({ inputTokens: 0 })).toEqual({
+      inputTokens: 0,
+      reportingStatus: "partial",
+    })
+    expect(normalizeAiModelCallUsage({ cacheReadInputTokens: 0 })).toEqual({
+      cacheReadInputTokens: 0,
+      reportingStatus: "partial",
+    })
+  })
+
+  test("does not require provider detail fields to sum to their totals", () => {
+    expect(
+      normalizeAiModelCallUsage({
+        inputTokens: 10,
+        outputTokens: 2,
+        uncachedInputTokens: 10,
+        cacheReadInputTokens: 4,
+        reasoningOutputTokens: 3,
+      })
+    ).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 2,
+      totalTokens: 12,
+      reportingStatus: "complete",
+    })
+  })
+
+  test("rejects invalid counts and totals outside the safe integer range", () => {
+    for (const invalid of [-1, 1.5, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() => normalizeAiModelCallUsage({ inputTokens: invalid })).toThrow(
+        "inputTokens must be a non-negative safe integer"
+      )
+    }
+
+    expect(() =>
+      normalizeAiModelCallUsage({
+        inputTokens: Number.MAX_SAFE_INTEGER,
+        outputTokens: 1,
+      })
+    ).toThrow("totalTokens exceeds the safe integer range")
+  })
+
+  test("aggregates exact fields across model calls", () => {
+    expect(
+      aggregateAiModelCallUsage([
+        {
+          inputTokens: 12,
+          outputTokens: 8,
+          uncachedInputTokens: 9,
+          cacheReadInputTokens: 3,
+          cacheWriteInputTokens: 1,
+          textOutputTokens: 6,
+          reasoningOutputTokens: 2,
+        },
+        {
+          inputTokens: 4,
+          outputTokens: 6,
+          uncachedInputTokens: 4,
+          cacheReadInputTokens: 0,
+          cacheWriteInputTokens: 2,
+          textOutputTokens: 5,
+          reasoningOutputTokens: 1,
+        },
+      ])
+    ).toEqual({
+      inputTokens: 16,
+      outputTokens: 14,
+      totalTokens: 30,
+      uncachedInputTokens: 13,
+      cacheReadInputTokens: 3,
+      cacheWriteInputTokens: 3,
+      textOutputTokens: 11,
+      reasoningOutputTokens: 3,
+      reportingStatus: "complete",
+    })
+  })
+
+  test("does not turn a missing call count into an aggregate zero", () => {
+    expect(
+      aggregateAiModelCallUsage([
+        { inputTokens: 10, outputTokens: 5, cacheReadInputTokens: 0 },
+        { inputTokens: 4, uncachedInputTokens: 4 },
+      ])
+    ).toEqual({
+      inputTokens: 14,
+      reportingStatus: "partial",
+    })
+
+    expect(aggregateAiModelCallUsage([{ inputTokens: 10, outputTokens: 5 }, {}])).toEqual({
+      reportingStatus: "partial",
+    })
+    expect(aggregateAiModelCallUsage([])).toEqual({ reportingStatus: "unavailable" })
+  })
+
+  test("rejects aggregate sums outside the safe integer range", () => {
+    expect(() =>
+      aggregateAiModelCallUsage([{ inputTokens: Number.MAX_SAFE_INTEGER }, { inputTokens: 1 }])
+    ).toThrow("aggregate inputTokens exceeds the safe integer range")
+  })
+})

--- a/packages/core/tests/ai-usage.types.ts
+++ b/packages/core/tests/ai-usage.types.ts
@@ -1,0 +1,51 @@
+import type {
+  AiModelCallUsageRecord,
+  AiUsageStorage,
+  Principal,
+  ReadonlyJsonObject,
+  RecordAiModelCallInput,
+  RecordAiModelCallResult,
+} from "@sixb/core/storage"
+
+const requesterPrincipal: Principal = { type: "user", id: "usr_1" }
+const rawUsage: ReadonlyJsonObject = { provider_counter: 1 }
+
+const input: RecordAiModelCallInput = {
+  id: "usage_1",
+  projectId: "project_1",
+  execution: { kind: "agentRun", runId: "run_1" },
+  attempt: 1,
+  callId: "call_1",
+  requesterPrincipal,
+  requesterGroupIds: ["support"],
+  providerId: "gateway",
+  requestedModelId: "openai/gpt-5",
+  responseId: "response_1",
+  usage: { inputTokens: 10, outputTokens: 2 },
+  rawUsage,
+  occurredAt: new Date("2026-06-23T10:00:00.000Z"),
+}
+
+const provider = {
+  async recordModelCall(recordInput: RecordAiModelCallInput): Promise<RecordAiModelCallResult> {
+    const record: AiModelCallUsageRecord = {
+      ...recordInput,
+      usage: {
+        ...recordInput.usage,
+        totalTokens: 12,
+        reportingStatus: "complete",
+      },
+      recordedAt: new Date("2026-06-23T10:00:01.000Z"),
+    }
+    return { record, created: true }
+  },
+  async summarizeExecution() {
+    return { reportingStatus: "unavailable" as const }
+  },
+  async summarizeExecutions({ executions }) {
+    return executions.map(() => ({ reportingStatus: "unavailable" as const }))
+  },
+} satisfies AiUsageStorage
+
+void input
+void provider

--- a/packages/core/tests/ai-usage.types.ts
+++ b/packages/core/tests/ai-usage.types.ts
@@ -1,5 +1,6 @@
 import type {
   AiModelCallUsageRecord,
+  AiUsageExecutionSummary,
   AiUsageStorage,
   Principal,
   ReadonlyJsonObject,
@@ -9,6 +10,10 @@ import type {
 
 const requesterPrincipal: Principal = { type: "user", id: "usr_1" }
 const rawUsage: ReadonlyJsonObject = { provider_counter: 1 }
+const emptySummary: AiUsageExecutionSummary = {
+  modelCallCount: 0,
+  usage: { reportingStatus: "unavailable" },
+}
 
 const input: RecordAiModelCallInput = {
   id: "usage_1",
@@ -40,10 +45,10 @@ const provider = {
     return { record, created: true }
   },
   async summarizeExecution() {
-    return { reportingStatus: "unavailable" as const }
+    return emptySummary
   },
   async summarizeExecutions({ executions }) {
-    return executions.map(() => ({ reportingStatus: "unavailable" as const }))
+    return executions.map(() => emptySummary)
   },
 } satisfies AiUsageStorage
 


### PR DESCRIPTION
## Summary

> Stack: **#354** → #355 → #356 → #357 → #358

This is PR 1 of 5 in the Phase 1 AI usage accounting stack. It defines the provider-neutral facts
and storage contract that every later capture, cost, and budget layer will use.

This PR deliberately stops before runtime or SQL wiring. Reviewers can focus on the accounting model:
what one billable model call means, how missing usage differs from zero, and how retries/tool loops are
identified without double-counting.

## Why this is the first step toward token budgets

A run-level token total is not a reliable accounting unit. One agent turn may make several provider
calls around tool execution, and a provider call can be billable even if the run later fails,
cancels, loses queue ownership, or fails output validation.

Project, group, and principal budgets therefore need one immutable fact per completed provider call.
Later phases can sum these facts by accounting period and attribution without guessing from terminal
run state.

This PR establishes that fact model. It does **not** enforce a limit yet.

## What this PR adds

- A normalized usage vocabulary covering:
  - input and output totals;
  - uncached input;
  - cache reads and writes;
  - text and reasoning output;
  - complete, partial, and unavailable reporting.
- An immutable `AiModelCallUsageRecord` with:
  - project and execution identity;
  - delivery attempt, AI SDK call ID, and provider response ID;
  - requester principal and snapshotted groups;
  - requested/response model identity and provider identity;
  - normalized usage plus raw provider usage;
  - occurrence and recording timestamps.
- Idempotent append semantics. The accounting identity is:
  - project;
  - execution;
  - delivery attempt;
  - call ID;
  - response ID.
- Conservative normalization and aggregation:
  - missing counts remain missing;
  - reported zeroes remain zeroes;
  - details are not added to totals a second time;
  - an aggregate field is present only when every call reported it;
  - unsafe integer overflow is rejected.
- `AiUsageStorage`, including ordered batch summaries for list consumers.
- A standalone in-memory implementation with group rows, defensive cloning, snapshots, restore, and
  idempotency indexes.
- A reusable provider contract suite for in-memory, SQLite, PostgreSQL, and future third-party
  implementations.

## Important design choices

### One record per completed provider call

The ledger records provider-call facts, not messages, steps, or terminal runs. Tool-loop calls sharing
one AI SDK generation ID remain distinct through their response IDs.

### Missing is not zero

An absent provider count cannot be used as free usage in a future budget calculation. The contract
preserves unknown values explicitly rather than coercing them to zero.

### Normalized and raw usage are both retained

Normalized fields support portable token accounting. Raw usage protects provider-specific meters
that may matter for future cost rating without prematurely expanding the stable vocabulary.

### Batch summaries are part of the contract

Run-history APIs eventually need summaries for many executions. A batch method prevents N SQL
queries and prevents the in-memory provider from rescanning the complete ledger N times.

## What is intentionally not in this PR

- No composite `Storage.aiUsage` wiring.
- No SQLite or PostgreSQL tables.
- No requester admission changes.
- No worker capture.
- No HTTP, generated-client, or Atlas changes.
- No pricing, budgets, quota configuration, or enforcement.

## Phase 1 stack

1. **This PR:** accounting contract and standalone in-memory model.
2. Durable storage and immutable requester attribution.
3. Conversation model-call capture.
4. Workflow agent-node model-call capture.
5. Ledger-backed API cutover and removal of legacy run projections.

Each PR targets the previous branch so reviewers see only that slice.

## What comes after Phase 1

Phase 1 records trustworthy usage facts. Later work will add, separately:

1. an effective-dated local price catalog and immutable cost ratings;
2. provider billing reconciliation using provider response IDs;
3. monthly project/group/principal counters rebuilt from the ledgers;
4. budget definitions and management APIs/UI;
5. admission checks and `prepareStep` rechecks before another provider call;
6. bounded-overrun behavior, alerts, and enforcement reporting.

Pricing APIs will not be called in the model-call hot path, and unpriceable usage will not be treated
as free.

## Review guide

Suggested order:

1. `packages/core/src/storage/ai-usage/types.ts`
2. `packages/core/src/storage/ai-usage/usage.ts`
3. `packages/core/src/storage/ai-usage/record.ts`
4. `packages/core/src/storage/ai-usage/in-memory.ts`
5. `packages/core/src/testing/ai-usage-storage-contract.ts`
6. the focused core tests

Questions to keep in mind:

- Can two distinct billable calls collapse into one identity?
- Can a replay double-count usage?
- Can missing provider data become an invented zero?
- Can an overlapping detail be counted twice?
- Can a provider implement the public contract without importing an internal type?

## Validation

```bash
bun test packages/core/tests/ai-usage-storage.test.ts packages/core/tests/ai-usage.test.ts
bun run typecheck
bun run check
```

The focused suites pass 21 tests. Root typecheck and Biome also pass.
