### PR TITLE
errors: define Action and Sync failure taxonomy

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -48,8 +48,8 @@ Each boundary exposes only the codes it can persist.
 
 | Boundary | Allowed codes |
 | --- | --- |
-| Action run or phase | `internal.unexpected`, `queue.enqueue_failed`, `runtime.cancelled` |
-| Sync run | `internal.unexpected`, `runtime.cancelled` |
+| Action run or phase | `action.phase_failed`, `internal.unexpected`, `queue.enqueue_failed`, `runtime.cancelled` |
+| Sync run | `internal.unexpected`, `runtime.cancelled`, `sync.execution_failed` |
 | Agent execution | `internal.unexpected`, `runtime.cancelled` |
 | Projection run | `internal.unexpected`, `runtime.cancelled` |
 | Pipeline run or step | `internal.unexpected`, `runtime.cancelled`, `pipeline.step_failed` |
@@ -76,6 +76,7 @@ Additional rules:
 
 | Code | Retryable | What happened | What to do |
 | --- | --- | --- | --- |
+| `action.phase_failed` | No | An Action phase could not complete successfully. | Inspect `phase` and the cause; retry only when its side-effect boundary makes that safe. |
 | `dataset.not_found` | No | Dataset is unavailable to the caller. | Check its ID and access policy. |
 | `dataset.version_incompatible` | No | Version does not match the required dataset or schema. | Materialize a compatible version. |
 | `dataset.version_not_found` | No | Version does not exist or nothing has been committed yet. | Check the ID or materialize the dataset. |
@@ -89,5 +90,6 @@ Additional rules:
 | `projection.run_identity_mismatch` | No | Delivery does not match the run's pinned identity. | Discard it and dispatch from the current definition. |
 | `queue.enqueue_failed` | Yes | A job could not be handed to its queue. | Retry while the run remains in its enqueue phase. |
 | `runtime.cancelled` | No | Work was cancelled before completion. | Confirm the cancellation before requesting another run. |
+| `sync.execution_failed` | No | A Sync failed while reading, validating, or writing its dataset. | Inspect the `onError` report, fix the source or data, then request a new run. |
 | `webhook.delivery_failed` | Yes | A claimed webhook delivery failed retryably. | Let the provider retry; inspect the handler if it persists. |
 | `workflow.node_failed` | No | A node failed during preparation or execution. | Inspect its identity and `onError` report. |

--- a/packages/action-worker/src/action-execution/edits-commit.ts
+++ b/packages/action-worker/src/action-execution/edits-commit.ts
@@ -4,6 +4,7 @@ import { recordEdits } from "@sixb/core/actions/worker"
 import type { ActionEditCommitResult, ActionReadRecorder } from "@sixb/core/internal/actions"
 import { commitActionEdits, createActionReadFacade } from "@sixb/core/internal/actions"
 import type { ActionRunRecord } from "@sixb/core/storage"
+import { translateActionPhaseError } from "../normalize"
 import { type BasePhaseContext, requireObjectSubject } from "./context"
 import type {
   LoadedObjectTarget,
@@ -58,42 +59,51 @@ export async function runEditsAndCommitPhase(
     )
   }
 
-  const batch = await recordEdits(
-    {
-      runId: run.id,
-      valueTypesById: input.runtime.sixb.objects.getValueTypesById(),
-    },
-    async ({ objects }) => {
-      const baseContext = {
-        ...input.baseContext,
-        objects,
-        read: createActionReadFacade(
-          (objectType) => input.runtime.sixb.objects(objectType) as ActionReadObjectSetSource,
-          {
-            recorder: reads,
-            resolveLinkIds: (objectTypeId) =>
-              input.runtime.sixb.objects
-                .resolveType(objectTypeId)
-                .links.map((definition) => definition.id),
-          }
-        ),
-        writeback: input.writeback,
-      }
+  let batch: Awaited<ReturnType<typeof recordEdits>>
+  try {
+    batch = await recordEdits(
+      {
+        runId: run.id,
+        valueTypesById: input.runtime.sixb.objects.getValueTypesById(),
+      },
+      async ({ objects }) => {
+        const baseContext = {
+          ...input.baseContext,
+          objects,
+          read: createActionReadFacade(
+            (objectType) => input.runtime.sixb.objects(objectType) as ActionReadObjectSetSource,
+            {
+              recorder: reads,
+              resolveLinkIds: (objectTypeId) =>
+                input.runtime.sixb.objects
+                  .resolveType(objectTypeId)
+                  .links.map((definition) => definition.id),
+            }
+          ),
+          writeback: input.writeback,
+        }
 
-      if (isObjectActionDefinition(input.action)) {
-        await handler({
-          ...baseContext,
-          subject: requireObjectSubject(input.run.subject, {
-            actionId: input.action.id,
-            runId: input.run.id,
-          }),
-        })
-        return
-      }
+        if (isObjectActionDefinition(input.action)) {
+          await handler({
+            ...baseContext,
+            subject: requireObjectSubject(input.run.subject, {
+              actionId: input.action.id,
+              runId: input.run.id,
+            }),
+          })
+          return
+        }
 
-      await handler(baseContext)
-    }
-  )
+        await handler(baseContext)
+      }
+    )
+  } catch (error) {
+    throw translateActionPhaseError(error, "edits", {
+      actionId: input.action.id,
+      runId: input.run.id,
+      signal: input.signal,
+    })
+  }
 
   run = await input.runtime.actionRunsStorage.enterPhase({
     projectId: input.runtime.id,
@@ -102,14 +112,23 @@ export async function runEditsAndCommitPhase(
   })
   input.updateActiveRun(run)
 
-  const commit = await commitActionEdits({
-    mutations: input.runtime.ontologyMutations,
-    projectId: input.runtime.id,
-    runId: run.id,
-    actionId: input.action.id,
-    batch,
-    dependencies: reads.dependencies(),
-  })
+  let commit: ActionEditCommitResult
+  try {
+    commit = await commitActionEdits({
+      mutations: input.runtime.ontologyMutations,
+      projectId: input.runtime.id,
+      runId: run.id,
+      actionId: input.action.id,
+      batch,
+      dependencies: reads.dependencies(),
+    })
+  } catch (error) {
+    throw translateActionPhaseError(error, "commit", {
+      actionId: input.action.id,
+      runId: input.run.id,
+      signal: input.signal,
+    })
+  }
 
   return { run, result: commit }
 }

--- a/packages/action-worker/src/action-execution/effects.ts
+++ b/packages/action-worker/src/action-execution/effects.ts
@@ -3,7 +3,7 @@ import { isObjectActionDefinition } from "@sixb/core"
 import type { ActionEditCommitResult } from "@sixb/core/internal/actions"
 import { reportActionPhaseFailure } from "@sixb/core/internal/error-reporting"
 import type { ActionRunRecord } from "@sixb/core/storage"
-import { toActionRunFailure } from "../normalize"
+import { toActionRunFailure, translateActionPhaseError } from "../normalize"
 import { type BasePhaseContext, requireObjectSubject, toActionRuntimeFacade } from "./context"
 import type { LoadedObjectTarget, PhaseExecutionBase, UpdateActiveRun } from "./types"
 
@@ -50,17 +50,14 @@ export async function runEffectsPhase(
         commit: input.commit,
       })
     }
-
-    run = await input.runtime.actionRunsStorage.recordEffects({
-      projectId: input.runtime.id,
-      id: input.run.id,
-      status: "succeeded",
-    })
-    input.updateActiveRun(run)
-    return run
   } catch (error) {
     const completedAt = new Date()
-    const failure = toActionRunFailure(error, "effects", {
+    const phaseError = translateActionPhaseError(error, "effects", {
+      actionId: input.action.id,
+      runId: input.run.id,
+      signal: input.signal,
+    })
+    const failure = toActionRunFailure(phaseError, "effects", {
       actionId: input.action.id,
       runId: input.run.id,
       at: completedAt,
@@ -82,4 +79,12 @@ export async function runEffectsPhase(
     })
     return run
   }
+
+  run = await input.runtime.actionRunsStorage.recordEffects({
+    projectId: input.runtime.id,
+    id: input.run.id,
+    status: "succeeded",
+  })
+  input.updateActiveRun(run)
+  return run
 }

--- a/packages/action-worker/src/action-execution/phases.ts
+++ b/packages/action-worker/src/action-execution/phases.ts
@@ -6,7 +6,7 @@ import {
 } from "@sixb/core/internal/actions"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import type { ActionRunRecord } from "@sixb/core/storage"
-import { throwIfAborted } from "../normalize"
+import { throwIfAborted, translateActionPhaseError } from "../normalize"
 import { createBasePhaseContext, loadObjectTarget } from "./context"
 import { runEditsAndCommitPhase } from "./edits-commit"
 import { runEffectsPhase } from "./effects"
@@ -33,7 +33,16 @@ export async function executeActionPhases(
     projectId: runtime.id,
     runId: run.id,
   })
-  const objectTarget = existingCommit ? null : await loadObjectTarget({ runtime, action, run })
+  let objectTarget: Awaited<ReturnType<typeof loadObjectTarget>> | null
+  try {
+    objectTarget = existingCommit ? null : await loadObjectTarget({ runtime, action, run })
+  } catch (error) {
+    throw translateActionPhaseError(error, "validation", {
+      actionId: action.id,
+      runId: run.id,
+      signal,
+    })
+  }
   const phaseContext = createBasePhaseContext({
     runtime,
     action,
@@ -108,12 +117,20 @@ async function executePreCommitPhases(
       phase: "validation",
     })
     input.updateActiveRun(run)
-    await runActionValidators({
-      action,
-      subject: run.subject,
-      baseContext: phaseContext,
-      target: isObjectActionDefinition(action) ? objectTarget?.snapshot : undefined,
-    })
+    try {
+      await runActionValidators({
+        action,
+        subject: run.subject,
+        baseContext: phaseContext,
+        target: isObjectActionDefinition(action) ? objectTarget?.snapshot : undefined,
+      })
+    } catch (error) {
+      throw translateActionPhaseError(error, "validation", {
+        actionId: action.id,
+        runId: run.id,
+        signal,
+      })
+    }
   }
 
   throwIfAborted(signal)

--- a/packages/action-worker/src/action-execution/writeback.ts
+++ b/packages/action-worker/src/action-execution/writeback.ts
@@ -3,7 +3,7 @@ import { assertJsonValue, cloneJsonValue, isObjectActionDefinition } from "@sixb
 import type { ActionReadRecorder } from "@sixb/core/internal/actions"
 import { createActionReadFacade } from "@sixb/core/internal/actions"
 import type { ActionRunRecord } from "@sixb/core/storage"
-import { toActionRunFailure } from "../normalize"
+import { toActionRunFailure, translateActionPhaseError } from "../normalize"
 import { type BasePhaseContext, requireObjectTarget, toActionRuntimeFacade } from "./context"
 import type {
   LoadedObjectTarget,
@@ -37,6 +37,7 @@ export async function runWritebackPhase(
   })
   input.updateActiveRun(run)
 
+  let result: JsonValue
   try {
     // Reads are side-effect-free, so the writeback phase can safely enrich its
     // external payload from related objects (links, traversals) before the edit
@@ -63,18 +64,15 @@ export async function runWritebackPhase(
           }).snapshot,
         })
       : await handler({ ...input.baseContext, sixb: toActionRuntimeFacade(input.runtime), read })
-    const result = normalizeWritebackResult(rawResult)
-    run = await input.runtime.actionRunsStorage.recordWriteback({
-      projectId: input.runtime.id,
-      id: input.run.id,
-      status: "succeeded",
-      result,
-    })
-    input.updateActiveRun(run)
-    return { run, value: result }
+    result = normalizeWritebackResult(rawResult)
   } catch (error) {
     const completedAt = new Date()
-    const failure = toActionRunFailure(error, "writeback", {
+    const phaseError = translateActionPhaseError(error, "writeback", {
+      actionId: input.action.id,
+      runId: input.run.id,
+      signal: input.signal,
+    })
+    const failure = toActionRunFailure(phaseError, "writeback", {
       actionId: input.action.id,
       runId: input.run.id,
       at: completedAt,
@@ -89,6 +87,15 @@ export async function runWritebackPhase(
     input.updateActiveRun(run)
     throw error
   }
+
+  run = await input.runtime.actionRunsStorage.recordWriteback({
+    projectId: input.runtime.id,
+    id: input.run.id,
+    status: "succeeded",
+    result,
+  })
+  input.updateActiveRun(run)
+  return { run, value: result }
 }
 
 function normalizeWritebackResult(result: unknown): JsonValue {

--- a/packages/action-worker/src/normalize.ts
+++ b/packages/action-worker/src/normalize.ts
@@ -20,6 +20,41 @@ export function throwIfAborted(signal: AbortSignal): void {
   }
 }
 
+/** Translate work performed by an Action phase without misclassifying its bookkeeping. */
+export function translateActionPhaseError(
+  error: unknown,
+  phase: Exclude<ActionRunPhase, "request" | "enqueue" | "cancelled">,
+  input: {
+    readonly actionId: string
+    readonly runId: string
+    readonly signal: AbortSignal
+  }
+): unknown {
+  if (input.signal.aborted || (isSixbError(error) && error.code === "internal.unexpected")) {
+    return error
+  }
+
+  return createSixbError(
+    "action.phase_failed",
+    summarizeErrorMessage(error, "Action phase execution failed."),
+    {
+      cause: error,
+      details: {
+        actionId: input.actionId,
+        runId: input.runId,
+        phase,
+      },
+    }
+  )
+}
+
+/** Recover the native phase error for direct callers and error-monitoring integrations. */
+export function unwrapActionPhaseError(error: unknown): unknown {
+  return isSixbError(error) && error.code === "action.phase_failed" && error.cause !== undefined
+    ? error.cause
+    : error
+}
+
 export function toActionRunFailure<TPhase extends ActionRunPhase>(
   error: unknown,
   phase: TPhase,
@@ -39,7 +74,7 @@ export function toActionRunFailure<TPhase extends ActionRunPhase>(
     code,
     summarizeErrorMessage(error, "Action execution failed."),
     {
-      cause: error,
+      cause: unwrapActionPhaseError(error),
       details: {
         actionId: input.actionId,
         runId: input.runId,

--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -8,7 +8,7 @@ import {
   requireFinishedAt,
   resolveRedeliveredRunningRun,
 } from "./action-execution/results"
-import { throwIfAborted, toActionRunFailure } from "./normalize"
+import { throwIfAborted, toActionRunFailure, unwrapActionPhaseError } from "./normalize"
 import type { ActionRunResult, RunActionJobInput } from "./types"
 
 export async function runActionJob(input: RunActionJobInput): Promise<ActionRunResult> {
@@ -126,6 +126,7 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       record: finalRun,
     }
   } catch (error) {
+    const nativeError = unwrapActionPhaseError(error)
     const status = signal.aborted ? "cancelled" : "failed"
     const finishedAt = new Date()
     const writebackFailure =
@@ -155,10 +156,10 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
       .catch(() => null)
 
     if (!finishedRun) {
-      throw error
+      throw nativeError
     }
     if (status === "failed" && finishedRun.status === "failed") {
-      reportActionFailure(input, error, failure)
+      reportActionFailure(input, nativeError, failure)
     }
 
     const startedAt = startedRun?.startedAt ?? finishedRun.startedAt ?? finishedRun.queuedAt

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -272,8 +272,8 @@ describe("runActionJob", () => {
     expect(result.status).toBe("failed")
     if ("error" in result) {
       expect(result.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "action.phase_failed",
+        message: "Action execution failed.",
         retryable: false,
         details: { actionId: "failWriteback", runId: "act_1", phase: "writeback" },
       })
@@ -287,6 +287,42 @@ describe("runActionJob", () => {
     ).toBeNull()
     const updated = await deviceObjects(sixb).get("device-1")
     expect(updated?.properties.status).toBe("old")
+  })
+
+  test("keeps run finalization failures out of the phase-failed vocabulary", async () => {
+    const complete = defineAction("complete")
+      .params({})
+      .writeback(() => ({ ok: true }))
+    const { host } = createSixb([complete])
+    await queueActionRun(host, {
+      id: "act_finalize",
+      actionId: "complete",
+      subject: { kind: "none" },
+      params: {},
+    })
+
+    const actionRuns = host.storage.actionRuns!
+    const finish = actionRuns.finish.bind(actionRuns)
+    actionRuns.finish = async (input) => {
+      if (input.status === "succeeded") {
+        throw new Error("finish exploded")
+      }
+      return finish(input)
+    }
+
+    const result = await runStoredActionJob({
+      runtime: createContext(host),
+      job: { id: "act_finalize", actionId: "complete" },
+    })
+
+    expect(result.status).toBe("failed")
+    if ("error" in result) {
+      expect(result.error).toMatchObject({
+        code: "internal.unexpected",
+        message: "An unexpected internal error occurred.",
+        details: { actionId: "complete", runId: "act_finalize", phase: "writeback" },
+      })
+    }
   })
 
   test("exposes immutable blob operations inside action writeback", async () => {
@@ -986,8 +1022,8 @@ describe("runActionJob", () => {
     expect(run?.effects).toMatchObject({
       status: "failed",
       error: {
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "action.phase_failed",
+        message: "Action execution failed.",
         retryable: false,
         details: { actionId: "setStatus", runId: "act_1", phase: "effects" },
       },

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -271,6 +271,10 @@ describe("ActionWorker", () => {
     await reporter.flush()
 
     expect(failed.status).toBe("failed")
+    expect(failed.error).toMatchObject({
+      code: "action.phase_failed",
+      details: { actionId: "fail", runId: failed.id, phase: "writeback" },
+    })
     expect(reports).toHaveLength(1)
     expect(reports[0]?.error).toBe(originalError)
     expect(reports[0]?.context).toMatchObject({
@@ -324,7 +328,7 @@ describe("ActionWorker", () => {
       actionId: "fail",
     })
     expect(failed.status).toBe("failed")
-    expect(failed.error?.message).toBe("An unexpected internal error occurred.")
+    expect(failed.error?.message).toBe("Action execution failed.")
 
     await worker.stop()
   })

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -6089,7 +6089,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "sync.execution_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -6355,7 +6359,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "sync.execution_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -6578,7 +6586,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "sync.execution_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -16733,7 +16745,8 @@
                                 "enum": [
                                   "internal.unexpected",
                                   "runtime.cancelled",
-                                  "queue.enqueue_failed"
+                                  "queue.enqueue_failed",
+                                  "action.phase_failed"
                                 ]
                               },
                               "message": {
@@ -16949,7 +16962,8 @@
                           "enum": [
                             "internal.unexpected",
                             "runtime.cancelled",
-                            "queue.enqueue_failed"
+                            "queue.enqueue_failed",
+                            "action.phase_failed"
                           ]
                         },
                         "message": {
@@ -17058,7 +17072,8 @@
                                   "enum": [
                                     "internal.unexpected",
                                     "runtime.cancelled",
-                                    "queue.enqueue_failed"
+                                    "queue.enqueue_failed",
+                                    "action.phase_failed"
                                   ]
                                 },
                                 "message": {
@@ -17137,7 +17152,8 @@
                                   "enum": [
                                     "internal.unexpected",
                                     "runtime.cancelled",
-                                    "queue.enqueue_failed"
+                                    "queue.enqueue_failed",
+                                    "action.phase_failed"
                                   ]
                                 },
                                 "message": {

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -2153,7 +2153,7 @@ export type ListSyncsResponses = {
       expectedLatestVersionId?: string
       commitMessage?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "sync.execution_failed"
         message: string
         retryable: boolean
         at: string
@@ -2254,7 +2254,7 @@ export type GetSyncResponses = {
       expectedLatestVersionId?: string
       commitMessage?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "sync.execution_failed"
         message: string
         retryable: boolean
         at: string
@@ -2333,7 +2333,7 @@ export type ListSyncRunsResponses = {
       expectedLatestVersionId?: string
       commitMessage?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "sync.execution_failed"
         message: string
         retryable: boolean
         at: string
@@ -5864,7 +5864,11 @@ export type ListActionRunsResponses = {
       startedAt?: string
       finishedAt?: string
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled" | "queue.enqueue_failed"
+        code:
+          | "internal.unexpected"
+          | "runtime.cancelled"
+          | "queue.enqueue_failed"
+          | "action.phase_failed"
         message: string
         retryable: boolean
         at: string
@@ -5954,7 +5958,11 @@ export type GetActionRunResponses = {
     startedAt?: string
     finishedAt?: string
     error?: {
-      code: "internal.unexpected" | "runtime.cancelled" | "queue.enqueue_failed"
+      code:
+        | "internal.unexpected"
+        | "runtime.cancelled"
+        | "queue.enqueue_failed"
+        | "action.phase_failed"
       message: string
       retryable: boolean
       at: string
@@ -5997,7 +6005,11 @@ export type GetActionRunResponses = {
           status: "failed"
           completedAt: string
           error: {
-            code: "internal.unexpected" | "runtime.cancelled" | "queue.enqueue_failed"
+            code:
+              | "internal.unexpected"
+              | "runtime.cancelled"
+              | "queue.enqueue_failed"
+              | "action.phase_failed"
             message: string
             retryable: boolean
             at: string
@@ -6018,7 +6030,11 @@ export type GetActionRunResponses = {
           status: "failed"
           completedAt: string
           error: {
-            code: "internal.unexpected" | "runtime.cancelled" | "queue.enqueue_failed"
+            code:
+              | "internal.unexpected"
+              | "runtime.cancelled"
+              | "queue.enqueue_failed"
+              | "action.phase_failed"
             message: string
             retryable: boolean
             at: string

--- a/packages/client/tests/actions.test.ts
+++ b/packages/client/tests/actions.test.ts
@@ -64,7 +64,7 @@ function actionFailure(
   message: string
 ): ActionRunFailure {
   return {
-    code: phase === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
+    code: phase === "cancelled" ? "runtime.cancelled" : "action.phase_failed",
     message,
     retryable: false,
     at: "2026-06-29T12:00:02.000Z",

--- a/packages/client/tests/events-builder.types.ts
+++ b/packages/client/tests/events-builder.types.ts
@@ -305,7 +305,8 @@ events
   .run("run-1")
   .subscribe((event) => {
     if (event.type === "sync.run.finished" && event.payload.error) {
-      const code: "internal.unexpected" | "runtime.cancelled" = event.payload.error.code
+      const code: "internal.unexpected" | "runtime.cancelled" | "sync.execution_failed" =
+        event.payload.error.code
       const message: string = event.payload.error.message
       // @ts-expect-error — sync lifecycle failures expose only their primitive's code union.
       const datasetCode: "dataset.not_found" = event.payload.error.code
@@ -335,8 +336,15 @@ events
   .byId("sensor-1")
   .failed()
   .subscribe((event) => {
+    const code:
+      | "internal.unexpected"
+      | "runtime.cancelled"
+      | "queue.enqueue_failed"
+      | "action.phase_failed" = event.payload.error.code
     const message: string = event.payload.error.message
-    void message
+    // @ts-expect-error — Action lifecycle failures expose only their primitive's code union.
+    const datasetCode: "dataset.not_found" = event.payload.error.code
+    void [code, message, datasetCode]
   })
 
 events

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -10,6 +10,10 @@ interface SixbErrorDefinition {
  * `SixbFailure` values, not a mutable registry.
  */
 export const SIXB_ERROR_DEFINITIONS = {
+  "action.phase_failed": {
+    publicMessage: "Action execution failed.",
+    retryable: false,
+  },
   "dataset.not_found": {
     publicMessage: "Dataset not found.",
     retryable: false,
@@ -60,6 +64,10 @@ export const SIXB_ERROR_DEFINITIONS = {
   },
   "runtime.cancelled": {
     publicMessage: "Execution was cancelled.",
+    retryable: false,
+  },
+  "sync.execution_failed": {
+    publicMessage: "Sync execution failed.",
     retryable: false,
   },
   "webhook.delivery_failed": {

--- a/packages/core/src/storage/action-runs/types.ts
+++ b/packages/core/src/storage/action-runs/types.ts
@@ -26,6 +26,7 @@ export const ACTION_RUN_FAILURE_CODES = [
   "internal.unexpected",
   "runtime.cancelled",
   "queue.enqueue_failed",
+  "action.phase_failed",
 ] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
 
 export type ActionRunFailureCode = (typeof ACTION_RUN_FAILURE_CODES)[number]

--- a/packages/core/src/storage/sync-runs/types.ts
+++ b/packages/core/src/storage/sync-runs/types.ts
@@ -10,6 +10,7 @@ export type SyncRunStatus = "running" | "succeeded" | "failed" | "cancelled"
 export const SYNC_RUN_FAILURE_CODES = [
   "internal.unexpected",
   "runtime.cancelled",
+  "sync.execution_failed",
 ] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
 
 export type SyncRunFailureCode = (typeof SYNC_RUN_FAILURE_CODES)[number]

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -12,7 +12,12 @@ import {
   type MergeChange,
   type SyncDefinition,
 } from "@sixb/core"
-import { captureSixbFailure } from "@sixb/core/internal/errors"
+import {
+  captureSixbFailure,
+  createSixbError,
+  isSixbError,
+  summarizeErrorMessage,
+} from "@sixb/core/internal/errors"
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import { type DatasetVersion, getDatasetMergeChangeValidationError } from "@sixb/core/lake-storage"
 import { SYNC_RUN_FAILURE_CODES, type SyncRunRecord } from "@sixb/core/storage"
@@ -39,18 +44,61 @@ function createBookkeepingError(options: {
   cause: unknown
 }): Error {
   // The lake commit is already durable here, so we surface an explicit repair-needed error.
-  return new Error(
+  return createSixbError(
+    "internal.unexpected",
     `[SixbSyncWorker] Sync '${options.syncId}' committed dataset version '${options.version.versionId}', but failed to finalize sync run '${options.runId}'. The dataset commit may already have succeeded and the sync run record may need repair.`,
-    { cause: options.cause }
+    {
+      cause: options.cause,
+      details: {
+        syncId: options.syncId,
+        runId: options.runId,
+        datasetId: options.version.datasetId,
+        versionId: options.version.versionId,
+      },
+    }
   )
 }
 
-function requireFinishedAt(runId: string, finishedAt: Date | undefined): Date {
-  if (finishedAt) {
-    return finishedAt
+function requireFinishedAt(input: {
+  readonly syncId: string
+  readonly runId: string
+  readonly finishedAt: Date | undefined
+}): Date {
+  if (input.finishedAt) {
+    return input.finishedAt
   }
 
-  throw new Error(`[SixbSyncWorker] Sync run '${runId}' finished without a finishedAt timestamp.`)
+  throw createSixbError(
+    "internal.unexpected",
+    `[SixbSyncWorker] Sync run '${input.runId}' finished without a finishedAt timestamp.`,
+    { details: { syncId: input.syncId, runId: input.runId } }
+  )
+}
+
+function translateSyncExecutionError(
+  error: unknown,
+  input: {
+    readonly syncId: string
+    readonly runId: string
+    readonly datasetId: string
+  }
+): unknown {
+  if (isSixbError(error) && error.code === "internal.unexpected") {
+    return error
+  }
+
+  return createSixbError(
+    "sync.execution_failed",
+    summarizeErrorMessage(error, "Sync execution failed."),
+    {
+      cause: error,
+      details: {
+        syncId: input.syncId,
+        runId: input.runId,
+        datasetId: input.datasetId,
+      },
+    }
+  )
 }
 
 async function verifyFileRef(options: {
@@ -376,7 +424,11 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
               : {}),
             checkpoint: nextCheckpoint,
           })
-          const finishedAt = requireFinishedAt(job.id, finishedRun.finishedAt)
+          const finishedAt = requireFinishedAt({
+            syncId: sync.id,
+            runId: job.id,
+            finishedAt: finishedRun.finishedAt,
+          })
           await notifyRunFinished(input.onRunFinished, finishedRun)
 
           return {
@@ -404,7 +456,11 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
     const { outcome, version } = commitResult
     if (outcome === "created") {
       if (!version) {
-        throw new Error(`[SixbSyncWorker] Sync '${sync.id}' created no dataset version.`)
+        throw createSixbError(
+          "internal.unexpected",
+          `[SixbSyncWorker] Sync '${sync.id}' created no dataset version.`,
+          { details: { syncId: sync.id, runId: job.id, datasetId: dataset.id } }
+        )
       }
       committedVersion = version
     }
@@ -433,7 +489,11 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
       throw error
     }
 
-    const finishedAt = requireFinishedAt(job.id, finishedRun.finishedAt)
+    const finishedAt = requireFinishedAt({
+      syncId: sync.id,
+      runId: job.id,
+      finishedAt: finishedRun.finishedAt,
+    })
     await notifyRunFinished(input.onRunFinished, finishedRun, committedVersion)
     const result = {
       id: job.id,
@@ -454,10 +514,18 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
 
       const status = signal.aborted ? "cancelled" : "failed"
       try {
-        const failure = captureSixbFailure(error, {
+        const failureError =
+          status === "failed"
+            ? translateSyncExecutionError(error, {
+                syncId: sync.id,
+                runId: job.id,
+                datasetId: dataset.id,
+              })
+            : error
+        const failure = captureSixbFailure(failureError, {
           allowedCodes: SYNC_RUN_FAILURE_CODES,
           defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
-          details: { syncId: sync.id, runId: job.id },
+          details: { syncId: sync.id, runId: job.id, datasetId: dataset.id },
         })
         const run = await syncRunsStorage.finish({
           projectId: runtime.id,

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -955,11 +955,15 @@ describe("runSyncJob", () => {
       status: "failed",
       rowsRead: 1,
       error: {
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "sync.execution_failed",
+        message: "Sync execution failed.",
         retryable: false,
         at: expect.any(String),
-        details: { syncId: "sync-orders", runId: "run_1" },
+        details: {
+          syncId: "sync-orders",
+          runId: "run_1",
+          datasetId: "raw.erp.orders",
+        },
       },
     })
   })
@@ -992,11 +996,15 @@ describe("runSyncJob", () => {
       status: "failed",
       rowsRead: 0,
       error: {
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "sync.execution_failed",
+        message: "Sync execution failed.",
         retryable: false,
         at: expect.any(String),
-        details: { syncId: "sync-orders", runId: "run_1" },
+        details: {
+          syncId: "sync-orders",
+          runId: "run_1",
+          datasetId: "raw.erp.orders",
+        },
       },
     })
   })
@@ -1029,11 +1037,15 @@ describe("runSyncJob", () => {
       status: "failed",
       rowsRead: 0,
       error: {
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "sync.execution_failed",
+        message: "Sync execution failed.",
         retryable: false,
         at: expect.any(String),
-        details: { syncId: "sync-orders", runId: "run_schema_error" },
+        details: {
+          syncId: "sync-orders",
+          runId: "run_schema_error",
+          datasetId: "raw.erp.orders",
+        },
       },
     })
   })
@@ -1075,11 +1087,15 @@ describe("runSyncJob", () => {
       status: "failed",
       rowsRead: 0,
       error: {
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "sync.execution_failed",
+        message: "Sync execution failed.",
         retryable: false,
         at: expect.any(String),
-        details: { syncId: "sync-docs", runId: "run_missing_blob" },
+        details: {
+          syncId: "sync-docs",
+          runId: "run_missing_blob",
+          datasetId: "raw.docs",
+        },
       },
     })
   })
@@ -1268,7 +1284,16 @@ describe("runSyncJob", () => {
           finishedRuns.push(run)
         },
       })
-    ).rejects.toThrow("dataset commit may already have succeeded")
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      message: expect.stringContaining("dataset commit may already have succeeded"),
+      details: {
+        syncId: "sync-orders",
+        runId: "run_1",
+        datasetId: "raw.erp.orders",
+        versionId: expect.any(String),
+      },
+    })
 
     const latestVersion = await lakeStorage.getLatestVersion("raw.erp.orders")
     expect(latestVersion?.producer).toEqual({

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -185,6 +185,14 @@ describe("SyncWorker", () => {
         (count) => count === 1
       )
 
+      expect(run?.error).toMatchObject({
+        code: "sync.execution_failed",
+        details: {
+          syncId: sync.id,
+          runId: "run-failed",
+          datasetId: dataset.id,
+        },
+      })
       expect(reports).toHaveLength(1)
       expect(reports[0]?.error).toBe(originalError)
       expect(reports[0]?.context).toEqual({


### PR DESCRIPTION
## Summary

- add the primitive-specific `action.phase_failed` and `sync.execution_failed` failure codes
- translate Action phase and Sync execution failures at their durable boundaries while keeping bookkeeping and invariant failures `internal.unexpected`
- preserve native causes for direct callers and `onError`, with Action phase and run identity attached to persisted failures
- retain the existing Action effects outcome and worker retry semantics
- regenerate the OpenAPI client and document the narrowed Action and Sync failure unions

## Validation

- `bun test packages/action-worker/tests/run-action-job.test.ts packages/action-worker/tests/worker.test.ts`
- `bun test packages/sync-worker/tests/run-sync-job.test.ts packages/sync-worker/tests/worker.test.ts`
- `bun test packages/core/tests/error-model.test.ts packages/core/tests/action-runs.test.ts packages/core/tests/sync-runs.test.ts storage/sqlite/tests/sqlite-action-run-storage.test.ts storage/sqlite/tests/sqlite-sync-run-storage.test.ts`
- `bun test packages/client/tests/actions.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run build`