### PR TITLE
google: add Analytics Admin and Data APIs

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -8,7 +8,8 @@ One package spans Google's many APIs: auth and HTTP conventions live in a shared
 API is a **surface** of declarative typed resources. Adding a surface (e.g. `meet`, `calendar`)
 costs a base-URL entry, its resources, and one wiring line — the auth/HTTP core never changes.
 
-Surfaces implemented: **`drive`** (v3), **`calendar`** (v3), **`gmail`** (v1).
+Surfaces implemented: **`drive`** (v3), **`calendar`** (v3), **`gmail`** (v1), and
+**`analytics`** with **Admin** (v1beta) plus **Data** (v1beta).
 
 ## Usage
 
@@ -202,6 +203,52 @@ permanently delete mail and should only be used when narrower scopes cannot cove
 when the final response carries state you need to retain, notably `history.historyId`. Repeated
 query parameters such as `labelIds`, `metadataHeaders`, and `historyTypes` accept arrays and are
 encoded as repeated keys, matching the Gmail API contract.
+
+### Google Analytics (Admin v1beta + Data v1beta)
+
+Analytics is grouped under one evolvable façade: `client.analytics.admin.*` for account/property
+discovery and configuration, and `client.analytics.data.*` for reports and audience exports.
+
+For the common read path, `accountSummaries` returns every Analytics account visible to the
+authenticated principal together with its property summaries. You can then fetch complete property
+records or query each property:
+
+```ts
+for await (const summary of client.analytics.admin.accountSummaries.listAll()) {
+  console.log(summary.account, summary.displayName)
+
+  for (const property of summary.propertySummaries ?? []) {
+    const details = await client.analytics.admin.properties.get(property.property!)
+    console.log(details.name, details.timeZone, details.currencyCode)
+  }
+}
+
+const rows = client.analytics.data.properties.runReportAll("properties/123456789", {
+  dateRanges: [{ startDate: "30daysAgo", endDate: "today" }],
+  dimensions: [{ name: "date" }, { name: "country" }],
+  metrics: [{ name: "sessions" }, { name: "activeUsers" }],
+  orderBys: [{ dimension: { dimensionName: "date" } }],
+})
+
+for await (const row of rows) {
+  console.log(row.dimensionValues, row.metricValues)
+}
+```
+
+The Admin surface covers all non-deprecated stable v1beta resources: accounts, properties, custom
+dimensions and metrics, data streams and measurement protocol secrets, Firebase links, Google Ads
+links, key events, access reports, and change history. Deprecated `conversionEvents` and alpha-only
+resources are intentionally excluded.
+
+The Data surface includes standard, pivot, batch, realtime, metadata and compatibility reports,
+plus audience export creation, discovery and querying. `runReportPages` / `runReportAll` and audience
+export `queryPages` / `queryAll` use Google’s `offset` pagination; `limit` is their per-request page
+size and may not exceed 250,000. Data API `int64` fields remain strings so values are not truncated.
+
+Use `https://www.googleapis.com/auth/analytics.readonly` for account/property discovery and report
+reads. Admin mutations require `https://www.googleapis.com/auth/analytics.edit`. A service account
+must also be granted access inside Google Analytics (directly or through a group); assigning Google
+Cloud IAM roles alone does not make Analytics accounts visible to it.
 
 ## Auth
 

--- a/connectors/google/package.json
+++ b/connectors/google/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sixb/connector-google",
   "version": "0.1.2",
-  "description": "Typed Google Workspace connector for Sixb (Drive, Calendar, and Gmail)",
+  "description": "Typed Google connector for Sixb (Drive, Calendar, Gmail, and Analytics)",
   "keywords": [
     "sixb",
     "bun",

--- a/connectors/google/src/client.ts
+++ b/connectors/google/src/client.ts
@@ -1,4 +1,6 @@
 import type { GoogleHttp } from "./http"
+import { type AnalyticsAdminSurface, analyticsAdminSurface } from "./surfaces/analytics/admin"
+import { type AnalyticsDataSurface, analyticsDataSurface } from "./surfaces/analytics/data"
 import { type AclResource, aclResource } from "./surfaces/calendar/acl"
 import { type CalendarListResource, calendarListResource } from "./surfaces/calendar/calendarList"
 import { type CalendarsResource, calendarsResource } from "./surfaces/calendar/calendars"
@@ -43,10 +45,16 @@ export interface GmailSurface {
   readonly settings: GmailSettingsResource
 }
 
+export interface AnalyticsSurface {
+  readonly admin: AnalyticsAdminSurface
+  readonly data: AnalyticsDataSurface
+}
+
 export interface GoogleClient {
   readonly drive: DriveSurface
   readonly calendar: CalendarSurface
   readonly gmail: GmailSurface
+  readonly analytics: AnalyticsSurface
 }
 
 export function createGoogleClient(http: GoogleHttp): GoogleClient {
@@ -73,6 +81,10 @@ export function createGoogleClient(http: GoogleHttp): GoogleClient {
       labels: gmailLabelsResource(http),
       threads: gmailThreadsResource(http),
       settings: gmailSettingsResource(http),
+    },
+    analytics: {
+      admin: analyticsAdminSurface(http),
+      data: analyticsDataSurface(http),
     },
   }
 }

--- a/connectors/google/src/google.ts
+++ b/connectors/google/src/google.ts
@@ -14,6 +14,8 @@ const BASE_URLS = {
   drive: "https://www.googleapis.com/drive/v3/",
   calendar: "https://www.googleapis.com/calendar/v3/",
   gmail: "https://gmail.googleapis.com/gmail/v1/",
+  analyticsAdmin: "https://analyticsadmin.googleapis.com/v1beta/",
+  analyticsData: "https://analyticsdata.googleapis.com/v1beta/",
 } as const satisfies Record<GoogleSurface, string>
 
 /**

--- a/connectors/google/src/http.ts
+++ b/connectors/google/src/http.ts
@@ -20,7 +20,7 @@ import {
  * name here, a base URL in `google.ts`, its typed resources, and one wiring
  * line in `client.ts` — the auth and HTTP core below never change.
  */
-export type GoogleSurface = "drive" | "calendar" | "gmail"
+export type GoogleSurface = "drive" | "calendar" | "gmail" | "analyticsAdmin" | "analyticsData"
 
 export interface GoogleHttpClients {
   /** JSON API clients, keyed by surface. */
@@ -35,6 +35,8 @@ export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
 export interface GoogleRequestOptions {
   readonly query?: QueryParams
   readonly body?: unknown
+  /** Override whether the connector retry policy may replay this request. */
+  readonly retryable?: boolean
 }
 
 export interface GoogleUploadOptions {
@@ -86,14 +88,26 @@ export function createGoogleHttp(clients: GoogleHttpClients): GoogleHttp {
   ): Promise<T> => {
     const client = clients.api[surface]
     const url = withQuery(path, options?.query)
+    // Existing Workspace surfaces preserve their historical replay behavior.
+    // Analytics is stricter: GET is safe by default, and read-only POST methods
+    // opt in explicitly while mutations stay single-attempt.
+    const retryable =
+      options?.retryable ??
+      (method === "GET" || (surface !== "analyticsAdmin" && surface !== "analyticsData"))
     // `post` serializes a JSON body and sets content-type under any verb;
     // `request` covers the bodiless verbs (GET/DELETE) without one.
     const response =
       method === "GET"
-        ? await client.get(url)
+        ? await client.get(url, { retry: retryable })
         : method === "DELETE"
-          ? await client.request(url, { method: "DELETE" })
-          : await client.post(url, options?.body, { method })
+          ? await client.request(url, {
+              method: "DELETE",
+              retry: retryable,
+            })
+          : await client.post(url, options?.body, {
+              method,
+              retry: retryable,
+            })
     return readJson<T>(response)
   }
 

--- a/connectors/google/src/index.ts
+++ b/connectors/google/src/index.ts
@@ -1,11 +1,31 @@
 export type { GoogleAuthOptions, ServiceAccountKey, TokenSource } from "./auth"
 export { createTokenSource } from "./auth"
-export type { CalendarSurface, DriveSurface, GmailSurface, GoogleClient } from "./client"
+export type {
+  AnalyticsSurface,
+  CalendarSurface,
+  DriveSurface,
+  GmailSurface,
+  GoogleClient,
+} from "./client"
 export { createGoogleClient } from "./client"
 export { GoogleApiError, GoogleAuthError } from "./errors"
 export type { GoogleConnector } from "./google"
 export { google } from "./google"
 export type { GoogleHttp, GoogleSurface, GoogleUploadOptions, HttpMethod } from "./http"
+export type { AnalyticsAdminSurface } from "./surfaces/analytics/admin"
+export type { AnalyticsAccountSummariesResource } from "./surfaces/analytics/admin/accountSummaries"
+export type { AnalyticsAccountsResource } from "./surfaces/analytics/admin/accounts"
+export type { AnalyticsCustomDimensionsResource } from "./surfaces/analytics/admin/customDimensions"
+export type { AnalyticsCustomMetricsResource } from "./surfaces/analytics/admin/customMetrics"
+export type { AnalyticsDataStreamsResource } from "./surfaces/analytics/admin/dataStreams"
+export type { AnalyticsFirebaseLinksResource } from "./surfaces/analytics/admin/firebaseLinks"
+export type { AnalyticsGoogleAdsLinksResource } from "./surfaces/analytics/admin/googleAdsLinks"
+export type { AnalyticsKeyEventsResource } from "./surfaces/analytics/admin/keyEvents"
+export type { AnalyticsMeasurementProtocolSecretsResource } from "./surfaces/analytics/admin/measurementProtocolSecrets"
+export type { AnalyticsAdminPropertiesResource } from "./surfaces/analytics/admin/properties"
+export type { AnalyticsDataSurface } from "./surfaces/analytics/data"
+export type { AnalyticsAudienceExportsResource } from "./surfaces/analytics/data/audienceExports"
+export type { AnalyticsDataPropertiesResource } from "./surfaces/analytics/data/properties"
 export type { AclResource } from "./surfaces/calendar/acl"
 export type { CalendarListResource } from "./surfaces/calendar/calendarList"
 export type { CalendarsResource } from "./surfaces/calendar/calendars"

--- a/connectors/google/src/surfaces/analytics/admin/accountSummaries.ts
+++ b/connectors/google/src/surfaces/analytics/admin/accountSummaries.ts
@@ -1,0 +1,32 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsAccountSummary,
+  AnalyticsListAccountSummariesResponse,
+  AnalyticsPageOptions,
+} from "../../../types/analytics-admin"
+
+export interface AnalyticsAccountSummariesResource {
+  /** `GET /v1beta/accountSummaries` — accounts and their visible properties. */
+  list(options?: AnalyticsPageOptions): Promise<AnalyticsListAccountSummariesResponse>
+  /** Iterate all account summaries across every page. */
+  listAll(options?: AnalyticsPageOptions): AsyncIterable<AnalyticsAccountSummary>
+}
+
+export function analyticsAccountSummariesResource(
+  http: GoogleHttp
+): AnalyticsAccountSummariesResource {
+  const resource: AnalyticsAccountSummariesResource = {
+    list(options) {
+      return http.json("analyticsAdmin", "GET", "accountSummaries", { query: options })
+    },
+    listAll(options) {
+      return listAllPages(
+        (pageToken) => resource.list({ ...options, pageToken }),
+        (page) => page.accountSummaries,
+        options?.pageToken
+      )
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/accounts.ts
+++ b/connectors/google/src/surfaces/analytics/admin/accounts.ts
@@ -1,0 +1,104 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsAccount,
+  AnalyticsAccountListOptions,
+  AnalyticsChangeHistoryEvent,
+  AnalyticsDataSharingSettings,
+  AnalyticsListAccountsResponse,
+  AnalyticsProvisionAccountTicketRequest,
+  AnalyticsProvisionAccountTicketResponse,
+  AnalyticsRunAccessReportRequest,
+  AnalyticsRunAccessReportResponse,
+  AnalyticsSearchChangeHistoryRequest,
+  AnalyticsSearchChangeHistoryResponse,
+  AnalyticsUpdateOptions,
+} from "../../../types/analytics-admin"
+import { accountName } from "../paths"
+
+export interface AnalyticsAccountsResource {
+  list(options?: AnalyticsAccountListOptions): Promise<AnalyticsListAccountsResponse>
+  listAll(options?: AnalyticsAccountListOptions): AsyncIterable<AnalyticsAccount>
+  get(name: string): Promise<AnalyticsAccount>
+  /** Soft-delete an account. It can still be restored through the Analytics UI. */
+  delete(name: string): Promise<void>
+  patch(
+    name: string,
+    account: Partial<AnalyticsAccount>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsAccount>
+  getDataSharingSettings(name: string): Promise<AnalyticsDataSharingSettings>
+  provisionAccountTicket(
+    request: AnalyticsProvisionAccountTicketRequest
+  ): Promise<AnalyticsProvisionAccountTicketResponse>
+  runAccessReport(
+    name: string,
+    request: AnalyticsRunAccessReportRequest
+  ): Promise<AnalyticsRunAccessReportResponse>
+  searchChangeHistoryEvents(
+    name: string,
+    request?: AnalyticsSearchChangeHistoryRequest
+  ): Promise<AnalyticsSearchChangeHistoryResponse>
+  searchChangeHistoryEventsAll(
+    name: string,
+    request?: AnalyticsSearchChangeHistoryRequest
+  ): AsyncIterable<AnalyticsChangeHistoryEvent>
+}
+
+export function analyticsAccountsResource(http: GoogleHttp): AnalyticsAccountsResource {
+  const resource: AnalyticsAccountsResource = {
+    list(options) {
+      return http.json("analyticsAdmin", "GET", "accounts", { query: options })
+    },
+    listAll(options) {
+      return listAllPages(
+        (pageToken) => resource.list({ ...options, pageToken }),
+        (page) => page.accounts,
+        options?.pageToken
+      )
+    },
+    get(name) {
+      return http.json("analyticsAdmin", "GET", accountName(name, "name"))
+    },
+    delete(name) {
+      return http.json("analyticsAdmin", "DELETE", accountName(name, "name"))
+    },
+    patch(name, account, options) {
+      const path = accountName(name, "name")
+      return http.json("analyticsAdmin", "PATCH", path, {
+        query: options,
+        body: { ...account, name },
+      })
+    },
+    getDataSharingSettings(name) {
+      return http.json("analyticsAdmin", "GET", `${accountName(name, "name")}/dataSharingSettings`)
+    },
+    provisionAccountTicket(request) {
+      return http.json("analyticsAdmin", "POST", "accounts:provisionAccountTicket", {
+        body: request,
+      })
+    },
+    runAccessReport(name, request) {
+      return http.json("analyticsAdmin", "POST", `${accountName(name, "name")}:runAccessReport`, {
+        body: request,
+        retryable: true,
+      })
+    },
+    searchChangeHistoryEvents(name, request = {}) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${accountName(name, "name")}:searchChangeHistoryEvents`,
+        { body: request, retryable: true }
+      )
+    },
+    searchChangeHistoryEventsAll(name, request = {}) {
+      return listAllPages(
+        (pageToken) => resource.searchChangeHistoryEvents(name, { ...request, pageToken }),
+        (page) => page.changeHistoryEvents,
+        request.pageToken
+      )
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/customDimensions.ts
+++ b/connectors/google/src/surfaces/analytics/admin/customDimensions.ts
@@ -1,0 +1,77 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsCustomDimension,
+  AnalyticsCustomDimensionListOptions,
+  AnalyticsListCustomDimensionsResponse,
+  AnalyticsUpdateOptions,
+} from "../../../types/analytics-admin"
+import { childResourceName, propertyName } from "../paths"
+
+export interface AnalyticsCustomDimensionsResource {
+  list(
+    parent: string,
+    options?: AnalyticsCustomDimensionListOptions
+  ): Promise<AnalyticsListCustomDimensionsResponse>
+  listAll(
+    parent: string,
+    options?: AnalyticsCustomDimensionListOptions
+  ): AsyncIterable<AnalyticsCustomDimension>
+  get(name: string): Promise<AnalyticsCustomDimension>
+  create(parent: string, dimension: AnalyticsCustomDimension): Promise<AnalyticsCustomDimension>
+  patch(
+    name: string,
+    dimension: Partial<AnalyticsCustomDimension>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsCustomDimension>
+  archive(name: string): Promise<void>
+}
+
+export function analyticsCustomDimensionsResource(
+  http: GoogleHttp
+): AnalyticsCustomDimensionsResource {
+  const resource: AnalyticsCustomDimensionsResource = {
+    list(parent, options) {
+      return http.json(
+        "analyticsAdmin",
+        "GET",
+        `${propertyName(parent, "parent")}/customDimensions`,
+        { query: options }
+      )
+    },
+    listAll(parent, options) {
+      return listAllPages(
+        (pageToken) => resource.list(parent, { ...options, pageToken }),
+        (page) => page.customDimensions,
+        options?.pageToken
+      )
+    },
+    get(name) {
+      return http.json("analyticsAdmin", "GET", childResourceName(name, "customDimensions"))
+    },
+    create(parent, dimension) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${propertyName(parent, "parent")}/customDimensions`,
+        { body: dimension }
+      )
+    },
+    patch(name, dimension, options) {
+      const path = childResourceName(name, "customDimensions")
+      return http.json("analyticsAdmin", "PATCH", path, {
+        query: options,
+        body: { ...dimension, name },
+      })
+    },
+    archive(name) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${childResourceName(name, "customDimensions")}:archive`,
+        { body: {} }
+      )
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/customMetrics.ts
+++ b/connectors/google/src/surfaces/analytics/admin/customMetrics.ts
@@ -1,0 +1,72 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsCustomMetric,
+  AnalyticsCustomMetricListOptions,
+  AnalyticsListCustomMetricsResponse,
+  AnalyticsUpdateOptions,
+} from "../../../types/analytics-admin"
+import { childResourceName, propertyName } from "../paths"
+
+export interface AnalyticsCustomMetricsResource {
+  list(
+    parent: string,
+    options?: AnalyticsCustomMetricListOptions
+  ): Promise<AnalyticsListCustomMetricsResponse>
+  listAll(
+    parent: string,
+    options?: AnalyticsCustomMetricListOptions
+  ): AsyncIterable<AnalyticsCustomMetric>
+  get(name: string): Promise<AnalyticsCustomMetric>
+  create(parent: string, metric: AnalyticsCustomMetric): Promise<AnalyticsCustomMetric>
+  patch(
+    name: string,
+    metric: Partial<AnalyticsCustomMetric>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsCustomMetric>
+  archive(name: string): Promise<void>
+}
+
+export function analyticsCustomMetricsResource(http: GoogleHttp): AnalyticsCustomMetricsResource {
+  const resource: AnalyticsCustomMetricsResource = {
+    list(parent, options) {
+      return http.json("analyticsAdmin", "GET", `${propertyName(parent, "parent")}/customMetrics`, {
+        query: options,
+      })
+    },
+    listAll(parent, options) {
+      return listAllPages(
+        (pageToken) => resource.list(parent, { ...options, pageToken }),
+        (page) => page.customMetrics,
+        options?.pageToken
+      )
+    },
+    get(name) {
+      return http.json("analyticsAdmin", "GET", childResourceName(name, "customMetrics"))
+    },
+    create(parent, metric) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${propertyName(parent, "parent")}/customMetrics`,
+        { body: metric }
+      )
+    },
+    patch(name, metric, options) {
+      const path = childResourceName(name, "customMetrics")
+      return http.json("analyticsAdmin", "PATCH", path, {
+        query: options,
+        body: { ...metric, name },
+      })
+    },
+    archive(name) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${childResourceName(name, "customMetrics")}:archive`,
+        { body: {} }
+      )
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/dataStreams.ts
+++ b/connectors/google/src/surfaces/analytics/admin/dataStreams.ts
@@ -1,0 +1,70 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsDataStream,
+  AnalyticsDataStreamListOptions,
+  AnalyticsListDataStreamsResponse,
+  AnalyticsUpdateOptions,
+} from "../../../types/analytics-admin"
+import { dataStreamName, propertyName } from "../paths"
+import {
+  type AnalyticsMeasurementProtocolSecretsResource,
+  analyticsMeasurementProtocolSecretsResource,
+} from "./measurementProtocolSecrets"
+
+export interface AnalyticsDataStreamsResource {
+  readonly measurementProtocolSecrets: AnalyticsMeasurementProtocolSecretsResource
+  list(
+    parent: string,
+    options?: AnalyticsDataStreamListOptions
+  ): Promise<AnalyticsListDataStreamsResponse>
+  listAll(
+    parent: string,
+    options?: AnalyticsDataStreamListOptions
+  ): AsyncIterable<AnalyticsDataStream>
+  get(name: string): Promise<AnalyticsDataStream>
+  create(parent: string, stream: AnalyticsDataStream): Promise<AnalyticsDataStream>
+  patch(
+    name: string,
+    stream: Partial<AnalyticsDataStream>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsDataStream>
+  delete(name: string): Promise<void>
+}
+
+export function analyticsDataStreamsResource(http: GoogleHttp): AnalyticsDataStreamsResource {
+  const resource: AnalyticsDataStreamsResource = {
+    measurementProtocolSecrets: analyticsMeasurementProtocolSecretsResource(http),
+    list(parent, options) {
+      return http.json("analyticsAdmin", "GET", `${propertyName(parent, "parent")}/dataStreams`, {
+        query: options,
+      })
+    },
+    listAll(parent, options) {
+      return listAllPages(
+        (pageToken) => resource.list(parent, { ...options, pageToken }),
+        (page) => page.dataStreams,
+        options?.pageToken
+      )
+    },
+    get(name) {
+      return http.json("analyticsAdmin", "GET", dataStreamName(name, "name"))
+    },
+    create(parent, stream) {
+      return http.json("analyticsAdmin", "POST", `${propertyName(parent, "parent")}/dataStreams`, {
+        body: stream,
+      })
+    },
+    patch(name, stream, options) {
+      const path = dataStreamName(name, "name")
+      return http.json("analyticsAdmin", "PATCH", path, {
+        query: options,
+        body: { ...stream, name },
+      })
+    },
+    delete(name) {
+      return http.json("analyticsAdmin", "DELETE", dataStreamName(name, "name"))
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/firebaseLinks.ts
+++ b/connectors/google/src/surfaces/analytics/admin/firebaseLinks.ts
@@ -1,0 +1,50 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsFirebaseLink,
+  AnalyticsFirebaseLinkListOptions,
+  AnalyticsListFirebaseLinksResponse,
+} from "../../../types/analytics-admin"
+import { childResourceName, propertyName } from "../paths"
+
+export interface AnalyticsFirebaseLinksResource {
+  list(
+    parent: string,
+    options?: AnalyticsFirebaseLinkListOptions
+  ): Promise<AnalyticsListFirebaseLinksResponse>
+  listAll(
+    parent: string,
+    options?: AnalyticsFirebaseLinkListOptions
+  ): AsyncIterable<AnalyticsFirebaseLink>
+  create(parent: string, link: AnalyticsFirebaseLink): Promise<AnalyticsFirebaseLink>
+  delete(name: string): Promise<void>
+}
+
+export function analyticsFirebaseLinksResource(http: GoogleHttp): AnalyticsFirebaseLinksResource {
+  const resource: AnalyticsFirebaseLinksResource = {
+    list(parent, options) {
+      return http.json("analyticsAdmin", "GET", `${propertyName(parent, "parent")}/firebaseLinks`, {
+        query: options,
+      })
+    },
+    listAll(parent, options) {
+      return listAllPages(
+        (pageToken) => resource.list(parent, { ...options, pageToken }),
+        (page) => page.firebaseLinks,
+        options?.pageToken
+      )
+    },
+    create(parent, link) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${propertyName(parent, "parent")}/firebaseLinks`,
+        { body: link }
+      )
+    },
+    delete(name) {
+      return http.json("analyticsAdmin", "DELETE", childResourceName(name, "firebaseLinks"))
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/googleAdsLinks.ts
+++ b/connectors/google/src/surfaces/analytics/admin/googleAdsLinks.ts
@@ -1,0 +1,66 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsGoogleAdsLink,
+  AnalyticsGoogleAdsLinkListOptions,
+  AnalyticsListGoogleAdsLinksResponse,
+  AnalyticsUpdateOptions,
+} from "../../../types/analytics-admin"
+import { childResourceName, propertyName } from "../paths"
+
+export interface AnalyticsGoogleAdsLinksResource {
+  list(
+    parent: string,
+    options?: AnalyticsGoogleAdsLinkListOptions
+  ): Promise<AnalyticsListGoogleAdsLinksResponse>
+  listAll(
+    parent: string,
+    options?: AnalyticsGoogleAdsLinkListOptions
+  ): AsyncIterable<AnalyticsGoogleAdsLink>
+  create(parent: string, link: AnalyticsGoogleAdsLink): Promise<AnalyticsGoogleAdsLink>
+  patch(
+    name: string,
+    link: Partial<AnalyticsGoogleAdsLink>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsGoogleAdsLink>
+  delete(name: string): Promise<void>
+}
+
+export function analyticsGoogleAdsLinksResource(http: GoogleHttp): AnalyticsGoogleAdsLinksResource {
+  const resource: AnalyticsGoogleAdsLinksResource = {
+    list(parent, options) {
+      return http.json(
+        "analyticsAdmin",
+        "GET",
+        `${propertyName(parent, "parent")}/googleAdsLinks`,
+        { query: options }
+      )
+    },
+    listAll(parent, options) {
+      return listAllPages(
+        (pageToken) => resource.list(parent, { ...options, pageToken }),
+        (page) => page.googleAdsLinks,
+        options?.pageToken
+      )
+    },
+    create(parent, link) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${propertyName(parent, "parent")}/googleAdsLinks`,
+        { body: link }
+      )
+    },
+    patch(name, link, options) {
+      const path = childResourceName(name, "googleAdsLinks")
+      return http.json("analyticsAdmin", "PATCH", path, {
+        query: options,
+        body: { ...link, name },
+      })
+    },
+    delete(name) {
+      return http.json("analyticsAdmin", "DELETE", childResourceName(name, "googleAdsLinks"))
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/index.ts
+++ b/connectors/google/src/surfaces/analytics/admin/index.ts
@@ -1,0 +1,24 @@
+import type { GoogleHttp } from "../../../http"
+import {
+  type AnalyticsAccountSummariesResource,
+  analyticsAccountSummariesResource,
+} from "./accountSummaries"
+import { type AnalyticsAccountsResource, analyticsAccountsResource } from "./accounts"
+import {
+  type AnalyticsAdminPropertiesResource,
+  analyticsAdminPropertiesResource,
+} from "./properties"
+
+export interface AnalyticsAdminSurface {
+  readonly accountSummaries: AnalyticsAccountSummariesResource
+  readonly accounts: AnalyticsAccountsResource
+  readonly properties: AnalyticsAdminPropertiesResource
+}
+
+export function analyticsAdminSurface(http: GoogleHttp): AnalyticsAdminSurface {
+  return {
+    accountSummaries: analyticsAccountSummariesResource(http),
+    accounts: analyticsAccountsResource(http),
+    properties: analyticsAdminPropertiesResource(http),
+  }
+}

--- a/connectors/google/src/surfaces/analytics/admin/keyEvents.ts
+++ b/connectors/google/src/surfaces/analytics/admin/keyEvents.ts
@@ -1,0 +1,61 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsKeyEvent,
+  AnalyticsKeyEventListOptions,
+  AnalyticsListKeyEventsResponse,
+  AnalyticsUpdateOptions,
+} from "../../../types/analytics-admin"
+import { childResourceName, propertyName } from "../paths"
+
+export interface AnalyticsKeyEventsResource {
+  list(
+    parent: string,
+    options?: AnalyticsKeyEventListOptions
+  ): Promise<AnalyticsListKeyEventsResponse>
+  listAll(parent: string, options?: AnalyticsKeyEventListOptions): AsyncIterable<AnalyticsKeyEvent>
+  get(name: string): Promise<AnalyticsKeyEvent>
+  create(parent: string, event: AnalyticsKeyEvent): Promise<AnalyticsKeyEvent>
+  patch(
+    name: string,
+    event: Partial<AnalyticsKeyEvent>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsKeyEvent>
+  delete(name: string): Promise<void>
+}
+
+export function analyticsKeyEventsResource(http: GoogleHttp): AnalyticsKeyEventsResource {
+  const resource: AnalyticsKeyEventsResource = {
+    list(parent, options) {
+      return http.json("analyticsAdmin", "GET", `${propertyName(parent, "parent")}/keyEvents`, {
+        query: options,
+      })
+    },
+    listAll(parent, options) {
+      return listAllPages(
+        (pageToken) => resource.list(parent, { ...options, pageToken }),
+        (page) => page.keyEvents,
+        options?.pageToken
+      )
+    },
+    get(name) {
+      return http.json("analyticsAdmin", "GET", childResourceName(name, "keyEvents"))
+    },
+    create(parent, event) {
+      return http.json("analyticsAdmin", "POST", `${propertyName(parent, "parent")}/keyEvents`, {
+        body: event,
+      })
+    },
+    patch(name, event, options) {
+      const path = childResourceName(name, "keyEvents")
+      return http.json("analyticsAdmin", "PATCH", path, {
+        query: options,
+        body: { ...event, name },
+      })
+    },
+    delete(name) {
+      return http.json("analyticsAdmin", "DELETE", childResourceName(name, "keyEvents"))
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/measurementProtocolSecrets.ts
+++ b/connectors/google/src/surfaces/analytics/admin/measurementProtocolSecrets.ts
@@ -1,0 +1,75 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsListMeasurementProtocolSecretsResponse,
+  AnalyticsMeasurementProtocolSecret,
+  AnalyticsMeasurementProtocolSecretListOptions,
+  AnalyticsUpdateOptions,
+} from "../../../types/analytics-admin"
+import { dataStreamName, measurementProtocolSecretName } from "../paths"
+
+export interface AnalyticsMeasurementProtocolSecretsResource {
+  list(
+    parent: string,
+    options?: AnalyticsMeasurementProtocolSecretListOptions
+  ): Promise<AnalyticsListMeasurementProtocolSecretsResponse>
+  listAll(
+    parent: string,
+    options?: AnalyticsMeasurementProtocolSecretListOptions
+  ): AsyncIterable<AnalyticsMeasurementProtocolSecret>
+  get(name: string): Promise<AnalyticsMeasurementProtocolSecret>
+  create(
+    parent: string,
+    secret: AnalyticsMeasurementProtocolSecret
+  ): Promise<AnalyticsMeasurementProtocolSecret>
+  patch(
+    name: string,
+    secret: Partial<AnalyticsMeasurementProtocolSecret>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsMeasurementProtocolSecret>
+  delete(name: string): Promise<void>
+}
+
+export function analyticsMeasurementProtocolSecretsResource(
+  http: GoogleHttp
+): AnalyticsMeasurementProtocolSecretsResource {
+  const resource: AnalyticsMeasurementProtocolSecretsResource = {
+    list(parent, options) {
+      return http.json(
+        "analyticsAdmin",
+        "GET",
+        `${dataStreamName(parent, "parent")}/measurementProtocolSecrets`,
+        { query: options }
+      )
+    },
+    listAll(parent, options) {
+      return listAllPages(
+        (pageToken) => resource.list(parent, { ...options, pageToken }),
+        (page) => page.measurementProtocolSecrets,
+        options?.pageToken
+      )
+    },
+    get(name) {
+      return http.json("analyticsAdmin", "GET", measurementProtocolSecretName(name))
+    },
+    create(parent, secret) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${dataStreamName(parent, "parent")}/measurementProtocolSecrets`,
+        { body: secret }
+      )
+    },
+    patch(name, secret, options) {
+      const path = measurementProtocolSecretName(name)
+      return http.json("analyticsAdmin", "PATCH", path, {
+        query: options,
+        body: { ...secret, name },
+      })
+    },
+    delete(name) {
+      return http.json("analyticsAdmin", "DELETE", measurementProtocolSecretName(name))
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/admin/properties.ts
+++ b/connectors/google/src/surfaces/analytics/admin/properties.ts
@@ -1,0 +1,135 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsAcknowledgeUserDataCollectionRequest,
+  AnalyticsDataRetentionSettings,
+  AnalyticsListPropertiesResponse,
+  AnalyticsProperty,
+  AnalyticsPropertyListOptions,
+  AnalyticsRunAccessReportRequest,
+  AnalyticsRunAccessReportResponse,
+  AnalyticsUpdateOptions,
+} from "../../../types/analytics-admin"
+import { propertyName } from "../paths"
+import {
+  type AnalyticsCustomDimensionsResource,
+  analyticsCustomDimensionsResource,
+} from "./customDimensions"
+import {
+  type AnalyticsCustomMetricsResource,
+  analyticsCustomMetricsResource,
+} from "./customMetrics"
+import { type AnalyticsDataStreamsResource, analyticsDataStreamsResource } from "./dataStreams"
+import {
+  type AnalyticsFirebaseLinksResource,
+  analyticsFirebaseLinksResource,
+} from "./firebaseLinks"
+import {
+  type AnalyticsGoogleAdsLinksResource,
+  analyticsGoogleAdsLinksResource,
+} from "./googleAdsLinks"
+import { type AnalyticsKeyEventsResource, analyticsKeyEventsResource } from "./keyEvents"
+
+export interface AnalyticsAdminPropertiesResource {
+  readonly customDimensions: AnalyticsCustomDimensionsResource
+  readonly customMetrics: AnalyticsCustomMetricsResource
+  readonly dataStreams: AnalyticsDataStreamsResource
+  readonly firebaseLinks: AnalyticsFirebaseLinksResource
+  readonly googleAdsLinks: AnalyticsGoogleAdsLinksResource
+  readonly keyEvents: AnalyticsKeyEventsResource
+  list(options: AnalyticsPropertyListOptions): Promise<AnalyticsListPropertiesResponse>
+  listAll(options: AnalyticsPropertyListOptions): AsyncIterable<AnalyticsProperty>
+  get(name: string): Promise<AnalyticsProperty>
+  create(property: AnalyticsProperty): Promise<AnalyticsProperty>
+  patch(
+    name: string,
+    property: Partial<AnalyticsProperty>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsProperty>
+  /** Soft-delete a property and return its trashed representation. */
+  delete(name: string): Promise<AnalyticsProperty>
+  acknowledgeUserDataCollection(
+    name: string,
+    request: AnalyticsAcknowledgeUserDataCollectionRequest
+  ): Promise<void>
+  getDataRetentionSettings(name: string): Promise<AnalyticsDataRetentionSettings>
+  updateDataRetentionSettings(
+    name: string,
+    settings: Partial<AnalyticsDataRetentionSettings>,
+    options: AnalyticsUpdateOptions
+  ): Promise<AnalyticsDataRetentionSettings>
+  runAccessReport(
+    name: string,
+    request: AnalyticsRunAccessReportRequest
+  ): Promise<AnalyticsRunAccessReportResponse>
+}
+
+export function analyticsAdminPropertiesResource(
+  http: GoogleHttp
+): AnalyticsAdminPropertiesResource {
+  const resource: AnalyticsAdminPropertiesResource = {
+    customDimensions: analyticsCustomDimensionsResource(http),
+    customMetrics: analyticsCustomMetricsResource(http),
+    dataStreams: analyticsDataStreamsResource(http),
+    firebaseLinks: analyticsFirebaseLinksResource(http),
+    googleAdsLinks: analyticsGoogleAdsLinksResource(http),
+    keyEvents: analyticsKeyEventsResource(http),
+    list(options) {
+      return http.json("analyticsAdmin", "GET", "properties", { query: options })
+    },
+    listAll(options) {
+      return listAllPages(
+        (pageToken) => resource.list({ ...options, pageToken }),
+        (page) => page.properties,
+        options.pageToken
+      )
+    },
+    get(name) {
+      return http.json("analyticsAdmin", "GET", propertyName(name, "name"))
+    },
+    create(property) {
+      return http.json("analyticsAdmin", "POST", "properties", { body: property })
+    },
+    patch(name, property, options) {
+      const path = propertyName(name, "name")
+      return http.json("analyticsAdmin", "PATCH", path, {
+        query: options,
+        body: { ...property, name },
+      })
+    },
+    delete(name) {
+      return http.json("analyticsAdmin", "DELETE", propertyName(name, "name"))
+    },
+    acknowledgeUserDataCollection(name, request) {
+      return http.json(
+        "analyticsAdmin",
+        "POST",
+        `${propertyName(name, "property")}:acknowledgeUserDataCollection`,
+        { body: request }
+      )
+    },
+    getDataRetentionSettings(name) {
+      return http.json(
+        "analyticsAdmin",
+        "GET",
+        `${propertyName(name, "name")}/dataRetentionSettings`
+      )
+    },
+    updateDataRetentionSettings(name, settings, options) {
+      const settingsName = `${name}/dataRetentionSettings`
+      return http.json(
+        "analyticsAdmin",
+        "PATCH",
+        `${propertyName(name, "name")}/dataRetentionSettings`,
+        { query: options, body: { ...settings, name: settingsName } }
+      )
+    },
+    runAccessReport(name, request) {
+      return http.json("analyticsAdmin", "POST", `${propertyName(name, "name")}:runAccessReport`, {
+        body: request,
+        retryable: true,
+      })
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/data/audienceExports.ts
+++ b/connectors/google/src/surfaces/analytics/data/audienceExports.ts
@@ -1,0 +1,112 @@
+import type { GoogleHttp } from "../../../http"
+import { listAllPages } from "../../../pagination"
+import type {
+  AnalyticsAudienceExport,
+  AnalyticsAudienceRow,
+  AnalyticsListAudienceExportsOptions,
+  AnalyticsListAudienceExportsResponse,
+  AnalyticsOperation,
+  AnalyticsQueryAudienceExportRequest,
+  AnalyticsQueryAudienceExportResponse,
+} from "../../../types/analytics-data"
+import { childResourceName, propertyName } from "../paths"
+import { analyticsOffset, analyticsPageSize, nextAnalyticsOffset } from "./pagination"
+
+export interface AnalyticsAudienceExportsResource {
+  create(parent: string, audienceExport: AnalyticsAudienceExport): Promise<AnalyticsOperation>
+  get(name: string): Promise<AnalyticsAudienceExport>
+  list(
+    parent: string,
+    options?: AnalyticsListAudienceExportsOptions
+  ): Promise<AnalyticsListAudienceExportsResponse>
+  listAll(
+    parent: string,
+    options?: AnalyticsListAudienceExportsOptions
+  ): AsyncIterable<AnalyticsAudienceExport>
+  query(
+    name: string,
+    request?: AnalyticsQueryAudienceExportRequest
+  ): Promise<AnalyticsQueryAudienceExportResponse>
+  /** Fetch every query page. `limit` is used as the page size, not a total-row cap. */
+  queryPages(
+    name: string,
+    request?: AnalyticsQueryAudienceExportRequest
+  ): AsyncIterable<AnalyticsQueryAudienceExportResponse>
+  queryAll(
+    name: string,
+    request?: AnalyticsQueryAudienceExportRequest
+  ): AsyncIterable<AnalyticsAudienceRow>
+}
+
+export function analyticsAudienceExportsResource(
+  http: GoogleHttp
+): AnalyticsAudienceExportsResource {
+  const resource: AnalyticsAudienceExportsResource = {
+    create(parent, audienceExport) {
+      return http.json(
+        "analyticsData",
+        "POST",
+        `${propertyName(parent, "parent")}/audienceExports`,
+        {
+          body: audienceExport,
+        }
+      )
+    },
+    get(name) {
+      return http.json("analyticsData", "GET", childResourceName(name, "audienceExports", "name"))
+    },
+    list(parent, options) {
+      return http.json(
+        "analyticsData",
+        "GET",
+        `${propertyName(parent, "parent")}/audienceExports`,
+        {
+          query: options,
+        }
+      )
+    },
+    listAll(parent, options) {
+      return listAllPages(
+        (pageToken) => resource.list(parent, { ...options, pageToken }),
+        (page) => page.audienceExports,
+        options?.pageToken
+      )
+    },
+    query(name, request = {}) {
+      return http.json(
+        "analyticsData",
+        "POST",
+        `${childResourceName(name, "audienceExports", "name")}:query`,
+        { body: request, retryable: true }
+      )
+    },
+    async *queryPages(name, request = {}) {
+      const limit = analyticsPageSize(request.limit, "request.limit")
+      let offset = analyticsOffset(request.offset, "request.offset")
+
+      for (;;) {
+        const page = await resource.query(name, {
+          ...request,
+          limit: String(limit),
+          offset: String(offset),
+        })
+        yield page
+
+        const rowCount = page.audienceRows?.length ?? 0
+        const next = nextAnalyticsOffset(offset, rowCount, page.rowCount)
+        if (next === undefined) {
+          break
+        }
+        offset = next
+      }
+    },
+    async *queryAll(name, request = {}) {
+      for await (const page of resource.queryPages(name, request)) {
+        for (const row of page.audienceRows ?? []) {
+          yield row
+        }
+      }
+    },
+  }
+  return resource
+}

--- a/connectors/google/src/surfaces/analytics/data/index.ts
+++ b/connectors/google/src/surfaces/analytics/data/index.ts
@@ -1,0 +1,12 @@
+import type { GoogleHttp } from "../../../http"
+import { type AnalyticsDataPropertiesResource, analyticsDataPropertiesResource } from "./properties"
+
+export interface AnalyticsDataSurface {
+  readonly properties: AnalyticsDataPropertiesResource
+}
+
+export function analyticsDataSurface(http: GoogleHttp): AnalyticsDataSurface {
+  return {
+    properties: analyticsDataPropertiesResource(http),
+  }
+}

--- a/connectors/google/src/surfaces/analytics/data/pagination.ts
+++ b/connectors/google/src/surfaces/analytics/data/pagination.ts
@@ -1,0 +1,42 @@
+const MAX_ANALYTICS_PAGE_SIZE = 250_000
+
+export function analyticsPageSize(value: string | undefined, field: string): number {
+  if (value === undefined) {
+    return MAX_ANALYTICS_PAGE_SIZE
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`[SixbGoogle] ${field} must be a positive integer string.`)
+  }
+
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_ANALYTICS_PAGE_SIZE) {
+    throw new Error(`[SixbGoogle] ${field} must be between 1 and 250000.`)
+  }
+  return parsed
+}
+
+export function analyticsOffset(value: string | undefined, field: string): bigint {
+  if (value === undefined) {
+    return 0n
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`[SixbGoogle] ${field} must be a non-negative integer string.`)
+  }
+  return BigInt(value)
+}
+
+export function nextAnalyticsOffset(
+  offset: bigint,
+  returnedRows: number,
+  totalRows: number | undefined
+): bigint | undefined {
+  if (returnedRows === 0) {
+    return undefined
+  }
+
+  const next = offset + BigInt(returnedRows)
+  if (totalRows !== undefined && next >= BigInt(totalRows)) {
+    return undefined
+  }
+  return next
+}

--- a/connectors/google/src/surfaces/analytics/data/properties.ts
+++ b/connectors/google/src/surfaces/analytics/data/properties.ts
@@ -1,0 +1,173 @@
+import type { GoogleHttp } from "../../../http"
+import type {
+  AnalyticsBatchRunPivotReportsRequest,
+  AnalyticsBatchRunPivotReportsResponse,
+  AnalyticsBatchRunReportsRequest,
+  AnalyticsBatchRunReportsResponse,
+  AnalyticsCheckCompatibilityRequest,
+  AnalyticsCheckCompatibilityResponse,
+  AnalyticsDataMetadata,
+  AnalyticsDataRow,
+  AnalyticsRunPivotReportRequest,
+  AnalyticsRunPivotReportResponse,
+  AnalyticsRunRealtimeReportRequest,
+  AnalyticsRunRealtimeReportResponse,
+  AnalyticsRunReportRequest,
+  AnalyticsRunReportResponse,
+} from "../../../types/analytics-data"
+import { propertyName } from "../paths"
+import {
+  type AnalyticsAudienceExportsResource,
+  analyticsAudienceExportsResource,
+} from "./audienceExports"
+import { analyticsOffset, analyticsPageSize, nextAnalyticsOffset } from "./pagination"
+
+export interface AnalyticsDataPropertiesResource {
+  readonly audienceExports: AnalyticsAudienceExportsResource
+  runReport(
+    property: string,
+    request: AnalyticsRunReportRequest
+  ): Promise<AnalyticsRunReportResponse>
+  /** Fetch every report page. `limit` is used as the page size, not a total-row cap. */
+  runReportPages(
+    property: string,
+    request: AnalyticsRunReportRequest
+  ): AsyncIterable<AnalyticsRunReportResponse>
+  runReportAll(
+    property: string,
+    request: AnalyticsRunReportRequest
+  ): AsyncIterable<AnalyticsDataRow>
+  batchRunReports(
+    property: string,
+    request: AnalyticsBatchRunReportsRequest
+  ): Promise<AnalyticsBatchRunReportsResponse>
+  runPivotReport(
+    property: string,
+    request: AnalyticsRunPivotReportRequest
+  ): Promise<AnalyticsRunPivotReportResponse>
+  batchRunPivotReports(
+    property: string,
+    request: AnalyticsBatchRunPivotReportsRequest
+  ): Promise<AnalyticsBatchRunPivotReportsResponse>
+  runRealtimeReport(
+    property: string,
+    request: AnalyticsRunRealtimeReportRequest
+  ): Promise<AnalyticsRunRealtimeReportResponse>
+  getMetadata(property: string): Promise<AnalyticsDataMetadata>
+  checkCompatibility(
+    property: string,
+    request: AnalyticsCheckCompatibilityRequest
+  ): Promise<AnalyticsCheckCompatibilityResponse>
+}
+
+export function analyticsDataPropertiesResource(http: GoogleHttp): AnalyticsDataPropertiesResource {
+  const resource: AnalyticsDataPropertiesResource = {
+    audienceExports: analyticsAudienceExportsResource(http),
+    runReport(property, request) {
+      const path = propertyName(property)
+      return http.json("analyticsData", "POST", `${path}:runReport`, {
+        body: reportRequestBody(path, request),
+        retryable: true,
+      })
+    },
+    async *runReportPages(property, request) {
+      const limit = analyticsPageSize(request.limit, "request.limit")
+      let offset = analyticsOffset(request.offset, "request.offset")
+
+      for (;;) {
+        const page = await resource.runReport(property, {
+          ...request,
+          limit: String(limit),
+          offset: String(offset),
+        })
+        yield page
+
+        const rowCount = page.rows?.length ?? 0
+        const next = nextAnalyticsOffset(offset, rowCount, page.rowCount)
+        if (next === undefined) {
+          break
+        }
+        offset = next
+      }
+    },
+    async *runReportAll(property, request) {
+      for await (const page of resource.runReportPages(property, request)) {
+        for (const row of page.rows ?? []) {
+          yield row
+        }
+      }
+    },
+    batchRunReports(property, request) {
+      const path = propertyName(property)
+      assertBatchRequests(path, request.requests)
+      return http.json("analyticsData", "POST", `${path}:batchRunReports`, {
+        body: request,
+        retryable: true,
+      })
+    },
+    runPivotReport(property, request) {
+      const path = propertyName(property)
+      return http.json("analyticsData", "POST", `${path}:runPivotReport`, {
+        body: reportRequestBody(path, request),
+        retryable: true,
+      })
+    },
+    batchRunPivotReports(property, request) {
+      const path = propertyName(property)
+      assertBatchRequests(path, request.requests)
+      return http.json("analyticsData", "POST", `${path}:batchRunPivotReports`, {
+        body: request,
+        retryable: true,
+      })
+    },
+    runRealtimeReport(property, request) {
+      const path = propertyName(property)
+      return http.json("analyticsData", "POST", `${path}:runRealtimeReport`, {
+        body: request,
+        retryable: true,
+      })
+    },
+    getMetadata(property) {
+      return http.json("analyticsData", "GET", `${propertyName(property)}/metadata`)
+    },
+    checkCompatibility(property, request) {
+      const path = propertyName(property)
+      return http.json("analyticsData", "POST", `${path}:checkCompatibility`, {
+        body: request,
+        retryable: true,
+      })
+    },
+  }
+  return resource
+}
+
+function reportRequestBody<T extends { readonly property?: string }>(
+  property: string,
+  request: T
+): Omit<T, "property"> {
+  if (
+    request.property !== undefined &&
+    propertyName(request.property, "request.property") !== property
+  ) {
+    throw new Error(`[SixbGoogle] request.property must match "${property}".`)
+  }
+  const { property: _property, ...body } = request
+  return body
+}
+
+function assertBatchRequests(
+  property: string,
+  requests: readonly { readonly property?: string }[]
+): void {
+  if (requests.length > 5) {
+    throw new Error("[SixbGoogle] Analytics batch requests accept at most 5 reports.")
+  }
+  for (const request of requests) {
+    if (
+      request.property !== undefined &&
+      propertyName(request.property, "request.property") !== property
+    ) {
+      throw new Error(`[SixbGoogle] Every batch request.property must match "${property}".`)
+    }
+  }
+}

--- a/connectors/google/src/surfaces/analytics/paths.ts
+++ b/connectors/google/src/surfaces/analytics/paths.ts
@@ -1,0 +1,49 @@
+/**
+ * Encode a Google AIP-122 resource name while preserving its `/` separators.
+ *
+ * Analytics APIs use resource names such as `properties/123/dataStreams/456`
+ * as a single path binding. `encodeURIComponent` cannot be applied to the
+ * whole value because it would turn separators into `%2F`.
+ */
+export function analyticsResourceName(
+  value: string,
+  field: string,
+  pattern: RegExp,
+  example: string
+): string {
+  if (!pattern.test(value)) {
+    throw new Error(`[SixbGoogle] ${field} must match ${example}.`)
+  }
+  return value.split("/").map(encodeURIComponent).join("/")
+}
+
+export function accountName(value: string, field = "account"): string {
+  return analyticsResourceName(value, field, /^accounts\/[^/]+$/, '"accounts/{accountId}"')
+}
+
+export function propertyName(value: string, field = "property"): string {
+  return analyticsResourceName(value, field, /^properties\/[^/]+$/, '"properties/{propertyId}"')
+}
+
+export function childResourceName(value: string, collection: string, field = "name"): string {
+  const escaped = collection.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return analyticsResourceName(
+    value,
+    field,
+    new RegExp(`^properties/[^/]+/${escaped}/[^/]+$`),
+    `"properties/{propertyId}/${collection}/{resourceId}"`
+  )
+}
+
+export function dataStreamName(value: string, field = "dataStream"): string {
+  return childResourceName(value, "dataStreams", field)
+}
+
+export function measurementProtocolSecretName(value: string, field = "name"): string {
+  return analyticsResourceName(
+    value,
+    field,
+    /^properties\/[^/]+\/dataStreams\/[^/]+\/measurementProtocolSecrets\/[^/]+$/,
+    '"properties/{propertyId}/dataStreams/{streamId}/measurementProtocolSecrets/{secretId}"'
+  )
+}

--- a/connectors/google/src/types/analytics-admin.ts
+++ b/connectors/google/src/types/analytics-admin.ts
@@ -1,0 +1,546 @@
+/**
+ * Hand-written public types for Google Analytics Admin API v1beta.
+ *
+ * Resource shapes stay open because Google supports partial-response selectors
+ * and can add output fields without requiring a connector release. Request
+ * types name the stable v1beta fields for editor discoverability.
+ */
+import type { QueryParams } from "./common"
+
+export type AnalyticsPropertyType =
+  | "PROPERTY_TYPE_UNSPECIFIED"
+  | "PROPERTY_TYPE_ORDINARY"
+  | "PROPERTY_TYPE_SUBPROPERTY"
+  | "PROPERTY_TYPE_ROLLUP"
+
+export type AnalyticsServiceLevel =
+  | "SERVICE_LEVEL_UNSPECIFIED"
+  | "GOOGLE_ANALYTICS_STANDARD"
+  | "GOOGLE_ANALYTICS_360"
+
+export type AnalyticsIndustryCategory =
+  | "INDUSTRY_CATEGORY_UNSPECIFIED"
+  | "AUTOMOTIVE"
+  | "BUSINESS_AND_INDUSTRIAL_MARKETS"
+  | "FINANCE"
+  | "HEALTHCARE"
+  | "TECHNOLOGY"
+  | "TRAVEL"
+  | "OTHER"
+  | "ARTS_AND_ENTERTAINMENT"
+  | "BEAUTY_AND_FITNESS"
+  | "BOOKS_AND_LITERATURE"
+  | "FOOD_AND_DRINK"
+  | "GAMES"
+  | "HOBBIES_AND_LEISURE"
+  | "HOME_AND_GARDEN"
+  | "INTERNET_AND_TELECOM"
+  | "LAW_AND_GOVERNMENT"
+  | "NEWS"
+  | "ONLINE_COMMUNITIES"
+  | "PEOPLE_AND_SOCIETY"
+  | "PETS_AND_ANIMALS"
+  | "REAL_ESTATE"
+  | "REFERENCE"
+  | "SCIENCE"
+  | "SPORTS"
+  | "JOBS_AND_EDUCATION"
+  | "SHOPPING"
+
+export interface AnalyticsAccount {
+  readonly name?: string
+  readonly displayName?: string
+  readonly regionCode?: string
+  readonly createTime?: string
+  readonly updateTime?: string
+  readonly deleted?: boolean
+  readonly gmpOrganization?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsPropertySummary {
+  readonly property?: string
+  readonly displayName?: string
+  readonly propertyType?: AnalyticsPropertyType
+  readonly parent?: string
+  readonly canEdit?: boolean
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsAccountSummary {
+  readonly name?: string
+  readonly account?: string
+  readonly displayName?: string
+  readonly propertySummaries?: readonly AnalyticsPropertySummary[]
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsProperty {
+  readonly name?: string
+  readonly displayName?: string
+  readonly propertyType?: AnalyticsPropertyType
+  readonly parent?: string
+  readonly account?: string
+  readonly industryCategory?: AnalyticsIndustryCategory
+  readonly timeZone?: string
+  readonly currencyCode?: string
+  readonly serviceLevel?: AnalyticsServiceLevel
+  readonly createTime?: string
+  readonly updateTime?: string
+  readonly deleteTime?: string
+  readonly expireTime?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsDataSharingSettings {
+  readonly name?: string
+  readonly sharingWithGoogleSupportEnabled?: boolean
+  readonly sharingWithGoogleAssignedSalesEnabled?: boolean
+  /** Deprecated by Google and always false. */
+  readonly sharingWithGoogleAnySalesEnabled?: boolean
+  readonly sharingWithGoogleProductsEnabled?: boolean
+  readonly sharingWithOthersEnabled?: boolean
+  readonly [key: string]: unknown
+}
+
+export type AnalyticsRetentionDuration =
+  | "RETENTION_DURATION_UNSPECIFIED"
+  | "TWO_MONTHS"
+  | "FOURTEEN_MONTHS"
+  | "TWENTY_SIX_MONTHS"
+  | "THIRTY_EIGHT_MONTHS"
+  | "FIFTY_MONTHS"
+
+export interface AnalyticsDataRetentionSettings {
+  readonly name?: string
+  readonly eventDataRetention?: AnalyticsRetentionDuration
+  readonly userDataRetention?: AnalyticsRetentionDuration
+  readonly resetUserDataOnNewActivity?: boolean
+  readonly [key: string]: unknown
+}
+
+export type AnalyticsDataStreamType =
+  | "DATA_STREAM_TYPE_UNSPECIFIED"
+  | "WEB_DATA_STREAM"
+  | "ANDROID_APP_DATA_STREAM"
+  | "IOS_APP_DATA_STREAM"
+
+export interface AnalyticsWebStreamData {
+  readonly measurementId?: string
+  readonly firebaseAppId?: string
+  readonly defaultUri?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsAndroidAppStreamData {
+  readonly firebaseAppId?: string
+  readonly packageName?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsIosAppStreamData {
+  readonly firebaseAppId?: string
+  readonly bundleId?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsDataStream {
+  readonly name?: string
+  readonly type?: AnalyticsDataStreamType
+  readonly displayName?: string
+  readonly createTime?: string
+  readonly updateTime?: string
+  readonly webStreamData?: AnalyticsWebStreamData
+  readonly androidAppStreamData?: AnalyticsAndroidAppStreamData
+  readonly iosAppStreamData?: AnalyticsIosAppStreamData
+  readonly [key: string]: unknown
+}
+
+export type AnalyticsCustomDimensionScope =
+  | "DIMENSION_SCOPE_UNSPECIFIED"
+  | "EVENT"
+  | "USER"
+  | "ITEM"
+
+export interface AnalyticsCustomDimension {
+  readonly name?: string
+  readonly parameterName?: string
+  readonly displayName?: string
+  readonly description?: string
+  readonly scope?: AnalyticsCustomDimensionScope
+  readonly disallowAdsPersonalization?: boolean
+  readonly [key: string]: unknown
+}
+
+export type AnalyticsMetricScope = "METRIC_SCOPE_UNSPECIFIED" | "EVENT"
+export type AnalyticsMeasurementUnit =
+  | "MEASUREMENT_UNIT_UNSPECIFIED"
+  | "STANDARD"
+  | "CURRENCY"
+  | "FEET"
+  | "METERS"
+  | "KILOMETERS"
+  | "MILES"
+  | "MILLISECONDS"
+  | "SECONDS"
+  | "MINUTES"
+  | "HOURS"
+export type AnalyticsRestrictedMetricType =
+  | "RESTRICTED_METRIC_TYPE_UNSPECIFIED"
+  | "COST_DATA"
+  | "REVENUE_DATA"
+
+export interface AnalyticsCustomMetric {
+  readonly name?: string
+  readonly parameterName?: string
+  readonly displayName?: string
+  readonly description?: string
+  readonly scope?: AnalyticsMetricScope
+  readonly measurementUnit?: AnalyticsMeasurementUnit
+  readonly restrictedMetricType?: readonly AnalyticsRestrictedMetricType[]
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsMeasurementProtocolSecret {
+  readonly name?: string
+  readonly displayName?: string
+  readonly secretValue?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsFirebaseLink {
+  readonly name?: string
+  readonly project?: string
+  readonly createTime?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsGoogleAdsLink {
+  readonly name?: string
+  readonly customerId?: string
+  readonly canManageClients?: boolean
+  readonly adsPersonalizationEnabled?: boolean
+  readonly creatorEmailAddress?: string
+  readonly createTime?: string
+  readonly updateTime?: string
+  readonly [key: string]: unknown
+}
+
+export type AnalyticsKeyEventCountingMethod =
+  | "COUNTING_METHOD_UNSPECIFIED"
+  | "ONCE_PER_EVENT"
+  | "ONCE_PER_SESSION"
+
+export interface AnalyticsKeyEventDefaultValue {
+  readonly numericValue?: number
+  readonly currencyCode?: string
+}
+
+export interface AnalyticsKeyEvent {
+  readonly name?: string
+  readonly eventName?: string
+  readonly createTime?: string
+  readonly deletable?: boolean
+  readonly custom?: boolean
+  readonly countingMethod?: AnalyticsKeyEventCountingMethod
+  readonly defaultValue?: AnalyticsKeyEventDefaultValue
+  readonly [key: string]: unknown
+}
+
+export type AnalyticsChangeAction = "ACTION_TYPE_UNSPECIFIED" | "CREATED" | "UPDATED" | "DELETED"
+
+export type AnalyticsChangeActorType = "ACTOR_TYPE_UNSPECIFIED" | "USER" | "SYSTEM" | "SUPPORT"
+
+export type AnalyticsChangeResourceType =
+  | "CHANGE_HISTORY_RESOURCE_TYPE_UNSPECIFIED"
+  | "ACCOUNT"
+  | "PROPERTY"
+  | "FIREBASE_LINK"
+  | "GOOGLE_ADS_LINK"
+  | "GOOGLE_SIGNALS_SETTINGS"
+  | "CONVERSION_EVENT"
+  | "MEASUREMENT_PROTOCOL_SECRET"
+  | "CUSTOM_DIMENSION"
+  | "CUSTOM_METRIC"
+  | "DATA_RETENTION_SETTINGS"
+  | "DISPLAY_VIDEO_360_ADVERTISER_LINK"
+  | "DISPLAY_VIDEO_360_ADVERTISER_LINK_PROPOSAL"
+  | "DATA_STREAM"
+  | "ATTRIBUTION_SETTINGS"
+
+export interface AnalyticsChangeHistoryResource {
+  readonly account?: AnalyticsAccount
+  readonly property?: AnalyticsProperty
+  readonly dataStream?: AnalyticsDataStream
+  readonly firebaseLink?: AnalyticsFirebaseLink
+  readonly googleAdsLink?: AnalyticsGoogleAdsLink
+  readonly measurementProtocolSecret?: AnalyticsMeasurementProtocolSecret
+  readonly dataRetentionSettings?: AnalyticsDataRetentionSettings
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsChangeHistoryChange {
+  readonly resource?: string
+  readonly action?: AnalyticsChangeAction
+  readonly resourceBeforeChange?: AnalyticsChangeHistoryResource
+  readonly resourceAfterChange?: AnalyticsChangeHistoryResource
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsChangeHistoryEvent {
+  readonly id?: string
+  readonly changeTime?: string
+  readonly actorType?: AnalyticsChangeActorType
+  readonly userActorEmail?: string
+  readonly changesFiltered?: boolean
+  readonly changes?: readonly AnalyticsChangeHistoryChange[]
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsNumericValue {
+  readonly int64Value?: string
+  readonly doubleValue?: number
+}
+
+export interface AnalyticsAccessDateRange {
+  readonly startDate?: string
+  readonly endDate?: string
+}
+
+export interface AnalyticsAccessDimension {
+  readonly dimensionName?: string
+}
+
+export interface AnalyticsAccessMetric {
+  readonly metricName?: string
+}
+
+export interface AnalyticsAccessStringFilter {
+  readonly matchType?:
+    | "MATCH_TYPE_UNSPECIFIED"
+    | "EXACT"
+    | "BEGINS_WITH"
+    | "ENDS_WITH"
+    | "CONTAINS"
+    | "FULL_REGEXP"
+    | "PARTIAL_REGEXP"
+  readonly value?: string
+  readonly caseSensitive?: boolean
+}
+
+export interface AnalyticsAccessInListFilter {
+  readonly values?: readonly string[]
+  readonly caseSensitive?: boolean
+}
+
+export interface AnalyticsAccessNumericFilter {
+  readonly operation?:
+    | "OPERATION_UNSPECIFIED"
+    | "EQUAL"
+    | "LESS_THAN"
+    | "LESS_THAN_OR_EQUAL"
+    | "GREATER_THAN"
+    | "GREATER_THAN_OR_EQUAL"
+  readonly value?: AnalyticsNumericValue
+}
+
+export interface AnalyticsAccessBetweenFilter {
+  readonly fromValue?: AnalyticsNumericValue
+  readonly toValue?: AnalyticsNumericValue
+}
+
+export interface AnalyticsAccessFilter {
+  readonly fieldName?: string
+  readonly stringFilter?: AnalyticsAccessStringFilter
+  readonly inListFilter?: AnalyticsAccessInListFilter
+  readonly numericFilter?: AnalyticsAccessNumericFilter
+  readonly betweenFilter?: AnalyticsAccessBetweenFilter
+}
+
+export interface AnalyticsAccessFilterExpressionList {
+  readonly expressions?: readonly AnalyticsAccessFilterExpression[]
+}
+
+export interface AnalyticsAccessFilterExpression {
+  readonly andGroup?: AnalyticsAccessFilterExpressionList
+  readonly orGroup?: AnalyticsAccessFilterExpressionList
+  readonly notExpression?: AnalyticsAccessFilterExpression
+  readonly accessFilter?: AnalyticsAccessFilter
+}
+
+export interface AnalyticsAccessOrderBy {
+  readonly desc?: boolean
+  readonly metric?: { readonly metricName?: string }
+  readonly dimension?: {
+    readonly dimensionName?: string
+    readonly orderType?:
+      | "ORDER_TYPE_UNSPECIFIED"
+      | "ALPHANUMERIC"
+      | "CASE_INSENSITIVE_ALPHANUMERIC"
+      | "NUMERIC"
+  }
+}
+
+export interface AnalyticsAccessDimensionHeader {
+  readonly dimensionName?: string
+}
+
+export interface AnalyticsAccessMetricHeader {
+  readonly metricName?: string
+}
+
+export interface AnalyticsAccessDimensionValue {
+  readonly value?: string
+}
+
+export interface AnalyticsAccessMetricValue {
+  readonly value?: string
+}
+
+export interface AnalyticsAccessRow {
+  readonly dimensionValues?: readonly AnalyticsAccessDimensionValue[]
+  readonly metricValues?: readonly AnalyticsAccessMetricValue[]
+}
+
+export interface AnalyticsAccessQuotaStatus {
+  readonly consumed?: number
+  readonly remaining?: number
+}
+
+export interface AnalyticsAccessQuota {
+  readonly tokensPerDay?: AnalyticsAccessQuotaStatus
+  readonly tokensPerHour?: AnalyticsAccessQuotaStatus
+  readonly tokensPerProjectPerHour?: AnalyticsAccessQuotaStatus
+  readonly concurrentRequests?: AnalyticsAccessQuotaStatus
+  readonly serverErrorsPerProjectPerHour?: AnalyticsAccessQuotaStatus
+}
+
+export interface AnalyticsRunAccessReportRequest {
+  readonly dimensions?: readonly AnalyticsAccessDimension[]
+  readonly metrics?: readonly AnalyticsAccessMetric[]
+  readonly dateRanges?: readonly AnalyticsAccessDateRange[]
+  readonly dimensionFilter?: AnalyticsAccessFilterExpression
+  readonly metricFilter?: AnalyticsAccessFilterExpression
+  readonly offset?: string
+  readonly limit?: string
+  readonly timeZone?: string
+  readonly orderBys?: readonly AnalyticsAccessOrderBy[]
+  readonly returnEntityQuota?: boolean
+  readonly includeAllUsers?: boolean
+  readonly expandGroups?: boolean
+}
+
+export interface AnalyticsRunAccessReportResponse {
+  readonly dimensionHeaders?: readonly AnalyticsAccessDimensionHeader[]
+  readonly metricHeaders?: readonly AnalyticsAccessMetricHeader[]
+  readonly rows?: readonly AnalyticsAccessRow[]
+  readonly rowCount?: number
+  readonly quota?: AnalyticsAccessQuota
+}
+
+export interface AnalyticsSearchChangeHistoryRequest {
+  readonly property?: string
+  readonly resourceType?: readonly AnalyticsChangeResourceType[]
+  readonly action?: readonly AnalyticsChangeAction[]
+  readonly actorEmail?: readonly string[]
+  readonly earliestChangeTime?: string
+  readonly latestChangeTime?: string
+  readonly pageSize?: number
+  readonly pageToken?: string
+}
+
+export interface AnalyticsSearchChangeHistoryResponse {
+  readonly changeHistoryEvents?: readonly AnalyticsChangeHistoryEvent[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListAccountSummariesResponse {
+  readonly accountSummaries?: readonly AnalyticsAccountSummary[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListAccountsResponse {
+  readonly accounts?: readonly AnalyticsAccount[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListPropertiesResponse {
+  readonly properties?: readonly AnalyticsProperty[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListCustomDimensionsResponse {
+  readonly customDimensions?: readonly AnalyticsCustomDimension[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListCustomMetricsResponse {
+  readonly customMetrics?: readonly AnalyticsCustomMetric[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListDataStreamsResponse {
+  readonly dataStreams?: readonly AnalyticsDataStream[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListMeasurementProtocolSecretsResponse {
+  readonly measurementProtocolSecrets?: readonly AnalyticsMeasurementProtocolSecret[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListFirebaseLinksResponse {
+  readonly firebaseLinks?: readonly AnalyticsFirebaseLink[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListGoogleAdsLinksResponse {
+  readonly googleAdsLinks?: readonly AnalyticsGoogleAdsLink[]
+  readonly nextPageToken?: string
+}
+
+export interface AnalyticsListKeyEventsResponse {
+  readonly keyEvents?: readonly AnalyticsKeyEvent[]
+  readonly nextPageToken?: string
+}
+
+export type AnalyticsPageOptions = QueryParams & {
+  readonly pageSize?: number
+  readonly pageToken?: string
+}
+
+export type AnalyticsAccountListOptions = AnalyticsPageOptions & {
+  readonly showDeleted?: boolean
+}
+
+export type AnalyticsPropertyListOptions = AnalyticsPageOptions & {
+  /** Required, e.g. `parent:accounts/123` or `ancestor:accounts/123`. */
+  readonly filter: string
+  readonly showDeleted?: boolean
+}
+
+export type AnalyticsUpdateOptions = QueryParams & {
+  /** Required Google field mask. Field names use snake_case. */
+  readonly updateMask: string
+}
+
+export type AnalyticsCustomDimensionListOptions = AnalyticsPageOptions
+export type AnalyticsCustomMetricListOptions = AnalyticsPageOptions
+export type AnalyticsDataStreamListOptions = AnalyticsPageOptions
+export type AnalyticsMeasurementProtocolSecretListOptions = AnalyticsPageOptions
+export type AnalyticsFirebaseLinkListOptions = AnalyticsPageOptions
+export type AnalyticsGoogleAdsLinkListOptions = AnalyticsPageOptions
+export type AnalyticsKeyEventListOptions = AnalyticsPageOptions
+
+export interface AnalyticsProvisionAccountTicketRequest {
+  readonly account: AnalyticsAccount
+  readonly redirectUri: string
+}
+
+export interface AnalyticsProvisionAccountTicketResponse {
+  readonly accountTicketId?: string
+}
+
+export interface AnalyticsAcknowledgeUserDataCollectionRequest {
+  readonly acknowledgement: string
+}

--- a/connectors/google/src/types/analytics-data.ts
+++ b/connectors/google/src/types/analytics-data.ts
@@ -1,0 +1,485 @@
+export type AnalyticsMetricAggregation =
+  | "METRIC_AGGREGATION_UNSPECIFIED"
+  | "TOTAL"
+  | "MINIMUM"
+  | "MAXIMUM"
+  | "COUNT"
+
+export type AnalyticsCompatibility = "COMPATIBILITY_UNSPECIFIED" | "COMPATIBLE" | "INCOMPATIBLE"
+
+export type AnalyticsMetricType =
+  | "METRIC_TYPE_UNSPECIFIED"
+  | "TYPE_INTEGER"
+  | "TYPE_FLOAT"
+  | "TYPE_SECONDS"
+  | "TYPE_MILLISECONDS"
+  | "TYPE_MINUTES"
+  | "TYPE_HOURS"
+  | "TYPE_STANDARD"
+  | "TYPE_CURRENCY"
+  | "TYPE_FEET"
+  | "TYPE_MILES"
+  | "TYPE_METERS"
+  | "TYPE_KILOMETERS"
+
+export interface AnalyticsDataDimension {
+  readonly name?: string
+  readonly dimensionExpression?: AnalyticsDataDimensionExpression
+}
+
+export interface AnalyticsDataDimensionExpression {
+  readonly lowerCase?: AnalyticsDataCaseExpression
+  readonly upperCase?: AnalyticsDataCaseExpression
+  readonly concatenate?: AnalyticsDataConcatenateExpression
+}
+
+export interface AnalyticsDataCaseExpression {
+  readonly dimensionName?: string
+}
+
+export interface AnalyticsDataConcatenateExpression {
+  readonly dimensionNames?: readonly string[]
+  readonly delimiter?: string
+}
+
+export interface AnalyticsDataMetric {
+  readonly name?: string
+  readonly expression?: string
+  readonly invisible?: boolean
+}
+
+export interface AnalyticsDataDateRange {
+  readonly startDate?: string
+  readonly endDate?: string
+  readonly name?: string
+}
+
+export interface AnalyticsDataMinuteRange {
+  readonly startMinutesAgo?: number
+  readonly endMinutesAgo?: number
+  readonly name?: string
+}
+
+export interface AnalyticsDataFilterExpression {
+  readonly andGroup?: AnalyticsDataFilterExpressionList
+  readonly orGroup?: AnalyticsDataFilterExpressionList
+  readonly notExpression?: AnalyticsDataFilterExpression
+  readonly filter?: AnalyticsDataFilter
+}
+
+export interface AnalyticsDataFilterExpressionList {
+  readonly expressions?: readonly AnalyticsDataFilterExpression[]
+}
+
+export interface AnalyticsDataFilter {
+  readonly fieldName?: string
+  readonly stringFilter?: AnalyticsDataStringFilter
+  readonly inListFilter?: AnalyticsDataInListFilter
+  readonly numericFilter?: AnalyticsDataNumericFilter
+  readonly betweenFilter?: AnalyticsDataBetweenFilter
+  readonly emptyFilter?: Record<string, never>
+}
+
+export interface AnalyticsDataStringFilter {
+  readonly matchType?:
+    | "MATCH_TYPE_UNSPECIFIED"
+    | "EXACT"
+    | "BEGINS_WITH"
+    | "ENDS_WITH"
+    | "CONTAINS"
+    | "FULL_REGEXP"
+    | "PARTIAL_REGEXP"
+  readonly value?: string
+  readonly caseSensitive?: boolean
+}
+
+export interface AnalyticsDataInListFilter {
+  readonly values?: readonly string[]
+  readonly caseSensitive?: boolean
+}
+
+export interface AnalyticsDataNumericFilter {
+  readonly operation?:
+    | "OPERATION_UNSPECIFIED"
+    | "EQUAL"
+    | "LESS_THAN"
+    | "LESS_THAN_OR_EQUAL"
+    | "GREATER_THAN"
+    | "GREATER_THAN_OR_EQUAL"
+  readonly value?: AnalyticsDataNumericValue
+}
+
+export interface AnalyticsDataNumericValue {
+  readonly int64Value?: string
+  readonly doubleValue?: number
+}
+
+export interface AnalyticsDataBetweenFilter {
+  readonly fromValue?: AnalyticsDataNumericValue
+  readonly toValue?: AnalyticsDataNumericValue
+}
+
+export interface AnalyticsDataOrderBy {
+  readonly metric?: AnalyticsDataMetricOrderBy
+  readonly dimension?: AnalyticsDataDimensionOrderBy
+  readonly pivot?: AnalyticsDataPivotOrderBy
+  readonly desc?: boolean
+}
+
+export interface AnalyticsDataMetricOrderBy {
+  readonly metricName?: string
+}
+
+export interface AnalyticsDataDimensionOrderBy {
+  readonly dimensionName?: string
+  readonly orderType?:
+    | "ORDER_TYPE_UNSPECIFIED"
+    | "ALPHANUMERIC"
+    | "CASE_INSENSITIVE_ALPHANUMERIC"
+    | "NUMERIC"
+}
+
+export interface AnalyticsDataPivotOrderBy {
+  readonly metricName?: string
+  readonly pivotSelections?: readonly AnalyticsDataPivotSelection[]
+}
+
+export interface AnalyticsDataPivotSelection {
+  readonly dimensionName?: string
+  readonly dimensionValue?: string
+}
+
+export interface AnalyticsDataComparison {
+  readonly name?: string
+  readonly dimensionFilter?: AnalyticsDataFilterExpression
+  readonly comparison?: string
+}
+
+export interface AnalyticsDataCohortSpec {
+  readonly cohorts?: readonly AnalyticsDataCohort[]
+  readonly cohortsRange?: AnalyticsDataCohortsRange
+  readonly cohortReportSettings?: AnalyticsDataCohortReportSettings
+}
+
+export interface AnalyticsDataCohort {
+  readonly name?: string
+  readonly dimension?: string
+  readonly dateRange?: AnalyticsDataDateRange
+}
+
+export interface AnalyticsDataCohortsRange {
+  readonly granularity?: "GRANULARITY_UNSPECIFIED" | "DAILY" | "WEEKLY" | "MONTHLY"
+  readonly startOffset?: number
+  readonly endOffset?: number
+}
+
+export interface AnalyticsDataCohortReportSettings {
+  readonly accumulate?: boolean
+}
+
+export interface AnalyticsRunReportRequest {
+  readonly property?: string
+  readonly dimensions?: readonly AnalyticsDataDimension[]
+  readonly metrics?: readonly AnalyticsDataMetric[]
+  readonly dateRanges?: readonly AnalyticsDataDateRange[]
+  readonly dimensionFilter?: AnalyticsDataFilterExpression
+  readonly metricFilter?: AnalyticsDataFilterExpression
+  readonly offset?: string
+  readonly limit?: string
+  readonly metricAggregations?: readonly AnalyticsMetricAggregation[]
+  readonly orderBys?: readonly AnalyticsDataOrderBy[]
+  readonly currencyCode?: string
+  readonly cohortSpec?: AnalyticsDataCohortSpec
+  readonly keepEmptyRows?: boolean
+  readonly returnPropertyQuota?: boolean
+  readonly comparisons?: readonly AnalyticsDataComparison[]
+}
+
+export interface AnalyticsRunPivotReportRequest {
+  readonly property?: string
+  readonly dimensions?: readonly AnalyticsDataDimension[]
+  readonly metrics?: readonly AnalyticsDataMetric[]
+  readonly dateRanges?: readonly AnalyticsDataDateRange[]
+  readonly pivots?: readonly AnalyticsDataPivot[]
+  readonly dimensionFilter?: AnalyticsDataFilterExpression
+  readonly metricFilter?: AnalyticsDataFilterExpression
+  readonly currencyCode?: string
+  readonly cohortSpec?: AnalyticsDataCohortSpec
+  readonly keepEmptyRows?: boolean
+  readonly returnPropertyQuota?: boolean
+  readonly comparisons?: readonly AnalyticsDataComparison[]
+}
+
+export interface AnalyticsDataPivot {
+  readonly fieldNames?: readonly string[]
+  readonly orderBys?: readonly AnalyticsDataOrderBy[]
+  readonly offset?: string
+  readonly limit?: string
+  readonly metricAggregations?: readonly AnalyticsMetricAggregation[]
+}
+
+export interface AnalyticsRunRealtimeReportRequest {
+  readonly dimensions?: readonly AnalyticsDataDimension[]
+  readonly metrics?: readonly AnalyticsDataMetric[]
+  readonly dimensionFilter?: AnalyticsDataFilterExpression
+  readonly metricFilter?: AnalyticsDataFilterExpression
+  readonly limit?: string
+  readonly metricAggregations?: readonly AnalyticsMetricAggregation[]
+  readonly orderBys?: readonly AnalyticsDataOrderBy[]
+  readonly returnPropertyQuota?: boolean
+  readonly minuteRanges?: readonly AnalyticsDataMinuteRange[]
+}
+
+export interface AnalyticsDataDimensionHeader {
+  readonly name?: string
+}
+
+export interface AnalyticsDataMetricHeader {
+  readonly name?: string
+  readonly type?: AnalyticsMetricType
+}
+
+export interface AnalyticsDataDimensionValue {
+  readonly value?: string
+}
+
+export interface AnalyticsDataMetricValue {
+  readonly value?: string
+}
+
+export interface AnalyticsDataRow {
+  readonly dimensionValues?: readonly AnalyticsDataDimensionValue[]
+  readonly metricValues?: readonly AnalyticsDataMetricValue[]
+}
+
+export interface AnalyticsDataResponseMetadata {
+  readonly dataLossFromOtherRow?: boolean
+  readonly schemaRestrictionResponse?: AnalyticsDataSchemaRestrictionResponse
+  readonly currencyCode?: string
+  readonly timeZone?: string
+  readonly emptyReason?: string
+  readonly subjectToThresholding?: boolean
+  readonly samplingMetadatas?: readonly AnalyticsDataSamplingMetadata[]
+}
+
+export interface AnalyticsDataSamplingMetadata {
+  readonly samplesReadCount?: string
+  readonly samplingSpaceSize?: string
+}
+
+export interface AnalyticsDataSchemaRestrictionResponse {
+  readonly activeMetricRestrictions?: readonly AnalyticsDataActiveMetricRestriction[]
+}
+
+export interface AnalyticsDataActiveMetricRestriction {
+  readonly metricName?: string
+  readonly restrictedMetricTypes?: readonly (
+    | "RESTRICTED_METRIC_TYPE_UNSPECIFIED"
+    | "COST_DATA"
+    | "REVENUE_DATA"
+  )[]
+}
+
+export interface AnalyticsDataQuotaStatus {
+  readonly consumed?: number
+  readonly remaining?: number
+}
+
+export interface AnalyticsDataPropertyQuota {
+  readonly tokensPerDay?: AnalyticsDataQuotaStatus
+  readonly tokensPerHour?: AnalyticsDataQuotaStatus
+  readonly concurrentRequests?: AnalyticsDataQuotaStatus
+  readonly serverErrorsPerProjectPerHour?: AnalyticsDataQuotaStatus
+  readonly potentiallyThresholdedRequestsPerHour?: AnalyticsDataQuotaStatus
+  readonly tokensPerProjectPerHour?: AnalyticsDataQuotaStatus
+}
+
+export interface AnalyticsRunReportResponse {
+  readonly dimensionHeaders?: readonly AnalyticsDataDimensionHeader[]
+  readonly metricHeaders?: readonly AnalyticsDataMetricHeader[]
+  readonly rows?: readonly AnalyticsDataRow[]
+  readonly totals?: readonly AnalyticsDataRow[]
+  readonly maximums?: readonly AnalyticsDataRow[]
+  readonly minimums?: readonly AnalyticsDataRow[]
+  readonly rowCount?: number
+  readonly metadata?: AnalyticsDataResponseMetadata
+  readonly propertyQuota?: AnalyticsDataPropertyQuota
+  readonly kind?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsDataPivotDimensionHeader {
+  readonly dimensionValues?: readonly AnalyticsDataDimensionValue[]
+}
+
+export interface AnalyticsDataPivotHeader {
+  readonly pivotDimensionHeaders?: readonly AnalyticsDataPivotDimensionHeader[]
+  readonly rowCount?: number
+}
+
+export interface AnalyticsRunPivotReportResponse {
+  readonly pivotHeaders?: readonly AnalyticsDataPivotHeader[]
+  readonly dimensionHeaders?: readonly AnalyticsDataDimensionHeader[]
+  readonly metricHeaders?: readonly AnalyticsDataMetricHeader[]
+  readonly rows?: readonly AnalyticsDataRow[]
+  readonly aggregates?: readonly AnalyticsDataRow[]
+  readonly metadata?: AnalyticsDataResponseMetadata
+  readonly propertyQuota?: AnalyticsDataPropertyQuota
+  readonly kind?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsRunRealtimeReportResponse {
+  readonly dimensionHeaders?: readonly AnalyticsDataDimensionHeader[]
+  readonly metricHeaders?: readonly AnalyticsDataMetricHeader[]
+  readonly rows?: readonly AnalyticsDataRow[]
+  readonly totals?: readonly AnalyticsDataRow[]
+  readonly maximums?: readonly AnalyticsDataRow[]
+  readonly minimums?: readonly AnalyticsDataRow[]
+  readonly rowCount?: number
+  readonly propertyQuota?: AnalyticsDataPropertyQuota
+  readonly kind?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsBatchRunReportsRequest {
+  readonly requests: readonly AnalyticsRunReportRequest[]
+}
+
+export interface AnalyticsBatchRunReportsResponse {
+  readonly reports?: readonly AnalyticsRunReportResponse[]
+  readonly kind?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsBatchRunPivotReportsRequest {
+  readonly requests: readonly AnalyticsRunPivotReportRequest[]
+}
+
+export interface AnalyticsBatchRunPivotReportsResponse {
+  readonly pivotReports?: readonly AnalyticsRunPivotReportResponse[]
+  readonly kind?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsDimensionMetadata {
+  readonly apiName?: string
+  readonly uiName?: string
+  readonly description?: string
+  readonly deprecatedApiNames?: readonly string[]
+  readonly customDefinition?: boolean
+  readonly category?: string
+}
+
+export interface AnalyticsMetricMetadata extends AnalyticsDimensionMetadata {
+  readonly expression?: string
+  readonly type?: AnalyticsMetricType
+  readonly blockedReasons?: readonly (
+    | "BLOCKED_REASON_UNSPECIFIED"
+    | "NO_REVENUE_METRICS"
+    | "NO_COST_METRICS"
+  )[]
+}
+
+export interface AnalyticsComparisonMetadata {
+  readonly apiName?: string
+  readonly uiName?: string
+  readonly description?: string
+}
+
+export interface AnalyticsDataMetadata {
+  readonly name?: string
+  readonly dimensions?: readonly AnalyticsDimensionMetadata[]
+  readonly metrics?: readonly AnalyticsMetricMetadata[]
+  readonly comparisons?: readonly AnalyticsComparisonMetadata[]
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsCheckCompatibilityRequest {
+  readonly dimensions?: readonly AnalyticsDataDimension[]
+  readonly metrics?: readonly AnalyticsDataMetric[]
+  readonly dimensionFilter?: AnalyticsDataFilterExpression
+  readonly metricFilter?: AnalyticsDataFilterExpression
+  readonly compatibilityFilter?: AnalyticsCompatibility
+}
+
+export interface AnalyticsDimensionCompatibility {
+  readonly dimensionMetadata?: AnalyticsDimensionMetadata
+  readonly compatibility?: AnalyticsCompatibility
+}
+
+export interface AnalyticsMetricCompatibility {
+  readonly metricMetadata?: AnalyticsMetricMetadata
+  readonly compatibility?: AnalyticsCompatibility
+}
+
+export interface AnalyticsCheckCompatibilityResponse {
+  readonly dimensionCompatibilities?: readonly AnalyticsDimensionCompatibility[]
+  readonly metricCompatibilities?: readonly AnalyticsMetricCompatibility[]
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsAudienceDimension {
+  readonly dimensionName: string
+}
+
+export interface AnalyticsAudienceExport {
+  readonly name?: string
+  readonly audience: string
+  readonly audienceDisplayName?: string
+  readonly dimensions: readonly AnalyticsAudienceDimension[]
+  readonly state?: "STATE_UNSPECIFIED" | "CREATING" | "ACTIVE" | "FAILED"
+  readonly beginCreatingTime?: string
+  readonly creationQuotaTokensCharged?: number
+  readonly rowCount?: number
+  readonly errorMessage?: string
+  readonly percentageCompleted?: number
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsOperation {
+  readonly name?: string
+  readonly done?: boolean
+  readonly error?: AnalyticsOperationStatus
+  readonly metadata?: Readonly<Record<string, unknown>>
+  readonly response?: Readonly<Record<string, unknown>>
+}
+
+export interface AnalyticsOperationStatus {
+  readonly code?: number
+  readonly message?: string
+  readonly details?: readonly Readonly<Record<string, unknown>>[]
+}
+
+export type AnalyticsListAudienceExportsOptions = QueryParams & {
+  readonly pageSize?: number
+  readonly pageToken?: string
+}
+
+export interface AnalyticsListAudienceExportsResponse {
+  readonly audienceExports?: readonly AnalyticsAudienceExport[]
+  readonly nextPageToken?: string
+  readonly [key: string]: unknown
+}
+
+export interface AnalyticsQueryAudienceExportRequest {
+  readonly offset?: string
+  readonly limit?: string
+}
+
+export interface AnalyticsAudienceDimensionValue {
+  readonly value?: string
+}
+
+export interface AnalyticsAudienceRow {
+  readonly dimensionValues?: readonly AnalyticsAudienceDimensionValue[]
+}
+
+export interface AnalyticsQueryAudienceExportResponse {
+  readonly audienceExport?: AnalyticsAudienceExport
+  readonly audienceRows?: readonly AnalyticsAudienceRow[]
+  readonly rowCount?: number
+  readonly [key: string]: unknown
+}
+
+import type { QueryParams } from "./common"

--- a/connectors/google/src/types/index.ts
+++ b/connectors/google/src/types/index.ts
@@ -8,6 +8,8 @@ export interface GoogleConnectorOptions {
   readonly retry?: RestRetryPolicy
 }
 
+export type * from "./analytics-admin"
+export type * from "./analytics-data"
 export type * from "./calendar"
 export type * from "./drive"
 export type * from "./gmail"

--- a/connectors/google/tests/analytics.e2e.ts
+++ b/connectors/google/tests/analytics.e2e.ts
@@ -1,0 +1,89 @@
+/**
+ * End-to-end smoke test against Google Analytics Admin API v1beta and Data API v1beta.
+ *
+ * The authenticated principal must have access to at least one GA4 property. For a service
+ * account, add its email as a user on the Analytics account or property; Cloud IAM alone does
+ * not grant Google Analytics access.
+ *
+ * Application Default Credentials (recommended):
+ *
+ *   GOOGLE_ADC=1 \
+ *   GOOGLE_SCOPE="https://www.googleapis.com/auth/analytics.readonly" \
+ *   bun connectors/google/tests/analytics.e2e.ts
+ *
+ * Or use GOOGLE_ACCESS_TOKEN / GOOGLE_SA_KEY like the other Google connector smoke tests.
+ * Optional: GOOGLE_ANALYTICS_PROPERTY_ID=123456789 selects a property explicitly. Otherwise,
+ * the test uses the first property returned by accountSummaries.listAll().
+ */
+import { google } from "../src/google"
+import type { AnalyticsAccountSummary, GoogleAuthOptions } from "../src/index"
+
+const accessToken = process.env.GOOGLE_ACCESS_TOKEN
+const key = process.env.GOOGLE_SA_KEY
+const useApplicationDefault = process.env.GOOGLE_ADC === "1"
+const scope = process.env.GOOGLE_SCOPE ?? "https://www.googleapis.com/auth/analytics.readonly"
+const subject = process.env.GOOGLE_SUBJECT
+
+if (!useApplicationDefault && !accessToken && !key) {
+  console.error(
+    "Missing env. Set one of GOOGLE_ADC=1, GOOGLE_ACCESS_TOKEN, or GOOGLE_SA_KEY. " +
+      "See the header of this file for a complete command."
+  )
+  process.exit(1)
+}
+
+const auth: GoogleAuthOptions = useApplicationDefault
+  ? { applicationDefault: true, scopes: [scope] }
+  : accessToken
+    ? { token: () => accessToken }
+    : subject
+      ? { serviceAccountKey: key as string, scopes: [scope], subject }
+      : { serviceAccountKey: key as string, scopes: [scope] }
+
+const client = await google({ auth }).connect({
+  projectId: "e2e",
+  connectorId: "google",
+  signal: new AbortController().signal,
+})
+
+console.log("\nDiscovering Analytics accounts and properties …")
+const summaries: AnalyticsAccountSummary[] = []
+for await (const summary of client.analytics.admin.accountSummaries.listAll({ pageSize: 200 })) {
+  summaries.push(summary)
+  console.log(`  - ${summary.displayName ?? summary.account} (${summary.account})`)
+  for (const property of summary.propertySummaries ?? []) {
+    console.log(`      ${property.displayName ?? property.property} (${property.property})`)
+  }
+}
+
+const explicitPropertyId = process.env.GOOGLE_ANALYTICS_PROPERTY_ID
+const propertyName = explicitPropertyId
+  ? explicitPropertyId.startsWith("properties/")
+    ? explicitPropertyId
+    : `properties/${explicitPropertyId}`
+  : summaries.flatMap((summary) => summary.propertySummaries ?? [])[0]?.property
+
+if (!propertyName) {
+  throw new Error(
+    "No Analytics property was discovered. Grant this principal access or set " +
+      "GOOGLE_ANALYTICS_PROPERTY_ID."
+  )
+}
+
+console.log(`\nRunning a seven-day country report for ${propertyName} …`)
+const report = await client.analytics.data.properties.runReport(propertyName, {
+  dateRanges: [{ startDate: "7daysAgo", endDate: "today" }],
+  dimensions: [{ name: "country" }],
+  metrics: [{ name: "activeUsers" }],
+  orderBys: [{ metric: { metricName: "activeUsers" }, desc: true }],
+  limit: "10",
+})
+
+for (const row of report.rows ?? []) {
+  console.log(
+    `  ${row.dimensionValues?.[0]?.value ?? "(unknown)"}: ` +
+      `${row.metricValues?.[0]?.value ?? "0"} active user(s)`
+  )
+}
+console.log(`  ${report.rowCount ?? 0} total row(s); ${report.rows?.length ?? 0} shown.`)
+console.log("\nE2E OK.")

--- a/connectors/google/tests/analytics.test.ts
+++ b/connectors/google/tests/analytics.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { google } from "../src/google"
+import type { GoogleClient } from "../src/index"
+import { CONTEXT, collect, json, mockFetch, restoreFetch } from "./helpers"
+
+const ADMIN_BASE = "https://analyticsadmin.googleapis.com/v1beta/"
+const DATA_BASE = "https://analyticsdata.googleapis.com/v1beta/"
+
+interface RecordedRequest {
+  readonly url: string
+  readonly method: string
+  readonly auth: string | null
+  readonly body: unknown
+}
+
+let requests: RecordedRequest[]
+
+async function connect(options?: { readonly retry?: boolean }): Promise<GoogleClient> {
+  return google({
+    auth: { token: () => "analytics-token" },
+    retry: options?.retry ? { maxRetries: 1, delayMs: () => 0 } : { maxRetries: 0 },
+  }).connect(CONTEXT)
+}
+
+function record(input: RequestInfo | URL, init?: RequestInit): void {
+  let body: unknown
+  if (typeof init?.body === "string") {
+    try {
+      body = JSON.parse(init.body)
+    } catch {
+      body = init.body
+    }
+  }
+  requests.push({
+    url: input.toString(),
+    method: String(init?.method ?? "GET"),
+    auth: new Headers(init?.headers).get("authorization"),
+    body,
+  })
+}
+
+function expectRequest(
+  index: number,
+  base: string,
+  method: string,
+  path: string,
+  body?: unknown
+): void {
+  const request = requests[index]
+  expect(request?.url).toBe(`${base}${path}`)
+  expect(request?.method).toBe(method)
+  expect(request?.auth).toBe("Bearer analytics-token")
+  if (body !== undefined) {
+    expect(request?.body).toEqual(body)
+  }
+}
+
+beforeEach(() => {
+  requests = []
+})
+
+afterEach(restoreFetch)
+
+describe("analytics.admin", () => {
+  test("discovers every account summary and property page", async () => {
+    const responses = [
+      {
+        accountSummaries: [
+          {
+            account: "accounts/1",
+            propertySummaries: [{ property: "properties/10", displayName: "Store" }],
+          },
+        ],
+        nextPageToken: "accounts-2",
+      },
+      { accountSummaries: [{ account: "accounts/2" }] },
+      { properties: [{ name: "properties/10" }], nextPageToken: "properties-2" },
+      { properties: [{ name: "properties/11" }] },
+    ]
+    let call = 0
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return json(responses[call++])
+    })
+
+    const admin = (await connect()).analytics.admin
+    const summaries = await collect(admin.accountSummaries.listAll({ pageSize: 1 }))
+    const properties = await collect(
+      admin.properties.listAll({ filter: "ancestor:accounts/1", pageSize: 1 })
+    )
+
+    expect(summaries.map((summary) => summary.account)).toEqual(["accounts/1", "accounts/2"])
+    expect(properties.map((property) => property.name)).toEqual(["properties/10", "properties/11"])
+    expectRequest(0, ADMIN_BASE, "GET", "accountSummaries?pageSize=1")
+    expectRequest(1, ADMIN_BASE, "GET", "accountSummaries?pageSize=1&pageToken=accounts-2")
+    expectRequest(2, ADMIN_BASE, "GET", "properties?filter=ancestor%3Aaccounts%2F1&pageSize=1")
+    expectRequest(
+      3,
+      ADMIN_BASE,
+      "GET",
+      "properties?filter=ancestor%3Aaccounts%2F1&pageSize=1&pageToken=properties-2"
+    )
+  })
+
+  test("routes account, property, and nested discovery resources", async () => {
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return json({})
+    })
+
+    const admin = (await connect()).analytics.admin
+    await admin.accounts.get("accounts/1")
+    await admin.accounts.getDataSharingSettings("accounts/1")
+    await admin.properties.get("properties/10")
+    await admin.properties.getDataRetentionSettings("properties/10")
+    await admin.properties.customDimensions.list("properties/10")
+    await admin.properties.customMetrics.list("properties/10")
+    await admin.properties.dataStreams.list("properties/10")
+    await admin.properties.dataStreams.measurementProtocolSecrets.list(
+      "properties/10/dataStreams/20"
+    )
+    await admin.properties.firebaseLinks.list("properties/10")
+    await admin.properties.googleAdsLinks.list("properties/10")
+    await admin.properties.keyEvents.list("properties/10")
+
+    const expected = [
+      "accounts/1",
+      "accounts/1/dataSharingSettings",
+      "properties/10",
+      "properties/10/dataRetentionSettings",
+      "properties/10/customDimensions",
+      "properties/10/customMetrics",
+      "properties/10/dataStreams",
+      "properties/10/dataStreams/20/measurementProtocolSecrets",
+      "properties/10/firebaseLinks",
+      "properties/10/googleAdsLinks",
+      "properties/10/keyEvents",
+    ]
+    expect(requests.map((request) => request.url)).toEqual(
+      expected.map((path) => `${ADMIN_BASE}${path}`)
+    )
+    expect(requests.every((request) => request.method === "GET")).toBe(true)
+  })
+
+  test("routes writes, field masks, archives, and read-only POST methods", async () => {
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return json({})
+    })
+
+    const admin = (await connect()).analytics.admin
+    await admin.properties.patch(
+      "properties/10",
+      { displayName: "Renamed" },
+      { updateMask: "display_name" }
+    )
+    await admin.properties.customDimensions.create("properties/10", {
+      parameterName: "customer_tier",
+      displayName: "Customer tier",
+      scope: "USER",
+    })
+    await admin.properties.customDimensions.archive("properties/10/customDimensions/customer_tier")
+    await admin.accounts.runAccessReport("accounts/1", {
+      dateRanges: [{ startDate: "2026-08-01", endDate: "2026-08-12" }],
+      dimensions: [{ dimensionName: "userEmail" }],
+      metrics: [{ metricName: "accessCount" }],
+    })
+    await admin.accounts.searchChangeHistoryEvents("accounts/1", {
+      resourceType: ["PROPERTY"],
+    })
+
+    expectRequest(0, ADMIN_BASE, "PATCH", "properties/10?updateMask=display_name", {
+      displayName: "Renamed",
+      name: "properties/10",
+    })
+    expectRequest(1, ADMIN_BASE, "POST", "properties/10/customDimensions", {
+      parameterName: "customer_tier",
+      displayName: "Customer tier",
+      scope: "USER",
+    })
+    expectRequest(2, ADMIN_BASE, "POST", "properties/10/customDimensions/customer_tier:archive", {})
+    expectRequest(3, ADMIN_BASE, "POST", "accounts/1:runAccessReport")
+    expectRequest(4, ADMIN_BASE, "POST", "accounts/1:searchChangeHistoryEvents", {
+      resourceType: ["PROPERTY"],
+    })
+  })
+
+  test("rejects malformed Analytics resource names before issuing a request", async () => {
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return json({})
+    })
+
+    const properties = (await connect()).analytics.admin.properties
+    expect(() => properties.get("10")).toThrow(/properties\/\{propertyId\}/)
+    expect(() => properties.dataStreams.get("properties/10/notDataStreams/20")).toThrow(
+      /dataStreams/
+    )
+    expect(requests).toHaveLength(0)
+  })
+})
+
+describe("analytics.data", () => {
+  test("routes every stable v1beta report method", async () => {
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return json({})
+    })
+
+    const properties = (await connect()).analytics.data.properties
+    const report = {
+      property: "properties/10",
+      dateRanges: [{ startDate: "7daysAgo", endDate: "today" }],
+      dimensions: [{ name: "country" }],
+      metrics: [{ name: "activeUsers" }],
+    } as const
+    await properties.runReport("properties/10", report)
+    await properties.batchRunReports("properties/10", { requests: [report] })
+    await properties.runPivotReport("properties/10", {
+      ...report,
+      pivots: [{ fieldNames: ["country"] }],
+    })
+    await properties.batchRunPivotReports("properties/10", {
+      requests: [{ ...report, pivots: [{ fieldNames: ["country"] }] }],
+    })
+    await properties.runRealtimeReport("properties/10", {
+      dimensions: [{ name: "country" }],
+      metrics: [{ name: "activeUsers" }],
+    })
+    await properties.getMetadata("properties/10")
+    await properties.checkCompatibility("properties/10", {
+      dimensions: [{ name: "country" }],
+      metrics: [{ name: "activeUsers" }],
+      compatibilityFilter: "COMPATIBLE",
+    })
+
+    expect(requests.map(({ method, url }) => [method, url])).toEqual([
+      ["POST", `${DATA_BASE}properties/10:runReport`],
+      ["POST", `${DATA_BASE}properties/10:batchRunReports`],
+      ["POST", `${DATA_BASE}properties/10:runPivotReport`],
+      ["POST", `${DATA_BASE}properties/10:batchRunPivotReports`],
+      ["POST", `${DATA_BASE}properties/10:runRealtimeReport`],
+      ["GET", `${DATA_BASE}properties/10/metadata`],
+      ["POST", `${DATA_BASE}properties/10:checkCompatibility`],
+    ])
+    expect(requests[0]?.body).not.toHaveProperty("property")
+    expect(requests[1]?.body).toEqual({ requests: [report] })
+  })
+
+  test("paginates report rows by returned row count", async () => {
+    const responses = [
+      { rows: [{ dimensionValues: [{ value: "FR" }] }], rowCount: 3 },
+      {
+        rows: [{ dimensionValues: [{ value: "CA" }] }, { dimensionValues: [{ value: "US" }] }],
+        rowCount: 3,
+      },
+    ]
+    let call = 0
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return json(responses[call++])
+    })
+
+    const rows = await collect(
+      (await connect()).analytics.data.properties.runReportAll("properties/10", {
+        dimensions: [{ name: "country" }],
+        metrics: [{ name: "activeUsers" }],
+        dateRanges: [{ startDate: "7daysAgo", endDate: "today" }],
+        limit: "2",
+      })
+    )
+
+    expect(rows.map((row) => row.dimensionValues?.[0]?.value)).toEqual(["FR", "CA", "US"])
+    expect(requests.map((request) => request.body)).toEqual([
+      expect.objectContaining({ limit: "2", offset: "0" }),
+      expect.objectContaining({ limit: "2", offset: "1" }),
+    ])
+  })
+
+  test("routes and paginates audience exports", async () => {
+    const responses = [
+      { name: "operations/1" },
+      { name: "properties/10/audienceExports/20", state: "ACTIVE" },
+      {
+        audienceExports: [{ name: "properties/10/audienceExports/20" }],
+        nextPageToken: "page-2",
+      },
+      { audienceExports: [{ name: "properties/10/audienceExports/21" }] },
+      { audienceRows: [{ dimensionValues: [{ value: "u1" }] }], rowCount: 2 },
+      { audienceRows: [{ dimensionValues: [{ value: "u2" }] }], rowCount: 2 },
+    ]
+    let call = 0
+    mockFetch(async (input, init) => {
+      record(input, init)
+      return json(responses[call++])
+    })
+
+    const exports = (await connect()).analytics.data.properties.audienceExports
+    await exports.create("properties/10", {
+      audience: "properties/10/audiences/30",
+      dimensions: [{ dimensionName: "deviceId" }],
+    })
+    await exports.get("properties/10/audienceExports/20")
+    const listed = await collect(exports.listAll("properties/10", { pageSize: 1 }))
+    const rows = await collect(exports.queryAll("properties/10/audienceExports/20", { limit: "1" }))
+
+    expect(listed.map((item) => item.name)).toEqual([
+      "properties/10/audienceExports/20",
+      "properties/10/audienceExports/21",
+    ])
+    expect(rows.map((row) => row.dimensionValues?.[0]?.value)).toEqual(["u1", "u2"])
+    expectRequest(0, DATA_BASE, "POST", "properties/10/audienceExports")
+    expectRequest(1, DATA_BASE, "GET", "properties/10/audienceExports/20")
+    expectRequest(2, DATA_BASE, "GET", "properties/10/audienceExports?pageSize=1")
+    expectRequest(3, DATA_BASE, "GET", "properties/10/audienceExports?pageSize=1&pageToken=page-2")
+    expect(requests[4]?.body).toEqual({ limit: "1", offset: "0" })
+    expect(requests[5]?.body).toEqual({ limit: "1", offset: "1" })
+  })
+
+  test("validates batch and pagination limits locally", async () => {
+    const properties = (await connect()).analytics.data.properties
+    const request = { metrics: [{ name: "activeUsers" }] }
+
+    expect(() =>
+      properties.batchRunReports("properties/10", {
+        requests: [request, request, request, request, request, request],
+      })
+    ).toThrow(/at most 5/)
+    expect(() =>
+      properties.batchRunReports("properties/10", {
+        requests: [{ ...request, property: "properties/11" }],
+      })
+    ).toThrow(/must match/)
+    await expect(
+      collect(properties.runReportAll("properties/10", { ...request, limit: "250001" }))
+    ).rejects.toThrow(/between 1 and 250000/)
+  })
+
+  test("retries read-only POST reports but not Admin mutations", async () => {
+    let attempts = 0
+    mockFetch(async (input, init) => {
+      record(input, init)
+      attempts++
+      return attempts === 1 ? new Response("busy", { status: 503 }) : json({ rows: [] })
+    })
+
+    const client = await connect({ retry: true })
+    await client.analytics.data.properties.runReport("properties/10", {
+      metrics: [{ name: "activeUsers" }],
+      dateRanges: [{ startDate: "yesterday", endDate: "today" }],
+    })
+    expect(attempts).toBe(2)
+
+    attempts = 0
+    requests = []
+    mockFetch(async (input, init) => {
+      record(input, init)
+      attempts++
+      return new Response("busy", { status: 503 })
+    })
+    await expect(
+      client.analytics.admin.properties.create({
+        parent: "accounts/1",
+        displayName: "New property",
+        timeZone: "Europe/Paris",
+        currencyCode: "EUR",
+      })
+    ).rejects.toThrow(/Google API request failed/)
+    expect(attempts).toBe(1)
+  })
+})

--- a/connectors/rest/README.md
+++ b/connectors/rest/README.md
@@ -43,3 +43,7 @@ how to read the body.
 
 `headers` being a resolver rather than a value is the part worth remembering: it is what lets a
 connector hold a short-lived credential without reconstructing the connector.
+
+Retry is enabled per request by default when the connector has a retry policy. Pass
+`{ retry: false }` in `request`, `get`, or `post` options for non-idempotent mutations that must not
+be replayed. This local option is stripped before the native `fetch` call.

--- a/connectors/rest/src/index.ts
+++ b/connectors/rest/src/index.ts
@@ -5,6 +5,7 @@ export type {
   RestConnectorOptions,
   RestHeadersResolver,
   RestRequestContext,
+  RestRequestInit,
   RestRetryContext,
   RestRetryPolicy,
 } from "./types"

--- a/connectors/rest/src/rest.ts
+++ b/connectors/rest/src/rest.ts
@@ -5,6 +5,7 @@ import type {
   RestConnectorOptions,
   RestHeadersResolver,
   RestRequestContext,
+  RestRequestInit,
   RestRetryContext,
   RestRetryPolicy,
 } from "./types"
@@ -62,19 +63,20 @@ function createRestClient(options: RestConnectorOptions, context: ConnectorConte
   }
   let lastRequestAt = 0
 
-  const request = async (path: string, init: RequestInit = {}): Promise<Response> => {
+  const request = async (path: string, init: RestRequestInit = {}): Promise<Response> => {
+    const { retry = true, ...fetchInit } = init
     const baseRequestContext: RestRequestContext = {
       projectId: context.projectId,
       connectorId: context.connectorId,
       path,
-      init,
+      init: fetchInit,
     }
 
     let unauthorizedRetried = false
     // A stream body is consumed by the first attempt and can never be replayed,
     // so neither the 401 refresh nor the retry policy may re-send this request —
     // retrying would only mask the real failure behind a "stream already used" error.
-    const replayable = !(init.body instanceof ReadableStream)
+    const replayable = !(fetchInit.body instanceof ReadableStream)
 
     for (let attempt = 0; ; attempt++) {
       // Apply the same pacing to retries as the initial request.
@@ -87,7 +89,7 @@ function createRestClient(options: RestConnectorOptions, context: ConnectorConte
       )
 
       const resolvedInit = await resolveRequestInit(
-        init,
+        fetchInit,
         options.headers,
         options.timeoutMs,
         baseRequestContext
@@ -116,6 +118,7 @@ function createRestClient(options: RestConnectorOptions, context: ConnectorConte
 
       const retryContext: RestRetryContext = { attempt, response, error }
       const canRetry =
+        retry &&
         replayable &&
         attempt < retryPolicy.maxRetries &&
         retryPolicy.shouldRetry?.(retryContext) === true

--- a/connectors/rest/src/types.ts
+++ b/connectors/rest/src/types.ts
@@ -33,10 +33,15 @@ export interface RestConnectorOptions {
   readonly webhooks?: readonly WebhookDefinition<unknown, RestClient>[]
 }
 
+/** Native fetch options plus a local retry gate that is never sent over the wire. */
+export interface RestRequestInit extends RequestInit {
+  readonly retry?: boolean
+}
+
 export interface RestClient {
-  request(path: string, init?: RequestInit): Promise<Response>
-  get(path: string, init?: RequestInit): Promise<Response>
-  post(path: string, body?: unknown, init?: RequestInit): Promise<Response>
+  request(path: string, init?: RestRequestInit): Promise<Response>
+  get(path: string, init?: RestRequestInit): Promise<Response>
+  post(path: string, body?: unknown, init?: RestRequestInit): Promise<Response>
 }
 
 export type RestConnector = ConnectorAdapter<"rest", RestClient>

--- a/connectors/rest/tests/rest.test.ts
+++ b/connectors/rest/tests/rest.test.ts
@@ -149,6 +149,29 @@ describe("rest connector", () => {
     expect(attempts).toBe(2)
   })
 
+  test("allows an individual request to opt out of retries", async () => {
+    let attempts = 0
+
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(new Response("busy", { status: 503 }))
+    })
+
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      retry: { maxRetries: 3, delayMs: () => 0 },
+    }).connect({
+      projectId: "demo",
+      connectorId: "hubspot",
+      signal: new AbortController().signal,
+    })
+
+    const response = await client.post("/mutation", {}, { retry: false })
+
+    expect(response.status).toBe(503)
+    expect(attempts).toBe(1)
+  })
+
   test("never retries a request with a stream body — it cannot be replayed", async () => {
     let attempts = 0
 


### PR DESCRIPTION
## Summary

Adds Google Analytics to the Google connector through a single, extensible facade:

```text
client.analytics
├── admin
│   ├── accountSummaries
│   ├── accounts
│   └── properties
│       ├── customDimensions
│       ├── customMetrics
│       ├── dataStreams
│       │   └── measurementProtocolSecrets
│       ├── firebaseLinks
│       ├── googleAdsLinks
│       └── keyEvents
└── data
    └── properties
        ├── reports
        ├── metadata / compatibility
        └── audienceExports
```

## Primary flow

```text
Analytics account
  → accountSummaries.listAll()
  → visible properties
  → analytics.data.properties.runReportAll()
  → paginated data rows
```

| Area | Scope |
| --- | --- |
| `analytics.admin` | 50 non-deprecated Admin API v1beta methods covering accounts, properties, streams, custom definitions, links, key events, access reports, and change history |
| `analytics.data` | 11 Data API v1beta methods covering standard, pivot, batch, and realtime reports, metadata, compatibility, and audience exports |
| Shared REST layer | Per-request retry opt-out so Analytics mutations are never replayed automatically |
| Types | Public Admin/Data types, validated resource names, and lossless string representations for `int64` fields |
| Pagination | `listAll`, `runReportPages`, `runReportAll`, `queryPages`, and `queryAll` |

Alpha resources and deprecated `conversionEvents` are intentionally excluded.

## Example

```ts
for await (const summary of client.analytics.admin.accountSummaries.listAll()) {
  for (const property of summary.propertySummaries ?? []) {
    for await (const row of client.analytics.data.properties.runReportAll(
      property.property!,
      {
        dateRanges: [{ startDate: "30daysAgo", endDate: "today" }],
        dimensions: [{ name: "date" }, { name: "country" }],
        metrics: [{ name: "sessions" }, { name: "activeUsers" }],
      }
    )) {
      // Consume the report row.
    }
  }
}
```

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `bun run test:ci` — 3,715 tests passed and 7 live tests skipped
- `bun run test:publish` — 49 publishable packages verified
- Added a live Analytics smoke test; not executed because Google Analytics credentials are not available locally
