### PR TITLE
agents: expose failure records in run streams

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -38,6 +38,7 @@ Expected non-retryable outcomes remain represented by their HTTP status and clai
 Workflow completion events reuse the exact failure stored on the run or node.
 Pipeline completion events reuse the exact failure stored on the run or step run.
 Sync completion events reuse the exact failure stored on the run.
+`agent.run.finished.error` reuses the exact failure stored on the Agent run.
 The ontology outbox declares `event.delivery_failed`; its durable record is retained while publication
 is retried.
 

--- a/packages/agent-ui/src/liveRun.ts
+++ b/packages/agent-ui/src/liveRun.ts
@@ -1,4 +1,4 @@
-import type { AgentRunStreamEvent } from "@sixb/client"
+import type { AgentRunFailure, AgentRunStreamEvent } from "@sixb/client"
 import type { NormalizedPart, NormalizedTool } from "./parts"
 import type { AgentRunStatus } from "./types"
 
@@ -21,8 +21,8 @@ export interface LiveRunState {
   readonly finalizedMessageId: string | null
   /** Terminal run status, or null while in-flight. */
   readonly finishStatus: AgentRunStatus | null
-  /** Error text from a failed run. */
-  readonly finishError: string | null
+  /** Exact durable failure from a failed or cancelled run. */
+  readonly finishError: AgentRunFailure | null
   /** Error text surfaced by a stream `error` chunk (not necessarily fatal). */
   readonly streamError: string | null
 }

--- a/packages/agent-ui/tests/liveRun.test.ts
+++ b/packages/agent-ui/tests/liveRun.test.ts
@@ -136,13 +136,20 @@ describe("liveRunReducer", () => {
   })
 
   test("captures a failed run's terminal status and error", () => {
+    const failure = {
+      code: "internal.unexpected" as const,
+      message: "nope",
+      retryable: false,
+      at: "2026-01-02T03:04:05.000Z",
+      details: { agentId: "assistant", runId: "run" },
+    }
     const state = liveRunReducer(createLiveRunState("run"), {
       type: "event",
-      event: event({ type: "agent.run.finished", status: "failed", error: "nope" }),
+      event: event({ type: "agent.run.finished", status: "failed", error: failure }),
     })
     expect(state.active).toBe(false)
     expect(state.finishStatus).toBe("failed")
-    expect(state.finishError).toBe("nope")
+    expect(state.finishError).toEqual(failure)
   })
 
   test("surfaces stream errors from both the action and error chunks", () => {

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -4911,6 +4911,7 @@ describe("AgentWorker", () => {
         status: "failed",
         runId: run.id,
         attempt: 1,
+        error: run.error,
       })
 
       // Thread released so a later message can run.

--- a/packages/client/src/agent-streams.ts
+++ b/packages/client/src/agent-streams.ts
@@ -1,7 +1,7 @@
 import type { AgentRunStreamEvent } from "@sixb/core/agents/streams"
-// Import the schema-version value from the browser-safe streams subpath: the `@sixb/core` root pulls
-// in node-only runtime (e.g. `node:crypto`), which breaks the Atlas browser bundle.
-import { AGENT_RUN_STREAM_SCHEMA_VERSION } from "@sixb/core/agents/streams"
+// Import the wire validator from the browser-safe streams subpath: the `@sixb/core` root pulls in
+// node-only runtime (e.g. `node:crypto`), which breaks the Atlas browser bundle.
+import { isAgentRunStreamEvent } from "@sixb/core/agents/streams"
 import type { BrokerRecord } from "@sixb/core/broker"
 import type { GetAgentRunResponses } from "./generated/types.gen"
 import {
@@ -11,7 +11,7 @@ import {
   type ReconnectingSocketState,
 } from "./ws-socket"
 
-export type { AgentRunStreamEvent } from "@sixb/core/agents/streams"
+export type { AgentRunFailure, AgentRunStreamEvent } from "@sixb/core/agents/streams"
 export type { ReconnectingSocket, ReconnectingSocketState } from "./ws-socket"
 
 export type AgentRunSnapshot = GetAgentRunResponses[200]
@@ -220,39 +220,6 @@ function isAgentRunStreamRecord(value: unknown): value is AgentRunStreamRecord {
   )
 }
 
-function isAgentRunStreamEvent(value: unknown): value is AgentRunStreamEvent {
-  if (
-    !isRecord(value) ||
-    value.schemaVersion !== AGENT_RUN_STREAM_SCHEMA_VERSION ||
-    typeof value.projectId !== "string" ||
-    typeof value.runId !== "string" ||
-    typeof value.threadId !== "string" ||
-    typeof value.agentId !== "string" ||
-    !isFiniteNumber(value.attempt) ||
-    typeof value.occurredAt !== "string" ||
-    typeof value.type !== "string"
-  ) {
-    return false
-  }
-
-  switch (value.type) {
-    case "agent.run.started":
-      return value.modelId === undefined || typeof value.modelId === "string"
-    case "agent.ui.chunk":
-      return Number.isInteger(value.chunkIndex) && Object.hasOwn(value, "chunk")
-    case "agent.message.finalized":
-      return typeof value.messageId === "string"
-    case "agent.run.finished":
-      return (
-        isAgentRunStatus(value.status) &&
-        (value.finishReason === undefined || typeof value.finishReason === "string") &&
-        (value.error === undefined || typeof value.error === "string")
-      )
-    default:
-      return false
-  }
-}
-
 function isDurableAgentRunStatus(value: unknown): value is AgentRunSnapshot["status"] {
   return (
     value === "queued" ||
@@ -261,10 +228,6 @@ function isDurableAgentRunStatus(value: unknown): value is AgentRunSnapshot["sta
     value === "failed" ||
     value === "cancelled"
   )
-}
-
-function isAgentRunStatus(value: unknown): value is "succeeded" | "failed" | "cancelled" {
-  return value === "succeeded" || value === "failed" || value === "cancelled"
 }
 
 function isFiniteNumber(value: unknown): value is number {

--- a/packages/client/tests/browser.test.ts
+++ b/packages/client/tests/browser.test.ts
@@ -160,6 +160,53 @@ describe("agent stream websocket helpers", () => {
     expect(parsed?.type === "record" ? parsed.record.cursor : null).toBe("cursor_1")
   })
 
+  test("preserves the durable failure on terminal Agent records", () => {
+    const failure = {
+      code: "internal.unexpected",
+      message: "provider unavailable",
+      retryable: false,
+      at: "2026-06-27T15:59:59.000Z",
+      details: { agentId: "agent_1", runId: "run_1" },
+      causeChain: [{ name: "ProviderError", message: "connection reset" }],
+    } as const
+    const frame = {
+      type: "record",
+      record: {
+        streamId: "agents.runs.run_1",
+        cursor: "cursor_2",
+        name: "agent.run.finished",
+        key: "run_1",
+        publishedAt: "2026-06-27T16:00:00.000Z",
+        payload: {
+          schemaVersion: 1,
+          type: "agent.run.finished",
+          projectId: "project_1",
+          runId: "run_1",
+          threadId: "thread_1",
+          agentId: "agent_1",
+          attempt: 1,
+          occurredAt: "2026-06-27T16:00:00.000Z",
+          status: "failed",
+          finishReason: "error",
+          error: failure,
+        },
+      },
+    }
+
+    const parsed = parseAgentRunStreamServerMessage(JSON.stringify(frame))
+    const payload = parsed?.type === "record" ? parsed.record.payload : null
+    expect(payload?.type === "agent.run.finished" ? payload.error : null).toEqual(failure)
+
+    const flattened = {
+      ...frame,
+      record: {
+        ...frame.record,
+        payload: { ...frame.record.payload, error: "provider unavailable" },
+      },
+    }
+    expect(parseAgentRunStreamServerMessage(JSON.stringify(flattened))).toBeNull()
+  })
+
   test("drops malformed frames without throwing", () => {
     expect(parseAgentRunStreamServerMessage("not json")).toBeNull()
     expect(

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -106,6 +106,7 @@ export {
 } from "./request"
 export type {
   AgentRunControlStreamId,
+  AgentRunFailure,
   AgentRunFinishedEvent,
   AgentRunStreamEvent,
   AgentRunStreamId,
@@ -120,6 +121,7 @@ export {
   agentRunStreamId,
   agentRunStreamIdempotencyKey,
   DEFAULT_AGENT_RUN_STREAM_RETENTION,
+  isAgentRunStreamEvent,
   publishAgentRunCancel,
   publishAgentRunFinished,
   subscribeAgentRunCancel,

--- a/packages/core/src/agents/streams.ts
+++ b/packages/core/src/agents/streams.ts
@@ -1,6 +1,12 @@
 import type { Broker, BrokerStreamDefinition } from "../broker"
-import type { JsonValue } from "../json"
-import type { AgentRunRecord } from "../storage/agents/types"
+import { parseSixbFailure } from "../errors/internal"
+import type { SixbFailure } from "../errors/types"
+import { isJsonValue, isPlainRecord, type JsonValue } from "../json"
+import {
+  AGENT_RUN_FAILURE_CODES,
+  type AgentRunFailureCode,
+  type AgentRunRecord,
+} from "../storage/agents/types"
 
 export const AGENT_RUN_STREAM_SCHEMA_VERSION = 1 as const
 export const DEFAULT_AGENT_RUN_STREAM_RETENTION = {
@@ -100,6 +106,9 @@ export async function subscribeAgentRunCancel(
   )
 }
 
+/** Exact portable failure exposed by a terminal Agent run stream event. */
+export type AgentRunFailure = SixbFailure<AgentRunFailureCode>
+
 export type AgentRunStreamEvent =
   | (AgentRunStreamEventBase & {
       readonly type: "agent.run.started"
@@ -118,7 +127,7 @@ export type AgentRunStreamEvent =
       readonly type: "agent.run.finished"
       readonly status: "succeeded" | "failed" | "cancelled"
       readonly finishReason?: string
-      readonly error?: string
+      readonly error?: AgentRunFailure
     })
 
 export type AgentRunFinishedEvent = Extract<AgentRunStreamEvent, { type: "agent.run.finished" }>
@@ -149,8 +158,61 @@ export function agentRunFinishedEvent(
     attempt: run.attempt,
     status: run.status,
     ...(run.finishReason === undefined ? {} : { finishReason: run.finishReason }),
-    ...(run.error === undefined ? {} : { error: run.error.message }),
+    ...(run.error === undefined ? {} : { error: run.error }),
     occurredAt: occurredAt.toISOString(),
+  }
+}
+
+/** Validate an Agent stream payload using the same contract its producers use. */
+export function isAgentRunStreamEvent(value: unknown): value is AgentRunStreamEvent {
+  if (
+    !isPlainRecord(value) ||
+    value.schemaVersion !== AGENT_RUN_STREAM_SCHEMA_VERSION ||
+    typeof value.projectId !== "string" ||
+    typeof value.runId !== "string" ||
+    typeof value.threadId !== "string" ||
+    typeof value.agentId !== "string" ||
+    typeof value.attempt !== "number" ||
+    !Number.isFinite(value.attempt) ||
+    typeof value.occurredAt !== "string" ||
+    typeof value.type !== "string"
+  ) {
+    return false
+  }
+
+  switch (value.type) {
+    case "agent.run.started":
+      return value.modelId === undefined || typeof value.modelId === "string"
+    case "agent.ui.chunk":
+      return (
+        Number.isInteger(value.chunkIndex) &&
+        Object.hasOwn(value, "chunk") &&
+        isJsonValue(value.chunk)
+      )
+    case "agent.message.finalized":
+      return typeof value.messageId === "string"
+    case "agent.run.finished":
+      return (
+        isTerminalAgentRunStatus(value.status) &&
+        (value.finishReason === undefined || typeof value.finishReason === "string") &&
+        (value.error === undefined || isAgentRunFailure(value.error))
+      )
+    default:
+      return false
+  }
+}
+
+function isTerminalAgentRunStatus(value: unknown): value is "succeeded" | "failed" | "cancelled" {
+  return value === "succeeded" || value === "failed" || value === "cancelled"
+}
+
+function isAgentRunFailure(value: unknown): value is AgentRunFailure {
+  if (!isPlainRecord(value)) return false
+  try {
+    parseSixbFailure(value, AGENT_RUN_FAILURE_CODES)
+    return true
+  } catch {
+    return false
   }
 }
 

--- a/packages/core/tests/agent-run-stream-records.test.ts
+++ b/packages/core/tests/agent-run-stream-records.test.ts
@@ -5,6 +5,7 @@ import {
   agentRunFinishedEvent,
   agentRunStreamId,
   agentRunStreamIdempotencyKey,
+  isAgentRunStreamEvent,
 } from "../src/agents/streams"
 import type { AgentRunRecord } from "../src/storage"
 
@@ -14,6 +15,8 @@ const FAILURE = {
   message: "boom",
   retryable: false,
   at: "2026-01-02T03:04:04.000Z",
+  details: { agentId: "assistant", runId: "agt_run_1" },
+  causeChain: [{ name: "ProviderError", message: "provider unavailable" }],
 }
 
 function runRecord(overrides: Partial<AgentRunRecord> = {}): AgentRunRecord {
@@ -49,9 +52,23 @@ describe("agent run stream records", () => {
       attempt: 2,
       status: "failed",
       finishReason: "error",
-      error: "boom",
+      error: FAILURE,
       occurredAt: "2026-01-02T03:04:05.000Z",
     })
+  })
+
+  test("validates the exact durable failure on a finished event", () => {
+    const event = agentRunFinishedEvent(
+      runRecord({ status: "failed", error: FAILURE }),
+      OCCURRED_AT
+    )
+
+    expect(isAgentRunStreamEvent(event)).toBe(true)
+    expect(isAgentRunStreamEvent({ ...event, error: FAILURE.message })).toBe(false)
+    expect(isAgentRunStreamEvent({ ...event, error: { ...FAILURE, retryable: true } })).toBe(false)
+    expect(
+      isAgentRunStreamEvent({ ...event, error: { ...FAILURE, code: "dataset.not_found" } })
+    ).toBe(false)
   })
 
   test("refuses to build a finished event for a non-terminal run", () => {


### PR DESCRIPTION
## Summary

- expose the exact durable Agent run failure on agent.run.finished stream records
- centralize Agent stream payload validation in the browser-safe Core subpath and reuse it in the client
- preserve structured failures in Agent UI while keeping schemaVersion 1

## Testing

- bun test packages/core/tests/agent-run-stream-records.test.ts packages/client/tests/browser.test.ts packages/agent-ui/tests/liveRun.test.ts
- bun test packages/agent-worker/tests/worker.test.ts
- bun --filter @sixb/core typecheck
- bun --filter @sixb/client typecheck
- bun --filter @sixb/agent-ui typecheck
- bun --filter @sixb/agent-worker typecheck
- bun run typecheck
- bun run build
- bun run test:publish
- bun run generate:client
- bun run check

Stacked on #378.