### PR TITLE
agents: record every completed conversation model call

### DIFF
--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -37,15 +37,12 @@ await worker.start()
 
 ## Usage accounting
 
-Every completed conversation provider call is appended to `storage.aiUsage`, including individual
-calls in tool loops and calls completed before later cancellation, tool failure, or execution
-ownership loss. Usage writes are intentionally not fenced: a stale worker cannot finalize the run,
-but a provider call it completed remains billable.
+Every completed conversation provider call observed by the AI SDK lifecycle is appended to `storage.aiUsage`, including individual calls in tool loops and calls completed before later cancellation, tool failure, or execution ownership loss. Usage writes are intentionally not fenced: a stale worker cannot finalize the run, but a provider call it completed remains billable.
 
-The AI SDK swallows lifecycle callback errors, so the worker retains accounting failures, retries the
-idempotent append, blocks another model step through `prepareStep`, and fails the run rather than
-silently losing usage. During the staged rollout, the existing run aggregate remains for display;
-the model-call ledger is the accounting authority and a later stack PR removes the projection.
+The AI SDK swallows lifecycle callback errors, so the worker retries the idempotent append and hands any persistent infrastructure failure to a durable job in `queues.agents`. Recovery retries with bounded backoff and cannot trigger another provider call. Once an append is deferred, `prepareStep`
+blocks the next model step and the run fails closed while accounting recovery continues independently. If the durable handoff also fails, the same stop prevents silent usage loss. This local path cannot close a process-crash window before lifecycle delivery; provider-side reconciliation is the appropriate later layer for that guarantee.
+
+During the staged rollout, the existing run aggregate remains for display; the model-call ledger is the accounting authority and a later stack PR removes the projection.
 
 ## Live Stream
 

--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -18,8 +18,8 @@ const worker = new AgentWorker(sixb, {
 await worker.start()
 ```
 
-`sixb` must provide `storage.agents`, `storage.auth`, `queues.agents`, `agents`, `broker`, and
-`sandboxes`.
+`sixb` must provide `storage.agents`, `storage.aiUsage`, `storage.auth`, `queues.agents`, `agents`,
+`broker`, and `sandboxes`.
 
 ## Execution Model
 
@@ -34,6 +34,18 @@ await worker.start()
   a projection of the queue lease—not a separate run lease, timer, or heartbeat—and is extended only
   from successful queue renewals.
 - The assistant message append and successful run finish happen in one storage transaction.
+
+## Usage accounting
+
+Every completed conversation provider call is appended to `storage.aiUsage`, including individual
+calls in tool loops and calls completed before later cancellation, tool failure, or execution
+ownership loss. Usage writes are intentionally not fenced: a stale worker cannot finalize the run,
+but a provider call it completed remains billable.
+
+The AI SDK swallows lifecycle callback errors, so the worker retains accounting failures, retries the
+idempotent append, blocks another model step through `prepareStep`, and fails the run rather than
+silently losing usage. During the staged rollout, the existing run aggregate remains for display;
+the model-call ledger is the accounting authority and a later stack PR removes the projection.
 
 ## Live Stream
 

--- a/packages/agent-worker/src/ai-sdk-adapters.ts
+++ b/packages/agent-worker/src/ai-sdk-adapters.ts
@@ -15,7 +15,7 @@ import {
   validateAndNormalizeAgentToolInput,
 } from "@sixb/core/internal/agents"
 import { schemaRecordToJsonSchema } from "@sixb/core/internal/ontology"
-import type { AgentRunUsage } from "@sixb/core/storage"
+import type { AgentRunUsage, AiModelCallUsageInput } from "@sixb/core/storage"
 import { jsonSchema, type LanguageModelUsage, type Tool, type ToolSet, tool } from "ai"
 import { AgentToolExecutionError, AgentToolOutputError, AgentWorkerError } from "./errors"
 
@@ -252,4 +252,27 @@ export function agentRunUsageFromAiSdk(usage: LanguageModelUsage): AgentRunUsage
       : { cachedInputTokens: usage.inputTokenDetails.cacheReadTokens }),
   }
   return Object.keys(mapped).length > 0 ? mapped : undefined
+}
+
+/** Preserve every provider-neutral count from one AI SDK model call without inventing zeroes. */
+export function aiModelCallUsageFromAiSdk(usage: LanguageModelUsage): AiModelCallUsageInput {
+  return {
+    ...(usage.inputTokens === undefined ? {} : { inputTokens: usage.inputTokens }),
+    ...(usage.outputTokens === undefined ? {} : { outputTokens: usage.outputTokens }),
+    ...(usage.inputTokenDetails.noCacheTokens === undefined
+      ? {}
+      : { uncachedInputTokens: usage.inputTokenDetails.noCacheTokens }),
+    ...(usage.inputTokenDetails.cacheReadTokens === undefined
+      ? {}
+      : { cacheReadInputTokens: usage.inputTokenDetails.cacheReadTokens }),
+    ...(usage.inputTokenDetails.cacheWriteTokens === undefined
+      ? {}
+      : { cacheWriteInputTokens: usage.inputTokenDetails.cacheWriteTokens }),
+    ...(usage.outputTokenDetails.textTokens === undefined
+      ? {}
+      : { textOutputTokens: usage.outputTokenDetails.textTokens }),
+    ...(usage.outputTokenDetails.reasoningTokens === undefined
+      ? {}
+      : { reasoningOutputTokens: usage.outputTokenDetails.reasoningTokens }),
+  }
 }

--- a/packages/agent-worker/src/errors.ts
+++ b/packages/agent-worker/src/errors.ts
@@ -2,13 +2,26 @@ import { AgentToolPublicError } from "@sixb/core"
 
 /** Infra-level failure in the agent worker (unknown agent, missing storage, malformed job). */
 export class AgentWorkerError extends Error {
-  readonly name = "AgentWorkerError"
+  readonly name: string = "AgentWorkerError"
   constructor(message: string, options?: ErrorOptions) {
     super(`[SixbAgentWorker] ${message}`, options)
   }
 }
 
-/** This delivery's execution token is stale, so it must make no further durable writes. */
+/** A completed provider call could not be written to the durable accounting ledger. */
+export class AgentUsageRecordingError extends AgentWorkerError {
+  override readonly name = "AgentUsageRecordingError"
+
+  constructor(
+    readonly runId: string,
+    readonly callId: string,
+    options?: ErrorOptions
+  ) {
+    super(`Could not record AI usage for call '${callId}' in agent execution '${runId}'.`, options)
+  }
+}
+
+/** This delivery's execution token is stale, so it must make no further run or message writes. */
 export class AgentExecutionLostError extends Error {
   readonly name = "AgentExecutionLostError"
   constructor(readonly runId: string) {
@@ -17,10 +30,10 @@ export class AgentExecutionLostError extends Error {
 }
 
 /**
- * Recording a run's terminal state failed on a non-terminal (infra) error that persisted across
- * in-place retries. The run is still `running` and its thread is still locked, so the worker must
- * **not** acknowledge the job: it lets the queue redeliver it, so a later delivery can finalize the
- * run once storage recovers. Distinct from {@link AgentExecutionLostError} (run no longer ours → ack).
+ * Recording an agent execution's terminal state failed on a non-terminal infrastructure error that
+ * persisted across in-place retries. The execution is still running, so the worker must **not**
+ * acknowledge the job: it lets the queue redeliver it, so a later delivery can finalize once
+ * storage recovers. Distinct from {@link AgentExecutionLostError} (run no longer ours → ack).
  */
 export class AgentFinalizationError extends Error {
   readonly name = "AgentFinalizationError"
@@ -29,7 +42,7 @@ export class AgentFinalizationError extends Error {
     options?: ErrorOptions
   ) {
     super(
-      `[SixbAgentWorker] Could not finalize agent run '${runId}'; storage is unavailable.`,
+      `[SixbAgentWorker] Could not finalize agent execution '${runId}'; storage is unavailable.`,
       options
     )
   }

--- a/packages/agent-worker/src/errors.ts
+++ b/packages/agent-worker/src/errors.ts
@@ -8,16 +8,22 @@ export class AgentWorkerError extends Error {
   }
 }
 
-/** A completed provider call could not be written to the durable accounting ledger. */
+/** A completed provider call was not recorded synchronously, so this turn must stop. */
 export class AgentUsageRecordingError extends AgentWorkerError {
   override readonly name = "AgentUsageRecordingError"
 
   constructor(
     readonly runId: string,
     readonly callId: string,
+    readonly recoveryScheduled: boolean,
     options?: ErrorOptions
   ) {
-    super(`Could not record AI usage for call '${callId}' in agent execution '${runId}'.`, options)
+    super(
+      recoveryScheduled
+        ? `AI usage for call '${callId}' in agent execution '${runId}' was deferred to durable recovery.`
+        : `Could not preserve AI usage for call '${callId}' in agent execution '${runId}'.`,
+      options
+    )
   }
 }
 

--- a/packages/agent-worker/src/model-call-recorder.ts
+++ b/packages/agent-worker/src/model-call-recorder.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto"
+import { omitUndefinedObjectProperties } from "@sixb/core/internal/agents"
+import type {
+  AiUsageExecutionIdentity,
+  AiUsageStorage,
+  ReadonlyJsonObject,
+  RecordAiModelCallInput,
+} from "@sixb/core/storage"
+import type { LanguageModelCallEndEvent } from "ai"
+import { aiModelCallUsageFromAiSdk } from "./ai-sdk-adapters"
+import { AgentUsageRecordingError } from "./errors"
+
+const STORAGE_RETRY_DELAYS_MS = [50, 200, 600] as const
+
+export interface AiModelCallRecorderInput {
+  readonly storage: AiUsageStorage
+  readonly projectId: string
+  readonly execution: AiUsageExecutionIdentity
+  readonly attempt: number
+  readonly requesterPrincipal: RecordAiModelCallInput["requesterPrincipal"]
+  readonly requesterGroupIds: readonly string[]
+  /** Run identity used only to report recorder and terminal-summary failures. */
+  readonly errorRunId: string
+}
+
+interface AiModelCallRecorderInternals {
+  readonly generateId?: () => string
+  readonly now?: () => Date
+  readonly retryDelaysMs?: readonly number[]
+  readonly sleep?: (ms: number) => Promise<void>
+}
+
+/**
+ * Persist every completed AI SDK provider call before the tool loop can begin another model step.
+ *
+ * AI SDK deliberately swallows lifecycle callback errors. This recorder therefore retains a
+ * terminal append failure and exposes `prepareStep`, which throws it before another provider call.
+ */
+export class AiModelCallRecorder {
+  private readonly generateId: () => string
+  private readonly now: () => Date
+  private readonly retryDelaysMs: readonly number[]
+  private readonly sleep: (ms: number) => Promise<void>
+  private recordingError: AgentUsageRecordingError | undefined
+
+  constructor(
+    private readonly input: AiModelCallRecorderInput,
+    internals: AiModelCallRecorderInternals = {}
+  ) {
+    this.generateId = internals.generateId ?? (() => `ai_usage_${randomUUID()}`)
+    this.now = internals.now ?? (() => new Date())
+    this.retryDelaysMs = internals.retryDelaysMs ?? STORAGE_RETRY_DELAYS_MS
+    this.sleep = internals.sleep ?? sleep
+  }
+
+  readonly onLanguageModelCallEnd = async (event: LanguageModelCallEndEvent): Promise<void> => {
+    if (this.recordingError) return
+
+    try {
+      // AI SDK's JSONObject permits optional object properties with `undefined`; omission is the
+      // canonical JSON representation of those properties. Storage still validates the result.
+      const rawUsage =
+        event.usage.raw === undefined
+          ? undefined
+          : (omitUndefinedObjectProperties(event.usage.raw) as ReadonlyJsonObject)
+      const record: RecordAiModelCallInput = {
+        id: this.generateId(),
+        projectId: this.input.projectId,
+        execution: this.input.execution,
+        attempt: this.input.attempt,
+        callId: event.callId,
+        requesterPrincipal: this.input.requesterPrincipal,
+        requesterGroupIds: this.input.requesterGroupIds,
+        providerId: event.provider,
+        requestedModelId: event.modelId,
+        responseId: event.responseId,
+        usage: aiModelCallUsageFromAiSdk(event.usage),
+        ...(rawUsage === undefined ? {} : { rawUsage }),
+        occurredAt: this.now(),
+      }
+
+      await retryStorageOperation(
+        () => this.input.storage.recordModelCall(record),
+        this.retryDelaysMs,
+        this.sleep
+      )
+    } catch (error) {
+      this.recordingError = new AgentUsageRecordingError(this.input.errorRunId, event.callId, {
+        cause: error,
+      })
+    }
+  }
+
+  /** AI SDK invokes this before every step; a prior append failure prevents the next provider call. */
+  readonly prepareStep = (): undefined => {
+    this.assertHealthy()
+    return undefined
+  }
+
+  assertHealthy(): void {
+    if (this.recordingError) throw this.recordingError
+  }
+}
+
+async function retryStorageOperation<TResult>(
+  operation: () => Promise<TResult>,
+  retryDelaysMs: readonly number[],
+  wait: (ms: number) => Promise<void>
+): Promise<TResult> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation()
+    } catch (error) {
+      const delay = retryDelaysMs[attempt]
+      if (delay === undefined) throw error
+      await wait(delay)
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/agent-worker/src/model-call-recorder.ts
+++ b/packages/agent-worker/src/model-call-recorder.ts
@@ -1,25 +1,23 @@
 import { randomUUID } from "node:crypto"
 import { omitUndefinedObjectProperties } from "@sixb/core/internal/agents"
-import type {
-  AiUsageExecutionIdentity,
-  AiUsageStorage,
-  ReadonlyJsonObject,
-  RecordAiModelCallInput,
-} from "@sixb/core/storage"
+import type { AiUsageStorage, ReadonlyJsonObject, RecordAiModelCallInput } from "@sixb/core/storage"
+import { normalizeAiModelCallRecord } from "@sixb/core/storage"
 import type { LanguageModelCallEndEvent } from "ai"
 import { aiModelCallUsageFromAiSdk } from "./ai-sdk-adapters"
 import { AgentUsageRecordingError } from "./errors"
+import { isPermanentAiUsageRecoveryError } from "./model-call-recovery"
+import type { RecoverAiModelCall } from "./types"
 
 const STORAGE_RETRY_DELAYS_MS = [50, 200, 600] as const
 
 export interface AiModelCallRecorderInput {
   readonly storage: AiUsageStorage
   readonly projectId: string
-  readonly execution: AiUsageExecutionIdentity
+  readonly executionId: string
   readonly attempt: number
-  readonly requesterPrincipal: RecordAiModelCallInput["requesterPrincipal"]
   readonly requesterGroupIds: readonly string[]
-  /** Run identity used only to report recorder and terminal-summary failures. */
+  readonly recoverAiModelCall: RecoverAiModelCall
+  /** Run identity used only in terminal recorder diagnostics. */
   readonly errorRunId: string
 }
 
@@ -33,8 +31,9 @@ interface AiModelCallRecorderInternals {
 /**
  * Persist every completed AI SDK provider call before the tool loop can begin another model step.
  *
- * AI SDK deliberately swallows lifecycle callback errors. This recorder therefore retains a
- * terminal append failure and exposes `prepareStep`, which throws it before another provider call.
+ * AI SDK deliberately swallows lifecycle callback errors. This recorder therefore hands a failed
+ * append to durable recovery and retains the failure for `prepareStep` to surface before another
+ * provider call. Recovery can then continue independently without allowing unaccounted spend.
  */
 export class AiModelCallRecorder {
   private readonly generateId: () => string
@@ -66,10 +65,9 @@ export class AiModelCallRecorder {
       const record: RecordAiModelCallInput = {
         id: this.generateId(),
         projectId: this.input.projectId,
-        execution: this.input.execution,
+        executionId: this.input.executionId,
         attempt: this.input.attempt,
         callId: event.callId,
-        requesterPrincipal: this.input.requesterPrincipal,
         requesterGroupIds: this.input.requesterGroupIds,
         providerId: event.provider,
         requestedModelId: event.modelId,
@@ -78,16 +76,44 @@ export class AiModelCallRecorder {
         ...(rawUsage === undefined ? {} : { rawUsage }),
         occurredAt: this.now(),
       }
+      // Reject malformed SDK/provider data before retrying storage or handing a poison record to
+      // the durable queue. The storage boundary repeats this validation defensively.
+      normalizeAiModelCallRecord(record)
 
-      await retryStorageOperation(
-        () => this.input.storage.recordModelCall(record),
-        this.retryDelaysMs,
-        this.sleep
-      )
+      try {
+        await retryOperation(
+          () => this.input.storage.recordModelCall(record),
+          this.retryDelaysMs,
+          this.sleep,
+          (error) => !isPermanentAiUsageRecoveryError(error)
+        )
+      } catch (storageError) {
+        if (isPermanentAiUsageRecoveryError(storageError)) throw storageError
+
+        try {
+          await retryOperation(
+            () => this.input.recoverAiModelCall(record),
+            this.retryDelaysMs,
+            this.sleep,
+            (error) => !isPermanentAiUsageRecoveryError(error)
+          )
+        } catch (recoveryError) {
+          throw new AggregateError(
+            [storageError, recoveryError],
+            "Direct AI usage recording and durable recovery both failed."
+          )
+        }
+        throw new AgentUsageRecordingError(this.input.errorRunId, event.callId, true, {
+          cause: storageError,
+        })
+      }
     } catch (error) {
-      this.recordingError = new AgentUsageRecordingError(this.input.errorRunId, event.callId, {
-        cause: error,
-      })
+      this.recordingError =
+        error instanceof AgentUsageRecordingError
+          ? error
+          : new AgentUsageRecordingError(this.input.errorRunId, event.callId, false, {
+              cause: error,
+            })
     }
   }
 
@@ -102,15 +128,17 @@ export class AiModelCallRecorder {
   }
 }
 
-async function retryStorageOperation<TResult>(
+async function retryOperation<TResult>(
   operation: () => Promise<TResult>,
   retryDelaysMs: readonly number[],
-  wait: (ms: number) => Promise<void>
+  wait: (ms: number) => Promise<void>,
+  shouldRetry: (error: unknown) => boolean
 ): Promise<TResult> {
   for (let attempt = 0; ; attempt += 1) {
     try {
       return await operation()
     } catch (error) {
+      if (!shouldRetry(error)) throw error
       const delay = retryDelaysMs[attempt]
       if (delay === undefined) throw error
       await wait(delay)

--- a/packages/agent-worker/src/model-call-recovery.ts
+++ b/packages/agent-worker/src/model-call-recovery.ts
@@ -1,0 +1,116 @@
+import type {
+  AgentAiUsageRecordPayload,
+  AgentAiUsageRecordRequestedQueueJob,
+  AgentQueueJob,
+  Queue,
+} from "@sixb/core/queues"
+import type {
+  AiModelCallUsageInput,
+  AiUsageStorage,
+  RecordAiModelCallInput,
+  RecordAiModelCallResult,
+} from "@sixb/core/storage"
+import { AiUsageStorageError, normalizeAiModelCallRecord } from "@sixb/core/storage"
+import { AgentWorkerError } from "./errors"
+
+const AGENT_AI_USAGE_RECOVERY_JOB_PREFIX = "agt_usage_job_"
+
+class InvalidAiUsageRecoveryJobError extends AgentWorkerError {}
+
+/** Stable queue identity: a lost enqueue response can safely retry the same accounting handoff. */
+export function agentAiUsageRecoveryJobId(recordId: string): string {
+  return `${AGENT_AI_USAGE_RECOVERY_JOB_PREFIX}${recordId}`
+}
+
+/** Hand one failed ledger append to the durable agent lane without serializing Date objects. */
+export async function enqueueAiModelCallRecovery(
+  queue: Pick<Queue<AgentQueueJob>, "enqueue">,
+  record: RecordAiModelCallInput
+): Promise<void> {
+  normalizeAiModelCallRecord(record)
+  const jobId = agentAiUsageRecoveryJobId(record.id)
+  const [job] = await queue.enqueue({
+    projectId: record.projectId,
+    jobs: [
+      {
+        id: jobId,
+        type: "agent.ai-usage.record.requested",
+        payload: { record: toQueuePayload(record) },
+      },
+    ],
+  })
+
+  if (job?.id !== jobId || job.type !== "agent.ai-usage.record.requested") {
+    throw new AgentWorkerError(`Agent queue did not confirm AI usage recovery job '${jobId}'.`)
+  }
+}
+
+/** Replay one durable handoff through the idempotent model-call ledger boundary. */
+export async function recordRecoveredAiModelCall(
+  storage: AiUsageStorage,
+  job: AgentAiUsageRecordRequestedQueueJob
+): Promise<RecordAiModelCallResult> {
+  return storage.recordModelCall(fromQueuePayload(job))
+}
+
+/** Validation and referential-integrity failures cannot become valid through queue redelivery. */
+export function isPermanentAiUsageRecoveryError(error: unknown): boolean {
+  return (
+    error instanceof InvalidAiUsageRecoveryJobError ||
+    error instanceof TypeError ||
+    (error instanceof AiUsageStorageError &&
+      (error.code === "duplicate_id" || error.code === "missing_execution"))
+  )
+}
+
+function toQueuePayload(record: RecordAiModelCallInput): AgentAiUsageRecordPayload {
+  return {
+    id: record.id,
+    executionId: record.executionId,
+    attempt: record.attempt,
+    callId: record.callId,
+    requesterGroupIds: [...record.requesterGroupIds],
+    providerId: record.providerId,
+    requestedModelId: record.requestedModelId,
+    ...(record.responseModelId === undefined ? {} : { responseModelId: record.responseModelId }),
+    responseId: record.responseId,
+    usage: toQueueUsage(record.usage),
+    ...(record.rawUsage === undefined ? {} : { rawUsage: structuredClone(record.rawUsage) }),
+    occurredAt: record.occurredAt.toISOString(),
+  }
+}
+
+function toQueueUsage(usage: AiModelCallUsageInput): AgentAiUsageRecordPayload["usage"] {
+  return {
+    ...(usage.inputTokens === undefined ? {} : { inputTokens: usage.inputTokens }),
+    ...(usage.outputTokens === undefined ? {} : { outputTokens: usage.outputTokens }),
+    ...(usage.uncachedInputTokens === undefined
+      ? {}
+      : { uncachedInputTokens: usage.uncachedInputTokens }),
+    ...(usage.cacheReadInputTokens === undefined
+      ? {}
+      : { cacheReadInputTokens: usage.cacheReadInputTokens }),
+    ...(usage.cacheWriteInputTokens === undefined
+      ? {}
+      : { cacheWriteInputTokens: usage.cacheWriteInputTokens }),
+    ...(usage.textOutputTokens === undefined ? {} : { textOutputTokens: usage.textOutputTokens }),
+    ...(usage.reasoningOutputTokens === undefined
+      ? {}
+      : { reasoningOutputTokens: usage.reasoningOutputTokens }),
+  }
+}
+
+function fromQueuePayload(job: AgentAiUsageRecordRequestedQueueJob): RecordAiModelCallInput {
+  const occurredAt = new Date(job.payload.record.occurredAt)
+  if (!Number.isFinite(occurredAt.getTime())) {
+    throw new InvalidAiUsageRecoveryJobError(
+      `AI usage recovery job '${job.id}' has an invalid occurredAt timestamp.`
+    )
+  }
+
+  return {
+    ...job.payload.record,
+    projectId: job.projectId,
+    occurredAt,
+  }
+}

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -1,9 +1,10 @@
-import type {
-  AgentDefinition,
-  AgentInboundUiMessagePart,
-  AgentMessage,
-  AgentMessagePart,
-  Storage,
+import {
+  type AgentDefinition,
+  type AgentInboundUiMessagePart,
+  type AgentMessage,
+  type AgentMessagePart,
+  type Storage,
+  SYSTEM_PRINCIPAL,
 } from "@sixb/core"
 import {
   buildAgentSystemPrompt,
@@ -18,6 +19,7 @@ import { agentRunUsageFromAiSdk, agentToolErrorText } from "./ai-sdk-adapters"
 import { attachmentKey, modelSupportsInlineImages, prepareAgentAttachments } from "./attachments"
 import { AgentTurnTimeoutError, AgentWorkerError } from "./errors"
 import { appendMessageAndFinishRunOrThrow, finishRunOrThrow } from "./finalize"
+import { AiModelCallRecorder } from "./model-call-recorder"
 import {
   type AgentOutputAttachmentResult,
   collectAgentOutputAttachments,
@@ -40,8 +42,9 @@ export interface RunAgentTurnInput {
  * Drive one agent turn to completion and persist it.
  *
  * Loads thread history, streams the model with the configured stop condition, then persists the
- * assistant message and finalizes the run with usage and finish reason. Every durable write is
- * fenced by the delivery's execution token; if queue ownership is lost, the turn writes nothing.
+ * assistant message and finalizes the run with usage and finish reason. Message and run writes are
+ * fenced by the delivery's execution token; completed provider-call usage remains billable and is
+ * recorded even when queue ownership is later lost.
  *
  * On success it returns the finalized (`succeeded`) run record. Model/tool failures and shutdown
  * aborts propagate to the caller (the worker), which records the run's terminal fate.
@@ -55,6 +58,13 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     throw new AgentWorkerError(`Agent run '${runId}' has no execution token.`)
   }
   const agents = storage.agents
+  const durableExecution = await storage.executions.getById({
+    projectId,
+    id: run.executionId,
+  })
+  if (!durableExecution) {
+    throw new AgentWorkerError(`Agent run '${runId}' has no durable execution.`)
+  }
 
   const history = await agents.messages.list({ projectId, threadId: run.threadId, order: "asc" })
   const attachmentContext =
@@ -81,6 +91,15 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
   }) as ModelMessage[]
 
   const maxSteps = agent.loop?.stopWhen?.maxSteps ?? defaultMaxSteps
+  const usageRecorder = new AiModelCallRecorder({
+    storage: storage.aiUsage,
+    projectId,
+    execution: { kind: "agentRun", runId },
+    attempt: run.attempt,
+    requesterPrincipal: durableExecution.requestedBy ?? SYSTEM_PRINCIPAL,
+    requesterGroupIds: run.requesterGroupIds,
+    errorRunId: runId,
+  })
 
   // The model call is aborted by worker shutdown, queue delivery loss, or the turn exceeding its
   // wall-clock budget (a slow-but-alive model must not hold the thread forever).
@@ -117,6 +136,8 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     messages: modelMessages,
     tools,
     stopWhen: stepCountIs(maxSteps),
+    prepareStep: usageRecorder.prepareStep,
+    onLanguageModelCallEnd: usageRecorder.onLanguageModelCallEnd,
     abortSignal,
   })
 
@@ -162,6 +183,9 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     if (signal.reason instanceof QueueDeliveryLeaseLostError) {
       throw signal.reason
     }
+    // AI SDK swallows lifecycle callback errors, so surface a retained ledger append failure before
+    // interpreting the stream as a success or cancellation.
+    usageRecorder.assertHealthy()
     // A sandbox failure and a timeout take precedence over the abort-shaped error they cause.
     if (provisionError !== undefined) {
       throw provisionError
@@ -229,7 +253,6 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
       return interruptedAfterCollection
     }
     const assistantParts = assistantPartsWithOutputAttachments(assistant.parts, outputAttachments)
-
     const usage = agentRunUsageFromAiSdk(await result.usage)
     const assistantMessageId = createAgentMessageId()
 
@@ -347,6 +370,7 @@ async function finalizeCancelledTurn(input: {
       id: run.id,
       executionToken,
       status: "cancelled",
+      ...(modelId === undefined ? {} : { modelId }),
     })
     await context.streamSink.publishRunFinished(finalizedRun)
     return finalizedRun

--- a/packages/agent-worker/src/run-agent-turn.ts
+++ b/packages/agent-worker/src/run-agent-turn.ts
@@ -1,10 +1,9 @@
-import {
-  type AgentDefinition,
-  type AgentInboundUiMessagePart,
-  type AgentMessage,
-  type AgentMessagePart,
-  type Storage,
-  SYSTEM_PRINCIPAL,
+import type {
+  AgentDefinition,
+  AgentInboundUiMessagePart,
+  AgentMessage,
+  AgentMessagePart,
+  Storage,
 } from "@sixb/core"
 import {
   buildAgentSystemPrompt,
@@ -58,13 +57,6 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
     throw new AgentWorkerError(`Agent run '${runId}' has no execution token.`)
   }
   const agents = storage.agents
-  const durableExecution = await storage.executions.getById({
-    projectId,
-    id: run.executionId,
-  })
-  if (!durableExecution) {
-    throw new AgentWorkerError(`Agent run '${runId}' has no durable execution.`)
-  }
 
   const history = await agents.messages.list({ projectId, threadId: run.threadId, order: "asc" })
   const attachmentContext =
@@ -94,10 +86,10 @@ export async function runAgentTurn(input: RunAgentTurnInput): Promise<AgentRunRe
   const usageRecorder = new AiModelCallRecorder({
     storage: storage.aiUsage,
     projectId,
-    execution: { kind: "agentRun", runId },
+    executionId: run.executionId,
     attempt: run.attempt,
-    requesterPrincipal: durableExecution.requestedBy ?? SYSTEM_PRINCIPAL,
     requesterGroupIds: run.requesterGroupIds,
+    recoverAiModelCall: context.recoverAiModelCall,
     errorRunId: runId,
   })
 

--- a/packages/agent-worker/src/run-environment.ts
+++ b/packages/agent-worker/src/run-environment.ts
@@ -190,6 +190,7 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
       sandboxReady: ready,
       sandboxWasUsed: () => sandboxWasUsed,
       streamSink: context.streamSink,
+      recoverAiModelCall: context.recoverAiModelCall,
       defaultMaxSteps: context.defaultMaxSteps,
       turnTimeoutMs: context.turnTimeoutMs,
     },

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -12,7 +12,12 @@ import type {
 } from "@sixb/core"
 import type { AgentExecutionHost } from "@sixb/core/internal/agent-execution"
 import type { LoggingService } from "@sixb/core/internal/logging"
-import type { AgentStorage, AiUsageStorage, AuthStorage } from "@sixb/core/storage"
+import type {
+  AgentStorage,
+  AiUsageStorage,
+  AuthStorage,
+  RecordAiModelCallInput,
+} from "@sixb/core/storage"
 import type { ToolSet } from "ai"
 import type { AgentSkill } from "./agent-skills"
 import type { PreparedAgentAttachmentContext } from "./attachments"
@@ -25,6 +30,8 @@ export type AgentWorkerStorage = Storage & {
   readonly aiUsage: AiUsageStorage
   readonly auth: AuthStorage
 }
+
+export type RecoverAiModelCall = (record: RecordAiModelCallInput) => Promise<void>
 
 /**
  * The host surface the agent worker is constructed with. `SixbHost` satisfies it structurally, so
@@ -56,6 +63,8 @@ export interface AgentWorkerContext {
   readonly valueTypesById: ReadonlyMap<string, ValueType>
   readonly apiBaseUrl: string
   readonly streamSink: StreamSink
+  /** Durable fallback used only when the direct model-call ledger append remains unavailable. */
+  readonly recoverAiModelCall: RecoverAiModelCall
   readonly agentSkills: Promise<readonly AgentSkill[]>
   readonly defaultMaxSteps: number
   readonly turnTimeoutMs: number
@@ -87,6 +96,7 @@ export interface AgentTurnContext {
   readonly sandboxReady?: Promise<BashSandboxHandle>
   readonly sandboxWasUsed?: () => boolean
   readonly streamSink: StreamSink
+  readonly recoverAiModelCall: RecoverAiModelCall
   readonly defaultMaxSteps: number
   readonly turnTimeoutMs: number
 }

--- a/packages/agent-worker/src/types.ts
+++ b/packages/agent-worker/src/types.ts
@@ -12,7 +12,7 @@ import type {
 } from "@sixb/core"
 import type { AgentExecutionHost } from "@sixb/core/internal/agent-execution"
 import type { LoggingService } from "@sixb/core/internal/logging"
-import type { AgentStorage, AuthStorage } from "@sixb/core/storage"
+import type { AgentStorage, AiUsageStorage, AuthStorage } from "@sixb/core/storage"
 import type { ToolSet } from "ai"
 import type { AgentSkill } from "./agent-skills"
 import type { PreparedAgentAttachmentContext } from "./attachments"
@@ -22,6 +22,7 @@ import type { StreamSink } from "./stream-sink"
 // Keep root storage for transactions while making worker-required stores non-optional after setup.
 export type AgentWorkerStorage = Storage & {
   readonly agents: AgentStorage
+  readonly aiUsage: AiUsageStorage
   readonly auth: AuthStorage
 }
 

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -15,7 +15,12 @@ import type { AgentRunExecution, AgentRunRecord } from "@sixb/core/storage"
 import { AgentStorageError } from "@sixb/core/storage"
 import { loadAgentSkills } from "./agent-skills"
 import { normalizeApiBaseUrl } from "./api-url"
-import { AgentExecutionLostError, AgentFinalizationError, AgentWorkerError } from "./errors"
+import {
+  AgentExecutionLostError,
+  AgentFinalizationError,
+  AgentUsageRecordingError,
+  AgentWorkerError,
+} from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { finishRunOrThrow } from "./finalize"
 import { DEFAULT_MAX_STEPS, runAgentTurn } from "./run-agent-turn"
@@ -276,7 +281,9 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
       // record the fate at all it raises `AgentFinalizationError`, which propagates here so the job
       // is redelivered rather than acked with the thread left silently locked. A user cancel is
       // detected off its own signal so it records `cancelled` however the aborted stream surfaced.
-      const aborted = signal.aborted || cancel.signal.aborted || isAbortError(error)
+      const aborted =
+        !(error instanceof AgentUsageRecordingError) &&
+        (signal.aborted || cancel.signal.aborted || isAbortError(error))
       const finalized = await this.recordFate(
         context,
         run.id,
@@ -611,6 +618,9 @@ function assertAgentWorkerStorage(
   }
   if (!storage.auth) {
     throw new AgentWorkerError("Agent workers require storage.auth support.")
+  }
+  if (!storage.aiUsage) {
+    throw new AgentWorkerError("Agent workers require storage.aiUsage support.")
   }
 }
 

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -23,6 +23,11 @@ import {
 } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { finishRunOrThrow } from "./finalize"
+import {
+  enqueueAiModelCallRecovery,
+  isPermanentAiUsageRecoveryError,
+  recordRecoveredAiModelCall,
+} from "./model-call-recovery"
 import { DEFAULT_MAX_STEPS, runAgentTurn } from "./run-agent-turn"
 import {
   type AgentExecutionEnvironment,
@@ -47,6 +52,8 @@ const MAX_AGENT_DISPATCH_BACKOFF_MS = 30_000
 /** Backoff before redelivering a job whose run could not be finalized (storage was unavailable). */
 const FINALIZE_RETRY_BACKOFF_MS = 5_000
 const PRESTART_RETRY_BACKOFF_MS = 5_000
+const AI_USAGE_RECOVERY_INITIAL_BACKOFF_MS = 5_000
+const AI_USAGE_RECOVERY_MAX_BACKOFF_MS = 5 * 60_000
 /** Cap retries for persistent setup or finalization failures so jobs cannot churn forever. */
 const MAX_AGENT_DELIVERY_ATTEMPTS = 10
 
@@ -142,6 +149,10 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
   ): Promise<void> {
     const context = this.requireContext()
     const { job } = claimed
+    if (job.type === "agent.ai-usage.record.requested") {
+      await recordRecoveredAiModelCall(context.storage.aiUsage, job)
+      return
+    }
     if (job.type === "agent.workflow-node.requested") {
       await executeWorkflowAgentNode({
         context,
@@ -313,6 +324,14 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
     claimed: ClaimedQueueJob<AgentQueueJob>,
     error: unknown
   ): Promise<QueueWorkerFailureDecision> {
+    if (claimed.job.type === "agent.ai-usage.record.requested") {
+      return isPermanentAiUsageRecoveryError(error)
+        ? { kind: "fail" }
+        : {
+            kind: "retry",
+            availableAt: backoff(aiUsageRecoveryBackoffMs(claimed.job.attempt)),
+          }
+    }
     // We could not finalize the run (storage unavailable). Redeliver so a later delivery records the
     // fate — but cap the redeliveries so a persistent failure dead-letters instead of churning.
     if (error instanceof AgentFinalizationError) {
@@ -357,6 +376,12 @@ export class AgentWorker extends QueueWorker<AgentQueueJob> {
     claimed: ClaimedQueueJob<AgentQueueJob>,
     error: unknown
   ): QueueWorkerFailureDecision {
+    if (claimed.job.type === "agent.ai-usage.record.requested") {
+      return {
+        kind: "retry",
+        availableAt: backoff(aiUsageRecoveryBackoffMs(claimed.job.attempt)),
+      }
+    }
     if (claimed.job.type === "agent.workflow-node.requested") {
       return { kind: "retry", availableAt: backoff(FINALIZE_RETRY_BACKOFF_MS) }
     }
@@ -604,6 +629,7 @@ function buildAgentContext(host: AgentWorkerHost, options: AgentWorkerOptions): 
     streamSink: isolateStreamSink(
       options.streamSink ?? createBrokerStreamSink({ broker: host.broker, projectId: host.id })
     ),
+    recoverAiModelCall: (record) => enqueueAiModelCallRecovery(host.queues.agents, record),
     agentSkills,
     defaultMaxSteps: options.defaultMaxSteps ?? DEFAULT_MAX_STEPS,
     turnTimeoutMs: options.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS,
@@ -642,6 +668,14 @@ function isExecutionGone(error: unknown): boolean {
 
 function backoff(ms: number): string {
   return new Date(Date.now() + ms).toISOString()
+}
+
+function aiUsageRecoveryBackoffMs(attempt: number): number {
+  const exponent = Math.max(0, Math.min(attempt - 1, 10))
+  return Math.min(
+    AI_USAGE_RECOVERY_INITIAL_BACKOFF_MS * 2 ** exponent,
+    AI_USAGE_RECOVERY_MAX_BACKOFF_MS
+  )
 }
 
 function toErrorMessage(error: unknown): string {

--- a/packages/agent-worker/tests/ai-sdk-adapters.test.ts
+++ b/packages/agent-worker/tests/ai-sdk-adapters.test.ts
@@ -14,6 +14,7 @@ import {
   agentRunUsageFromAiSdk,
   agentToolErrorText,
   agentTraceFromAiSdkSteps,
+  aiModelCallUsageFromAiSdk,
   aiSdkToolsFromAgentDefinitions,
 } from "../src/ai-sdk-adapters"
 
@@ -429,6 +430,35 @@ describe("AI SDK agent adapters", () => {
     })
 
     expect(agentRunUsageFromAiSdk(usage({}))).toBeUndefined()
+  })
+
+  test("preserves every provider-neutral model-call usage field", () => {
+    expect(
+      aiModelCallUsageFromAiSdk({
+        inputTokens: 12,
+        inputTokenDetails: {
+          noCacheTokens: 9,
+          cacheReadTokens: 3,
+          cacheWriteTokens: 1,
+        },
+        outputTokens: 8,
+        outputTokenDetails: {
+          textTokens: 6,
+          reasoningTokens: 2,
+        },
+        totalTokens: 20,
+        raw: { provider_meter: 4 },
+      })
+    ).toEqual({
+      inputTokens: 12,
+      outputTokens: 8,
+      uncachedInputTokens: 9,
+      cacheReadInputTokens: 3,
+      cacheWriteInputTokens: 1,
+      textOutputTokens: 6,
+      reasoningOutputTokens: 2,
+    })
+    expect(aiModelCallUsageFromAiSdk(usage({}))).toEqual({})
   })
 })
 

--- a/packages/agent-worker/tests/ai-sdk-compat.types.ts
+++ b/packages/agent-worker/tests/ai-sdk-compat.types.ts
@@ -6,9 +6,13 @@
 import type { LanguageModelV4 } from "@ai-sdk/provider"
 import type { AgentInboundUiMessage, AgentMessage } from "@sixb/core"
 import { toModelMessages } from "@sixb/core/internal/agents"
-import type { AgentRunUsage } from "@sixb/core/storage"
+import type { AgentRunUsage, AiModelCallUsageInput } from "@sixb/core/storage"
 import type { LanguageModelUsage, ModelMessage, StepResult, streamText, UIMessage } from "ai"
-import { agentRunUsageFromAiSdk, agentTraceFromAiSdkSteps } from "../src/ai-sdk-adapters"
+import {
+  agentRunUsageFromAiSdk,
+  agentTraceFromAiSdkSteps,
+  aiModelCallUsageFromAiSdk,
+} from "../src/ai-sdk-adapters"
 
 // A real `UIMessage` must assign to `fromAiSdk`'s inbound shape *without a cast* — this is the
 // safety net at the SDK boundary and the reason the worker can pass `responseMessage` straight in.
@@ -29,6 +33,21 @@ const _streamTextOptions: Parameters<typeof streamText>[0] = {
   prompt: "hello",
   reasoning: "medium",
   providerOptions: { openai: { reasoningSummary: "detailed" } },
+  prepareStep: () => undefined,
+  onLanguageModelCallEnd(event) {
+    const callId: string = event.callId
+    const providerId: string = event.provider
+    const requestedModelId: string = event.modelId
+    const responseId: string = event.responseId
+    const usage: AiModelCallUsageInput = aiModelCallUsageFromAiSdk(event.usage)
+    const rawUsage = event.usage.raw
+    void callId
+    void providerId
+    void requestedModelId
+    void responseId
+    void usage
+    void rawUsage
+  },
 }
 
 // A real final StepResult and LanguageModelUsage must cross the worker adapter without a cast.

--- a/packages/agent-worker/tests/model-call-recorder.test.ts
+++ b/packages/agent-worker/tests/model-call-recorder.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  AiUsageExecutionSummary,
+  AiUsageStorage,
+  RecordAiModelCallInput,
+} from "@sixb/core/storage"
+import { InMemoryAiUsageStorage, normalizeAiModelCallRecord } from "@sixb/core/storage"
+import type { LanguageModelCallEndEvent } from "ai"
+import { AgentUsageRecordingError } from "../src/errors"
+import { AiModelCallRecorder } from "../src/model-call-recorder"
+
+const occurredAt = new Date("2026-07-01T12:00:00.000Z")
+const emptySummary: AiUsageExecutionSummary = {
+  modelCallCount: 0,
+  usage: { reportingStatus: "unavailable" },
+}
+
+function callEndEvent(): LanguageModelCallEndEvent {
+  return {
+    callId: "call_1",
+    provider: "gateway",
+    modelId: "openai/gpt-5",
+    finishReason: "stop",
+    usage: {
+      inputTokens: 12,
+      inputTokenDetails: {
+        noCacheTokens: 9,
+        cacheReadTokens: 3,
+        cacheWriteTokens: 1,
+      },
+      outputTokens: 8,
+      outputTokenDetails: {
+        textTokens: 6,
+        reasoningTokens: 2,
+      },
+      totalTokens: 20,
+      raw: {
+        input_tokens: 12,
+        output_tokens: 8,
+        provider_meter: 4,
+        omitted_optional_meter: undefined,
+      },
+    },
+    content: [],
+    responseId: "response_1",
+    performance: {
+      responseTimeMs: 100,
+      effectiveOutputTokensPerSecond: 80,
+      outputTokensPerSecond: 75,
+      inputTokensPerSecond: 120,
+      effectiveTotalTokensPerSecond: 200,
+      timeToFirstOutputMs: 20,
+    },
+  }
+}
+
+function recorder(
+  storage: AiUsageStorage,
+  internals: ConstructorParameters<typeof AiModelCallRecorder>[1] = {}
+): AiModelCallRecorder {
+  return new AiModelCallRecorder(
+    {
+      storage,
+      projectId: "project_1",
+      execution: { kind: "agentRun", runId: "run_1" },
+      attempt: 2,
+      requesterPrincipal: { type: "user", id: "usr_1" },
+      requesterGroupIds: ["support", "engineering"],
+      errorRunId: "run_1",
+    },
+    internals
+  )
+}
+
+describe("AiModelCallRecorder", () => {
+  test("retries and records one complete provider call with stable identity", async () => {
+    const inputs: RecordAiModelCallInput[] = []
+    const delays: number[] = []
+    let attempts = 0
+    const storage: AiUsageStorage = {
+      async recordModelCall(input) {
+        attempts += 1
+        inputs.push(structuredClone(input))
+        if (attempts < 3) throw new Error("temporary storage failure")
+        return { record: normalizeAiModelCallRecord(input), created: true }
+      },
+      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
+        return emptySummary
+      },
+      async summarizeExecutions() {
+        return []
+      },
+    }
+    const usage = recorder(storage, {
+      generateId: () => "usage_1",
+      now: () => occurredAt,
+      retryDelaysMs: [10, 20],
+      sleep: async (ms) => {
+        delays.push(ms)
+      },
+    })
+
+    await usage.onLanguageModelCallEnd(callEndEvent())
+    expect(attempts).toBe(3)
+    expect(delays).toEqual([10, 20])
+    expect(inputs).toHaveLength(3)
+    expect(inputs[0]).toEqual({
+      id: "usage_1",
+      projectId: "project_1",
+      execution: { kind: "agentRun", runId: "run_1" },
+      attempt: 2,
+      callId: "call_1",
+      requesterPrincipal: { type: "user", id: "usr_1" },
+      requesterGroupIds: ["support", "engineering"],
+      providerId: "gateway",
+      requestedModelId: "openai/gpt-5",
+      responseId: "response_1",
+      usage: {
+        inputTokens: 12,
+        outputTokens: 8,
+        uncachedInputTokens: 9,
+        cacheReadInputTokens: 3,
+        cacheWriteInputTokens: 1,
+        textOutputTokens: 6,
+        reasoningOutputTokens: 2,
+      },
+      rawUsage: { input_tokens: 12, output_tokens: 8, provider_meter: 4 },
+      occurredAt,
+    })
+    expect(inputs[1]).toEqual(inputs[0])
+    expect(inputs[2]).toEqual(inputs[0])
+    expect(usage.prepareStep()).toBeUndefined()
+  })
+
+  test("deduplicates a repeated lifecycle callback without double-counting usage", async () => {
+    // The recorder deliberately generates a fresh row ID for each callback. Removing the storage
+    // idempotency lookup makes this exact callback replay produce two records and double the total.
+    const storage = new InMemoryAiUsageStorage()
+    let nextId = 0
+    const usage = recorder(storage, {
+      generateId: () => `usage_${++nextId}`,
+      now: () => occurredAt,
+    })
+
+    const event = callEndEvent()
+    await usage.onLanguageModelCallEnd(event)
+    await usage.onLanguageModelCallEnd(event)
+
+    expect(nextId).toBe(2)
+    expect(storage.snapshot().records.size).toBe(1)
+    await expect(
+      storage.summarizeExecution({
+        projectId: "project_1",
+        execution: { kind: "agentRun", runId: "run_1" },
+      })
+    ).resolves.toMatchObject({
+      modelCallCount: 1,
+      usage: { inputTokens: 12, outputTokens: 8, totalTokens: 20 },
+    })
+  })
+
+  test("preserves entirely missing callback usage without inventing zeroes", async () => {
+    // Default any omitted SDK count to zero in the adapter and both assertions below fail.
+    const storage = new InMemoryAiUsageStorage()
+    const usage = recorder(storage, {
+      generateId: () => "usage_missing",
+      now: () => occurredAt,
+    })
+    const event: LanguageModelCallEndEvent = {
+      ...callEndEvent(),
+      usage: {
+        inputTokens: undefined,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokens: undefined,
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+        totalTokens: undefined,
+        raw: undefined,
+      },
+    }
+
+    await usage.onLanguageModelCallEnd(event)
+
+    const [record] = storage.snapshot().records.values()
+    expect(record?.usage).toEqual({ reportingStatus: "unavailable" })
+    expect(record?.rawUsage).toBeUndefined()
+    await expect(
+      storage.summarizeExecution({
+        projectId: "project_1",
+        execution: { kind: "agentRun", runId: "run_1" },
+      })
+    ).resolves.toEqual({
+      modelCallCount: 1,
+      usage: { reportingStatus: "unavailable" },
+    })
+  })
+
+  test("retains a swallowed callback failure and blocks the next model step", async () => {
+    let attempts = 0
+    const storage: AiUsageStorage = {
+      async recordModelCall() {
+        attempts += 1
+        throw new Error("storage unavailable")
+      },
+      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
+        return emptySummary
+      },
+      async summarizeExecutions() {
+        return []
+      },
+    }
+    const usage = recorder(storage, {
+      retryDelaysMs: [10, 20],
+      sleep: async () => undefined,
+    })
+
+    await expect(usage.onLanguageModelCallEnd(callEndEvent())).resolves.toBeUndefined()
+    expect(attempts).toBe(3)
+    expect(() => usage.prepareStep()).toThrow(AgentUsageRecordingError)
+  })
+
+  test("retains failures raised while constructing the callback record", async () => {
+    let records = 0
+    const storage: AiUsageStorage = {
+      async recordModelCall(input) {
+        records += 1
+        return { record: normalizeAiModelCallRecord(input), created: true }
+      },
+      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
+        return emptySummary
+      },
+      async summarizeExecutions() {
+        return []
+      },
+    }
+    const usage = recorder(storage, {
+      generateId: () => {
+        throw new Error("ID generation unavailable")
+      },
+    })
+
+    await expect(usage.onLanguageModelCallEnd(callEndEvent())).resolves.toBeUndefined()
+    expect(records).toBe(0)
+    expect(() => usage.prepareStep()).toThrow(AgentUsageRecordingError)
+  })
+})

--- a/packages/agent-worker/tests/model-call-recorder.test.ts
+++ b/packages/agent-worker/tests/model-call-recorder.test.ts
@@ -4,12 +4,19 @@ import type {
   AiUsageStorage,
   RecordAiModelCallInput,
 } from "@sixb/core/storage"
-import { InMemoryAiUsageStorage, normalizeAiModelCallRecord } from "@sixb/core/storage"
+import {
+  AiUsageStorageError,
+  InMemoryAiUsageStorage,
+  InMemoryStorage,
+  normalizeAiModelCallRecord,
+} from "@sixb/core/storage"
+import { createTestAgentExecution } from "@sixb/core/testing"
 import type { LanguageModelCallEndEvent } from "ai"
 import { AgentUsageRecordingError } from "../src/errors"
 import { AiModelCallRecorder } from "../src/model-call-recorder"
 
 const occurredAt = new Date("2026-07-01T12:00:00.000Z")
+const executionId = "test_agent_execution:run_1"
 const emptySummary: AiUsageExecutionSummary = {
   modelCallCount: 0,
   usage: { reportingStatus: "unavailable" },
@@ -56,20 +63,34 @@ function callEndEvent(): LanguageModelCallEndEvent {
 
 function recorder(
   storage: AiUsageStorage,
-  internals: ConstructorParameters<typeof AiModelCallRecorder>[1] = {}
+  internals: ConstructorParameters<typeof AiModelCallRecorder>[1] = {},
+  recoverAiModelCall: (record: RecordAiModelCallInput) => Promise<void> = async () => {
+    throw new Error("Unexpected AI usage recovery handoff.")
+  }
 ): AiModelCallRecorder {
   return new AiModelCallRecorder(
     {
       storage,
       projectId: "project_1",
-      execution: { kind: "agentRun", runId: "run_1" },
+      executionId,
       attempt: 2,
-      requesterPrincipal: { type: "user", id: "usr_1" },
       requesterGroupIds: ["support", "engineering"],
+      recoverAiModelCall,
       errorRunId: "run_1",
     },
     internals
   )
+}
+
+async function createInMemoryUsageStorage(): Promise<InMemoryAiUsageStorage> {
+  const bundle = new InMemoryStorage()
+  await createTestAgentExecution(bundle, {
+    projectId: "project_1",
+    agentId: "assistant",
+    runId: "run_1",
+    executionId,
+  })
+  return new InMemoryAiUsageStorage(bundle.executions)
 }
 
 describe("AiModelCallRecorder", () => {
@@ -107,10 +128,9 @@ describe("AiModelCallRecorder", () => {
     expect(inputs[0]).toEqual({
       id: "usage_1",
       projectId: "project_1",
-      execution: { kind: "agentRun", runId: "run_1" },
+      executionId,
       attempt: 2,
       callId: "call_1",
-      requesterPrincipal: { type: "user", id: "usr_1" },
       requesterGroupIds: ["support", "engineering"],
       providerId: "gateway",
       requestedModelId: "openai/gpt-5",
@@ -135,7 +155,7 @@ describe("AiModelCallRecorder", () => {
   test("deduplicates a repeated lifecycle callback without double-counting usage", async () => {
     // The recorder deliberately generates a fresh row ID for each callback. Removing the storage
     // idempotency lookup makes this exact callback replay produce two records and double the total.
-    const storage = new InMemoryAiUsageStorage()
+    const storage = await createInMemoryUsageStorage()
     let nextId = 0
     const usage = recorder(storage, {
       generateId: () => `usage_${++nextId}`,
@@ -151,7 +171,7 @@ describe("AiModelCallRecorder", () => {
     await expect(
       storage.summarizeExecution({
         projectId: "project_1",
-        execution: { kind: "agentRun", runId: "run_1" },
+        executionId,
       })
     ).resolves.toMatchObject({
       modelCallCount: 1,
@@ -161,7 +181,7 @@ describe("AiModelCallRecorder", () => {
 
   test("preserves entirely missing callback usage without inventing zeroes", async () => {
     // Default any omitted SDK count to zero in the adapter and both assertions below fail.
-    const storage = new InMemoryAiUsageStorage()
+    const storage = await createInMemoryUsageStorage()
     const usage = recorder(storage, {
       generateId: () => "usage_missing",
       now: () => occurredAt,
@@ -193,7 +213,7 @@ describe("AiModelCallRecorder", () => {
     await expect(
       storage.summarizeExecution({
         projectId: "project_1",
-        execution: { kind: "agentRun", runId: "run_1" },
+        executionId,
       })
     ).resolves.toEqual({
       modelCallCount: 1,
@@ -201,8 +221,9 @@ describe("AiModelCallRecorder", () => {
     })
   })
 
-  test("retains a swallowed callback failure and blocks the next model step", async () => {
+  test("hands a persistent storage failure to durable recovery and blocks the next step", async () => {
     let attempts = 0
+    const recovered: RecordAiModelCallInput[] = []
     const storage: AiUsageStorage = {
       async recordModelCall() {
         attempts += 1
@@ -215,14 +236,105 @@ describe("AiModelCallRecorder", () => {
         return []
       },
     }
-    const usage = recorder(storage, {
-      retryDelaysMs: [10, 20],
-      sleep: async () => undefined,
-    })
+    const usage = recorder(
+      storage,
+      {
+        retryDelaysMs: [10, 20],
+        sleep: async () => undefined,
+      },
+      async (record) => {
+        recovered.push(structuredClone(record))
+      }
+    )
 
     await expect(usage.onLanguageModelCallEnd(callEndEvent())).resolves.toBeUndefined()
     expect(attempts).toBe(3)
-    expect(() => usage.prepareStep()).toThrow(AgentUsageRecordingError)
+    expect(recovered).toHaveLength(1)
+    expect(recovered[0]).toMatchObject({ executionId, callId: "call_1" })
+    let failure: unknown
+    try {
+      usage.prepareStep()
+    } catch (error) {
+      failure = error
+    }
+    expect(failure).toBeInstanceOf(AgentUsageRecordingError)
+    expect(failure).toMatchObject({ recoveryScheduled: true })
+  })
+
+  test("blocks the next model step when storage and durable recovery both fail", async () => {
+    let storageAttempts = 0
+    let recoveryAttempts = 0
+    const storage: AiUsageStorage = {
+      async recordModelCall() {
+        storageAttempts += 1
+        throw new Error("storage unavailable")
+      },
+      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
+        return emptySummary
+      },
+      async summarizeExecutions() {
+        return []
+      },
+    }
+    const usage = recorder(
+      storage,
+      {
+        retryDelaysMs: [10, 20],
+        sleep: async () => undefined,
+      },
+      async () => {
+        recoveryAttempts += 1
+        throw new Error("queue unavailable")
+      }
+    )
+
+    await expect(usage.onLanguageModelCallEnd(callEndEvent())).resolves.toBeUndefined()
+    expect(storageAttempts).toBe(3)
+    expect(recoveryAttempts).toBe(3)
+    let failure: unknown
+    try {
+      usage.prepareStep()
+    } catch (error) {
+      failure = error
+    }
+    expect(failure).toBeInstanceOf(AgentUsageRecordingError)
+    expect(failure).toMatchObject({ recoveryScheduled: false })
+  })
+
+  test("does not retry or enqueue a permanently invalid ledger append", async () => {
+    let storageAttempts = 0
+    let recoveryAttempts = 0
+    const storage: AiUsageStorage = {
+      async recordModelCall() {
+        storageAttempts += 1
+        throw new AiUsageStorageError("missing_execution", "missing execution")
+      },
+      async summarizeExecution(): Promise<AiUsageExecutionSummary> {
+        return emptySummary
+      },
+      async summarizeExecutions() {
+        return []
+      },
+    }
+    const usage = recorder(
+      storage,
+      { retryDelaysMs: [10, 20], sleep: async () => undefined },
+      async () => {
+        recoveryAttempts += 1
+      }
+    )
+
+    await usage.onLanguageModelCallEnd(callEndEvent())
+    expect(storageAttempts).toBe(1)
+    expect(recoveryAttempts).toBe(0)
+    let failure: unknown
+    try {
+      usage.prepareStep()
+    } catch (error) {
+      failure = error
+    }
+    expect(failure).toBeInstanceOf(AgentUsageRecordingError)
+    expect(failure).toMatchObject({ recoveryScheduled: false })
   })
 
   test("retains failures raised while constructing the callback record", async () => {

--- a/packages/agent-worker/tests/model-call-recovery.test.ts
+++ b/packages/agent-worker/tests/model-call-recovery.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test"
+import { InMemoryQueues, InMemoryStorage, type ReadonlyJsonValue } from "@sixb/core"
+import type { AgentAiUsageRecordRequestedQueueJob } from "@sixb/core/queues"
+import { AiUsageStorageError, type RecordAiModelCallInput } from "@sixb/core/storage"
+import { createTestAgentExecution } from "@sixb/core/testing"
+import { AgentWorkerError } from "../src/errors"
+import {
+  agentAiUsageRecoveryJobId,
+  enqueueAiModelCallRecovery,
+  isPermanentAiUsageRecoveryError,
+  recordRecoveredAiModelCall,
+} from "../src/model-call-recovery"
+
+const projectId = "project_1"
+const executionId = "test_agent_execution:run_1"
+
+function modelCall(): RecordAiModelCallInput {
+  return {
+    id: "usage_1",
+    projectId,
+    executionId,
+    attempt: 2,
+    callId: "call_1",
+    requesterGroupIds: ["support", "engineering"],
+    providerId: "gateway",
+    requestedModelId: "openai/gpt-5",
+    responseId: "response_1",
+    usage: { inputTokens: 12, outputTokens: 8, cacheReadInputTokens: undefined },
+    rawUsage: { input_tokens: 12, output_tokens: 8 },
+    occurredAt: new Date("2026-07-01T12:00:00.000Z"),
+    recordedAt: new Date("2026-07-01T12:00:01.000Z"),
+  }
+}
+
+describe("AI usage recovery", () => {
+  test("serializes one stable job and replays it idempotently", async () => {
+    const queues = new InMemoryQueues()
+    const storage = new InMemoryStorage()
+    await createTestAgentExecution(storage, {
+      projectId,
+      agentId: "assistant",
+      runId: "run_1",
+      executionId,
+    })
+
+    const record = modelCall()
+    await enqueueAiModelCallRecovery(queues.agents, record)
+    await enqueueAiModelCallRecovery(queues.agents, record)
+
+    const [claimed] = await queues.agents.claim({
+      projectId,
+      workerId: "test-worker",
+      limit: 2,
+    })
+    expect(claimed?.job.id).toBe(agentAiUsageRecoveryJobId(record.id))
+    expect(claimed?.job.type).toBe("agent.ai-usage.record.requested")
+    if (claimed?.job.type !== "agent.ai-usage.record.requested") {
+      throw new Error("Expected an AI usage recovery job.")
+    }
+    const jsonRecord: ReadonlyJsonValue = claimed.job.payload.record
+    expect(jsonRecord).toBeDefined()
+    expect(claimed.job.payload.record).toMatchObject({
+      id: "usage_1",
+      executionId,
+      occurredAt: "2026-07-01T12:00:00.000Z",
+    })
+    expect(claimed.job.payload.record).not.toHaveProperty("projectId")
+    expect(claimed.job.payload.record).not.toHaveProperty("recordedAt")
+    expect(claimed.job.payload.record.usage).not.toHaveProperty("cacheReadInputTokens")
+
+    await expect(recordRecoveredAiModelCall(storage.aiUsage, claimed.job)).resolves.toMatchObject({
+      created: true,
+    })
+    await expect(recordRecoveredAiModelCall(storage.aiUsage, claimed.job)).resolves.toMatchObject({
+      created: false,
+    })
+    await expect(
+      storage.aiUsage.summarizeExecution({ projectId, executionId })
+    ).resolves.toMatchObject({
+      modelCallCount: 1,
+      usage: { inputTokens: 12, outputTokens: 8, totalTokens: 20 },
+    })
+  })
+
+  test("rejects malformed jobs instead of retrying them forever", async () => {
+    const record = modelCall()
+    const job: AgentAiUsageRecordRequestedQueueJob = {
+      id: agentAiUsageRecoveryJobId(record.id),
+      projectId,
+      createdAt: "2026-07-01T12:00:00.000Z",
+      availableAt: "2026-07-01T12:00:00.000Z",
+      attempt: 1,
+      type: "agent.ai-usage.record.requested",
+      payload: {
+        record: {
+          ...record,
+          occurredAt: "not-a-date",
+        },
+      },
+    }
+
+    const storage = new InMemoryStorage()
+    await expect(recordRecoveredAiModelCall(storage.aiUsage, job)).rejects.toBeInstanceOf(
+      AgentWorkerError
+    )
+    expect(isPermanentAiUsageRecoveryError(new TypeError("invalid"))).toBe(true)
+    expect(
+      isPermanentAiUsageRecoveryError(
+        new AiUsageStorageError("missing_execution", "missing execution")
+      )
+    ).toBe(true)
+    expect(isPermanentAiUsageRecoveryError(new AgentWorkerError("queue response mismatch"))).toBe(
+      false
+    )
+    expect(isPermanentAiUsageRecoveryError(new Error("storage unavailable"))).toBe(false)
+  })
+})

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -53,6 +53,7 @@ import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import {
   type AgentStorage,
   AgentStorageError,
+  type AiUsageStorage,
   type AppendAgentMessageInput,
 } from "@sixb/core/storage"
 import {
@@ -88,6 +89,7 @@ const AGENT_RUNTIME_GROUP = defineGroup("agent-runtime", { label: "Agent runtime
 const USAGE: LanguageModelV4Usage = {
   inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
   outputTokens: { total: 7, text: 7, reasoning: 0 },
+  raw: { input_tokens: 10, output_tokens: 7, provider_meter: 1 },
 }
 
 function stream(chunks: LanguageModelV4StreamPart[]) {
@@ -851,12 +853,23 @@ function withStorage(sixb: TestSixb, storage: Storage): TestSixb {
   })
 }
 
+function aiUsageStorageOf(sixb: TestSixb): AiUsageStorage {
+  const storage = sixb.storage.aiUsage
+  if (!storage) {
+    throw new Error("expected AI usage storage")
+  }
+  return storage
+}
+
 function workerStorageOf(storage: Storage): AgentWorkerStorage {
   if (!storage.agents) {
     throw new Error("expected agent storage")
   }
   if (!storage.auth) {
     throw new Error("expected auth storage")
+  }
+  if (!storage.aiUsage) {
+    throw new Error("expected AI usage storage")
   }
   return storage as AgentWorkerStorage
 }
@@ -2386,6 +2399,8 @@ describe("AgentWorker", () => {
       expect(run.attempt).toBe(1)
       expect(run.finishReason).toBe("stop")
       expect(run.modelId).toBe("mock-model")
+      // The legacy run aggregate remains during the staged rollout, while accounting authority is
+      // already the per-call ledger. The two tool-loop provider calls must both be present there.
       expect(run.usage?.outputTokens).toBeGreaterThan(0)
       expect(run.usage?.inputTokens).toBeGreaterThan(0)
       const durableExecution = await sixb.storage.executions.getById({
@@ -2395,6 +2410,25 @@ describe("AgentWorker", () => {
       expect(durableExecution?.authorizationRef).toEqual({
         type: "principal",
         principal: { type: "serviceAccount", id: "svc_agent_assistant" },
+      })
+      await expect(
+        aiUsageStorageOf(sixb).summarizeExecution({
+          projectId: PROJECT_ID,
+          execution: { kind: "agentRun", runId },
+        })
+      ).resolves.toEqual({
+        modelCallCount: 2,
+        usage: {
+          inputTokens: 20,
+          outputTokens: 14,
+          totalTokens: 34,
+          uncachedInputTokens: 20,
+          cacheReadInputTokens: 0,
+          cacheWriteInputTokens: 0,
+          textOutputTokens: 14,
+          reasoningOutputTokens: 0,
+          reportingStatus: "complete",
+        },
       })
 
       // Thread released after finalization (single-flight pointer cleared).
@@ -2473,6 +2507,66 @@ describe("AgentWorker", () => {
         runId,
         attempt: 1,
       })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("fails the run and blocks another provider call when usage recording stays unavailable", async () => {
+    let modelCalls = 0
+    const model = new MockLanguageModelV4({
+      modelId: "mock-model",
+      doStream: async () => {
+        modelCalls += 1
+        if (modelCalls === 1) {
+          return stream([
+            { type: "stream-start", warnings: [] },
+            {
+              type: "tool-call",
+              toolCallId: "c1",
+              toolName: "echo",
+              input: JSON.stringify({ value: "hi" }),
+            },
+            finish("tool-calls"),
+          ])
+        }
+        return stream([
+          { type: "stream-start", warnings: [] },
+          { type: "text-start", id: "answer" },
+          { type: "text-delta", id: "answer", delta: "should not run" },
+          { type: "text-end", id: "answer" },
+          finish("stop"),
+        ])
+      },
+    })
+    const sixb = buildSixbWithEchoTool(model)
+    const storage = agentStorageOf(sixb)
+    const aiUsage = aiUsageStorageOf(sixb)
+    let appendAttempts = 0
+    aiUsage.recordModelCall = async () => {
+      appendAttempts += 1
+      throw new Error("usage storage unavailable")
+    }
+
+    const worker = new AgentWorker(sixb, workerOptions())
+    await worker.start()
+    try {
+      const request = await requestAgent(sixb, { agentId: "assistant", text: "echo hi" })
+      const run = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({
+            projectId: PROJECT_ID,
+            id: request.run.id,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "usage recording failure" }
+      )
+
+      expect(run.status).toBe("failed")
+      expect(run.error).toContain("Could not record AI usage")
+      expect(modelCalls).toBe(1)
+      expect(appendAttempts).toBe(4)
     } finally {
       await worker.stop()
     }
@@ -2803,6 +2897,15 @@ describe("AgentWorker", () => {
         { label: "cancel during output collection" }
       )
       expect(run.status).toBe("cancelled")
+      await expect(
+        aiUsageStorageOf(sixb).summarizeExecution({
+          projectId: PROJECT_ID,
+          execution: { kind: "agentRun", runId: run.id },
+        })
+      ).resolves.toMatchObject({
+        modelCallCount: 2,
+        usage: { inputTokens: 20, outputTokens: 14, totalTokens: 34 },
+      })
       const messages = await listMessages(storage, request.run.threadId)
       const persistedAssistant = messages.find((message) => message.role === "assistant")
       expect(persistedAssistant?.parts.some((part) => part.type === "file")).toBe(false)
@@ -3593,6 +3696,15 @@ describe("AgentWorker", () => {
       projectId: PROJECT_ID,
       execution: freshTestExecution(),
     })
+    // Regression guard: hard-code the recorder attempt to 1 instead of using the reclaimed durable
+    // run and this captures [1, 1], even though the terminal run correctly reports attempt 2.
+    const recordedAttempts: number[] = []
+    const aiUsage = aiUsageStorageOf(sixb)
+    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
+    aiUsage.recordModelCall = async (input) => {
+      recordedAttempts.push(input.attempt)
+      return recordModelCall(input)
+    }
 
     const worker = new AgentWorker(sixb, workerOptions())
     await worker.start()
@@ -3606,6 +3718,7 @@ describe("AgentWorker", () => {
       )
       expect(reclaimed.status).toBe("succeeded")
       expect(reclaimed.attempt).toBe(2)
+      expect(recordedAttempts).toEqual([2, 2])
 
       const streamRecords = await listRunStreamRecords(sixb.broker, crashedRunId)
       expect(
@@ -3628,7 +3741,7 @@ describe("AgentWorker", () => {
     }
   })
 
-  test("a worker whose execution token was rotated writes nothing (fencing)", async () => {
+  test("a stale worker records billable calls but cannot write the fenced run or message", async () => {
     const sixb = buildSixb(toolThenAnswerModel())
     const storage = agentStorageOf(sixb)
 
@@ -3668,11 +3781,21 @@ describe("AgentWorker", () => {
     })
     await expect(promise).rejects.toBeInstanceOf(AgentExecutionLostError)
 
-    // No assistant message was written; the run is still owned by the reclaiming worker.
+    // No assistant message was written; the run is still owned by the reclaiming worker. Usage is
+    // intentionally not fenced because the completed provider calls remain billable.
     const messages = await listMessages(storage, threadId)
     expect(messages.every((message) => message.role !== "assistant")).toBe(true)
     const run = await storage.runs.getById({ projectId: PROJECT_ID, id: runId })
     expect(run?.status).toBe("running")
+    await expect(
+      aiUsageStorageOf(sixb).summarizeExecution({
+        projectId: PROJECT_ID,
+        execution: { kind: "agentRun", runId },
+      })
+    ).resolves.toMatchObject({
+      modelCallCount: 2,
+      usage: { inputTokens: 20, outputTokens: 14, totalTokens: 34 },
+    })
   })
 
   test("adds concise Sixb context to every model system prompt", async () => {

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -69,6 +69,7 @@ import { normalizeApiBaseUrl } from "../src/api-url"
 import { prepareAgentAttachments } from "../src/attachments"
 import { AgentExecutionLostError, AgentFinalizationError, AgentWorkerError } from "../src/errors"
 import { finishRunOrThrow } from "../src/finalize"
+import { enqueueAiModelCallRecovery } from "../src/model-call-recovery"
 import { runAgentTurn } from "../src/run-agent-turn"
 import { createConversationAgentEnvironment } from "../src/run-environment"
 import { createBrokerStreamSink, NOOP_STREAM_SINK } from "../src/stream-sink"
@@ -861,6 +862,11 @@ function aiUsageStorageOf(sixb: TestSixb): AiUsageStorage {
   return storage
 }
 
+function recoverAiModelCall(sixb: TestSixb) {
+  return (record: Parameters<typeof enqueueAiModelCallRecovery>[1]) =>
+    enqueueAiModelCallRecovery(sixb.queues.agents, record)
+}
+
 function workerStorageOf(storage: Storage): AgentWorkerStorage {
   if (!storage.agents) {
     throw new Error("expected agent storage")
@@ -890,6 +896,7 @@ async function buildAgentWorkerContext(
     // Mirror the production boundary (worker.ts buildAgentContext): normalize the server base once.
     apiBaseUrl: normalizeApiBaseUrl(input.apiBaseUrl ?? TEST_AGENT_API_BASE_URL),
     streamSink: NOOP_STREAM_SINK,
+    recoverAiModelCall: recoverAiModelCall(sixb),
     agentSkills: loadAgentSkills({ projectSkillsDir: false }),
     defaultMaxSteps: 4,
     turnTimeoutMs: 60_000,
@@ -2414,7 +2421,7 @@ describe("AgentWorker", () => {
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,
-          execution: { kind: "agentRun", runId },
+          executionId: run.executionId,
         })
       ).resolves.toEqual({
         modelCallCount: 2,
@@ -2512,7 +2519,7 @@ describe("AgentWorker", () => {
     }
   })
 
-  test("fails the run and blocks another provider call when usage recording stays unavailable", async () => {
+  test("hands a failed usage append to the queue and fails closed before another provider call", async () => {
     let modelCalls = 0
     const model = new MockLanguageModelV4({
       modelId: "mock-model",
@@ -2542,10 +2549,27 @@ describe("AgentWorker", () => {
     const sixb = buildSixbWithEchoTool(model)
     const storage = agentStorageOf(sixb)
     const aiUsage = aiUsageStorageOf(sixb)
+    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
+    const queue = sixb.queues.agents
+    const enqueue = queue.enqueue.bind(queue)
+    let storageAvailable = false
     let appendAttempts = 0
-    aiUsage.recordModelCall = async () => {
+    let recoveryJobs = 0
+    aiUsage.recordModelCall = async (input) => {
+      if (storageAvailable) return recordModelCall(input)
       appendAttempts += 1
       throw new Error("usage storage unavailable")
+    }
+    queue.enqueue = async (params) => {
+      const jobs = await enqueue(params)
+      const handedOff = params.jobs.filter(
+        (job) => job.type === "agent.ai-usage.record.requested"
+      ).length
+      if (handedOff > 0) {
+        recoveryJobs += handedOff
+        storageAvailable = true
+      }
+      return jobs
     }
 
     const worker = new AgentWorker(sixb, workerOptions())
@@ -2560,13 +2584,151 @@ describe("AgentWorker", () => {
           })
           return record && record.status !== "queued" && record.status !== "running" ? record : null
         },
-        { label: "usage recording failure" }
+        { label: "usage recovery run terminal" }
       )
 
       expect(run.status).toBe("failed")
-      expect(run.error).toContain("Could not record AI usage")
+      expect(run.error).toContain("deferred to durable recovery")
+      const summary = await waitFor(
+        async () => {
+          const value = await aiUsage.summarizeExecution({
+            projectId: PROJECT_ID,
+            executionId: run.executionId,
+          })
+          return value.modelCallCount === 1 ? value : null
+        },
+        { label: "queued AI usage recovery" }
+      )
+      expect(summary.modelCallCount).toBe(1)
       expect(modelCalls).toBe(1)
       expect(appendAttempts).toBe(4)
+      expect(recoveryJobs).toBe(1)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("redelivers a recovery job until its idempotent ledger append succeeds", async () => {
+    const sixb = buildSixb(answerModel())
+    const executionId = await createTestAgentExecution(sixb.storage, {
+      projectId: PROJECT_ID,
+      agentId: "assistant",
+      runId: "usage-recovery",
+    })
+    const aiUsage = aiUsageStorageOf(sixb)
+    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
+    let appendAttempts = 0
+    aiUsage.recordModelCall = async (input) => {
+      appendAttempts += 1
+      if (appendAttempts === 1) throw new Error("temporary usage storage failure")
+      return recordModelCall(input)
+    }
+
+    const queue = sixb.queues.agents
+    const retry = queue.retry.bind(queue)
+    let retryRequests = 0
+    queue.retry = async (params) => {
+      retryRequests += 1
+      expect(new Date(params.availableAt ?? 0).getTime()).toBeGreaterThan(Date.now())
+      return retry({ ...params, availableAt: new Date(0).toISOString() })
+    }
+    await enqueueAiModelCallRecovery(queue, {
+      id: "usage_recovery_1",
+      projectId: PROJECT_ID,
+      executionId,
+      attempt: 1,
+      callId: "call_recovery_1",
+      requesterGroupIds: ["support"],
+      providerId: "gateway",
+      requestedModelId: "mock-model",
+      responseId: "response_recovery_1",
+      usage: { inputTokens: 12, outputTokens: 8 },
+      occurredAt: new Date("2026-07-01T12:00:00.000Z"),
+    })
+
+    const worker = new AgentWorker(sixb, workerOptions())
+    await worker.start()
+    try {
+      await waitFor(
+        async () => {
+          const summary = await aiUsage.summarizeExecution({ projectId: PROJECT_ID, executionId })
+          return summary.modelCallCount === 1 ? summary : null
+        },
+        { label: "redelivered AI usage recovery" }
+      )
+      expect(appendAttempts).toBe(2)
+      expect(retryRequests).toBe(1)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("fails the run before another provider call when storage and recovery queue fail", async () => {
+    let modelCalls = 0
+    const model = new MockLanguageModelV4({
+      modelId: "mock-model",
+      doStream: async () => {
+        modelCalls += 1
+        if (modelCalls === 1) {
+          return stream([
+            { type: "stream-start", warnings: [] },
+            {
+              type: "tool-call",
+              toolCallId: "c1",
+              toolName: "echo",
+              input: JSON.stringify({ value: "hi" }),
+            },
+            finish("tool-calls"),
+          ])
+        }
+        return stream([
+          { type: "stream-start", warnings: [] },
+          { type: "text-start", id: "answer" },
+          { type: "text-delta", id: "answer", delta: "should not run" },
+          { type: "text-end", id: "answer" },
+          finish("stop"),
+        ])
+      },
+    })
+    const sixb = buildSixbWithEchoTool(model)
+    const storage = agentStorageOf(sixb)
+    const aiUsage = aiUsageStorageOf(sixb)
+    const queue = sixb.queues.agents
+    const enqueue = queue.enqueue.bind(queue)
+    let appendAttempts = 0
+    let recoveryAttempts = 0
+    aiUsage.recordModelCall = async () => {
+      appendAttempts += 1
+      throw new Error("usage storage unavailable")
+    }
+    queue.enqueue = async (params) => {
+      if (params.jobs.some((job) => job.type === "agent.ai-usage.record.requested")) {
+        recoveryAttempts += 1
+        throw new Error("agent queue unavailable")
+      }
+      return enqueue(params)
+    }
+
+    const worker = new AgentWorker(sixb, workerOptions())
+    await worker.start()
+    try {
+      const request = await requestAgent(sixb, { agentId: "assistant", text: "echo hi" })
+      const run = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({
+            projectId: PROJECT_ID,
+            id: request.run.id,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "usage recording and recovery failure" }
+      )
+
+      expect(run.status).toBe("failed")
+      expect(run.error).toContain("Could not preserve AI usage")
+      expect(modelCalls).toBe(1)
+      expect(appendAttempts).toBe(4)
+      expect(recoveryAttempts).toBe(4)
     } finally {
       await worker.stop()
     }
@@ -2900,7 +3062,7 @@ describe("AgentWorker", () => {
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,
-          execution: { kind: "agentRun", runId: run.id },
+          executionId: run.executionId,
         })
       ).resolves.toMatchObject({
         modelCallCount: 2,
@@ -3772,6 +3934,7 @@ describe("AgentWorker", () => {
         blobStorage: sixb.blobStorage,
         tools: echoTool,
         streamSink: NOOP_STREAM_SINK,
+        recoverAiModelCall: recoverAiModelCall(sixb),
         defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
       },
@@ -3790,7 +3953,7 @@ describe("AgentWorker", () => {
     await expect(
       aiUsageStorageOf(sixb).summarizeExecution({
         projectId: PROJECT_ID,
-        execution: { kind: "agentRun", runId },
+        executionId: staleRun.executionId,
       })
     ).resolves.toMatchObject({
       modelCallCount: 2,
@@ -3826,6 +3989,7 @@ describe("AgentWorker", () => {
         tools: {},
         systemAddendum: "Extra sandbox context.",
         streamSink: NOOP_STREAM_SINK,
+        recoverAiModelCall: recoverAiModelCall(sixb),
         defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
       },
@@ -3881,6 +4045,7 @@ describe("AgentWorker", () => {
         blobStorage: sixb.blobStorage,
         tools: {},
         streamSink: NOOP_STREAM_SINK,
+        recoverAiModelCall: recoverAiModelCall(sixb),
         defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
       },
@@ -4119,6 +4284,7 @@ describe("AgentWorker", () => {
             broker: sixb.broker,
             projectId: PROJECT_ID,
           }),
+          recoverAiModelCall: recoverAiModelCall(sixb),
           defaultMaxSteps: 4,
           turnTimeoutMs: 60_000,
         },
@@ -4156,6 +4322,7 @@ describe("AgentWorker", () => {
           broker: sixb.broker,
           projectId: PROJECT_ID,
         }),
+        recoverAiModelCall: recoverAiModelCall(sixb),
         defaultMaxSteps: 4,
         turnTimeoutMs: 60_000,
       },

--- a/packages/core/src/agents/adapters.ts
+++ b/packages/core/src/agents/adapters.ts
@@ -210,7 +210,11 @@ function optionalJson(value: unknown, label: string): JsonValue | undefined {
  * and every other non-JSON shape are left for `requireJson` to accept or reject. This helper only
  * turns `{ key: undefined }` into `{}` for metadata compatibility with SDK output.
  */
-function omitUndefinedObjectProperties(value: unknown, seen = new Set<object>()): unknown {
+export function omitUndefinedObjectProperties(value: unknown): unknown {
+  return omitUndefinedObjectPropertiesInternal(value, new Set())
+}
+
+function omitUndefinedObjectPropertiesInternal(value: unknown, seen: Set<object>): unknown {
   if (typeof value !== "object" || value === null) return value
 
   // Avoid recursing forever on a malformed/cyclic metadata object. Leaving the cycle in place lets
@@ -220,7 +224,7 @@ function omitUndefinedObjectProperties(value: unknown, seen = new Set<object>())
   seen.add(value)
   try {
     if (Array.isArray(value)) {
-      return value.map((entry) => omitUndefinedObjectProperties(entry, seen))
+      return value.map((entry) => omitUndefinedObjectPropertiesInternal(entry, seen))
     }
 
     if (!isPlainRecord(value)) return value
@@ -228,7 +232,7 @@ function omitUndefinedObjectProperties(value: unknown, seen = new Set<object>())
     return Object.fromEntries(
       Object.entries(value)
         .filter(([, entry]) => entry !== undefined)
-        .map(([key, entry]) => [key, omitUndefinedObjectProperties(entry, seen)])
+        .map(([key, entry]) => [key, omitUndefinedObjectPropertiesInternal(entry, seen)])
     )
   } finally {
     seen.delete(value)

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -16,7 +16,12 @@ export type {
   AgentUiToolPart,
   ToModelMessagesOptions,
 } from "./adapters"
-export { fromAiSdk, toModelMessages, toUiMessage } from "./adapters"
+export {
+  fromAiSdk,
+  omitUndefinedObjectProperties,
+  toModelMessages,
+  toUiMessage,
+} from "./adapters"
 export type { AgentApiGatewayCapabilityInput, AgentApiRoute } from "./api-gateway"
 export {
   AGENT_API_GATEWAY_PREFIX,

--- a/packages/core/src/queues/index.ts
+++ b/packages/core/src/queues/index.ts
@@ -3,6 +3,8 @@ export { QueueError } from "./errors"
 export { InMemoryQueues } from "./in-memory"
 export type {
   ActionRunRequestedQueueJob,
+  AgentAiUsageRecordPayload,
+  AgentAiUsageRecordRequestedQueueJob,
   AgentQueueJob,
   AgentRunRequestedQueueJob,
   AgentWorkflowNodeRequestedQueueJob,

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -1,6 +1,7 @@
 import type { JsonValue } from "../json"
 import type { ProjectionMaterializationIdentity } from "../materialization/model"
 import type { ProviderScope } from "../provider-scope"
+import type { RecordAiModelCallInput } from "../storage/ai-usage"
 
 export interface QueueJobEnvelope {
   readonly id: string
@@ -185,7 +186,29 @@ export interface AgentWorkflowNodeRequestedQueueJob
     }
   > {}
 
-export type AgentQueueJob = AgentRunRequestedQueueJob | AgentWorkflowNodeRequestedQueueJob
+/** JSON-safe representation of one model-call ledger append awaiting durable recovery. */
+export type AgentAiUsageRecordPayload = Omit<
+  RecordAiModelCallInput,
+  "projectId" | "usage" | "occurredAt" | "recordedAt"
+> & {
+  readonly usage: {
+    readonly [Field in keyof RecordAiModelCallInput["usage"]]: RecordAiModelCallInput["usage"][Field]
+  }
+  readonly occurredAt: string
+}
+
+export interface AgentAiUsageRecordRequestedQueueJob
+  extends QueueJob<
+    "agent.ai-usage.record.requested",
+    {
+      readonly record: AgentAiUsageRecordPayload
+    }
+  > {}
+
+export type AgentQueueJob =
+  | AgentRunRequestedQueueJob
+  | AgentWorkflowNodeRequestedQueueJob
+  | AgentAiUsageRecordRequestedQueueJob
 
 export interface Queues {
   readonly syncRuns: Queue<SyncRunRequestedQueueJob>


### PR DESCRIPTION
## Summary

> Stack: #354 → #355 → **#356** → #357 → #358

This is PR 3 of 5 in the Phase 1 AI usage accounting stack. It records every completed conversation
provider call made through `streamText`, including individual calls in tool loops and calls completed
before a later failure, cancellation, or ownership loss.

The previous PR supplied durable storage and immutable requester attribution. This PR connects the
conversation execution lifecycle to that foundation.

The existing run-row aggregate remains temporarily for display and rollout compatibility. The
model-call ledger is already the accounting authority; PR 5 removes the projection after both
execution paths and public reads have cut over.

## Why final run usage is insufficient for budgets

`result.usage` is a final aggregate. It is unavailable or too late on several important paths:

- a tool loop makes multiple provider calls;
- a tool fails after the provider returned usage;
- output or message projection fails;
- a user cancels after a completed call;
- queue ownership changes before finalization;
- the run fails before its terminal aggregate is persisted.

A budget system based on terminal run totals would undercount those billable calls. This PR captures
usage at the provider-call lifecycle boundary instead.

## What this PR adds

### Model-call recorder

- Adds a reusable `AiModelCallRecorder` around AI SDK lifecycle events.
- Captures on `onLanguageModelCallEnd`, after provider normalization and before client-side tool
  execution.
- Records:
  - call, provider, requested model, response model/ID;
  - every normalized token detail;
  - raw provider usage;
  - occurrence time;
  - durable execution attempt;
  - admission-time principal and group snapshot.
- Uses a stable idempotent append path so callback replay does not double-count.

### Fail-closed accounting behavior

AI SDK intentionally swallows lifecycle callback errors. The recorder therefore retains append
failures and:

1. retries the idempotent storage write in place;
2. throws from `prepareStep` before another provider call;
3. checks health again before a successful finalization;
4. fails the run rather than silently losing accounting.

A completed call can cross a future budget because its final usage is known only afterward. This
`prepareStep` boundary is also where later enforcement can deny the **next** call.

### Execution ownership behavior

Run/message finalization remains fenced by the durable execution token. Usage writes deliberately do
not: if a stale worker completed a provider call, the call remains billable even though that worker
may no longer update the run.

### Tests

Covers:

- multi-step tool-loop calls;
- all normalized token details and raw usage;
- duplicate lifecycle callbacks;
- repeated call/response IDs on later delivery attempts;
- missing provider usage remaining unavailable;
- retry and persistent storage failure;
- blocking another provider step after accounting failure;
- cancellation after completed calls;
- reclaimed-run attempt propagation;
- stale execution ownership;
- AI SDK lifecycle type compatibility.

## Rollout behavior

For this intermediate stack position:

- conversations write authoritative per-call ledger records;
- the existing run aggregate is still written on normal finalization;
- public APIs still read that aggregate;
- workflow agent nodes do not write the ledger until PR 4.

The temporary projection is unchanged existing behavior, not a second accounting source.

## What is intentionally not in this PR

- No workflow `generateText` capture yet.
- No public API cutover.
- No usage-column drop.
- No pricing or currency conversion.
- No budget configuration, counters, or call denial.

## Phase 1 stack

1. Accounting contract and standalone in-memory model.
2. Durable storage and immutable requester attribution.
3. **This PR:** conversation model-call capture.
4. Workflow agent-node model-call capture.
5. Ledger-backed API cutover and removal of legacy run projections.

## How this supports later budgets

This PR establishes the conversation enforcement seam:

```text
completed call
  → durable usage append
  → later: rate cost and increment monthly counters
  → prepareStep
  → later: deny the next call if a budget is exhausted
```

Later phases will add effective-dated pricing, reconciliation, monthly project/group/principal
counters, budget definitions, alerts, and enforcement. Pricing lookups will use a local catalog; no
external pricing API belongs in this callback path.

## Review guide

Suggested order:

1. `packages/agent-worker/src/model-call-recorder.ts`
2. `aiModelCallUsageFromAiSdk`
3. recorder wiring in `run-agent-turn.ts`
4. accounting-error classification in `worker.ts`
5. recorder unit tests
6. conversation worker integration tests and AI SDK type contract

Questions to keep in mind:

- Is the callback early enough to survive later tool/finalization failures?
- Can a callback failure be swallowed and followed by another provider call?
- Does redelivery use the durable attempt rather than a hard-coded first attempt?
- Can stale ownership suppress real billable usage?
- Does missing usage remain missing throughout the adapter?

## Validation

```bash
bun run typecheck
bun run check
bun test packages/agent-worker/tests/model-call-recorder.test.ts \
  packages/agent-worker/tests/ai-sdk-adapters.test.ts
bun test packages/agent-worker/tests/worker.test.ts
bun --filter @sixb/agent-worker build
```

The recorder/adapter suites pass 17 tests and the conversation-capable worker suite passes 55 tests.
Root typecheck, Biome, and the agent-worker build pass.
