### PR TITLE
storage: add durable AI usage attribution

### DIFF
--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1223,6 +1223,7 @@ describe("AgentWorker", () => {
       executionId,
       workflowId: workflow.id,
       input: { query: "alpha" },
+      requesterGroupIds: [],
     })
     await runs.start({
       id: runId,
@@ -4144,6 +4145,7 @@ describe("AgentWorker", () => {
       threadId,
       agentId: "removed-agent",
       triggerMessageId,
+      requesterGroupIds: [],
     })
     await sixb.queues.agents.enqueue({
       projectId: PROJECT_ID,

--- a/packages/core/src/agents/request.ts
+++ b/packages/core/src/agents/request.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import type { Principal } from "../auth"
 import { SYSTEM_PRINCIPAL } from "../auth"
+import { snapshotRequesterGroupIds } from "../auth/attribution"
 import { assertAuthorized } from "../authorization"
 import type { FileRef } from "../blob-storage"
 import { createAgentExecutionRecord } from "../execution/agent"
@@ -38,7 +39,7 @@ export interface RequestAgentRunInput {
   readonly title?: string
   /** Explicit id for the trigger (user) message. Defaults to a generated id. */
   readonly messageId?: string
-  /** Owner principal for a new thread. Defaults to system for an auth-disabled execution. */
+  /** Caller principal for privileged integrations; scoped runtimes use their authorization principal. */
   readonly principal?: Principal
 }
 
@@ -74,8 +75,9 @@ export async function requestAgentRun(
 
   const agents = requireAgentStorage(runtime)
   const projectId = runtime.projectId
-  const principal = input.principal ?? SYSTEM_PRINCIPAL
-
+  // A scoped runtime is authoritative for caller identity. `input.principal` remains available to
+  // privileged server integrations that have already authenticated their request.
+  const principal = runtime.authorization?.principal ?? input.principal ?? SYSTEM_PRINCIPAL
   const { thread, createdThread } = await resolveThread(agents, {
     projectId,
     agentId: agent.id,
@@ -100,6 +102,13 @@ export async function requestAgentRun(
     agent,
     runId
   )
+  const requesterGroupIds = durableExecution.requestedBy
+    ? await snapshotRequesterGroupIds({
+        auth: runtime.storage.auth,
+        projectId,
+        principal: durableExecution.requestedBy,
+      })
+    : []
   const triggerMessageId = input.messageId ?? createAgentMessageId()
   let run: AgentRunRecord
   try {
@@ -132,6 +141,7 @@ export async function requestAgentRun(
         threadId: thread.id,
         agentId: agent.id,
         triggerMessageId,
+        requesterGroupIds,
       })
     })
   } catch (error) {
@@ -181,6 +191,13 @@ export async function retryAgentRun(
     agent,
     runId
   )
+  const requesterGroupIds = durableExecution.requestedBy
+    ? await snapshotRequesterGroupIds({
+        auth: runtime.storage.auth,
+        projectId: runtime.projectId,
+        principal: durableExecution.requestedBy,
+      })
+    : []
   const run = await runtime.storage.transaction(async (tx) => {
     const agents = tx.agents
     if (!agents) {
@@ -194,6 +211,7 @@ export async function retryAgentRun(
       threadId: failedRun.threadId,
       agentId: agent.id,
       triggerMessageId: failedRun.triggerMessageId,
+      requesterGroupIds,
     })
   })
   const jobId = await dispatchAgentRun(runtime, agents, runId)

--- a/packages/core/src/auth/attribution.ts
+++ b/packages/core/src/auth/attribution.ts
@@ -1,3 +1,4 @@
+import { compareStrings } from "../json"
 import type { AuthStorage } from "../storage/auth"
 import type { Principal } from "./types"
 
@@ -28,5 +29,20 @@ export async function snapshotRequesterGroupIds(input: {
           serviceAccountId: input.principal.id,
         })
 
-  return [...new Set(memberships.map((membership) => membership.groupId))].sort()
+  return normalizeRequesterGroupIds(memberships.map((membership) => membership.groupId))
+}
+
+/** Validate and canonicalize an immutable requester-group snapshot at a storage boundary. */
+export function normalizeRequesterGroupIds(groupIds: readonly string[]): readonly string[] {
+  if (!Array.isArray(groupIds)) {
+    throw new TypeError("[Sixb] requesterGroupIds must be an array.")
+  }
+  const unique = new Set<string>()
+  for (const groupId of groupIds) {
+    if (typeof groupId !== "string" || groupId.trim().length === 0) {
+      throw new TypeError("[Sixb] requesterGroupIds entries must be nonblank.")
+    }
+    unique.add(groupId)
+  }
+  return [...unique].sort(compareStrings)
 }

--- a/packages/core/src/auth/attribution.ts
+++ b/packages/core/src/auth/attribution.ts
@@ -1,0 +1,32 @@
+import type { AuthStorage } from "../storage/auth"
+import type { Principal } from "./types"
+
+/**
+ * Resolve the durable group-membership snapshot used to attribute admitted work.
+ *
+ * Authorization contexts can carry a token-restricted subset of the principal's groups, so they
+ * are deliberately not accepted here. Accounting attribution comes from auth storage whenever it
+ * is configured. A system principal, or a runtime with no durable auth storage, has no groups.
+ */
+export async function snapshotRequesterGroupIds(input: {
+  readonly auth: AuthStorage | undefined
+  readonly projectId: string
+  readonly principal: Principal
+}): Promise<readonly string[]> {
+  if (input.principal.type === "system" || !input.auth) {
+    return []
+  }
+
+  const memberships =
+    input.principal.type === "user"
+      ? await input.auth.groupMemberships.listForUser({
+          projectId: input.projectId,
+          userId: input.principal.id,
+        })
+      : await input.auth.serviceAccountGroupMemberships.listForServiceAccount({
+          projectId: input.projectId,
+          serviceAccountId: input.principal.id,
+        })
+
+  return [...new Set(memberships.map((membership) => membership.groupId))].sort()
+}

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -9,6 +9,7 @@ export {
   parseAccessTokenValue,
   SERVICE_ACCOUNT_ACCESS_TOKEN_PREFIX,
 } from "./access-tokens"
+export { snapshotRequesterGroupIds } from "./attribution"
 export type { AuthSessionAudience, AuthSessionAudienceOptions } from "./audience"
 export {
   DEFAULT_AUTH_SESSION_AUDIENCE,

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -9,7 +9,7 @@ export {
   parseAccessTokenValue,
   SERVICE_ACCOUNT_ACCESS_TOKEN_PREFIX,
 } from "./access-tokens"
-export { snapshotRequesterGroupIds } from "./attribution"
+export { normalizeRequesterGroupIds, snapshotRequesterGroupIds } from "./attribution"
 export type { AuthSessionAudience, AuthSessionAudienceOptions } from "./audience"
 export {
   DEFAULT_AUTH_SESSION_AUDIENCE,

--- a/packages/core/src/storage/agents/in-memory.ts
+++ b/packages/core/src/storage/agents/in-memory.ts
@@ -1,5 +1,6 @@
 import { AGENT_MESSAGE_CONTENT_VERSION } from "../../agents/message"
 import { principalsEqual } from "../../auth"
+import { normalizeRequesterGroupIds } from "../../auth/attribution"
 import type { ExecutionStorage } from "../executions"
 import { AgentStorageError } from "./errors"
 import { assertAgentRunExecution } from "./provider"
@@ -207,7 +208,7 @@ class InMemoryAgentRunStore implements AgentRunStore {
       threadId: input.threadId,
       agentId: input.agentId,
       triggerMessageId: input.triggerMessageId,
-      requesterGroupIds: clone(input.requesterGroupIds),
+      requesterGroupIds: normalizeRequesterGroupIds(input.requesterGroupIds),
       status: "queued",
       attempt: 0,
       createdAt,

--- a/packages/core/src/storage/agents/in-memory.ts
+++ b/packages/core/src/storage/agents/in-memory.ts
@@ -207,6 +207,7 @@ class InMemoryAgentRunStore implements AgentRunStore {
       threadId: input.threadId,
       agentId: input.agentId,
       triggerMessageId: input.triggerMessageId,
+      requesterGroupIds: clone(input.requesterGroupIds),
       status: "queued",
       attempt: 0,
       createdAt,

--- a/packages/core/src/storage/agents/types.ts
+++ b/packages/core/src/storage/agents/types.ts
@@ -147,6 +147,8 @@ export interface AgentRunRecord {
   readonly threadId: string
   readonly agentId: string
   readonly triggerMessageId: string
+  /** Durable group memberships snapshotted when the run was admitted. */
+  readonly requesterGroupIds: readonly string[]
   readonly status: AgentRunStatus
   readonly modelId?: string
   /** Why the run ended (our own SDK-independent enum). */
@@ -171,6 +173,7 @@ export interface CreateAgentRunInput {
   readonly threadId: string
   readonly agentId: string
   readonly triggerMessageId: string
+  readonly requesterGroupIds: readonly string[]
   readonly createdAt?: Date
 }
 

--- a/packages/core/src/storage/ai-usage/errors.ts
+++ b/packages/core/src/storage/ai-usage/errors.ts
@@ -1,4 +1,4 @@
-export type AiUsageStorageErrorCode = "duplicate_id"
+export type AiUsageStorageErrorCode = "duplicate_id" | "missing_execution"
 
 /** Storage failure specific to the AI model-call usage ledger. */
 export class AiUsageStorageError extends Error {

--- a/packages/core/src/storage/ai-usage/in-memory.ts
+++ b/packages/core/src/storage/ai-usage/in-memory.ts
@@ -1,8 +1,8 @@
+import type { ExecutionStorage } from "../executions"
 import { AiUsageStorageError } from "./errors"
-import { assertAiUsageExecution, normalizeAiModelCallRecord } from "./record"
+import { assertAiUsageExecutionId, normalizeAiModelCallRecord } from "./record"
 import type {
   AiModelCallUsageRecord,
-  AiUsageExecutionIdentity,
   AiUsageExecutionSummary,
   AiUsageStorage,
   RecordAiModelCallInput,
@@ -31,8 +31,11 @@ export class InMemoryAiUsageStorage implements AiUsageStorage {
   private readonly recordKeysByIdempotencyKey = new Map<string, string>()
   private readonly groupRows = new Map<string, InMemoryAiUsageGroupRow>()
 
+  constructor(private readonly executions: Pick<ExecutionStorage, "getById">) {}
+
   async recordModelCall(input: RecordAiModelCallInput): Promise<RecordAiModelCallResult> {
     const record = normalizeAiModelCallRecord(input)
+    await this.assertExecutionExists(record.projectId, record.executionId)
     const idempotencyKey = modelCallIdempotencyKey(record)
     const existingRecordKey = this.recordKeysByIdempotencyKey.get(idempotencyKey)
     if (existingRecordKey !== undefined) {
@@ -71,7 +74,7 @@ export class InMemoryAiUsageStorage implements AiUsageStorage {
   ): Promise<AiUsageExecutionSummary> {
     const [summary] = await this.summarizeExecutions({
       projectId: input.projectId,
-      executions: [input.execution],
+      executionIds: [input.executionId],
     })
     return summary!
   }
@@ -83,20 +86,20 @@ export class InMemoryAiUsageStorage implements AiUsageStorage {
       throw new TypeError("[Sixb] AI usage projectId must be nonblank.")
     }
 
-    const usageByExecution = new Map<string, AiModelCallUsageRecord["usage"][]>()
-    for (const execution of input.executions) {
-      assertAiUsageExecution(execution)
-      usageByExecution.set(executionKey(execution), [])
+    const usageByExecutionId = new Map<string, AiModelCallUsageRecord["usage"][]>()
+    for (const executionId of input.executionIds) {
+      assertAiUsageExecutionId(executionId)
+      usageByExecutionId.set(executionId, [])
     }
-    if (usageByExecution.size === 0) return []
+    if (usageByExecutionId.size === 0) return []
 
     for (const record of this.records.values()) {
       if (record.projectId !== input.projectId) continue
-      usageByExecution.get(executionKey(record.execution))?.push(record.usage)
+      usageByExecutionId.get(record.executionId)?.push(record.usage)
     }
 
-    return input.executions.map((execution) => {
-      const usages = usageByExecution.get(executionKey(execution)) ?? []
+    return input.executionIds.map((executionId) => {
+      const usages = usageByExecutionId.get(executionId) ?? []
       return {
         modelCallCount: usages.length,
         usage: aggregateAiModelCallUsage(usages),
@@ -117,6 +120,15 @@ export class InMemoryAiUsageStorage implements AiUsageStorage {
     replaceMap(this.recordKeysByIdempotencyKey, snapshot.recordKeysByIdempotencyKey)
     replaceMap(this.groupRows, snapshot.groupRows)
   }
+
+  private async assertExecutionExists(projectId: string, executionId: string): Promise<void> {
+    const execution = await this.executions.getById({ projectId, id: executionId })
+    if (execution) return
+    throw new AiUsageStorageError(
+      "missing_execution",
+      `[Sixb] AI usage execution '${executionId}' does not exist in project '${projectId}'.`
+    )
+  }
 }
 
 function modelCallRecordKey(projectId: string, id: string): string {
@@ -126,26 +138,16 @@ function modelCallRecordKey(projectId: string, id: string): string {
 function modelCallIdempotencyKey(
   record: Pick<
     AiModelCallUsageRecord,
-    "projectId" | "execution" | "attempt" | "callId" | "responseId"
+    "projectId" | "executionId" | "attempt" | "callId" | "responseId"
   >
 ): string {
   return JSON.stringify([
     record.projectId,
-    ...executionKeyParts(record.execution),
+    record.executionId,
     record.attempt,
     record.callId,
     record.responseId,
   ])
-}
-
-function executionKeyParts(execution: AiUsageExecutionIdentity): readonly string[] {
-  return execution.kind === "agentRun"
-    ? [execution.kind, execution.runId]
-    : [execution.kind, execution.workflowRunId, execution.nodeRunId]
-}
-
-function executionKey(execution: AiUsageExecutionIdentity): string {
-  return JSON.stringify(executionKeyParts(execution))
 }
 
 function groupRowKey(row: InMemoryAiUsageGroupRow): string {

--- a/packages/core/src/storage/ai-usage/index.ts
+++ b/packages/core/src/storage/ai-usage/index.ts
@@ -5,12 +5,11 @@ export type {
   InMemoryAiUsageStorageSnapshot,
 } from "./in-memory"
 export { InMemoryAiUsageStorage } from "./in-memory"
-export { assertAiUsageExecution, normalizeAiModelCallRecord } from "./record"
+export { assertAiUsageExecutionId, normalizeAiModelCallRecord } from "./record"
 export type {
   AiModelCallUsage,
   AiModelCallUsageInput,
   AiModelCallUsageRecord,
-  AiUsageExecutionIdentity,
   AiUsageExecutionSummary,
   AiUsageReportingStatus,
   AiUsageStorage,

--- a/packages/core/src/storage/ai-usage/record.ts
+++ b/packages/core/src/storage/ai-usage/record.ts
@@ -1,19 +1,15 @@
-import { assertJsonValue, compareStrings, isPlainRecord } from "../../json"
-import type {
-  AiModelCallUsageRecord,
-  AiUsageExecutionIdentity,
-  RecordAiModelCallInput,
-} from "./types"
+import { normalizeRequesterGroupIds } from "../../auth/attribution"
+import { assertJsonValue, isPlainRecord } from "../../json"
+import type { AiModelCallUsageRecord, RecordAiModelCallInput } from "./types"
 import { normalizeAiModelCallUsage } from "./usage"
 
 /** Validate and defensively snapshot one provider-neutral model-call ledger input. */
 export function normalizeAiModelCallRecord(input: RecordAiModelCallInput): AiModelCallUsageRecord {
   assertNonBlank(input.id, "id")
   assertNonBlank(input.projectId, "projectId")
-  assertAiUsageExecution(input.execution)
+  assertAiUsageExecutionId(input.executionId)
   assertPositiveSafeInteger(input.attempt, "attempt")
   assertNonBlank(input.callId, "callId")
-  assertPrincipal(input.requesterPrincipal)
   assertNonBlank(input.providerId, "providerId")
   assertNonBlank(input.requestedModelId, "requestedModelId")
   if (input.responseModelId !== undefined) {
@@ -23,16 +19,15 @@ export function normalizeAiModelCallRecord(input: RecordAiModelCallInput): AiMod
 
   const occurredAt = cloneValidDate(input.occurredAt, "occurredAt")
   const recordedAt = cloneValidDate(input.recordedAt ?? new Date(), "recordedAt")
-  const requesterGroupIds = normalizeGroupIds(input.requesterGroupIds)
+  const requesterGroupIds = normalizeRequesterGroupIds(input.requesterGroupIds)
   const rawUsage = cloneRawUsage(input.rawUsage)
 
   return {
     id: input.id,
     projectId: input.projectId,
-    execution: structuredClone(input.execution),
+    executionId: input.executionId,
     attempt: input.attempt,
     callId: input.callId,
-    requesterPrincipal: structuredClone(input.requesterPrincipal),
     requesterGroupIds,
     providerId: input.providerId,
     requestedModelId: input.requestedModelId,
@@ -45,27 +40,9 @@ export function normalizeAiModelCallRecord(input: RecordAiModelCallInput): AiMod
   }
 }
 
-/** Validate a durable execution identity at storage and query boundaries. */
-export function assertAiUsageExecution(execution: AiUsageExecutionIdentity): void {
-  if (execution.kind === "agentRun") {
-    assertNonBlank(execution.runId, "execution.runId")
-    return
-  }
-  if (execution.kind === "workflowAgentNode") {
-    assertNonBlank(execution.workflowRunId, "execution.workflowRunId")
-    assertNonBlank(execution.nodeRunId, "execution.nodeRunId")
-    return
-  }
-  throw new TypeError("[Sixb] AI usage execution kind is invalid.")
-}
-
-function normalizeGroupIds(groupIds: readonly string[]): readonly string[] {
-  const unique = new Set<string>()
-  for (const groupId of groupIds) {
-    assertNonBlank(groupId, "requesterGroupIds[]")
-    unique.add(groupId)
-  }
-  return [...unique].sort(compareStrings)
+/** Validate a durable execution reference at storage and query boundaries. */
+export function assertAiUsageExecutionId(executionId: string): void {
+  assertNonBlank(executionId, "executionId")
 }
 
 function cloneRawUsage(rawUsage: RecordAiModelCallInput["rawUsage"]) {
@@ -75,17 +52,6 @@ function cloneRawUsage(rawUsage: RecordAiModelCallInput["rawUsage"]) {
   }
   assertJsonValue(rawUsage, "AI usage rawUsage")
   return structuredClone(rawUsage)
-}
-
-function assertPrincipal(principal: RecordAiModelCallInput["requesterPrincipal"]): void {
-  if (
-    principal.type !== "user" &&
-    principal.type !== "serviceAccount" &&
-    principal.type !== "system"
-  ) {
-    throw new TypeError("[Sixb] AI usage requesterPrincipal.type is invalid.")
-  }
-  assertNonBlank(principal.id, "requesterPrincipal.id")
 }
 
 function assertNonBlank(value: string, field: string): void {

--- a/packages/core/src/storage/ai-usage/types.ts
+++ b/packages/core/src/storage/ai-usage/types.ts
@@ -1,4 +1,3 @@
-import type { Principal } from "../../auth"
 import type { ReadonlyJsonObject } from "../../json"
 
 /** How much normalized token usage a provider reported for one model call. */
@@ -30,29 +29,20 @@ export interface AiUsageExecutionSummary {
   readonly usage: AiModelCallUsage
 }
 
-/** The durable execution that owns a model call. */
-export type AiUsageExecutionIdentity =
-  | {
-      readonly kind: "agentRun"
-      readonly runId: string
-    }
-  | {
-      readonly kind: "workflowAgentNode"
-      readonly workflowRunId: string
-      readonly nodeRunId: string
-    }
-
 /** Input for an idempotent model-call ledger append. */
 export interface RecordAiModelCallInput {
   readonly id: string
   readonly projectId: string
-  readonly execution: AiUsageExecutionIdentity
+  /** Immutable execution-ledger record that owns this provider call. */
+  readonly executionId: string
   /** Queue delivery attempt that made the provider call. */
   readonly attempt: number
   /** AI SDK generation ID. Tool-loop model calls share it and are distinguished by responseId. */
   readonly callId: string
-  readonly requesterPrincipal: Principal
-  /** Durable group memberships snapshotted when the parent run was admitted. */
+  /**
+   * Durable group memberships snapshotted when the parent run was admitted. The requester itself
+   * is read from the immutable execution record.
+   */
   readonly requesterGroupIds: readonly string[]
   /** AI SDK provider that handled the call, such as `openai`, `anthropic`, or `gateway`. */
   readonly providerId: string
@@ -82,18 +72,18 @@ export interface RecordAiModelCallResult {
 
 export interface SummarizeAiUsageExecutionInput {
   readonly projectId: string
-  readonly execution: AiUsageExecutionIdentity
+  readonly executionId: string
 }
 
 export interface SummarizeAiUsageExecutionsInput {
   readonly projectId: string
-  readonly executions: readonly AiUsageExecutionIdentity[]
+  readonly executionIds: readonly string[]
 }
 
 /** Durable, provider-neutral accounting for completed language-model calls. */
 export interface AiUsageStorage {
   /**
-   * Append one model-call record idempotently. The identity is project, execution, attempt, call
+   * Append one model-call record idempotently. The identity is project, execution ID, attempt, call
    * ID, and response ID; retrying that identity returns the existing record with `created: false`.
    */
   recordModelCall(input: RecordAiModelCallInput): Promise<RecordAiModelCallResult>
@@ -103,7 +93,7 @@ export interface AiUsageStorage {
 
   /**
    * Aggregate multiple executions in one storage read. Results have the same length and order as
-   * `executions`. Executions without ledger records have a zero model-call count and unavailable
+   * `executionIds`. Executions without ledger records have a zero model-call count and unavailable
    * usage.
    */
   summarizeExecutions(

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -56,7 +56,7 @@ export class InMemoryStorage implements Storage {
   private readonly authStorage = new InMemoryAuthStorage()
   private readonly executionStorage = new InMemoryExecutionStorage(this.authStorage)
   private readonly agentStorage = new InMemoryAgentStorage(this.executionStorage)
-  private readonly aiUsageStorage = new InMemoryAiUsageStorage()
+  private readonly aiUsageStorage = new InMemoryAiUsageStorage(this.executionStorage)
   private readonly actionRunStorage = new InMemoryActionRunStorage(this.executionStorage)
   private readonly syncRunStorage = new InMemorySyncRunStorage()
   private readonly pipelineRunStorage = new InMemoryPipelineRunStorage()

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks"
 import { InMemoryActionRunStorage } from "../action-runs"
 import { type AgentStorage, InMemoryAgentStorage } from "../agents"
+import { type AiUsageStorage, InMemoryAiUsageStorage } from "../ai-usage"
 import { type AuthStorage, InMemoryAuthStorage } from "../auth"
 import { StorageTransactionError } from "../errors"
 import { InMemoryExecutionStorage } from "../executions/in-memory"
@@ -55,6 +56,7 @@ export class InMemoryStorage implements Storage {
   private readonly authStorage = new InMemoryAuthStorage()
   private readonly executionStorage = new InMemoryExecutionStorage(this.authStorage)
   private readonly agentStorage = new InMemoryAgentStorage(this.executionStorage)
+  private readonly aiUsageStorage = new InMemoryAiUsageStorage()
   private readonly actionRunStorage = new InMemoryActionRunStorage(this.executionStorage)
   private readonly syncRunStorage = new InMemorySyncRunStorage()
   private readonly pipelineRunStorage = new InMemoryPipelineRunStorage()
@@ -68,6 +70,7 @@ export class InMemoryStorage implements Storage {
   readonly auth: AuthStorage
   readonly executions: ExecutionStorage
   readonly agents: AgentStorage
+  readonly aiUsage: AiUsageStorage
   readonly actionRuns: InMemoryActionRunStorage
   readonly syncRuns: SyncRunStorage
   readonly pipelineRuns: PipelineRunStorage
@@ -89,6 +92,7 @@ export class InMemoryStorage implements Storage {
     this.auth = createAuthOperationScope(this.authStorage, scope)
     this.executions = createOperationScopedFacade(this.executionStorage, scope)
     this.agents = createAgentOperationScope(this.agentStorage, scope)
+    this.aiUsage = createOperationScopedFacade(this.aiUsageStorage, scope)
     this.actionRuns = createOperationScopedFacade(this.actionRunStorage, scope)
     this.syncRuns = createOperationScopedFacade(this.syncRunStorage, scope)
     this.pipelineRuns = createOperationScopedFacade(this.pipelineRunStorage, scope)
@@ -228,6 +232,7 @@ export class InMemoryStorage implements Storage {
       auth: this.authStorage,
       executions: this.executionStorage,
       agents: this.agentStorage,
+      aiUsage: this.aiUsageStorage,
       actionRuns: this.actionRunStorage,
       syncRuns: this.syncRunStorage,
       pipelineRuns: this.pipelineRunStorage,
@@ -253,6 +258,7 @@ export class InMemoryStorage implements Storage {
       auth: this.authStorage.snapshot(),
       executions: this.executionStorage.snapshot(),
       agents: this.agentStorage.snapshot(),
+      aiUsage: this.aiUsageStorage.snapshot(),
       actionRuns: this.actionRunStorage.snapshot(),
       syncRuns: this.syncRunStorage.snapshot(),
       pipelineRuns: this.pipelineRunStorage.snapshot(),
@@ -273,6 +279,7 @@ export class InMemoryStorage implements Storage {
     this.authStorage.restore(snapshot.auth)
     this.executionStorage.restore(snapshot.executions)
     this.agentStorage.restore(snapshot.agents)
+    this.aiUsageStorage.restore(snapshot.aiUsage)
     this.actionRunStorage.restore(snapshot.actionRuns)
     this.syncRunStorage.restore(snapshot.syncRuns)
     this.pipelineRunStorage.restore(snapshot.pipelineRuns)
@@ -293,6 +300,7 @@ export interface InMemoryStorageSnapshot {
   readonly auth: ReturnType<InMemoryAuthStorage["snapshot"]>
   readonly executions: ReturnType<InMemoryExecutionStorage["snapshot"]>
   readonly agents: ReturnType<InMemoryAgentStorage["snapshot"]>
+  readonly aiUsage: ReturnType<InMemoryAiUsageStorage["snapshot"]>
   readonly actionRuns: ReturnType<InMemoryActionRunStorage["snapshot"]>
   readonly syncRuns: ReturnType<InMemorySyncRunStorage["snapshot"]>
   readonly pipelineRuns: ReturnType<InMemoryPipelineRunStorage["snapshot"]>

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -89,7 +89,6 @@ export type {
   AiModelCallUsage,
   AiModelCallUsageInput,
   AiModelCallUsageRecord,
-  AiUsageExecutionIdentity,
   AiUsageExecutionSummary,
   AiUsageReportingStatus,
   AiUsageStorage,
@@ -104,7 +103,7 @@ export type {
 export {
   AiUsageStorageError,
   aggregateAiModelCallUsage,
-  assertAiUsageExecution,
+  assertAiUsageExecutionId,
   InMemoryAiUsageStorage,
   normalizeAiModelCallRecord,
   normalizeAiModelCallUsage,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -62,7 +62,7 @@ export type {
   AiModelCallUsage,
   AiModelCallUsageInput,
   AiModelCallUsageRecord,
-  AiUsageExecutionIdentity,
+  AiUsageExecutionSummary,
   AiUsageReportingStatus,
   AiUsageStorage,
   AiUsageStorageErrorCode,
@@ -74,7 +74,7 @@ export type {
 export {
   AiUsageStorageError,
   aggregateAiModelCallUsage,
-  assertAiUsageExecution,
+  assertAiUsageExecutionId,
   normalizeAiModelCallRecord,
   normalizeAiModelCallUsage,
 } from "./ai-usage"

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,5 +1,6 @@
 import type { ActionRunStorage } from "./action-runs"
 import type { AgentStorage } from "./agents"
+import type { AiUsageStorage } from "./ai-usage"
 import type { AuthStorage } from "./auth"
 import type { ExecutionStorage } from "./executions"
 import type { FileUploadSessionStore } from "./file-upload-sessions"
@@ -57,6 +58,26 @@ export type {
   StartAgentRunInput,
 } from "./agents"
 export { AgentStorageError } from "./agents"
+export type {
+  AiModelCallUsage,
+  AiModelCallUsageInput,
+  AiModelCallUsageRecord,
+  AiUsageExecutionIdentity,
+  AiUsageReportingStatus,
+  AiUsageStorage,
+  AiUsageStorageErrorCode,
+  RecordAiModelCallInput,
+  RecordAiModelCallResult,
+  SummarizeAiUsageExecutionInput,
+  SummarizeAiUsageExecutionsInput,
+} from "./ai-usage"
+export {
+  AiUsageStorageError,
+  aggregateAiModelCallUsage,
+  assertAiUsageExecution,
+  normalizeAiModelCallRecord,
+  normalizeAiModelCallUsage,
+} from "./ai-usage"
 export type {
   AuthGroupMembershipStore,
   AuthInvitationStore,
@@ -268,6 +289,7 @@ export interface Storage {
   executions: ExecutionStorage
   auth?: AuthStorage
   agents?: AgentStorage
+  aiUsage?: AiUsageStorage
   actionRuns?: ActionRunStorage
   syncRuns?: SyncRunStorage
   pipelineRuns?: PipelineRunStorage

--- a/packages/core/src/storage/workflow-runs/in-memory.ts
+++ b/packages/core/src/storage/workflow-runs/in-memory.ts
@@ -1,3 +1,4 @@
+import { normalizeRequesterGroupIds } from "../../auth/attribution"
 import type { ExecutionStorage } from "../executions"
 import {
   cloneRecord,
@@ -124,7 +125,7 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
       queuedAt,
       startedAt: queuedAt,
       attempt: 0,
-      requesterGroupIds: cloneRecord(input.requesterGroupIds),
+      requesterGroupIds: normalizeRequesterGroupIds(input.requesterGroupIds),
     }
 
     this.runs.set(key, cloneRecord(record))

--- a/packages/core/src/storage/workflow-runs/in-memory.ts
+++ b/packages/core/src/storage/workflow-runs/in-memory.ts
@@ -124,6 +124,7 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
       queuedAt,
       startedAt: queuedAt,
       attempt: 0,
+      requesterGroupIds: cloneRecord(input.requesterGroupIds),
     }
 
     this.runs.set(key, cloneRecord(record))

--- a/packages/core/src/storage/workflow-runs/types.ts
+++ b/packages/core/src/storage/workflow-runs/types.ts
@@ -126,6 +126,8 @@ export interface WorkflowRunRecord {
   readonly startedAt: Date
   readonly finishedAt?: Date
   readonly error?: string
+  /** Durable group memberships snapshotted when the workflow run was admitted. */
+  readonly requesterGroupIds: readonly string[]
   readonly attempt: number
   readonly execution?: WorkflowRunExecution
 }
@@ -161,6 +163,7 @@ export interface QueueWorkflowRunInput {
   readonly workflowId: string
   readonly input: WorkflowIOSnapshot
   readonly queuedAt?: Date
+  readonly requesterGroupIds: readonly string[]
 }
 
 export interface ReclaimWorkflowRunInput {

--- a/packages/core/src/testing/agent-storage-contract.ts
+++ b/packages/core/src/testing/agent-storage-contract.ts
@@ -81,7 +81,7 @@ function runInput(overrides: Partial<TestRunInput> = {}): TestRunInput {
     agentId: "sales",
     triggerMessageId: "msg_user_1",
     executionId: "test_agent_execution:run_1",
-    requesterGroupIds: ["engineering", "support"],
+    requesterGroupIds: ["support", "engineering", "support"],
     execution: execution("exec_1"),
     createdAt: at("2026-06-23T10:00:10.000Z"),
     ...overrides,

--- a/packages/core/src/testing/agent-storage-contract.ts
+++ b/packages/core/src/testing/agent-storage-contract.ts
@@ -81,6 +81,7 @@ function runInput(overrides: Partial<TestRunInput> = {}): TestRunInput {
     agentId: "sales",
     triggerMessageId: "msg_user_1",
     executionId: "test_agent_execution:run_1",
+    requesterGroupIds: ["engineering", "support"],
     execution: execution("exec_1"),
     createdAt: at("2026-06-23T10:00:10.000Z"),
     ...overrides,
@@ -341,6 +342,7 @@ export function runAgentStorageContractSuite<TStorage extends AgentStorageContra
         const run = await createAndStartRun(storage, fixture, runInput({ id: "run_1" }))
         expect(run).toMatchObject({ status: "running", attempt: 1, threadId: "thr_1" })
         expect(run.executionId).toBe("test_agent_execution:run_1")
+        expect(run.requesterGroupIds).toEqual(["engineering", "support"])
         expect(run.execution?.token).toBe("exec_1")
         await expect(storage.threads.getById({ projectId, id: "thr_1" })).resolves.toMatchObject({
           activeRunId: "run_1",
@@ -476,8 +478,10 @@ export function runAgentStorageContractSuite<TStorage extends AgentStorageContra
           mutableExecution.token = "mutated"
           mutableExecution.queueLeaseExpiresAt.setTime(0)
         }
+        ;(run.requesterGroupIds as string[]).push("mutated")
         const reread = await storage.runs.getById({ projectId, id: "run_1" })
         expect(reread?.execution?.token).toBe("exec_1")
+        expect(reread?.requesterGroupIds).toEqual(["engineering", "support"])
       })
     })
 

--- a/packages/core/src/testing/ai-usage-storage-contract.ts
+++ b/packages/core/src/testing/ai-usage-storage-contract.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import type { Principal } from "../auth"
 import {
   type AiUsageStorage,
   AiUsageStorageError,
   type RecordAiModelCallInput,
 } from "../storage/ai-usage"
+import type { ExecutionStorage } from "../storage/executions"
 
 export interface AiUsageStorageContractSuiteOptions<
   TStorage extends AiUsageStorage = AiUsageStorage,
@@ -16,8 +16,9 @@ export interface AiUsageStorageContractSuiteOptions<
 }
 
 const projectId = "contract-project"
-const requester: Principal = { type: "user", id: "usr_1" }
-const agentExecution = { kind: "agentRun", runId: "run_1" } as const
+const agentExecutionId = "exec_agent_1"
+const otherAgentExecutionId = "exec_agent_2"
+const workflowExecutionId = "exec_workflow_1"
 
 function at(value: string): Date {
   return new Date(value)
@@ -27,10 +28,9 @@ function modelCallInput(overrides: Partial<RecordAiModelCallInput> = {}): Record
   return {
     id: "usage_1",
     projectId,
-    execution: agentExecution,
+    executionId: agentExecutionId,
     attempt: 1,
     callId: "call_1",
-    requesterPrincipal: requester,
     requesterGroupIds: ["support", "engineering"],
     providerId: "gateway",
     requestedModelId: "openai/gpt-5",
@@ -127,7 +127,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         )
 
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toEqual({
           modelCallCount: 2,
           usage: {
@@ -167,7 +167,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         )
 
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toEqual({
           modelCallCount: 2,
           usage: {
@@ -194,7 +194,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
 
         expect(results.map((result) => result.created).sort()).toEqual([false, true])
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toEqual({
           modelCallCount: 1,
           usage: {
@@ -214,15 +214,10 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
 
     test("keeps projects and workflow executions isolated", async () => {
       await withStorage(async (storage) => {
-        const workflowExecution = {
-          kind: "workflowAgentNode",
-          workflowRunId: "workflow_run_1",
-          nodeRunId: "node_run_1",
-        } as const
         await storage.recordModelCall(
           modelCallInput({
             id: "usage_workflow",
-            execution: workflowExecution,
+            executionId: workflowExecutionId,
             usage: { inputTokens: 5, outputTokens: 3 },
           })
         )
@@ -230,13 +225,13 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
           modelCallInput({
             id: "usage_other_project",
             projectId: "other-project",
-            execution: workflowExecution,
+            executionId: workflowExecutionId,
             usage: { inputTokens: 100, outputTokens: 100 },
           })
         )
 
         await expect(
-          storage.summarizeExecution({ projectId, execution: workflowExecution })
+          storage.summarizeExecution({ projectId, executionId: workflowExecutionId })
         ).resolves.toEqual({
           modelCallCount: 1,
           usage: {
@@ -247,7 +242,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
           },
         })
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toEqual({
           modelCallCount: 0,
           usage: { reportingStatus: "unavailable" },
@@ -255,7 +250,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(
           storage.summarizeExecution({
             projectId,
-            execution: { ...workflowExecution, workflowRunId: "workflow_run_2" },
+            executionId: "exec_workflow_2",
           })
         ).resolves.toEqual({
           modelCallCount: 0,
@@ -266,21 +261,15 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
 
     test("summarizes multiple executions in input order with one zero-call entry per miss", async () => {
       await withStorage(async (storage) => {
-        await expect(storage.summarizeExecutions({ projectId, executions: [] })).resolves.toEqual(
+        await expect(storage.summarizeExecutions({ projectId, executionIds: [] })).resolves.toEqual(
           []
         )
 
-        const otherAgentExecution = { kind: "agentRun", runId: "run_2" } as const
-        const workflowExecution = {
-          kind: "workflowAgentNode",
-          workflowRunId: "workflow_run_1",
-          nodeRunId: "node_run_1",
-        } as const
         await storage.recordModelCall(modelCallInput())
         await storage.recordModelCall(
           modelCallInput({
             id: "usage_agent_2",
-            execution: otherAgentExecution,
+            executionId: otherAgentExecutionId,
             callId: "call_agent_2",
             responseId: "response_agent_2",
             usage: { inputTokens: 4, outputTokens: 6 },
@@ -289,7 +278,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await storage.recordModelCall(
           modelCallInput({
             id: "usage_workflow",
-            execution: workflowExecution,
+            executionId: workflowExecutionId,
             callId: "call_workflow",
             responseId: "response_workflow",
             usage: { inputTokens: 5, outputTokens: 3 },
@@ -299,12 +288,12 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(
           storage.summarizeExecutions({
             projectId,
-            executions: [
-              otherAgentExecution,
-              { kind: "agentRun", runId: "missing" },
-              workflowExecution,
-              agentExecution,
-              otherAgentExecution,
+            executionIds: [
+              otherAgentExecutionId,
+              "missing",
+              workflowExecutionId,
+              agentExecutionId,
+              otherAgentExecutionId,
             ],
           })
         ).resolves.toEqual([
@@ -359,7 +348,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
       // complete zero-token report instead of an unavailable one.
       await withStorage(async (storage) => {
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toEqual({
           modelCallCount: 0,
           usage: { reportingStatus: "unavailable" },
@@ -372,7 +361,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         expect(result.record.usage).toEqual({ reportingStatus: "unavailable" })
         expect(result.record.rawUsage).toBeUndefined()
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toEqual({
           modelCallCount: 1,
           usage: { reportingStatus: "unavailable" },
@@ -411,7 +400,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         )
 
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toEqual({
           modelCallCount: 2,
           usage: {
@@ -457,7 +446,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(error).rejects.toBeInstanceOf(AiUsageStorageError)
         await expect(error).rejects.toMatchObject({ code: "duplicate_id" })
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toMatchObject({
           modelCallCount: 1,
           usage: { inputTokens: 12, outputTokens: 8, totalTokens: 20 },
@@ -465,7 +454,17 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
       })
     })
 
-    test("rejects invalid identity, usage, dates, groups, and raw JSON", async () => {
+    test("rejects a model call whose durable execution does not exist", async () => {
+      await withStorage(async (storage) => {
+        const error = storage.recordModelCall(
+          modelCallInput({ id: "usage_missing", executionId: "exec_missing" })
+        )
+        await expect(error).rejects.toBeInstanceOf(AiUsageStorageError)
+        await expect(error).rejects.toMatchObject({ code: "missing_execution" })
+      })
+    })
+
+    test("rejects invalid execution IDs, usage, dates, groups, and raw JSON", async () => {
       await withStorage(async (storage) => {
         const invalidInputs: RecordAiModelCallInput[] = [
           modelCallInput({ attempt: 0 }),
@@ -474,7 +473,7 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
           modelCallInput({ usage: { inputTokens: -1 } }),
           modelCallInput({ occurredAt: new Date(Number.NaN) }),
           modelCallInput({ rawUsage: { invalid: undefined } as never }),
-          modelCallInput({ execution: { kind: "agentRun", runId: "" } }),
+          modelCallInput({ executionId: "" }),
         ]
 
         for (const input of invalidInputs) {
@@ -483,11 +482,11 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
         await expect(
           storage.summarizeExecutions({
             projectId,
-            executions: [{ kind: "agentRun", runId: "" }],
+            executionIds: [""],
           })
         ).rejects.toThrow()
         await expect(
-          storage.summarizeExecution({ projectId, execution: agentExecution })
+          storage.summarizeExecution({ projectId, executionId: agentExecutionId })
         ).resolves.toEqual({
           modelCallCount: 0,
           usage: { reportingStatus: "unavailable" },
@@ -495,4 +494,35 @@ export function runAiUsageStorageContractSuite<TStorage extends AiUsageStorage>(
       })
     })
   })
+}
+
+/** Seed the immutable execution references used by the provider-neutral AI usage contract. */
+export async function seedAiUsageStorageContractExecutions(
+  executions: ExecutionStorage
+): Promise<void> {
+  for (const fixture of [
+    { projectId, executionId: agentExecutionId },
+    { projectId, executionId: otherAgentExecutionId },
+    { projectId, executionId: workflowExecutionId },
+    { projectId: "other-project", executionId: workflowExecutionId },
+  ]) {
+    const existing = await executions.getById({
+      projectId: fixture.projectId,
+      id: fixture.executionId,
+    })
+    if (existing) continue
+    const primitive = {
+      kind: "workflow" as const,
+      id: "ai-usage-contract",
+      runId: fixture.executionId,
+    }
+    await executions.create({
+      id: fixture.executionId,
+      projectId: fixture.projectId,
+      executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+      source: { type: "event", eventId: `test_event:${fixture.executionId}` },
+      correlationId: `test_correlation:${fixture.executionId}`,
+      authorizationRef: { type: "trustedPrimitive", primitive },
+    })
+  }
 }

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -10,6 +10,7 @@ export {
 export {
   type AiUsageStorageContractSuiteOptions,
   runAiUsageStorageContractSuite,
+  seedAiUsageStorageContractExecutions,
 } from "./ai-usage-storage-contract"
 export {
   type AuthStorageContractSuiteOptions,

--- a/packages/core/src/workflows/request.ts
+++ b/packages/core/src/workflows/request.ts
@@ -1,3 +1,4 @@
+import { snapshotRequesterGroupIds } from "../auth/attribution"
 import { assertAuthorized } from "../authorization"
 import {
   createPrimitiveExecutionRecord,
@@ -44,6 +45,13 @@ export async function requestWorkflowRun(
   options: WorkflowRunRequestOptions = {}
 ): Promise<WorkflowRunRequestResult> {
   assertAuthorized(runtime, { kind: "workflow.run", workflowId: workflow.id })
+  const requesterGroupIds = execution.requestedBy
+    ? await snapshotRequesterGroupIds({
+        auth: runtime.storage.auth,
+        projectId: runtime.projectId,
+        principal: execution.requestedBy,
+      })
+    : []
   return dispatchWorkflowRun({
     errorReporterHost: runtime,
     projectId: runtime.projectId,
@@ -55,6 +63,7 @@ export async function requestWorkflowRun(
     runId: options.runId,
     input: options.input,
     source: options.source,
+    requesterGroupIds,
     createExecution: async (executionId, runId) => {
       const caller = await ensureExecutionRecord(
         runtime.storage.executions,

--- a/packages/core/src/workflows/run-dispatch.ts
+++ b/packages/core/src/workflows/run-dispatch.ts
@@ -54,6 +54,7 @@ interface DispatchWorkflowRunInput {
   readonly runId?: string
   readonly input?: Readonly<Record<string, unknown>>
   readonly source?: WorkflowRunSource
+  readonly requesterGroupIds: readonly string[]
   readonly metadata?: Readonly<Record<string, string>>
   readonly queueJobId?: string
   readonly createExecution: (executionId: string, runId: string) => Promise<CreateExecutionInput>
@@ -103,6 +104,7 @@ export class WorkflowRunDispatcher implements WorkflowRunDispatchPort {
         eventId: input.source.eventId,
         principal: SYSTEM_PRINCIPAL,
       },
+      requesterGroupIds: [],
       metadata: input.metadata,
       queueJobId: input.runId,
       createExecution: async (executionId, runId) =>
@@ -189,6 +191,7 @@ async function persistWorkflowRun(
           workflowId: input.workflow.id,
           input: request.snapshot,
           queuedAt,
+          requesterGroupIds: input.requesterGroupIds,
         })
         return { run, execution, queuedAt, created: true }
       },

--- a/packages/core/tests/agent-dispatch.test.ts
+++ b/packages/core/tests/agent-dispatch.test.ts
@@ -24,6 +24,7 @@ async function createQueuedRun(storage: InMemoryStorage, id = "run-1") {
     threadId: `thread-${id}`,
     agentId: "assistant",
     triggerMessageId: `message-${id}`,
+    requesterGroupIds: [],
   })
 }
 

--- a/packages/core/tests/agent-run-stream-records.test.ts
+++ b/packages/core/tests/agent-run-stream-records.test.ts
@@ -18,6 +18,7 @@ function runRecord(overrides: Partial<AgentRunRecord> = {}): AgentRunRecord {
     threadId: "agt_thr_1",
     agentId: "assistant",
     triggerMessageId: "agt_msg_1",
+    requesterGroupIds: [],
     status: "cancelled",
     attempt: 0,
     createdAt: new Date("2026-01-02T03:00:00.000Z"),

--- a/packages/core/tests/agents-storage.test.ts
+++ b/packages/core/tests/agents-storage.test.ts
@@ -37,6 +37,7 @@ describe("InMemoryStorage agents", () => {
           threadId: "thr_1",
           agentId: "sales",
           triggerMessageId: "msg_1",
+          requesterGroupIds: ["engineering"],
           createdAt: new Date("2026-06-23T10:00:10.000Z"),
         })
         await tx.agents?.messages.append({
@@ -82,6 +83,7 @@ describe("InMemoryStorage agents", () => {
       threadId: "thr_1",
       agentId: "sales",
       triggerMessageId: "msg_1",
+      requesterGroupIds: ["engineering"],
       createdAt: new Date("2026-06-23T10:00:10.000Z"),
     })
     await storage.agents.runs.start({

--- a/packages/core/tests/ai-usage-storage.test.ts
+++ b/packages/core/tests/ai-usage-storage.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { InMemoryAiUsageStorage, type RecordAiModelCallInput } from "../src/storage"
+import { InMemoryStorage, type Storage } from "../src"
+import {
+  type AiUsageStorage,
+  InMemoryAiUsageStorage,
+  type RecordAiModelCallInput,
+} from "../src/storage"
 import { runAiUsageStorageContractSuite } from "../src/testing"
 
 runAiUsageStorageContractSuite("InMemoryAiUsageStorage", {
@@ -41,6 +46,52 @@ describe("InMemoryAiUsageStorage", () => {
   })
 })
 
+describe("InMemoryStorage AI usage", () => {
+  test("is wired into the composite storage", () => {
+    const storage = new InMemoryStorage()
+    expect(storage.aiUsage).toBeDefined()
+  })
+
+  test("rolls back ledger records, idempotency keys, and group rows", async () => {
+    const storage = new InMemoryStorage()
+
+    await expect(
+      storage.transaction(async (tx) => {
+        await requireAiUsage(tx).recordModelCall(modelCallInput())
+        throw new Error("boom")
+      })
+    ).rejects.toThrow("boom")
+
+    await expect(storage.aiUsage.summarizeExecution(executionSummaryInput())).resolves.toEqual({
+      modelCallCount: 0,
+      usage: { reportingStatus: "unavailable" },
+    })
+    await expect(storage.aiUsage.recordModelCall(modelCallInput())).resolves.toMatchObject({
+      created: true,
+    })
+  })
+
+  test("commits ledger records through the transaction facade", async () => {
+    const storage = new InMemoryStorage()
+
+    await storage.transaction(async (tx) => {
+      await requireAiUsage(tx).recordModelCall(modelCallInput())
+    })
+
+    await expect(
+      storage.aiUsage.summarizeExecution(executionSummaryInput())
+    ).resolves.toMatchObject({
+      modelCallCount: 1,
+      usage: {
+        inputTokens: 12,
+        outputTokens: 8,
+        totalTokens: 20,
+        reportingStatus: "complete",
+      },
+    })
+  })
+})
+
 function modelCallInput(): RecordAiModelCallInput {
   return {
     id: "usage_1",
@@ -65,4 +116,9 @@ function executionSummaryInput() {
     projectId: "project_1",
     execution: { kind: "agentRun", runId: "run_1" },
   } as const
+}
+
+function requireAiUsage(storage: Storage): AiUsageStorage {
+  if (!storage.aiUsage) throw new Error("Expected AI usage storage")
+  return storage.aiUsage
 }

--- a/packages/core/tests/ai-usage-storage.test.ts
+++ b/packages/core/tests/ai-usage-storage.test.ts
@@ -5,15 +5,34 @@ import {
   InMemoryAiUsageStorage,
   type RecordAiModelCallInput,
 } from "../src/storage"
-import { runAiUsageStorageContractSuite } from "../src/testing"
+import {
+  runAiUsageStorageContractSuite,
+  seedAiUsageStorageContractExecutions,
+} from "../src/testing"
 
+const contractBundles = new Map<AiUsageStorage, InMemoryStorage>()
 runAiUsageStorageContractSuite("InMemoryAiUsageStorage", {
-  createStorage: () => new InMemoryAiUsageStorage(),
+  createStorage: () => {
+    const bundle = new InMemoryStorage()
+    const storage = new InMemoryAiUsageStorage(bundle.executions)
+    contractBundles.set(storage, bundle)
+    return storage
+  },
+  setup: async (storage) => {
+    const bundle = contractBundles.get(storage)
+    if (!bundle) throw new Error("Expected in-memory storage bundle")
+    await seedAiUsageStorageContractExecutions(bundle.executions)
+  },
+  cleanup: (storage) => {
+    contractBundles.delete(storage)
+  },
 })
 
 describe("InMemoryAiUsageStorage", () => {
   test("snapshots model-call records, idempotency keys, and group rows", async () => {
-    const storage = new InMemoryAiUsageStorage()
+    const bundle = new InMemoryStorage()
+    const storage = new InMemoryAiUsageStorage(bundle.executions)
+    await createExecution(bundle, "project_1", "exec_1")
     const empty = storage.snapshot()
 
     await storage.recordModelCall(modelCallInput())
@@ -54,6 +73,7 @@ describe("InMemoryStorage AI usage", () => {
 
   test("rolls back ledger records, idempotency keys, and group rows", async () => {
     const storage = new InMemoryStorage()
+    await createExecution(storage, "project_1", "exec_1")
 
     await expect(
       storage.transaction(async (tx) => {
@@ -73,6 +93,7 @@ describe("InMemoryStorage AI usage", () => {
 
   test("commits ledger records through the transaction facade", async () => {
     const storage = new InMemoryStorage()
+    await createExecution(storage, "project_1", "exec_1")
 
     await storage.transaction(async (tx) => {
       await requireAiUsage(tx).recordModelCall(modelCallInput())
@@ -96,10 +117,9 @@ function modelCallInput(): RecordAiModelCallInput {
   return {
     id: "usage_1",
     projectId: "project_1",
-    execution: { kind: "agentRun", runId: "run_1" },
+    executionId: "exec_1",
     attempt: 1,
     callId: "call_1",
-    requesterPrincipal: { type: "user", id: "usr_1" },
     requesterGroupIds: ["support", "engineering", "support"],
     providerId: "gateway",
     requestedModelId: "openai/gpt-5",
@@ -114,8 +134,24 @@ function modelCallInput(): RecordAiModelCallInput {
 function executionSummaryInput() {
   return {
     projectId: "project_1",
-    execution: { kind: "agentRun", runId: "run_1" },
+    executionId: "exec_1",
   } as const
+}
+
+async function createExecution(
+  storage: InMemoryStorage,
+  projectId: string,
+  executionId: string
+): Promise<void> {
+  const primitive = { kind: "workflow" as const, id: "ai-usage-test", runId: executionId }
+  await storage.executions.create({
+    id: executionId,
+    projectId,
+    executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+    source: { type: "event", eventId: `event:${executionId}` },
+    correlationId: `correlation:${executionId}`,
+    authorizationRef: { type: "trustedPrimitive", primitive },
+  })
 }
 
 function requireAiUsage(storage: Storage): AiUsageStorage {

--- a/packages/core/tests/ai-usage.types.ts
+++ b/packages/core/tests/ai-usage.types.ts
@@ -2,13 +2,11 @@ import type {
   AiModelCallUsageRecord,
   AiUsageExecutionSummary,
   AiUsageStorage,
-  Principal,
   ReadonlyJsonObject,
   RecordAiModelCallInput,
   RecordAiModelCallResult,
 } from "@sixb/core/storage"
 
-const requesterPrincipal: Principal = { type: "user", id: "usr_1" }
 const rawUsage: ReadonlyJsonObject = { provider_counter: 1 }
 const emptySummary: AiUsageExecutionSummary = {
   modelCallCount: 0,
@@ -18,10 +16,9 @@ const emptySummary: AiUsageExecutionSummary = {
 const input: RecordAiModelCallInput = {
   id: "usage_1",
   projectId: "project_1",
-  execution: { kind: "agentRun", runId: "run_1" },
+  executionId: "exec_1",
   attempt: 1,
   callId: "call_1",
-  requesterPrincipal,
   requesterGroupIds: ["support"],
   providerId: "gateway",
   requestedModelId: "openai/gpt-5",
@@ -47,8 +44,8 @@ const provider = {
   async summarizeExecution() {
     return emptySummary
   },
-  async summarizeExecutions({ executions }) {
-    return executions.map(() => emptySummary)
+  async summarizeExecutions({ executionIds }) {
+    return executionIds.map(() => emptySummary)
   },
 } satisfies AiUsageStorage
 

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -31,6 +31,7 @@ import {
 } from "../src"
 import { agentServiceAccountId, ensureAgentExecutionIdentity } from "../src/agents/authority"
 import { createAgentScope } from "../src/execution/scopes"
+import type { AuthStorage } from "../src/storage"
 import { createTestSixb, type TestExecutionHost } from "../src/testing"
 import { createTestRuntimeDeps, waitFor } from "./test-runtime-deps"
 
@@ -285,6 +286,22 @@ async function seedPrincipal(
   })
 }
 
+async function seedRequesterMemberships(
+  host: { readonly id: string; readonly storage: { readonly auth?: AuthStorage } },
+  groupIds: readonly string[]
+): Promise<void> {
+  const auth = host.storage.auth
+  if (!auth) throw new Error("Test requires auth storage")
+  for (const groupId of groupIds) {
+    await auth.groupMemberships.upsert({
+      projectId: host.id,
+      userId: principal.id,
+      groupId,
+      source: "manual",
+    })
+  }
+}
+
 describe("bound Sixb object reads", () => {
   test("granted types support get, list, byId.get, and query", async () => {
     const host = createRuntime()
@@ -427,10 +444,11 @@ describe("bound Sixb operational access", () => {
     expect(runner.datasets.list()).toEqual([])
   })
 
-  test("workflow runs require can.run", async () => {
+  test("workflow runs require can.run and snapshot all durable requester groups", async () => {
     const host = createRuntime()
     await seedPrincipal(host)
     const sixb = createTestSixb(host)
+    await seedRequesterMemberships(host, ["operations", "commercial"])
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
     const input = {
       workflowId: "renew-contract",
@@ -440,6 +458,17 @@ describe("bound Sixb operational access", () => {
     const runner = bindPrincipal(host, contextFor(host, ["operations"]))
     const result = await runner.workflows.requestById(input)
     expect(result.runId).toBeString()
+    const run = await host.storage.workflowRuns?.getById({
+      projectId: host.id,
+      id: result.runId,
+    })
+    expect(run).toBeDefined()
+    await expect(
+      host.storage.executions.getById({ projectId: host.id, id: run?.executionId ?? "" })
+    ).resolves.toMatchObject({ requestedBy: principal })
+    // The authorization context carries only "operations". Attribution resolves the complete
+    // durable membership set so a token-scoped caller cannot avoid the commercial group quota.
+    expect(run?.requesterGroupIds).toEqual(["commercial", "operations"])
 
     const operator = bindPrincipal(host, contextFor(host, ["commercial"]))
     expect(operator.workflows.requestById(input)).rejects.toThrow(AuthorizationError)
@@ -638,14 +667,11 @@ describe("bound Sixb operational access", () => {
     expect(operator.agents.getById("contract-agent")).toBeNull()
   })
 
-  test("agent run requests require can.run", async () => {
+  test("agent run requests require can.run and retain the admission snapshot", async () => {
     const host = createRuntime()
     const _sixb = createTestSixb(host)
-    await host.storage.auth?.users.create({
-      id: "adam",
-      projectId: host.id,
-      email: "adam@example.com",
-    })
+    await seedPrincipal(host)
+    await seedRequesterMemberships(host, ["operations", "commercial"])
 
     const runner = bindPrincipal(host, contextFor(host, ["operations"]))
     const result = await runner.agents.runs.request({
@@ -653,6 +679,21 @@ describe("bound Sixb operational access", () => {
       text: "Summarize this account.",
     })
     expect(result.run.id).toBeString()
+    expect(result.run.requesterGroupIds).toEqual(["commercial", "operations"])
+    await expect(
+      host.storage.executions.getById({ projectId: host.id, id: result.run.executionId })
+    ).resolves.toMatchObject({ requestedBy: principal })
+
+    await host.storage.auth?.groupMemberships.remove({
+      projectId: host.id,
+      userId: principal.id,
+      groupId: "commercial",
+    })
+    const stored = await host.storage.agents?.runs.getById({
+      projectId: host.id,
+      id: result.run.id,
+    })
+    expect(stored?.requesterGroupIds).toEqual(["commercial", "operations"])
 
     const operator = bindPrincipal(host, contextFor(host, ["commercial"]))
     expect(

--- a/packages/core/tests/workflow-request.test.ts
+++ b/packages/core/tests/workflow-request.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test"
 import {
+  type AuthorizationContext,
   defineObjectType,
   defineWorkflow,
   defineWorkflowStep,
+  emptyGrantIndex,
   prop,
   type Queues,
   ref,
@@ -272,6 +274,50 @@ describe("sixb.workflows.request", () => {
 
     const events = await sixb.events.read({ types: ["workflow.run.queued"] })
     expect(events[0]?.payload).toMatchObject({ source })
+  })
+
+  test("snapshots durable service-account groups from request authority", async () => {
+    const { host } = createSixb()
+    const auth = host.storage.auth
+    if (!auth) throw new Error("Test requires auth storage")
+    const principal = { type: "serviceAccount", id: "svc_scheduler" } as const
+    await auth.serviceAccounts.create({
+      id: principal.id,
+      projectId: host.id,
+      name: "Workflow scheduler",
+    })
+    for (const groupId of ["operations", "finance"]) {
+      await auth.serviceAccountGroupMemberships.upsert({
+        projectId: host.id,
+        serviceAccountId: principal.id,
+        groupId,
+        source: "manual",
+      })
+    }
+    const authorization: AuthorizationContext = {
+      principal,
+      groupIds: ["operations"],
+      roleIds: [],
+      grants: {
+        ...emptyGrantIndex(),
+        "run:workflow": new Set([draftInvoice.id]),
+      },
+    }
+    const sixb = createTestSixb(host, { authorization })
+
+    const result = await sixb.workflows.request(draftInvoice, {
+      input: validInput(),
+    })
+
+    const run = await host.storage.workflowRuns?.getById({
+      projectId: host.id,
+      id: result.runId,
+    })
+    expect(run).toBeDefined()
+    await expect(
+      host.storage.executions.getById({ projectId: host.id, id: run?.executionId ?? "" })
+    ).resolves.toMatchObject({ requestedBy: principal })
+    expect(run?.requesterGroupIds).toEqual(["finance", "operations"])
   })
 
   test("retried webhook delivery with a deterministic runId enqueues a single run", async () => {

--- a/packages/core/tests/workflow-runs.test.ts
+++ b/packages/core/tests/workflow-runs.test.ts
@@ -209,7 +209,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       workflowId: "reconcile-transaction",
       input: { transactionId: "txn_123" },
       queuedAt,
-      requesterGroupIds: ["engineering", "support"],
+      requesterGroupIds: ["support", "engineering", "support"],
     })
 
     const running = await storage.start({

--- a/packages/core/tests/workflow-runs.test.ts
+++ b/packages/core/tests/workflow-runs.test.ts
@@ -47,6 +47,7 @@ function createWorkflowRunStorage() {
           projectId: input.projectId,
           workflowId: input.workflowId,
           input: input.input,
+          requesterGroupIds: [],
         })
       }
       return start({
@@ -130,6 +131,7 @@ describe("InMemoryWorkflowRunStorage", () => {
         executionId: "orphan-workflow-execution",
         workflowId: "reconcile-transaction",
         input: {},
+        requesterGroupIds: [],
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -145,6 +147,7 @@ describe("InMemoryWorkflowRunStorage", () => {
         executionId,
         workflowId: "reconcile-transaction",
         input: {},
+        requesterGroupIds: [],
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -161,6 +164,7 @@ describe("InMemoryWorkflowRunStorage", () => {
         executionId: automaticExecutionId,
         workflowId: "reconcile-transaction",
         input: {},
+        requesterGroupIds: [],
       })
     ).resolves.toMatchObject({ id: "wf-run-automatic", executionId: automaticExecutionId })
   })
@@ -172,6 +176,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       projectId: "my-app",
       workflowId: "reconcile-transaction",
       input: {},
+      requesterGroupIds: [],
     })
 
     const results = await Promise.allSettled([
@@ -204,6 +209,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       workflowId: "reconcile-transaction",
       input: { transactionId: "txn_123" },
       queuedAt,
+      requesterGroupIds: ["engineering", "support"],
     })
 
     const running = await storage.start({
@@ -219,6 +225,7 @@ describe("InMemoryWorkflowRunStorage", () => {
     expect(running.status).toBe("running")
     expect(running.queuedAt?.toISOString()).toBe(queuedAt.toISOString())
     expect(running.startedAt.toISOString()).toBe(startedAt.toISOString())
+    expect(running.requesterGroupIds).toEqual(["engineering", "support"])
 
     const failed = await storage.queue({
       id: "wf-run-failed-before-start",
@@ -226,6 +233,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       workflowId: "reconcile-transaction",
       input: { transactionId: "txn_456" },
       queuedAt,
+      requesterGroupIds: [],
     })
     expect(failed.status).toBe("queued")
 

--- a/packages/server/tests/agent-api-gateway.test.ts
+++ b/packages/server/tests/agent-api-gateway.test.ts
@@ -409,6 +409,7 @@ async function createGatewayRuntime(
     executionId: completedWorkflowExecutionId,
     workflowId: inspectDevices.id,
     input: { document: fileRefJson(completedWorkflowOutput) },
+    requesterGroupIds: [],
     queuedAt: NOW,
   })
   await storage.workflowRuns.start({
@@ -478,6 +479,7 @@ async function createGatewayRuntime(
       executionId: parentWorkflowExecutionId,
       workflowId: inspectDevices.id,
       input: {},
+      requesterGroupIds: [],
       queuedAt: NOW,
     })
     await storage.workflowRuns.start({
@@ -538,6 +540,7 @@ async function createGatewayRuntime(
       threadId,
       agentId: "assistant",
       triggerMessageId: "msg-1",
+      requesterGroupIds: ["engineering"],
       createdAt: NOW,
     })
     await storage.agents.runs.start({

--- a/packages/server/tests/agent-streams-ws.test.ts
+++ b/packages/server/tests/agent-streams-ws.test.ts
@@ -127,6 +127,7 @@ describe("/ws/agents", () => {
         threadId,
         agentId,
         triggerMessageId: "msg_queued",
+        requesterGroupIds: [],
       })
       const ws = new WebSocket(`${baseUrl.replace("http://", "ws://")}/ws/agents`)
 
@@ -267,6 +268,7 @@ describe("canAccessAgentRunStream", () => {
       threadId,
       agentId,
       triggerMessageId: "msg_ws_1",
+      requesterGroupIds: ["support-users"],
     })
 
     await expect(
@@ -439,6 +441,7 @@ async function advanceDurableRun(
       threadId,
       agentId,
       triggerMessageId: `msg_${input.runId}`,
+      requesterGroupIds: [],
     })
   }
   if (run.status === "queued") {

--- a/packages/server/tests/agents-routes.test.ts
+++ b/packages/server/tests/agents-routes.test.ts
@@ -747,12 +747,14 @@ describe("agent routes", () => {
     const request = (await messageResponse.json()) as {
       run: { id: string; threadId: string; triggerMessageId: string }
     }
-    await expect(
-      storage.agents.runs.getById({ projectId: sixb.id, id: request.run.id })
-    ).resolves.toMatchObject({
-      requestedByPrincipal: { type: "user", id: "usr_retry" },
-      requesterGroupIds: ["admins", "support-users"],
+    const originalRun = await storage.agents.runs.getById({
+      projectId: sixb.id,
+      id: request.run.id,
     })
+    expect(originalRun).toMatchObject({ requesterGroupIds: ["admins", "support-users"] })
+    await expect(
+      storage.executions.getById({ projectId: sixb.id, id: originalRun?.executionId ?? "" })
+    ).resolves.toMatchObject({ requestedBy: { type: "user", id: "usr_retry" } })
     await storage.agents.runs.finishQueued({
       id: request.run.id,
       projectId: sixb.id,
@@ -789,12 +791,11 @@ describe("agent routes", () => {
       triggerMessageId: request.run.triggerMessageId,
     })
     expect(body.run.id).not.toBe(request.run.id)
+    const retriedRun = await storage.agents.runs.getById({ projectId: sixb.id, id: body.run.id })
+    expect(retriedRun).toMatchObject({ requesterGroupIds: ["ops-users", "support-users"] })
     await expect(
-      storage.agents.runs.getById({ projectId: sixb.id, id: body.run.id })
-    ).resolves.toMatchObject({
-      requestedByPrincipal: { type: "user", id: "usr_retry" },
-      requesterGroupIds: ["ops-users", "support-users"],
-    })
+      storage.executions.getById({ projectId: sixb.id, id: retriedRun?.executionId ?? "" })
+    ).resolves.toMatchObject({ requestedBy: { type: "user", id: "usr_retry" } })
 
     await expect(
       storage.agents.messages.list({ projectId: sixb.id, threadId: request.run.threadId })

--- a/packages/server/tests/agents-routes.test.ts
+++ b/packages/server/tests/agents-routes.test.ts
@@ -560,6 +560,7 @@ describe("agent routes", () => {
       threadId: thread.id,
       agentId: "assistant",
       triggerMessageId: "trigger-diagnostics",
+      requesterGroupIds: [],
       execution: testExecution(executionToken),
     })
     await storage.agents.messages.append({
@@ -620,6 +621,7 @@ describe("agent routes", () => {
       threadId: thread.id,
       agentId: "assistant",
       triggerMessageId: "msg-existing",
+      requesterGroupIds: [],
       execution: testExecution(),
     })
 
@@ -725,11 +727,31 @@ describe("agent routes", () => {
     })
   })
 
-  test("retries a failed run without duplicating its trigger message", async () => {
-    const { app, storage, sixb } = createApp()
-    const request = await createTestSixb(sixb).agents.runs.request({
-      agentId: "assistant",
-      text: "try this",
+  test("retries a failed run with a fresh attribution snapshot and the same trigger", async () => {
+    const { app, storage, sixb } = createApp({ auth: true })
+    const session = await seedSession(storage, "usr_retry", ["support-users", "admins"])
+    const createThreadResponse = await app.fetch(
+      jsonRequest("/api/agent-threads", "POST", { agentId: "assistant" }, session.csrfHeaders)
+    )
+    expect(createThreadResponse.status).toBe(201)
+    const thread = (await createThreadResponse.json()) as { thread: { id: string } }
+    const messageResponse = await app.fetch(
+      jsonRequest(
+        `/api/agent-threads/${thread.thread.id}/messages`,
+        "POST",
+        { text: "try this" },
+        session.csrfHeaders
+      )
+    )
+    expect(messageResponse.status).toBe(202)
+    const request = (await messageResponse.json()) as {
+      run: { id: string; threadId: string; triggerMessageId: string }
+    }
+    await expect(
+      storage.agents.runs.getById({ projectId: sixb.id, id: request.run.id })
+    ).resolves.toMatchObject({
+      requestedByPrincipal: { type: "user", id: "usr_retry" },
+      requesterGroupIds: ["admins", "support-users"],
     })
     await storage.agents.runs.finishQueued({
       id: request.run.id,
@@ -738,11 +760,24 @@ describe("agent routes", () => {
       error: "dispatch failed",
     })
 
+    await storage.auth.groupMemberships.remove({
+      projectId: sixb.id,
+      userId: "usr_retry",
+      groupId: "admins",
+    })
+    await storage.auth.groupMemberships.upsert({
+      projectId: sixb.id,
+      userId: "usr_retry",
+      groupId: "ops-users",
+      source: "manual",
+    })
+
     const response = await app.fetch(
       jsonRequest(
         `/api/agent-threads/${request.run.threadId}/runs/${request.run.id}/retry`,
         "POST",
-        {}
+        {},
+        session.csrfHeaders
       )
     )
     expect(response.status).toBe(202)
@@ -754,6 +789,12 @@ describe("agent routes", () => {
       triggerMessageId: request.run.triggerMessageId,
     })
     expect(body.run.id).not.toBe(request.run.id)
+    await expect(
+      storage.agents.runs.getById({ projectId: sixb.id, id: body.run.id })
+    ).resolves.toMatchObject({
+      requestedByPrincipal: { type: "user", id: "usr_retry" },
+      requesterGroupIds: ["ops-users", "support-users"],
+    })
 
     await expect(
       storage.agents.messages.list({ projectId: sixb.id, threadId: request.run.threadId })
@@ -780,6 +821,7 @@ describe("agent routes", () => {
       threadId: thread.id,
       agentId: "assistant",
       triggerMessageId: "msg-user",
+      requesterGroupIds: [],
       modelId: "test-model",
       execution: testExecution(),
       createdAt: new Date("2026-06-27T10:00:00.000Z"),
@@ -817,6 +859,7 @@ describe("agent routes", () => {
       threadId: thread.id,
       agentId: "assistant",
       triggerMessageId: "msg-user",
+      requesterGroupIds: [],
       execution: testExecution(),
     })
 
@@ -857,6 +900,7 @@ describe("agent routes", () => {
       threadId: otherThread.id,
       agentId: "assistant",
       triggerMessageId: "msg-other",
+      requesterGroupIds: [],
       execution: testExecution(),
     })
     const crossThread = await app.fetch(

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -1404,6 +1404,7 @@ describe("authorized event and workflow routes", () => {
       executionId: hiddenExecutionId,
       workflowId: "hidden-workflow",
       input: {},
+      requesterGroupIds: [],
       queuedAt: new Date("2099-01-01T00:00:00.000Z"),
     })
     await storage.workflowInterventions.create({

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -240,6 +240,7 @@ async function seedPendingReviewIntervention(
     executionId: workflowExecutionId,
     workflowId: "review-device-health-workflow",
     input: { deviceId: "fan-1" },
+    requesterGroupIds: [],
     queuedAt: new Date("2026-02-18T09:19:59.000Z"),
   })
   await workflowRuns.start({
@@ -465,6 +466,7 @@ describe("SixbServer HTTP contract", () => {
       executionId: previousWorkflowExecutionId,
       workflowId: "inspect-device-workflow",
       input: { deviceId: "fan-1" },
+      requesterGroupIds: [],
       queuedAt: new Date("2026-02-18T09:06:59.000Z"),
     })
     await sixb.storage.workflowRuns!.start({
@@ -1908,6 +1910,7 @@ describe("SixbServer HTTP contract", () => {
         executionId: workflowExecutionId,
         workflowId: "review-device-health-workflow",
         input: { deviceId: "fan-1" },
+        requesterGroupIds: [],
       })
       await runs.start({ id: runId, projectId: sixb.id })
       await runs.nodes.start({

--- a/packages/server/tests/run-file-content-routes.test.ts
+++ b/packages/server/tests/run-file-content-routes.test.ts
@@ -128,6 +128,7 @@ async function createRunFileApi(options: { readonly auth?: boolean } = {}) {
       document: fileRefJson(workflowInput),
       title: "not a file",
     },
+    requesterGroupIds: [],
     queuedAt: new Date("2026-06-30T12:00:59.000Z"),
   })
   await storage.workflowRuns.start({

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -304,6 +304,7 @@ async function runWorkflowJob(input: RunWorkflowJobInput) {
       projectId: input.runtime.projectId,
       workflowId: input.job.workflowId,
       input: snapshot,
+      requesterGroupIds: [],
     })
     existing = await input.runtime.workflowRuns.getById({
       projectId: input.runtime.projectId,
@@ -469,6 +470,7 @@ describe("runWorkflowJob", () => {
       projectId: sixb.id,
       workflowId: workflow.id,
       input: workflowInput,
+      requesterGroupIds: [],
       queuedAt: new Date("2026-05-08T09:59:00.000Z"),
     })
 
@@ -551,6 +553,7 @@ describe("runWorkflowJob", () => {
       projectId: sixb.id,
       workflowId: workflow.id,
       input,
+      requesterGroupIds: [],
     })
     await runs.start({
       id: "wfrun_recovered",
@@ -1130,6 +1133,7 @@ describe("runWorkflowJob", () => {
       projectId: sixb.id,
       workflowId: workflow.id,
       input: {},
+      requesterGroupIds: [],
     })
 
     await expect(

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -479,6 +479,7 @@ describe("WorkflowWorker", () => {
       executionId,
       workflowId: workflow.id,
       input: {},
+      requesterGroupIds: [],
     })
     await sixb.queues.workflows.enqueue({
       projectId: sixb.id,

--- a/storage/pg/src/agents/rows.ts
+++ b/storage/pg/src/agents/rows.ts
@@ -34,6 +34,7 @@ export interface AgentRunRow {
   thread_id: string
   agent_id: string
   trigger_message_id: string
+  requester_group_ids: string[] | string
   status: AgentRunRecord["status"]
   model_id: string | null
   finish_reason: string | null
@@ -94,6 +95,10 @@ export function rowToRunRecord(row: AgentRunRow): AgentRunRecord {
     threadId: row.thread_id,
     agentId: row.agent_id,
     triggerMessageId: row.trigger_message_id,
+    requesterGroupIds:
+      typeof row.requester_group_ids === "string"
+        ? (JSON.parse(row.requester_group_ids) as string[])
+        : row.requester_group_ids,
     status: row.status,
     modelId: row.model_id ?? undefined,
     finishReason: coerceAgentRunFinishReason(row.finish_reason),

--- a/storage/pg/src/agents/runs.ts
+++ b/storage/pg/src/agents/runs.ts
@@ -1,4 +1,5 @@
 import { assertAgentRunExecution } from "@sixb/core/internal/agent-run-storage-provider"
+import { normalizeRequesterGroupIds } from "@sixb/core/internal/auth"
 import {
   type AgentRunRecord,
   type AgentRunStore,
@@ -78,7 +79,7 @@ export class PgAgentRunStore implements AgentRunStore {
             ${input.threadId},
             ${input.agentId},
             ${input.triggerMessageId},
-            ${JSON.stringify(input.requesterGroupIds)}::text::jsonb,
+            ${JSON.stringify(normalizeRequesterGroupIds(input.requesterGroupIds))}::text::jsonb,
             ${"queued"},
             ${0},
             ${createdAt}

--- a/storage/pg/src/agents/runs.ts
+++ b/storage/pg/src/agents/runs.ts
@@ -67,6 +67,7 @@ export class PgAgentRunStore implements AgentRunStore {
             thread_id,
             agent_id,
             trigger_message_id,
+            requester_group_ids,
             status,
             attempt,
             created_at
@@ -77,6 +78,7 @@ export class PgAgentRunStore implements AgentRunStore {
             ${input.threadId},
             ${input.agentId},
             ${input.triggerMessageId},
+            ${JSON.stringify(input.requesterGroupIds)}::text::jsonb,
             ${"queued"},
             ${0},
             ${createdAt}

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -29,6 +29,7 @@ import { PgAuthStorage } from "./auth-storage"
 import { createPostgresStorageMigrators, dropSchema } from "./migrations"
 import { PgOntologyStorage, type PgOntologyTransactionContext } from "./ontology-storage"
 import { PgActionRunStorage } from "./pg-action-run-storage"
+import { PgAiUsageStorage } from "./pg-ai-usage-storage"
 import { createPgClient, type SQL, type SQLClient } from "./pg-client"
 import { PgExecutionStorage } from "./pg-execution-storage"
 import { PgObjectStorage } from "./pg-object-storage"
@@ -107,8 +108,8 @@ export interface PostgresStorageOptions {
 /**
  * PostgreSQL storage provider for Sixb.
  *
- * Bundles Sixb storage adapters backed by a shared PostgreSQL connection pool (porsager
- * `postgres`), which reliably reclaims connections under load.
+ * Bundles Sixb storage adapters, including the AI usage ledger, behind a shared PostgreSQL
+ * connection pool (porsager `postgres`), which reliably reclaims connections under load.
  *
  * The storage exposes a core `StorageMigrator`. Sixb CLI startup and
  * `sixb db migrate` run it automatically through `migrateStorage(storage)`.
@@ -131,6 +132,7 @@ export class PostgresStorage implements MigrationCapableStorage {
   readonly auth: PgAuthStorage
   readonly executions: PgExecutionStorage
   readonly agents: PgAgentStorage
+  readonly aiUsage: PgAiUsageStorage
   readonly actionRuns: PgActionRunStorage
   readonly pipelineRuns: PgPipelineRunStorage
   readonly workflowRuns: PgWorkflowRunStorage
@@ -203,6 +205,7 @@ export class PostgresStorage implements MigrationCapableStorage {
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)
     this.agents = createAgentOperationScope(stores.agents, scope)
+    this.aiUsage = createOperationScopedFacade(stores.aiUsage, scope)
     this.actionRuns = createOperationScopedFacade(stores.actionRuns, scope)
     this.pipelineRuns = createOperationScopedFacade(stores.pipelineRuns, scope)
     this.workflowRuns = createWorkflowRunOperationScope(stores.workflowRuns, scope)
@@ -328,6 +331,7 @@ function createPostgresStores(
     auth,
     executions,
     agents: new PgAgentStorage({ sql, executions }),
+    aiUsage: new PgAiUsageStorage(sql),
     actionRuns: new PgActionRunStorage(sql, executions),
     pipelineRuns: new PgPipelineRunStorage(sql),
     workflowRuns: new PgWorkflowRunStorage(sql, executions),
@@ -347,6 +351,7 @@ interface PostgresStoreSet {
   readonly auth: PgAuthStorage
   readonly executions: PgExecutionStorage
   readonly agents: PgAgentStorage
+  readonly aiUsage: PgAiUsageStorage
   readonly actionRuns: PgActionRunStorage
   readonly pipelineRuns: PgPipelineRunStorage
   readonly workflowRuns: PgWorkflowRunStorage

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -19,6 +19,7 @@ import {
   createWorkflowRunOperationScope,
 } from "@sixb/core/internal/storage-operation-scope"
 import {
+  type AiUsageStorage,
   createTransactionStorageProxy,
   type ObjectStorage,
   StorageTransactionError,
@@ -132,7 +133,7 @@ export class PostgresStorage implements MigrationCapableStorage {
   readonly auth: PgAuthStorage
   readonly executions: PgExecutionStorage
   readonly agents: PgAgentStorage
-  readonly aiUsage: PgAiUsageStorage
+  readonly aiUsage: AiUsageStorage
   readonly actionRuns: PgActionRunStorage
   readonly pipelineRuns: PgPipelineRunStorage
   readonly workflowRuns: PgWorkflowRunStorage

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -24,6 +24,9 @@ import narrowOntologySourceRootIndexSql from "./migrations/006-narrow-ontology-s
 import splitOverridesSql from "./migrations/007-split-overrides.sql" with { type: "text" }
 import actionExecutionsSql from "./migrations/008-action-executions.sql" with { type: "text" }
 import agentExecutionsSql from "./migrations/009-agent-executions.sql" with { type: "text" }
+import aiUsageAccountingFoundationSql from "./migrations/010-ai-usage-accounting-foundation.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -286,6 +289,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("007-split-overrides", splitOverridesSql),
     pgSql("008-action-executions", actionExecutionsSql),
     pgSql("009-agent-executions", agentExecutionsSql),
+    pgSql("010-ai-usage-accounting-foundation", aiUsageAccountingFoundationSql),
   ],
 })
 

--- a/storage/pg/src/migrations/010-ai-usage-accounting-foundation.sql
+++ b/storage/pg/src/migrations/010-ai-usage-accounting-foundation.sql
@@ -11,24 +11,17 @@ ALTER TABLE workflow_runs
   CHECK (jsonb_typeof(requester_group_ids) = 'array');
 
 CREATE TABLE ai_model_call_usage (
-  project_id TEXT NOT NULL,
-  id TEXT NOT NULL,
-  execution_kind TEXT NOT NULL CHECK (
-    execution_kind IN ('agentRun', 'workflowAgentNode')
-  ),
-  agent_run_id TEXT,
-  workflow_run_id TEXT,
-  workflow_node_run_id TEXT,
+  project_id TEXT NOT NULL CHECK (length(trim(project_id)) > 0),
+  id TEXT NOT NULL CHECK (length(trim(id)) > 0),
+  execution_id TEXT NOT NULL CHECK (length(trim(execution_id)) > 0),
   attempt BIGINT NOT NULL CHECK (attempt >= 1),
-  call_id TEXT NOT NULL,
-  requester_principal_type TEXT NOT NULL CHECK (
-    requester_principal_type IN ('user', 'serviceAccount', 'system')
+  call_id TEXT NOT NULL CHECK (length(trim(call_id)) > 0),
+  provider_id TEXT NOT NULL CHECK (length(trim(provider_id)) > 0),
+  requested_model_id TEXT NOT NULL CHECK (length(trim(requested_model_id)) > 0),
+  response_model_id TEXT CHECK (
+    response_model_id IS NULL OR length(trim(response_model_id)) > 0
   ),
-  requester_principal_id TEXT NOT NULL,
-  provider_id TEXT NOT NULL,
-  requested_model_id TEXT NOT NULL,
-  response_model_id TEXT,
-  response_id TEXT NOT NULL,
+  response_id TEXT NOT NULL CHECK (length(trim(response_id)) > 0),
   input_tokens BIGINT CHECK (input_tokens IS NULL OR input_tokens >= 0),
   output_tokens BIGINT CHECK (output_tokens IS NULL OR output_tokens >= 0),
   total_tokens BIGINT CHECK (total_tokens IS NULL OR total_tokens >= 0),
@@ -50,60 +43,21 @@ CREATE TABLE ai_model_call_usage (
   reporting_status TEXT NOT NULL CHECK (
     reporting_status IN ('complete', 'partial', 'unavailable')
   ),
-  raw_usage JSONB,
+  raw_usage JSONB CHECK (raw_usage IS NULL OR jsonb_typeof(raw_usage) = 'object'),
   occurred_at TIMESTAMPTZ NOT NULL,
   recorded_at TIMESTAMPTZ NOT NULL,
   PRIMARY KEY (project_id, id),
-  CHECK (
-    (
-      execution_kind = 'agentRun'
-      AND agent_run_id IS NOT NULL
-      AND workflow_run_id IS NULL
-      AND workflow_node_run_id IS NULL
-    ) OR (
-      execution_kind = 'workflowAgentNode'
-      AND agent_run_id IS NULL
-      AND workflow_run_id IS NOT NULL
-      AND workflow_node_run_id IS NOT NULL
-    )
-  )
+  FOREIGN KEY (project_id, execution_id)
+    REFERENCES executions(project_id, id)
+    ON DELETE RESTRICT
 );
 
-CREATE UNIQUE INDEX idx_ai_model_call_usage_agent_idempotency
-  ON ai_model_call_usage (project_id, agent_run_id, attempt, call_id, response_id)
-  WHERE execution_kind = 'agentRun';
-CREATE UNIQUE INDEX idx_ai_model_call_usage_workflow_idempotency
-  ON ai_model_call_usage (
-    project_id,
-    workflow_run_id,
-    workflow_node_run_id,
-    attempt,
-    call_id,
-    response_id
-  )
-  WHERE execution_kind = 'workflowAgentNode';
-CREATE INDEX idx_ai_model_call_usage_agent_execution
-  ON ai_model_call_usage (project_id, agent_run_id, occurred_at, id)
-  WHERE execution_kind = 'agentRun';
-CREATE INDEX idx_ai_model_call_usage_workflow_execution
-  ON ai_model_call_usage (
-    project_id,
-    workflow_run_id,
-    workflow_node_run_id,
-    occurred_at,
-    id
-  )
-  WHERE execution_kind = 'workflowAgentNode';
+CREATE UNIQUE INDEX idx_ai_model_call_usage_idempotency
+  ON ai_model_call_usage (project_id, execution_id, attempt, call_id, response_id);
+CREATE INDEX idx_ai_model_call_usage_execution
+  ON ai_model_call_usage (project_id, execution_id, occurred_at, id);
 CREATE INDEX idx_ai_model_call_usage_project_time
   ON ai_model_call_usage (project_id, occurred_at, id);
-CREATE INDEX idx_ai_model_call_usage_principal_time
-  ON ai_model_call_usage (
-    project_id,
-    requester_principal_type,
-    requester_principal_id,
-    occurred_at,
-    id
-  );
 CREATE INDEX idx_ai_model_call_usage_provider_response
   ON ai_model_call_usage (project_id, provider_id, response_id);
 

--- a/storage/pg/src/migrations/010-ai-usage-accounting-foundation.sql
+++ b/storage/pg/src/migrations/010-ai-usage-accounting-foundation.sql
@@ -1,0 +1,122 @@
+ALTER TABLE agent_runs
+  ADD COLUMN requester_group_ids JSONB NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE agent_runs
+  ADD CONSTRAINT agent_runs_requester_group_ids_array
+  CHECK (jsonb_typeof(requester_group_ids) = 'array');
+
+ALTER TABLE workflow_runs
+  ADD COLUMN requester_group_ids JSONB NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE workflow_runs
+  ADD CONSTRAINT workflow_runs_requester_group_ids_array
+  CHECK (jsonb_typeof(requester_group_ids) = 'array');
+
+CREATE TABLE ai_model_call_usage (
+  project_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  execution_kind TEXT NOT NULL CHECK (
+    execution_kind IN ('agentRun', 'workflowAgentNode')
+  ),
+  agent_run_id TEXT,
+  workflow_run_id TEXT,
+  workflow_node_run_id TEXT,
+  attempt BIGINT NOT NULL CHECK (attempt >= 1),
+  call_id TEXT NOT NULL,
+  requester_principal_type TEXT NOT NULL CHECK (
+    requester_principal_type IN ('user', 'serviceAccount', 'system')
+  ),
+  requester_principal_id TEXT NOT NULL,
+  provider_id TEXT NOT NULL,
+  requested_model_id TEXT NOT NULL,
+  response_model_id TEXT,
+  response_id TEXT NOT NULL,
+  input_tokens BIGINT CHECK (input_tokens IS NULL OR input_tokens >= 0),
+  output_tokens BIGINT CHECK (output_tokens IS NULL OR output_tokens >= 0),
+  total_tokens BIGINT CHECK (total_tokens IS NULL OR total_tokens >= 0),
+  uncached_input_tokens BIGINT CHECK (
+    uncached_input_tokens IS NULL OR uncached_input_tokens >= 0
+  ),
+  cache_read_input_tokens BIGINT CHECK (
+    cache_read_input_tokens IS NULL OR cache_read_input_tokens >= 0
+  ),
+  cache_write_input_tokens BIGINT CHECK (
+    cache_write_input_tokens IS NULL OR cache_write_input_tokens >= 0
+  ),
+  text_output_tokens BIGINT CHECK (
+    text_output_tokens IS NULL OR text_output_tokens >= 0
+  ),
+  reasoning_output_tokens BIGINT CHECK (
+    reasoning_output_tokens IS NULL OR reasoning_output_tokens >= 0
+  ),
+  reporting_status TEXT NOT NULL CHECK (
+    reporting_status IN ('complete', 'partial', 'unavailable')
+  ),
+  raw_usage JSONB,
+  occurred_at TIMESTAMPTZ NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (project_id, id),
+  CHECK (
+    (
+      execution_kind = 'agentRun'
+      AND agent_run_id IS NOT NULL
+      AND workflow_run_id IS NULL
+      AND workflow_node_run_id IS NULL
+    ) OR (
+      execution_kind = 'workflowAgentNode'
+      AND agent_run_id IS NULL
+      AND workflow_run_id IS NOT NULL
+      AND workflow_node_run_id IS NOT NULL
+    )
+  )
+);
+
+CREATE UNIQUE INDEX idx_ai_model_call_usage_agent_idempotency
+  ON ai_model_call_usage (project_id, agent_run_id, attempt, call_id, response_id)
+  WHERE execution_kind = 'agentRun';
+CREATE UNIQUE INDEX idx_ai_model_call_usage_workflow_idempotency
+  ON ai_model_call_usage (
+    project_id,
+    workflow_run_id,
+    workflow_node_run_id,
+    attempt,
+    call_id,
+    response_id
+  )
+  WHERE execution_kind = 'workflowAgentNode';
+CREATE INDEX idx_ai_model_call_usage_agent_execution
+  ON ai_model_call_usage (project_id, agent_run_id, occurred_at, id)
+  WHERE execution_kind = 'agentRun';
+CREATE INDEX idx_ai_model_call_usage_workflow_execution
+  ON ai_model_call_usage (
+    project_id,
+    workflow_run_id,
+    workflow_node_run_id,
+    occurred_at,
+    id
+  )
+  WHERE execution_kind = 'workflowAgentNode';
+CREATE INDEX idx_ai_model_call_usage_project_time
+  ON ai_model_call_usage (project_id, occurred_at, id);
+CREATE INDEX idx_ai_model_call_usage_principal_time
+  ON ai_model_call_usage (
+    project_id,
+    requester_principal_type,
+    requester_principal_id,
+    occurred_at,
+    id
+  );
+CREATE INDEX idx_ai_model_call_usage_provider_response
+  ON ai_model_call_usage (project_id, provider_id, response_id);
+
+CREATE TABLE ai_model_call_usage_groups (
+  project_id TEXT NOT NULL,
+  usage_record_id TEXT NOT NULL,
+  group_id TEXT NOT NULL,
+  occurred_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (project_id, usage_record_id, group_id),
+  FOREIGN KEY (project_id, usage_record_id)
+    REFERENCES ai_model_call_usage(project_id, id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX idx_ai_model_call_usage_groups_group_time
+  ON ai_model_call_usage_groups (project_id, group_id, occurred_at, usage_record_id);

--- a/storage/pg/src/pg-ai-usage-storage.ts
+++ b/storage/pg/src/pg-ai-usage-storage.ts
@@ -1,0 +1,370 @@
+import type { Principal, ReadonlyJsonObject } from "@sixb/core/storage"
+import {
+  type AiModelCallUsageInput,
+  type AiModelCallUsageRecord,
+  type AiUsageExecutionIdentity,
+  type AiUsageExecutionSummary,
+  type AiUsageStorage,
+  AiUsageStorageError,
+  aggregateAiModelCallUsage,
+  assertAiUsageExecution,
+  normalizeAiModelCallRecord,
+  type RecordAiModelCallInput,
+  type RecordAiModelCallResult,
+  type SummarizeAiUsageExecutionInput,
+  type SummarizeAiUsageExecutionsInput,
+} from "@sixb/core/storage"
+import type { SQLClient } from "./pg-client"
+import { type PgStoreClient, runPgTransaction } from "./transactions"
+
+/** PostgreSQL-backed append-only model-call usage ledger. */
+export class PgAiUsageStorage implements AiUsageStorage {
+  constructor(private readonly sql: PgStoreClient) {}
+
+  async recordModelCall(input: RecordAiModelCallInput): Promise<RecordAiModelCallResult> {
+    const record = normalizeAiModelCallRecord(input)
+    return runPgTransaction(this.sql, async (tx) => {
+      const existing = await this.findByIdempotencyKey(tx, record)
+      if (existing) return { record: existing, created: false }
+
+      const execution = executionColumns(record.execution)
+      const inserted = await tx<{ id: string }[]>`
+        INSERT INTO ai_model_call_usage (
+          project_id,
+          id,
+          execution_kind,
+          agent_run_id,
+          workflow_run_id,
+          workflow_node_run_id,
+          attempt,
+          call_id,
+          requester_principal_type,
+          requester_principal_id,
+          provider_id,
+          requested_model_id,
+          response_model_id,
+          response_id,
+          input_tokens,
+          output_tokens,
+          total_tokens,
+          uncached_input_tokens,
+          cache_read_input_tokens,
+          cache_write_input_tokens,
+          text_output_tokens,
+          reasoning_output_tokens,
+          reporting_status,
+          raw_usage,
+          occurred_at,
+          recorded_at
+        ) VALUES (
+          ${record.projectId},
+          ${record.id},
+          ${record.execution.kind},
+          ${execution.agentRunId},
+          ${execution.workflowRunId},
+          ${execution.workflowNodeRunId},
+          ${record.attempt},
+          ${record.callId},
+          ${record.requesterPrincipal.type},
+          ${record.requesterPrincipal.id},
+          ${record.providerId},
+          ${record.requestedModelId},
+          ${record.responseModelId ?? null},
+          ${record.responseId},
+          ${record.usage.inputTokens ?? null},
+          ${record.usage.outputTokens ?? null},
+          ${record.usage.totalTokens ?? null},
+          ${record.usage.uncachedInputTokens ?? null},
+          ${record.usage.cacheReadInputTokens ?? null},
+          ${record.usage.cacheWriteInputTokens ?? null},
+          ${record.usage.textOutputTokens ?? null},
+          ${record.usage.reasoningOutputTokens ?? null},
+          ${record.usage.reportingStatus},
+          ${record.rawUsage === undefined ? null : JSON.stringify(record.rawUsage)}::text::jsonb,
+          ${record.occurredAt},
+          ${record.recordedAt}
+        )
+        ON CONFLICT DO NOTHING
+        RETURNING id
+      `
+
+      if (inserted.length === 0) {
+        const concurrent = await this.findByIdempotencyKey(tx, record)
+        if (concurrent) return { record: concurrent, created: false }
+        throw new AiUsageStorageError(
+          "duplicate_id",
+          `[SixbPg] AI usage record '${record.id}' already exists for project '${record.projectId}'.`
+        )
+      }
+
+      for (const groupId of record.requesterGroupIds) {
+        await tx`
+          INSERT INTO ai_model_call_usage_groups (
+            project_id, usage_record_id, group_id, occurred_at
+          ) VALUES (
+            ${record.projectId}, ${record.id}, ${groupId}, ${record.occurredAt}
+          )
+        `
+      }
+
+      return { record: await this.requireById(tx, record.projectId, record.id), created: true }
+    })
+  }
+
+  async summarizeExecution(
+    input: SummarizeAiUsageExecutionInput
+  ): Promise<AiUsageExecutionSummary> {
+    const [summary] = await this.summarizeExecutions({
+      projectId: input.projectId,
+      executions: [input.execution],
+    })
+    return summary!
+  }
+
+  async summarizeExecutions(
+    input: SummarizeAiUsageExecutionsInput
+  ): Promise<readonly AiUsageExecutionSummary[]> {
+    assertNonBlankProjectId(input.projectId)
+    for (const execution of input.executions) assertAiUsageExecution(execution)
+    if (input.executions.length === 0) return []
+
+    const rows = await this.executionRows(this.sql, input)
+    return aggregateExecutionRows(input.executions, rows)
+  }
+
+  private async findByIdempotencyKey(
+    sql: PgStoreClient,
+    record: Pick<
+      AiModelCallUsageRecord,
+      "projectId" | "execution" | "attempt" | "callId" | "responseId"
+    >
+  ): Promise<AiModelCallUsageRecord | null> {
+    const rows =
+      record.execution.kind === "agentRun"
+        ? await sql<AiUsageRow[]>`
+            SELECT * FROM ai_model_call_usage
+            WHERE project_id = ${record.projectId}
+              AND execution_kind = ${"agentRun"}
+              AND agent_run_id = ${record.execution.runId}
+              AND attempt = ${record.attempt}
+              AND call_id = ${record.callId}
+              AND response_id = ${record.responseId}
+          `
+        : await sql<AiUsageRow[]>`
+            SELECT * FROM ai_model_call_usage
+            WHERE project_id = ${record.projectId}
+              AND execution_kind = ${"workflowAgentNode"}
+              AND workflow_run_id = ${record.execution.workflowRunId}
+              AND workflow_node_run_id = ${record.execution.nodeRunId}
+              AND attempt = ${record.attempt}
+              AND call_id = ${record.callId}
+              AND response_id = ${record.responseId}
+          `
+    return rows[0] ? this.rowToRecord(sql, rows[0]) : null
+  }
+
+  private async requireById(
+    sql: SQLClient,
+    projectId: string,
+    id: string
+  ): Promise<AiModelCallUsageRecord> {
+    const [row] = await sql<AiUsageRow[]>`
+      SELECT * FROM ai_model_call_usage WHERE project_id = ${projectId} AND id = ${id}
+    `
+    if (!row) throw new Error(`[SixbPg] AI usage record '${id}' disappeared after insert.`)
+    return this.rowToRecord(sql, row)
+  }
+
+  private async rowToRecord(sql: PgStoreClient, row: AiUsageRow): Promise<AiModelCallUsageRecord> {
+    const groupRows = await sql<Array<{ group_id: string }>>`
+      SELECT group_id FROM ai_model_call_usage_groups
+      WHERE project_id = ${row.project_id} AND usage_record_id = ${row.id}
+      ORDER BY group_id
+    `
+
+    return {
+      id: row.id,
+      projectId: row.project_id,
+      execution: executionFromRow(row),
+      attempt: Number(row.attempt),
+      callId: row.call_id,
+      requesterPrincipal: {
+        type: row.requester_principal_type,
+        id: row.requester_principal_id,
+      },
+      requesterGroupIds: groupRows.map((group) => group.group_id),
+      providerId: row.provider_id,
+      requestedModelId: row.requested_model_id,
+      ...(row.response_model_id === null ? {} : { responseModelId: row.response_model_id }),
+      responseId: row.response_id,
+      usage: {
+        ...usageFromRow(row),
+        ...(row.total_tokens === null ? {} : { totalTokens: Number(row.total_tokens) }),
+        reportingStatus: row.reporting_status,
+      },
+      ...(row.raw_usage === null ? {} : { rawUsage: rawUsageFromRow(row.raw_usage) }),
+      occurredAt: new Date(row.occurred_at),
+      recordedAt: new Date(row.recorded_at),
+    }
+  }
+
+  private executionRows(
+    sql: PgStoreClient,
+    input: SummarizeAiUsageExecutionsInput
+  ): Promise<AiUsageRow[]> {
+    const uniqueExecutions = new Map(
+      input.executions.map((execution) => [executionKey(execution), execution])
+    )
+    const agentRunIds: string[] = []
+    const workflowRunIds: string[] = []
+    const workflowNodeRunIds: string[] = []
+    for (const execution of uniqueExecutions.values()) {
+      if (execution.kind === "agentRun") {
+        agentRunIds.push(execution.runId)
+      } else {
+        workflowRunIds.push(execution.workflowRunId)
+        workflowNodeRunIds.push(execution.nodeRunId)
+      }
+    }
+
+    return sql<AiUsageRow[]>`
+      WITH requested_agent_runs(run_id) AS (
+        SELECT * FROM unnest(${sql.array(agentRunIds)}::text[])
+      ), requested_workflow_nodes(workflow_run_id, node_run_id) AS (
+        SELECT * FROM unnest(
+          ${sql.array(workflowRunIds)}::text[],
+          ${sql.array(workflowNodeRunIds)}::text[]
+        )
+      )
+      SELECT usage.* FROM requested_agent_runs AS requested
+      JOIN ai_model_call_usage AS usage
+        ON usage.project_id = ${input.projectId}
+        AND usage.execution_kind = ${"agentRun"}
+        AND usage.agent_run_id = requested.run_id
+      UNION ALL
+      SELECT usage.* FROM requested_workflow_nodes AS requested
+      JOIN ai_model_call_usage AS usage
+        ON usage.project_id = ${input.projectId}
+        AND usage.execution_kind = ${"workflowAgentNode"}
+        AND usage.workflow_run_id = requested.workflow_run_id
+        AND usage.workflow_node_run_id = requested.node_run_id
+    `
+  }
+}
+
+interface AiUsageRow {
+  readonly project_id: string
+  readonly id: string
+  readonly execution_kind: AiUsageExecutionIdentity["kind"]
+  readonly agent_run_id: string | null
+  readonly workflow_run_id: string | null
+  readonly workflow_node_run_id: string | null
+  readonly attempt: number | string
+  readonly call_id: string
+  readonly requester_principal_type: Principal["type"]
+  readonly requester_principal_id: string
+  readonly provider_id: string
+  readonly requested_model_id: string
+  readonly response_model_id: string | null
+  readonly response_id: string
+  readonly input_tokens: number | string | null
+  readonly output_tokens: number | string | null
+  readonly total_tokens: number | string | null
+  readonly uncached_input_tokens: number | string | null
+  readonly cache_read_input_tokens: number | string | null
+  readonly cache_write_input_tokens: number | string | null
+  readonly text_output_tokens: number | string | null
+  readonly reasoning_output_tokens: number | string | null
+  readonly reporting_status: AiModelCallUsageRecord["usage"]["reportingStatus"]
+  readonly raw_usage: ReadonlyJsonObject | string | null
+  readonly occurred_at: Date | string
+  readonly recorded_at: Date | string
+}
+
+function aggregateExecutionRows(
+  executions: readonly AiUsageExecutionIdentity[],
+  rows: readonly AiUsageRow[]
+): readonly AiUsageExecutionSummary[] {
+  const usageByExecution = new Map<string, AiModelCallUsageInput[]>()
+  for (const execution of executions) usageByExecution.set(executionKey(execution), [])
+  for (const row of rows) {
+    usageByExecution.get(executionKey(executionFromRow(row)))?.push(usageFromRow(row))
+  }
+  return executions.map((execution) => {
+    const usages = usageByExecution.get(executionKey(execution)) ?? []
+    return {
+      modelCallCount: usages.length,
+      usage: aggregateAiModelCallUsage(usages),
+    }
+  })
+}
+
+function executionKey(execution: AiUsageExecutionIdentity): string {
+  return execution.kind === "agentRun"
+    ? JSON.stringify([execution.kind, execution.runId])
+    : JSON.stringify([execution.kind, execution.workflowRunId, execution.nodeRunId])
+}
+
+function usageFromRow(row: AiUsageRow): AiModelCallUsageInput {
+  return {
+    ...(row.input_tokens === null ? {} : { inputTokens: Number(row.input_tokens) }),
+    ...(row.output_tokens === null ? {} : { outputTokens: Number(row.output_tokens) }),
+    ...(row.uncached_input_tokens === null
+      ? {}
+      : { uncachedInputTokens: Number(row.uncached_input_tokens) }),
+    ...(row.cache_read_input_tokens === null
+      ? {}
+      : { cacheReadInputTokens: Number(row.cache_read_input_tokens) }),
+    ...(row.cache_write_input_tokens === null
+      ? {}
+      : { cacheWriteInputTokens: Number(row.cache_write_input_tokens) }),
+    ...(row.text_output_tokens === null
+      ? {}
+      : { textOutputTokens: Number(row.text_output_tokens) }),
+    ...(row.reasoning_output_tokens === null
+      ? {}
+      : { reasoningOutputTokens: Number(row.reasoning_output_tokens) }),
+  }
+}
+
+function executionColumns(execution: AiUsageExecutionIdentity): {
+  readonly agentRunId: string | null
+  readonly workflowRunId: string | null
+  readonly workflowNodeRunId: string | null
+} {
+  return execution.kind === "agentRun"
+    ? { agentRunId: execution.runId, workflowRunId: null, workflowNodeRunId: null }
+    : {
+        agentRunId: null,
+        workflowRunId: execution.workflowRunId,
+        workflowNodeRunId: execution.nodeRunId,
+      }
+}
+
+function executionFromRow(row: AiUsageRow): AiUsageExecutionIdentity {
+  if (row.execution_kind === "agentRun" && row.agent_run_id) {
+    return { kind: "agentRun", runId: row.agent_run_id }
+  }
+  if (
+    row.execution_kind === "workflowAgentNode" &&
+    row.workflow_run_id &&
+    row.workflow_node_run_id
+  ) {
+    return {
+      kind: "workflowAgentNode",
+      workflowRunId: row.workflow_run_id,
+      nodeRunId: row.workflow_node_run_id,
+    }
+  }
+  throw new Error(`[SixbPg] AI usage record '${row.id}' has an invalid execution identity.`)
+}
+
+function rawUsageFromRow(value: Exclude<AiUsageRow["raw_usage"], null>): ReadonlyJsonObject {
+  return typeof value === "string" ? (JSON.parse(value) as ReadonlyJsonObject) : value
+}
+
+function assertNonBlankProjectId(projectId: string): void {
+  if (typeof projectId !== "string" || projectId.trim().length === 0) {
+    throw new TypeError("[Sixb] AI usage projectId must be nonblank.")
+  }
+}

--- a/storage/pg/src/pg-ai-usage-storage.ts
+++ b/storage/pg/src/pg-ai-usage-storage.ts
@@ -1,13 +1,12 @@
-import type { Principal, ReadonlyJsonObject } from "@sixb/core/storage"
+import type { ReadonlyJsonObject } from "@sixb/core/storage"
 import {
   type AiModelCallUsageInput,
   type AiModelCallUsageRecord,
-  type AiUsageExecutionIdentity,
   type AiUsageExecutionSummary,
   type AiUsageStorage,
   AiUsageStorageError,
   aggregateAiModelCallUsage,
-  assertAiUsageExecution,
+  assertAiUsageExecutionId,
   normalizeAiModelCallRecord,
   type RecordAiModelCallInput,
   type RecordAiModelCallResult,
@@ -26,20 +25,15 @@ export class PgAiUsageStorage implements AiUsageStorage {
     return runPgTransaction(this.sql, async (tx) => {
       const existing = await this.findByIdempotencyKey(tx, record)
       if (existing) return { record: existing, created: false }
+      await this.assertExecutionExists(tx, record.projectId, record.executionId)
 
-      const execution = executionColumns(record.execution)
       const inserted = await tx<{ id: string }[]>`
         INSERT INTO ai_model_call_usage (
           project_id,
           id,
-          execution_kind,
-          agent_run_id,
-          workflow_run_id,
-          workflow_node_run_id,
+          execution_id,
           attempt,
           call_id,
-          requester_principal_type,
-          requester_principal_id,
           provider_id,
           requested_model_id,
           response_model_id,
@@ -59,14 +53,9 @@ export class PgAiUsageStorage implements AiUsageStorage {
         ) VALUES (
           ${record.projectId},
           ${record.id},
-          ${record.execution.kind},
-          ${execution.agentRunId},
-          ${execution.workflowRunId},
-          ${execution.workflowNodeRunId},
+          ${record.executionId},
           ${record.attempt},
           ${record.callId},
-          ${record.requesterPrincipal.type},
-          ${record.requesterPrincipal.id},
           ${record.providerId},
           ${record.requestedModelId},
           ${record.responseModelId ?? null},
@@ -116,7 +105,7 @@ export class PgAiUsageStorage implements AiUsageStorage {
   ): Promise<AiUsageExecutionSummary> {
     const [summary] = await this.summarizeExecutions({
       projectId: input.projectId,
-      executions: [input.execution],
+      executionIds: [input.executionId],
     })
     return summary!
   }
@@ -125,41 +114,28 @@ export class PgAiUsageStorage implements AiUsageStorage {
     input: SummarizeAiUsageExecutionsInput
   ): Promise<readonly AiUsageExecutionSummary[]> {
     assertNonBlankProjectId(input.projectId)
-    for (const execution of input.executions) assertAiUsageExecution(execution)
-    if (input.executions.length === 0) return []
+    for (const executionId of input.executionIds) assertAiUsageExecutionId(executionId)
+    if (input.executionIds.length === 0) return []
 
     const rows = await this.executionRows(this.sql, input)
-    return aggregateExecutionRows(input.executions, rows)
+    return aggregateExecutionRows(input.executionIds, rows)
   }
 
   private async findByIdempotencyKey(
     sql: PgStoreClient,
     record: Pick<
       AiModelCallUsageRecord,
-      "projectId" | "execution" | "attempt" | "callId" | "responseId"
+      "projectId" | "executionId" | "attempt" | "callId" | "responseId"
     >
   ): Promise<AiModelCallUsageRecord | null> {
-    const rows =
-      record.execution.kind === "agentRun"
-        ? await sql<AiUsageRow[]>`
-            SELECT * FROM ai_model_call_usage
-            WHERE project_id = ${record.projectId}
-              AND execution_kind = ${"agentRun"}
-              AND agent_run_id = ${record.execution.runId}
-              AND attempt = ${record.attempt}
-              AND call_id = ${record.callId}
-              AND response_id = ${record.responseId}
-          `
-        : await sql<AiUsageRow[]>`
-            SELECT * FROM ai_model_call_usage
-            WHERE project_id = ${record.projectId}
-              AND execution_kind = ${"workflowAgentNode"}
-              AND workflow_run_id = ${record.execution.workflowRunId}
-              AND workflow_node_run_id = ${record.execution.nodeRunId}
-              AND attempt = ${record.attempt}
-              AND call_id = ${record.callId}
-              AND response_id = ${record.responseId}
-          `
+    const rows = await sql<AiUsageRow[]>`
+      SELECT * FROM ai_model_call_usage
+      WHERE project_id = ${record.projectId}
+        AND execution_id = ${record.executionId}
+        AND attempt = ${record.attempt}
+        AND call_id = ${record.callId}
+        AND response_id = ${record.responseId}
+    `
     return rows[0] ? this.rowToRecord(sql, rows[0]) : null
   }
 
@@ -185,13 +161,9 @@ export class PgAiUsageStorage implements AiUsageStorage {
     return {
       id: row.id,
       projectId: row.project_id,
-      execution: executionFromRow(row),
+      executionId: row.execution_id,
       attempt: Number(row.attempt),
       callId: row.call_id,
-      requesterPrincipal: {
-        type: row.requester_principal_type,
-        id: row.requester_principal_id,
-      },
       requesterGroupIds: groupRows.map((group) => group.group_id),
       providerId: row.provider_id,
       requestedModelId: row.requested_model_id,
@@ -212,57 +184,43 @@ export class PgAiUsageStorage implements AiUsageStorage {
     sql: PgStoreClient,
     input: SummarizeAiUsageExecutionsInput
   ): Promise<AiUsageRow[]> {
-    const uniqueExecutions = new Map(
-      input.executions.map((execution) => [executionKey(execution), execution])
-    )
-    const agentRunIds: string[] = []
-    const workflowRunIds: string[] = []
-    const workflowNodeRunIds: string[] = []
-    for (const execution of uniqueExecutions.values()) {
-      if (execution.kind === "agentRun") {
-        agentRunIds.push(execution.runId)
-      } else {
-        workflowRunIds.push(execution.workflowRunId)
-        workflowNodeRunIds.push(execution.nodeRunId)
-      }
-    }
+    const executionIds = [...new Set(input.executionIds)]
 
     return sql<AiUsageRow[]>`
-      WITH requested_agent_runs(run_id) AS (
-        SELECT * FROM unnest(${sql.array(agentRunIds)}::text[])
-      ), requested_workflow_nodes(workflow_run_id, node_run_id) AS (
-        SELECT * FROM unnest(
-          ${sql.array(workflowRunIds)}::text[],
-          ${sql.array(workflowNodeRunIds)}::text[]
-        )
+      WITH requested(execution_id) AS (
+        SELECT * FROM unnest(${sql.array(executionIds)}::text[])
       )
-      SELECT usage.* FROM requested_agent_runs AS requested
+      SELECT usage.* FROM requested
       JOIN ai_model_call_usage AS usage
         ON usage.project_id = ${input.projectId}
-        AND usage.execution_kind = ${"agentRun"}
-        AND usage.agent_run_id = requested.run_id
-      UNION ALL
-      SELECT usage.* FROM requested_workflow_nodes AS requested
-      JOIN ai_model_call_usage AS usage
-        ON usage.project_id = ${input.projectId}
-        AND usage.execution_kind = ${"workflowAgentNode"}
-        AND usage.workflow_run_id = requested.workflow_run_id
-        AND usage.workflow_node_run_id = requested.node_run_id
+        AND usage.execution_id = requested.execution_id
     `
+  }
+
+  private async assertExecutionExists(
+    sql: PgStoreClient,
+    projectId: string,
+    executionId: string
+  ): Promise<void> {
+    const [execution] = await sql<{ exists: boolean }[]>`
+      SELECT EXISTS (
+        SELECT 1 FROM executions WHERE project_id = ${projectId} AND id = ${executionId}
+      ) AS exists
+    `
+    if (execution?.exists) return
+    throw new AiUsageStorageError(
+      "missing_execution",
+      `[SixbPg] AI usage execution '${executionId}' does not exist in project '${projectId}'.`
+    )
   }
 }
 
 interface AiUsageRow {
   readonly project_id: string
   readonly id: string
-  readonly execution_kind: AiUsageExecutionIdentity["kind"]
-  readonly agent_run_id: string | null
-  readonly workflow_run_id: string | null
-  readonly workflow_node_run_id: string | null
+  readonly execution_id: string
   readonly attempt: number | string
   readonly call_id: string
-  readonly requester_principal_type: Principal["type"]
-  readonly requester_principal_id: string
   readonly provider_id: string
   readonly requested_model_id: string
   readonly response_model_id: string | null
@@ -282,27 +240,21 @@ interface AiUsageRow {
 }
 
 function aggregateExecutionRows(
-  executions: readonly AiUsageExecutionIdentity[],
+  executionIds: readonly string[],
   rows: readonly AiUsageRow[]
 ): readonly AiUsageExecutionSummary[] {
-  const usageByExecution = new Map<string, AiModelCallUsageInput[]>()
-  for (const execution of executions) usageByExecution.set(executionKey(execution), [])
+  const usageByExecutionId = new Map<string, AiModelCallUsageInput[]>()
+  for (const executionId of executionIds) usageByExecutionId.set(executionId, [])
   for (const row of rows) {
-    usageByExecution.get(executionKey(executionFromRow(row)))?.push(usageFromRow(row))
+    usageByExecutionId.get(row.execution_id)?.push(usageFromRow(row))
   }
-  return executions.map((execution) => {
-    const usages = usageByExecution.get(executionKey(execution)) ?? []
+  return executionIds.map((executionId) => {
+    const usages = usageByExecutionId.get(executionId) ?? []
     return {
       modelCallCount: usages.length,
       usage: aggregateAiModelCallUsage(usages),
     }
   })
-}
-
-function executionKey(execution: AiUsageExecutionIdentity): string {
-  return execution.kind === "agentRun"
-    ? JSON.stringify([execution.kind, execution.runId])
-    : JSON.stringify([execution.kind, execution.workflowRunId, execution.nodeRunId])
 }
 
 function usageFromRow(row: AiUsageRow): AiModelCallUsageInput {
@@ -325,38 +277,6 @@ function usageFromRow(row: AiUsageRow): AiModelCallUsageInput {
       ? {}
       : { reasoningOutputTokens: Number(row.reasoning_output_tokens) }),
   }
-}
-
-function executionColumns(execution: AiUsageExecutionIdentity): {
-  readonly agentRunId: string | null
-  readonly workflowRunId: string | null
-  readonly workflowNodeRunId: string | null
-} {
-  return execution.kind === "agentRun"
-    ? { agentRunId: execution.runId, workflowRunId: null, workflowNodeRunId: null }
-    : {
-        agentRunId: null,
-        workflowRunId: execution.workflowRunId,
-        workflowNodeRunId: execution.nodeRunId,
-      }
-}
-
-function executionFromRow(row: AiUsageRow): AiUsageExecutionIdentity {
-  if (row.execution_kind === "agentRun" && row.agent_run_id) {
-    return { kind: "agentRun", runId: row.agent_run_id }
-  }
-  if (
-    row.execution_kind === "workflowAgentNode" &&
-    row.workflow_run_id &&
-    row.workflow_node_run_id
-  ) {
-    return {
-      kind: "workflowAgentNode",
-      workflowRunId: row.workflow_run_id,
-      nodeRunId: row.workflow_node_run_id,
-    }
-  }
-  throw new Error(`[SixbPg] AI usage record '${row.id}' has an invalid execution identity.`)
 }
 
 function rawUsageFromRow(value: Exclude<AiUsageRow["raw_usage"], null>): ReadonlyJsonObject {

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -1,3 +1,4 @@
+import { normalizeRequesterGroupIds } from "@sixb/core/internal/auth"
 import {
   assertWorkflowAgentNodeRunExecution,
   assertWorkflowRunExecution,
@@ -87,7 +88,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           ${serializeRecord(input.input)}::text::jsonb,
           ${queuedAt},
           ${queuedAt},
-          ${JSON.stringify(input.requesterGroupIds)}::text::jsonb,
+          ${JSON.stringify(normalizeRequesterGroupIds(input.requesterGroupIds))}::text::jsonb,
           ${0}
         )
         RETURNING *

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -76,6 +76,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           input,
           queued_at,
           started_at,
+          requester_group_ids,
           attempt
         ) VALUES (
           ${input.projectId},
@@ -86,6 +87,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
           ${serializeRecord(input.input)}::text::jsonb,
           ${queuedAt},
           ${queuedAt},
+          ${JSON.stringify(input.requesterGroupIds)}::text::jsonb,
           ${0}
         )
         RETURNING *
@@ -814,6 +816,7 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     error: row.error ?? undefined,
+    requesterGroupIds: parseJson(row.requester_group_ids),
     attempt: Number(row.attempt),
     ...(row.execution_token && row.execution_queue_lease_expires_at
       ? {
@@ -874,6 +877,7 @@ interface WorkflowRunDatabaseRow {
   started_at: Date | string
   finished_at: Date | string | null
   error: string | null
+  requester_group_ids: string[] | string
   attempt: number | string
   execution_token: string | null
   execution_queue_lease_expires_at: Date | string | null

--- a/storage/pg/tests/pg-agent-storage.e2e.ts
+++ b/storage/pg/tests/pg-agent-storage.e2e.ts
@@ -43,6 +43,7 @@ describe("PostgresStorage agents", () => {
             threadId: "thr_1",
             agentId: "sales",
             triggerMessageId: "msg_1",
+            requesterGroupIds: ["engineering"],
             createdAt: new Date("2026-06-23T10:00:10.000Z"),
           })
           await tx.agents?.messages.append({

--- a/storage/pg/tests/pg-ai-usage-storage.e2e.ts
+++ b/storage/pg/tests/pg-ai-usage-storage.e2e.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import type { AiUsageStorage, RecordAiModelCallInput } from "@sixb/core/storage"
-import { runAiUsageStorageContractSuite } from "@sixb/core/testing"
+import {
+  runAiUsageStorageContractSuite,
+  seedAiUsageStorageContractExecutions,
+} from "@sixb/core/testing"
 import type { PostgresStorage } from "../src"
 import { createTestStorage } from "./helpers"
 
@@ -11,6 +14,11 @@ runAiUsageStorageContractSuite("PgAiUsageStorage", {
     const { storage } = await createTestStorage()
     bundles.set(storage.aiUsage, storage)
     return storage.aiUsage
+  },
+  setup: async (aiUsage) => {
+    const storage = bundles.get(aiUsage)
+    if (!storage) throw new Error("Expected PostgreSQL storage bundle")
+    await seedAiUsageStorageContractExecutions(storage.executions)
   },
   cleanup: async (aiUsage) => {
     const storage = bundles.get(aiUsage)
@@ -28,6 +36,7 @@ describe("PostgresStorage AI usage", () => {
 
     try {
       expect(storage.aiUsage).toBeDefined()
+      await seedAiUsageStorageContractExecutions(storage.executions)
       await expect(
         storage.transaction(async (tx) => {
           await requireAiUsage(tx.aiUsage).recordModelCall(modelCallInput())
@@ -52,11 +61,10 @@ describe("PostgresStorage AI usage", () => {
 function modelCallInput(): RecordAiModelCallInput {
   return {
     id: "usage_1",
-    projectId: "project_1",
-    execution: { kind: "agentRun", runId: "run_1" },
+    projectId: "contract-project",
+    executionId: "exec_agent_1",
     attempt: 1,
     callId: "call_1",
-    requesterPrincipal: { type: "user", id: "usr_1" },
     requesterGroupIds: ["engineering", "support"],
     providerId: "gateway",
     requestedModelId: "openai/gpt-5",
@@ -69,8 +77,8 @@ function modelCallInput(): RecordAiModelCallInput {
 
 function summaryInput() {
   return {
-    projectId: "project_1",
-    execution: { kind: "agentRun", runId: "run_1" },
+    projectId: "contract-project",
+    executionId: "exec_agent_1",
   } as const
 }
 

--- a/storage/pg/tests/pg-ai-usage-storage.e2e.ts
+++ b/storage/pg/tests/pg-ai-usage-storage.e2e.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test"
+import type { AiUsageStorage, RecordAiModelCallInput } from "@sixb/core/storage"
+import { runAiUsageStorageContractSuite } from "@sixb/core/testing"
+import type { PostgresStorage } from "../src"
+import { createTestStorage } from "./helpers"
+
+const bundles = new Map<AiUsageStorage, PostgresStorage>()
+
+runAiUsageStorageContractSuite("PgAiUsageStorage", {
+  createStorage: async () => {
+    const { storage } = await createTestStorage()
+    bundles.set(storage.aiUsage, storage)
+    return storage.aiUsage
+  },
+  cleanup: async (aiUsage) => {
+    const storage = bundles.get(aiUsage)
+    if (storage) {
+      bundles.delete(aiUsage)
+      await storage.dropSchema()
+      await storage.close()
+    }
+  },
+})
+
+describe("PostgresStorage AI usage", () => {
+  test("is bundled and rolls ledger writes back with the outer transaction", async () => {
+    const { storage } = await createTestStorage()
+
+    try {
+      expect(storage.aiUsage).toBeDefined()
+      await expect(
+        storage.transaction(async (tx) => {
+          await requireAiUsage(tx.aiUsage).recordModelCall(modelCallInput())
+          throw new Error("boom")
+        })
+      ).rejects.toThrow("boom")
+
+      await expect(storage.aiUsage.summarizeExecution(summaryInput())).resolves.toEqual({
+        modelCallCount: 0,
+        usage: { reportingStatus: "unavailable" },
+      })
+      await expect(storage.aiUsage.recordModelCall(modelCallInput())).resolves.toMatchObject({
+        created: true,
+      })
+    } finally {
+      await storage.dropSchema()
+      await storage.close()
+    }
+  })
+})
+
+function modelCallInput(): RecordAiModelCallInput {
+  return {
+    id: "usage_1",
+    projectId: "project_1",
+    execution: { kind: "agentRun", runId: "run_1" },
+    attempt: 1,
+    callId: "call_1",
+    requesterPrincipal: { type: "user", id: "usr_1" },
+    requesterGroupIds: ["engineering", "support"],
+    providerId: "gateway",
+    requestedModelId: "openai/gpt-5",
+    responseId: "response_1",
+    usage: { inputTokens: 12, outputTokens: 8 },
+    occurredAt: new Date("2026-06-23T10:00:00.000Z"),
+    recordedAt: new Date("2026-06-23T10:00:01.000Z"),
+  }
+}
+
+function summaryInput() {
+  return {
+    projectId: "project_1",
+    execution: { kind: "agentRun", runId: "run_1" },
+  } as const
+}
+
+function requireAiUsage(storage: AiUsageStorage | undefined): AiUsageStorage {
+  if (!storage) throw new Error("Expected AI usage storage")
+  return storage
+}

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -45,6 +45,7 @@ describe("Postgres storage migrations", () => {
             "007-split-overrides",
             "008-action-executions",
             "009-agent-executions",
+            "010-ai-usage-accounting-foundation",
           ],
         },
       ])
@@ -111,6 +112,13 @@ describe("Postgres storage migrations", () => {
           id: "009-agent-executions",
           status: "applied",
           version: 9,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "010-ai-usage-accounting-foundation",
+          status: "applied",
+          version: 10,
         },
       ])
     })
@@ -585,7 +593,7 @@ describe("Postgres storage migrations", () => {
     })
   })
 
-  test("migrations install agent storage tables", async () => {
+  test("migrations install agent attribution and AI usage storage tables", async () => {
     await withStorage(false, async (storage, schemaName) => {
       await migrateStorage(storage)
 
@@ -602,8 +610,19 @@ describe("Postgres storage migrations", () => {
 
       expect(thread).toMatchObject({ id: "thr_1", agentId: "sales", messageCount: 0 })
       expect(tableNames).toEqual(
-        expect.arrayContaining(["agent_threads", "agent_runs", "agent_messages"])
+        expect.arrayContaining([
+          "agent_threads",
+          "agent_runs",
+          "agent_messages",
+          "ai_model_call_usage",
+          "ai_model_call_usage_groups",
+        ])
       )
+      expect(await readTableColumns(schemaName, "agent_runs")).toEqual(
+        expect.arrayContaining(["requester_group_ids", "usage_input_tokens"])
+      )
+      expect(await readTableColumns(schemaName, "workflow_runs")).toContain("requester_group_ids")
+      expect(await readTableColumns(schemaName, "workflow_agent_node_runs")).toContain("usage")
     })
   })
 
@@ -736,6 +755,13 @@ describe("Postgres storage migrations", () => {
           status: "applied",
           version: 9,
         },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "010-ai-usage-accounting-foundation",
+          status: "applied",
+          version: 10,
+        },
       ])
     } finally {
       await storages[0]?.dropSchema()
@@ -839,6 +865,7 @@ async function seedExistingStoreRows(storage: PostgresStorage): Promise<void> {
     input: {
       transactionId: "txn-1",
     },
+    requesterGroupIds: [],
     queuedAt: new Date("2026-04-19T11:59:59.000Z"),
   })
   await storage.workflowRuns.start({

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -618,6 +618,19 @@ describe("Postgres storage migrations", () => {
           "ai_model_call_usage_groups",
         ])
       )
+      expect(await readTableColumns(schemaName, "ai_model_call_usage")).toContain("execution_id")
+      expect(await readTableColumns(schemaName, "ai_model_call_usage")).not.toContain(
+        "execution_kind"
+      )
+      expect(await readTableColumns(schemaName, "ai_model_call_usage")).not.toContain(
+        "requester_principal_id"
+      )
+      expect(await readTableForeignKeys(schemaName, "ai_model_call_usage")).toContainEqual({
+        column_name: "execution_id",
+        delete_action: "r",
+        foreign_column_name: "id",
+        foreign_table_name: "executions",
+      })
       expect(await readTableColumns(schemaName, "agent_runs")).toEqual(
         expect.arrayContaining(["requester_group_ids", "usage_input_tokens"])
       )
@@ -974,6 +987,54 @@ async function readTableColumns(schemaName: string, tableName: string): Promise<
     )) as Array<{ column_name: string }>
 
     return rows.map((row) => row.column_name)
+  })
+}
+
+async function readTableForeignKeys(
+  schemaName: string,
+  tableName: string
+): Promise<
+  readonly {
+    readonly column_name: string
+    readonly delete_action: string
+    readonly foreign_column_name: string
+    readonly foreign_table_name: string
+  }[]
+> {
+  return withSql(async (sql) => {
+    return (await sql.unsafe(
+      `
+        SELECT
+          source_column.attname AS column_name,
+          target_table.relname AS foreign_table_name,
+          target_column.attname AS foreign_column_name,
+          c.confdeltype::text AS delete_action
+        FROM pg_constraint AS c
+        JOIN pg_class AS source_table ON source_table.oid = c.conrelid
+        JOIN pg_namespace AS source_schema ON source_schema.oid = source_table.relnamespace
+        JOIN pg_class AS target_table ON target_table.oid = c.confrelid
+        JOIN LATERAL unnest(c.conkey) WITH ORDINALITY AS source_key(attnum, position)
+          ON TRUE
+        JOIN LATERAL unnest(c.confkey) WITH ORDINALITY AS target_key(attnum, position)
+          ON target_key.position = source_key.position
+        JOIN pg_attribute AS source_column
+          ON source_column.attrelid = source_table.oid
+          AND source_column.attnum = source_key.attnum
+        JOIN pg_attribute AS target_column
+          ON target_column.attrelid = target_table.oid
+          AND target_column.attnum = target_key.attnum
+        WHERE c.contype = 'f'
+          AND source_schema.nspname = $1
+          AND source_table.relname = $2
+        ORDER BY c.conname, source_key.position
+      `,
+      [schemaName, tableName]
+    )) as Array<{
+      readonly column_name: string
+      readonly delete_action: string
+      readonly foreign_column_name: string
+      readonly foreign_table_name: string
+    }>
   })
 }
 

--- a/storage/pg/tests/pg-workflow-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-workflow-run-storage.e2e.ts
@@ -106,7 +106,7 @@ describe("PgWorkflowRunStorage", () => {
       projectId: "my-app",
       workflowId: "reconcile-transaction",
       input: {},
-      requesterGroupIds: [],
+      requesterGroupIds: ["support", "engineering", "support"],
     })
 
     const results = await Promise.allSettled([
@@ -126,6 +126,9 @@ describe("PgWorkflowRunStorage", () => {
 
     expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1)
     expect(results.filter((result) => result.status === "rejected")).toHaveLength(1)
+    await expect(
+      storage.workflowRuns.getById({ projectId: "my-app", id: "wf-run-claim" })
+    ).resolves.toMatchObject({ requesterGroupIds: ["engineering", "support"] })
   })
 
   test("waits and resumes workflow and intervention node runs", async () => {

--- a/storage/pg/tests/pg-workflow-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-workflow-run-storage.e2e.ts
@@ -78,6 +78,7 @@ describe("PgWorkflowRunStorage", () => {
         executionId,
         workflowId: "reconcile-transaction",
         input: {},
+        requesterGroupIds: [],
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -94,6 +95,7 @@ describe("PgWorkflowRunStorage", () => {
         executionId: automaticExecutionId,
         workflowId: "reconcile-transaction",
         input: {},
+        requesterGroupIds: [],
       })
     ).resolves.toMatchObject({ id: "wf-run-automatic", executionId: automaticExecutionId })
   })
@@ -104,6 +106,7 @@ describe("PgWorkflowRunStorage", () => {
       projectId: "my-app",
       workflowId: "reconcile-transaction",
       input: {},
+      requesterGroupIds: [],
     })
 
     const results = await Promise.allSettled([
@@ -721,6 +724,7 @@ function createWorkflowRunStorage(root: PostgresStorage) {
           projectId: input.projectId,
           workflowId: input.workflowId,
           input: input.input,
+          requesterGroupIds: [],
         })
       }
       return start({

--- a/storage/sqlite/src/agents/rows.ts
+++ b/storage/sqlite/src/agents/rows.ts
@@ -34,6 +34,7 @@ export interface AgentRunRow {
   thread_id: string
   agent_id: string
   trigger_message_id: string
+  requester_group_ids: string
   status: AgentRunRecord["status"]
   model_id: string | null
   finish_reason: string | null
@@ -94,6 +95,7 @@ export function rowToRunRecord(row: AgentRunRow): AgentRunRecord {
     threadId: row.thread_id,
     agentId: row.agent_id,
     triggerMessageId: row.trigger_message_id,
+    requesterGroupIds: JSON.parse(row.requester_group_ids) as string[],
     status: row.status,
     modelId: row.model_id ?? undefined,
     finishReason: coerceAgentRunFinishReason(row.finish_reason),

--- a/storage/sqlite/src/agents/runs.ts
+++ b/storage/sqlite/src/agents/runs.ts
@@ -71,10 +71,11 @@ export class SqliteAgentRunStore implements AgentRunStore {
               thread_id,
               agent_id,
               trigger_message_id,
+              requester_group_ids,
               status,
               attempt,
               created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, 'queued', 0, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', 0, ?)
           `
           )
           .run(
@@ -84,6 +85,7 @@ export class SqliteAgentRunStore implements AgentRunStore {
             input.threadId,
             input.agentId,
             input.triggerMessageId,
+            JSON.stringify(input.requesterGroupIds),
             createdAt.toISOString()
           )
       } catch (error) {

--- a/storage/sqlite/src/agents/runs.ts
+++ b/storage/sqlite/src/agents/runs.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite"
 import { assertAgentRunExecution } from "@sixb/core/internal/agent-run-storage-provider"
+import { normalizeRequesterGroupIds } from "@sixb/core/internal/auth"
 import {
   type AgentRunRecord,
   type AgentRunStore,
@@ -85,7 +86,7 @@ export class SqliteAgentRunStore implements AgentRunStore {
             input.threadId,
             input.agentId,
             input.triggerMessageId,
-            JSON.stringify(input.requesterGroupIds),
+            JSON.stringify(normalizeRequesterGroupIds(input.requesterGroupIds)),
             createdAt.toISOString()
           )
       } catch (error) {

--- a/storage/sqlite/src/ai-usage-storage.ts
+++ b/storage/sqlite/src/ai-usage-storage.ts
@@ -1,0 +1,416 @@
+import type { Principal, ReadonlyJsonObject } from "@sixb/core/storage"
+import {
+  type AiModelCallUsageInput,
+  type AiModelCallUsageRecord,
+  type AiUsageExecutionIdentity,
+  type AiUsageExecutionSummary,
+  type AiUsageStorage,
+  AiUsageStorageError,
+  aggregateAiModelCallUsage,
+  assertAiUsageExecution,
+  normalizeAiModelCallRecord,
+  type RecordAiModelCallInput,
+  type RecordAiModelCallResult,
+  type SummarizeAiUsageExecutionInput,
+  type SummarizeAiUsageExecutionsInput,
+} from "@sixb/core/storage"
+import { installFreshSqliteSchema } from "./migrations"
+import { isUniqueConstraintError } from "./storage-errors"
+import {
+  closeSqliteStoreConnection,
+  openSqliteStoreConnection,
+  runImmediateTransaction,
+  type SqliteStoreConnection,
+} from "./transactions"
+
+export interface SqliteAiUsageStorageOptions {
+  readonly path?: string
+  readonly connection?: SqliteStoreConnection
+}
+
+/** SQLite-backed append-only model-call usage ledger. */
+export class SqliteAiUsageStorage implements AiUsageStorage {
+  private readonly connection: SqliteStoreConnection
+
+  constructor(options: SqliteAiUsageStorageOptions = {}) {
+    this.connection = openSqliteStoreConnection(options)
+    if (this.connection.installFreshSchema) {
+      installFreshSqliteSchema(this.connection.db)
+    }
+  }
+
+  async recordModelCall(input: RecordAiModelCallInput): Promise<RecordAiModelCallResult> {
+    const record = normalizeAiModelCallRecord(input)
+    return runImmediateTransaction(this.connection.db, () => {
+      const existing = this.findByIdempotencyKey(record)
+      if (existing) return { record: existing, created: false }
+
+      try {
+        this.insertRecord(record)
+      } catch (error) {
+        if (!isUniqueConstraintError(error)) throw error
+
+        const concurrent = this.findByIdempotencyKey(record)
+        if (concurrent) return { record: concurrent, created: false }
+        throw new AiUsageStorageError(
+          "duplicate_id",
+          `[SixbSqlite] AI usage record '${record.id}' already exists for project '${record.projectId}'.`
+        )
+      }
+
+      for (const groupId of record.requesterGroupIds) {
+        this.connection.db
+          .query(
+            `
+              INSERT INTO ai_model_call_usage_groups (
+                project_id, usage_record_id, group_id, occurred_at
+              ) VALUES (?, ?, ?, ?)
+            `
+          )
+          .run(record.projectId, record.id, groupId, record.occurredAt.toISOString())
+      }
+
+      return { record: this.requireById(record.projectId, record.id), created: true }
+    })
+  }
+
+  async summarizeExecution(
+    input: SummarizeAiUsageExecutionInput
+  ): Promise<AiUsageExecutionSummary> {
+    const [summary] = await this.summarizeExecutions({
+      projectId: input.projectId,
+      executions: [input.execution],
+    })
+    return summary!
+  }
+
+  async summarizeExecutions(
+    input: SummarizeAiUsageExecutionsInput
+  ): Promise<readonly AiUsageExecutionSummary[]> {
+    assertNonBlankProjectId(input.projectId)
+    for (const execution of input.executions) assertAiUsageExecution(execution)
+    if (input.executions.length === 0) return []
+
+    const rows = this.executionRows(input)
+    return aggregateExecutionRows(input.executions, rows)
+  }
+
+  close(): void {
+    closeSqliteStoreConnection(this.connection)
+  }
+
+  private insertRecord(record: AiModelCallUsageRecord): void {
+    const execution = executionColumns(record.execution)
+    this.connection.db
+      .query(
+        `
+          INSERT INTO ai_model_call_usage (
+            project_id,
+            id,
+            execution_kind,
+            agent_run_id,
+            workflow_run_id,
+            workflow_node_run_id,
+            attempt,
+            call_id,
+            requester_principal_type,
+            requester_principal_id,
+            provider_id,
+            requested_model_id,
+            response_model_id,
+            response_id,
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            uncached_input_tokens,
+            cache_read_input_tokens,
+            cache_write_input_tokens,
+            text_output_tokens,
+            reasoning_output_tokens,
+            reporting_status,
+            raw_usage,
+            occurred_at,
+            recorded_at
+          ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          )
+        `
+      )
+      .run(
+        record.projectId,
+        record.id,
+        record.execution.kind,
+        execution.agentRunId,
+        execution.workflowRunId,
+        execution.workflowNodeRunId,
+        record.attempt,
+        record.callId,
+        record.requesterPrincipal.type,
+        record.requesterPrincipal.id,
+        record.providerId,
+        record.requestedModelId,
+        record.responseModelId ?? null,
+        record.responseId,
+        record.usage.inputTokens ?? null,
+        record.usage.outputTokens ?? null,
+        record.usage.totalTokens ?? null,
+        record.usage.uncachedInputTokens ?? null,
+        record.usage.cacheReadInputTokens ?? null,
+        record.usage.cacheWriteInputTokens ?? null,
+        record.usage.textOutputTokens ?? null,
+        record.usage.reasoningOutputTokens ?? null,
+        record.usage.reportingStatus,
+        record.rawUsage === undefined ? null : JSON.stringify(record.rawUsage),
+        record.occurredAt.toISOString(),
+        record.recordedAt.toISOString()
+      )
+  }
+
+  private findByIdempotencyKey(
+    record: Pick<
+      AiModelCallUsageRecord,
+      "projectId" | "execution" | "attempt" | "callId" | "responseId"
+    >
+  ): AiModelCallUsageRecord | null {
+    const row =
+      record.execution.kind === "agentRun"
+        ? (this.connection.db
+            .query(
+              `
+                SELECT * FROM ai_model_call_usage
+                WHERE project_id = ?
+                  AND execution_kind = 'agentRun'
+                  AND agent_run_id = ?
+                  AND attempt = ?
+                  AND call_id = ?
+                  AND response_id = ?
+              `
+            )
+            .get(
+              record.projectId,
+              record.execution.runId,
+              record.attempt,
+              record.callId,
+              record.responseId
+            ) as AiUsageRow | null)
+        : (this.connection.db
+            .query(
+              `
+                SELECT * FROM ai_model_call_usage
+                WHERE project_id = ?
+                  AND execution_kind = 'workflowAgentNode'
+                  AND workflow_run_id = ?
+                  AND workflow_node_run_id = ?
+                  AND attempt = ?
+                  AND call_id = ?
+                  AND response_id = ?
+              `
+            )
+            .get(
+              record.projectId,
+              record.execution.workflowRunId,
+              record.execution.nodeRunId,
+              record.attempt,
+              record.callId,
+              record.responseId
+            ) as AiUsageRow | null)
+    return row ? this.rowToRecord(row) : null
+  }
+
+  private requireById(projectId: string, id: string): AiModelCallUsageRecord {
+    const row = this.connection.db
+      .query("SELECT * FROM ai_model_call_usage WHERE project_id = ? AND id = ?")
+      .get(projectId, id) as AiUsageRow | null
+    if (!row) throw new Error(`[SixbSqlite] AI usage record '${id}' disappeared after insert.`)
+    return this.rowToRecord(row)
+  }
+
+  private rowToRecord(row: AiUsageRow): AiModelCallUsageRecord {
+    const groupRows = this.connection.db
+      .query(
+        `
+          SELECT group_id FROM ai_model_call_usage_groups
+          WHERE project_id = ? AND usage_record_id = ?
+          ORDER BY group_id
+        `
+      )
+      .all(row.project_id, row.id) as Array<{ group_id: string }>
+
+    return {
+      id: row.id,
+      projectId: row.project_id,
+      execution: executionFromRow(row),
+      attempt: row.attempt,
+      callId: row.call_id,
+      requesterPrincipal: {
+        type: row.requester_principal_type,
+        id: row.requester_principal_id,
+      },
+      requesterGroupIds: groupRows.map((group) => group.group_id),
+      providerId: row.provider_id,
+      requestedModelId: row.requested_model_id,
+      ...(row.response_model_id === null ? {} : { responseModelId: row.response_model_id }),
+      responseId: row.response_id,
+      usage: {
+        ...usageFromRow(row),
+        ...(row.total_tokens === null ? {} : { totalTokens: row.total_tokens }),
+        reportingStatus: row.reporting_status,
+      },
+      ...(row.raw_usage === null
+        ? {}
+        : { rawUsage: JSON.parse(row.raw_usage) as ReadonlyJsonObject }),
+      occurredAt: new Date(row.occurred_at),
+      recordedAt: new Date(row.recorded_at),
+    }
+  }
+
+  private executionRows(input: SummarizeAiUsageExecutionsInput): AiUsageRow[] {
+    const requested = JSON.stringify([
+      ...new Map(
+        input.executions.map((execution) => [executionKey(execution), execution])
+      ).values(),
+    ])
+    return this.connection.db
+      .query(
+        `
+          WITH requested AS (
+            SELECT DISTINCT
+              json_extract(value, '$.kind') AS kind,
+              json_extract(value, '$.runId') AS agent_run_id,
+              json_extract(value, '$.workflowRunId') AS workflow_run_id,
+              json_extract(value, '$.nodeRunId') AS workflow_node_run_id
+            FROM json_each(?)
+          ), requested_agent_runs AS (
+            SELECT agent_run_id FROM requested WHERE kind = 'agentRun'
+          ), requested_workflow_nodes AS (
+            SELECT workflow_run_id, workflow_node_run_id
+            FROM requested WHERE kind = 'workflowAgentNode'
+          )
+          SELECT usage.* FROM requested_agent_runs AS requested
+          CROSS JOIN ai_model_call_usage AS usage
+            ON usage.project_id = ?
+            AND usage.execution_kind = 'agentRun'
+            AND usage.agent_run_id = requested.agent_run_id
+          UNION ALL
+          SELECT usage.* FROM requested_workflow_nodes AS requested
+          CROSS JOIN ai_model_call_usage AS usage
+            ON usage.project_id = ?
+            AND usage.execution_kind = 'workflowAgentNode'
+            AND usage.workflow_run_id = requested.workflow_run_id
+            AND usage.workflow_node_run_id = requested.workflow_node_run_id
+        `
+      )
+      .all(requested, input.projectId, input.projectId) as AiUsageRow[]
+  }
+}
+
+interface AiUsageRow {
+  readonly project_id: string
+  readonly id: string
+  readonly execution_kind: AiUsageExecutionIdentity["kind"]
+  readonly agent_run_id: string | null
+  readonly workflow_run_id: string | null
+  readonly workflow_node_run_id: string | null
+  readonly attempt: number
+  readonly call_id: string
+  readonly requester_principal_type: Principal["type"]
+  readonly requester_principal_id: string
+  readonly provider_id: string
+  readonly requested_model_id: string
+  readonly response_model_id: string | null
+  readonly response_id: string
+  readonly input_tokens: number | null
+  readonly output_tokens: number | null
+  readonly total_tokens: number | null
+  readonly uncached_input_tokens: number | null
+  readonly cache_read_input_tokens: number | null
+  readonly cache_write_input_tokens: number | null
+  readonly text_output_tokens: number | null
+  readonly reasoning_output_tokens: number | null
+  readonly reporting_status: AiModelCallUsageRecord["usage"]["reportingStatus"]
+  readonly raw_usage: string | null
+  readonly occurred_at: string
+  readonly recorded_at: string
+}
+
+function aggregateExecutionRows(
+  executions: readonly AiUsageExecutionIdentity[],
+  rows: readonly AiUsageRow[]
+): readonly AiUsageExecutionSummary[] {
+  const usageByExecution = new Map<string, AiModelCallUsageInput[]>()
+  for (const execution of executions) usageByExecution.set(executionKey(execution), [])
+  for (const row of rows) {
+    usageByExecution.get(executionKey(executionFromRow(row)))?.push(usageFromRow(row))
+  }
+  return executions.map((execution) => {
+    const usages = usageByExecution.get(executionKey(execution)) ?? []
+    return {
+      modelCallCount: usages.length,
+      usage: aggregateAiModelCallUsage(usages),
+    }
+  })
+}
+
+function executionKey(execution: AiUsageExecutionIdentity): string {
+  return execution.kind === "agentRun"
+    ? JSON.stringify([execution.kind, execution.runId])
+    : JSON.stringify([execution.kind, execution.workflowRunId, execution.nodeRunId])
+}
+
+function usageFromRow(row: AiUsageRow): AiModelCallUsageInput {
+  return {
+    ...(row.input_tokens === null ? {} : { inputTokens: row.input_tokens }),
+    ...(row.output_tokens === null ? {} : { outputTokens: row.output_tokens }),
+    ...(row.uncached_input_tokens === null
+      ? {}
+      : { uncachedInputTokens: row.uncached_input_tokens }),
+    ...(row.cache_read_input_tokens === null
+      ? {}
+      : { cacheReadInputTokens: row.cache_read_input_tokens }),
+    ...(row.cache_write_input_tokens === null
+      ? {}
+      : { cacheWriteInputTokens: row.cache_write_input_tokens }),
+    ...(row.text_output_tokens === null ? {} : { textOutputTokens: row.text_output_tokens }),
+    ...(row.reasoning_output_tokens === null
+      ? {}
+      : { reasoningOutputTokens: row.reasoning_output_tokens }),
+  }
+}
+
+function executionColumns(execution: AiUsageExecutionIdentity): {
+  readonly agentRunId: string | null
+  readonly workflowRunId: string | null
+  readonly workflowNodeRunId: string | null
+} {
+  return execution.kind === "agentRun"
+    ? { agentRunId: execution.runId, workflowRunId: null, workflowNodeRunId: null }
+    : {
+        agentRunId: null,
+        workflowRunId: execution.workflowRunId,
+        workflowNodeRunId: execution.nodeRunId,
+      }
+}
+
+function executionFromRow(row: AiUsageRow): AiUsageExecutionIdentity {
+  if (row.execution_kind === "agentRun" && row.agent_run_id) {
+    return { kind: "agentRun", runId: row.agent_run_id }
+  }
+  if (
+    row.execution_kind === "workflowAgentNode" &&
+    row.workflow_run_id &&
+    row.workflow_node_run_id
+  ) {
+    return {
+      kind: "workflowAgentNode",
+      workflowRunId: row.workflow_run_id,
+      nodeRunId: row.workflow_node_run_id,
+    }
+  }
+  throw new Error(`[SixbSqlite] AI usage record '${row.id}' has an invalid execution identity.`)
+}
+
+function assertNonBlankProjectId(projectId: string): void {
+  if (typeof projectId !== "string" || projectId.trim().length === 0) {
+    throw new TypeError("[Sixb] AI usage projectId must be nonblank.")
+  }
+}

--- a/storage/sqlite/src/ai-usage-storage.ts
+++ b/storage/sqlite/src/ai-usage-storage.ts
@@ -1,13 +1,12 @@
-import type { Principal, ReadonlyJsonObject } from "@sixb/core/storage"
+import type { ReadonlyJsonObject } from "@sixb/core/storage"
 import {
   type AiModelCallUsageInput,
   type AiModelCallUsageRecord,
-  type AiUsageExecutionIdentity,
   type AiUsageExecutionSummary,
   type AiUsageStorage,
   AiUsageStorageError,
   aggregateAiModelCallUsage,
-  assertAiUsageExecution,
+  assertAiUsageExecutionId,
   normalizeAiModelCallRecord,
   type RecordAiModelCallInput,
   type RecordAiModelCallResult,
@@ -44,6 +43,7 @@ export class SqliteAiUsageStorage implements AiUsageStorage {
     return runImmediateTransaction(this.connection.db, () => {
       const existing = this.findByIdempotencyKey(record)
       if (existing) return { record: existing, created: false }
+      this.assertExecutionExists(record.projectId, record.executionId)
 
       try {
         this.insertRecord(record)
@@ -79,7 +79,7 @@ export class SqliteAiUsageStorage implements AiUsageStorage {
   ): Promise<AiUsageExecutionSummary> {
     const [summary] = await this.summarizeExecutions({
       projectId: input.projectId,
-      executions: [input.execution],
+      executionIds: [input.executionId],
     })
     return summary!
   }
@@ -88,11 +88,11 @@ export class SqliteAiUsageStorage implements AiUsageStorage {
     input: SummarizeAiUsageExecutionsInput
   ): Promise<readonly AiUsageExecutionSummary[]> {
     assertNonBlankProjectId(input.projectId)
-    for (const execution of input.executions) assertAiUsageExecution(execution)
-    if (input.executions.length === 0) return []
+    for (const executionId of input.executionIds) assertAiUsageExecutionId(executionId)
+    if (input.executionIds.length === 0) return []
 
     const rows = this.executionRows(input)
-    return aggregateExecutionRows(input.executions, rows)
+    return aggregateExecutionRows(input.executionIds, rows)
   }
 
   close(): void {
@@ -100,21 +100,15 @@ export class SqliteAiUsageStorage implements AiUsageStorage {
   }
 
   private insertRecord(record: AiModelCallUsageRecord): void {
-    const execution = executionColumns(record.execution)
     this.connection.db
       .query(
         `
           INSERT INTO ai_model_call_usage (
             project_id,
             id,
-            execution_kind,
-            agent_run_id,
-            workflow_run_id,
-            workflow_node_run_id,
+            execution_id,
             attempt,
             call_id,
-            requester_principal_type,
-            requester_principal_id,
             provider_id,
             requested_model_id,
             response_model_id,
@@ -132,21 +126,16 @@ export class SqliteAiUsageStorage implements AiUsageStorage {
             occurred_at,
             recorded_at
           ) VALUES (
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
           )
         `
       )
       .run(
         record.projectId,
         record.id,
-        record.execution.kind,
-        execution.agentRunId,
-        execution.workflowRunId,
-        execution.workflowNodeRunId,
+        record.executionId,
         record.attempt,
         record.callId,
-        record.requesterPrincipal.type,
-        record.requesterPrincipal.id,
         record.providerId,
         record.requestedModelId,
         record.responseModelId ?? null,
@@ -169,51 +158,27 @@ export class SqliteAiUsageStorage implements AiUsageStorage {
   private findByIdempotencyKey(
     record: Pick<
       AiModelCallUsageRecord,
-      "projectId" | "execution" | "attempt" | "callId" | "responseId"
+      "projectId" | "executionId" | "attempt" | "callId" | "responseId"
     >
   ): AiModelCallUsageRecord | null {
-    const row =
-      record.execution.kind === "agentRun"
-        ? (this.connection.db
-            .query(
-              `
-                SELECT * FROM ai_model_call_usage
-                WHERE project_id = ?
-                  AND execution_kind = 'agentRun'
-                  AND agent_run_id = ?
-                  AND attempt = ?
-                  AND call_id = ?
-                  AND response_id = ?
-              `
-            )
-            .get(
-              record.projectId,
-              record.execution.runId,
-              record.attempt,
-              record.callId,
-              record.responseId
-            ) as AiUsageRow | null)
-        : (this.connection.db
-            .query(
-              `
-                SELECT * FROM ai_model_call_usage
-                WHERE project_id = ?
-                  AND execution_kind = 'workflowAgentNode'
-                  AND workflow_run_id = ?
-                  AND workflow_node_run_id = ?
-                  AND attempt = ?
-                  AND call_id = ?
-                  AND response_id = ?
-              `
-            )
-            .get(
-              record.projectId,
-              record.execution.workflowRunId,
-              record.execution.nodeRunId,
-              record.attempt,
-              record.callId,
-              record.responseId
-            ) as AiUsageRow | null)
+    const row = this.connection.db
+      .query(
+        `
+          SELECT * FROM ai_model_call_usage
+          WHERE project_id = ?
+            AND execution_id = ?
+            AND attempt = ?
+            AND call_id = ?
+            AND response_id = ?
+        `
+      )
+      .get(
+        record.projectId,
+        record.executionId,
+        record.attempt,
+        record.callId,
+        record.responseId
+      ) as AiUsageRow | null
     return row ? this.rowToRecord(row) : null
   }
 
@@ -239,13 +204,9 @@ export class SqliteAiUsageStorage implements AiUsageStorage {
     return {
       id: row.id,
       projectId: row.project_id,
-      execution: executionFromRow(row),
+      executionId: row.execution_id,
       attempt: row.attempt,
       callId: row.call_id,
-      requesterPrincipal: {
-        type: row.requester_principal_type,
-        id: row.requester_principal_id,
-      },
       requesterGroupIds: groupRows.map((group) => group.group_id),
       providerId: row.provider_id,
       requestedModelId: row.requested_model_id,
@@ -265,56 +226,41 @@ export class SqliteAiUsageStorage implements AiUsageStorage {
   }
 
   private executionRows(input: SummarizeAiUsageExecutionsInput): AiUsageRow[] {
-    const requested = JSON.stringify([
-      ...new Map(
-        input.executions.map((execution) => [executionKey(execution), execution])
-      ).values(),
-    ])
+    const requested = JSON.stringify([...new Set(input.executionIds)])
     return this.connection.db
       .query(
         `
           WITH requested AS (
-            SELECT DISTINCT
-              json_extract(value, '$.kind') AS kind,
-              json_extract(value, '$.runId') AS agent_run_id,
-              json_extract(value, '$.workflowRunId') AS workflow_run_id,
-              json_extract(value, '$.nodeRunId') AS workflow_node_run_id
+            SELECT DISTINCT value AS execution_id
             FROM json_each(?)
-          ), requested_agent_runs AS (
-            SELECT agent_run_id FROM requested WHERE kind = 'agentRun'
-          ), requested_workflow_nodes AS (
-            SELECT workflow_run_id, workflow_node_run_id
-            FROM requested WHERE kind = 'workflowAgentNode'
           )
-          SELECT usage.* FROM requested_agent_runs AS requested
-          CROSS JOIN ai_model_call_usage AS usage
+          SELECT usage.* FROM requested
+          JOIN ai_model_call_usage AS usage
             ON usage.project_id = ?
-            AND usage.execution_kind = 'agentRun'
-            AND usage.agent_run_id = requested.agent_run_id
-          UNION ALL
-          SELECT usage.* FROM requested_workflow_nodes AS requested
-          CROSS JOIN ai_model_call_usage AS usage
-            ON usage.project_id = ?
-            AND usage.execution_kind = 'workflowAgentNode'
-            AND usage.workflow_run_id = requested.workflow_run_id
-            AND usage.workflow_node_run_id = requested.workflow_node_run_id
+            AND usage.execution_id = requested.execution_id
         `
       )
-      .all(requested, input.projectId, input.projectId) as AiUsageRow[]
+      .all(requested, input.projectId) as AiUsageRow[]
+  }
+
+  private assertExecutionExists(projectId: string, executionId: string): void {
+    const execution = this.connection.db
+      .query("SELECT 1 FROM executions WHERE project_id = ? AND id = ?")
+      .get(projectId, executionId)
+    if (execution) return
+    throw new AiUsageStorageError(
+      "missing_execution",
+      `[SixbSqlite] AI usage execution '${executionId}' does not exist in project '${projectId}'.`
+    )
   }
 }
 
 interface AiUsageRow {
   readonly project_id: string
   readonly id: string
-  readonly execution_kind: AiUsageExecutionIdentity["kind"]
-  readonly agent_run_id: string | null
-  readonly workflow_run_id: string | null
-  readonly workflow_node_run_id: string | null
+  readonly execution_id: string
   readonly attempt: number
   readonly call_id: string
-  readonly requester_principal_type: Principal["type"]
-  readonly requester_principal_id: string
   readonly provider_id: string
   readonly requested_model_id: string
   readonly response_model_id: string | null
@@ -334,27 +280,21 @@ interface AiUsageRow {
 }
 
 function aggregateExecutionRows(
-  executions: readonly AiUsageExecutionIdentity[],
+  executionIds: readonly string[],
   rows: readonly AiUsageRow[]
 ): readonly AiUsageExecutionSummary[] {
-  const usageByExecution = new Map<string, AiModelCallUsageInput[]>()
-  for (const execution of executions) usageByExecution.set(executionKey(execution), [])
+  const usageByExecutionId = new Map<string, AiModelCallUsageInput[]>()
+  for (const executionId of executionIds) usageByExecutionId.set(executionId, [])
   for (const row of rows) {
-    usageByExecution.get(executionKey(executionFromRow(row)))?.push(usageFromRow(row))
+    usageByExecutionId.get(row.execution_id)?.push(usageFromRow(row))
   }
-  return executions.map((execution) => {
-    const usages = usageByExecution.get(executionKey(execution)) ?? []
+  return executionIds.map((executionId) => {
+    const usages = usageByExecutionId.get(executionId) ?? []
     return {
       modelCallCount: usages.length,
       usage: aggregateAiModelCallUsage(usages),
     }
   })
-}
-
-function executionKey(execution: AiUsageExecutionIdentity): string {
-  return execution.kind === "agentRun"
-    ? JSON.stringify([execution.kind, execution.runId])
-    : JSON.stringify([execution.kind, execution.workflowRunId, execution.nodeRunId])
 }
 
 function usageFromRow(row: AiUsageRow): AiModelCallUsageInput {
@@ -375,38 +315,6 @@ function usageFromRow(row: AiUsageRow): AiModelCallUsageInput {
       ? {}
       : { reasoningOutputTokens: row.reasoning_output_tokens }),
   }
-}
-
-function executionColumns(execution: AiUsageExecutionIdentity): {
-  readonly agentRunId: string | null
-  readonly workflowRunId: string | null
-  readonly workflowNodeRunId: string | null
-} {
-  return execution.kind === "agentRun"
-    ? { agentRunId: execution.runId, workflowRunId: null, workflowNodeRunId: null }
-    : {
-        agentRunId: null,
-        workflowRunId: execution.workflowRunId,
-        workflowNodeRunId: execution.nodeRunId,
-      }
-}
-
-function executionFromRow(row: AiUsageRow): AiUsageExecutionIdentity {
-  if (row.execution_kind === "agentRun" && row.agent_run_id) {
-    return { kind: "agentRun", runId: row.agent_run_id }
-  }
-  if (
-    row.execution_kind === "workflowAgentNode" &&
-    row.workflow_run_id &&
-    row.workflow_node_run_id
-  ) {
-    return {
-      kind: "workflowAgentNode",
-      workflowRunId: row.workflow_run_id,
-      nodeRunId: row.workflow_node_run_id,
-    }
-  }
-  throw new Error(`[SixbSqlite] AI usage record '${row.id}' has an invalid execution identity.`)
 }
 
 function assertNonBlankProjectId(projectId: string): void {

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from "@sixb/core/storage"
 import { SqliteActionRunStorage } from "./action-run-storage"
 import { SqliteAgentStorage } from "./agents"
+import { SqliteAiUsageStorage } from "./ai-usage-storage"
 import { SqliteAuthStorage } from "./auth-storage"
 import { SqliteExecutionStorage } from "./execution-storage"
 import {
@@ -58,8 +59,8 @@ export interface SqliteStorageOptions {
 /**
  * SQLite storage provider for Sixb.
  *
- * Bundles object, timeseries, auth, execution, sync run, pipeline run, projection run, workflow
- * run, webhook run, and webhook delivery storage backed by SQLite.
+ * Bundles object, timeseries, auth, execution, AI usage, sync run, pipeline run, projection run,
+ * workflow run, webhook run, and webhook delivery storage backed by SQLite.
  *
  * Usage:
  * ```ts
@@ -77,6 +78,7 @@ export class SqliteStorage implements MigrationCapableStorage {
   readonly auth: SqliteAuthStorage
   readonly executions: SqliteExecutionStorage
   readonly agents: SqliteAgentStorage
+  readonly aiUsage: SqliteAiUsageStorage
   readonly actionRuns: SqliteActionRunStorage
   readonly pipelineRuns: SqlitePipelineRunStorage
   readonly syncRuns: SqliteSyncRunStorage
@@ -138,6 +140,7 @@ export class SqliteStorage implements MigrationCapableStorage {
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)
     this.agents = createAgentOperationScope(stores.agents, scope)
+    this.aiUsage = createOperationScopedFacade(stores.aiUsage, scope)
     this.actionRuns = createOperationScopedFacade(stores.actionRuns, scope)
     this.pipelineRuns = createOperationScopedFacade(stores.pipelineRuns, scope)
     this.timeseries = createOperationScopedFacade(readTimeseries, readScope)
@@ -289,6 +292,7 @@ function createSqliteStores(
     auth,
     executions,
     agents: new SqliteAgentStorage({ connection, executions }),
+    aiUsage: new SqliteAiUsageStorage({ connection }),
     actionRuns: new SqliteActionRunStorage({ connection, executions }),
     pipelineRuns: new SqlitePipelineRunStorage({ connection }),
     timeseries: new SqliteTimeseriesStorage({ connection }),
@@ -308,6 +312,7 @@ interface SqliteStoreSet {
   readonly auth: SqliteAuthStorage
   readonly executions: SqliteExecutionStorage
   readonly agents: SqliteAgentStorage
+  readonly aiUsage: SqliteAiUsageStorage
   readonly actionRuns: SqliteActionRunStorage
   readonly pipelineRuns: SqlitePipelineRunStorage
   readonly syncRuns: SqliteSyncRunStorage

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -19,6 +19,7 @@ import {
   createWorkflowRunOperationScope,
 } from "@sixb/core/internal/storage-operation-scope"
 import {
+  type AiUsageStorage,
   createTransactionStorageProxy,
   StorageTransactionError,
   throwNestedStorageTransaction,
@@ -78,7 +79,7 @@ export class SqliteStorage implements MigrationCapableStorage {
   readonly auth: SqliteAuthStorage
   readonly executions: SqliteExecutionStorage
   readonly agents: SqliteAgentStorage
-  readonly aiUsage: SqliteAiUsageStorage
+  readonly aiUsage: AiUsageStorage
   readonly actionRuns: SqliteActionRunStorage
   readonly pipelineRuns: SqlitePipelineRunStorage
   readonly syncRuns: SqliteSyncRunStorage

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -27,6 +27,9 @@ import narrowOntologySourceRootIndexSql from "./migrations/006-narrow-ontology-s
 import splitOverridesSql from "./migrations/007-split-overrides.sql" with { type: "text" }
 import actionExecutionsSql from "./migrations/008-action-executions.sql" with { type: "text" }
 import agentExecutionsSql from "./migrations/009-agent-executions.sql" with { type: "text" }
+import aiUsageAccountingFoundationSql from "./migrations/010-ai-usage-accounting-foundation.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -56,6 +59,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("007-split-overrides", splitOverridesSql),
     sqliteSql("008-action-executions", actionExecutionsSql),
     sqliteSql("009-agent-executions", agentExecutionsSql),
+    sqliteSql("010-ai-usage-accounting-foundation", aiUsageAccountingFoundationSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/010-ai-usage-accounting-foundation.sql
+++ b/storage/sqlite/src/migrations/010-ai-usage-accounting-foundation.sql
@@ -1,0 +1,118 @@
+ALTER TABLE agent_runs
+  ADD COLUMN requester_group_ids TEXT NOT NULL DEFAULT '[]'
+  CHECK (json_valid(requester_group_ids) AND json_type(requester_group_ids) = 'array');
+
+ALTER TABLE workflow_runs
+  ADD COLUMN requester_group_ids TEXT NOT NULL DEFAULT '[]'
+  CHECK (json_valid(requester_group_ids) AND json_type(requester_group_ids) = 'array');
+
+CREATE TABLE ai_model_call_usage (
+  project_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  execution_kind TEXT NOT NULL CHECK (
+    execution_kind IN ('agentRun', 'workflowAgentNode')
+  ),
+  agent_run_id TEXT,
+  workflow_run_id TEXT,
+  workflow_node_run_id TEXT,
+  attempt INTEGER NOT NULL CHECK (attempt >= 1),
+  call_id TEXT NOT NULL,
+  requester_principal_type TEXT NOT NULL CHECK (
+    requester_principal_type IN ('user', 'serviceAccount', 'system')
+  ),
+  requester_principal_id TEXT NOT NULL,
+  provider_id TEXT NOT NULL,
+  requested_model_id TEXT NOT NULL,
+  response_model_id TEXT,
+  response_id TEXT NOT NULL,
+  input_tokens INTEGER CHECK (input_tokens IS NULL OR input_tokens >= 0),
+  output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
+  total_tokens INTEGER CHECK (total_tokens IS NULL OR total_tokens >= 0),
+  uncached_input_tokens INTEGER CHECK (
+    uncached_input_tokens IS NULL OR uncached_input_tokens >= 0
+  ),
+  cache_read_input_tokens INTEGER CHECK (
+    cache_read_input_tokens IS NULL OR cache_read_input_tokens >= 0
+  ),
+  cache_write_input_tokens INTEGER CHECK (
+    cache_write_input_tokens IS NULL OR cache_write_input_tokens >= 0
+  ),
+  text_output_tokens INTEGER CHECK (
+    text_output_tokens IS NULL OR text_output_tokens >= 0
+  ),
+  reasoning_output_tokens INTEGER CHECK (
+    reasoning_output_tokens IS NULL OR reasoning_output_tokens >= 0
+  ),
+  reporting_status TEXT NOT NULL CHECK (
+    reporting_status IN ('complete', 'partial', 'unavailable')
+  ),
+  raw_usage TEXT CHECK (raw_usage IS NULL OR json_valid(raw_usage)),
+  occurred_at TEXT NOT NULL,
+  recorded_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, id),
+  CHECK (
+    (
+      execution_kind = 'agentRun'
+      AND agent_run_id IS NOT NULL
+      AND workflow_run_id IS NULL
+      AND workflow_node_run_id IS NULL
+    ) OR (
+      execution_kind = 'workflowAgentNode'
+      AND agent_run_id IS NULL
+      AND workflow_run_id IS NOT NULL
+      AND workflow_node_run_id IS NOT NULL
+    )
+  )
+);
+
+CREATE UNIQUE INDEX idx_ai_model_call_usage_agent_idempotency
+  ON ai_model_call_usage (project_id, agent_run_id, attempt, call_id, response_id)
+  WHERE execution_kind = 'agentRun';
+CREATE UNIQUE INDEX idx_ai_model_call_usage_workflow_idempotency
+  ON ai_model_call_usage (
+    project_id,
+    workflow_run_id,
+    workflow_node_run_id,
+    attempt,
+    call_id,
+    response_id
+  )
+  WHERE execution_kind = 'workflowAgentNode';
+CREATE INDEX idx_ai_model_call_usage_agent_execution
+  ON ai_model_call_usage (project_id, agent_run_id, occurred_at, id)
+  WHERE execution_kind = 'agentRun';
+CREATE INDEX idx_ai_model_call_usage_workflow_execution
+  ON ai_model_call_usage (
+    project_id,
+    workflow_run_id,
+    workflow_node_run_id,
+    occurred_at,
+    id
+  )
+  WHERE execution_kind = 'workflowAgentNode';
+CREATE INDEX idx_ai_model_call_usage_project_time
+  ON ai_model_call_usage (project_id, occurred_at, id);
+CREATE INDEX idx_ai_model_call_usage_principal_time
+  ON ai_model_call_usage (
+    project_id,
+    requester_principal_type,
+    requester_principal_id,
+    occurred_at,
+    id
+  );
+CREATE INDEX idx_ai_model_call_usage_provider_response
+  ON ai_model_call_usage (project_id, provider_id, response_id);
+
+CREATE TABLE ai_model_call_usage_groups (
+  project_id TEXT NOT NULL,
+  usage_record_id TEXT NOT NULL,
+  group_id TEXT NOT NULL,
+  occurred_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, usage_record_id, group_id),
+  FOREIGN KEY (project_id, usage_record_id)
+    REFERENCES ai_model_call_usage(project_id, id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX idx_ai_model_call_usage_groups_group_time
+  ON ai_model_call_usage_groups (project_id, group_id, occurred_at, usage_record_id);

--- a/storage/sqlite/src/migrations/010-ai-usage-accounting-foundation.sql
+++ b/storage/sqlite/src/migrations/010-ai-usage-accounting-foundation.sql
@@ -7,24 +7,17 @@ ALTER TABLE workflow_runs
   CHECK (json_valid(requester_group_ids) AND json_type(requester_group_ids) = 'array');
 
 CREATE TABLE ai_model_call_usage (
-  project_id TEXT NOT NULL,
-  id TEXT NOT NULL,
-  execution_kind TEXT NOT NULL CHECK (
-    execution_kind IN ('agentRun', 'workflowAgentNode')
-  ),
-  agent_run_id TEXT,
-  workflow_run_id TEXT,
-  workflow_node_run_id TEXT,
+  project_id TEXT NOT NULL CHECK (length(trim(project_id)) > 0),
+  id TEXT NOT NULL CHECK (length(trim(id)) > 0),
+  execution_id TEXT NOT NULL CHECK (length(trim(execution_id)) > 0),
   attempt INTEGER NOT NULL CHECK (attempt >= 1),
-  call_id TEXT NOT NULL,
-  requester_principal_type TEXT NOT NULL CHECK (
-    requester_principal_type IN ('user', 'serviceAccount', 'system')
+  call_id TEXT NOT NULL CHECK (length(trim(call_id)) > 0),
+  provider_id TEXT NOT NULL CHECK (length(trim(provider_id)) > 0),
+  requested_model_id TEXT NOT NULL CHECK (length(trim(requested_model_id)) > 0),
+  response_model_id TEXT CHECK (
+    response_model_id IS NULL OR length(trim(response_model_id)) > 0
   ),
-  requester_principal_id TEXT NOT NULL,
-  provider_id TEXT NOT NULL,
-  requested_model_id TEXT NOT NULL,
-  response_model_id TEXT,
-  response_id TEXT NOT NULL,
+  response_id TEXT NOT NULL CHECK (length(trim(response_id)) > 0),
   input_tokens INTEGER CHECK (input_tokens IS NULL OR input_tokens >= 0),
   output_tokens INTEGER CHECK (output_tokens IS NULL OR output_tokens >= 0),
   total_tokens INTEGER CHECK (total_tokens IS NULL OR total_tokens >= 0),
@@ -46,60 +39,23 @@ CREATE TABLE ai_model_call_usage (
   reporting_status TEXT NOT NULL CHECK (
     reporting_status IN ('complete', 'partial', 'unavailable')
   ),
-  raw_usage TEXT CHECK (raw_usage IS NULL OR json_valid(raw_usage)),
+  raw_usage TEXT CHECK (
+    raw_usage IS NULL OR (json_valid(raw_usage) AND json_type(raw_usage) = 'object')
+  ),
   occurred_at TEXT NOT NULL,
   recorded_at TEXT NOT NULL,
   PRIMARY KEY (project_id, id),
-  CHECK (
-    (
-      execution_kind = 'agentRun'
-      AND agent_run_id IS NOT NULL
-      AND workflow_run_id IS NULL
-      AND workflow_node_run_id IS NULL
-    ) OR (
-      execution_kind = 'workflowAgentNode'
-      AND agent_run_id IS NULL
-      AND workflow_run_id IS NOT NULL
-      AND workflow_node_run_id IS NOT NULL
-    )
-  )
+  FOREIGN KEY (project_id, execution_id)
+    REFERENCES executions(project_id, id)
+    ON DELETE RESTRICT
 );
 
-CREATE UNIQUE INDEX idx_ai_model_call_usage_agent_idempotency
-  ON ai_model_call_usage (project_id, agent_run_id, attempt, call_id, response_id)
-  WHERE execution_kind = 'agentRun';
-CREATE UNIQUE INDEX idx_ai_model_call_usage_workflow_idempotency
-  ON ai_model_call_usage (
-    project_id,
-    workflow_run_id,
-    workflow_node_run_id,
-    attempt,
-    call_id,
-    response_id
-  )
-  WHERE execution_kind = 'workflowAgentNode';
-CREATE INDEX idx_ai_model_call_usage_agent_execution
-  ON ai_model_call_usage (project_id, agent_run_id, occurred_at, id)
-  WHERE execution_kind = 'agentRun';
-CREATE INDEX idx_ai_model_call_usage_workflow_execution
-  ON ai_model_call_usage (
-    project_id,
-    workflow_run_id,
-    workflow_node_run_id,
-    occurred_at,
-    id
-  )
-  WHERE execution_kind = 'workflowAgentNode';
+CREATE UNIQUE INDEX idx_ai_model_call_usage_idempotency
+  ON ai_model_call_usage (project_id, execution_id, attempt, call_id, response_id);
+CREATE INDEX idx_ai_model_call_usage_execution
+  ON ai_model_call_usage (project_id, execution_id, occurred_at, id);
 CREATE INDEX idx_ai_model_call_usage_project_time
   ON ai_model_call_usage (project_id, occurred_at, id);
-CREATE INDEX idx_ai_model_call_usage_principal_time
-  ON ai_model_call_usage (
-    project_id,
-    requester_principal_type,
-    requester_principal_id,
-    occurred_at,
-    id
-  );
 CREATE INDEX idx_ai_model_call_usage_provider_response
   ON ai_model_call_usage (project_id, provider_id, response_id);
 

--- a/storage/sqlite/src/workflow-run-storage.ts
+++ b/storage/sqlite/src/workflow-run-storage.ts
@@ -106,8 +106,9 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
             input,
             queued_at,
             started_at,
+            requester_group_ids,
             attempt
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `
         )
         .run(
@@ -119,6 +120,7 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
           serializeRecord(input.input),
           queuedAt.toISOString(),
           queuedAt.toISOString(),
+          JSON.stringify(input.requesterGroupIds),
           0
         )
     } catch (error) {
@@ -968,6 +970,7 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     error: row.error ?? undefined,
+    requesterGroupIds: JSON.parse(row.requester_group_ids) as string[],
     attempt: row.attempt,
     ...(row.execution_token && row.execution_queue_lease_expires_at
       ? {
@@ -1030,6 +1033,7 @@ interface WorkflowRunDatabaseRow {
   started_at: string
   finished_at: string | null
   error: string | null
+  requester_group_ids: string
   attempt: number
   execution_token: string | null
   execution_queue_lease_expires_at: string | null

--- a/storage/sqlite/src/workflow-run-storage.ts
+++ b/storage/sqlite/src/workflow-run-storage.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite"
+import { normalizeRequesterGroupIds } from "@sixb/core/internal/auth"
 import {
   assertWorkflowAgentNodeRunExecution,
   assertWorkflowRunExecution,
@@ -120,7 +121,7 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
           serializeRecord(input.input),
           queuedAt.toISOString(),
           queuedAt.toISOString(),
-          JSON.stringify(input.requesterGroupIds),
+          JSON.stringify(normalizeRequesterGroupIds(input.requesterGroupIds)),
           0
         )
     } catch (error) {

--- a/storage/sqlite/tests/sqlite-agent-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-agent-storage.test.ts
@@ -58,6 +58,7 @@ describe("SqliteStorage agents", () => {
             threadId: "thr_1",
             agentId: "sales",
             triggerMessageId: "msg_1",
+            requesterGroupIds: ["engineering"],
             createdAt: new Date("2026-06-23T10:00:10.000Z"),
           })
           await tx.agents?.messages.append({

--- a/storage/sqlite/tests/sqlite-ai-usage-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-ai-usage-storage.test.ts
@@ -1,13 +1,27 @@
 import { describe, expect, test } from "bun:test"
 import type { AiUsageStorage, RecordAiModelCallInput } from "@sixb/core/storage"
-import { runAiUsageStorageContractSuite } from "@sixb/core/testing"
+import {
+  runAiUsageStorageContractSuite,
+  seedAiUsageStorageContractExecutions,
+} from "@sixb/core/testing"
 import { SqliteStorage } from "../src"
-import { SqliteAiUsageStorage } from "../src/ai-usage-storage"
 
+const contractBundles = new Map<AiUsageStorage, SqliteStorage>()
 runAiUsageStorageContractSuite("SqliteAiUsageStorage", {
-  createStorage: () => new SqliteAiUsageStorage(),
+  createStorage: () => {
+    const bundle = new SqliteStorage()
+    contractBundles.set(bundle.aiUsage, bundle)
+    return bundle.aiUsage
+  },
+  setup: async (storage) => {
+    const bundle = contractBundles.get(storage)
+    if (!bundle) throw new Error("Expected SQLite storage bundle")
+    await seedAiUsageStorageContractExecutions(bundle.executions)
+  },
   cleanup: (storage) => {
-    storage.close()
+    const bundle = contractBundles.get(storage)
+    contractBundles.delete(storage)
+    bundle?.close()
   },
 })
 
@@ -17,6 +31,7 @@ describe("SqliteStorage AI usage", () => {
 
     try {
       expect(storage.aiUsage).toBeDefined()
+      await seedAiUsageStorageContractExecutions(storage.executions)
       await expect(
         storage.transaction(async (tx) => {
           await requireAiUsage(tx.aiUsage).recordModelCall(modelCallInput())
@@ -40,11 +55,10 @@ describe("SqliteStorage AI usage", () => {
 function modelCallInput(): RecordAiModelCallInput {
   return {
     id: "usage_1",
-    projectId: "project_1",
-    execution: { kind: "agentRun", runId: "run_1" },
+    projectId: "contract-project",
+    executionId: "exec_agent_1",
     attempt: 1,
     callId: "call_1",
-    requesterPrincipal: { type: "user", id: "usr_1" },
     requesterGroupIds: ["engineering", "support"],
     providerId: "gateway",
     requestedModelId: "openai/gpt-5",
@@ -57,8 +71,8 @@ function modelCallInput(): RecordAiModelCallInput {
 
 function summaryInput() {
   return {
-    projectId: "project_1",
-    execution: { kind: "agentRun", runId: "run_1" },
+    projectId: "contract-project",
+    executionId: "exec_agent_1",
   } as const
 }
 

--- a/storage/sqlite/tests/sqlite-ai-usage-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-ai-usage-storage.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import type { AiUsageStorage, RecordAiModelCallInput } from "@sixb/core/storage"
+import { runAiUsageStorageContractSuite } from "@sixb/core/testing"
+import { SqliteStorage } from "../src"
+import { SqliteAiUsageStorage } from "../src/ai-usage-storage"
+
+runAiUsageStorageContractSuite("SqliteAiUsageStorage", {
+  createStorage: () => new SqliteAiUsageStorage(),
+  cleanup: (storage) => {
+    storage.close()
+  },
+})
+
+describe("SqliteStorage AI usage", () => {
+  test("is bundled and rolls ledger writes back with the outer transaction", async () => {
+    const storage = new SqliteStorage()
+
+    try {
+      expect(storage.aiUsage).toBeDefined()
+      await expect(
+        storage.transaction(async (tx) => {
+          await requireAiUsage(tx.aiUsage).recordModelCall(modelCallInput())
+          throw new Error("boom")
+        })
+      ).rejects.toThrow("boom")
+
+      await expect(storage.aiUsage.summarizeExecution(summaryInput())).resolves.toEqual({
+        modelCallCount: 0,
+        usage: { reportingStatus: "unavailable" },
+      })
+      await expect(storage.aiUsage.recordModelCall(modelCallInput())).resolves.toMatchObject({
+        created: true,
+      })
+    } finally {
+      storage.close()
+    }
+  })
+})
+
+function modelCallInput(): RecordAiModelCallInput {
+  return {
+    id: "usage_1",
+    projectId: "project_1",
+    execution: { kind: "agentRun", runId: "run_1" },
+    attempt: 1,
+    callId: "call_1",
+    requesterPrincipal: { type: "user", id: "usr_1" },
+    requesterGroupIds: ["engineering", "support"],
+    providerId: "gateway",
+    requestedModelId: "openai/gpt-5",
+    responseId: "response_1",
+    usage: { inputTokens: 12, outputTokens: 8 },
+    occurredAt: new Date("2026-06-23T10:00:00.000Z"),
+    recordedAt: new Date("2026-06-23T10:00:01.000Z"),
+  }
+}
+
+function summaryInput() {
+  return {
+    projectId: "project_1",
+    execution: { kind: "agentRun", runId: "run_1" },
+  } as const
+}
+
+function requireAiUsage(storage: AiUsageStorage | undefined): AiUsageStorage {
+  if (!storage) throw new Error("Expected AI usage storage")
+  return storage
+}

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -79,6 +79,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 9,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "010-ai-usage-accounting-foundation",
+    status: "applied",
+    version: 10,
+  },
 ]
 
 afterEach(async () => {
@@ -744,7 +751,7 @@ describe("SQLite storage migrations", () => {
     expect(sessionColumns).toContain("ip_address")
   })
 
-  test("migrations install agent storage tables", async () => {
+  test("migrations install agent attribution and AI usage storage tables", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "sixb-sqlite-agent-migrations-"))
     tempDirs.push(tempDir)
 
@@ -764,10 +771,17 @@ describe("SQLite storage migrations", () => {
 
     closeStorage(storage)
 
-    const tables = readTableNames(sqliteStoragePath(tempDir))
+    const path = sqliteStoragePath(tempDir)
+    const tables = readTableNames(path)
     expect(tables).toContain("agent_threads")
     expect(tables).toContain("agent_runs")
     expect(tables).toContain("agent_messages")
+    expect(tables).toContain("ai_model_call_usage")
+    expect(tables).toContain("ai_model_call_usage_groups")
+    expect(readTableColumns(path, "agent_runs")).toContain("requester_group_ids")
+    expect(readTableColumns(path, "workflow_runs")).toContain("requester_group_ids")
+    expect(readTableColumns(path, "agent_runs")).toContain("usage_input_tokens")
+    expect(readTableColumns(path, "workflow_agent_node_runs")).toContain("usage")
   })
 
   test("untracked existing schema collides and rolls back without conversion", async () => {

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -778,6 +778,15 @@ describe("SQLite storage migrations", () => {
     expect(tables).toContain("agent_messages")
     expect(tables).toContain("ai_model_call_usage")
     expect(tables).toContain("ai_model_call_usage_groups")
+    expect(readTableColumns(path, "ai_model_call_usage")).toContain("execution_id")
+    expect(readTableColumns(path, "ai_model_call_usage")).not.toContain("execution_kind")
+    expect(readTableColumns(path, "ai_model_call_usage")).not.toContain("requester_principal_id")
+    expect(readTableForeignKeys(path, "ai_model_call_usage")).toContainEqual({
+      from: "execution_id",
+      onDelete: "RESTRICT",
+      table: "executions",
+      to: "id",
+    })
     expect(readTableColumns(path, "agent_runs")).toContain("requester_group_ids")
     expect(readTableColumns(path, "workflow_runs")).toContain("requester_group_ids")
     expect(readTableColumns(path, "agent_runs")).toContain("usage_input_tokens")
@@ -925,6 +934,35 @@ function readTableColumns(path: string, tableName: string): readonly string[] {
     }>
 
     return rows.map((row) => row.name)
+  } finally {
+    db.close()
+  }
+}
+
+function readTableForeignKeys(
+  path: string,
+  tableName: string
+): readonly {
+  readonly from: string
+  readonly onDelete: string
+  readonly table: string
+  readonly to: string
+}[] {
+  const db = new Database(path, { readonly: true })
+
+  try {
+    const rows = db.query(`PRAGMA foreign_key_list(${tableName})`).all() as Array<{
+      readonly from: string
+      readonly on_delete: string
+      readonly table: string
+      readonly to: string
+    }>
+    return rows.map(({ from, on_delete, table, to }) => ({
+      from,
+      onDelete: on_delete,
+      table,
+      to,
+    }))
   } finally {
     db.close()
   }

--- a/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
@@ -76,6 +76,7 @@ describe("SqliteWorkflowRunStorage", () => {
         executionId,
         workflowId: "reconcile-transaction",
         input: {},
+        requesterGroupIds: [],
       })
     ).rejects.toBeInstanceOf(WorkflowRunError)
 
@@ -92,6 +93,7 @@ describe("SqliteWorkflowRunStorage", () => {
         executionId: automaticExecutionId,
         workflowId: "reconcile-transaction",
         input: {},
+        requesterGroupIds: [],
       })
     ).resolves.toMatchObject({ id: "wf-run-automatic", executionId: automaticExecutionId })
   })
@@ -102,6 +104,7 @@ describe("SqliteWorkflowRunStorage", () => {
       projectId: "my-app",
       workflowId: "reconcile-transaction",
       input: {},
+      requesterGroupIds: [],
     })
 
     const results = await Promise.allSettled([
@@ -675,6 +678,7 @@ function createWorkflowRunStorage(root: SqliteStorage) {
           projectId: input.projectId,
           workflowId: input.workflowId,
           input: input.input,
+          requesterGroupIds: [],
         })
       }
       return start({

--- a/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
@@ -104,7 +104,7 @@ describe("SqliteWorkflowRunStorage", () => {
       projectId: "my-app",
       workflowId: "reconcile-transaction",
       input: {},
-      requesterGroupIds: [],
+      requesterGroupIds: ["support", "engineering", "support"],
     })
 
     const results = await Promise.allSettled([
@@ -124,6 +124,9 @@ describe("SqliteWorkflowRunStorage", () => {
 
     expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1)
     expect(results.filter((result) => result.status === "rejected")).toHaveLength(1)
+    await expect(
+      storage.getById({ projectId: "my-app", id: "wf-run-claim" })
+    ).resolves.toMatchObject({ requesterGroupIds: ["engineering", "support"] })
   })
 
   test("waits and resumes workflow and intervention node runs", async () => {


### PR DESCRIPTION
## Summary

> Stack: #354 → **#355** → #356 → #357 → #358

This is PR 2 of 5 in the Phase 1 AI usage accounting stack. It takes the provider-neutral contract
from the previous PR and makes it durable in the composite in-memory, SQLite, and PostgreSQL storage
providers. It also snapshots requester group attribution when parent runs are admitted.

The existing run-level usage projections and API behavior remain unchanged in this PR. That keeps
this additive storage rollout independently deployable; the final stack PR removes those projections
after both capture paths and ledger-backed reads exist.

## Why durable attribution is required for token budgets

A future budget may apply simultaneously to:

- the project;
- the requesting principal;
- every group the requester belonged to when the work was admitted.

Resolving groups when a model call finishes would move historical usage when membership changes.
Using only a token-restricted authorization context would also let a caller avoid a shared group
budget by presenting a narrower token.

This PR therefore snapshots all durable group memberships at admission and carries that immutable
snapshot through the parent run. Later capture PRs copy it onto every model-call ledger record.

## What this PR adds

### Durable AI usage storage

- Wires `Storage.aiUsage` into the composite storage surface.
- Adds transactional in-memory snapshots and rollback.
- Adds SQLite and PostgreSQL append-only ledger implementations.
- Writes model-call rows and requester-group rows atomically.
- Enforces idempotent replay and duplicate-record behavior.
- Adds execution/project/time/principal/group/provider-response indexes.
- Implements ordered batch summaries efficiently:
  - one in-memory ledger pass;
  - one set-based SQL read;
  - unavailable entries preserved in input order.
- Runs the same provider contract against all three implementations.

### Admission-time attribution

- Adds immutable `requesterGroupIds` to conversation parent runs.
- Adds immutable `requesterGroupIds` to workflow parent runs.
- Resolves memberships from durable auth storage rather than authorization-token group subsets.
- Makes scoped runtime identity authoritative over caller-supplied principal fields.
- Snapshots user and service-account memberships.
- Gives system principals an empty group snapshot.
- Treats an agent retry as a fresh admission with a fresh membership snapshot.
- Uses the workflow parent run as the only attribution source for workflow agent nodes.

### Migration 004

Adds one combined additive migration for each SQL provider:

`004-ai-usage-accounting-foundation`

It:

- creates the ledger and group tables;
- creates idempotency and query indexes;
- adds `requester_group_ids` to agent parent runs;
- adds `requester_group_ids` to workflow parent runs.

The original implementation had separate ledger and attribution migrations. They are combined here
because trustworthy usage storage and stable attribution are one operational foundation, not two
independent rollout states.

## Rollout behavior

This PR is additive:

- workers do not write the ledger yet;
- existing run-row usage aggregates continue to be written;
- HTTP and Atlas continue to read existing run summaries;
- no historical usage is removed.

That means migration 004 can land before worker capture without causing a user-visible gap.

## What is intentionally not in this PR

- No `streamText` or `generateText` lifecycle capture.
- No accounting failure gating.
- No ledger-backed API reads.
- No usage-column drop.
- No pricing, budget counters, configuration, or enforcement.

## Phase 1 stack

1. Accounting contract and standalone in-memory model.
2. **This PR:** durable storage and immutable requester attribution.
3. Conversation model-call capture.
4. Workflow agent-node model-call capture.
5. Ledger-backed API cutover and removal of legacy run projections.

## How this supports later budgets

This PR establishes the durable dimensions future counters need:

- project ID;
- principal type and ID;
- stable group IDs;
- provider/model/response identity;
- occurrence time;
- normalized and raw usage.

A later monthly-budget transaction can rate one immutable usage fact and increment project,
principal, and group counters without re-resolving identity or membership.

After Phase 1, separate work will add effective-dated pricing, reconciliation, monthly counters,
budget definitions, and pre-call/between-step enforcement. None of those concerns are coupled into
this storage hot path yet.

## Review guide

Suggested order:

1. `packages/core/src/auth/attribution.ts`
2. agent/workflow admission changes
3. combined migration 004 for one provider, then parity-check the other
4. SQLite/PostgreSQL `*ai-usage-storage.ts`
5. composite transaction wiring
6. provider and migration tests

Questions to keep in mind:

- Can token-scoped groups evade attribution?
- Does a membership change mutate an existing run snapshot?
- Are workflow child nodes prevented from inventing separate attribution?
- Are model-call/group rows atomic?
- Does replay return the original record without changing attribution?
- Are project and execution identities isolated in every summary query?
- Does the batch path avoid N reads?

## Validation

```bash
bun run typecheck
bun run check
bun test packages/core/tests/ai-usage-storage.test.ts \
  packages/core/tests/agent-dispatch.test.ts \
  packages/core/tests/scoped-sixb.test.ts \
  packages/core/tests/workflow-request.test.ts \
  packages/core/tests/agents-storage.test.ts \
  packages/core/tests/workflow-runs.test.ts
bun test storage/sqlite/tests/sqlite-ai-usage-storage.test.ts \
  storage/sqlite/tests/sqlite-agent-storage.test.ts \
  storage/sqlite/tests/sqlite-workflow-run-storage.test.ts \
  storage/sqlite/tests/sqlite-storage-migrations.test.ts
bun --filter @sixb/pg test:e2e
```

Validated results include 105 focused core tests, 58 focused SQLite tests, and all 183 PostgreSQL E2E
tests. Core, SQLite, PostgreSQL, and server builds pass.
