### PR TITLE
storage: optimize ontology materialization at scale

### DIFF
--- a/packages/core/src/storage/ontology/provider.ts
+++ b/packages/core/src/storage/ontology/provider.ts
@@ -530,10 +530,12 @@ function materializationPlanKindRank(kind: MaterializationPlanWorkItem["kind"]):
   }
 }
 
-export function duplicateMaterializationWork(key: string): MaterializationConflictError {
+export function duplicateMaterializationWork(key?: string): MaterializationConflictError {
   return new MaterializationConflictError(
     "effective-state",
-    `Duplicate materialization work key '${key}'.`
+    key === undefined
+      ? "Duplicate materialization work."
+      : `Duplicate materialization work key '${key}'.`
   )
 }
 

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -18,6 +18,9 @@ import workflowRunOutputSql from "./migrations/002-workflow-run-output.sql" with
 import mergeSyncRunsSql from "./migrations/003-merge-sync-runs.sql" with { type: "text" }
 import executionsSql from "./migrations/004-executions.sql" with { type: "text" }
 import workflowExecutionsSql from "./migrations/005-workflow-executions.sql" with { type: "text" }
+import narrowOntologySourceRootIndexSql from "./migrations/006-narrow-ontology-source-root-index.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -276,6 +279,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("003-merge-sync-runs", mergeSyncRunsSql),
     pgSql("004-executions", executionsSql),
     pgSql("005-workflow-executions", workflowExecutionsSql),
+    pgSql("006-narrow-ontology-source-root-index", narrowOntologySourceRootIndexSql),
   ],
 })
 

--- a/storage/pg/src/migrations/006-narrow-ontology-source-root-index.sql
+++ b/storage/pg/src/migrations/006-narrow-ontology-source-root-index.sql
@@ -1,0 +1,4 @@
+DROP INDEX idx_ontology_source_rows_root;
+
+CREATE INDEX idx_ontology_source_rows_root
+  ON ontology_source_rows (project_id, source_id, materialization_id, root_sort_key);

--- a/storage/pg/src/ontology-storage/materialization-session.ts
+++ b/storage/pg/src/ontology-storage/materialization-session.ts
@@ -19,6 +19,7 @@ import type {
   StreamMaterializationWorkInput,
 } from "@sixb/core/storage"
 import type { SQLClient } from "../pg-client"
+import { isUniqueViolation } from "../storage-errors"
 import { PG_MATERIALIZATION_WORK_TABLE, PG_REPLACEMENT_WORK_TABLE } from "./materialization-state"
 import { jsonParameter } from "./shared"
 
@@ -119,21 +120,6 @@ export class PgMaterializationSessions {
     const session = this.require(input.session)
     const records = prepareMaterializationWork(session, input)
     if (records.length === 0) return
-    const keys = records.map(({ record }) => record.recordKey)
-    const uniqueKeys = records.map(({ uniqueKey }) => uniqueKey)
-
-    const [duplicate] = await this.sql<{ readonly record_key: string }[]>`
-      SELECT record_key
-      FROM ${this.sql(PG_MATERIALIZATION_WORK_TABLE)}
-      WHERE session_id = ${session.id}
-        AND (
-          record_key = ANY(${this.sql.array(keys)}::text[])
-          OR unique_key = ANY(${this.sql.array(uniqueKeys)}::text[])
-        )
-      LIMIT 1
-    `
-    if (duplicate) throw duplicateWork(duplicate.record_key)
-
     const payload = records.map(({ record, uniqueKey, columns }) => {
       return {
         recordKey: record.recordKey,
@@ -147,19 +133,30 @@ export class PgMaterializationSessions {
         record,
       }
     })
-    await this.sql`
-      WITH staged AS (
-        SELECT value FROM jsonb_array_elements(${jsonParameter(this.sql, payload)}::jsonb)
-      )
-      INSERT INTO ${this.sql(PG_MATERIALIZATION_WORK_TABLE)} (
-        session_id, record_key, unique_key, kind, lane,
-        major_order, minor_order, sort_one, sort_two, payload
-      )
-      SELECT ${session.id}, value->>'recordKey', value->>'uniqueKey', value->>'kind',
-        value->>'lane', (value->>'majorOrder')::integer, (value->>'minorOrder')::integer,
-        value->>'sortOne', value->>'sortTwo', value->'record'
-      FROM staged
-    `
+    // This session is the only writer to its transaction-local temp rows. Let the two unique
+    // constraints arbitrate cross-chunk duplicates instead of issuing a duplicate probe before
+    // every insert; a violation aborts the enclosing materialization transaction and is mapped
+    // back to the provider contract below.
+    try {
+      await this.sql`
+        WITH staged AS (
+          SELECT value FROM jsonb_array_elements(${jsonParameter(this.sql, payload)}::jsonb)
+        )
+        INSERT INTO ${this.sql(PG_MATERIALIZATION_WORK_TABLE)} (
+          session_id, record_key, unique_key, kind, lane,
+          major_order, minor_order, sort_one, sort_two, payload
+        )
+        SELECT ${session.id}, value->>'recordKey', value->>'uniqueKey', value->>'kind',
+          value->>'lane', (value->>'majorOrder')::integer, (value->>'minorOrder')::integer,
+          value->>'sortOne', value->>'sortTwo', value->'record'
+        FROM staged
+      `
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw duplicateWork()
+      }
+      throw error
+    }
   }
 
   async *stream(input: StreamMaterializationWorkInput): AsyncIterable<MaterializationWorkPage> {

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -40,6 +40,7 @@ describe("Postgres storage migrations", () => {
             "003-merge-sync-runs",
             "004-executions",
             "005-workflow-executions",
+            "006-narrow-ontology-source-root-index",
           ],
         },
       ])
@@ -78,6 +79,13 @@ describe("Postgres storage migrations", () => {
           id: "005-workflow-executions",
           status: "applied",
           version: 5,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "006-narrow-ontology-source-root-index",
+          status: "applied",
+          version: 6,
         },
       ])
     })
@@ -431,7 +439,7 @@ describe("Postgres storage migrations", () => {
       expect(await migrator?.status()).toMatchObject({
         adapterId: POSTGRES_STORAGE_ADAPTER_ID,
         state: "current",
-        appliedVersion: 5,
+        appliedVersion: 6,
       })
     })
   })
@@ -488,6 +496,13 @@ describe("Postgres storage migrations", () => {
           id: "005-workflow-executions",
           status: "applied",
           version: 5,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "006-narrow-ontology-source-root-index",
+          status: "applied",
+          version: 6,
         },
       ])
     } finally {

--- a/storage/sqlite/README.md
+++ b/storage/sqlite/README.md
@@ -33,9 +33,10 @@ empty.
 With a `path`, `SqliteStorage` exposes core's `StorageMigrator` contract and the CLI runs it at
 startup. You do not write migrations — they ship inside this package.
 
-Applied migrations are checksummed. Schema changes ship as new ordered steps; changing an already
-applied step fails startup instead of silently rewriting migration history. Before 1.0, an explicitly
-breaking migration may still require deleting the database file and starting over.
+Applied migrations are checksummed and schema changes ship as new ordered steps. Keep the database
+file when upgrading normally; incompatible or dirty history fails startup instead of silently
+rewriting an unknown schema. Before 1.0, an explicitly breaking migration may still require deleting
+the database file and starting over.
 
 ## Transactions
 
@@ -45,13 +46,16 @@ await storage.transaction(async (tx) => {
 })
 ```
 
-Nested transactions are rejected. The `isolation` option is accepted and **ignored**: every
-transaction runs through one shared connection, serialized by an internal lock and a
-`BEGIN IMMEDIATE`, so there is no concurrent transaction to isolate against — the lock already gives
-serializable semantics for transaction-vs-transaction races. `isolation: "serializable"` only becomes
-meaningful on a provider with true concurrent connections, such as [`@sixb/pg`](../pg).
+Nested transactions are rejected. The `isolation` option is accepted and **ignored**: every write
+transaction runs through one connection, serialized by an internal lock and a `BEGIN IMMEDIATE`, so
+there is no concurrent writer to isolate against. `isolation: "serializable"` only becomes meaningful
+on a provider with true concurrent connections, such as [`@sixb/pg`](../pg).
 
-That single-connection design is also the reason to reach for `@sixb/pg` before you scale out: every
-process needs its own file, so replicas cannot share this storage.
+File-backed storage uses WAL mode and serves object and timeseries queries from a separate read-only
+snapshot connection. Long materializations therefore do not block those reads behind the writer.
+In-memory storage keeps one connection because SQLite in-memory databases are connection-local.
+
+Reach for `@sixb/pg` before scaling out: SQLite still has one writer and is intended for one local
+Sixb process, not shared replicas.
 
 Call `close()` on shutdown.

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -90,12 +90,19 @@ export class SqliteStorage implements MigrationCapableStorage {
   readonly migrators: readonly StorageMigrator[]
 
   private readonly connection: SqliteStoreConnection
+  private readonly readConnection: SqliteStoreConnection
   private readonly transactionScope = new AsyncLocalStorage<{ active: boolean }>()
   private transactionTail: Promise<void> = Promise.resolve()
 
   constructor(options: SqliteStorageOptions = {}) {
     const path = options.path ? sqliteStoragePath(options.path) : undefined
     this.connection = openSqliteStoreConnection({ path })
+    if (path) {
+      this.connection.db.run("PRAGMA journal_mode = WAL")
+      this.readConnection = openSqliteStoreConnection({ path, readonly: true })
+    } else {
+      this.readConnection = this.connection
+    }
 
     if (this.connection.installFreshSchema) {
       installFreshSqliteSchema(this.connection.db)
@@ -114,14 +121,26 @@ export class SqliteStorage implements MigrationCapableStorage {
       (run) => this.runRootOntologyOperation(run),
       assertRootOperationAvailable
     )
-    this.objects = createOperationScopedFacade(stores.objects, scope)
+    const readScope = path
+      ? createStorageOperationScope(async (run) => {
+          this.assertRootOperationAvailable()
+          return run()
+        }, assertRootOperationAvailable)
+      : scope
+    const readObjects = path
+      ? new SqliteObjectStorage({ connection: this.readConnection })
+      : stores.objects
+    const readTimeseries = path
+      ? new SqliteTimeseriesStorage({ connection: this.readConnection })
+      : stores.timeseries
+    this.objects = createOperationScopedFacade(readObjects, readScope)
     this.ontology = createOntologyOperationScope(stores.ontology, ontologyScope)
     this.auth = createAuthOperationScope(stores.auth, scope)
     this.executions = createOperationScopedFacade(stores.executions, scope)
     this.agents = createAgentOperationScope(stores.agents, scope)
     this.actionRuns = createOperationScopedFacade(stores.actionRuns, scope)
     this.pipelineRuns = createOperationScopedFacade(stores.pipelineRuns, scope)
-    this.timeseries = createOperationScopedFacade(stores.timeseries, scope)
+    this.timeseries = createOperationScopedFacade(readTimeseries, readScope)
     this.syncRuns = createOperationScopedFacade(stores.syncRuns, scope)
     this.projectionRuns = createOperationScopedFacade(stores.projectionRuns, scope)
     this.workflowRuns = createWorkflowRunOperationScope(stores.workflowRuns, scope)
@@ -133,17 +152,21 @@ export class SqliteStorage implements MigrationCapableStorage {
   }
 
   async ping(): Promise<void> {
+    this.assertRootOperationAvailable()
+    if (this.readConnection !== this.connection) {
+      this.readConnection.db.query("SELECT 1").get()
+      return
+    }
     await this.runRootStorageOperation(() => {
       this.connection.db.query("SELECT 1").get()
     })
   }
 
   /**
-   * The `isolation` option is intentionally ignored. SQLite runs every transaction through one
-   * shared connection serialized by {@link withTransactionLock} and a `BEGIN IMMEDIATE`, so there is
-   * no concurrent transaction to isolate against — the lock already provides serializable semantics
-   * for transaction-vs-transaction races. Postgres, which has true concurrent connections, is where
-   * `isolation: "serializable"` translates to a real isolation level.
+   * The `isolation` option is intentionally ignored. SQLite runs every write transaction through
+   * one connection serialized by {@link withTransactionLock} and a `BEGIN IMMEDIATE`, so there is no
+   * concurrent writer to isolate against. File-backed object and timeseries reads use a separate WAL
+   * snapshot connection; Postgres is where `isolation: "serializable"` maps to a real isolation level.
    */
   async transaction<T>(
     run: (tx: Storage) => Promise<T> | T,
@@ -186,6 +209,7 @@ export class SqliteStorage implements MigrationCapableStorage {
   }
 
   close(): void {
+    if (this.readConnection !== this.connection) closeSqliteStoreConnection(this.readConnection)
     closeSqliteStoreConnection(this.connection)
   }
 

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -21,6 +21,9 @@ import workflowRunOutputSql from "./migrations/002-workflow-run-output.sql" with
 import mergeSyncRunsSql from "./migrations/003-merge-sync-runs.sql" with { type: "text" }
 import executionsSql from "./migrations/004-executions.sql" with { type: "text" }
 import workflowExecutionsSql from "./migrations/005-workflow-executions.sql" with { type: "text" }
+import narrowOntologySourceRootIndexSql from "./migrations/006-narrow-ontology-source-root-index.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -46,6 +49,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("003-merge-sync-runs", mergeSyncRunsSql),
     sqliteSql("004-executions", executionsSql),
     sqliteSql("005-workflow-executions", workflowExecutionsSql),
+    sqliteSql("006-narrow-ontology-source-root-index", narrowOntologySourceRootIndexSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/006-narrow-ontology-source-root-index.sql
+++ b/storage/sqlite/src/migrations/006-narrow-ontology-source-root-index.sql
@@ -1,0 +1,4 @@
+DROP INDEX idx_ontology_source_rows_root;
+
+CREATE INDEX idx_ontology_source_rows_root
+  ON ontology_source_rows(project_id, source_id, materialization_id, root_sort_key);

--- a/storage/sqlite/src/ontology-storage/materialization-session.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-session.ts
@@ -1,9 +1,5 @@
 import type { Database } from "bun:sqlite"
-import {
-  linkRefKey,
-  MaterializationConflictError,
-  objectRefKey,
-} from "@sixb/core/internal/materialization"
+import { MaterializationConflictError } from "@sixb/core/internal/materialization"
 import {
   correlateMaterializationChunk,
   duplicateMaterializationWork as duplicateWork,
@@ -25,7 +21,6 @@ import type {
   StreamMaterializationWorkInput,
 } from "@sixb/core/storage"
 import {
-  type ReplacementIdentity,
   SQLITE_MATERIALIZATION_WORK_TABLE,
   SQLITE_REPLACEMENT_WORK_TABLE,
 } from "./materialization-state"
@@ -103,8 +98,10 @@ export class SqliteMaterializationSessions {
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, json(?))
       `
     )
+    let currentRecordKey: string | undefined
     try {
       for (const { record, uniqueKey, columns } of records) {
+        currentRecordKey = record.recordKey
         insert.run(
           session.id,
           record.recordKey,
@@ -120,7 +117,7 @@ export class SqliteMaterializationSessions {
       }
     } catch (error) {
       if (isSqliteConstraintError(error)) {
-        throw duplicateWork(input.records[0]?.recordKey ?? "unknown")
+        throw duplicateWork(currentRecordKey)
       }
       throw error
     }
@@ -203,29 +200,6 @@ export class SqliteMaterializationSessions {
     session.appliedOutboxCount = progress.appliedOutboxCount
   }
 
-  recordReplacementIdentities(
-    session: SqliteMaterializationSessionState,
-    identities: readonly ReplacementIdentity[]
-  ): void {
-    const upsert = this.db.query(
-      `
-        INSERT INTO ${SQLITE_REPLACEMENT_WORK_TABLE} (
-          session_id, entity_kind, identity_key, diff_required
-        ) VALUES (?, ?, ?, ?)
-        ON CONFLICT(session_id, entity_kind, identity_key) DO UPDATE SET
-          diff_required = MAX(diff_required, excluded.diff_required)
-      `
-    )
-    for (const identity of identities) {
-      upsert.run(
-        session.id,
-        identity.kind,
-        identity.kind === "object" ? objectRefKey(identity.ref) : linkRefKey(identity.ref),
-        identity.diffRequired ? 1 : 0
-      )
-    }
-  }
-
   count(session: SqliteMaterializationSessionState, kind: string): number {
     const row = this.db
       .query(
@@ -278,11 +252,19 @@ export class SqliteMaterializationSessions {
             WHERE session_id = ? AND diff_required = 1
               AND (entity_kind = 'link' OR ? = 1)
           ), actual AS (
-            SELECT json_extract(payload, '$.entityKind') AS entity_kind,
-              json_extract(payload, '$.identityKey') AS identity_key
+            SELECT CASE
+                WHEN unique_key LIKE 'classification:object:%' THEN 'object'
+                ELSE 'link'
+              END AS entity_kind,
+              CASE
+                WHEN unique_key LIKE 'classification:object:%'
+                  THEN substr(unique_key, length('classification:object:') + 1)
+                ELSE substr(unique_key, length('classification:link:') + 1)
+              END AS identity_key
             FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
             WHERE session_id = ? AND kind = 'classification'
-              AND json_extract(payload, '$.entityKind') IN ('object', 'link')
+              AND (unique_key LIKE 'classification:object:%'
+                OR unique_key LIKE 'classification:link:%')
           ), differences AS (
             SELECT * FROM expected EXCEPT SELECT * FROM actual
             UNION ALL
@@ -297,7 +279,7 @@ export class SqliteMaterializationSessions {
         `
           SELECT 1 FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
           WHERE session_id = ? AND kind = 'classification'
-            AND json_extract(payload, '$.entityKind') = 'point'
+            AND unique_key LIKE 'classification:point:%'
           LIMIT 1
         `
       )
@@ -376,9 +358,14 @@ export class SqliteMaterializationSessions {
         session_id TEXT NOT NULL,
         entity_kind TEXT NOT NULL,
         identity_key TEXT NOT NULL,
+        sort_key TEXT NOT NULL,
         diff_required INTEGER NOT NULL CHECK (diff_required IN (0, 1)),
         PRIMARY KEY (session_id, entity_kind, identity_key)
       );
+      CREATE INDEX IF NOT EXISTS idx_ontology_replacement_work_order
+        ON ${SQLITE_REPLACEMENT_WORK_TABLE}(
+          session_id, entity_kind, sort_key, identity_key
+        );
     `)
   }
 

--- a/storage/sqlite/src/ontology-storage/materialization-state.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-state.ts
@@ -122,6 +122,18 @@ interface ReplacementIdentityInput {
   readonly pageRows: number
 }
 
+interface ReplacementWorkRow {
+  readonly entity_kind: "object" | "link"
+  readonly identity_key: string
+  readonly sort_key: string
+  readonly diff_required: number
+}
+
+interface ReplacementCursor {
+  readonly sortKey: string
+  readonly identityKey: string
+}
+
 export class SqliteMaterializationStateReader {
   constructor(
     private readonly db: Database,
@@ -509,29 +521,15 @@ export class SqliteMaterializationStateReader {
   }
 
   *replacementIdentities(input: ReplacementIdentityInput): Iterable<ReplacementIdentity[]> {
-    let cursor: string | null = null
+    this.prepareReplacementIdentities(input)
+    let cursor: ReplacementCursor | null = null
     while (true) {
-      if (input.kind === "object") {
-        const rows = this.replacementObjectRows(input, cursor)
-        if (rows.length === 0) break
-        yield rows.map((row) => ({
-          kind: "object",
-          ref: { objectTypeId: row.object_type_id, primaryId: row.primary_id },
-          sortKey: row.sort_key,
-          diffRequired: true,
-        }))
-        cursor = rows[rows.length - 1]?.sort_key ?? null
-        continue
-      }
-      const rows = this.replacementLinkRows(input, cursor)
+      const rows = this.replacementRows(input, cursor)
       if (rows.length === 0) break
-      yield rows.map((row) => ({
-        kind: "link",
-        ref: linkRefFromColumns(row),
-        sortKey: row.sort_key,
-        diffRequired: row.diff_required === 1,
-      }))
-      cursor = rows[rows.length - 1]?.sort_key ?? null
+      yield rows.map(replacementIdentity)
+      if (rows.length < input.pageRows) break
+      const last = rows[rows.length - 1]!
+      cursor = { sortKey: last.sort_key, identityKey: last.identity_key }
     }
   }
 
@@ -682,62 +680,48 @@ export class SqliteMaterializationStateReader {
     return { owned, byMaterialization }
   }
 
-  private replacementObjectRows(
-    input: ReplacementIdentityInput,
-    cursor: string | null
-  ): (EffectiveObjectRow & { readonly sort_key: string })[] {
-    return this.db
+  private prepareReplacementIdentities(input: ReplacementIdentityInput): void {
+    if (input.kind === "object") {
+      this.prepareReplacementObjects(input)
+      return
+    }
+    this.prepareReplacementLinks(input)
+  }
+
+  private prepareReplacementObjects(input: ReplacementIdentityInput): void {
+    this.db
       .query(
         `
-          SELECT DISTINCT object_type_id, primary_id, entity_sort_key AS sort_key
+          INSERT INTO ${SQLITE_REPLACEMENT_WORK_TABLE} (
+            session_id, entity_kind, identity_key, sort_key, diff_required
+          )
+          SELECT ?, 'object', json_array(object_type_id, primary_id),
+            MIN(entity_sort_key), 1
           FROM ontology_source_rows
           WHERE project_id = ? AND source_id = ? AND entity_kind = 'object'
             AND materialization_id IN (?, COALESCE(?, ''))
-            AND (? IS NULL OR entity_sort_key > ?)
-          ORDER BY sort_key
-          LIMIT ?
+          GROUP BY object_type_id, primary_id
         `
       )
-      .all(
+      .run(
+        input.sessionId,
         this.projectId,
         input.sourceId,
         input.candidateMaterializationId,
-        input.previousMaterializationId,
-        cursor,
-        cursor,
-        input.pageRows
-      ) as (EffectiveObjectRow & { readonly sort_key: string })[]
+        input.previousMaterializationId
+      )
   }
 
-  private replacementLinkRows(
-    input: ReplacementIdentityInput,
-    cursor: string | null
-  ): (EffectiveLinkRow & { readonly sort_key: string; readonly diff_required: number })[] {
-    return this.db
+  private prepareReplacementLinks(input: ReplacementIdentityInput): void {
+    this.db
       .query(
         `
           WITH incident_objects AS (
-            SELECT
+            SELECT DISTINCT
               json_extract(payload, '$.ref.objectTypeId') AS object_type_id,
               json_extract(payload, '$.ref.primaryId') AS primary_id
             FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
             WHERE session_id = ? AND kind = 'incident-object'
-          ), authority_links AS (
-            SELECT source_type_id, source_id, link_id, target_type_id, target_id
-            FROM links WHERE project_id = ?
-            UNION
-            SELECT source_type_id, source_primary_id, link_id, target_type_id, target_primary_id
-            FROM ontology_overrides
-            WHERE project_id = ? AND entity_kind = 'link'
-            UNION
-            SELECT rows.source_type_id, rows.source_primary_id, rows.link_id,
-              rows.target_type_id, rows.target_primary_id
-            FROM ontology_source_rows AS rows
-            JOIN ontology_sources AS sources
-              ON sources.project_id = rows.project_id
-             AND sources.source_id = rows.source_id
-             AND sources.materialization_id = rows.materialization_id
-            WHERE rows.project_id = ? AND rows.entity_kind = 'link' AND sources.status = 'active'
           ), replacement_links AS (
             SELECT source_type_id, source_primary_id AS source_id, link_id,
               target_type_id, target_primary_id AS target_id
@@ -745,14 +729,67 @@ export class SqliteMaterializationStateReader {
             WHERE project_id = ? AND source_id = ? AND entity_kind = 'link'
               AND materialization_id IN (?, COALESCE(?, ''))
           ), incident_links AS (
-            SELECT links.* FROM authority_links AS links
-            WHERE EXISTS (
-              SELECT 1 FROM incident_objects
-              WHERE (incident_objects.object_type_id = links.source_type_id
-                  AND incident_objects.primary_id = links.source_id)
-                 OR (incident_objects.object_type_id = links.target_type_id
-                  AND incident_objects.primary_id = links.target_id)
-            )
+            SELECT links.source_type_id, links.source_id, links.link_id,
+              links.target_type_id, links.target_id
+            FROM links
+            JOIN incident_objects
+              ON incident_objects.object_type_id = links.source_type_id
+             AND incident_objects.primary_id = links.source_id
+            WHERE links.project_id = ?
+            UNION
+            SELECT links.source_type_id, links.source_id, links.link_id,
+              links.target_type_id, links.target_id
+            FROM links
+            JOIN incident_objects
+              ON incident_objects.object_type_id = links.target_type_id
+             AND incident_objects.primary_id = links.target_id
+            WHERE links.project_id = ?
+            UNION
+            SELECT overrides.source_type_id,
+              overrides.source_primary_id AS source_id,
+              overrides.link_id, overrides.target_type_id,
+              overrides.target_primary_id AS target_id
+            FROM ontology_overrides AS overrides
+            JOIN incident_objects
+              ON incident_objects.object_type_id = overrides.source_type_id
+             AND incident_objects.primary_id = overrides.source_primary_id
+            WHERE overrides.project_id = ? AND overrides.entity_kind = 'link'
+            UNION
+            SELECT overrides.source_type_id,
+              overrides.source_primary_id AS source_id,
+              overrides.link_id, overrides.target_type_id,
+              overrides.target_primary_id AS target_id
+            FROM ontology_overrides AS overrides
+            JOIN incident_objects
+              ON incident_objects.object_type_id = overrides.target_type_id
+             AND incident_objects.primary_id = overrides.target_primary_id
+            WHERE overrides.project_id = ? AND overrides.entity_kind = 'link'
+            UNION
+            SELECT rows.source_type_id, rows.source_primary_id AS source_id,
+              rows.link_id, rows.target_type_id, rows.target_primary_id AS target_id
+            FROM ontology_source_rows AS rows
+            JOIN ontology_sources AS sources
+              ON sources.project_id = rows.project_id
+             AND sources.source_id = rows.source_id
+             AND sources.materialization_id = rows.materialization_id
+            JOIN incident_objects
+              ON incident_objects.object_type_id = rows.source_type_id
+             AND incident_objects.primary_id = rows.source_primary_id
+            WHERE rows.project_id = ? AND rows.entity_kind = 'link'
+              AND sources.status = 'active'
+            UNION
+            SELECT rows.source_type_id, rows.source_primary_id AS source_id,
+              rows.link_id, rows.target_type_id, rows.target_primary_id AS target_id
+            FROM ontology_source_rows AS rows
+            JOIN ontology_sources AS sources
+              ON sources.project_id = rows.project_id
+             AND sources.source_id = rows.source_id
+             AND sources.materialization_id = rows.materialization_id
+            JOIN incident_objects
+              ON incident_objects.object_type_id = rows.target_type_id
+             AND incident_objects.primary_id = rows.target_primary_id
+            WHERE rows.project_id = ? AND rows.entity_kind = 'link'
+              AND sources.status = 'active'
           ), diff_links AS (
             SELECT * FROM replacement_links
             UNION SELECT * FROM incident_links
@@ -773,26 +810,77 @@ export class SqliteMaterializationStateReader {
             FROM all_links
             GROUP BY source_type_id, source_id, link_id, target_type_id, target_id
           )
-          SELECT * FROM selected
-          WHERE (? IS NULL OR sort_key > ?)
-          ORDER BY sort_key
-          LIMIT ?
+          INSERT INTO ${SQLITE_REPLACEMENT_WORK_TABLE} (
+            session_id, entity_kind, identity_key, sort_key, diff_required
+          )
+          SELECT ?, 'link',
+            json_array(source_type_id, source_id, link_id, target_type_id, target_id),
+            sort_key, diff_required
+          FROM selected
         `
       )
-      .all(
+      .run(
         input.sessionId,
-        this.projectId,
-        this.projectId,
-        this.projectId,
         this.projectId,
         input.sourceId,
         input.candidateMaterializationId,
         input.previousMaterializationId,
         this.projectId,
-        cursor,
-        cursor,
+        this.projectId,
+        this.projectId,
+        this.projectId,
+        this.projectId,
+        this.projectId,
+        this.projectId,
+        input.sessionId
+      )
+  }
+
+  private replacementRows(
+    input: ReplacementIdentityInput,
+    cursor: ReplacementCursor | null
+  ): ReplacementWorkRow[] {
+    return this.db
+      .query(
+        `
+          SELECT entity_kind, identity_key, sort_key, diff_required
+          FROM ${SQLITE_REPLACEMENT_WORK_TABLE}
+          WHERE session_id = ? AND entity_kind = ?
+            AND (? IS NULL OR (sort_key, identity_key) > (?, ?))
+          ORDER BY sort_key, identity_key
+          LIMIT ?
+        `
+      )
+      .all(
+        input.sessionId,
+        input.kind,
+        cursor?.sortKey ?? null,
+        cursor?.sortKey ?? null,
+        cursor?.identityKey ?? null,
         input.pageRows
-      ) as (EffectiveLinkRow & { readonly sort_key: string; readonly diff_required: number })[]
+      ) as ReplacementWorkRow[]
+  }
+}
+
+function replacementIdentity(row: ReplacementWorkRow): ReplacementIdentity {
+  const parts = parseJson<string[]>(row.identity_key)
+  if (row.entity_kind === "object") {
+    return {
+      kind: "object",
+      ref: { objectTypeId: parts[0]!, primaryId: parts[1]! },
+      sortKey: row.sort_key,
+      diffRequired: true,
+    }
+  }
+  return {
+    kind: "link",
+    ref: {
+      source: { objectTypeId: parts[0]!, primaryId: parts[1]! },
+      linkId: parts[2]!,
+      target: { objectTypeId: parts[3]!, primaryId: parts[4]! },
+    },
+    sortKey: row.sort_key,
+    diffRequired: row.diff_required === 1,
   }
 }
 

--- a/storage/sqlite/src/ontology-storage/materializations.ts
+++ b/storage/sqlite/src/ontology-storage/materializations.ts
@@ -30,11 +30,8 @@ import type {
   ApplyMaterializationChunkInput,
   ApplyMaterializationResult,
   FinalizeMaterializationInput,
-  MaterializationCardinalityOccupantWorkRecord,
-  MaterializationClassificationWorkRecord,
   MaterializationObjectExistence,
   MaterializationPlanHeader,
-  MaterializationPlanWorkRecord,
   MaterializationSession,
   MaterializationStatePage,
   MaterializationWorkPage,
@@ -48,7 +45,7 @@ import type {
   StreamMaterializationWorkInput,
   StreamSourceReplacementStateInput,
 } from "@sixb/core/storage"
-import { stableJsonStringify } from "@sixb/core/storage"
+import { yieldSqliteEventLoop } from "../transactions"
 import {
   type SqliteMaterializationSessionState,
   SqliteMaterializationSessions,
@@ -202,7 +199,6 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
         pageRows: input.pageRows,
       })) {
         this.sessions.require(input.session)
-        this.sessions.recordReplacementIdentities(session, identities)
         const refs = identities.map((identity) => {
           if (identity.kind !== "object") {
             invalidCorrelation("Object replacement returned a link identity.")
@@ -247,7 +243,6 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
       pageRows: input.pageRows,
     })) {
       this.sessions.require(input.session)
-      this.sessions.recordReplacementIdentities(session, identities)
       const linkIdentities = identities.map((identity) => {
         if (identity.kind !== "link") {
           invalidCorrelation("Link replacement returned an object identity.")
@@ -268,6 +263,7 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
 
   async stageWork(input: StageMaterializationWorkInput): Promise<void> {
     this.sessions.stage(input)
+    await yieldSqliteEventLoop()
   }
 
   streamWork(input: StreamMaterializationWorkInput): AsyncIterable<MaterializationWorkPage> {
@@ -300,12 +296,13 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
       session.appliedOutboxCount = outboxCount
       throw error
     }
+    await yieldSqliteEventLoop()
   }
 
   async finalize(input: FinalizeMaterializationInput): Promise<ApplyMaterializationResult> {
     const session = this.sessions.require(input.session)
     this.assertCommitAbsent(session.header)
-    this.assertFinalization(session, input)
+    await this.assertFinalization(session, input)
     for (const activation of input.finalization.sourceActivations) {
       this.activateSource(session, activation)
     }
@@ -484,16 +481,17 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
     }
   }
 
-  private assertFinalization(
+  private async assertFinalization(
     session: SqliteMaterializationSessionState,
     input: FinalizeMaterializationInput
-  ): void {
+  ): Promise<void> {
     const { commit } = session.header
     const { result } = input.finalization
     assertMaterializationFinalizationCorrelation(session, input)
     const laneCounts = this.sessions.laneCounts(session)
     assertMaterializationLaneCompletion(session, laneCounts)
     this.assertFinalCardinality(session)
+    await yieldSqliteEventLoop()
     const eventCount = laneCounts.event
     const outbox = this.db
       .query(
@@ -513,149 +511,183 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
     ) {
       invalidCorrelation("Outbox event ordinals must be contiguous from zero.")
     }
+    await yieldSqliteEventLoop()
 
     if (commit.intent.kind === "telemetry") {
-      const classifiedPoints = this.db
-        .query(
-          `
-            SELECT COUNT(*) AS count FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-            WHERE session_id = ? AND kind = 'classification'
-              AND json_extract(payload, '$.entityKind') = 'point'
-          `
-        )
-        .get(session.id) as { readonly count: number }
-      if (classifiedPoints.count !== commit.intent.pointCount) {
+      const summary = this.telemetrySummary(session, commit.intent.pointCount)
+      await yieldSqliteEventLoop()
+      if (summary.classifiedPoints !== commit.intent.pointCount) {
         invalidCorrelation(
           "Telemetry point classification coverage does not match the commit intent."
         )
       }
-      if (
-        result.kind !== "telemetry" ||
-        !sameCounts(result, this.telemetryCounts(session, commit.intent.pointCount))
-      ) {
+      if (result.kind !== "telemetry" || !sameCounts(result, summary.counts)) {
         invalidCorrelation("Telemetry result counts do not correlate with finalized work.")
       }
     }
     if (commit.intent.kind === "projection") {
       if (result.kind !== "projection") return
       this.sessions.assertClassificationCoverage(session)
-      if (!sameCounts(result.counts, this.projectionCounts(session))) {
+      await yieldSqliteEventLoop()
+      const counts = this.projectionCounts(session)
+      await yieldSqliteEventLoop()
+      if (!sameCounts(result.counts, counts)) {
         invalidCorrelation("Projection result counts do not correlate with finalized work.")
       }
     }
   }
 
   private assertFinalCardinality(session: SqliteMaterializationSessionState): void {
-    const duplicate = this.db
+    const violation = this.db
       .query(
         `
-          SELECT json_extract(payload, '$.scopeSortKey') AS scope_key
-          FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-          WHERE session_id = ? AND kind = 'cardinality'
-            AND json_extract(payload, '$.occupied') = 1
-          GROUP BY scope_key HAVING COUNT(*) > 1 LIMIT 1
+          WITH work AS (
+            SELECT json_extract(payload, '$.scopeSortKey') AS scope_sort_key,
+              json_extract(payload, '$.linkSortKey') AS link_sort_key,
+              json_extract(payload, '$.occupied') AS occupied,
+              json_extract(payload, '$.ref.source.objectTypeId') AS source_type_id,
+              json_extract(payload, '$.ref.source.primaryId') AS source_id,
+              json_extract(payload, '$.ref.linkId') AS link_id
+            FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
+            WHERE session_id = ? AND kind = 'cardinality'
+          ), duplicate AS (
+            SELECT scope_sort_key FROM work WHERE occupied = 1
+            GROUP BY scope_sort_key HAVING COUNT(*) > 1
+          ), scopes AS (
+            SELECT DISTINCT scope_sort_key, source_type_id, source_id, link_id FROM work
+          ), expected AS (
+            SELECT scope_sort_key, link_sort_key FROM work WHERE occupied = 1
+          ), actual AS (
+            SELECT scopes.scope_sort_key,
+              ${linkSortExpression("links")} AS link_sort_key
+            FROM scopes
+            -- json-derived temp scopes have no useful cardinality estimate. Fixing them on the
+            -- outer side keeps each lookup on the complete links primary-key prefix.
+            CROSS JOIN links
+              ON links.project_id = ?
+             AND links.source_type_id = scopes.source_type_id
+             AND links.source_id = scopes.source_id
+             AND links.link_id = scopes.link_id
+          ), differences AS (
+            SELECT * FROM expected EXCEPT SELECT * FROM actual
+            UNION ALL
+            SELECT * FROM actual EXCEPT SELECT * FROM expected
+          )
+          SELECT 'duplicate' AS reason FROM duplicate
+          UNION ALL
+          SELECT 'mismatch' AS reason FROM differences
+          LIMIT 1
         `
       )
-      .get(session.id)
-    if (duplicate) {
+      .get(session.id, session.header.commit.projectId) as {
+      readonly reason: "duplicate" | "mismatch"
+    } | null
+    if (violation?.reason === "duplicate") {
       invalidCorrelation("Materialization cardinality work violates cardinality-one.")
     }
-    const records = this.sessions.records(
-      session,
-      "cardinality"
-    ) as MaterializationCardinalityOccupantWorkRecord[]
-    const scopes = new Map<string, MaterializationCardinalityOccupantWorkRecord>()
-    for (const record of records) scopes.set(record.scopeSortKey, record)
-    for (const record of scopes.values()) {
-      const effective = this.db
-        .query(
-          `
-            SELECT ${linkSortExpression()} AS sort_key FROM links
-            WHERE project_id = ? AND source_type_id = ? AND source_id = ? AND link_id = ?
-            ORDER BY sort_key
-          `
-        )
-        .all(
-          session.header.commit.projectId,
-          record.ref.source.objectTypeId,
-          record.ref.source.primaryId,
-          record.ref.linkId
-        ) as { readonly sort_key: string }[]
-      const occupied = records
-        .filter((candidate) => candidate.scopeSortKey === record.scopeSortKey && candidate.occupied)
-        .map((candidate) => candidate.linkSortKey)
-        .sort()
-      if (
-        stableJsonStringify(effective.map((row) => row.sort_key)) !== stableJsonStringify(occupied)
-      ) {
-        invalidCorrelation(
-          "Materialization cardinality work does not match the final effective link scope."
-        )
-      }
+    if (violation) {
+      invalidCorrelation(
+        "Materialization cardinality work does not match the final effective link scope."
+      )
     }
   }
 
   private projectionCounts(session: SqliteMaterializationSessionState): EffectiveChangeCounts {
-    const classifications = this.sessions.records(
-      session,
-      "classification"
-    ) as MaterializationClassificationWorkRecord[]
-    const plans = this.sessions.records(session, "plan") as MaterializationPlanWorkRecord[]
-    const counts: MutableEffectiveChangeCounts = {
-      objectsCreated: 0,
-      objectsUpdated: 0,
-      objectsDeleted: 0,
-      objectsUnchanged: classifications.filter((record) => record.entityKind === "object").length,
-      linksCreated: 0,
-      linksUpdated: 0,
-      linksDeleted: 0,
-      linksUnchanged: classifications.filter((record) => record.entityKind === "link").length,
+    const row = this.db
+      .query(
+        `
+          SELECT
+            COUNT(*) FILTER (
+              WHERE kind = 'classification'
+                AND unique_key LIKE 'classification:object:%'
+            ) AS object_classifications,
+            COUNT(*) FILTER (
+              WHERE kind = 'classification'
+                AND unique_key LIKE 'classification:link:%'
+            ) AS link_classifications,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'object-upsert'
+                AND json_extract(payload, '$.item.value.expected.exists') = 0
+            ) AS objects_created,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'object-upsert'
+                AND json_extract(payload, '$.item.value.expected.exists') = 1
+            ) AS objects_updated,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'object-delete'
+            ) AS objects_deleted,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'link-upsert'
+                AND json_extract(payload, '$.item.value.expected.exists') = 0
+            ) AS links_created,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'link-upsert'
+                AND json_extract(payload, '$.item.value.expected.exists') = 1
+            ) AS links_updated,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'link-delete'
+            ) AS links_deleted
+          FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
+          WHERE session_id = ?
+        `
+      )
+      .get(session.id) as ProjectionCountsRow
+    const objectsChanged = row.objects_created + row.objects_updated + row.objects_deleted
+    const linksChanged = row.links_created + row.links_updated + row.links_deleted
+    return {
+      objectsCreated: row.objects_created,
+      objectsUpdated: row.objects_updated,
+      objectsDeleted: row.objects_deleted,
+      objectsUnchanged: row.object_classifications - objectsChanged,
+      linksCreated: row.links_created,
+      linksUpdated: row.links_updated,
+      linksDeleted: row.links_deleted,
+      linksUnchanged: row.link_classifications - linksChanged,
     }
-    for (const record of plans) {
-      switch (record.item.kind) {
-        case "object-upsert":
-          if (record.item.value.expected.exists) counts.objectsUpdated += 1
-          else counts.objectsCreated += 1
-          counts.objectsUnchanged -= 1
-          break
-        case "object-delete":
-          counts.objectsDeleted += 1
-          counts.objectsUnchanged -= 1
-          break
-        case "link-upsert":
-          if (record.item.value.expected.exists) counts.linksUpdated += 1
-          else counts.linksCreated += 1
-          counts.linksUnchanged -= 1
-          break
-        case "link-delete":
-          counts.linksDeleted += 1
-          counts.linksUnchanged -= 1
-          break
-      }
-    }
-    return counts
   }
 
-  private telemetryCounts(session: SqliteMaterializationSessionState, pointCount: number) {
-    let pointsCreated = 0
-    let pointsUpdated = 0
-    let latestObjectsChanged = 0
-    for (const record of this.sessions.records(
-      session,
-      "plan"
-    ) as MaterializationPlanWorkRecord[]) {
-      if (record.item.kind === "point-upsert") {
-        if (record.item.value.expected.lastCommitId === null) pointsCreated += 1
-        else pointsUpdated += 1
-      } else if (record.item.kind === "object-upsert") {
-        latestObjectsChanged += 1
-      }
-    }
+  private telemetrySummary(session: SqliteMaterializationSessionState, pointCount: number) {
+    const row = this.db
+      .query(
+        `
+          SELECT
+            COUNT(*) FILTER (
+              WHERE kind = 'classification'
+                AND unique_key LIKE 'classification:point:%'
+            ) AS classified_points,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'point-upsert'
+                AND json_extract(payload, '$.item.value.expected.lastCommitId') IS NULL
+            ) AS points_created,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'point-upsert'
+                AND json_extract(payload, '$.item.value.expected.lastCommitId') IS NOT NULL
+            ) AS points_updated,
+            COUNT(*) FILTER (
+              WHERE kind = 'plan'
+                AND json_extract(payload, '$.item.kind') = 'object-upsert'
+            ) AS latest_objects_changed
+          FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
+          WHERE session_id = ?
+        `
+      )
+      .get(session.id) as TelemetrySummaryRow
     return {
-      pointsCreated,
-      pointsUpdated,
-      pointsUnchanged: pointCount - pointsCreated - pointsUpdated,
-      latestObjectsChanged,
+      classifiedPoints: row.classified_points,
+      counts: {
+        pointsCreated: row.points_created,
+        pointsUpdated: row.points_updated,
+        pointsUnchanged: pointCount - row.points_created - row.points_updated,
+        latestObjectsChanged: row.latest_objects_changed,
+      },
     }
   }
 
@@ -833,6 +865,20 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
   }
 }
 
-type MutableEffectiveChangeCounts = {
-  -readonly [TKey in keyof EffectiveChangeCounts]: EffectiveChangeCounts[TKey]
+interface ProjectionCountsRow {
+  readonly object_classifications: number
+  readonly link_classifications: number
+  readonly objects_created: number
+  readonly objects_updated: number
+  readonly objects_deleted: number
+  readonly links_created: number
+  readonly links_updated: number
+  readonly links_deleted: number
+}
+
+interface TelemetrySummaryRow {
+  readonly classified_points: number
+  readonly points_created: number
+  readonly points_updated: number
+  readonly latest_objects_changed: number
 }

--- a/storage/sqlite/src/ontology-storage/sources.ts
+++ b/storage/sqlite/src/ontology-storage/sources.ts
@@ -33,6 +33,7 @@ import type {
   SummarizeTerminalSourceMaterializationsInput,
   TerminalSourceMaterializationSummary,
 } from "@sixb/core/storage"
+import { yieldSqliteEventLoop } from "../transactions"
 import {
   assertNonblank,
   assertNonnegativeInteger,
@@ -125,7 +126,7 @@ export class SqliteOntologySourceStorage implements OntologySourceStorage {
   }
 
   async stageRows(input: StageSourceRowsInput): Promise<StageSourceRowsResult> {
-    return this.runRootOperation(() => {
+    const result = await this.runRootOperation(() => {
       assertWriteIdentity(input)
       this.assertExecution(input)
       const manifest = this.requireManifest(
@@ -146,6 +147,8 @@ export class SqliteOntologySourceStorage implements OntologySourceStorage {
       this.insertStageRows(input, pending)
       return { inserted: pending.length, unchanged }
     })
+    await yieldSqliteEventLoop()
+    return result
   }
 
   async markReady(input: MarkSourceMaterializationReadyInput): Promise<OntologySourceRecord> {

--- a/storage/sqlite/src/transactions.ts
+++ b/storage/sqlite/src/transactions.ts
@@ -12,6 +12,7 @@ export interface SqliteStoreConnection {
 export interface SqliteStoreConnectionOptions {
   readonly path?: string
   readonly connection?: SqliteStoreConnection
+  readonly readonly?: boolean
 }
 
 export function openSqliteStoreConnection(
@@ -26,13 +27,14 @@ export function openSqliteStoreConnection(
   }
 
   const path = options.path ?? ":memory:"
-  if (path !== ":memory:") mkdirSync(dirname(path), { recursive: true })
-  const db = new SqliteDatabase(path)
+  if (path !== ":memory:" && !options.readonly) mkdirSync(dirname(path), { recursive: true })
+  const db = new SqliteDatabase(path, options.readonly ? { readonly: true } : undefined)
   db.run("PRAGMA foreign_keys = ON")
+  db.run("PRAGMA busy_timeout = 5000")
   return {
     db,
     ownsConnection: true,
-    installFreshSchema: path === ":memory:",
+    installFreshSchema: path === ":memory:" && !options.readonly,
   }
 }
 
@@ -62,6 +64,11 @@ export function runImmediateTransaction<T>(db: Database, run: () => T): T {
   } finally {
     activeImmediateTransactions.delete(db)
   }
+}
+
+/** Lets timers and request handlers run between bounded synchronous SQLite chunks. */
+export function yieldSqliteEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
 }
 
 export async function runImmediateTransactionAsync<T>(

--- a/storage/sqlite/tests/sqlite-materialization-query-plan.test.ts
+++ b/storage/sqlite/tests/sqlite-materialization-query-plan.test.ts
@@ -2,7 +2,11 @@ import { Database, type SQLQueryBindings } from "bun:sqlite"
 import { describe, expect, test } from "bun:test"
 import type { OntologyLinkRef, OntologyObjectRef } from "@sixb/core/internal/materialization"
 import { installFreshSqliteSchema } from "../src/migrations"
-import { SqliteMaterializationStateReader } from "../src/ontology-storage/materialization-state"
+import {
+  SQLITE_MATERIALIZATION_WORK_TABLE,
+  SQLITE_REPLACEMENT_WORK_TABLE,
+  SqliteMaterializationStateReader,
+} from "../src/ontology-storage/materialization-state"
 
 interface RecordedQuery {
   readonly sql: string
@@ -138,6 +142,38 @@ describe("SQLite materialization query plans", () => {
       )
     })
   })
+
+  test("prepares a linked replacement union once before paging it", () => {
+    // Regression proof: restore per-page replacementLinkRows() construction and this records four
+    // executions of the incident/replacement union (three one-row pages plus the terminal read).
+    // The prepared implementation executes that union once, then keyset-pages its temp table.
+    withRecordedReader(({ db, reader, recorded }) => {
+      installReplacementWorkTables(db)
+      insertReadyLinkCandidate(db, 3)
+
+      const pages = [
+        ...reader.replacementIdentities({
+          sessionId: "session-1",
+          sourceId: "employees",
+          candidateMaterializationId: "candidate-1",
+          previousMaterializationId: null,
+          kind: "link",
+          pageRows: 1,
+        }),
+      ]
+
+      expect(pages).toHaveLength(3)
+      expect(pages.flat()).toHaveLength(3)
+      expect(recorded.filter(({ sql }) => sql.includes("WITH incident_objects AS")).length).toBe(1)
+      expect(
+        recorded.filter(
+          ({ sql }) =>
+            sql.includes(`FROM ${SQLITE_REPLACEMENT_WORK_TABLE}`) &&
+            sql.includes("ORDER BY sort_key")
+        ).length
+      ).toBe(4)
+    })
+  })
 })
 
 function withRecordedReader(
@@ -178,6 +214,12 @@ function recordingDatabase(db: Database, recorded: RecordedQuery[]): Database {
                   return statementTarget.iterate(...bindings)
                 }
               }
+              if (statementProperty === "run") {
+                return (...bindings: SQLQueryBindings[]) => {
+                  recorded.push({ sql, bindings })
+                  return statementTarget.run(...bindings)
+                }
+              }
               const value = Reflect.get(statementTarget, statementProperty, statementTarget)
               return typeof value === "function" ? value.bind(statementTarget) : value
             },
@@ -188,6 +230,88 @@ function recordingDatabase(db: Database, recorded: RecordedQuery[]): Database {
       return typeof value === "function" ? value.bind(target) : value
     },
   })
+}
+
+function installReplacementWorkTables(db: Database): void {
+  db.run(`
+    CREATE TEMP TABLE ${SQLITE_MATERIALIZATION_WORK_TABLE} (
+      session_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      payload TEXT NOT NULL CHECK (json_valid(payload))
+    );
+    CREATE TEMP TABLE ${SQLITE_REPLACEMENT_WORK_TABLE} (
+      session_id TEXT NOT NULL,
+      entity_kind TEXT NOT NULL,
+      identity_key TEXT NOT NULL,
+      sort_key TEXT NOT NULL,
+      diff_required INTEGER NOT NULL CHECK (diff_required IN (0, 1)),
+      PRIMARY KEY (session_id, entity_kind, identity_key)
+    );
+    CREATE INDEX ontology_replacement_work_order
+      ON ${SQLITE_REPLACEMENT_WORK_TABLE}(
+        session_id, entity_kind, sort_key, identity_key
+      );
+  `)
+}
+
+function insertReadyLinkCandidate(db: Database, count: number): void {
+  const timestamp = "2026-01-01T00:00:00.000Z"
+  db.query(
+    `INSERT INTO ontology_sources (
+      project_id, source_id, materialization_id, projection_run_id,
+      projection_kind, protocol, status, execution_token,
+      dataset_id, dataset_version_id, dataset_version_created_at,
+      projection_revision, ownership_hash, ontology_revision,
+      root_count, assertion_count, created_at, ready_at, activated_at,
+      terminal_at, last_commit_id, updated_at
+    ) VALUES (?, 'employees', 'candidate-1', 'run-1',
+      'object', 'replacement', 'ready', 'execution-1',
+      'employees', 'version-1', ?, 'projection-revision', 'ownership-hash',
+      'ontology-revision', ?, ?, ?, ?, NULL, NULL, NULL, ?)`
+  ).run(projectId, timestamp, count, count, timestamp, timestamp, timestamp)
+
+  const insert = db.query(
+    `INSERT INTO ontology_source_rows (
+      project_id, source_id, materialization_id,
+      entity_kind, entity_key, entity_sort_key,
+      root_kind, root_key, root_sort_key, staging_ordinal,
+      root, assertion,
+      object_type_id, primary_id,
+      source_type_id, source_primary_id, link_id, target_type_id, target_primary_id,
+      root_object_type_id, root_primary_id,
+      root_source_type_id, root_source_primary_id, root_link_id,
+      root_target_type_id, root_target_primary_id
+    ) VALUES (?, 'employees', 'candidate-1',
+      'link', json(?), ?, 'object', json(?), ?, ?, json(?), json(?),
+      NULL, NULL, 'Employee', ?, 'timecards', 'Timecard', ?,
+      'Employee', ?, NULL, NULL, NULL, NULL, NULL)`
+  )
+  for (let index = 0; index < count; index += 1) {
+    const employeeId = `employee-${index}`
+    const timecardId = `timecard-${index}`
+    const root = { kind: "object", ref: { objectTypeId: "Employee", primaryId: employeeId } }
+    const assertion = {
+      kind: "link",
+      ref: {
+        source: root.ref,
+        linkId: "timecards",
+        target: { objectTypeId: "Timecard", primaryId: timecardId },
+      },
+    }
+    insert.run(
+      projectId,
+      JSON.stringify(["link", "Employee", employeeId, "timecards", "Timecard", timecardId]),
+      `entity-${index}`,
+      JSON.stringify(["object", "Employee", employeeId]),
+      `root-${index}`,
+      index,
+      JSON.stringify(root),
+      JSON.stringify(assertion),
+      employeeId,
+      timecardId,
+      employeeId
+    )
+  }
 }
 
 function findRecorded(

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -50,6 +50,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 5,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "006-narrow-ontology-source-root-index",
+    status: "applied",
+    version: 6,
+  },
 ]
 
 afterEach(async () => {
@@ -442,6 +449,31 @@ describe("SQLite storage migrations", () => {
     closeStorage(storage)
   })
 
+  test("narrows the source-root index without changing its lookup prefix", () => {
+    const db = new Database(":memory:")
+    try {
+      sqliteStorageMigrations.steps[0]?.up(db)
+      expect(readMemoryIndexColumns(db, "idx_ontology_source_rows_root")).toEqual([
+        "project_id",
+        "source_id",
+        "materialization_id",
+        "root_sort_key",
+        "staging_ordinal",
+        "entity_sort_key",
+      ])
+
+      sqliteStorageMigrations.steps[5]?.up(db)
+      expect(readMemoryIndexColumns(db, "idx_ontology_source_rows_root")).toEqual([
+        "project_id",
+        "source_id",
+        "materialization_id",
+        "root_sort_key",
+      ])
+    } finally {
+      db.close()
+    }
+  })
+
   test("the timeseries primary key enforces the (series, at) natural key", () => {
     const db = new Database(":memory:")
     try {
@@ -541,6 +573,12 @@ function readMemoryTableColumns(db: Database, tableName: string): string[] {
   )
 }
 
+function readMemoryIndexColumns(db: Database, indexName: string): string[] {
+  return (db.query(`PRAGMA index_info(${indexName})`).all() as { readonly name: string }[]).map(
+    (row) => row.name
+  )
+}
+
 function readMemoryColumn(
   db: Database,
   tableName: string,
@@ -620,7 +658,7 @@ describe("SQLite migration status is read-only", () => {
     expect(await migrator?.status()).toMatchObject({
       adapterId: SQLITE_STORAGE_ADAPTER_ID,
       state: "current",
-      appliedVersion: 5,
+      appliedVersion: 6,
     })
 
     expect(statSync(path).mtimeMs).toBe(before)

--- a/storage/sqlite/tests/sqlite-storage-transaction.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-transaction.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import type { Storage } from "@sixb/core"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { migrateStorage, type Storage } from "@sixb/core"
 import { type ActionRunStorage, StorageTransactionError } from "@sixb/core/storage"
 import { SqliteStorage } from "../src"
 import { closeSqliteStoreConnection, openSqliteStoreConnection } from "../src/transactions"
@@ -10,6 +13,43 @@ test("SQLite storage connections enforce foreign keys", () => {
     expect(connection.db.query("PRAGMA foreign_keys").get()).toEqual({ foreign_keys: 1 })
   } finally {
     closeSqliteStoreConnection(connection)
+  }
+})
+
+test("file-backed snapshot reads remain available during a write transaction", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "sixb-sqlite-concurrent-read-"))
+  const storage = new SqliteStorage({ path: directory })
+  await migrateStorage(storage)
+  let releaseTransaction!: () => void
+  const blocked = new Promise<void>((resolve) => {
+    releaseTransaction = resolve
+  })
+  let transactionEntered!: () => void
+  const entered = new Promise<void>((resolve) => {
+    transactionEntered = resolve
+  })
+  const transaction = storage.transaction(async (tx) => {
+    await requireActionRuns(tx).queue(actionRunInput("concurrent-read-writer"))
+    transactionEntered()
+    await blocked
+  })
+
+  try {
+    await entered
+    const read = storage.objects
+      .getByPrimaryId({
+        projectId: "my-app",
+        objectTypeId: "Room",
+        primaryId: "room-1",
+      })
+      .then(() => "read" as const)
+    const outcome = await Promise.race([read, Bun.sleep(500).then(() => "blocked" as const)])
+    expect(outcome).toBe("read")
+  } finally {
+    releaseTransaction()
+    await transaction
+    storage.close()
+    await rm(directory, { recursive: true, force: true })
   }
 })
 


### PR DESCRIPTION
## Summary

Optimize large dataset-to-ontology replacement projections in the SQLite and PostgreSQL storage providers.

The largest issue was SQLite rebuilding the complete replacement-link union for every state page. A 5,000-row unchanged linked projection spent 129.99s in that stream alone, and the equivalent 15,000-row run did not finish within 20 minutes. This change prepares the replacement identities once in an indexed temporary table and keyset-pages the result.

The PR also:

- replaces SQLite N+1 cardinality checks and JavaScript-side finalization aggregation with set-based SQL
- yields between bounded SQLite materialization chunks to avoid monopolizing the event loop
- enables WAL for file-backed SQLite and uses a separate read-only snapshot connection for object/timeseries reads and `ping`
- removes PostgreSQL's redundant staged-work duplicate preflight query while preserving unique-constraint arbitration and provider error mapping
- adds migration 004 for both providers to narrow the source-root index to its complete four-column lookup prefix
- adds query-plan, migration, and concurrent-read regression coverage

## Benchmarks

Benchmarks fed `ProjectionSourceEntry` values directly to the materializer, isolating materializer/provider costs from dataset scanning and projection mapping. The linked shape modeled a BACnet-style object with 21 properties and one cardinality-one link per root. Runs used fresh provider storage, default 1,000-row stage/page/chunk limits, Bun 1.3.14, and an Apple M1 Pro with 16GB RAM.

`unchanged` results are the second complete replacement over the same logical assertions. Values below are representative local runs from the same harness and workload shape.

| Provider / workload | Before | After | Change |
|---|---:|---:|---:|
| SQLite fresh linked, 5k | 5.259s | 5.094s | 3% faster |
| SQLite fresh linked, 15k | 18.786s | 16.703s | 11% faster |
| SQLite unchanged linked, 5k | 132.500s | **2.469s** | **53.7x faster** |
| SQLite unchanged linked, 15k | >1,180s / timeout | **8.741s** | **>135x faster** |
| PostgreSQL fresh linked, 5k | 7.841s | 6.363s | 19% faster |
| PostgreSQL fresh linked, 15k | 44.005s | **32.719s** | **26% faster** |
| PostgreSQL unchanged linked, 15k | 11.700s | 11.320s | 3% faster |

Notable phase and responsiveness changes:

| Metric | Before | After |
|---|---:|---:|
| SQLite unchanged-5k link-state stream | 129.988s | **0.210s** |
| PostgreSQL fresh-15k staged work | 18.673s | **4.936s** |
| PostgreSQL fresh-15k transaction | 31.411s | **18.216s** |
| SQLite fresh-15k max event-loop stall | 18.788s | **1.249s** |
| SQLite fresh-15k storage ping p95 | no usable samples | **0.61ms** |
| SQLite fresh-15k peak RSS | 826MB | **596MB** |

The benchmark harness and raw results remain local under `.local/` and are intentionally not part of the product diff.

## Linked issue

None.

## Scope

This keeps the materializer contracts, replacement semantics, transaction fencing, and final validation intact. Existing migration checksums are unchanged; migration 004 only replaces the oversized source-root index.

File-backed SQLite object/timeseries reads can now proceed during the materialization write transaction. Other SQLite writes and run-history operations continue to serialize behind the single writer and are outside this PR's scope.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun --filter @sixb/sqlite build`
- `bun --filter @sixb/pg build`
- `bun test storage/sqlite/tests/` — 192 passed
- targeted core materializer suite — 97 passed
- PostgreSQL ontology and migration e2e suites — 25 passed

## Notes

PostgreSQL duplicate detection now relies on the work table's existing unique constraints rather than a separate preflight scan. SQLSTATE `23505` is mapped to the existing materialization conflict error, so duplicate work still aborts the complete transaction.
