### PR TITLE
runtime: establish execution capability foundation

### DIFF
--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -1,0 +1,232 @@
+import type { Principal } from "../auth"
+import { emptyGrantSets, GRANT_KIND_KEYS } from "../authorization/grant-kinds"
+import type { AuthorizationContext, GrantIndex } from "../authorization/types"
+import {
+  type AuthorizablePrincipal,
+  type AuthorizationRef,
+  createRuntimeAuthorizationCapability,
+  type ExecutionScope,
+  isRuntimeAuthorizationCapability,
+  type KernelOperation,
+  type RuntimeAuthorization,
+  type TrustedPrimitiveKind,
+  type TrustedPrimitiveRef,
+} from "./types"
+
+export type ResolvedRuntimeAuthorization =
+  | {
+      readonly type: "principal"
+      readonly projectId: string
+      readonly context: AuthorizationContext
+      readonly ref: Extract<AuthorizationRef, { readonly type: "principal" }>
+    }
+  | {
+      readonly type: "unrestricted"
+      readonly projectId: string
+      readonly ref: Exclude<AuthorizationRef, { readonly type: "principal" }>
+    }
+  | { readonly type: "denied" }
+
+type RegisteredRuntimeAuthorization = Exclude<
+  ResolvedRuntimeAuthorization,
+  { readonly type: "denied" }
+>
+
+type PrincipalAuthorizationContext = Omit<AuthorizationContext, "principal"> & {
+  readonly principal: AuthorizablePrincipal
+}
+
+const registeredAuthorizations = new WeakMap<RuntimeAuthorization, RegisteredRuntimeAuthorization>()
+
+export function createPrincipalRuntimeAuthorization(input: {
+  readonly projectId: string
+  readonly context: AuthorizationContext
+  readonly credential?: Extract<AuthorizationRef, { readonly type: "principal" }>["credential"]
+}): RuntimeAuthorization {
+  const context = snapshotAuthorizationContext(input.context)
+  const credential = input.credential ? snapshotCredential(input.credential) : undefined
+  assertCredentialMatchesContext(context, credential)
+  const ref: Extract<AuthorizationRef, { readonly type: "principal" }> = Object.freeze({
+    type: "principal",
+    principal: context.principal,
+    ...(credential === undefined ? {} : { credential }),
+  })
+  return register({ type: "principal", projectId: input.projectId, context, ref })
+}
+
+export function createDisabledRuntimeAuthorization(projectId: string): RuntimeAuthorization {
+  return register({ type: "unrestricted", projectId, ref: Object.freeze({ type: "disabled" }) })
+}
+
+export function createTrustedPrimitiveRuntimeAuthorization(input: {
+  readonly projectId: string
+  readonly primitive: TrustedPrimitiveRef
+}): RuntimeAuthorization {
+  const primitive = snapshotTrustedPrimitive(input.primitive)
+  return register({
+    type: "unrestricted",
+    projectId: input.projectId,
+    ref: Object.freeze({ type: "trustedPrimitive", primitive }),
+  })
+}
+
+export function createKernelRuntimeAuthorization(input: {
+  readonly projectId: string
+  readonly operation: KernelOperation
+}): RuntimeAuthorization {
+  const operation = snapshotKernelOperation(input.operation)
+  return register({
+    type: "unrestricted",
+    projectId: input.projectId,
+    ref: Object.freeze({ type: "kernel", operation }),
+  })
+}
+
+export function resolveRuntimeAuthorization(authorization: unknown): ResolvedRuntimeAuthorization {
+  if (!isRuntimeAuthorizationCapability(authorization)) {
+    return { type: "denied" }
+  }
+  return registeredAuthorizations.get(authorization) ?? { type: "denied" }
+}
+
+export function getAuthorizationRef(authorization: RuntimeAuthorization): AuthorizationRef {
+  const resolved = resolveRuntimeAuthorization(authorization)
+  if (resolved.type === "denied") {
+    throw new Error("[Sixb] Runtime authorization is not a registered Core capability.")
+  }
+  return cloneAuthorizationRef(resolved.ref)
+}
+
+export function assertExecutionScopeProject(projectId: string, scope: ExecutionScope): void {
+  assertNonEmpty(projectId, "Project id")
+  if (scope.execution.projectId !== projectId) {
+    throw new Error(
+      `[Sixb] Execution scope belongs to project '${scope.execution.projectId}', not '${projectId}'.`
+    )
+  }
+
+  const resolved = resolveRuntimeAuthorization(scope.authorization)
+  if (resolved.type === "denied") {
+    throw new Error("[Sixb] Execution scope carries unregistered runtime authorization.")
+  }
+  if (resolved.projectId !== projectId) {
+    throw new Error(
+      `[Sixb] Execution authorization belongs to project '${resolved.projectId}', not '${projectId}'.`
+    )
+  }
+}
+
+function register(input: RegisteredRuntimeAuthorization): RuntimeAuthorization {
+  assertNonEmpty(input.projectId, "Authorization project id")
+  const authorization = createRuntimeAuthorizationCapability()
+  registeredAuthorizations.set(authorization, Object.freeze(input))
+  return authorization
+}
+
+function snapshotAuthorizationContext(
+  context: AuthorizationContext
+): PrincipalAuthorizationContext {
+  const principal = snapshotAuthorizablePrincipal(context.principal)
+  const grants = emptyGrantSets()
+  for (const kind of GRANT_KIND_KEYS) {
+    grants[kind] = new Set(context.grants[kind])
+  }
+  const frozenGrants: GrantIndex = Object.freeze(grants)
+  return Object.freeze({
+    principal,
+    ...(context.sessionId === undefined ? {} : { sessionId: context.sessionId }),
+    groupIds: Object.freeze([...context.groupIds]),
+    roleIds: Object.freeze([...context.roleIds]),
+    grants: frozenGrants,
+  })
+}
+
+function snapshotAuthorizablePrincipal(principal: Principal): AuthorizablePrincipal {
+  if (principal.type !== "user" && principal.type !== "serviceAccount") {
+    throw new Error(`[Sixb] Principal type '${principal.type}' cannot hold runtime authorization.`)
+  }
+  assertNonEmpty(principal.id, "Authorization principal id")
+  return Object.freeze({ type: principal.type, id: principal.id })
+}
+
+function snapshotCredential(
+  credential: NonNullable<Extract<AuthorizationRef, { readonly type: "principal" }>["credential"]>
+): NonNullable<Extract<AuthorizationRef, { readonly type: "principal" }>["credential"]> {
+  assertNonEmpty(credential.id, "Authorization credential id")
+  if (credential.type !== "session" && credential.type !== "accessToken") {
+    const credentialType = (credential as { readonly type: string }).type
+    throw new Error(`[Sixb] Unknown authorization credential type '${credentialType}'.`)
+  }
+  return Object.freeze({ type: credential.type, id: credential.id })
+}
+
+function assertCredentialMatchesContext(
+  context: PrincipalAuthorizationContext,
+  credential:
+    | NonNullable<Extract<AuthorizationRef, { readonly type: "principal" }>["credential"]>
+    | undefined
+): void {
+  if (credential?.type === "session") {
+    if (context.sessionId !== credential.id) {
+      throw new Error(
+        "[Sixb] Session credential id must match the authorization context session id."
+      )
+    }
+    return
+  }
+  if (context.sessionId !== undefined) {
+    throw new Error("[Sixb] Authorization context session requires a matching session credential.")
+  }
+}
+
+function snapshotTrustedPrimitive(primitive: TrustedPrimitiveRef): TrustedPrimitiveRef {
+  if (!isTrustedPrimitiveKind(primitive.kind)) {
+    throw new Error(`[Sixb] Unknown trusted primitive kind '${primitive.kind}'.`)
+  }
+  assertNonEmpty(primitive.id, "Trusted primitive id")
+  assertNonEmpty(primitive.runId, "Trusted primitive run id")
+  return Object.freeze({ kind: primitive.kind, id: primitive.id, runId: primitive.runId })
+}
+
+function snapshotKernelOperation(operation: KernelOperation): KernelOperation {
+  if (operation.type !== "ontology.recover") {
+    throw new Error(`[Sixb] Unknown kernel operation '${operation.type}'.`)
+  }
+  assertNonEmpty(operation.recoveryId, "Kernel recovery id")
+  return Object.freeze({ type: operation.type, recoveryId: operation.recoveryId })
+}
+
+function cloneAuthorizationRef(ref: AuthorizationRef): AuthorizationRef {
+  switch (ref.type) {
+    case "principal":
+      return {
+        type: "principal",
+        principal: { ...ref.principal },
+        ...(ref.credential === undefined ? {} : { credential: { ...ref.credential } }),
+      }
+    case "trustedPrimitive":
+      return { type: "trustedPrimitive", primitive: { ...ref.primitive } }
+    case "kernel":
+      return { type: "kernel", operation: { ...ref.operation } }
+    case "disabled":
+      return { type: "disabled" }
+  }
+}
+
+function isTrustedPrimitiveKind(value: string): value is TrustedPrimitiveKind {
+  return (
+    value === "action" ||
+    value === "pipeline" ||
+    value === "projection" ||
+    value === "rule" ||
+    value === "sync" ||
+    value === "webhook" ||
+    value === "workflow"
+  )
+}
+
+function assertNonEmpty(value: string, label: string): void {
+  if (!value.trim()) {
+    throw new Error(`[Sixb] ${label} must not be empty.`)
+  }
+}

--- a/packages/core/src/execution/index.ts
+++ b/packages/core/src/execution/index.ts
@@ -1,0 +1,12 @@
+export type {
+  AuthorizablePrincipal,
+  AuthorizationRef,
+  ExecutionContext,
+  ExecutionExecutor,
+  ExecutionScope,
+  ExecutionSource,
+  KernelOperation,
+  RuntimeAuthorization,
+  TrustedPrimitiveKind,
+  TrustedPrimitiveRef,
+} from "./types"

--- a/packages/core/src/execution/scopes.ts
+++ b/packages/core/src/execution/scopes.ts
@@ -1,0 +1,283 @@
+import { randomUUID } from "node:crypto"
+import type { AuthorizationContext } from "../authorization"
+import {
+  createDisabledRuntimeAuthorization,
+  createKernelRuntimeAuthorization,
+  createPrincipalRuntimeAuthorization,
+  createTrustedPrimitiveRuntimeAuthorization,
+} from "./authorization"
+import type {
+  AuthorizablePrincipal,
+  AuthorizationRef,
+  ExecutionContext,
+  ExecutionScope,
+  ExecutionSource,
+  KernelOperation,
+  TrustedPrimitiveRef,
+} from "./types"
+
+export function createPrincipalRequestScope(input: {
+  readonly projectId: string
+  readonly requestId: string
+  readonly correlationId: string
+  readonly context: AuthorizationContext
+  readonly credential?: Extract<AuthorizationRef, { readonly type: "principal" }>["credential"]
+}): ExecutionScope {
+  const execution = createRequestExecution({
+    projectId: input.projectId,
+    requestId: input.requestId,
+    correlationId: input.correlationId,
+    requestedBy: asAuthorizablePrincipal(input.context.principal),
+  })
+
+  return Object.freeze({
+    execution,
+    authorization: createPrincipalRuntimeAuthorization({
+      projectId: input.projectId,
+      context: input.context,
+      ...(input.credential === undefined ? {} : { credential: input.credential }),
+    }),
+  })
+}
+
+export function createDisabledRequestScope(input: {
+  readonly projectId: string
+  readonly requestId: string
+  readonly correlationId: string
+}): ExecutionScope {
+  return Object.freeze({
+    execution: createRequestExecution(input),
+    authorization: createDisabledRuntimeAuthorization(input.projectId),
+  })
+}
+
+export function createTrustedPrimitiveScope(input: {
+  readonly projectId: string
+  readonly primitive: TrustedPrimitiveRef
+  readonly source: ExecutionSource
+  readonly requestedBy?: AuthorizablePrincipal
+  readonly correlationId?: string
+  readonly parentExecutionId?: string
+}): ExecutionScope {
+  const execution = createInternalExecution({
+    projectId: input.projectId,
+    requestedBy: input.requestedBy,
+    executor: Object.freeze({
+      type: "primitive",
+      kind: input.primitive.kind,
+      id: input.primitive.id,
+      runId: input.primitive.runId,
+    }),
+    source: input.source,
+    correlationId: input.correlationId,
+    parentExecutionId: input.parentExecutionId,
+  })
+  return Object.freeze({
+    execution,
+    authorization: createTrustedPrimitiveRuntimeAuthorization({
+      projectId: input.projectId,
+      primitive: input.primitive,
+    }),
+  })
+}
+
+export function createAgentScope(input: {
+  readonly projectId: string
+  readonly agentId: string
+  readonly runId: string
+  readonly context: AuthorizationContext
+  readonly source: ExecutionSource
+  readonly requestedBy?: AuthorizablePrincipal
+  readonly correlationId?: string
+  readonly parentExecutionId?: string
+}): ExecutionScope {
+  if (input.context.principal.type !== "serviceAccount") {
+    throw new Error("[Sixb] Agent execution authority must belong to a service account.")
+  }
+  assertNonEmpty(input.agentId, "Agent id")
+  assertNonEmpty(input.runId, "Agent run id")
+  const execution = createInternalExecution({
+    projectId: input.projectId,
+    requestedBy: input.requestedBy,
+    executor: Object.freeze({ type: "agent", agentId: input.agentId, runId: input.runId }),
+    source: input.source,
+    correlationId: input.correlationId,
+    parentExecutionId: input.parentExecutionId,
+  })
+  return Object.freeze({
+    execution,
+    authorization: createPrincipalRuntimeAuthorization({
+      projectId: input.projectId,
+      context: input.context,
+    }),
+  })
+}
+
+export function createKernelScope(input: {
+  readonly projectId: string
+  readonly operation: KernelOperation
+  readonly source: ExecutionSource
+  readonly correlationId?: string
+}): ExecutionScope {
+  const operation = Object.freeze({ ...input.operation })
+  const execution = createInternalExecution({
+    projectId: input.projectId,
+    executor: Object.freeze({ type: "kernel", operation }),
+    source: input.source,
+    correlationId: input.correlationId,
+  })
+  return Object.freeze({
+    execution,
+    authorization: createKernelRuntimeAuthorization({ projectId: input.projectId, operation }),
+  })
+}
+
+function createInternalExecution(input: {
+  readonly projectId: string
+  readonly requestedBy?: AuthorizablePrincipal
+  readonly executor: Exclude<ExecutionContext["executor"], { readonly type: "request" }>
+  readonly source: ExecutionSource
+  readonly correlationId?: string
+  readonly parentExecutionId?: string
+}): ExecutionContext {
+  const source = snapshotExecutionSource(input.source)
+  assertNestedProvenance(source, input.parentExecutionId, input.correlationId)
+  return freezeExecution({
+    id: `exec_${randomUUID()}`,
+    projectId: input.projectId,
+    ...(input.requestedBy === undefined
+      ? {}
+      : { requestedBy: asAuthorizablePrincipal(input.requestedBy) }),
+    executor: input.executor,
+    source,
+    correlationId: input.correlationId ?? `corr_${randomUUID()}`,
+    ...(input.parentExecutionId === undefined
+      ? {}
+      : { parentExecutionId: input.parentExecutionId }),
+  })
+}
+
+function assertNestedProvenance(
+  source: ExecutionSource,
+  parentExecutionId: string | undefined,
+  correlationId: string | undefined
+): void {
+  if (parentExecutionId !== undefined) {
+    assertNonEmpty(parentExecutionId, "Parent execution id")
+    if (correlationId === undefined) {
+      throw new Error("[Sixb] Nested execution must preserve its parent correlation id.")
+    }
+  }
+  if (source.type === "execution" && source.executionId !== parentExecutionId) {
+    throw new Error("[Sixb] Execution source must match the direct parent execution id.")
+  }
+}
+
+export function createTestingScope(input: {
+  readonly projectId: string
+  readonly context?: AuthorizationContext
+  readonly executionId?: string
+  readonly requestId?: string
+  readonly correlationId?: string
+}): ExecutionScope {
+  const context = input.context ? withoutSession(input.context) : undefined
+  const requestId = input.requestId ?? `test_request_${randomUUID()}`
+  const execution = createRequestExecution({
+    projectId: input.projectId,
+    requestId,
+    correlationId: input.correlationId ?? `test_correlation_${randomUUID()}`,
+    ...(context === undefined ? {} : { requestedBy: asAuthorizablePrincipal(context.principal) }),
+    executionId: input.executionId,
+  })
+  return Object.freeze({
+    execution,
+    authorization: context
+      ? createPrincipalRuntimeAuthorization({ projectId: input.projectId, context })
+      : createDisabledRuntimeAuthorization(input.projectId),
+  })
+}
+
+function withoutSession(context: AuthorizationContext): AuthorizationContext {
+  return {
+    principal: context.principal,
+    groupIds: context.groupIds,
+    roleIds: context.roleIds,
+    grants: context.grants,
+  }
+}
+
+function createRequestExecution(input: {
+  readonly projectId: string
+  readonly requestId: string
+  readonly correlationId: string
+  readonly requestedBy?: AuthorizablePrincipal
+  readonly executionId?: string
+}): ExecutionContext {
+  assertNonEmpty(input.projectId, "Execution project id")
+  assertNonEmpty(input.requestId, "Execution request id")
+  assertNonEmpty(input.correlationId, "Execution correlation id")
+  const id = input.executionId ?? `exec_${randomUUID()}`
+  assertNonEmpty(id, "Execution id")
+  return freezeExecution({
+    id,
+    projectId: input.projectId,
+    ...(input.requestedBy === undefined ? {} : { requestedBy: input.requestedBy }),
+    executor: Object.freeze({ type: "request", requestId: input.requestId }),
+    source: Object.freeze({ type: "http", requestId: input.requestId }),
+    correlationId: input.correlationId,
+  })
+}
+
+function freezeExecution(execution: ExecutionContext): ExecutionContext {
+  assertNonEmpty(execution.id, "Execution id")
+  assertNonEmpty(execution.projectId, "Execution project id")
+  assertNonEmpty(execution.correlationId, "Execution correlation id")
+  if (execution.parentExecutionId !== undefined) {
+    assertNonEmpty(execution.parentExecutionId, "Parent execution id")
+  }
+  return Object.freeze(execution)
+}
+
+function snapshotExecutionSource(source: ExecutionSource): ExecutionSource {
+  const field = sourceIdentifier(source)
+  assertNonEmpty(field.value, field.label)
+  if (source.type === "queue") {
+    assertNonEmpty(source.queue, "Execution source queue")
+  }
+  return Object.freeze({ ...source })
+}
+
+function sourceIdentifier(source: ExecutionSource): {
+  readonly label: string
+  readonly value: string
+} {
+  switch (source.type) {
+    case "http":
+      return { label: "Execution source request id", value: source.requestId }
+    case "webhook":
+      return { label: "Execution source delivery id", value: source.deliveryId }
+    case "schedule":
+    case "event":
+      return { label: "Execution source event id", value: source.eventId }
+    case "execution":
+      return { label: "Execution source execution id", value: source.executionId }
+    case "queue":
+      return { label: "Execution source job id", value: source.jobId }
+  }
+}
+
+function asAuthorizablePrincipal(
+  principal: AuthorizationContext["principal"]
+): AuthorizablePrincipal {
+  if (principal.type !== "user" && principal.type !== "serviceAccount") {
+    throw new Error(`[Sixb] Principal type '${principal.type}' cannot hold runtime authorization.`)
+  }
+  assertNonEmpty(principal.id, "Execution principal id")
+  return Object.freeze({ type: principal.type, id: principal.id })
+}
+
+function assertNonEmpty(value: string, label: string): void {
+  if (!value.trim()) {
+    throw new Error(`[Sixb] ${label} must not be empty.`)
+  }
+}

--- a/packages/core/src/execution/types.ts
+++ b/packages/core/src/execution/types.ts
@@ -1,0 +1,114 @@
+import type { Principal } from "../auth/types"
+
+/** User or service account that may initiate or authorize an execution. */
+export type AuthorizablePrincipal = Extract<Principal, { readonly type: "user" | "serviceAccount" }>
+
+/** Registered primitive kinds that may receive internal trusted authority. */
+export type TrustedPrimitiveKind =
+  | "action"
+  | "pipeline"
+  | "projection"
+  | "rule"
+  | "sync"
+  | "webhook"
+  | "workflow"
+
+export interface TrustedPrimitiveRef {
+  readonly kind: TrustedPrimitiveKind
+  readonly id: string
+  readonly runId: string
+}
+
+export type KernelOperation = {
+  readonly type: "ontology.recover"
+  readonly recoveryId: string
+}
+
+/** Workload currently executing. This is provenance and never grants authority by itself. */
+export type ExecutionExecutor =
+  | { readonly type: "request"; readonly requestId: string }
+  | {
+      readonly type: "primitive"
+      readonly kind: TrustedPrimitiveKind
+      readonly id: string
+      readonly runId: string
+    }
+  | { readonly type: "agent"; readonly agentId: string; readonly runId: string }
+  | { readonly type: "kernel"; readonly operation: KernelOperation }
+
+/**
+ * Occurrence that directly triggered an execution.
+ *
+ * The `queue` source is transitional until workers restore durable execution authority.
+ */
+export type ExecutionSource =
+  | { readonly type: "http"; readonly requestId: string }
+  | { readonly type: "webhook"; readonly deliveryId: string }
+  | { readonly type: "schedule"; readonly eventId: string }
+  | { readonly type: "event"; readonly eventId: string }
+  | { readonly type: "execution"; readonly executionId: string }
+  | { readonly type: "queue"; readonly queue: string; readonly jobId: string }
+
+/** Immutable provenance for one request, primitive run, agent run, or kernel operation. */
+export interface ExecutionContext {
+  readonly id: string
+  readonly projectId: string
+  readonly requestedBy?: AuthorizablePrincipal
+  readonly executor: ExecutionExecutor
+  readonly source: ExecutionSource
+  readonly correlationId: string
+  readonly parentExecutionId?: string
+}
+
+/** Durable descriptor used to rebuild authority. A reference is never authoritative by itself. */
+export type AuthorizationRef =
+  | {
+      readonly type: "principal"
+      readonly principal: AuthorizablePrincipal
+      readonly credential?:
+        | { readonly type: "session"; readonly id: string }
+        | { readonly type: "accessToken"; readonly id: string }
+    }
+  | { readonly type: "trustedPrimitive"; readonly primitive: TrustedPrimitiveRef }
+  | { readonly type: "kernel"; readonly operation: KernelOperation }
+  | { readonly type: "disabled" }
+
+class RuntimeAuthorizationCapability {
+  readonly #runtimeAuthorization = true
+
+  private constructor() {}
+
+  static create(): RuntimeAuthorizationCapability {
+    const capability = new RuntimeAuthorizationCapability()
+    Object.freeze(capability)
+    return capability
+  }
+
+  static is(value: unknown): value is RuntimeAuthorizationCapability {
+    return typeof value === "object" && value !== null && #runtimeAuthorization in value
+  }
+}
+
+/**
+ * Opaque, process-local authority.
+ *
+ * The private class makes it nominal in TypeScript; Core registry membership makes it authoritative
+ * at runtime. The capability itself is never persisted.
+ */
+export type RuntimeAuthorization = RuntimeAuthorizationCapability
+
+/** Execution provenance paired with the process-local authority that permits its operations. */
+export interface ExecutionScope {
+  readonly execution: ExecutionContext
+  readonly authorization: RuntimeAuthorization
+}
+
+/** Internal constructor; the package root exports only the opaque type. */
+export function createRuntimeAuthorizationCapability(): RuntimeAuthorization {
+  return RuntimeAuthorizationCapability.create()
+}
+
+/** Internal runtime guard; registry membership remains the source of authority. */
+export function isRuntimeAuthorizationCapability(value: unknown): value is RuntimeAuthorization {
+  return RuntimeAuthorizationCapability.is(value)
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -781,6 +781,21 @@ export {
   WorkflowValidationError,
 } from "./workflows"
 
+// ── Execution ───────────────────────────────────────────────
+
+export type {
+  AuthorizablePrincipal,
+  AuthorizationRef,
+  ExecutionContext,
+  ExecutionExecutor,
+  ExecutionScope,
+  ExecutionSource,
+  KernelOperation,
+  RuntimeAuthorization,
+  TrustedPrimitiveKind,
+  TrustedPrimitiveRef,
+} from "./execution"
+
 // ── Runtime ─────────────────────────────────────────────────
 
 export type {

--- a/packages/core/src/testing/execution.ts
+++ b/packages/core/src/testing/execution.ts
@@ -1,0 +1,31 @@
+import type { AuthorizationContext } from "../authorization"
+import { createTestingScope } from "../execution/scopes"
+import type { ExecutionScope } from "../execution/types"
+
+export type { AuthorizationContext } from "../authorization"
+export type { ExecutionScope } from "../execution/types"
+
+export interface TestExecutionOptions {
+  readonly authorization?: AuthorizationContext
+  readonly executionId?: string
+  readonly requestId?: string
+  readonly correlationId?: string
+}
+
+/**
+ * Create a principal test scope from `authorization`, or an explicit disabled scope when omitted.
+ * Test scopes deliberately omit live session identity. Trusted primitive and kernel authority
+ * remain unavailable to application tests.
+ */
+export function createTestExecutionScope(
+  projectId: string,
+  options: TestExecutionOptions = {}
+): ExecutionScope {
+  return createTestingScope({
+    projectId,
+    ...(options.authorization === undefined ? {} : { context: options.authorization }),
+    ...(options.executionId === undefined ? {} : { executionId: options.executionId }),
+    ...(options.requestId === undefined ? {} : { requestId: options.requestId }),
+    ...(options.correlationId === undefined ? {} : { correlationId: options.correlationId }),
+  })
+}

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -19,6 +19,12 @@ export {
   runEffectiveStorageContractSuite,
 } from "./effective-storage-contract"
 export {
+  type AuthorizationContext,
+  createTestExecutionScope,
+  type ExecutionScope,
+  type TestExecutionOptions,
+} from "./execution"
+export {
   type LakeMergeStorageContractSuiteOptions,
   runLakeMergeStorageContractSuite,
 } from "./lake-merge-storage-contract"

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, test } from "bun:test"
+import type { Principal } from "../src/auth"
+import { type AuthorizationContext, emptyGrantIndex } from "../src/authorization"
+import {
+  assertExecutionScopeProject,
+  createPrincipalRuntimeAuthorization,
+  getAuthorizationRef,
+  resolveRuntimeAuthorization,
+} from "../src/execution/authorization"
+import {
+  createAgentScope,
+  createDisabledRequestScope,
+  createKernelScope,
+  createPrincipalRequestScope,
+  createTestingScope,
+  createTrustedPrimitiveScope,
+} from "../src/execution/scopes"
+import {
+  createRuntimeAuthorizationCapability,
+  type ExecutionScope,
+  type RuntimeAuthorization,
+} from "../src/execution/types"
+
+describe("runtime authorization capabilities", () => {
+  test("snapshots principal authority and exposes only a defensive durable reference", () => {
+    const context = authorizationContext({ type: "user", id: "user-1" }, "session-1")
+    const groups = context.groupIds as string[]
+    const agentGrants = context.grants["run:agent"] as Set<string>
+    const authorization = createPrincipalRuntimeAuthorization({
+      projectId: "project-1",
+      context,
+      credential: { type: "session", id: "session-1" },
+    })
+
+    groups.push("late-group")
+    agentGrants.add("late-agent")
+
+    const resolved = resolveRuntimeAuthorization(authorization)
+    expect(resolved.type).toBe("principal")
+    if (resolved.type !== "principal") throw new Error("expected principal authorization")
+    expect(resolved.context.groupIds).toEqual(["group-1"])
+    expect(resolved.context.grants["run:agent"].has("late-agent")).toBe(false)
+
+    const firstRef = getAuthorizationRef(authorization)
+    expect(firstRef).toEqual({
+      type: "principal",
+      principal: { type: "user", id: "user-1" },
+      credential: { type: "session", id: "session-1" },
+    })
+    if (firstRef.type !== "principal") throw new Error("expected principal ref")
+    const mutablePrincipal = firstRef.principal as { id: string }
+    mutablePrincipal.id = "mutated"
+    expect(getAuthorizationRef(authorization)).toEqual({
+      type: "principal",
+      principal: { type: "user", id: "user-1" },
+      credential: { type: "session", id: "session-1" },
+    })
+  })
+
+  test("rejects structurally forged capabilities", () => {
+    const forged = {} as RuntimeAuthorization
+    const unregistered = createRuntimeAuthorizationCapability()
+    expect(resolveRuntimeAuthorization(undefined)).toEqual({ type: "denied" })
+    expect(resolveRuntimeAuthorization(forged)).toEqual({ type: "denied" })
+    expect(resolveRuntimeAuthorization(unregistered)).toEqual({ type: "denied" })
+    expect(() => getAuthorizationRef(forged)).toThrow("not a registered Core capability")
+
+    const legitimate = createTestingScope({ projectId: "project-1" })
+    const serialized = JSON.parse(JSON.stringify(legitimate.authorization))
+    expect(resolveRuntimeAuthorization(serialized)).toEqual({ type: "denied" })
+    const forgedScope: ExecutionScope = { execution: legitimate.execution, authorization: forged }
+    expect(() => assertExecutionScopeProject("project-1", forgedScope)).toThrow(
+      "unregistered runtime authorization"
+    )
+  })
+
+  test("keeps execution identity and authority inside one project", () => {
+    const projectOne = createTestingScope({ projectId: "project-1" })
+    const projectTwo = createTestingScope({ projectId: "project-2" })
+
+    expect(() => assertExecutionScopeProject("project-1", projectOne)).not.toThrow()
+    expect(() => assertExecutionScopeProject("project-2", projectOne)).toThrow(
+      "Execution scope belongs to project 'project-1', not 'project-2'"
+    )
+    expect(() =>
+      assertExecutionScopeProject("project-1", {
+        execution: projectOne.execution,
+        authorization: projectTwo.authorization,
+      })
+    ).toThrow("Execution authorization belongs to project 'project-2', not 'project-1'")
+  })
+
+  test("rejects system principals and invalid authority identifiers", () => {
+    expect(() =>
+      createPrincipalRuntimeAuthorization({
+        projectId: "project-1",
+        context: authorizationContext({ type: "system", id: "system" }),
+      })
+    ).toThrow("Principal type 'system' cannot hold runtime authorization")
+    expect(() => createTestingScope({ projectId: " " })).toThrow(
+      "Execution project id must not be empty"
+    )
+  })
+
+  test("rejects inconsistent session credential references", () => {
+    expect(() =>
+      createPrincipalRuntimeAuthorization({
+        projectId: "project-1",
+        context: authorizationContext({ type: "user", id: "user-1" }, "session-1"),
+      })
+    ).toThrow("Authorization context session requires a matching session credential")
+    expect(() =>
+      createPrincipalRuntimeAuthorization({
+        projectId: "project-1",
+        context: authorizationContext({ type: "user", id: "user-1" }),
+        credential: { type: "session", id: "session-1" },
+      })
+    ).toThrow("Session credential id must match the authorization context session id")
+  })
+})
+
+describe("execution scope factories", () => {
+  test("creates a principal request scope with explicit request provenance", () => {
+    const scope = createPrincipalRequestScope({
+      projectId: "project-1",
+      requestId: "request-1",
+      correlationId: "correlation-1",
+      context: authorizationContext({ type: "serviceAccount", id: "service-account-1" }),
+      credential: { type: "accessToken", id: "access-token-1" },
+    })
+
+    expect(scope.execution).toMatchObject({
+      projectId: "project-1",
+      requestedBy: { type: "serviceAccount", id: "service-account-1" },
+      executor: { type: "request", requestId: "request-1" },
+      source: { type: "http", requestId: "request-1" },
+      correlationId: "correlation-1",
+    })
+    expect(scope.execution.id).toStartWith("exec_")
+    expect(getAuthorizationRef(scope.authorization)).toEqual({
+      type: "principal",
+      principal: { type: "serviceAccount", id: "service-account-1" },
+      credential: { type: "accessToken", id: "access-token-1" },
+    })
+  })
+
+  test("models disabled auth explicitly instead of omitting authority", () => {
+    const scope = createDisabledRequestScope({
+      projectId: "project-1",
+      requestId: "request-1",
+      correlationId: "correlation-1",
+    })
+
+    expect(getAuthorizationRef(scope.authorization)).toEqual({ type: "disabled" })
+    expect(resolveRuntimeAuthorization(scope.authorization).type).toBe("unrestricted")
+  })
+
+  test("creates synthetic principal test scopes without live session identity", () => {
+    const scope = createTestingScope({
+      projectId: "project-1",
+      context: authorizationContext({ type: "user", id: "user-1" }, "session-1"),
+    })
+
+    expect(getAuthorizationRef(scope.authorization)).toEqual({
+      type: "principal",
+      principal: { type: "user", id: "user-1" },
+    })
+    const resolved = resolveRuntimeAuthorization(scope.authorization)
+    expect(resolved.type).toBe("principal")
+    if (resolved.type !== "principal") throw new Error("expected principal authorization")
+    expect(resolved.context.sessionId).toBeUndefined()
+  })
+
+  test("creates an immutable trusted primitive scope", () => {
+    const scope = createTrustedPrimitiveScope({
+      projectId: "project-1",
+      primitive: { kind: "action", id: "send-email", runId: "action-run-1" },
+      source: { type: "queue", queue: "actions", jobId: "job-1" },
+      requestedBy: { type: "user", id: "user-1" },
+      correlationId: "correlation-1",
+      parentExecutionId: "execution-parent",
+    })
+
+    expect(scope.execution).toMatchObject({
+      executor: {
+        type: "primitive",
+        kind: "action",
+        id: "send-email",
+        runId: "action-run-1",
+      },
+      source: { type: "queue", queue: "actions", jobId: "job-1" },
+      requestedBy: { type: "user", id: "user-1" },
+      correlationId: "correlation-1",
+      parentExecutionId: "execution-parent",
+    })
+    expect(getAuthorizationRef(scope.authorization)).toEqual({
+      type: "trustedPrimitive",
+      primitive: { kind: "action", id: "send-email", runId: "action-run-1" },
+    })
+    expect(Object.isFrozen(scope)).toBe(true)
+    expect(Object.isFrozen(scope.execution)).toBe(true)
+    expect(Object.isFrozen(scope.execution.executor)).toBe(true)
+    expect(Object.isFrozen(scope.execution.source)).toBe(true)
+    expect(Object.isFrozen(scope.execution.requestedBy)).toBe(true)
+  })
+
+  test("runs agents with service-account authority", () => {
+    const parent = createTestingScope({
+      projectId: "project-1",
+      context: authorizationContext({ type: "user", id: "user-1" }),
+      executionId: "execution-parent",
+      requestId: "request-parent",
+      correlationId: "correlation-1",
+    })
+    const scope = createAgentScope({
+      projectId: "project-1",
+      agentId: "research",
+      runId: "agent-run-1",
+      context: authorizationContext({
+        type: "serviceAccount",
+        id: "agent-service-account",
+      }),
+      source: { type: "execution", executionId: parent.execution.id },
+      requestedBy: { type: "user", id: "user-1" },
+      correlationId: parent.execution.correlationId,
+      parentExecutionId: parent.execution.id,
+    })
+
+    expect(scope.execution.executor).toEqual({
+      type: "agent",
+      agentId: "research",
+      runId: "agent-run-1",
+    })
+    expect(scope.execution.requestedBy).toEqual({ type: "user", id: "user-1" })
+    expect(scope.execution.parentExecutionId).toBe(parent.execution.id)
+    expect(scope.execution.correlationId).toBe(parent.execution.correlationId)
+    expect(getAuthorizationRef(scope.authorization)).toEqual({
+      type: "principal",
+      principal: { type: "serviceAccount", id: "agent-service-account" },
+    })
+  })
+
+  test("rejects trusted authority for agents", () => {
+    expect(() =>
+      createAgentScope({
+        projectId: "project-1",
+        agentId: "research",
+        runId: "agent-run-2",
+        context: authorizationContext({ type: "user", id: "user-1" }),
+        source: { type: "queue", queue: "agents", jobId: "job-2" },
+      })
+    ).toThrow("Agent execution authority must belong to a service account")
+    expect(() =>
+      createTrustedPrimitiveScope({
+        projectId: "project-1",
+        primitive: { kind: "agent", id: "research", runId: "agent-run-2" } as never,
+        source: { type: "queue", queue: "agents", jobId: "job-2" },
+      })
+    ).toThrow("Unknown trusted primitive kind 'agent'")
+  })
+
+  test("creates an explicit kernel recovery scope", () => {
+    const scope = createKernelScope({
+      projectId: "project-1",
+      operation: { type: "ontology.recover", recoveryId: "recovery-1" },
+      source: { type: "event", eventId: "event-1" },
+    })
+
+    expect(scope.execution.executor).toEqual({
+      type: "kernel",
+      operation: { type: "ontology.recover", recoveryId: "recovery-1" },
+    })
+    expect(getAuthorizationRef(scope.authorization)).toEqual({
+      type: "kernel",
+      operation: { type: "ontology.recover", recoveryId: "recovery-1" },
+    })
+  })
+
+  test("rejects incomplete or contradictory nested provenance", () => {
+    const primitive = { kind: "workflow", id: "onboarding", runId: "workflow-run-1" } as const
+
+    expect(() =>
+      createTrustedPrimitiveScope({
+        projectId: "project-1",
+        primitive,
+        source: { type: "execution", executionId: "execution-parent" },
+        correlationId: "correlation-1",
+      })
+    ).toThrow("Execution source must match the direct parent execution id")
+    expect(() =>
+      createTrustedPrimitiveScope({
+        projectId: "project-1",
+        primitive,
+        source: { type: "execution", executionId: "execution-other" },
+        correlationId: "correlation-1",
+        parentExecutionId: "execution-parent",
+      })
+    ).toThrow("Execution source must match the direct parent execution id")
+    expect(() =>
+      createTrustedPrimitiveScope({
+        projectId: "project-1",
+        primitive,
+        source: { type: "queue", queue: "workflows", jobId: "job-1" },
+        parentExecutionId: "execution-parent",
+      })
+    ).toThrow("Nested execution must preserve its parent correlation id")
+  })
+})
+
+function authorizationContext(principal: Principal, sessionId?: string): AuthorizationContext {
+  return {
+    principal,
+    ...(sessionId === undefined ? {} : { sessionId }),
+    groupIds: ["group-1"],
+    roleIds: ["role-1"],
+    grants: emptyGrantIndex(),
+  }
+}

--- a/packages/core/tests/execution.types.ts
+++ b/packages/core/tests/execution.types.ts
@@ -1,0 +1,59 @@
+import type {
+  AuthorizationRef,
+  ExecutionContext,
+  ExecutionScope,
+  RuntimeAuthorization,
+  TrustedPrimitiveRef,
+} from "../src"
+import * as core from "../src"
+import { createTestExecutionScope } from "../src/testing"
+
+declare const authorization: RuntimeAuthorization
+
+const execution: ExecutionContext = {
+  id: "execution-1",
+  projectId: "project-1",
+  requestedBy: { type: "user", id: "user-1" },
+  executor: { type: "request", requestId: "request-1" },
+  source: { type: "http", requestId: "request-1" },
+  correlationId: "correlation-1",
+}
+
+const scope: ExecutionScope = { execution, authorization }
+const ref: AuthorizationRef = {
+  type: "principal",
+  principal: { type: "serviceAccount", id: "service-account-1" },
+  credential: { type: "accessToken", id: "token-1" },
+}
+
+const invalidTrustedPrimitive: TrustedPrimitiveRef = {
+  // @ts-expect-error Agents execute with service-account authority, not trusted primitive authority.
+  kind: "agent",
+  id: "agent-1",
+  runId: "agent-run-1",
+}
+
+// @ts-expect-error Runtime authority cannot be constructed structurally.
+const forgedAuthorization: RuntimeAuthorization = {}
+
+const invalidExecution: ExecutionContext = {
+  ...execution,
+  // @ts-expect-error System identity is provenance, not an authorizable caller.
+  requestedBy: { type: "system", id: "system" },
+}
+
+// @ts-expect-error Privileged scope factories are intentionally absent from the package root.
+core.createTrustedPrimitiveScope
+
+// @ts-expect-error The raw capability allocator is private to Core.
+core.createRuntimeAuthorizationCapability
+
+// @ts-expect-error Test scope creation is available only from @sixb/core/testing.
+core.createTestExecutionScope
+
+void createTestExecutionScope("project-1")
+void scope
+void ref
+void forgedAuthorization
+void invalidExecution
+void invalidTrustedPrimitive


### PR DESCRIPTION
## Stack

This PR is stacked on #353. It contains only the execution capability foundation for #183.

## Why

Before binding requests and workers to an execution-scoped SDK, Core needs a small, explicit model
that separates execution provenance from runtime authority.

A durable authorization reference must describe how authority can be restored later, without ever
granting authority by itself.

## What this implements

- Defines `ExecutionContext`, `ExecutionScope`, `AuthorizationRef`, and the opaque
  `RuntimeAuthorization` capability.
- Keeps runtime authority process-local in a Core-owned registry and rejects forged, serialized,
  unregistered, or cross-project capabilities.
- Adds Core-private scope factories for principal requests, disabled auth, trusted primitives,
  agents, kernel operations, and tests.
- Validates project ownership, session credentials, identifiers, parent execution provenance, and
  correlation propagation.
- Runs agents with service-account authority; agents cannot receive trusted primitive authority.
- Exports only execution types from `@sixb/core` and exposes a constrained test helper from
  `@sixb/core/testing`.

## Intentionally deferred

This PR does not bind existing runtime consumers, rename `Sixb`, introduce `SixbHost`, migrate
server routes or workers, or persist execution records. Existing runtime behavior is unchanged.

## Next

The next stacked slice binds HTTP and WebSocket requests once at the boundary, moves protected
operations behind execution-bound domain facades, and removes duplicate `*As` APIs and raw-storage
authorization decisions.

The following slice then introduces the `SixbHost` / execution-bound `Sixb` split and migrates
trusted workers, agent service accounts, and kernel operations onto explicit scopes.

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test:publish`
- `bun run test:ci` — 3,664 passed, 7 skipped, 0 failed
