### PR TITLE
storage: accelerate dataset-to-ontology delivery

### DIFF
--- a/packages/core/src/events/outbox-dispatcher.ts
+++ b/packages/core/src/events/outbox-dispatcher.ts
@@ -2,12 +2,15 @@ import { randomUUID } from "node:crypto"
 import type { ClaimedOntologyOutboxRow, OntologyOutboxStorage, Storage } from "../storage"
 import type { StableEventPublisher } from "./service"
 
-const DEFAULT_BATCH_SIZE = 100
+const DEFAULT_BATCH_SIZE = 1_000
 const DEFAULT_LEASE_DURATION_MS = 30_000
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000
 const DEFAULT_MAX_RETRY_DELAY_MS = 5 * 60_000
 const DEFAULT_RETRY_JITTER_RATIO = 0.2
-const DEFAULT_MAX_ISOLATION_ATTEMPTS = 16
+// Isolating one poison row from a 1,000-row batch needs up to 21 broker calls: one failed call
+// and, at each split depth, one healthy sibling plus the failing half. Keep bounded headroom for
+// uneven splits while rescheduling unresolved groups once this pass reaches the cap.
+const DEFAULT_MAX_ISOLATION_ATTEMPTS = 32
 const DEFAULT_MAX_CLAIMS_PER_DRAIN = 10
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000
 const SHUTDOWN_RESCHEDULE_ERROR = "Outbox dispatcher stopped before publication completed."

--- a/packages/core/src/materializer/shared/batching.ts
+++ b/packages/core/src/materializer/shared/batching.ts
@@ -9,7 +9,10 @@ export interface MaterializationBatching {
 }
 
 export const DEFAULT_MATERIALIZATION_BATCHING: MaterializationBatching = Object.freeze({
-  sourceStageRows: 1_000,
+  // Source staging pays execution fencing, manifest locking, conflict reconciliation, and one
+  // provider transaction per chunk. Two thousand rows cuts that fixed cost without the large RSS
+  // increase observed when every materialization boundary was raised to five thousand.
+  sourceStageRows: 2_000,
   sourceStageBytes: 4 * 1024 * 1024,
   statePageRows: 1_000,
   planChunkRows: 1_000,

--- a/packages/core/tests/events-outbox-dispatcher.test.ts
+++ b/packages/core/tests/events-outbox-dispatcher.test.ts
@@ -320,6 +320,45 @@ describe("OntologyOutboxDispatcher", () => {
     expect((await events.read()).map(objectPrimaryId).sort()).toEqual(["valid-1", "valid-2"])
   })
 
+  test("isolates one poison envelope from the default large publication batch", async () => {
+    const storage = new InMemoryStorage()
+    const { materializer } = createMaterializerFixture({ storage })
+    await materializer.edits.commit({
+      mode: "atomic",
+      source: { kind: "runtime", requestId: "request-large-poison-batch" },
+      operations: Array.from({ length: 1_000 }, (_, index) => ({
+        id: `create-large-${index}`,
+        kind: "object.create" as const,
+        ref: { objectTypeId: "Device", primaryId: `large-${index}` },
+        properties: { name: `large-${index}` },
+      })),
+      expectedObjects: [],
+      expectedLinks: [],
+      expectedLinkScopes: [],
+    })
+    const poisonId = outboxRows(storage)[731]!.envelope.id
+    const broker = new PoisonEnvelopeBroker(poisonId)
+    const events = new DomainEventService({ projectId: "project", broker })
+    const dispatcher = new OntologyOutboxDispatcher({
+      projectId: "project",
+      storage,
+      events,
+      now: () => NOW,
+      retryJitterRatio: 0,
+    })
+
+    await dispatcher.drain()
+
+    const rows = outboxRows(storage)
+    expect(rows.filter((row) => row.publishedAt !== null)).toHaveLength(999)
+    expect(rows.find((row) => row.envelope.id === poisonId)).toMatchObject({
+      publishedAt: null,
+      leaseId: null,
+      lastError: "Error: poison envelope",
+    })
+    expect(await events.read({ limit: 1_000 })).toHaveLength(999)
+  })
+
   test("coalesces a drain that arrives during an in-flight publication", async () => {
     const storage = new InMemoryStorage()
     const broker = new FirstHeldBroker()

--- a/storage/ducklake/README.md
+++ b/storage/ducklake/README.md
@@ -94,15 +94,22 @@ const report = await lakeStorage.runMaintenance({
 Reads, writes, SQL previews, and SQL transforms use the same DuckDB runtime and
 the same DuckLake PostgreSQL metadata pool. Work is serialized inside one
 `DuckLakeStorage` instance, so a queued DuckDB operation makes later operations
-wait. Only actual DuckDB work holds the runtime: batch appends, commits, SQL
-transforms, and metadata reads. A large streaming read can also make a later
-write wait until the stream is consumed or closed.
+wait. Only actual DuckDB work holds the runtime: bounded read pages, batch
+appends, commits, SQL transforms, and metadata reads.
+
+Large `readRows(...)` calls materialize bounded pages, using a physical-row keyset when available,
+and release the DuckDB queue between pages. This also applies when an explicit limit exceeds one
+page. A JavaScript pipeline can therefore stream one DuckLake dataset directly into another on the
+same provider without buffering the complete input or deadlocking at the destination appender's
+first flush. The read remains pinned to one immutable snapshot and keeps its attachment lease until
+the iterator completes or closes.
 
 A write does not hold the runtime while its source iterable is producing rows.
 `writeRows(...)` validates and stages rows in bounded in-memory batches, then
 takes a queue slot only to flush each batch into the staging table. Slow external
 reads (pagination, APIs, SFTP, retries) run outside the queue, so other reads and
-write batches can interleave between a write's batches.
+write batches can interleave between a write's batches. Large in-memory writes
+also yield to the event loop between batches.
 
 ```txt
 same provider instance:

--- a/storage/ducklake/src/internal/ducklake-merge-session.ts
+++ b/storage/ducklake/src/internal/ducklake-merge-session.ts
@@ -108,6 +108,7 @@ class DuckLakeMergeSession implements LakeMergeSession {
       if (batch.length >= MERGE_CHANGE_BATCH_SIZE) {
         await this.appendBatchToStagingTable(batch)
         batch = []
+        await Bun.sleep(0)
       }
     }
 

--- a/storage/ducklake/src/internal/ducklake-row-reader.ts
+++ b/storage/ducklake/src/internal/ducklake-row-reader.ts
@@ -2,6 +2,7 @@ import type { DatasetColumnDefinition, DatasetRow } from "@sixb/core"
 import type { DatasetVersion, ReadDatasetRowsInput } from "@sixb/core/lake-storage"
 import { LakeStorageError } from "@sixb/core/lake-storage"
 import type { DuckLakeStorageOptions } from "../types"
+import { getBigIntLike } from "./duckdb-row"
 import type { DuckDbQueryRuntime } from "./duckdb-runtime"
 import type { DuckLakeConnectionManager } from "./ducklake-connection-manager"
 import { type DatasetTableRef, resolveDatasetTableRef } from "./ducklake-dataset-table-ref"
@@ -9,6 +10,13 @@ import type { DuckLakeSnapshotReader } from "./ducklake-snapshot-reader"
 import { normalizeReadValue } from "./schema"
 import { qualifiedTableName, quoteIdentifier } from "./sql"
 import { parseVersionId } from "./versions"
+
+// Large reads release the provider's single DuckDB queue slot between bounded pages. Besides
+// bounding converted-row memory, this lets a JavaScript pipeline feed one DuckLake dataset into
+// another: the destination appender can use the runtime after each page instead of waiting forever
+// behind its own still-open source stream.
+const READ_PAGE_ROWS = 5_000
+const PHYSICAL_ROW_ID_ALIAS = "__sixb_physical_row_id"
 
 /**
  * Reads dataset rows from DuckLake snapshots.
@@ -27,50 +35,66 @@ export class DuckLakeRowReader {
   async *readRows(input: ReadDatasetRowsInput): AsyncIterable<DatasetRow> {
     this.connections.assertOpen()
 
+    // Keep the attachment lease across pages so local catalogs do not pay DETACH/ATTACH for every
+    // page. Individual query() calls still release the DuckDB queue before rows are yielded.
     const lease = await this.connections.acquireAttachedRuntime()
     try {
       const runtime = lease.runtime
-
-      // Step 1: resolve the physical table from DuckLake metadata directly. Row
-      // previews must not go through broad catalog introspection.
+      // Resolve latest exactly once so a paged read stays pinned even if another writer commits
+      // between pages. DuckLake snapshots are immutable; every page names this snapshot.
       const tableRef = await resolveDatasetTableRef(this.options, runtime, input.datasetId)
       if (!tableRef) {
         throw new LakeStorageError(`[SixbDuckLake] Unknown dataset '${input.datasetId}'.`)
       }
-
       const version = await this.resolveVersion(runtime, tableRef, input.versionId)
-      const snapshotId = parseVersionId(version.versionId)
       const selectedColumns = this.resolveReadColumns(
         tableRef.datasetId,
         version.schema,
         input.columns
       )
-
-      // Step 2: query DuckLake at the exact snapshot id. Version ids are just
-      // `ducklake:<snapshot_id>`, so reads can use native DuckLake time travel
-      // directly after validation.
+      const snapshotId = parseVersionId(version.versionId)
       const columnsSql = selectedColumns.map((column) => quoteIdentifier(column.name)).join(", ")
       const tableSql = qualifiedTableName(this.options, tableRef.tableName)
       // A user column named `rowid` shadows DuckDB's virtual row id. In that edge case the
       // connection-level invariant still preserves insertion order; otherwise make it explicit.
-      const orderSql = version.schema.columns.some(
-        (column) => column.name.toLowerCase() === "rowid"
-      )
-        ? ""
-        : " ORDER BY rowid"
-      const limitSql =
-        input.limit === undefined ? "" : ` LIMIT ${Math.max(0, Math.trunc(input.limit))}`
-      const offsetSql =
-        input.offset === undefined ? "" : ` OFFSET ${Math.max(0, Math.trunc(input.offset))}`
-      const sql = `SELECT ${columnsSql} FROM ${tableSql} AT (VERSION => ${snapshotId})${orderSql}${limitSql}${offsetSql}`
+      const schemaNames = new Set(version.schema.columns.map((column) => column.name.toLowerCase()))
+      const canUsePhysicalRowId =
+        !schemaNames.has("rowid") && !schemaNames.has(PHYSICAL_ROW_ID_ALIAS.toLowerCase())
+      const orderSql = canUsePhysicalRowId ? " ORDER BY rowid" : ""
+      const baseSql = `SELECT ${columnsSql} FROM ${tableSql} AT (VERSION => ${snapshotId})`
+      const requestedOffset = Math.max(0, Math.trunc(input.offset ?? 0))
+      let remaining = input.limit === undefined ? undefined : Math.max(0, Math.trunc(input.limit))
+      if (remaining === 0) return
 
-      // HTTP previews are bounded, so materialize them eagerly and release the
-      // runtime queue as soon as DuckDB has returned the small page.
-      const rows = input.limit === undefined ? runtime.streamRows(sql) : await runtime.query(sql)
+      // Materialize one bounded page and release its queue operation before yielding it. A
+      // consumer may enqueue another DuckLake operation while processing the yielded rows.
+      // Holding a native stream open here would make that operation wait behind itself.
+      let offset = requestedOffset
+      let physicalCursor: bigint | null = null
+      while (true) {
+        const pageRows =
+          remaining === undefined ? READ_PAGE_ROWS : Math.min(READ_PAGE_ROWS, remaining)
+        const pageSql = canUsePhysicalRowId
+          ? `SELECT rowid AS ${quoteIdentifier(PHYSICAL_ROW_ID_ALIAS)}, ${columnsSql}
+              FROM ${tableSql} AT (VERSION => ${snapshotId})
+              ${physicalCursor === null ? "" : `WHERE rowid > ${physicalCursor}`}
+              ORDER BY rowid LIMIT ${pageRows}
+              ${physicalCursor === null && offset > 0 ? `OFFSET ${offset}` : ""}`
+          : `${baseSql}${orderSql} LIMIT ${pageRows} OFFSET ${offset}`
+        const rows = await runtime.query(pageSql)
+        if (rows.length === 0) return
 
-      // Step 3: DuckDB returns driver-native values. Normalize each projected
-      // column through the schema that was active at the resolved version.
-      yield* this.normalizeRows(rows, selectedColumns)
+        yield* this.normalizeRows(rows, selectedColumns)
+        offset += rows.length
+        if (remaining !== undefined) {
+          remaining -= rows.length
+          if (remaining === 0) return
+        }
+        if (canUsePhysicalRowId) {
+          physicalCursor = getBigIntLike(rows[rows.length - 1]!, PHYSICAL_ROW_ID_ALIAS)
+        }
+        if (rows.length < pageRows) return
+      }
     } finally {
       await lease.release()
     }

--- a/storage/ducklake/src/internal/ducklake-write-session.ts
+++ b/storage/ducklake/src/internal/ducklake-write-session.ts
@@ -106,6 +106,10 @@ class DuckLakeWriteSession implements LakeWriteSession {
         await this.appendBatchToStagingTable(batch, batchPrimaryKeys)
         batch = []
         batchPrimaryKeys = new Set()
+        // Native appender promises can settle through microtasks quickly enough to starve timers
+        // across a large in-memory iterable. Yield once per bounded batch so API traffic remains
+        // responsive without adding per-row scheduling overhead.
+        await Bun.sleep(0)
       }
     }
 

--- a/storage/ducklake/tests/ducklake-writes.e2e.ts
+++ b/storage/ducklake/tests/ducklake-writes.e2e.ts
@@ -12,7 +12,7 @@ import { collectRows, createLocalDuckLakeStorage, localDuckLakeOptions } from ".
 interface DuckLakeStorageInternals {
   readonly connections: {
     attachedRuntime(): Promise<{
-      query(sql: string): Promise<readonly Record<string, unknown>[]>
+      query(sql: string, values?: readonly unknown[]): Promise<readonly Record<string, unknown>[]>
     }>
   }
   readonly snapshotReader: {
@@ -203,8 +203,8 @@ describe("DuckLakeStorage writes and latest reads", () => {
     ).resolves.toHaveLength(2)
   })
 
-  test("writes large row streams through the appender staging path", async () => {
-    const ROW_COUNT = 1001
+  test("bounds large row streams on both the write and read paths", async () => {
+    const ROW_COUNT = 5_001
 
     const rows = Array.from({ length: ROW_COUNT }, (_, index) => ({
       orderId: `ord_${index + 1}`,
@@ -241,7 +241,64 @@ describe("DuckLakeStorage writes and latest reads", () => {
       orderCount: String(ROW_COUNT),
       metadata: null,
     })
+
+    const runtime = await (
+      storage as unknown as DuckLakeStorageInternals
+    ).connections.attachedRuntime()
+    const originalQuery = runtime.query
+    const rowPageQueries: string[] = []
+    runtime.query = (sql, values) => {
+      if (sql.includes(" AT (VERSION => ")) rowPageQueries.push(sql)
+      return originalQuery.call(runtime, sql, values)
+    }
+    try {
+      await expect(
+        collectRows(
+          storage.readRows({
+            datasetId: ordersDataset.id,
+            columns: ["orderId"],
+            limit: ROW_COUNT,
+          })
+        )
+      ).resolves.toHaveLength(ROW_COUNT)
+    } finally {
+      runtime.query = originalQuery
+    }
+
+    // Regression proof: restoring the one-shot explicit-limit query produces one LIMIT 5001
+    // statement here. The bounded path must release the runtime queue after each page.
+    expect(rowPageQueries).toHaveLength(2)
+    expect(rowPageQueries[0]).toContain("LIMIT 5000")
+    expect(rowPageQueries[1]).toContain("WHERE rowid >")
+    expect(rowPageQueries[1]).toContain("LIMIT 1")
   })
+
+  test("streams one DuckLake dataset into another without deadlocking the shared runtime", async () => {
+    // Regression proof: restore DuckLakeRowReader's unbounded runtime.streamRows() path and this
+    // child reaches the destination appender's first flush, then times out. Keep it isolated in a
+    // child because a native stream waiting on its own runtime queue cannot be cancelled safely.
+    const childRoot = await mkdtemp(join(tmpdir(), "sixb-ducklake-stream-copy-"))
+    const child = Bun.spawn(
+      ["bun", join(import.meta.dir, "fixtures", "stream-copy.ts"), childRoot],
+      { stdout: "pipe", stderr: "pipe" }
+    )
+    try {
+      const result = await Promise.race([
+        child.exited.then((exitCode) => ({ kind: "exit" as const, exitCode })),
+        Bun.sleep(20_000).then(() => ({ kind: "timeout" as const })),
+      ])
+      if (result.kind === "timeout") {
+        child.kill()
+        await child.exited
+        throw new Error("DuckLake stream-to-write child timed out after 20 seconds.")
+      }
+      const stderr = await new Response(child.stderr).text()
+      expect(result.exitCode, stderr).toBe(0)
+    } finally {
+      child.kill()
+      await rm(childRoot, { recursive: true, force: true })
+    }
+  }, 30_000)
 
   test("appends streamed rows before reusable row objects mutate again", async () => {
     function* reusedOrderRows(): Iterable<DatasetRow> {

--- a/storage/ducklake/tests/fixtures/stream-copy.ts
+++ b/storage/ducklake/tests/fixtures/stream-copy.ts
@@ -1,0 +1,40 @@
+import { mkdir, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { col, defineDataset } from "@sixb/core"
+import { DuckLakeStorage } from "../../src"
+
+const rootDir = process.argv[2]
+if (!rootDir) throw new Error("Expected a temporary root directory.")
+await mkdir(rootDir, { recursive: true })
+
+const source = defineDataset("stream-copy-source", {
+  schema: [col("id", "int64"), col("name", "string")],
+})
+const destination = defineDataset("stream-copy-destination", {
+  schema: [col("id", "int64"), col("name", "string")],
+})
+const storage = new DuckLakeStorage({
+  catalog: { type: "duckdb", path: join(rootDir, "metadata.ducklake") },
+  dataPath: join(rootDir, "data"),
+})
+
+try {
+  await storage.createDataset(source)
+  await storage.createDataset(destination)
+
+  const sourceWrite = await storage.beginWrite({ dataset: source, mode: "snapshot" })
+  await sourceWrite.writeRows(
+    Array.from({ length: 5_001 }, (_, index) => ({ id: index, name: `Row ${index}` }))
+  )
+  await sourceWrite.commit()
+
+  const destinationWrite = await storage.beginWrite({ dataset: destination, mode: "snapshot" })
+  await destinationWrite.writeRows(storage.readRows({ datasetId: source.id }))
+  const version = await destinationWrite.commit()
+  if (version.rowCount !== 5_001) {
+    throw new Error(`Expected 5001 copied rows, received ${version.rowCount ?? "unknown"}.`)
+  }
+} finally {
+  await storage.close().catch(() => {})
+  await rm(rootDir, { recursive: true, force: true }).catch(() => {})
+}

--- a/storage/sqlite/src/ontology-storage/materialization-session.ts
+++ b/storage/sqlite/src/ontology-storage/materialization-session.ts
@@ -1,5 +1,8 @@
 import type { Database } from "bun:sqlite"
-import { MaterializationConflictError } from "@sixb/core/internal/materialization"
+import {
+  type EffectiveChangeCounts,
+  MaterializationConflictError,
+} from "@sixb/core/internal/materialization"
 import {
   correlateMaterializationChunk,
   duplicateMaterializationWork as duplicateWork,
@@ -13,7 +16,6 @@ import type {
   MaterializationEventWorkRecord,
   MaterializationPlanChunk,
   MaterializationPlanHeader,
-  MaterializationPlanWorkItem,
   MaterializationSession,
   MaterializationWorkPage,
   MaterializationWorkRecord,
@@ -32,7 +34,53 @@ export interface SqliteOntologyTransactionContext {
   active: boolean
 }
 
-export class SqliteMaterializationSessionState extends ProviderMaterializationSessionState {}
+interface WorkCursor {
+  readonly majorOrder: number
+  readonly minorOrder: number
+  readonly sortOne: string
+  readonly sortTwo: string
+  readonly recordKey: string
+}
+
+interface WorkDatabaseRow {
+  readonly record_key: string
+  readonly major_order: number
+  readonly minor_order: number
+  readonly sort_one: string
+  readonly sort_two: string
+  readonly payload: string
+}
+
+interface WorkSummary {
+  apply: number
+  cardinality: number
+  event: number
+  objectClassifications: number
+  linkClassifications: number
+  pointClassifications: number
+  objectsCreated: number
+  objectsUpdated: number
+  objectsDeleted: number
+  linksCreated: number
+  linksUpdated: number
+  linksDeleted: number
+  pointsCreated: number
+  pointsUpdated: number
+  latestObjectsChanged: number
+}
+
+export interface SqliteChunkSequenceProgress {
+  readonly appliedPlanCount: number
+  readonly appliedOutboxCount: number
+  readonly appliedPlanCursor: WorkCursor | null
+  readonly appliedEventCursor: WorkCursor | null
+}
+
+export class SqliteMaterializationSessionState extends ProviderMaterializationSessionState {
+  appliedPlanCursor: WorkCursor | null = null
+  appliedEventCursor: WorkCursor | null = null
+  readonly summary: WorkSummary = emptyWorkSummary()
+}
 
 export class SqliteMaterializationSessions {
   private readonly sessions = new WeakMap<object, SqliteMaterializationSessionState>()
@@ -76,10 +124,14 @@ export class SqliteMaterializationSessions {
 
   release(session: SqliteMaterializationSessionState): void {
     if (!session.active) return
-    this.deleteWork(session.id)
     session.active = false
     session.replacement = null
     this.live.delete(session)
+    // The normal transaction has one session. Dropping its transaction-local spool avoids an
+    // indexed DELETE over hundreds of thousands of rows and releases temp pages immediately.
+    // Preserve per-session deletion only when another live session still shares the tables.
+    if (this.live.size === 0) this.dropWorkTables()
+    else this.deleteWork(session.id)
     this.context?.materializations.complete(session.providerToken)
   }
 
@@ -90,18 +142,26 @@ export class SqliteMaterializationSessions {
   stage(input: StageMaterializationWorkInput): void {
     const session = this.require(input.session)
     const records = prepareMaterializationWork(session, input)
+    if (records.length === 0) return
     const insert = this.db.query(
       `
         INSERT INTO ${SQLITE_MATERIALIZATION_WORK_TABLE} (
           session_id, record_key, unique_key, kind, lane,
-          major_order, minor_order, sort_one, sort_two, payload
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, json(?))
+          major_order, minor_order, sort_one, sort_two,
+          classification_entity_kind, classification_identity_key,
+          cardinality_occupied, cardinality_source_type_id,
+          cardinality_source_primary_id, cardinality_link_id,
+          cardinality_target_type_id, cardinality_target_primary_id, payload
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, json(?))
       `
     )
+    this.db.run("SAVEPOINT sixb_ontology_stage_work")
     let currentRecordKey: string | undefined
     try {
       for (const { record, uniqueKey, columns } of records) {
         currentRecordKey = record.recordKey
+        const classification = record.kind === "classification" ? record : null
+        const cardinality = record.kind === "cardinality" ? record : null
         insert.run(
           session.id,
           record.recordKey,
@@ -112,15 +172,28 @@ export class SqliteMaterializationSessions {
           columns.minorOrder,
           columns.sortOne,
           columns.sortTwo,
+          classification?.entityKind ?? null,
+          classification?.identityKey ?? null,
+          cardinality ? Number(cardinality.occupied) : null,
+          cardinality?.ref.source.objectTypeId ?? null,
+          cardinality?.ref.source.primaryId ?? null,
+          cardinality?.ref.linkId ?? null,
+          cardinality?.ref.target.objectTypeId ?? null,
+          cardinality?.ref.target.primaryId ?? null,
           canonicalJson(record)
         )
       }
+      this.db.run("RELEASE SAVEPOINT sixb_ontology_stage_work")
     } catch (error) {
+      this.db.run("ROLLBACK TO SAVEPOINT sixb_ontology_stage_work")
+      this.db.run("RELEASE SAVEPOINT sixb_ontology_stage_work")
       if (isSqliteConstraintError(error)) {
         throw duplicateWork(currentRecordKey)
       }
       throw error
     }
+    for (const prepared of records)
+      recordSummary(session.summary, prepared.record, prepared.columns)
   }
 
   async *stream(input: StreamMaterializationWorkInput): AsyncIterable<MaterializationWorkPage> {
@@ -134,26 +207,16 @@ export class SqliteMaterializationSessions {
     }
     stream.started = true
     session.workSealed = true
-    let offset = 0
+    let cursor: WorkCursor | null = null
     while (true) {
       this.require(input.session)
-      const rows = this.db
-        .query(
-          `
-            SELECT payload
-            FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-            WHERE session_id = ? AND lane = ?
-            ORDER BY major_order, minor_order, sort_one, sort_two, record_key
-            LIMIT ? OFFSET ?
-          `
-        )
-        .all(session.id, input.order, input.pageRows, offset) as { readonly payload: string }[]
+      const rows = this.readLane(input.order, session.id, cursor, input.pageRows)
       if (rows.length === 0) break
       const records = rows.map((row) =>
         parseJson<MaterializationWorkRecord>(row.payload)
       ) as MaterializationWorkPage["records"]
-      offset += records.length
-      stream.emittedCount = offset
+      cursor = workCursor(rows[rows.length - 1]!)
+      stream.emittedCount += records.length
       yield { records }
     }
     this.require(input.session)
@@ -184,30 +247,55 @@ export class SqliteMaterializationSessions {
     })
   }
 
-  assertChunkSequence(
+  prepareChunkSequence(
     session: SqliteMaterializationSessionState,
     chunk: MaterializationPlanChunk
-  ): void {
+  ): SqliteChunkSequenceProgress {
     const items = materializationPlanItems(chunk)
+    const planRows = this.readLane("apply", session.id, session.appliedPlanCursor, items.length)
+    const expectedItems = planRows.map((row) => {
+      const record = parseJson<Extract<MaterializationWorkRecord, { readonly kind: "plan" }>>(
+        row.payload
+      )
+      return record.item
+    })
+    const eventRows = this.readLane(
+      "event",
+      session.id,
+      session.appliedEventCursor,
+      chunk.outbox.length
+    )
+    const expectedEvents = eventRows.map((row) =>
+      parseJson<MaterializationEventWorkRecord>(row.payload)
+    )
     const progress = correlateMaterializationChunk(
       session,
       chunk,
       items,
-      this.planItems(session, session.appliedPlanCount, items.length),
-      this.eventRecords(session, session.appliedOutboxCount, chunk.outbox.length)
+      expectedItems,
+      expectedEvents
     )
-    session.appliedPlanCount = progress.appliedPlanCount
-    session.appliedOutboxCount = progress.appliedOutboxCount
+    return {
+      ...progress,
+      appliedPlanCursor:
+        planRows.length === 0
+          ? session.appliedPlanCursor
+          : workCursor(planRows[planRows.length - 1]!),
+      appliedEventCursor:
+        eventRows.length === 0
+          ? session.appliedEventCursor
+          : workCursor(eventRows[eventRows.length - 1]!),
+    }
   }
 
-  count(session: SqliteMaterializationSessionState, kind: string): number {
-    const row = this.db
-      .query(
-        `SELECT COUNT(*) AS count FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-         WHERE session_id = ? AND kind = ?`
-      )
-      .get(session.id, kind) as { readonly count: number }
-    return row.count
+  commitChunkSequence(
+    session: SqliteMaterializationSessionState,
+    progress: SqliteChunkSequenceProgress
+  ): void {
+    session.appliedPlanCount = progress.appliedPlanCount
+    session.appliedOutboxCount = progress.appliedOutboxCount
+    session.appliedPlanCursor = progress.appliedPlanCursor
+    session.appliedEventCursor = progress.appliedEventCursor
   }
 
   laneCounts(session: SqliteMaterializationSessionState): {
@@ -215,29 +303,46 @@ export class SqliteMaterializationSessions {
     readonly cardinality: number
     readonly event: number
   } {
-    const rows = this.db
-      .query(
-        `SELECT lane, COUNT(*) AS count FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-         WHERE session_id = ? AND lane <> 'none'
-         GROUP BY lane`
-      )
-      .all(session.id) as {
-      readonly lane: "apply" | "cardinality" | "event"
-      readonly count: number
-    }[]
-    const counts = { apply: 0, cardinality: 0, event: 0 }
-    for (const row of rows) counts[row.lane] = row.count
-    return counts
+    return {
+      apply: session.summary.apply,
+      cardinality: session.summary.cardinality,
+      event: session.summary.event,
+    }
   }
 
-  records(session: SqliteMaterializationSessionState, kind?: string): MaterializationWorkRecord[] {
-    const rows = this.db
-      .query(
-        `SELECT payload FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-         WHERE session_id = ? ${kind ? "AND kind = ?" : ""}`
-      )
-      .all(...(kind ? [session.id, kind] : [session.id])) as { readonly payload: string }[]
-    return rows.map((row) => parseJson<MaterializationWorkRecord>(row.payload))
+  projectionCounts(session: SqliteMaterializationSessionState): EffectiveChangeCounts {
+    const summary = session.summary
+    return {
+      objectsCreated: summary.objectsCreated,
+      objectsUpdated: summary.objectsUpdated,
+      objectsDeleted: summary.objectsDeleted,
+      objectsUnchanged:
+        summary.objectClassifications -
+        summary.objectsCreated -
+        summary.objectsUpdated -
+        summary.objectsDeleted,
+      linksCreated: summary.linksCreated,
+      linksUpdated: summary.linksUpdated,
+      linksDeleted: summary.linksDeleted,
+      linksUnchanged:
+        summary.linkClassifications -
+        summary.linksCreated -
+        summary.linksUpdated -
+        summary.linksDeleted,
+    }
+  }
+
+  telemetrySummary(session: SqliteMaterializationSessionState, pointCount: number) {
+    const summary = session.summary
+    return {
+      classifiedPoints: summary.pointClassifications,
+      counts: {
+        pointsCreated: summary.pointsCreated,
+        pointsUpdated: summary.pointsUpdated,
+        pointsUnchanged: pointCount - summary.pointsCreated - summary.pointsUpdated,
+        latestObjectsChanged: summary.latestObjectsChanged,
+      },
+    }
   }
 
   assertClassificationCoverage(session: SqliteMaterializationSessionState): void {
@@ -246,92 +351,84 @@ export class SqliteMaterializationSessions {
     const mismatch = this.db
       .query(
         `
-          WITH expected AS (
-            SELECT entity_kind, identity_key
-            FROM ${SQLITE_REPLACEMENT_WORK_TABLE}
-            WHERE session_id = ? AND diff_required = 1
-              AND (entity_kind = 'link' OR ? = 1)
-          ), actual AS (
-            SELECT CASE
-                WHEN unique_key LIKE 'classification:object:%' THEN 'object'
-                ELSE 'link'
-              END AS entity_kind,
-              CASE
-                WHEN unique_key LIKE 'classification:object:%'
-                  THEN substr(unique_key, length('classification:object:') + 1)
-                ELSE substr(unique_key, length('classification:link:') + 1)
-              END AS identity_key
-            FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-            WHERE session_id = ? AND kind = 'classification'
-              AND (unique_key LIKE 'classification:object:%'
-                OR unique_key LIKE 'classification:link:%')
-          ), differences AS (
-            SELECT * FROM expected EXCEPT SELECT * FROM actual
+          WITH invalid AS (
+            SELECT 1
+            FROM ${SQLITE_REPLACEMENT_WORK_TABLE} AS expected
+            WHERE expected.session_id = ? AND expected.diff_required = 1
+              AND (expected.entity_kind = 'link' OR ? = 1)
+              AND NOT EXISTS (
+                SELECT 1 FROM ${SQLITE_MATERIALIZATION_WORK_TABLE} AS actual
+                WHERE actual.session_id = expected.session_id
+                  AND actual.unique_key = 'classification:' || expected.entity_kind || ':'
+                    || expected.identity_key
+              )
             UNION ALL
-            SELECT * FROM actual EXCEPT SELECT * FROM expected
+            SELECT 1
+            FROM ${SQLITE_MATERIALIZATION_WORK_TABLE} AS actual
+            WHERE actual.session_id = ?
+              -- A bounded range uses the existing (session_id, unique_key) unique index and scans
+              -- classification entries only, instead of sorting the complete JSON work spool.
+              AND actual.unique_key >= 'classification:'
+              AND actual.unique_key < 'classification;'
+              AND (
+                actual.classification_entity_kind = 'point'
+                OR NOT EXISTS (
+                  SELECT 1 FROM ${SQLITE_REPLACEMENT_WORK_TABLE} AS expected
+                  WHERE expected.session_id = actual.session_id
+                    AND expected.entity_kind = actual.classification_entity_kind
+                    AND expected.identity_key = actual.classification_identity_key
+                    AND expected.diff_required = 1
+                    AND (expected.entity_kind = 'link' OR ? = 1)
+                )
+              )
           )
-          SELECT 1 FROM differences LIMIT 1
+          SELECT 1 FROM invalid LIMIT 1
         `
       )
-      .get(session.id, expectedObject, session.id)
-    const pointClassifications = this.db
-      .query(
-        `
-          SELECT 1 FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-          WHERE session_id = ? AND kind = 'classification'
-            AND unique_key LIKE 'classification:point:%'
-          LIMIT 1
-        `
-      )
-      .get(session.id)
-    if (mismatch || pointClassifications) {
+      .get(session.id, expectedObject, session.id, expectedObject)
+    if (mismatch) {
       invalidCorrelation(
         "Projection replacement classification coverage does not match its streamed state."
       )
     }
   }
 
-  private planItems(
-    session: SqliteMaterializationSessionState,
-    offset: number,
+  private readLane(
+    lane: StreamMaterializationWorkInput["order"],
+    sessionId: string,
+    cursor: WorkCursor | null,
     limit: number
-  ): MaterializationPlanWorkItem[] {
+  ): WorkDatabaseRow[] {
     if (limit === 0) return []
-    const rows = this.db
+    const selected = `record_key, major_order, minor_order, sort_one, sort_two, payload`
+    if (!cursor) {
+      return this.db
+        .query(
+          `SELECT ${selected} FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
+           WHERE session_id = ? AND lane = ?
+           ORDER BY major_order, minor_order, sort_one, sort_two, record_key
+           LIMIT ?`
+        )
+        .all(sessionId, lane, limit) as WorkDatabaseRow[]
+    }
+    return this.db
       .query(
-        `
-          SELECT payload FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-          WHERE session_id = ? AND lane = 'apply'
-          ORDER BY major_order, minor_order, sort_one, sort_two, record_key
-          LIMIT ? OFFSET ?
-        `
+        `SELECT ${selected} FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
+         WHERE session_id = ? AND lane = ?
+           AND (major_order, minor_order, sort_one, sort_two, record_key) > (?, ?, ?, ?, ?)
+         ORDER BY major_order, minor_order, sort_one, sort_two, record_key
+         LIMIT ?`
       )
-      .all(session.id, limit, offset) as { readonly payload: string }[]
-    return rows.map((row) => {
-      const record = parseJson<Extract<MaterializationWorkRecord, { readonly kind: "plan" }>>(
-        row.payload
-      )
-      return record.item
-    })
-  }
-
-  private eventRecords(
-    session: SqliteMaterializationSessionState,
-    offset: number,
-    limit: number
-  ): MaterializationEventWorkRecord[] {
-    if (limit === 0) return []
-    const rows = this.db
-      .query(
-        `
-          SELECT payload FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-          WHERE session_id = ? AND lane = 'event'
-          ORDER BY major_order, minor_order, sort_one, sort_two, record_key
-          LIMIT ? OFFSET ?
-        `
-      )
-      .all(session.id, limit, offset) as { readonly payload: string }[]
-    return rows.map((row) => parseJson<MaterializationEventWorkRecord>(row.payload))
+      .all(
+        sessionId,
+        lane,
+        cursor.majorOrder,
+        cursor.minorOrder,
+        cursor.sortOne,
+        cursor.sortTwo,
+        cursor.recordKey,
+        limit
+      ) as WorkDatabaseRow[]
   }
 
   private ensureTables(): void {
@@ -346,6 +443,14 @@ export class SqliteMaterializationSessions {
         minor_order INTEGER NOT NULL,
         sort_one TEXT NOT NULL,
         sort_two TEXT NOT NULL,
+        classification_entity_kind TEXT,
+        classification_identity_key TEXT,
+        cardinality_occupied INTEGER,
+        cardinality_source_type_id TEXT,
+        cardinality_source_primary_id TEXT,
+        cardinality_link_id TEXT,
+        cardinality_target_type_id TEXT,
+        cardinality_target_primary_id TEXT,
         payload TEXT NOT NULL CHECK (json_valid(payload)),
         PRIMARY KEY (session_id, record_key),
         UNIQUE (session_id, unique_key)
@@ -376,5 +481,85 @@ export class SqliteMaterializationSessions {
     this.db
       .query(`DELETE FROM ${SQLITE_REPLACEMENT_WORK_TABLE} WHERE session_id = ?`)
       .run(sessionId)
+  }
+
+  private dropWorkTables(): void {
+    this.db.run(`
+      DROP TABLE IF EXISTS ${SQLITE_MATERIALIZATION_WORK_TABLE};
+      DROP TABLE IF EXISTS ${SQLITE_REPLACEMENT_WORK_TABLE};
+    `)
+  }
+}
+
+function workCursor(row: WorkDatabaseRow): WorkCursor {
+  return {
+    majorOrder: row.major_order,
+    minorOrder: row.minor_order,
+    sortOne: row.sort_one,
+    sortTwo: row.sort_two,
+    recordKey: row.record_key,
+  }
+}
+
+function emptyWorkSummary(): WorkSummary {
+  return {
+    apply: 0,
+    cardinality: 0,
+    event: 0,
+    objectClassifications: 0,
+    linkClassifications: 0,
+    pointClassifications: 0,
+    objectsCreated: 0,
+    objectsUpdated: 0,
+    objectsDeleted: 0,
+    linksCreated: 0,
+    linksUpdated: 0,
+    linksDeleted: 0,
+    pointsCreated: 0,
+    pointsUpdated: 0,
+    latestObjectsChanged: 0,
+  }
+}
+
+function recordSummary(
+  summary: WorkSummary,
+  record: MaterializationWorkRecord,
+  columns: { readonly lane: "none" | "apply" | "cardinality" | "event" }
+): void {
+  if (columns.lane !== "none") summary[columns.lane] += 1
+
+  if (record.kind === "classification") {
+    if (record.entityKind === "object") summary.objectClassifications += 1
+    if (record.entityKind === "link") summary.linkClassifications += 1
+    if (record.entityKind === "point") summary.pointClassifications += 1
+    return
+  }
+  if (record.kind !== "plan") return
+
+  switch (record.item.kind) {
+    case "object-upsert":
+      summary.latestObjectsChanged += 1
+      if (record.item.value.expected.exists) summary.objectsUpdated += 1
+      else summary.objectsCreated += 1
+      return
+    case "object-delete":
+      summary.objectsDeleted += 1
+      return
+    case "link-upsert":
+      if (record.item.value.expected.exists) summary.linksUpdated += 1
+      else summary.linksCreated += 1
+      return
+    case "link-delete":
+      summary.linksDeleted += 1
+      return
+    case "point-upsert":
+      if (record.item.value.expected.lastCommitId === null) summary.pointsCreated += 1
+      else summary.pointsUpdated += 1
+      return
+    case "object-override-upsert":
+    case "object-override-delete":
+    case "link-override-upsert":
+    case "link-override-delete":
+      return
   }
 }

--- a/storage/sqlite/src/ontology-storage/materializations.ts
+++ b/storage/sqlite/src/ontology-storage/materializations.ts
@@ -1,6 +1,5 @@
 import type { Database } from "bun:sqlite"
 import type {
-  EffectiveChangeCounts,
   ExpectedLinkRevision,
   ExpectedObjectRevision,
 } from "@sixb/core/internal/materialization"
@@ -52,7 +51,6 @@ import {
   type SqliteOntologyTransactionContext,
 } from "./materialization-session"
 import {
-  linkSortExpression,
   SQLITE_MATERIALIZATION_WORK_TABLE,
   SqliteMaterializationStateReader,
 } from "./materialization-state"
@@ -282,18 +280,15 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
     const session = this.sessions.require(input.session)
     const { commit } = session.header
     assertPlanChunkCorrelations(input.chunk, commit)
-    const planCount = session.appliedPlanCount
-    const outboxCount = session.appliedOutboxCount
-    this.sessions.assertChunkSequence(session, input.chunk)
+    const sequence = this.sessions.prepareChunkSequence(session, input.chunk)
     this.db.run("SAVEPOINT sixb_ontology_apply_chunk")
     try {
       this.writer.apply(commit.projectId, commit.id, input.chunk)
       this.db.run("RELEASE SAVEPOINT sixb_ontology_apply_chunk")
+      this.sessions.commitChunkSequence(session, sequence)
     } catch (error) {
       this.db.run("ROLLBACK TO SAVEPOINT sixb_ontology_apply_chunk")
       this.db.run("RELEASE SAVEPOINT sixb_ontology_apply_chunk")
-      session.appliedPlanCount = planCount
-      session.appliedOutboxCount = outboxCount
       throw error
     }
     await yieldSqliteEventLoop()
@@ -514,7 +509,7 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
     await yieldSqliteEventLoop()
 
     if (commit.intent.kind === "telemetry") {
-      const summary = this.telemetrySummary(session, commit.intent.pointCount)
+      const summary = this.sessions.telemetrySummary(session, commit.intent.pointCount)
       await yieldSqliteEventLoop()
       if (summary.classifiedPoints !== commit.intent.pointCount) {
         invalidCorrelation(
@@ -529,7 +524,7 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
       if (result.kind !== "projection") return
       this.sessions.assertClassificationCoverage(session)
       await yieldSqliteEventLoop()
-      const counts = this.projectionCounts(session)
+      const counts = this.sessions.projectionCounts(session)
       await yieldSqliteEventLoop()
       if (!sameCounts(result.counts, counts)) {
         invalidCorrelation("Projection result counts do not correlate with finalized work.")
@@ -541,41 +536,41 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
     const violation = this.db
       .query(
         `
-          WITH work AS (
-            SELECT json_extract(payload, '$.scopeSortKey') AS scope_sort_key,
-              json_extract(payload, '$.linkSortKey') AS link_sort_key,
-              json_extract(payload, '$.occupied') AS occupied,
-              json_extract(payload, '$.ref.source.objectTypeId') AS source_type_id,
-              json_extract(payload, '$.ref.source.primaryId') AS source_id,
-              json_extract(payload, '$.ref.linkId') AS link_id
+          WITH scopes AS (
+            SELECT sort_one AS scope_sort_key,
+              cardinality_source_type_id AS source_type_id,
+              cardinality_source_primary_id AS source_id,
+              cardinality_link_id AS link_id,
+              SUM(cardinality_occupied) AS expected_count,
+              MAX(CASE WHEN cardinality_occupied = 1
+                THEN cardinality_target_type_id END) AS expected_target_type_id,
+              MAX(CASE WHEN cardinality_occupied = 1
+                THEN cardinality_target_primary_id END) AS expected_target_id
             FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
             WHERE session_id = ? AND kind = 'cardinality'
-          ), duplicate AS (
-            SELECT scope_sort_key FROM work WHERE occupied = 1
-            GROUP BY scope_sort_key HAVING COUNT(*) > 1
-          ), scopes AS (
-            SELECT DISTINCT scope_sort_key, source_type_id, source_id, link_id FROM work
-          ), expected AS (
-            SELECT scope_sort_key, link_sort_key FROM work WHERE occupied = 1
-          ), actual AS (
-            SELECT scopes.scope_sort_key,
-              ${linkSortExpression("links")} AS link_sort_key
+            GROUP BY sort_one, cardinality_source_type_id,
+              cardinality_source_primary_id, cardinality_link_id
+          ), validated AS (
+            SELECT scopes.scope_sort_key, scopes.expected_count,
+              COUNT(links.source_id) AS actual_count,
+              COUNT(links.source_id) FILTER (
+                WHERE links.target_type_id = scopes.expected_target_type_id
+                  AND links.target_id = scopes.expected_target_id
+              ) AS matching_count
             FROM scopes
-            -- json-derived temp scopes have no useful cardinality estimate. Fixing them on the
-            -- outer side keeps each lookup on the complete links primary-key prefix.
-            CROSS JOIN links
+            LEFT JOIN links
               ON links.project_id = ?
              AND links.source_type_id = scopes.source_type_id
              AND links.source_id = scopes.source_id
              AND links.link_id = scopes.link_id
-          ), differences AS (
-            SELECT * FROM expected EXCEPT SELECT * FROM actual
-            UNION ALL
-            SELECT * FROM actual EXCEPT SELECT * FROM expected
+            GROUP BY scopes.scope_sort_key, scopes.expected_count,
+              scopes.expected_target_type_id, scopes.expected_target_id
           )
-          SELECT 'duplicate' AS reason FROM duplicate
-          UNION ALL
-          SELECT 'mismatch' AS reason FROM differences
+          SELECT CASE WHEN expected_count > 1 THEN 'duplicate' ELSE 'mismatch' END AS reason
+          FROM validated
+          WHERE expected_count > 1
+            OR actual_count <> expected_count
+            OR matching_count <> expected_count
           LIMIT 1
         `
       )
@@ -589,105 +584,6 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
       invalidCorrelation(
         "Materialization cardinality work does not match the final effective link scope."
       )
-    }
-  }
-
-  private projectionCounts(session: SqliteMaterializationSessionState): EffectiveChangeCounts {
-    const row = this.db
-      .query(
-        `
-          SELECT
-            COUNT(*) FILTER (
-              WHERE kind = 'classification'
-                AND unique_key LIKE 'classification:object:%'
-            ) AS object_classifications,
-            COUNT(*) FILTER (
-              WHERE kind = 'classification'
-                AND unique_key LIKE 'classification:link:%'
-            ) AS link_classifications,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'object-upsert'
-                AND json_extract(payload, '$.item.value.expected.exists') = 0
-            ) AS objects_created,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'object-upsert'
-                AND json_extract(payload, '$.item.value.expected.exists') = 1
-            ) AS objects_updated,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'object-delete'
-            ) AS objects_deleted,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'link-upsert'
-                AND json_extract(payload, '$.item.value.expected.exists') = 0
-            ) AS links_created,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'link-upsert'
-                AND json_extract(payload, '$.item.value.expected.exists') = 1
-            ) AS links_updated,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'link-delete'
-            ) AS links_deleted
-          FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-          WHERE session_id = ?
-        `
-      )
-      .get(session.id) as ProjectionCountsRow
-    const objectsChanged = row.objects_created + row.objects_updated + row.objects_deleted
-    const linksChanged = row.links_created + row.links_updated + row.links_deleted
-    return {
-      objectsCreated: row.objects_created,
-      objectsUpdated: row.objects_updated,
-      objectsDeleted: row.objects_deleted,
-      objectsUnchanged: row.object_classifications - objectsChanged,
-      linksCreated: row.links_created,
-      linksUpdated: row.links_updated,
-      linksDeleted: row.links_deleted,
-      linksUnchanged: row.link_classifications - linksChanged,
-    }
-  }
-
-  private telemetrySummary(session: SqliteMaterializationSessionState, pointCount: number) {
-    const row = this.db
-      .query(
-        `
-          SELECT
-            COUNT(*) FILTER (
-              WHERE kind = 'classification'
-                AND unique_key LIKE 'classification:point:%'
-            ) AS classified_points,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'point-upsert'
-                AND json_extract(payload, '$.item.value.expected.lastCommitId') IS NULL
-            ) AS points_created,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'point-upsert'
-                AND json_extract(payload, '$.item.value.expected.lastCommitId') IS NOT NULL
-            ) AS points_updated,
-            COUNT(*) FILTER (
-              WHERE kind = 'plan'
-                AND json_extract(payload, '$.item.kind') = 'object-upsert'
-            ) AS latest_objects_changed
-          FROM ${SQLITE_MATERIALIZATION_WORK_TABLE}
-          WHERE session_id = ?
-        `
-      )
-      .get(session.id) as TelemetrySummaryRow
-    return {
-      classifiedPoints: row.classified_points,
-      counts: {
-        pointsCreated: row.points_created,
-        pointsUpdated: row.points_updated,
-        pointsUnchanged: pointCount - row.points_created - row.points_updated,
-        latestObjectsChanged: row.latest_objects_changed,
-      },
     }
   }
 
@@ -863,22 +759,4 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
       )
       .get(projectId, sourceId, materializationId) as SqliteOntologySourceRow | null
   }
-}
-
-interface ProjectionCountsRow {
-  readonly object_classifications: number
-  readonly link_classifications: number
-  readonly objects_created: number
-  readonly objects_updated: number
-  readonly objects_deleted: number
-  readonly links_created: number
-  readonly links_updated: number
-  readonly links_deleted: number
-}
-
-interface TelemetrySummaryRow {
-  readonly classified_points: number
-  readonly points_created: number
-  readonly points_updated: number
-  readonly latest_objects_changed: number
 }

--- a/storage/sqlite/tests/sqlite-ontology-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-ontology-storage.test.ts
@@ -1,8 +1,10 @@
 import { Database } from "bun:sqlite"
+import { expect, test } from "bun:test"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { migrateStorage } from "@sixb/core"
+import type { MaterializationPlanHeader, MaterializationWorkRecord } from "@sixb/core/storage"
 import {
   runMaterializationFailureContractSuite,
   runOntologyStorageContractSuite,
@@ -17,6 +19,45 @@ runOntologyStorageContractSuite("SQLite ontology storage contract", {
   cleanup(storage) {
     storage.close()
   },
+})
+
+test("SQLite work staging rolls back a partial batch after a later record conflicts", async () => {
+  const storage = new SqliteStorage()
+  const header = atomicStageHeader()
+  const first = classificationWork("first")
+  const pending = classificationWork("pending")
+  try {
+    await storage.transaction(async (tx) => {
+      const materializations = tx.ontology.materializations
+      const session = await materializations.begin(header)
+      await materializations.stageWork({ session, records: [first] })
+      await expect(
+        materializations.stageWork({ session, records: [pending, first] })
+      ).rejects.toThrow("Duplicate materialization work key 'classification:first'.")
+
+      // The valid first row from the rejected batch must not remain staged.
+      await expect(
+        materializations.stageWork({ session, records: [pending] })
+      ).resolves.toBeUndefined()
+      await materializations.finalize({
+        session,
+        finalization: {
+          sourceActivations: [],
+          result: {
+            kind: "edit",
+            commitId: header.commit.id,
+            created: true,
+            eventCount: 0,
+            committedAt: header.commit.committedAt,
+            outcomes: [],
+            changes: { objects: [], links: [] },
+          },
+        },
+      })
+    })
+  } finally {
+    storage.close()
+  }
 })
 
 runProjectionRunStorageContractSuite("SQLite projection-run storage contract", {
@@ -78,6 +119,31 @@ runMaterializationFailureContractSuite("SQLite materialization failure contract"
     })
   },
 })
+
+function atomicStageHeader(): MaterializationPlanHeader {
+  return {
+    commit: {
+      projectId: "contract-project",
+      id: "atomic-work-stage",
+      idempotencyKey: "runtime:atomic-work-stage",
+      requestHash: "hash:atomic-work-stage",
+      origin: { kind: "runtime", requestId: "atomic-work-stage" },
+      ontologyRevision: "ontology-contract-revision",
+      intent: { kind: "edit", mode: "atomic", operationCount: 0 },
+      committedAt: "2026-01-02T00:00:00.000Z",
+    },
+    expected: { sources: [], objects: [], links: [], linkScopes: [], points: [] },
+  }
+}
+
+function classificationWork(id: string): MaterializationWorkRecord {
+  return {
+    kind: "classification",
+    recordKey: `classification:${id}`,
+    entityKind: "object",
+    identityKey: `["ContractDevice","${id}"]`,
+  }
+}
 
 function withDatabase<T>(path: string, run: (db: Database) => T): T {
   const db = new Database(path)


### PR DESCRIPTION
## Summary

Accelerate the complete dataset-to-ontology delivery path after the provider-scale materialization improvements in #369.

This stacked PR removes a deterministic DuckLake JavaScript pipeline deadlock, reduces SQLite materialization finalization from minutes to seconds at Building OS scale, improves PostgreSQL source staging through a safer bounded default, and increases authoritative ontology event publication throughput.

At 85,000 linked roots, the full DuckLake → projection worker → SQLite ontology path improved from **218.4s to 130.5s**. Direct SQLite materialization improved from **289.0s to 121.5s**, while PostgreSQL improved from **217.6s to 144.9s**.

## Linked issue

Stacked on #369.

## Scope

### DuckLake streaming and responsiveness

- Replace unbounded native read-stream ownership with bounded, immutable-snapshot pages.
- Use physical `rowid` keyset pagination when the schema permits it while preserving the existing insertion-order fallback for datasets that shadow `rowid`.
- Keep one DuckLake attachment lease across the read, but release the DuckDB operation queue between pages.
- Yield to the event loop between bounded write and merge appender batches.
- Add a child-process regression for streaming 5,001 rows directly from one DuckLake dataset into another.

The regression is intentionally process-isolated: reverting to the old unbounded stream causes the destination's first 1,000-row flush to wait on its own open input stream indefinitely.

### Materializer batching

- Raise only source assertion staging from 1,000 to 2,000 rows.
- Preserve the 4MiB source byte ceiling and the existing 1,000-row state, work, and apply limits.

The narrower change avoids the large RSS increase measured when all materialization boundaries were raised together.

### SQLite work spool and finalization

- Port PostgreSQL's keyset work-lane and apply-correlation cursors to SQLite.
- Advance apply/event sequence cursors only after the physical chunk succeeds.
- Wrap work staging in a savepoint so each staged batch is actually atomic when a later row conflicts.
- Extract compact classification/cardinality columns while staging work.
- Maintain exact lane, classification, projection-result, and telemetry-result counters in session state.
- Replace classification `EXCEPT` sorts with indexed anti-lookups.
- Verify cardinality through grouped exact target columns instead of reconstructing and sorting link identities.
- Drop the transaction-local work spool when the final session closes rather than deleting hundreds of thousands of indexed rows individually.

### Outbox publication

- Raise the default ontology outbox publication batch from 100 to 1,000 events.
- Increase the bounded poison-isolation budget from 16 to 32 broker attempts.
- Add a 1,000-event regression proving that 999 healthy envelopes publish while only the poison envelope is rescheduled.

## Benchmarks

Benchmarks use the same Building OS-shaped linked projection as #369: one object with 21 properties and one cardinality-one link per root. Runs used fresh storage, Bun 1.3.14, and an Apple M1 Pro with 16GB RAM. Raw harnesses/results remain ignored under `.local/`.

### 85k direct ontology materialization

| Provider / metric | Before | After | Change |
|---|---:|---:|---:|
| SQLite total | 288.958s | **121.512s** | **58.0% faster** |
| SQLite throughput | 294 roots/s | **700 roots/s** | **2.38x** |
| SQLite transaction | 233.569s | **71.611s** | **69.3% faster** |
| SQLite finalization | 153.170s | **4.725s** | **96.9% faster** |
| SQLite source staging | 52.501s | **46.853s** | 10.8% faster |
| SQLite apply chunks | 26.828s | **18.458s** | 31.2% faster |
| SQLite max event-loop stall | 75.942s | **3.359s** | **95.6% lower** |
| SQLite sampled peak RSS | 560MB | 603MB | +7.7% |
| PostgreSQL total | 217.570s | **144.937s** | **33.4% faster** |
| PostgreSQL throughput | 391 roots/s | **586 roots/s** | **1.50x** |
| PostgreSQL source staging | 95.490s | **38.250s** | **59.9% faster** |
| PostgreSQL transaction | 117.690s | **102.526s** | 12.9% faster |
| PostgreSQL sampled peak RSS | 267MB | 329MB | +23.2% |

The PostgreSQL improvement comes from the new 2,000-row source default. An optimistic insert/reconciliation prototype produced no measurable 15k source-stage improvement and was removed rather than adding complexity.

### Full DuckLake → projection worker → SQLite path

| Metric | Before | After | Change |
|---|---:|---:|---:|
| 85k projection | 218.422s | **130.466s** | **40.3% faster** |
| Root throughput | 389/s | **652/s** | **67.4% higher** |
| DuckLake read held open | 61.392s | **48.036s** | **21.8% lower** |

The after harness also retained 169k events in an in-memory broker, so its process peak is not comparable to the before projection run. The direct after materializer run, without retained broker events, peaked at 603MB.

### DuckLake and application responsiveness

| Metric | Before | After |
|---|---:|---:|
| Direct JavaScript lake-to-lake stream copy | deadlock at 1,000 rows | **85k rows in 280ms** |
| Direct stream-copy max RSS | n/a | **283MB** |
| Snapshot write | 1.748s | **1.628s** |
| Snapshot-write max event-loop stall | 1.597s | **18ms** |
| Isolated projected read | 131ms | 259ms |

Bounded paging intentionally adds 128ms to an isolated 85k projected read. In exchange it eliminates the deterministic stream-to-write deadlock, prevents one consumer from reserving the DuckDB queue for the entire stream, and removes multi-second write-loop starvation.

### Ontology event publication

| 15k linked projection (~30k events) | Before | After | Change |
|---|---:|---:|---:|
| Drain time | 9.98s | **2.676s** | **73.2% faster** |
| Throughput | 2,996 events/s | **10,838 events/s** | **3.62x** |

## Validation

- `bun run check`
- `bun run typecheck`
- `bun --filter @sixb/core build`
- `bun --filter @sixb/ducklake build`
- `bun --filter @sixb/sqlite build`
- `bun --filter @sixb/pg build`
- SQLite suite — **193 passed**
- focused core materializer/outbox/maintenance suites — **116 passed**
- DuckLake e2e — **133 passed** across local and remote-catalog suites
- PostgreSQL e2e — **169 passed**

## Notes

- This PR intentionally does not change pipeline authoring APIs or automatically rewrite JavaScript transforms as SQL. Building OS can now delete its buffer-all workaround and stream directly; deterministic transforms should still prefer SQL where practical.
- The source-stage byte ceiling remains the hard memory bound even though the row default increased.
- Outbox publication remains at-least-once. Larger claims preserve lease fencing, stable event IDs, order within each broker call, bounded poison bisection, retry backoff, and shutdown recovery.
- Review this PR after #369 because it builds directly on that branch's replacement-state, WAL/read-snapshot, migration, and PostgreSQL work-staging changes.
