### PR TITLE
syncs: expose run failure records in events

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -37,6 +37,7 @@ failures use the delivery code. The idempotency journal and run reuse the same f
 Expected non-retryable outcomes remain represented by their HTTP status and claim result.
 Workflow completion events reuse the exact failure stored on the run or node.
 Pipeline completion events reuse the exact failure stored on the run or step run.
+Sync completion events reuse the exact failure stored on the run.
 The ontology outbox declares `event.delivery_failed`; its durable record is retained while publication
 is retried.
 

--- a/packages/client/tests/events-builder.types.ts
+++ b/packages/client/tests/events-builder.types.ts
@@ -299,6 +299,19 @@ events
   })
 
 events
+  .syncs()
+  .run("run-1")
+  .subscribe((event) => {
+    if (event.type === "sync.run.finished" && event.payload.error) {
+      const code: "internal.unexpected" | "runtime.cancelled" = event.payload.error.code
+      const message: string = event.payload.error.message
+      // @ts-expect-error — sync lifecycle failures expose only their primitive's code union.
+      const datasetCode: "dataset.not_found" = event.payload.error.code
+      void [code, message, datasetCode]
+    }
+  })
+
+events
   .actions()
   .run("act-1")
   .action("approveQuote")

--- a/packages/core/src/events/types/syncs.ts
+++ b/packages/core/src/events/types/syncs.ts
@@ -1,3 +1,5 @@
+import type { SixbFailure } from "../../errors/types"
+import type { SyncRunFailureCode } from "../../storage/sync-runs/types"
 import type { EventEnvelope } from "../envelope"
 
 export interface SyncRunStartedEvent extends EventEnvelope {
@@ -21,6 +23,7 @@ export interface SyncRunFinishedEvent extends EventEnvelope {
     status: "succeeded" | "failed" | "cancelled"
     datasetId?: string
     versionId?: string
+    error?: SixbFailure<SyncRunFailureCode>
   }
 }
 

--- a/packages/core/tests/worker-run-events.test.ts
+++ b/packages/core/tests/worker-run-events.test.ts
@@ -26,6 +26,17 @@ const PIPELINE_RUN_FAILURE = {
   },
 } as const
 
+const SYNC_RUN_FAILURE = {
+  code: "internal.unexpected",
+  retryable: false,
+  message: "Sync run failed.",
+  at: "2026-05-08T10:00:03.000Z",
+  details: {
+    syncId: "sync-transactions",
+    runId: "run-001",
+  },
+} as const
+
 describe("worker run lifecycle events", () => {
   test("stores sync run lifecycle events with sync topic and run partition", () => {
     const started = toStoredEvent({
@@ -69,6 +80,35 @@ describe("worker run lifecycle events", () => {
         }),
       ])
     )
+  })
+
+  test("preserves the sync run failure record", async () => {
+    const eventsRuntime = new DomainEventService({
+      projectId: "project-a",
+      broker: new InMemoryBroker(),
+    })
+
+    await eventsRuntime.append({
+      events: [
+        {
+          type: "sync.run.finished",
+          payload: {
+            syncId: "sync-transactions",
+            runId: "run-001",
+            status: "failed",
+            datasetId: "raw.transactions",
+            error: SYNC_RUN_FAILURE,
+          },
+        },
+      ],
+    })
+
+    const [event] = await eventsRuntime.read({ types: ["sync.run.finished"] })
+    expect(event?.type).toBe("sync.run.finished")
+    if (event?.type !== "sync.run.finished") {
+      throw new Error("Expected a sync run completion event.")
+    }
+    expect(event.payload.error).toEqual(SYNC_RUN_FAILURE)
   })
 
   test("appends and reads pipeline run lifecycle events in order", async () => {

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -17,7 +17,12 @@ import { resolveLoggingService } from "@sixb/core/internal/logging"
 import { type DatasetVersion, getDatasetMergeChangeValidationError } from "@sixb/core/lake-storage"
 import { SYNC_RUN_FAILURE_CODES, type SyncRunRecord } from "@sixb/core/storage"
 import { assertDatasetRow, normalizeReadResult, throwIfAborted } from "./normalize"
-import type { RunSyncJobInput, SyncRunResult, SyncWorkerContext } from "./types"
+import type {
+  RunSyncJobInput,
+  SyncRunFinishedHandler,
+  SyncRunResult,
+  SyncWorkerContext,
+} from "./types"
 
 export class SyncRunAlreadyStartedError extends Error {
   override readonly name = "SyncRunAlreadyStartedError"
@@ -371,6 +376,8 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
               : {}),
             checkpoint: nextCheckpoint,
           })
+          const finishedAt = requireFinishedAt(job.id, finishedRun.finishedAt)
+          await notifyRunFinished(input.onRunFinished, finishedRun)
 
           return {
             id: job.id,
@@ -378,7 +385,7 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
             datasetId: dataset.id,
             mode: sync.config.mode,
             startedAt: startedRun.startedAt,
-            finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
+            finishedAt,
             rowsRead,
             ...(version ? { version } : {}),
             versionCreated: false,
@@ -426,13 +433,15 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
       throw error
     }
 
+    const finishedAt = requireFinishedAt(job.id, finishedRun.finishedAt)
+    await notifyRunFinished(input.onRunFinished, finishedRun, committedVersion)
     const result = {
       id: job.id,
       syncId: sync.id,
       datasetId: dataset.id,
       mode: sync.config.mode,
       startedAt: startedRun.startedAt,
-      finishedAt: requireFinishedAt(job.id, finishedRun.finishedAt),
+      finishedAt,
       rowsRead,
     }
     return version
@@ -456,6 +465,7 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
             details: { syncId: sync.id, runId: job.id },
           }),
         })
+        await notifyRunFinished(input.onRunFinished, run)
         if (status === "failed" && run.status === "failed") input.onRunFailed?.(error, run)
       } catch {
         // The run did not transition to the requested terminal status.
@@ -465,5 +475,19 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
     throw error
   } finally {
     await logSession.flush()
+  }
+}
+
+async function notifyRunFinished(
+  handler: SyncRunFinishedHandler | undefined,
+  run: SyncRunRecord,
+  createdVersion?: DatasetVersion
+): Promise<void> {
+  try {
+    await handler?.(run, createdVersion)
+  } catch (error) {
+    // The built-in event log reports lost batches itself. Anything reaching here is a broken
+    // invariant in a custom lifecycle handler and must not change an already durable outcome.
+    console.error("[SixbSyncWorker] Sync run lifecycle handler failed:", error)
   }
 }

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -33,10 +33,17 @@ export interface RunSyncJobInput {
   readonly job: SyncJob
   readonly signal?: AbortSignal
   readonly onRunStarted?: SyncRunStartedHandler
+  readonly onRunFinished?: SyncRunFinishedHandler
   readonly onRunFailed?: SyncRunFailedHandler
 }
 
 export type SyncRunStartedHandler = (run: SyncRunRecord) => Promise<void> | void
+
+export type SyncRunFinishedHandler = (
+  run: SyncRunRecord,
+  /** Dataset version created by this run, when the durable output is new. */
+  createdVersion?: DatasetVersion
+) => Promise<void> | void
 
 export type SyncRunFailedHandler = (error: unknown, run: SyncRunRecord) => void
 

--- a/packages/sync-worker/src/worker.ts
+++ b/packages/sync-worker/src/worker.ts
@@ -5,12 +5,12 @@ import {
   bindPrimitiveExecution,
   type PrimitiveExecutionHost,
 } from "@sixb/core/internal/primitive-execution"
-import type { QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { QueueWorker } from "@sixb/core/internal/workers"
+import type { DatasetVersion } from "@sixb/core/lake-storage"
 import type { ClaimedQueueJob, SyncRunRequestedQueueJob } from "@sixb/core/queues"
-import { SYNC_RUN_FAILURE_CODES, type SyncRunRecord } from "@sixb/core/storage"
+import { SYNC_RUN_FAILURE_CODES, type SyncRunRecord, type SyncRunStatus } from "@sixb/core/storage"
 import { runSyncJob, SyncRunAlreadyStartedError } from "./run-sync-job"
-import type { SyncJob, SyncRunResult, SyncWorkerContext } from "./types"
+import type { SyncJob, SyncWorkerContext } from "./types"
 
 const SOURCE = "SixbSyncWorker"
 
@@ -62,13 +62,14 @@ export class SyncWorker extends QueueWorker<
     })
     const context = buildSyncContext(this.host, execution.sixb)
 
-    let result: SyncRunResult
     try {
-      result = await runSyncJob({
+      await runSyncJob({
         runtime: context,
         job: syncJob,
         signal,
         onRunStarted: (run) => emitSyncRunStarted(this.host, run),
+        onRunFinished: (run, createdVersion) =>
+          emitSyncRunFinishedEvents(this.host, run, createdVersion),
         onRunFailed: (error, run) => {
           reportRunFailure(this.host, error, {
             projectId: this.host.id,
@@ -86,21 +87,6 @@ export class SyncWorker extends QueueWorker<
       if (error instanceof SyncRunAlreadyStartedError) return
       throw error
     }
-
-    await emitSyncSucceededEvents(this.host, syncJob, result)
-  }
-
-  protected override async onExecutionError(
-    claimed: ClaimedQueueJob<SyncRunRequestedQueueJob>,
-    _error: unknown
-  ): Promise<QueueWorkerFailureDecision> {
-    const { job } = claimed
-    await emitSyncRunFinished(this.host, {
-      id: job.payload.runId ?? `${job.id}:attempt:${job.attempt}`,
-      syncId: job.payload.syncId,
-    })
-
-    return { kind: "fail" }
   }
 }
 
@@ -125,26 +111,26 @@ async function emitSyncRunStarted(
   )
 }
 
-async function emitSyncSucceededEvents(
+async function emitSyncRunFinishedEvents(
   host: SyncWorkerHost,
-  job: Pick<SyncJob, "id" | "syncId">,
-  result: SyncRunResult
+  run: Pick<SyncRunRecord, "id" | "syncId" | "datasetId" | "status" | "output" | "error">,
+  createdVersion?: DatasetVersion
 ): Promise<void> {
   await host.events?.emit(
     {
       events: [
-        ...(result.versionCreated
+        ...(createdVersion
           ? [
               {
                 type: "dataset.version.committed" as const,
                 payload: {
-                  datasetId: result.datasetId,
-                  versionId: result.version.versionId,
-                  createdAt: result.version.createdAt.toISOString(),
+                  datasetId: createdVersion.datasetId,
+                  versionId: createdVersion.versionId,
+                  createdAt: createdVersion.createdAt.toISOString(),
                   producer: {
                     kind: "sync" as const,
-                    id: job.syncId,
-                    runId: job.id,
+                    id: run.syncId,
+                    runId: run.id,
                   },
                 },
               },
@@ -153,11 +139,12 @@ async function emitSyncSucceededEvents(
         {
           type: "sync.run.finished",
           payload: {
-            syncId: job.syncId,
-            runId: job.id,
-            status: "succeeded",
-            datasetId: result.datasetId,
-            ...(result.version ? { versionId: result.version.versionId } : {}),
+            syncId: run.syncId,
+            runId: run.id,
+            status: requireTerminalStatus(run.status, `Sync run '${run.id}'`),
+            datasetId: run.datasetId,
+            ...(run.output ? { versionId: run.output.versionId } : {}),
+            ...(run.error ? { error: run.error } : {}),
           },
         },
       ],
@@ -166,25 +153,15 @@ async function emitSyncSucceededEvents(
   )
 }
 
-async function emitSyncRunFinished(
-  host: SyncWorkerHost,
-  job: Pick<SyncJob, "id" | "syncId">
-): Promise<void> {
-  await host.events?.emit(
-    {
-      events: [
-        {
-          type: "sync.run.finished",
-          payload: {
-            syncId: job.syncId,
-            runId: job.id,
-            status: "failed",
-          },
-        },
-      ],
-    },
-    { source: SOURCE }
-  )
+function requireTerminalStatus(
+  status: SyncRunStatus,
+  context: string
+): Exclude<SyncRunStatus, "running"> {
+  if (status === "running") {
+    throw new Error(`[SixbSyncWorker] ${context} is still running.`)
+  }
+
+  return status
 }
 
 function assertSyncStorage(host: SyncWorkerHost): void {

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -24,7 +24,7 @@ import {
   InMemoryStorage,
 } from "@sixb/core"
 import type { BeginDatasetWriteInput, LakeWriteSession } from "@sixb/core/lake-storage"
-import type { SyncRunStorage } from "@sixb/core/storage"
+import type { SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
 import { InMemorySyncRunStorage } from "@sixb/core/storage"
 import { LocalLakeStorage } from "@sixb/lake-local"
 import { runSyncJob } from "../src/run-sync-job"
@@ -225,12 +225,16 @@ describe("runSyncJob", () => {
       syncRunsStorage,
       lakeStorage: wrappedLakeStorage,
     })
+    const finishedRuns: SyncRunRecord[] = []
 
     const result = await runSyncJob({
       runtime,
       job: {
         id: "run_1",
         syncId: "sync-orders",
+      },
+      onRunFinished(run) {
+        finishedRuns.push(run)
       },
     })
 
@@ -262,6 +266,8 @@ describe("runSyncJob", () => {
         versionId: result.version!.versionId,
       },
     })
+    if (!run) throw new Error("Expected the sync run to be persisted.")
+    expect(finishedRuns).toEqual([run])
 
     const rows = await collectRows(runtime.lakeStorage.readRows({ datasetId: "raw.erp.orders" }))
     expect(rows).toEqual([
@@ -1241,6 +1247,7 @@ describe("runSyncJob", () => {
     }
 
     const lakeStorage = new InMemoryLakeStorage()
+    const finishedRuns: SyncRunRecord[] = []
     const sync = defineSync("sync-orders")
       .from(erpDb)
       .read(() => [{ orderId: "ord_1" }])
@@ -1257,6 +1264,9 @@ describe("runSyncJob", () => {
           id: "run_1",
           syncId: "sync-orders",
         },
+        onRunFinished(run) {
+          finishedRuns.push(run)
+        },
       })
     ).rejects.toThrow("dataset commit may already have succeeded")
 
@@ -1272,6 +1282,7 @@ describe("runSyncJob", () => {
       id: "run_1",
     })
     expect(run?.status).toBe("running")
+    expect(finishedRuns).toHaveLength(0)
   })
 
   test("works against LocalLakeStorage", async () => {

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -208,6 +208,21 @@ describe("SyncWorker", () => {
     } finally {
       await worker.stop()
     }
+
+    const failedRun = await sixb.storage.syncRuns!.getById({
+      projectId: sixb.id,
+      id: "run-failed",
+    })
+    if (!failedRun) throw new Error("Expected the failed sync run to be persisted.")
+    const events = await sixb.events.read({ types: ["sync.run.finished"] })
+    expect(events).toHaveLength(1)
+    expect(events[0]?.payload).toEqual({
+      syncId: failedRun.syncId,
+      runId: failedRun.id,
+      status: "failed",
+      datasetId: failedRun.datasetId,
+      error: failedRun.error,
+    })
   })
 
   test("streams a run-scoped log line to the broker", async () => {
@@ -348,6 +363,16 @@ describe("SyncWorker", () => {
 
     expect(retried?.job.id).toBe(queued?.id)
     expect(retried?.job.attempt).toBe(2)
+    if (!cancelledRun) throw new Error("Expected the cancelled sync run to be persisted.")
+    const events = await sixb.events.read({ types: ["sync.run.finished"] })
+    expect(events).toHaveLength(1)
+    expect(events[0]?.payload).toEqual({
+      syncId: cancelledRun.syncId,
+      runId: cancelledRun.id,
+      status: "cancelled",
+      datasetId: cancelledRun.datasetId,
+      error: cancelledRun.error,
+    })
     expect(reportCount).toBe(0)
   })
 
@@ -413,7 +438,7 @@ describe("SyncWorker", () => {
 
     await worker.start()
 
-    await waitFor(
+    const run = await waitFor(
       () => sixb.storage.syncRuns!.getById({ projectId: sixb.id, id: "run-emit" }),
       (value) => value?.status === "succeeded"
     )
@@ -459,10 +484,14 @@ describe("SyncWorker", () => {
       datasetId?: string
       versionId?: string
     }
-    expect(payload.syncId).toBe("sync-orders")
-    expect(payload.runId).toBe("run-emit")
-    expect(payload.status).toBe("succeeded")
-    expect(payload.datasetId).toBe("raw.erp.orders")
+    if (!run) throw new Error("Expected the succeeded sync run to be persisted.")
+    expect(payload).toEqual({
+      syncId: run.syncId,
+      runId: run.id,
+      status: "succeeded",
+      datasetId: run.datasetId,
+      versionId: run.output?.versionId,
+    })
     expect(payload.versionId).toBe(datasetPayload.versionId)
   })
 


### PR DESCRIPTION
## Summary

- expose the typed persisted failure on sync.run.finished events
- emit sync completion from the durable SyncRunRecord instead of rebuilding it in the queue error hook
- keep dataset version events ordered with durable run completion and avoid publishing a terminal event when finalization did not succeed

## Testing

- bun test packages/sync-worker/tests/run-sync-job.test.ts packages/sync-worker/tests/worker.test.ts packages/core/tests/worker-run-events.test.ts
- bun --filter @sixb/sync-worker typecheck
- bun --filter @sixb/sync-worker build
- bun run typecheck
- bun run build
- bun run generate:client
- bun run check

Stacked on #377.