### PR TITLE
agents: record every completed workflow model call

### DIFF
--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -37,7 +37,12 @@ await worker.start()
 
 ## Usage accounting
 
-Every completed conversation provider call observed by the AI SDK lifecycle is appended to `storage.aiUsage`, including individual calls in tool loops and calls completed before later cancellation, tool failure, or execution ownership loss. Usage writes are intentionally not fenced: a stale worker cannot finalize the run, but a provider call it completed remains billable.
+Every completed conversation and workflow-agent provider call observed by the AI SDK lifecycle is
+appended to `storage.aiUsage`, including individual calls in tool loops and calls completed before
+later cancellation, tool failure, output validation, or execution ownership loss. Workflow nodes
+use their own durable execution and inherit the parent workflow's admission-time group snapshot.
+Usage writes are intentionally not fenced: a stale worker cannot finalize the execution, but a
+provider call it completed remains billable.
 
 The AI SDK swallows lifecycle callback errors, so the worker retries the idempotent append and hands any persistent infrastructure failure to a durable job in `queues.agents`. Recovery retries with bounded backoff and cannot trigger another provider call. Once an append is deferred, `prepareStep`
 blocks the next model step and the run fails closed while accounting recovery continues independently. If the durable handoff also fails, the same stop prevents silent usage loss. This local path cannot close a process-crash window before lifecycle delivery; provider-side reconciliation is the appropriate later layer for that guarantee.

--- a/packages/agent-worker/README.md
+++ b/packages/agent-worker/README.md
@@ -45,7 +45,7 @@ Usage writes are intentionally not fenced: a stale worker cannot finalize the ex
 provider call it completed remains billable.
 
 The AI SDK swallows lifecycle callback errors, so the worker retries the idempotent append and hands any persistent infrastructure failure to a durable job in `queues.agents`. Recovery retries with bounded backoff and cannot trigger another provider call. Once an append is deferred, `prepareStep`
-blocks the next model step and the run fails closed while accounting recovery continues independently. If the durable handoff also fails, the same stop prevents silent usage loss. This local path cannot close a process-crash window before lifecycle delivery; provider-side reconciliation is the appropriate later layer for that guarantee.
+blocks the next model step and the owning Agent run or workflow fails closed while accounting recovery continues independently. If the durable handoff also fails, the same stop prevents silent usage loss. This local path cannot close a process-crash window before lifecycle delivery; provider-side reconciliation is the appropriate later layer for that guarantee.
 
 During the staged rollout, the existing run aggregate remains for display; the model-call ledger is the accounting authority and a later stack PR removes the projection.
 

--- a/packages/agent-worker/src/run-workflow-agent-node.ts
+++ b/packages/agent-worker/src/run-workflow-agent-node.ts
@@ -11,6 +11,7 @@ import type { AgentRunUsage } from "@sixb/core/storage"
 import { coerceAgentRunFinishReason } from "@sixb/core/storage"
 import { generateText, jsonSchema, Output, stepCountIs } from "ai"
 import { agentRunUsageFromAiSdk, agentTraceFromAiSdkSteps } from "./ai-sdk-adapters"
+import type { AiModelCallRecorder } from "./model-call-recorder"
 import type { AgentTurnContext } from "./types"
 
 export interface RunWorkflowAgentNodeInput {
@@ -20,6 +21,7 @@ export interface RunWorkflowAgentNodeInput {
   readonly workflowId: string
   readonly prompt: string
   readonly valueTypesById: ReadonlyMap<string, ValueType>
+  readonly usageRecorder: AiModelCallRecorder
   readonly signal: AbortSignal
 }
 
@@ -79,9 +81,13 @@ export async function runWorkflowAgentNode(
       tools: input.context.tools,
       stopWhen: stepCountIs(maxSteps),
       output: Output.object({ schema, name: input.agentStep.id }),
+      prepareStep: input.usageRecorder.prepareStep,
+      onLanguageModelCallEnd: input.usageRecorder.onLanguageModelCallEnd,
       abortSignal: AbortSignal.any([input.signal, timeout.signal]),
     })
 
+    // A final-step callback failure has no later `prepareStep` invocation to surface it.
+    input.usageRecorder.assertHealthy()
     const output = snapshotWorkflowAgentStepOutput({
       workflowId: input.workflowId,
       agentStep: input.agentStep,

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -1,9 +1,4 @@
-import {
-  type AgentDefinition,
-  SYSTEM_PRINCIPAL,
-  type ValueType,
-  type WorkflowDefinition,
-} from "@sixb/core"
+import type { AgentDefinition, ValueType, WorkflowDefinition } from "@sixb/core"
 import {
   createAgentRunExecutionToken,
   resolveAgentExecutionAuthorization,
@@ -21,7 +16,7 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
-import { AgentFinalizationError, AgentUsageRecordingError, AgentWorkerError } from "./errors"
+import { AgentUsageRecordingError, AgentWorkerError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
 import { AiModelCallRecorder } from "./model-call-recorder"
 import {
@@ -101,18 +96,13 @@ export async function executeWorkflowAgentNode(
   if (!executionToken) {
     throw new AgentWorkerError(`Agent workflow node '${nodeRun.id}' has no execution token.`)
   }
-  const usageExecution = {
-    kind: "workflowAgentNode" as const,
-    workflowRunId: workflowRun.id,
-    nodeRunId: nodeRun.id,
-  }
   const usageRecorder = new AiModelCallRecorder({
     storage: context.storage.aiUsage,
     projectId: context.id,
-    execution: usageExecution,
+    executionId: executionRecord.executionId,
     attempt: reserved.attempt,
-    requesterPrincipal: durableExecution.requestedBy ?? SYSTEM_PRINCIPAL,
     requesterGroupIds: workflowRun.requesterGroupIds,
+    recoverAiModelCall: context.recoverAiModelCall,
     errorRunId: nodeRun.id,
   })
 
@@ -176,11 +166,10 @@ export async function executeWorkflowAgentNode(
       executionError = recordingError
     }
 
-    if (executionError instanceof AgentFinalizationError) throw executionError
     if (signal.aborted) throw executionError
     if (cancel.signal.aborted && (await isAlreadyCancelled(runs, context.id, nodeRun.id))) {
       // The cancellation endpoint has already made the execution terminal, so it cannot be fenced
-      // again. Still surface a lost accounting append to the queue instead of acknowledging it.
+      // again. Still surface an accounting failure instead of silently acknowledging it.
       if (executionError instanceof AgentUsageRecordingError) throw executionError
       return
     }

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -1,4 +1,9 @@
-import type { AgentDefinition, ValueType, WorkflowDefinition } from "@sixb/core"
+import {
+  type AgentDefinition,
+  SYSTEM_PRINCIPAL,
+  type ValueType,
+  type WorkflowDefinition,
+} from "@sixb/core"
 import {
   createAgentRunExecutionToken,
   resolveAgentExecutionAuthorization,
@@ -16,8 +21,9 @@ import type {
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
-import { AgentWorkerError } from "./errors"
+import { AgentFinalizationError, AgentUsageRecordingError, AgentWorkerError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
+import { AiModelCallRecorder } from "./model-call-recorder"
 import {
   type AgentExecutionEnvironment,
   createWorkflowAgentNodeEnvironment,
@@ -42,6 +48,7 @@ interface WorkflowAgentNodeExecutionContext {
   readonly runs: WorkflowRunStorage
   readonly executionRecord: WorkflowAgentNodeRunRecord
   readonly nodeRun: WorkflowNodeRunRecord
+  readonly workflowRun: WorkflowRunRecord
   readonly workflow: WorkflowDefinition
   readonly node: WorkflowAgentNodeDefinition
   readonly agent: AgentDefinition
@@ -60,6 +67,7 @@ export async function executeWorkflowAgentNode(
     runs,
     executionRecord,
     nodeRun,
+    workflowRun,
     workflow,
     node,
     agent,
@@ -93,6 +101,21 @@ export async function executeWorkflowAgentNode(
   if (!executionToken) {
     throw new AgentWorkerError(`Agent workflow node '${nodeRun.id}' has no execution token.`)
   }
+  const usageExecution = {
+    kind: "workflowAgentNode" as const,
+    workflowRunId: workflowRun.id,
+    nodeRunId: nodeRun.id,
+  }
+  const usageRecorder = new AiModelCallRecorder({
+    storage: context.storage.aiUsage,
+    projectId: context.id,
+    execution: usageExecution,
+    attempt: reserved.attempt,
+    requesterPrincipal: durableExecution.requestedBy ?? SYSTEM_PRINCIPAL,
+    requesterGroupIds: workflowRun.requesterGroupIds,
+    errorRunId: nodeRun.id,
+  })
+
   let environment: AgentExecutionEnvironment | null = null
   const cancel = await input.watchForCancel(nodeRun.id)
   const stopOwnershipProjection = projectQueueOwnership({
@@ -125,6 +148,7 @@ export async function executeWorkflowAgentNode(
       workflowId: workflow.id,
       prompt: reserved.prompt,
       valueTypesById,
+      usageRecorder,
       signal: AbortSignal.any([signal, cancel.signal]),
     })
     const completedNode = await finishWorkflowAgentNodeSucceeded({
@@ -142,20 +166,39 @@ export async function executeWorkflowAgentNode(
     })
   } catch (error) {
     if (lostQueueDelivery(error, signal)) return
-    if (signal.aborted) throw error
-    if (cancel.signal.aborted && (await isAlreadyCancelled(runs, context.id, nodeRun.id))) return
 
-    const status = cancel.signal.aborted ? "cancelled" : "failed"
+    // Output parsing and tool handling can fail after the final provider callback. Accounting
+    // failure takes precedence because AI SDK otherwise swallows the callback error.
+    let executionError = error
+    try {
+      usageRecorder.assertHealthy()
+    } catch (recordingError) {
+      executionError = recordingError
+    }
+
+    if (executionError instanceof AgentFinalizationError) throw executionError
+    if (signal.aborted) throw executionError
+    if (cancel.signal.aborted && (await isAlreadyCancelled(runs, context.id, nodeRun.id))) {
+      // The cancellation endpoint has already made the execution terminal, so it cannot be fenced
+      // again. Still surface a lost accounting append to the queue instead of acknowledging it.
+      if (executionError instanceof AgentUsageRecordingError) throw executionError
+      return
+    }
+
+    const status =
+      cancel.signal.aborted && !(executionError instanceof AgentUsageRecordingError)
+        ? "cancelled"
+        : "failed"
     const failed = await finishWorkflowAgentNodeFailed({
       context,
       nodeRun,
       agent,
       executionToken,
       status,
-      error,
+      error: executionError,
     })
     if (status === "failed") {
-      reportRunFailure(input.host, error, {
+      reportRunFailure(input.host, executionError, {
         projectId: context.id,
         occurredAt: failed.run.finishedAt,
         attempt: job.attempt,
@@ -236,6 +279,7 @@ async function loadWorkflowAgentNodeExecution(
     runs,
     executionRecord,
     nodeRun,
+    workflowRun,
     workflow,
     node,
     agent,

--- a/packages/agent-worker/tests/ai-sdk-compat.types.ts
+++ b/packages/agent-worker/tests/ai-sdk-compat.types.ts
@@ -7,7 +7,14 @@ import type { LanguageModelV4 } from "@ai-sdk/provider"
 import type { AgentInboundUiMessage, AgentMessage } from "@sixb/core"
 import { toModelMessages } from "@sixb/core/internal/agents"
 import type { AgentRunUsage, AiModelCallUsageInput } from "@sixb/core/storage"
-import type { LanguageModelUsage, ModelMessage, StepResult, streamText, UIMessage } from "ai"
+import type {
+  generateText,
+  LanguageModelUsage,
+  ModelMessage,
+  StepResult,
+  streamText,
+  UIMessage,
+} from "ai"
 import {
   agentRunUsageFromAiSdk,
   agentTraceFromAiSdkSteps,
@@ -50,6 +57,27 @@ const _streamTextOptions: Parameters<typeof streamText>[0] = {
   },
 }
 
+// Workflow generateText calls use the same lifecycle contract as conversation streams.
+const _generateTextOptions: Parameters<typeof generateText>[0] = {
+  model: sdkModel,
+  prompt: "hello",
+  prepareStep: () => undefined,
+  onLanguageModelCallEnd(event) {
+    const callId: string = event.callId
+    const providerId: string = event.provider
+    const requestedModelId: string = event.modelId
+    const responseId: string = event.responseId
+    const usage: AiModelCallUsageInput = aiModelCallUsageFromAiSdk(event.usage)
+    const rawUsage = event.usage.raw
+    void callId
+    void providerId
+    void requestedModelId
+    void responseId
+    void usage
+    void rawUsage
+  },
+}
+
 // A real final StepResult and LanguageModelUsage must cross the worker adapter without a cast.
 declare const sdkSteps: readonly StepResult<Record<string, never>>[]
 declare const sdkUsage: LanguageModelUsage
@@ -59,5 +87,6 @@ const _usage: AgentRunUsage | undefined = agentRunUsageFromAiSdk(sdkUsage)
 void _inbound
 void _model
 void _streamTextOptions
+void _generateTextOptions
 void _trace
 void _usage

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1038,7 +1038,7 @@ async function queueWorkflowAgentNode(input: {
     ],
   })
 
-  return { sixb, runs, workflow, agent, nodeRunId }
+  return { sixb, runs, workflow, agent, nodeRunId, agentExecutionId }
 }
 
 class FailingRunStreamBroker extends InMemoryBroker {
@@ -1541,16 +1541,21 @@ describe("AgentWorker", () => {
       expect(execution.trace).toBeArray()
       expect(lookupCalls).toBe(1)
       expect(recordedUsage).toHaveLength(2)
-      expect(recordedUsage.map((usage) => usage.execution)).toEqual([
-        { kind: "workflowAgentNode", workflowRunId: runId, nodeRunId },
-        { kind: "workflowAgentNode", workflowRunId: runId, nodeRunId },
+      expect(recordedUsage.map((usage) => usage.executionId)).toEqual([
+        agentExecutionId,
+        agentExecutionId,
       ])
       expect(recordedUsage.map((usage) => usage.attempt)).toEqual([1, 1])
-      expect(recordedUsage.map((usage) => usage.requesterPrincipal)).toEqual([REQUESTER, REQUESTER])
       expect(recordedUsage.map((usage) => usage.requesterGroupIds)).toEqual([
         ["operations", "project-alpha"],
         ["operations", "project-alpha"],
       ])
+      await expect(
+        sixb.storage.executions.getById({ projectId: PROJECT_ID, id: agentExecutionId })
+      ).resolves.toMatchObject({
+        requestedBy: REQUESTER,
+        parentExecutionId: executionId,
+      })
       expect(recordedUsage.map((usage) => usage.usage)).toEqual([
         {
           inputTokens: 10,
@@ -1584,7 +1589,7 @@ describe("AgentWorker", () => {
       await expect(
         aiUsage.summarizeExecution({
           projectId: PROJECT_ID,
-          execution: { kind: "workflowAgentNode", workflowRunId: runId, nodeRunId },
+          executionId: agentExecutionId,
         })
       ).resolves.toMatchObject({
         modelCallCount: 2,
@@ -1631,7 +1636,7 @@ describe("AgentWorker", () => {
   })
 
   test("keeps workflow usage when structured output validation fails", async () => {
-    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+    const { sixb, runs, nodeRunId, agentExecutionId } = await queueWorkflowAgentNode({
       model: invalidStructuredAnswerModel(),
       runId: "workflow-invalid-output",
     })
@@ -1654,11 +1659,7 @@ describe("AgentWorker", () => {
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,
-          execution: {
-            kind: "workflowAgentNode",
-            workflowRunId: "workflow-invalid-output",
-            nodeRunId,
-          },
+          executionId: agentExecutionId,
         })
       ).resolves.toMatchObject({
         modelCallCount: 1,
@@ -1683,7 +1684,7 @@ describe("AgentWorker", () => {
         toolCalls += 1
         throw new Error("project lookup unavailable")
       })
-    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+    const { sixb, runs, nodeRunId, agentExecutionId } = await queueWorkflowAgentNode({
       model: structuredToolThenProviderFailureModel(),
       tools: [failingTool],
       runId: "workflow-tool-failure",
@@ -1708,11 +1709,7 @@ describe("AgentWorker", () => {
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,
-          execution: {
-            kind: "workflowAgentNode",
-            workflowRunId: "workflow-tool-failure",
-            nodeRunId,
-          },
+          executionId: agentExecutionId,
         })
       ).resolves.toMatchObject({
         modelCallCount: 1,
@@ -1723,7 +1720,7 @@ describe("AgentWorker", () => {
     }
   })
 
-  test("blocks another workflow model call and fails when accounting stays unavailable", async () => {
+  test("hands failed workflow usage to durable recovery and fails closed", async () => {
     let modelCalls = 0
     const model = structuredToolThenAnswerModel(() => {
       modelCalls += 1
@@ -1732,16 +1729,33 @@ describe("AgentWorker", () => {
       .description("Look up a project.")
       .input({ query: "string" })
       .run(() => ({ project: "Project Alpha" }))
-    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+    const { sixb, runs, nodeRunId, agentExecutionId } = await queueWorkflowAgentNode({
       model,
       tools: [lookup],
       runId: "workflow-accounting-failure",
     })
     const aiUsage = aiUsageStorageOf(sixb)
+    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
+    const queue = sixb.queues.agents
+    const enqueue = queue.enqueue.bind(queue)
+    let storageAvailable = false
     let appendAttempts = 0
-    aiUsage.recordModelCall = async () => {
+    let recoveryJobs = 0
+    aiUsage.recordModelCall = async (input) => {
+      if (storageAvailable) return recordModelCall(input)
       appendAttempts += 1
       throw new Error("usage storage unavailable")
+    }
+    queue.enqueue = async (params) => {
+      const jobs = await enqueue(params)
+      const handedOff = params.jobs.filter(
+        (job) => job.type === "agent.ai-usage.record.requested"
+      ).length
+      if (handedOff > 0) {
+        recoveryJobs += handedOff
+        storageAvailable = true
+      }
+      return jobs
     }
     const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
 
@@ -1759,15 +1773,36 @@ describe("AgentWorker", () => {
       )
 
       expect(execution.status).toBe("failed")
-      expect(execution.error).toContain("Could not record AI usage")
+      expect(execution.error).toContain("deferred to durable recovery")
+      await expect(
+        runs.getById({ projectId: PROJECT_ID, id: "workflow-accounting-failure" })
+      ).resolves.toMatchObject({ status: "failed" })
+      const summary = await waitFor(
+        async () => {
+          const value = await aiUsage.summarizeExecution({
+            projectId: PROJECT_ID,
+            executionId: agentExecutionId,
+          })
+          return value.modelCallCount === 1 ? value : null
+        },
+        { label: "queued workflow AI usage recovery" }
+      )
+      expect(summary.modelCallCount).toBe(1)
       expect(modelCalls).toBe(1)
       expect(appendAttempts).toBe(4)
+      expect(recoveryJobs).toBe(1)
+      await expect(
+        sixb.queues.workflows.claim({
+          projectId: PROJECT_ID,
+          workerId: "workflow-accounting-failure-test",
+        })
+      ).resolves.toHaveLength(0)
     } finally {
       await worker.stop()
     }
   })
 
-  test("surfaces a final workflow callback accounting failure without another step", async () => {
+  test("surfaces final workflow accounting failure when durable handoff also fails", async () => {
     let modelCalls = 0
     const model = new MockLanguageModelV4({
       modelId: "mock-model",
@@ -1791,10 +1826,20 @@ describe("AgentWorker", () => {
       runId: "workflow-final-callback-failure",
     })
     const aiUsage = aiUsageStorageOf(sixb)
+    const queue = sixb.queues.agents
+    const enqueue = queue.enqueue.bind(queue)
     let appendAttempts = 0
+    let recoveryAttempts = 0
     aiUsage.recordModelCall = async () => {
       appendAttempts += 1
       throw new Error("usage storage unavailable")
+    }
+    queue.enqueue = async (params) => {
+      if (params.jobs.some((job) => job.type === "agent.ai-usage.record.requested")) {
+        recoveryAttempts += 1
+        throw new Error("agent queue unavailable")
+      }
+      return enqueue(params)
     }
     const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
 
@@ -1812,9 +1857,10 @@ describe("AgentWorker", () => {
       )
 
       expect(execution.status).toBe("failed")
-      expect(execution.error).toContain("Could not record AI usage")
+      expect(execution.error).toContain("Could not preserve AI usage")
       expect(modelCalls).toBe(1)
       expect(appendAttempts).toBe(4)
+      expect(recoveryAttempts).toBe(4)
     } finally {
       await worker.stop()
     }
@@ -1822,7 +1868,7 @@ describe("AgentWorker", () => {
 
   test("keeps workflow usage outside a failed node-finalization transaction", async () => {
     const storage = withOneFailingWorkflowAgentFinalization(new InMemoryStorage())
-    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+    const { sixb, runs, nodeRunId, agentExecutionId } = await queueWorkflowAgentNode({
       model: structuredAnswerModel(),
       storage,
       runId: "workflow-finalization-failure",
@@ -1847,11 +1893,7 @@ describe("AgentWorker", () => {
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,
-          execution: {
-            kind: "workflowAgentNode",
-            workflowRunId: "workflow-finalization-failure",
-            nodeRunId,
-          },
+          executionId: agentExecutionId,
         })
       ).resolves.toMatchObject({
         modelCallCount: 1,
@@ -1887,7 +1929,7 @@ describe("AgentWorker", () => {
         return { project: "unreachable" }
       })
     const runId = "workflow-cancelled-during-tool"
-    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+    const { sixb, runs, nodeRunId, agentExecutionId } = await queueWorkflowAgentNode({
       model: structuredToolThenAnswerModel(),
       tools: [blockingTool],
       runId,
@@ -1924,7 +1966,7 @@ describe("AgentWorker", () => {
       await expect(
         aiUsageStorageOf(sixb).summarizeExecution({
           projectId: PROJECT_ID,
-          execution: { kind: "workflowAgentNode", workflowRunId: runId, nodeRunId },
+          executionId: agentExecutionId,
         })
       ).resolves.toMatchObject({
         modelCallCount: 1,

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -55,6 +55,8 @@ import {
   AgentStorageError,
   type AiUsageStorage,
   type AppendAgentMessageInput,
+  type RecordAiModelCallInput,
+  type WorkflowRunStorage,
 } from "@sixb/core/storage"
 import {
   createTestAgentExecution,
@@ -137,6 +139,21 @@ function toolThenAnswerModel(captureReplay?: (prompt: string) => void): MockLang
         finish("stop"),
       ])
     },
+  })
+}
+
+function invalidMetadataAnswerModel(): MockLanguageModelV4 {
+  const invalidProviderMetadata = { mock: { generatedAt: new Date() } } as never
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    doStream: async () =>
+      stream([
+        { type: "stream-start", warnings: [] },
+        { type: "text-start", id: "answer", providerMetadata: invalidProviderMetadata },
+        { type: "text-delta", id: "answer", delta: "Done" },
+        { type: "text-end", id: "answer" },
+        finish("stop"),
+      ]),
   })
 }
 
@@ -283,6 +300,61 @@ function toolOnlyModel(): MockLanguageModelV4 {
         },
         finish("tool-calls"),
       ])
+    },
+  })
+}
+
+function structuredAnswerModel(): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    doGenerate: async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ answer: "Project Alpha", confidence: 0.96 }),
+        },
+      ],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: USAGE,
+      warnings: [],
+    }),
+  })
+}
+
+function invalidStructuredAnswerModel(): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    doGenerate: async () => ({
+      content: [{ type: "text", text: JSON.stringify({ answer: 42, confidence: "high" }) }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: USAGE,
+      warnings: [],
+    }),
+  })
+}
+
+function structuredToolThenProviderFailureModel(): MockLanguageModelV4 {
+  let call = 0
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    doGenerate: async () => {
+      call += 1
+      if (call === 1) {
+        return {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "workflow-failure",
+              toolName: "fail_lookup",
+              input: JSON.stringify({ query: "alpha" }),
+            },
+          ],
+          finishReason: { unified: "tool-calls", raw: "tool-calls" },
+          usage: USAGE,
+          warnings: [],
+        }
+      }
+      throw new Error("provider unavailable after tool failure")
     },
   })
 }
@@ -819,6 +891,156 @@ function buildSixbWithEchoTool(
   return buildSixb(model, broker, sandboxes, { agentTools: [echoAgentTool] })
 }
 
+function withOneFailingWorkflowAgentFinalization(storage: Storage): Storage {
+  const rootRuns = storage.workflowRuns
+  if (!rootRuns) throw new Error("expected workflow run storage")
+  let failed = false
+  const wrapRuns = (runs: WorkflowRunStorage): WorkflowRunStorage => {
+    const agentNodes = new Proxy(runs.agentNodes, {
+      get(target, property, receiver) {
+        if (property === "finish") {
+          return (input: Parameters<typeof target.finish>[0]) => {
+            if (!failed) {
+              failed = true
+              return Promise.reject(new Error("workflow node finalization unavailable"))
+            }
+            return target.finish(input)
+          }
+        }
+        const value = Reflect.get(target, property, receiver)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    })
+    return new Proxy(runs, {
+      get(target, property, receiver) {
+        if (property === "agentNodes") return agentNodes
+        const value = Reflect.get(target, property, receiver)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    })
+  }
+
+  return {
+    ...storage,
+    workflowRuns: rootRuns,
+    transaction: (run, options) =>
+      storage.transaction((tx) => {
+        const runs = tx.workflowRuns
+        return run({
+          ...tx,
+          ...(runs ? { workflowRuns: wrapRuns(runs) } : {}),
+        })
+      }, options),
+  }
+}
+
+async function seedRequesterUser(storage: Storage, principal = REQUESTER): Promise<void> {
+  const auth = storage.auth
+  if (!auth) throw new Error("expected auth storage")
+  const existing = await auth.users.getById({ projectId: PROJECT_ID, id: principal.id })
+  if (!existing) {
+    await auth.users.create({
+      id: principal.id,
+      projectId: PROJECT_ID,
+      email: `${principal.id}@example.com`,
+    })
+  }
+}
+
+async function queueWorkflowAgentNode(input: {
+  readonly model: LanguageModelV4
+  readonly tools?: readonly AgentToolDefinition[]
+  readonly storage?: Storage
+  readonly runId: string
+  readonly requestedByPrincipal?: typeof REQUESTER
+  readonly requesterGroupIds?: readonly string[]
+}) {
+  const agent = defineAgent("workflow-usage-agent", {
+    name: "Workflow usage agent",
+    model: input.model,
+    instructions: "Resolve the best project.",
+    groups: [AGENT_RUNTIME_GROUP],
+    ...(input.tools === undefined ? {} : { tools: input.tools }),
+  })
+  const agentStep = defineAgentStep("workflow-usage-step", agent)
+    .input({ query: "string" })
+    .output({ answer: "string", confidence: "double" })
+    .prompt(({ input: stepInput }) => `Resolve '${stepInput.query}'.`)
+  const workflow = defineWorkflow("workflow-usage-test").input({ query: "string" }).then(agentStep)
+  const sixb = new SixbHost({
+    id: PROJECT_ID,
+    ontology: [],
+    agents: [agent],
+    workflows: [workflow],
+    groups: [AGENT_RUNTIME_GROUP],
+    broker: new InMemoryBroker(),
+    storage: input.storage ?? new InMemoryStorage(),
+    lakeStorage: new InMemoryLakeStorage(),
+    blobStorage: new InMemoryBlobStorage(),
+    queues: new InMemoryQueues(),
+    sandboxes: new RecordingSandboxFactory(),
+  })
+  const runs = sixb.storage.workflowRuns
+  if (!runs) throw new Error("expected workflow run storage")
+  const requestedBy = input.requestedByPrincipal ?? REQUESTER
+  await seedRequesterUser(sixb.storage, requestedBy)
+
+  const nodeRunId = `${input.runId}:node:0`
+  const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
+    projectId: PROJECT_ID,
+    workflowId: workflow.id,
+    runId: input.runId,
+    requestedBy,
+  })
+  await runs.queue({
+    id: input.runId,
+    projectId: PROJECT_ID,
+    executionId,
+    workflowId: workflow.id,
+    input: { query: "alpha" },
+    requesterGroupIds: input.requesterGroupIds ?? ["workflow-users"],
+  })
+  await runs.start({ id: input.runId, projectId: PROJECT_ID })
+  await runs.nodes.start({
+    id: nodeRunId,
+    projectId: PROJECT_ID,
+    workflowRunId: input.runId,
+    workflowId: workflow.id,
+    nodeIndex: 0,
+    nodeType: "agent",
+    nodeId: agentStep.id,
+    nodeKey: "workflowUsageStep",
+    input: { query: "alpha" },
+  })
+  const agentExecutionId = await createTestAgentExecution(sixb.storage, {
+    projectId: PROJECT_ID,
+    agentId: agent.id,
+    runId: nodeRunId,
+    parentExecutionId: executionId,
+  })
+  await runs.agentNodes.create({
+    projectId: PROJECT_ID,
+    nodeRunId,
+    executionId: agentExecutionId,
+    agentId: agent.id,
+    prompt: "Resolve 'alpha'.",
+  })
+  await runs.nodes.wait({ projectId: PROJECT_ID, id: nodeRunId })
+  await runs.wait({ projectId: PROJECT_ID, id: input.runId })
+  await sixb.queues.agents.enqueue({
+    projectId: PROJECT_ID,
+    jobs: [
+      {
+        id: `wfa_job_${nodeRunId}`,
+        type: "agent.workflow-node.requested",
+        payload: { nodeRunId },
+      },
+    ],
+  })
+
+  return { sixb, runs, workflow, agent, nodeRunId }
+}
+
 class FailingRunStreamBroker extends InMemoryBroker {
   override append(
     params: Parameters<InMemoryBroker["append"]>[0]
@@ -1232,10 +1454,12 @@ describe("AgentWorker", () => {
     const runs = sixb.storage.workflowRuns!
     const runId = "workflow-agent-run"
     const nodeRunId = `${runId}:node:0`
+    await seedRequesterUser(sixb.storage)
     const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
       projectId: PROJECT_ID,
       workflowId: workflow.id,
       runId,
+      requestedBy: REQUESTER,
     })
     await runs.queue({
       id: runId,
@@ -1243,7 +1467,7 @@ describe("AgentWorker", () => {
       executionId,
       workflowId: workflow.id,
       input: { query: "alpha" },
-      requesterGroupIds: [],
+      requesterGroupIds: ["operations", "project-alpha"],
     })
     await runs.start({
       id: runId,
@@ -1285,6 +1509,13 @@ describe("AgentWorker", () => {
         },
       ],
     })
+    const recordedUsage: RecordAiModelCallInput[] = []
+    const aiUsage = aiUsageStorageOf(sixb)
+    const recordModelCall = aiUsage.recordModelCall.bind(aiUsage)
+    aiUsage.recordModelCall = async (usage) => {
+      recordedUsage.push(structuredClone(usage))
+      return recordModelCall(usage)
+    }
 
     const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
     await worker.start()
@@ -1309,6 +1540,61 @@ describe("AgentWorker", () => {
       expect(execution.execution).toBeUndefined()
       expect(execution.trace).toBeArray()
       expect(lookupCalls).toBe(1)
+      expect(recordedUsage).toHaveLength(2)
+      expect(recordedUsage.map((usage) => usage.execution)).toEqual([
+        { kind: "workflowAgentNode", workflowRunId: runId, nodeRunId },
+        { kind: "workflowAgentNode", workflowRunId: runId, nodeRunId },
+      ])
+      expect(recordedUsage.map((usage) => usage.attempt)).toEqual([1, 1])
+      expect(recordedUsage.map((usage) => usage.requesterPrincipal)).toEqual([REQUESTER, REQUESTER])
+      expect(recordedUsage.map((usage) => usage.requesterGroupIds)).toEqual([
+        ["operations", "project-alpha"],
+        ["operations", "project-alpha"],
+      ])
+      expect(recordedUsage.map((usage) => usage.usage)).toEqual([
+        {
+          inputTokens: 10,
+          outputTokens: 7,
+          uncachedInputTokens: 10,
+          cacheReadInputTokens: 0,
+          cacheWriteInputTokens: 0,
+          textOutputTokens: 7,
+          reasoningOutputTokens: 0,
+        },
+        {
+          inputTokens: 10,
+          outputTokens: 7,
+          uncachedInputTokens: 10,
+          cacheReadInputTokens: 0,
+          cacheWriteInputTokens: 0,
+          textOutputTokens: 7,
+          reasoningOutputTokens: 0,
+        },
+      ])
+      expect(recordedUsage.map((usage) => usage.requestedModelId)).toEqual([
+        "mock-model",
+        "mock-model",
+      ])
+      expect(recordedUsage.map((usage) => usage.rawUsage)).toEqual([
+        { input_tokens: 10, output_tokens: 7, provider_meter: 1 },
+        { input_tokens: 10, output_tokens: 7, provider_meter: 1 },
+      ])
+      expect(recordedUsage.every((usage) => usage.occurredAt instanceof Date)).toBe(true)
+      expect(new Set(recordedUsage.map((usage) => usage.responseId)).size).toBe(2)
+      await expect(
+        aiUsage.summarizeExecution({
+          projectId: PROJECT_ID,
+          execution: { kind: "workflowAgentNode", workflowRunId: runId, nodeRunId },
+        })
+      ).resolves.toMatchObject({
+        modelCallCount: 2,
+        usage: {
+          inputTokens: 20,
+          outputTokens: 14,
+          totalTokens: 34,
+          reportingStatus: "complete",
+        },
+      })
       expect(execution.trace).toContainEqual(
         expect.objectContaining({
           type: "tool-call",
@@ -1339,6 +1625,319 @@ describe("AgentWorker", () => {
           resume: { kind: "agentNode", nodeRunId },
         },
       })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("keeps workflow usage when structured output validation fails", async () => {
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model: invalidStructuredAnswerModel(),
+      runId: "workflow-invalid-output",
+    })
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const record = await runs.agentNodes.getByNodeRunId({
+            projectId: PROJECT_ID,
+            nodeRunId,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "workflow output validation failure" }
+      )
+
+      expect(execution.status).toBe("failed")
+      await expect(
+        aiUsageStorageOf(sixb).summarizeExecution({
+          projectId: PROJECT_ID,
+          execution: {
+            kind: "workflowAgentNode",
+            workflowRunId: "workflow-invalid-output",
+            nodeRunId,
+          },
+        })
+      ).resolves.toMatchObject({
+        modelCallCount: 1,
+        usage: {
+          inputTokens: 10,
+          outputTokens: 7,
+          totalTokens: 17,
+          reportingStatus: "complete",
+        },
+      })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("keeps completed workflow usage when a tool path later fails", async () => {
+    let toolCalls = 0
+    const failingTool = defineAgentTool("fail_lookup")
+      .description("Fail a project lookup.")
+      .input({ query: "string" })
+      .run(() => {
+        toolCalls += 1
+        throw new Error("project lookup unavailable")
+      })
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model: structuredToolThenProviderFailureModel(),
+      tools: [failingTool],
+      runId: "workflow-tool-failure",
+    })
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const record = await runs.agentNodes.getByNodeRunId({
+            projectId: PROJECT_ID,
+            nodeRunId,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "workflow tool path failure" }
+      )
+
+      expect(toolCalls).toBe(1)
+      expect(execution.status).toBe("failed")
+      await expect(
+        aiUsageStorageOf(sixb).summarizeExecution({
+          projectId: PROJECT_ID,
+          execution: {
+            kind: "workflowAgentNode",
+            workflowRunId: "workflow-tool-failure",
+            nodeRunId,
+          },
+        })
+      ).resolves.toMatchObject({
+        modelCallCount: 1,
+        usage: { inputTokens: 10, outputTokens: 7, totalTokens: 17 },
+      })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("blocks another workflow model call and fails when accounting stays unavailable", async () => {
+    let modelCalls = 0
+    const model = structuredToolThenAnswerModel(() => {
+      modelCalls += 1
+    })
+    const lookup = defineAgentTool("lookup_project")
+      .description("Look up a project.")
+      .input({ query: "string" })
+      .run(() => ({ project: "Project Alpha" }))
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model,
+      tools: [lookup],
+      runId: "workflow-accounting-failure",
+    })
+    const aiUsage = aiUsageStorageOf(sixb)
+    let appendAttempts = 0
+    aiUsage.recordModelCall = async () => {
+      appendAttempts += 1
+      throw new Error("usage storage unavailable")
+    }
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const record = await runs.agentNodes.getByNodeRunId({
+            projectId: PROJECT_ID,
+            nodeRunId,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "workflow accounting failure" }
+      )
+
+      expect(execution.status).toBe("failed")
+      expect(execution.error).toContain("Could not record AI usage")
+      expect(modelCalls).toBe(1)
+      expect(appendAttempts).toBe(4)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("surfaces a final workflow callback accounting failure without another step", async () => {
+    let modelCalls = 0
+    const model = new MockLanguageModelV4({
+      modelId: "mock-model",
+      doGenerate: async () => {
+        modelCalls += 1
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ answer: "Project Alpha", confidence: 0.96 }),
+            },
+          ],
+          finishReason: { unified: "stop", raw: "stop" },
+          usage: USAGE,
+          warnings: [],
+        }
+      },
+    })
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model,
+      runId: "workflow-final-callback-failure",
+    })
+    const aiUsage = aiUsageStorageOf(sixb)
+    let appendAttempts = 0
+    aiUsage.recordModelCall = async () => {
+      appendAttempts += 1
+      throw new Error("usage storage unavailable")
+    }
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const record = await runs.agentNodes.getByNodeRunId({
+            projectId: PROJECT_ID,
+            nodeRunId,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "final workflow callback accounting failure" }
+      )
+
+      expect(execution.status).toBe("failed")
+      expect(execution.error).toContain("Could not record AI usage")
+      expect(modelCalls).toBe(1)
+      expect(appendAttempts).toBe(4)
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("keeps workflow usage outside a failed node-finalization transaction", async () => {
+    const storage = withOneFailingWorkflowAgentFinalization(new InMemoryStorage())
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model: structuredAnswerModel(),
+      storage,
+      runId: "workflow-finalization-failure",
+    })
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const record = await runs.agentNodes.getByNodeRunId({
+            projectId: PROJECT_ID,
+            nodeRunId,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "workflow node finalization failure" }
+      )
+
+      expect(execution.status).toBe("failed")
+      expect(execution.error).toContain("workflow node finalization unavailable")
+      await expect(
+        aiUsageStorageOf(sixb).summarizeExecution({
+          projectId: PROJECT_ID,
+          execution: {
+            kind: "workflowAgentNode",
+            workflowRunId: "workflow-finalization-failure",
+            nodeRunId,
+          },
+        })
+      ).resolves.toMatchObject({
+        modelCallCount: 1,
+        usage: { inputTokens: 10, outputTokens: 7, totalTokens: 17 },
+      })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("keeps completed workflow usage when the parent run is cancelled during a tool", async () => {
+    let markToolStarted!: () => void
+    let markToolAborted!: () => void
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve
+    })
+    const toolAborted = new Promise<void>((resolve) => {
+      markToolAborted = resolve
+    })
+    const blockingTool = defineAgentTool("lookup_project")
+      .description("Wait for a project lookup.")
+      .input({ query: "string" })
+      .run(async ({ signal }) => {
+        markToolStarted()
+        await new Promise<void>((_resolve, reject) => {
+          const abort = () => {
+            markToolAborted()
+            reject(new DOMException("Aborted", "AbortError"))
+          }
+          if (signal.aborted) abort()
+          else signal.addEventListener("abort", abort, { once: true })
+        })
+        return { project: "unreachable" }
+      })
+    const runId = "workflow-cancelled-during-tool"
+    const { sixb, runs, nodeRunId } = await queueWorkflowAgentNode({
+      model: structuredToolThenAnswerModel(),
+      tools: [blockingTool],
+      runId,
+    })
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      await toolStarted
+      await sixb.storage.transaction(async (tx) => {
+        const transactionalRuns = tx.workflowRuns
+        if (!transactionalRuns) throw new Error("expected transactional workflow storage")
+        await transactionalRuns.agentNodes.cancel({
+          projectId: PROJECT_ID,
+          nodeRunId,
+          error: "Workflow run cancelled.",
+        })
+        await transactionalRuns.nodes.finish({
+          projectId: PROJECT_ID,
+          id: nodeRunId,
+          status: "cancelled",
+          error: "Workflow run cancelled.",
+        })
+        await transactionalRuns.finish({
+          projectId: PROJECT_ID,
+          id: runId,
+          status: "cancelled",
+          error: "Workflow run cancelled.",
+        })
+      })
+      await publishAgentRunCancel(sixb.broker, { projectId: PROJECT_ID, runId: nodeRunId })
+      await toolAborted
+
+      await expect(
+        aiUsageStorageOf(sixb).summarizeExecution({
+          projectId: PROJECT_ID,
+          execution: { kind: "workflowAgentNode", workflowRunId: runId, nodeRunId },
+        })
+      ).resolves.toMatchObject({
+        modelCallCount: 1,
+        usage: {
+          inputTokens: 10,
+          outputTokens: 7,
+          totalTokens: 17,
+          reportingStatus: "complete",
+        },
+      })
+      await expect(
+        runs.agentNodes.getByNodeRunId({ projectId: PROJECT_ID, nodeRunId })
+      ).resolves.toMatchObject({ status: "cancelled" })
     } finally {
       await worker.stop()
     }
@@ -2513,6 +3112,44 @@ describe("AgentWorker", () => {
         status: "succeeded",
         runId,
         attempt: 1,
+      })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("keeps completed-call usage when durable response projection fails", async () => {
+    const sixb = buildSixb(invalidMetadataAnswerModel())
+    const storage = agentStorageOf(sixb)
+    const worker = new AgentWorker(sixb, workerOptions())
+    await worker.start()
+    try {
+      const request = await requestAgent(sixb, { agentId: "assistant", text: "echo hi" })
+      const run = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({
+            projectId: PROJECT_ID,
+            id: request.run.id,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "durable response projection failure" }
+      )
+
+      expect(run.status).toBe("failed")
+      await expect(
+        aiUsageStorageOf(sixb).summarizeExecution({
+          projectId: PROJECT_ID,
+          executionId: run.executionId,
+        })
+      ).resolves.toMatchObject({
+        modelCallCount: 1,
+        usage: {
+          inputTokens: 10,
+          outputTokens: 7,
+          totalTokens: 17,
+          reportingStatus: "complete",
+        },
       })
     } finally {
       await worker.stop()
@@ -4435,7 +5072,7 @@ describe("AgentWorker", () => {
       threadId,
       agentId: "removed-agent",
       triggerMessageId,
-      requesterGroupIds: [],
+      requesterGroupIds: ["engineering"],
     })
     await sixb.queues.agents.enqueue({
       projectId: PROJECT_ID,

--- a/packages/core/src/testing/workflow-execution.ts
+++ b/packages/core/src/testing/workflow-execution.ts
@@ -1,4 +1,4 @@
-import type { TrustedPrimitiveRef } from "../execution"
+import type { AuthorizablePrincipal, TrustedPrimitiveRef } from "../execution"
 import type { ExecutionStorage } from "../storage/executions"
 
 /** Create the durable execution chain required by a workflow-run storage fixture. */
@@ -9,6 +9,7 @@ export async function createTestWorkflowExecution(
     readonly workflowId: string
     readonly runId: string
     readonly executionId?: string
+    readonly requestedBy?: AuthorizablePrincipal
   }
 ): Promise<string> {
   const parentExecutionId = `test_request_execution:${input.runId}`
@@ -24,14 +25,19 @@ export async function createTestWorkflowExecution(
     projectId: input.projectId,
     executor: { type: "request", requestId: `test_request:${input.runId}` },
     source: { type: "http", requestId: `test_request:${input.runId}` },
+    ...(input.requestedBy === undefined ? {} : { requestedBy: structuredClone(input.requestedBy) }),
     correlationId: `test_correlation:${input.runId}`,
-    authorizationRef: { type: "disabled" },
+    authorizationRef:
+      input.requestedBy === undefined
+        ? { type: "disabled" }
+        : { type: "principal", principal: structuredClone(input.requestedBy) },
   })
   await executions.create({
     id: executionId,
     projectId: input.projectId,
     executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
     source: { type: "execution", executionId: parentExecutionId },
+    ...(input.requestedBy === undefined ? {} : { requestedBy: structuredClone(input.requestedBy) }),
     correlationId: `test_correlation:${input.runId}`,
     parentExecutionId,
     authorizationRef: { type: "trustedPrimitive", primitive },


### PR DESCRIPTION
## Summary

> Stack: #354 → #355 → #356 → **#357** → #358

This is PR 4 of 5 in the Phase 1 AI usage accounting stack. It reuses the conversation recorder for
workflow agent nodes executed through `generateText`.

After this PR, every Sixb-owned language-model execution path writes the same authoritative
model-call ledger. The remaining stack PR changes public reads to that ledger and removes legacy run
projections.

## Why workflow capture needs its own review

Workflow agent nodes have failure and transaction boundaries that conversations do not:

- structured output validation can fail after a completed provider call;
- tool execution can fail before a later provider attempt;
- a parent workflow can be cancelled while a child tool is active;
- node finalization can roll back in a transaction after usage has become billable;
- child execution attribution must come from the parent workflow admission, not be recomputed.

These are exactly the paths a future token or cost budget must account for consistently.

## What this PR adds

### `generateText` lifecycle capture

- Passes the shared recorder to workflow agent-node execution.
- Uses `onLanguageModelCallEnd` for every provider response in a tool loop.
- Uses `prepareStep` to block another provider call after a persistent accounting failure.
- Performs a final recorder health check because a last-step callback has no later `prepareStep`.

### Stable workflow attribution

- Loads the immutable parent `WorkflowRunRecord`.
- Copies its requester principal and group snapshot onto every child model-call record.
- Uses execution identity:
  - workflow run ID;
  - workflow node run ID;
  - durable delivery attempt.
- Does not duplicate requester fields onto the workflow agent-node run row.

### Failure and transaction behavior

- Usage remains outside the fenced node-finalization transaction.
- A rolled-back success/failure write cannot roll back an already recorded billable call.
- Accounting failure takes precedence over output parsing or cancellation classification.
- A cancellation endpoint that already made a node terminal still cannot cause a lost accounting
  append to be acknowledged silently.

### Tests

Covers:

- multi-step workflow tool loops;
- raw and normalized usage details;
- parent principal/group attribution;
- structured-output validation failure;
- tool failure after a completed provider call;
- persistent accounting-storage failure before another step;
- final callback failure with no next step;
- failed node-finalization transaction;
- cancellation of the parent workflow during a tool;
- workflow worker resume behavior.

## Rollout behavior

At this point in the stack:

- conversations write per-call ledger records;
- workflow agent nodes write per-call ledger records;
- existing run/node aggregate projections remain temporarily for current API consumers;
- no destructive migration has run.

This creates a verification window before the final cutover: operators can confirm ledger rows exist
for both `agentRun` and `workflowAgentNode` execution kinds.

## What is intentionally not in this PR

- No API/client/Atlas cutover.
- No removal of run/node usage projections.
- No destructive migration.
- No pricing, reconciliation, budget definitions, counters, or enforcement.

## Phase 1 stack

1. Accounting contract and standalone in-memory model.
2. Durable storage and immutable requester attribution.
3. Conversation model-call capture.
4. **This PR:** workflow agent-node model-call capture.
5. Ledger-backed API cutover and removal of legacy run projections.

## How this supports later budgets

After this PR, a future budget evaluator sees the same facts regardless of whether an agent was
started from a conversation or embedded in a workflow. That prevents workflow usage from bypassing
project, principal, or group limits.

The later enforcement path can use the same sequence in both runtimes:

```text
provider call completes
  → persist usage
  → later: rate cost and update monthly counters
  → prepareStep recheck
  → later: deny another call when exhausted
```

Pricing and reconciliation remain separate future layers. Provider response IDs and occurrence times
recorded here are the joins those layers need.

## Review guide

Suggested order:

1. `run-workflow-agent-node.ts`
2. `workflow-node-execution.ts`
3. workflow-related additions in `worker.test.ts`
4. the `generateText` AI SDK compatibility contract

Questions to keep in mind:

- Is attribution always inherited from the parent run?
- Can structured-output validation erase usage?
- Can a failed finalization transaction erase usage?
- Can cancellation turn an accounting failure into an acknowledged job?
- Does the same recorder behavior apply to stream and generate paths?

## Validation

```bash
bun run typecheck
bun run check
bun test packages/agent-worker/tests/worker.test.ts
bun test packages/workflow-worker/tests/run-workflow-job.test.ts \
  packages/workflow-worker/tests/worker.test.ts
bun --filter @sixb/agent-worker build
bun --filter @sixb/workflow-worker build
```

The agent-worker suite passes 62 tests at this stack point. The workflow-worker suites pass all 36
tests. Root typecheck, Biome, and both worker builds pass.
