### PR TITLE
workflows: link runs to durable executions

### DIFF
--- a/examples/auth/tests/atlas-authorization.test.ts
+++ b/examples/auth/tests/atlas-authorization.test.ts
@@ -47,6 +47,13 @@ describe("auth example Atlas authorization", () => {
   test("team members only see and do what their roles grant", async () => {
     const host = await createAuthExampleRuntime()
     await seedAuthExampleObjects(createTestSixb(host))
+    const auth = host.storage.auth
+    if (!auth) throw new Error("Auth example test requires auth storage.")
+    await auth.users.create({
+      projectId: host.id,
+      id: "atlas-user",
+      email: "atlas-user@example.com",
+    })
 
     const roles = host.definitions.security.listResolvedRoles()
     const teamMemberContext = atlasContext(host, [teamMembers.id])

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -1,4 +1,9 @@
-import type { AgentDefinition, Principal, ValueType, WorkflowDefinition } from "@sixb/core"
+import type {
+  AgentDefinition,
+  AuthorizablePrincipal,
+  ValueType,
+  WorkflowDefinition,
+} from "@sixb/core"
 import { createAgentRunExecutionToken } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { QueueDelivery } from "@sixb/core/internal/workers"
@@ -43,7 +48,7 @@ interface WorkflowAgentNodeExecutionContext {
   readonly node: WorkflowAgentNodeDefinition
   readonly agent: AgentDefinition
   readonly valueTypesById: ReadonlyMap<string, ValueType>
-  readonly requestedBy: Principal
+  readonly requestedBy?: AuthorizablePrincipal
 }
 
 export async function executeWorkflowAgentNode(
@@ -194,6 +199,16 @@ async function loadWorkflowAgentNodeExecution(
     return null
   }
 
+  const workflowExecution = await context.storage.executions.getById({
+    projectId: context.id,
+    id: workflowRun.executionId,
+  })
+  if (!workflowExecution) {
+    throw new AgentWorkerError(
+      `Workflow run '${workflowRun.id}' references missing execution '${workflowRun.executionId}'.`
+    )
+  }
+
   const workflow = host.definitions.workflows.getById(nodeRun.workflowId)
   const node = workflow?.nodes[nodeRun.nodeIndex]
   if (!workflow || !node || node.type !== "agent" || node.id !== nodeRun.nodeId) {
@@ -214,7 +229,7 @@ async function loadWorkflowAgentNodeExecution(
     node,
     agent,
     valueTypesById: host.definitions.ontology.getValueTypesById(),
-    requestedBy: workflowRun.requestedByPrincipal,
+    requestedBy: workflowExecution.requestedBy,
   }
 }
 

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -431,7 +431,7 @@ async function emitNodeAndRunFailed(
 
 export async function enqueueWorkflowAgentNodeResume(
   host: AgentWorkerHost,
-  node: Pick<WorkflowNodeRunRecord, "id" | "workflowId" | "workflowRunId">
+  node: Pick<WorkflowNodeRunRecord, "id" | "workflowRunId">
 ): Promise<void> {
   await host.queues.workflows.enqueue({
     projectId: host.id,
@@ -440,7 +440,6 @@ export async function enqueueWorkflowAgentNodeResume(
         id: workflowAgentResumeQueueJobId(node.id),
         type: "workflow.run.resume.requested",
         payload: {
-          workflowId: node.workflowId,
           runId: node.workflowRunId,
           resume: { kind: "agentNode", nodeRunId: node.id },
         },

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -54,7 +54,7 @@ import {
   AgentStorageError,
   type AppendAgentMessageInput,
 } from "@sixb/core/storage"
-import { createTestSixb } from "@sixb/core/testing"
+import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
 import { jsonSchema, type ToolSet, tool } from "ai"
 import { convertArrayToReadableStream, MockLanguageModelV4 } from "ai/test"
 import { AgentWorker, type AgentWorkerOptions } from "../src"
@@ -1155,11 +1155,21 @@ describe("AgentWorker", () => {
     const runs = sixb.storage.workflowRuns!
     const runId = "workflow-agent-run"
     const nodeRunId = `${runId}:node:0`
+    const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
+      projectId: PROJECT_ID,
+      workflowId: workflow.id,
+      runId,
+    })
+    await runs.queue({
+      id: runId,
+      projectId: PROJECT_ID,
+      executionId,
+      workflowId: workflow.id,
+      input: { query: "alpha" },
+    })
     await runs.start({
       id: runId,
       projectId: PROJECT_ID,
-      workflowId: workflow.id,
-      input: { query: "alpha" },
     })
     await runs.nodes.start({
       id: nodeRunId,

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1251,7 +1251,6 @@ describe("AgentWorker", () => {
         type: "workflow.run.resume.requested",
         payload: {
           runId,
-          workflowId: workflow.id,
           resume: { kind: "agentNode", nodeRunId },
         },
       })

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -5,6 +5,7 @@ import { migrateStorage } from "@sixb/core"
 import { flushSixbErrors } from "@sixb/core/internal/error-reporting"
 import { getProjectionDispatchDescriptors } from "@sixb/core/internal/projections"
 import type { Worker } from "@sixb/core/internal/workers"
+import { WorkflowRunDispatcher } from "@sixb/core/internal/workflows"
 import { assertLakeDatasetDefinitionsCompatible } from "@sixb/core/lake-storage"
 import {
   type CompileRoutesDiagnostic,
@@ -150,6 +151,9 @@ export async function startOrchestratorRuntime(
       events: sixb.events,
       queues: sixb.queues,
       routes,
+      dispatchers: {
+        workflows: new WorkflowRunDispatcher(sixb),
+      },
       ...(projectionDispatch ? { projectionDispatch } : {}),
     })
     await orchestratorWorker.start()

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -128,7 +128,7 @@ async function appendScheduleTriggered(
   scheduleId: string
 ) {
   const occurrenceAt = "2026-04-18T02:00:00.000Z"
-  await sixb.events.append({
+  const [event] = await sixb.events.append({
     events: [
       {
         type: "schedule.triggered",
@@ -141,6 +141,7 @@ async function appendScheduleTriggered(
       },
     ],
   })
+  return event!
 }
 
 describe("startSixbRuntime", () => {
@@ -626,7 +627,7 @@ describe("startSixbRuntime", () => {
       expect(runtime.orchestratorWorker).not.toBeNull()
       expect(runtime.warnings).toHaveLength(0)
 
-      await appendScheduleTriggered(sixb, daily.id)
+      const sourceEvent = await appendScheduleTriggered(sixb, daily.id)
 
       const workflowRuns = await waitFor(
         () =>
@@ -639,6 +640,16 @@ describe("startSixbRuntime", () => {
       )
 
       expect(workflowRuns.runs[0]?.input).toEqual({})
+      const workflowExecution = await sixb.storage.executions.getById({
+        projectId: sixb.id,
+        id: workflowRuns.runs[0]!.executionId,
+      })
+      expect(workflowExecution).toMatchObject({
+        source: { type: "schedule", eventId: sourceEvent.id },
+        correlationId: sourceEvent.id,
+      })
+      expect(workflowExecution?.parentExecutionId).toBeUndefined()
+      expect(workflowExecution?.requestedBy).toBeUndefined()
 
       const workflowJobs = await sixb.queues.workflows.claim({
         projectId: sixb.id,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -257,6 +257,12 @@
       "import": "./dist/workflows/index.js",
       "default": "./dist/workflows/index.js"
     },
+    "./internal/workflow-run-storage-provider": {
+      "types": "./dist/storage/workflow-runs/provider.d.ts",
+      "bun": "./src/storage/workflow-runs/provider.ts",
+      "import": "./dist/storage/workflow-runs/provider.js",
+      "default": "./dist/storage/workflow-runs/provider.js"
+    },
     "./lake-storage": {
       "types": "./dist/lake-storage/index.d.ts",
       "bun": "./src/lake-storage/index.ts",

--- a/packages/core/src/execution/dispatch.ts
+++ b/packages/core/src/execution/dispatch.ts
@@ -1,0 +1,7 @@
+/**
+ * Typed boundary for turning one resolved primitive run intent into durable state and transport.
+ * Implementations own their primitive-specific validation, persistence, and queue publication.
+ */
+export interface RunDispatcher<TInput, TResult> {
+  dispatch(input: TInput): Promise<TResult>
+}

--- a/packages/core/src/execution/durable.ts
+++ b/packages/core/src/execution/durable.ts
@@ -1,0 +1,206 @@
+import { isDeepStrictEqual } from "node:util"
+import {
+  type CreateExecutionInput,
+  type ExecutionRecord,
+  type ExecutionStorage,
+  ExecutionStorageError,
+} from "../storage/executions"
+import { createTrustedPrimitiveRuntimeAuthorization, getAuthorizationRef } from "./authorization"
+import type {
+  ExecutionContext,
+  ExecutionScope,
+  RuntimeAuthorization,
+  TrustedPrimitiveRef,
+} from "./types"
+
+/** Convert one currently bound execution to the immutable provider representation. */
+export function executionRecordInputFromRuntime(input: {
+  readonly execution: ExecutionContext
+  readonly runtimeAuthorization: RuntimeAuthorization
+}): CreateExecutionInput {
+  const execution = input.execution
+  return {
+    id: execution.id,
+    projectId: execution.projectId,
+    ...(execution.requestedBy === undefined
+      ? {}
+      : { requestedBy: structuredClone(execution.requestedBy) }),
+    executor: durableExecutor(execution),
+    source: durableSource(execution),
+    correlationId: execution.correlationId,
+    ...(execution.parentExecutionId === undefined
+      ? {}
+      : { parentExecutionId: execution.parentExecutionId }),
+    authorizationRef: getAuthorizationRef(input.runtimeAuthorization),
+  }
+}
+
+/**
+ * Store a caller execution once. Repeated boundaries may observe the same immutable execution;
+ * only an exact match is idempotent.
+ */
+export async function ensureExecutionRecord(
+  storage: ExecutionStorage,
+  input: CreateExecutionInput
+): Promise<ExecutionRecord> {
+  const existing = await storage.getById({ projectId: input.projectId, id: input.id })
+  if (existing) {
+    assertExecutionRecordMatches(existing, input)
+    return existing
+  }
+
+  try {
+    return await storage.create(input)
+  } catch (error) {
+    if (!(error instanceof ExecutionStorageError) || error.code !== "duplicate_execution") {
+      throw error
+    }
+
+    const raced = await storage.getById({ projectId: input.projectId, id: input.id })
+    if (!raced) throw error
+    assertExecutionRecordMatches(raced, input)
+    return raced
+  }
+}
+
+type PrimitiveExecutionOrigin =
+  | {
+      readonly type: "execution"
+      readonly parent: ExecutionRecord
+    }
+  | {
+      readonly type: "automatic"
+      readonly projectId: string
+      readonly source: Extract<
+        CreateExecutionInput["source"],
+        { readonly type: "schedule" | "event" }
+      >
+      readonly correlationId: string
+    }
+
+/** Build an immutable primitive execution from its parent execution or automatic trigger. */
+export function createPrimitiveExecutionRecord(input: {
+  readonly id: string
+  readonly primitive: TrustedPrimitiveRef
+  readonly origin: PrimitiveExecutionOrigin
+}): CreateExecutionInput {
+  const provenance =
+    input.origin.type === "execution"
+      ? {
+          projectId: input.origin.parent.projectId,
+          ...(input.origin.parent.requestedBy === undefined
+            ? {}
+            : { requestedBy: structuredClone(input.origin.parent.requestedBy) }),
+          source: { type: "execution" as const, executionId: input.origin.parent.id },
+          correlationId: input.origin.parent.correlationId,
+          parentExecutionId: input.origin.parent.id,
+        }
+      : {
+          projectId: input.origin.projectId,
+          source: structuredClone(input.origin.source),
+          correlationId: input.origin.correlationId,
+        }
+
+  return {
+    id: input.id,
+    ...provenance,
+    executor: {
+      type: "primitive",
+      kind: input.primitive.kind,
+      runId: input.primitive.runId,
+    },
+    authorizationRef: {
+      type: "trustedPrimitive",
+      primitive: structuredClone(input.primitive),
+    },
+  }
+}
+
+/** Restore the trusted scope of a provider-validated primitive execution record. */
+export function restoreTrustedPrimitiveExecutionScope(input: {
+  readonly execution: ExecutionRecord
+  readonly primitive: TrustedPrimitiveRef
+}): ExecutionScope {
+  assertPrimitiveExecution(input.execution, input.primitive)
+  const context: ExecutionContext = Object.freeze({
+    id: input.execution.id,
+    projectId: input.execution.projectId,
+    ...(input.execution.requestedBy === undefined
+      ? {}
+      : { requestedBy: structuredClone(input.execution.requestedBy) }),
+    executor: Object.freeze({ type: "primitive", ...structuredClone(input.primitive) }),
+    source: Object.freeze(structuredClone(input.execution.source)),
+    correlationId: input.execution.correlationId,
+    ...(input.execution.parentExecutionId === undefined
+      ? {}
+      : { parentExecutionId: input.execution.parentExecutionId }),
+  })
+  return Object.freeze({
+    execution: context,
+    authorization: createTrustedPrimitiveRuntimeAuthorization({
+      projectId: input.execution.projectId,
+      primitive: input.primitive,
+    }),
+  })
+}
+
+function durableExecutor(execution: ExecutionContext): CreateExecutionInput["executor"] {
+  switch (execution.executor.type) {
+    case "request":
+      return { type: "request", requestId: execution.executor.requestId }
+    case "primitive":
+      return {
+        type: "primitive",
+        kind: execution.executor.kind,
+        runId: execution.executor.runId,
+      }
+    case "agent":
+      return { type: "agent", runId: execution.executor.runId }
+    case "kernel":
+      return { type: "kernel", operation: structuredClone(execution.executor.operation) }
+  }
+}
+
+function durableSource(execution: ExecutionContext): CreateExecutionInput["source"] {
+  if (execution.source.type === "queue") {
+    throw new ExecutionStorageError(
+      "invalid_input",
+      `[Sixb] Execution '${execution.id}' has a transient queue source and cannot be persisted.`
+    )
+  }
+  return structuredClone(execution.source)
+}
+
+function assertExecutionRecordMatches(
+  existing: ExecutionRecord,
+  input: CreateExecutionInput
+): void {
+  const { createdAt: _createdAt, ...stored } = existing
+  if (!isDeepStrictEqual(stored, input)) {
+    throw new ExecutionStorageError(
+      "duplicate_execution",
+      `[Sixb] Execution '${input.id}' already exists with different immutable provenance.`
+    )
+  }
+}
+
+function assertPrimitiveExecution(
+  execution: ExecutionRecord,
+  primitive: TrustedPrimitiveRef
+): void {
+  const authority = execution.authorizationRef
+  if (
+    execution.executor.type !== "primitive" ||
+    execution.executor.kind !== primitive.kind ||
+    execution.executor.runId !== primitive.runId ||
+    authority.type !== "trustedPrimitive" ||
+    authority.primitive.kind !== primitive.kind ||
+    authority.primitive.id !== primitive.id ||
+    authority.primitive.runId !== primitive.runId
+  ) {
+    throw new ExecutionStorageError(
+      "invalid_input",
+      `[Sixb] Execution '${execution.id}' does not authorize ${primitive.kind} run '${primitive.runId}'.`
+    )
+  }
+}

--- a/packages/core/src/execution/primitive.ts
+++ b/packages/core/src/execution/primitive.ts
@@ -3,6 +3,8 @@ import type { OntologySource } from "../ontology"
 import type { OntologyMutationRuntime } from "../runtime/ontology-mutations"
 import { getOntologyMutationRuntime } from "../runtime/ontology-mutations"
 import { isBoundSixb, type Sixb } from "../runtime/sixb"
+import type { ExecutionRecord } from "../storage/executions"
+import { restoreTrustedPrimitiveExecutionScope } from "./durable"
 import { createTrustedPrimitiveScope } from "./scopes"
 import type {
   AuthorizablePrincipal,
@@ -46,6 +48,24 @@ export function bindPrimitiveExecution(
       ? {}
       : { parentExecutionId: input.parentExecutionId }),
   })
+  return bindPrimitiveScope(host, scope)
+}
+
+/** Bind a worker to the immutable execution already owned by its durable primitive run. */
+export function bindDurablePrimitiveExecution(
+  host: PrimitiveExecutionHost,
+  input: {
+    readonly execution: ExecutionRecord
+    readonly primitive: TrustedPrimitiveRef
+  }
+): BoundPrimitiveExecution {
+  return bindPrimitiveScope(host, restoreTrustedPrimitiveExecutionScope(input))
+}
+
+function bindPrimitiveScope(
+  host: PrimitiveExecutionHost,
+  scope: ExecutionScope
+): BoundPrimitiveExecution {
   let ontologyMutations: OntologyMutationRuntime | undefined
 
   const sixb = host.withScope(scope)

--- a/packages/core/src/execution/request.ts
+++ b/packages/core/src/execution/request.ts
@@ -35,8 +35,11 @@ export type { RuleStatesRuntime, RulesRuntime } from "../rules/execution"
 export type { Sixb } from "../runtime/sixb"
 export type { SyncRunsRuntime, SyncsRuntime } from "../syncs/execution"
 export type {
+  LatestWorkflowRunListResult,
   WorkflowInterventionsRuntime,
+  WorkflowRunListResult,
   WorkflowRunsRuntime,
+  WorkflowRunView,
   WorkflowsRuntime,
 } from "../workflows/execution"
 export type { AuthorizationRef, ExecutionContext } from "./types"

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -131,9 +131,7 @@ export interface WorkflowRunRequestedQueueJob
   extends QueueJob<
     "workflow.run.requested",
     {
-      readonly workflowId: string
-      readonly runId?: string
-      readonly input?: Readonly<Record<string, unknown>>
+      readonly runId: string
     }
   > {}
 
@@ -151,7 +149,6 @@ export interface WorkflowRunResumeRequestedQueueJob
   extends QueueJob<
     "workflow.run.resume.requested",
     {
-      readonly workflowId: string
       readonly runId: string
       readonly resume: WorkflowRunResumeCause
     }

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -1,7 +1,6 @@
 import type { JsonValue } from "../json"
 import type { ProjectionMaterializationIdentity } from "../materialization/model"
 import type { ProviderScope } from "../provider-scope"
-import type { WorkflowRunSource } from "../workflows/types"
 
 export interface QueueJobEnvelope {
   readonly id: string
@@ -135,7 +134,6 @@ export interface WorkflowRunRequestedQueueJob
       readonly workflowId: string
       readonly runId?: string
       readonly input?: Readonly<Record<string, unknown>>
-      readonly source?: WorkflowRunSource
     }
   > {}
 

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -78,7 +78,7 @@ function createExecutionFacades<TOntologySources extends readonly OntologySource
     objects: createObjectsRuntime<TOntologySources>(runtime),
     actions: createActionsRuntime(runtime),
     datasets: createDatasetsRuntime(runtime, dependencies.definitions.datasets),
-    workflows: createWorkflowsRuntime(runtime, dependencies.definitions.workflows),
+    workflows: createWorkflowsRuntime(runtime, execution, dependencies.definitions.workflows),
     syncs: createSyncsRuntime(runtime, dependencies.definitions.syncs),
     pipelines: createPipelinesRuntime(runtime, dependencies.definitions.pipelines),
     projections: createProjectionsRuntime(runtime, dependencies.definitions.projections),

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -59,7 +59,7 @@ export class InMemoryStorage implements Storage {
   private readonly syncRunStorage = new InMemorySyncRunStorage()
   private readonly pipelineRunStorage = new InMemoryPipelineRunStorage()
   private readonly projectionRunStorage = new InMemoryProjectionRunStorage()
-  private readonly workflowRunStorage = new InMemoryWorkflowRunStorage()
+  private readonly workflowRunStorage = new InMemoryWorkflowRunStorage(this.executionStorage)
   private readonly workflowInterventionStorage = new InMemoryWorkflowInterventionStorage()
   private readonly webhookDeliveryStorage = new InMemoryWebhookDeliveryStorage()
   private readonly webhookRunStorage = new InMemoryWebhookRunStorage()

--- a/packages/core/src/storage/workflow-runs/in-memory.ts
+++ b/packages/core/src/storage/workflow-runs/in-memory.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_PRINCIPAL } from "../../auth"
+import type { ExecutionStorage } from "../executions"
 import {
   cloneRecord,
   compareStartedAt,
@@ -10,6 +10,7 @@ import {
   toStatusSet,
 } from "../run-listing"
 import { WorkflowRunError } from "./errors"
+import { assertWorkflowRunExecution } from "./provider"
 import type {
   CancelWorkflowAgentNodeRunInput,
   ConfirmWorkflowAgentNodeRunExecutionOwnershipInput,
@@ -55,7 +56,7 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
 
   private readonly runs = new Map<string, WorkflowRunRecord>()
 
-  constructor() {
+  constructor(private readonly executions: ExecutionStorage) {
     this.nodes = new InMemoryWorkflowNodeRunStorage({
       requireRunningWorkflowRun: (projectId, id) => this.requireRunningWorkflowRun(projectId, id),
       requireActiveWorkflowRun: (projectId, id) => this.requireActiveWorkflowRun(projectId, id),
@@ -91,19 +92,34 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
         `[Sixb] Workflow run '${input.id}' already exists for project '${input.projectId}'.`
       )
     }
+    if (
+      [...this.runs.values()].some(
+        (run) => run.projectId === input.projectId && run.executionId === input.executionId
+      )
+    ) {
+      throw new WorkflowRunError(
+        `[Sixb] Execution '${input.executionId}' already belongs to another workflow run.`
+      )
+    }
+    await assertWorkflowRunExecution({
+      executions: this.executions,
+      projectId: input.projectId,
+      executionId: input.executionId,
+      runId: input.id,
+      workflowId: input.workflowId,
+    })
 
     const queuedAt = new Date(input.queuedAt ?? new Date())
     const record: WorkflowRunRecord = {
       id: input.id,
       projectId: input.projectId,
+      executionId: input.executionId,
       workflowId: input.workflowId,
       status: "queued",
       input: cloneRecord(input.input),
       queuedAt,
       startedAt: queuedAt,
       attempt: 0,
-      requestedByPrincipal: cloneRecord(input.requestedByPrincipal ?? SYSTEM_PRINCIPAL),
-      ...(input.source ? { source: cloneRecord(input.source) } : {}),
     }
 
     this.runs.set(key, cloneRecord(record))
@@ -113,51 +129,26 @@ export class InMemoryWorkflowRunStorage implements WorkflowRunStorage {
   async start(input: StartWorkflowRunInput): Promise<WorkflowRunRecord> {
     const key = storageKey(input.projectId, input.id)
     const existing = this.runs.get(key)
-    if (existing) {
-      if (existing.status !== "queued") {
-        throw new WorkflowRunError(
-          `[Sixb] Workflow run '${input.id}' already exists for project '${input.projectId}'.`
-        )
-      }
-
-      if (existing.workflowId !== input.workflowId) {
-        throw new WorkflowRunError(
-          `[Sixb] Workflow run '${input.id}' workflow '${input.workflowId}' does not match existing workflow '${existing.workflowId}'.`
-        )
-      }
-
-      const next: WorkflowRunRecord = {
-        ...existing,
-        status: "running",
-        input: cloneRecord(input.input),
-        startedAt: new Date(input.startedAt ?? new Date()),
-        finishedAt: undefined,
-        error: undefined,
-        source:
-          existing.source ?? (input.source === undefined ? undefined : cloneRecord(input.source)),
-        attempt: existing.attempt + 1,
-        execution: input.execution ? cloneRecord(input.execution) : undefined,
-      }
-
-      this.runs.set(key, cloneRecord(next))
-      return cloneRecord(next)
+    if (!existing || existing.status !== "queued") {
+      throw new WorkflowRunError(
+        existing
+          ? `[Sixb] Workflow run '${input.id}' cannot start from status '${existing.status}'.`
+          : `[Sixb] Workflow run '${input.id}' not found for project '${input.projectId}'.`
+      )
     }
 
-    const record: WorkflowRunRecord = {
-      id: input.id,
-      projectId: input.projectId,
-      workflowId: input.workflowId,
+    const next: WorkflowRunRecord = {
+      ...existing,
       status: "running",
-      input: cloneRecord(input.input),
       startedAt: new Date(input.startedAt ?? new Date()),
-      attempt: 1,
-      requestedByPrincipal: cloneRecord(input.requestedByPrincipal ?? SYSTEM_PRINCIPAL),
-      ...(input.execution ? { execution: cloneRecord(input.execution) } : {}),
-      ...(input.source ? { source: cloneRecord(input.source) } : {}),
+      finishedAt: undefined,
+      error: undefined,
+      attempt: existing.attempt + 1,
+      execution: input.execution ? cloneRecord(input.execution) : undefined,
     }
 
-    this.runs.set(key, cloneRecord(record))
-    return cloneRecord(record)
+    this.runs.set(key, cloneRecord(next))
+    return cloneRecord(next)
   }
 
   async finish(input: FinishWorkflowRunInput): Promise<WorkflowRunRecord> {

--- a/packages/core/src/storage/workflow-runs/provider.ts
+++ b/packages/core/src/storage/workflow-runs/provider.ts
@@ -1,4 +1,3 @@
-import { isDeepStrictEqual } from "node:util"
 import type { ExecutionStorage } from "../executions"
 import { WorkflowRunError } from "./errors"
 
@@ -30,28 +29,15 @@ export async function assertWorkflowRunExecution(input: {
   }
 
   if (execution.source.type === "schedule" || execution.source.type === "event") {
-    if (execution.parentExecutionId !== undefined || execution.requestedBy !== undefined) {
+    if (execution.requestedBy !== undefined) {
       invalidExecution(input.executionId, input.runId)
     }
     return
   }
 
-  if (
-    execution.source.type !== "execution" ||
-    execution.parentExecutionId !== execution.source.executionId
-  ) {
-    invalidExecution(input.executionId, input.runId)
-  }
-
-  const parent = await input.executions.getById({
-    projectId: input.projectId,
-    id: execution.parentExecutionId,
-  })
-  if (
-    !parent ||
-    execution.correlationId !== parent.correlationId ||
-    !isDeepStrictEqual(execution.requestedBy, parent.requestedBy)
-  ) {
+  // ExecutionStorage already validates the immutable parent reference, correlation id, and
+  // requested-by propagation. This boundary only owns the workflow-specific source restriction.
+  if (execution.source.type !== "execution") {
     invalidExecution(input.executionId, input.runId)
   }
 }

--- a/packages/core/src/storage/workflow-runs/provider.ts
+++ b/packages/core/src/storage/workflow-runs/provider.ts
@@ -1,0 +1,63 @@
+import { isDeepStrictEqual } from "node:util"
+import type { ExecutionStorage } from "../executions"
+import { WorkflowRunError } from "./errors"
+
+/** Validate the semantic link between a durable workflow run and its immutable execution. */
+
+export async function assertWorkflowRunExecution(input: {
+  readonly executions: ExecutionStorage
+  readonly projectId: string
+  readonly executionId: string
+  readonly runId: string
+  readonly workflowId: string
+}): Promise<void> {
+  const execution = await input.executions.getById({
+    projectId: input.projectId,
+    id: input.executionId,
+  })
+  const authority = execution?.authorizationRef
+  if (
+    !execution ||
+    execution.executor.type !== "primitive" ||
+    execution.executor.kind !== "workflow" ||
+    execution.executor.runId !== input.runId ||
+    authority?.type !== "trustedPrimitive" ||
+    authority.primitive.kind !== "workflow" ||
+    authority.primitive.id !== input.workflowId ||
+    authority.primitive.runId !== input.runId
+  ) {
+    invalidExecution(input.executionId, input.runId)
+  }
+
+  if (execution.source.type === "schedule" || execution.source.type === "event") {
+    if (execution.parentExecutionId !== undefined || execution.requestedBy !== undefined) {
+      invalidExecution(input.executionId, input.runId)
+    }
+    return
+  }
+
+  if (
+    execution.source.type !== "execution" ||
+    execution.parentExecutionId !== execution.source.executionId
+  ) {
+    invalidExecution(input.executionId, input.runId)
+  }
+
+  const parent = await input.executions.getById({
+    projectId: input.projectId,
+    id: execution.parentExecutionId,
+  })
+  if (
+    !parent ||
+    execution.correlationId !== parent.correlationId ||
+    !isDeepStrictEqual(execution.requestedBy, parent.requestedBy)
+  ) {
+    invalidExecution(input.executionId, input.runId)
+  }
+}
+
+function invalidExecution(executionId: string, runId: string): never {
+  throw new WorkflowRunError(
+    `[Sixb] Execution '${executionId}' does not authorize workflow run '${runId}'.`
+  )
+}

--- a/packages/core/src/storage/workflow-runs/types.ts
+++ b/packages/core/src/storage/workflow-runs/types.ts
@@ -1,10 +1,10 @@
 import type { AgentMessagePart } from "../../agents/message"
 import type { Principal } from "../../auth"
 import type { JsonValue } from "../../json"
-import type { WorkflowIOSnapshot, WorkflowRunSource } from "../../workflows/types"
+import type { WorkflowIOSnapshot } from "../../workflows/types"
 import type { AgentExecutionStatus, AgentRunFinishReason, AgentRunUsage } from "../agents"
 
-export type { WorkflowIOSnapshot, WorkflowRunSource } from "../../workflows/types"
+export type { WorkflowIOSnapshot } from "../../workflows/types"
 
 export type WorkflowRunStatus =
   | "queued"
@@ -118,6 +118,7 @@ export interface ListWorkflowAgentNodeRunsResult {
 export interface WorkflowRunRecord {
   readonly id: string
   readonly projectId: string
+  readonly executionId: string
   readonly workflowId: string
   readonly status: WorkflowRunStatus
   readonly input: WorkflowIOSnapshot
@@ -126,8 +127,6 @@ export interface WorkflowRunRecord {
   readonly startedAt: Date
   readonly finishedAt?: Date
   readonly error?: string
-  readonly source?: WorkflowRunSource
-  readonly requestedByPrincipal: Principal
   readonly attempt: number
   readonly execution?: WorkflowRunExecution
 }
@@ -152,22 +151,17 @@ export interface WorkflowNodeRunRecord {
 export interface StartWorkflowRunInput {
   readonly id: string
   readonly projectId: string
-  readonly workflowId: string
-  readonly input: WorkflowIOSnapshot
   readonly startedAt?: Date
-  readonly source?: WorkflowRunSource
-  readonly requestedByPrincipal?: Principal
   readonly execution?: WorkflowRunExecution
 }
 
 export interface QueueWorkflowRunInput {
   readonly id: string
   readonly projectId: string
+  readonly executionId: string
   readonly workflowId: string
   readonly input: WorkflowIOSnapshot
   readonly queuedAt?: Date
-  readonly source?: WorkflowRunSource
-  readonly requestedByPrincipal?: Principal
 }
 
 export interface ReclaimWorkflowRunInput {

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -82,3 +82,7 @@ export {
   type SandboxesContractCapabilities,
   type SandboxesContractSuiteOptions,
 } from "./sandboxes-contract"
+export {
+  createTestAutomaticWorkflowExecution,
+  createTestWorkflowExecution,
+} from "./workflow-execution"

--- a/packages/core/src/testing/queues-contract.ts
+++ b/packages/core/src/testing/queues-contract.ts
@@ -298,12 +298,7 @@ export function runQueueContractSuite(label: string, options: QueueContractSuite
             jobs: [
               {
                 type: "workflow.run.requested",
-                payload: {
-                  workflowId: "reconcile-transaction",
-                  input: {
-                    transaction: { objectTypeId: "Transaction", primaryId: "txn_123" },
-                  },
-                },
+                payload: { runId: "workflow-run-1" },
               },
             ],
           })
@@ -351,7 +346,7 @@ export function runQueueContractSuite(label: string, options: QueueContractSuite
           expect(projectionLane).toHaveLength(1)
           expect(projectionLane[0]?.job.payload.projectionId).toBe("room-projection")
           expect(workflowLane).toHaveLength(1)
-          expect(workflowLane[0]?.job.payload.workflowId).toBe("reconcile-transaction")
+          expect(workflowLane[0]?.job.payload.runId).toBe("workflow-run-1")
           expect(actionLane).toHaveLength(1)
           expect(actionLane[0]?.job.payload.actionId).toBe("mark-paid")
           expect(sameLane).toHaveLength(1)

--- a/packages/core/src/testing/workflow-execution.ts
+++ b/packages/core/src/testing/workflow-execution.ts
@@ -1,0 +1,72 @@
+import type { TrustedPrimitiveRef } from "../execution"
+import type { ExecutionStorage } from "../storage/executions"
+
+/** Create the durable execution chain required by a workflow-run storage fixture. */
+export async function createTestWorkflowExecution(
+  executions: ExecutionStorage,
+  input: {
+    readonly projectId: string
+    readonly workflowId: string
+    readonly runId: string
+    readonly executionId?: string
+  }
+): Promise<string> {
+  const parentExecutionId = `test_request_execution:${input.runId}`
+  const executionId = input.executionId ?? `test_workflow_execution:${input.runId}`
+  const primitive: TrustedPrimitiveRef = {
+    kind: "workflow",
+    id: input.workflowId,
+    runId: input.runId,
+  }
+
+  await executions.create({
+    id: parentExecutionId,
+    projectId: input.projectId,
+    executor: { type: "request", requestId: `test_request:${input.runId}` },
+    source: { type: "http", requestId: `test_request:${input.runId}` },
+    correlationId: `test_correlation:${input.runId}`,
+    authorizationRef: { type: "disabled" },
+  })
+  await executions.create({
+    id: executionId,
+    projectId: input.projectId,
+    executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+    source: { type: "execution", executionId: parentExecutionId },
+    correlationId: `test_correlation:${input.runId}`,
+    parentExecutionId,
+    authorizationRef: { type: "trustedPrimitive", primitive },
+  })
+
+  return executionId
+}
+
+/** Create a root workflow execution as produced by an automatic trigger. */
+export async function createTestAutomaticWorkflowExecution(
+  executions: ExecutionStorage,
+  input: {
+    readonly projectId: string
+    readonly workflowId: string
+    readonly runId: string
+    readonly executionId?: string
+    readonly source?: { readonly type: "schedule" | "event"; readonly eventId: string }
+    readonly correlationId?: string
+  }
+): Promise<string> {
+  const executionId = input.executionId ?? `test_workflow_execution:${input.runId}`
+  const primitive: TrustedPrimitiveRef = {
+    kind: "workflow",
+    id: input.workflowId,
+    runId: input.runId,
+  }
+
+  await executions.create({
+    id: executionId,
+    projectId: input.projectId,
+    executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+    source: input.source ?? { type: "event", eventId: `test_event:${input.runId}` },
+    correlationId: input.correlationId ?? `test_correlation:${input.runId}`,
+    authorizationRef: { type: "trustedPrimitive", primitive },
+  })
+
+  return executionId
+}

--- a/packages/core/src/workflows/execution.ts
+++ b/packages/core/src/workflows/execution.ts
@@ -1,4 +1,5 @@
 import { canViewWorkflowIntervention, canViewWorkflowRun, isAllowed } from "../authorization"
+import type { AuthorizablePrincipal, ExecutionContext } from "../execution"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type {
   ListWorkflowInterventionsInput,
@@ -21,11 +22,24 @@ import {
 import type { WorkflowDefinition } from "./types"
 
 export interface WorkflowRunsRuntime {
-  getById(runId: string): Promise<WorkflowRunRecord | null>
+  getById(runId: string): Promise<WorkflowRunView | null>
   list(
     input?: Omit<ListWorkflowRunsInput, "projectId" | "workflowIds">
-  ): Promise<ListWorkflowRunsResult>
-  listLatest(workflowIds: readonly string[]): Promise<ListLatestWorkflowRunsResult>
+  ): Promise<WorkflowRunListResult>
+  listLatest(workflowIds: readonly string[]): Promise<LatestWorkflowRunListResult>
+}
+
+/** Execution-facing run view with provenance resolved from the immutable execution ledger. */
+export interface WorkflowRunView extends WorkflowRunRecord {
+  readonly requestedBy?: AuthorizablePrincipal
+}
+
+export interface WorkflowRunListResult extends Omit<ListWorkflowRunsResult, "runs"> {
+  readonly runs: readonly WorkflowRunView[]
+}
+
+export interface LatestWorkflowRunListResult extends Omit<ListLatestWorkflowRunsResult, "runs"> {
+  readonly runs: readonly WorkflowRunView[]
 }
 
 export interface WorkflowInterventionsRuntime {
@@ -49,6 +63,7 @@ export interface WorkflowsRuntime {
 
 export function createWorkflowsRuntime(
   runtime: SixbRuntimeContext,
+  execution: ExecutionContext,
   source: Pick<WorkflowsRuntime, "list" | "getById">
 ): WorkflowsRuntime {
   const allowed = (workflowId: string) =>
@@ -67,13 +82,13 @@ export function createWorkflowsRuntime(
       const workflow = source.getById(workflowId)
       return workflow && allowed(workflowId) ? workflow : null
     },
-    request: (workflow, options) => requestWorkflowRun(runtime, workflow, options),
+    request: (workflow, options) => requestWorkflowRun(runtime, execution, workflow, options),
     requestById: async (input) => {
       const workflow = source.getById(input.workflowId)
       if (!workflow) {
         throw new WorkflowValidationError(`[Sixb] Unknown workflow '${input.workflowId}'`)
       }
-      return requestWorkflowRun(runtime, workflow, input)
+      return requestWorkflowRun(runtime, execution, workflow, input)
     },
     runs: {
       getById: async (runId) => {
@@ -85,28 +100,34 @@ export function createWorkflowsRuntime(
         return run &&
           canViewWorkflowRun(runtime.authorization, run) &&
           canAccessHistory(run.workflowId)
-          ? run
+          ? attachRequestedBy(runtime, run)
           : null
       },
-      list: (input = {}) => {
+      list: async (input = {}) => {
         const storage = runtime.storage.workflowRuns
-        if (!storage) return Promise.resolve({ runs: [], hasMore: false, total: 0 })
-        return storage.list({
+        if (!storage) return { runs: [], hasMore: false, total: 0 }
+        const result = await storage.list({
           projectId: runtime.projectId,
           ...input,
           workflowIds: runtime.authorization ? visibleIds() : undefined,
         })
+        return {
+          ...result,
+          runs: await Promise.all(result.runs.map((run) => attachRequestedBy(runtime, run))),
+        }
       },
-      listLatest: (workflowIds) => {
+      listLatest: async (workflowIds) => {
         const storage = runtime.storage.workflowRuns
-        if (!storage || workflowIds.length === 0) return Promise.resolve({ runs: [] })
+        if (!storage || workflowIds.length === 0) return { runs: [] }
         const allowedIds = workflowIds.filter(canAccessHistory)
-        return allowedIds.length === 0
-          ? Promise.resolve({ runs: [] })
-          : storage.listLatestByWorkflowIds({
-              projectId: runtime.projectId,
-              workflowIds: allowedIds,
-            })
+        if (allowedIds.length === 0) return { runs: [] }
+        const result = await storage.listLatestByWorkflowIds({
+          projectId: runtime.projectId,
+          workflowIds: allowedIds,
+        })
+        return {
+          runs: await Promise.all(result.runs.map((run) => attachRequestedBy(runtime, run))),
+        }
       },
     },
     interventions: {
@@ -132,5 +153,26 @@ export function createWorkflowsRuntime(
         })
       },
     },
+  }
+}
+
+async function attachRequestedBy(
+  runtime: SixbRuntimeContext,
+  run: WorkflowRunRecord
+): Promise<WorkflowRunView> {
+  const execution = await runtime.storage.executions.getById({
+    projectId: runtime.projectId,
+    id: run.executionId,
+  })
+  if (!execution) {
+    throw new Error(
+      `[Sixb] Workflow run '${run.id}' references missing execution '${run.executionId}'.`
+    )
+  }
+  return {
+    ...run,
+    ...(execution.requestedBy === undefined
+      ? {}
+      : { requestedBy: structuredClone(execution.requestedBy) }),
   }
 }

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -13,6 +13,13 @@ export type {
 } from "./request"
 export { requestWorkflowRun } from "./request"
 export {
+  type AutomaticWorkflowExecutionSource,
+  type AutomaticWorkflowRunDispatchInput,
+  WorkflowRunDispatcher,
+  type WorkflowRunDispatcherDependencies,
+  type WorkflowRunDispatchPort,
+} from "./run-dispatch"
+export {
   snapshotWorkflowActionInput,
   snapshotWorkflowAgentStepInput,
   snapshotWorkflowAgentStepOutput,

--- a/packages/core/src/workflows/request.ts
+++ b/packages/core/src/workflows/request.ts
@@ -1,10 +1,12 @@
-import { randomUUID } from "node:crypto"
-import { SYSTEM_PRINCIPAL } from "../auth"
 import { assertAuthorized } from "../authorization"
-import { reportRunFailure } from "../error-reporting/capability"
+import {
+  createPrimitiveExecutionRecord,
+  ensureExecutionRecord,
+  executionRecordInputFromRuntime,
+} from "../execution/durable"
+import type { ExecutionContext } from "../execution/types"
 import type { SixbRuntimeContext } from "../runtime/types"
-import { WorkflowValidationError } from "./errors"
-import { snapshotWorkflowInput } from "./snapshot"
+import { dispatchWorkflowRun } from "./run-dispatch"
 import type { WorkflowDefinition, WorkflowRunSource } from "./types"
 
 export interface WorkflowRunRequestOptions {
@@ -37,125 +39,35 @@ export interface WorkflowRunRequestResult {
  */
 export async function requestWorkflowRun(
   runtime: SixbRuntimeContext,
+  execution: ExecutionContext,
   workflow: WorkflowDefinition,
   options: WorkflowRunRequestOptions = {}
 ): Promise<WorkflowRunRequestResult> {
   assertAuthorized(runtime, { kind: "workflow.run", workflowId: workflow.id })
-  const storage = runtime.storage.workflowRuns
-  if (!storage) {
-    throw new WorkflowValidationError("[Sixb] Workflow run storage is not configured.")
-  }
-
-  const queue = runtime.queues.workflows
-  if (!queue) {
-    throw new WorkflowValidationError("[Sixb] Workflow run queue is not configured.")
-  }
-
-  const runId = createWorkflowRunId(options.runId)
-  const value = options.input ?? {}
-  // Validates the input against the workflow contract and rejects before any
-  // storage or queue write.
-  const snapshot = snapshotWorkflowInput({
-    workflow,
-    value,
-    valueTypesById: runtime.ontology.getValueTypesById(),
-  })
-
-  const existing = await storage.getById({ projectId: runtime.projectId, id: runId })
-  if (existing) {
-    if (existing.workflowId !== workflow.id) {
-      throw new WorkflowValidationError(
-        `[Sixb] Workflow run '${runId}' already exists for a different workflow '${existing.workflowId}'.`
-      )
-    }
-
-    return {
-      workflowId: workflow.id,
-      runId,
-      queuedAt: (existing.queuedAt ?? existing.startedAt).toISOString(),
-      created: false,
-    }
-  }
-
-  const queuedAt = new Date()
-  await storage.queue({
+  return dispatchWorkflowRun({
+    errorReporterHost: runtime,
     projectId: runtime.projectId,
-    id: runId,
-    workflowId: workflow.id,
-    input: snapshot,
-    queuedAt,
+    workflow,
+    valueTypesById: runtime.ontology.getValueTypesById(),
+    storage: runtime.storage,
+    queue: runtime.queues.workflows,
+    events: runtime.events,
+    runId: options.runId,
+    input: options.input,
     source: options.source,
-    requestedByPrincipal:
-      runtime.authorization?.principal ??
-      (options.source?.type === "schedule" ? options.source.principal : SYSTEM_PRINCIPAL),
-  })
-
-  let job: Awaited<ReturnType<typeof queue.enqueue>>[number] | undefined
-  try {
-    ;[job] = await queue.enqueue({
-      projectId: runtime.projectId,
-      jobs: [
-        {
-          type: "workflow.run.requested",
-          payload: { workflowId: workflow.id, runId, input: value },
-        },
-      ],
-    })
-  } catch (error) {
-    const failed = await storage.finish({
-      projectId: runtime.projectId,
-      id: runId,
-      status: "failed",
-      error: error instanceof Error ? error.message : String(error),
-    })
-    reportRunFailure(runtime, error, {
-      projectId: runtime.projectId,
-      occurredAt: failed.finishedAt,
-      run: {
-        kind: "workflow",
-        runId,
-        workflowId: workflow.id,
-      },
-    })
-    throw error
-  }
-
-  // Past this point the run row exists and the job is queued, so the run *will* execute. Rejecting
-  // here would report a failure for work already under way, and leave the run unmarked either way.
-  await runtime.events.emit(
-    {
-      events: [
-        {
-          type: "workflow.run.queued",
-          payload: {
-            workflowId: workflow.id,
-            runId,
-            queuedAt: queuedAt.toISOString(),
-            ...(job?.id ? { jobId: job.id } : {}),
-            ...(options.source ? { source: options.source } : {}),
-          },
-        },
-      ],
+    createExecution: async (executionId, runId) => {
+      const caller = await ensureExecutionRecord(
+        runtime.storage.executions,
+        executionRecordInputFromRuntime({
+          execution,
+          runtimeAuthorization: runtime.runtimeAuthorization,
+        })
+      )
+      return createPrimitiveExecutionRecord({
+        id: executionId,
+        primitive: { kind: "workflow", id: workflow.id, runId },
+        origin: { type: "execution", parent: caller },
+      })
     },
-    { source: "Sixb" }
-  )
-
-  return {
-    workflowId: workflow.id,
-    runId,
-    queuedAt: queuedAt.toISOString(),
-    jobId: job?.id,
-    created: true,
-  }
-}
-
-function createWorkflowRunId(runId: string | undefined): string {
-  if (runId !== undefined) {
-    if (!runId.trim()) {
-      throw new WorkflowValidationError("[Sixb] Workflow run id must not be empty")
-    }
-    return runId
-  }
-
-  return `run_${randomUUID()}`
+  })
 }

--- a/packages/core/src/workflows/run-dispatch.ts
+++ b/packages/core/src/workflows/run-dispatch.ts
@@ -1,0 +1,352 @@
+import { randomUUID } from "node:crypto"
+import { isDeepStrictEqual } from "node:util"
+import { SYSTEM_PRINCIPAL } from "../auth"
+import { reportRunFailure } from "../error-reporting/capability"
+import type { DomainEventLog } from "../events"
+import type { RunDispatcher } from "../execution/dispatch"
+import { createPrimitiveExecutionRecord } from "../execution/durable"
+import type { ValueType } from "../ontology"
+import type { Queues } from "../queues"
+import type { SixbDefinitions } from "../runtime/definitions"
+import type { CreateExecutionInput, Storage, WorkflowRunRecord } from "../storage"
+import { WorkflowRunError } from "../storage"
+import { WorkflowValidationError } from "./errors"
+import type { WorkflowRunRequestResult } from "./request"
+import { snapshotWorkflowInput } from "./snapshot"
+import type { WorkflowDefinition, WorkflowIOSnapshot, WorkflowRunSource } from "./types"
+
+export type AutomaticWorkflowExecutionSource =
+  | { readonly type: "schedule"; readonly eventId: string }
+  | { readonly type: "event"; readonly eventId: string }
+
+/** One automatic match already resolved to a stable workflow run identity by the orchestrator. */
+export interface AutomaticWorkflowRunDispatchInput {
+  readonly workflowId: string
+  readonly runId: string
+  readonly input?: Readonly<Record<string, unknown>>
+  readonly scheduleId: string
+  readonly source: AutomaticWorkflowExecutionSource
+  readonly correlationId: string
+  readonly metadata?: Readonly<Record<string, string>>
+}
+
+export type WorkflowRunDispatchPort = RunDispatcher<
+  AutomaticWorkflowRunDispatchInput,
+  WorkflowRunRequestResult
+>
+
+export interface WorkflowRunDispatcherDependencies {
+  readonly id: string
+  readonly definitions: Pick<SixbDefinitions, "ontology" | "workflows">
+  readonly storage: Storage
+  readonly queues: Pick<Queues, "workflows">
+  readonly events: DomainEventLog
+}
+
+interface DispatchWorkflowRunInput {
+  readonly errorReporterHost: object
+  readonly projectId: string
+  readonly workflow: WorkflowDefinition
+  readonly valueTypesById: ReadonlyMap<string, ValueType>
+  readonly storage: Storage
+  readonly queue: Queues["workflows"]
+  readonly events: DomainEventLog
+  readonly runId?: string
+  readonly input?: Readonly<Record<string, unknown>>
+  readonly source?: WorkflowRunSource
+  readonly metadata?: Readonly<Record<string, string>>
+  readonly queueJobId?: string
+  readonly createExecution: (executionId: string, runId: string) => Promise<CreateExecutionInput>
+}
+
+interface PreparedWorkflowRun {
+  readonly runId: string
+  readonly snapshot: WorkflowIOSnapshot
+}
+
+type PersistedWorkflowRun =
+  | {
+      readonly created: false
+      readonly run: WorkflowRunRecord
+    }
+  | {
+      readonly created: true
+      readonly run: WorkflowRunRecord
+      readonly execution: CreateExecutionInput
+      readonly queuedAt: Date
+    }
+
+/** Core-owned durable dispatch boundary used by automatic trigger runtimes. */
+export class WorkflowRunDispatcher implements WorkflowRunDispatchPort {
+  constructor(private readonly dependencies: WorkflowRunDispatcherDependencies) {}
+
+  async dispatch(input: AutomaticWorkflowRunDispatchInput): Promise<WorkflowRunRequestResult> {
+    assertAutomaticDispatchInput(input)
+    const workflow = this.dependencies.definitions.workflows.getById(input.workflowId)
+    if (!workflow) {
+      throw new WorkflowValidationError(`[Sixb] Unknown workflow '${input.workflowId}'`)
+    }
+
+    const result = await dispatchWorkflowRun({
+      errorReporterHost: this.dependencies,
+      projectId: this.dependencies.id,
+      workflow,
+      valueTypesById: this.dependencies.definitions.ontology.getValueTypesById(),
+      storage: this.dependencies.storage,
+      queue: this.dependencies.queues.workflows,
+      events: this.dependencies.events,
+      runId: input.runId,
+      input: input.input,
+      source: {
+        type: "schedule",
+        scheduleId: input.scheduleId,
+        eventId: input.source.eventId,
+        principal: SYSTEM_PRINCIPAL,
+      },
+      metadata: input.metadata,
+      queueJobId: input.runId,
+      createExecution: async (executionId, runId) =>
+        createPrimitiveExecutionRecord({
+          id: executionId,
+          primitive: { kind: "workflow", id: workflow.id, runId },
+          origin: {
+            type: "automatic",
+            projectId: this.dependencies.id,
+            source: input.source,
+            correlationId: input.correlationId,
+          },
+        }),
+    })
+    await assertAutomaticExecutionIdentity(this.dependencies, input, result.runId)
+    return result
+  }
+}
+
+/** Persist a workflow execution and run before publishing its queue job. */
+export async function dispatchWorkflowRun(
+  input: DispatchWorkflowRunInput
+): Promise<WorkflowRunRequestResult> {
+  const request = prepareWorkflowRun(input)
+  const persisted = await persistWorkflowRun(input, request)
+  if (!persisted.created) return existingWorkflowRunResult(persisted.run)
+  return publishWorkflowRun(input, persisted)
+}
+
+function prepareWorkflowRun(input: DispatchWorkflowRunInput): PreparedWorkflowRun {
+  const value = input.input ?? {}
+  return {
+    runId: resolveWorkflowRunId(input.runId),
+    snapshot: snapshotWorkflowInput({
+      workflow: input.workflow,
+      value,
+      valueTypesById: input.valueTypesById,
+    }),
+  }
+}
+
+async function persistWorkflowRun(
+  input: DispatchWorkflowRunInput,
+  request: PreparedWorkflowRun
+): Promise<PersistedWorkflowRun> {
+  const workflowRuns = input.storage.workflowRuns
+  if (!workflowRuns) {
+    throw new WorkflowValidationError("[Sixb] Workflow run storage is not configured.")
+  }
+
+  const existing = await workflowRuns.getById({
+    projectId: input.projectId,
+    id: request.runId,
+  })
+  if (existing) {
+    assertExistingWorkflowRun(existing, input.workflow.id, request.snapshot)
+    return { run: existing, created: false }
+  }
+
+  const execution = await input.createExecution(`exec_${randomUUID()}`, request.runId)
+  const queuedAt = new Date()
+  try {
+    return await input.storage.transaction(
+      async (tx): Promise<PersistedWorkflowRun> => {
+        const raced = await tx.workflowRuns?.getById({
+          projectId: input.projectId,
+          id: request.runId,
+        })
+        if (raced) {
+          assertExistingWorkflowRun(raced, input.workflow.id, request.snapshot)
+          return { run: raced, created: false }
+        }
+        if (!tx.workflowRuns) {
+          throw new WorkflowValidationError("[Sixb] Workflow run storage is not configured.")
+        }
+
+        await tx.executions.create(execution)
+        const run = await tx.workflowRuns.queue({
+          projectId: input.projectId,
+          id: request.runId,
+          executionId: execution.id,
+          workflowId: input.workflow.id,
+          input: request.snapshot,
+          queuedAt,
+        })
+        return { run, execution, queuedAt, created: true }
+      },
+      { isolation: "serializable" }
+    )
+  } catch (error) {
+    if (!(error instanceof WorkflowRunError)) throw error
+    const raced = await workflowRuns.getById({
+      projectId: input.projectId,
+      id: request.runId,
+    })
+    if (!raced) throw error
+    assertExistingWorkflowRun(raced, input.workflow.id, request.snapshot)
+    return { run: raced, created: false }
+  }
+}
+
+async function publishWorkflowRun(
+  input: DispatchWorkflowRunInput,
+  persisted: Extract<PersistedWorkflowRun, { readonly created: true }>
+): Promise<WorkflowRunRequestResult> {
+  let job: Awaited<ReturnType<Queues["workflows"]["enqueue"]>>[number] | undefined
+  try {
+    const jobs = await input.queue.enqueue({
+      projectId: input.projectId,
+      jobs: [
+        {
+          ...(input.queueJobId === undefined ? {} : { id: input.queueJobId }),
+          type: "workflow.run.requested",
+          payload: {
+            workflowId: persisted.run.workflowId,
+            runId: persisted.run.id,
+            input: persisted.run.input,
+          },
+          ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
+        },
+      ],
+    })
+    job = jobs[0]
+  } catch (error) {
+    await failWorkflowRunPublication(input, persisted.run, error)
+    throw error
+  }
+
+  await input.events.emit(
+    {
+      events: [
+        {
+          type: "workflow.run.queued",
+          payload: {
+            workflowId: persisted.run.workflowId,
+            runId: persisted.run.id,
+            queuedAt: persisted.queuedAt.toISOString(),
+            ...(job?.id ? { jobId: job.id } : {}),
+            ...(input.source === undefined ? {} : { source: input.source }),
+          },
+        },
+      ],
+      correlationId: persisted.execution.correlationId,
+    },
+    { source: "Sixb" }
+  )
+
+  return {
+    workflowId: persisted.run.workflowId,
+    runId: persisted.run.id,
+    queuedAt: persisted.queuedAt.toISOString(),
+    jobId: job?.id,
+    created: true,
+  }
+}
+
+async function failWorkflowRunPublication(
+  input: DispatchWorkflowRunInput,
+  run: WorkflowRunRecord,
+  error: unknown
+): Promise<void> {
+  const workflowRuns = input.storage.workflowRuns
+  if (!workflowRuns) {
+    throw new WorkflowValidationError("[Sixb] Workflow run storage is not configured.")
+  }
+  const failed = await workflowRuns.finish({
+    projectId: input.projectId,
+    id: run.id,
+    status: "failed",
+    error: error instanceof Error ? error.message : String(error),
+  })
+  reportRunFailure(input.errorReporterHost, error, {
+    projectId: input.projectId,
+    occurredAt: failed.finishedAt,
+    run: { kind: "workflow", runId: run.id, workflowId: run.workflowId },
+  })
+}
+
+function resolveWorkflowRunId(runId: string | undefined): string {
+  if (runId === undefined) return `run_${randomUUID()}`
+  if (!runId.trim()) {
+    throw new WorkflowValidationError("[Sixb] Workflow run id must not be empty")
+  }
+  return runId
+}
+
+function assertExistingWorkflowRun(
+  existing: WorkflowRunRecord,
+  workflowId: string,
+  input: WorkflowRunRecord["input"]
+): void {
+  if (existing.workflowId !== workflowId || !isDeepStrictEqual(existing.input, input)) {
+    throw new WorkflowValidationError(
+      `[Sixb] Workflow run '${existing.id}' already exists with a different request payload.`
+    )
+  }
+}
+
+function existingWorkflowRunResult(existing: WorkflowRunRecord): WorkflowRunRequestResult {
+  return {
+    workflowId: existing.workflowId,
+    runId: existing.id,
+    queuedAt: (existing.queuedAt ?? existing.startedAt).toISOString(),
+    created: false,
+  }
+}
+
+function assertAutomaticDispatchInput(input: AutomaticWorkflowRunDispatchInput): void {
+  assertNonBlank(input.workflowId, "Workflow id")
+  assertNonBlank(input.runId, "Workflow run id")
+  assertNonBlank(input.scheduleId, "Workflow schedule id")
+  assertNonBlank(input.source.eventId, "Workflow source event id")
+  assertNonBlank(input.correlationId, "Workflow correlation id")
+}
+
+async function assertAutomaticExecutionIdentity(
+  dependencies: WorkflowRunDispatcherDependencies,
+  input: AutomaticWorkflowRunDispatchInput,
+  runId: string
+): Promise<void> {
+  const run = await dependencies.storage.workflowRuns?.getById({
+    projectId: dependencies.id,
+    id: runId,
+  })
+  const execution = run
+    ? await dependencies.storage.executions.getById({
+        projectId: dependencies.id,
+        id: run.executionId,
+      })
+    : null
+  if (
+    !execution ||
+    execution.source.type !== input.source.type ||
+    execution.source.eventId !== input.source.eventId ||
+    execution.correlationId !== input.correlationId ||
+    execution.parentExecutionId !== undefined ||
+    execution.requestedBy !== undefined
+  ) {
+    throw new WorkflowValidationError(
+      `[Sixb] Workflow run '${runId}' already exists with different automatic provenance.`
+    )
+  }
+}
+
+function assertNonBlank(value: string, label: string): void {
+  if (!value.trim()) throw new WorkflowValidationError(`[Sixb] ${label} must not be empty.`)
+}

--- a/packages/core/src/workflows/run-dispatch.ts
+++ b/packages/core/src/workflows/run-dispatch.ts
@@ -117,7 +117,9 @@ export class WorkflowRunDispatcher implements WorkflowRunDispatchPort {
           },
         }),
     })
-    await assertAutomaticExecutionIdentity(this.dependencies, input, result.runId)
+    if (!result.created) {
+      await assertAutomaticExecutionIdentity(this.dependencies, input, result.runId)
+    }
     return result
   }
 }
@@ -216,11 +218,7 @@ async function publishWorkflowRun(
         {
           ...(input.queueJobId === undefined ? {} : { id: input.queueJobId }),
           type: "workflow.run.requested",
-          payload: {
-            workflowId: persisted.run.workflowId,
-            runId: persisted.run.id,
-            input: persisted.run.input,
-          },
+          payload: { runId: persisted.run.id },
           ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
         },
       ],

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -217,10 +217,8 @@ export type WorkflowTriggerDefinition = WorkflowScheduleTriggerDefinition
 /**
  * Origin of a workflow run request.
  *
- * Captured on the queued run record and emitted with `workflow.run.queued`
- * so downstream consumers can trace why a run started. Intentionally minimal
- * for now — additional sources (schedule, sync, pipeline, ...) can be added
- * when the triggers that produce them land.
+ * Emitted with `workflow.run.queued` for downstream consumers. The immutable execution record is
+ * the authoritative durable provenance; this event detail is descriptive only.
  */
 export type WorkflowRunSource =
   | { readonly type: "manual" }

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -25,6 +25,7 @@ import {
   resolveAuthorizationContext,
   type SecurityRegistry,
   SixbHost,
+  type Storage,
   type StoredDomainEvent,
   type WorkflowDefinition,
 } from "../src"
@@ -271,6 +272,18 @@ function contextFor(
   })
 }
 
+async function seedPrincipal(
+  host: TestExecutionHost & { readonly storage: Pick<Storage, "auth"> }
+): Promise<void> {
+  const auth = host.storage.auth
+  if (!auth) throw new Error("Test runtime requires auth storage.")
+  await auth.users.create({
+    projectId: host.id,
+    id: principal.id,
+    email: "adam@example.com",
+  })
+}
+
 describe("bound Sixb object reads", () => {
   test("granted types support get, list, byId.get, and query", async () => {
     const host = createRuntime()
@@ -399,6 +412,7 @@ describe("bound Sixb operational access", () => {
 
   test("workflow runs require can.run", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const sixb = createTestSixb(host)
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
     const input = {
@@ -514,6 +528,7 @@ describe("bound Sixb operational access", () => {
 
   test("workflow permission encapsulates agent nodes", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const _sixb = createTestSixb(host)
     const workflowOnlyPrincipal = bindPrincipal(host, contextFor(host, ["workflow-only"]))
 

--- a/packages/core/tests/workflow-request.test.ts
+++ b/packages/core/tests/workflow-request.test.ts
@@ -99,11 +99,7 @@ describe("sixb.workflows.request", () => {
 
     const jobs = await claimAll(host)
     expect(jobs).toHaveLength(1)
-    expect(jobs[0]?.job.payload).toMatchObject({
-      workflowId: "draft-invoice",
-      runId: result.runId,
-      input: { transaction: { objectTypeId: "Transaction", primaryId: "txn_1" } },
-    })
+    expect(jobs[0]?.job.payload).toEqual({ runId: result.runId })
 
     const events = await sixb.events.read({ types: ["workflow.run.queued"] })
     expect(events).toHaveLength(1)
@@ -350,7 +346,7 @@ describe("automatic workflow dispatch", () => {
     const [claimed] = await claimAll(host)
     expect(claimed?.job).toMatchObject({
       id: result.runId,
-      payload: { workflowId: draftInvoice.id, runId: result.runId, input: validInput() },
+      payload: { runId: result.runId },
       metadata: { sourceEventId: "event-1" },
     })
     const [queuedEvent] = await host.events.read({ types: ["workflow.run.queued"] })

--- a/packages/core/tests/workflow-request.test.ts
+++ b/packages/core/tests/workflow-request.test.ts
@@ -11,7 +11,9 @@ import {
   WorkflowValidationError,
 } from "../src"
 import { flushSixbErrors } from "../src/error-reporting/internal"
+import { WorkflowRunError } from "../src/storage"
 import { createTestSixb } from "../src/testing"
+import { WorkflowRunDispatcher } from "../src/workflows/run-dispatch"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
 const Transaction = defineObjectType({
@@ -76,9 +78,23 @@ describe("sixb.workflows.request", () => {
     })
     expect(run?.status).toBe("queued")
     expect(run?.workflowId).toBe("draft-invoice")
-    expect(run?.requestedByPrincipal).toEqual({ type: "system", id: "system" })
     expect(run?.input).toEqual({
       transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+    })
+    const execution = run
+      ? await host.storage.executions.getById({
+          projectId: sixb.execution.projectId,
+          id: run.executionId,
+        })
+      : null
+    expect(execution).toMatchObject({
+      executor: { type: "primitive", kind: "workflow", runId: result.runId },
+      source: { type: "execution", executionId: sixb.execution.id },
+      parentExecutionId: sixb.execution.id,
+      authorizationRef: {
+        type: "trustedPrimitive",
+        primitive: { kind: "workflow", id: "draft-invoice", runId: result.runId },
+      },
     })
 
     const jobs = await claimAll(host)
@@ -132,6 +148,51 @@ describe("sixb.workflows.request", () => {
     expect(reports).toEqual([
       `project:workflow-enqueue-failure:run:workflow:run_enqueue_failure:failed:${run?.finishedAt?.toISOString()}:workflow queue unavailable`,
     ])
+  })
+
+  test("rolls back the workflow execution when run persistence fails", async () => {
+    const { host, sixb } = createSixb()
+    const executions = host.storage.executions
+    const workflowRuns = host.storage.workflowRuns!
+    const transaction = host.storage.transaction.bind(host.storage)
+    let childExecutionId: string | undefined
+    host.storage.transaction = (run, options) => {
+      return transaction(async (tx) => {
+        await run(tx)
+        const queued = await tx.workflowRuns?.getById({
+          projectId: sixb.execution.projectId,
+          id: "run_storage_failure",
+        })
+        childExecutionId = queued?.executionId
+        throw new WorkflowRunError("workflow storage unavailable")
+      }, options)
+    }
+
+    await expect(
+      sixb.workflows.request(draftInvoice, {
+        runId: "run_storage_failure",
+        input: validInput(),
+      })
+    ).rejects.toThrow("workflow storage unavailable")
+
+    expect(childExecutionId).toBeDefined()
+    expect(
+      await executions.getById({ projectId: sixb.execution.projectId, id: sixb.execution.id })
+    ).not.toBeNull()
+    expect(
+      childExecutionId
+        ? await executions.getById({
+            projectId: sixb.execution.projectId,
+            id: childExecutionId,
+          })
+        : null
+    ).toBeNull()
+    expect(
+      await workflowRuns.getById({
+        projectId: sixb.execution.projectId,
+        id: "run_storage_failure",
+      })
+    ).toBeNull()
   })
 
   test("requestById rejects unknown input fields at runtime", async () => {
@@ -199,11 +260,11 @@ describe("sixb.workflows.request", () => {
         runId: "run_shared",
         input: validInput(),
       })
-    ).rejects.toThrow("already exists for a different workflow")
+    ).rejects.toThrow("already exists with a different request payload")
   })
 
-  test("persists and emits the run source", async () => {
-    const { host, sixb } = createSixb()
+  test("emits the request source without duplicating it on the run", async () => {
+    const { sixb } = createSixb()
     const source = {
       type: "webhook" as const,
       connectorId: "companycam",
@@ -211,13 +272,7 @@ describe("sixb.workflows.request", () => {
       deliveryId: "delivery-1",
     }
 
-    const result = await sixb.workflows.request(draftInvoice, { input: validInput(), source })
-
-    const run = await host.storage.workflowRuns?.getById({
-      projectId: sixb.execution.projectId,
-      id: result.runId,
-    })
-    expect(run?.source).toEqual(source)
+    await sixb.workflows.request(draftInvoice, { input: validInput(), source })
 
     const events = await sixb.events.read({ types: ["workflow.run.queued"] })
     expect(events[0]?.payload).toMatchObject({ source })
@@ -254,5 +309,84 @@ describe("sixb.workflows.request", () => {
     await expect(sixb.workflows.request(draftInvoice, { input: validInput() })).rejects.toThrow(
       "[Sixb] Workflow run storage is not configured."
     )
+  })
+})
+
+describe("automatic workflow dispatch", () => {
+  test("persists an honest root execution before publishing the queue job", async () => {
+    const { host } = createSixb()
+    const dispatcher = new WorkflowRunDispatcher(host)
+
+    const result = await dispatcher.dispatch({
+      workflowId: draftInvoice.id,
+      runId: "workflow:draft-invoice:schedule:daily:event:event-1",
+      input: validInput(),
+      scheduleId: "daily",
+      source: { type: "schedule", eventId: "event-1" },
+      correlationId: "correlation-1",
+      metadata: { sourceEventId: "event-1" },
+    })
+
+    const run = await host.storage.workflowRuns?.getById({
+      projectId: host.id,
+      id: result.runId,
+    })
+    const execution = run
+      ? await host.storage.executions.getById({ projectId: host.id, id: run.executionId })
+      : null
+    expect(execution).toMatchObject({
+      projectId: host.id,
+      executor: { type: "primitive", kind: "workflow", runId: result.runId },
+      source: { type: "schedule", eventId: "event-1" },
+      correlationId: "correlation-1",
+      authorizationRef: {
+        type: "trustedPrimitive",
+        primitive: { kind: "workflow", id: draftInvoice.id, runId: result.runId },
+      },
+    })
+    expect(execution?.parentExecutionId).toBeUndefined()
+    expect(execution?.requestedBy).toBeUndefined()
+
+    const [claimed] = await claimAll(host)
+    expect(claimed?.job).toMatchObject({
+      id: result.runId,
+      payload: { workflowId: draftInvoice.id, runId: result.runId, input: validInput() },
+      metadata: { sourceEventId: "event-1" },
+    })
+    const [queuedEvent] = await host.events.read({ types: ["workflow.run.queued"] })
+    expect(
+      queuedEvent && "correlationId" in queuedEvent ? queuedEvent.correlationId : undefined
+    ).toBe("correlation-1")
+  })
+
+  test("uses event provenance for event-based schedules and deduplicates replay", async () => {
+    const { host } = createSixb()
+    const dispatcher = new WorkflowRunDispatcher(host)
+    const input = {
+      workflowId: draftInvoice.id,
+      runId: "workflow:draft-invoice:schedule:on-update:event:event-2",
+      input: validInput(),
+      scheduleId: "on-update",
+      source: { type: "event" as const, eventId: "event-2" },
+      correlationId: "upstream-correlation",
+    }
+
+    const first = await dispatcher.dispatch(input)
+    const second = await dispatcher.dispatch(input)
+
+    expect(first.created).toBe(true)
+    expect(second.created).toBe(false)
+    const run = await host.storage.workflowRuns?.getById({ projectId: host.id, id: input.runId })
+    const execution = run
+      ? await host.storage.executions.getById({ projectId: host.id, id: run.executionId })
+      : null
+    expect(execution).toMatchObject({
+      source: { type: "event", eventId: "event-2" },
+      correlationId: "upstream-correlation",
+    })
+    expect(await claimAll(host)).toHaveLength(1)
+    await expect(
+      dispatcher.dispatch({ ...input, correlationId: "different-correlation" })
+    ).rejects.toThrow("already exists with different automatic provenance")
   })
 })

--- a/packages/core/tests/workflow-runs.test.ts
+++ b/packages/core/tests/workflow-runs.test.ts
@@ -1,10 +1,62 @@
 import { describe, expect, test } from "bun:test"
 import { InMemoryStorage } from "../src"
-import { InMemoryWorkflowRunStorage, WorkflowRunError } from "../src/storage"
+import {
+  InMemoryWorkflowRunStorage,
+  type QueueWorkflowRunInput,
+  type StartWorkflowRunInput,
+  WorkflowRunError,
+} from "../src/storage"
+import { createTestAutomaticWorkflowExecution, createTestWorkflowExecution } from "../src/testing"
+
+type TestQueueWorkflowRunInput = Omit<QueueWorkflowRunInput, "executionId"> & {
+  readonly executionId?: string
+}
+
+type TestStartWorkflowRunInput = StartWorkflowRunInput & {
+  readonly workflowId?: string
+  readonly input?: QueueWorkflowRunInput["input"]
+}
+
+function createWorkflowRunStorage() {
+  const root = new InMemoryStorage()
+  const storage = root.workflowRuns!
+  const queue = storage.queue.bind(storage)
+  const start = storage.start.bind(storage)
+  const queueFixture = async (input: TestQueueWorkflowRunInput) => {
+    const executionId = await createTestWorkflowExecution(root.executions, {
+      projectId: input.projectId,
+      workflowId: input.workflowId,
+      runId: input.id,
+      ...(input.executionId === undefined ? {} : { executionId: input.executionId }),
+    })
+    return queue({ ...input, executionId })
+  }
+
+  return Object.assign(storage, {
+    queue: queueFixture,
+    start: async (input: TestStartWorkflowRunInput) => {
+      const existing = await storage.getById({ projectId: input.projectId, id: input.id })
+      if (!existing && input.workflowId && input.input) {
+        await queueFixture({
+          id: input.id,
+          projectId: input.projectId,
+          workflowId: input.workflowId,
+          input: input.input,
+        })
+      }
+      return start({
+        id: input.id,
+        projectId: input.projectId,
+        ...(input.startedAt === undefined ? {} : { startedAt: input.startedAt }),
+        ...(input.execution === undefined ? {} : { execution: input.execution }),
+      })
+    },
+  })
+}
 
 describe("InMemoryWorkflowRunStorage", () => {
   test("starts and finishes a successful workflow run", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
     const startedAt = new Date("2026-05-08T10:00:00.000Z")
     const finishedAt = new Date("2026-05-08T10:00:04.500Z")
 
@@ -43,69 +95,73 @@ describe("InMemoryWorkflowRunStorage", () => {
     expect(stored?.finishedAt?.toISOString()).toBe(finishedAt.toISOString())
   })
 
-  test("persists workflow run source when starting directly or from a queued run", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
-    const scheduleSource = {
-      type: "schedule",
-      scheduleId: "invoice-payment-linked",
-      eventId: "evt_1",
-      principal: { type: "system", id: "sixb-orchestrator" },
-    } as const
+  test("requires a queued run linked to its matching workflow execution", async () => {
+    const root = new InMemoryStorage()
+    const storage = root.workflowRuns!
 
-    const started = await storage.start({
-      id: "wf-run-triggered",
+    await expect(
+      storage.start({ id: "wf-run-missing", projectId: "my-app" })
+    ).rejects.toBeInstanceOf(WorkflowRunError)
+
+    await root.executions.create({
+      id: "orphan-workflow-execution",
       projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_123" },
-      source: scheduleSource,
+      executor: { type: "primitive", kind: "workflow", runId: "wf-run-orphan" },
+      source: { type: "http", requestId: "request-without-parent" },
+      correlationId: "orphan-correlation",
+      authorizationRef: {
+        type: "trustedPrimitive",
+        primitive: {
+          kind: "workflow",
+          id: "reconcile-transaction",
+          runId: "wf-run-orphan",
+        },
+      },
     })
-
-    expect(started.source).toEqual(scheduleSource)
-    expect(
-      await storage.getById({
+    await expect(
+      storage.queue({
+        id: "wf-run-orphan",
         projectId: "my-app",
-        id: "wf-run-triggered",
+        executionId: "orphan-workflow-execution",
+        workflowId: "reconcile-transaction",
+        input: {},
       })
-    ).toMatchObject({ source: scheduleSource })
+    ).rejects.toBeInstanceOf(WorkflowRunError)
 
-    await storage.queue({
-      id: "wf-run-queued-without-source",
+    const executionId = await createTestWorkflowExecution(root.executions, {
+      projectId: "my-app",
+      workflowId: "other-workflow",
+      runId: "wf-run-mismatched",
+    })
+    await expect(
+      storage.queue({
+        id: "wf-run-mismatched",
+        projectId: "my-app",
+        executionId,
+        workflowId: "reconcile-transaction",
+        input: {},
+      })
+    ).rejects.toBeInstanceOf(WorkflowRunError)
+
+    const automaticExecutionId = await createTestAutomaticWorkflowExecution(root.executions, {
       projectId: "my-app",
       workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_456" },
+      runId: "wf-run-automatic",
+      source: { type: "schedule", eventId: "schedule-event-1" },
     })
-
-    const running = await storage.start({
-      id: "wf-run-queued-without-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_456" },
-      source: scheduleSource,
-    })
-
-    expect(running.source).toEqual(scheduleSource)
-
-    await storage.queue({
-      id: "wf-run-queued-with-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_789" },
-      source: { type: "manual" },
-    })
-
-    const alreadySourced = await storage.start({
-      id: "wf-run-queued-with-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_789" },
-      source: scheduleSource,
-    })
-
-    expect(alreadySourced.source).toEqual({ type: "manual" })
+    await expect(
+      storage.queue({
+        id: "wf-run-automatic",
+        projectId: "my-app",
+        executionId: automaticExecutionId,
+        workflowId: "reconcile-transaction",
+        input: {},
+      })
+    ).resolves.toMatchObject({ id: "wf-run-automatic", executionId: automaticExecutionId })
   })
 
   test("allows exactly one concurrent claim of a queued workflow run", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
     await storage.queue({
       id: "wf-run-claim",
       projectId: "my-app",
@@ -133,7 +189,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("queues workflow runs before transitioning them to running", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
     const queuedAt = new Date("2026-05-08T09:59:00.000Z")
     const startedAt = new Date("2026-05-08T10:00:00.000Z")
 
@@ -179,7 +235,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("waits and resumes workflow and node runs", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
 
     await storage.start({
       id: "wf-run-waiting",
@@ -261,7 +317,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("stores failed workflow runs and lists with filters, ordering, and paging", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
 
     await storage.start({
       id: "run-1",
@@ -331,7 +387,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("lists the latest run for multiple workflow ids", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
 
     await storage.start({
       id: "run-reconcile-a",
@@ -371,7 +427,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("starts and finishes node runs with pinned input and output", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
 
     await storage.start({
       id: "wf-run-1",
@@ -426,7 +482,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("stores failed node runs and lists with filters, ordering, and paging", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
 
     await storage.start({
       id: "wf-run-1",
@@ -508,7 +564,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("rejects invalid workflow and node run lifecycle transitions", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
 
     await storage.start({
       id: "wf-run-1",
@@ -656,7 +712,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("fences stale workflow deliveries after reclaim", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
     await storage.start({
       id: "wf-run-unowned",
       projectId: "my-app",
@@ -723,7 +779,7 @@ describe("InMemoryWorkflowRunStorage", () => {
   })
 
   test("persists and cancels agent node execution metadata independently from node IO", async () => {
-    const storage = new InMemoryWorkflowRunStorage()
+    const storage = createWorkflowRunStorage()
     await storage.start({
       id: "wf-run-agent",
       projectId: "my-app",

--- a/packages/orchestrator/README.md
+++ b/packages/orchestrator/README.md
@@ -7,7 +7,7 @@ Bridges runtime events to queue lanes and durably reconciles projection dispatch
 Schedule, sync, pipeline, and workflow routes consume runtime events. Their delivery guarantee follows
 the event source and route-specific retry policy.
 
-Projection dispatch has two paths:
+Workflow routes use a Core-owned dispatch port that persists the workflow execution and run before publishing the queue job. Projection dispatch has two paths:
 
 ```text
 dataset.version.committed -> immediate deterministic job
@@ -22,10 +22,11 @@ completion; queue-level IDs deduplicate concurrent dispatches.
 When `cohostWorkers` is enabled, `sixb dev` automatically compiles routes from registered syncs,
 pipelines, and projections, starts the orchestrator, co-hosts available workers, and starts the scheduler. No manual wiring is needed.
 
-Custom framework hosts with projection routes must also provide the narrow reconciliation ports:
+Custom framework hosts must provide the narrow durable ports used by their compiled routes:
 
 ```ts
 import { getProjectionDispatchDescriptors } from "@sixb/core/internal/projections"
+import { WorkflowRunDispatcher } from "@sixb/core/internal/workflows"
 import { compileRoutesWithDiagnostics, OrchestratorWorker } from "@sixb/orchestrator"
 
 const projectionDispatchDescriptors = getProjectionDispatchDescriptors(sixb)
@@ -34,6 +35,7 @@ const { routes } = compileRoutesWithDiagnostics({
   syncs: sixb.definitions.syncs.list(),
   pipelines: sixb.definitions.pipelines.list(),
   projections: projectionDispatchDescriptors,
+  workflows: sixb.definitions.workflows.list(),
 })
 
 const worker = new OrchestratorWorker({
@@ -41,6 +43,9 @@ const worker = new OrchestratorWorker({
   events: sixb.events,
   queues: sixb.queues,
   routes,
+  dispatchers: {
+    workflows: new WorkflowRunDispatcher(sixb),
+  },
   projectionDispatch: {
     lakeStorage: sixb.lakeStorage,
     projectionRuns: sixb.storage.projectionRuns,

--- a/packages/orchestrator/src/index.ts
+++ b/packages/orchestrator/src/index.ts
@@ -3,7 +3,10 @@ export type {
   CompileRoutesDiagnostic,
   CompileRoutesParams,
   CompileRoutesResult,
+  OrchestratorDispatchers,
   OrchestratorRoutes,
   OrchestratorRuntimeOptions,
+  WorkflowDispatcherPort,
+  WorkflowDispatchInput,
 } from "./types"
 export { OrchestratorWorker } from "./worker"

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -22,7 +22,6 @@ import type {
   PipelineRunRequestedQueueJob,
   ProjectionRunRequestedQueueJob,
   SyncRunRequestedQueueJob,
-  WorkflowRunRequestedQueueJob,
 } from "@sixb/core/queues"
 import type { ProjectionRunStorage } from "@sixb/core/storage"
 
@@ -45,11 +44,19 @@ export interface ProjectionRunRequestedJobTemplate {
   readonly payload: ProjectionDispatchDescriptor
 }
 
+export interface WorkflowRunDispatchJobTemplate {
+  readonly type: "workflow.run.requested"
+  readonly payload: {
+    readonly workflowId: string
+    readonly input?: Readonly<Record<string, unknown>>
+  }
+}
+
 export type OrchestratorJob =
   | { readonly queue: "syncRuns"; readonly job: NewQueueJob<SyncRunRequestedQueueJob> }
   | { readonly queue: "pipelines"; readonly job: NewQueueJob<PipelineRunRequestedQueueJob> }
   | { readonly queue: "projections"; readonly job: ProjectionRunRequestedJobTemplate }
-  | { readonly queue: "workflows"; readonly job: NewQueueJob<WorkflowRunRequestedQueueJob> }
+  | { readonly queue: "workflows"; readonly job: WorkflowRunDispatchJobTemplate }
 
 export type OrchestratorEventScheduleTarget =
   | { readonly queue: "syncRuns"; readonly syncId: string }

--- a/packages/orchestrator/src/types.ts
+++ b/packages/orchestrator/src/types.ts
@@ -12,6 +12,10 @@ import type {
 } from "@sixb/core"
 import type { ProjectionDispatchDescriptor } from "@sixb/core/internal/projections"
 import type { RuntimeEventScheduleDefinition } from "@sixb/core/internal/schedules"
+import type {
+  AutomaticWorkflowRunDispatchInput,
+  WorkflowRunDispatchPort,
+} from "@sixb/core/internal/workflows"
 import type { LakeStorage } from "@sixb/core/lake-storage"
 import type {
   NewQueueJob,
@@ -103,11 +107,20 @@ export interface ProjectionDispatchPorts {
   readonly projectionRuns: Pick<ProjectionRunStorage, "getById">
 }
 
+export type WorkflowDispatchInput = AutomaticWorkflowRunDispatchInput
+export type WorkflowDispatcherPort = WorkflowRunDispatchPort
+
+export interface OrchestratorDispatchers {
+  /** Required when the compiled routes contain automatic workflow triggers. */
+  readonly workflows?: WorkflowDispatcherPort
+}
+
 export interface OrchestratorRuntimeOptions {
   readonly projectId: string
   readonly events: DomainEventLog
   readonly queues: Queues
   readonly routes: OrchestratorRoutes
+  readonly dispatchers: OrchestratorDispatchers
   /** Required when the compiled routes contain projections. */
   readonly projectionDispatch?: ProjectionDispatchPorts
 }

--- a/packages/orchestrator/src/worker.ts
+++ b/packages/orchestrator/src/worker.ts
@@ -1,5 +1,4 @@
 import type { DomainEvent } from "@sixb/core"
-import { SYSTEM_PRINCIPAL } from "@sixb/core"
 import type { StoredDomainEvent } from "@sixb/core/internal/events"
 import type { ProjectionDispatchDescriptor } from "@sixb/core/internal/projections"
 import { evaluateEventSchedule } from "@sixb/core/internal/schedules"
@@ -9,6 +8,7 @@ import { runProjectionDispatchReconciler } from "./projection-dispatch-reconcile
 import { buildProjectionJob } from "./projection-job"
 import { routeKeysForEvent } from "./route-key"
 import type {
+  OrchestratorDispatchers,
   OrchestratorEventScheduleBinding,
   OrchestratorEventScheduleTarget,
   OrchestratorJob,
@@ -35,6 +35,7 @@ export class OrchestratorWorker extends Worker {
         "Projection routes require lake and projection-run storage for durable dispatch."
       )
     }
+    if (hasWorkflowRoutes(options.routes)) requireDispatcher(options.dispatchers, "workflows")
   }
 
   protected async run(signal: AbortSignal): Promise<void> {
@@ -283,29 +284,25 @@ async function enqueueDirectJob(
       return
     }
     case "workflows": {
-      const scheduleSource = workflowScheduleSource(sourceEvent)
-      await options.queues.workflows.enqueue({
-        projectId: options.projectId,
-        jobs: [
-          {
-            ...item.job,
-            payload: {
-              ...item.job.payload,
-              ...(scheduleSource
-                ? {
-                    runId: scheduleConsumerRunId(
-                      "workflow",
-                      item.job.payload.workflowId,
-                      scheduleSource.scheduleId,
-                      sourceEvent.id
-                    ),
-                    source: scheduleSource,
-                  }
-                : {}),
-            },
-            metadata,
-          },
-        ],
+      if (sourceEvent.type !== "schedule.triggered") {
+        throw new OrchestratorError(
+          `Direct workflow route received unsupported event '${sourceEvent.type}'.`
+        )
+      }
+      const scheduleId = sourceEvent.payload.scheduleId
+      await requireDispatcher(options.dispatchers, "workflows").dispatch({
+        workflowId: item.job.payload.workflowId,
+        runId: scheduleConsumerRunId(
+          "workflow",
+          item.job.payload.workflowId,
+          scheduleId,
+          sourceEvent.id
+        ),
+        input: item.job.payload.input,
+        scheduleId,
+        source: { type: "schedule", eventId: sourceEvent.id },
+        correlationId: correlationIdForEvent(sourceEvent),
+        metadata,
       })
       return
     }
@@ -363,30 +360,14 @@ async function enqueueEventScheduleTarget(
           `Workflow '${target.workflowId}' schedule mapper must return an input object.`
         )
       }
-      await options.queues.workflows.enqueue({
-        projectId: options.projectId,
-        jobs: [
-          {
-            type: "workflow.run.requested",
-            payload: {
-              workflowId: target.workflowId,
-              runId: scheduleConsumerRunId(
-                "workflow",
-                target.workflowId,
-                scheduleId,
-                sourceEvent.id
-              ),
-              input,
-              source: {
-                type: "schedule",
-                scheduleId,
-                eventId: sourceEvent.id,
-                principal: SYSTEM_PRINCIPAL,
-              },
-            },
-            metadata,
-          },
-        ],
+      await requireDispatcher(options.dispatchers, "workflows").dispatch({
+        workflowId: target.workflowId,
+        runId: scheduleConsumerRunId("workflow", target.workflowId, scheduleId, sourceEvent.id),
+        input,
+        scheduleId,
+        source: { type: "event", eventId: sourceEvent.id },
+        correlationId: correlationIdForEvent(sourceEvent),
+        metadata,
       })
       return
     }
@@ -422,16 +403,6 @@ function withPipelineScheduleRunId(
       sourceEvent.payload.scheduleId,
       sourceEvent.id
     ),
-  }
-}
-
-function workflowScheduleSource(sourceEvent: StoredDomainEvent) {
-  if (sourceEvent.type !== "schedule.triggered") return null
-  return {
-    type: "schedule" as const,
-    scheduleId: sourceEvent.payload.scheduleId,
-    eventId: sourceEvent.id,
-    principal: SYSTEM_PRINCIPAL,
   }
 }
 
@@ -486,6 +457,17 @@ function buildMetadata(event: StoredDomainEvent): Record<string, string> {
   }
 }
 
+function correlationIdForEvent(event: StoredDomainEvent): string {
+  if (
+    "correlationId" in event &&
+    typeof event.correlationId === "string" &&
+    event.correlationId.trim()
+  ) {
+    return event.correlationId
+  }
+  return event.id
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -509,6 +491,31 @@ function projectionDescriptors(
   return [...descriptors.values()].sort((left, right) =>
     left.projectionId.localeCompare(right.projectionId)
   )
+}
+
+function hasWorkflowRoutes(routes: OrchestratorRoutes): boolean {
+  for (const route of routes.values()) {
+    if (route.jobs.some((item) => item.queue === "workflows")) return true
+    if (
+      route.eventSchedules?.some((binding) =>
+        binding.targets.some((target) => target.queue === "workflows")
+      )
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+function requireDispatcher<TKey extends keyof OrchestratorDispatchers>(
+  dispatchers: OrchestratorDispatchers,
+  key: TKey
+): NonNullable<OrchestratorDispatchers[TKey]> {
+  const dispatcher = dispatchers[key]
+  if (!dispatcher) {
+    throw new OrchestratorError(`Routes require the '${key}' dispatcher.`)
+  }
+  return dispatcher
 }
 
 function projectionDescriptorsEqual(

--- a/packages/orchestrator/tests/worker.test.ts
+++ b/packages/orchestrator/tests/worker.test.ts
@@ -195,11 +195,7 @@ function createTestWorkflowRunDispatcher(
           {
             id: input.runId,
             type: "workflow.run.requested",
-            payload: {
-              workflowId: input.workflowId,
-              runId: input.runId,
-              input: input.input,
-            },
+            payload: { runId: input.runId },
             metadata: input.metadata,
           },
         ],
@@ -284,13 +280,12 @@ describe("OrchestratorWorker", () => {
         `sync:${sync.id}:schedule:${daily.id}:event:${sourceEvent!.id}`
       )
       expect(workflowJobs[0]!.job.payload).toEqual({
-        workflowId: workflow.id,
         runId: `workflow:${workflow.id}:schedule:${daily.id}:event:${sourceEvent!.id}`,
-        input: {},
       })
       expect(dispatches).toEqual([
         expect.objectContaining({
           workflowId: workflow.id,
+          input: {},
           scheduleId: daily.id,
           source: { type: "schedule", eventId: sourceEvent!.id },
           correlationId: sourceEvent!.id,
@@ -325,13 +320,12 @@ describe("OrchestratorWorker", () => {
       const claimed = await queues.workflows.claim({ projectId: PROJECT_ID, workerId: "edge" })
       if (claimed.length === 0) return false
       expect(claimed[0]!.job.payload).toEqual({
-        workflowId: highValueInvoiceWorkflow.id,
         runId: `workflow:${highValueInvoiceWorkflow.id}:schedule:${highValueInvoice.id}:event:${sourceEvent!.id}`,
-        input: { invoiceId: "inv-1", amount: 700 },
       })
       expect(dispatches).toEqual([
         expect.objectContaining({
           workflowId: highValueInvoiceWorkflow.id,
+          input: { invoiceId: "inv-1", amount: 700 },
           scheduleId: highValueInvoice.id,
           source: { type: "event", eventId: sourceEvent!.id },
           correlationId: sourceEvent!.id,

--- a/packages/orchestrator/tests/worker.test.ts
+++ b/packages/orchestrator/tests/worker.test.ts
@@ -16,7 +16,6 @@ import {
   InMemoryLakeStorage,
   InMemoryQueues,
   prop,
-  SYSTEM_PRINCIPAL,
 } from "@sixb/core"
 import {
   DomainEventService,
@@ -31,7 +30,12 @@ import type { DatasetVersion } from "@sixb/core/lake-storage"
 import { InMemoryProjectionRunStorage } from "@sixb/core/storage"
 import { compileRoutes } from "../src/compile-routes"
 import { reconcileProjectionDispatch } from "../src/projection-dispatch-reconciler"
-import type { OrchestratorRoutes, OrchestratorRuntimeOptions } from "../src/types"
+import type {
+  OrchestratorRoutes,
+  OrchestratorRuntimeOptions,
+  WorkflowDispatcherPort,
+  WorkflowDispatchInput,
+} from "../src/types"
 import { OrchestratorWorker } from "../src/worker"
 
 const PROJECT_ID = "test-project"
@@ -161,18 +165,54 @@ async function startWorker(
   queues: InMemoryQueues,
   routes: OrchestratorRoutes,
   projectId = PROJECT_ID,
-  projectionDispatch?: OrchestratorRuntimeOptions["projectionDispatch"]
+  projectionDispatch?: OrchestratorRuntimeOptions["projectionDispatch"],
+  workflowDispatcher = createTestWorkflowRunDispatcher(queues, undefined, projectId)
 ): Promise<OrchestratorWorker> {
   const worker = new OrchestratorWorker({
     projectId,
     events: eventRuntime,
     queues,
     routes,
+    dispatchers: { workflows: workflowDispatcher },
     ...(projectionDispatch === undefined ? {} : { projectionDispatch }),
   })
   workers.push(worker)
   await worker.start()
   return worker
+}
+
+function createTestWorkflowRunDispatcher(
+  queues: InMemoryQueues,
+  calls?: WorkflowDispatchInput[],
+  projectId = PROJECT_ID
+): WorkflowDispatcherPort {
+  return {
+    async dispatch(input) {
+      calls?.push(structuredClone(input))
+      const [job] = await queues.workflows.enqueue({
+        projectId,
+        jobs: [
+          {
+            id: input.runId,
+            type: "workflow.run.requested",
+            payload: {
+              workflowId: input.workflowId,
+              runId: input.runId,
+              input: input.input,
+            },
+            metadata: input.metadata,
+          },
+        ],
+      })
+      return {
+        workflowId: input.workflowId,
+        runId: input.runId,
+        queuedAt: job!.createdAt,
+        jobId: job!.id,
+        created: true,
+      }
+    },
+  }
 }
 
 function invoiceProjectionDescriptor(
@@ -218,7 +258,15 @@ describe("OrchestratorWorker", () => {
     })
     const eventRuntime = createEvents()
     const queues = new InMemoryQueues()
-    await startWorker(eventRuntime, queues, routes)
+    const dispatches: WorkflowDispatchInput[] = []
+    await startWorker(
+      eventRuntime,
+      queues,
+      routes,
+      PROJECT_ID,
+      undefined,
+      createTestWorkflowRunDispatcher(queues, dispatches)
+    )
 
     const [sourceEvent] = await eventRuntime.append({
       events: [makeScheduleTriggeredEvent(daily.id)],
@@ -239,13 +287,15 @@ describe("OrchestratorWorker", () => {
         workflowId: workflow.id,
         runId: `workflow:${workflow.id}:schedule:${daily.id}:event:${sourceEvent!.id}`,
         input: {},
-        source: {
-          type: "schedule",
-          scheduleId: daily.id,
-          eventId: sourceEvent!.id,
-          principal: SYSTEM_PRINCIPAL,
-        },
       })
+      expect(dispatches).toEqual([
+        expect.objectContaining({
+          workflowId: workflow.id,
+          scheduleId: daily.id,
+          source: { type: "schedule", eventId: sourceEvent!.id },
+          correlationId: sourceEvent!.id,
+        }),
+      ])
       return true
     })
   })
@@ -253,7 +303,15 @@ describe("OrchestratorWorker", () => {
   test("event schedule fires only on a false-to-true transition and maps { event }", async () => {
     const eventRuntime = createEvents()
     const queues = new InMemoryQueues()
-    await startWorker(eventRuntime, queues, eventWorkflowRoutes())
+    const dispatches: WorkflowDispatchInput[] = []
+    await startWorker(
+      eventRuntime,
+      queues,
+      eventWorkflowRoutes(),
+      PROJECT_ID,
+      undefined,
+      createTestWorkflowRunDispatcher(queues, dispatches)
+    )
 
     await eventRuntime.publishEnvelopes([makeInvoiceUpdatedEvent(600, 700)])
     await Bun.sleep(50)
@@ -270,13 +328,15 @@ describe("OrchestratorWorker", () => {
         workflowId: highValueInvoiceWorkflow.id,
         runId: `workflow:${highValueInvoiceWorkflow.id}:schedule:${highValueInvoice.id}:event:${sourceEvent!.id}`,
         input: { invoiceId: "inv-1", amount: 700 },
-        source: {
-          type: "schedule",
-          scheduleId: highValueInvoice.id,
-          eventId: sourceEvent!.id,
-          principal: SYSTEM_PRINCIPAL,
-        },
       })
+      expect(dispatches).toEqual([
+        expect.objectContaining({
+          workflowId: highValueInvoiceWorkflow.id,
+          scheduleId: highValueInvoice.id,
+          source: { type: "event", eventId: sourceEvent!.id },
+          correlationId: sourceEvent!.id,
+        }),
+      ])
       return true
     })
   })
@@ -397,7 +457,15 @@ describe("OrchestratorWorker", () => {
     })
     const eventRuntime = createEvents()
     const queues = new InMemoryQueues()
-    await startWorker(eventRuntime, queues, routes)
+    const dispatches: WorkflowDispatchInput[] = []
+    await startWorker(
+      eventRuntime,
+      queues,
+      routes,
+      PROJECT_ID,
+      undefined,
+      createTestWorkflowRunDispatcher(queues, dispatches)
+    )
 
     await eventRuntime.append({
       events: [
@@ -413,6 +481,7 @@ describe("OrchestratorWorker", () => {
     ).toHaveLength(0)
 
     await eventRuntime.append({
+      correlationId: "upstream-correlation",
       events: [
         {
           type: "sync.run.finished",
@@ -424,6 +493,8 @@ describe("OrchestratorWorker", () => {
       const claimed = await queues.workflows.claim({ projectId: PROJECT_ID, workerId: "ok" })
       return claimed.length === 1
     })
+    expect(dispatches).toHaveLength(1)
+    expect(dispatches[0]?.correlationId).toBe("upstream-correlation")
   })
 
   test("dataset commits inject the version into direct projection jobs", async () => {
@@ -732,7 +803,21 @@ describe("OrchestratorWorker", () => {
           events: createEvents(),
           queues: new InMemoryQueues(),
           routes: new Map(),
+          dispatchers: {},
         })
     ).toThrow("[SixbOrchestrator] projectId is required.")
+  })
+
+  test("requires durable Core dispatch for workflow routes", () => {
+    expect(
+      () =>
+        new OrchestratorWorker({
+          projectId: PROJECT_ID,
+          events: createEvents(),
+          queues: new InMemoryQueues(),
+          routes: eventWorkflowRoutes(),
+          dispatchers: {},
+        })
+    ).toThrow("[SixbOrchestrator] Routes require the 'workflows' dispatcher.")
   })
 })

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -6,7 +6,7 @@ import {
   type WorkflowDefinition,
 } from "@sixb/core"
 import { publishAgentRunCancel } from "@sixb/core/internal/agents"
-import type { Sixb } from "@sixb/core/internal/request-execution"
+import type { Sixb, WorkflowRunView } from "@sixb/core/internal/request-execution"
 import {
   snapshotWorkflowInterventionResponse,
   type WorkflowInterventionNodeDefinition,
@@ -85,7 +85,7 @@ const WorkflowNodeFileContentParamsSchema = WorkflowRunParamsSchema.extend({
   nodeKey: z.string().min(1),
 })
 
-function serializeWorkflowRunSummary(run: WorkflowRunRecord) {
+function serializeWorkflowRunSummary(run: WorkflowRunView) {
   return {
     id: run.id,
     projectId: run.projectId,
@@ -95,11 +95,11 @@ function serializeWorkflowRunSummary(run: WorkflowRunRecord) {
     startedAt: toIsoString(run.startedAt),
     finishedAt: run.finishedAt ? toIsoString(run.finishedAt) : undefined,
     error: run.error,
-    requestedBy: serializePrincipal(run.requestedByPrincipal),
+    requestedBy: serializePrincipal(run.requestedBy ?? SYSTEM_PRINCIPAL),
   }
 }
 
-function serializeWorkflowRunDetail(run: WorkflowRunRecord) {
+function serializeWorkflowRunDetail(run: WorkflowRunView) {
   return {
     ...serializeWorkflowRunSummary(run),
     input: run.input,
@@ -1146,7 +1146,10 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
             order: "asc",
           })
           return CancelWorkflowRunResponseSchema.parse({
-            run: serializeWorkflowRunDetail(result.run),
+            run: serializeWorkflowRunDetail({
+              ...result.run,
+              ...(existing.requestedBy === undefined ? {} : { requestedBy: existing.requestedBy }),
+            }),
             nodes: await Promise.all(
               nodes.nodes.map((node) => serializeWorkflowNodeWithExecution(storage, node))
             ),

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -709,7 +709,6 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
               {
                 type: "workflow.run.resume.requested",
                 payload: {
-                  workflowId: submitted.workflowId,
                   runId: submitted.workflowRunId,
                   resume: { kind: "intervention", interventionId: submitted.id },
                 },

--- a/packages/server/tests/agent-api-gateway.test.ts
+++ b/packages/server/tests/agent-api-gateway.test.ts
@@ -22,7 +22,7 @@ import {
   createAgentApiGatewayCapability,
   createAgentRunExecutionToken,
 } from "@sixb/core/internal/agents"
-import { createTestSixb } from "@sixb/core/testing"
+import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
 
@@ -394,11 +394,22 @@ async function createGatewayRuntime(
     fileName: "workflow-result.txt",
     mediaType: "text/plain",
   })
+  const completedWorkflowExecutionId = await createTestWorkflowExecution(storage.executions, {
+    projectId: PROJECT_ID,
+    workflowId: inspectDevices.id,
+    runId: "completed-workflow-run",
+  })
+  await storage.workflowRuns.queue({
+    id: "completed-workflow-run",
+    projectId: PROJECT_ID,
+    executionId: completedWorkflowExecutionId,
+    workflowId: inspectDevices.id,
+    input: { document: fileRefJson(completedWorkflowOutput) },
+    queuedAt: NOW,
+  })
   await storage.workflowRuns.start({
     id: "completed-workflow-run",
     projectId: PROJECT_ID,
-    workflowId: inspectDevices.id,
-    input: { document: fileRefJson(completedWorkflowOutput) },
     startedAt: NOW,
   })
   await storage.workflowRuns.nodes.start({
@@ -452,11 +463,22 @@ async function createGatewayRuntime(
     queueLeaseExpiresAt: options.queueLeaseExpiresAt ?? new Date(Date.now() + 60_000),
   }
   if (options.executionKind === "workflow") {
+    const parentWorkflowExecutionId = await createTestWorkflowExecution(storage.executions, {
+      projectId: PROJECT_ID,
+      workflowId: inspectDevices.id,
+      runId: "parent-workflow-run",
+    })
+    await storage.workflowRuns.queue({
+      id: "parent-workflow-run",
+      projectId: PROJECT_ID,
+      executionId: parentWorkflowExecutionId,
+      workflowId: inspectDevices.id,
+      input: {},
+      queuedAt: NOW,
+    })
     await storage.workflowRuns.start({
       id: "parent-workflow-run",
       projectId: PROJECT_ID,
-      workflowId: inspectDevices.id,
-      input: {},
       startedAt: NOW,
     })
     await storage.workflowRuns.nodes.start({

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -30,7 +30,7 @@ import {
   type WorkflowDefinition,
 } from "@sixb/core"
 import { createSessionCredential } from "@sixb/core/internal/auth"
-import { createTestSixb } from "@sixb/core/testing"
+import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
 
@@ -1393,9 +1393,15 @@ describe("authorized event and workflow routes", () => {
       })
     )
     const requested = (await request.json()) as { runId: string }
+    const hiddenExecutionId = await createTestWorkflowExecution(storage.executions, {
+      projectId: "test-project",
+      workflowId: "hidden-workflow",
+      runId: "wf_hidden",
+    })
     await storage.workflowRuns.queue({
       id: "wf_hidden",
       projectId: "test-project",
+      executionId: hiddenExecutionId,
       workflowId: "hidden-workflow",
       input: {},
       queuedAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -1433,7 +1439,12 @@ describe("authorized event and workflow routes", () => {
       new Request("http://localhost/api/workflow-runs?limit=1", { headers: runner.headers })
     )
     expect(await runnerRuns.json()).toMatchObject({
-      runs: [expect.objectContaining({ id: requested.runId })],
+      runs: [
+        expect.objectContaining({
+          id: requested.runId,
+          requestedBy: { principalType: "user", principalId: "usr_run" },
+        }),
+      ],
       hasMore: false,
       total: 1,
     })

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -1780,7 +1780,6 @@ describe("SixbServer HTTP contract", () => {
         metadata: undefined,
         type: "workflow.run.resume.requested",
         payload: {
-          workflowId: "review-device-health-workflow",
           runId: pending.workflowRunId,
           resume: { kind: "intervention", interventionId: pending.id },
         },
@@ -2272,11 +2271,7 @@ describe("SixbServer HTTP contract", () => {
         projectId: sixb.id,
         workerId: "contract-test",
       })
-      expect(queuedWorkflowRun?.job.payload).toEqual({
-        workflowId: "inspect-device-workflow",
-        runId: requestWorkflowRunBody.runId,
-        input: { deviceId: "fan-2" },
-      })
+      expect(queuedWorkflowRun?.job.payload).toEqual({ runId: requestWorkflowRunBody.runId })
 
       const workflowEvents = await events.read({
         topics: ["workflows"],

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -34,7 +34,7 @@ import {
   type Storage,
   type WorkflowDefinition,
 } from "@sixb/core"
-import { createTestSixb } from "@sixb/core/testing"
+import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
 import { SqliteStorage } from "@sixb/sqlite"
 import { SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
@@ -224,11 +224,22 @@ async function seedPendingReviewIntervention(
   const pendingInterventionId = `workflow-intervention-${suffix}`
   const stepOutput = { deviceId: "fan-1", healthy: true }
 
+  const workflowExecutionId = await createTestWorkflowExecution(sixb.storage.executions, {
+    projectId: sixb.id,
+    workflowId: "review-device-health-workflow",
+    runId,
+  })
+  await workflowRuns.queue({
+    id: runId,
+    projectId: sixb.id,
+    executionId: workflowExecutionId,
+    workflowId: "review-device-health-workflow",
+    input: { deviceId: "fan-1" },
+    queuedAt: new Date("2026-02-18T09:19:59.000Z"),
+  })
   await workflowRuns.start({
     id: runId,
     projectId: sixb.id,
-    workflowId: "review-device-health-workflow",
-    input: { deviceId: "fan-1" },
     startedAt: new Date("2026-02-18T09:20:00.000Z"),
   })
   await workflowRuns.nodes.start({
@@ -438,11 +449,22 @@ describe("SixbServer HTTP contract", () => {
       },
     })
 
+    const previousWorkflowExecutionId = await createTestWorkflowExecution(sixb.storage.executions, {
+      projectId: "contract-project",
+      workflowId: "inspect-device-workflow",
+      runId: "workflow-run-previous",
+    })
+    await sixb.storage.workflowRuns!.queue({
+      id: "workflow-run-previous",
+      projectId: "contract-project",
+      executionId: previousWorkflowExecutionId,
+      workflowId: "inspect-device-workflow",
+      input: { deviceId: "fan-1" },
+      queuedAt: new Date("2026-02-18T09:06:59.000Z"),
+    })
     await sixb.storage.workflowRuns!.start({
       id: "workflow-run-previous",
       projectId: "contract-project",
-      workflowId: "inspect-device-workflow",
-      input: { deviceId: "fan-1" },
       startedAt: new Date("2026-02-18T09:07:00.000Z"),
     })
     await sixb.storage.workflowRuns!.nodes.start({
@@ -1871,12 +1893,19 @@ describe("SixbServer HTTP contract", () => {
       const runs = sixb.storage.workflowRuns!
       const runId = "workflow-agent-observability"
       const nodeRunId = `${runId}:node:0`
-      await runs.start({
+      const workflowExecutionId = await createTestWorkflowExecution(sixb.storage.executions, {
+        projectId: sixb.id,
+        workflowId: "review-device-health-workflow",
+        runId,
+      })
+      await runs.queue({
         id: runId,
         projectId: sixb.id,
+        executionId: workflowExecutionId,
         workflowId: "review-device-health-workflow",
         input: { deviceId: "fan-1" },
       })
+      await runs.start({ id: runId, projectId: sixb.id })
       await runs.nodes.start({
         id: nodeRunId,
         projectId: sixb.id,

--- a/packages/server/tests/run-file-content-routes.test.ts
+++ b/packages/server/tests/run-file-content-routes.test.ts
@@ -18,7 +18,7 @@ import {
   SixbHost,
 } from "@sixb/core"
 import { createSessionCredential } from "@sixb/core/internal/auth"
-import { createTestSixb } from "@sixb/core/testing"
+import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
 
@@ -114,14 +114,25 @@ async function createRunFileApi(options: { readonly auth?: boolean } = {}) {
     completedAt: new Date("2026-06-30T12:00:45.000Z"),
   })
 
-  await storage.workflowRuns.start({
+  const workflowExecutionId = await createTestWorkflowExecution(storage.executions, {
+    projectId: sixb.id,
+    workflowId: inspectDocumentWorkflow.id,
+    runId: "workflow_run_1",
+  })
+  await storage.workflowRuns.queue({
     id: "workflow_run_1",
     projectId: sixb.id,
+    executionId: workflowExecutionId,
     workflowId: inspectDocumentWorkflow.id,
     input: {
       document: fileRefJson(workflowInput),
       title: "not a file",
     },
+    queuedAt: new Date("2026-06-30T12:00:59.000Z"),
+  })
+  await storage.workflowRuns.start({
+    id: "workflow_run_1",
+    projectId: sixb.id,
     startedAt: new Date("2026-06-30T12:01:00.000Z"),
   })
   await storage.workflowRuns.nodes.start({

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -477,10 +477,7 @@ export class WorkflowRunSession {
     if (this.dependencies.recorder.hasStarted) {
       return
     }
-    await this.dependencies.recorder.startRun({
-      input: this.dependencies.workflowInputSnapshot,
-      source: this.dependencies.job.source,
-    })
+    await this.dependencies.recorder.startRun()
   }
 
   async runAllNodes(): Promise<WorkflowRunRecord | null> {

--- a/packages/workflow-worker/src/recorder.ts
+++ b/packages/workflow-worker/src/recorder.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util"
-import type { WorkflowDefinition, WorkflowRunSource } from "@sixb/core"
+import type { WorkflowDefinition } from "@sixb/core"
 import type { WorkflowIOSnapshot } from "@sixb/core/internal/workflows"
 import type {
   WorkflowInterventionRecord,
@@ -60,16 +60,10 @@ export class WorkflowRunRecorder {
     return [...this.nodeRuns]
   }
 
-  async startRun(params: {
-    readonly input: WorkflowIOSnapshot
-    readonly source?: WorkflowRunSource
-  }): Promise<WorkflowRunRecord> {
+  async startRun(): Promise<WorkflowRunRecord> {
     const run = await this.dependencies.workflowRuns.start({
       projectId: this.dependencies.projectId,
       id: this.dependencies.runId,
-      workflowId: this.dependencies.workflow.id,
-      input: params.input,
-      source: params.source,
       execution: this.dependencies.execution,
     })
     this.started = true

--- a/packages/workflow-worker/src/types.ts
+++ b/packages/workflow-worker/src/types.ts
@@ -4,7 +4,6 @@ import type {
   Queues,
   Sixb,
   Storage,
-  WorkflowRunSource,
   WorkflowStepOutputs,
 } from "@sixb/core"
 import type { LoggingService } from "@sixb/core/internal/logging"
@@ -33,7 +32,6 @@ export interface WorkflowJob {
   readonly id: string
   readonly workflowId: string
   readonly input?: Readonly<Record<string, unknown>>
-  readonly source?: WorkflowRunSource
   readonly execution?: WorkflowRunExecution
 }
 

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -22,12 +22,7 @@ import type {
 } from "@sixb/core/storage"
 import { EventsRuntimeWorkflowRunObserver } from "./events"
 import { runWorkflowJob, runWorkflowResumeJob } from "./run-workflow-job"
-import type {
-  WorkflowJob,
-  WorkflowResumeJob,
-  WorkflowRunObserver,
-  WorkflowWorkerContext,
-} from "./types"
+import type { WorkflowRunObserver, WorkflowWorkerContext } from "./types"
 
 const MAX_WORKFLOW_DELIVERY_ATTEMPTS = 5
 const WORKFLOW_RETRY_BACKOFF_MS = 1_000
@@ -70,8 +65,8 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
     delivery: QueueDelivery<WorkflowQueueJob>
   ): Promise<void> {
     const execution = freshWorkflowExecution(delivery.leaseExpiresAt)
-    const runId = workflowRunIdFromClaimed(claimed)
-    const run = await this.requireWorkflowRun(claimed, runId)
+    const runId = claimed.job.payload.runId
+    const run = await this.requireWorkflowRun(runId)
     const durableExecution = await this.host.storage.executions.getById({
       projectId: this.host.id,
       id: run.executionId,
@@ -94,7 +89,12 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
       if (claimed.job.type === "workflow.run.resume.requested") {
         await runWorkflowResumeJob({
           runtime: context,
-          job: workflowResumeJobFromClaimed(claimed, run, execution),
+          job: {
+            id: run.id,
+            workflowId: run.workflowId,
+            resume: claimed.job.payload.resume,
+            execution,
+          },
           signal,
           observer: this.observer,
           onRunFailed: (error, run) => this.reportFailedRun(claimed, error, run),
@@ -102,11 +102,14 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
         return
       }
 
-      const workflowJob = workflowJobFromClaimed(claimed, run, execution)
-
       await runWorkflowJob({
         runtime: context,
-        job: workflowJob,
+        job: {
+          id: run.id,
+          workflowId: run.workflowId,
+          input: run.input,
+          execution,
+        },
         signal,
         observer: this.observer,
         onRunFailed: (error, run) => this.reportFailedRun(claimed, error, run),
@@ -116,18 +119,10 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
     }
   }
 
-  private async requireWorkflowRun(
-    claimed: ClaimedQueueJob<WorkflowQueueJob>,
-    runId: string
-  ): Promise<WorkflowRunRecord> {
+  private async requireWorkflowRun(runId: string): Promise<WorkflowRunRecord> {
     const run = await this.workflowRuns.getById({ projectId: this.host.id, id: runId })
     if (!run) {
       throw new Error(`[SixbWorkflowWorker] Workflow run '${runId}' was not found.`)
-    }
-    if (run.workflowId !== claimed.job.payload.workflowId) {
-      throw new Error(
-        `[SixbWorkflowWorker] Workflow run '${runId}' belongs to workflow '${run.workflowId}', not '${claimed.job.payload.workflowId}'.`
-      )
     }
     return run
   }
@@ -181,7 +176,7 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
     const run = await this.workflowRuns
       .getById({
         projectId: this.host.id,
-        id: workflowRunIdFromClaimed(claimed),
+        id: claimed.job.payload.runId,
       })
       .catch(() => null)
     if (
@@ -211,48 +206,6 @@ function requiresWorkflowInterventionStorage(host: WorkflowWorkerHost): boolean 
   return host.definitions.workflows
     .list()
     .some((workflow) => workflow.nodes.some((node) => node.type === "intervention"))
-}
-
-function workflowJobFromClaimed(
-  claimed: ClaimedQueueJob<WorkflowQueueJob>,
-  run: WorkflowRunRecord,
-  execution: WorkflowRunExecution
-): WorkflowJob {
-  const { job } = claimed
-  if (job.type !== "workflow.run.requested") {
-    throw new Error(`[SixbWorkflowWorker] Unsupported workflow job type '${job.type}'.`)
-  }
-
-  return {
-    id: run.id,
-    workflowId: run.workflowId,
-    input: run.input,
-    execution,
-  }
-}
-
-function workflowResumeJobFromClaimed(
-  claimed: ClaimedQueueJob<WorkflowQueueJob>,
-  run: WorkflowRunRecord,
-  execution: WorkflowRunExecution
-): WorkflowResumeJob {
-  const { job } = claimed
-  if (job.type !== "workflow.run.resume.requested") {
-    throw new Error(`[SixbWorkflowWorker] Unsupported workflow job type '${job.type}'.`)
-  }
-
-  return {
-    id: run.id,
-    workflowId: run.workflowId,
-    resume: job.payload.resume,
-    execution,
-  }
-}
-
-function workflowRunIdFromClaimed(claimed: ClaimedQueueJob<WorkflowQueueJob>): string {
-  return claimed.job.type === "workflow.run.resume.requested"
-    ? claimed.job.payload.runId
-    : (claimed.job.payload.runId ?? `${claimed.job.id}:attempt:${claimed.job.attempt}`)
 }
 
 function freshWorkflowExecution(queueLeaseExpiresAt: string): WorkflowRunExecution {

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -9,7 +9,7 @@ import type {
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
 import type { LoggingService } from "@sixb/core/internal/logging"
 import {
-  bindPrimitiveExecution,
+  bindDurablePrimitiveExecution,
   type PrimitiveExecutionHost,
 } from "@sixb/core/internal/primitive-execution"
 import type { QueueDelivery, QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
@@ -71,10 +71,19 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
   ): Promise<void> {
     const execution = freshWorkflowExecution(delivery.leaseExpiresAt)
     const runId = workflowRunIdFromClaimed(claimed)
-    const workflowId = claimed.job.payload.workflowId
-    const executionScope = bindPrimitiveExecution(this.host, {
-      primitive: { kind: "workflow", id: workflowId, runId },
-      source: { type: "queue", queue: "workflows", jobId: claimed.job.id },
+    const run = await this.requireWorkflowRun(claimed, runId)
+    const durableExecution = await this.host.storage.executions.getById({
+      projectId: this.host.id,
+      id: run.executionId,
+    })
+    if (!durableExecution) {
+      throw new Error(
+        `[SixbWorkflowWorker] Workflow run '${run.id}' references missing execution '${run.executionId}'.`
+      )
+    }
+    const executionScope = bindDurablePrimitiveExecution(this.host, {
+      execution: durableExecution,
+      primitive: { kind: "workflow", id: run.workflowId, runId: run.id },
     })
     const context = buildWorkflowContext(this.host, this.workflowRuns, executionScope.sixb)
     const stopOwnershipProjection = delivery.onLeaseRenewed((renewed) => {
@@ -85,7 +94,7 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
       if (claimed.job.type === "workflow.run.resume.requested") {
         await runWorkflowResumeJob({
           runtime: context,
-          job: workflowResumeJobFromClaimed(claimed, execution),
+          job: workflowResumeJobFromClaimed(claimed, run, execution),
           signal,
           observer: this.observer,
           onRunFailed: (error, run) => this.reportFailedRun(claimed, error, run),
@@ -93,7 +102,7 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
         return
       }
 
-      const workflowJob = workflowJobFromClaimed(claimed, execution)
+      const workflowJob = workflowJobFromClaimed(claimed, run, execution)
 
       await runWorkflowJob({
         runtime: context,
@@ -105,6 +114,22 @@ export class WorkflowWorker extends QueueWorker<WorkflowQueueJob> {
     } finally {
       stopOwnershipProjection()
     }
+  }
+
+  private async requireWorkflowRun(
+    claimed: ClaimedQueueJob<WorkflowQueueJob>,
+    runId: string
+  ): Promise<WorkflowRunRecord> {
+    const run = await this.workflowRuns.getById({ projectId: this.host.id, id: runId })
+    if (!run) {
+      throw new Error(`[SixbWorkflowWorker] Workflow run '${runId}' was not found.`)
+    }
+    if (run.workflowId !== claimed.job.payload.workflowId) {
+      throw new Error(
+        `[SixbWorkflowWorker] Workflow run '${runId}' belongs to workflow '${run.workflowId}', not '${claimed.job.payload.workflowId}'.`
+      )
+    }
+    return run
   }
 
   private async projectExecutionOwnership(
@@ -190,6 +215,7 @@ function requiresWorkflowInterventionStorage(host: WorkflowWorkerHost): boolean 
 
 function workflowJobFromClaimed(
   claimed: ClaimedQueueJob<WorkflowQueueJob>,
+  run: WorkflowRunRecord,
   execution: WorkflowRunExecution
 ): WorkflowJob {
   const { job } = claimed
@@ -198,16 +224,16 @@ function workflowJobFromClaimed(
   }
 
   return {
-    id: job.payload.runId ?? `${job.id}:attempt:${job.attempt}`,
-    workflowId: job.payload.workflowId,
-    input: job.payload.input,
-    source: job.payload.source,
+    id: run.id,
+    workflowId: run.workflowId,
+    input: run.input,
     execution,
   }
 }
 
 function workflowResumeJobFromClaimed(
   claimed: ClaimedQueueJob<WorkflowQueueJob>,
+  run: WorkflowRunRecord,
   execution: WorkflowRunExecution
 ): WorkflowResumeJob {
   const { job } = claimed
@@ -216,8 +242,8 @@ function workflowResumeJobFromClaimed(
   }
 
   return {
-    id: job.payload.runId,
-    workflowId: job.payload.workflowId,
+    id: run.id,
+    workflowId: run.workflowId,
     resume: job.payload.resume,
     execution,
   }

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -19,17 +19,21 @@ import {
   prop,
   ref,
   SixbHost,
-  SYSTEM_PRINCIPAL,
   type WorkflowDefinition,
   WorkflowValidationError,
 } from "@sixb/core"
 import { bindPrimitiveExecution } from "@sixb/core/internal/primitive-execution"
-import type { ActionRunStorage, WorkflowRunStorage } from "@sixb/core/storage"
-import { createTestSixb } from "@sixb/core/testing"
+import { snapshotWorkflowInput } from "@sixb/core/internal/workflows"
+import type {
+  ActionRunStorage,
+  QueueWorkflowRunInput,
+  WorkflowRunStorage,
+} from "@sixb/core/storage"
+import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
 import { WorkflowWorkerError } from "../src/errors"
 import { EventsRuntimeWorkflowRunObserver } from "../src/events"
-import { runWorkflowJob, runWorkflowResumeJob } from "../src/run-workflow-job"
-import type { WorkflowRunObserver, WorkflowWorkerContext } from "../src/types"
+import { runWorkflowJob as executeWorkflowJob, runWorkflowResumeJob } from "../src/run-workflow-job"
+import type { RunWorkflowJobInput, WorkflowRunObserver, WorkflowWorkerContext } from "../src/types"
 import type { WorkflowWorkerHost } from "../src/worker"
 
 const Transaction = defineObjectType({
@@ -252,6 +256,43 @@ function createRuntime(host: WorkflowWorkerHost): WorkflowWorkerContext {
   }
 }
 
+async function queueWorkflowRunFixture(
+  host: Pick<WorkflowWorkerContext, "storage">,
+  input: Omit<QueueWorkflowRunInput, "executionId">
+) {
+  const executionId = await createTestWorkflowExecution(host.storage.executions, {
+    projectId: input.projectId,
+    workflowId: input.workflowId,
+    runId: input.id,
+  })
+  return requireWorkflowRunsStorage(host).queue({ ...input, executionId })
+}
+
+async function runWorkflowJob(input: RunWorkflowJobInput) {
+  const existing = await input.runtime.workflowRuns.getById({
+    projectId: input.runtime.projectId,
+    id: input.job.id,
+  })
+  if (!existing) {
+    const workflow = input.runtime.sixb.workflows.getById(input.job.workflowId)
+    if (!workflow) {
+      return executeWorkflowJob(input)
+    }
+    const snapshot = snapshotWorkflowInput({
+      workflow,
+      value: input.job.input ?? {},
+      valueTypesById: input.runtime.ontology.getValueTypesById(),
+    })
+    await queueWorkflowRunFixture(input.runtime, {
+      id: input.job.id,
+      projectId: input.runtime.projectId,
+      workflowId: input.job.workflowId,
+      input: snapshot,
+    })
+  }
+  return executeWorkflowJob(input)
+}
+
 async function completeRequestedActions(
   sixb: {
     readonly id: string
@@ -389,7 +430,7 @@ describe("runWorkflowJob", () => {
     const workflowInput = {
       transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
     }
-    await sixb.storage.workflowRuns!.queue({
+    await queueWorkflowRunFixture(sixb, {
       id: "wfrun_observed",
       projectId: sixb.id,
       workflowId: workflow.id,
@@ -419,41 +460,6 @@ describe("runWorkflowJob", () => {
       "node-finished:0:succeeded",
       "run-finished:succeeded",
     ])
-  })
-
-  test("persists workflow run source from the requested queue job", async () => {
-    const workflow = defineWorkflow("triggered-workflow")
-      .input({
-        transaction: ref(Transaction),
-      })
-      .then(findBestInvoice)
-    const sixb = createSixb({ workflows: [workflow] })
-    const source = {
-      type: "schedule" as const,
-      scheduleId: "transaction.high-value",
-      eventId: "evt-1",
-      principal: SYSTEM_PRINCIPAL,
-    }
-    const workflowInput = {
-      transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
-    }
-
-    await runWorkflowJob({
-      runtime: createRuntime(sixb),
-      job: {
-        id: "wfrun_triggered",
-        workflowId: workflow.id,
-        input: workflowInput,
-        source,
-      },
-    })
-
-    const run = await sixb.storage.workflowRuns!.getById({
-      projectId: sixb.id,
-      id: "wfrun_triggered",
-    })
-
-    expect(run?.source).toEqual(source)
   })
 
   test("treats duplicate requested jobs for an existing run as no-op", async () => {
@@ -506,11 +512,15 @@ describe("runWorkflowJob", () => {
       confidence: 0.98,
     } as const
     const runs = sixb.storage.workflowRuns!
-    await runs.start({
+    await queueWorkflowRunFixture(sixb, {
       id: "wfrun_recovered",
       projectId: sixb.id,
       workflowId: workflow.id,
       input,
+    })
+    await runs.start({
+      id: "wfrun_recovered",
+      projectId: sixb.id,
       execution: {
         token: "workflow-exec-old",
         queueLeaseExpiresAt: new Date("2026-05-08T10:05:00.000Z"),
@@ -1081,7 +1091,7 @@ describe("runWorkflowJob", () => {
     const sixb = createSixb({ workflows: [workflow] })
     const observerCalls: string[] = []
 
-    await sixb.storage.workflowRuns!.queue({
+    await queueWorkflowRunFixture(sixb, {
       id: "wfrun_queued_invalid_input",
       projectId: sixb.id,
       workflowId: workflow.id,

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -18,6 +18,11 @@ import {
   type WorkflowDefinition,
 } from "@sixb/core"
 import { LOGS_STREAM } from "@sixb/core/internal/logging"
+import {
+  createTestSixb,
+  createTestWorkflowExecution,
+  type TestExecutionHost,
+} from "@sixb/core/testing"
 import { WorkflowWorker } from "../src"
 
 const Transaction = defineObjectType({
@@ -110,6 +115,15 @@ function createSixb(options: {
   })
 }
 
+async function requestWorkflowRun(
+  sixb: TestExecutionHost,
+  workflow: WorkflowDefinition,
+  runId: string,
+  input: Readonly<Record<string, unknown>>
+): Promise<void> {
+  await createTestSixb(sixb).workflows.requestById({ workflowId: workflow.id, runId, input })
+}
+
 async function waitFor<T>(
   fn: () => Promise<T>,
   predicate: (value: T) => boolean,
@@ -186,18 +200,8 @@ describe("WorkflowWorker", () => {
       .input({ transaction: ref(Transaction) })
       .then(loggedStep)
     const sixb = createSixb({ workflows: [workflow] })
-    await sixb.queues.workflows.enqueue({
-      projectId: sixb.id,
-      jobs: [
-        {
-          type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_log",
-            input: { transaction: { objectTypeId: "Transaction", primaryId: "txn_1" } },
-          },
-        },
-      ],
+    await requestWorkflowRun(sixb, workflow, "wfrun_log", {
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
     })
 
     const worker = new WorkflowWorker(sixb)
@@ -236,20 +240,8 @@ describe("WorkflowWorker", () => {
       })
       .then(findBestInvoice)
     const sixb = createSixb({ workflows: [workflow] })
-    await sixb.queues.workflows.enqueue({
-      projectId: sixb.id,
-      jobs: [
-        {
-          type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_worker_success",
-            input: {
-              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
-            },
-          },
-        },
-      ],
+    await requestWorkflowRun(sixb, workflow, "wfrun_worker_success", {
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
     })
 
     const worker = new WorkflowWorker(sixb)
@@ -314,6 +306,59 @@ describe("WorkflowWorker", () => {
     expect(claimed).toHaveLength(0)
   })
 
+  test("uses the persisted run instead of untrusted queue payload data", async () => {
+    const echoTransaction = defineWorkflowStep("echo-transaction")
+      .input({ transaction: ref(Transaction) })
+      .output({ transaction: ref(Transaction) })
+      .run(({ input }) => input)
+    const workflow = defineWorkflow("persisted-workflow-input")
+      .input({ transaction: ref(Transaction) })
+      .then(echoTransaction)
+    const sixb = createSixb({ workflows: [workflow] })
+    const runId = "wfrun_persisted_input"
+    await requestWorkflowRun(sixb, workflow, runId, {
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_persisted" },
+    })
+
+    const [original] = await sixb.queues.workflows.claim({
+      projectId: sixb.id,
+      workerId: "discard-original",
+    })
+    if (!original) throw new Error("Expected the original workflow delivery.")
+    await sixb.queues.workflows.complete({
+      projectId: sixb.id,
+      jobId: original.job.id,
+      leaseId: original.leaseId,
+    })
+    await sixb.queues.workflows.enqueue({
+      projectId: sixb.id,
+      jobs: [
+        {
+          type: "workflow.run.requested",
+          payload: {
+            workflowId: workflow.id,
+            runId,
+            input: {
+              transaction: { objectTypeId: "Transaction", primaryId: "txn_forged" },
+            },
+          },
+        },
+      ],
+    })
+
+    const worker = new WorkflowWorker(sixb)
+    workers.push(worker)
+    await worker.start()
+
+    const run = await waitFor(
+      () => sixb.storage.workflowRuns!.getById({ projectId: sixb.id, id: runId }),
+      (value) => value?.status === "succeeded"
+    )
+    expect(run?.output).toEqual({
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_persisted" },
+    })
+  })
+
   test("reports a terminal failed workflow once with the original error", async () => {
     const reports: Array<{ error: Error; context: SixbErrorContext }> = []
     const workflow = defineWorkflow("failing-workflow")
@@ -327,19 +372,12 @@ describe("WorkflowWorker", () => {
         reports.push({ error, context })
       },
     })
+    await requestWorkflowRun(sixb, workflow, "wfrun_worker_failed", {
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+    })
     await sixb.queues.workflows.enqueue({
       projectId: sixb.id,
       jobs: [
-        {
-          type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_worker_failed",
-            input: {
-              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
-            },
-          },
-        },
         {
           type: "workflow.run.requested",
           payload: {
@@ -442,9 +480,15 @@ describe("WorkflowWorker", () => {
       },
     })
 
+    const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
+      projectId: sixb.id,
+      workflowId: workflow.id,
+      runId: "wfrun_queued_invalid",
+    })
     await sixb.storage.workflowRuns!.queue({
       projectId: sixb.id,
       id: "wfrun_queued_invalid",
+      executionId,
       workflowId: workflow.id,
       input: {},
     })
@@ -503,20 +547,8 @@ describe("WorkflowWorker", () => {
         invoice: steps.findBestInvoice.invoice,
       }))
     const sixb = createSixb({ workflows: [workflow] })
-    await sixb.queues.workflows.enqueue({
-      projectId: sixb.id,
-      jobs: [
-        {
-          type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_worker_waiting",
-            input: {
-              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
-            },
-          },
-        },
-      ],
+    await requestWorkflowRun(sixb, workflow, "wfrun_worker_waiting", {
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
     })
 
     const worker = new WorkflowWorker(sixb)
@@ -594,20 +626,8 @@ describe("WorkflowWorker", () => {
       }))
     const sixb = createSixb({ workflows: [workflow] })
 
-    await sixb.queues.workflows.enqueue({
-      projectId: sixb.id,
-      jobs: [
-        {
-          type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_worker_resume",
-            input: {
-              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
-            },
-          },
-        },
-      ],
+    await requestWorkflowRun(sixb, workflow, "wfrun_worker_resume", {
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
     })
 
     const worker = new WorkflowWorker(sixb)
@@ -713,20 +733,8 @@ describe("WorkflowWorker", () => {
       },
     })
 
-    await sixb.queues.workflows.enqueue({
-      projectId: sixb.id,
-      jobs: [
-        {
-          type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_worker_resume_failed",
-            input: {
-              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
-            },
-          },
-        },
-      ],
+    await requestWorkflowRun(sixb, workflow, "wfrun_worker_resume_failed", {
+      transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
     })
 
     const worker = new WorkflowWorker(sixb)
@@ -799,19 +807,7 @@ describe("WorkflowWorker", () => {
         reports.push({ error, context })
       },
     })
-    await sixb.queues.workflows.enqueue({
-      projectId: sixb.id,
-      jobs: [
-        {
-          type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_worker_cancelled",
-            input: {},
-          },
-        },
-      ],
-    })
+    await requestWorkflowRun(sixb, workflow, "wfrun_worker_cancelled", {})
 
     const worker = new WorkflowWorker(sixb)
     workers.push(worker)

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -306,7 +306,7 @@ describe("WorkflowWorker", () => {
     expect(claimed).toHaveLength(0)
   })
 
-  test("uses the persisted run instead of untrusted queue payload data", async () => {
+  test("loads workflow input from the persisted run referenced by the queue job", async () => {
     const echoTransaction = defineWorkflowStep("echo-transaction")
       .input({ transaction: ref(Transaction) })
       .output({ transaction: ref(Transaction) })
@@ -335,13 +335,7 @@ describe("WorkflowWorker", () => {
       jobs: [
         {
           type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId,
-            input: {
-              transaction: { objectTypeId: "Transaction", primaryId: "txn_forged" },
-            },
-          },
+          payload: { runId },
         },
       ],
     })
@@ -380,13 +374,7 @@ describe("WorkflowWorker", () => {
       jobs: [
         {
           type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_worker_failed",
-            input: {
-              transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
-            },
-          },
+          payload: { runId: "wfrun_worker_failed" },
         },
       ],
     })
@@ -497,11 +485,7 @@ describe("WorkflowWorker", () => {
       jobs: [
         {
           type: "workflow.run.requested",
-          payload: {
-            workflowId: workflow.id,
-            runId: "wfrun_queued_invalid",
-            input: {},
-          },
+          payload: { runId: "wfrun_queued_invalid" },
         },
       ],
     })
@@ -656,7 +640,6 @@ describe("WorkflowWorker", () => {
         {
           type: "workflow.run.resume.requested",
           payload: {
-            workflowId: workflow.id,
             runId: "wfrun_worker_resume",
             resume: {
               kind: "intervention",
@@ -762,7 +745,6 @@ describe("WorkflowWorker", () => {
         {
           type: "workflow.run.resume.requested",
           payload: {
-            workflowId: workflow.id,
             runId: "wfrun_worker_resume_failed",
             resume: {
               kind: "intervention",

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -317,6 +317,7 @@ function createPostgresStores(
   }
 ): PostgresStoreSet {
   const auth = new PgAuthStorage({ sql })
+  const executions = new PgExecutionStorage(sql, auth)
   return {
     objects: new PgObjectStorage(sql),
     ontology: new PgOntologyStorage({
@@ -325,11 +326,11 @@ function createPostgresStores(
       transactionContext: options.transactionContext,
     }),
     auth,
-    executions: new PgExecutionStorage(sql, auth),
+    executions,
     agents: new PgAgentStorage({ sql }),
     actionRuns: new PgActionRunStorage(sql),
     pipelineRuns: new PgPipelineRunStorage(sql),
-    workflowRuns: new PgWorkflowRunStorage(sql),
+    workflowRuns: new PgWorkflowRunStorage(sql, executions),
     workflowInterventions: new PgWorkflowInterventionStorage(sql),
     syncRuns: new PgSyncRunStorage(sql),
     projectionRuns: new PgProjectionRunStorage(sql),

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -17,6 +17,7 @@ import initialSchemaSql from "./migrations/001-initial-schema.sql" with { type: 
 import workflowRunOutputSql from "./migrations/002-workflow-run-output.sql" with { type: "text" }
 import mergeSyncRunsSql from "./migrations/003-merge-sync-runs.sql" with { type: "text" }
 import executionsSql from "./migrations/004-executions.sql" with { type: "text" }
+import workflowExecutionsSql from "./migrations/005-workflow-executions.sql" with { type: "text" }
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -274,6 +275,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("002-workflow-run-output", workflowRunOutputSql),
     pgSql("003-merge-sync-runs", mergeSyncRunsSql),
     pgSql("004-executions", executionsSql),
+    pgSql("005-workflow-executions", workflowExecutionsSql),
   ],
 })
 

--- a/storage/pg/src/migrations/005-workflow-executions.sql
+++ b/storage/pg/src/migrations/005-workflow-executions.sql
@@ -1,0 +1,10 @@
+ALTER TABLE workflow_runs
+  ADD COLUMN execution_id TEXT NOT NULL,
+  DROP COLUMN source,
+  DROP COLUMN requested_by_principal_type,
+  DROP COLUMN requested_by_principal_id,
+  ADD CONSTRAINT fk_workflow_runs_execution
+    FOREIGN KEY (project_id, execution_id)
+    REFERENCES executions (project_id, id)
+    ON DELETE RESTRICT,
+  ADD CONSTRAINT uq_workflow_runs_execution UNIQUE (project_id, execution_id);

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -1,10 +1,11 @@
-import type { Principal, WorkflowRunSource } from "@sixb/core"
+import { assertWorkflowRunExecution } from "@sixb/core/internal/workflow-run-storage-provider"
 import type { WorkflowIOSnapshot } from "@sixb/core/internal/workflows"
 import type {
   CancelWorkflowAgentNodeRunInput,
   ConfirmWorkflowAgentNodeRunExecutionOwnershipInput,
   ConfirmWorkflowRunExecutionOwnershipInput,
   CreateWorkflowAgentNodeRunInput,
+  ExecutionStorage,
   FinishWorkflowAgentNodeRunInput,
   FinishWorkflowNodeRunInput,
   FinishWorkflowRunInput,
@@ -43,39 +44,45 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
   readonly nodes: PgWorkflowNodeRunStorage
   readonly agentNodes: PgWorkflowAgentNodeRunStorage
 
-  constructor(private readonly sql: PgStoreClient) {
+  constructor(
+    private readonly sql: PgStoreClient,
+    private readonly executions: ExecutionStorage
+  ) {
     this.nodes = new PgWorkflowNodeRunStorage(sql)
     this.agentNodes = new PgWorkflowAgentNodeRunStorage(sql)
   }
 
   async queue(input: QueueWorkflowRunInput): Promise<WorkflowRunRecord> {
     const queuedAt = input.queuedAt ?? new Date()
+    await assertWorkflowRunExecution({
+      executions: this.executions,
+      projectId: input.projectId,
+      executionId: input.executionId,
+      runId: input.id,
+      workflowId: input.workflowId,
+    })
 
     try {
       const [row] = await this.sql<WorkflowRunDatabaseRow[]>`
         INSERT INTO workflow_runs (
           project_id,
           id,
+          execution_id,
           workflow_id,
           status,
           input,
           queued_at,
           started_at,
-          source,
-          requested_by_principal_type,
-          requested_by_principal_id,
           attempt
         ) VALUES (
           ${input.projectId},
           ${input.id},
+          ${input.executionId},
           ${input.workflowId},
           ${"queued"},
           ${serializeRecord(input.input)}::text::jsonb,
           ${queuedAt},
           ${queuedAt},
-          ${input.source ? JSON.stringify(input.source) : null}::text::jsonb,
-          ${input.requestedByPrincipal?.type ?? "system"},
-          ${input.requestedByPrincipal?.id ?? "system"},
           ${0}
         )
         RETURNING *
@@ -85,7 +92,7 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
     } catch (error) {
       if (isUniqueViolation(error)) {
         throw new WorkflowRunError(
-          `[SixbPg] Workflow run '${input.id}' already exists for project '${input.projectId}'.`
+          `[SixbPg] Workflow run '${input.id}' or execution '${input.executionId}' is already linked for project '${input.projectId}'.`
         )
       }
 
@@ -102,83 +109,29 @@ export class PgWorkflowRunStorage implements WorkflowRunStorage {
         FOR UPDATE
       `
 
-      if (existing) {
-        if (existing.status !== "queued") {
-          throw new WorkflowRunError(
-            `[SixbPg] Workflow run '${input.id}' already exists for project '${input.projectId}'.`
-          )
-        }
-
-        if (existing.workflow_id !== input.workflowId) {
-          throw new WorkflowRunError(
-            `[SixbPg] Workflow run '${input.id}' workflow '${input.workflowId}' does not match existing workflow '${existing.workflow_id}'.`
-          )
-        }
-
-        const [updated] = await tx<WorkflowRunDatabaseRow[]>`
-          UPDATE workflow_runs
-          SET
-            status = ${"running"},
-            input = ${serializeRecord(input.input)}::text::jsonb,
-            started_at = ${startedAt},
-            finished_at = ${null},
-            error = ${null},
-            source = COALESCE(
-              source,
-              ${input.source ? JSON.stringify(input.source) : null}::text::jsonb
-            ),
-            attempt = attempt + 1,
-            execution_token = ${input.execution?.token ?? null},
-            execution_queue_lease_expires_at = ${input.execution?.queueLeaseExpiresAt ?? null}
-          WHERE project_id = ${input.projectId} AND id = ${input.id}
-          RETURNING *
-        `
-
-        return rowToWorkflowRunRecord(updated)
+      if (!existing || existing.status !== "queued") {
+        throw new WorkflowRunError(
+          existing
+            ? `[SixbPg] Workflow run '${input.id}' cannot start from status '${existing.status}'.`
+            : `[SixbPg] Workflow run '${input.id}' not found for project '${input.projectId}'.`
+        )
       }
 
-      try {
-        const [row] = await tx<WorkflowRunDatabaseRow[]>`
-          INSERT INTO workflow_runs (
-            project_id,
-            id,
-            workflow_id,
-            status,
-            input,
-            started_at,
-            source,
-            requested_by_principal_type,
-            requested_by_principal_id,
-            attempt,
-            execution_token,
-            execution_queue_lease_expires_at
-          ) VALUES (
-            ${input.projectId},
-            ${input.id},
-            ${input.workflowId},
-            ${"running"},
-            ${serializeRecord(input.input)}::text::jsonb,
-            ${startedAt},
-            ${input.source ? JSON.stringify(input.source) : null}::text::jsonb,
-            ${input.requestedByPrincipal?.type ?? "system"},
-            ${input.requestedByPrincipal?.id ?? "system"},
-            ${1},
-            ${input.execution?.token ?? null},
-            ${input.execution?.queueLeaseExpiresAt ?? null}
-          )
-          RETURNING *
-        `
+      const [updated] = await tx<WorkflowRunDatabaseRow[]>`
+        UPDATE workflow_runs
+        SET
+          status = ${"running"},
+          started_at = ${startedAt},
+          finished_at = ${null},
+          error = ${null},
+          attempt = attempt + 1,
+          execution_token = ${input.execution?.token ?? null},
+          execution_queue_lease_expires_at = ${input.execution?.queueLeaseExpiresAt ?? null}
+        WHERE project_id = ${input.projectId} AND id = ${input.id}
+        RETURNING *
+      `
 
-        return rowToWorkflowRunRecord(row)
-      } catch (error) {
-        if (isUniqueViolation(error)) {
-          throw new WorkflowRunError(
-            `[SixbPg] Workflow run '${input.id}' already exists for project '${input.projectId}'.`
-          )
-        }
-
-        throw error
-      }
+      return rowToWorkflowRunRecord(updated)
     })
   }
 
@@ -824,6 +777,7 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
   return {
     id: row.id,
     projectId: row.project_id,
+    executionId: row.execution_id,
     workflowId: row.workflow_id,
     status: row.status,
     input: parseRecord(row.input),
@@ -832,11 +786,6 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     error: row.error ?? undefined,
-    source: parseSource(row.source),
-    requestedByPrincipal: {
-      type: row.requested_by_principal_type,
-      id: row.requested_by_principal_id,
-    },
     attempt: Number(row.attempt),
     ...(row.execution_token && row.execution_queue_lease_expires_at
       ? {
@@ -847,14 +796,6 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
         }
       : {}),
   }
-}
-
-function parseSource(value: WorkflowRunSource | string | null): WorkflowRunSource | undefined {
-  if (value === null || value === undefined) {
-    return undefined
-  }
-
-  return typeof value === "string" ? (JSON.parse(value) as WorkflowRunSource) : value
 }
 
 function rowToWorkflowNodeRunRecord(row: WorkflowNodeRunDatabaseRow): WorkflowNodeRunRecord {
@@ -896,6 +837,7 @@ function canFinishWorkflowRun(
 interface WorkflowRunDatabaseRow {
   project_id: string
   id: string
+  execution_id: string
   workflow_id: string
   status: WorkflowRunRecord["status"]
   input: WorkflowIOSnapshot | string
@@ -904,9 +846,6 @@ interface WorkflowRunDatabaseRow {
   started_at: Date | string
   finished_at: Date | string | null
   error: string | null
-  source: WorkflowRunSource | string | null
-  requested_by_principal_type: Principal["type"]
-  requested_by_principal_id: string
   attempt: number | string
   execution_token: string | null
   execution_queue_lease_expires_at: Date | string | null

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { defineObjectType, migrateStorage, OntologyRegistry, prop } from "@sixb/core"
 import { defineMigrations } from "@sixb/core/storage"
-import { createMaterializerTestFixture } from "@sixb/core/testing"
+import { createMaterializerTestFixture, createTestWorkflowExecution } from "@sixb/core/testing"
 import { SQL } from "bun"
 import { PostgresStorage, type PostgresStorage as PostgresStorageType } from "../src"
 import {
@@ -39,6 +39,7 @@ describe("Postgres storage migrations", () => {
             "002-workflow-run-output",
             "003-merge-sync-runs",
             "004-executions",
+            "005-workflow-executions",
           ],
         },
       ])
@@ -70,6 +71,13 @@ describe("Postgres storage migrations", () => {
           id: "004-executions",
           status: "applied",
           version: 4,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "005-workflow-executions",
+          status: "applied",
+          version: 5,
         },
       ])
     })
@@ -200,6 +208,19 @@ describe("Postgres storage migrations", () => {
           "input_exhausted",
         ])
       )
+      expect(await readTableColumns(schemaName, "workflow_runs")).toEqual(
+        expect.arrayContaining(["execution_id"])
+      )
+      expect(await readTableColumns(schemaName, "workflow_runs")).not.toEqual(
+        expect.arrayContaining([
+          "source",
+          "requested_by_principal_type",
+          "requested_by_principal_id",
+        ])
+      )
+      await expect(readColumnNullable(schemaName, "workflow_runs", "execution_id")).resolves.toBe(
+        "NO"
+      )
     })
   })
 
@@ -249,6 +270,36 @@ describe("Postgres storage migrations", () => {
           { id: "data-run", output: { winner: 10 } },
           { id: "failed-run", output: null },
         ])
+      } finally {
+        await sql.unsafe("RESET search_path")
+        await sql.unsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+      }
+    })
+  })
+
+  test("requires explicit project handling for legacy workflow runs", async () => {
+    const schemaName = `sixb_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    await withSql(async (sql) => {
+      const schema = quoteIdent(schemaName)
+      const context = { exec: (sqlText: string) => sql.unsafe(sqlText).then(() => undefined) }
+
+      try {
+        await sql.unsafe(`CREATE SCHEMA ${schema}`)
+        await sql.unsafe(`SET search_path TO ${schema}`)
+        for (const migration of postgresStorageMigrations.steps.slice(0, 4)) {
+          await migration.up(context)
+        }
+        await sql.unsafe(`
+          INSERT INTO workflow_runs (
+            project_id, id, workflow_id, status, input, started_at
+          ) VALUES (
+            'project-a', 'legacy-run', 'legacy-workflow', 'queued', '{}',
+            '2026-01-01T00:00:00.000Z'
+          )
+        `)
+
+        await expect(postgresStorageMigrations.steps[4]?.up(context)).rejects.toThrow()
+        expect(await readTableColumns(schemaName, "workflow_runs")).not.toContain("execution_id")
       } finally {
         await sql.unsafe("RESET search_path")
         await sql.unsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
@@ -380,7 +431,7 @@ describe("Postgres storage migrations", () => {
       expect(await migrator?.status()).toMatchObject({
         adapterId: POSTGRES_STORAGE_ADAPTER_ID,
         state: "current",
-        appliedVersion: 4,
+        appliedVersion: 5,
       })
     })
   })
@@ -430,6 +481,13 @@ describe("Postgres storage migrations", () => {
           id: "004-executions",
           status: "applied",
           version: 4,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "005-workflow-executions",
+          status: "applied",
+          version: 5,
         },
       ])
     } finally {
@@ -521,13 +579,24 @@ async function seedExistingStoreRows(storage: PostgresStorage): Promise<void> {
     finishedAt: new Date("2026-04-19T12:00:01.000Z"),
     progress: { sourceRowsRead: 4 },
   })
-  await storage.workflowRuns.start({
+  const workflowExecutionId = await createTestWorkflowExecution(storage.executions, {
+    projectId: "project-a",
+    workflowId: "reconcile-transaction",
+    runId: "workflow-run-1",
+  })
+  await storage.workflowRuns.queue({
     id: "workflow-run-1",
     projectId: "project-a",
+    executionId: workflowExecutionId,
     workflowId: "reconcile-transaction",
     input: {
       transactionId: "txn-1",
     },
+    queuedAt: new Date("2026-04-19T11:59:59.000Z"),
+  })
+  await storage.workflowRuns.start({
+    id: "workflow-run-1",
+    projectId: "project-a",
     startedAt: new Date("2026-04-19T12:00:00.000Z"),
   })
   await storage.workflowRuns.finish({

--- a/storage/pg/tests/pg-workflow-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-workflow-run-storage.e2e.ts
@@ -1,19 +1,29 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { WorkflowRunError } from "@sixb/core/storage"
+import {
+  type QueueWorkflowRunInput,
+  type StartWorkflowRunInput,
+  WorkflowRunError,
+} from "@sixb/core/storage"
+import {
+  createTestAutomaticWorkflowExecution,
+  createTestWorkflowExecution,
+} from "@sixb/core/testing"
 import type { PostgresStorage } from "../src"
 import { PgWorkflowRunStorage } from "../src/pg-workflow-run-storage"
 import { createTestStorage } from "./helpers"
 
 describe("PgWorkflowRunStorage", () => {
-  let storage: PostgresStorage
+  let root: PostgresStorage
+  let storage: ReturnType<typeof createWorkflowRunStorage>
 
   beforeEach(async () => {
-    ;({ storage } = await createTestStorage())
+    ;({ storage: root } = await createTestStorage())
+    storage = createWorkflowRunStorage(root)
   })
 
   afterEach(async () => {
-    await storage.dropSchema()
-    await storage.close()
+    await root.dropSchema()
+    await root.close()
   })
 
   test("starts and finishes workflow runs with JSON input", async () => {
@@ -50,64 +60,41 @@ describe("PgWorkflowRunStorage", () => {
     expect(stored?.finishedAt?.toISOString()).toBe("2026-05-08T10:00:04.500Z")
   })
 
-  test("persists workflow run source when starting directly or from a queued run", async () => {
-    const scheduleSource = {
-      type: "schedule",
-      scheduleId: "invoice-payment-linked",
-      eventId: "evt_1",
-      principal: { type: "system", id: "sixb-orchestrator" },
-    } as const
+  test("requires a queued run linked to its matching workflow execution", async () => {
+    await expect(
+      root.workflowRuns.start({ id: "wf-run-missing", projectId: "my-app" })
+    ).rejects.toBeInstanceOf(WorkflowRunError)
 
-    const started = await storage.workflowRuns.start({
-      id: "wf-run-triggered",
+    const executionId = await createTestWorkflowExecution(root.executions, {
       projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_123" },
-      source: scheduleSource,
+      workflowId: "other-workflow",
+      runId: "wf-run-mismatched",
     })
-
-    expect(started.source).toEqual(scheduleSource)
-    expect(
-      await storage.workflowRuns.getById({
+    await expect(
+      PgWorkflowRunStorage.prototype.queue.call(root.workflowRuns, {
+        id: "wf-run-mismatched",
         projectId: "my-app",
-        id: "wf-run-triggered",
+        executionId,
+        workflowId: "reconcile-transaction",
+        input: {},
       })
-    ).toMatchObject({ source: scheduleSource })
+    ).rejects.toBeInstanceOf(WorkflowRunError)
 
-    await storage.workflowRuns.queue({
-      id: "wf-run-queued-without-source",
+    const automaticExecutionId = await createTestAutomaticWorkflowExecution(root.executions, {
       projectId: "my-app",
       workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_456" },
+      runId: "wf-run-automatic",
+      source: { type: "event", eventId: "source-event-1" },
     })
-
-    const running = await storage.workflowRuns.start({
-      id: "wf-run-queued-without-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_456" },
-      source: scheduleSource,
-    })
-
-    expect(running.source).toEqual(scheduleSource)
-
-    await storage.workflowRuns.queue({
-      id: "wf-run-queued-with-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_789" },
-      source: { type: "manual" },
-    })
-
-    const alreadySourced = await storage.workflowRuns.start({
-      id: "wf-run-queued-with-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_789" },
-      source: scheduleSource,
-    })
-
-    expect(alreadySourced.source).toEqual({ type: "manual" })
+    await expect(
+      PgWorkflowRunStorage.prototype.queue.call(root.workflowRuns, {
+        id: "wf-run-automatic",
+        projectId: "my-app",
+        executionId: automaticExecutionId,
+        workflowId: "reconcile-transaction",
+        input: {},
+      })
+    ).resolves.toMatchObject({ id: "wf-run-automatic", executionId: automaticExecutionId })
   })
 
   test("allows exactly one concurrent claim of a queued workflow run", async () => {
@@ -672,3 +659,48 @@ describe("PgWorkflowRunStorage", () => {
     expect(storage.workflowRuns).toBeInstanceOf(PgWorkflowRunStorage)
   })
 })
+
+type TestQueueWorkflowRunInput = Omit<QueueWorkflowRunInput, "executionId"> & {
+  readonly executionId?: string
+}
+
+type TestStartWorkflowRunInput = StartWorkflowRunInput & {
+  readonly workflowId?: string
+  readonly input?: QueueWorkflowRunInput["input"]
+}
+
+function createWorkflowRunStorage(root: PostgresStorage) {
+  const workflowRuns = root.workflowRuns
+  const queue = workflowRuns.queue.bind(workflowRuns)
+  const start = workflowRuns.start.bind(workflowRuns)
+  const queueFixture = async (input: TestQueueWorkflowRunInput) => {
+    const executionId = await createTestWorkflowExecution(root.executions, {
+      projectId: input.projectId,
+      workflowId: input.workflowId,
+      runId: input.id,
+      ...(input.executionId === undefined ? {} : { executionId: input.executionId }),
+    })
+    return queue({ ...input, executionId })
+  }
+  const testWorkflowRuns = Object.assign(workflowRuns, {
+    queue: queueFixture,
+    start: async (input: TestStartWorkflowRunInput) => {
+      const existing = await workflowRuns.getById({ projectId: input.projectId, id: input.id })
+      if (!existing && input.workflowId && input.input) {
+        await queueFixture({
+          id: input.id,
+          projectId: input.projectId,
+          workflowId: input.workflowId,
+          input: input.input,
+        })
+      }
+      return start({
+        id: input.id,
+        projectId: input.projectId,
+        ...(input.startedAt === undefined ? {} : { startedAt: input.startedAt }),
+        ...(input.execution === undefined ? {} : { execution: input.execution }),
+      })
+    },
+  })
+  return Object.assign(root, { workflowRuns: testWorkflowRuns })
+}

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -254,6 +254,7 @@ function createSqliteStores(
   }
 ): SqliteStoreSet {
   const auth = new SqliteAuthStorage({ connection })
+  const executions = new SqliteExecutionStorage(connection.db, auth)
   return {
     objects: new SqliteObjectStorage({ connection }),
     ontology: new SqliteOntologyStorage({
@@ -262,14 +263,14 @@ function createSqliteStores(
       transactionContext: options.transactionContext,
     }),
     auth,
-    executions: new SqliteExecutionStorage(connection.db, auth),
+    executions,
     agents: new SqliteAgentStorage({ connection }),
     actionRuns: new SqliteActionRunStorage({ connection }),
     pipelineRuns: new SqlitePipelineRunStorage({ connection }),
     timeseries: new SqliteTimeseriesStorage({ connection }),
     syncRuns: new SqliteSyncRunStorage({ connection }),
     projectionRuns: new SqliteProjectionRunStorage({ connection }),
-    workflowRuns: new SqliteWorkflowRunStorage({ connection }),
+    workflowRuns: new SqliteWorkflowRunStorage({ connection, executions }),
     workflowInterventions: new SqliteWorkflowInterventionStorage({ connection }),
     webhookDeliveries: new SqliteWebhookDeliveryStorage({ connection }),
     webhookRuns: new SqliteWebhookRunStorage({ connection }),

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -20,6 +20,7 @@ import initialSchemaSql from "./migrations/001-initial-schema.sql" with { type: 
 import workflowRunOutputSql from "./migrations/002-workflow-run-output.sql" with { type: "text" }
 import mergeSyncRunsSql from "./migrations/003-merge-sync-runs.sql" with { type: "text" }
 import executionsSql from "./migrations/004-executions.sql" with { type: "text" }
+import workflowExecutionsSql from "./migrations/005-workflow-executions.sql" with { type: "text" }
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -44,6 +45,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("002-workflow-run-output", workflowRunOutputSql),
     sqliteSql("003-merge-sync-runs", mergeSyncRunsSql),
     sqliteSql("004-executions", executionsSql),
+    sqliteSql("005-workflow-executions", workflowExecutionsSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/005-workflow-executions.sql
+++ b/storage/sqlite/src/migrations/005-workflow-executions.sql
@@ -1,0 +1,7 @@
+ALTER TABLE workflow_runs ADD COLUMN execution_id TEXT NOT NULL;
+ALTER TABLE workflow_runs DROP COLUMN source;
+ALTER TABLE workflow_runs DROP COLUMN requested_by_principal_type;
+ALTER TABLE workflow_runs DROP COLUMN requested_by_principal_id;
+
+CREATE UNIQUE INDEX idx_workflow_runs_project_execution
+  ON workflow_runs(project_id, execution_id);

--- a/storage/sqlite/src/workflow-run-storage.ts
+++ b/storage/sqlite/src/workflow-run-storage.ts
@@ -1,11 +1,12 @@
 import type { Database } from "bun:sqlite"
-import type { Principal, WorkflowRunSource } from "@sixb/core"
+import { assertWorkflowRunExecution } from "@sixb/core/internal/workflow-run-storage-provider"
 import type { WorkflowIOSnapshot } from "@sixb/core/internal/workflows"
 import type {
   CancelWorkflowAgentNodeRunInput,
   ConfirmWorkflowAgentNodeRunExecutionOwnershipInput,
   ConfirmWorkflowRunExecutionOwnershipInput,
   CreateWorkflowAgentNodeRunInput,
+  ExecutionStorage,
   FinishWorkflowAgentNodeRunInput,
   FinishWorkflowNodeRunInput,
   FinishWorkflowRunInput,
@@ -50,6 +51,8 @@ import {
 } from "./transactions"
 
 export interface SqliteWorkflowRunStorageOptions {
+  /** Execution lookup sharing the same provider transaction. */
+  executions: ExecutionStorage
   /** Path to SQLite database file. Defaults to ':memory:' for in-memory database. */
   path?: string
   /** Internal shared connection used by bundled SqliteStorage. */
@@ -62,10 +65,12 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
 
   private readonly connection: SqliteStoreConnection
   private readonly db: Database
+  private readonly executions: ExecutionStorage
 
-  constructor(options: SqliteWorkflowRunStorageOptions = {}) {
+  constructor(options: SqliteWorkflowRunStorageOptions) {
     this.connection = openSqliteStoreConnection(options)
     this.db = this.connection.db
+    this.executions = options.executions
 
     if (this.connection.installFreshSchema) {
       installFreshSqliteSchema(this.db)
@@ -77,6 +82,13 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
 
   async queue(input: QueueWorkflowRunInput): Promise<WorkflowRunRecord> {
     const queuedAt = input.queuedAt ?? new Date()
+    await assertWorkflowRunExecution({
+      executions: this.executions,
+      projectId: input.projectId,
+      executionId: input.executionId,
+      runId: input.id,
+      workflowId: input.workflowId,
+    })
 
     try {
       this.db
@@ -85,35 +97,31 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
           INSERT INTO workflow_runs (
             project_id,
             id,
+            execution_id,
             workflow_id,
             status,
             input,
             queued_at,
             started_at,
-            source,
-            requested_by_principal_type,
-            requested_by_principal_id,
             attempt
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         `
         )
         .run(
           input.projectId,
           input.id,
+          input.executionId,
           input.workflowId,
           "queued",
           serializeRecord(input.input),
           queuedAt.toISOString(),
           queuedAt.toISOString(),
-          input.source ? JSON.stringify(input.source) : null,
-          input.requestedByPrincipal?.type ?? "system",
-          input.requestedByPrincipal?.id ?? "system",
           0
         )
     } catch (error) {
       if (isUniqueConstraintError(error)) {
         throw new WorkflowRunError(
-          `[SixbSqlite] Workflow run '${input.id}' already exists for project '${input.projectId}'.`
+          `[SixbSqlite] Workflow run '${input.id}' or execution '${input.executionId}' is already linked for project '${input.projectId}'.`
         )
       }
 
@@ -131,92 +139,36 @@ export class SqliteWorkflowRunStorage implements WorkflowRunStorage {
         .query("SELECT * FROM workflow_runs WHERE project_id = ? AND id = ?")
         .get(input.projectId, input.id) as WorkflowRunDatabaseRow | null
 
-      if (existing) {
-        if (existing.status !== "queued") {
-          throw new WorkflowRunError(
-            `[SixbSqlite] Workflow run '${input.id}' already exists for project '${input.projectId}'.`
-          )
-        }
-
-        if (existing.workflow_id !== input.workflowId) {
-          throw new WorkflowRunError(
-            `[SixbSqlite] Workflow run '${input.id}' workflow '${input.workflowId}' does not match existing workflow '${existing.workflow_id}'.`
-          )
-        }
-
-        this.db
-          .query(
-            `
-            UPDATE workflow_runs
-            SET
-              status = ?,
-              input = ?,
-              started_at = ?,
-              finished_at = NULL,
-              error = NULL,
-              source = COALESCE(source, ?)
-              , attempt = attempt + 1,
-              execution_token = ?, execution_queue_lease_expires_at = ?
-            WHERE project_id = ? AND id = ?
-          `
-          )
-          .run(
-            "running",
-            serializeRecord(input.input),
-            startedAt.toISOString(),
-            input.source ? JSON.stringify(input.source) : null,
-            input.execution?.token ?? null,
-            input.execution?.queueLeaseExpiresAt.toISOString() ?? null,
-            input.projectId,
-            input.id
-          )
-
-        return this.requireWorkflowRun(input.projectId, input.id)
+      if (!existing || existing.status !== "queued") {
+        throw new WorkflowRunError(
+          existing
+            ? `[SixbSqlite] Workflow run '${input.id}' cannot start from status '${existing.status}'.`
+            : `[SixbSqlite] Workflow run '${input.id}' not found for project '${input.projectId}'.`
+        )
       }
 
-      try {
-        this.db
-          .query(
-            `
-            INSERT INTO workflow_runs (
-              project_id,
-              id,
-              workflow_id,
-              status,
-              input,
-              started_at,
-              source,
-              requested_by_principal_type,
-              requested_by_principal_id,
-              attempt,
-              execution_token,
-              execution_queue_lease_expires_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      this.db
+        .query(
           `
-          )
-          .run(
-            input.projectId,
-            input.id,
-            input.workflowId,
-            "running",
-            serializeRecord(input.input),
-            startedAt.toISOString(),
-            input.source ? JSON.stringify(input.source) : null,
-            input.requestedByPrincipal?.type ?? "system",
-            input.requestedByPrincipal?.id ?? "system",
-            1,
-            input.execution?.token ?? null,
-            input.execution?.queueLeaseExpiresAt.toISOString() ?? null
-          )
-      } catch (error) {
-        if (isUniqueConstraintError(error)) {
-          throw new WorkflowRunError(
-            `[SixbSqlite] Workflow run '${input.id}' already exists for project '${input.projectId}'.`
-          )
-        }
-
-        throw error
-      }
+          UPDATE workflow_runs
+          SET
+            status = ?,
+            started_at = ?,
+            finished_at = NULL,
+            error = NULL,
+            attempt = attempt + 1,
+            execution_token = ?, execution_queue_lease_expires_at = ?
+          WHERE project_id = ? AND id = ?
+        `
+        )
+        .run(
+          "running",
+          startedAt.toISOString(),
+          input.execution?.token ?? null,
+          input.execution?.queueLeaseExpiresAt.toISOString() ?? null,
+          input.projectId,
+          input.id
+        )
 
       return this.requireWorkflowRun(input.projectId, input.id)
     })()
@@ -974,6 +926,7 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
   return {
     id: row.id,
     projectId: row.project_id,
+    executionId: row.execution_id,
     workflowId: row.workflow_id,
     status: row.status,
     input: parseRecord(row.input),
@@ -982,11 +935,6 @@ function rowToWorkflowRunRecord(row: WorkflowRunDatabaseRow): WorkflowRunRecord 
     startedAt: new Date(row.started_at),
     finishedAt: row.finished_at ? new Date(row.finished_at) : undefined,
     error: row.error ?? undefined,
-    source: row.source ? (JSON.parse(row.source) as WorkflowRunSource) : undefined,
-    requestedByPrincipal: {
-      type: row.requested_by_principal_type,
-      id: row.requested_by_principal_id,
-    },
     attempt: row.attempt,
     ...(row.execution_token && row.execution_queue_lease_expires_at
       ? {
@@ -1040,6 +988,7 @@ function canFinishWorkflowRun(
 interface WorkflowRunDatabaseRow {
   project_id: string
   id: string
+  execution_id: string
   workflow_id: string
   status: WorkflowRunRecord["status"]
   input: string
@@ -1048,9 +997,6 @@ interface WorkflowRunDatabaseRow {
   started_at: string
   finished_at: string | null
   error: string | null
-  source: string | null
-  requested_by_principal_type: Principal["type"]
-  requested_by_principal_id: string
   attempt: number
   execution_token: string | null
   execution_queue_lease_expires_at: string | null

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -43,6 +43,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 4,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "005-workflow-executions",
+    status: "applied",
+    version: 5,
+  },
 ]
 
 afterEach(async () => {
@@ -244,6 +251,86 @@ describe("SQLite storage migrations", () => {
         { id: "data-run", output: { winner: 10 } },
         { id: "failed-run", output: null },
       ])
+    } finally {
+      db.close()
+    }
+  })
+
+  test("requires explicit project handling for legacy workflow runs", () => {
+    const db = new Database(":memory:")
+    try {
+      for (const migration of sqliteStorageMigrations.steps.slice(0, 4)) {
+        migration.up(db)
+      }
+      db.query(`
+        INSERT INTO workflow_runs (
+          project_id, id, workflow_id, status, input, started_at
+        ) VALUES (?, ?, ?, 'queued', '{}', ?)
+      `).run("project-a", "legacy-run", "legacy-workflow", "2026-01-01T00:00:00.000Z")
+
+      expect(() => sqliteStorageMigrations.steps[4]?.up(db)).toThrow()
+      expect(readMemoryTableColumns(db, "workflow_runs")).not.toContain("execution_id")
+    } finally {
+      db.close()
+    }
+  })
+
+  test("makes the workflow execution link required and unique on an empty schema", () => {
+    const db = new Database(":memory:")
+    try {
+      for (const migration of sqliteStorageMigrations.steps) {
+        migration.up(db)
+      }
+
+      const columns = readMemoryTableColumns(db, "workflow_runs")
+      expect(columns).toContain("execution_id")
+      expect(columns).not.toContain("source")
+      expect(columns).not.toContain("requested_by_principal_type")
+      expect(columns).not.toContain("requested_by_principal_id")
+      expect(readMemoryColumn(db, "workflow_runs", "execution_id")?.notnull).toBe(1)
+
+      db.query(`
+        INSERT INTO executions (
+          project_id, id, executor_kind, executor_id, source_kind, source_id,
+          correlation_id, authority_kind, authority_primitive_kind,
+          authority_primitive_id, created_at
+        ) VALUES (?, ?, 'workflow', ?, 'schedule', ?, ?, 'trustedPrimitive', 'workflow', ?, ?)
+      `).run(
+        "project-a",
+        "workflow-execution",
+        "workflow-run",
+        "schedule-event",
+        "workflow-correlation",
+        "reconcile-transaction",
+        "2026-01-01T00:00:00.000Z"
+      )
+      db.query(`
+        INSERT INTO workflow_runs (
+          project_id, id, execution_id, workflow_id, status, input, started_at
+        ) VALUES (?, ?, ?, ?, 'queued', '{}', ?)
+      `).run(
+        "project-a",
+        "workflow-run",
+        "workflow-execution",
+        "reconcile-transaction",
+        "2026-01-01T00:00:00.000Z"
+      )
+
+      expect(() =>
+        db
+          .query(`
+          INSERT INTO workflow_runs (
+            project_id, id, execution_id, workflow_id, status, input, started_at
+          ) VALUES (?, ?, ?, ?, 'queued', '{}', ?)
+        `)
+          .run(
+            "project-a",
+            "second-workflow-run",
+            "workflow-execution",
+            "reconcile-transaction",
+            "2026-01-01T00:00:00.000Z"
+          )
+      ).toThrow("UNIQUE constraint failed")
     } finally {
       db.close()
     }
@@ -533,7 +620,7 @@ describe("SQLite migration status is read-only", () => {
     expect(await migrator?.status()).toMatchObject({
       adapterId: SQLITE_STORAGE_ADAPTER_ID,
       state: "current",
-      appliedVersion: 4,
+      appliedVersion: 5,
     })
 
     expect(statSync(path).mtimeMs).toBe(before)

--- a/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
@@ -1,17 +1,27 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { WorkflowRunError } from "@sixb/core/storage"
+import {
+  type QueueWorkflowRunInput,
+  type StartWorkflowRunInput,
+  WorkflowRunError,
+} from "@sixb/core/storage"
+import {
+  createTestAutomaticWorkflowExecution,
+  createTestWorkflowExecution,
+} from "@sixb/core/testing"
 import { SqliteStorage } from "../src"
 import { SqliteWorkflowRunStorage } from "../src/workflow-run-storage"
 
 describe("SqliteWorkflowRunStorage", () => {
-  let storage: SqliteWorkflowRunStorage
+  let root: SqliteStorage
+  let storage: ReturnType<typeof createWorkflowRunStorage>
 
   beforeEach(() => {
-    storage = new SqliteWorkflowRunStorage()
+    root = new SqliteStorage()
+    storage = createWorkflowRunStorage(root)
   })
 
   afterEach(() => {
-    storage.close()
+    root.close()
   })
 
   test("starts and finishes workflow runs with JSON input", async () => {
@@ -48,64 +58,41 @@ describe("SqliteWorkflowRunStorage", () => {
     expect(stored?.finishedAt?.toISOString()).toBe("2026-05-08T10:00:04.500Z")
   })
 
-  test("persists workflow run source when starting directly or from a queued run", async () => {
-    const scheduleSource = {
-      type: "schedule",
-      scheduleId: "invoice-payment-linked",
-      eventId: "evt_1",
-      principal: { type: "system", id: "sixb-orchestrator" },
-    } as const
+  test("requires a queued run linked to its matching workflow execution", async () => {
+    await expect(
+      root.workflowRuns.start({ id: "wf-run-missing", projectId: "my-app" })
+    ).rejects.toBeInstanceOf(WorkflowRunError)
 
-    const started = await storage.start({
-      id: "wf-run-triggered",
+    const executionId = await createTestWorkflowExecution(root.executions, {
       projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_123" },
-      source: scheduleSource,
+      workflowId: "other-workflow",
+      runId: "wf-run-mismatched",
     })
-
-    expect(started.source).toEqual(scheduleSource)
-    expect(
-      await storage.getById({
+    await expect(
+      SqliteWorkflowRunStorage.prototype.queue.call(root.workflowRuns, {
+        id: "wf-run-mismatched",
         projectId: "my-app",
-        id: "wf-run-triggered",
+        executionId,
+        workflowId: "reconcile-transaction",
+        input: {},
       })
-    ).toMatchObject({ source: scheduleSource })
+    ).rejects.toBeInstanceOf(WorkflowRunError)
 
-    await storage.queue({
-      id: "wf-run-queued-without-source",
+    const automaticExecutionId = await createTestAutomaticWorkflowExecution(root.executions, {
       projectId: "my-app",
       workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_456" },
+      runId: "wf-run-automatic",
+      source: { type: "event", eventId: "source-event-1" },
     })
-
-    const running = await storage.start({
-      id: "wf-run-queued-without-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_456" },
-      source: scheduleSource,
-    })
-
-    expect(running.source).toEqual(scheduleSource)
-
-    await storage.queue({
-      id: "wf-run-queued-with-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_789" },
-      source: { type: "manual" },
-    })
-
-    const alreadySourced = await storage.start({
-      id: "wf-run-queued-with-source",
-      projectId: "my-app",
-      workflowId: "reconcile-transaction",
-      input: { transactionId: "txn_789" },
-      source: scheduleSource,
-    })
-
-    expect(alreadySourced.source).toEqual({ type: "manual" })
+    await expect(
+      SqliteWorkflowRunStorage.prototype.queue.call(root.workflowRuns, {
+        id: "wf-run-automatic",
+        projectId: "my-app",
+        executionId: automaticExecutionId,
+        workflowId: "reconcile-transaction",
+        input: {},
+      })
+    ).resolves.toMatchObject({ id: "wf-run-automatic", executionId: automaticExecutionId })
   })
 
   test("allows exactly one concurrent claim of a queued workflow run", async () => {
@@ -627,4 +614,49 @@ describe("SqliteWorkflowRunStorage", () => {
 
 function closeSqliteStorage(storage: SqliteStorage): void {
   storage.close()
+}
+
+type TestQueueWorkflowRunInput = Omit<QueueWorkflowRunInput, "executionId"> & {
+  readonly executionId?: string
+}
+
+type TestStartWorkflowRunInput = StartWorkflowRunInput & {
+  readonly workflowId?: string
+  readonly input?: QueueWorkflowRunInput["input"]
+}
+
+function createWorkflowRunStorage(root: SqliteStorage) {
+  const storage = root.workflowRuns
+  const queue = storage.queue.bind(storage)
+  const start = storage.start.bind(storage)
+  const queueFixture = async (input: TestQueueWorkflowRunInput) => {
+    const executionId = await createTestWorkflowExecution(root.executions, {
+      projectId: input.projectId,
+      workflowId: input.workflowId,
+      runId: input.id,
+      ...(input.executionId === undefined ? {} : { executionId: input.executionId }),
+    })
+    return queue({ ...input, executionId })
+  }
+
+  return Object.assign(storage, {
+    queue: queueFixture,
+    start: async (input: TestStartWorkflowRunInput) => {
+      const existing = await storage.getById({ projectId: input.projectId, id: input.id })
+      if (!existing && input.workflowId && input.input) {
+        await queueFixture({
+          id: input.id,
+          projectId: input.projectId,
+          workflowId: input.workflowId,
+          input: input.input,
+        })
+      }
+      return start({
+        id: input.id,
+        projectId: input.projectId,
+        ...(input.startedAt === undefined ? {} : { startedAt: input.startedAt }),
+        ...(input.execution === undefined ? {} : { execution: input.execution }),
+      })
+    },
+  })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,9 @@
       "@sixb/core/internal/projection-run-storage-provider": [
         "./packages/core/src/storage/projection-runs/lifecycle.ts"
       ],
+      "@sixb/core/internal/workflow-run-storage-provider": [
+        "./packages/core/src/storage/workflow-runs/provider.ts"
+      ],
       "@sixb/core/internal/projections": ["./packages/core/src/projections/internal.ts"],
       "@sixb/core/internal/agent-execution": ["./packages/core/src/execution/agent.ts"],
       "@sixb/core/internal/primitive-execution": ["./packages/core/src/execution/primitive.ts"],


### PR DESCRIPTION
## Why

Workflow runs crossed the queue boundary without a durable link to the execution that created them.
That made it impossible for a worker to restore the run's authority and provenance from storage
alone.

## What changes

- Every workflow run now has one required, unique `executionId`.
- Manual and automatic workflow dispatch persists the execution and run before publishing the queue
  job.
- Schedule and event triggers use the Core-owned `WorkflowRunDispatcher` through the orchestrator's
  typed `dispatchers` registry.
- The workflow worker loads the linked execution and restores its trusted scope instead of trusting
  queue-provided authority.
- Workflow history resolves `requestedBy` from the immutable execution ledger rather than storing a
  duplicate value on the run.
- In-memory, SQLite, and PostgreSQL providers enforce the same semantic run/execution relationship.

```text
request / schedule / event
          |
          v
WorkflowRunDispatcher
          |
          +-- transaction: ExecutionRecord + WorkflowRunRecord(executionId)
          |
          v
       queue job
          |
          v
WorkflowWorker -> load run + execution -> restore execution scope
```

## Migration behavior

Existing workflow runs cannot be assigned honest execution authority retroactively. The migrations
therefore reject populated legacy workflow-run tables instead of fabricating execution records.

The validation remains provider-owned. No database functions or triggers are introduced.

## Next

The next slice will apply the same atomic execution/run linkage to Action runs, including Actions
started from a workflow execution.

## Validation

- 3,732 tests passed; 7 live tests skipped
- Full typecheck
- Full build
- Biome check
- Publish smoke test for 49 packages

PostgreSQL E2E tests were not run locally because `DATABASE_URL` is not configured.

Part of #183
