### PR TITLE
actions: link runs to durable executions

### DIFF
--- a/packages/action-worker/src/run-action-job.ts
+++ b/packages/action-worker/src/run-action-job.ts
@@ -17,16 +17,14 @@ export async function runActionJob(input: RunActionJobInput): Promise<ActionRunR
 
   throwIfAborted(signal)
 
-  let existingRun = await runtime.actionRunsStorage.getById({
-    projectId: runtime.id,
-    id: job.id,
-  })
-  if (!existingRun) {
-    throw new ActionWorkerError(`Action run '${job.id}' was not found.`)
-  }
-  if (existingRun.actionId !== job.actionId) {
+  let existingRun = input.run
+  if (
+    existingRun.projectId !== runtime.id ||
+    existingRun.id !== job.id ||
+    existingRun.actionId !== job.actionId
+  ) {
     throw new ActionWorkerError(
-      `Action job '${job.id}' references action '${job.actionId}' but the stored run references '${existingRun.actionId}'.`
+      `Action job '${job.id}' does not match durable run '${existingRun.id}' in project '${existingRun.projectId}'.`
     )
   }
   if (isTerminalActionRun(existingRun)) {

--- a/packages/action-worker/src/types.ts
+++ b/packages/action-worker/src/types.ts
@@ -53,6 +53,8 @@ interface BaseActionRunResult {
 export interface RunActionJobInput {
   readonly runtime: ActionWorkerContext
   readonly job: ActionJob
+  /** Durable run loaded before the execution scope is restored. */
+  readonly run: ActionRunRecord
   readonly signal?: AbortSignal
   /** Queue delivery attempt, when invoked by ActionWorker. */
   readonly attempt?: number

--- a/packages/action-worker/src/worker.ts
+++ b/packages/action-worker/src/worker.ts
@@ -1,7 +1,7 @@
 import type { DomainEventLog, Queues, SixbDefinitions, Storage } from "@sixb/core"
 import type { LoggingService } from "@sixb/core/internal/logging"
 import {
-  bindPrimitiveExecution,
+  bindDurablePrimitiveExecution,
   type PrimitiveExecutionHost,
 } from "@sixb/core/internal/primitive-execution"
 import type { QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
@@ -77,24 +77,40 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
       throw new ActionWorkerError(`Unsupported action job type '${job.type}'.`)
     }
 
-    const actionJob: ActionJob = {
-      id: job.payload.runId,
-      actionId: job.payload.actionId,
+    const actionRuns = this.host.storage.actionRuns
+    if (!actionRuns) {
+      throw new ActionWorkerError("Action workers require storage.actionRuns support.")
+    }
+    const run = await actionRuns.getById({ projectId: this.host.id, id: job.payload.runId })
+    if (!run) {
+      throw new ActionWorkerError(`Action run '${job.payload.runId}' was not found.`)
     }
 
-    const execution = bindPrimitiveExecution(this.host, {
+    const durableExecution = await this.host.storage.executions.getById({
+      projectId: this.host.id,
+      id: run.executionId,
+    })
+    if (!durableExecution) {
+      throw new ActionWorkerError(
+        `Action run '${run.id}' references missing execution '${run.executionId}'.`
+      )
+    }
+
+    const actionJob: ActionJob = { id: run.id, actionId: run.actionId }
+    const execution = bindDurablePrimitiveExecution(this.host, {
+      execution: durableExecution,
       primitive: {
         kind: "action",
-        id: actionJob.actionId,
-        runId: actionJob.id,
+        id: run.actionId,
+        runId: run.id,
       },
-      source: { type: "queue", queue: "actions", jobId: job.id },
     })
     const context = buildActionContext(this.host, execution)
 
     const result = await runActionJob({
       runtime: context,
       job: actionJob,
+      run,
       signal,
       attempt: job.attempt,
     })
@@ -103,7 +119,7 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
       return
     }
 
-    await emitActionTerminalEvent(this.host, result)
+    await emitActionTerminalEvent(this.host, result, durableExecution.correlationId)
   }
 
   protected override async onExecutionError(
@@ -123,7 +139,8 @@ export class ActionWorker extends QueueWorker<ActionRunRequestedQueueJob> {
 
 async function emitActionTerminalEvent(
   host: ActionWorkerHost,
-  result: Exclude<ActionRunResult, { skipped: true }>
+  result: Exclude<ActionRunResult, { skipped: true }>,
+  correlationId: string
 ): Promise<void> {
   const finishedAt = result.finishedAt.toISOString()
 
@@ -156,6 +173,7 @@ async function emitActionTerminalEvent(
                 },
               },
             ],
+      correlationId,
     },
     { source: "SixbActionWorker" }
   )
@@ -163,7 +181,7 @@ async function emitActionTerminalEvent(
 
 function buildActionContext(
   host: ActionWorkerHost,
-  execution: ReturnType<typeof bindPrimitiveExecution>
+  execution: ReturnType<typeof bindDurablePrimitiveExecution>
 ): ActionWorkerContext {
   const actionRunsStorage = host.storage.actionRuns
   if (!actionRunsStorage) {

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -18,11 +18,11 @@ import {
 import { findActionEditCommit } from "@sixb/core/internal/actions"
 import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import { bindPrimitiveExecution } from "@sixb/core/internal/primitive-execution"
-import type { ActionRunParams } from "@sixb/core/storage"
-import { createTestSixb } from "@sixb/core/testing"
+import type { ActionRunParams, ActionRunRecord } from "@sixb/core/storage"
+import { createTestSixb, queueTestActionRun } from "@sixb/core/testing"
 import { ActionWorkerError } from "../src/errors"
 import { runActionJob } from "../src/run-action-job"
-import type { ActionWorkerContext } from "../src/types"
+import type { ActionWorkerContext, RunActionJobInput } from "../src/types"
 import type { ActionWorkerHost } from "../src/worker"
 
 const Device = defineObjectType({
@@ -105,8 +105,8 @@ async function queueActionRun(
     readonly subject: ActionSubject
     readonly params: ActionRunParams
   }
-): Promise<void> {
-  await host.storage.actionRuns!.queue({
+): Promise<ActionRunRecord> {
+  return queueTestActionRun(host.storage, {
     projectId: host.id,
     id: input.id,
     actionId: input.actionId,
@@ -116,20 +116,40 @@ async function queueActionRun(
   })
 }
 
+async function runStoredActionJob(
+  input: Omit<RunActionJobInput, "run">
+): ReturnType<typeof runActionJob> {
+  const run = await input.runtime.actionRunsStorage.getById({
+    projectId: input.runtime.id,
+    id: input.job.id,
+  })
+  if (!run) {
+    throw new Error(`[Test] Action run '${input.job.id}' was not queued.`)
+  }
+  return runActionJob({ ...input, run })
+}
+
 describe("runActionJob", () => {
-  test("throws ActionWorkerError when the stored run is missing", async () => {
+  test("rejects a durable run that does not match the requested job", async () => {
     const count = defineAction("count")
       .params({})
       .writeback(() => {})
     const { host } = createSixb([count])
+    const run = await queueActionRun(host, {
+      id: "act_stored",
+      actionId: "count",
+      subject: { kind: "none" },
+      params: {},
+    })
 
     await expect(
       runActionJob({
         runtime: createContext(host),
         job: {
-          id: "act_missing",
+          id: "act_other",
           actionId: "count",
         },
+        run,
       })
     ).rejects.toBeInstanceOf(ActionWorkerError)
   })
@@ -149,7 +169,7 @@ describe("runActionJob", () => {
       params: { reviewedAt: null },
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: { id: "act_nullable", actionId: "captureNullable" },
     })
@@ -179,7 +199,7 @@ describe("runActionJob", () => {
       params: { status: "ready" },
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -229,7 +249,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -280,7 +300,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_blob",
@@ -328,7 +348,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    await runActionJob({
+    await runStoredActionJob({
       runtime: context,
       job: {
         id: "act_1",
@@ -336,7 +356,7 @@ describe("runActionJob", () => {
       },
     })
 
-    const duplicate = await runActionJob({
+    const duplicate = await runStoredActionJob({
       runtime: context,
       job: {
         id: "act_1",
@@ -367,7 +387,7 @@ describe("runActionJob", () => {
       subject: { kind: "none" },
       params: { id: "device-1" },
     })
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -405,7 +425,7 @@ describe("runActionJob", () => {
       subject: { kind: "none" },
       params: { id: "device-1", name: "Device 1" },
     })
-    const created = await runActionJob({
+    const created = await runStoredActionJob({
       runtime: createContext(host),
       job: { id: "act_create", actionId: "createDevice" },
     })
@@ -416,7 +436,7 @@ describe("runActionJob", () => {
       subject: { kind: "none" },
       params: { id: "device-1", name: "Renamed Device" },
     })
-    const updated = await runActionJob({
+    const updated = await runStoredActionJob({
       runtime: createContext(host),
       job: { id: "act_rename", actionId: "renameDevice" },
     })
@@ -508,7 +528,7 @@ describe("runActionJob", () => {
     })
     expect(
       (
-        await runActionJob({
+        await runStoredActionJob({
           runtime: createContext(host),
           job: { id: "act_assign_sensor", actionId: "assignSensor" },
         })
@@ -539,7 +559,7 @@ describe("runActionJob", () => {
     })
     expect(
       (
-        await runActionJob({
+        await runStoredActionJob({
           runtime: createContext(host),
           job: { id: "act_clear_sensor", actionId: "clearSensor" },
         })
@@ -605,7 +625,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -671,7 +691,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -732,7 +752,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: { id: "act_1", actionId: "captureSensorName" },
     })
@@ -751,7 +771,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -793,7 +813,7 @@ describe("runActionJob", () => {
       id: "act_1",
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -813,7 +833,7 @@ describe("runActionJob", () => {
     expect(run?.phase).toBe("validation")
     expect(run?.finishedAt).toBeInstanceOf(Date)
 
-    const redelivered = await runActionJob({
+    const redelivered = await runStoredActionJob({
       runtime: createContext(host),
       job: { id: "act_1", actionId: "count" },
       attempt: 2,
@@ -855,7 +875,7 @@ describe("runActionJob", () => {
       result: { status: "persisted" },
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -900,7 +920,7 @@ describe("runActionJob", () => {
       expectedLinkScopes: [],
     })
 
-    const resumed = await runActionJob({
+    const resumed = await runStoredActionJob({
       runtime: createContext(host),
       job: { id: "act_delete", actionId: "deleteDevice" },
       attempt: 2,
@@ -937,7 +957,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",
@@ -991,7 +1011,7 @@ describe("runActionJob", () => {
     })
     const controller = new AbortController()
 
-    const execution = runActionJob({
+    const execution = runStoredActionJob({
       runtime: createContext(host),
       job: { id: "act_cancelled", actionId: "waitForCancel" },
       signal: controller.signal,
@@ -1027,7 +1047,7 @@ describe("runActionJob", () => {
       params: {},
     })
 
-    const result = await runActionJob({
+    const result = await runStoredActionJob({
       runtime: createContext(host),
       job: {
         id: "act_1",

--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -197,6 +197,18 @@ describe("ActionWorker", () => {
       (value) => value?.status === "succeeded"
     )
     expect(run?.actionId).toBe("setStatus")
+    const durableExecution = run
+      ? await host.storage.executions.getById({ projectId: host.id, id: run.executionId })
+      : null
+    expect(durableExecution).toMatchObject({
+      source: { type: "execution", executionId: sixb.execution.id },
+      parentExecutionId: sixb.execution.id,
+      correlationId: sixb.execution.correlationId,
+      authorizationRef: {
+        type: "trustedPrimitive",
+        primitive: { kind: "action", id: "setStatus", runId },
+      },
+    })
 
     const events = await waitFor(
       () => host.events.read({ types: ["action.completed"] }),
@@ -204,6 +216,7 @@ describe("ActionWorker", () => {
     )
     expect(events[0]).toMatchObject({
       type: "action.completed",
+      correlationId: sixb.execution.correlationId,
       idempotencyKey: `action.completed:${runId}`,
       payload: {
         actionId: "setStatus",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,6 +89,12 @@
       "import": "./dist/actions/index.js",
       "default": "./dist/actions/index.js"
     },
+    "./internal/action-run-storage-provider": {
+      "types": "./dist/storage/action-runs/provider.d.ts",
+      "bun": "./src/storage/action-runs/provider.ts",
+      "import": "./dist/storage/action-runs/provider.js",
+      "default": "./dist/storage/action-runs/provider.js"
+    },
     "./internal/agents": {
       "types": "./dist/agents/index.d.ts",
       "bun": "./src/agents/index.ts",

--- a/packages/core/src/actions/execution.ts
+++ b/packages/core/src/actions/execution.ts
@@ -1,4 +1,5 @@
 import { canViewActionRun, isAllowed } from "../authorization"
+import type { ExecutionContext } from "../execution"
 import type { ObjectType } from "../ontology"
 import type { SixbRuntimeContext } from "../runtime/types"
 import type {
@@ -32,7 +33,10 @@ export interface ActionsRuntime {
   readonly runs: ActionRunsRuntime
 }
 
-export function createActionsRuntime(runtime: SixbRuntimeContext): ActionsRuntime {
+export function createActionsRuntime(
+  runtime: SixbRuntimeContext,
+  execution: ExecutionContext
+): ActionsRuntime {
   const canList = (action: ActionDefinition) =>
     isAllowed(runtime.authorization, { kind: "action.apply", actionId: action.id }) &&
     (action.binding.kind === "global" ||
@@ -49,8 +53,8 @@ export function createActionsRuntime(runtime: SixbRuntimeContext): ActionsRuntim
     },
     listGlobal: () => runtime.actionRegistry.listGlobal().filter(canList),
     listForType: (objectType) => runtime.actionRegistry.listForType(objectType).filter(canList),
-    request: (input) => requestAction(runtime, input),
-    requestAndWait: (input) => requestActionAndWait(runtime, input),
+    request: (input) => requestAction(runtime, execution, input),
+    requestAndWait: (input) => requestActionAndWait(runtime, execution, input),
     runs: {
       getById: async (runId) => {
         const run =

--- a/packages/core/src/actions/request.ts
+++ b/packages/core/src/actions/request.ts
@@ -1,19 +1,22 @@
 import { assertAuthorized } from "../authorization"
-import { reportRunFailure } from "../error-reporting/capability"
+import {
+  createPrimitiveExecutionRecord,
+  ensureExecutionRecord,
+  executionRecordInputFromRuntime,
+} from "../execution/durable"
+import type { ExecutionContext } from "../execution/types"
 import { ActionRunTimeoutError } from "../objects/action/errors"
 import { OntologyValidationError } from "../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
 import type { SixbRuntimeContext } from "../runtime/types"
 import {
   ActionRunError,
-  type ActionRunParams,
   type ActionRunRecord,
   type ActionRunStorage,
-  actionRunParamsEqual,
-  actionSubjectsEqual,
   isTerminalActionRun,
 } from "../storage"
-import { createActionRunId, createActionRunIdempotencyKey } from "./run-id"
+import { dispatchActionRun } from "./run-dispatch"
+import { createActionRunId } from "./run-id"
 import type { ActionDefinition, ActionSubject } from "./types"
 import {
   isObjectActionDefinition,
@@ -77,9 +80,10 @@ function getActionDefinition(runtime: SixbRuntimeContext, actionId: string): Act
 
 export async function requestAction(
   runtime: SixbRuntimeContext,
+  execution: ExecutionContext,
   input: RequestActionInput
 ): Promise<RequestActionResult> {
-  const actionRuns = requireActionRunStorage(runtime)
+  requireActionRunStorage(runtime)
   const action = getActionDefinition(runtime, input.actionId)
   const actionId = action.id
   const rawParams: Record<string, unknown> = input.params ?? {}
@@ -103,147 +107,41 @@ export async function requestAction(
 
   const actionParams = normalizeActionParams(runtime, action.params, rawParams, pathPrefix)
 
-  const runId = createActionRunId(input.runId)
-  const existing = await actionRuns.getById({ projectId: runtime.projectId, id: runId })
-  if (existing) {
-    assertExistingRunMatchesRequest(existing, {
-      actionId,
-      subject,
-      params: actionParams,
-    })
-    if (isRetryableEnqueueFailure(existing)) {
-      const queuedAt = new Date()
-      await actionRuns.queue({
-        projectId: runtime.projectId,
-        id: runId,
-        actionId,
-        subject,
-        params: actionParams,
-        idempotencyKey: existing.idempotencyKey,
-        queuedAt,
-      })
-      return enqueueActionRunJob(runtime, {
-        actionRuns,
-        actionId,
-        subject,
-        params: actionParams,
-        runId,
-        queuedAt,
-        created: false,
-      })
-    }
-    return {
-      runId,
-      queuedAt: existing.queuedAt.toISOString(),
-      created: false,
-    }
-  }
-
-  const queuedAt = new Date()
-  const idempotencyKey = createActionRunIdempotencyKey(runtime.projectId, runId)
-
-  await actionRuns.queue({
+  return dispatchActionRun({
+    errorReporterHost: runtime,
     projectId: runtime.projectId,
-    id: runId,
+    storage: runtime.storage,
+    queue: runtime.queues.actions,
+    events: runtime.events,
     actionId,
     subject,
     params: actionParams,
-    idempotencyKey,
-    queuedAt,
-  })
-
-  return enqueueActionRunJob(runtime, {
-    actionRuns,
-    actionId,
-    subject,
-    params: actionParams,
-    runId,
-    queuedAt,
-    created: true,
-  })
-}
-
-async function enqueueActionRunJob(
-  runtime: SixbRuntimeContext,
-  params: {
-    readonly actionRuns: ActionRunStorage
-    readonly actionId: string
-    readonly subject: ActionSubject
-    readonly params: ActionRunParams
-    readonly runId: string
-    readonly queuedAt: Date
-    readonly created: boolean
-  }
-): Promise<RequestActionResult> {
-  let jobId: string | undefined
-  try {
-    const [job] = await runtime.queues.actions.enqueue({
-      projectId: runtime.projectId,
-      jobs: [
-        {
-          type: "action.run.requested",
-          payload: {
-            actionId: params.actionId,
-            runId: params.runId,
-          },
-        },
-      ],
-    })
-    jobId = job?.id
-  } catch (error) {
-    const failed = await params.actionRuns.finish({
-      projectId: runtime.projectId,
-      id: params.runId,
-      status: "failed",
-      phase: "enqueue",
-      error: toActionRunFailure(error, "enqueue"),
-    })
-    reportRunFailure(runtime, error, {
-      projectId: runtime.projectId,
-      occurredAt: failed.finishedAt,
-      run: {
-        kind: "action",
-        runId: params.runId,
-        actionId: params.actionId,
-      },
-    })
-    throw error
-  }
-
-  // The run is persisted and the job is queued, so the request has succeeded and the caller must not
-  // be told otherwise. `emit` keeps that promise and still escalates the lost trigger edge.
-  await runtime.events.emit(
-    {
-      events: [
-        {
-          type: "action.requested",
-          payload: {
-            actionId: params.actionId,
-            subject: params.subject,
-            params: params.params,
-            runId: params.runId,
-          },
-        },
-      ],
+    runId: input.runId,
+    createExecution: async (executionId, runId) => {
+      const caller = await ensureExecutionRecord(
+        runtime.storage.executions,
+        executionRecordInputFromRuntime({
+          execution,
+          runtimeAuthorization: runtime.runtimeAuthorization,
+        })
+      )
+      return createPrimitiveExecutionRecord({
+        id: executionId,
+        primitive: { kind: "action", id: actionId, runId },
+        origin: { type: "execution", parent: caller },
+      })
     },
-    { source: "Sixb" }
-  )
-
-  return {
-    runId: params.runId,
-    queuedAt: params.queuedAt.toISOString(),
-    ...(jobId ? { jobId } : {}),
-    created: params.created,
-  }
+  })
 }
 
 export async function requestActionAndWait(
   runtime: SixbRuntimeContext,
+  execution: ExecutionContext,
   input: RequestActionAndWaitInput
 ): Promise<ActionRunRecord> {
   const runId = createActionRunId(input.runId)
 
-  await requestAction(runtime, {
+  await requestAction(runtime, execution, {
     ...input,
     runId,
   })
@@ -363,45 +261,4 @@ function requireActionRunStorage(runtime: SixbRuntimeContext): ActionRunStorage 
     throw new ActionRunError("[Sixb] Action run storage is not configured.")
   }
   return actionRuns
-}
-
-function assertExistingRunMatchesRequest(
-  existing: ActionRunRecord,
-  request: {
-    readonly actionId: string
-    readonly subject: ActionSubject
-    readonly params: ActionRunParams
-  }
-): void {
-  const matches =
-    existing.actionId === request.actionId &&
-    actionSubjectsEqual(existing.subject, request.subject) &&
-    actionRunParamsEqual(existing.params, request.params)
-
-  if (!matches) {
-    throw new ActionRunError(
-      `[Sixb] Action run '${existing.id}' already exists with a different request payload.`
-    )
-  }
-}
-
-function isRetryableEnqueueFailure(record: ActionRunRecord): boolean {
-  return record.status === "failed" && record.phase === "enqueue"
-}
-
-function toActionRunFailure(
-  error: unknown,
-  phase: "enqueue"
-): { name?: string; message: string; phase: "enqueue" } {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-      phase,
-    }
-  }
-  return {
-    message: String(error),
-    phase,
-  }
 }

--- a/packages/core/src/actions/run-dispatch.ts
+++ b/packages/core/src/actions/run-dispatch.ts
@@ -1,0 +1,243 @@
+import { randomUUID } from "node:crypto"
+import { reportRunFailure } from "../error-reporting/capability"
+import type { DomainEventLog } from "../events"
+import type { Queues } from "../queues"
+import type { ActionRunParams, ActionRunRecord, CreateExecutionInput, Storage } from "../storage"
+import { ActionRunError, actionRunParamsEqual, actionSubjectsEqual } from "../storage"
+import type { RequestActionResult } from "./request"
+import { createActionRunId, createActionRunIdempotencyKey } from "./run-id"
+import type { ActionSubject } from "./types"
+
+interface DispatchActionRunInput {
+  readonly errorReporterHost: object
+  readonly projectId: string
+  readonly storage: Storage
+  readonly queue: Queues["actions"]
+  readonly events: DomainEventLog
+  readonly actionId: string
+  readonly subject: ActionSubject
+  readonly params: ActionRunParams
+  readonly runId?: string
+  readonly createExecution: (executionId: string, runId: string) => Promise<CreateExecutionInput>
+}
+
+interface PreparedActionRun {
+  readonly runId: string
+  readonly idempotencyKey: string
+}
+
+type PersistedActionRun =
+  | { readonly publish: false; readonly run: ActionRunRecord }
+  | {
+      readonly publish: true
+      readonly run: ActionRunRecord
+      readonly execution: CreateExecutionInput
+      readonly queuedAt: Date
+      readonly created: boolean
+    }
+
+/** Persist an Action execution and run before publishing its queue job. */
+export async function dispatchActionRun(
+  input: DispatchActionRunInput
+): Promise<RequestActionResult> {
+  const request = prepareActionRun(input)
+  const persisted = await persistActionRun(input, request)
+  if (!persisted.publish) return existingActionRunResult(persisted.run)
+  return publishActionRun(input, persisted)
+}
+
+function prepareActionRun(input: DispatchActionRunInput): PreparedActionRun {
+  const runId = createActionRunId(input.runId)
+  return {
+    runId,
+    idempotencyKey: createActionRunIdempotencyKey(input.projectId, runId),
+  }
+}
+
+async function persistActionRun(
+  input: DispatchActionRunInput,
+  request: PreparedActionRun
+): Promise<PersistedActionRun> {
+  const actionRuns = requireActionRunStorage(input.storage)
+  const existing = await actionRuns.getById({ projectId: input.projectId, id: request.runId })
+  if (existing) return reuseActionRun(input, existing)
+
+  const execution = await input.createExecution(`exec_${randomUUID()}`, request.runId)
+  const queuedAt = new Date()
+  try {
+    return await input.storage.transaction(
+      async (tx): Promise<PersistedActionRun> => {
+        const transactionalRuns = requireActionRunStorage(tx)
+        const raced = await transactionalRuns.getById({
+          projectId: input.projectId,
+          id: request.runId,
+        })
+        if (raced) {
+          assertExistingRunMatchesRequest(raced, input)
+          return { publish: false, run: raced }
+        }
+
+        await tx.executions.create(execution)
+        const run = await transactionalRuns.queue({
+          projectId: input.projectId,
+          id: request.runId,
+          executionId: execution.id,
+          actionId: input.actionId,
+          subject: input.subject,
+          params: input.params,
+          idempotencyKey: request.idempotencyKey,
+          queuedAt,
+        })
+        return { publish: true, run, execution, queuedAt, created: true }
+      },
+      { isolation: "serializable" }
+    )
+  } catch (error) {
+    if (!(error instanceof ActionRunError)) throw error
+    const raced = await actionRuns.getById({ projectId: input.projectId, id: request.runId })
+    if (!raced) throw error
+    assertExistingRunMatchesRequest(raced, input)
+    return { publish: false, run: raced }
+  }
+}
+
+async function reuseActionRun(
+  input: DispatchActionRunInput,
+  existing: ActionRunRecord
+): Promise<PersistedActionRun> {
+  assertExistingRunMatchesRequest(existing, input)
+  if (!isRetryableEnqueueFailure(existing)) return { publish: false, run: existing }
+
+  const execution = await input.storage.executions.getById({
+    projectId: input.projectId,
+    id: existing.executionId,
+  })
+  if (!execution) {
+    throw new ActionRunError(
+      `[Sixb] Execution '${existing.executionId}' for Action run '${existing.id}' was not found.`
+    )
+  }
+
+  const queuedAt = new Date()
+  const run = await requireActionRunStorage(input.storage).queue({
+    projectId: input.projectId,
+    id: existing.id,
+    executionId: existing.executionId,
+    actionId: existing.actionId,
+    subject: existing.subject,
+    params: existing.params,
+    idempotencyKey: existing.idempotencyKey,
+    queuedAt,
+  })
+  return { publish: true, run, execution, queuedAt, created: false }
+}
+
+async function publishActionRun(
+  input: DispatchActionRunInput,
+  persisted: Extract<PersistedActionRun, { readonly publish: true }>
+): Promise<RequestActionResult> {
+  let job: Awaited<ReturnType<Queues["actions"]["enqueue"]>>[number] | undefined
+  try {
+    const jobs = await input.queue.enqueue({
+      projectId: input.projectId,
+      jobs: [
+        {
+          id: persisted.run.id,
+          type: "action.run.requested",
+          payload: {
+            runId: persisted.run.id,
+          },
+        },
+      ],
+    })
+    job = jobs[0]
+  } catch (error) {
+    await failActionRunPublication(input, persisted.run, error)
+    throw error
+  }
+
+  await input.events.emit(
+    {
+      events: [
+        {
+          type: "action.requested",
+          payload: {
+            actionId: persisted.run.actionId,
+            subject: persisted.run.subject,
+            params: persisted.run.params,
+            runId: persisted.run.id,
+          },
+        },
+      ],
+      correlationId: persisted.execution.correlationId,
+    },
+    { source: "Sixb" }
+  )
+
+  return {
+    runId: persisted.run.id,
+    queuedAt: persisted.queuedAt.toISOString(),
+    ...(job?.id ? { jobId: job.id } : {}),
+    created: persisted.created,
+  }
+}
+
+async function failActionRunPublication(
+  input: DispatchActionRunInput,
+  run: ActionRunRecord,
+  error: unknown
+): Promise<void> {
+  const failed = await requireActionRunStorage(input.storage).finish({
+    projectId: input.projectId,
+    id: run.id,
+    status: "failed",
+    phase: "enqueue",
+    error: toActionRunFailure(error),
+  })
+  reportRunFailure(input.errorReporterHost, error, {
+    projectId: input.projectId,
+    occurredAt: failed.finishedAt,
+    run: { kind: "action", runId: run.id, actionId: run.actionId },
+  })
+}
+
+function requireActionRunStorage(storage: Storage): NonNullable<Storage["actionRuns"]> {
+  if (!storage.actionRuns) {
+    throw new ActionRunError("[Sixb] Action run storage is not configured.")
+  }
+  return storage.actionRuns
+}
+
+function assertExistingRunMatchesRequest(
+  existing: ActionRunRecord,
+  request: Pick<DispatchActionRunInput, "actionId" | "subject" | "params">
+): void {
+  if (
+    existing.actionId !== request.actionId ||
+    !actionSubjectsEqual(existing.subject, request.subject) ||
+    !actionRunParamsEqual(existing.params, request.params)
+  ) {
+    throw new ActionRunError(
+      `[Sixb] Action run '${existing.id}' already exists with a different request payload.`
+    )
+  }
+}
+
+function isRetryableEnqueueFailure(record: ActionRunRecord): boolean {
+  return record.status === "failed" && record.phase === "enqueue"
+}
+
+function existingActionRunResult(existing: ActionRunRecord): RequestActionResult {
+  return {
+    runId: existing.id,
+    queuedAt: existing.queuedAt.toISOString(),
+    created: false,
+  }
+}
+
+function toActionRunFailure(error: unknown): { name?: string; message: string; phase: "enqueue" } {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, phase: "enqueue" }
+  }
+  return { message: String(error), phase: "enqueue" }
+}

--- a/packages/core/src/objects/action/request.ts
+++ b/packages/core/src/objects/action/request.ts
@@ -12,12 +12,12 @@ import {
   requestActionAndWait as requestRuntimeActionAndWait,
 } from "../../actions/request"
 import type { ActionRunRecord } from "../../storage"
-import type { ResolvedObjectContext } from "../context"
+import type { ExecutionObjectContext } from "../context"
 
 export type { RequestActionAndWaitOptions, RequestActionOptions }
 
 export async function requestAction(
-  ctx: ResolvedObjectContext,
+  ctx: ExecutionObjectContext,
   params: {
     primaryId: string
     actionId: string
@@ -25,7 +25,7 @@ export async function requestAction(
     options?: RequestActionOptions
   }
 ): Promise<RequestActionResult> {
-  return requestRuntimeAction(ctx, {
+  return requestRuntimeAction(ctx, ctx.execution, {
     actionId: params.actionId,
     subject: {
       kind: "object",
@@ -39,7 +39,7 @@ export async function requestAction(
 }
 
 export async function requestActionAndWait(
-  ctx: ResolvedObjectContext,
+  ctx: ExecutionObjectContext,
   params: {
     primaryId: string
     actionId: string
@@ -47,7 +47,7 @@ export async function requestActionAndWait(
     options?: RequestActionAndWaitOptions
   }
 ): Promise<ActionRunRecord> {
-  return requestRuntimeActionAndWait(ctx, {
+  return requestRuntimeActionAndWait(ctx, ctx.execution, {
     actionId: params.actionId,
     subject: {
       kind: "object",

--- a/packages/core/src/objects/context/index.ts
+++ b/packages/core/src/objects/context/index.ts
@@ -1,5 +1,6 @@
 export { requireLinkDefinition, resolveLinkContext, resolveObjectContext } from "./resolve"
 export type {
+  ExecutionObjectContext,
   ResolvedLinkBatchItem,
   ResolvedLinkContext,
   ResolvedObjectContext,

--- a/packages/core/src/objects/context/types.ts
+++ b/packages/core/src/objects/context/types.ts
@@ -4,6 +4,7 @@
  * Context hierarchy: SixbRuntimeContext → ResolvedObjectContext → ResolvedLinkContext
  */
 
+import type { ExecutionContext } from "../../execution"
 import type { ObjectLink } from "../../ontology"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
 import type { SixbRuntimeContext } from "../../runtime/types"
@@ -12,6 +13,11 @@ import type { SixbRuntimeContext } from "../../runtime/types"
 export interface ResolvedObjectContext extends SixbRuntimeContext {
   readonly objectType: ObjectTypeWithPropertyTokens
   readonly primaryPropertyId: string
+}
+
+/** Object operations bound to one immutable execution. */
+export interface ExecutionObjectContext extends ResolvedObjectContext {
+  readonly execution: ExecutionContext
 }
 
 /** Resolved context for link operations. */

--- a/packages/core/src/objects/execution.ts
+++ b/packages/core/src/objects/execution.ts
@@ -1,4 +1,5 @@
 import { assertAuthorized, isAllowed } from "../authorization"
+import type { ExecutionContext } from "../execution"
 import type { ValueType } from "../ontology"
 import { assertObjectTypeRegistered } from "../ontology"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
@@ -159,7 +160,8 @@ export interface ObjectsRuntime<TOntologySources extends readonly OntologySource
 }
 
 export function createObjectsRuntime<TOntologySources extends readonly OntologySource[]>(
-  runtime: SixbRuntimeContext
+  runtime: SixbRuntimeContext,
+  execution: ExecutionContext
 ): ObjectsRuntime<TOntologySources> {
   const objects = Object.assign(
     <TObjectType extends RegisteredObjectType<TOntologySources>>(objectType: TObjectType) => {
@@ -168,7 +170,7 @@ export function createObjectsRuntime<TOntologySources extends readonly OntologyS
         TObjectType,
         RegisteredObjectType<TOntologySources>,
         RegisteredValueTypes<TOntologySources>
-      >({ ...runtime, objectType }) as ExecutionObjectSet<
+      >({ ...runtime, execution, objectType }) as ExecutionObjectSet<
         TObjectType,
         RegisteredValueTypes<TOntologySources>,
         RegisteredObjectType<TOntologySources>

--- a/packages/core/src/objects/sdk/object-handle.ts
+++ b/packages/core/src/objects/sdk/object-handle.ts
@@ -14,7 +14,7 @@ import {
   requestActionAndWait as requestActionAndWaitLeaf,
   requestAction as requestActionLeaf,
 } from "../action"
-import type { ResolvedLinkContext, ResolvedObjectContext } from "../context"
+import type { ExecutionObjectContext, ResolvedLinkContext } from "../context"
 import { removeLink as removeLinkLeaf, upsertLink as upsertLinkLeaf } from "../link"
 import { deleteObject, restoreObject } from "../object"
 import { createTelemetryChannel } from "./telemetry-channel"
@@ -25,7 +25,7 @@ type AnyLinkToken = LinkToken<string, string, string | readonly string[], Object
 export function createObjectByIdHandle<
   TObjectType extends ObjectTypeWithPropertyTokens,
   TValueTypes extends readonly ValueType[],
->(ctx: ResolvedObjectContext, primaryId: string): ObjectByIdHandle<TObjectType, TValueTypes> {
+>(ctx: ExecutionObjectContext, primaryId: string): ObjectByIdHandle<TObjectType, TValueTypes> {
   const objectHandle = {
     get: async () => {
       assertAuthorized(ctx, { kind: "object.view", objectTypeId: ctx.objectType.id })

--- a/packages/core/src/objects/sdk/object-set.ts
+++ b/packages/core/src/objects/sdk/object-set.ts
@@ -8,6 +8,7 @@ import type { ActionDefinition } from "../../actions"
 import type { AuthorizationContext } from "../../authorization"
 import { assertAuthorized } from "../../authorization"
 import { shareSixbErrorReporter } from "../../error-reporting/capability"
+import type { ExecutionContext } from "../../execution"
 import type { ValueType } from "../../ontology"
 import { OntologyValidationError } from "../../ontology/errors"
 import type { ObjectTypeWithPropertyTokens } from "../../ontology/tokens"
@@ -22,7 +23,7 @@ import {
   requestActionAndWait as requestActionAndWaitLeaf,
   requestAction as requestActionLeaf,
 } from "../action"
-import type { ResolvedLinkContext, ResolvedObjectContext } from "../context"
+import type { ExecutionObjectContext, ResolvedLinkContext } from "../context"
 import { requireLinkDefinition } from "../context"
 import { removeLink as removeLinkLeaf, upsertLink as upsertLinkLeaf } from "../link"
 import { upsertObject as upsertObjectLeaf } from "../object"
@@ -37,6 +38,7 @@ export function createObjectSet<
   TValueTypes extends readonly ValueType[],
 >(
   params: SixbRuntimeContext & {
+    readonly execution: ExecutionContext
     readonly objectType: TObjectType
     readonly authorization?: AuthorizationContext
   }
@@ -57,6 +59,7 @@ export function createObjectSet<
     queues,
     runtimeAuthorization,
     authorization,
+    execution,
   } = params
   const queryExecutor = createRuntimeQueryExecutor({
     projectId,
@@ -66,7 +69,7 @@ export function createObjectSet<
     authorization,
   })
 
-  const resolvedCtx: ResolvedObjectContext = {
+  const resolvedCtx: ExecutionObjectContext = {
     projectId,
     ontology,
     actionRegistry,
@@ -75,6 +78,7 @@ export function createObjectSet<
     queues,
     runtimeAuthorization,
     authorization,
+    execution,
     objectType,
     primaryPropertyId,
   }

--- a/packages/core/src/objects/service/action-service.ts
+++ b/packages/core/src/objects/service/action-service.ts
@@ -5,6 +5,7 @@
  */
 
 import type { RequestActionResult } from "../../actions/request"
+import type { ExecutionContext } from "../../execution"
 import type { SixbRuntimeContext } from "../../runtime/types"
 import type { ActionRunRecord } from "../../storage"
 import {
@@ -17,24 +18,26 @@ import { resolveObjectContext } from "../context"
 
 export async function requestAction(
   runtime: SixbRuntimeContext,
+  execution: ExecutionContext,
   objectTypeId: string,
   primaryId: string,
   actionId: string,
   params?: Record<string, unknown>,
   options?: RequestActionOptions
 ): Promise<RequestActionResult> {
-  const ctx = resolveObjectContext(runtime, objectTypeId)
+  const ctx = { ...resolveObjectContext(runtime, objectTypeId), execution }
   return requestActionLeaf(ctx, { primaryId, actionId, params, options })
 }
 
 export async function requestActionAndWait(
   runtime: SixbRuntimeContext,
+  execution: ExecutionContext,
   objectTypeId: string,
   primaryId: string,
   actionId: string,
   params?: Record<string, unknown>,
   options?: RequestActionAndWaitOptions
 ): Promise<ActionRunRecord> {
-  const ctx = resolveObjectContext(runtime, objectTypeId)
+  const ctx = { ...resolveObjectContext(runtime, objectTypeId), execution }
   return requestActionAndWaitLeaf(ctx, { primaryId, actionId, params, options })
 }

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -160,7 +160,6 @@ export interface ActionRunRequestedQueueJob
   extends QueueJob<
     "action.run.requested",
     {
-      readonly actionId: string
       readonly runId: string
     }
   > {}

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -75,8 +75,8 @@ function createExecutionFacades<TOntologySources extends readonly OntologySource
   dependencies: SixbDependencies
 ): Omit<Sixb<TOntologySources>, "execution"> {
   return {
-    objects: createObjectsRuntime<TOntologySources>(runtime),
-    actions: createActionsRuntime(runtime),
+    objects: createObjectsRuntime<TOntologySources>(runtime, execution),
+    actions: createActionsRuntime(runtime, execution),
     datasets: createDatasetsRuntime(runtime, dependencies.definitions.datasets),
     workflows: createWorkflowsRuntime(runtime, execution, dependencies.definitions.workflows),
     syncs: createSyncsRuntime(runtime, dependencies.definitions.syncs),

--- a/packages/core/src/storage/action-runs/idempotency.ts
+++ b/packages/core/src/storage/action-runs/idempotency.ts
@@ -47,6 +47,7 @@ export function canRequeueActionRunAfterEnqueueFailure(
   return (
     existing.status === "failed" &&
     existing.phase === "enqueue" &&
+    existing.executionId === input.executionId &&
     existing.actionId === input.actionId &&
     existing.idempotencyKey === input.idempotencyKey &&
     actionSubjectsEqual(existing.subject, input.subject) &&

--- a/packages/core/src/storage/action-runs/in-memory.ts
+++ b/packages/core/src/storage/action-runs/in-memory.ts
@@ -1,3 +1,4 @@
+import type { ExecutionStorage } from "../executions"
 import { ActionRunError } from "./errors"
 import {
   actionRunPhaseRecordsEqual,
@@ -5,6 +6,7 @@ import {
   canRequeueActionRunAfterEnqueueFailure,
   isTerminalActionRun,
 } from "./idempotency"
+import { assertActionRunExecution } from "./provider"
 import type {
   ActionRunEffectsRecord,
   ActionRunFailure,
@@ -109,7 +111,10 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
   private readonly rows = new Map<string, ActionRunRecord>()
   private readonly runRootOperation: RunRootOperation
 
-  constructor(input: { readonly runRootOperation?: RunRootOperation } = {}) {
+  constructor(
+    private readonly executions: ExecutionStorage,
+    input: { readonly runRootOperation?: RunRootOperation } = {}
+  ) {
     this.runRootOperation = input.runRootOperation ?? runDirectly
   }
 
@@ -129,7 +134,7 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
   }
 
   async queue(input: QueueActionRunInput): Promise<ActionRunRecord> {
-    return this.runRootOperation(() => {
+    return this.runRootOperation(async () => {
       const key = actionRunKey(input.projectId, input.id)
       const existing = this.rows.get(key)
       if (existing && !canRequeueActionRunAfterEnqueueFailure(existing, input)) {
@@ -137,10 +142,30 @@ export class InMemoryActionRunStorage implements ActionRunStorage {
           `[Sixb] Action run '${input.id}' already exists for project '${input.projectId}'.`
         )
       }
+      if (
+        [...this.rows.values()].some(
+          (run) =>
+            run.projectId === input.projectId &&
+            run.id !== input.id &&
+            run.executionId === input.executionId
+        )
+      ) {
+        throw new ActionRunError(
+          `[Sixb] Execution '${input.executionId}' already belongs to another Action run.`
+        )
+      }
+      await assertActionRunExecution({
+        executions: this.executions,
+        projectId: input.projectId,
+        executionId: input.executionId,
+        runId: input.id,
+        actionId: input.actionId,
+      })
 
       const record: ActionRunRecord = {
         id: input.id,
         projectId: input.projectId,
+        executionId: input.executionId,
         actionId: input.actionId,
         subject: normalizeSubject(input.subject),
         status: "queued",

--- a/packages/core/src/storage/action-runs/provider.ts
+++ b/packages/core/src/storage/action-runs/provider.ts
@@ -1,0 +1,25 @@
+import type { ExecutionStorage } from "../executions"
+import { findPrimitiveRunExecution } from "../executions/run-link"
+import { ActionRunError } from "./errors"
+
+/** Validate the semantic link between a durable Action run and its immutable execution. */
+export async function assertActionRunExecution(input: {
+  readonly executions: ExecutionStorage
+  readonly projectId: string
+  readonly executionId: string
+  readonly runId: string
+  readonly actionId: string
+}): Promise<void> {
+  const execution = await findPrimitiveRunExecution({
+    executions: input.executions,
+    projectId: input.projectId,
+    executionId: input.executionId,
+    primitive: { kind: "action", id: input.actionId, runId: input.runId },
+    sourceTypes: ["execution"],
+  })
+  if (!execution) {
+    throw new ActionRunError(
+      `[Sixb] Execution '${input.executionId}' does not authorize Action run '${input.runId}'.`
+    )
+  }
+}

--- a/packages/core/src/storage/action-runs/types.ts
+++ b/packages/core/src/storage/action-runs/types.ts
@@ -39,6 +39,7 @@ export interface ActionRunEffectsRecord {
 export interface ActionRunRecord {
   readonly id: string
   readonly projectId: string
+  readonly executionId: string
   readonly actionId: string
   readonly subject: ActionSubject
   readonly status: ActionRunStatus
@@ -56,6 +57,7 @@ export interface ActionRunRecord {
 export interface QueueActionRunInput {
   readonly id: string
   readonly projectId: string
+  readonly executionId: string
   readonly actionId: string
   readonly subject: ActionSubject
   readonly params: ActionRunParams

--- a/packages/core/src/storage/executions/run-link.ts
+++ b/packages/core/src/storage/executions/run-link.ts
@@ -1,0 +1,36 @@
+import type { TrustedPrimitiveRef } from "../../execution/types"
+import type { ExecutionRecord, ExecutionStorage } from "./types"
+
+/**
+ * Find the immutable execution that is the authority owned by a primitive run.
+ *
+ * ExecutionStorage owns generic provenance invariants. Primitive providers remain responsible for
+ * deciding which sources they accept and translating a mismatch to their domain-specific error.
+ */
+export async function findPrimitiveRunExecution(input: {
+  readonly executions: ExecutionStorage
+  readonly projectId: string
+  readonly executionId: string
+  readonly primitive: TrustedPrimitiveRef
+  readonly sourceTypes: readonly ("event" | "execution" | "schedule" | "webhook")[]
+}): Promise<ExecutionRecord | null> {
+  const execution = await input.executions.getById({
+    projectId: input.projectId,
+    id: input.executionId,
+  })
+  const authority = execution?.authorizationRef
+  if (
+    !execution ||
+    !input.sourceTypes.some((type) => type === execution.source.type) ||
+    execution.executor.type !== "primitive" ||
+    execution.executor.kind !== input.primitive.kind ||
+    execution.executor.runId !== input.primitive.runId ||
+    authority?.type !== "trustedPrimitive" ||
+    authority.primitive.kind !== input.primitive.kind ||
+    authority.primitive.id !== input.primitive.id ||
+    authority.primitive.runId !== input.primitive.runId
+  ) {
+    return null
+  }
+  return execution
+}

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -55,7 +55,7 @@ export class InMemoryStorage implements Storage {
   private readonly authStorage = new InMemoryAuthStorage()
   private readonly executionStorage = new InMemoryExecutionStorage(this.authStorage)
   private readonly agentStorage = new InMemoryAgentStorage()
-  private readonly actionRunStorage = new InMemoryActionRunStorage()
+  private readonly actionRunStorage = new InMemoryActionRunStorage(this.executionStorage)
   private readonly syncRunStorage = new InMemorySyncRunStorage()
   private readonly pipelineRunStorage = new InMemoryPipelineRunStorage()
   private readonly projectionRunStorage = new InMemoryProjectionRunStorage()

--- a/packages/core/src/storage/workflow-runs/provider.ts
+++ b/packages/core/src/storage/workflow-runs/provider.ts
@@ -1,4 +1,5 @@
 import type { ExecutionStorage } from "../executions"
+import { findPrimitiveRunExecution } from "../executions/run-link"
 import { WorkflowRunError } from "./errors"
 
 /** Validate the semantic link between a durable workflow run and its immutable execution. */
@@ -10,21 +11,14 @@ export async function assertWorkflowRunExecution(input: {
   readonly runId: string
   readonly workflowId: string
 }): Promise<void> {
-  const execution = await input.executions.getById({
+  const execution = await findPrimitiveRunExecution({
+    executions: input.executions,
     projectId: input.projectId,
-    id: input.executionId,
+    executionId: input.executionId,
+    primitive: { kind: "workflow", id: input.workflowId, runId: input.runId },
+    sourceTypes: ["execution", "schedule", "event"],
   })
-  const authority = execution?.authorizationRef
-  if (
-    !execution ||
-    execution.executor.type !== "primitive" ||
-    execution.executor.kind !== "workflow" ||
-    execution.executor.runId !== input.runId ||
-    authority?.type !== "trustedPrimitive" ||
-    authority.primitive.kind !== "workflow" ||
-    authority.primitive.id !== input.workflowId ||
-    authority.primitive.runId !== input.runId
-  ) {
+  if (!execution) {
     invalidExecution(input.executionId, input.runId)
   }
 

--- a/packages/core/src/testing/action-execution.ts
+++ b/packages/core/src/testing/action-execution.ts
@@ -1,0 +1,62 @@
+import type { TrustedPrimitiveRef } from "../execution"
+import type { ActionRunRecord, QueueActionRunInput, Storage } from "../storage"
+import type { ExecutionStorage } from "../storage/executions"
+
+/** Create the durable execution chain required by an Action-run storage fixture. */
+export async function createTestActionExecution(
+  executions: ExecutionStorage,
+  input: {
+    readonly projectId: string
+    readonly actionId: string
+    readonly runId: string
+    readonly executionId?: string
+  }
+): Promise<string> {
+  const parentExecutionId = `test_request_execution:${input.runId}`
+  const executionId = input.executionId ?? `test_action_execution:${input.runId}`
+  const primitive: TrustedPrimitiveRef = {
+    kind: "action",
+    id: input.actionId,
+    runId: input.runId,
+  }
+
+  const existing = await executions.getById({ projectId: input.projectId, id: executionId })
+  if (existing) return executionId
+
+  const parent = await executions.getById({ projectId: input.projectId, id: parentExecutionId })
+  if (!parent) {
+    await executions.create({
+      id: parentExecutionId,
+      projectId: input.projectId,
+      executor: { type: "request", requestId: `test_request:${input.runId}` },
+      source: { type: "http", requestId: `test_request:${input.runId}` },
+      correlationId: `test_correlation:${input.runId}`,
+      authorizationRef: { type: "disabled" },
+    })
+  }
+  await executions.create({
+    id: executionId,
+    projectId: input.projectId,
+    executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+    source: { type: "execution", executionId: parentExecutionId },
+    correlationId: `test_correlation:${input.runId}`,
+    parentExecutionId,
+    authorizationRef: { type: "trustedPrimitive", primitive },
+  })
+
+  return executionId
+}
+
+/** Queue an Action run with the valid durable execution fixture required by every provider. */
+export async function queueTestActionRun(
+  storage: Pick<Storage, "actionRuns" | "executions">,
+  input: Omit<QueueActionRunInput, "executionId">
+): Promise<ActionRunRecord> {
+  if (!storage.actionRuns) throw new Error("Action run storage is not configured for this test.")
+  const executionId = await createTestActionExecution(storage.executions, {
+    projectId: input.projectId,
+    actionId: input.actionId,
+    runId: input.id,
+  })
+  return storage.actionRuns.queue({ ...input, executionId })
+}

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,4 +1,8 @@
 export {
+  createTestActionExecution,
+  queueTestActionRun,
+} from "./action-execution"
+export {
   type AgentStorageContractSuiteOptions,
   runAgentStorageContractSuite,
 } from "./agent-storage-contract"

--- a/packages/core/src/testing/materializer-storage-contract.ts
+++ b/packages/core/src/testing/materializer-storage-contract.ts
@@ -17,6 +17,7 @@ import {
   type ProjectionSourceEntry,
 } from "../materializer"
 import type { ActionRunStorage, ProjectionRunStorage } from "../storage"
+import { queueTestActionRun } from "./action-execution"
 
 export interface MaterializerStorageContractProvider<TStorage extends Storage> {
   readonly createStorage: () => TStorage | Promise<TStorage>
@@ -173,7 +174,7 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         })
       ).rejects.toThrow("missing-action-run")
 
-      await storage.actionRuns.queue({
+      await queueTestActionRun(storage, {
         id: "action-run",
         projectId: "materializer-storage-contract",
         actionId: "renameDevice",

--- a/packages/core/src/testing/queues-contract.ts
+++ b/packages/core/src/testing/queues-contract.ts
@@ -308,7 +308,6 @@ export function runQueueContractSuite(label: string, options: QueueContractSuite
               {
                 type: "action.run.requested",
                 payload: {
-                  actionId: "mark-paid",
                   runId: "act_1",
                 },
               },
@@ -348,7 +347,7 @@ export function runQueueContractSuite(label: string, options: QueueContractSuite
           expect(workflowLane).toHaveLength(1)
           expect(workflowLane[0]?.job.payload.runId).toBe("workflow-run-1")
           expect(actionLane).toHaveLength(1)
-          expect(actionLane[0]?.job.payload.actionId).toBe("mark-paid")
+          expect(actionLane[0]?.job.payload.runId).toBe("act_1")
           expect(sameLane).toHaveLength(1)
         })
       })

--- a/packages/core/tests/action-runs.test.ts
+++ b/packages/core/tests/action-runs.test.ts
@@ -1,14 +1,87 @@
 import { describe, expect, test } from "bun:test"
-import { ActionRunError, InMemoryActionRunStorage } from "../src/storage"
+import type { QueueActionRunInput } from "../src/storage"
+import { ActionRunError, InMemoryStorage } from "../src/storage"
+import { createTestActionExecution, queueTestActionRun } from "../src/testing"
+
+function createActionRunFixture() {
+  const provider = new InMemoryStorage()
+  return {
+    storage: provider.actionRuns,
+    queue: (input: Omit<QueueActionRunInput, "executionId">) => queueTestActionRun(provider, input),
+  }
+}
 
 describe("InMemoryActionRunStorage", () => {
+  test("requires one matching execution owned by the Action run", async () => {
+    const provider = new InMemoryStorage()
+
+    await expect(
+      provider.actionRuns.queue({
+        id: "act_missing",
+        projectId: "my-app",
+        executionId: "exec_missing",
+        actionId: "sendQuote",
+        subject: { kind: "none" },
+        params: {},
+        idempotencyKey: "action:my-app:act_missing",
+      })
+    ).rejects.toThrow("does not authorize Action run")
+
+    const executionId = await createTestActionExecution(provider.executions, {
+      projectId: "my-app",
+      actionId: "otherAction",
+      runId: "act_mismatch",
+    })
+    await expect(
+      provider.actionRuns.queue({
+        id: "act_mismatch",
+        projectId: "my-app",
+        executionId,
+        actionId: "sendQuote",
+        subject: { kind: "none" },
+        params: {},
+        idempotencyKey: "action:my-app:act_mismatch",
+      })
+    ).rejects.toThrow("does not authorize Action run")
+  })
+
+  test("links an execution to at most one Action run", async () => {
+    const provider = new InMemoryStorage()
+    const executionId = await createTestActionExecution(provider.executions, {
+      projectId: "my-app",
+      actionId: "sendQuote",
+      runId: "act_1",
+    })
+    await provider.actionRuns.queue({
+      id: "act_1",
+      projectId: "my-app",
+      executionId,
+      actionId: "sendQuote",
+      subject: { kind: "none" },
+      params: {},
+      idempotencyKey: "action:my-app:act_1",
+    })
+
+    await expect(
+      provider.actionRuns.queue({
+        id: "act_2",
+        projectId: "my-app",
+        executionId,
+        actionId: "sendQuote",
+        subject: { kind: "none" },
+        params: {},
+        idempotencyKey: "action:my-app:act_2",
+      })
+    ).rejects.toThrow("already belongs to another Action run")
+  })
+
   test("queues, starts, and finishes a successful action run", async () => {
-    const storage = new InMemoryActionRunStorage()
+    const { storage, queue } = createActionRunFixture()
     const queuedAt = new Date("2026-04-29T10:14:00.000Z")
     const startedAt = new Date("2026-04-29T10:14:01.000Z")
     const finishedAt = new Date("2026-04-29T10:14:03.842Z")
 
-    const queued = await storage.queue({
+    const queued = await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -51,9 +124,9 @@ describe("InMemoryActionRunStorage", () => {
   })
 
   test("rejects duplicate queues, invalid starts, and missing finishes", async () => {
-    const storage = new InMemoryActionRunStorage()
+    const { storage, queue } = createActionRunFixture()
 
-    await storage.queue({
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -63,7 +136,7 @@ describe("InMemoryActionRunStorage", () => {
     })
 
     await expect(
-      storage.queue({
+      queue({
         id: "act_1",
         projectId: "my-app",
         actionId: "sendQuote",
@@ -99,9 +172,9 @@ describe("InMemoryActionRunStorage", () => {
   })
 
   test("rejects finishing terminal runs", async () => {
-    const storage = new InMemoryActionRunStorage()
+    const { storage, queue } = createActionRunFixture()
 
-    await storage.queue({
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -133,9 +206,9 @@ describe("InMemoryActionRunStorage", () => {
   })
 
   test("stores failed runs and lists with filters, ordering, and paging", async () => {
-    const storage = new InMemoryActionRunStorage()
+    const { storage, queue } = createActionRunFixture()
 
-    await storage.queue({
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -160,7 +233,7 @@ describe("InMemoryActionRunStorage", () => {
       },
     })
 
-    await storage.queue({
+    await queue({
       id: "act_2",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -175,7 +248,7 @@ describe("InMemoryActionRunStorage", () => {
       startedAt: new Date("2026-04-29T11:00:00.000Z"),
     })
 
-    await storage.queue({
+    await queue({
       id: "act_3",
       projectId: "my-app",
       actionId: "closeOpportunity",
@@ -214,9 +287,9 @@ describe("InMemoryActionRunStorage", () => {
   })
 
   test("records V2 lifecycle records without failing committed actions on effects errors", async () => {
-    const storage = new InMemoryActionRunStorage()
+    const { storage, queue } = createActionRunFixture()
 
-    await storage.queue({
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "createInvoice",
@@ -279,9 +352,9 @@ describe("InMemoryActionRunStorage", () => {
   })
 
   test("compares phase records without stripping user result fields", async () => {
-    const storage = new InMemoryActionRunStorage()
+    const { storage, queue } = createActionRunFixture()
 
-    await storage.queue({
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "createInvoice",

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../src"
 import { flushSixbErrors } from "../src/error-reporting/internal"
 import { ActionRunError } from "../src/storage"
+import { decorateOperationScopedMethodForTesting } from "../src/storage/operation-scope"
 import { createTestSixb } from "../src/testing"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
@@ -688,14 +689,40 @@ describe("requestAction", () => {
       params: {},
       idempotencyKey: `action:action-test:${result.runId}`,
     })
+    expect(run?.executionId).toBeString()
+    const execution = run
+      ? await runtimeDeps.storage.executions.getById({
+          projectId: "action-test",
+          id: run.executionId,
+        })
+      : null
+    expect(execution).toMatchObject({
+      executor: { type: "primitive", kind: "action", runId: result.runId },
+      source: { type: "execution", executionId: sixb.execution.id },
+      correlationId: sixb.execution.correlationId,
+      parentExecutionId: sixb.execution.id,
+      authorizationRef: {
+        type: "trustedPrimitive",
+        primitive: { kind: "action", id: "counted", runId: result.runId },
+      },
+    })
+    expect(
+      await runtimeDeps.storage.executions.getById({
+        projectId: "action-test",
+        id: sixb.execution.id,
+      })
+    ).toMatchObject({
+      id: sixb.execution.id,
+      correlationId: sixb.execution.correlationId,
+    })
     const jobs = await runtimeDeps.queues.actions.claim({
       projectId: "action-test",
       workerId: "test-worker",
       limit: 1,
     })
     expect(jobs).toHaveLength(1)
+    expect(jobs[0].job.id).toBe(result.runId)
     expect(jobs[0].job.payload).toEqual({
-      actionId: "counted",
       runId: result.runId,
     })
     expect(events.length).toBe(1)
@@ -710,6 +737,55 @@ describe("requestAction", () => {
       expect(events[0].payload.params).toEqual({})
       expect(events[0].payload.runId).toBe(result.runId)
     }
+  })
+
+  test("rolls back the Action execution when run persistence fails", async () => {
+    const runtimeDeps = createTestRuntimeDeps()
+    const sixb = createTestSixb({
+      id: "action-atomic-dispatch-test",
+      ontology: [Room],
+      actions: [actionDefinition(setTemperature)],
+      ...runtimeDeps,
+    })
+    let childExecutionId: string | undefined
+    const restore = decorateOperationScopedMethodForTesting(
+      runtimeDeps.storage.actionRuns,
+      "queue",
+      (queue) => async (input) => {
+        childExecutionId = input.executionId
+        await queue(input)
+        throw new Error("injected Action run persistence failure")
+      }
+    )
+
+    try {
+      await expect(
+        sixb.objects(Room).requestAction({
+          id: "room:1",
+          actionId: "setTemperature",
+          params: { target: 72 },
+          runId: "act_atomic_failure",
+        })
+      ).rejects.toThrow("injected Action run persistence failure")
+    } finally {
+      restore()
+    }
+
+    expect(childExecutionId).toBeString()
+    expect(
+      await runtimeDeps.storage.actionRuns.getById({
+        projectId: "action-atomic-dispatch-test",
+        id: "act_atomic_failure",
+      })
+    ).toBeNull()
+    expect(
+      childExecutionId
+        ? await runtimeDeps.storage.executions.getById({
+            projectId: "action-atomic-dispatch-test",
+            id: childExecutionId,
+          })
+        : undefined
+    ).toBeNull()
   })
 
   test("keeps a queued run when the action.requested observation event fails", async () => {
@@ -757,7 +833,6 @@ describe("requestAction", () => {
         limit: 1,
       })
       expect(jobs[0]?.job.payload).toEqual({
-        actionId: "createRoom",
         runId: "act_event_failure",
       })
 
@@ -895,7 +970,6 @@ describe("requestAction", () => {
       limit: 1,
     })
     expect(jobs[0]?.job.payload).toEqual({
-      actionId: "setTemperature",
       runId: "act_enqueue_retry",
     })
   })

--- a/packages/core/tests/edits.test.ts
+++ b/packages/core/tests/edits.test.ts
@@ -20,7 +20,7 @@ import { createLinkScopeFingerprint } from "../src/materializer"
 import { getOntologyMutationRuntime } from "../src/runtime/internal"
 import type { ObjectRow, Storage } from "../src/storage"
 import { StorageTransactionError } from "../src/storage"
-import { createTestSixb } from "../src/testing"
+import { createTestSixb, queueTestActionRun } from "../src/testing"
 import { createTestRuntimeDeps } from "./test-runtime-deps"
 
 const Customer = defineObjectType({
@@ -75,7 +75,7 @@ type EditsHost = ReturnType<typeof createRuntime>["host"]
 async function startActionRun(host: EditsHost, runId: string, actionId = "markPaid") {
   const actionRuns = host.storage.actionRuns
   if (!actionRuns) throw new Error("Expected action run storage in the test runtime.")
-  await actionRuns.queue({
+  await queueTestActionRun(host.storage, {
     projectId: host.id,
     id: runId,
     actionId,

--- a/packages/core/tests/materializer-edits.test.ts
+++ b/packages/core/tests/materializer-edits.test.ts
@@ -3,6 +3,7 @@ import { createEventId, MaterializationConflictError } from "../src/materializer
 import { InMemoryStorage, type Storage, type StoredLinkSlotOverride } from "../src/storage"
 import { getInMemoryOntologyStorageTestingAdapter } from "../src/storage/ontology/in-memory/testing"
 import { decorateOperationScopedMethodForTesting } from "../src/storage/operation-scope"
+import { queueTestActionRun } from "../src/testing"
 import {
   atomic,
   createMaterializerFixture,
@@ -53,7 +54,7 @@ describe("ontology materializer edits", () => {
       const storage = new InMemoryStorage()
       const runId = `run-${scenario.kind}`
       if (scenario.storedActionId) {
-        await storage.actionRuns.queue({
+        await queueTestActionRun(storage, {
           id: runId,
           projectId: "project",
           actionId: scenario.storedActionId,
@@ -112,7 +113,7 @@ describe("ontology materializer edits", () => {
 
   test("materializes a valid running Action without duplicating its ontology commit", async () => {
     const storage = new InMemoryStorage()
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "run-valid",
       projectId: "project",
       actionId: "approve",
@@ -157,7 +158,7 @@ describe("ontology materializer edits", () => {
 
   test("replays an exact Action commit after the run becomes terminal", async () => {
     const storage = new InMemoryStorage()
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "run-replay",
       projectId: "project",
       actionId: "approve",
@@ -204,7 +205,7 @@ describe("ontology materializer edits", () => {
 
   test("rechecks the Action run inside the transaction before ontology work", async () => {
     const storage = new InMemoryStorage()
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "run-recheck",
       projectId: "project",
       actionId: "approve",

--- a/packages/core/tests/ontology-storage-in-memory.test.ts
+++ b/packages/core/tests/ontology-storage-in-memory.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/storage"
 import { getInMemoryStorageTestingAdapter } from "../src/storage/in-memory/testing"
 import { getInMemoryOntologyStorageTestingAdapter } from "../src/storage/ontology/in-memory/testing"
+import { queueTestActionRun } from "../src/testing"
 import {
   atomic,
   createMaterializerFixture,
@@ -40,7 +41,7 @@ describe("in-memory ontology storage", () => {
     expect(replacementCommit?.id).toBe(replacementResult.commitId)
     await expectLogicalOriginDuplicateRejected(storage, replacementCommit)
 
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "origin-action-run",
       projectId: "project",
       actionId: "noop",
@@ -1015,7 +1016,7 @@ describe("in-memory ontology storage", () => {
   test("keeps Action materialization history exclusively in ontology commits", async () => {
     const storage = new InMemoryStorage()
     const { materializer } = createMaterializerFixture({ storage })
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "action-materialization-run",
       projectId: "project",
       actionId: "createDevice",
@@ -1882,7 +1883,7 @@ describe("in-memory ontology storage", () => {
 
   test("rejects ordinal finalization mismatches with rollback", async () => {
     const storage = new InMemoryStorage()
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "run",
       projectId: "project",
       actionId: "action",

--- a/packages/core/tests/projection-run-materialization.test.ts
+++ b/packages/core/tests/projection-run-materialization.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import type { ProjectionMaterializationIdentity } from "../src/materialization/model"
-import { InMemoryActionRunStorage } from "../src/storage/action-runs/in-memory"
 import { InMemoryStorage } from "../src/storage/index"
 import { InMemoryProjectionRunStorage } from "../src/storage/projection-runs/in-memory"
+import { queueTestActionRun } from "../src/testing"
 
 const replacementIdentity = {
   projectionId: "devices",
@@ -244,7 +244,8 @@ describe("projection run materialization ownership", () => {
 
 describe("action run materialization correlation", () => {
   test("requires an existing matching running Action", async () => {
-    const storage = new InMemoryActionRunStorage()
+    const provider = new InMemoryStorage()
+    const storage = provider.actionRuns
 
     await expect(
       storage.lockForMaterialization({
@@ -253,7 +254,7 @@ describe("action run materialization correlation", () => {
         runId: "action-run",
       })
     ).rejects.toThrow("not found")
-    await storage.queue({
+    await queueTestActionRun(provider, {
       id: "action-run",
       projectId: "project",
       actionId: "sendQuote",
@@ -350,7 +351,7 @@ describe("in-memory run root lock", () => {
       identity: replacementIdentity,
       target: { objectTypeId: "Device" },
     })
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "action-run",
       projectId: "project",
       actionId: "sendQuote",
@@ -430,7 +431,7 @@ describe("in-memory run root lock", () => {
 
   test("does not treat async work inherited from a completed transaction as reentrant", async () => {
     const storage = new InMemoryStorage()
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "action-run",
       projectId: "project",
       actionId: "sendQuote",

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -370,6 +370,7 @@ describe("bound Sixb cross-type list", () => {
 describe("bound Sixb actions", () => {
   test("object actions require apply and view together", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const sixb = createTestSixb(host)
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
 
@@ -381,10 +382,25 @@ describe("bound Sixb actions", () => {
 
     // view without apply
     await sixb.objects(Invoice).upsert({ properties: { id: "i1" } })
-    const viewerOnly = bindPrincipal(host, contextFor(host, ["finance"]))
+    const viewerOnly = createTestSixb(host, {
+      authorization: contextFor(host, ["finance"]),
+      executionId: "exec_denied_action",
+      requestId: "request_denied_action",
+      correlationId: "correlation_denied_action",
+    })
     expect(
-      viewerOnly.objects(Invoice).requestAction({ id: "i1", actionId: "archive-invoice" })
+      viewerOnly.objects(Invoice).requestAction({
+        id: "i1",
+        actionId: "archive-invoice",
+        runId: "act_denied_action",
+      })
     ).rejects.toThrow(AuthorizationError)
+    expect(
+      await host.storage.actionRuns?.getById({ projectId: host.id, id: "act_denied_action" })
+    ).toBeNull()
+    expect(
+      await host.storage.executions.getById({ projectId: host.id, id: "exec_denied_action" })
+    ).toBeNull()
 
     // apply without view
     const senderOnly = bindPrincipal(host, contextFor(host, ["ops"]))
@@ -474,6 +490,7 @@ describe("bound Sixb operational access", () => {
 
   test("dynamic action requests enforce apply and view", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const sixb = createTestSixb(host)
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
 

--- a/packages/core/tests/storage-transaction.test.ts
+++ b/packages/core/tests/storage-transaction.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { defineObjectType, InMemoryStorage, OntologyRegistry, prop, type Storage } from "../src"
-import { type ActionRunStorage, StorageTransactionError } from "../src/storage"
-import { createMaterializerTestFixture } from "../src/testing"
+import { StorageTransactionError } from "../src/storage"
+import { createMaterializerTestFixture, queueTestActionRun } from "../src/testing"
 
 const Room = defineObjectType({
   id: "Room",
@@ -19,7 +19,7 @@ describe("InMemoryStorage.transaction", () => {
     const storage = new InMemoryStorage()
 
     await storage.transaction(async (tx) => {
-      await requireActionRuns(tx).queue(actionRunInput("run_commit"))
+      await queueTestActionRun(tx, actionRunInput("run_commit"))
     })
 
     expect(
@@ -85,7 +85,7 @@ describe("InMemoryStorage.transaction", () => {
     await expect(
       storage.transaction(async (tx) => {
         const runs = requireTransactionalRunStores(tx)
-        await runs.actionRuns.queue(actionRunInput("run_rollback"))
+        await queueTestActionRun(tx, actionRunInput("run_rollback"))
         await runs.syncRuns.start(syncRunInput("sync_rollback"))
         await runs.webhookRuns.start(webhookRunInput("webhook_rollback"))
 
@@ -105,7 +105,7 @@ describe("InMemoryStorage.transaction", () => {
 
     await storage.transaction(async (tx) => {
       const runs = requireTransactionalRunStores(tx)
-      await runs.actionRuns.queue(actionRunInput("run_commit"))
+      await queueTestActionRun(tx, actionRunInput("run_commit"))
       await runs.syncRuns.start(syncRunInput("sync_commit"))
       await runs.webhookRuns.start(webhookRunInput("webhook_commit"))
     })
@@ -147,7 +147,7 @@ describe("InMemoryStorage.transaction", () => {
     const releaseTransaction = deferred()
     const transactionResult = storage
       .transaction(async (tx) => {
-        await requireActionRuns(tx).queue(actionRunInput("run_uncommitted"))
+        await queueTestActionRun(tx, actionRunInput("run_uncommitted"))
         transactionStarted.resolve()
         await releaseTransaction.promise
         throw new Error("rollback")
@@ -378,13 +378,6 @@ describe("InMemoryStorage.transaction", () => {
     expect(() => transactionStorage.objects.queryCapabilities()).toThrow(StorageTransactionError)
   })
 })
-
-function requireActionRuns(tx: Storage): ActionRunStorage {
-  if (!tx.actionRuns) {
-    throw new Error("[test] expected transaction storage to expose actionRuns")
-  }
-  return tx.actionRuns
-}
 
 function requireTransactionalRunStores(tx: Storage) {
   if (!tx.actionRuns || !tx.syncRuns || !tx.webhookRuns) {

--- a/packages/server/tests/authorization-routes.test.ts
+++ b/packages/server/tests/authorization-routes.test.ts
@@ -30,7 +30,7 @@ import {
   type WorkflowDefinition,
 } from "@sixb/core"
 import { createSessionCredential } from "@sixb/core/internal/auth"
-import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
+import { createTestSixb, createTestWorkflowExecution, queueTestActionRun } from "@sixb/core/testing"
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
 
@@ -1044,7 +1044,7 @@ describe("authorized action routes", () => {
       })
     )
     const requested = (await request.json()) as { runId: string }
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "act_hidden_invoice",
       projectId: "test-project",
       actionId: "send-contract",

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -34,7 +34,7 @@ import {
   type Storage,
   type WorkflowDefinition,
 } from "@sixb/core"
-import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
+import { createTestSixb, createTestWorkflowExecution, queueTestActionRun } from "@sixb/core/testing"
 import { SqliteStorage } from "@sixb/sqlite"
 import { SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
@@ -512,7 +512,7 @@ describe("SixbServer HTTP contract", () => {
       responseStatus: 202,
     })
 
-    await sixb.storage.actionRuns!.queue({
+    await queueTestActionRun(sixb.storage, {
       id: "act_audit_previous",
       projectId: "contract-project",
       actionId: "syncDeviceLabel",

--- a/packages/server/tests/run-file-content-routes.test.ts
+++ b/packages/server/tests/run-file-content-routes.test.ts
@@ -18,7 +18,7 @@ import {
   SixbHost,
 } from "@sixb/core"
 import { createSessionCredential } from "@sixb/core/internal/auth"
-import { createTestSixb, createTestWorkflowExecution } from "@sixb/core/testing"
+import { createTestSixb, createTestWorkflowExecution, queueTestActionRun } from "@sixb/core/testing"
 import { createSixbApi, SixbServer } from "../src/server"
 import { createTestBrowserPolicy } from "./helpers"
 
@@ -89,7 +89,7 @@ async function createRunFileApi(options: { readonly auth?: boolean } = {}) {
     mediaType: "text/markdown",
   })
 
-  await storage.actionRuns.queue({
+  await queueTestActionRun(storage, {
     id: "action_run_1",
     projectId: sixb.id,
     actionId: extractDocument.id,

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -22,7 +22,7 @@ import {
   type WorkflowDefinition,
   WorkflowValidationError,
 } from "@sixb/core"
-import { bindPrimitiveExecution } from "@sixb/core/internal/primitive-execution"
+import { bindDurablePrimitiveExecution } from "@sixb/core/internal/primitive-execution"
 import { snapshotWorkflowInput } from "@sixb/core/internal/workflows"
 import type {
   ActionRunStorage,
@@ -241,9 +241,22 @@ function createRuntime(host: WorkflowWorkerHost): WorkflowWorkerContext {
   const workflowId = host.definitions.workflows.list()[0]?.id ?? "missing-workflow"
   // Direct handler tests use one explicit trusted execution. Queue-worker tests exercise the real
   // per-delivery workflow id and run id binding in WorkflowWorker.execute.
-  const execution = bindPrimitiveExecution(host, {
-    primitive: { kind: "workflow", id: workflowId, runId: "direct-workflow-job-test" },
-    source: { type: "queue", queue: "workflows", jobId: "direct-workflow-job-test" },
+  const primitive = {
+    kind: "workflow" as const,
+    id: workflowId,
+    runId: "direct-workflow-job-test",
+  }
+  const execution = bindDurablePrimitiveExecution(host, {
+    execution: {
+      id: "direct-workflow-execution-test",
+      projectId: host.id,
+      executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+      source: { type: "event", eventId: "direct-workflow-event-test" },
+      correlationId: "direct-workflow-correlation-test",
+      authorizationRef: { type: "trustedPrimitive", primitive },
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    },
+    primitive,
   })
   return {
     projectId: host.id,
@@ -1279,6 +1292,32 @@ describe("runWorkflowJob", () => {
         actionRunId: "wfrun_action:action:1",
       })
       expect(result.run.output).toEqual(result.nodes[0]?.output)
+
+      const actionRun = await sixb.storage.actionRuns?.getById({
+        projectId: sixb.id,
+        id: "wfrun_action:action:1",
+      })
+      expect(actionRun).not.toBeNull()
+      const actionExecution = actionRun
+        ? await sixb.storage.executions.getById({
+            projectId: sixb.id,
+            id: actionRun.executionId,
+          })
+        : null
+      expect(actionExecution).toMatchObject({
+        executor: { type: "primitive", kind: "action", runId: "wfrun_action:action:1" },
+        source: { type: "execution", executionId: "direct-workflow-execution-test" },
+        parentExecutionId: "direct-workflow-execution-test",
+        correlationId: "direct-workflow-correlation-test",
+        authorizationRef: {
+          type: "trustedPrimitive",
+          primitive: {
+            kind: "action",
+            id: "attach-invoice",
+            runId: "wfrun_action:action:1",
+          },
+        },
+      })
     } finally {
       unsubscribe()
     }

--- a/storage/pg/src/index.ts
+++ b/storage/pg/src/index.ts
@@ -328,7 +328,7 @@ function createPostgresStores(
     auth,
     executions,
     agents: new PgAgentStorage({ sql }),
-    actionRuns: new PgActionRunStorage(sql),
+    actionRuns: new PgActionRunStorage(sql, executions),
     pipelineRuns: new PgPipelineRunStorage(sql),
     workflowRuns: new PgWorkflowRunStorage(sql, executions),
     workflowInterventions: new PgWorkflowInterventionStorage(sql),

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -22,6 +22,7 @@ import narrowOntologySourceRootIndexSql from "./migrations/006-narrow-ontology-s
   type: "text",
 }
 import splitOverridesSql from "./migrations/007-split-overrides.sql" with { type: "text" }
+import actionExecutionsSql from "./migrations/008-action-executions.sql" with { type: "text" }
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -282,6 +283,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("005-workflow-executions", workflowExecutionsSql),
     pgSql("006-narrow-ontology-source-root-index", narrowOntologySourceRootIndexSql),
     pgSql("007-split-overrides", splitOverridesSql),
+    pgSql("008-action-executions", actionExecutionsSql),
   ],
 })
 

--- a/storage/pg/src/migrations/008-action-executions.sql
+++ b/storage/pg/src/migrations/008-action-executions.sql
@@ -1,0 +1,7 @@
+ALTER TABLE action_runs
+  ADD COLUMN execution_id TEXT NOT NULL,
+  ADD CONSTRAINT fk_action_runs_execution
+    FOREIGN KEY (project_id, execution_id)
+    REFERENCES executions (project_id, id)
+    ON DELETE RESTRICT,
+  ADD CONSTRAINT uq_action_runs_execution UNIQUE (project_id, execution_id);

--- a/storage/pg/src/pg-action-run-storage.ts
+++ b/storage/pg/src/pg-action-run-storage.ts
@@ -1,4 +1,5 @@
 import type { ActionSubject, JsonValue } from "@sixb/core"
+import { assertActionRunExecution } from "@sixb/core/internal/action-run-storage-provider"
 import type {
   ActionRunEffectsRecord,
   ActionRunFailure,
@@ -8,6 +9,7 @@ import type {
   ActionRunStorage,
   ActionRunWritebackRecord,
   EnterActionRunPhaseInput,
+  ExecutionStorage,
   FinishActionRunInput,
   ListActionRunsInput,
   ListActionRunsResult,
@@ -29,7 +31,10 @@ import { isUniqueViolation } from "./storage-errors"
 import { type PgStoreClient, runPgTransaction } from "./transactions"
 
 export class PgActionRunStorage implements ActionRunStorage {
-  constructor(private readonly sql: PgStoreClient) {}
+  constructor(
+    private readonly sql: PgStoreClient,
+    private readonly executions: ExecutionStorage
+  ) {}
 
   async lockForMaterialization(input: LockActionMaterializationRunInput): Promise<ActionRunRecord> {
     const [row] = await this.sql<DatabaseRow[]>`
@@ -57,11 +62,20 @@ export class PgActionRunStorage implements ActionRunStorage {
   }
 
   async queue(input: QueueActionRunInput): Promise<ActionRunRecord> {
+    await assertActionRunExecution({
+      executions: this.executions,
+      projectId: input.projectId,
+      executionId: input.executionId,
+      runId: input.id,
+      actionId: input.actionId,
+    })
+
     try {
       const [row] = await this.sql<DatabaseRow[]>`
         INSERT INTO action_runs (
           project_id,
           id,
+          execution_id,
           action_id,
           subject_kind,
           object_type_id,
@@ -90,6 +104,7 @@ export class PgActionRunStorage implements ActionRunStorage {
         ) VALUES (
           ${input.projectId},
           ${input.id},
+          ${input.executionId},
           ${input.actionId},
           ${input.subject.kind},
           ${input.subject.kind === "object" ? input.subject.objectTypeId : null},
@@ -595,6 +610,7 @@ function rowToActionRunRecord(row: DatabaseRow): ActionRunRecord {
   return {
     id: row.id,
     projectId: row.project_id,
+    executionId: row.execution_id,
     actionId: row.action_id,
     subject: rowToActionSubject(row),
     status: row.status,
@@ -629,6 +645,7 @@ function rowToActionSubject(row: DatabaseRow): ActionSubject {
 interface DatabaseRow {
   project_id: string
   id: string
+  execution_id: string
   action_id: string
   subject_kind: ActionSubject["kind"]
   object_type_id: string | null

--- a/storage/pg/tests/pg-action-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-action-run-storage.e2e.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { queueTestActionRun } from "@sixb/core/testing"
 import type { PostgresStorage } from "../src"
 import { createTestStorage } from "./helpers"
 
@@ -15,7 +16,7 @@ describe("PgActionRunStorage", () => {
   })
 
   test("persists V2 lifecycle records and recomposes relational commit diffs", async () => {
-    await storage.actionRuns.queue({
+    await queueTestActionRun(storage, {
       id: "act_1",
       projectId: "my-app",
       actionId: "createInvoice",
@@ -169,7 +170,7 @@ describe("PgActionRunStorage", () => {
 })
 
 async function queueRunningAction(storage: PostgresStorage, id: string): Promise<void> {
-  await storage.actionRuns.queue({
+  await queueTestActionRun(storage, {
     id,
     projectId: "my-app",
     actionId: "createInvoice",

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -43,6 +43,7 @@ describe("Postgres storage migrations", () => {
             "005-workflow-executions",
             "006-narrow-ontology-source-root-index",
             "007-split-overrides",
+            "008-action-executions",
           ],
         },
       ])
@@ -95,6 +96,13 @@ describe("Postgres storage migrations", () => {
           id: "007-split-overrides",
           status: "applied",
           version: 7,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "008-action-executions",
+          status: "applied",
+          version: 8,
         },
       ])
     })
@@ -168,13 +176,16 @@ describe("Postgres storage migrations", () => {
       if (!connectionString) throw new Error("[SixbPg] DATABASE_URL is required.")
       const sql = createPgClient({ connectionString, schemaName, max: 1 })
       try {
-        const splitOverridesMigration = postgresStorageMigrations.steps.at(-1)
-        if (splitOverridesMigration?.id !== "007-split-overrides") {
+        const splitOverridesIndex = postgresStorageMigrations.steps.findIndex(
+          (migration) => migration.id === "007-split-overrides"
+        )
+        const splitOverridesMigration = postgresStorageMigrations.steps[splitOverridesIndex]
+        if (!splitOverridesMigration) {
           throw new Error("PostgreSQL split-overrides migration is missing.")
         }
         const beforeScopeAuthority = defineMigrations({
           adapterId: POSTGRES_STORAGE_ADAPTER_ID,
-          steps: postgresStorageMigrations.steps.slice(0, -1),
+          steps: postgresStorageMigrations.steps.slice(0, splitOverridesIndex),
         })
         await createPostgresMigrator({
           sql,
@@ -341,6 +352,10 @@ describe("Postgres storage migrations", () => {
       await expect(readColumnNullable(schemaName, "workflow_runs", "execution_id")).resolves.toBe(
         "NO"
       )
+      expect(await readTableColumns(schemaName, "action_runs")).toContain("execution_id")
+      await expect(readColumnNullable(schemaName, "action_runs", "execution_id")).resolves.toBe(
+        "NO"
+      )
     })
   })
 
@@ -420,6 +435,37 @@ describe("Postgres storage migrations", () => {
 
         await expect(postgresStorageMigrations.steps[4]?.up(context)).rejects.toThrow()
         expect(await readTableColumns(schemaName, "workflow_runs")).not.toContain("execution_id")
+      } finally {
+        await sql.unsafe("RESET search_path")
+        await sql.unsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+      }
+    })
+  })
+
+  test("rejects legacy Action runs instead of inventing their execution authority", async () => {
+    const schemaName = `sixb_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    await withSql(async (sql) => {
+      const schema = quoteIdent(schemaName)
+      const context = { exec: (sqlText: string) => sql.unsafe(sqlText).then(() => undefined) }
+
+      try {
+        await sql.unsafe(`CREATE SCHEMA ${schema}`)
+        await sql.unsafe(`SET search_path TO ${schema}`)
+        for (const migration of postgresStorageMigrations.steps.slice(0, 6)) {
+          await migration.up(context)
+        }
+        await sql.unsafe(`
+          INSERT INTO action_runs (
+            project_id, id, action_id, subject_kind, status, phase, queued_at, params,
+            idempotency_key
+          ) VALUES (
+            'project-a', 'legacy-action-run', 'legacy-action', 'none', 'queued', 'request',
+            '2026-01-01T00:00:00.000Z', '{}', 'action:project-a:legacy-action-run'
+          )
+        `)
+
+        await expect(postgresStorageMigrations.steps[6]?.up(context)).rejects.toThrow()
+        expect(await readTableColumns(schemaName, "action_runs")).not.toContain("execution_id")
       } finally {
         await sql.unsafe("RESET search_path")
         await sql.unsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
@@ -622,6 +668,13 @@ describe("Postgres storage migrations", () => {
           id: "007-split-overrides",
           status: "applied",
           version: 7,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "008-action-executions",
+          status: "applied",
+          version: 8,
         },
       ])
     } finally {

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -464,7 +464,13 @@ describe("Postgres storage migrations", () => {
           )
         `)
 
-        await expect(postgresStorageMigrations.steps[6]?.up(context)).rejects.toThrow()
+        const actionExecutionsMigration = postgresStorageMigrations.steps.find(
+          (migration) => migration.id === "008-action-executions"
+        )
+        if (!actionExecutionsMigration) {
+          throw new Error("PostgreSQL action-executions migration is missing.")
+        }
+        await expect(actionExecutionsMigration.up(context)).rejects.toThrow()
         expect(await readTableColumns(schemaName, "action_runs")).not.toContain("execution_id")
       } finally {
         await sql.unsafe("RESET search_path")
@@ -593,11 +599,13 @@ describe("Postgres storage migrations", () => {
   test("status() reports current after a migration", async () => {
     await withStorage(true, async (storage) => {
       const [migrator] = storage.migrators
+      const expectedVersion = postgresStorageMigrations.latestVersion
 
       expect(await migrator?.status()).toMatchObject({
         adapterId: POSTGRES_STORAGE_ADAPTER_ID,
         state: "current",
-        appliedVersion: 7,
+        latestVersion: expectedVersion,
+        appliedVersion: expectedVersion,
       })
     })
   })

--- a/storage/pg/tests/pg-storage-transaction.e2e.ts
+++ b/storage/pg/tests/pg-storage-transaction.e2e.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import type { Storage } from "@sixb/core"
-import { type ActionRunStorage, StorageTransactionError } from "@sixb/core/storage"
+import { StorageTransactionError } from "@sixb/core/storage"
+import { queueTestActionRun } from "@sixb/core/testing"
 import type { PostgresStorage } from "../src"
 import { createTestStorage } from "./helpers"
 
@@ -18,7 +19,7 @@ describe("PostgresStorage.transaction", () => {
 
   test("commits writes atomically", async () => {
     await storage.transaction(async (tx) => {
-      await requireActionRuns(tx).queue(actionRunInput("run_commit"))
+      await queueTestActionRun(tx, actionRunInput("run_commit"))
     })
 
     expect(
@@ -42,7 +43,7 @@ describe("PostgresStorage.transaction", () => {
     await expect(
       storage.transaction(async (tx) => {
         const runs = requireTransactionalRunStores(tx)
-        await runs.actionRuns.queue(actionRunInput("run_rollback"))
+        await queueTestActionRun(tx, actionRunInput("run_rollback"))
         await runs.syncRuns.start(syncRunInput("sync_rollback"))
         await runs.webhookRuns.start(webhookRunInput("webhook_rollback"))
 
@@ -88,13 +89,6 @@ function actionRunInput(id: string) {
     params: {},
     idempotencyKey: `action:my-app:${id}`,
   }
-}
-
-function requireActionRuns(tx: Storage): ActionRunStorage {
-  if (!tx.actionRuns) {
-    throw new Error("[test] expected transaction storage to expose actionRuns")
-  }
-  return tx.actionRuns
 }
 
 function requireTransactionalRunStores(tx: Storage) {

--- a/storage/sqlite/src/action-run-storage.ts
+++ b/storage/sqlite/src/action-run-storage.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite"
 import type { ActionSubject, JsonValue } from "@sixb/core"
+import { assertActionRunExecution } from "@sixb/core/internal/action-run-storage-provider"
 import type {
   ActionRunEffectsRecord,
   ActionRunFailure,
@@ -9,6 +10,7 @@ import type {
   ActionRunStorage,
   ActionRunWritebackRecord,
   EnterActionRunPhaseInput,
+  ExecutionStorage,
   FinishActionRunInput,
   ListActionRunsInput,
   ListActionRunsResult,
@@ -33,6 +35,8 @@ import {
 } from "./transactions"
 
 export interface SqliteActionRunStorageOptions {
+  /** Execution lookup sharing the same provider transaction. */
+  executions: ExecutionStorage
   /** Path to SQLite database file. Defaults to ':memory:' for in-memory database. */
   path?: string
   /** Internal shared connection used by bundled SqliteStorage. */
@@ -43,9 +47,12 @@ export class SqliteActionRunStorage implements ActionRunStorage {
   private readonly connection: SqliteStoreConnection
   private readonly db: Database
 
-  constructor(options: SqliteActionRunStorageOptions = {}) {
+  private readonly executions: ExecutionStorage
+
+  constructor(options: SqliteActionRunStorageOptions) {
     this.connection = openSqliteStoreConnection(options)
     this.db = this.connection.db
+    this.executions = options.executions
 
     if (this.connection.installFreshSchema) {
       installFreshSqliteSchema(this.db)
@@ -85,6 +92,13 @@ export class SqliteActionRunStorage implements ActionRunStorage {
 
   async queue(input: QueueActionRunInput): Promise<ActionRunRecord> {
     const queuedAt = input.queuedAt ?? new Date()
+    await assertActionRunExecution({
+      executions: this.executions,
+      projectId: input.projectId,
+      executionId: input.executionId,
+      runId: input.id,
+      actionId: input.actionId,
+    })
 
     try {
       this.db
@@ -93,6 +107,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
           INSERT INTO action_runs (
             project_id,
             id,
+            execution_id,
             action_id,
             subject_kind,
             object_type_id,
@@ -119,7 +134,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
             error_message,
             error_phase
           ) VALUES (
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?,
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?,
             NULL, NULL, NULL, NULL, NULL, NULL,
             NULL, NULL, NULL, NULL, NULL,
             NULL, NULL, NULL
@@ -129,6 +144,7 @@ export class SqliteActionRunStorage implements ActionRunStorage {
         .run(
           input.projectId,
           input.id,
+          input.executionId,
           input.actionId,
           input.subject.kind,
           input.subject.kind === "object" ? input.subject.objectTypeId : null,
@@ -695,6 +711,7 @@ function rowToActionRunRecord(row: DatabaseRow): ActionRunRecord {
   return {
     id: row.id,
     projectId: row.project_id,
+    executionId: row.execution_id,
     actionId: row.action_id,
     subject: rowToActionSubject(row),
     status: row.status,
@@ -733,6 +750,7 @@ function isUniqueConstraintError(error: unknown): boolean {
 interface DatabaseRow {
   project_id: string
   id: string
+  execution_id: string
   action_id: string
   subject_kind: ActionSubject["kind"]
   object_type_id: string | null

--- a/storage/sqlite/src/index.ts
+++ b/storage/sqlite/src/index.ts
@@ -289,7 +289,7 @@ function createSqliteStores(
     auth,
     executions,
     agents: new SqliteAgentStorage({ connection }),
-    actionRuns: new SqliteActionRunStorage({ connection }),
+    actionRuns: new SqliteActionRunStorage({ connection, executions }),
     pipelineRuns: new SqlitePipelineRunStorage({ connection }),
     timeseries: new SqliteTimeseriesStorage({ connection }),
     syncRuns: new SqliteSyncRunStorage({ connection }),

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -25,6 +25,7 @@ import narrowOntologySourceRootIndexSql from "./migrations/006-narrow-ontology-s
   type: "text",
 }
 import splitOverridesSql from "./migrations/007-split-overrides.sql" with { type: "text" }
+import actionExecutionsSql from "./migrations/008-action-executions.sql" with { type: "text" }
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -52,6 +53,7 @@ export const sqliteStorageMigrations = defineMigrations({
     sqliteSql("005-workflow-executions", workflowExecutionsSql),
     sqliteSql("006-narrow-ontology-source-root-index", narrowOntologySourceRootIndexSql),
     sqliteSql("007-split-overrides", splitOverridesSql),
+    sqliteSql("008-action-executions", actionExecutionsSql),
   ],
 })
 

--- a/storage/sqlite/src/migrations/008-action-executions.sql
+++ b/storage/sqlite/src/migrations/008-action-executions.sql
@@ -1,0 +1,4 @@
+ALTER TABLE action_runs ADD COLUMN execution_id TEXT NOT NULL;
+
+CREATE UNIQUE INDEX idx_action_runs_project_execution
+  ON action_runs(project_id, execution_id);

--- a/storage/sqlite/tests/sqlite-action-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-action-run-storage.test.ts
@@ -1,20 +1,25 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import type { QueueActionRunInput } from "@sixb/core/storage"
 import { ActionRunError } from "@sixb/core/storage"
-import { SqliteActionRunStorage } from "../src/action-run-storage"
+import { queueTestActionRun } from "@sixb/core/testing"
+import { SqliteStorage } from "../src"
 
 describe("SqliteActionRunStorage", () => {
-  let storage: SqliteActionRunStorage
+  let root: SqliteStorage
 
   beforeEach(() => {
-    storage = new SqliteActionRunStorage()
+    root = new SqliteStorage()
   })
 
   afterEach(() => {
-    storage.close()
+    root.close()
   })
 
+  const queue = (input: Omit<QueueActionRunInput, "executionId">) => queueTestActionRun(root, input)
+
   test("queues, starts, and finishes runs", async () => {
-    await storage.queue({
+    const storage = root.actionRuns
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -48,7 +53,8 @@ describe("SqliteActionRunStorage", () => {
   })
 
   test("stores failures and supports filtered paging", async () => {
-    await storage.queue({
+    const storage = root.actionRuns
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -73,7 +79,7 @@ describe("SqliteActionRunStorage", () => {
       },
     })
 
-    await storage.queue({
+    await queue({
       id: "act_2",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -110,7 +116,8 @@ describe("SqliteActionRunStorage", () => {
   })
 
   test("rejects duplicates and missing runs", async () => {
-    await storage.queue({
+    const storage = root.actionRuns
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -120,7 +127,7 @@ describe("SqliteActionRunStorage", () => {
     })
 
     await expect(
-      storage.queue({
+      queue({
         id: "act_1",
         projectId: "my-app",
         actionId: "sendQuote",
@@ -155,7 +162,8 @@ describe("SqliteActionRunStorage", () => {
   })
 
   test("rejects finishing terminal runs", async () => {
-    await storage.queue({
+    const storage = root.actionRuns
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -187,7 +195,8 @@ describe("SqliteActionRunStorage", () => {
   })
 
   test("requeues matching runs that failed during enqueue", async () => {
-    await storage.queue({
+    const storage = root.actionRuns
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -208,7 +217,7 @@ describe("SqliteActionRunStorage", () => {
       },
     })
 
-    const requeued = await storage.queue({
+    const requeued = await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "sendQuote",
@@ -227,7 +236,7 @@ describe("SqliteActionRunStorage", () => {
     expect(requeued.queuedAt.toISOString()).toBe("2026-04-29T10:00:02.000Z")
 
     await expect(
-      storage.queue({
+      queue({
         id: "act_1",
         projectId: "my-app",
         actionId: "sendQuote",
@@ -239,7 +248,8 @@ describe("SqliteActionRunStorage", () => {
   })
 
   test("persists V2 lifecycle records and recomposes relational commit diffs", async () => {
-    await storage.queue({
+    const storage = root.actionRuns
+    await queue({
       id: "act_1",
       projectId: "my-app",
       actionId: "createInvoice",

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -65,6 +65,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 7,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "008-action-executions",
+    status: "applied",
+    version: 8,
+  },
 ]
 
 afterEach(async () => {
@@ -168,11 +175,16 @@ describe("SQLite storage migrations", () => {
   test("splits legacy overrides and derives unambiguous link slot authority", () => {
     const db = new Database(":memory:")
     try {
-      const splitOverridesMigration = sqliteStorageMigrations.steps.at(-1)
-      if (splitOverridesMigration?.id !== "007-split-overrides") {
+      const splitOverridesIndex = sqliteStorageMigrations.steps.findIndex(
+        (migration) => migration.id === "007-split-overrides"
+      )
+      const splitOverridesMigration = sqliteStorageMigrations.steps[splitOverridesIndex]
+      if (!splitOverridesMigration) {
         throw new Error("SQLite split-overrides migration is missing.")
       }
-      for (const migration of sqliteStorageMigrations.steps.slice(0, -1)) migration.up(db)
+      for (const migration of sqliteStorageMigrations.steps.slice(0, splitOverridesIndex)) {
+        migration.up(db)
+      }
 
       db.query(
         `INSERT INTO ontology_overrides (
@@ -531,6 +543,87 @@ describe("SQLite storage migrations", () => {
             "2026-01-01T00:00:00.000Z"
           )
       ).toThrow("UNIQUE constraint failed")
+    } finally {
+      db.close()
+    }
+  })
+
+  test("rejects legacy Action runs instead of inventing their execution authority", () => {
+    const db = new Database(":memory:")
+    try {
+      for (const migration of sqliteStorageMigrations.steps.slice(0, 6)) migration.up(db)
+      db.query(`
+        INSERT INTO action_runs (
+          project_id, id, action_id, subject_kind, status, phase, queued_at, params,
+          idempotency_key
+        ) VALUES (?, ?, ?, 'none', 'queued', 'request', ?, '{}', ?)
+      `).run(
+        "project-a",
+        "legacy-action-run",
+        "legacy-action",
+        "2026-01-01T00:00:00.000Z",
+        "action:project-a:legacy-action-run"
+      )
+
+      expect(() => sqliteStorageMigrations.steps[6]?.up(db)).toThrow()
+      expect(readMemoryTableColumns(db, "action_runs")).not.toContain("execution_id")
+    } finally {
+      db.close()
+    }
+  })
+
+  test("makes the Action execution link required and unique on an empty schema", () => {
+    const db = new Database(":memory:")
+    try {
+      for (const migration of sqliteStorageMigrations.steps) migration.up(db)
+
+      expect(readMemoryColumn(db, "action_runs", "execution_id")?.notnull).toBe(1)
+      db.query(`
+        INSERT INTO executions (
+          project_id, id, executor_kind, executor_id, source_kind, source_id,
+          correlation_id, authority_kind, authority_primitive_kind,
+          authority_primitive_id, created_at
+        ) VALUES (?, ?, 'action', ?, 'event', ?, ?, 'trustedPrimitive', 'action', ?, ?)
+      `).run(
+        "project-a",
+        "action-execution",
+        "action-run",
+        "action-event",
+        "action-correlation",
+        "send-quote",
+        "2026-01-01T00:00:00.000Z"
+      )
+      db.query(`
+        INSERT INTO action_runs (
+          project_id, id, execution_id, action_id, subject_kind, status, phase, queued_at,
+          params, idempotency_key
+        ) VALUES (?, ?, ?, ?, 'none', 'queued', 'request', ?, '{}', ?)
+      `).run(
+        "project-a",
+        "action-run",
+        "action-execution",
+        "send-quote",
+        "2026-01-01T00:00:00.000Z",
+        "action:project-a:action-run"
+      )
+
+      expect(() =>
+        db
+          .query(`
+            INSERT INTO action_runs (
+              project_id, id, execution_id, action_id, subject_kind, status, phase, queued_at,
+              params, idempotency_key
+            ) VALUES (?, ?, ?, ?, 'none', 'queued', 'request', ?, '{}', ?)
+          `)
+          .run(
+            "project-a",
+            "second-action-run",
+            "action-execution",
+            "send-quote",
+            "2026-01-01T00:00:00.000Z",
+            "action:project-a:second-action-run"
+          )
+      ).toThrow("UNIQUE")
     } finally {
       db.close()
     }

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -565,7 +565,13 @@ describe("SQLite storage migrations", () => {
         "action:project-a:legacy-action-run"
       )
 
-      expect(() => sqliteStorageMigrations.steps[6]?.up(db)).toThrow()
+      const actionExecutionsMigration = sqliteStorageMigrations.steps.find(
+        (migration) => migration.id === "008-action-executions"
+      )
+      if (!actionExecutionsMigration) {
+        throw new Error("SQLite action-executions migration is missing.")
+      }
+      expect(() => actionExecutionsMigration.up(db)).toThrow()
       expect(readMemoryTableColumns(db, "action_runs")).not.toContain("execution_id")
     } finally {
       db.close()
@@ -976,10 +982,12 @@ describe("SQLite migration status is read-only", () => {
     const before = statSync(path).mtimeMs
 
     const [migrator] = createSqliteStorageMigrators(tempDir)
+    const expectedVersion = sqliteStorageMigrations.latestVersion
     expect(await migrator?.status()).toMatchObject({
       adapterId: SQLITE_STORAGE_ADAPTER_ID,
       state: "current",
-      appliedVersion: 7,
+      latestVersion: expectedVersion,
+      appliedVersion: expectedVersion,
     })
 
     expect(statSync(path).mtimeMs).toBe(before)

--- a/storage/sqlite/tests/sqlite-storage-transaction.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-transaction.test.ts
@@ -3,7 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { migrateStorage, type Storage } from "@sixb/core"
-import { type ActionRunStorage, StorageTransactionError } from "@sixb/core/storage"
+import { StorageTransactionError } from "@sixb/core/storage"
+import { queueTestActionRun } from "@sixb/core/testing"
 import { SqliteStorage } from "../src"
 import { closeSqliteStoreConnection, openSqliteStoreConnection } from "../src/transactions"
 
@@ -29,7 +30,7 @@ test("file-backed snapshot reads remain available during a write transaction", a
     transactionEntered = resolve
   })
   const transaction = storage.transaction(async (tx) => {
-    await requireActionRuns(tx).queue(actionRunInput("concurrent-read-writer"))
+    await queueTestActionRun(tx, actionRunInput("concurrent-read-writer"))
     transactionEntered()
     await blocked
   })
@@ -66,7 +67,7 @@ describe("SqliteStorage.transaction", () => {
 
   test("commits writes atomically", async () => {
     await storage.transaction(async (tx) => {
-      await requireActionRuns(tx).queue(actionRunInput("run_commit"))
+      await queueTestActionRun(tx, actionRunInput("run_commit"))
     })
 
     expect(
@@ -90,7 +91,7 @@ describe("SqliteStorage.transaction", () => {
     await expect(
       storage.transaction(async (tx) => {
         const runs = requireTransactionalRunStores(tx)
-        await runs.actionRuns.queue(actionRunInput("run_rollback"))
+        await queueTestActionRun(tx, actionRunInput("run_rollback"))
         await runs.syncRuns.start(syncRunInput("sync_rollback"))
         await runs.webhookRuns.start(webhookRunInput("webhook_rollback"))
 
@@ -116,7 +117,7 @@ describe("SqliteStorage.transaction", () => {
     })
 
     const failed = storage.transaction(async (tx) => {
-      await requireActionRuns(tx).queue({
+      await queueTestActionRun(tx, {
         id: "rolled-back",
         projectId: "my-app",
         actionId: "paint",
@@ -131,19 +132,17 @@ describe("SqliteStorage.transaction", () => {
     await entered
 
     let rootFinished = false
-    const rootWrite = storage.actionRuns
-      .queue({
-        id: "root-write",
-        projectId: "my-app",
-        actionId: "paint",
-        subject: { kind: "none" },
-        params: {},
-        idempotencyKey: "root-write",
-      })
-      .then((run) => {
-        rootFinished = true
-        return run
-      })
+    const rootWrite = queueTestActionRun(storage, {
+      id: "root-write",
+      projectId: "my-app",
+      actionId: "paint",
+      subject: { kind: "none" },
+      params: {},
+      idempotencyKey: "root-write",
+    }).then((run) => {
+      rootFinished = true
+      return run
+    })
     await Promise.resolve()
     expect(rootFinished).toBe(false)
 
@@ -164,7 +163,7 @@ describe("SqliteStorage.transaction", () => {
     await storage.transaction(() => {
       detachedWrite = Promise.resolve().then(async () => {
         await detachedGate
-        return storage.actionRuns.queue({
+        return queueTestActionRun(storage, {
           id: "detached-write",
           projectId: "my-app",
           actionId: "paint",
@@ -239,13 +238,6 @@ function actionRunInput(id: string) {
     params: {},
     idempotencyKey: `action:my-app:${id}`,
   }
-}
-
-function requireActionRuns(tx: Storage): ActionRunStorage {
-  if (!tx.actionRuns) {
-    throw new Error("[test] expected transaction storage to expose actionRuns")
-  }
-  return tx.actionRuns
 }
 
 function requireTransactionalRunStores(tx: Storage) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -73,6 +73,9 @@
       "@sixb/core/internal/workflow-run-storage-provider": [
         "./packages/core/src/storage/workflow-runs/provider.ts"
       ],
+      "@sixb/core/internal/action-run-storage-provider": [
+        "./packages/core/src/storage/action-runs/provider.ts"
+      ],
       "@sixb/core/internal/projections": ["./packages/core/src/projections/internal.ts"],
       "@sixb/core/internal/agent-execution": ["./packages/core/src/execution/agent.ts"],
       "@sixb/core/internal/primitive-execution": ["./packages/core/src/execution/primitive.ts"],


### PR DESCRIPTION
## Why

Action runs crossed the queue without a durable execution link. The worker therefore could not
restore the exact execution that created the run, including its parent and correlation identity.

This is especially important for nested `Workflow -> Action` calls.

## What changes

```text
bound caller execution
  -> authorize and validate
  -> persist the caller when needed
  -> transaction: Action execution + Action run
  -> enqueue: { runId }
  -> worker loads the run and execution
  -> restore the trusted Action scope
```

- Adds a required, unique `executionId` to every Action run.
- Persists the child execution and Action run atomically before queue publication.
- Preserves parent execution, caller, and correlation across global and object Actions.
- Makes the durable run the source of queue identity: the payload is only `{ runId }`.
- Makes `ActionWorker` restore the stored execution instead of creating a new transient scope.
- Shares the primitive run/execution identity check with Workflow while keeping primitive-specific
  source rules in their providers.
- Adds matching in-memory, SQLite, and PostgreSQL provider enforcement and migrations.

## Guarantees

| Case | Result |
| --- | --- |
| Authorization or validation fails | No caller, child execution, or Action run is created |
| Action run persistence fails | The child execution is rolled back with the run |
| Queue publication fails | The durable run records an enqueue failure and can be retried |
| Existing legacy Action runs | Migration fails instead of inventing execution authority |

The database migrations use regular columns, constraints, and indexes—no database functions or
triggers.

## Stack

- Builds on merged #382, which establishes the same durable model for Workflow runs.
- Continues #183 with the Action lifecycle.
- The next slices apply the model to the remaining asynchronous primitives and agents.

## Validation

- `bun run typecheck`
- `bun run build`
- `bun run check`
- `bun run test:ci` — 3,746 passed, 7 infrastructure tests skipped, 0 failed
