### PR TITLE
app: accelerate cold Atlas and custom-app loads

### DIFF
--- a/packages/app/src/build.ts
+++ b/packages/app/src/build.ts
@@ -1,11 +1,23 @@
-import { copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
-import { basename, dirname, join } from "node:path"
+import { existsSync } from "node:fs"
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { basename, dirname, extname, join, resolve } from "node:path"
+import { promisify } from "node:util"
+import {
+  brotliCompress as brotliCompressCallback,
+  gzip as gzipCallback,
+  constants as zlibConstants,
+} from "node:zlib"
 
 const STATIC_ASSET_ORIGIN = "https://sixb-static.invalid"
+const brotliCompress = promisify(brotliCompressCallback)
+const gzip = promisify(gzipCallback)
+const PRECOMPRESSION_CONCURRENCY = 4
 
 export interface BuildAppOptions {
   /** Path to the generated index.html entry point */
   entryPath: string
+  /** Browser TypeScript entry generated alongside `entryPath`. */
+  scriptEntryPath: string
   /** Generated manifest copied to the stable `/app.webmanifest` output path. */
   manifestPath?: string
   /** Output directory, defaults to `.sixb/dist/app` */
@@ -19,8 +31,7 @@ export interface BuildAppResult {
 }
 
 /**
- * Builds the app using `Bun.build()` on the generated HTML entry point.
- * Outputs a production-ready static bundle.
+ * Builds the generated browser entry and writes a production-ready static shell and bundle.
  */
 export async function buildApp(options: BuildAppOptions): Promise<BuildAppResult> {
   const outdir = options.outdir ?? join(process.cwd(), ".sixb", "dist", "app")
@@ -29,26 +40,31 @@ export async function buildApp(options: BuildAppOptions): Promise<BuildAppResult
   await rm(outdir, { recursive: true, force: true })
   await mkdir(outdir, { recursive: true })
 
-  const bundleEntryPath = await prepareAppHtmlBundleEntry(options.entryPath)
-  let result: Awaited<ReturnType<typeof Bun.build>>
-  try {
-    result = await Bun.build({
-      entrypoints: [bundleEntryPath],
-      outdir,
-      target: "browser",
-      conditions: ["bun"],
-      publicPath: "/",
-      minify: true,
-      // React is bundled into this browser output, so without pinning NODE_ENV the production build
-      // of a user's app ships React's development build: dev-only checks on every render, and the
-      // warnings that go with them. This is also the only knob that selects the production JSX
-      // runtime — an ambient NODE_ENV does not.
-      define: { "process.env.NODE_ENV": '"production"' },
-      sourcemap: "external",
-    })
-  } finally {
-    await rm(bundleEntryPath, { force: true })
-  }
+  const result = await Bun.build({
+    // Build the script entry directly rather than Bun's HTML entry. Bun cannot currently preserve
+    // a large dynamic-import graph reliably when splitting an HTML entry: one of the lazy chunks
+    // can be written into the shell's script tag. Building TypeScript directly also lets Shiki's
+    // hundreds of grammars remain off the initial custom-app path.
+    entrypoints: [options.scriptEntryPath],
+    outdir,
+    target: "browser",
+    conditions: ["bun"],
+    publicPath: "/",
+    minify: true,
+    splitting: true,
+    naming: {
+      entry: "app-[hash].[ext]",
+      chunk: "chunk-[name]-[hash].[ext]",
+      asset: "asset-[name]-[hash].[ext]",
+    },
+    plugins: [extensionlessSourceImportPlugin],
+    // React is bundled into this browser output, so without pinning NODE_ENV the production build
+    // of a user's app ships React's development build: dev-only checks on every render, and the
+    // warnings that go with them. This is also the only knob that selects the production JSX
+    // runtime — an ambient NODE_ENV does not.
+    define: { "process.env.NODE_ENV": '"production"' },
+    sourcemap: "external",
+  })
 
   if (!result.success) {
     return {
@@ -58,12 +74,38 @@ export async function buildApp(options: BuildAppOptions): Promise<BuildAppResult
     }
   }
 
-  const bundleHtmlPath = join(outdir, basename(bundleEntryPath))
-  await rename(bundleHtmlPath, join(outdir, "index.html"))
-  await rewriteIndexAssetPaths(outdir)
+  const script = result.outputs.find(
+    (output) => output.kind === "entry-point" && output.type.startsWith("text/javascript")
+  )
+  const stylesheets = result.outputs.filter((output) => output.type.startsWith("text/css"))
+  if (!script || stylesheets.length > 1) {
+    throw new Error(
+      `[SixbCustomApp] Expected one browser entry and at most one stylesheet, found ${script ? 1 : 0} entries and ${stylesheets.length} stylesheets.`
+    )
+  }
+
+  const sourceHtml = restoreAppStaticUrls(await readFile(options.entryPath, "utf-8"))
+  const sourceEntryPattern =
+    /\s*<script\s+type=["']module["']\s+src=["']\.\/main\.tsx["']><\/script>/
+  if (!sourceEntryPattern.test(sourceHtml)) {
+    throw new Error("[SixbCustomApp] Generated app shell is missing its ./main.tsx entry.")
+  }
+
+  const assetTags = [
+    ...stylesheets.map(
+      (stylesheet) => `<link rel="stylesheet" crossorigin href="/${basename(stylesheet.path)}">`
+    ),
+    `<script type="module" crossorigin src="/${basename(script.path)}"></script>`,
+  ].join("")
+  const html = withLoadingShell(sourceHtml)
+    .replace(sourceEntryPattern, "")
+    .replace("</head>", `  ${assetTags}</head>`)
+  await writeFile(join(outdir, "index.html"), html, "utf-8")
+
   if (options.manifestPath) {
     await copyFile(options.manifestPath, join(outdir, "app.webmanifest"))
   }
+  await precompressBuildAssets(result.outputs)
 
   return { success: true, outdir }
 }
@@ -86,20 +128,79 @@ export function restoreAppStaticUrls(html: string): string {
   return html.replaceAll(STATIC_ASSET_ORIGIN, "")
 }
 
-async function rewriteIndexAssetPaths(outdir: string): Promise<void> {
-  const indexPath = join(outdir, "index.html")
-  const originalHtml = await readFile(indexPath, "utf-8")
-  const html = restoreAppStaticUrls(originalHtml)
+function withLoadingShell(html: string): string {
+  const styles = `<style data-sixb-loading-shell>
+      .sixb-loading-shell{position:fixed;inset:0;display:grid;place-items:center;background:#fff;color:#71717a}
+      .sixb-loading-spinner{width:1.25rem;height:1.25rem;border:2px solid currentColor;border-right-color:transparent;border-radius:9999px;animation:sixb-loading-spin .7s linear infinite}
+      @media(prefers-color-scheme:dark){.sixb-loading-shell{background:#09090b;color:#a1a1aa}}
+      @media(prefers-reduced-motion:reduce){.sixb-loading-spinner{animation-duration:1.5s}}
+      @keyframes sixb-loading-spin{to{transform:rotate(360deg)}}
+    </style>`
+  const root =
+    '<div id="root"><div class="sixb-loading-shell" role="status" aria-label="Loading application"><span class="sixb-loading-spinner" aria-hidden="true"></span></div></div>'
 
-  const rewritten = html.replace(
-    /(href|src)=(["'])((?!\/|#|[a-zA-Z][a-zA-Z\d+.-]*:)(?:\.\/)?[^"'?#]+(?:[?#][^"']*)?)\2/g,
-    (_match, attr: string, quote: string, url: string) => {
-      const normalized = url.startsWith("./") ? url.slice(2) : url
-      return `${attr}=${quote}/${normalized}${quote}`
-    }
-  )
-
-  if (rewritten !== originalHtml) {
-    await writeFile(indexPath, rewritten, "utf-8")
+  if (!html.includes('<div id="root"></div>') || !html.includes("</head>")) {
+    throw new Error("[SixbCustomApp] Generated app shell is missing its root or head element.")
   }
+
+  return html.replace("</head>", `${styles}\n  </head>`).replace('<div id="root"></div>', root)
+}
+
+const extensionlessSourceImportPlugin: Bun.BunPlugin = {
+  name: "sixb-extensionless-source-imports",
+  setup(build) {
+    // A direct TypeScript entry with splitting exposes a Bun 1.3 resolver edge in linked workspace
+    // packages: extensionless relative imports such as `../json` can fail even though `json.ts`
+    // exists. HTML entries masked it, but HTML splitting can point at the wrong dynamic chunk.
+    build.onResolve({ filter: /^\.\.?\// }, (args) => {
+      if (extname(args.path)) return undefined
+
+      const base = resolve(dirname(args.importer), args.path)
+      for (const candidate of [
+        `${base}.ts`,
+        `${base}.tsx`,
+        `${base}.js`,
+        `${base}.jsx`,
+        join(base, "index.ts"),
+        join(base, "index.tsx"),
+        join(base, "index.js"),
+        join(base, "index.jsx"),
+      ]) {
+        if (existsSync(candidate)) return { path: candidate }
+      }
+
+      return undefined
+    })
+  },
+}
+
+async function precompressBuildAssets(
+  outputs: readonly { readonly path: string; readonly type: string }[]
+): Promise<void> {
+  const paths = outputs
+    .filter(
+      (output) => output.type.startsWith("text/javascript") || output.type.startsWith("text/css")
+    )
+    .map((output) => output.path)
+  let cursor = 0
+
+  const worker = async () => {
+    while (cursor < paths.length) {
+      const path = paths[cursor++]
+      const bytes = await Bun.file(path).arrayBuffer()
+      const [brotli, gzipped] = await Promise.all([
+        brotliCompress(bytes, {
+          params: {
+            [zlibConstants.BROTLI_PARAM_QUALITY]: 5,
+          },
+        }),
+        gzip(bytes, { level: 9 }),
+      ])
+      await Promise.all([writeFile(`${path}.br`, brotli), writeFile(`${path}.gz`, gzipped)])
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(PRECOMPRESSION_CONCURRENCY, paths.length) }, worker)
+  )
 }

--- a/packages/app/src/createCustomApp.ts
+++ b/packages/app/src/createCustomApp.ts
@@ -214,6 +214,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
 
   async function prepareGeneratedApp(): Promise<{
     htmlPath: string
+    mainPath: string
     manifestPath: string
     routes: PageRoute[]
   }> {
@@ -225,7 +226,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
     const builtInRoutes = agentRoutesEnabled ? builtInAgentRoutesFor(routes) : []
     const stylesheets = await prepareStylesheets(builtInRoutes)
     await generateRouteManifest(routes, generatedDir, { builtInRoutes })
-    const { htmlPath, manifestPath } = await generateAppEntry(rootDir, generatedDir, {
+    const { htmlPath, mainPath, manifestPath } = await generateAppEntry(rootDir, generatedDir, {
       apiBaseUrl,
       audience,
       authEnabled,
@@ -234,7 +235,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
       frameworkStylesheetPaths: stylesheets.frameworkStylesheetPaths,
       stylesheetPath: stylesheets.stylesheetPath,
     })
-    return { htmlPath, manifestPath, routes }
+    return { htmlPath, mainPath, manifestPath, routes }
   }
 
   return {
@@ -338,9 +339,10 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
 
     async build(buildOptions: CustomAppBuildOptions = {}) {
       const outdir = resolve(rootDir, buildOptions.outdir ?? join(".sixb", "dist", "app"))
-      const { htmlPath, manifestPath } = await prepareGeneratedApp()
+      const { htmlPath, mainPath, manifestPath } = await prepareGeneratedApp()
       const result = await buildApp({
         entryPath: htmlPath,
+        scriptEntryPath: mainPath,
         manifestPath,
         outdir,
       })
@@ -396,7 +398,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
 
           const directFile = Bun.file(resolvedPath)
           if (await directFile.exists()) {
-            return fileResponse(req, directFile, staticAssetHeaders(url.pathname))
+            return staticFileResponse(req, resolvedPath, staticAssetHeaders(url.pathname))
           }
 
           if (isAssetRequest(url.pathname)) {
@@ -633,11 +635,11 @@ function htmlResponse(request: Request, html: string): Response {
   })
 }
 
-// Bun.build emits content-hashed bundles named `chunk-<hash>.<ext>` (see buildApp).
-// Their contents can never change under the same URL, so they are safe to cache
-// forever — matching how Atlas serves its hashed assets. Files copied
-// from `public/` keep their names across deploys and stay uncached.
-const IMMUTABLE_ASSET_PATTERN = /^chunk-[a-z0-9]+\.(js|css|js\.map|css\.map)$/
+// buildApp emits content-hashed entry, chunk, and asset names. Their contents can never change
+// under the same URL, so they are safe to cache forever. Files copied from `public/` keep their
+// names across deploys and stay uncached.
+const IMMUTABLE_ASSET_PATTERN =
+  /^(?:(?:app|chunk)-[a-z0-9]+|(?:chunk|asset)-.+-[a-z0-9]+)\.[a-z0-9]+(?:\.map)?$/
 
 function staticAssetHeaders(pathname: string): Record<string, string> {
   if (pathname === customAppManifestRoute) {
@@ -653,6 +655,67 @@ function staticAssetHeaders(pathname: string): Record<string, string> {
   }
 
   return { "cache-control": "public, max-age=31536000, immutable" }
+}
+
+async function staticFileResponse(
+  request: Request,
+  path: string,
+  headers: Record<string, string>
+): Promise<Response> {
+  const responseHeaders = new Headers(headers)
+  const originalFile = Bun.file(path)
+  let responseFile = originalFile
+
+  if (isPrecompressedAsset(path)) {
+    responseHeaders.append("vary", "Accept-Encoding")
+    if (!request.headers.has("range")) {
+      for (const encoding of acceptedPrecompressedEncodings(request)) {
+        const candidate = Bun.file(`${path}.${encoding === "br" ? "br" : "gz"}`)
+        if (!(await candidate.exists())) continue
+
+        responseFile = candidate
+        responseHeaders.set("content-encoding", encoding)
+        responseHeaders.set("content-type", originalFile.type)
+        break
+      }
+    }
+  }
+
+  return new Response(request.method === "HEAD" ? null : responseFile, {
+    headers: responseHeaders,
+  })
+}
+
+function isPrecompressedAsset(path: string): boolean {
+  return path.endsWith(".js") || path.endsWith(".css")
+}
+
+function acceptedPrecompressedEncodings(request: Request): ("br" | "gzip")[] {
+  const header = request.headers.get("accept-encoding")
+  if (!header) return []
+
+  const qualities = new Map<string, number>()
+  for (const item of header.split(",")) {
+    const [rawName, ...parameters] = item.trim().split(";")
+    const name = rawName.toLowerCase()
+    let quality = 1
+    for (const parameter of parameters) {
+      const match = parameter.trim().match(/^q=(0(?:\.\d+)?|1(?:\.0+)?)$/)
+      if (match) quality = Number(match[1])
+    }
+    qualities.set(name, quality)
+  }
+
+  const wildcard = qualities.get("*") ?? 0
+  return (["br", "gzip"] as const)
+    .map((encoding, preference) => ({
+      encoding,
+      preference,
+      quality: qualities.get(encoding) ?? wildcard,
+    }))
+    .filter((candidate) => candidate.quality > 0)
+    .sort((left, right) => right.quality - left.quality || left.preference - right.preference)
+    .map((candidate) => candidate.encoding)
 }
 
 function fileResponse(

--- a/packages/app/tests/createCustomApp.test.ts
+++ b/packages/app/tests/createCustomApp.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
+import { brotliCompressSync, gzipSync } from "node:zlib"
 import { generateAppEntry, generateRouteManifest } from "../src/codegen"
 import { createCustomApp } from "../src/createCustomApp"
 
@@ -141,8 +142,12 @@ describe("createCustomApp.start", () => {
 
   test("serves hashed build chunks with immutable cache headers", async () => {
     const outdir = join(tempRoot, ".sixb", "dist", "app")
-    await writeFile(join(outdir, "chunk-ab12cd34.js"), "console.log('chunk')\n")
-    await writeFile(join(outdir, "chunk-ab12cd34.css"), "body{}\n")
+    const javascript = "console.log('chunk')\n"
+    const stylesheet = "body{}\n"
+    await writeFile(join(outdir, "chunk-ab12cd34.js"), javascript)
+    await writeFile(join(outdir, "chunk-ab12cd34.js.br"), brotliCompressSync(javascript))
+    await writeFile(join(outdir, "chunk-ab12cd34.css"), stylesheet)
+    await writeFile(join(outdir, "chunk-ab12cd34.css.gz"), gzipSync(stylesheet))
 
     const port = await getFreePort()
     const app = await createCustomApp({ rootDir: tempRoot, audience: "app" })
@@ -154,12 +159,22 @@ describe("createCustomApp.start", () => {
 
     try {
       const immutable = "public, max-age=31536000, immutable"
-      const chunkJs = await fetch(`http://127.0.0.1:${port}/chunk-ab12cd34.js`)
+      const chunkJs = await fetch(`http://127.0.0.1:${port}/chunk-ab12cd34.js`, {
+        headers: { "accept-encoding": "br, gzip" },
+      })
       expect(chunkJs.status).toBe(200)
       expect(chunkJs.headers.get("cache-control")).toBe(immutable)
+      expect(chunkJs.headers.get("content-encoding")).toBe("br")
+      expect(chunkJs.headers.get("vary")).toContain("Accept-Encoding")
+      expect(await chunkJs.text()).toBe(javascript)
 
-      const chunkCss = await fetch(`http://127.0.0.1:${port}/chunk-ab12cd34.css`)
+      const chunkCss = await fetch(`http://127.0.0.1:${port}/chunk-ab12cd34.css`, {
+        headers: { "accept-encoding": "gzip" },
+      })
       expect(chunkCss.headers.get("cache-control")).toBe(immutable)
+      expect(chunkCss.headers.get("content-encoding")).toBe("gzip")
+      expect(chunkCss.headers.get("vary")).toContain("Accept-Encoding")
+      expect(await chunkCss.text()).toBe(stylesheet)
 
       // Non-hashed files (public/ copies) and the SPA shell stay uncached.
       const mainJs = await fetch(`http://127.0.0.1:${port}/main.js`)

--- a/packages/app/tests/manifest.test.ts
+++ b/packages/app/tests/manifest.test.ts
@@ -3,7 +3,6 @@ import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { generateAppEntry } from "../src/codegen"
-import { createCustomApp } from "../src/createCustomApp"
 
 interface GeneratedFixture {
   readonly root: string
@@ -201,23 +200,44 @@ describe("custom app metadata and manifest generation", () => {
       "dir"
     )
 
-    const app = await createCustomApp({
-      rootDir: fixture.root,
-      authEnabled: false,
-      agentRoutes: false,
-    })
-    const result = await app.build()
-
-    expect(result.success).toBe(true)
-    const builtHtml = await readFile(join(result.outdir, "index.html"), "utf-8")
-    const builtManifest = JSON.parse(
-      await readFile(join(result.outdir, "app.webmanifest"), "utf-8")
+    // Keep Bun.build in a disposable process. A completed in-process split build leaves bundler
+    // state that can break a later HTML dev bundle in the same bun:test process.
+    const buildScript = join(fixture.root, "run-build.ts")
+    const createCustomAppPath = join(import.meta.dir, "..", "src", "createCustomApp.ts")
+    await writeFile(
+      buildScript,
+      [
+        `import { createCustomApp } from ${JSON.stringify(createCustomAppPath)}`,
+        `const app = await createCustomApp({ rootDir: ${JSON.stringify(fixture.root)}, authEnabled: false, agentRoutes: false })`,
+        "const result = await app.build()",
+        "if (!result.success) throw new Error((result.logs ?? []).join('\\n'))",
+        "",
+      ].join("\n")
     )
+    const proc = Bun.spawn([process.execPath, "run", buildScript], {
+      cwd: fixture.root,
+      stdout: "ignore",
+      stderr: "pipe",
+    })
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
+      throw new Error(await new Response(proc.stderr).text())
+    }
+
+    const outdir = join(fixture.root, ".sixb", "dist", "app")
+    const builtHtml = await readFile(join(outdir, "index.html"), "utf-8")
+    const builtManifest = JSON.parse(await readFile(join(outdir, "app.webmanifest"), "utf-8"))
     expect(builtHtml).toContain('href="/app.webmanifest"')
     expect(builtHtml).toContain('href="/favicon.svg"')
+    expect(builtHtml).toContain('class="sixb-loading-shell"')
+    expect(builtHtml).not.toContain("main.tsx")
+    const scriptFile = builtHtml.match(/src="\/(app-[a-z0-9]+\.js)"/)?.[1]
+    expect(scriptFile).toBeDefined()
+    expect(await Bun.file(join(outdir, `${scriptFile}.br`)).exists()).toBe(true)
+    expect(await Bun.file(join(outdir, `${scriptFile}.gz`)).exists()).toBe(true)
     expect(builtManifest.name).toBe("Built PWA")
     expect(builtManifest.icons[0].src).toBe("/icon-192.png")
-    expect(await readFile(join(result.outdir, "icon-192.png"), "utf-8")).toBe("fixture png")
+    expect(await readFile(join(outdir, "icon-192.png"), "utf-8")).toBe("fixture png")
   })
 
   test("does not rewrite unchanged HTML or manifest output", async () => {

--- a/packages/app/tests/styles.test.ts
+++ b/packages/app/tests/styles.test.ts
@@ -266,6 +266,20 @@ describe("custom app Tailwind build (e2e)", () => {
     expect(cssBundles.join("\n")).toContain("line-through")
     expect(cssBundles.join("\n")).not.toContain("@source")
 
+    const builtHtml = await readFile(join(outdir, "index.html"), "utf-8")
+    const entryFile = builtHtml.match(/src="\/(app-[a-z0-9]+\.js)"/)?.[1]
+    expect(entryFile).toBeDefined()
+    const javascriptFiles = await Array.fromAsync(new Bun.Glob("*.js").scan({ cwd: outdir }))
+    expect(javascriptFiles.length).toBeGreaterThan(1)
+    const hasDynamicChunk = await Promise.all(
+      javascriptFiles.map(async (file) =>
+        (await readFile(join(outdir, file), "utf-8")).includes('import("/chunk-')
+      )
+    )
+    expect(hasDynamicChunk).toContain(true)
+    // Regression proof: restoring the HTML entry without `splitting` emits one ~10 MB JavaScript
+    // file for this fixture (all Shiki grammars) and fails both assertions above.
+
     expect(await Bun.file(staleChunkPath).exists()).toBe(false)
   }, 30_000)
 

--- a/packages/atlas/src/assets.ts
+++ b/packages/atlas/src/assets.ts
@@ -1,5 +1,11 @@
-import { access, mkdir, readdir, rm } from "node:fs/promises"
+import { access, mkdir, readdir, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
+import { promisify } from "node:util"
+import {
+  brotliCompress as brotliCompressCallback,
+  gzip as gzipCallback,
+  constants as zlibConstants,
+} from "node:zlib"
 import { renderSixbBrowserRuntimeScript } from "@sixb/client/browser"
 import type { AuthSessionAudience } from "@sixb/core"
 
@@ -34,6 +40,9 @@ export interface BuiltInUiShellConfig extends BuiltInUiRuntimeConfig {
  * bundler is presumed stuck rather than slow.
  */
 const BUNDLE_TIMEOUT_MS = 120_000
+const PRECOMPRESSION_CONCURRENCY = 4
+const brotliCompress = promisify(brotliCompressCallback)
+const gzip = promisify(gzipCallback)
 
 const packageRoot = join(import.meta.dir, "..")
 const sourceDir = join(packageRoot, "src")
@@ -128,6 +137,7 @@ export async function buildBuiltInUiBundle(
     await stderrText.catch(() => "")
   }
 
+  await precompressBuiltInUiAssets(outdir)
   return await resolveBuiltInUiBundle(outdir)
 }
 
@@ -163,14 +173,48 @@ export function renderBuiltInUiShell(config: BuiltInUiShellConfig): string {
     <meta name="theme-color" content="#f6f7fb" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)" />
     <title>Sixb Atlas</title>
+    <style data-sixb-loading-shell>
+      .sixb-loading-shell{position:fixed;inset:0;display:grid;place-items:center;background:#f6f7fb;color:#71717a}
+      .sixb-loading-spinner{width:1.25rem;height:1.25rem;border:2px solid currentColor;border-right-color:transparent;border-radius:9999px;animation:sixb-loading-spin .7s linear infinite}
+      @media(prefers-color-scheme:dark){.sixb-loading-shell{background:#09090b;color:#a1a1aa}}
+      @media(prefers-reduced-motion:reduce){.sixb-loading-spinner{animation-duration:1.5s}}
+      @keyframes sixb-loading-spin{to{transform:rotate(360deg)}}
+    </style>
     <link rel="stylesheet" href="${config.stylesheetPath}" />
     ${runtimeConfigScript}
     <script type="module" src="${config.scriptPath}"></script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root"><div class="sixb-loading-shell" role="status" aria-label="Loading Atlas"><span class="sixb-loading-spinner" aria-hidden="true"></span></div></div>
   </body>
 </html>`
+}
+
+async function precompressBuiltInUiAssets(outdir: string): Promise<void> {
+  const paths = (await readdir(outdir))
+    .filter((file) => file.endsWith(".js") || file.endsWith(".css"))
+    .map((file) => join(outdir, file))
+  let cursor = 0
+
+  const worker = async () => {
+    while (cursor < paths.length) {
+      const path = paths[cursor++]
+      const bytes = await Bun.file(path).arrayBuffer()
+      const [brotli, gzipped] = await Promise.all([
+        brotliCompress(bytes, {
+          params: {
+            [zlibConstants.BROTLI_PARAM_QUALITY]: 5,
+          },
+        }),
+        gzip(bytes, { level: 9 }),
+      ])
+      await Promise.all([writeFile(`${path}.br`, brotli), writeFile(`${path}.gz`, gzipped)])
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(PRECOMPRESSION_CONCURRENCY, paths.length) }, worker)
+  )
 }
 
 async function resolveBuiltInUiBundle(outdir: string): Promise<BuiltInUiBundle> {

--- a/packages/atlas/src/components/layout/AppLayout.tsx
+++ b/packages/atlas/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "@sixb/ui/components"
 import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 import { Outlet, useLocation, useNavigate } from "react-router-dom"
+import { preloadWorkspaceView } from "../../pages/workspaceRoutes"
 import { AppShell } from "./AppShell"
 import { Sidebar, type ViewMode } from "./Sidebar"
 import { type ProjectSidebarData, SidebarDataContext } from "./sidebarData"
@@ -38,6 +39,7 @@ export function AppLayout() {
       selectedProject={selectedProject}
       viewMode={viewMode}
       onViewChange={handleViewChange}
+      onViewIntent={preloadWorkspaceView}
       objectCount={sidebarData?.objectCount}
       connectorCount={sidebarData?.connectorCount}
       datasetCount={sidebarData?.datasetCount}

--- a/packages/atlas/src/components/layout/Sidebar.tsx
+++ b/packages/atlas/src/components/layout/Sidebar.tsx
@@ -78,6 +78,7 @@ interface SidebarProps {
   selectedProject: ProjectInfo | null
   viewMode: ViewMode
   onViewChange: (mode: ViewMode) => void
+  onViewIntent?: (mode: ViewMode) => void
   datasetCount?: number
   connectorCount?: number
   syncCount?: number
@@ -95,6 +96,7 @@ export function Sidebar({
   selectedProject,
   viewMode,
   onViewChange,
+  onViewIntent,
   datasetCount,
   connectorCount,
   syncCount,
@@ -166,6 +168,9 @@ export function Sidebar({
                     <SidebarMenuButton
                       isActive={isActive}
                       tooltip={item.label}
+                      onPointerEnter={() => onViewIntent?.(item.id)}
+                      onPointerDown={() => onViewIntent?.(item.id)}
+                      onFocus={() => onViewIntent?.(item.id)}
                       onClick={() => onViewChange(item.id)}
                     >
                       <item.Icon />

--- a/packages/atlas/src/index.ts
+++ b/packages/atlas/src/index.ts
@@ -225,12 +225,59 @@ async function fileResponse(
   path: string,
   headers: Record<string, string> = {}
 ): Promise<Response> {
-  const file = Bun.file(path)
-  if (!(await file.exists())) {
+  const originalFile = Bun.file(path)
+  if (!(await originalFile.exists())) {
     return notFoundResponse()
   }
 
-  return new Response(request.method === "HEAD" ? null : file, { headers })
+  const responseHeaders = new Headers(headers)
+  let responseFile = originalFile
+  if (path.endsWith(".js") || path.endsWith(".css")) {
+    responseHeaders.append("vary", "Accept-Encoding")
+    if (!request.headers.has("range")) {
+      for (const encoding of acceptedPrecompressedEncodings(request)) {
+        const candidate = Bun.file(`${path}.${encoding === "br" ? "br" : "gz"}`)
+        if (!(await candidate.exists())) continue
+
+        responseFile = candidate
+        responseHeaders.set("content-encoding", encoding)
+        responseHeaders.set("content-type", originalFile.type)
+        break
+      }
+    }
+  }
+
+  return new Response(request.method === "HEAD" ? null : responseFile, {
+    headers: responseHeaders,
+  })
+}
+
+function acceptedPrecompressedEncodings(request: Request): ("br" | "gzip")[] {
+  const header = request.headers.get("accept-encoding")
+  if (!header) return []
+
+  const qualities = new Map<string, number>()
+  for (const item of header.split(",")) {
+    const [rawName, ...parameters] = item.trim().split(";")
+    const name = rawName.toLowerCase()
+    let quality = 1
+    for (const parameter of parameters) {
+      const match = parameter.trim().match(/^q=(0(?:\.\d+)?|1(?:\.0+)?)$/)
+      if (match) quality = Number(match[1])
+    }
+    qualities.set(name, quality)
+  }
+
+  const wildcard = qualities.get("*") ?? 0
+  return (["br", "gzip"] as const)
+    .map((encoding, preference) => ({
+      encoding,
+      preference,
+      quality: qualities.get(encoding) ?? wildcard,
+    }))
+    .filter((candidate) => candidate.quality > 0)
+    .sort((left, right) => right.quality - left.quality || left.preference - right.preference)
+    .map((candidate) => candidate.encoding)
 }
 
 function notFoundResponse(): Response {

--- a/packages/atlas/src/main.tsx
+++ b/packages/atlas/src/main.tsx
@@ -13,6 +13,7 @@ import React from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { BrowserRouter } from "react-router-dom"
 import App from "./App"
+import { preloadWorkspacePath } from "./pages/workspaceRoutes"
 import "../.sixb/ui.css"
 
 let canRenderApp = false
@@ -37,6 +38,7 @@ async function start(): Promise<void> {
 
   const runtimeConfig = readSixbBrowserRuntimeConfig({ audience: "atlas" })
   browserClient = configureSixbBrowserClient(runtimeConfig)
+  preloadWorkspacePath(window.location.pathname)
   const authSession = runtimeConfig.auth.enabled
     ? await requireSixbBrowserAuthSession(runtimeConfig, browserClient)
     : null

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -19,7 +19,15 @@ import { Button, Card, EmptyState } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { useQueries, useQuery } from "@tanstack/react-query"
 import { Box, Loader2 } from "lucide-react"
-import { type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from "react"
+import {
+  type ReactNode,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import {
   Navigate,
   Route,
@@ -31,31 +39,39 @@ import {
 } from "react-router-dom"
 import { SidebarDataContext } from "../components/layout/sidebarData"
 import { KNOWN_VIEWS } from "../components/layout/viewMode"
-import { SettingsMembersPage } from "../components/SettingsMembersPage"
-import { SettingsServiceAccountsPage } from "../components/SettingsServiceAccountsPage"
-import { SettingsSessionsPage } from "../components/SettingsSessionsPage"
-import { SettingsTokensPage } from "../components/SettingsTokensPage"
 import {
   getObjectSortPreference,
   type ObjectSortPreference,
   setObjectSortPreference,
 } from "../lib/userPreferences"
-import { ActionRunDetailPage } from "./ActionRunDetailPage"
-import { ActionsPage } from "./ActionsPage"
-import { AgentsPage } from "./AgentsPage"
-import { ConnectorDetailPage, ConnectorsPage } from "./ConnectorsPage"
-import { DatasetDetailPage, DatasetsPage } from "./DatasetsPage"
-import { LogsPage } from "./LogsPage"
-import { ObjectDetailPage } from "./ObjectDetailPage"
 import { ObjectsWorkbench, type ObjectTypePreviewSection } from "./ObjectsWorkbench"
-import { ObjectTypeDetail } from "./ObjectTypeDetail"
-import { OntologyExplorer } from "./OntologyExplorer"
-import { PipelineDetailPage, PipelinesPage } from "./PipelinesPage"
-import { ProjectionDetailPage, ProjectionsPage } from "./ProjectionsPage"
-import { RuleDetailPage, RulesPage } from "./RulesPage"
-import { SyncDetailPage, SyncsPage } from "./SyncsPage"
-import { WorkflowDetailPage } from "./WorkflowDetailPage"
-import { WorkflowsPage } from "./WorkflowsPage"
+import {
+  ActionRunDetailPage,
+  ActionsPage,
+  AgentsPage,
+  ConnectorDetailPage,
+  ConnectorsPage,
+  DatasetDetailPage,
+  DatasetsPage,
+  LogsPage,
+  ObjectDetailPage,
+  ObjectTypeDetail,
+  OntologyExplorer,
+  PipelineDetailPage,
+  PipelinesPage,
+  ProjectionDetailPage,
+  ProjectionsPage,
+  RuleDetailPage,
+  RulesPage,
+  SettingsMembersPage,
+  SettingsServiceAccountsPage,
+  SettingsSessionsPage,
+  SettingsTokensPage,
+  SyncDetailPage,
+  SyncsPage,
+  WorkflowDetailPage,
+  WorkflowsPage,
+} from "./workspaceRoutes"
 
 const emptyObjectList: ObjectSummary[] = []
 const OBJECT_PAGE_SIZE = 300
@@ -336,82 +352,86 @@ export function ProjectWorkspace() {
     <div className={cn("mx-auto w-full max-w-7xl min-w-0 p-3 sm:p-4 lg:p-6")}>{children}</div>
   )
 
+  // BrowserRouter transitions keep the current route visible while an intent-preloaded chunk
+  // resolves. The destination page then owns the only loading state: its actual data.
   return (
-    <Routes>
-      <Route path="pipelines/:pipelineId" element={<PipelineDetailPage />} />
-      <Route path="datasets/:datasetId" element={<DatasetDetailPage />} />
-      <Route path="actions" element={<ActionsPage />} />
-      <Route path="actions/runs/:runId" element={<ActionRunDetailPage />} />
-      <Route path="agents" element={<AgentsPage />} />
-      <Route path="agents/new/:agentId" element={<AgentsPage />} />
-      <Route path="agents/:threadId" element={<AgentsPage />} />
-      <Route path="workflows" element={<WorkflowsPage />} />
-      <Route path="workflows/:workflowId" element={<WorkflowDetailPage />} />
-      <Route path="logs" element={<LogsPage />} />
-      <Route path="runs" element={<RunsTabRedirect />} />
-      <Route path="runs/:runId" element={<RunRedirect />} />
-      <Route
-        path="*"
-        element={constrained(
-          <Routes>
-            <Route
-              index
-              element={
-                <ObjectsWorkbench
-                  projectName={resolvedProjectName}
-                  objectPageSize={OBJECT_PAGE_SIZE}
-                  allObjectsTotal={allObjectsTotal}
-                  objectTypeCounts={objectTypeCounts}
-                  overviewSections={objectTypePreviewSections}
-                  overviewLoading={overviewLoading}
-                  objectTypesLoading={objectTypesLoading}
-                  sortBy={objectSortBy}
-                  classFilter={classFilter}
-                  selectedObjectType={selectedObjectType}
-                  selectedObjectId={selectedObjectIdForSidebar}
-                  onSortByChange={handleObjectSortByChange}
-                  onClassFilterChange={setClassFilter}
-                  onSelectObject={(objectId) => navigate(toProjectPath(objectId))}
-                />
-              }
-            />
-            <Route path="home" element={<Navigate to="/" replace />} />
-            <Route path="objects" element={<Navigate to="/" replace />} />
-            <Route path="datasets" element={<DatasetsPage />} />
-            <Route path="connectors" element={<ConnectorsPage />} />
-            <Route path="connectors/:connectorId" element={<ConnectorDetailPage />} />
-            <Route path="syncs" element={<SyncsPage />} />
-            <Route path="syncs/:syncId" element={<SyncDetailPage />} />
-            <Route path="projections" element={<ProjectionsPage />} />
-            <Route path="projections/:projectionId" element={<ProjectionDetailPage />} />
-            <Route path="pipelines" element={<PipelinesPage />} />
-            <Route path="rules" element={<RulesPage />} />
-            <Route path="rules/:ruleId" element={<RuleDetailPage />} />
-            <Route path="settings" element={<Navigate to="/settings/members" replace />} />
-            <Route path="settings/tokens" element={<SettingsTokensPage />} />
-            <Route path="settings/members" element={<SettingsMembersPage />} />
-            <Route path="settings/service-accounts" element={<SettingsServiceAccountsPage />} />
-            <Route path="settings/sessions" element={<SettingsSessionsPage />} />
-            <Route
-              path="ontology"
-              element={
-                <OntologyExplorer
-                  onSelectType={(typeId) => navigate(toProjectPath(`ontology/${typeId}`))}
-                />
-              }
-            />
-            <Route path="ontology/:typeId" element={<ObjectTypeDetail />} />
-            <Route
-              path=":objectId"
-              element={
-                <ObjectDetailPage projectName={resolvedProjectName} objectLookup={objectLookup} />
-              }
-            />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        )}
-      />
-    </Routes>
+    <Suspense fallback={null}>
+      <Routes>
+        <Route path="pipelines/:pipelineId" element={<PipelineDetailPage />} />
+        <Route path="datasets/:datasetId" element={<DatasetDetailPage />} />
+        <Route path="actions" element={<ActionsPage />} />
+        <Route path="actions/runs/:runId" element={<ActionRunDetailPage />} />
+        <Route path="agents" element={<AgentsPage />} />
+        <Route path="agents/new/:agentId" element={<AgentsPage />} />
+        <Route path="agents/:threadId" element={<AgentsPage />} />
+        <Route path="workflows" element={<WorkflowsPage />} />
+        <Route path="workflows/:workflowId" element={<WorkflowDetailPage />} />
+        <Route path="logs" element={<LogsPage />} />
+        <Route path="runs" element={<RunsTabRedirect />} />
+        <Route path="runs/:runId" element={<RunRedirect />} />
+        <Route
+          path="*"
+          element={constrained(
+            <Routes>
+              <Route
+                index
+                element={
+                  <ObjectsWorkbench
+                    projectName={resolvedProjectName}
+                    objectPageSize={OBJECT_PAGE_SIZE}
+                    allObjectsTotal={allObjectsTotal}
+                    objectTypeCounts={objectTypeCounts}
+                    overviewSections={objectTypePreviewSections}
+                    overviewLoading={overviewLoading}
+                    objectTypesLoading={objectTypesLoading}
+                    sortBy={objectSortBy}
+                    classFilter={classFilter}
+                    selectedObjectType={selectedObjectType}
+                    selectedObjectId={selectedObjectIdForSidebar}
+                    onSortByChange={handleObjectSortByChange}
+                    onClassFilterChange={setClassFilter}
+                    onSelectObject={(objectId) => navigate(toProjectPath(objectId))}
+                  />
+                }
+              />
+              <Route path="home" element={<Navigate to="/" replace />} />
+              <Route path="objects" element={<Navigate to="/" replace />} />
+              <Route path="datasets" element={<DatasetsPage />} />
+              <Route path="connectors" element={<ConnectorsPage />} />
+              <Route path="connectors/:connectorId" element={<ConnectorDetailPage />} />
+              <Route path="syncs" element={<SyncsPage />} />
+              <Route path="syncs/:syncId" element={<SyncDetailPage />} />
+              <Route path="projections" element={<ProjectionsPage />} />
+              <Route path="projections/:projectionId" element={<ProjectionDetailPage />} />
+              <Route path="pipelines" element={<PipelinesPage />} />
+              <Route path="rules" element={<RulesPage />} />
+              <Route path="rules/:ruleId" element={<RuleDetailPage />} />
+              <Route path="settings" element={<Navigate to="/settings/members" replace />} />
+              <Route path="settings/tokens" element={<SettingsTokensPage />} />
+              <Route path="settings/members" element={<SettingsMembersPage />} />
+              <Route path="settings/service-accounts" element={<SettingsServiceAccountsPage />} />
+              <Route path="settings/sessions" element={<SettingsSessionsPage />} />
+              <Route
+                path="ontology"
+                element={
+                  <OntologyExplorer
+                    onSelectType={(typeId) => navigate(toProjectPath(`ontology/${typeId}`))}
+                  />
+                }
+              />
+              <Route path="ontology/:typeId" element={<ObjectTypeDetail />} />
+              <Route
+                path=":objectId"
+                element={
+                  <ObjectDetailPage projectName={resolvedProjectName} objectLookup={objectLookup} />
+                }
+              />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          )}
+        />
+      </Routes>
+    </Suspense>
   )
 }
 

--- a/packages/atlas/src/pages/workspaceRoutes.ts
+++ b/packages/atlas/src/pages/workspaceRoutes.ts
@@ -1,0 +1,166 @@
+import { lazy } from "react"
+import type { ViewMode } from "../components/layout/Sidebar"
+import { KNOWN_VIEWS } from "../components/layout/viewMode"
+
+const loadActionRunDetailPage = () => import("./ActionRunDetailPage")
+const loadActionsPage = () => import("./ActionsPage")
+const loadAgentsPage = () => import("./AgentsPage")
+const loadConnectorsPage = () => import("./ConnectorsPage")
+const loadDatasetsPage = () => import("./DatasetsPage")
+const loadLogsPage = () => import("./LogsPage")
+const loadObjectDetailPage = () => import("./ObjectDetailPage")
+const loadObjectTypeDetailPage = () => import("./ObjectTypeDetail")
+const loadOntologyExplorer = () => import("./OntologyExplorer")
+const loadPipelinesPage = () => import("./PipelinesPage")
+const loadProjectionsPage = () => import("./ProjectionsPage")
+const loadRulesPage = () => import("./RulesPage")
+const loadSyncsPage = () => import("./SyncsPage")
+const loadWorkflowDetailPage = () => import("./WorkflowDetailPage")
+const loadWorkflowsPage = () => import("./WorkflowsPage")
+const loadSettingsMembersPage = () => import("../components/SettingsMembersPage")
+const loadSettingsServiceAccountsPage = () => import("../components/SettingsServiceAccountsPage")
+const loadSettingsSessionsPage = () => import("../components/SettingsSessionsPage")
+const loadSettingsTokensPage = () => import("../components/SettingsTokensPage")
+
+export const ActionRunDetailPage = lazy(() =>
+  loadActionRunDetailPage().then((module) => ({ default: module.ActionRunDetailPage }))
+)
+export const ActionsPage = lazy(() =>
+  loadActionsPage().then((module) => ({ default: module.ActionsPage }))
+)
+export const AgentsPage = lazy(() =>
+  loadAgentsPage().then((module) => ({ default: module.AgentsPage }))
+)
+export const ConnectorDetailPage = lazy(() =>
+  loadConnectorsPage().then((module) => ({ default: module.ConnectorDetailPage }))
+)
+export const ConnectorsPage = lazy(() =>
+  loadConnectorsPage().then((module) => ({ default: module.ConnectorsPage }))
+)
+export const DatasetDetailPage = lazy(() =>
+  loadDatasetsPage().then((module) => ({ default: module.DatasetDetailPage }))
+)
+export const DatasetsPage = lazy(() =>
+  loadDatasetsPage().then((module) => ({ default: module.DatasetsPage }))
+)
+export const LogsPage = lazy(() => loadLogsPage().then((module) => ({ default: module.LogsPage })))
+export const ObjectDetailPage = lazy(() =>
+  loadObjectDetailPage().then((module) => ({ default: module.ObjectDetailPage }))
+)
+export const ObjectTypeDetail = lazy(() =>
+  loadObjectTypeDetailPage().then((module) => ({ default: module.ObjectTypeDetail }))
+)
+export const OntologyExplorer = lazy(() =>
+  loadOntologyExplorer().then((module) => ({ default: module.OntologyExplorer }))
+)
+export const PipelineDetailPage = lazy(() =>
+  loadPipelinesPage().then((module) => ({ default: module.PipelineDetailPage }))
+)
+export const PipelinesPage = lazy(() =>
+  loadPipelinesPage().then((module) => ({ default: module.PipelinesPage }))
+)
+export const ProjectionDetailPage = lazy(() =>
+  loadProjectionsPage().then((module) => ({ default: module.ProjectionDetailPage }))
+)
+export const ProjectionsPage = lazy(() =>
+  loadProjectionsPage().then((module) => ({ default: module.ProjectionsPage }))
+)
+export const RuleDetailPage = lazy(() =>
+  loadRulesPage().then((module) => ({ default: module.RuleDetailPage }))
+)
+export const RulesPage = lazy(() =>
+  loadRulesPage().then((module) => ({ default: module.RulesPage }))
+)
+export const SyncDetailPage = lazy(() =>
+  loadSyncsPage().then((module) => ({ default: module.SyncDetailPage }))
+)
+export const SyncsPage = lazy(() =>
+  loadSyncsPage().then((module) => ({ default: module.SyncsPage }))
+)
+export const WorkflowDetailPage = lazy(() =>
+  loadWorkflowDetailPage().then((module) => ({ default: module.WorkflowDetailPage }))
+)
+export const WorkflowsPage = lazy(() =>
+  loadWorkflowsPage().then((module) => ({ default: module.WorkflowsPage }))
+)
+export const SettingsMembersPage = lazy(() =>
+  loadSettingsMembersPage().then((module) => ({ default: module.SettingsMembersPage }))
+)
+export const SettingsServiceAccountsPage = lazy(() =>
+  loadSettingsServiceAccountsPage().then((module) => ({
+    default: module.SettingsServiceAccountsPage,
+  }))
+)
+export const SettingsSessionsPage = lazy(() =>
+  loadSettingsSessionsPage().then((module) => ({ default: module.SettingsSessionsPage }))
+)
+export const SettingsTokensPage = lazy(() =>
+  loadSettingsTokensPage().then((module) => ({ default: module.SettingsTokensPage }))
+)
+
+type WorkspaceRouteLoader = () => Promise<unknown>
+
+const workspaceViewLoaders: Partial<Record<ViewMode, WorkspaceRouteLoader>> = {
+  actions: loadActionsPage,
+  agents: loadAgentsPage,
+  connectors: loadConnectorsPage,
+  datasets: loadDatasetsPage,
+  logs: loadLogsPage,
+  ontology: loadOntologyExplorer,
+  pipelines: loadPipelinesPage,
+  projections: loadProjectionsPage,
+  rules: loadRulesPage,
+  settings: loadSettingsMembersPage,
+  syncs: loadSyncsPage,
+  workflows: loadWorkflowsPage,
+}
+
+export function preloadWorkspaceView(view: ViewMode): void {
+  preload(workspaceViewLoaders[view])
+}
+
+export function preloadWorkspacePath(pathname: string): void {
+  const [view, detail, id] = pathname.split("/").filter(Boolean)
+
+  if (!view || view === "home" || view === "objects") return
+
+  if (view === "actions" && detail === "runs" && id) {
+    preload(loadActionRunDetailPage)
+    return
+  }
+  if (view === "workflows" && detail) {
+    preload(loadWorkflowDetailPage)
+    return
+  }
+  if (view === "runs") {
+    preload(loadWorkflowDetailPage)
+    return
+  }
+  if (view === "ontology" && detail) {
+    preload(loadObjectTypeDetailPage)
+    return
+  }
+  if (view === "settings") {
+    preload(settingsLoader(detail))
+    return
+  }
+
+  if (KNOWN_VIEWS.has(view)) {
+    preload(workspaceViewLoaders[view as ViewMode])
+    return
+  }
+
+  preload(loadObjectDetailPage)
+}
+
+function settingsLoader(section: string | undefined): WorkspaceRouteLoader {
+  if (section === "tokens") return loadSettingsTokensPage
+  if (section === "service-accounts") return loadSettingsServiceAccountsPage
+  if (section === "sessions") return loadSettingsSessionsPage
+  return loadSettingsMembersPage
+}
+
+function preload(loader: WorkspaceRouteLoader | undefined): void {
+  // Preloading is opportunistic. If it fails, React.lazy owns the visible route error path.
+  void loader?.().catch(() => undefined)
+}

--- a/packages/atlas/tests/atlas-app.test.ts
+++ b/packages/atlas/tests/atlas-app.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, readdir, rm } from "node:fs/promises"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -77,8 +77,14 @@ describe("createAtlasApp", () => {
       // chunk. Naming both `[name]-[hash]` made `main.tsx` and its 47 shared chunks indistinguishable.
       expect(scriptPath).toMatch(/^\/__sixb\/atlas-[^.]+\.js$/)
       expect(stylesheetPath).toMatch(/^\/__sixb\/atlas-[^.]+\.css$/)
-      expect(html).toContain('<div id="root"></div>')
-      expect(dottedRouteHtml).toContain('<div id="root"></div>')
+      expect(html).toContain('class="sixb-loading-shell"')
+      expect(dottedRouteHtml).toContain('class="sixb-loading-shell"')
+
+      const builtFiles = await readdir(assetsOutdir)
+      expect(builtFiles.some((file) => /^chunk-AgentsPage-[^.]+\.js$/.test(file))).toBe(true)
+      expect(builtFiles.some((file) => /^chunk-PipelinesPage-[^.]+\.js$/.test(file))).toBe(true)
+      // Regression proof: replacing the lazy ProjectWorkspace routes with static imports removes
+      // these chunks and puts their agent/canvas dependencies back on Atlas's initial path.
 
       for (const assetPath of [scriptPath, stylesheetPath]) {
         const assetResponse = await fetch(`${baseUrl}${assetPath}`)
@@ -87,6 +93,13 @@ describe("createAtlasApp", () => {
           "public, max-age=31536000, immutable"
         )
       }
+
+      const encodedAssetResponse = await fetch(`${baseUrl}${scriptPath}`, {
+        headers: { "accept-encoding": "br, gzip" },
+      })
+      expect(encodedAssetResponse.headers.get("content-encoding")).toBe("br")
+      expect(encodedAssetResponse.headers.get("vary")).toContain("Accept-Encoding")
+      expect((await encodedAssetResponse.text()).length).toBeGreaterThan(1000)
 
       const stableAssetResponse = await fetch(`${baseUrl}/__sixb/main.js`)
       expect(stableAssetResponse.status).toBe(404)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "build": "bun ../../scripts/build-package.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "test:e2e": "bun test ./tests/prod-roles.e2e.ts && bun test ./tests/worker-group.e2e.ts",
+    "test:e2e": "bun test ./tests/build.e2e.ts && bun test ./tests/prod-roles.e2e.ts && bun test ./tests/worker-group.e2e.ts",
     "prepack": "bun run build"
   },
   "dependencies": {

--- a/packages/cli/tests/build.e2e.ts
+++ b/packages/cli/tests/build.e2e.ts
@@ -2,30 +2,34 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
+import { runCliToCompletion } from "./shared/cli-process"
 
-function runBuildEntry(
+// A cold production build drives the custom-app and Atlas bundlers plus asset precompression. Keep
+// that production work out of the parallel unit suite, and bound its child so a wedged bundler
+// cannot consume the E2E job wall-clock timeout.
+
+const BUILD_TIMEOUT_MS = 150_000
+
+function buildTest(name: string, run: () => Promise<void>): void {
+  test(name, run, BUILD_TIMEOUT_MS + 10_000)
+}
+
+async function runBuildEntry(
   entry: string,
   outdir: string
-): {
+): Promise<{
   exitCode: number
   stdout: string
   stderr: string
-} {
+}> {
   const repoRoot = resolve(import.meta.dir, "..", "..", "..")
   const cliEntry = resolve(import.meta.dir, "..", "src", "index.tsx")
 
-  const result = Bun.spawnSync({
+  return await runCliToCompletion({
     cmd: ["bun", cliEntry, "build", "--entry", entry, "--outdir", outdir],
     cwd: repoRoot,
-    stdout: "pipe",
-    stderr: "pipe",
+    timeoutMs: BUILD_TIMEOUT_MS,
   })
-
-  return {
-    exitCode: result.exitCode,
-    stdout: Buffer.from(result.stdout).toString("utf-8"),
-    stderr: Buffer.from(result.stderr).toString("utf-8"),
-  }
 }
 
 describe("sixb build", () => {
@@ -49,12 +53,12 @@ describe("sixb build", () => {
     }
   })
 
-  test("builds the custom app from the entry project root", async () => {
+  buildTest("builds the custom app from the entry project root", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "sixb-cli-build-"))
     tempDirs.push(tempDir)
     const outdir = join(tempDir, "dist")
 
-    const result = runBuildEntry(exampleEntry, outdir)
+    const result = await runBuildEntry(exampleEntry, outdir)
 
     expect(result.exitCode).toBe(0)
     expect(result.stderr).toBe("")
@@ -71,10 +75,10 @@ describe("sixb build", () => {
     expect(atlasAssets.some((file) => /^chunk-.+\.js$/.test(file))).toBe(true)
 
     const html = await readFile(join(outdir, "app", "index.html"), "utf-8")
-    expect(html).toContain('<div id="root"></div>')
+    expect(html).toContain('class="sixb-loading-shell"')
   })
 
-  test("does not overwrite custom app files watched by the dev server", async () => {
+  buildTest("does not overwrite custom app files watched by the dev server", async () => {
     const tempDir = await mkdtemp(join(dirname(exampleEntry), ".tmp-sixb-cli-build-isolation-"))
     tempDirs.push(tempDir)
     const appDir = join(tempDir, "app")
@@ -97,7 +101,7 @@ describe("sixb build", () => {
       await writeFile(join(devGeneratedDir, name), content)
     }
 
-    const result = runBuildEntry(entry, outdir)
+    const result = await runBuildEntry(entry, outdir)
 
     expect(result.exitCode).toBe(0)
     expect(result.stderr).toBe("")
@@ -106,9 +110,9 @@ describe("sixb build", () => {
       expect(await readFile(join(devGeneratedDir, name), "utf-8")).toBe(content)
     }
     await stat(join(tempDir, ".sixb", "build", "app", "index.html"))
-  }, 30_000)
+  })
 
-  test("externalizes package dependencies when bundling runtime config", async () => {
+  buildTest("externalizes package dependencies when bundling runtime config", async () => {
     const repoRoot = resolve(import.meta.dir, "..", "..", "..")
     const tempDir = await mkdtemp(join(repoRoot, ".tmp-sixb-cli-build-packages-"))
     tempDirs.push(tempDir)
@@ -126,7 +130,7 @@ describe("sixb build", () => {
       ].join("\n")
     )
 
-    const result = runBuildEntry(entry, outdir)
+    const result = await runBuildEntry(entry, outdir)
 
     expect(result.exitCode).toBe(0)
     expect(result.stderr).toBe("")


### PR DESCRIPTION
## Summary

This PR makes a cold browser load of hosted Atlas and custom apps substantially smaller and faster. It targets the first visit after the browser cache is empty; warm loads were already fast because hashed assets use immutable browser caching.

The slowdown was not a sleeping application process. Production-like testing showed that browsers were downloading decoded multi-megabyte JavaScript bundles, and heavyweight route-only dependencies were included on the initial path.

## Benchmark

Measured in Chromium with an empty browser cache, 10 Mbps download throughput, 80 ms latency, and authentication disabled to isolate static UI delivery from API/auth/storage latency:

| Surface | Transfer before | Transfer after | FCP before | FCP after |
| --- | ---: | ---: | ---: | ---: |
| Atlas | 2,850 KiB | 350 KiB (-88%) | 2.78 s | 0.84 s (-70%) |
| Custom app | 11,035 KiB | 414 KiB (-96%) | 9.23 s | 0.73 s (-92%) |

These are cold-cache results. Content-hashed URLs and their one-year immutable policy preserve the existing fast warm-cache behavior.

## What changed

### Compress browser assets once, at build time

- `sixb build` writes Brotli and gzip sidecars for Atlas and custom-app JavaScript/CSS.
- Production servers negotiate `Accept-Encoding`, prefer Brotli at equal quality, and return `Content-Encoding` plus `Vary: Accept-Encoding`.
- Range requests continue to use the original representation.
- Hashed assets remain `public, max-age=31536000, immutable`; runtime-configured HTML remains `no-store`.

Precompression avoids spending application CPU compressing the same large bundle on every cold request.

### Keep route-only code off the initial path

- Custom apps build their generated `main.tsx` directly with splitting enabled and explicit entry/chunk naming.
- This avoids a Bun HTML-entry splitting edge where a lazy chunk could become the shell script and keeps Shiki's language grammar graph out of the initial custom-app bundle.
- A narrow resolver plugin handles extensionless relative imports in linked workspace source exposed by the direct TypeScript build.
- Atlas workspace pages are lazy route modules, moving agents, canvases, charts, settings, detail views, and syntax-highlighting dependencies behind their routes.

### Avoid introducing a second loading experience

- Both production shells paint an immediate theme-aware loading surface instead of a blank page during bootstrap.
- Atlas preloads the active deep-link chunk during auth startup and preloads sidebar destinations on pointer/focus intent.
- BrowserRouter transitions retain the current route while a destination chunk resolves. Code loading has no separate spinner; the destination page owns the only visible loading state for its data.

## Linked issue

None. This follows investigation of slow first visits to hosted Sixb applications.

## Scope

This changes browser build and static-serving behavior only. It does not change API, authentication, storage, or process lifecycle behavior, and it does not add a CDN or proxy requirement.

## Validation

- `bun test packages/app/tests/ packages/atlas/tests/atlas-app.test.ts` (46 passed)
- `bun --filter @sixb/app typecheck`
- `bun --filter @sixb/app build`
- `bun --filter @sixb/atlas typecheck`
- `bun --filter @sixb/atlas build`
- `bun run check`

Tests cover split entry/chunk output, Brotli negotiation, `Vary`/cache headers, generated manifests/styles, lazy Atlas chunks, and the immediate loading shells.

## Notes

The companion [sixb-ai/deploy#2](https://github.com/sixb-ai/deploy/pull/2) adds zstd/gzip at Caddy for eligible responses left unencoded by an upstream and for older Sixb deployments. This PR does not depend on that proxy change: Atlas and custom-app assets negotiate their prebuilt Brotli/gzip representations directly.

The benchmark intentionally excludes auth and API time so it measures the static-delivery regression directly. If a deployed site remains slow after these changes, HTML TTFB, auth-session requests, and project API requests can be measured independently rather than conflated with bundle transfer.
