### PR TITLE
errors: define pipeline and workflow failure taxonomy

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -1,9 +1,18 @@
 # Runtime error codes
 
-Sixb failures carry a stable `code` for programmatic decisions and a message for humans. Code can
-branch on `failure.code`; it must never parse `failure.message`.
+Sixb failures have two identities:
 
-HTTP error responses expose the same identity as an optional `code` while endpoints migrate. The Sixb client copies it to `SixbApiError.code`; clients should handle unknown strings so an older client remains compatible with codes introduced by a newer server.
+- `code` is stable and intended for programmatic decisions.
+- `message` is written for humans and must not be parsed.
+
+Unknown legacy exceptions use `internal.unexpected` until their call site receives a specific code.
+
+## API errors
+
+HTTP errors expose an optional `code` while endpoints migrate. The client copies it to
+`SixbApiError.code`.
+
+Always tolerate unknown codes: a newer server may introduce one before the client is upgraded.
 
 ```ts
 if (isSixbApiError(error) && error.code === "dataset.not_found") {
@@ -11,12 +20,9 @@ if (isSixbApiError(error) && error.code === "dataset.not_found") {
 }
 ```
 
-The catalog starts deliberately small and grows with each primitive's vertical migration. Unknown
-legacy exceptions use `internal.unexpected` until their call site receives a specific code.
-
 ## Failure records
 
-Persisted run failures use the same portable record returned by their API:
+Persisted failures and API responses use the same portable record:
 
 ```ts
 interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
@@ -29,36 +35,59 @@ interface SixbFailure<TCode extends SixbErrorCode = SixbErrorCode> {
 }
 ```
 
-Each primitive specializes `TCode` to the codes it can persist. Most migrated runs currently allow
-`internal.unexpected | runtime.cancelled`. Action failures also allow the retryable
-`queue.enqueue_failed` code and require `{ actionId, runId, phase }` in `details`.
-Webhook runs allow `internal.unexpected | webhook.delivery_failed`; only retryable post-claim
-failures use the delivery code. The idempotency journal and run reuse the same failure record.
-Expected non-retryable outcomes remain represented by their HTTP status and claim result.
-Workflow completion events reuse the exact failure stored on the run or node.
-Pipeline completion events reuse the exact failure stored on the run or step run.
-Sync completion events reuse the exact failure stored on the run.
-`agent.run.finished.error` reuses the exact failure stored on the Agent run.
-The ontology outbox declares `event.delivery_failed`; its durable record is retained while publication
-is retried.
+Messages are safe, bounded summaries owned by Sixb. Native errors, stacks, and causes stay on the
+private `error` argument passed to `onError`; they are never copied into storage or API responses.
+`truncated` indicates that optional context exceeded the durable failure size budget.
 
-Runtime `onError(error, context)` notifications expose the same record as `context.failure`. Failed runs and persisted outbox attempts reuse the exact object written to storage; failures without durable storage, such as rejected framework emits and rule evaluations, are normalized once at the reporting
-boundary. The native `error` argument remains available for stacks and error-monitoring integrations.
+`retryable` is the policy attached to the code. It does not override a worker's safety rules; a
+worker may still refuse to replay work that has already produced side effects.
 
-Each storage and wire change remains independently reviewable even though every migrated primitive shares the same portable base record.
+## Contracts by boundary
+
+Each boundary exposes only the codes it can persist.
+
+| Boundary | Allowed codes |
+| --- | --- |
+| Action run or phase | `internal.unexpected`, `queue.enqueue_failed`, `runtime.cancelled` |
+| Sync run | `internal.unexpected`, `runtime.cancelled` |
+| Agent execution | `internal.unexpected`, `runtime.cancelled` |
+| Projection run | `internal.unexpected`, `runtime.cancelled` |
+| Pipeline run or step | `internal.unexpected`, `runtime.cancelled`, `pipeline.step_failed` |
+| Workflow run or node | `internal.unexpected`, `runtime.cancelled`, `workflow.node_failed` |
+| Webhook run | `internal.unexpected`, `webhook.delivery_failed` |
+| Ontology outbox | `event.delivery_failed` |
+
+Additional rules:
+
+- Action failures require `{ actionId, runId, phase }` in `details`.
+- Agent, Pipeline, Sync, and Workflow completion events reuse the failure stored on the run.
+- `agent.run.finished.error` reuses the failure stored on the Agent run.
+- Webhook non-retryable outcomes remain HTTP outcomes; only retryable post-claim failures use
+  `webhook.delivery_failed`.
+- The outbox retains `event.delivery_failed` while publication is retried.
+
+## Reporting
+
+- `context.failure` is the same record written to durable storage when one exists.
+- `error` remains the native error for stacks and monitoring integrations.
+- Failures without durable storage are normalized once at the reporting boundary.
+
+## Error catalog
 
 | Code | Retryable | What happened | What to do |
 | --- | --- | --- | --- |
-| `dataset.not_found` | No | The requested dataset is not registered or is not visible to the caller. | Check the dataset ID and the caller's access. |
-| `dataset.version_incompatible` | No | The immutable dataset version does not match the dataset or schema required by the operation. | Materialize a compatible version and dispatch a new run. |
-| `dataset.version_not_found` | No | The requested dataset version does not exist, or the dataset has no committed version yet. | Check the version ID or materialize the dataset before reading rows. |
+| `dataset.not_found` | No | Dataset is unavailable to the caller. | Check its ID and access policy. |
+| `dataset.version_incompatible` | No | Version does not match the required dataset or schema. | Materialize a compatible version. |
+| `dataset.version_not_found` | No | Version does not exist or nothing has been committed yet. | Check the ID or materialize the dataset. |
 | `dataset.version_read_inconsistent` | Yes | Read results conflict with immutable version metadata. | Retry, then inspect lake storage integrity. |
-| `event.delivery_failed` | Yes | A persisted ontology event could not be published. | Let the outbox retry, then inspect the broker. |
-| `internal.unexpected` | No | Sixb caught an exception that has not yet been assigned a more specific code. | Inspect internal logs. Do not retry automatically. |
-| `queue.enqueue_failed` | Yes | A job could not be handed to its queue. | Retry the unchanged request while the durable run remains in its enqueue phase. |
-| `projection.definition_invalid` | No | A projection definition is incompatible with its ontology or dataset mapping. | Fix the projection definition and dispatch a new run. |
-| `projection.not_found` | No | The requested projection is not registered in the current runtime. | Check the projection ID and ensure its definition is deployed. |
-| `projection.run_already_terminal` | No | A delivery targeted a projection run that had already failed or been cancelled. | Do not reuse the terminal run ID; dispatch a new semantic run if needed. |
-| `projection.run_identity_mismatch` | No | A projection run or delivery does not match its pinned semantic identity. | Discard the stale delivery and dispatch from the current projection definition. |
-| `runtime.cancelled` | No | An in-flight operation was cancelled before completion. | Confirm the cancellation was intentional before requesting another run. |
-| `webhook.delivery_failed` | Yes | A webhook handler failed with a retryable outcome. | Let the provider retry, then inspect the handler. |
+| `event.delivery_failed` | Yes | A persisted event could not reach the event stream. | Let the outbox retry; inspect the broker if it persists. |
+| `internal.unexpected` | No | The exception has no specific code yet. | Inspect its `onError` report and correlation details. |
+| `pipeline.step_failed` | No | A step failed before committing its output. | Fix the cause and request a new pipeline run. |
+| `projection.definition_invalid` | No | Projection definition is invalid for its ontology or dataset. | Fix the definition and request a new run. |
+| `projection.not_found` | No | Projection is not registered. | Check its ID and deployment. |
+| `projection.run_already_terminal` | No | Delivery targets a run that is already terminal. | Use a new run ID for new work. |
+| `projection.run_identity_mismatch` | No | Delivery does not match the run's pinned identity. | Discard it and dispatch from the current definition. |
+| `queue.enqueue_failed` | Yes | A job could not be handed to its queue. | Retry while the run remains in its enqueue phase. |
+| `runtime.cancelled` | No | Work was cancelled before completion. | Confirm the cancellation before requesting another run. |
+| `webhook.delivery_failed` | Yes | A claimed webhook delivery failed retryably. | Let the provider retry; inspect the handler if it persists. |
+| `workflow.node_failed` | No | A node failed during preparation or execution. | Inspect its identity and `onError` report. |

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -4,10 +4,16 @@ import {
   resolveAgentExecutionAuthorization,
 } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
-import { captureSixbFailure, createSixbError, toSixbFailure } from "@sixb/core/internal/errors"
+import {
+  captureSixbFailure,
+  createSixbError,
+  summarizeErrorMessage,
+  toSixbFailure,
+} from "@sixb/core/internal/errors"
 import type { QueueDelivery } from "@sixb/core/internal/workers"
 import { QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { WorkflowAgentNodeDefinition } from "@sixb/core/internal/workflows"
+import { createWorkflowNodeFailure } from "@sixb/core/internal/workflows"
 import type {
   AgentQueueJob,
   AgentQueueJobFailureCode,
@@ -437,26 +443,32 @@ async function finishWorkflowAgentNodeFailed(input: {
   readonly failure: SixbFailure<WorkflowRunFailureCode>
 }> {
   const at = new Date()
-  const failure = captureSixbFailure(input.error, {
+  const workflowFailureError =
+    input.status === "failed"
+      ? createWorkflowNodeFailure(input.error, {
+          workflowId: input.nodeRun.workflowId,
+          workflowRunId: input.nodeRun.workflowRunId,
+          nodeId: input.nodeRun.nodeId,
+          nodeRunId: input.nodeRun.id,
+          child: { type: "agent", agentId: input.agent.id },
+        })
+      : createSixbError(
+          "runtime.cancelled",
+          summarizeErrorMessage(input.error, "Agent workflow node execution failed."),
+          {
+            cause: input.error,
+            details: workflowAgentErrorDetails(input.agent.id, input.nodeRun),
+          }
+        )
+  const workflowFailure = toSixbFailure(workflowFailureError, {
     allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
-    defaultCode: input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
     at,
-    details: {
-      workflowId: input.nodeRun.workflowId,
-      workflowRunId: input.nodeRun.workflowRunId,
-      nodeRunId: input.nodeRun.id,
-    },
   })
   const agentFailure = captureSixbFailure(input.error, {
     allowedCodes: AGENT_RUN_FAILURE_CODES,
     defaultCode: input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
     at,
-    details: {
-      agentId: input.agent.id,
-      workflowId: input.nodeRun.workflowId,
-      workflowRunId: input.nodeRun.workflowRunId,
-      nodeRunId: input.nodeRun.id,
-    },
+    details: workflowAgentErrorDetails(input.agent.id, input.nodeRun),
   })
   return input.context.storage.transaction(async (tx) => {
     const runs = tx.workflowRuns
@@ -480,17 +492,17 @@ async function finishWorkflowAgentNodeFailed(input: {
       projectId: input.context.id,
       id: input.nodeRun.id,
       status: input.status,
-      error: failure,
       finishedAt: at,
+      error: workflowFailure,
     })
     const run = await runs.finish({
       projectId: input.context.id,
       id: input.nodeRun.workflowRunId,
       status: input.status,
-      error: failure,
       finishedAt: at,
+      error: workflowFailure,
     })
-    return { node, run, failure }
+    return { node, run, failure: workflowFailure }
   })
 }
 
@@ -641,12 +653,13 @@ function requireFinishedAt(
 
 function workflowAgentErrorDetails(
   agentId: string,
-  nodeRun: Pick<WorkflowNodeRunRecord, "id" | "workflowId" | "workflowRunId">
+  nodeRun: Pick<WorkflowNodeRunRecord, "id" | "workflowId" | "workflowRunId" | "nodeId">
 ): Readonly<Record<string, string>> {
   return {
     agentId,
     workflowId: nodeRun.workflowId,
     workflowRunId: nodeRun.workflowRunId,
+    nodeId: nodeRun.nodeId,
     nodeRunId: nodeRun.id,
   }
 }

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -2080,6 +2080,157 @@ describe("AgentWorker", () => {
     }
   })
 
+  test("translates a failed agent execution into the parent workflow vocabulary", async () => {
+    const originalError = new Error("workflow agent provider failed")
+    const model = new MockLanguageModelV4({
+      modelId: "mock-model",
+      doGenerate: async () => {
+        throw originalError
+      },
+    })
+    const agent = defineAgent("workflow-failure-agent", {
+      name: "Workflow failure agent",
+      model,
+      instructions: "Fail for this test.",
+      groups: [AGENT_RUNTIME_GROUP],
+    })
+    const agentStep = defineAgentStep("resolve-or-fail", agent)
+      .input({ query: "string" })
+      .output({ answer: "string" })
+      .prompt(({ input }) => `Resolve '${input.query}'.`)
+    const workflow = defineWorkflow("agent-failure-workflow")
+      .input({ query: "string" })
+      .then(agentStep)
+    const sixb = new SixbHost({
+      id: PROJECT_ID,
+      ontology: [],
+      agents: [agent],
+      workflows: [workflow],
+      groups: [AGENT_RUNTIME_GROUP],
+      broker: new InMemoryBroker(),
+      storage: new InMemoryStorage(),
+      lakeStorage: new InMemoryLakeStorage(),
+      blobStorage: new InMemoryBlobStorage(),
+      queues: new InMemoryQueues(),
+      sandboxes: new RecordingSandboxFactory(),
+    })
+    const reports: Array<{ error: Error; context: SixbErrorContext }> = []
+    const reporter = attachSixbErrorReporter(sixb, (error, context) => {
+      reports.push({ error, context })
+    })
+    const runs = sixb.storage.workflowRuns!
+    const runId = "workflow-agent-failure-run"
+    const nodeRunId = `${runId}:node:0`
+    const executionId = await createTestWorkflowExecution(sixb.storage.executions, {
+      projectId: PROJECT_ID,
+      workflowId: workflow.id,
+      runId,
+    })
+    await runs.queue({
+      id: runId,
+      projectId: PROJECT_ID,
+      executionId,
+      workflowId: workflow.id,
+      input: { query: "alpha" },
+      requesterGroupIds: [],
+    })
+    await runs.start({ id: runId, projectId: PROJECT_ID })
+    await runs.nodes.start({
+      id: nodeRunId,
+      projectId: PROJECT_ID,
+      workflowRunId: runId,
+      workflowId: workflow.id,
+      nodeIndex: 0,
+      nodeType: "agent",
+      nodeId: agentStep.id,
+      nodeKey: "resolveOrFail",
+      input: { query: "alpha" },
+    })
+    const agentExecutionId = await createTestAgentExecution(sixb.storage, {
+      projectId: PROJECT_ID,
+      agentId: agent.id,
+      runId: nodeRunId,
+      parentExecutionId: executionId,
+    })
+    await runs.agentNodes.create({
+      projectId: PROJECT_ID,
+      nodeRunId,
+      executionId: agentExecutionId,
+      agentId: agent.id,
+      prompt: "Resolve 'alpha'.",
+    })
+    await runs.nodes.wait({ projectId: PROJECT_ID, id: nodeRunId })
+    await runs.wait({ projectId: PROJECT_ID, id: runId })
+    await sixb.queues.agents.enqueue({
+      projectId: PROJECT_ID,
+      jobs: [
+        {
+          id: `wfa_job_${nodeRunId}`,
+          type: "agent.workflow-node.requested",
+          payload: { nodeRunId },
+        },
+      ],
+    })
+
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+    await worker.start()
+    try {
+      const execution = await waitFor(
+        async () => {
+          const record = await runs.agentNodes.getByNodeRunId({
+            projectId: PROJECT_ID,
+            nodeRunId,
+          })
+          return record?.status === "failed" ? record : null
+        },
+        { label: "workflow agent node failed" }
+      )
+      const [nodeRun, run] = await Promise.all([
+        runs.nodes.getById({ projectId: PROJECT_ID, id: nodeRunId }),
+        runs.getById({ projectId: PROJECT_ID, id: runId }),
+      ])
+
+      expect(execution.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        retryable: false,
+        details: {
+          agentId: agent.id,
+          workflowId: workflow.id,
+          workflowRunId: runId,
+          nodeId: agentStep.id,
+          nodeRunId,
+        },
+      })
+      expect(run?.status).toBe("failed")
+      expect(run?.error).toMatchObject({
+        code: "workflow.node_failed",
+        message: "Workflow node execution failed.",
+        retryable: false,
+        details: {
+          agentId: agent.id,
+          workflowId: workflow.id,
+          workflowRunId: runId,
+          nodeId: agentStep.id,
+          nodeRunId,
+        },
+      })
+      expect(nodeRun?.error).toEqual(run?.error)
+
+      await reporter.flush()
+      expect(reports).toHaveLength(1)
+      expect(reports[0]?.error).toBe(originalError)
+      expect(reports[0]?.context).toMatchObject({
+        type: "run.failed",
+        runKind: "workflow",
+        run: { runId, workflowId: workflow.id },
+        failure: run?.error,
+      })
+    } finally {
+      await worker.stop()
+    }
+  })
+
   test("fails startup when a project Agent Skill is invalid", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "sixb-agent-skills-startup-"))
     try {

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -7131,7 +7131,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "pipeline.step_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -7497,7 +7501,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "pipeline.step_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -7688,7 +7696,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "pipeline.step_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -7851,7 +7863,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "pipeline.step_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -7973,7 +7989,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "pipeline.step_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -8565,7 +8585,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "workflow.node_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -9025,7 +9049,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "workflow.node_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -10506,7 +10534,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "workflow.node_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -10693,7 +10725,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "workflow.node_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -10913,7 +10949,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "workflow.node_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -11359,7 +11399,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "workflow.node_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -11579,7 +11623,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "workflow.node_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2502,7 +2502,7 @@ export type ListPipelinesResponses = {
         versionId: string
       }
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "pipeline.step_failed"
         message: string
         retryable: boolean
         at: string
@@ -2633,7 +2633,7 @@ export type GetPipelineResponses = {
         versionId: string
       }
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "pipeline.step_failed"
         message: string
         retryable: boolean
         at: string
@@ -2706,7 +2706,7 @@ export type ListPipelineRunsResponses = {
         versionId: string
       }
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "pipeline.step_failed"
         message: string
         retryable: boolean
         at: string
@@ -2781,7 +2781,7 @@ export type GetPipelineRunResponses = {
         versionId: string
       }
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "pipeline.step_failed"
         message: string
         retryable: boolean
         at: string
@@ -2821,7 +2821,7 @@ export type GetPipelineRunResponses = {
       }
       rowsWritten?: number
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "pipeline.step_failed"
         message: string
         retryable: boolean
         at: string
@@ -3031,7 +3031,7 @@ export type ListWorkflowsResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
         message: string
         retryable: boolean
         at: string
@@ -3211,7 +3211,7 @@ export type GetWorkflowResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
         message: string
         retryable: boolean
         at: string
@@ -3713,7 +3713,7 @@ export type ListWorkflowRunsResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
         message: string
         retryable: boolean
         at: string
@@ -3789,7 +3789,7 @@ export type GetWorkflowRunResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
         message: string
         retryable: boolean
         at: string
@@ -3869,7 +3869,7 @@ export type GetWorkflowRunResponses = {
           | null
       }
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
         message: string
         retryable: boolean
         at: string
@@ -4032,7 +4032,7 @@ export type CancelWorkflowRunResponses = {
       startedAt: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
         message: string
         retryable: boolean
         at: string
@@ -4112,7 +4112,7 @@ export type CancelWorkflowRunResponses = {
           | null
       }
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed"
         message: string
         retryable: boolean
         at: string

--- a/packages/client/tests/events-builder.types.ts
+++ b/packages/client/tests/events-builder.types.ts
@@ -273,7 +273,8 @@ events
       (event.type === "workflow.run.finished" || event.type === "workflow.run.node.finished") &&
       event.payload.error
     ) {
-      const code: "internal.unexpected" | "runtime.cancelled" = event.payload.error.code
+      const code: "internal.unexpected" | "runtime.cancelled" | "workflow.node_failed" =
+        event.payload.error.code
       const message: string = event.payload.error.message
       // @ts-expect-error — workflow lifecycle failures expose only their primitive's code union.
       const datasetCode: "dataset.not_found" = event.payload.error.code
@@ -290,7 +291,8 @@ events
       (event.type === "pipeline.run.finished" || event.type === "pipeline.run.step.finished") &&
       event.payload.error
     ) {
-      const code: "internal.unexpected" | "runtime.cancelled" = event.payload.error.code
+      const code: "internal.unexpected" | "runtime.cancelled" | "pipeline.step_failed" =
+        event.payload.error.code
       const message: string = event.payload.error.message
       // @ts-expect-error — pipeline lifecycle failures expose only their primitive's code union.
       const datasetCode: "dataset.not_found" = event.payload.error.code

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -38,6 +38,10 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "The job could not be enqueued.",
     retryable: true,
   },
+  "pipeline.step_failed": {
+    publicMessage: "Pipeline step execution failed.",
+    retryable: false,
+  },
   "projection.definition_invalid": {
     publicMessage: "Projection definition is invalid.",
     retryable: false,
@@ -61,6 +65,10 @@ export const SIXB_ERROR_DEFINITIONS = {
   "webhook.delivery_failed": {
     publicMessage: "Webhook delivery failed.",
     retryable: true,
+  },
+  "workflow.node_failed": {
+    publicMessage: "Workflow node execution failed.",
+    retryable: false,
   },
 } as const satisfies Readonly<Record<string, SixbErrorDefinition>>
 

--- a/packages/core/src/storage/pipeline-runs/types.ts
+++ b/packages/core/src/storage/pipeline-runs/types.ts
@@ -7,6 +7,7 @@ export type PipelineRunStatus = "running" | "succeeded" | "failed" | "cancelled"
 export const PIPELINE_RUN_FAILURE_CODES = [
   "internal.unexpected",
   "runtime.cancelled",
+  "pipeline.step_failed",
 ] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
 
 export type PipelineRunFailureCode = (typeof PIPELINE_RUN_FAILURE_CODES)[number]

--- a/packages/core/src/storage/workflow-runs/types.ts
+++ b/packages/core/src/storage/workflow-runs/types.ts
@@ -25,6 +25,7 @@ export type WorkflowNodeRunType = "step" | "action" | "intervention" | "agent"
 export const WORKFLOW_RUN_FAILURE_CODES = [
   "internal.unexpected",
   "runtime.cancelled",
+  "workflow.node_failed",
 ] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
 
 export type WorkflowRunFailureCode = (typeof WORKFLOW_RUN_FAILURE_CODES)[number]

--- a/packages/core/src/workflows/failure.ts
+++ b/packages/core/src/workflows/failure.ts
@@ -1,0 +1,63 @@
+import { createSixbError, isSixbError, summarizeErrorMessage } from "../errors/internal"
+
+interface WorkflowNodeFailureIdentityBase {
+  readonly workflowId: string
+  readonly workflowRunId: string
+  readonly nodeId: string
+  readonly nodeRunId?: string
+}
+
+export interface WorkflowNodeFailureIdentity extends WorkflowNodeFailureIdentityBase {
+  readonly child:
+    | { readonly type: "step"; readonly stepId: string }
+    | {
+        readonly type: "action"
+        readonly actionId: string
+        readonly actionRunId?: string
+      }
+    | { readonly type: "agent"; readonly agentId: string }
+    | { readonly type: "intervention"; readonly interventionId: string }
+}
+
+/** Translate a node-local failure into the workflow primitive's durable vocabulary. */
+export function createWorkflowNodeFailure(error: unknown, identity: WorkflowNodeFailureIdentity) {
+  return createSixbError(
+    "workflow.node_failed",
+    summarizeErrorMessage(error, "Workflow node execution failed."),
+    {
+      cause: error,
+      details: workflowNodeFailureDetails(identity),
+    }
+  )
+}
+
+/** Recover the native child error for direct callers and error-monitoring integrations. */
+export function unwrapWorkflowNodeFailure(error: unknown): unknown {
+  return isSixbError(error) && error.code === "workflow.node_failed" && error.cause !== undefined
+    ? error.cause
+    : error
+}
+
+function workflowNodeFailureDetails(identity: WorkflowNodeFailureIdentity) {
+  const base = {
+    workflowId: identity.workflowId,
+    workflowRunId: identity.workflowRunId,
+    nodeId: identity.nodeId,
+    ...(identity.nodeRunId ? { nodeRunId: identity.nodeRunId } : {}),
+  }
+
+  switch (identity.child.type) {
+    case "step":
+      return { ...base, stepId: identity.child.stepId }
+    case "action":
+      return {
+        ...base,
+        actionId: identity.child.actionId,
+        ...(identity.child.actionRunId ? { actionRunId: identity.child.actionRunId } : {}),
+      }
+    case "agent":
+      return { ...base, agentId: identity.child.agentId }
+    case "intervention":
+      return { ...base, interventionId: identity.child.interventionId }
+  }
+}

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -6,6 +6,8 @@ export {
   interventionField,
 } from "./builders"
 export { WorkflowDefinitionError, WorkflowValidationError } from "./errors"
+export type { WorkflowNodeFailureIdentity } from "./failure"
+export { createWorkflowNodeFailure, unwrapWorkflowNodeFailure } from "./failure"
 export type {
   RequestWorkflowRunInput,
   WorkflowRunRequestOptions,

--- a/packages/pipeline-worker/src/errors.ts
+++ b/packages/pipeline-worker/src/errors.ts
@@ -1,5 +1,5 @@
 import type { DatasetDefinition, PipelineDefinition } from "@sixb/core"
-import { createSixbError } from "@sixb/core/internal/errors"
+import { createSixbError, isSixbError, summarizeErrorMessage } from "@sixb/core/internal/errors"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
 import type { PipelineRunStatus } from "@sixb/core/storage"
 import type { PipelineJob } from "./types"
@@ -57,6 +57,34 @@ export function createStepBookkeepingError(options: {
       },
     }
   )
+}
+
+export function createPipelineStepFailure(options: {
+  readonly pipelineId: string
+  readonly pipelineRunId: string
+  readonly stepId: string
+  readonly stepRunId?: string
+  readonly cause: unknown
+}) {
+  return createSixbError(
+    "pipeline.step_failed",
+    summarizeErrorMessage(options.cause, "Pipeline step execution failed."),
+    {
+      cause: options.cause,
+      details: {
+        pipelineId: options.pipelineId,
+        pipelineRunId: options.pipelineRunId,
+        stepId: options.stepId,
+        ...(options.stepRunId ? { stepRunId: options.stepRunId } : {}),
+      },
+    }
+  )
+}
+
+export function unwrapPipelineStepFailure(error: unknown): unknown {
+  return isSixbError(error) && error.code === "pipeline.step_failed" && error.cause !== undefined
+    ? error.cause
+    : error
 }
 
 export function createPipelineBookkeepingError(options: {

--- a/packages/pipeline-worker/src/run-pipeline-job.ts
+++ b/packages/pipeline-worker/src/run-pipeline-job.ts
@@ -8,6 +8,7 @@ import {
   requirePipeline,
   statusForFailure,
   throwIfAborted,
+  unwrapPipelineStepFailure,
 } from "./errors"
 import { runStep } from "./run-step"
 import type {
@@ -119,6 +120,7 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
       version: finalVersion,
     }
   } catch (error) {
+    const reportedError = unwrapPipelineStepFailure(error)
     if (startedRun && !finished) {
       const status = statusForFailure(signal, error)
       try {
@@ -134,7 +136,7 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
           error: failure,
         })
         if (status === "failed" && run.status === "failed") {
-          input.onRunFailed?.(error, run, failure)
+          input.onRunFailed?.(reportedError, run, failure)
         }
         await notifyRunFinished(input.onRunFinished, run)
       } catch {
@@ -142,7 +144,7 @@ export async function runPipelineJob(input: RunPipelineJobInput): Promise<Pipeli
       }
     }
 
-    throw error
+    throw reportedError
   } finally {
     await logSession.flush()
   }

--- a/packages/pipeline-worker/src/run-step.ts
+++ b/packages/pipeline-worker/src/run-step.ts
@@ -3,6 +3,7 @@ import { captureSixbFailure } from "@sixb/core/internal/errors"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
 import { PIPELINE_RUN_FAILURE_CODES, type PipelineStepRunRecord } from "@sixb/core/storage"
 import {
+  createPipelineStepFailure,
   createStepBookkeepingError,
   requireRegisteredDataset,
   statusForFailure,
@@ -44,23 +45,37 @@ export async function runStep(input: {
   }
 
   throwIfAborted(signal)
-  const resolvedInputs = await resolveStepInputs({
-    runtime,
-    pipeline,
-    step,
-    pipelineRunId: job.id,
-  })
-  const inputRefs = resolvedInputs.map((resolved) => resolved.ref)
-  const outputDataset = requireRegisteredDataset({
-    dataset: runtime.datasets.getById(step.output.id),
-    pipelineId: pipeline.id,
-    pipelineRunId: job.id,
-    stepId: step.id,
-    role: "output",
-    datasetId: step.output.id,
-  })
+  let resolvedInputs: readonly ResolvedStepInput[]
+  let outputDataset: DatasetDefinition
+  try {
+    resolvedInputs = await resolveStepInputs({
+      runtime,
+      pipeline,
+      step,
+      pipelineRunId: job.id,
+    })
+    outputDataset = requireRegisteredDataset({
+      dataset: runtime.datasets.getById(step.output.id),
+      pipelineId: pipeline.id,
+      pipelineRunId: job.id,
+      stepId: step.id,
+      role: "output",
+      datasetId: step.output.id,
+    })
 
-  await runtime.lakeStorage.createDataset(outputDataset)
+    await runtime.lakeStorage.createDataset(outputDataset)
+  } catch (error) {
+    if (statusForFailure(signal, error) === "failed") {
+      throw createPipelineStepFailure({
+        pipelineId: pipeline.id,
+        pipelineRunId: job.id,
+        stepId: step.id,
+        cause: error,
+      })
+    }
+    throw error
+  }
+  const inputRefs = resolvedInputs.map((resolved) => resolved.ref)
 
   const stepRunId = `${job.id}:step:${stepIndex + 1}:${step.id}`
   const startedStepRun = await runtime.pipelineRunsStorage.startStep({
@@ -124,13 +139,23 @@ export async function runStep(input: {
   } catch (error) {
     if (!committedVersion) {
       const status = statusForFailure(signal, error)
+      const failureError =
+        status === "failed"
+          ? createPipelineStepFailure({
+              pipelineId: pipeline.id,
+              pipelineRunId: job.id,
+              stepId: step.id,
+              stepRunId,
+              cause: error,
+            })
+          : error
       const failedStepRun = await runtime.pipelineRunsStorage
         .finishStep({
           projectId: runtime.id,
           id: stepRunId,
           status,
           rowsWritten,
-          error: captureSixbFailure(error, {
+          error: captureSixbFailure(failureError, {
             allowedCodes: PIPELINE_RUN_FAILURE_CODES,
             defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
             details: {
@@ -146,6 +171,8 @@ export async function runStep(input: {
       if (failedStepRun) {
         await input.onStepFinished?.(failedStepRun, lifecycleContext)
       }
+
+      throw failureError
     }
 
     throw error

--- a/packages/pipeline-worker/tests/run-pipeline-job.test.ts
+++ b/packages/pipeline-worker/tests/run-pipeline-job.test.ts
@@ -209,6 +209,59 @@ describe("runPipelineJob", () => {
     })
   })
 
+  test("keeps step finalization failures out of the step-failed vocabulary", async () => {
+    const lakeStorage = new InMemoryLakeStorage()
+    await seedDatasetVersion(lakeStorage, rawCustomersDataset, [{ id: "cust_1", name: "Ada" }])
+    const step = definePipelineStep("clean-customers")
+      .inputs({ rawCustomers: rawCustomersDataset })
+      .output(customersDataset)
+      .run(async ({ inputs, output }) => {
+        await output.writeRows(inputs.rawCustomers.readRows({ columns: ["id", "name"] }))
+      })
+    const pipeline = definePipeline("customers").then(step)
+    const pipelineRunsStorage = new InMemoryPipelineRunStorage()
+    const finishStep = pipelineRunsStorage.finishStep.bind(pipelineRunsStorage)
+    const finishCause = new Error("step finish unavailable")
+    pipelineRunsStorage.finishStep = async (input) => {
+      if (input.status === "succeeded") throw finishCause
+      return finishStep(input)
+    }
+    const runtime = createRuntime({
+      pipelines: [pipeline],
+      datasets: [rawCustomersDataset, customersDataset],
+      lakeStorage,
+      pipelineRunsStorage,
+    })
+
+    await expect(
+      runPipelineJob({ runtime, job: { id: "run_step_finish_failed", pipelineId: pipeline.id } })
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      cause: finishCause,
+      details: {
+        pipelineId: pipeline.id,
+        pipelineRunId: "run_step_finish_failed",
+        stepId: step.id,
+        stepRunId: "run_step_finish_failed:step:1:clean-customers",
+      },
+    })
+
+    const run = await pipelineRunsStorage.getById({
+      projectId: runtime.id,
+      id: "run_step_finish_failed",
+    })
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      details: {
+        pipelineId: pipeline.id,
+        pipelineRunId: "run_step_finish_failed",
+        stepId: step.id,
+        stepRunId: "run_step_finish_failed:step:1:clean-customers",
+      },
+    })
+  })
+
   test("fails clearly when an input has no committed version", async () => {
     const cleanStep = definePipelineStep("clean-customers")
       .inputs({ rawCustomers: rawCustomersDataset })
@@ -249,16 +302,15 @@ describe("runPipelineJob", () => {
     })
     expect(run?.status).toBe("failed")
     expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
+      code: "pipeline.step_failed",
       retryable: false,
       details: {
         pipelineId: "customers",
         pipelineRunId: "run_missing_input",
         stepId: "clean-customers",
-        datasetId: "raw.customers",
       },
     })
-    expect(run?.error?.message).toBe("An unexpected internal error occurred.")
+    expect(run?.error?.message).toBe("Pipeline step execution failed.")
 
     const steps = await pipelineRunsStorage.listSteps({
       projectId: runtime.id,
@@ -509,11 +561,8 @@ describe("runPipelineJob", () => {
     })
     expect(stepRuns.steps.map((step) => step.status)).toEqual(["succeeded", "failed"])
     expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
-      details: { pipelineId: "customers", runId: "run_failure" },
-    })
-    expect(stepRuns.steps[1]?.error).toMatchObject({
-      code: "internal.unexpected",
+      code: "pipeline.step_failed",
+      retryable: false,
       details: {
         pipelineId: "customers",
         pipelineRunId: "run_failure",
@@ -521,7 +570,17 @@ describe("runPipelineJob", () => {
         stepRunId: "run_failure:step:2:customer-stats",
       },
     })
-    expect(stepRuns.steps[1]?.error?.message).toBe("An unexpected internal error occurred.")
+    expect(stepRuns.steps[1]?.error).toMatchObject({
+      code: "pipeline.step_failed",
+      retryable: false,
+      details: {
+        pipelineId: "customers",
+        pipelineRunId: "run_failure",
+        stepId: "customer-stats",
+        stepRunId: "run_failure:step:2:customer-stats",
+      },
+    })
+    expect(stepRuns.steps[1]?.error?.message).toBe("Pipeline step execution failed.")
 
     const committedRows = await collectRows(lakeStorage.readRows({ datasetId: "customers" }))
     expect(committedRows).toEqual([{ id: "cust_1", name: "Ada" }])
@@ -683,6 +742,16 @@ describe("runPipelineJob", () => {
       id: "run_sql_no_support",
     })
     expect(run?.status).toBe("failed")
+    expect(run?.error).toMatchObject({
+      code: "pipeline.step_failed",
+      retryable: false,
+      details: {
+        pipelineId: "customers",
+        pipelineRunId: "run_sql_no_support",
+        stepId: "customer-stats",
+        stepRunId: "run_sql_no_support:step:1:customer-stats",
+      },
+    })
 
     const stepRuns = await pipelineRunsStorage.listSteps({
       projectId: runtime.id,
@@ -692,16 +761,16 @@ describe("runPipelineJob", () => {
       stepId: "customer-stats",
       status: "failed",
       error: {
-        code: "internal.unexpected",
+        code: "pipeline.step_failed",
         retryable: false,
         details: {
           pipelineId: "customers",
           pipelineRunId: "run_sql_no_support",
           stepId: "customer-stats",
-          datasetId: "customer_stats",
+          stepRunId: "run_sql_no_support:step:1:customer-stats",
         },
       },
     })
-    expect(stepRuns.steps[0]?.error?.message).toBe("An unexpected internal error occurred.")
+    expect(stepRuns.steps[0]?.error?.message).toBe("Pipeline step execution failed.")
   })
 })

--- a/packages/pipeline-worker/tests/worker.test.ts
+++ b/packages/pipeline-worker/tests/worker.test.ts
@@ -481,8 +481,8 @@ describe("PipelineWorker", () => {
       totalSteps: 2,
       status: "failed",
       error: {
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "pipeline.step_failed",
+        message: "Pipeline step execution failed.",
         retryable: false,
         at: expect.any(String),
         details: {

--- a/packages/workflow-worker/src/execution/workflow-node-runner.ts
+++ b/packages/workflow-worker/src/execution/workflow-node-runner.ts
@@ -1,12 +1,20 @@
+import { ActionRunFailedError } from "@sixb/core"
 import { createSixbError } from "@sixb/core/internal/errors"
-import type { WorkflowIOSnapshot, WorkflowNodeDefinition } from "@sixb/core/internal/workflows"
+import {
+  createWorkflowNodeFailure,
+  type WorkflowIOSnapshot,
+  type WorkflowNodeDefinition,
+  type WorkflowNodeFailureIdentity,
+} from "@sixb/core/internal/workflows"
 import type { WorkflowRunRecord } from "@sixb/core/storage"
-import { throwIfAborted } from "../normalize"
+import { isAbortError, throwIfAborted } from "../normalize"
 import type { WorkflowRunRecorder } from "../recorder"
 import type {
+  PreparedWorkflowNode,
   WorkflowNodeExecutionContext,
   WorkflowNodeExecutor,
   WorkflowNodeExecutorRegistry,
+  WorkflowNodeOutcome,
   WorkflowNodeStatePatch,
 } from "./node-executor"
 
@@ -24,10 +32,15 @@ export class WorkflowNodeRunner {
     readonly context: WorkflowNodeExecutionContext
   }): Promise<WorkflowNodeRunResult> {
     const executor = this.executorFor(input.node)
-    const prepared = await executor.prepare({
-      node: input.node,
-      context: input.context,
-    })
+    let prepared: PreparedWorkflowNode
+    try {
+      prepared = await executor.prepare({
+        node: input.node,
+        context: input.context,
+      })
+    } catch (error) {
+      throwNodeExecutionError(error, input)
+    }
     const nodeRun = await this.dependencies.recorder.startNode({
       nodeIndex: input.nodeIndex,
       nodeType: input.node.type,
@@ -38,13 +51,18 @@ export class WorkflowNodeRunner {
 
     throwIfAborted(input.context.signal)
 
-    const outcome = await executor.execute({
-      node: input.node,
-      nodeIndex: input.nodeIndex,
-      nodeRun,
-      prepared,
-      context: input.context,
-    })
+    let outcome: WorkflowNodeOutcome
+    try {
+      outcome = await executor.execute({
+        node: input.node,
+        nodeIndex: input.nodeIndex,
+        nodeRun,
+        prepared,
+        context: input.context,
+      })
+    } catch (error) {
+      throwNodeExecutionError(error, input, nodeRun.id)
+    }
 
     if (outcome.status === "waiting") {
       if ("agentExecution" in outcome) {
@@ -111,10 +129,26 @@ export class WorkflowNodeRunner {
     }
     assertStatePatchIsPersistable(outcome.statePatch, outcome.outputSnapshot, details)
 
-    await this.dependencies.recorder.finishNodeSucceeded({
-      nodeRunId: nodeRun.id,
-      output: outcome.outputSnapshot,
-    })
+    try {
+      await this.dependencies.recorder.finishNodeSucceeded({
+        nodeRunId: nodeRun.id,
+        output: outcome.outputSnapshot,
+      })
+    } catch (error) {
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow '${input.context.workflow.id}' node '${input.node.id}' completed, but failed to finalize node run '${nodeRun.id}'. The node run record may need repair.`,
+        {
+          cause: error,
+          details: {
+            workflowId: input.context.workflow.id,
+            workflowRunId: input.context.job.id,
+            nodeId: input.node.id,
+            nodeRunId: nodeRun.id,
+          },
+        }
+      )
+    }
 
     applyStatePatch(input.context.state, outcome.statePatch, outcome.outputSnapshot, details)
 
@@ -127,6 +161,47 @@ export class WorkflowNodeRunner {
     node: TNode
   ): WorkflowNodeExecutor<TNode> {
     return this.dependencies.executors[node.type] as WorkflowNodeExecutor<TNode>
+  }
+}
+
+function throwNodeExecutionError(
+  error: unknown,
+  input: {
+    readonly node: WorkflowNodeDefinition
+    readonly context: WorkflowNodeExecutionContext
+  },
+  nodeRunId?: string
+): never {
+  if (input.context.signal.aborted || isAbortError(error)) {
+    throw error
+  }
+
+  throw createWorkflowNodeFailure(error, {
+    workflowId: input.context.workflow.id,
+    workflowRunId: input.context.job.id,
+    nodeId: input.node.id,
+    ...(nodeRunId ? { nodeRunId } : {}),
+    child: workflowNodeFailureChild(input.node, error),
+  })
+}
+
+function workflowNodeFailureChild(
+  node: WorkflowNodeDefinition,
+  error: unknown
+): WorkflowNodeFailureIdentity["child"] {
+  switch (node.type) {
+    case "step":
+      return { type: "step", stepId: node.step.id }
+    case "action":
+      return {
+        type: "action",
+        actionId: node.action.id,
+        ...(error instanceof ActionRunFailedError ? { actionRunId: error.runId } : {}),
+      }
+    case "agent":
+      return { type: "agent", agentId: node.agentStep.agent.id }
+    case "intervention":
+      return { type: "intervention", interventionId: node.intervention.id }
   }
 }
 

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -10,6 +10,7 @@ import type {
 import {
   snapshotWorkflowInput,
   snapshotWorkflowInterventionResponse,
+  unwrapWorkflowNodeFailure,
   validateWorkflowAgentStepOutput,
   validateWorkflowInput,
   validateWorkflowInterventionResponse,
@@ -642,9 +643,10 @@ export class WorkflowRunSession {
 
     const at = new Date()
     const activeNodeRunId = this.dependencies.recorder.activeNodeId
+    const failureCode = status === "cancelled" ? "runtime.cancelled" : "internal.unexpected"
     const failure = captureSixbFailure(error, {
       allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
-      defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+      defaultCode: failureCode,
       details: {
         workflowId: this.dependencies.workflow.id,
         workflowRunId: this.dependencies.job.id,
@@ -657,7 +659,11 @@ export class WorkflowRunSession {
       error: failure,
     })
 
-    await this.finishWorkflowRunAfterError({ reportedError: error, failure, status })
+    await this.finishWorkflowRunAfterError({
+      reportedError: unwrapWorkflowNodeFailure(error),
+      failure,
+      status,
+    })
   }
 
   flushLogs(): Promise<void> {

--- a/packages/workflow-worker/src/run-workflow-job.ts
+++ b/packages/workflow-worker/src/run-workflow-job.ts
@@ -1,4 +1,5 @@
 import { captureSixbFailure } from "@sixb/core/internal/errors"
+import { unwrapWorkflowNodeFailure } from "@sixb/core/internal/workflows"
 import { WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { workflowNodeExecutors } from "./execution/node-executors"
 import { WorkflowRunSession } from "./execution/workflow-run-session"
@@ -43,7 +44,7 @@ export async function runWorkflowJob(input: RunWorkflowJobInput): Promise<Workfl
     }
     await session.finishAfterError(error)
     await failQueuedRun(input, error)
-    throw error
+    throw unwrapWorkflowNodeFailure(error)
   } finally {
     await session.flushLogs()
   }
@@ -71,7 +72,7 @@ export async function runWorkflowResumeJob(
       throw error
     }
     await session.finishAfterError(error)
-    throw error
+    throw unwrapWorkflowNodeFailure(error)
   } finally {
     await session.flushLogs()
   }

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -1203,7 +1203,19 @@ describe("runWorkflowJob", () => {
     expect(run?.status).toBe("failed")
     expect(nodes.nodes).toHaveLength(1)
     expect(nodes.nodes[0]?.status).toBe("failed")
-    expect(nodes.nodes[0]?.error?.message).toBe("An unexpected internal error occurred.")
+    expect(run?.error).toMatchObject({
+      code: "workflow.node_failed",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_invalid_output",
+        nodeId: invalidOutputStep.id,
+        nodeRunId: "wfrun_invalid_output:node:0",
+        stepId: invalidOutputStep.id,
+      },
+    })
+    expect(nodes.nodes[0]?.error).toEqual(run?.error)
+    expect(nodes.nodes[0]?.error?.message).toBe("Workflow node execution failed.")
   })
 
   test("marks the active step and workflow failed when a step handler throws", async () => {
@@ -1242,24 +1254,29 @@ describe("runWorkflowJob", () => {
     expect(run?.status).toBe("failed")
     expect(nodes.nodes.map((node) => node.status)).toEqual(["succeeded", "failed"])
     expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
+      code: "workflow.node_failed",
       retryable: false,
       details: {
         workflowId: workflow.id,
         workflowRunId: "wfrun_step_failed",
+        nodeId: failingStep.id,
         nodeRunId: "wfrun_step_failed:node:1",
+        stepId: failingStep.id,
       },
     })
     expect(nodes.nodes[1]?.error).toMatchObject({
-      code: "internal.unexpected",
+      code: "workflow.node_failed",
       retryable: false,
       details: {
         workflowId: workflow.id,
         workflowRunId: "wfrun_step_failed",
+        nodeId: failingStep.id,
         nodeRunId: "wfrun_step_failed:node:1",
+        stepId: failingStep.id,
       },
     })
-    expect(nodes.nodes[1]?.error?.message).toBe("An unexpected internal error occurred.")
+    expect(nodes.nodes[1]?.error).toEqual(run?.error)
+    expect(nodes.nodes[1]?.error?.message).toBe("Workflow node execution failed.")
   })
 
   test("preserves the cause and run details when workflow finalization fails after side effects", async () => {
@@ -1314,6 +1331,62 @@ describe("runWorkflowJob", () => {
         runId: "wfrun_bookkeeping_failed",
       },
     })
+  })
+
+  test("keeps node finalization failures out of the node-failed vocabulary", async () => {
+    const workflow = defineWorkflow("node-finalization-failure-workflow")
+      .input({ transaction: ref(Transaction) })
+      .then(findBestInvoice)
+    const sixb = createSixb({ workflows: [workflow] })
+    const runtime = createRuntime(sixb)
+    const finishNode = runtime.workflowRuns.nodes.finish.bind(runtime.workflowRuns.nodes)
+    const finishCause = new Error("node finish unavailable")
+    runtime.workflowRuns.nodes.finish = async (input) => {
+      if (input.status === "succeeded") throw finishCause
+      return finishNode(input)
+    }
+
+    await expect(
+      runWorkflowJob({
+        runtime,
+        job: {
+          id: "wfrun_node_finish_failed",
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      cause: finishCause,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_node_finish_failed",
+        nodeId: findBestInvoice.id,
+        nodeRunId: "wfrun_node_finish_failed:node:0",
+      },
+    })
+
+    const run = await runtime.workflowRuns.getById({
+      projectId: sixb.id,
+      id: "wfrun_node_finish_failed",
+    })
+    const node = await runtime.workflowRuns.nodes.getById({
+      projectId: sixb.id,
+      id: "wfrun_node_finish_failed:node:0",
+    })
+    expect(run?.error).toMatchObject({
+      code: "internal.unexpected",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_node_finish_failed",
+        nodeId: findBestInvoice.id,
+        nodeRunId: "wfrun_node_finish_failed:node:0",
+      },
+    })
+    expect(node?.error).toEqual(run?.error)
   })
 
   test("uses the workflow input as output when every node is an action", async () => {
@@ -1533,11 +1606,22 @@ describe("runWorkflowJob", () => {
       .then(createInvoice)
     const sixb = createSixb({ actions: [createInvoice], workflows: [workflow] })
 
-    const details = {
-      actionId: createInvoice.id,
-      workflowId: workflow.id,
-      workflowRunId: "wfrun_invalid_global_action_input",
-      nodeId: "create-invoice",
+    const expectedOriginalError = {
+      code: "internal.unexpected",
+      retryable: false,
+      message:
+        "[SixbWorkflowWorker] Workflow 'invalid-global-action-input-workflow' action node 'create-invoice' direct input must not include subject for a global action.",
+      details: {
+        actionId: createInvoice.id,
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_invalid_global_action_input",
+        nodeId: "create-invoice",
+      },
+    }
+    const expectedFailure = {
+      ...expectedOriginalError,
+      code: "workflow.node_failed",
+      message: "Workflow node execution failed.",
     }
     await expect(
       runWorkflowJob({
@@ -1550,13 +1634,7 @@ describe("runWorkflowJob", () => {
           },
         },
       })
-    ).rejects.toMatchObject({
-      code: "internal.unexpected",
-      retryable: false,
-      message:
-        "[SixbWorkflowWorker] Workflow 'invalid-global-action-input-workflow' action node 'create-invoice' direct input must not include subject for a global action.",
-      details,
-    })
+    ).rejects.toMatchObject(expectedOriginalError)
 
     const run = await sixb.storage.workflowRuns!.getById({
       projectId: sixb.id,
@@ -1567,12 +1645,7 @@ describe("runWorkflowJob", () => {
       workflowRunId: "wfrun_invalid_global_action_input",
       order: "asc",
     })
-    expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
-      retryable: false,
-      message: "An unexpected internal error occurred.",
-      details,
-    })
+    expect(run?.error).toMatchObject(expectedFailure)
     expect(nodes.nodes.map((node) => node.nodeId)).toEqual([
       "find-best-invoice",
       "prepare-attach-invoice-action",
@@ -1848,7 +1921,20 @@ describe("runWorkflowJob", () => {
     })
     expect(run?.status).toBe("failed")
     expect(nodes.nodes.map((node) => node.status)).toEqual(["succeeded", "failed"])
-    expect(nodes.nodes[1]?.error?.message).toBe("An unexpected internal error occurred.")
+    expect(run?.error).toMatchObject({
+      code: "workflow.node_failed",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_action_run_failed",
+        nodeId: attachInvoice.id,
+        nodeRunId: "wfrun_action_run_failed:node:1",
+        actionId: attachInvoice.id,
+        actionRunId: "wfrun_action_run_failed:action:1",
+      },
+    })
+    expect(nodes.nodes[1]?.error).toEqual(run?.error)
+    expect(nodes.nodes[1]?.error?.message).toBe("Workflow node execution failed.")
   })
 
   test("marks action node and workflow failed when the action run fails after request", async () => {
@@ -1948,10 +2034,24 @@ describe("runWorkflowJob", () => {
       })
     ).rejects.toThrow("mapper exploded")
 
+    const run = await sixb.storage.workflowRuns!.getById({
+      projectId: sixb.id,
+      id: "wfrun_mapper_failed",
+    })
     const nodes = await sixb.storage.workflowRuns!.nodes.list({
       projectId: sixb.id,
       workflowRunId: "wfrun_mapper_failed",
       order: "asc",
+    })
+    expect(run?.error).toMatchObject({
+      code: "workflow.node_failed",
+      retryable: false,
+      details: {
+        workflowId: workflow.id,
+        workflowRunId: "wfrun_mapper_failed",
+        nodeId: reviewInvoiceMatch.id,
+        stepId: reviewInvoiceMatch.id,
+      },
     })
     expect(nodes.nodes.map((node) => node.nodeId)).toEqual(["find-best-invoice"])
   })

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -392,13 +392,15 @@ describe("WorkflowWorker", () => {
       (value) => value?.status === "failed"
     )
     expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
-      message: "An unexpected internal error occurred.",
+      code: "workflow.node_failed",
+      message: "Workflow node execution failed.",
       retryable: false,
       details: {
         workflowId: workflow.id,
         workflowRunId: "wfrun_worker_failed",
+        nodeId: "explode",
         nodeRunId: "wfrun_worker_failed:node:0",
+        stepId: "explode",
       },
     })
 
@@ -445,14 +447,16 @@ describe("WorkflowWorker", () => {
       nodeRunId: "wfrun_worker_failed:node:0",
       status: "failed",
       error: {
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "workflow.node_failed",
+        message: "Workflow node execution failed.",
         retryable: false,
         at: expect.any(String),
         details: {
           workflowId: workflow.id,
           workflowRunId: "wfrun_worker_failed",
+          nodeId: "explode",
           nodeRunId: "wfrun_worker_failed:node:0",
+          stepId: "explode",
         },
       },
     })
@@ -462,14 +466,16 @@ describe("WorkflowWorker", () => {
       status: "failed",
       finishedAt: expect.any(String),
       error: {
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "workflow.node_failed",
+        message: "Workflow node execution failed.",
         retryable: false,
         at: expect.any(String),
         details: {
           workflowId: workflow.id,
           workflowRunId: "wfrun_worker_failed",
+          nodeId: "explode",
           nodeRunId: "wfrun_worker_failed:node:0",
+          stepId: "explode",
         },
       },
     })
@@ -801,13 +807,15 @@ describe("WorkflowWorker", () => {
     )
 
     expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
-      message: "An unexpected internal error occurred.",
+      code: "workflow.node_failed",
+      message: "Workflow node execution failed.",
       retryable: false,
       details: {
         workflowId: workflow.id,
         workflowRunId: "wfrun_worker_resume_failed",
+        nodeId: "fail-after-resume",
         nodeRunId: "wfrun_worker_resume_failed:node:2",
+        stepId: "fail-after-resume",
       },
     })
     expect(reported[0]?.error).toBe(resumeError)


### PR DESCRIPTION
## Summary

- add the primitive-specific `pipeline.step_failed` and `workflow.node_failed` failure codes
- translate execution failures at their durable boundary while preserving native causes for direct callers and `onError`
- retain workflow child identity across step, action, agent, and intervention nodes
- centralize safe thrown-value message extraction and document the failure contracts concisely
- regenerate the OpenAPI client for the narrowed Pipeline and Workflow failure unions

## Validation

- `bun test packages/core/tests/error-model.test.ts`
- `bun test packages/pipeline-worker/tests/run-pipeline-job.test.ts packages/pipeline-worker/tests/worker.test.ts`
- `bun test packages/workflow-worker/tests/run-workflow-job.test.ts packages/workflow-worker/tests/worker.test.ts`
- `bun test packages/agent-worker/tests/worker.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run build`