### PR TITLE
redis: prepare 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Sixb packages are versioned independently. Each release entry names the packages that shipped.
 
+## 2026-08-14
+
+### Redis subscription recovery
+
+- `@sixb/broker-redis` `0.1.2`: recover live subscriptions after a blocked `XREAD`
+  connection fails or stalls by replacing disposable subscription clients and resuming from the
+  last observed cursor.
+- Abort pending subscription client connections and reconnect attempts during unsubscribe or broker
+  shutdown so drains complete promptly.
+
+
 ## 2026-08-07
 
 ### Workspace dependency compatibility

--- a/broker/redis/package.json
+++ b/broker/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sixb/broker-redis",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Redis-backed event broker for Sixb",
   "keywords": [
     "sixb",

--- a/bun.lock
+++ b/bun.lock
@@ -77,7 +77,7 @@
     },
     "broker/redis": {
       "name": "@sixb/broker-redis",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@sixb/core": "workspace:*",
         "@types/bun": "latest",


### PR DESCRIPTION
## Summary

- release `@sixb/broker-redis` 0.1.2
- recover subscriptions after failed or stalled Redis `XREAD` calls
- abort pending reconnects during unsubscribe and broker shutdown

## Verification

- targeted connection and subscription-pump tests
- Redis broker E2E suite
- lint and typecheck
- unit test suite
- release build and package smoke tests