### PR TITLE
ontology-outbox: persist structured failures

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -34,6 +34,8 @@ Each primitive specializes `TCode` to the codes it can persist. Most migrated ru
 `queue.enqueue_failed` code and require `{ actionId, runId, phase }` in `details`.
 Webhook runs declare only `internal.unexpected`: their lifecycle has no cancellation state,
 while expected delivery outcomes remain represented by their HTTP status and delivery claim result.
+The ontology outbox declares `event.delivery_failed`; its durable record is retained while publication
+is retried.
 
 Each storage and wire change remains independently reviewable even though every migrated primitive shares the same portable base record.
 
@@ -43,6 +45,7 @@ Each storage and wire change remains independently reviewable even though every 
 | `dataset.version_incompatible` | No | The immutable dataset version does not match the dataset or schema required by the operation. | Materialize a compatible version and dispatch a new run. |
 | `dataset.version_not_found` | No | The requested dataset version does not exist, or the dataset has no committed version yet. | Check the version ID or materialize the dataset before reading rows. |
 | `dataset.version_read_inconsistent` | Yes | Read results conflict with immutable version metadata. | Retry, then inspect lake storage integrity. |
+| `event.delivery_failed` | Yes | A persisted ontology event could not be published. | Let the outbox retry, then inspect the broker. |
 | `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect internal logs. Do not retry automatically. |
 | `queue.enqueue_failed` | Yes | A job could not be handed to its queue. | Retry the unchanged request while the durable run remains in its enqueue phase. |
 | `projection.definition_invalid` | No | A projection definition is incompatible with its ontology or dataset mapping. | Fix the projection definition and dispatch a new run. |

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -26,6 +26,10 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "Dataset version could not be read consistently.",
     retryable: true,
   },
+  "event.delivery_failed": {
+    publicMessage: "Event delivery failed.",
+    retryable: true,
+  },
   "internal.unexpected": {
     publicMessage: "An unexpected internal error occurred.",
     retryable: false,

--- a/packages/core/src/events/outbox-dispatcher.ts
+++ b/packages/core/src/events/outbox-dispatcher.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto"
+import { createSixbError, toSixbFailure } from "../errors/internal"
 import type { ClaimedOntologyOutboxRow, OntologyOutboxStorage, Storage } from "../storage"
+import { ONTOLOGY_OUTBOX_FAILURE_CODES } from "../storage/ontology/outbox"
 import type { StableEventPublisher } from "./service"
 
 const DEFAULT_BATCH_SIZE = 1_000
@@ -13,7 +15,6 @@ const DEFAULT_RETRY_JITTER_RATIO = 0.2
 const DEFAULT_MAX_ISOLATION_ATTEMPTS = 32
 const DEFAULT_MAX_CLAIMS_PER_DRAIN = 10
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000
-const SHUTDOWN_RESCHEDULE_ERROR = "Outbox dispatcher stopped before publication completed."
 
 export interface OntologyOutboxDeliveryFailure {
   readonly occurredAt: string
@@ -320,7 +321,12 @@ export class OntologyOutboxDispatcher {
     const failedAt = this.now()
 
     for (const [attempts, attemptRows] of rowsByAttempts(settling)) {
-      failures.add(error, failedAt.toISOString(), attempts, attemptRows)
+      const deliveryError = createEventDeliveryError(error, attempts, attemptRows)
+      const failure = toSixbFailure(deliveryError, {
+        allowedCodes: ONTOLOGY_OUTBOX_FAILURE_CODES,
+        at: failedAt,
+      })
+      failures.add(deliveryError, failedAt.toISOString(), attempts, attemptRows)
       try {
         await this.withOutbox((outbox) =>
           outbox.reschedule({
@@ -328,7 +334,7 @@ export class OntologyOutboxDispatcher {
             ids: eventIds(attemptRows),
             leaseId: sharedLeaseId(attemptRows),
             availableAt: new Date(failedAt.getTime() + this.retryDelayMs(attempts)).toISOString(),
-            error: errorMessage(error),
+            failure,
           })
         )
       } catch (rescheduleError) {
@@ -358,7 +364,6 @@ export class OntologyOutboxDispatcher {
           ids: eventIds(rows),
           leaseId: sharedLeaseId(rows),
           availableAt: this.now().toISOString(),
-          error: SHUTDOWN_RESCHEDULE_ERROR,
         })
       )
     } catch (error) {
@@ -487,9 +492,23 @@ function sharedLeaseId(rows: readonly ClaimedOntologyOutboxRow[]): string {
   return leaseId
 }
 
-function errorMessage(error: unknown): string {
-  const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
-  return message.slice(0, 2_000)
+function createEventDeliveryError(
+  cause: unknown,
+  attempts: number,
+  rows: readonly ClaimedOntologyOutboxRow[]
+) {
+  return createSixbError(
+    "event.delivery_failed",
+    "[Sixb] Could not deliver persisted ontology events.",
+    {
+      cause,
+      details: {
+        attempts,
+        eventIds: eventIds(rows).sort(),
+        eventTypes: [...new Set(rows.map((row) => row.envelope.type))].sort(),
+      },
+    }
+  )
 }
 
 async function publishUntilStopped(

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -329,6 +329,8 @@ export type {
   OntologyMaterializationEvent,
   OntologyMaterializationEventDraft,
   OntologyMaterializationStorage,
+  OntologyOutboxFailure,
+  OntologyOutboxFailureCode,
   OntologyOutboxRecord,
   OntologyOutboxStorage,
   OntologyOutboxSummary,
@@ -365,6 +367,7 @@ export type {
   TelemetryOntologyCommitIntent,
   TerminalSourceMaterializationSummary,
 } from "./ontology"
+export { ONTOLOGY_OUTBOX_FAILURE_CODES } from "./ontology"
 export type {
   FinishPipelineRunInput,
   FinishPipelineStepRunInput,

--- a/packages/core/src/storage/ontology/in-memory/materializations.ts
+++ b/packages/core/src/storage/ontology/in-memory/materializations.ts
@@ -725,7 +725,7 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
           leaseId: null,
           leaseExpiresAt: null,
           publishedAt: null,
-          lastError: null,
+          lastFailure: null,
           createdAt: item.createdAt,
         })
         session.outboxEnvelopes.set(envelope.commitOrdinal, structuredClone(envelope))

--- a/packages/core/src/storage/ontology/in-memory/outbox.ts
+++ b/packages/core/src/storage/ontology/in-memory/outbox.ts
@@ -94,7 +94,7 @@ export class InMemoryOntologyOutboxStorage implements OntologyOutboxStorage {
       this.state.outbox.set(key, {
         ...row,
         availableAt: input.availableAt,
-        lastError: input.error,
+        lastFailure: input.failure === undefined ? row.lastFailure : structuredClone(input.failure),
         leaseId: null,
         leaseExpiresAt: null,
       })

--- a/packages/core/src/storage/ontology/index.ts
+++ b/packages/core/src/storage/ontology/index.ts
@@ -82,6 +82,8 @@ export type {
   CompleteOntologyOutboxLeaseInput,
   OntologyMaterializationEvent,
   OntologyMaterializationEventDraft,
+  OntologyOutboxFailure,
+  OntologyOutboxFailureCode,
   OntologyOutboxRecord,
   OntologyOutboxStorage,
   OntologyOutboxSummary,
@@ -90,6 +92,7 @@ export type {
   RescheduleOntologyOutboxLeaseInput,
   SummarizeOntologyOutboxInput,
 } from "./outbox"
+export { ONTOLOGY_OUTBOX_FAILURE_CODES } from "./outbox"
 export type {
   AbandonSourceMaterializationCandidateInput,
   AbandonSourceMaterializationInput,

--- a/packages/core/src/storage/ontology/outbox.ts
+++ b/packages/core/src/storage/ontology/outbox.ts
@@ -1,3 +1,4 @@
+import type { SixbErrorCode, SixbFailure } from "../../errors/types"
 import type { OntologyMaterializationEvent } from "../../materialization/events"
 
 export type {
@@ -12,6 +13,15 @@ export interface OntologyOutboxWrite {
   readonly createdAt: string
 }
 
+/** Error codes a durable ontology outbox delivery can persist. */
+export const ONTOLOGY_OUTBOX_FAILURE_CODES = ["event.delivery_failed"] as const satisfies readonly [
+  SixbErrorCode,
+  ...SixbErrorCode[],
+]
+
+export type OntologyOutboxFailureCode = (typeof ONTOLOGY_OUTBOX_FAILURE_CODES)[number]
+export type OntologyOutboxFailure = SixbFailure<OntologyOutboxFailureCode>
+
 export interface OntologyOutboxRecord {
   readonly envelope: OntologyMaterializationEvent
   readonly availableAt: string
@@ -19,7 +29,7 @@ export interface OntologyOutboxRecord {
   readonly leaseId: string | null
   readonly leaseExpiresAt: string | null
   readonly publishedAt: string | null
-  readonly lastError: string | null
+  readonly lastFailure: OntologyOutboxFailure | null
   readonly createdAt: string
 }
 
@@ -48,7 +58,8 @@ export interface RescheduleOntologyOutboxLeaseInput {
   readonly ids: readonly string[]
   readonly leaseId: string
   readonly availableAt: string
-  readonly error: string
+  /** The delivery failure that caused this retry. Omitted for lifecycle-only rescheduling. */
+  readonly failure?: OntologyOutboxFailure
 }
 
 export interface PurgePublishedOntologyOutboxInput {

--- a/packages/core/src/testing/ontology-storage-contract.ts
+++ b/packages/core/src/testing/ontology-storage-contract.ts
@@ -7,6 +7,7 @@ import type {
   MaterializationPlanFinalization,
   MaterializationPlanHeader,
   MaterializationSession,
+  OntologyOutboxFailure,
   OntologySourceRecord,
 } from "../storage/ontology"
 import type { ProjectionRunStorage } from "../storage/projection-runs"
@@ -69,6 +70,15 @@ interface ReadyCandidate {
   readonly execution: ProjectionExecution
   readonly materializationId: string
   readonly source: { readonly projectionId: string }
+}
+
+function ontologyOutboxFailure(message: string): OntologyOutboxFailure {
+  return {
+    code: "event.delivery_failed",
+    message,
+    retryable: true,
+    at: "2026-01-03T02:00:00.000Z",
+  }
 }
 
 /**
@@ -583,7 +593,7 @@ export function runOntologyStorageContractSuite<TStorage extends OntologyStorage
           ids: [reclaimed[0].envelope.id],
           leaseId: "lease-two",
           availableAt: "2026-01-04T00:00:00.000Z",
-          error: "broker unavailable",
+          failure: ontologyOutboxFailure("broker unavailable"),
         })
         const retried = await storage.ontology.outbox.claim({
           projectId: "contract-project",
@@ -592,14 +602,34 @@ export function runOntologyStorageContractSuite<TStorage extends OntologyStorage
           leaseId: "lease-three",
           leaseExpiresAt: "2026-01-04T01:00:00.000Z",
         })
-        expect(retried[0]).toMatchObject({ attempts: 3, lastError: "broker unavailable" })
-        expect(
-          await storage.ontology.outbox.summarize({ projectId: "contract-project" })
-        ).toMatchObject({ pendingCount: 2, retryingCount: 2, maxAttempts: 3 })
-        await storage.ontology.outbox.markPublished({
+        expect(retried[0]).toMatchObject({
+          attempts: 3,
+          lastFailure: ontologyOutboxFailure("broker unavailable"),
+        })
+        await storage.ontology.outbox.reschedule({
           projectId: "contract-project",
           ids: [retried[0].envelope.id],
           leaseId: "lease-three",
+          availableAt: "2026-01-04T00:15:00.000Z",
+        })
+        const lifecycleRescheduled = await storage.ontology.outbox.claim({
+          projectId: "contract-project",
+          now: "2026-01-04T00:15:00.000Z",
+          limit: 1,
+          leaseId: "lease-four",
+          leaseExpiresAt: "2026-01-04T01:15:00.000Z",
+        })
+        expect(lifecycleRescheduled[0]).toMatchObject({
+          attempts: 4,
+          lastFailure: ontologyOutboxFailure("broker unavailable"),
+        })
+        expect(
+          await storage.ontology.outbox.summarize({ projectId: "contract-project" })
+        ).toMatchObject({ pendingCount: 2, retryingCount: 2, maxAttempts: 4 })
+        await storage.ontology.outbox.markPublished({
+          projectId: "contract-project",
+          ids: [lifecycleRescheduled[0].envelope.id],
+          leaseId: "lease-four",
           publishedAt: "2026-01-04T00:30:00.000Z",
         })
         expect(

--- a/packages/core/tests/events-outbox-dispatcher.test.ts
+++ b/packages/core/tests/events-outbox-dispatcher.test.ts
@@ -6,7 +6,7 @@ import {
   type StorageTransactionOptions,
 } from "../src"
 import { DomainEventService, OntologyOutboxDispatcher, type StoredDomainEvent } from "../src/events"
-import type { OntologyMaterializationEvent } from "../src/storage"
+import type { OntologyMaterializationEvent, OntologyOutboxFailure } from "../src/storage"
 import { getInMemoryOntologyStorageTestingAdapter } from "../src/storage/ontology/in-memory/testing"
 import { createMaterializerFixture } from "./materializer-fixture"
 
@@ -105,6 +105,7 @@ describe("OntologyOutboxDispatcher", () => {
     const events = new DomainEventService({ projectId: "project", broker })
     const { materializer } = createMaterializerFixture({ storage })
     await seedObjectCreated(materializer, "request-retry", "retry")
+    const eventId = outboxRows(storage)[0]!.envelope.id
     let nowMs = NOW.getTime()
     const randomValues = [1, 0.5, 1]
 
@@ -133,7 +134,17 @@ describe("OntologyOutboxDispatcher", () => {
       availableAt: "2026-01-02T03:04:05.575Z",
       leaseId: null,
       leaseExpiresAt: null,
-      lastError: "Error: broker unavailable",
+      lastFailure: {
+        code: "event.delivery_failed",
+        message: "Event delivery failed.",
+        retryable: true,
+        at: "2026-01-02T03:04:05.325Z",
+        details: {
+          attempts: 3,
+          eventIds: [eventId],
+          eventTypes: ["object.created"],
+        },
+      },
     })
     expect(
       await storage.ontology.outbox.claim({
@@ -174,7 +185,7 @@ describe("OntologyOutboxDispatcher", () => {
       ids: [olderId],
       leaseId: olderClaim!.leaseId,
       availableAt: NOW.toISOString(),
-      error: "seed retry",
+      failure: outboxFailure("seed retry"),
     })
     await seedObjectCreated(materializer, "request-newer", "newer")
     const newerId = outboxRows(storage).find((row) => row.envelope.id !== olderId)!.envelope.id
@@ -314,7 +325,17 @@ describe("OntologyOutboxDispatcher", () => {
     expect(rows.find((row) => row.envelope.id === poisonId)).toMatchObject({
       publishedAt: null,
       leaseId: null,
-      lastError: "Error: poison envelope",
+      lastFailure: {
+        code: "event.delivery_failed",
+        message: "Event delivery failed.",
+        retryable: true,
+        at: NOW.toISOString(),
+        details: {
+          attempts: 1,
+          eventIds: [poisonId],
+          eventTypes: ["object.created"],
+        },
+      },
     })
     expect(failures).toMatchObject([{ attempts: 1, eventIds: [poisonId] }])
     expect((await events.read()).map(objectPrimaryId).sort()).toEqual(["valid-1", "valid-2"])
@@ -354,7 +375,17 @@ describe("OntologyOutboxDispatcher", () => {
     expect(rows.find((row) => row.envelope.id === poisonId)).toMatchObject({
       publishedAt: null,
       leaseId: null,
-      lastError: "Error: poison envelope",
+      lastFailure: {
+        code: "event.delivery_failed",
+        message: "Event delivery failed.",
+        retryable: true,
+        at: NOW.toISOString(),
+        details: {
+          attempts: 1,
+          eventIds: [poisonId],
+          eventTypes: ["object.created"],
+        },
+      },
     })
     expect(await events.read({ limit: 1_000 })).toHaveLength(999)
   })
@@ -474,7 +505,7 @@ describe("OntologyOutboxDispatcher", () => {
       availableAt: NOW.toISOString(),
       leaseId: null,
       leaseExpiresAt: null,
-      lastError: "Outbox dispatcher stopped before publication completed.",
+      lastFailure: null,
     })
 
     broker.release.resolve()
@@ -528,6 +559,15 @@ async function seedObjectCreated(
 
 function outboxRows(storage: InMemoryStorage) {
   return [...getInMemoryOntologyStorageTestingAdapter(storage.ontology).snapshot().outbox.values()]
+}
+
+function outboxFailure(message: string): OntologyOutboxFailure {
+  return {
+    code: "event.delivery_failed",
+    message,
+    retryable: true,
+    at: NOW.toISOString(),
+  }
 }
 
 function objectPrimaryId(event: StoredDomainEvent): string | undefined {

--- a/packages/core/tests/ontology-storage-in-memory.test.ts
+++ b/packages/core/tests/ontology-storage-in-memory.test.ts
@@ -14,6 +14,7 @@ import {
   type MaterializationPlanWorkItem,
   type OntologyCommitRecord,
   type OntologyCommitWrite,
+  type OntologyOutboxFailure,
   StorageTransactionError,
 } from "../src/storage"
 import { getInMemoryStorageTestingAdapter } from "../src/storage/in-memory/testing"
@@ -26,6 +27,13 @@ import {
   replacement,
   sourceEntry,
 } from "./materializer-fixture"
+
+const TEST_OUTBOX_FAILURE = {
+  code: "event.delivery_failed",
+  message: "broker down",
+  retryable: true,
+  at: "2027-01-01T00:00:00.000Z",
+} as const satisfies OntologyOutboxFailure
 
 describe("in-memory ontology storage", () => {
   test("uniquely indexes authoritative commits by logical Action and projection origin", async () => {
@@ -485,7 +493,7 @@ describe("in-memory ontology storage", () => {
       ids: [claimed[0].envelope.id],
       leaseId: "lease",
       availableAt: "2027-01-02T00:00:00.000Z",
-      error: "broker down",
+      failure: TEST_OUTBOX_FAILURE,
     })
     const reclaimed = await storage.ontology.outbox.claim({
       projectId: "project",
@@ -1142,7 +1150,7 @@ describe("in-memory ontology storage", () => {
         ids,
         leaseId: "lease-1",
         availableAt: "2026-01-04T00:00:00.000Z",
-        error: "stale",
+        failure: TEST_OUTBOX_FAILURE,
       })
     ).rejects.toThrow("lease does not match")
     await expect(

--- a/packages/core/tests/storage.types.ts
+++ b/packages/core/tests/storage.types.ts
@@ -1,9 +1,20 @@
 import type {
   ObjectQueryCapabilities,
   ObjectStorage,
+  OntologyOutboxFailureCode,
+  OntologyOutboxRecord,
   QueryObjectsInput,
   QueryObjectsResult,
 } from "../src/storage"
+
+const outboxFailureCode: OntologyOutboxFailureCode = "event.delivery_failed"
+const storedOutboxFailureCode: NonNullable<OntologyOutboxRecord["lastFailure"]>["code"] =
+  outboxFailureCode
+// @ts-expect-error The outbox exposes only its declared delivery-failure code.
+const unrelatedOutboxFailureCode: OntologyOutboxFailureCode = "internal.unexpected"
+
+void storedOutboxFailureCode
+void unrelatedOutboxFailureCode
 
 const capabilities: ObjectQueryCapabilities = {
   queryObjects: true,

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -44,6 +44,9 @@ import webhookRunFailureRecordSql from "./migrations/016-webhook-run-failure-rec
 import actionFailureRecordSql from "./migrations/017-action-failure-record.sql" with {
   type: "text",
 }
+import ontologyOutboxFailureRecordSql from "./migrations/018-ontology-outbox-failure-record.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -314,6 +317,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("015-projection-failure-record", projectionFailureRecordSql),
     pgSql("016-webhook-run-failure-record", webhookRunFailureRecordSql),
     pgSql("017-action-failure-record", actionFailureRecordSql),
+    pgSql("018-ontology-outbox-failure-record", ontologyOutboxFailureRecordSql),
   ],
 })
 

--- a/storage/pg/src/migrations/018-ontology-outbox-failure-record.sql
+++ b/storage/pg/src/migrations/018-ontology-outbox-failure-record.sql
@@ -1,0 +1,29 @@
+-- The legacy record has no failure timestamp. Use its next availability time as the closest
+-- durable timestamp and mark that approximation explicitly in details.
+ALTER TABLE ontology_outbox RENAME COLUMN last_error TO last_failure;
+
+ALTER TABLE ontology_outbox
+  ALTER COLUMN last_failure TYPE JSONB
+  USING (
+    CASE
+      WHEN last_failure IS NULL
+        OR last_failure = 'Outbox dispatcher stopped before publication completed.'
+      THEN NULL
+      ELSE jsonb_build_object(
+        'code', 'event.delivery_failed',
+        'message', 'Event delivery failed.',
+        'retryable', true,
+        'at', to_char(
+          available_at AT TIME ZONE 'UTC',
+          'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+        ),
+        'details', jsonb_build_object(
+          'attempts', attempts,
+          'eventIds', jsonb_build_array(id),
+          'eventTypes', jsonb_build_array(envelope->>'type'),
+          'migratedFromLegacyLastError', true,
+          'timestampSource', 'availableAt'
+        )
+      )
+    END
+  );

--- a/storage/pg/src/ontology-storage/materialization-writer.ts
+++ b/storage/pg/src/ontology-storage/materialization-writer.ts
@@ -493,7 +493,7 @@ export class PgMaterializationWriter {
       INSERT INTO ontology_outbox (
         project_id, id, commit_id, commit_ordinal, envelope,
         available_at, attempts, lease_id, lease_expires_at,
-        published_at, last_error, created_at
+        published_at, last_failure, created_at
       )
       SELECT ${projectId}, value->>'id', ${commitId},
         (value->>'commitOrdinal')::bigint, value->'envelope',

--- a/storage/pg/src/ontology-storage/outbox.ts
+++ b/storage/pg/src/ontology-storage/outbox.ts
@@ -1,3 +1,4 @@
+import { serializeSixbFailure } from "@sixb/core/internal/errors"
 import {
   MaterializationConflictError,
   MaterializationValidationError,
@@ -12,6 +13,7 @@ import type {
   RescheduleOntologyOutboxLeaseInput,
   SummarizeOntologyOutboxInput,
 } from "@sixb/core/storage"
+import { ONTOLOGY_OUTBOX_FAILURE_CODES } from "@sixb/core/storage"
 import {
   assertNonblank,
   assertPositiveInteger,
@@ -57,7 +59,7 @@ export class PgOntologyOutboxStorage implements OntologyOutboxStorage {
           WHERE outbox.project_id = candidates.project_id AND outbox.id = candidates.id
           RETURNING outbox.id AS row_id, outbox.envelope, outbox.available_at,
             outbox.attempts, outbox.lease_id, outbox.lease_expires_at,
-            outbox.published_at, outbox.last_error, outbox.created_at,
+            outbox.published_at, outbox.last_failure, outbox.created_at,
             outbox.commit_id, outbox.commit_ordinal
         )
         SELECT * FROM claimed ORDER BY created_at, commit_id, commit_ordinal
@@ -109,6 +111,10 @@ export class PgOntologyOutboxStorage implements OntologyOutboxStorage {
       assertTimestamp(input.availableAt, "Ontology outbox availableAt")
       const ids = validateLeaseIds(input.ids)
       if (ids.length === 0) return
+      const failure =
+        input.failure === undefined
+          ? null
+          : serializeSixbFailure(input.failure, ONTOLOGY_OUTBOX_FAILURE_CODES)
       const rows = await sql<{ readonly id: string }[]>`
         WITH leased AS MATERIALIZED (
           SELECT id FROM ontology_outbox
@@ -122,7 +128,8 @@ export class PgOntologyOutboxStorage implements OntologyOutboxStorage {
           WHERE (SELECT COUNT(*) FROM leased) = ${ids.length}
         )
         UPDATE ontology_outbox AS outbox
-        SET available_at = ${input.availableAt}, last_error = ${input.error},
+        SET available_at = ${input.availableAt},
+          last_failure = COALESCE(${failure}::text::jsonb, outbox.last_failure),
           lease_id = NULL, lease_expires_at = NULL
         FROM eligible
         WHERE outbox.project_id = ${input.projectId} AND outbox.id = eligible.id

--- a/storage/pg/src/ontology-storage/shared.ts
+++ b/storage/pg/src/ontology-storage/shared.ts
@@ -1,3 +1,4 @@
+import { parseSixbFailure } from "@sixb/core/internal/errors"
 import type { ProjectionEntityRef } from "@sixb/core/internal/materialization"
 import { MaterializationConflictError } from "@sixb/core/internal/materialization"
 import type {
@@ -8,6 +9,7 @@ import type {
   OntologySourceRecord,
   StageSourceAssertion,
 } from "@sixb/core/storage"
+import { ONTOLOGY_OUTBOX_FAILURE_CODES } from "@sixb/core/storage"
 import type { SQLClient } from "../pg-client"
 
 export {
@@ -98,7 +100,7 @@ export interface PgOntologyOutboxRow {
   readonly lease_id: string | null
   readonly lease_expires_at: Date | string | null
   readonly published_at: Date | string | null
-  readonly last_error: string | null
+  readonly last_failure: unknown | null
   readonly created_at: Date | string
 }
 
@@ -196,7 +198,10 @@ export function outboxRecord(row: PgOntologyOutboxRow): OntologyOutboxRecord {
     leaseId: row.lease_id,
     leaseExpiresAt: optionalIsoString(row.lease_expires_at),
     publishedAt: optionalIsoString(row.published_at),
-    lastError: row.last_error,
+    lastFailure:
+      row.last_failure === null
+        ? null
+        : parseSixbFailure(row.last_failure, ONTOLOGY_OUTBOX_FAILURE_CODES),
     createdAt: toIsoString(row.created_at),
   }
 }

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { defineObjectType, migrateStorage, OntologyRegistry, prop } from "@sixb/core"
-import { defineMigrations } from "@sixb/core/storage"
+import { parseSixbFailure } from "@sixb/core/internal/errors"
+import { defineMigrations, ONTOLOGY_OUTBOX_FAILURE_CODES } from "@sixb/core/storage"
 import { createMaterializerTestFixture, createTestWorkflowExecution } from "@sixb/core/testing"
 import { SQL } from "bun"
 import { PostgresStorage, type PostgresStorage as PostgresStorageType } from "../src"
@@ -53,6 +54,7 @@ describe("Postgres storage migrations", () => {
             "015-projection-failure-record",
             "016-webhook-run-failure-record",
             "017-action-failure-record",
+            "018-ontology-outbox-failure-record",
           ],
         },
       ])
@@ -175,6 +177,13 @@ describe("Postgres storage migrations", () => {
           id: "017-action-failure-record",
           status: "applied",
           version: 17,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "018-ontology-outbox-failure-record",
+          status: "applied",
+          version: 18,
         },
       ])
     })
@@ -341,6 +350,73 @@ describe("Postgres storage migrations", () => {
             },
           },
         ])
+      } finally {
+        await sql.end()
+      }
+    })
+  })
+
+  test("ontology outbox failure migration replaces legacy diagnostics with a safe failure", async () => {
+    await withStorage(false, async (storage, schemaName) => {
+      const failureMigrationIndex = postgresStorageMigrations.steps.findIndex(
+        (migration) => migration.id === "018-ontology-outbox-failure-record"
+      )
+      if (failureMigrationIndex !== 17) {
+        throw new Error("PostgreSQL ontology outbox failure migration is missing.")
+      }
+      const connectionString = process.env.DATABASE_URL
+      if (!connectionString) throw new Error("[SixbPg] DATABASE_URL is required.")
+
+      const sql = createPgClient({ connectionString, schemaName, max: 1 })
+      try {
+        const beforeFailureRecord = defineMigrations({
+          adapterId: POSTGRES_STORAGE_ADAPTER_ID,
+          steps: postgresStorageMigrations.steps.slice(0, failureMigrationIndex),
+        })
+        await createPostgresMigrator({
+          sql,
+          schemaName,
+          migrations: beforeFailureRecord,
+        }).migrate()
+        await sql.unsafe(`
+          INSERT INTO ${quoteIdent(schemaName)}.ontology_outbox (
+            project_id, id, commit_id, commit_ordinal, envelope, available_at,
+            attempts, published_at, last_error, created_at
+          ) VALUES
+            (
+              'project-a', 'event-failed', 'commit-failed', 0,
+              '{"type":"object.created"}'::jsonb, '2026-08-10T12:01:00.000Z',
+              2, NULL, 'Error: broker unavailable', '2026-08-10T12:00:00.000Z'
+            ),
+            (
+              'project-a', 'event-stopped', 'commit-stopped', 0,
+              '{"type":"object.updated"}'::jsonb, '2026-08-10T12:02:00.000Z',
+              1, NULL, 'Outbox dispatcher stopped before publication completed.',
+              '2026-08-10T12:00:00.000Z'
+            )
+        `)
+
+        await expect(migrateStorage(storage)).resolves.toMatchObject({ status: "migrated" })
+
+        const rows = await sql.unsafe<
+          Array<{ readonly id: string; readonly last_failure: unknown | null }>
+        >(`SELECT id, last_failure FROM ${quoteIdent(schemaName)}.ontology_outbox ORDER BY id`)
+        expect(parseSixbFailure(rows[0]?.last_failure, ONTOLOGY_OUTBOX_FAILURE_CODES)).toEqual({
+          code: "event.delivery_failed",
+          message: "Event delivery failed.",
+          retryable: true,
+          at: "2026-08-10T12:01:00.000Z",
+          details: {
+            attempts: 2,
+            eventIds: ["event-failed"],
+            eventTypes: ["object.created"],
+            migratedFromLegacyLastError: true,
+            timestampSource: "availableAt",
+          },
+        })
+        expect(rows[1]).toEqual({ id: "event-stopped", last_failure: null })
+        expect(await readTableColumns(schemaName, "ontology_outbox")).toContain("last_failure")
+        expect(await readTableColumns(schemaName, "ontology_outbox")).not.toContain("last_error")
       } finally {
         await sql.end()
       }
@@ -880,6 +956,13 @@ describe("Postgres storage migrations", () => {
           id: "017-action-failure-record",
           status: "applied",
           version: 17,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "018-ontology-outbox-failure-record",
+          status: "applied",
+          version: 18,
         },
       ])
     } finally {

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -47,6 +47,9 @@ import webhookRunFailureRecordSql from "./migrations/016-webhook-run-failure-rec
 import actionFailureRecordSql from "./migrations/017-action-failure-record.sql" with {
   type: "text",
 }
+import ontologyOutboxFailureRecordSql from "./migrations/018-ontology-outbox-failure-record.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -84,6 +87,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("015-projection-failure-record", projectionFailureRecordSql),
     sqliteSql("016-webhook-run-failure-record", webhookRunFailureRecordSql),
     sqliteSql("017-action-failure-record", actionFailureRecordSql),
+    sqliteSql("018-ontology-outbox-failure-record", ontologyOutboxFailureRecordSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/018-ontology-outbox-failure-record.sql
+++ b/storage/sqlite/src/migrations/018-ontology-outbox-failure-record.sql
@@ -1,0 +1,80 @@
+-- SQLite cannot add the JSON constraint while changing the legacy column, so rebuild the table.
+-- The legacy record has no failure timestamp. Use its next availability time as the closest
+-- durable timestamp and mark that approximation explicitly in details.
+DROP INDEX idx_ontology_outbox_claim;
+DROP INDEX idx_ontology_outbox_published;
+
+ALTER TABLE ontology_outbox RENAME TO ontology_outbox_before_failure_record;
+
+CREATE TABLE ontology_outbox (
+  project_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  commit_id TEXT NOT NULL,
+  commit_ordinal INTEGER NOT NULL CHECK (commit_ordinal >= 0),
+  envelope TEXT NOT NULL CHECK (json_valid(envelope)),
+  available_at TEXT NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  lease_id TEXT,
+  lease_expires_at TEXT,
+  published_at TEXT,
+  last_failure TEXT CHECK (last_failure IS NULL OR json_valid(last_failure)),
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, id),
+  UNIQUE (project_id, commit_id, commit_ordinal),
+  CHECK ((lease_id IS NULL) = (lease_expires_at IS NULL))
+);
+
+INSERT INTO ontology_outbox (
+  project_id,
+  id,
+  commit_id,
+  commit_ordinal,
+  envelope,
+  available_at,
+  attempts,
+  lease_id,
+  lease_expires_at,
+  published_at,
+  last_failure,
+  created_at
+)
+SELECT
+  project_id,
+  id,
+  commit_id,
+  commit_ordinal,
+  envelope,
+  available_at,
+  attempts,
+  lease_id,
+  lease_expires_at,
+  published_at,
+  CASE
+    WHEN last_error IS NULL
+      OR last_error = 'Outbox dispatcher stopped before publication completed.'
+    THEN NULL
+    ELSE json_object(
+      'code', 'event.delivery_failed',
+      'message', 'Event delivery failed.',
+      'retryable', json('true'),
+      'at', available_at,
+      'details', json_object(
+        'attempts', attempts,
+        'eventIds', json_array(id),
+        'eventTypes', json_array(json_extract(envelope, '$.type')),
+        'migratedFromLegacyLastError', json('true'),
+        'timestampSource', 'availableAt'
+      )
+    )
+  END,
+  created_at
+FROM ontology_outbox_before_failure_record;
+
+DROP TABLE ontology_outbox_before_failure_record;
+
+CREATE INDEX idx_ontology_outbox_claim
+  ON ontology_outbox(project_id, available_at, lease_expires_at, created_at, commit_id, commit_ordinal)
+  WHERE published_at IS NULL;
+CREATE INDEX idx_ontology_outbox_published
+  ON ontology_outbox(project_id, published_at, id)
+  WHERE published_at IS NOT NULL;

--- a/storage/sqlite/src/ontology-storage/materialization-writer.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-writer.ts
@@ -441,7 +441,7 @@ export class SqliteMaterializationWriter {
         INSERT INTO ontology_outbox (
           project_id, id, commit_id, commit_ordinal, envelope,
           available_at, attempts, lease_id, lease_expires_at,
-          published_at, last_error, created_at
+          published_at, last_failure, created_at
         ) VALUES (?, ?, ?, ?, json(?), ?, 0, NULL, NULL, NULL, NULL, ?)
       `
     )

--- a/storage/sqlite/src/ontology-storage/outbox.ts
+++ b/storage/sqlite/src/ontology-storage/outbox.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite"
+import { serializeSixbFailure } from "@sixb/core/internal/errors"
 import {
   MaterializationConflictError,
   MaterializationValidationError,
@@ -13,6 +14,7 @@ import type {
   RescheduleOntologyOutboxLeaseInput,
   SummarizeOntologyOutboxInput,
 } from "@sixb/core/storage"
+import { ONTOLOGY_OUTBOX_FAILURE_CODES } from "@sixb/core/storage"
 import {
   assertNonblank,
   assertPositiveInteger,
@@ -55,7 +57,7 @@ export class SqliteOntologyOutboxStorage implements OntologyOutboxStorage {
               LIMIT ?
             )
             RETURNING envelope, available_at, attempts, lease_id, lease_expires_at,
-              published_at, last_error, created_at
+              published_at, last_failure, created_at
           `
         )
         .all(
@@ -127,6 +129,10 @@ export class SqliteOntologyOutboxStorage implements OntologyOutboxStorage {
       assertLeaseInput(input)
       assertTimestamp(input.availableAt, "Ontology outbox availableAt")
       const ids = validateLeaseIds(input.ids)
+      const failure =
+        input.failure === undefined
+          ? null
+          : serializeSixbFailure(input.failure, ONTOLOGY_OUTBOX_FAILURE_CODES)
       const changed = this.db
         .query(
           `
@@ -141,7 +147,8 @@ export class SqliteOntologyOutboxStorage implements OntologyOutboxStorage {
               SELECT id FROM leased WHERE (SELECT COUNT(*) FROM leased) = ?
             )
             UPDATE ontology_outbox
-            SET available_at = ?, last_error = ?, lease_id = NULL, lease_expires_at = NULL
+            SET available_at = ?, last_failure = COALESCE(?, last_failure),
+              lease_id = NULL, lease_expires_at = NULL
             WHERE project_id = ? AND id IN (SELECT id FROM eligible)
               AND lease_id = ? AND lease_expires_at IS NOT NULL
           `
@@ -152,7 +159,7 @@ export class SqliteOntologyOutboxStorage implements OntologyOutboxStorage {
           input.leaseId,
           ids.length,
           input.availableAt,
-          input.error,
+          failure,
           input.projectId,
           input.leaseId
         ).changes

--- a/storage/sqlite/src/ontology-storage/shared.ts
+++ b/storage/sqlite/src/ontology-storage/shared.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite"
+import { parseSixbFailure } from "@sixb/core/internal/errors"
 import type { ProjectionEntityRef } from "@sixb/core/internal/materialization"
 import { MaterializationConflictError } from "@sixb/core/internal/materialization"
 import type {
@@ -9,6 +10,7 @@ import type {
   OntologySourceRecord,
   StageSourceAssertion,
 } from "@sixb/core/storage"
+import { ONTOLOGY_OUTBOX_FAILURE_CODES } from "@sixb/core/storage"
 
 export {
   assertNonblank,
@@ -96,7 +98,7 @@ export interface SqliteOntologyOutboxRow {
   readonly lease_id: string | null
   readonly lease_expires_at: string | null
   readonly published_at: string | null
-  readonly last_error: string | null
+  readonly last_failure: string | null
   readonly created_at: string
 }
 
@@ -169,7 +171,10 @@ export function outboxRecord(row: SqliteOntologyOutboxRow): OntologyOutboxRecord
     leaseId: row.lease_id,
     leaseExpiresAt: row.lease_expires_at,
     publishedAt: row.published_at,
-    lastError: row.last_error,
+    lastFailure:
+      row.last_failure === null
+        ? null
+        : parseSixbFailure(row.last_failure, ONTOLOGY_OUTBOX_FAILURE_CODES),
     createdAt: row.created_at,
   }
 }

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -9,6 +9,7 @@ import { parseActionRunFailure } from "@sixb/core/internal/action-run-storage"
 import { parseSixbFailure } from "@sixb/core/internal/errors"
 import {
   AGENT_RUN_FAILURE_CODES,
+  ONTOLOGY_OUTBOX_FAILURE_CODES,
   PIPELINE_RUN_FAILURE_CODES,
   PROJECTION_RUN_FAILURE_CODES,
   SYNC_RUN_FAILURE_CODES,
@@ -144,6 +145,13 @@ const expectedStorageMigrationRows = [
     id: "017-action-failure-record",
     status: "applied",
     version: 17,
+  },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "018-ontology-outbox-failure-record",
+    status: "applied",
+    version: 18,
   },
 ]
 
@@ -778,6 +786,79 @@ describe("SQLite storage migrations", () => {
           })
         )
       ).toThrow()
+    } finally {
+      db.close()
+    }
+  })
+
+  test("ontology outbox failure migration replaces legacy diagnostics with a safe failure", () => {
+    const db = new Database(":memory:")
+    try {
+      const failureMigrationIndex = sqliteStorageMigrations.steps.findIndex(
+        (migration) => migration.id === "018-ontology-outbox-failure-record"
+      )
+      const failureMigration = sqliteStorageMigrations.steps[failureMigrationIndex]
+      if (failureMigrationIndex !== 17 || !failureMigration) {
+        throw new Error("SQLite ontology outbox failure migration is missing.")
+      }
+      for (const migration of sqliteStorageMigrations.steps.slice(0, failureMigrationIndex)) {
+        migration.up(db)
+      }
+      db.query(`
+        INSERT INTO ontology_outbox (
+          project_id, id, commit_id, commit_ordinal, envelope, available_at,
+          attempts, published_at, last_error, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+      `).run(
+        "project-a",
+        "event-failed",
+        "commit-failed",
+        0,
+        JSON.stringify({ type: "object.created" }),
+        "2026-08-10T12:01:00.000Z",
+        2,
+        "Error: broker unavailable",
+        "2026-08-10T12:00:00.000Z"
+      )
+      db.query(`
+        INSERT INTO ontology_outbox (
+          project_id, id, commit_id, commit_ordinal, envelope, available_at,
+          attempts, published_at, last_error, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+      `).run(
+        "project-a",
+        "event-stopped",
+        "commit-stopped",
+        0,
+        JSON.stringify({ type: "object.updated" }),
+        "2026-08-10T12:02:00.000Z",
+        1,
+        "Outbox dispatcher stopped before publication completed.",
+        "2026-08-10T12:00:00.000Z"
+      )
+
+      failureMigration.up(db)
+
+      expect(readMemoryTableColumns(db, "ontology_outbox")).toContain("last_failure")
+      expect(readMemoryTableColumns(db, "ontology_outbox")).not.toContain("last_error")
+      const rows = db
+        .query("SELECT id, last_failure FROM ontology_outbox ORDER BY id")
+        .all() as Array<{ readonly id: string; readonly last_failure: string | null }>
+      expect(rows[0]?.id).toBe("event-failed")
+      expect(parseSixbFailure(rows[0]?.last_failure, ONTOLOGY_OUTBOX_FAILURE_CODES)).toEqual({
+        code: "event.delivery_failed",
+        message: "Event delivery failed.",
+        retryable: true,
+        at: "2026-08-10T12:01:00.000Z",
+        details: {
+          attempts: 2,
+          eventIds: ["event-failed"],
+          eventTypes: ["object.created"],
+          migratedFromLegacyLastError: true,
+          timestampSource: "availableAt",
+        },
+      })
+      expect(rows[1]).toEqual({ id: "event-stopped", last_failure: null })
     } finally {
       db.close()
     }


### PR DESCRIPTION
## Summary

- add the public retryable `event.delivery_failed` code and the precise `OntologyOutboxFailure` storage contract
- create coded delivery errors with event correlation details, then normalize them once at the persistence boundary
- persist structured failures consistently across the in-memory, PostgreSQL, and SQLite ontology outboxes
- keep lifecycle-only rescheduling separate from delivery failures and preserve the latest real failure
- add dedicated PostgreSQL and SQLite migrations that convert legacy `last_error` diagnostics without modifying the initial migrations

## Why

The ontology outbox was the remaining persistence boundary storing terminal diagnostics as opaque strings. It now follows the same portable `SixbFailure` model as the other primitives, while exposing only the exact code its storage contract accepts.

Legacy delivery diagnostics are backfilled as `event.delivery_failed`. The old dispatcher-shutdown marker becomes `null` because it represented lifecycle control rather than a broker failure. Since the legacy schema did not retain the exact failure time, migrated records use `available_at` and explicitly carry `migratedFromLegacyLastError: true` and `timestampSource: "availableAt"` details.

Queue delivery remains outside this vertical because the current queue provider contract does not expose an atomic durable failure or dead-letter record to migrate.

## Validation

- `bun test storage/sqlite/tests/sqlite-storage-migrations.test.ts storage/sqlite/tests/sqlite-ontology-storage.test.ts storage/sqlite/tests/sqlite-ontology-schema-parity.test.ts` — 37 passing
- `bun run test:ci` — 3,693 passing, 7 skipped
- `bun run typecheck`
- `bun run check`
- `bun --filter @sixb/pg build`
- `bun --filter @sixb/sqlite build`
- `bun run test:publish`
- `git diff --check`

The PostgreSQL migration e2e test requires `DATABASE_URL` and is left to CI.

## Stack

Depends on #352 and continues #274.
