### PR TITLE
errors: define Agent and Projection failure taxonomy

### DIFF
--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -50,8 +50,8 @@ Each boundary exposes only the codes it can persist.
 | --- | --- |
 | Action run or phase | `action.phase_failed`, `internal.unexpected`, `queue.enqueue_failed`, `runtime.cancelled` |
 | Sync run | `internal.unexpected`, `runtime.cancelled`, `sync.execution_failed` |
-| Agent execution | `internal.unexpected`, `runtime.cancelled` |
-| Projection run | `internal.unexpected`, `runtime.cancelled` |
+| Agent execution | `agent.execution_failed`, `internal.unexpected`, `runtime.cancelled` |
+| Projection run | `internal.unexpected`, `projection.execution_failed`, `runtime.cancelled` |
 | Pipeline run or step | `internal.unexpected`, `runtime.cancelled`, `pipeline.step_failed` |
 | Workflow run or node | `internal.unexpected`, `runtime.cancelled`, `workflow.node_failed` |
 | Webhook run | `internal.unexpected`, `webhook.delivery_failed` |
@@ -76,7 +76,8 @@ Additional rules:
 
 | Code | Retryable | What happened | What to do |
 | --- | --- | --- | --- |
-| `action.phase_failed` | No | An Action phase could not complete successfully. | Inspect `phase` and the cause; retry only when its side-effect boundary makes that safe. |
+| `action.phase_failed` | No | An Action phase could not complete successfully. | Inspect `phase` and the `onError` report; retry only when its side-effect boundary makes that safe. |
+| `agent.execution_failed` | No | An active Agent execution failed. | Inspect the run identity and `onError` report before requesting another run. |
 | `dataset.not_found` | No | Dataset is unavailable to the caller. | Check its ID and access policy. |
 | `dataset.version_incompatible` | No | Version does not match the required dataset or schema. | Materialize a compatible version. |
 | `dataset.version_not_found` | No | Version does not exist or nothing has been committed yet. | Check the ID or materialize the dataset. |
@@ -85,6 +86,7 @@ Additional rules:
 | `internal.unexpected` | No | The exception has no specific code yet. | Inspect its `onError` report and correlation details. |
 | `pipeline.step_failed` | No | A step failed before committing its output. | Fix the cause and request a new pipeline run. |
 | `projection.definition_invalid` | No | Projection definition is invalid for its ontology or dataset. | Fix the definition and request a new run. |
+| `projection.execution_failed` | No | Projection materialization failed permanently. | Inspect the projection, pinned dataset version, and `onError` report. |
 | `projection.not_found` | No | Projection is not registered. | Check its ID and deployment. |
 | `projection.run_already_terminal` | No | Delivery targets a run that is already terminal. | Use a new run ID for new work. |
 | `projection.run_identity_mismatch` | No | Delivery does not match the run's pinned identity. | Discard it and dispatch from the current definition. |

--- a/packages/agent-worker/src/failure.ts
+++ b/packages/agent-worker/src/failure.ts
@@ -1,0 +1,52 @@
+import type { SixbFailure } from "@sixb/core"
+import {
+  captureSixbFailure,
+  createSixbError,
+  isSixbError,
+  summarizeErrorMessage,
+} from "@sixb/core/internal/errors"
+import { AGENT_RUN_FAILURE_CODES, type AgentRunFailureCode } from "@sixb/core/storage"
+
+export type AgentRunFailure = SixbFailure<AgentRunFailureCode>
+
+interface AgentFailureInput {
+  readonly status: "failed" | "cancelled"
+  readonly at: Date
+  readonly details: Readonly<Record<string, string>>
+}
+
+/** Normalize a failure without changing its classification. Used outside active execution. */
+export function toAgentRunFailure(error: unknown, input: AgentFailureInput): AgentRunFailure {
+  const failureCode = input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected"
+  return captureSixbFailure(error, {
+    allowedCodes: AGENT_RUN_FAILURE_CODES,
+    defaultCode: failureCode,
+    details: input.details,
+    at: input.at,
+  })
+}
+
+/** Classify only work performed by an active Agent execution. */
+export function toAgentExecutionFailure(error: unknown, input: AgentFailureInput): AgentRunFailure {
+  const failureError =
+    input.status === "failed" ? translateAgentExecutionError(error, input.details) : error
+  return toAgentRunFailure(failureError, input)
+}
+
+function translateAgentExecutionError(
+  error: unknown,
+  details: Readonly<Record<string, string>>
+): unknown {
+  if (
+    isSixbError(error) &&
+    (error.code === "internal.unexpected" || error.code === "agent.execution_failed")
+  ) {
+    return error
+  }
+
+  return createSixbError(
+    "agent.execution_failed",
+    summarizeErrorMessage(error, "Agent execution failed."),
+    { cause: error, details }
+  )
+}

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path"
-import type { AgentDefinition, SixbFailure } from "@sixb/core"
+import type { AgentDefinition } from "@sixb/core"
 import {
   createAgentRunExecutionToken,
   dispatchQueuedAgentRuns,
@@ -8,16 +8,17 @@ import {
   workflowAgentNodeQueueJobId,
 } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
-import { captureSixbFailure, createSixbError, isSixbError } from "@sixb/core/internal/errors"
+import { createSixbError, isSixbError } from "@sixb/core/internal/errors"
 import type { QueueDelivery, QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { isAbortError, QueueDeliveryLeaseLostError, QueueWorker } from "@sixb/core/internal/workers"
 import type { AgentQueueJob, ClaimedQueueJob } from "@sixb/core/queues"
-import type { AgentRunExecution, AgentRunFailureCode, AgentRunRecord } from "@sixb/core/storage"
+import type { AgentRunExecution, AgentRunRecord } from "@sixb/core/storage"
 import { AGENT_RUN_FAILURE_CODES, AgentStorageError } from "@sixb/core/storage"
 import { loadAgentSkills } from "./agent-skills"
 import { normalizeApiBaseUrl } from "./api-url"
 import { AgentExecutionLostError, AgentFinalizationError, AgentUsageRecordingError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
+import { type AgentRunFailure, toAgentExecutionFailure, toAgentRunFailure } from "./failure"
 import { finishRunOrThrow } from "./finalize"
 import {
   enqueueAiModelCallRecovery,
@@ -57,8 +58,6 @@ const MAX_AGENT_DELIVERY_ATTEMPTS = 10
 type Reservation =
   | { readonly kind: "run"; readonly run: AgentRunRecord }
   | { readonly kind: "skip" }
-
-type AgentRunFailure = SixbFailure<AgentRunFailureCode>
 
 /**
  * Cohosted worker that turns durable queued agent runs into executing turns.
@@ -184,7 +183,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
       const error = createSixbError(
         "internal.unexpected",
         `[SixbAgentWorker] Unknown agent '${queuedRun.agentId}'.`,
-        { details: { agentId: queuedRun.agentId, runId } }
+        { details: agentRunFailureDetails(queuedRun) }
       )
       if (queuedRun.status === "queued") {
         const completedAt = new Date()
@@ -192,9 +191,13 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
           createSixbError(
             "internal.unexpected",
             `[SixbAgentWorker] Agent '${queuedRun.agentId}' is not registered.`,
-            { details: { agentId: queuedRun.agentId, runId } }
+            { details: agentRunFailureDetails(queuedRun) }
           ),
-          { status: "failed", at: completedAt, run: queuedRun }
+          {
+            status: "failed",
+            at: completedAt,
+            details: agentRunFailureDetails(queuedRun),
+          }
         )
         const failed = await context.storage.agents.runs.finishQueued({
           projectId: context.id,
@@ -392,7 +395,11 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
     })
     if (run?.status === "queued") {
       const completedAt = new Date()
-      const failure = toAgentRunFailure(error, { status: "failed", at: completedAt, run })
+      const failure = toAgentRunFailure(error, {
+        status: "failed",
+        at: completedAt,
+        details: agentRunFailureDetails(run),
+      })
       const failed = await this.requireContext().storage.agents.runs.finishQueued({
         projectId: this.host.id,
         id: run.id,
@@ -626,7 +633,11 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
   ): Promise<{ readonly run: AgentRunRecord; readonly failure: AgentRunFailure } | undefined> {
     try {
       const completedAt = new Date()
-      const failure = toAgentRunFailure(error, { status, at: completedAt, run })
+      const failure = toAgentExecutionFailure(error, {
+        status,
+        at: completedAt,
+        details: agentRunFailureDetails(run),
+      })
       const finalized = await finishRunOrThrow(context.storage.agents, {
         projectId: context.id,
         id: run.id,
@@ -734,24 +745,10 @@ function aiUsageRecoveryBackoffMs(attempt: number): number {
   )
 }
 
-function toAgentRunFailure(
-  error: unknown,
-  input: {
-    readonly status: "failed" | "cancelled"
-    readonly at: Date
-    readonly run: Pick<AgentRunRecord, "id" | "agentId" | "threadId">
-  }
-) {
-  return captureSixbFailure(error, {
-    allowedCodes: AGENT_RUN_FAILURE_CODES,
-    defaultCode: input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
-    at: input.at,
-    details: {
-      agentId: input.run.agentId,
-      runId: input.run.id,
-      threadId: input.run.threadId,
-    },
-  })
+function agentRunFailureDetails(
+  run: Pick<AgentRunRecord, "id" | "agentId" | "threadId">
+): Readonly<Record<string, string>> {
+  return { agentId: run.agentId, runId: run.id, threadId: run.threadId }
 }
 
 function normalizeRequiredString(value: string | undefined): string {

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -4,12 +4,7 @@ import {
   resolveAgentExecutionAuthorization,
 } from "@sixb/core/internal/agents"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
-import {
-  captureSixbFailure,
-  createSixbError,
-  summarizeErrorMessage,
-  toSixbFailure,
-} from "@sixb/core/internal/errors"
+import { createSixbError, summarizeErrorMessage, toSixbFailure } from "@sixb/core/internal/errors"
 import type { QueueDelivery } from "@sixb/core/internal/workers"
 import { QueueDeliveryLeaseLostError } from "@sixb/core/internal/workers"
 import type { WorkflowAgentNodeDefinition } from "@sixb/core/internal/workflows"
@@ -31,6 +26,7 @@ import type {
 import { AGENT_RUN_FAILURE_CODES, WORKFLOW_RUN_FAILURE_CODES } from "@sixb/core/storage"
 import { AgentUsageRecordingError } from "./errors"
 import { createAgentExecutionContext } from "./execution-context"
+import { toAgentExecutionFailure } from "./failure"
 import { AiModelCallRecorder } from "./model-call-recorder"
 import {
   type AgentExecutionEnvironment,
@@ -464,12 +460,6 @@ async function finishWorkflowAgentNodeFailed(input: {
     allowedCodes: WORKFLOW_RUN_FAILURE_CODES,
     at,
   })
-  const agentFailure = captureSixbFailure(input.error, {
-    allowedCodes: AGENT_RUN_FAILURE_CODES,
-    defaultCode: input.status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
-    at,
-    details: workflowAgentErrorDetails(input.agent.id, input.nodeRun),
-  })
   return input.context.storage.transaction(async (tx) => {
     const runs = tx.workflowRuns
     if (!runs) {
@@ -485,7 +475,11 @@ async function finishWorkflowAgentNodeFailed(input: {
       executionToken: input.executionToken,
       status: input.status,
       modelId: input.agent.model.modelId,
-      error: agentFailure,
+      error: toAgentExecutionFailure(input.error, {
+        status: input.status,
+        at,
+        details: workflowAgentErrorDetails(input.agent.id, input.nodeRun),
+      }),
       completedAt: at,
     })
     const node = await runs.nodes.finish({

--- a/packages/agent-worker/tests/failure.test.ts
+++ b/packages/agent-worker/tests/failure.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import { createSixbError } from "@sixb/core/internal/errors"
+import { toAgentExecutionFailure } from "../src/failure"
+
+const at = new Date("2026-08-14T12:00:00.000Z")
+const details = {
+  agentId: "assistant",
+  runId: "agt_run_1",
+  threadId: "agt_thr_1",
+}
+
+describe("Agent execution failure", () => {
+  test("classifies native active-execution errors without exposing their message", () => {
+    const error = new Error("provider unavailable")
+
+    expect(toAgentExecutionFailure(error, { status: "failed", at, details })).toEqual({
+      code: "agent.execution_failed",
+      message: "Agent execution failed.",
+      retryable: false,
+      at: at.toISOString(),
+      details,
+    })
+  })
+
+  test("preserves coded internal invariants without exposing their message", () => {
+    const error = createSixbError("internal.unexpected", "Execution state is inconsistent.", {
+      details: { agentId: details.agentId, runId: details.runId },
+    })
+
+    expect(toAgentExecutionFailure(error, { status: "failed", at, details })).toEqual({
+      code: "internal.unexpected",
+      message: "An unexpected internal error occurred.",
+      retryable: false,
+      at: at.toISOString(),
+      details: { agentId: details.agentId, runId: details.runId },
+    })
+  })
+
+  test("keeps cancellation in the runtime vocabulary", () => {
+    expect(
+      toAgentExecutionFailure(new Error("Run cancelled."), {
+        status: "cancelled",
+        at,
+        details,
+      })
+    ).toEqual({
+      code: "runtime.cancelled",
+      message: "Execution was cancelled.",
+      retryable: false,
+      at: at.toISOString(),
+      details,
+    })
+  })
+})

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1815,13 +1815,14 @@ describe("AgentWorker", () => {
 
       expect(execution.status).toBe("failed")
       expect(execution.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
         retryable: false,
         details: {
           agentId: "workflow-usage-agent",
           workflowId: "workflow-usage-test",
           workflowRunId: "workflow-accounting-failure",
+          nodeId: "workflow-usage-step",
           nodeRunId,
         },
       })
@@ -1909,13 +1910,14 @@ describe("AgentWorker", () => {
 
       expect(execution.status).toBe("failed")
       expect(execution.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
         retryable: false,
         details: {
           agentId: "workflow-usage-agent",
           workflowId: "workflow-usage-test",
           workflowRunId: "workflow-final-callback-failure",
+          nodeId: "workflow-usage-step",
           nodeRunId,
         },
       })
@@ -1951,13 +1953,14 @@ describe("AgentWorker", () => {
 
       expect(execution.status).toBe("failed")
       expect(execution.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
         retryable: false,
         details: {
           agentId: "workflow-usage-agent",
           workflowId: "workflow-usage-test",
           workflowRunId: "workflow-finalization-failure",
+          nodeId: "workflow-usage-step",
           nodeRunId,
         },
       })
@@ -2191,8 +2194,8 @@ describe("AgentWorker", () => {
       ])
 
       expect(execution.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
         retryable: false,
         details: {
           agentId: agent.id,
@@ -3514,8 +3517,8 @@ describe("AgentWorker", () => {
 
       expect(run.status).toBe("failed")
       expect(run.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
         retryable: false,
         details: {
           agentId: "assistant",
@@ -3660,8 +3663,8 @@ describe("AgentWorker", () => {
 
       expect(run.status).toBe("failed")
       expect(run.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
         retryable: false,
         details: {
           agentId: "assistant",
@@ -5037,8 +5040,9 @@ describe("AgentWorker", () => {
       )
       expect(run.status).toBe("failed")
       expect(run.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
+        retryable: false,
         details: { agentId: "assistant", runId: run.id, threadId },
       })
       expect(run.error?.at).toBe(run.completedAt?.toISOString())
@@ -5107,7 +5111,12 @@ describe("AgentWorker", () => {
         { label: "run failed" }
       )
       expect(run.status).toBe("failed")
-      expect(run.error?.message).toBe("An unexpected internal error occurred.")
+      expect(run.error).toMatchObject({
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
+        retryable: false,
+        details: { agentId: "assistant", runId: run.id, threadId },
+      })
 
       // The turn threw before finalizing, so no assistant message was persisted.
       const messages = await listMessages(storage, threadId)
@@ -5329,7 +5338,12 @@ describe("AgentWorker", () => {
       )
 
       expect(run.status).toBe("failed")
-      expect(run.error?.message).toBe("An unexpected internal error occurred.")
+      expect(run.error).toMatchObject({
+        code: "agent.execution_failed",
+        message: "Agent execution failed.",
+        retryable: false,
+        details: { agentId: "assistant", runId: run.id, threadId },
+      })
       expect(
         (await listRunStreamRecords(sixb.broker, run.id)).find(
           (record) => record.name === "agent.run.finished"
@@ -5415,7 +5429,7 @@ describe("AgentWorker", () => {
           code: "internal.unexpected",
           retryable: false,
           message: "An unexpected internal error occurred.",
-          details: { agentId: "removed-agent", runId },
+          details: { agentId: "removed-agent", runId, threadId },
         },
       })
       await reporter.flush()
@@ -5424,7 +5438,7 @@ describe("AgentWorker", () => {
         code: "internal.unexpected",
         retryable: false,
         message: "[SixbAgentWorker] Unknown agent 'removed-agent'.",
-        details: { agentId: "removed-agent", runId },
+        details: { agentId: "removed-agent", runId, threadId },
       })
       expect(reports[0]?.context).toMatchObject({
         projectId: PROJECT_ID,

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -11205,7 +11205,11 @@
                       "properties": {
                         "code": {
                           "type": "string",
-                          "enum": ["internal.unexpected", "runtime.cancelled"]
+                          "enum": [
+                            "internal.unexpected",
+                            "runtime.cancelled",
+                            "agent.execution_failed"
+                          ]
                         },
                         "message": {
                           "type": "string",
@@ -19403,7 +19407,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "agent.execution_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -19953,7 +19961,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "agent.execution_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -20255,7 +20267,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "agent.execution_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -20579,7 +20595,11 @@
                             "properties": {
                               "code": {
                                 "type": "string",
-                                "enum": ["internal.unexpected", "runtime.cancelled"]
+                                "enum": [
+                                  "internal.unexpected",
+                                  "runtime.cancelled",
+                                  "agent.execution_failed"
+                                ]
                               },
                               "message": {
                                 "type": "string",
@@ -20854,7 +20874,11 @@
                       "properties": {
                         "code": {
                           "type": "string",
-                          "enum": ["internal.unexpected", "runtime.cancelled"]
+                          "enum": [
+                            "internal.unexpected",
+                            "runtime.cancelled",
+                            "agent.execution_failed"
+                          ]
                         },
                         "message": {
                           "type": "string",
@@ -25299,7 +25323,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -25457,7 +25485,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -25618,7 +25650,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -25824,7 +25860,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -25982,7 +26022,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -26143,7 +26187,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -26354,7 +26402,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -26512,7 +26564,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -26673,7 +26729,11 @@
                                     "properties": {
                                       "code": {
                                         "type": "string",
-                                        "enum": ["internal.unexpected", "runtime.cancelled"]
+                                        "enum": [
+                                          "internal.unexpected",
+                                          "runtime.cancelled",
+                                          "projection.execution_failed"
+                                        ]
                                       },
                                       "message": {
                                         "type": "string",
@@ -26928,7 +26988,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -27086,7 +27150,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -27247,7 +27315,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -27450,7 +27522,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -27608,7 +27684,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -27769,7 +27849,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -27977,7 +28061,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -28135,7 +28223,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -28296,7 +28388,11 @@
                                   "properties": {
                                     "code": {
                                       "type": "string",
-                                      "enum": ["internal.unexpected", "runtime.cancelled"]
+                                      "enum": [
+                                        "internal.unexpected",
+                                        "runtime.cancelled",
+                                        "projection.execution_failed"
+                                      ]
                                     },
                                     "message": {
                                       "type": "string",
@@ -28598,7 +28694,11 @@
                                 "properties": {
                                   "code": {
                                     "type": "string",
-                                    "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    "enum": [
+                                      "internal.unexpected",
+                                      "runtime.cancelled",
+                                      "projection.execution_failed"
+                                    ]
                                   },
                                   "message": {
                                     "type": "string",
@@ -28756,7 +28856,11 @@
                                 "properties": {
                                   "code": {
                                     "type": "string",
-                                    "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    "enum": [
+                                      "internal.unexpected",
+                                      "runtime.cancelled",
+                                      "projection.execution_failed"
+                                    ]
                                   },
                                   "message": {
                                     "type": "string",
@@ -28917,7 +29021,11 @@
                                 "properties": {
                                   "code": {
                                     "type": "string",
-                                    "enum": ["internal.unexpected", "runtime.cancelled"]
+                                    "enum": [
+                                      "internal.unexpected",
+                                      "runtime.cancelled",
+                                      "projection.execution_failed"
+                                    ]
                                   },
                                   "message": {
                                     "type": "string",
@@ -29151,7 +29259,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "projection.execution_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -29309,7 +29421,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "projection.execution_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",
@@ -29470,7 +29586,11 @@
                           "properties": {
                             "code": {
                               "type": "string",
-                              "enum": ["internal.unexpected", "runtime.cancelled"]
+                              "enum": [
+                                "internal.unexpected",
+                                "runtime.cancelled",
+                                "projection.execution_failed"
+                              ]
                             },
                             "message": {
                               "type": "string",

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -3959,7 +3959,7 @@ export type GetWorkflowAgentNodeExecutionResponses = {
     trace?: Array<unknown>
     diagnostics?: Array<unknown>
     error?: {
-      code: "internal.unexpected" | "runtime.cancelled"
+      code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
       message: string
       retryable: boolean
       at: string
@@ -6782,7 +6782,7 @@ export type PostAgentThreadMessageResponses = {
         message: string
       }>
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
         message: string
         retryable: boolean
         at: string
@@ -6993,7 +6993,7 @@ export type CancelAgentRunResponses = {
         message: string
       }>
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
         message: string
         retryable: boolean
         at: string
@@ -7107,7 +7107,7 @@ export type RetryAgentRunResponses = {
         message: string
       }>
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
         message: string
         retryable: boolean
         at: string
@@ -7219,7 +7219,7 @@ export type ListAgentThreadRunsResponses = {
         message: string
       }>
       error?: {
-        code: "internal.unexpected" | "runtime.cancelled"
+        code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
         message: string
         retryable: boolean
         at: string
@@ -7328,7 +7328,7 @@ export type GetAgentRunResponses = {
       message: string
     }>
     error?: {
-      code: "internal.unexpected" | "runtime.cancelled"
+      code: "internal.unexpected" | "runtime.cancelled" | "agent.execution_failed"
       message: string
       retryable: boolean
       at: string
@@ -8802,7 +8802,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -8849,7 +8849,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -8897,7 +8897,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -8956,7 +8956,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -9003,7 +9003,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -9051,7 +9051,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -9111,7 +9111,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -9158,7 +9158,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -9206,7 +9206,7 @@ export type ListProjectionsResponses = {
             startedAt: string
             finishedAt?: string
             error?: {
-              code: "internal.unexpected" | "runtime.cancelled"
+              code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
               message: string
               retryable: boolean
               at: string
@@ -9302,7 +9302,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9349,7 +9349,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9397,7 +9397,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9456,7 +9456,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9503,7 +9503,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9551,7 +9551,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9611,7 +9611,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9658,7 +9658,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9706,7 +9706,7 @@ export type GetProjectionResponses = {
               startedAt: string
               finishedAt?: string
               error?: {
-                code: "internal.unexpected" | "runtime.cancelled"
+                code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
                 message: string
                 retryable: boolean
                 at: string
@@ -9800,7 +9800,7 @@ export type ListProjectionRunsResponses = {
           startedAt: string
           finishedAt?: string
           error?: {
-            code: "internal.unexpected" | "runtime.cancelled"
+            code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
             message: string
             retryable: boolean
             at: string
@@ -9847,7 +9847,7 @@ export type ListProjectionRunsResponses = {
           startedAt: string
           finishedAt?: string
           error?: {
-            code: "internal.unexpected" | "runtime.cancelled"
+            code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
             message: string
             retryable: boolean
             at: string
@@ -9895,7 +9895,7 @@ export type ListProjectionRunsResponses = {
           startedAt: string
           finishedAt?: string
           error?: {
-            code: "internal.unexpected" | "runtime.cancelled"
+            code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
             message: string
             retryable: boolean
             at: string
@@ -9988,7 +9988,7 @@ export type GetProjectionRunResponses = {
         startedAt: string
         finishedAt?: string
         error?: {
-          code: "internal.unexpected" | "runtime.cancelled"
+          code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
           message: string
           retryable: boolean
           at: string
@@ -10035,7 +10035,7 @@ export type GetProjectionRunResponses = {
         startedAt: string
         finishedAt?: string
         error?: {
-          code: "internal.unexpected" | "runtime.cancelled"
+          code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
           message: string
           retryable: boolean
           at: string
@@ -10083,7 +10083,7 @@ export type GetProjectionRunResponses = {
         startedAt: string
         finishedAt?: string
         error?: {
-          code: "internal.unexpected" | "runtime.cancelled"
+          code: "internal.unexpected" | "runtime.cancelled" | "projection.execution_failed"
           message: string
           retryable: boolean
           at: string

--- a/packages/client/tests/agent-failure.types.ts
+++ b/packages/client/tests/agent-failure.types.ts
@@ -8,7 +8,9 @@ type ListedAgentRunFailureCode = NonNullable<ListedAgentRun["error"]>["code"]
 
 const unexpected: AgentRunFailureCode = "internal.unexpected"
 const cancelled: AgentRunFailureCode = "runtime.cancelled"
+const executionFailed: AgentRunFailureCode = "agent.execution_failed"
 const listedUnexpected: ListedAgentRunFailureCode = "internal.unexpected"
+const listedExecutionFailed: ListedAgentRunFailureCode = "agent.execution_failed"
 
 // Dataset lookup codes belong to HTTP route failures, not persisted agent-run failures.
 // @ts-expect-error the generated agent-run failure contract must stay scoped to its producer
@@ -16,4 +18,12 @@ const unrelatedRun: AgentRunFailureCode = "dataset.not_found"
 // @ts-expect-error the generated agent history contract must stay scoped to its producer
 const unrelatedListed: ListedAgentRunFailureCode = "dataset.not_found"
 
-void [unexpected, cancelled, listedUnexpected, unrelatedRun, unrelatedListed]
+void [
+  unexpected,
+  cancelled,
+  executionFailed,
+  listedUnexpected,
+  listedExecutionFailed,
+  unrelatedRun,
+  unrelatedListed,
+]

--- a/packages/client/tests/projection-failure.types.ts
+++ b/packages/client/tests/projection-failure.types.ts
@@ -19,8 +19,11 @@ type DetailedFailureCode = NonNullable<DetailedRun["error"]>["code"]
 
 const latestUnexpected: LatestFailureCode = "internal.unexpected"
 const projectionCancelled: ProjectionFailureCode = "runtime.cancelled"
+const projectionExecutionFailed: ProjectionFailureCode = "projection.execution_failed"
 const listedUnexpected: ListedFailureCode = "internal.unexpected"
+const listedExecutionFailed: ListedFailureCode = "projection.execution_failed"
 const detailedCancelled: DetailedFailureCode = "runtime.cancelled"
+const detailedExecutionFailed: DetailedFailureCode = "projection.execution_failed"
 
 // Dataset lookup codes belong to HTTP route failures, not persisted projection-run failures.
 // @ts-expect-error the generated projection failure contract must stay scoped to its producer
@@ -31,8 +34,11 @@ const unrelatedDetailed: DetailedFailureCode = "dataset.not_found"
 void [
   latestUnexpected,
   projectionCancelled,
+  projectionExecutionFailed,
   listedUnexpected,
+  listedExecutionFailed,
   detailedCancelled,
+  detailedExecutionFailed,
   unrelatedLatest,
   unrelatedDetailed,
 ]

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -14,6 +14,10 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "Action execution failed.",
     retryable: false,
   },
+  "agent.execution_failed": {
+    publicMessage: "Agent execution failed.",
+    retryable: false,
+  },
   "dataset.not_found": {
     publicMessage: "Dataset not found.",
     retryable: false,
@@ -48,6 +52,10 @@ export const SIXB_ERROR_DEFINITIONS = {
   },
   "projection.definition_invalid": {
     publicMessage: "Projection definition is invalid.",
+    retryable: false,
+  },
+  "projection.execution_failed": {
+    publicMessage: "Projection execution failed.",
     retryable: false,
   },
   "projection.not_found": {

--- a/packages/core/src/projections/types.ts
+++ b/packages/core/src/projections/types.ts
@@ -4,6 +4,7 @@ import type { SixbErrorCode } from "../errors/types"
 export const PROJECTION_RUN_FAILURE_CODES = [
   "internal.unexpected",
   "runtime.cancelled",
+  "projection.execution_failed",
 ] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
 
 export type ProjectionRunFailureCode = (typeof PROJECTION_RUN_FAILURE_CODES)[number]

--- a/packages/core/src/storage/agents/types.ts
+++ b/packages/core/src/storage/agents/types.ts
@@ -63,6 +63,7 @@ export type AgentRunStatus = AgentExecutionStatus
 export const AGENT_RUN_FAILURE_CODES = [
   "internal.unexpected",
   "runtime.cancelled",
+  "agent.execution_failed",
 ] as const satisfies readonly [SixbErrorCode, ...SixbErrorCode[]]
 
 export type AgentRunFailureCode = (typeof AGENT_RUN_FAILURE_CODES)[number]

--- a/packages/projection-worker/src/run-projection-job.ts
+++ b/packages/projection-worker/src/run-projection-job.ts
@@ -5,7 +5,12 @@ import {
   MaterializationValidationError,
   type ProjectionDefinition,
 } from "@sixb/core"
-import { captureSixbFailure, createSixbError, isSixbError } from "@sixb/core/internal/errors"
+import {
+  captureSixbFailure,
+  createSixbError,
+  isSixbError,
+  summarizeErrorMessage,
+} from "@sixb/core/internal/errors"
 import {
   MaterializationObjectNotFoundError,
   type ProjectionRunTerminalDecision,
@@ -226,17 +231,41 @@ function projectionFailure(
   readonly error: SixbFailure<ProjectionRunFailureCode>
 } {
   const finishedAt = new Date(input.now?.() ?? Date.now())
+  const failureError = status === "failed" ? translateProjectionExecutionError(input, error) : error
   return {
     protocol: input.job.protocol,
     status,
     finishedAt,
-    error: captureSixbFailure(error, {
+    error: captureSixbFailure(failureError, {
       allowedCodes: PROJECTION_RUN_FAILURE_CODES,
       defaultCode: status === "cancelled" ? "runtime.cancelled" : "internal.unexpected",
       details: { projectionId: input.job.projectionId, runId: input.job.id },
       at: finishedAt,
     }),
   }
+}
+
+function translateProjectionExecutionError(input: RunProjectionJobInput, error: unknown): unknown {
+  if (
+    isSixbError(error) &&
+    (error.code === "internal.unexpected" || error.code === "projection.execution_failed")
+  ) {
+    return error
+  }
+
+  return createSixbError(
+    "projection.execution_failed",
+    summarizeErrorMessage(error, "Projection execution failed."),
+    {
+      cause: error,
+      details: {
+        projectionId: input.job.projectionId,
+        runId: input.job.id,
+        datasetId: input.job.datasetVersion.datasetId,
+        versionId: input.job.datasetVersion.versionId,
+      },
+    }
+  )
 }
 
 type ProjectionSuccessfulCompletion =

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -2460,11 +2460,14 @@ describe("runProjectionJob", () => {
     expect(run?.progress.sourceRowsRead).toBe(1)
     expect(run?.progress.sourceRowsSkipped).toBe(0)
     expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
-      message: "An unexpected internal error occurred.",
+      code: "projection.execution_failed",
+      message: "Projection execution failed.",
+      retryable: false,
       details: {
         projectionId: "device-proj",
         runId: canonicalRunId("projrun-invalid-property"),
+        datasetId: devicesDataset.id,
+        versionId: version.versionId,
       },
     })
     expect(run?.error?.at).toBe(run?.finishedAt?.toISOString())
@@ -2483,6 +2486,70 @@ describe("runProjectionJob", () => {
         datasetId: devicesDataset.id,
         versionId: version.versionId,
         status: "failed",
+      },
+    })
+  })
+
+  test("preserves coded internal errors raised after the run is claimed", async () => {
+    const deps = createDeps()
+    const sixb = createSixb(
+      {
+        datasets: [roomsDataset],
+        projections: [roomProjection],
+      },
+      deps
+    )
+    const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
+      { room_id: "r1", room_name: "Kitchen", building_ref: null },
+    ])
+    const testRunId = "projrun-coded-invariant"
+    let invariant: unknown
+    deps.lakeStorage.readRows = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          next: async () => {
+            invariant = createSixbError(
+              "internal.unexpected",
+              "[SixbProjectionWorker] Projection execution state is inconsistent.",
+              {
+                details: {
+                  projectionId: roomProjection.id,
+                  runId: canonicalRunId(testRunId),
+                },
+              }
+            )
+            throw invariant
+          },
+        }
+      },
+    })
+
+    const caught = await runProjectionJob({
+      runtime: createRuntime(sixb),
+      job: {
+        id: testRunId,
+        projectionId: roomProjection.id,
+        projectionKind: "object",
+        datasetId: roomsDataset.id,
+        versionId: version.versionId,
+      },
+    }).catch((error: unknown) => error)
+
+    expect(caught).toBe(invariant)
+    const run = await deps.storage.projectionRuns.getById({
+      projectId: sixb.id,
+      id: canonicalRunId(testRunId),
+    })
+    expect(run).toMatchObject({
+      status: "failed",
+      error: {
+        code: "internal.unexpected",
+        retryable: false,
+        message: "An unexpected internal error occurred.",
+        details: {
+          projectionId: roomProjection.id,
+          runId: canonicalRunId(testRunId),
+        },
       },
     })
   })
@@ -2605,8 +2672,15 @@ describe("runProjectionJob", () => {
     expect(run?.progress.sourceRowsRead).toBe(1)
     expect(run?.progress.sourceRowsSkipped).toBe(0)
     expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
-      message: "An unexpected internal error occurred.",
+      code: "projection.execution_failed",
+      message: "Projection execution failed.",
+      retryable: false,
+      details: {
+        projectionId: deviceProjection.id,
+        runId: canonicalRunId("projrun-unsafe-int64-string"),
+        datasetId: devicesDataset.id,
+        versionId: version.versionId,
+      },
     })
   })
 
@@ -3162,8 +3236,15 @@ describe("runProjectionJob", () => {
     expect(run?.status).toBe("failed")
     expect(run?.progress.sourceRowsRead).toBe(0)
     expect(run?.error).toMatchObject({
-      code: "internal.unexpected",
-      message: "An unexpected internal error occurred.",
+      code: "projection.execution_failed",
+      message: "Projection execution failed.",
+      retryable: false,
+      details: {
+        projectionId: roomTargetProjection.id,
+        runId: canonicalRunId("projrun-target-bad-unit"),
+        datasetId: roomTargetsDataset.id,
+        versionId: version.versionId,
+      },
     })
 
     // The fixed physical batch is atomic: no prefix of it is committed.

--- a/packages/projection-worker/tests/worker.test.ts
+++ b/packages/projection-worker/tests/worker.test.ts
@@ -219,8 +219,15 @@ describe("ProjectionWorker", () => {
         (value) => value?.status === "failed"
       )
       expect(run?.error).toMatchObject({
-        code: "internal.unexpected",
-        message: "An unexpected internal error occurred.",
+        code: "projection.execution_failed",
+        message: "Projection execution failed.",
+        retryable: false,
+        details: {
+          projectionId: roomProjection.id,
+          runId,
+          datasetId: roomsDataset.id,
+          versionId: version.versionId,
+        },
       })
 
       await waitFor(


### PR DESCRIPTION
## Summary

- add the primitive-specific `agent.execution_failed` and `projection.execution_failed` failure codes
- classify only active Agent execution failures while keeping pre-start, invariant, and finalization failures `internal.unexpected`
- preserve Agent control-flow and sanitization classes, native errors for `onError`, and the existing retry policy
- classify only permanent post-claim Projection materialization failures while retaining pre-execution codes and transient retries
- attach durable run identities and cause chains, then regenerate the OpenAPI client and error-code reference

## Validation

- `bun test packages/agent-worker/tests/failure.test.ts packages/agent-worker/tests/worker.test.ts`
- `bun test packages/projection-worker/tests/run-projection-job.test.ts packages/projection-worker/tests/worker.test.ts`
- `bun test packages/core/tests/error-model.test.ts packages/core/tests/agents-storage.test.ts packages/core/tests/projection-runs.test.ts storage/sqlite/tests/sqlite-agent-storage.test.ts`
- `bun run generate:client`
- `bun run typecheck`
- `bun run check`
- `bun run build`