### PR TITLE
storage: add durable execution ledger

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -131,6 +131,12 @@
       "import": "./dist/events/index.js",
       "default": "./dist/events/index.js"
     },
+    "./internal/execution-storage": {
+      "types": "./dist/storage/executions/provider.d.ts",
+      "bun": "./src/storage/executions/provider.ts",
+      "import": "./dist/storage/executions/provider.js",
+      "default": "./dist/storage/executions/provider.js"
+    },
     "./internal/http": {
       "types": "./dist/http/index.d.ts",
       "bun": "./src/http/index.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -466,6 +466,11 @@ export {
 // The full storage-provider contract lives at `@sixb/core/storage`.
 
 export type {
+  CreateExecutionInput,
+  DurableExecutionExecutor,
+  DurableExecutionSource,
+  ExecutionRecord,
+  ExecutionStorage,
   MigrationCapableStorage,
   MigrationReport,
   // `status()` returns these, so reading a migrator from here needs them; without them

--- a/packages/core/src/storage/executions/errors.ts
+++ b/packages/core/src/storage/executions/errors.ts
@@ -1,0 +1,21 @@
+export type ExecutionStorageErrorCode =
+  | "duplicate_execution"
+  | "invalid_credential"
+  | "invalid_input"
+  | "invalid_parent_execution"
+  | "missing_credential"
+  | "missing_parent_execution"
+  | "missing_principal"
+
+/** Stable error raised when an execution record would violate ledger invariants. */
+export class ExecutionStorageError extends Error {
+  readonly name = "ExecutionStorageError"
+
+  constructor(
+    readonly code: ExecutionStorageErrorCode,
+    message: string,
+    options: ErrorOptions = {}
+  ) {
+    super(message, options)
+  }
+}

--- a/packages/core/src/storage/executions/in-memory.ts
+++ b/packages/core/src/storage/executions/in-memory.ts
@@ -1,0 +1,75 @@
+import type { AuthStorage } from "../auth"
+import { ExecutionStorageError } from "./errors"
+import type { CreateExecutionInput, ExecutionRecord, ExecutionStorage } from "./types"
+import {
+  cloneExecutionRecord,
+  normalizeExecutionRecord,
+  validateExecutionRecordReferences,
+} from "./validation"
+
+type RunRootOperation = <T>(run: () => Promise<T> | T) => Promise<T>
+
+const runDirectly: RunRootOperation = async <T>(run: () => Promise<T> | T): Promise<T> => run()
+
+function executionKey(projectId: string, id: string): string {
+  return JSON.stringify([projectId, id])
+}
+
+export class InMemoryExecutionStorage implements ExecutionStorage {
+  private readonly rows = new Map<string, ExecutionRecord>()
+  private readonly runRootOperation: RunRootOperation
+
+  constructor(
+    private readonly auth: AuthStorage,
+    input: { readonly runRootOperation?: RunRootOperation } = {}
+  ) {
+    this.runRootOperation = input.runRootOperation ?? runDirectly
+  }
+
+  snapshot(): InMemoryExecutionStorageSnapshot {
+    return structuredClone(this.rows)
+  }
+
+  restore(snapshot: InMemoryExecutionStorageSnapshot): void {
+    this.rows.clear()
+    for (const [key, record] of structuredClone(snapshot)) {
+      this.rows.set(key, record)
+    }
+  }
+
+  async create(input: CreateExecutionInput): Promise<ExecutionRecord> {
+    return this.runRootOperation(async () => {
+      const record = normalizeExecutionRecord(input)
+      const key = executionKey(record.projectId, record.id)
+      if (this.rows.has(key)) {
+        throw new ExecutionStorageError(
+          "duplicate_execution",
+          `[Sixb] Execution '${record.id}' already exists in project '${record.projectId}'.`
+        )
+      }
+
+      await validateExecutionRecordReferences(record, {
+        auth: this.auth,
+        getExecution: async ({ projectId, id }) => {
+          const existing = this.rows.get(executionKey(projectId, id))
+          return existing ? cloneExecutionRecord(existing) : null
+        },
+      })
+
+      this.rows.set(key, cloneExecutionRecord(record))
+      return cloneExecutionRecord(record)
+    })
+  }
+
+  async getById(params: {
+    readonly projectId: string
+    readonly id: string
+  }): Promise<ExecutionRecord | null> {
+    return this.runRootOperation(() => {
+      const record = this.rows.get(executionKey(params.projectId, params.id))
+      return record ? cloneExecutionRecord(record) : null
+    })
+  }
+}
+
+export type InMemoryExecutionStorageSnapshot = Map<string, ExecutionRecord>

--- a/packages/core/src/storage/executions/index.ts
+++ b/packages/core/src/storage/executions/index.ts
@@ -1,0 +1,16 @@
+export type {
+  AuthorizablePrincipal,
+  AuthorizationRef,
+  KernelOperation,
+  TrustedPrimitiveKind,
+  TrustedPrimitiveRef,
+} from "../../execution/types"
+export type { ExecutionStorageErrorCode } from "./errors"
+export { ExecutionStorageError } from "./errors"
+export type {
+  CreateExecutionInput,
+  DurableExecutionExecutor,
+  DurableExecutionSource,
+  ExecutionRecord,
+  ExecutionStorage,
+} from "./types"

--- a/packages/core/src/storage/executions/provider.ts
+++ b/packages/core/src/storage/executions/provider.ts
@@ -1,0 +1,252 @@
+import type { TrustedPrimitiveKind } from "../../execution/types"
+import type { CreateExecutionInput, ExecutionRecord } from "./types"
+import { normalizeExecutionRecord } from "./validation"
+
+export {
+  type ExecutionValidationLookup,
+  normalizeExecutionRecord,
+  validateExecutionRecordReferences,
+} from "./validation"
+
+/** Provider-neutral flattened representation used by the SQL adapters. */
+export interface ExecutionStorageRow {
+  readonly projectId: string
+  readonly id: string
+  readonly executorKind: "agent" | "kernel" | "request" | TrustedPrimitiveKind
+  readonly executorId: string
+  readonly sourceKind: "event" | "execution" | "http" | "schedule" | "webhook"
+  readonly sourceId: string
+  readonly requestedByUserId: string | null
+  readonly requestedByServiceAccountId: string | null
+  readonly correlationId: string
+  readonly parentExecutionId: string | null
+  readonly authorityKind: "disabled" | "kernel" | "principal" | "trustedPrimitive"
+  readonly authorityUserId: string | null
+  readonly authorityServiceAccountId: string | null
+  readonly authoritySessionId: string | null
+  readonly authorityAccessTokenId: string | null
+  readonly authorityPrimitiveKind: TrustedPrimitiveKind | null
+  readonly authorityPrimitiveId: string | null
+  readonly authorityKernelOperation: "ontology.recover" | null
+  readonly createdAt: Date
+}
+
+export function executionRecordToStorageRow(record: ExecutionRecord): ExecutionStorageRow {
+  const executor = flattenExecutor(record)
+  const source = flattenSource(record)
+  const authority = flattenAuthority(record)
+  return {
+    projectId: record.projectId,
+    id: record.id,
+    ...executor,
+    ...source,
+    requestedByUserId: record.requestedBy?.type === "user" ? record.requestedBy.id : null,
+    requestedByServiceAccountId:
+      record.requestedBy?.type === "serviceAccount" ? record.requestedBy.id : null,
+    correlationId: record.correlationId,
+    parentExecutionId: record.parentExecutionId ?? null,
+    ...authority,
+    createdAt: new Date(record.createdAt),
+  }
+}
+
+export function executionRecordFromStorageRow(row: ExecutionStorageRow): ExecutionRecord {
+  const executor = inflateExecutor(row)
+  const source = inflateSource(row)
+  const authorizationRef = inflateAuthority(row)
+  const requestedBy = row.requestedByUserId
+    ? ({ type: "user", id: row.requestedByUserId } as const)
+    : row.requestedByServiceAccountId
+      ? ({ type: "serviceAccount", id: row.requestedByServiceAccountId } as const)
+      : undefined
+
+  return normalizeExecutionRecord(
+    {
+      id: row.id,
+      projectId: row.projectId,
+      ...(requestedBy === undefined ? {} : { requestedBy }),
+      executor,
+      source,
+      correlationId: row.correlationId,
+      ...(row.parentExecutionId === null ? {} : { parentExecutionId: row.parentExecutionId }),
+      authorizationRef,
+    },
+    row.createdAt
+  )
+}
+
+function flattenExecutor(
+  record: ExecutionRecord
+): Pick<ExecutionStorageRow, "executorId" | "executorKind"> {
+  switch (record.executor.type) {
+    case "request":
+      return { executorKind: "request", executorId: record.executor.requestId }
+    case "primitive":
+      return { executorKind: record.executor.kind, executorId: record.executor.runId }
+    case "agent":
+      return { executorKind: "agent", executorId: record.executor.runId }
+    case "kernel":
+      return { executorKind: "kernel", executorId: record.executor.operation.recoveryId }
+  }
+}
+
+function flattenSource(
+  record: ExecutionRecord
+): Pick<ExecutionStorageRow, "sourceId" | "sourceKind"> {
+  switch (record.source.type) {
+    case "http":
+      return { sourceKind: "http", sourceId: record.source.requestId }
+    case "webhook":
+      return { sourceKind: "webhook", sourceId: record.source.deliveryId }
+    case "schedule":
+    case "event":
+      return { sourceKind: record.source.type, sourceId: record.source.eventId }
+    case "execution":
+      return { sourceKind: "execution", sourceId: record.source.executionId }
+  }
+}
+
+function flattenAuthority(
+  record: ExecutionRecord
+): Pick<
+  ExecutionStorageRow,
+  | "authorityAccessTokenId"
+  | "authorityKernelOperation"
+  | "authorityKind"
+  | "authorityPrimitiveId"
+  | "authorityPrimitiveKind"
+  | "authorityServiceAccountId"
+  | "authoritySessionId"
+  | "authorityUserId"
+> {
+  const empty = {
+    authorityUserId: null,
+    authorityServiceAccountId: null,
+    authoritySessionId: null,
+    authorityAccessTokenId: null,
+    authorityPrimitiveKind: null,
+    authorityPrimitiveId: null,
+    authorityKernelOperation: null,
+  }
+
+  switch (record.authorizationRef.type) {
+    case "principal":
+      return {
+        ...empty,
+        authorityKind: "principal",
+        authorityUserId:
+          record.authorizationRef.principal.type === "user"
+            ? record.authorizationRef.principal.id
+            : null,
+        authorityServiceAccountId:
+          record.authorizationRef.principal.type === "serviceAccount"
+            ? record.authorizationRef.principal.id
+            : null,
+        authoritySessionId:
+          record.authorizationRef.credential?.type === "session"
+            ? record.authorizationRef.credential.id
+            : null,
+        authorityAccessTokenId:
+          record.authorizationRef.credential?.type === "accessToken"
+            ? record.authorizationRef.credential.id
+            : null,
+      }
+    case "trustedPrimitive":
+      return {
+        ...empty,
+        authorityKind: "trustedPrimitive",
+        authorityPrimitiveKind: record.authorizationRef.primitive.kind,
+        authorityPrimitiveId: record.authorizationRef.primitive.id,
+      }
+    case "kernel":
+      return {
+        ...empty,
+        authorityKind: "kernel",
+        authorityKernelOperation: record.authorizationRef.operation.type,
+      }
+    case "disabled":
+      return { ...empty, authorityKind: "disabled" }
+  }
+}
+
+function inflateExecutor(row: ExecutionStorageRow): CreateExecutionInput["executor"] {
+  switch (row.executorKind) {
+    case "request":
+      return { type: "request", requestId: row.executorId }
+    case "agent":
+      return { type: "agent", runId: row.executorId }
+    case "kernel":
+      return {
+        type: "kernel",
+        operation: {
+          type: requireValue(row.authorityKernelOperation, "authority kernel operation"),
+          recoveryId: row.executorId,
+        },
+      }
+    default:
+      return { type: "primitive", kind: row.executorKind, runId: row.executorId }
+  }
+}
+
+function inflateSource(row: ExecutionStorageRow): CreateExecutionInput["source"] {
+  switch (row.sourceKind) {
+    case "http":
+      return { type: "http", requestId: row.sourceId }
+    case "webhook":
+      return { type: "webhook", deliveryId: row.sourceId }
+    case "schedule":
+    case "event":
+      return { type: row.sourceKind, eventId: row.sourceId }
+    case "execution":
+      return { type: "execution", executionId: row.sourceId }
+  }
+}
+
+function inflateAuthority(row: ExecutionStorageRow): CreateExecutionInput["authorizationRef"] {
+  switch (row.authorityKind) {
+    case "principal": {
+      const principal = row.authorityUserId
+        ? ({ type: "user", id: row.authorityUserId } as const)
+        : ({
+            type: "serviceAccount",
+            id: requireValue(row.authorityServiceAccountId, "authority service account id"),
+          } as const)
+      const credential = row.authoritySessionId
+        ? ({ type: "session", id: row.authoritySessionId } as const)
+        : row.authorityAccessTokenId
+          ? ({ type: "accessToken", id: row.authorityAccessTokenId } as const)
+          : undefined
+      return {
+        type: "principal",
+        principal,
+        ...(credential === undefined ? {} : { credential }),
+      }
+    }
+    case "trustedPrimitive":
+      return {
+        type: "trustedPrimitive",
+        primitive: {
+          kind: requireValue(row.authorityPrimitiveKind, "authority primitive kind"),
+          id: requireValue(row.authorityPrimitiveId, "authority primitive id"),
+          runId: row.executorId,
+        },
+      }
+    case "kernel":
+      return {
+        type: "kernel",
+        operation: {
+          type: requireValue(row.authorityKernelOperation, "authority kernel operation"),
+          recoveryId: row.executorId,
+        },
+      }
+    case "disabled":
+      return { type: "disabled" }
+  }
+}
+
+function requireValue<T>(value: T | null, label: string): T {
+  if (value === null) {
+    throw new Error(`[Sixb] Stored execution is missing ${label}.`)
+  }
+  return value
+}

--- a/packages/core/src/storage/executions/types.ts
+++ b/packages/core/src/storage/executions/types.ts
@@ -1,0 +1,46 @@
+import type {
+  AuthorizablePrincipal,
+  AuthorizationRef,
+  KernelOperation,
+  TrustedPrimitiveKind,
+} from "../../execution/types"
+
+/** Executor identity stored independently from the primitive definition owned by its run. */
+export type DurableExecutionExecutor =
+  | { readonly type: "request"; readonly requestId: string }
+  | { readonly type: "primitive"; readonly kind: TrustedPrimitiveKind; readonly runId: string }
+  | { readonly type: "agent"; readonly runId: string }
+  | { readonly type: "kernel"; readonly operation: KernelOperation }
+
+/** Durable trigger provenance. Queue delivery is attempt transport and is never persisted here. */
+export type DurableExecutionSource =
+  | { readonly type: "http"; readonly requestId: string }
+  | { readonly type: "webhook"; readonly deliveryId: string }
+  | { readonly type: "schedule"; readonly eventId: string }
+  | { readonly type: "event"; readonly eventId: string }
+  | { readonly type: "execution"; readonly executionId: string }
+
+/** Immutable execution provenance and the reference required to restore its runtime authority. */
+export interface ExecutionRecord {
+  readonly id: string
+  readonly projectId: string
+  readonly requestedBy?: AuthorizablePrincipal
+  readonly executor: DurableExecutionExecutor
+  readonly source: DurableExecutionSource
+  readonly correlationId: string
+  readonly parentExecutionId?: string
+  readonly authorizationRef: AuthorizationRef
+  readonly createdAt: Date
+}
+
+/** Creation input; the storage boundary assigns the immutable creation timestamp. */
+export type CreateExecutionInput = Omit<ExecutionRecord, "createdAt">
+
+/** Immutable execution ledger. Records can be created and read, never updated or deleted. */
+export interface ExecutionStorage {
+  create(input: CreateExecutionInput): Promise<ExecutionRecord>
+  getById(params: {
+    readonly projectId: string
+    readonly id: string
+  }): Promise<ExecutionRecord | null>
+}

--- a/packages/core/src/storage/executions/validation.ts
+++ b/packages/core/src/storage/executions/validation.ts
@@ -1,0 +1,379 @@
+import type {
+  AuthorizablePrincipal,
+  AuthorizationRef,
+  KernelOperation,
+} from "../../execution/types"
+import type { AuthStorage } from "../auth"
+import { ExecutionStorageError } from "./errors"
+import type {
+  CreateExecutionInput,
+  DurableExecutionExecutor,
+  DurableExecutionSource,
+  ExecutionRecord,
+} from "./types"
+
+export interface ExecutionValidationLookup {
+  readonly auth: AuthStorage
+  getExecution(params: {
+    readonly projectId: string
+    readonly id: string
+  }): Promise<ExecutionRecord | null>
+}
+
+export function normalizeExecutionRecord(
+  input: CreateExecutionInput,
+  createdAt: Date = new Date()
+): ExecutionRecord {
+  const record: ExecutionRecord = {
+    id: input.id,
+    projectId: input.projectId,
+    ...(input.requestedBy === undefined ? {} : { requestedBy: structuredClone(input.requestedBy) }),
+    executor: structuredClone(input.executor),
+    source: structuredClone(input.source),
+    correlationId: input.correlationId,
+    ...(input.parentExecutionId === undefined
+      ? {}
+      : { parentExecutionId: input.parentExecutionId }),
+    authorizationRef: structuredClone(input.authorizationRef),
+    createdAt: new Date(createdAt),
+  }
+
+  assertRecordShape(record)
+  assertExecutorAuthority(record)
+  return record
+}
+
+export async function validateExecutionRecordReferences(
+  record: ExecutionRecord,
+  lookup: ExecutionValidationLookup
+): Promise<void> {
+  await validatePrincipal(record.requestedBy, record.projectId, "Requested-by principal", lookup)
+
+  if (record.authorizationRef.type === "principal") {
+    await validatePrincipal(
+      record.authorizationRef.principal,
+      record.projectId,
+      "Authority principal",
+      lookup
+    )
+    await validateCredential(record, lookup)
+  }
+
+  await validateParent(record, lookup)
+}
+
+export function cloneExecutionRecord(record: ExecutionRecord): ExecutionRecord {
+  return structuredClone(record)
+}
+
+function assertRecordShape(record: ExecutionRecord): void {
+  assertNonBlank(record.id, "Execution id")
+  assertNonBlank(record.projectId, "Execution project id")
+  assertNonBlank(record.correlationId, "Execution correlation id")
+  assertValidDate(record.createdAt, "Execution createdAt")
+
+  if (record.requestedBy) {
+    assertPrincipal(record.requestedBy, "Requested-by principal")
+  }
+  if (record.parentExecutionId !== undefined) {
+    assertNonBlank(record.parentExecutionId, "Parent execution id")
+  }
+
+  assertExecutor(record.executor)
+  assertSource(record.source)
+  assertAuthorizationRef(record.authorizationRef)
+
+  if (record.source.type === "execution") {
+    if (record.parentExecutionId !== record.source.executionId) {
+      invalid("Execution source must match the direct parent execution id.")
+    }
+  } else if (record.parentExecutionId !== undefined) {
+    invalid("A parent execution requires an execution source.")
+  }
+}
+
+function assertExecutor(executor: DurableExecutionExecutor): void {
+  switch (executor.type) {
+    case "request":
+      assertNonBlank(executor.requestId, "Executor request id")
+      return
+    case "primitive":
+      assertTrustedPrimitiveKind(executor.kind, "Executor primitive kind")
+      assertNonBlank(executor.runId, "Executor primitive run id")
+      return
+    case "agent":
+      assertNonBlank(executor.runId, "Executor agent run id")
+      return
+    case "kernel":
+      assertKernelOperation(executor.operation, "Executor kernel operation")
+      return
+    default:
+      invalid(`Unknown execution executor type '${String((executor as { type?: unknown }).type)}'.`)
+  }
+}
+
+function assertSource(source: DurableExecutionSource): void {
+  switch (source.type) {
+    case "http":
+      assertNonBlank(source.requestId, "Execution source request id")
+      return
+    case "webhook":
+      assertNonBlank(source.deliveryId, "Execution source delivery id")
+      return
+    case "schedule":
+    case "event":
+      assertNonBlank(source.eventId, "Execution source event id")
+      return
+    case "execution":
+      assertNonBlank(source.executionId, "Execution source execution id")
+      return
+    default:
+      invalid(
+        `Execution source type '${String((source as { type?: unknown }).type)}' is not durable.`
+      )
+  }
+}
+
+function assertAuthorizationRef(ref: AuthorizationRef): void {
+  switch (ref.type) {
+    case "principal":
+      assertPrincipal(ref.principal, "Authority principal")
+      if (ref.credential) {
+        if (ref.credential.type !== "session" && ref.credential.type !== "accessToken") {
+          invalid(
+            `Unknown authority credential type '${String(
+              (ref.credential as { type?: unknown }).type
+            )}'.`
+          )
+        }
+        assertNonBlank(ref.credential.id, "Authority credential id")
+      }
+      return
+    case "trustedPrimitive":
+      assertTrustedPrimitiveKind(ref.primitive.kind, "Authority primitive kind")
+      assertNonBlank(ref.primitive.id, "Authority primitive id")
+      assertNonBlank(ref.primitive.runId, "Authority primitive run id")
+      return
+    case "kernel":
+      assertKernelOperation(ref.operation, "Authority kernel operation")
+      return
+    case "disabled":
+      return
+    default:
+      invalid(`Unknown authorization reference type '${String((ref as { type?: unknown }).type)}'.`)
+  }
+}
+
+function assertExecutorAuthority(record: ExecutionRecord): void {
+  const { executor, authorizationRef, requestedBy, source } = record
+
+  switch (executor.type) {
+    case "request": {
+      if (source.type !== "http" || source.requestId !== executor.requestId) {
+        invalid("Request executions require a matching HTTP source request id.")
+      }
+      if (authorizationRef.type === "principal") {
+        if (!principalsEqual(requestedBy, authorizationRef.principal)) {
+          invalid("Request authority must match its requested-by principal.")
+        }
+        return
+      }
+      if (authorizationRef.type === "disabled") {
+        if (requestedBy !== undefined) {
+          invalid("Auth-disabled request executions cannot have a requested-by principal.")
+        }
+        return
+      }
+      invalid("Request executions require principal or explicitly disabled authority.")
+      break
+    }
+    case "primitive": {
+      if (authorizationRef.type !== "trustedPrimitive") {
+        invalid("Primitive executions require trusted primitive authority.")
+      }
+      if (
+        authorizationRef.primitive.kind !== executor.kind ||
+        authorizationRef.primitive.runId !== executor.runId
+      ) {
+        invalid("Trusted primitive authority must match the executor kind and run id.")
+      }
+      return
+    }
+    case "agent": {
+      if (
+        authorizationRef.type !== "principal" ||
+        authorizationRef.principal.type !== "serviceAccount"
+      ) {
+        invalid("Agent executions require service-account authority.")
+      }
+      if (authorizationRef.credential !== undefined) {
+        invalid("Agent execution authority cannot carry an external credential.")
+      }
+      return
+    }
+    case "kernel": {
+      if (
+        authorizationRef.type !== "kernel" ||
+        !kernelOperationsEqual(authorizationRef.operation, executor.operation)
+      ) {
+        invalid("Kernel authority must match the executor operation.")
+      }
+      if (requestedBy !== undefined) {
+        invalid("Kernel executions cannot have a requested-by principal.")
+      }
+      return
+    }
+  }
+}
+
+async function validatePrincipal(
+  principal: AuthorizablePrincipal | undefined,
+  projectId: string,
+  label: string,
+  lookup: ExecutionValidationLookup
+): Promise<void> {
+  if (!principal) return
+
+  const record =
+    principal.type === "user"
+      ? await lookup.auth.users.getById({ projectId, id: principal.id })
+      : await lookup.auth.serviceAccounts.getById({ projectId, id: principal.id })
+  if (!record) {
+    throw new ExecutionStorageError(
+      "missing_principal",
+      `[Sixb] ${label} '${principal.id}' does not exist in project '${projectId}'.`
+    )
+  }
+}
+
+async function validateCredential(
+  record: ExecutionRecord,
+  lookup: ExecutionValidationLookup
+): Promise<void> {
+  if (record.authorizationRef.type !== "principal" || !record.authorizationRef.credential) return
+
+  const { principal, credential } = record.authorizationRef
+  if (credential.type === "session") {
+    const session = await lookup.auth.sessions.getById({
+      projectId: record.projectId,
+      id: credential.id,
+    })
+    if (!session) {
+      throw new ExecutionStorageError(
+        "missing_credential",
+        `[Sixb] Authority session '${credential.id}' does not exist in project '${record.projectId}'.`
+      )
+    }
+    if (principal.type !== "user" || session.userId !== principal.id) {
+      throw new ExecutionStorageError(
+        "invalid_credential",
+        `[Sixb] Authority session '${credential.id}' does not belong to principal '${principal.id}'.`
+      )
+    }
+    return
+  }
+
+  const token = await lookup.auth.accessTokens.getById({
+    projectId: record.projectId,
+    id: credential.id,
+  })
+  if (!token) {
+    throw new ExecutionStorageError(
+      "missing_credential",
+      `[Sixb] Authority access token '${credential.id}' does not exist in project '${record.projectId}'.`
+    )
+  }
+  if (token.subjectType !== principal.type || token.subjectId !== principal.id) {
+    throw new ExecutionStorageError(
+      "invalid_credential",
+      `[Sixb] Authority access token '${credential.id}' does not belong to principal '${principal.id}'.`
+    )
+  }
+}
+
+async function validateParent(
+  record: ExecutionRecord,
+  lookup: ExecutionValidationLookup
+): Promise<void> {
+  if (!record.parentExecutionId) return
+
+  const parent = await lookup.getExecution({
+    projectId: record.projectId,
+    id: record.parentExecutionId,
+  })
+  if (!parent) {
+    throw new ExecutionStorageError(
+      "missing_parent_execution",
+      `[Sixb] Parent execution '${record.parentExecutionId}' does not exist in project '${record.projectId}'.`
+    )
+  }
+  if (parent.correlationId !== record.correlationId) {
+    throw new ExecutionStorageError(
+      "invalid_parent_execution",
+      `[Sixb] Child execution '${record.id}' must preserve its parent correlation id.`
+    )
+  }
+  if (!principalsEqual(parent.requestedBy, record.requestedBy)) {
+    throw new ExecutionStorageError(
+      "invalid_parent_execution",
+      `[Sixb] Child execution '${record.id}' must preserve its parent requested-by principal.`
+    )
+  }
+}
+
+function assertPrincipal(principal: AuthorizablePrincipal, label: string): void {
+  if (principal.type !== "user" && principal.type !== "serviceAccount") {
+    invalid(`${label} has unsupported type '${String((principal as { type?: unknown }).type)}'.`)
+  }
+  assertNonBlank(principal.id, `${label} id`)
+}
+
+function assertKernelOperation(operation: KernelOperation, label: string): void {
+  if (operation.type !== "ontology.recover") {
+    invalid(`${label} has unsupported type '${String((operation as { type?: unknown }).type)}'.`)
+  }
+  assertNonBlank(operation.recoveryId, `${label} recovery id`)
+}
+
+function assertTrustedPrimitiveKind(value: string, label: string): void {
+  if (!TRUSTED_PRIMITIVE_KINDS.has(value)) {
+    invalid(`${label} '${value}' is not supported.`)
+  }
+}
+
+function assertNonBlank(value: string, label: string): void {
+  if (typeof value !== "string" || !value.trim()) {
+    invalid(`${label} must be a non-empty string.`)
+  }
+}
+
+function assertValidDate(value: Date, label: string): void {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    invalid(`${label} must be a valid date.`)
+  }
+}
+
+function principalsEqual(
+  left: AuthorizablePrincipal | undefined,
+  right: AuthorizablePrincipal | undefined
+): boolean {
+  return left?.type === right?.type && left?.id === right?.id
+}
+
+function kernelOperationsEqual(left: KernelOperation, right: KernelOperation): boolean {
+  return left.type === right.type && left.recoveryId === right.recoveryId
+}
+
+function invalid(message: string): never {
+  throw new ExecutionStorageError("invalid_input", `[Sixb] ${message}`)
+}
+
+const TRUSTED_PRIMITIVE_KINDS = new Set([
+  "action",
+  "pipeline",
+  "projection",
+  "rule",
+  "sync",
+  "webhook",
+  "workflow",
+])

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -3,6 +3,8 @@ import { InMemoryActionRunStorage } from "../action-runs"
 import { type AgentStorage, InMemoryAgentStorage } from "../agents"
 import { type AuthStorage, InMemoryAuthStorage } from "../auth"
 import { StorageTransactionError } from "../errors"
+import { InMemoryExecutionStorage } from "../executions/in-memory"
+import type { ExecutionStorage } from "../executions/types"
 import { type FileUploadSessionStore, InMemoryFileUploadSessions } from "../file-upload-sessions"
 import type { ObjectStorage } from "../objects"
 import { InMemoryObjectStorage } from "../objects/in-memory"
@@ -51,6 +53,7 @@ export class InMemoryStorage implements Storage {
   private readonly timeseriesStorage = new InMemoryTimeseriesStorage()
   private readonly ontologyStorage: InMemoryOntologyStorage
   private readonly authStorage = new InMemoryAuthStorage()
+  private readonly executionStorage = new InMemoryExecutionStorage(this.authStorage)
   private readonly agentStorage = new InMemoryAgentStorage()
   private readonly actionRunStorage = new InMemoryActionRunStorage()
   private readonly syncRunStorage = new InMemorySyncRunStorage()
@@ -63,6 +66,7 @@ export class InMemoryStorage implements Storage {
   private readonly rulesStorage = new InMemoryRulesStorage()
   private readonly fileUploadSessionStorage = new InMemoryFileUploadSessions()
   readonly auth: AuthStorage
+  readonly executions: ExecutionStorage
   readonly agents: AgentStorage
   readonly actionRuns: InMemoryActionRunStorage
   readonly syncRuns: SyncRunStorage
@@ -83,6 +87,7 @@ export class InMemoryStorage implements Storage {
     this.objects = createOperationScopedFacade(this.objectStorage, scope)
     this.timeseries = createOperationScopedFacade(this.timeseriesStorage, scope)
     this.auth = createAuthOperationScope(this.authStorage, scope)
+    this.executions = createOperationScopedFacade(this.executionStorage, scope)
     this.agents = createAgentOperationScope(this.agentStorage, scope)
     this.actionRuns = createOperationScopedFacade(this.actionRunStorage, scope)
     this.syncRuns = createOperationScopedFacade(this.syncRunStorage, scope)
@@ -221,6 +226,7 @@ export class InMemoryStorage implements Storage {
       timeseries: this.timeseriesStorage,
       ontology: this.ontologyStorage,
       auth: this.authStorage,
+      executions: this.executionStorage,
       agents: this.agentStorage,
       actionRuns: this.actionRunStorage,
       syncRuns: this.syncRunStorage,
@@ -245,6 +251,7 @@ export class InMemoryStorage implements Storage {
       timeseries: this.timeseriesStorage.snapshot(),
       ontology: this.ontologyStorage.snapshot(),
       auth: this.authStorage.snapshot(),
+      executions: this.executionStorage.snapshot(),
       agents: this.agentStorage.snapshot(),
       actionRuns: this.actionRunStorage.snapshot(),
       syncRuns: this.syncRunStorage.snapshot(),
@@ -264,6 +271,7 @@ export class InMemoryStorage implements Storage {
     this.timeseriesStorage.restore(snapshot.timeseries)
     this.ontologyStorage.restore(snapshot.ontology)
     this.authStorage.restore(snapshot.auth)
+    this.executionStorage.restore(snapshot.executions)
     this.agentStorage.restore(snapshot.agents)
     this.actionRunStorage.restore(snapshot.actionRuns)
     this.syncRunStorage.restore(snapshot.syncRuns)
@@ -283,6 +291,7 @@ export interface InMemoryStorageSnapshot {
   readonly timeseries: ReturnType<InMemoryTimeseriesStorage["snapshot"]>
   readonly ontology: ReturnType<InMemoryOntologyStorage["snapshot"]>
   readonly auth: ReturnType<InMemoryAuthStorage["snapshot"]>
+  readonly executions: ReturnType<InMemoryExecutionStorage["snapshot"]>
   readonly agents: ReturnType<InMemoryAgentStorage["snapshot"]>
   readonly actionRuns: ReturnType<InMemoryActionRunStorage["snapshot"]>
   readonly syncRuns: ReturnType<InMemorySyncRunStorage["snapshot"]>

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -151,6 +151,20 @@ export {
   StorageTransactionError,
 } from "./errors"
 export type {
+  AuthorizablePrincipal,
+  AuthorizationRef,
+  CreateExecutionInput,
+  DurableExecutionExecutor,
+  DurableExecutionSource,
+  ExecutionRecord,
+  ExecutionStorage,
+  ExecutionStorageErrorCode,
+  KernelOperation,
+  TrustedPrimitiveKind,
+  TrustedPrimitiveRef,
+} from "./executions"
+export { ExecutionStorageError } from "./executions"
+export type {
   CreateFileUploadSessionInput,
   FileUploadSession,
   FileUploadSessionErrorReason,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,6 +1,7 @@
 import type { ActionRunStorage } from "./action-runs"
 import type { AgentStorage } from "./agents"
 import type { AuthStorage } from "./auth"
+import type { ExecutionStorage } from "./executions"
 import type { FileUploadSessionStore } from "./file-upload-sessions"
 import type { ObjectStorage } from "./objects/types"
 import type { OntologyStorage } from "./ontology"
@@ -264,6 +265,7 @@ export interface Storage {
   objects: ObjectStorage
   timeseries: TimeseriesStorage
   ontology: OntologyStorage
+  executions: ExecutionStorage
   auth?: AuthStorage
   agents?: AgentStorage
   actionRuns?: ActionRunStorage

--- a/packages/core/src/testing/execution-storage-contract.ts
+++ b/packages/core/src/testing/execution-storage-contract.ts
@@ -1,0 +1,432 @@
+import { describe, expect, test } from "bun:test"
+import type { AuthStorage } from "../storage/auth"
+import type {
+  CreateExecutionInput,
+  ExecutionStorage,
+  TrustedPrimitiveKind,
+} from "../storage/executions"
+import type { Storage } from "../storage/types"
+
+export type ExecutionStorageContractStorage = Storage & {
+  readonly auth: AuthStorage
+  readonly executions: ExecutionStorage
+}
+
+export interface ExecutionStorageContractSuiteOptions<
+  TStorage extends ExecutionStorageContractStorage = ExecutionStorageContractStorage,
+> {
+  /** Factory that returns one isolated, migrated storage bundle for each test. */
+  readonly createStorage: () => TStorage | Promise<TStorage>
+  readonly cleanup?: (storage: TStorage) => void | Promise<void>
+}
+
+const projectId = "execution-contract"
+const createdAt = new Date("2026-06-01T12:00:00.000Z")
+const expiresAt = new Date("2027-06-01T12:00:00.000Z")
+
+/** Runs the immutable execution-ledger contract against one complete storage provider. */
+export function runExecutionStorageContractSuite<TStorage extends ExecutionStorageContractStorage>(
+  label: string,
+  options: ExecutionStorageContractSuiteOptions<TStorage>
+): void {
+  const withStorage = async (body: (storage: TStorage) => Promise<void>): Promise<void> => {
+    const storage = await options.createStorage()
+    try {
+      await body(storage)
+    } finally {
+      await options.cleanup?.(storage)
+    }
+  }
+
+  describe(label, () => {
+    test("round-trips every durable executor and authority shape", async () => {
+      await withStorage(async (storage) => {
+        await seedAuth(storage.auth)
+
+        const records = [
+          principalRequest({
+            id: "principal-request",
+            credential: { type: "session", id: "session-user" },
+          }),
+          principalRequest({
+            id: "service-request",
+            principal: { type: "serviceAccount", id: "service-one" },
+            credential: { type: "accessToken", id: "token-service" },
+          }),
+          disabledRequest("disabled-request"),
+          ...trustedPrimitiveKinds.map((kind) => trustedPrimitive(`${kind}-execution`, {}, kind)),
+          agentExecution("agent-execution"),
+          kernelExecution("kernel-execution"),
+        ] as const
+
+        for (const input of records) {
+          const creationStartedAt = new Date()
+          const created = await storage.executions.create(input)
+          const { createdAt: persistedAt, ...persistedInput } = created
+          expect(persistedInput).toEqual(input)
+          expect(Number.isFinite(persistedAt.getTime())).toBe(true)
+          expect(persistedAt.getTime()).toBeGreaterThanOrEqual(creationStartedAt.getTime())
+          expect(
+            await storage.executions.getById({ projectId: input.projectId, id: input.id })
+          ).toEqual(created)
+        }
+
+        const first = await storage.executions.getById({ projectId, id: "principal-request" })
+        if (!first || first.authorizationRef.type !== "principal") {
+          throw new Error("Expected principal execution fixture")
+        }
+        const persisted = structuredClone(first)
+        ;(first.authorizationRef.principal as { id: string }).id = "mutated"
+        first.createdAt.setUTCFullYear(2000)
+        expect(await storage.executions.getById({ projectId, id: first.id })).toEqual(persisted)
+      })
+    })
+
+    test("keeps execution identity immutable and project-scoped", async () => {
+      await withStorage(async (storage) => {
+        const first = disabledRequest("shared-id")
+        await storage.executions.create(first)
+
+        await expect(storage.executions.create(first)).rejects.toMatchObject({
+          code: "duplicate_execution",
+        })
+
+        const otherProject = disabledRequest("shared-id", "execution-contract-other")
+        await expect(storage.executions.create(otherProject)).resolves.toMatchObject({
+          projectId: otherProject.projectId,
+        })
+        expect(
+          await storage.executions.getById({ projectId: "missing-project", id: first.id })
+        ).toBeNull()
+
+        const backdated = await storage.executions.create({
+          ...disabledRequest("caller-timestamp"),
+          createdAt: new Date("2000-01-01T00:00:00.000Z"),
+        } as CreateExecutionInput)
+        expect(backdated.createdAt.getUTCFullYear()).not.toBe(2000)
+      })
+    })
+
+    test("admits exactly one concurrent create for an execution id", async () => {
+      await withStorage(async (storage) => {
+        const input = disabledRequest("concurrent-id")
+        const results = await Promise.allSettled([
+          storage.executions.create(input),
+          storage.executions.create(input),
+        ])
+
+        expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1)
+        const [rejected] = results.filter((result) => result.status === "rejected")
+        expect(rejected?.reason).toMatchObject({ code: "duplicate_execution" })
+      })
+    })
+
+    test("rejects non-durable sources and executor-authority mismatches", async () => {
+      await withStorage(async (storage) => {
+        await seedAuth(storage.auth)
+
+        const invalidInputs: readonly CreateExecutionInput[] = [
+          {
+            ...disabledRequest("queue-source"),
+            source: { type: "queue", queue: "actions", jobId: "job-1" },
+          } as unknown as CreateExecutionInput,
+          {
+            ...disabledRequest("wrong-request-source"),
+            source: { type: "http", requestId: "different-request" },
+          },
+          {
+            ...disabledRequest("principal-missing-requester"),
+            authorizationRef: {
+              type: "principal",
+              principal: { type: "user", id: "user-one" },
+            },
+          },
+          {
+            ...trustedPrimitive("untrusted-primitive"),
+            authorizationRef: { type: "disabled" },
+          },
+          {
+            ...agentExecution("user-agent"),
+            authorizationRef: {
+              type: "principal",
+              principal: { type: "user", id: "user-one" },
+            },
+          },
+          {
+            ...kernelExecution("requested-kernel"),
+            requestedBy: { type: "user", id: "user-one" },
+          },
+        ]
+
+        for (const input of invalidInputs) {
+          await expect(storage.executions.create(input)).rejects.toMatchObject({
+            code: "invalid_input",
+          })
+        }
+      })
+    })
+
+    test("requires every principal and verifies credential ownership", async () => {
+      await withStorage(async (storage) => {
+        await seedAuth(storage.auth)
+
+        await expect(
+          storage.executions.create(
+            principalRequest({
+              id: "missing-principal",
+              principal: { type: "user", id: "unknown-user" },
+            })
+          )
+        ).rejects.toMatchObject({ code: "missing_principal" })
+
+        await expect(
+          storage.executions.create(
+            principalRequest({
+              id: "missing-session",
+              credential: { type: "session", id: "missing-session" },
+            })
+          )
+        ).rejects.toMatchObject({ code: "missing_credential" })
+
+        await expect(
+          storage.executions.create(
+            principalRequest({
+              id: "wrong-session-owner",
+              credential: { type: "session", id: "session-other" },
+            })
+          )
+        ).rejects.toMatchObject({ code: "invalid_credential" })
+
+        await expect(
+          storage.executions.create({
+            ...trustedPrimitive("missing-requester"),
+            requestedBy: { type: "user", id: "unknown-user" },
+          })
+        ).rejects.toMatchObject({ code: "missing_principal" })
+      })
+    })
+
+    test("requires children to preserve direct parent provenance", async () => {
+      await withStorage(async (storage) => {
+        await seedAuth(storage.auth)
+        await storage.executions.create(principalRequest({ id: "parent" }))
+
+        const validChild = trustedPrimitive("valid-child", {
+          parentExecutionId: "parent",
+          correlationId: "correlation-parent",
+          source: { type: "execution", executionId: "parent" },
+        })
+        await expect(storage.executions.create(validChild)).resolves.toMatchObject({
+          parentExecutionId: "parent",
+        })
+
+        const invalidChildren: readonly [CreateExecutionInput, string][] = [
+          [
+            trustedPrimitive("missing-parent", {
+              parentExecutionId: "unknown-parent",
+              source: { type: "execution", executionId: "unknown-parent" },
+            }),
+            "missing_parent_execution",
+          ],
+          [
+            trustedPrimitive("wrong-correlation", {
+              parentExecutionId: "parent",
+              correlationId: "different-correlation",
+              source: { type: "execution", executionId: "parent" },
+            }),
+            "invalid_parent_execution",
+          ],
+          [
+            trustedPrimitive("wrong-requester", {
+              parentExecutionId: "parent",
+              requestedBy: { type: "user", id: "user-other" },
+              source: { type: "execution", executionId: "parent" },
+            }),
+            "invalid_parent_execution",
+          ],
+        ]
+
+        for (const [input, code] of invalidChildren) {
+          await expect(storage.executions.create(input)).rejects.toMatchObject({ code })
+        }
+      })
+    })
+
+    test("participates in storage transactions and rollback", async () => {
+      await withStorage(async (storage) => {
+        await expect(
+          storage.transaction(async (tx) => {
+            await tx.executions.create(disabledRequest("rolled-back"))
+            throw new Error("rollback")
+          })
+        ).rejects.toThrow("rollback")
+        expect(await storage.executions.getById({ projectId, id: "rolled-back" })).toBeNull()
+
+        await storage.transaction((tx) => tx.executions.create(disabledRequest("committed")))
+        expect(await storage.executions.getById({ projectId, id: "committed" })).not.toBeNull()
+      })
+    })
+  })
+}
+
+async function seedAuth(auth: AuthStorage): Promise<void> {
+  await auth.users.create({
+    id: "user-one",
+    projectId,
+    email: "one@example.com",
+    createdAt,
+    updatedAt: createdAt,
+  })
+  await auth.users.create({
+    id: "user-other",
+    projectId,
+    email: "other@example.com",
+    createdAt,
+    updatedAt: createdAt,
+  })
+  await auth.serviceAccounts.create({
+    id: "service-one",
+    projectId,
+    name: "Service one",
+    createdAt,
+    updatedAt: createdAt,
+  })
+  await auth.sessions.create({
+    id: "session-user",
+    projectId,
+    userId: "user-one",
+    strategyId: "contract",
+    audience: "atlas",
+    tokenHash: "session-user-hash",
+    createdAt,
+    expiresAt,
+  })
+  await auth.sessions.create({
+    id: "session-other",
+    projectId,
+    userId: "user-other",
+    strategyId: "contract",
+    audience: "atlas",
+    tokenHash: "session-other-hash",
+    createdAt,
+    expiresAt,
+  })
+  await auth.accessTokens.create({
+    id: "token-service",
+    projectId,
+    name: "Service token",
+    kind: "serviceAccount",
+    subjectType: "serviceAccount",
+    subjectId: "service-one",
+    tokenHash: "service-token-hash",
+    createdAt,
+    expiresAt,
+  })
+}
+
+function principalRequest(input: {
+  readonly id: string
+  readonly principal?: { readonly type: "user" | "serviceAccount"; readonly id: string }
+  readonly credential?:
+    | { readonly type: "session"; readonly id: string }
+    | { readonly type: "accessToken"; readonly id: string }
+}): CreateExecutionInput {
+  const principal = input.principal ?? ({ type: "user", id: "user-one" } as const)
+  return {
+    id: input.id,
+    projectId,
+    requestedBy: principal,
+    executor: { type: "request", requestId: `request-${input.id}` },
+    source: { type: "http", requestId: `request-${input.id}` },
+    correlationId: input.id === "parent" ? "correlation-parent" : `correlation-${input.id}`,
+    authorizationRef: {
+      type: "principal",
+      principal,
+      ...(input.credential === undefined ? {} : { credential: input.credential }),
+    },
+  }
+}
+
+function disabledRequest(id: string, inputProjectId = projectId): CreateExecutionInput {
+  return {
+    id,
+    projectId: inputProjectId,
+    executor: { type: "request", requestId: `request-${id}` },
+    source: { type: "http", requestId: `request-${id}` },
+    correlationId: `correlation-${id}`,
+    authorizationRef: { type: "disabled" },
+  }
+}
+
+function trustedPrimitive(
+  id: string,
+  overrides: Partial<
+    Pick<CreateExecutionInput, "correlationId" | "parentExecutionId" | "requestedBy" | "source">
+  > = {},
+  kind: TrustedPrimitiveKind = "action"
+): CreateExecutionInput {
+  const runId = `run-${id}`
+  return {
+    id,
+    projectId,
+    requestedBy: { type: "user", id: "user-one" },
+    executor: { type: "primitive", kind, runId },
+    source: trustedPrimitiveSource(kind, id),
+    correlationId: `correlation-${id}`,
+    authorizationRef: {
+      type: "trustedPrimitive",
+      primitive: { kind, id: `contract.${kind}`, runId },
+    },
+    ...overrides,
+  }
+}
+
+function trustedPrimitiveSource(
+  kind: TrustedPrimitiveKind,
+  id: string
+): CreateExecutionInput["source"] {
+  if (kind === "pipeline") {
+    return { type: "schedule", eventId: `schedule-event-${id}` }
+  }
+  if (kind === "webhook") {
+    return { type: "webhook", deliveryId: `delivery-${id}` }
+  }
+  return { type: "event", eventId: `event-${id}` }
+}
+
+const trustedPrimitiveKinds = [
+  "action",
+  "pipeline",
+  "projection",
+  "rule",
+  "sync",
+  "webhook",
+  "workflow",
+] as const satisfies readonly TrustedPrimitiveKind[]
+
+function agentExecution(id: string): CreateExecutionInput {
+  return {
+    id,
+    projectId,
+    requestedBy: { type: "user", id: "user-one" },
+    executor: { type: "agent", runId: `run-${id}` },
+    source: { type: "event", eventId: `event-${id}` },
+    correlationId: `correlation-${id}`,
+    authorizationRef: {
+      type: "principal",
+      principal: { type: "serviceAccount", id: "service-one" },
+    },
+  }
+}
+
+function kernelExecution(id: string): CreateExecutionInput {
+  const operation = { type: "ontology.recover", recoveryId: `recovery-${id}` } as const
+  return {
+    id,
+    projectId,
+    executor: { type: "kernel", operation },
+    source: { type: "event", eventId: `event-${id}` },
+    correlationId: `correlation-${id}`,
+    authorizationRef: { type: "kernel", operation },
+  }
+}

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -25,6 +25,11 @@ export {
   type TestExecutionOptions,
 } from "./execution"
 export {
+  type ExecutionStorageContractStorage,
+  type ExecutionStorageContractSuiteOptions,
+  runExecutionStorageContractSuite,
+} from "./execution-storage-contract"
+export {
   type LakeMergeStorageContractSuiteOptions,
   runLakeMergeStorageContractSuite,
 } from "./lake-merge-storage-contract"

--- a/packages/core/tests/execution-storage-contract.test.ts
+++ b/packages/core/tests/execution-storage-contract.test.ts
@@ -1,0 +1,6 @@
+import { InMemoryStorage } from "@sixb/core"
+import { runExecutionStorageContractSuite } from "../src/testing"
+
+runExecutionStorageContractSuite("InMemoryStorage execution ledger", {
+  createStorage: () => new InMemoryStorage(),
+})

--- a/storage/pg/README.md
+++ b/storage/pg/README.md
@@ -3,8 +3,9 @@
 PostgreSQL storage provider for Sixb.
 
 One shared connection pool (porsager `postgres`) backs every Sixb store: objects, ontology commits,
-auth, agents, timeseries, and the run history for actions, syncs, pipelines, projections, workflows,
-and webhooks. This is the provider to use for anything you intend to operate.
+auth, agents, the immutable execution ledger, timeseries, and the run history for actions, syncs,
+pipelines, projections, workflows, and webhooks. This is the provider to use for anything you intend
+to operate.
 
 ## Install
 
@@ -33,10 +34,10 @@ other applications; it is pinned through `search_path` on every pooled connectio
 `PostgresStorage` exposes core's `StorageMigrator` contract. The CLI runs it at startup and
 `sixb db migrate` runs it on demand — you do not write migrations, they ship inside this package.
 
-Before 1.0 the schema is a single migration whose checksum is verified at boot. A schema change
-**replaces** that migration instead of adding another, so moving between 0.x versions can require
-recreating the database. `dropSchema()` exists for exactly that, and for test teardown — it deletes
-every Sixb table and the schema itself.
+Applied migrations are checksummed. Schema changes ship as new ordered steps; changing an already
+applied step fails startup instead of silently rewriting migration history. Before 1.0, an explicitly
+breaking migration may still require recreating the database. `dropSchema()` exists for exactly
+that, and for test teardown — it deletes every Sixb table and the schema itself.
 
 ## Pooling and timeouts
 

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -30,6 +30,7 @@ import { createPostgresStorageMigrators, dropSchema } from "./migrations"
 import { PgOntologyStorage, type PgOntologyTransactionContext } from "./ontology-storage"
 import { PgActionRunStorage } from "./pg-action-run-storage"
 import { createPgClient, type SQL, type SQLClient } from "./pg-client"
+import { PgExecutionStorage } from "./pg-execution-storage"
 import { PgObjectStorage } from "./pg-object-storage"
 import { PgPipelineRunStorage } from "./pg-pipeline-run-storage"
 import { PgProjectionRunStorage } from "./pg-projection-run-storage"
@@ -128,6 +129,7 @@ export class PostgresStorage implements MigrationCapableStorage {
   readonly objects: ObjectStorage
   readonly ontology: PgOntologyStorage
   readonly auth: PgAuthStorage
+  readonly executions: PgExecutionStorage
   readonly agents: PgAgentStorage
   readonly actionRuns: PgActionRunStorage
   readonly pipelineRuns: PgPipelineRunStorage
@@ -199,6 +201,7 @@ export class PostgresStorage implements MigrationCapableStorage {
     this.objects = createOperationScopedFacade(stores.objects, scope)
     this.ontology = createOntologyOperationScope(stores.ontology, scope)
     this.auth = createAuthOperationScope(stores.auth, scope)
+    this.executions = createOperationScopedFacade(stores.executions, scope)
     this.agents = createAgentOperationScope(stores.agents, scope)
     this.actionRuns = createOperationScopedFacade(stores.actionRuns, scope)
     this.pipelineRuns = createOperationScopedFacade(stores.pipelineRuns, scope)
@@ -313,6 +316,7 @@ function createPostgresStores(
     readonly transactionContext: PgOntologyTransactionContext | null
   }
 ): PostgresStoreSet {
+  const auth = new PgAuthStorage({ sql })
   return {
     objects: new PgObjectStorage(sql),
     ontology: new PgOntologyStorage({
@@ -320,7 +324,8 @@ function createPostgresStores(
       runRootOperation: options.runOntologyOperation,
       transactionContext: options.transactionContext,
     }),
-    auth: new PgAuthStorage({ sql }),
+    auth,
+    executions: new PgExecutionStorage(sql, auth),
     agents: new PgAgentStorage({ sql }),
     actionRuns: new PgActionRunStorage(sql),
     pipelineRuns: new PgPipelineRunStorage(sql),
@@ -339,6 +344,7 @@ interface PostgresStoreSet {
   readonly objects: PgObjectStorage
   readonly ontology: PgOntologyStorage
   readonly auth: PgAuthStorage
+  readonly executions: PgExecutionStorage
   readonly agents: PgAgentStorage
   readonly actionRuns: PgActionRunStorage
   readonly pipelineRuns: PgPipelineRunStorage

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -16,6 +16,7 @@ import {
 import initialSchemaSql from "./migrations/001-initial-schema.sql" with { type: "text" }
 import workflowRunOutputSql from "./migrations/002-workflow-run-output.sql" with { type: "text" }
 import mergeSyncRunsSql from "./migrations/003-merge-sync-runs.sql" with { type: "text" }
+import executionsSql from "./migrations/004-executions.sql" with { type: "text" }
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -272,6 +273,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("001-initial-schema", initialSchemaSql),
     pgSql("002-workflow-run-output", workflowRunOutputSql),
     pgSql("003-merge-sync-runs", mergeSyncRunsSql),
+    pgSql("004-executions", executionsSql),
   ],
 })
 

--- a/storage/pg/src/migrations/004-executions.sql
+++ b/storage/pg/src/migrations/004-executions.sql
@@ -1,0 +1,140 @@
+CREATE TABLE executions (
+  project_id TEXT NOT NULL CHECK (length(trim(project_id)) > 0),
+  id TEXT NOT NULL CHECK (length(trim(id)) > 0),
+
+  executor_kind TEXT NOT NULL CHECK (
+    executor_kind IN (
+      'request', 'action', 'pipeline', 'projection', 'rule', 'sync', 'webhook', 'workflow',
+      'agent', 'kernel'
+    )
+  ),
+  executor_id TEXT NOT NULL CHECK (length(trim(executor_id)) > 0),
+  source_kind TEXT NOT NULL CHECK (
+    source_kind IN ('http', 'webhook', 'schedule', 'event', 'execution')
+  ),
+  source_id TEXT NOT NULL CHECK (length(trim(source_id)) > 0),
+
+  requested_by_user_id TEXT,
+  requested_by_service_account_id TEXT,
+  correlation_id TEXT NOT NULL CHECK (length(trim(correlation_id)) > 0),
+  parent_execution_id TEXT,
+
+  authority_kind TEXT NOT NULL CHECK (
+    authority_kind IN ('principal', 'trustedPrimitive', 'kernel', 'disabled')
+  ),
+  authority_user_id TEXT,
+  authority_service_account_id TEXT,
+  authority_session_id TEXT,
+  authority_access_token_id TEXT,
+  authority_primitive_kind TEXT CHECK (
+    authority_primitive_kind IS NULL
+      OR authority_primitive_kind IN (
+        'action', 'pipeline', 'projection', 'rule', 'sync', 'webhook', 'workflow'
+      )
+  ),
+  authority_primitive_id TEXT,
+  authority_kernel_operation TEXT CHECK (
+    authority_kernel_operation IS NULL OR authority_kernel_operation = 'ontology.recover'
+  ),
+
+  created_at TIMESTAMPTZ NOT NULL,
+
+  PRIMARY KEY (project_id, id),
+  FOREIGN KEY (project_id, parent_execution_id)
+    REFERENCES executions (project_id, id),
+  FOREIGN KEY (project_id, requested_by_user_id)
+    REFERENCES auth_users (project_id, id),
+  FOREIGN KEY (project_id, requested_by_service_account_id)
+    REFERENCES auth_service_accounts (project_id, id),
+  FOREIGN KEY (project_id, authority_user_id)
+    REFERENCES auth_users (project_id, id),
+  FOREIGN KEY (project_id, authority_service_account_id)
+    REFERENCES auth_service_accounts (project_id, id),
+  FOREIGN KEY (project_id, authority_session_id)
+    REFERENCES auth_sessions (project_id, id),
+  FOREIGN KEY (project_id, authority_access_token_id)
+    REFERENCES auth_access_tokens (project_id, id),
+
+  CHECK (num_nonnulls(requested_by_user_id, requested_by_service_account_id) <= 1),
+  CHECK (
+    (source_kind = 'execution' AND parent_execution_id = source_id)
+      OR (source_kind <> 'execution' AND parent_execution_id IS NULL)
+  ),
+  CHECK (
+    (
+      authority_kind = 'principal'
+      AND num_nonnulls(authority_user_id, authority_service_account_id) = 1
+      AND num_nonnulls(authority_session_id, authority_access_token_id) <= 1
+      AND (authority_session_id IS NULL OR authority_user_id IS NOT NULL)
+      AND authority_primitive_kind IS NULL
+      AND authority_primitive_id IS NULL
+      AND authority_kernel_operation IS NULL
+    )
+    OR (
+      authority_kind = 'trustedPrimitive'
+      AND authority_user_id IS NULL
+      AND authority_service_account_id IS NULL
+      AND authority_session_id IS NULL
+      AND authority_access_token_id IS NULL
+      AND authority_primitive_kind IS NOT NULL
+      AND authority_primitive_id IS NOT NULL
+      AND length(trim(authority_primitive_id)) > 0
+      AND authority_kernel_operation IS NULL
+    )
+    OR (
+      authority_kind = 'kernel'
+      AND authority_user_id IS NULL
+      AND authority_service_account_id IS NULL
+      AND authority_session_id IS NULL
+      AND authority_access_token_id IS NULL
+      AND authority_primitive_kind IS NULL
+      AND authority_primitive_id IS NULL
+      AND authority_kernel_operation IS NOT NULL
+    )
+    OR (
+      authority_kind = 'disabled'
+      AND authority_user_id IS NULL
+      AND authority_service_account_id IS NULL
+      AND authority_session_id IS NULL
+      AND authority_access_token_id IS NULL
+      AND authority_primitive_kind IS NULL
+      AND authority_primitive_id IS NULL
+      AND authority_kernel_operation IS NULL
+    )
+  ),
+  CHECK (
+    (
+      executor_kind = 'request'
+      AND source_kind = 'http'
+      AND executor_id = source_id
+      AND (
+        (
+          authority_kind = 'principal'
+          AND requested_by_user_id IS NOT DISTINCT FROM authority_user_id
+          AND requested_by_service_account_id IS NOT DISTINCT FROM authority_service_account_id
+        )
+        OR (
+          authority_kind = 'disabled'
+          AND requested_by_user_id IS NULL
+          AND requested_by_service_account_id IS NULL
+        )
+      )
+    )
+    OR (
+      executor_kind IN ('action', 'pipeline', 'projection', 'rule', 'sync', 'webhook', 'workflow')
+      AND authority_kind = 'trustedPrimitive'
+      AND executor_kind = authority_primitive_kind
+    )
+    OR (
+      executor_kind = 'agent'
+      AND authority_kind = 'principal'
+      AND authority_service_account_id IS NOT NULL
+      AND authority_session_id IS NULL
+      AND authority_access_token_id IS NULL
+    )
+    OR (
+      executor_kind = 'kernel'
+      AND authority_kind = 'kernel'
+    )
+  )
+);

--- a/storage/pg/src/pg-execution-storage.ts
+++ b/storage/pg/src/pg-execution-storage.ts
@@ -1,0 +1,147 @@
+import {
+  type ExecutionStorageRow,
+  executionRecordFromStorageRow,
+  executionRecordToStorageRow,
+  normalizeExecutionRecord,
+  validateExecutionRecordReferences,
+} from "@sixb/core/internal/execution-storage"
+import type { CreateExecutionInput, ExecutionRecord, ExecutionStorage } from "@sixb/core/storage"
+import { ExecutionStorageError } from "@sixb/core/storage"
+import type { PgAuthStorage } from "./auth-storage"
+import { isUniqueViolation } from "./storage-errors"
+import type { PgStoreClient } from "./transactions"
+
+export class PgExecutionStorage implements ExecutionStorage {
+  constructor(
+    private readonly sql: PgStoreClient,
+    private readonly auth: PgAuthStorage
+  ) {}
+
+  async create(input: CreateExecutionInput): Promise<ExecutionRecord> {
+    const record = normalizeExecutionRecord(input)
+    await validateExecutionRecordReferences(record, {
+      auth: this.auth,
+      getExecution: (params) => this.getById(params),
+    })
+    const row = executionRecordToStorageRow(record)
+
+    try {
+      const [created] = await this.sql<PgExecutionRow[]>`
+        INSERT INTO executions (
+          project_id,
+          id,
+          executor_kind,
+          executor_id,
+          source_kind,
+          source_id,
+          requested_by_user_id,
+          requested_by_service_account_id,
+          correlation_id,
+          parent_execution_id,
+          authority_kind,
+          authority_user_id,
+          authority_service_account_id,
+          authority_session_id,
+          authority_access_token_id,
+          authority_primitive_kind,
+          authority_primitive_id,
+          authority_kernel_operation,
+          created_at
+        ) VALUES (
+          ${row.projectId},
+          ${row.id},
+          ${row.executorKind},
+          ${row.executorId},
+          ${row.sourceKind},
+          ${row.sourceId},
+          ${row.requestedByUserId},
+          ${row.requestedByServiceAccountId},
+          ${row.correlationId},
+          ${row.parentExecutionId},
+          ${row.authorityKind},
+          ${row.authorityUserId},
+          ${row.authorityServiceAccountId},
+          ${row.authoritySessionId},
+          ${row.authorityAccessTokenId},
+          ${row.authorityPrimitiveKind},
+          ${row.authorityPrimitiveId},
+          ${row.authorityKernelOperation},
+          ${row.createdAt}
+        )
+        RETURNING *
+      `
+
+      if (!created) {
+        throw new Error("[SixbPg] Execution insert returned no row.")
+      }
+      return executionRecordFromStorageRow(toStorageRow(created))
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        throw new ExecutionStorageError(
+          "duplicate_execution",
+          `[SixbPg] Execution '${record.id}' already exists in project '${record.projectId}'.`,
+          { cause: error }
+        )
+      }
+      throw error
+    }
+  }
+
+  async getById(params: {
+    readonly projectId: string
+    readonly id: string
+  }): Promise<ExecutionRecord | null> {
+    const [row] = await this.sql<PgExecutionRow[]>`
+      SELECT *
+      FROM executions
+      WHERE project_id = ${params.projectId} AND id = ${params.id}
+    `
+    return row ? executionRecordFromStorageRow(toStorageRow(row)) : null
+  }
+}
+
+function toStorageRow(row: PgExecutionRow): ExecutionStorageRow {
+  return {
+    projectId: row.project_id,
+    id: row.id,
+    executorKind: row.executor_kind,
+    executorId: row.executor_id,
+    sourceKind: row.source_kind,
+    sourceId: row.source_id,
+    requestedByUserId: row.requested_by_user_id,
+    requestedByServiceAccountId: row.requested_by_service_account_id,
+    correlationId: row.correlation_id,
+    parentExecutionId: row.parent_execution_id,
+    authorityKind: row.authority_kind,
+    authorityUserId: row.authority_user_id,
+    authorityServiceAccountId: row.authority_service_account_id,
+    authoritySessionId: row.authority_session_id,
+    authorityAccessTokenId: row.authority_access_token_id,
+    authorityPrimitiveKind: row.authority_primitive_kind,
+    authorityPrimitiveId: row.authority_primitive_id,
+    authorityKernelOperation: row.authority_kernel_operation,
+    createdAt: new Date(row.created_at),
+  }
+}
+
+interface PgExecutionRow {
+  readonly project_id: string
+  readonly id: string
+  readonly executor_kind: ExecutionStorageRow["executorKind"]
+  readonly executor_id: string
+  readonly source_kind: ExecutionStorageRow["sourceKind"]
+  readonly source_id: string
+  readonly requested_by_user_id: string | null
+  readonly requested_by_service_account_id: string | null
+  readonly correlation_id: string
+  readonly parent_execution_id: string | null
+  readonly authority_kind: ExecutionStorageRow["authorityKind"]
+  readonly authority_user_id: string | null
+  readonly authority_service_account_id: string | null
+  readonly authority_session_id: string | null
+  readonly authority_access_token_id: string | null
+  readonly authority_primitive_kind: ExecutionStorageRow["authorityPrimitiveKind"]
+  readonly authority_primitive_id: string | null
+  readonly authority_kernel_operation: ExecutionStorageRow["authorityKernelOperation"]
+  readonly created_at: Date | string
+}

--- a/storage/pg/tests/pg-execution-storage.e2e.ts
+++ b/storage/pg/tests/pg-execution-storage.e2e.ts
@@ -1,0 +1,10 @@
+import { runExecutionStorageContractSuite } from "@sixb/core/testing"
+import { createTestStorage } from "./helpers"
+
+runExecutionStorageContractSuite("PostgresStorage execution ledger", {
+  createStorage: async () => (await createTestStorage()).storage,
+  cleanup: async (storage) => {
+    await storage.dropSchema()
+    await storage.close()
+  },
+})

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -34,7 +34,12 @@ describe("Postgres storage migrations", () => {
         {
           adapterId: POSTGRES_STORAGE_ADAPTER_ID,
           status: "migrated",
-          applied: ["001-initial-schema", "002-workflow-run-output", "003-merge-sync-runs"],
+          applied: [
+            "001-initial-schema",
+            "002-workflow-run-output",
+            "003-merge-sync-runs",
+            "004-executions",
+          ],
         },
       ])
       expect(await readMigrationRows(schemaName)).toEqual([
@@ -58,6 +63,13 @@ describe("Postgres storage migrations", () => {
           id: "003-merge-sync-runs",
           status: "applied",
           version: 3,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "004-executions",
+          status: "applied",
+          version: 4,
         },
       ])
     })
@@ -368,7 +380,7 @@ describe("Postgres storage migrations", () => {
       expect(await migrator?.status()).toMatchObject({
         adapterId: POSTGRES_STORAGE_ADAPTER_ID,
         state: "current",
-        appliedVersion: 3,
+        appliedVersion: 4,
       })
     })
   })
@@ -411,6 +423,13 @@ describe("Postgres storage migrations", () => {
           id: "003-merge-sync-runs",
           status: "applied",
           version: 3,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "004-executions",
+          status: "applied",
+          version: 4,
         },
       ])
     } finally {

--- a/storage/sqlite/README.md
+++ b/storage/sqlite/README.md
@@ -2,10 +2,10 @@
 
 SQLite storage provider for Sixb, built on `bun:sqlite`.
 
-Backs every Sixb store — objects, ontology commits, auth, agents, timeseries, and the run history for
-actions, syncs, pipelines, projections, workflows, and webhooks — from a single local database file.
-This is the storage `bun create sixb` scaffolds, and part of what makes a fresh project run with no
-service to install.
+Backs every Sixb store — objects, ontology commits, auth, agents, the immutable execution ledger,
+timeseries, and the run history for actions, syncs, pipelines, projections, workflows, and webhooks
+— from a single local database file. This is the storage `bun create sixb` scaffolds, and part of
+what makes a fresh project run with no service to install.
 
 ## Install
 
@@ -33,9 +33,9 @@ empty.
 With a `path`, `SqliteStorage` exposes core's `StorageMigrator` contract and the CLI runs it at
 startup. You do not write migrations — they ship inside this package.
 
-Before 1.0 the schema is a single migration whose checksum is verified at boot. A schema change
-**replaces** that migration instead of adding another, so moving between 0.x versions can require
-deleting the database file and starting over.
+Applied migrations are checksummed. Schema changes ship as new ordered steps; changing an already
+applied step fails startup instead of silently rewriting migration history. Before 1.0, an explicitly
+breaking migration may still require deleting the database file and starting over.
 
 ## Transactions
 

--- a/storage/sqlite/src/execution-storage.ts
+++ b/storage/sqlite/src/execution-storage.ts
@@ -1,0 +1,158 @@
+import type { Database } from "bun:sqlite"
+import {
+  type ExecutionStorageRow,
+  executionRecordFromStorageRow,
+  executionRecordToStorageRow,
+  normalizeExecutionRecord,
+  validateExecutionRecordReferences,
+} from "@sixb/core/internal/execution-storage"
+import type { CreateExecutionInput, ExecutionRecord, ExecutionStorage } from "@sixb/core/storage"
+import { ExecutionStorageError } from "@sixb/core/storage"
+import type { SqliteAuthStorage } from "./auth-storage"
+
+export class SqliteExecutionStorage implements ExecutionStorage {
+  constructor(
+    private readonly db: Database,
+    private readonly auth: SqliteAuthStorage
+  ) {}
+
+  async create(input: CreateExecutionInput): Promise<ExecutionRecord> {
+    const record = normalizeExecutionRecord(input)
+    await validateExecutionRecordReferences(record, {
+      auth: this.auth,
+      getExecution: (params) => this.getById(params),
+    })
+    const row = executionRecordToStorageRow(record)
+
+    try {
+      this.db
+        .query(
+          `
+          INSERT INTO executions (
+            project_id,
+            id,
+            executor_kind,
+            executor_id,
+            source_kind,
+            source_id,
+            requested_by_user_id,
+            requested_by_service_account_id,
+            correlation_id,
+            parent_execution_id,
+            authority_kind,
+            authority_user_id,
+            authority_service_account_id,
+            authority_session_id,
+            authority_access_token_id,
+            authority_primitive_kind,
+            authority_primitive_id,
+            authority_kernel_operation,
+            created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+        )
+        .run(
+          row.projectId,
+          row.id,
+          row.executorKind,
+          row.executorId,
+          row.sourceKind,
+          row.sourceId,
+          row.requestedByUserId,
+          row.requestedByServiceAccountId,
+          row.correlationId,
+          row.parentExecutionId,
+          row.authorityKind,
+          row.authorityUserId,
+          row.authorityServiceAccountId,
+          row.authoritySessionId,
+          row.authorityAccessTokenId,
+          row.authorityPrimitiveKind,
+          row.authorityPrimitiveId,
+          row.authorityKernelOperation,
+          row.createdAt.toISOString()
+        )
+    } catch (error) {
+      if (isDuplicateExecutionError(error)) {
+        throw new ExecutionStorageError(
+          "duplicate_execution",
+          `[SixbSqlite] Execution '${record.id}' already exists in project '${record.projectId}'.`,
+          { cause: error }
+        )
+      }
+      throw error
+    }
+
+    return executionRecordFromStorageRow(row)
+  }
+
+  async getById(params: {
+    readonly projectId: string
+    readonly id: string
+  }): Promise<ExecutionRecord | null> {
+    const row = this.db
+      .query(
+        `
+        SELECT *
+        FROM executions
+        WHERE project_id = ? AND id = ?
+      `
+      )
+      .get(params.projectId, params.id) as SqliteExecutionRow | null
+
+    return row ? executionRecordFromStorageRow(toStorageRow(row)) : null
+  }
+}
+
+function toStorageRow(row: SqliteExecutionRow): ExecutionStorageRow {
+  return {
+    projectId: row.project_id,
+    id: row.id,
+    executorKind: row.executor_kind,
+    executorId: row.executor_id,
+    sourceKind: row.source_kind,
+    sourceId: row.source_id,
+    requestedByUserId: row.requested_by_user_id,
+    requestedByServiceAccountId: row.requested_by_service_account_id,
+    correlationId: row.correlation_id,
+    parentExecutionId: row.parent_execution_id,
+    authorityKind: row.authority_kind,
+    authorityUserId: row.authority_user_id,
+    authorityServiceAccountId: row.authority_service_account_id,
+    authoritySessionId: row.authority_session_id,
+    authorityAccessTokenId: row.authority_access_token_id,
+    authorityPrimitiveKind: row.authority_primitive_kind,
+    authorityPrimitiveId: row.authority_primitive_id,
+    authorityKernelOperation: row.authority_kernel_operation,
+    createdAt: new Date(row.created_at),
+  }
+}
+
+function isDuplicateExecutionError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("UNIQUE constraint failed: executions.project_id, executions.id")
+  )
+}
+
+interface SqliteExecutionRow {
+  readonly project_id: string
+  readonly id: string
+  readonly executor_kind: ExecutionStorageRow["executorKind"]
+  readonly executor_id: string
+  readonly source_kind: ExecutionStorageRow["sourceKind"]
+  readonly source_id: string
+  readonly requested_by_user_id: string | null
+  readonly requested_by_service_account_id: string | null
+  readonly correlation_id: string
+  readonly parent_execution_id: string | null
+  readonly authority_kind: ExecutionStorageRow["authorityKind"]
+  readonly authority_user_id: string | null
+  readonly authority_service_account_id: string | null
+  readonly authority_session_id: string | null
+  readonly authority_access_token_id: string | null
+  readonly authority_primitive_kind: ExecutionStorageRow["authorityPrimitiveKind"]
+  readonly authority_primitive_id: string | null
+  readonly authority_kernel_operation: ExecutionStorageRow["authorityKernelOperation"]
+  readonly created_at: string
+}

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -26,6 +26,7 @@ import {
 import { SqliteActionRunStorage } from "./action-run-storage"
 import { SqliteAgentStorage } from "./agents"
 import { SqliteAuthStorage } from "./auth-storage"
+import { SqliteExecutionStorage } from "./execution-storage"
 import {
   createSqliteStorageMigrators,
   installFreshSqliteSchema,
@@ -57,8 +58,8 @@ export interface SqliteStorageOptions {
 /**
  * SQLite storage provider for Sixb.
  *
- * Bundles object, timeseries, auth, sync run, pipeline run, projection run, workflow run, webhook
- * run, and webhook delivery storage backed by SQLite.
+ * Bundles object, timeseries, auth, execution, sync run, pipeline run, projection run, workflow
+ * run, webhook run, and webhook delivery storage backed by SQLite.
  *
  * Usage:
  * ```ts
@@ -74,6 +75,7 @@ export class SqliteStorage implements MigrationCapableStorage {
   readonly objects: Storage["objects"]
   readonly ontology: SqliteOntologyStorage
   readonly auth: SqliteAuthStorage
+  readonly executions: SqliteExecutionStorage
   readonly agents: SqliteAgentStorage
   readonly actionRuns: SqliteActionRunStorage
   readonly pipelineRuns: SqlitePipelineRunStorage
@@ -115,6 +117,7 @@ export class SqliteStorage implements MigrationCapableStorage {
     this.objects = createOperationScopedFacade(stores.objects, scope)
     this.ontology = createOntologyOperationScope(stores.ontology, ontologyScope)
     this.auth = createAuthOperationScope(stores.auth, scope)
+    this.executions = createOperationScopedFacade(stores.executions, scope)
     this.agents = createAgentOperationScope(stores.agents, scope)
     this.actionRuns = createOperationScopedFacade(stores.actionRuns, scope)
     this.pipelineRuns = createOperationScopedFacade(stores.pipelineRuns, scope)
@@ -250,6 +253,7 @@ function createSqliteStores(
     readonly transactionContext: SqliteOntologyTransactionContext | null
   }
 ): SqliteStoreSet {
+  const auth = new SqliteAuthStorage({ connection })
   return {
     objects: new SqliteObjectStorage({ connection }),
     ontology: new SqliteOntologyStorage({
@@ -257,7 +261,8 @@ function createSqliteStores(
       runRootOperation: options.runOntologyOperation,
       transactionContext: options.transactionContext,
     }),
-    auth: new SqliteAuthStorage({ connection }),
+    auth,
+    executions: new SqliteExecutionStorage(connection.db, auth),
     agents: new SqliteAgentStorage({ connection }),
     actionRuns: new SqliteActionRunStorage({ connection }),
     pipelineRuns: new SqlitePipelineRunStorage({ connection }),
@@ -276,6 +281,7 @@ interface SqliteStoreSet {
   readonly objects: SqliteObjectStorage
   readonly ontology: SqliteOntologyStorage
   readonly auth: SqliteAuthStorage
+  readonly executions: SqliteExecutionStorage
   readonly agents: SqliteAgentStorage
   readonly actionRuns: SqliteActionRunStorage
   readonly pipelineRuns: SqlitePipelineRunStorage

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -19,6 +19,7 @@ import {
 import initialSchemaSql from "./migrations/001-initial-schema.sql" with { type: "text" }
 import workflowRunOutputSql from "./migrations/002-workflow-run-output.sql" with { type: "text" }
 import mergeSyncRunsSql from "./migrations/003-merge-sync-runs.sql" with { type: "text" }
+import executionsSql from "./migrations/004-executions.sql" with { type: "text" }
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -42,6 +43,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("001-initial-schema", initialSchemaSql),
     sqliteSql("002-workflow-run-output", workflowRunOutputSql),
     sqliteSql("003-merge-sync-runs", mergeSyncRunsSql),
+    sqliteSql("004-executions", executionsSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/004-executions.sql
+++ b/storage/sqlite/src/migrations/004-executions.sql
@@ -1,0 +1,142 @@
+CREATE TABLE executions (
+  project_id TEXT NOT NULL CHECK (length(trim(project_id)) > 0),
+  id TEXT NOT NULL CHECK (length(trim(id)) > 0),
+
+  executor_kind TEXT NOT NULL CHECK (
+    executor_kind IN (
+      'request', 'action', 'pipeline', 'projection', 'rule', 'sync', 'webhook', 'workflow',
+      'agent', 'kernel'
+    )
+  ),
+  executor_id TEXT NOT NULL CHECK (length(trim(executor_id)) > 0),
+  source_kind TEXT NOT NULL CHECK (
+    source_kind IN ('http', 'webhook', 'schedule', 'event', 'execution')
+  ),
+  source_id TEXT NOT NULL CHECK (length(trim(source_id)) > 0),
+
+  requested_by_user_id TEXT,
+  requested_by_service_account_id TEXT,
+  correlation_id TEXT NOT NULL CHECK (length(trim(correlation_id)) > 0),
+  parent_execution_id TEXT,
+
+  authority_kind TEXT NOT NULL CHECK (
+    authority_kind IN ('principal', 'trustedPrimitive', 'kernel', 'disabled')
+  ),
+  authority_user_id TEXT,
+  authority_service_account_id TEXT,
+  authority_session_id TEXT,
+  authority_access_token_id TEXT,
+  authority_primitive_kind TEXT CHECK (
+    authority_primitive_kind IS NULL
+      OR authority_primitive_kind IN (
+        'action', 'pipeline', 'projection', 'rule', 'sync', 'webhook', 'workflow'
+      )
+  ),
+  authority_primitive_id TEXT,
+  authority_kernel_operation TEXT CHECK (
+    authority_kernel_operation IS NULL OR authority_kernel_operation = 'ontology.recover'
+  ),
+
+  created_at TEXT NOT NULL,
+
+  PRIMARY KEY (project_id, id),
+  FOREIGN KEY (project_id, parent_execution_id)
+    REFERENCES executions (project_id, id),
+  FOREIGN KEY (project_id, requested_by_user_id)
+    REFERENCES auth_users (project_id, id),
+  FOREIGN KEY (project_id, requested_by_service_account_id)
+    REFERENCES auth_service_accounts (project_id, id),
+  FOREIGN KEY (project_id, authority_user_id)
+    REFERENCES auth_users (project_id, id),
+  FOREIGN KEY (project_id, authority_service_account_id)
+    REFERENCES auth_service_accounts (project_id, id),
+  FOREIGN KEY (project_id, authority_session_id)
+    REFERENCES auth_sessions (project_id, id),
+  FOREIGN KEY (project_id, authority_access_token_id)
+    REFERENCES auth_access_tokens (project_id, id),
+
+  CHECK (
+    (requested_by_user_id IS NOT NULL) + (requested_by_service_account_id IS NOT NULL) <= 1
+  ),
+  CHECK (
+    (source_kind = 'execution' AND parent_execution_id = source_id)
+      OR (source_kind <> 'execution' AND parent_execution_id IS NULL)
+  ),
+  CHECK (
+    (
+      authority_kind = 'principal'
+      AND (authority_user_id IS NOT NULL) + (authority_service_account_id IS NOT NULL) = 1
+      AND (authority_session_id IS NOT NULL) + (authority_access_token_id IS NOT NULL) <= 1
+      AND (authority_session_id IS NULL OR authority_user_id IS NOT NULL)
+      AND authority_primitive_kind IS NULL
+      AND authority_primitive_id IS NULL
+      AND authority_kernel_operation IS NULL
+    )
+    OR (
+      authority_kind = 'trustedPrimitive'
+      AND authority_user_id IS NULL
+      AND authority_service_account_id IS NULL
+      AND authority_session_id IS NULL
+      AND authority_access_token_id IS NULL
+      AND authority_primitive_kind IS NOT NULL
+      AND authority_primitive_id IS NOT NULL
+      AND length(trim(authority_primitive_id)) > 0
+      AND authority_kernel_operation IS NULL
+    )
+    OR (
+      authority_kind = 'kernel'
+      AND authority_user_id IS NULL
+      AND authority_service_account_id IS NULL
+      AND authority_session_id IS NULL
+      AND authority_access_token_id IS NULL
+      AND authority_primitive_kind IS NULL
+      AND authority_primitive_id IS NULL
+      AND authority_kernel_operation IS NOT NULL
+    )
+    OR (
+      authority_kind = 'disabled'
+      AND authority_user_id IS NULL
+      AND authority_service_account_id IS NULL
+      AND authority_session_id IS NULL
+      AND authority_access_token_id IS NULL
+      AND authority_primitive_kind IS NULL
+      AND authority_primitive_id IS NULL
+      AND authority_kernel_operation IS NULL
+    )
+  ),
+  CHECK (
+    (
+      executor_kind = 'request'
+      AND source_kind = 'http'
+      AND executor_id = source_id
+      AND (
+        (
+          authority_kind = 'principal'
+          AND requested_by_user_id IS authority_user_id
+          AND requested_by_service_account_id IS authority_service_account_id
+        )
+        OR (
+          authority_kind = 'disabled'
+          AND requested_by_user_id IS NULL
+          AND requested_by_service_account_id IS NULL
+        )
+      )
+    )
+    OR (
+      executor_kind IN ('action', 'pipeline', 'projection', 'rule', 'sync', 'webhook', 'workflow')
+      AND authority_kind = 'trustedPrimitive'
+      AND executor_kind = authority_primitive_kind
+    )
+    OR (
+      executor_kind = 'agent'
+      AND authority_kind = 'principal'
+      AND authority_service_account_id IS NOT NULL
+      AND authority_session_id IS NULL
+      AND authority_access_token_id IS NULL
+    )
+    OR (
+      executor_kind = 'kernel'
+      AND authority_kind = 'kernel'
+    )
+  )
+);

--- a/storage/sqlite/tests/sqlite-execution-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-execution-storage.test.ts
@@ -1,0 +1,7 @@
+import { runExecutionStorageContractSuite } from "@sixb/core/testing"
+import { SqliteStorage } from "../src"
+
+runExecutionStorageContractSuite("SqliteStorage execution ledger", {
+  createStorage: () => new SqliteStorage(),
+  cleanup: (storage) => storage.close(),
+})

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -36,6 +36,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 3,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "004-executions",
+    status: "applied",
+    version: 4,
+  },
 ]
 
 afterEach(async () => {
@@ -526,7 +533,7 @@ describe("SQLite migration status is read-only", () => {
     expect(await migrator?.status()).toMatchObject({
       adapterId: SQLITE_STORAGE_ADAPTER_ID,
       state: "current",
-      appliedVersion: 3,
+      appliedVersion: 4,
     })
 
     expect(statSync(path).mtimeMs).toBe(before)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -74,6 +74,9 @@
       "@sixb/core/internal/agent-execution": ["./packages/core/src/execution/agent.ts"],
       "@sixb/core/internal/primitive-execution": ["./packages/core/src/execution/primitive.ts"],
       "@sixb/core/internal/request-execution": ["./packages/core/src/execution/request.ts"],
+      "@sixb/core/internal/execution-storage": [
+        "./packages/core/src/storage/executions/provider.ts"
+      ],
       "@sixb/core/internal/query": ["./packages/core/src/objects/query/index.ts"],
       "@sixb/core/internal/rules": ["./packages/core/src/rules/internal.ts"],
       "@sixb/core/internal/runtime": ["./packages/core/src/runtime/internal.ts"],


### PR DESCRIPTION
## Stack

This PR is stacked on #368.

## Why

Workers cannot safely restore an execution from a queue payload alone. Before runs can carry and
restore authority, Sixb needs one immutable source of truth for execution identity, provenance, and
the durable authorization reference.

This slice adds that storage foundation without changing run lifecycles or dispatch yet.

```text
durable source ──> execution record ──> executor run
                       │
                       ├── requested-by + correlation + parent
                       └── durable AuthorizationRef
```

## What changes

- Adds the create/read-only `storage.executions` contract.
- Stores request, primitive, agent, and kernel executor identities.
- Stores only durable sources; transient queue delivery is explicitly rejected.
- Keeps runtime authorization capabilities process-local and persists only `AuthorizationRef`.
- Adds matching InMemory, SQLite, and PostgreSQL implementations.
- Adds append-only SQLite/PostgreSQL migration `004-executions` with relational constraints.
- Adds one shared provider contract covering every primitive kind, authority shape, parent
  propagation, credential ownership, transactions, isolation, defensive copies, and concurrent
  creation.
- Makes the storage boundary assign immutable `createdAt`; callers cannot backdate executions.

## Enforced invariants

| Area | Guarantee |
| --- | --- |
| Identity | One immutable execution ID per project |
| Authority | Principal, trusted primitive, agent, and kernel authority must match the executor |
| Credentials | Sessions and access tokens must belong to the recorded principal and project |
| Parentage | Children preserve the parent project, correlation, and requested-by principal |
| Durability | Queue delivery never becomes persisted authority |
| Atomicity | Execution writes participate in the provider transaction |

## What comes next

The next slice adds a unique execution ID to every durable run family and creates the child
execution and run atomically. Queue payload reduction and worker authority restoration remain in the
following dispatch slice.

Existing run rows are intentionally untouched: this PR does not fabricate authority for historical
data.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun run test:publish`
- Shared execution-storage contract on InMemory, SQLite, and PostgreSQL
- SQLite and PostgreSQL migration suites
