### PR TITLE
pipelines: expose step failure records in events

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -36,6 +36,7 @@ Webhook runs allow `internal.unexpected | webhook.delivery_failed`; only retryab
 failures use the delivery code. The idempotency journal and run reuse the same failure record.
 Expected non-retryable outcomes remain represented by their HTTP status and claim result.
 Workflow completion events reuse the exact failure stored on the run or node.
+Pipeline step completion events reuse the exact failure stored on the step run.
 The ontology outbox declares `event.delivery_failed`; its durable record is retained while publication
 is retried.
 

--- a/packages/client/tests/events-builder.types.ts
+++ b/packages/client/tests/events-builder.types.ts
@@ -283,6 +283,19 @@ events
   })
 
 events
+  .pipelines()
+  .run("run-1")
+  .subscribe((event) => {
+    if (event.type === "pipeline.run.step.finished" && event.payload.error) {
+      const code: "internal.unexpected" | "runtime.cancelled" = event.payload.error.code
+      const message: string = event.payload.error.message
+      // @ts-expect-error — pipeline step failures expose only their primitive's code union.
+      const datasetCode: "dataset.not_found" = event.payload.error.code
+      void [code, message, datasetCode]
+    }
+  })
+
+events
   .actions()
   .run("act-1")
   .action("approveQuote")

--- a/packages/core/src/events/types/pipelines.ts
+++ b/packages/core/src/events/types/pipelines.ts
@@ -1,3 +1,5 @@
+import type { SixbFailure } from "../../errors/types"
+import type { PipelineRunFailureCode } from "../../storage/pipeline-runs/types"
 import type { EventEnvelope } from "../envelope"
 
 export interface PipelineRunStartedEvent extends EventEnvelope {
@@ -43,7 +45,7 @@ export interface PipelineRunStepFinishedEvent extends EventEnvelope {
     finishedAt: string
     versionId?: string
     rowsWritten?: number
-    error?: string
+    error?: SixbFailure<PipelineRunFailureCode>
   }
 }
 

--- a/packages/core/tests/worker-run-events.test.ts
+++ b/packages/core/tests/worker-run-events.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, test } from "bun:test"
 import { InMemoryBroker } from "../src"
 import { DomainEventService, toStoredEvent } from "../src/events"
 
+const PIPELINE_STEP_FAILURE = {
+  code: "internal.unexpected",
+  retryable: false,
+  message: "Pipeline step failed.",
+  at: "2026-05-08T10:00:02.000Z",
+  details: {
+    pipelineId: "canonical-transactions",
+    pipelineRunId: "run-002",
+    stepId: "clean",
+    stepRunId: "run-002:step:1:clean",
+  },
+} as const
+
 describe("worker run lifecycle events", () => {
   test("stores sync run lifecycle events with sync topic and run partition", () => {
     const started = toStoredEvent({
@@ -121,5 +134,39 @@ describe("worker run lifecycle events", () => {
       "canonical-transactions:run-002",
       "canonical-transactions:run-002",
     ])
+  })
+
+  test("preserves the pipeline step failure record", async () => {
+    const eventsRuntime = new DomainEventService({
+      projectId: "project-a",
+      broker: new InMemoryBroker(),
+    })
+
+    await eventsRuntime.append({
+      events: [
+        {
+          type: "pipeline.run.step.finished",
+          payload: {
+            pipelineId: "canonical-transactions",
+            runId: "run-002",
+            stepRunId: "run-002:step:1:clean",
+            stepId: "clean",
+            stepIndex: 0,
+            totalSteps: 1,
+            datasetId: "canonical.transactions",
+            status: "failed",
+            finishedAt: "2026-05-08T10:00:02.000Z",
+            error: PIPELINE_STEP_FAILURE,
+          },
+        },
+      ],
+    })
+
+    const [event] = await eventsRuntime.read({ types: ["pipeline.run.step.finished"] })
+    expect(event?.type).toBe("pipeline.run.step.finished")
+    if (event?.type !== "pipeline.run.step.finished") {
+      throw new Error("Expected a pipeline step completion event.")
+    }
+    expect(event.payload.error).toEqual(PIPELINE_STEP_FAILURE)
   })
 })

--- a/packages/pipeline-worker/src/events.ts
+++ b/packages/pipeline-worker/src/events.ts
@@ -93,7 +93,7 @@ export async function emitPipelineRunStepFinished(
             finishedAt: requireFinishedAt(step.id, step.finishedAt).toISOString(),
             ...(step.output ? { versionId: step.output.versionId } : {}),
             ...(step.rowsWritten !== undefined ? { rowsWritten: step.rowsWritten } : {}),
-            ...(step.error ? { error: step.error.message } : {}),
+            ...(step.error ? { error: step.error } : {}),
           },
         },
       ],

--- a/packages/pipeline-worker/tests/worker.test.ts
+++ b/packages/pipeline-worker/tests/worker.test.ts
@@ -479,7 +479,18 @@ describe("PipelineWorker", () => {
       stepIndex: 1,
       totalSteps: 2,
       status: "failed",
-      error: "An unexpected internal error occurred.",
+      error: {
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: expect.any(String),
+        details: {
+          pipelineId: "customers",
+          pipelineRunId: "run-fails-late",
+          stepId: "explode",
+          stepRunId: "run-fails-late:step:2:explode",
+        },
+      },
     })
 
     const datasetPayload = events[3]?.payload as {
@@ -618,6 +629,7 @@ describe("PipelineWorker", () => {
       code: "runtime.cancelled",
       retryable: false,
     })
+    expect(events[5]?.payload).toMatchObject({ error: cancelledStep?.error })
     expect(reportCount).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

- expose typed `SixbFailure` records on pipeline step completion events
- reuse the exact failure snapshot already persisted by the step run
- preserve the pipeline-specific error-code union for event consumers
- verify failed and cancelled step events without changing pipeline run completion events

## Validation

- `bun test packages/core/tests/worker-run-events.test.ts packages/pipeline-worker/tests/worker.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun --filter @sixb/core --filter @sixb/client --filter @sixb/pipeline-worker build`
- `bun run generate:client`