### PR TITLE
pipelines: expose run failure records in events

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -36,7 +36,7 @@ Webhook runs allow `internal.unexpected | webhook.delivery_failed`; only retryab
 failures use the delivery code. The idempotency journal and run reuse the same failure record.
 Expected non-retryable outcomes remain represented by their HTTP status and claim result.
 Workflow completion events reuse the exact failure stored on the run or node.
-Pipeline step completion events reuse the exact failure stored on the step run.
+Pipeline completion events reuse the exact failure stored on the run or step run.
 The ontology outbox declares `event.delivery_failed`; its durable record is retained while publication
 is retried.
 

--- a/packages/client/tests/events-builder.types.ts
+++ b/packages/client/tests/events-builder.types.ts
@@ -286,10 +286,13 @@ events
   .pipelines()
   .run("run-1")
   .subscribe((event) => {
-    if (event.type === "pipeline.run.step.finished" && event.payload.error) {
+    if (
+      (event.type === "pipeline.run.finished" || event.type === "pipeline.run.step.finished") &&
+      event.payload.error
+    ) {
       const code: "internal.unexpected" | "runtime.cancelled" = event.payload.error.code
       const message: string = event.payload.error.message
-      // @ts-expect-error — pipeline step failures expose only their primitive's code union.
+      // @ts-expect-error — pipeline lifecycle failures expose only their primitive's code union.
       const datasetCode: "dataset.not_found" = event.payload.error.code
       void [code, message, datasetCode]
     }

--- a/packages/core/src/events/types/pipelines.ts
+++ b/packages/core/src/events/types/pipelines.ts
@@ -59,6 +59,7 @@ export interface PipelineRunFinishedEvent extends EventEnvelope {
     status: "succeeded" | "failed" | "cancelled"
     datasetId?: string
     versionId?: string
+    error?: SixbFailure<PipelineRunFailureCode>
   }
 }
 

--- a/packages/core/tests/worker-run-events.test.ts
+++ b/packages/core/tests/worker-run-events.test.ts
@@ -15,6 +15,17 @@ const PIPELINE_STEP_FAILURE = {
   },
 } as const
 
+const PIPELINE_RUN_FAILURE = {
+  code: "internal.unexpected",
+  retryable: false,
+  message: "Pipeline run failed.",
+  at: "2026-05-08T10:00:03.000Z",
+  details: {
+    pipelineId: "canonical-transactions",
+    runId: "run-002",
+  },
+} as const
+
 describe("worker run lifecycle events", () => {
   test("stores sync run lifecycle events with sync topic and run partition", () => {
     const started = toStoredEvent({
@@ -168,5 +179,33 @@ describe("worker run lifecycle events", () => {
       throw new Error("Expected a pipeline step completion event.")
     }
     expect(event.payload.error).toEqual(PIPELINE_STEP_FAILURE)
+  })
+
+  test("preserves the pipeline run failure record", async () => {
+    const eventsRuntime = new DomainEventService({
+      projectId: "project-a",
+      broker: new InMemoryBroker(),
+    })
+
+    await eventsRuntime.append({
+      events: [
+        {
+          type: "pipeline.run.finished",
+          payload: {
+            pipelineId: "canonical-transactions",
+            runId: "run-002",
+            status: "failed",
+            error: PIPELINE_RUN_FAILURE,
+          },
+        },
+      ],
+    })
+
+    const [event] = await eventsRuntime.read({ types: ["pipeline.run.finished"] })
+    expect(event?.type).toBe("pipeline.run.finished")
+    if (event?.type !== "pipeline.run.finished") {
+      throw new Error("Expected a pipeline run completion event.")
+    }
+    expect(event.payload.error).toEqual(PIPELINE_RUN_FAILURE)
   })
 })

--- a/packages/pipeline-worker/src/events.ts
+++ b/packages/pipeline-worker/src/events.ts
@@ -135,37 +135,28 @@ export async function emitDatasetVersionCommitted(
 
 export async function emitPipelineRunFinished(
   events: DomainEventLog | undefined,
-  job: {
-    readonly id: string
-    readonly pipelineId: string
-    readonly status: "succeeded" | "failed" | "cancelled"
-    readonly datasetId?: string
-    readonly versionId?: string
-  }
+  run: Pick<PipelineRunRecord, "id" | "pipelineId" | "status" | "output" | "error">
 ): Promise<void> {
   await events?.emit(
-    { events: [{ type: "pipeline.run.finished", payload: buildPipelineRunFinishedPayload(job) }] },
+    { events: [{ type: "pipeline.run.finished", payload: buildPipelineRunFinishedPayload(run) }] },
     { source: SOURCE }
   )
 }
 
-function buildPipelineRunFinishedPayload(job: {
-  readonly id: string
-  readonly pipelineId: string
-  readonly status: "succeeded" | "failed" | "cancelled"
-  readonly datasetId?: string
-  readonly versionId?: string
-}) {
+function buildPipelineRunFinishedPayload(
+  run: Pick<PipelineRunRecord, "id" | "pipelineId" | "status" | "output" | "error">
+) {
   return {
-    pipelineId: job.pipelineId,
-    runId: job.id,
-    status: job.status,
-    ...(job.datasetId && job.versionId
+    pipelineId: run.pipelineId,
+    runId: run.id,
+    status: requireTerminalStatus(run.status, `Pipeline run '${run.id}'`),
+    ...(run.output
       ? {
-          datasetId: job.datasetId,
-          versionId: job.versionId,
+          datasetId: run.output.datasetId,
+          versionId: run.output.versionId,
         }
       : {}),
+    ...(run.error ? { error: run.error } : {}),
   }
 }
 

--- a/packages/pipeline-worker/src/run-pipeline-job.ts
+++ b/packages/pipeline-worker/src/run-pipeline-job.ts
@@ -10,7 +10,12 @@ import {
   throwIfAborted,
 } from "./errors"
 import { runStep } from "./run-step"
-import type { PipelineRunResult, PipelineStepRunResult, RunPipelineJobInput } from "./types"
+import type {
+  PipelineRunFinishedHandler,
+  PipelineRunResult,
+  PipelineStepRunResult,
+  RunPipelineJobInput,
+} from "./types"
 
 export class PipelineRunAlreadyStartedError extends Error {
   override readonly name = "PipelineRunAlreadyStartedError"
@@ -97,17 +102,19 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
       }
       throw error
     }
-    finished = true
+    const finishedRun = {
+      ...run,
+      finishedAt: requireFinishedAt({
+        pipelineId: pipeline.id,
+        runId: job.id,
+        finishedAt: run.finishedAt,
+      }),
+    }
 
+    finished = true
+    await notifyRunFinished(input.onRunFinished, finishedRun)
     return {
-      run: {
-        ...run,
-        finishedAt: requireFinishedAt({
-          pipelineId: pipeline.id,
-          runId: job.id,
-          finishedAt: run.finishedAt,
-        }),
-      },
+      run: finishedRun,
       steps,
       version: finalVersion,
     }
@@ -126,6 +133,7 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
           }),
         })
         if (status === "failed" && run.status === "failed") input.onRunFailed?.(error, run)
+        await notifyRunFinished(input.onRunFinished, run)
       } catch {
         // The run did not transition to the requested terminal status.
       }
@@ -134,5 +142,18 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
     throw error
   } finally {
     await logSession.flush()
+  }
+}
+
+async function notifyRunFinished(
+  handler: PipelineRunFinishedHandler | undefined,
+  run: PipelineRunRecord
+): Promise<void> {
+  try {
+    await handler?.(run)
+  } catch (error) {
+    // The built-in event log reports lost batches itself. Anything reaching here is a broken
+    // invariant in a custom lifecycle handler and must not change an already durable outcome.
+    console.error("[SixbPipelineWorker] Pipeline run lifecycle handler failed:", error)
   }
 }

--- a/packages/pipeline-worker/src/types.ts
+++ b/packages/pipeline-worker/src/types.ts
@@ -39,6 +39,7 @@ export interface RunPipelineJobInput {
   readonly job: PipelineJob
   readonly signal?: AbortSignal
   readonly onRunStarted?: PipelineRunStartedHandler
+  readonly onRunFinished?: PipelineRunFinishedHandler
   readonly onRunFailed?: PipelineRunFailedHandler
   readonly onStepStarted?: PipelineStepStartedHandler
   readonly onStepFinished?: PipelineStepFinishedHandler
@@ -48,6 +49,8 @@ export interface RunPipelineJobInput {
 export type PipelineStepCommittedHandler = (result: PipelineStepRunResult) => Promise<void> | void
 
 export type PipelineRunStartedHandler = (run: PipelineRunRecord) => Promise<void> | void
+
+export type PipelineRunFinishedHandler = (run: PipelineRunRecord) => Promise<void> | void
 
 export type PipelineRunFailedHandler = (error: unknown, run: PipelineRunRecord) => void
 

--- a/packages/pipeline-worker/src/worker.ts
+++ b/packages/pipeline-worker/src/worker.ts
@@ -12,12 +12,7 @@ import {
   emitPipelineRunStepStarted,
 } from "./events"
 import { PipelineRunAlreadyStartedError, runPipelineJob } from "./run-pipeline-job"
-import type {
-  PipelineJob,
-  PipelineRunResult,
-  PipelineWorkerContext,
-  PipelineWorkerHost,
-} from "./types"
+import type { PipelineJob, PipelineWorkerContext, PipelineWorkerHost } from "./types"
 
 export class PipelineWorker extends QueueWorker<
   PipelineRunRequestedQueueJob,
@@ -62,13 +57,13 @@ export class PipelineWorker extends QueueWorker<
     })
     const context = { ...this.context, id: execution.sixb.execution.projectId }
 
-    let result: PipelineRunResult
     try {
-      result = await runPipelineJob({
+      await runPipelineJob({
         runtime: context,
         job: pipelineJob,
         signal,
         onRunStarted: (run) => emitPipelineRunStarted(this.host.events, run),
+        onRunFinished: (run) => emitPipelineRunFinished(this.host.events, run),
         onRunFailed: (error, run) => {
           reportRunFailure(this.host, error, {
             projectId: this.host.id,
@@ -91,27 +86,12 @@ export class PipelineWorker extends QueueWorker<
       if (error instanceof PipelineRunAlreadyStartedError) return
       throw error
     }
-
-    await emitPipelineRunFinished(this.host.events, {
-      id: pipelineJob.id,
-      pipelineId: pipelineJob.pipelineId,
-      status: "succeeded",
-      datasetId: result.version?.datasetId,
-      versionId: result.version?.versionId,
-    })
   }
 
   protected override async onExecutionError(
-    claimed: ClaimedQueueJob<PipelineRunRequestedQueueJob>,
+    _claimed: ClaimedQueueJob<PipelineRunRequestedQueueJob>,
     _error: unknown
   ): Promise<QueueWorkerFailureDecision> {
-    const { job } = claimed
-    await emitPipelineRunFinished(this.host.events, {
-      id: job.payload.runId ?? `${job.id}:attempt:${job.attempt}`,
-      pipelineId: job.payload.pipelineId,
-      status: "failed",
-    })
-
     // Pipeline runs are not all-or-nothing in V1. A previous step may have committed an append
     // output, so failed pipeline jobs must not be retried automatically.
     return { kind: "fail" }
@@ -132,12 +112,6 @@ export class PipelineWorker extends QueueWorker<
     }
 
     // After a step commit, rerunning the whole pipeline could duplicate append outputs.
-    await emitPipelineRunFinished(this.host.events, {
-      id: pipelineJob.id,
-      pipelineId: pipelineJob.pipelineId,
-      status: "cancelled",
-    })
-
     return { kind: "fail" }
   }
 }

--- a/packages/pipeline-worker/tests/run-pipeline-job.test.ts
+++ b/packages/pipeline-worker/tests/run-pipeline-job.test.ts
@@ -18,7 +18,11 @@ import type {
   ExecuteSqlTransformInput,
   LakeSqlTransformCapabilities,
 } from "@sixb/core/lake-storage"
-import type { PipelineRunStorage } from "@sixb/core/storage"
+import type {
+  FinishPipelineRunInput,
+  PipelineRunRecord,
+  PipelineRunStorage,
+} from "@sixb/core/storage"
 import { InMemoryPipelineRunStorage } from "@sixb/core/storage"
 import { createPipelineBookkeepingError, createStepBookkeepingError } from "../src/errors"
 import { runPipelineJob } from "../src/run-pipeline-job"
@@ -125,6 +129,12 @@ class SqlTransformLakeStorage extends InMemoryLakeStorage implements LakeStorage
         expectedLatestVersionId: input.expectedLatestVersionId,
       })
     },
+  }
+}
+
+class RejectingFinishPipelineRunStorage extends InMemoryPipelineRunStorage {
+  override async finish(_input: FinishPipelineRunInput): Promise<PipelineRunRecord> {
+    throw new Error("pipeline run storage unavailable")
   }
 }
 
@@ -257,6 +267,35 @@ describe("runPipelineJob", () => {
     expect(steps.steps).toHaveLength(0)
   })
 
+  test("does not notify a terminal run when the durable transition fails", async () => {
+    const cleanStep = definePipelineStep("clean-customers")
+      .inputs({ rawCustomers: rawCustomersDataset })
+      .output(customersDataset)
+      .run(async () => {})
+    const pipelineRunsStorage = new RejectingFinishPipelineRunStorage()
+    const runtime = createRuntime({
+      pipelines: [definePipeline("customers").then(cleanStep)],
+      datasets: [rawCustomersDataset, customersDataset],
+      pipelineRunsStorage,
+    })
+    const finishedRuns: PipelineRunRecord[] = []
+
+    await expect(
+      runPipelineJob({
+        runtime,
+        job: { id: "run_finish_rejected", pipelineId: "customers" },
+        onRunFinished(run) {
+          finishedRuns.push(run)
+        },
+      })
+    ).rejects.toThrow("has no committed version")
+
+    expect(finishedRuns).toHaveLength(0)
+    expect(
+      await pipelineRunsStorage.getById({ projectId: runtime.id, id: "run_finish_rejected" })
+    ).toMatchObject({ status: "running" })
+  })
+
   test("runs a JS step with pinned input readers and commits one output version", async () => {
     const lakeStorage = new InMemoryLakeStorage()
     const seededVersion = await seedDatasetVersion(lakeStorage, rawCustomersDataset, [
@@ -290,12 +329,16 @@ describe("runPipelineJob", () => {
       lakeStorage,
       pipelineRunsStorage,
     })
+    const finishedRuns: PipelineRunRecord[] = []
 
     const result = await runPipelineJob({
       runtime,
       job: {
         id: "run_clean",
         pipelineId: "customers",
+      },
+      onRunFinished(run) {
+        finishedRuns.push(run)
       },
     })
 
@@ -339,6 +382,8 @@ describe("runPipelineJob", () => {
         versionId: result.version?.versionId,
       },
     })
+    if (!run) throw new Error("Expected the pipeline run to be persisted.")
+    expect(finishedRuns).toEqual([run])
 
     const stepRuns = await pipelineRunsStorage.listSteps({
       projectId: runtime.id,
@@ -433,6 +478,7 @@ describe("runPipelineJob", () => {
       lakeStorage,
       pipelineRunsStorage,
     })
+    const finishedRuns: PipelineRunRecord[] = []
 
     await expect(
       runPipelineJob({
@@ -440,6 +486,9 @@ describe("runPipelineJob", () => {
         job: {
           id: "run_failure",
           pipelineId: "customers",
+        },
+        onRunFinished(run) {
+          finishedRuns.push(run)
         },
       })
     ).rejects.toThrow("stats exploded")
@@ -450,6 +499,8 @@ describe("runPipelineJob", () => {
     })
     expect(run?.status).toBe("failed")
     expect(run?.output).toBeUndefined()
+    if (!run) throw new Error("Expected the failed pipeline run to be persisted.")
+    expect(finishedRuns).toEqual([run])
 
     const stepRuns = await pipelineRunsStorage.listSteps({
       projectId: runtime.id,

--- a/packages/pipeline-worker/tests/worker.test.ts
+++ b/packages/pipeline-worker/tests/worker.test.ts
@@ -513,12 +513,18 @@ describe("PipelineWorker", () => {
       status: string
       datasetId?: string
       versionId?: string
+      error?: unknown
     }
-    expect(finishedPayload.pipelineId).toBe("customers")
-    expect(finishedPayload.runId).toBe("run-fails-late")
-    expect(finishedPayload.status).toBe("failed")
-    expect(finishedPayload.datasetId).toBeUndefined()
-    expect(finishedPayload.versionId).toBeUndefined()
+    const failedRun = await sixb.storage.pipelineRuns!.getById({
+      projectId: sixb.id,
+      id: "run-fails-late",
+    })
+    expect(finishedPayload).toEqual({
+      pipelineId: "customers",
+      runId: "run-fails-late",
+      status: "failed",
+      error: failedRun?.error,
+    })
   })
 
   test("fails an aborted queue job after a step has committed without reporting it", async () => {
@@ -630,6 +636,7 @@ describe("PipelineWorker", () => {
       retryable: false,
     })
     expect(events[5]?.payload).toMatchObject({ error: cancelledStep?.error })
+    expect(events[6]?.payload).toMatchObject({ error: cancelledRun?.error })
     expect(reportCount).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

- expose the typed persisted failure on pipeline.run.finished events
- emit run completion from the durable PipelineRunRecord instead of rebuilding it in queue error hooks
- avoid publishing a terminal event when the durable transition did not succeed

## Testing

- bun test packages/pipeline-worker/tests/run-pipeline-job.test.ts packages/pipeline-worker/tests/worker.test.ts packages/core/tests/worker-run-events.test.ts
- bun --filter @sixb/pipeline-worker typecheck
- bun --filter @sixb/pipeline-worker build
- bun run typecheck
- bun run build
- bun run generate:client
- bun run check

Stacked on #376.