### PR TITLE
errors: correlate onError contexts with durable failures

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -42,6 +42,9 @@ Sync completion events reuse the exact failure stored on the run.
 The ontology outbox declares `event.delivery_failed`; its durable record is retained while publication
 is retried.
 
+Runtime `onError(error, context)` notifications expose the same record as `context.failure`. Failed runs and persisted outbox attempts reuse the exact object written to storage; failures without durable storage, such as rejected framework emits and rule evaluations, are normalized once at the reporting
+boundary. The native `error` argument remains available for stacks and error-monitoring integrations.
+
 Each storage and wire change remains independently reviewable even though every migrated primitive shares the same portable base record.
 
 | Code | Retryable | What happened | What to do |

--- a/docs/runtime/error-handling.md
+++ b/docs/runtime/error-handling.md
@@ -12,13 +12,13 @@ export const sixb = await createSixb({
   async onError(error, context) {
     const subject =
       context.type === "run.failed"
-        ? `${context.run.kind} run ${context.run.runId}`
+        ? `${context.runKind} run ${context.run.runId}`
         : context.type === "event.delivery.failed"
           ? `delivery of ${context.eventTypes.join(", ")}`
           : `${context.source} rule evaluation`
     await sendToSlack({
       deduplicationKey: context.notificationId,
-      message: `${subject} failed: ${error.message}`,
+      message: `${subject} failed with ${context.failure.code}: ${error.message}`,
     })
   },
 })
@@ -37,20 +37,25 @@ pipeline steps separately, or routine webhook 4xx rejections.
 The second argument is a discriminated `SixbErrorContext`:
 
 ```ts
-interface SixbRunFailedContext {
-  readonly type: "run.failed"
-  readonly notificationId: string
-  readonly projectId: string
-  readonly occurredAt: string
-  readonly attempt?: number
-  readonly run: SixbFailedRun
-}
+type SixbRunFailedContext = {
+  [TKind in SixbRunKind]: {
+    readonly type: "run.failed"
+    readonly notificationId: string
+    readonly projectId: string
+    readonly occurredAt: string
+    readonly attempt?: number
+    readonly runKind: TKind
+    readonly run: SixbRunIdentityByKind[TKind]
+    readonly failure: SixbRunFailureByKind[TKind]
+  }
+}[SixbRunKind]
 
 interface SixbEventDeliveryFailedContext {
   readonly type: "event.delivery.failed"
   readonly notificationId: string
   readonly projectId: string
   readonly occurredAt: string
+  readonly failure: SixbFailure<"event.delivery_failed">
   readonly attempts: number
   readonly eventTypes: readonly string[]
   readonly eventIds?: readonly string[]
@@ -61,6 +66,7 @@ interface SixbRuleEvaluationFailedContext {
   readonly notificationId: string
   readonly projectId: string
   readonly occurredAt: string
+  readonly failure: SixbFailure<"internal.unexpected">
   readonly source: "live" | "reconciliation"
   readonly eventIds: readonly string[]
   readonly ruleId?: string
@@ -68,10 +74,17 @@ interface SixbRuleEvaluationFailedContext {
 }
 ```
 
-`SixbFailedRun` has one variant per run kind — action, agent, pipeline, projection, sync, workflow,
-webhook — and every one carries a `runId`. Rules are the exception and are absent from it: they are
-evaluated live, per subject, with no run record, so they report as `rule.evaluation.failed` rather
-than being handed an id nothing can resolve.
+`runKind` is the top-level discriminant for action, agent, pipeline, projection, sync, workflow, and
+webhook failures. Narrowing it narrows both `run` and `failure`: action failures retain their lifecycle
+`phase`, while every other primitive exposes its exact allowed code union without a cast. Every `run`
+carries a `runId`. Rules are the exception: they are evaluated live, per subject, with no run record,
+so they report as `rule.evaluation.failed` rather than being handed an id nothing can resolve.
+
+`failure` is the machine-readable contract. For run failures and persisted outbox attempts it is the
+same object sent to durable storage, not a second normalization. The first `error` argument remains the
+native exception when one exists, preserving its stack and identity for diagnostics.
+For every context variant, `occurredAt` equals `failure.at`; notification identity and the portable
+record therefore share one canonical failure timestamp.
 
 ### Lost events
 
@@ -87,6 +100,8 @@ Two paths report it, which is why `eventIds` is optional:
 | A rejected framework emit | absent — nothing was persisted | always `1`; the failure is terminal |
 
 `eventTypes` is filled on both paths, so it is the field to read first. Payloads are never included.
+For persisted outbox attempts, `failure` is the exact record stored with the envelopes. A rejected
+framework emit has no storage record, so Sixb normalizes it once when reporting the terminal loss.
 
 ### Rule evaluations
 
@@ -99,12 +114,20 @@ keeps failing, rule state stops converging.
 absent when a whole batch or pass died before any one rule could be blamed, which is the more serious
 case rather than the vaguer one.
 
-Narrow `context.run.kind` to access the definition identifier for that run:
+Rule evaluation failures currently use `internal.unexpected`. The context deliberately does not claim
+a retry policy until the evaluator can distinguish a deterministic rule defect from a transient
+dependency failure.
+
+Narrow `context.runKind` to access the definition identifier and exact failure for that run:
 
 ```ts
 onError(error, context) {
   if (context.type === "event.delivery.failed") {
-    console.error(`Delivery attempt ${context.attempts} failed`, context.eventTypes, error)
+    console.error(
+      `Delivery attempt ${context.attempts} failed with ${context.failure.code}`,
+      context.eventTypes,
+      error,
+    )
     return
   }
 
@@ -113,12 +136,12 @@ onError(error, context) {
     return
   }
 
-  if (context.run.kind === "projection") {
-    console.error(`Projection ${context.run.projectionId} failed`, error)
+  if (context.runKind === "projection") {
+    console.error(`Projection ${context.run.projectionId} failed`, context.failure, error)
   }
 
-  if (context.run.kind === "workflow") {
-    console.error(`Workflow ${context.run.workflowId} failed`, error)
+  if (context.runKind === "action") {
+    console.error(`Action ${context.run.actionId} failed in ${context.failure.phase}`, error)
   }
 }
 ```
@@ -139,6 +162,5 @@ graceful CLI shutdown. A process crash can still happen between persisting a fai
 delivering its notification, so this API does not provide exactly-once delivery. Integrations
 should use `notificationId` to tolerate possible duplicate delivery.
 
-The original `Error` is preserved when one exists. Sixb safely wraps non-`Error` thrown values. The
-context contains identifiers only; delivery failures expose stable envelope IDs, never payloads or
-lease IDs.
+The original `Error` is preserved when one exists. Sixb safely wraps non-`Error` thrown values.
+Delivery contexts expose stable envelope IDs, never payloads or lease IDs; serialized failure details remain JSON-safe and scoped to the failure contract.

--- a/examples/northline/sixb.config.ts
+++ b/examples/northline/sixb.config.ts
@@ -26,13 +26,13 @@ export const sixb = createSixb({
   onError(error, context) {
     let failure: string
     if (context.type === "run.failed") {
-      failure = `${context.run.kind} run '${context.run.runId}' failed`
+      failure = `${context.runKind} run '${context.run.runId}' failed with ${context.failure.code}`
     } else if (context.type === "action.phase.failed") {
       failure = `action '${context.actionId}' phase '${context.phase}' failed with ${context.failure.code}`
     } else if (context.type === "event.delivery.failed") {
-      failure = `event delivery failed after ${context.attempts} attempt(s)`
+      failure = `event delivery failed with ${context.failure.code} after ${context.attempts} attempt(s)`
     } else {
-      failure = `${context.source} rule evaluation failed`
+      failure = `${context.source} rule evaluation failed with ${context.failure.code}`
     }
     console.error(`[Northline] ${failure} (${context.notificationId}):`, error)
   },

--- a/packages/action-worker/src/action-execution/results.ts
+++ b/packages/action-worker/src/action-execution/results.ts
@@ -50,7 +50,7 @@ export async function resolveRedeliveredRunningRun(
   }
 
   if (resolution.kind === "resume") return resolution
-  reportRedeliveryFailure(input, resolution.run)
+  reportRedeliveryFailure(input, resolution.run, resolution.failure)
   return {
     kind: "finished",
     result: failedResult(input.job.id, input.job.actionId, resolution.run, resolution.failure),
@@ -129,7 +129,11 @@ function redeliveryFailure(runId: string, run: ActionRunRecord, failedAt: Date):
   )
 }
 
-function reportRedeliveryFailure(input: RunActionJobInput, run: ActionRunRecord): void {
+function reportRedeliveryFailure(
+  input: RunActionJobInput,
+  run: ActionRunRecord,
+  failure: ActionRunFailure
+): void {
   const error = createSixbError(
     "internal.unexpected",
     `[SixbActionWorker] ${run.error?.message ?? `Action run '${run.id}' lost its lease.`}`,
@@ -137,13 +141,13 @@ function reportRedeliveryFailure(input: RunActionJobInput, run: ActionRunRecord)
   )
   reportRunFailure(input.runtime.errorReporterHost, error, {
     projectId: input.runtime.id,
-    occurredAt: run.finishedAt,
     attempt: input.attempt,
+    runKind: "action",
     run: {
-      kind: "action",
       runId: input.job.id,
       actionId: input.job.actionId,
     },
+    failure,
   })
 }
 

--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -1,6 +1,6 @@
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import { createSixbError } from "@sixb/core/internal/errors"
-import type { ActionRunRecord } from "@sixb/core/storage"
+import type { ActionRunFailure, ActionRunRecord } from "@sixb/core/storage"
 import { isTerminalActionRun } from "@sixb/core/storage"
 import { executeActionPhases } from "./action-execution/phases"
 import {
@@ -68,7 +68,7 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       finishedAt: failedAt,
       error: failure,
     })
-    reportActionFailure(input, error, finishedRun)
+    reportActionFailure(input, error, failure)
 
     return failedResult(job.id, job.actionId, finishedRun, failure)
   }
@@ -158,7 +158,7 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       throw error
     }
     if (status === "failed" && finishedRun.status === "failed") {
-      reportActionFailure(input, error, finishedRun)
+      reportActionFailure(input, error, failure)
     }
 
     const startedAt = startedRun?.startedAt ?? finishedRun.startedAt ?? finishedRun.queuedAt
@@ -179,15 +179,19 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
   }
 }
 
-function reportActionFailure(input: RunActionJobInput, error: unknown, run: ActionRunRecord): void {
+function reportActionFailure(
+  input: RunActionJobInput,
+  error: unknown,
+  failure: ActionRunFailure
+): void {
   reportRunFailure(input.runtime.errorReporterHost, error, {
     projectId: input.runtime.id,
-    occurredAt: run.finishedAt,
     attempt: input.attempt,
+    runKind: "action",
     run: {
-      kind: "action",
       runId: input.job.id,
       actionId: input.job.actionId,
     },
+    failure,
   })
 }

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -275,16 +275,17 @@ describe("ActionWorker", () => {
     expect(reports[0]?.error).toBe(originalError)
     expect(reports[0]?.context).toMatchObject({
       type: "run.failed",
-      notificationId: `project:${host.id}:run:action:${failed.id}:failed:${failed.finishedAt?.toISOString()}`,
+      notificationId: `project:${host.id}:run:action:${failed.id}:failed:${failed.error?.at}`,
       projectId: host.id,
       attempt: 1,
+      runKind: "action",
       run: {
-        kind: "action",
         runId: failed.id,
         actionId: "fail",
       },
+      failure: failed.error,
     })
-    expect(reports[0]?.context.occurredAt).toBe(failed.finishedAt?.toISOString() ?? "")
+    expect(reports[0]?.context.occurredAt).toBe(failed.error?.at ?? "")
   })
 
   test("requestActionAndWait resolves with the terminal action run", async () => {

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path"
-import type { AgentDefinition } from "@sixb/core"
+import type { AgentDefinition, SixbFailure } from "@sixb/core"
 import {
   createAgentRunExecutionToken,
   dispatchQueuedAgentRuns,
@@ -12,7 +12,7 @@ import { captureSixbFailure, createSixbError, isSixbError } from "@sixb/core/int
 import type { QueueDelivery, QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { isAbortError, QueueDeliveryLeaseLostError, QueueWorker } from "@sixb/core/internal/workers"
 import type { AgentQueueJob, ClaimedQueueJob } from "@sixb/core/queues"
-import type { AgentRunExecution, AgentRunRecord } from "@sixb/core/storage"
+import type { AgentRunExecution, AgentRunFailureCode, AgentRunRecord } from "@sixb/core/storage"
 import { AGENT_RUN_FAILURE_CODES, AgentStorageError } from "@sixb/core/storage"
 import { loadAgentSkills } from "./agent-skills"
 import { normalizeApiBaseUrl } from "./api-url"
@@ -57,6 +57,8 @@ const MAX_AGENT_DELIVERY_ATTEMPTS = 10
 type Reservation =
   | { readonly kind: "run"; readonly run: AgentRunRecord }
   | { readonly kind: "skip" }
+
+type AgentRunFailure = SixbFailure<AgentRunFailureCode>
 
 /**
  * Cohosted worker that turns durable queued agent runs into executing turns.
@@ -186,21 +188,22 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
       )
       if (queuedRun.status === "queued") {
         const completedAt = new Date()
+        const failure = toAgentRunFailure(
+          createSixbError(
+            "internal.unexpected",
+            `[SixbAgentWorker] Agent '${queuedRun.agentId}' is not registered.`,
+            { details: { agentId: queuedRun.agentId, runId } }
+          ),
+          { status: "failed", at: completedAt, run: queuedRun }
+        )
         const failed = await context.storage.agents.runs.finishQueued({
           projectId: context.id,
           id: queuedRun.id,
           status: "failed",
-          error: toAgentRunFailure(
-            createSixbError(
-              "internal.unexpected",
-              `[SixbAgentWorker] Agent '${queuedRun.agentId}' is not registered.`,
-              { details: { agentId: queuedRun.agentId, runId } }
-            ),
-            { status: "failed", at: completedAt, run: queuedRun }
-          ),
+          error: failure,
           completedAt,
         })
-        this.reportFailure(error, failed, job.attempt)
+        this.reportFailure(error, failed, job.attempt, failure)
         await context.streamSink.publishRunFinished(failed)
         return
       }
@@ -329,10 +332,10 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
         error
       )
       if (finalized) {
-        if (finalized.status === "failed") {
-          this.reportFailure(error, finalized, job.attempt)
+        if (finalized.run.status === "failed") {
+          this.reportFailure(error, finalized.run, job.attempt, finalized.failure)
         }
-        await context.streamSink.publishRunFinished(finalized)
+        await context.streamSink.publishRunFinished(finalized.run)
       }
       // Shutdown abort: rethrow so `onAbortError` releases the job for another process. A user cancel
       // or a recorded model/tool failure keeps its fate on the record, so we ack by returning.
@@ -389,14 +392,15 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
     })
     if (run?.status === "queued") {
       const completedAt = new Date()
+      const failure = toAgentRunFailure(error, { status: "failed", at: completedAt, run })
       const failed = await this.requireContext().storage.agents.runs.finishQueued({
         projectId: this.host.id,
         id: run.id,
         status: "failed",
-        error: toAgentRunFailure(error, { status: "failed", at: completedAt, run }),
+        error: failure,
         completedAt,
       })
-      this.reportFailure(error, failed, claimed.job.attempt)
+      this.reportFailure(error, failed, claimed.job.attempt, failure)
       await this.requireContext().streamSink.publishRunFinished(failed)
     }
     return { kind: "fail" }
@@ -595,16 +599,21 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
     })
   }
 
-  private reportFailure(error: unknown, run: AgentRunRecord, attempt: number): void {
+  private reportFailure(
+    error: unknown,
+    run: AgentRunRecord,
+    attempt: number,
+    failure: AgentRunFailure
+  ): void {
     reportRunFailure(this.host, error, {
       projectId: this.host.id,
-      occurredAt: run.completedAt,
       attempt,
+      runKind: "agent",
       run: {
-        kind: "agent",
         runId: run.id,
         agentId: run.agentId,
       },
+      failure,
     })
   }
 
@@ -614,17 +623,19 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
     executionToken: string,
     status: "failed" | "cancelled",
     error: unknown
-  ): Promise<AgentRunRecord | undefined> {
+  ): Promise<{ readonly run: AgentRunRecord; readonly failure: AgentRunFailure } | undefined> {
     try {
       const completedAt = new Date()
-      return await finishRunOrThrow(context.storage.agents, {
+      const failure = toAgentRunFailure(error, { status, at: completedAt, run })
+      const finalized = await finishRunOrThrow(context.storage.agents, {
         projectId: context.id,
         id: run.id,
         executionToken,
         status,
-        error: toAgentRunFailure(error, { status, at: completedAt, run }),
+        error: failure,
         completedAt,
       })
+      return { run: finalized, failure }
     } catch (finalizeError) {
       // Execution already lost / run already terminal — nothing more to record.
       if (finalizeError instanceof AgentExecutionLostError) {

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinition, ValueType, WorkflowDefinition } from "@sixb/core"
+import type { AgentDefinition, SixbFailure, ValueType, WorkflowDefinition } from "@sixb/core"
 import {
   createAgentRunExecutionToken,
   resolveAgentExecutionAuthorization,
@@ -18,6 +18,7 @@ import type {
   WorkflowAgentNodeRunExecution,
   WorkflowAgentNodeRunRecord,
   WorkflowNodeRunRecord,
+  WorkflowRunFailureCode,
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
@@ -202,13 +203,13 @@ export async function executeWorkflowAgentNode(
     if (status === "failed") {
       reportRunFailure(input.host, executionError, {
         projectId: context.id,
-        occurredAt: failed.run.finishedAt,
         attempt: job.attempt,
+        runKind: "workflow",
         run: {
-          kind: "workflow",
           runId: failed.run.id,
           workflowId: failed.run.workflowId,
         },
+        failure: failed.failure,
       })
     }
     await emitNodeAndRunFailed(input.host, failed, workflow.nodes.length, status)
@@ -430,7 +431,11 @@ async function finishWorkflowAgentNodeFailed(input: {
   readonly executionToken: string
   readonly status: "failed" | "cancelled"
   readonly error: unknown
-}): Promise<{ readonly node: WorkflowNodeRunRecord; readonly run: WorkflowRunRecord }> {
+}): Promise<{
+  readonly node: WorkflowNodeRunRecord
+  readonly run: WorkflowRunRecord
+  readonly failure: SixbFailure<WorkflowRunFailureCode>
+}> {
   const at = new Date()
   const failure = captureSixbFailure(input.error, {
     allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
@@ -485,7 +490,7 @@ async function finishWorkflowAgentNodeFailed(input: {
       error: failure,
       finishedAt: at,
     })
-    return { node, run }
+    return { node, run, failure }
   })
 }
 

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -4896,12 +4896,14 @@ describe("AgentWorker", () => {
       expect(reports[0]?.error).toBe(originalError)
       expect(reports[0]?.context).toMatchObject({
         type: "run.failed",
-        notificationId: `project:${PROJECT_ID}:run:agent:${run.id}:failed:${run.completedAt?.toISOString()}`,
+        notificationId: `project:${PROJECT_ID}:run:agent:${run.id}:failed:${run.error?.at}`,
         projectId: PROJECT_ID,
         attempt: 1,
-        run: { kind: "agent", runId: run.id, agentId: "assistant" },
+        runKind: "agent",
+        run: { runId: run.id, agentId: "assistant" },
+        failure: run.error,
       })
-      expect(reports[0]?.context.occurredAt).toBe(run.completedAt?.toISOString() ?? "")
+      expect(reports[0]?.context.occurredAt).toBe(run.error?.at ?? "")
       expect(
         (await listRunStreamRecords(sixb.broker, run.id)).find(
           (record) => record.name === "agent.run.finished"
@@ -5276,7 +5278,9 @@ describe("AgentWorker", () => {
       expect(reports[0]?.context).toMatchObject({
         projectId: PROJECT_ID,
         attempt: 1,
-        run: { kind: "agent", runId, agentId: "removed-agent" },
+        runKind: "agent",
+        run: { runId, agentId: "removed-agent" },
+        failure: failed.error,
       })
       await expect(
         storage.threads.getById({ projectId: PROJECT_ID, id: threadId })

--- a/packages/core/src/actions/run-dispatch.ts
+++ b/packages/core/src/actions/run-dispatch.ts
@@ -202,7 +202,7 @@ async function failActionRunPublication(
 ): Promise<void> {
   const failedAt = new Date()
   const failure = toActionRunFailure(error, run, failedAt)
-  const failed = await requireActionRunStorage(input.storage).finish({
+  await requireActionRunStorage(input.storage).finish({
     projectId: input.projectId,
     id: run.id,
     status: "failed",
@@ -211,8 +211,9 @@ async function failActionRunPublication(
   })
   reportRunFailure(input.errorReporterHost, error, {
     projectId: input.projectId,
-    occurredAt: failed.finishedAt,
-    run: { kind: "action", runId: run.id, actionId: run.actionId },
+    runKind: "action",
+    run: { runId: run.id, actionId: run.actionId },
+    failure,
   })
 }
 

--- a/packages/core/src/error-reporting/reports.ts
+++ b/packages/core/src/error-reporting/reports.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto"
+import { captureSixbFailure } from "../errors/internal"
+import type { SixbFailure } from "../errors/types"
 import type { ActionRunFailure } from "../storage/action-runs"
 import type { ErrorReporter } from "./reporter"
 import type { SixbFailedRun } from "./types"
@@ -8,10 +10,8 @@ function resolveOccurredAt(occurredAt?: Date | string): string {
   return occurredAt ?? new Date().toISOString()
 }
 
-export interface ReportRunFailureInput {
+export type ReportRunFailureInput = SixbFailedRun & {
   readonly projectId: string
-  readonly run: SixbFailedRun
-  readonly occurredAt?: Date | string
   readonly attempt?: number
 }
 
@@ -20,14 +20,12 @@ export function reportRunFailure(
   error: unknown,
   input: ReportRunFailureInput
 ): void {
-  const occurredAt = resolveOccurredAt(input.occurredAt)
+  const occurredAt = input.failure.at
   reporter.report(error, {
+    ...input,
     type: "run.failed",
-    notificationId: `project:${input.projectId}:run:${input.run.kind}:${input.run.runId}:failed:${occurredAt}`,
-    projectId: input.projectId,
+    notificationId: `project:${input.projectId}:run:${input.runKind}:${input.run.runId}:failed:${occurredAt}`,
     occurredAt,
-    ...(input.attempt === undefined ? {} : { attempt: input.attempt }),
-    run: input.run,
   })
 }
 
@@ -58,6 +56,8 @@ export function reportActionPhaseFailure(
 
 export interface ReportEventDeliveryFailureInput {
   readonly projectId: string
+  /** Exact durable failure when this delivery was persisted by the ontology outbox. */
+  readonly failure?: SixbFailure<"event.delivery_failed">
   /** Event types that never reached subscribers. Payloads must not be passed in. */
   readonly eventTypes: readonly string[]
   readonly occurredAt?: Date | string
@@ -92,9 +92,22 @@ export function reportEventDeliveryFailure(
   error: unknown,
   input: ReportEventDeliveryFailureInput
 ): void {
-  const occurredAt = resolveOccurredAt(input.occurredAt)
+  const occurredAt = input.failure?.at ?? resolveOccurredAt(input.occurredAt)
   const attempts = input.attempts ?? 1
   const eventIds = input.eventIds === undefined ? undefined : [...input.eventIds].sort()
+  const eventTypes = [...input.eventTypes]
+  const failure =
+    input.failure ??
+    captureSixbFailure(error, {
+      allowedCodes: ["event.delivery_failed"],
+      defaultCode: "event.delivery_failed",
+      details: {
+        attempts,
+        eventTypes,
+        ...(eventIds === undefined ? {} : { eventIds }),
+      },
+      at: new Date(occurredAt),
+    })
   const firstEventId = eventIds?.[0]
   const occurrence = firstEventId
     ? `events:${firstEventId}:attempt:${attempts}`
@@ -104,8 +117,9 @@ export function reportEventDeliveryFailure(
     notificationId: `project:${input.projectId}:event-delivery:${occurrence}`,
     projectId: input.projectId,
     occurredAt,
+    failure,
     attempts,
-    eventTypes: input.eventTypes,
+    eventTypes,
     ...(eventIds === undefined ? {} : { eventIds }),
   })
 }
@@ -127,6 +141,17 @@ export function reportRuleEvaluationFailure(
 ): void {
   const occurredAt = resolveOccurredAt(input.occurredAt)
   const eventIds = [...(input.eventIds ?? [])].sort()
+  const failure = captureSixbFailure(error, {
+    allowedCodes: ["internal.unexpected"],
+    defaultCode: "internal.unexpected",
+    details: {
+      source: input.source,
+      eventIds,
+      ...(input.ruleId === undefined ? {} : { ruleId: input.ruleId }),
+      ...(input.subject === undefined ? {} : { subject: input.subject }),
+    },
+    at: new Date(occurredAt),
+  })
   // A candidate-level failure keys on the candidate, so two rules failing over the same batch stay
   // two notifications rather than collapsing into one.
   const occurrence =
@@ -138,6 +163,7 @@ export function reportRuleEvaluationFailure(
     notificationId: `project:${input.projectId}:rule-evaluation:${input.source}:${occurrence}:failed:${occurredAt}`,
     projectId: input.projectId,
     occurredAt,
+    failure,
     source: input.source,
     eventIds,
     ...(input.ruleId === undefined ? {} : { ruleId: input.ruleId }),

--- a/packages/core/src/error-reporting/types.ts
+++ b/packages/core/src/error-reporting/types.ts
@@ -1,51 +1,74 @@
+import type { SixbFailure } from "../errors/types"
 import type { ActionRunFailure } from "../storage/action-runs"
+import type { AgentRunFailureCode } from "../storage/agents"
+import type { PipelineRunFailureCode } from "../storage/pipeline-runs"
+import type { ProjectionRunFailureCode } from "../storage/projection-runs"
+import type { SyncRunFailureCode } from "../storage/sync-runs"
+import type { WebhookRunFailureCode } from "../storage/webhook-runs"
+import type { WorkflowRunFailureCode } from "../storage/workflow-runs"
+
+/** Correlation fields exposed by `run.failed`, indexed by run primitive. */
+export interface SixbRunIdentityByKind {
+  readonly action: {
+    readonly runId: string
+    readonly actionId: string
+  }
+  readonly agent: {
+    readonly runId: string
+    readonly agentId: string
+  }
+  readonly pipeline: {
+    readonly runId: string
+    readonly pipelineId: string
+  }
+  readonly projection: {
+    readonly runId: string
+    readonly projectionId: string
+    readonly projectionKind: "object" | "link" | "telemetry"
+  }
+  readonly sync: {
+    readonly runId: string
+    readonly syncId: string
+  }
+  readonly workflow: {
+    readonly runId: string
+    readonly workflowId: string
+  }
+  readonly webhook: {
+    readonly runId: string
+    readonly connectorId: string
+    readonly webhookId: string
+  }
+}
+
+/** Canonical failure record exposed by `run.failed`, indexed by run primitive. */
+export interface SixbRunFailureByKind {
+  readonly action: ActionRunFailure
+  readonly agent: SixbFailure<AgentRunFailureCode>
+  readonly pipeline: SixbFailure<PipelineRunFailureCode>
+  readonly projection: SixbFailure<ProjectionRunFailureCode>
+  readonly sync: SixbFailure<SyncRunFailureCode>
+  readonly workflow: SixbFailure<WorkflowRunFailureCode>
+  readonly webhook: SixbFailure<WebhookRunFailureCode>
+}
 
 /**
  * The failed unit of work, discriminated by primitive. Each variant carries the correlation its
- * primitive actually has, and there is exactly one variant per `SixbRunKind`.
+ * primitive actually has and the exact failure persisted by that run. There is exactly one variant
+ * per `SixbRunKind`.
  *
  * Rules are deliberately absent: they are evaluated live, per subject, with no run record, so they
  * report through `SixbRuleEvaluationFailedContext` instead of being handed a `runId` that would name
  * an entity nothing can resolve.
  */
-export type SixbFailedRun =
-  | {
-      readonly kind: "action"
-      readonly runId: string
-      readonly actionId: string
-    }
-  | {
-      readonly kind: "agent"
-      readonly runId: string
-      readonly agentId: string
-    }
-  | {
-      readonly kind: "pipeline"
-      readonly runId: string
-      readonly pipelineId: string
-    }
-  | {
-      readonly kind: "projection"
-      readonly runId: string
-      readonly projectionId: string
-      readonly projectionKind: "object" | "link" | "telemetry"
-    }
-  | {
-      readonly kind: "sync"
-      readonly runId: string
-      readonly syncId: string
-    }
-  | {
-      readonly kind: "workflow"
-      readonly runId: string
-      readonly workflowId: string
-    }
-  | {
-      readonly kind: "webhook"
-      readonly runId: string
-      readonly connectorId: string
-      readonly webhookId: string
-    }
+export type SixbFailedRun = {
+  readonly [TKind in keyof SixbRunIdentityByKind]: {
+    /** Top-level discriminant so TypeScript narrows both `run` and `failure` without casts. */
+    readonly runKind: TKind
+    readonly run: SixbRunIdentityByKind[TKind]
+    readonly failure: SixbRunFailureByKind[TKind]
+  }
+}[keyof SixbRunIdentityByKind]
 
 interface SixbFailureContext<TType extends string> {
   readonly type: TType
@@ -61,11 +84,11 @@ interface SixbFailureContext<TType extends string> {
   readonly occurredAt: string
 }
 
-export interface SixbRunFailedContext extends SixbFailureContext<"run.failed"> {
-  /** Queue delivery attempt, when the run was executed through a queue. */
-  readonly attempt?: number
-  readonly run: SixbFailedRun
-}
+export type SixbRunFailedContext = SixbFailureContext<"run.failed"> &
+  SixbFailedRun & {
+    /** Queue delivery attempt, when the run was executed through a queue. */
+    readonly attempt?: number
+  }
 
 /** A post-commit Action effects phase failed without changing the committed Action outcome. */
 export interface SixbActionPhaseFailedContext extends SixbFailureContext<"action.phase.failed"> {
@@ -89,6 +112,8 @@ export interface SixbActionPhaseFailedContext extends SixbFailureContext<"action
  */
 export interface SixbEventDeliveryFailedContext
   extends SixbFailureContext<"event.delivery.failed"> {
+  /** Canonical delivery failure, also persisted when the outbox owns the delivery. */
+  readonly failure: SixbFailure<"event.delivery_failed">
   /** Delivery attempts so far. A rejected emit is terminal, so it reports 1. */
   readonly attempts: number
   /** Which event types never reached subscribers. Payloads are never included. */
@@ -114,6 +139,11 @@ export interface SixbEventDeliveryFailedContext
  */
 export interface SixbRuleEvaluationFailedContext
   extends SixbFailureContext<"rule.evaluation.failed"> {
+  /**
+   * Canonical snapshot of the thrown value. Rule failures remain `internal.unexpected` until the
+   * evaluator can distinguish deterministic rule failures from retryable dependency failures.
+   */
+  readonly failure: SixbFailure<"internal.unexpected">
   readonly source: "live" | "reconciliation"
   /** Envelope IDs involved in a live evaluation; empty for reconciliation. */
   readonly eventIds: readonly string[]

--- a/packages/core/src/events/outbox-dispatcher.ts
+++ b/packages/core/src/events/outbox-dispatcher.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto"
-import { createSixbError, toSixbFailure } from "../errors/internal"
-import type { ClaimedOntologyOutboxRow, OntologyOutboxStorage, Storage } from "../storage"
+import { createSixbError, serializeSixbFailure, toSixbFailure } from "../errors/internal"
+import type {
+  ClaimedOntologyOutboxRow,
+  OntologyOutboxFailure,
+  OntologyOutboxStorage,
+  Storage,
+} from "../storage"
 import { ONTOLOGY_OUTBOX_FAILURE_CODES } from "../storage/ontology/outbox"
 import type { StableEventPublisher } from "./service"
 
@@ -18,6 +23,8 @@ const DEFAULT_SHUTDOWN_TIMEOUT_MS = 30_000
 
 export interface OntologyOutboxDeliveryFailure {
   readonly occurredAt: string
+  /** Exact failure persisted on every envelope represented by this report. */
+  readonly failure: OntologyOutboxFailure
   readonly attempts: number
   readonly eventIds: readonly string[]
   /** Types of the undelivered envelopes. The one field both delivery paths can always report. */
@@ -321,12 +328,12 @@ export class OntologyOutboxDispatcher {
     const failedAt = this.now()
 
     for (const [attempts, attemptRows] of rowsByAttempts(settling)) {
-      const deliveryError = createEventDeliveryError(error, attempts, attemptRows)
+      const deliveryError = createEventDeliveryError(error, attempts)
       const failure = toSixbFailure(deliveryError, {
         allowedCodes: ONTOLOGY_OUTBOX_FAILURE_CODES,
         at: failedAt,
       })
-      failures.add(deliveryError, failedAt.toISOString(), attempts, attemptRows)
+      failures.add(deliveryError, failure, failedAt.toISOString(), attempts, attemptRows)
       try {
         await this.withOutbox((outbox) =>
           outbox.reschedule({
@@ -412,19 +419,30 @@ interface AccumulatedDeliveryFailure {
 /** Coalesces bisection failures so one claimed row is reported once per delivery attempt. */
 class DeliveryFailureAccumulator {
   private readonly groups = new Map<
-    number,
-    { error: unknown; occurredAt: string; eventIds: Set<string>; eventTypes: Set<string> }
+    string,
+    {
+      error: unknown
+      failure: OntologyOutboxFailure
+      occurredAt: string
+      attempts: number
+      eventIds: Set<string>
+      eventTypes: Set<string>
+    }
   >()
 
   add(
     error: unknown,
+    failure: OntologyOutboxFailure,
     occurredAt: string,
     attempts: number,
     rows: readonly ClaimedOntologyOutboxRow[]
   ): void {
-    const group = this.groups.get(attempts) ?? {
+    const key = serializeSixbFailure(failure, ONTOLOGY_OUTBOX_FAILURE_CODES)
+    const group = this.groups.get(key) ?? {
       error,
+      failure,
       occurredAt,
+      attempts,
       eventIds: new Set<string>(),
       eventTypes: new Set<string>(),
     }
@@ -432,15 +450,16 @@ class DeliveryFailureAccumulator {
       group.eventIds.add(row.envelope.id)
       group.eventTypes.add(row.envelope.type)
     }
-    this.groups.set(attempts, group)
+    this.groups.set(key, group)
   }
 
   list(): readonly AccumulatedDeliveryFailure[] {
-    return [...this.groups.entries()].map(([attempts, group]) => ({
+    return [...this.groups.values()].map((group) => ({
       error: group.error,
       context: {
         occurredAt: group.occurredAt,
-        attempts,
+        failure: group.failure,
+        attempts: group.attempts,
         eventIds: [...group.eventIds].sort(),
         eventTypes: [...group.eventTypes].sort(),
       },
@@ -492,11 +511,7 @@ function sharedLeaseId(rows: readonly ClaimedOntologyOutboxRow[]): string {
   return leaseId
 }
 
-function createEventDeliveryError(
-  cause: unknown,
-  attempts: number,
-  rows: readonly ClaimedOntologyOutboxRow[]
-) {
+function createEventDeliveryError(cause: unknown, attempts: number) {
   return createSixbError(
     "event.delivery_failed",
     "[Sixb] Could not deliver persisted ontology events.",
@@ -504,8 +519,6 @@ function createEventDeliveryError(
       cause,
       details: {
         attempts,
-        eventIds: eventIds(rows).sort(),
-        eventTypes: [...new Set(rows.map((row) => row.envelope.type))].sort(),
       },
     }
   )

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -816,6 +816,8 @@ export type {
   SixbFailedRun,
   SixbRuleEvaluationFailedContext,
   SixbRunFailedContext,
+  SixbRunFailureByKind,
+  SixbRunIdentityByKind,
 } from "./error-reporting/types"
 export type { SixbErrorCode, SixbFailure } from "./errors/types"
 export type { EventsRuntime } from "./events/execution"
@@ -889,6 +891,17 @@ export {
   SyncValidationError,
 } from "./runtime"
 export type { SchedulesRuntime } from "./schedules/execution"
+export type {
+  ActionRunFailure,
+  ActionRunFailureCode,
+  ActionRunPhase,
+  AgentRunFailureCode,
+  PipelineRunFailureCode,
+  ProjectionRunFailureCode,
+  SyncRunFailureCode,
+  WebhookRunFailureCode,
+  WorkflowRunFailureCode,
+} from "./storage"
 export type { SyncRunsRuntime, SyncsRuntime } from "./syncs/execution"
 export type {
   WorkflowInterventionsRuntime,

--- a/packages/core/src/workflows/run-dispatch.ts
+++ b/packages/core/src/workflows/run-dispatch.ts
@@ -270,20 +270,22 @@ async function failWorkflowRunPublication(
   if (!workflowRuns) {
     throw new WorkflowValidationError("[Sixb] Workflow run storage is not configured.")
   }
-  const failed = await workflowRuns.finish({
+  const failure = captureSixbFailure(error, {
+    allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
+    defaultCode: "internal.unexpected",
+    details: { workflowId: run.workflowId, runId: run.id },
+  })
+  await workflowRuns.finish({
     projectId: input.projectId,
     id: run.id,
     status: "failed",
-    error: captureSixbFailure(error, {
-      allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
-      defaultCode: "internal.unexpected",
-      details: { workflowId: run.workflowId, runId: run.id },
-    }),
+    error: failure,
   })
   reportRunFailure(input.errorReporterHost, error, {
     projectId: input.projectId,
-    occurredAt: failed.finishedAt,
-    run: { kind: "workflow", runId: run.id, workflowId: run.workflowId },
+    runKind: "workflow",
+    run: { runId: run.id, workflowId: run.workflowId },
+    failure,
   })
 }
 

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -947,7 +947,7 @@ describe("requestAction", () => {
     })
     await flushSixbErrors(sixb)
     expect(reports).toEqual([
-      `project:action-enqueue-retry-test:run:action:act_enqueue_retry:failed:${failed?.finishedAt?.toISOString()}:queue unavailable`,
+      `project:action-enqueue-retry-test:run:action:act_enqueue_retry:failed:${failed?.error?.at}:queue unavailable`,
     ])
 
     const retry = await sixb.objects(Room).requestAction({

--- a/packages/core/tests/error-reporting.test.ts
+++ b/packages/core/tests/error-reporting.test.ts
@@ -16,6 +16,15 @@ import { DomainEventService } from "../src/events"
 const PROJECT_ID = "error-reporting-tests"
 const OCCURRED_AT = "2026-07-29T12:00:00.000Z"
 
+function unexpectedFailure(message: string, at = OCCURRED_AT) {
+  return {
+    code: "internal.unexpected" as const,
+    message,
+    retryable: false,
+    at,
+  }
+}
+
 describe("Sixb error reporting", () => {
   test("reports a normalized terminal run failure with stable context", async () => {
     const host = {}
@@ -24,16 +33,17 @@ describe("Sixb error reporting", () => {
       reports.push({ error, context })
     })
 
+    const failure = unexpectedFailure("projection exploded", "2026-01-02T03:04:05.000Z")
     reportRunFailure(host, "projection exploded", {
       projectId: PROJECT_ID,
-      occurredAt: "2026-01-02T03:04:05.000Z",
       attempt: 2,
+      runKind: "projection",
       run: {
-        kind: "projection",
         runId: "projection-run-1",
         projectionId: "rooms",
         projectionKind: "object",
       },
+      failure,
     })
     await flushSixbErrors(host)
 
@@ -47,13 +57,16 @@ describe("Sixb error reporting", () => {
       projectId: PROJECT_ID,
       occurredAt: "2026-01-02T03:04:05.000Z",
       attempt: 2,
+      runKind: "projection",
       run: {
-        kind: "projection",
         runId: "projection-run-1",
         projectionId: "rooms",
         projectionKind: "object",
       },
+      failure,
     })
+    if (reports[0]?.context.type !== "run.failed") throw new Error("expected a run failure")
+    expect(reports[0].context.failure).toBe(failure)
   })
 
   test("reports delivery failures with envelope IDs only", async () => {
@@ -63,9 +76,21 @@ describe("Sixb error reporting", () => {
       reports.push({ error, context })
     })
 
+    const failure = {
+      code: "event.delivery_failed" as const,
+      message: "broker unavailable",
+      retryable: true,
+      at: "2026-01-02T03:04:05.000Z",
+      details: {
+        attempts: 3,
+        eventTypes: ["object.updated"],
+        eventIds: ["event-a", "event-b"],
+      },
+    }
     reportEventDeliveryFailure(host, new Error("broker unavailable"), {
       projectId: PROJECT_ID,
       occurredAt: "2026-01-02T03:04:05.000Z",
+      failure,
       attempts: 3,
       eventTypes: ["object.updated"],
       eventIds: ["event-b", "event-a"],
@@ -77,6 +102,7 @@ describe("Sixb error reporting", () => {
       notificationId: "project:error-reporting-tests:event-delivery:events:event-a:attempt:3",
       projectId: PROJECT_ID,
       occurredAt: "2026-01-02T03:04:05.000Z",
+      failure,
       attempts: 3,
       eventTypes: ["object.updated"],
       eventIds: ["event-a", "event-b"],
@@ -149,6 +175,13 @@ describe("Sixb error reporting", () => {
         "project:error-reporting-tests:rule-evaluation:live:event-a:failed:2026-01-02T03:04:05.000Z",
       projectId: PROJECT_ID,
       occurredAt: "2026-01-02T03:04:05.000Z",
+      failure: {
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        at: "2026-01-02T03:04:05.000Z",
+        details: { source: "live", eventIds: ["event-a", "event-b"] },
+      },
       source: "live",
       eventIds: ["event-a", "event-b"],
     })
@@ -184,7 +217,9 @@ describe("Sixb error reporting", () => {
     expect(() =>
       reportRunFailure(host, new Error("run failed"), {
         projectId: PROJECT_ID,
-        run: { kind: "sync", runId: "sync-run-1", syncId: "customers" },
+        runKind: "sync",
+        run: { runId: "sync-run-1", syncId: "customers" },
+        failure: unexpectedFailure("run failed"),
       })
     ).not.toThrow()
     await flushSixbErrors(host)
@@ -201,14 +236,18 @@ describe("Sixb error reporting", () => {
       if (error.message === "first") {
         reportRunFailure(host, new Error("second"), {
           projectId: PROJECT_ID,
-          run: { kind: "sync", runId: "sync-run-2", syncId: "customers" },
+          runKind: "sync",
+          run: { runId: "sync-run-2", syncId: "customers" },
+          failure: unexpectedFailure("second"),
         })
       }
     })
 
     reportRunFailure(host, new Error("first"), {
       projectId: PROJECT_ID,
-      run: { kind: "sync", runId: "sync-run-1", syncId: "customers" },
+      runKind: "sync",
+      run: { runId: "sync-run-1", syncId: "customers" },
+      failure: unexpectedFailure("first"),
     })
     await flushSixbErrors(host)
 
@@ -221,7 +260,9 @@ describe("Sixb error reporting", () => {
     attachSixbErrorReporter(host, () => new Promise<void>(() => {}))
     reportRunFailure(host, new Error("run failed"), {
       projectId: PROJECT_ID,
-      run: { kind: "agent", runId: "agent-run-1", agentId: "assistant" },
+      runKind: "agent",
+      run: { runId: "agent-run-1", agentId: "assistant" },
+      failure: unexpectedFailure("run failed"),
     })
 
     await flushSixbErrors(host, 5)
@@ -239,7 +280,9 @@ describe("Sixb error reporting", () => {
       const error = new Error("workflow failed")
       reportRunFailure(host, error, {
         projectId: PROJECT_ID,
-        run: { kind: "workflow", runId: "workflow-run-1", workflowId: "approval" },
+        runKind: "workflow",
+        run: { runId: "workflow-run-1", workflowId: "approval" },
+        failure: unexpectedFailure("workflow failed"),
       })
       await flushSixbErrors(host)
 
@@ -249,7 +292,8 @@ describe("Sixb error reporting", () => {
         expect.objectContaining({
           type: "run.failed",
           projectId: PROJECT_ID,
-          run: { kind: "workflow", runId: "workflow-run-1", workflowId: "approval" },
+          runKind: "workflow",
+          run: { runId: "workflow-run-1", workflowId: "approval" },
         })
       )
     } finally {
@@ -265,7 +309,9 @@ describe("Sixb error reporting", () => {
       expect(() =>
         reportRunFailure({}, new Error("run failed"), {
           projectId: PROJECT_ID,
-          run: { kind: "sync", runId: "sync-run-1", syncId: "customers" },
+          runKind: "sync",
+          run: { runId: "sync-run-1", syncId: "customers" },
+          failure: unexpectedFailure("run failed"),
         })
       ).not.toThrow()
     } finally {

--- a/packages/core/tests/error-reporting.types.ts
+++ b/packages/core/tests/error-reporting.types.ts
@@ -1,4 +1,4 @@
-import type { SixbErrorContext, SixbFailedRun, SixbRunKind } from "../src"
+import type { SixbErrorContext, SixbFailedRun, SixbRunFailureByKind, SixbRunKind } from "../src"
 
 type Expect<T extends true> = T
 type Equal<A, B> =
@@ -9,7 +9,8 @@ type Equal<A, B> =
  * variant per kind. Adding a kind without a failure shape — or the reverse — fails here rather than
  * silently leaving a primitive unable to report why it broke.
  */
-type _everyRunKindCanFail = Expect<Equal<SixbFailedRun["kind"], SixbRunKind>>
+type _everyRunKindCanFail = Expect<Equal<SixbFailedRun["runKind"], SixbRunKind>>
+type _everyRunKindHasFailureContract = Expect<Equal<keyof SixbRunFailureByKind, SixbRunKind>>
 
 /**
  * Every variant carries a `runId`, which is what makes the invariant above meaningful: a kind that
@@ -17,7 +18,16 @@ type _everyRunKindCanFail = Expect<Equal<SixbFailedRun["kind"], SixbRunKind>>
  * per subject with no run record, so they are not a run kind and report through
  * `rule.evaluation.failed` instead.
  */
-type _everyFailedRunIsIdentifiable = Expect<Equal<SixbFailedRun["runId"], string>>
+type _everyFailedRunIsIdentifiable = Expect<Equal<SixbFailedRun["run"]["runId"], string>>
+
+/** The top-level run discriminant narrows both the correlation and its exact failure shape. */
+type ActionRunFailureContext = Extract<
+  SixbErrorContext,
+  { readonly type: "run.failed"; readonly runKind: "action" }
+>
+type _actionFailureKeepsItsPhase = Expect<
+  Equal<ActionRunFailureContext["failure"], SixbRunFailureByKind["action"]>
+>
 
 /** The error context is discriminated on `type`, and every member carries a dedup key. */
 type _errorContextIsDiscriminated = Expect<

--- a/packages/core/tests/events-outbox-dispatcher.test.ts
+++ b/packages/core/tests/events-outbox-dispatcher.test.ts
@@ -105,7 +105,6 @@ describe("OntologyOutboxDispatcher", () => {
     const events = new DomainEventService({ projectId: "project", broker })
     const { materializer } = createMaterializerFixture({ storage })
     await seedObjectCreated(materializer, "request-retry", "retry")
-    const eventId = outboxRows(storage)[0]!.envelope.id
     let nowMs = NOW.getTime()
     const randomValues = [1, 0.5, 1]
 
@@ -141,8 +140,6 @@ describe("OntologyOutboxDispatcher", () => {
         at: "2026-01-02T03:04:05.325Z",
         details: {
           attempts: 3,
-          eventIds: [eventId],
-          eventTypes: ["object.created"],
         },
       },
     })
@@ -189,7 +186,11 @@ describe("OntologyOutboxDispatcher", () => {
     })
     await seedObjectCreated(materializer, "request-newer", "newer")
     const newerId = outboxRows(storage).find((row) => row.envelope.id !== olderId)!.envelope.id
-    const failures: { readonly attempts: number; readonly eventIds: readonly string[] }[] = []
+    const failures: {
+      readonly failure: OntologyOutboxFailure
+      readonly attempts: number
+      readonly eventIds: readonly string[]
+    }[] = []
 
     const dispatcher = new OntologyOutboxDispatcher({
       projectId: "project",
@@ -230,7 +231,11 @@ describe("OntologyOutboxDispatcher", () => {
     for (let index = 0; index < 5; index += 1) {
       await seedObjectCreated(materializer, `request-${index}`, `device-${index}`)
     }
-    const failures: { readonly attempts: number; readonly eventIds: readonly string[] }[] = []
+    const failures: {
+      readonly failure: OntologyOutboxFailure
+      readonly attempts: number
+      readonly eventIds: readonly string[]
+    }[] = []
     const dispatcher = new OntologyOutboxDispatcher({
       projectId: "project",
       storage,
@@ -248,6 +253,10 @@ describe("OntologyOutboxDispatcher", () => {
     expect(outboxRows(storage).filter((row) => row.attempts === 0)).toHaveLength(3)
     expect(failures).toHaveLength(1)
     expect(failures[0]?.eventIds).toHaveLength(2)
+    const persistedFailures = outboxRows(storage)
+      .filter((row) => row.attempts === 1)
+      .map((row) => row.lastFailure)
+    expect(persistedFailures).toEqual([failures[0]?.failure, failures[0]?.failure])
     await dispatcher.stop()
   })
 
@@ -332,8 +341,6 @@ describe("OntologyOutboxDispatcher", () => {
         at: NOW.toISOString(),
         details: {
           attempts: 1,
-          eventIds: [poisonId],
-          eventTypes: ["object.created"],
         },
       },
     })
@@ -382,8 +389,6 @@ describe("OntologyOutboxDispatcher", () => {
         at: NOW.toISOString(),
         details: {
           attempts: 1,
-          eventIds: [poisonId],
-          eventTypes: ["object.created"],
         },
       },
     })

--- a/packages/core/tests/workflow-request.test.ts
+++ b/packages/core/tests/workflow-request.test.ts
@@ -152,7 +152,7 @@ describe("sixb.workflows.request", () => {
     })
     await flushSixbErrors(host)
     expect(reports).toEqual([
-      `project:workflow-enqueue-failure:run:workflow:run_enqueue_failure:failed:${run?.finishedAt?.toISOString()}:workflow queue unavailable`,
+      `project:workflow-enqueue-failure:run:workflow:run_enqueue_failure:failed:${run?.error?.at}:workflow queue unavailable`,
     ])
   })
 

--- a/packages/pipeline-worker/src/run-pipeline-job.ts
+++ b/packages/pipeline-worker/src/run-pipeline-job.ts
@@ -122,17 +122,20 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
     if (startedRun && !finished) {
       const status = statusForFailure(signal, error)
       try {
+        const failure = captureSixbFailure(error, {
+          allowedCodes: PIPELINE_RUN_FAILURE_CODES,
+          defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+          details: { pipelineId: pipeline.id, runId: job.id },
+        })
         const run = await runtime.pipelineRunsStorage.finish({
           projectId: runtime.id,
           id: job.id,
           status,
-          error: captureSixbFailure(error, {
-            allowedCodes: PIPELINE_RUN_FAILURE_CODES,
-            defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
-            details: { pipelineId: pipeline.id, runId: job.id },
-          }),
+          error: failure,
         })
-        if (status === "failed" && run.status === "failed") input.onRunFailed?.(error, run)
+        if (status === "failed" && run.status === "failed") {
+          input.onRunFailed?.(error, run, failure)
+        }
         await notifyRunFinished(input.onRunFinished, run)
       } catch {
         // The run did not transition to the requested terminal status.

--- a/packages/pipeline-worker/src/types.ts
+++ b/packages/pipeline-worker/src/types.ts
@@ -1,8 +1,16 @@
-import type { DomainEventLog, LakeStorage, Queues, SixbDefinitions, Storage } from "@sixb/core"
+import type {
+  DomainEventLog,
+  LakeStorage,
+  Queues,
+  SixbDefinitions,
+  SixbFailure,
+  Storage,
+} from "@sixb/core"
 import type { LoggingService } from "@sixb/core/internal/logging"
 import type { PrimitiveExecutionHost } from "@sixb/core/internal/primitive-execution"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
 import type {
+  PipelineRunFailureCode,
   PipelineRunRecord,
   PipelineRunStorage,
   PipelineStepRunRecord,
@@ -52,7 +60,11 @@ export type PipelineRunStartedHandler = (run: PipelineRunRecord) => Promise<void
 
 export type PipelineRunFinishedHandler = (run: PipelineRunRecord) => Promise<void> | void
 
-export type PipelineRunFailedHandler = (error: unknown, run: PipelineRunRecord) => void
+export type PipelineRunFailedHandler = (
+  error: unknown,
+  run: PipelineRunRecord,
+  failure: SixbFailure<PipelineRunFailureCode>
+) => void
 
 export interface PipelineStepLifecycleContext {
   readonly stepIndex: number

--- a/packages/pipeline-worker/src/worker.ts
+++ b/packages/pipeline-worker/src/worker.ts
@@ -64,16 +64,16 @@ export class PipelineWorker extends QueueWorker<
         signal,
         onRunStarted: (run) => emitPipelineRunStarted(this.host.events, run),
         onRunFinished: (run) => emitPipelineRunFinished(this.host.events, run),
-        onRunFailed: (error, run) => {
+        onRunFailed: (error, run, failure) => {
           reportRunFailure(this.host, error, {
             projectId: this.host.id,
-            occurredAt: run.finishedAt,
             attempt: job.attempt,
+            runKind: "pipeline",
             run: {
-              kind: "pipeline",
               runId: run.id,
               pipelineId: run.pipelineId,
             },
+            failure,
           })
         },
         onStepStarted: (step, context) =>

--- a/packages/pipeline-worker/tests/worker.test.ts
+++ b/packages/pipeline-worker/tests/worker.test.ts
@@ -431,15 +431,16 @@ describe("PipelineWorker", () => {
       expect(reports[0]?.error).toBe(originalError)
       expect(reports[0]?.context).toEqual({
         type: "run.failed",
-        notificationId: `project:${sixb.id}:run:pipeline:run-fails-late:failed:${run!.finishedAt!.toISOString()}`,
+        notificationId: `project:${sixb.id}:run:pipeline:run-fails-late:failed:${run!.error!.at}`,
         projectId: sixb.id,
-        occurredAt: run!.finishedAt!.toISOString(),
+        occurredAt: run!.error!.at,
         attempt: 1,
+        runKind: "pipeline",
         run: {
-          kind: "pipeline",
           runId: "run-fails-late",
           pipelineId: pipeline.id,
         },
+        failure: run!.error!,
       })
 
       const claimed = await sixb.queues.pipelines.claim({

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -1,9 +1,9 @@
+import type { SixbFailure } from "@sixb/core"
 import {
   isMaterializationConflictError,
   MaterializationCancellationError,
   MaterializationValidationError,
   type ProjectionDefinition,
-  type SixbFailure,
 } from "@sixb/core"
 import { captureSixbFailure, createSixbError, isSixbError } from "@sixb/core/internal/errors"
 import {
@@ -55,9 +55,10 @@ export async function runProjectionJob(input: RunProjectionJobInput): Promise<Pr
       throw error
     }
     if ((await isPermanentFailure(input, execution, error)) && !signal.aborted) {
-      await finishProjection(input, execution, projectionFailure(input, error, "failed"))
+      const decision = projectionFailure(input, error, "failed")
+      await finishProjection(input, execution, decision)
       const run = await requireRun(input)
-      input.onRunFailed?.(error, run)
+      input.onRunFailed?.(error, run, decision.error)
     }
     // Transient errors, delivery loss, shutdown, and stale executions deliberately leave the run
     // running so the next QueueDelivery can reclaim it with a fresh token.

--- a/packages/projection-worker/src/types.ts
+++ b/packages/projection-worker/src/types.ts
@@ -1,7 +1,13 @@
-import type { LakeStorage, OntologyDefinitionCatalog, SixbDefinitions } from "@sixb/core"
+import type {
+  LakeStorage,
+  OntologyDefinitionCatalog,
+  SixbDefinitions,
+  SixbFailure,
+} from "@sixb/core"
 import type { ProjectionMaterializationIdentity } from "@sixb/core/internal/materialization"
 import type {
   ProjectionRunClaim,
+  ProjectionRunFailureCode,
   ProjectionRunRecord,
   ProjectionRunStorage,
 } from "@sixb/core/storage"
@@ -36,7 +42,11 @@ export interface RunProjectionJobInput {
   readonly onRunFailed?: ProjectionRunFailedHandler
 }
 
-export type ProjectionRunFailedHandler = (error: unknown, run: ProjectionRunRecord) => void
+export type ProjectionRunFailedHandler = (
+  error: unknown,
+  run: ProjectionRunRecord,
+  failure: SixbFailure<ProjectionRunFailureCode>
+) => void
 
 export interface ProjectionJobResult {
   readonly run: ProjectionRunRecord

--- a/packages/projection-worker/src/worker.ts
+++ b/packages/projection-worker/src/worker.ts
@@ -61,17 +61,17 @@ export class ProjectionWorker extends QueueWorker<
       runtime: context,
       job: { id: job.id, ...job.payload },
       signal,
-      onRunFailed: (error, run) => {
+      onRunFailed: (error, run, failure) => {
         reportRunFailure(this.host, error, {
           projectId: this.host.id,
-          occurredAt: run.finishedAt,
           attempt: job.attempt,
+          runKind: "projection",
           run: {
-            kind: "projection",
             runId: run.id,
             projectionId: run.identity.projectionId,
             projectionKind: run.identity.projectionKind,
           },
+          failure,
         })
       },
     })

--- a/packages/projection-worker/tests/worker.test.ts
+++ b/packages/projection-worker/tests/worker.test.ts
@@ -231,16 +231,17 @@ describe("ProjectionWorker", () => {
       expect(reports[0]?.error.message).toContain("room_id")
       expect(reports[0]?.context).toEqual({
         type: "run.failed",
-        notificationId: `project:${sixb.id}:run:projection:${runId}:failed:${run!.finishedAt!.toISOString()}`,
+        notificationId: `project:${sixb.id}:run:projection:${runId}:failed:${run!.error!.at}`,
         projectId: sixb.id,
-        occurredAt: run!.finishedAt!.toISOString(),
+        occurredAt: run!.error!.at,
         attempt: 1,
+        runKind: "projection",
         run: {
-          kind: "projection",
           runId,
           projectionId: roomProjection.id,
           projectionKind: "object",
         },
+        failure: run!.error!,
       })
 
       const claimed = await sixb.queues.projections.claim({

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -5,6 +5,7 @@ import type {
   ConnectorDefinition,
   Logger,
   RegisteredWebhook,
+  SixbFailure,
   SixbHostView,
   WebhookDefinition,
   WebhookMetadata,
@@ -17,6 +18,7 @@ import type {
   WebhookDeliveryClaimResult,
   WebhookDeliveryFailure,
   WebhookDeliveryKey,
+  WebhookRunFailureCode,
 } from "@sixb/core/storage"
 import { WEBHOOK_DELIVERY_FAILURE_CODES, WEBHOOK_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import type { Elysia } from "elysia"
@@ -66,6 +68,8 @@ type WebhookRunFinishInput = WebhookRunFinishBaseInput &
       }
   )
 
+type WebhookRunFailure = SixbFailure<WebhookRunFailureCode>
+
 type DeliveryClaimResult =
   | {
       readonly status: "run"
@@ -113,18 +117,19 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
   })
   const logSession = host.logging.startExecution({ kind: "webhook", id: runId })
   let failureReported = false
-  const reportFailure = (error: unknown) => {
+  const reportFailure = (error: unknown, failure: WebhookRunFailure) => {
     if (failureReported) return
 
     failureReported = true
     reportRunFailure(host, error, {
       projectId: host.id,
+      runKind: "webhook",
       run: {
-        kind: "webhook",
         runId,
         connectorId: registered.connector.id,
         webhookId: registered.webhook.id,
       },
+      failure,
     })
   }
 
@@ -139,7 +144,7 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
       reportFailure
     )
   } catch (error) {
-    await finishWebhookRun({
+    const failure = await finishWebhookRun({
       host,
       registered,
       runId,
@@ -147,7 +152,7 @@ async function dispatchWebhook(options: DispatchWebhookOptions): Promise<unknown
       responseStatus: 500,
       error,
     })
-    reportFailure(error)
+    reportFailure(error, failure)
     throw error
   } finally {
     await logSession.flush()
@@ -159,7 +164,7 @@ async function dispatchWebhookRun(
   runId: string,
   sixb: ReturnType<typeof bindPrimitiveExecution>["sixb"],
   loggerForPhase: (phase: string) => Logger,
-  reportFailure: (error: unknown) => void
+  reportFailure: (error: unknown, failure: WebhookRunFailure) => void
 ): Promise<unknown> {
   const { host, registered, request, set } = options
   const { connector, webhook, route } = registered
@@ -280,9 +285,8 @@ async function dispatchWebhookRun(
     }
     deliveryKey = claim.key
   } catch (error) {
-    reportFailure(error)
     set.status = 500
-    await finishWebhookRun({
+    const failure = await finishWebhookRun({
       host,
       registered,
       runId,
@@ -291,6 +295,7 @@ async function dispatchWebhookRun(
       responseStatus: 500,
       error: "Webhook delivery claim failed",
     })
+    reportFailure(error, failure)
     return { error: "Webhook delivery claim failed" }
   }
 
@@ -306,7 +311,7 @@ async function dispatchWebhookRun(
       cause: error,
       responseStatus: 500,
     })
-    reportFailure(deliveryFailure.error)
+    reportFailure(deliveryFailure.error, deliveryFailure.failure)
     // Handler failures mark the key failed so the provider's next retry can
     // attempt the delivery again.
     if (deliveryKey) {
@@ -364,9 +369,8 @@ async function dispatchWebhookRun(
       }
     }
   } catch (error) {
-    reportFailure(error)
     set.status = 500
-    await finishWebhookRun({
+    const failure = await finishWebhookRun({
       host,
       registered,
       runId,
@@ -377,11 +381,12 @@ async function dispatchWebhookRun(
       deliveryClaimResult,
       error: "Webhook delivery completion failed",
     })
+    reportFailure(error, failure)
     return { error: "Webhook delivery completion failed" }
   }
 
   if (deliveryFailure) {
-    reportFailure(deliveryFailure.error)
+    reportFailure(deliveryFailure.error, deliveryFailure.failure)
   }
   const terminalMetadata = {
     host,
@@ -392,13 +397,15 @@ async function dispatchWebhookRun(
     idempotencyKey,
     deliveryClaimResult,
   }
-  await finishWebhookRun(
-    runStatus === "failed"
-      ? deliveryFailure
+  if (runStatus === "failed") {
+    await finishWebhookRun(
+      deliveryFailure
         ? { ...terminalMetadata, status: "failed", failure: deliveryFailure.failure }
         : { ...terminalMetadata, status: "failed", error: failureMessage }
-      : { ...terminalMetadata, status: "succeeded" }
-  )
+    )
+  } else {
+    await finishWebhookRun({ ...terminalMetadata, status: "succeeded" })
+  }
 
   return applyWebhookResponse(set, response)
 }
@@ -429,15 +436,31 @@ async function startWebhookRun(
   }
 }
 
-async function finishWebhookRun(input: WebhookRunFinishInput): Promise<void> {
+async function finishWebhookRun(
+  input: Extract<WebhookRunFinishInput, { readonly status: "failed" }>
+): Promise<WebhookRunFailure>
+async function finishWebhookRun(
+  input: Extract<WebhookRunFinishInput, { readonly status: "succeeded" | "skipped" }>
+): Promise<undefined>
+async function finishWebhookRun(
+  input: WebhookRunFinishInput
+): Promise<WebhookRunFailure | undefined> {
   const storage = input.host.storage.webhookRuns
-  if (!storage) {
-    return
-  }
-
-  try {
-    const finishedAt =
-      input.status === "failed" && input.failure ? new Date(input.failure.at) : new Date()
+  if (input.status === "failed") {
+    const finishedAt = input.failure ? new Date(input.failure.at) : new Date()
+    const failure =
+      input.failure ??
+      captureSixbFailure(input.error, {
+        allowedCodes: WEBHOOK_RUN_FAILURE_CODES,
+        defaultCode: "internal.unexpected",
+        details: {
+          connectorId: input.registered.connector.id,
+          webhookId: input.registered.webhook.id,
+          runId: input.runId,
+        },
+        at: finishedAt,
+      })
+    if (!storage) return failure
     const terminalMetadata = {
       id: input.runId,
       projectId: input.host.id,
@@ -447,26 +470,27 @@ async function finishWebhookRun(input: WebhookRunFinishInput): Promise<void> {
       idempotencyKey: input.idempotencyKey,
       deliveryClaimResult: input.deliveryClaimResult,
     }
-    await storage.finish(
-      input.status === "failed"
-        ? {
-            ...terminalMetadata,
-            status: "failed",
-            error:
-              input.failure ??
-              captureSixbFailure(input.error, {
-                allowedCodes: WEBHOOK_RUN_FAILURE_CODES,
-                defaultCode: "internal.unexpected",
-                details: {
-                  connectorId: input.registered.connector.id,
-                  webhookId: input.registered.webhook.id,
-                  runId: input.runId,
-                },
-                at: finishedAt,
-              }),
-          }
-        : { ...terminalMetadata, status: input.status }
-    )
+    try {
+      await storage.finish({ ...terminalMetadata, status: "failed", error: failure })
+    } catch {
+      // Webhook run history is observability-only. Do not change provider responses
+      // when history storage is unavailable or temporarily failing.
+    }
+    return failure
+  }
+
+  if (!storage) return
+  try {
+    await storage.finish({
+      id: input.runId,
+      projectId: input.host.id,
+      finishedAt: new Date(),
+      requestBodyBytes: input.requestBodyBytes,
+      responseStatus: input.responseStatus,
+      idempotencyKey: input.idempotencyKey,
+      deliveryClaimResult: input.deliveryClaimResult,
+      status: input.status,
+    })
   } catch {
     // Webhook run history is observability-only. Do not change provider responses
     // when history storage is unavailable or temporarily failing.

--- a/packages/server/tests/webhooks.test.ts
+++ b/packages/server/tests/webhooks.test.ts
@@ -455,12 +455,13 @@ describe("webhook routes", () => {
       type: "run.failed",
       notificationId: `project:test-project:run:webhook:${failedRun?.id}:failed:${reports[0]?.context.occurredAt}`,
       projectId: "test-project",
+      runKind: "webhook",
       run: {
-        kind: "webhook",
         runId: failedRun?.id,
         connectorId: "github",
         webhookId: "failing",
       },
+      failure: failedRun?.error,
     })
   })
 
@@ -590,31 +591,34 @@ describe("webhook routes", () => {
       }
       return report.context
     })
+    expect(runContexts.every((context) => context.runKind === "webhook")).toBe(true)
     expect(runContexts.map((context) => context.run)).toEqual([
       {
-        kind: "webhook",
         runId: expect.stringMatching(/^webhookrun_/),
         connectorId: "github",
         webhookId: "claim-failure",
       },
       {
-        kind: "webhook",
         runId: expect.stringMatching(/^webhookrun_/),
         connectorId: "github",
         webhookId: "completion-failure",
       },
       {
-        kind: "webhook",
         runId: expect.stringMatching(/^webhookrun_/),
         connectorId: "github",
         webhookId: "unavailable",
       },
       {
-        kind: "webhook",
         runId: expect.stringMatching(/^webhookrun_/),
         connectorId: "github",
         webhookId: "redirected",
       },
+    ])
+    expect(runContexts.map((context) => context.failure.code)).toEqual([
+      "internal.unexpected",
+      "internal.unexpected",
+      "webhook.delivery_failed",
+      "webhook.delivery_failed",
     ])
     expect(reports.every((report) => report.context.projectId === "test-project")).toBe(true)
     expect(new Set(runContexts.map((context) => context.run.runId)).size).toBe(4)

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -454,19 +454,22 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
 
       const status = signal.aborted ? "cancelled" : "failed"
       try {
+        const failure = captureSixbFailure(error, {
+          allowedCodes: SYNC_RUN_FAILURE_CODES,
+          defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+          details: { syncId: sync.id, runId: job.id },
+        })
         const run = await syncRunsStorage.finish({
           projectId: runtime.id,
           id: job.id,
           status,
           rowsRead,
-          error: captureSixbFailure(error, {
-            allowedCodes: SYNC_RUN_FAILURE_CODES,
-            defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
-            details: { syncId: sync.id, runId: job.id },
-          }),
+          error: failure,
         })
         await notifyRunFinished(input.onRunFinished, run)
-        if (status === "failed" && run.status === "failed") input.onRunFailed?.(error, run)
+        if (status === "failed" && run.status === "failed") {
+          input.onRunFailed?.(error, run, failure)
+        }
       } catch {
         // The run did not transition to the requested terminal status.
       }

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -3,11 +3,12 @@ import type {
   ConnectorRuntime,
   LakeStorage,
   SixbDefinitions,
+  SixbFailure,
   SyncMode,
 } from "@sixb/core"
 import type { LoggingService } from "@sixb/core/internal/logging"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
-import type { SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
+import type { SyncRunFailureCode, SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
 
 export interface SyncWorkerContext {
   readonly id: string
@@ -45,7 +46,11 @@ export type SyncRunFinishedHandler = (
   createdVersion?: DatasetVersion
 ) => Promise<void> | void
 
-export type SyncRunFailedHandler = (error: unknown, run: SyncRunRecord) => void
+export type SyncRunFailedHandler = (
+  error: unknown,
+  run: SyncRunRecord,
+  failure: SixbFailure<SyncRunFailureCode>
+) => void
 
 interface SyncRunResultBase {
   readonly id: string

--- a/packages/sync-worker/src/worker.ts
+++ b/packages/sync-worker/src/worker.ts
@@ -70,16 +70,16 @@ export class SyncWorker extends QueueWorker<
         onRunStarted: (run) => emitSyncRunStarted(this.host, run),
         onRunFinished: (run, createdVersion) =>
           emitSyncRunFinishedEvents(this.host, run, createdVersion),
-        onRunFailed: (error, run) => {
+        onRunFailed: (error, run, failure) => {
           reportRunFailure(this.host, error, {
             projectId: this.host.id,
-            occurredAt: run.finishedAt,
             attempt: job.attempt,
+            runKind: "sync",
             run: {
-              kind: "sync",
               runId: run.id,
               syncId: run.syncId,
             },
+            failure,
           })
         },
       })

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -189,15 +189,16 @@ describe("SyncWorker", () => {
       expect(reports[0]?.error).toBe(originalError)
       expect(reports[0]?.context).toEqual({
         type: "run.failed",
-        notificationId: `project:${sixb.id}:run:sync:run-failed:failed:${run!.finishedAt!.toISOString()}`,
+        notificationId: `project:${sixb.id}:run:sync:run-failed:failed:${run!.error!.at}`,
         projectId: sixb.id,
-        occurredAt: run!.finishedAt!.toISOString(),
+        occurredAt: run!.error!.at,
         attempt: 1,
+        runKind: "sync",
         run: {
-          kind: "sync",
           runId: "run-failed",
           syncId: sync.id,
         },
+        failure: run!.error!,
       })
 
       const claimed = await sixb.queues.syncRuns.claim({

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -657,7 +657,7 @@ export class WorkflowRunSession {
       error: failure,
     })
 
-    await this.finishWorkflowRunAfterError({ error, failure, status })
+    await this.finishWorkflowRunAfterError({ reportedError: error, failure, status })
   }
 
   flushLogs(): Promise<void> {
@@ -686,7 +686,7 @@ export class WorkflowRunSession {
   }
 
   private async finishWorkflowRunAfterError(input: {
-    readonly error: unknown
+    readonly reportedError: unknown
     readonly failure: SixbFailure<WorkflowRunFailureCode>
     readonly status: "failed" | "cancelled"
   }): Promise<void> {
@@ -696,7 +696,7 @@ export class WorkflowRunSession {
         error: input.failure,
         onTransition:
           input.status === "failed"
-            ? (run) => this.dependencies.onRunFailed?.(input.error, run)
+            ? (run) => this.dependencies.onRunFailed?.(input.reportedError, run, input.failure)
             : undefined,
       })
       .then(() => null)

--- a/packages/workflow-worker/src/run-workflow-job.ts
+++ b/packages/workflow-worker/src/run-workflow-job.ts
@@ -120,19 +120,20 @@ async function failQueuedRun(input: RunWorkflowJobInput, error: unknown): Promis
   }
 
   const status = statusForFailure(input.signal ?? new AbortController().signal, error)
+  const failure = captureSixbFailure(error, {
+    allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
+    defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+    details: { workflowId: input.job.workflowId, runId: input.job.id },
+  })
   const failed = await input.runtime.workflowRuns.finish({
     projectId: input.runtime.projectId,
     id: input.job.id,
     status,
-    error: captureSixbFailure(error, {
-      allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
-      defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
-      details: { workflowId: input.job.workflowId, runId: input.job.id },
-    }),
+    error: failure,
   })
 
   if (failed.status === "failed") {
-    input.onRunFailed?.(error, failed)
+    input.onRunFailed?.(error, failed, failure)
   }
 
   try {

--- a/packages/workflow-worker/src/types.ts
+++ b/packages/workflow-worker/src/types.ts
@@ -3,6 +3,7 @@ import type {
   OntologySource,
   Queues,
   Sixb,
+  SixbFailure,
   Storage,
   WorkflowStepOutputs,
 } from "@sixb/core"
@@ -12,6 +13,7 @@ import type {
   WorkflowInterventionRecord,
   WorkflowNodeRunRecord,
   WorkflowRunExecution,
+  WorkflowRunFailureCode,
   WorkflowRunRecord,
   WorkflowRunStorage,
 } from "@sixb/core/storage"
@@ -42,7 +44,11 @@ export interface WorkflowResumeJob {
   readonly execution?: WorkflowRunExecution
 }
 
-export type WorkflowRunFailureReporter = (error: unknown, run: WorkflowRunRecord) => void
+export type WorkflowRunFailureReporter = (
+  error: unknown,
+  run: WorkflowRunRecord,
+  failure: SixbFailure<WorkflowRunFailureCode>
+) => void
 
 export interface RunWorkflowJobInput {
   readonly runtime: WorkflowWorkerContext

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -23,7 +23,11 @@ import type {
 import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { EventsRuntimeWorkflowRunObserver } from "./events"
 import { runWorkflowJob, runWorkflowResumeJob } from "./run-workflow-job"
-import type { WorkflowRunObserver, WorkflowWorkerContext } from "./types"
+import type {
+  WorkflowRunFailureReporter,
+  WorkflowRunObserver,
+  WorkflowWorkerContext,
+} from "./types"
 
 const MAX_WORKFLOW_DELIVERY_ATTEMPTS = 5
 const WORKFLOW_RETRY_BACKOFF_MS = 1_000
@@ -102,7 +106,7 @@ export class WorkflowWorker extends QueueWorker<
           },
           signal,
           observer: this.observer,
-          onRunFailed: (error, run) => this.reportFailedRun(claimed, error, run),
+          onRunFailed: (error, run, failure) => this.reportFailedRun(claimed, error, run, failure),
         })
         return
       }
@@ -117,7 +121,7 @@ export class WorkflowWorker extends QueueWorker<
         },
         signal,
         observer: this.observer,
-        onRunFailed: (error, run) => this.reportFailedRun(claimed, error, run),
+        onRunFailed: (error, run, failure) => this.reportFailedRun(claimed, error, run, failure),
       })
     } finally {
       stopOwnershipProjection()
@@ -160,17 +164,18 @@ export class WorkflowWorker extends QueueWorker<
   private reportFailedRun(
     claimed: ClaimedQueueJob<WorkflowQueueJob>,
     error: unknown,
-    run: WorkflowRunRecord
+    run: WorkflowRunRecord,
+    failure: Parameters<WorkflowRunFailureReporter>[2]
   ): void {
     reportRunFailure(this.host, error, {
       projectId: this.host.id,
-      occurredAt: run.finishedAt,
       attempt: claimed.job.attempt,
+      runKind: "workflow",
       run: {
-        kind: "workflow",
         runId: run.id,
         workflowId: run.workflowId,
       },
+      failure,
     })
   }
 

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -409,16 +409,17 @@ describe("WorkflowWorker", () => {
     expect(reported[0]?.error).toBe(workflowExplosion)
     expect(reported[0]?.context).toMatchObject({
       type: "run.failed",
-      notificationId: `project:${sixb.id}:run:workflow:wfrun_worker_failed:failed:${run?.finishedAt?.toISOString()}`,
+      notificationId: `project:${sixb.id}:run:workflow:wfrun_worker_failed:failed:${run?.error?.at}`,
       projectId: sixb.id,
       attempt: 1,
+      runKind: "workflow",
       run: {
-        kind: "workflow",
         runId: "wfrun_worker_failed",
         workflowId: workflow.id,
       },
+      failure: run?.error,
     })
-    expect(reported[0]?.context.occurredAt).toBe(run?.finishedAt?.toISOString() ?? "")
+    expect(reported[0]?.context.occurredAt).toBe(run?.error?.at ?? "")
 
     const events = await waitFor(
       () =>
@@ -540,15 +541,16 @@ describe("WorkflowWorker", () => {
     expect(reported[0]?.error.message).toContain("Missing required field")
     expect(reported[0]?.context).toMatchObject({
       type: "run.failed",
-      notificationId: `project:${sixb.id}:run:workflow:wfrun_queued_invalid:failed:${run?.finishedAt?.toISOString()}`,
+      notificationId: `project:${sixb.id}:run:workflow:wfrun_queued_invalid:failed:${run?.error?.at}`,
       attempt: 1,
+      runKind: "workflow",
       run: {
-        kind: "workflow",
         runId: "wfrun_queued_invalid",
         workflowId: workflow.id,
       },
+      failure: run?.error,
     })
-    expect(reported[0]?.context.occurredAt).toBe(run?.finishedAt?.toISOString() ?? "")
+    expect(reported[0]?.context.occurredAt).toBe(run?.error?.at ?? "")
   })
 
   test("completes queue jobs when workflow runs suspend at intervention nodes", async () => {
@@ -811,11 +813,12 @@ describe("WorkflowWorker", () => {
     expect(reported[0]?.error).toBe(resumeError)
     expect(reported[0]?.context).toMatchObject({
       attempt: 1,
+      runKind: "workflow",
       run: {
-        kind: "workflow",
         runId: "wfrun_worker_resume_failed",
         workflowId: workflow.id,
       },
+      failure: run?.error,
     })
   })
 


### PR DESCRIPTION
## Summary

- require a canonical failure on every public onError context while preserving the native Error argument
- correlate runKind, run identity, and each primitive's precise failure-code union
- reuse the exact durable failure across workers, webhook delivery, and outbox reporting without renormalizing it
- document and test the public narrowing and timestamp invariants

## Testing

- bun run typecheck
- bun run build
- bun run check
- bun run test:publish
- bun run test:ci

Stacked on #379.