### PR TITLE
executions: normalize parent provenance

### DIFF
--- a/packages/action-worker/tests/worker.test.ts
+++ b/packages/action-worker/tests/worker.test.ts
@@ -216,7 +216,6 @@ describe("ActionWorker", () => {
       : null
     expect(durableExecution).toMatchObject({
       source: { type: "execution", executionId: sixb.execution.id },
-      parentExecutionId: sixb.execution.id,
       correlationId: sixb.execution.correlationId,
       authorizationRef: {
         type: "trustedPrimitive",

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -295,7 +295,10 @@ async function loadWorkflowAgentNodeExecution(
       }
     )
   }
-  if (durableExecution.parentExecutionId !== workflowRun.executionId) {
+  if (
+    durableExecution.source.type !== "execution" ||
+    durableExecution.source.executionId !== workflowRun.executionId
+  ) {
     throw createSixbError(
       "internal.unexpected",
       `[SixbAgentWorker] Agent workflow node '${nodeRun.id}' execution is not linked to workflow run '${workflowRun.id}'.`,

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1024,7 +1024,7 @@ async function queueWorkflowAgentNode(input: {
     projectId: PROJECT_ID,
     agentId: agent.id,
     runId: nodeRunId,
-    parentExecutionId: executionId,
+    sourceExecutionId: executionId,
   })
   await runs.agentNodes.create({
     projectId: PROJECT_ID,
@@ -1529,7 +1529,7 @@ describe("AgentWorker", () => {
       projectId: PROJECT_ID,
       agentId: agent.id,
       runId: nodeRunId,
-      parentExecutionId: executionId,
+      sourceExecutionId: executionId,
     })
     await runs.agentNodes.create({
       projectId: PROJECT_ID,
@@ -1595,7 +1595,7 @@ describe("AgentWorker", () => {
         sixb.storage.executions.getById({ projectId: PROJECT_ID, id: agentExecutionId })
       ).resolves.toMatchObject({
         requestedBy: REQUESTER,
-        parentExecutionId: executionId,
+        source: { type: "execution", executionId },
       })
       expect(recordedUsage.map((usage) => usage.usage)).toEqual([
         {
@@ -2153,7 +2153,7 @@ describe("AgentWorker", () => {
       projectId: PROJECT_ID,
       agentId: agent.id,
       runId: nodeRunId,
-      parentExecutionId: executionId,
+      sourceExecutionId: executionId,
     })
     await runs.agentNodes.create({
       projectId: PROJECT_ID,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -648,7 +648,6 @@ describe("startSixbRuntime", () => {
         source: { type: "schedule", eventId: sourceEvent.id },
         correlationId: sourceEvent.id,
       })
-      expect(workflowExecution?.parentExecutionId).toBeUndefined()
       expect(workflowExecution?.requestedBy).toBeUndefined()
 
       const workflowJobs = await sixb.queues.workflows.claim({

--- a/packages/core/src/execution/agent.ts
+++ b/packages/core/src/execution/agent.ts
@@ -31,7 +31,6 @@ export function createAgentExecutionRecord(input: {
     executor: { type: "agent", runId: input.runId },
     source: { type: "execution", executionId: input.parent.id },
     correlationId: input.parent.correlationId,
-    parentExecutionId: input.parent.id,
     authorizationRef: {
       type: "principal",
       principal: structuredClone(input.principal),
@@ -74,9 +73,6 @@ export function restoreAgentExecutionScope(input: {
     executor: Object.freeze({ type: "agent", agentId: input.agentId, runId: input.runId }),
     source: Object.freeze(structuredClone(input.execution.source)),
     correlationId: input.execution.correlationId,
-    ...(input.execution.parentExecutionId === undefined
-      ? {}
-      : { parentExecutionId: input.execution.parentExecutionId }),
   })
   return Object.freeze({
     execution: context,
@@ -102,7 +98,6 @@ export function assertAgentExecutionRecord(input: {
     input.execution.executor.type !== "agent" ||
     input.execution.executor.runId !== input.runId ||
     input.execution.source.type !== "execution" ||
-    input.execution.source.executionId !== input.execution.parentExecutionId ||
     authority.type !== "principal" ||
     authority.principal.type !== "serviceAccount" ||
     input.authorization.principal.type !== "serviceAccount" ||

--- a/packages/core/src/execution/durable.ts
+++ b/packages/core/src/execution/durable.ts
@@ -28,9 +28,6 @@ export function executionRecordInputFromRuntime(input: {
     executor: durableExecutor(execution),
     source: durableSource(execution),
     correlationId: execution.correlationId,
-    ...(execution.parentExecutionId === undefined
-      ? {}
-      : { parentExecutionId: execution.parentExecutionId }),
     authorizationRef: getAuthorizationRef(input.runtimeAuthorization),
   }
 }
@@ -93,7 +90,6 @@ export function createPrimitiveExecutionRecord(input: {
             : { requestedBy: structuredClone(input.origin.parent.requestedBy) }),
           source: { type: "execution" as const, executionId: input.origin.parent.id },
           correlationId: input.origin.parent.correlationId,
-          parentExecutionId: input.origin.parent.id,
         }
       : {
           projectId: input.origin.projectId,
@@ -131,9 +127,6 @@ export function restoreTrustedPrimitiveExecutionScope(input: {
     executor: Object.freeze({ type: "primitive", ...structuredClone(input.primitive) }),
     source: Object.freeze(structuredClone(input.execution.source)),
     correlationId: input.execution.correlationId,
-    ...(input.execution.parentExecutionId === undefined
-      ? {}
-      : { parentExecutionId: input.execution.parentExecutionId }),
   })
   return Object.freeze({
     execution: context,

--- a/packages/core/src/execution/primitive.ts
+++ b/packages/core/src/execution/primitive.ts
@@ -30,7 +30,6 @@ export interface BindPrimitiveExecutionInput {
   readonly source: ExecutionSource
   readonly requestedBy?: AuthorizablePrincipal
   readonly correlationId?: string
-  readonly parentExecutionId?: string
 }
 
 /** Bind the trusted authority of one claimed primitive run to the domain SDK. */
@@ -44,9 +43,6 @@ export function bindPrimitiveExecution(
     source: input.source,
     ...(input.requestedBy === undefined ? {} : { requestedBy: input.requestedBy }),
     ...(input.correlationId === undefined ? {} : { correlationId: input.correlationId }),
-    ...(input.parentExecutionId === undefined
-      ? {}
-      : { parentExecutionId: input.parentExecutionId }),
   })
   return bindPrimitiveScope(host, scope)
 }

--- a/packages/core/src/execution/scopes.ts
+++ b/packages/core/src/execution/scopes.ts
@@ -58,7 +58,6 @@ export function createTrustedPrimitiveScope(input: {
   readonly source: ExecutionSource
   readonly requestedBy?: AuthorizablePrincipal
   readonly correlationId?: string
-  readonly parentExecutionId?: string
 }): ExecutionScope {
   const execution = createInternalExecution({
     projectId: input.projectId,
@@ -71,7 +70,6 @@ export function createTrustedPrimitiveScope(input: {
     }),
     source: input.source,
     correlationId: input.correlationId,
-    parentExecutionId: input.parentExecutionId,
   })
   return Object.freeze({
     execution,
@@ -90,7 +88,6 @@ export function createAgentScope(input: {
   readonly source: ExecutionSource
   readonly requestedBy?: AuthorizablePrincipal
   readonly correlationId?: string
-  readonly parentExecutionId?: string
 }): ExecutionScope {
   if (input.context.principal.type !== "serviceAccount") {
     throw new Error("[Sixb] Agent execution authority must belong to a service account.")
@@ -103,7 +100,6 @@ export function createAgentScope(input: {
     executor: Object.freeze({ type: "agent", agentId: input.agentId, runId: input.runId }),
     source: input.source,
     correlationId: input.correlationId,
-    parentExecutionId: input.parentExecutionId,
   })
   return Object.freeze({
     execution,
@@ -142,10 +138,9 @@ function createInternalExecution(input: {
   readonly executor: Exclude<ExecutionContext["executor"], { readonly type: "request" }>
   readonly source: ExecutionSource
   readonly correlationId?: string
-  readonly parentExecutionId?: string
 }): ExecutionContext {
   const source = snapshotExecutionSource(input.source)
-  assertNestedProvenance(source, input.parentExecutionId, input.correlationId)
+  assertNestedProvenance(source, input.correlationId)
   return freezeExecution({
     id: `exec_${randomUUID()}`,
     projectId: input.projectId,
@@ -155,25 +150,12 @@ function createInternalExecution(input: {
     executor: input.executor,
     source,
     correlationId: input.correlationId ?? `corr_${randomUUID()}`,
-    ...(input.parentExecutionId === undefined
-      ? {}
-      : { parentExecutionId: input.parentExecutionId }),
   })
 }
 
-function assertNestedProvenance(
-  source: ExecutionSource,
-  parentExecutionId: string | undefined,
-  correlationId: string | undefined
-): void {
-  if (parentExecutionId !== undefined) {
-    assertNonEmpty(parentExecutionId, "Parent execution id")
-    if (correlationId === undefined) {
-      throw new Error("[Sixb] Nested execution must preserve its parent correlation id.")
-    }
-  }
-  if (source.type === "execution" && source.executionId !== parentExecutionId) {
-    throw new Error("[Sixb] Execution source must match the direct parent execution id.")
+function assertNestedProvenance(source: ExecutionSource, correlationId: string | undefined): void {
+  if (source.type === "execution" && correlationId === undefined) {
+    throw new Error("[Sixb] Nested execution must preserve its parent correlation id.")
   }
 }
 
@@ -236,9 +218,6 @@ function freezeExecution(execution: ExecutionContext): ExecutionContext {
   assertNonEmpty(execution.id, "Execution id")
   assertNonEmpty(execution.projectId, "Execution project id")
   assertNonEmpty(execution.correlationId, "Execution correlation id")
-  if (execution.parentExecutionId !== undefined) {
-    assertNonEmpty(execution.parentExecutionId, "Parent execution id")
-  }
   return Object.freeze(execution)
 }
 

--- a/packages/core/src/execution/types.ts
+++ b/packages/core/src/execution/types.ts
@@ -39,6 +39,7 @@ export type ExecutionExecutor =
 /**
  * Occurrence that directly triggered an execution.
  *
+ * An `execution` source is the single logical parent of a nested execution.
  * The `queue` source is transitional until workers restore durable execution authority.
  */
 export type ExecutionSource =
@@ -57,7 +58,6 @@ export interface ExecutionContext {
   readonly executor: ExecutionExecutor
   readonly source: ExecutionSource
   readonly correlationId: string
-  readonly parentExecutionId?: string
 }
 
 /** Durable descriptor used to rebuild authority. A reference is never authoritative by itself. */

--- a/packages/core/src/pipelines/run-dispatch.ts
+++ b/packages/core/src/pipelines/run-dispatch.ts
@@ -279,7 +279,6 @@ async function assertAutomaticExecutionIdentity(
     execution.source.type !== input.source.type ||
     execution.source.eventId !== input.source.eventId ||
     execution.correlationId !== input.correlationId ||
-    execution.parentExecutionId !== undefined ||
     execution.requestedBy !== undefined
   ) {
     throw new PipelineError(

--- a/packages/core/src/storage/executions/provider.ts
+++ b/packages/core/src/storage/executions/provider.ts
@@ -19,6 +19,7 @@ export interface ExecutionStorageRow {
   readonly requestedByUserId: string | null
   readonly requestedByServiceAccountId: string | null
   readonly correlationId: string
+  /** SQL-only projection of an execution source, used to enforce the parent foreign key. */
   readonly parentExecutionId: string | null
   readonly authorityKind: "disabled" | "kernel" | "principal" | "trustedPrimitive"
   readonly authorityUserId: string | null
@@ -44,7 +45,7 @@ export function executionRecordToStorageRow(record: ExecutionRecord): ExecutionS
     requestedByServiceAccountId:
       record.requestedBy?.type === "serviceAccount" ? record.requestedBy.id : null,
     correlationId: record.correlationId,
-    parentExecutionId: record.parentExecutionId ?? null,
+    parentExecutionId: record.source.type === "execution" ? record.source.executionId : null,
     ...authority,
     createdAt: new Date(record.createdAt),
   }
@@ -53,6 +54,7 @@ export function executionRecordToStorageRow(record: ExecutionRecord): ExecutionS
 export function executionRecordFromStorageRow(row: ExecutionStorageRow): ExecutionRecord {
   const executor = inflateExecutor(row)
   const source = inflateSource(row)
+  assertStoredParent(row, source)
   const authorizationRef = inflateAuthority(row)
   const requestedBy = row.requestedByUserId
     ? ({ type: "user", id: row.requestedByUserId } as const)
@@ -68,11 +70,22 @@ export function executionRecordFromStorageRow(row: ExecutionStorageRow): Executi
       executor,
       source,
       correlationId: row.correlationId,
-      ...(row.parentExecutionId === null ? {} : { parentExecutionId: row.parentExecutionId }),
       authorizationRef,
     },
     row.createdAt
   )
+}
+
+function assertStoredParent(
+  row: ExecutionStorageRow,
+  source: CreateExecutionInput["source"]
+): void {
+  const expected = source.type === "execution" ? source.executionId : null
+  if (row.parentExecutionId !== expected) {
+    throw new Error(
+      `[Sixb] Stored execution '${row.id}' has inconsistent parent execution provenance.`
+    )
+  }
 }
 
 function flattenExecutor(

--- a/packages/core/src/storage/executions/provider.ts
+++ b/packages/core/src/storage/executions/provider.ts
@@ -1,4 +1,5 @@
 import type { TrustedPrimitiveKind } from "../../execution/types"
+import { ExecutionStorageError } from "./errors"
 import type { CreateExecutionInput, ExecutionRecord } from "./types"
 import { normalizeExecutionRecord } from "./validation"
 
@@ -82,7 +83,8 @@ function assertStoredParent(
 ): void {
   const expected = source.type === "execution" ? source.executionId : null
   if (row.parentExecutionId !== expected) {
-    throw new Error(
+    throw new ExecutionStorageError(
+      "invalid_parent_execution",
       `[Sixb] Stored execution '${row.id}' has inconsistent parent execution provenance.`
     )
   }

--- a/packages/core/src/storage/executions/types.ts
+++ b/packages/core/src/storage/executions/types.ts
@@ -12,7 +12,10 @@ export type DurableExecutionExecutor =
   | { readonly type: "agent"; readonly runId: string }
   | { readonly type: "kernel"; readonly operation: KernelOperation }
 
-/** Durable trigger provenance. Queue delivery is attempt transport and is never persisted here. */
+/**
+ * Durable trigger provenance. An `execution` source is the single logical parent; queue delivery
+ * is attempt transport and is never persisted here.
+ */
 export type DurableExecutionSource =
   | { readonly type: "http"; readonly requestId: string }
   | { readonly type: "webhook"; readonly deliveryId: string }
@@ -28,7 +31,6 @@ export interface ExecutionRecord {
   readonly executor: DurableExecutionExecutor
   readonly source: DurableExecutionSource
   readonly correlationId: string
-  readonly parentExecutionId?: string
   readonly authorizationRef: AuthorizationRef
   readonly createdAt: Date
 }

--- a/packages/core/src/storage/executions/validation.ts
+++ b/packages/core/src/storage/executions/validation.ts
@@ -31,9 +31,6 @@ export function normalizeExecutionRecord(
     executor: structuredClone(input.executor),
     source: structuredClone(input.source),
     correlationId: input.correlationId,
-    ...(input.parentExecutionId === undefined
-      ? {}
-      : { parentExecutionId: input.parentExecutionId }),
     authorizationRef: structuredClone(input.authorizationRef),
     createdAt: new Date(createdAt),
   }
@@ -75,21 +72,10 @@ function assertRecordShape(record: ExecutionRecord): void {
   if (record.requestedBy) {
     assertPrincipal(record.requestedBy, "Requested-by principal")
   }
-  if (record.parentExecutionId !== undefined) {
-    assertNonBlank(record.parentExecutionId, "Parent execution id")
-  }
 
   assertExecutor(record.executor)
   assertSource(record.source)
   assertAuthorizationRef(record.authorizationRef)
-
-  if (record.source.type === "execution") {
-    if (record.parentExecutionId !== record.source.executionId) {
-      invalid("Execution source must match the direct parent execution id.")
-    }
-  } else if (record.parentExecutionId !== undefined) {
-    invalid("A parent execution requires an execution source.")
-  }
 }
 
 function assertExecutor(executor: DurableExecutionExecutor): void {
@@ -295,16 +281,17 @@ async function validateParent(
   record: ExecutionRecord,
   lookup: ExecutionValidationLookup
 ): Promise<void> {
-  if (!record.parentExecutionId) return
+  if (record.source.type !== "execution") return
+  const parentExecutionId = record.source.executionId
 
   const parent = await lookup.getExecution({
     projectId: record.projectId,
-    id: record.parentExecutionId,
+    id: parentExecutionId,
   })
   if (!parent) {
     throw new ExecutionStorageError(
       "missing_parent_execution",
-      `[Sixb] Parent execution '${record.parentExecutionId}' does not exist in project '${record.projectId}'.`
+      `[Sixb] Parent execution '${parentExecutionId}' does not exist in project '${record.projectId}'.`
     )
   }
   if (parent.correlationId !== record.correlationId) {

--- a/packages/core/src/storage/workflow-runs/in-memory.ts
+++ b/packages/core/src/storage/workflow-runs/in-memory.ts
@@ -629,7 +629,7 @@ export class InMemoryWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRun
       executionId: input.executionId,
       nodeRunId: input.nodeRunId,
       agentId: input.agentId,
-      parentExecutionId: workflowRun.executionId,
+      workflowExecutionId: workflowRun.executionId,
     })
     if (node.status !== "running") {
       throw new WorkflowRunError(

--- a/packages/core/src/storage/workflow-runs/provider.ts
+++ b/packages/core/src/storage/workflow-runs/provider.ts
@@ -43,7 +43,7 @@ export async function assertWorkflowAgentNodeRunExecution(input: {
   readonly executionId: string
   readonly nodeRunId: string
   readonly agentId: string
-  readonly parentExecutionId: string
+  readonly workflowExecutionId: string
 }): Promise<void> {
   const execution = await findAgentRunExecution({
     executions: input.executions,
@@ -52,7 +52,11 @@ export async function assertWorkflowAgentNodeRunExecution(input: {
     runId: input.nodeRunId,
     serviceAccountId: agentServiceAccountId(input.agentId),
   })
-  if (!execution || execution.parentExecutionId !== input.parentExecutionId) {
+  if (
+    !execution ||
+    execution.source.type !== "execution" ||
+    execution.source.executionId !== input.workflowExecutionId
+  ) {
     throw new WorkflowRunError(
       `[Sixb] Execution '${input.executionId}' does not authorize Workflow Agent-node run '${input.nodeRunId}'.`
     )

--- a/packages/core/src/syncs/run-dispatch.ts
+++ b/packages/core/src/syncs/run-dispatch.ts
@@ -283,7 +283,6 @@ async function assertAutomaticExecutionIdentity(
     execution.source.type !== input.source.type ||
     execution.source.eventId !== input.source.eventId ||
     execution.correlationId !== input.correlationId ||
-    execution.parentExecutionId !== undefined ||
     execution.requestedBy !== undefined
   ) {
     throw new SyncValidationError(

--- a/packages/core/src/testing/action-execution.ts
+++ b/packages/core/src/testing/action-execution.ts
@@ -40,7 +40,6 @@ export async function createTestActionExecution(
     executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
     source: { type: "execution", executionId: parentExecutionId },
     correlationId: `test_correlation:${input.runId}`,
-    parentExecutionId,
     authorizationRef: { type: "trustedPrimitive", primitive },
   })
 

--- a/packages/core/src/testing/agent-execution.ts
+++ b/packages/core/src/testing/agent-execution.ts
@@ -11,7 +11,7 @@ export async function createTestAgentExecution(
     readonly agentId: string
     readonly runId: string
     readonly executionId?: string
-    readonly parentExecutionId?: string
+    readonly sourceExecutionId?: string
   }
 ): Promise<string> {
   const auth = storage.auth
@@ -41,7 +41,7 @@ export async function createTestAgentExecution(
     }
   }
 
-  const parentExecutionId = input.parentExecutionId ?? `test_request_execution:${input.runId}`
+  const sourceExecutionId = input.sourceExecutionId ?? `test_request_execution:${input.runId}`
   const executionId = input.executionId ?? `test_agent_execution:${input.runId}`
   const existing = await storage.executions.getById({
     projectId: input.projectId,
@@ -51,11 +51,11 @@ export async function createTestAgentExecution(
 
   let parent = await storage.executions.getById({
     projectId: input.projectId,
-    id: parentExecutionId,
+    id: sourceExecutionId,
   })
   if (!parent) {
     parent = await storage.executions.create({
-      id: parentExecutionId,
+      id: sourceExecutionId,
       projectId: input.projectId,
       executor: { type: "request", requestId: `test_request:${input.runId}` },
       source: { type: "http", requestId: `test_request:${input.runId}` },
@@ -67,7 +67,7 @@ export async function createTestAgentExecution(
     id: executionId,
     projectId: input.projectId,
     executor: { type: "agent", runId: input.runId },
-    source: { type: "execution", executionId: parentExecutionId },
+    source: { type: "execution", executionId: sourceExecutionId },
     ...(parent.requestedBy === undefined
       ? {}
       : { requestedBy: structuredClone(parent.requestedBy) }),

--- a/packages/core/src/testing/agent-execution.ts
+++ b/packages/core/src/testing/agent-execution.ts
@@ -72,7 +72,6 @@ export async function createTestAgentExecution(
       ? {}
       : { requestedBy: structuredClone(parent.requestedBy) }),
     correlationId: parent.correlationId,
-    parentExecutionId,
     authorizationRef: {
       type: "principal",
       principal: { type: "serviceAccount", id: serviceAccountId },

--- a/packages/core/src/testing/execution-storage-contract.ts
+++ b/packages/core/src/testing/execution-storage-contract.ts
@@ -212,25 +212,24 @@ export function runExecutionStorageContractSuite<TStorage extends ExecutionStora
         await storage.executions.create(principalRequest({ id: "parent" }))
 
         const validChild = trustedPrimitive("valid-child", {
-          parentExecutionId: "parent",
           correlationId: "correlation-parent",
           source: { type: "execution", executionId: "parent" },
         })
-        await expect(storage.executions.create(validChild)).resolves.toMatchObject({
-          parentExecutionId: "parent",
+        const storedChild = await storage.executions.create(validChild)
+        expect(storedChild).toMatchObject({
+          source: { type: "execution", executionId: "parent" },
         })
+        expect(storedChild).not.toHaveProperty("parentExecutionId")
 
         const invalidChildren: readonly [CreateExecutionInput, string][] = [
           [
             trustedPrimitive("missing-parent", {
-              parentExecutionId: "unknown-parent",
               source: { type: "execution", executionId: "unknown-parent" },
             }),
             "missing_parent_execution",
           ],
           [
             trustedPrimitive("wrong-correlation", {
-              parentExecutionId: "parent",
               correlationId: "different-correlation",
               source: { type: "execution", executionId: "parent" },
             }),
@@ -238,7 +237,6 @@ export function runExecutionStorageContractSuite<TStorage extends ExecutionStora
           ],
           [
             trustedPrimitive("wrong-requester", {
-              parentExecutionId: "parent",
               requestedBy: { type: "user", id: "user-other" },
               source: { type: "execution", executionId: "parent" },
             }),
@@ -360,9 +358,7 @@ function disabledRequest(id: string, inputProjectId = projectId): CreateExecutio
 
 function trustedPrimitive(
   id: string,
-  overrides: Partial<
-    Pick<CreateExecutionInput, "correlationId" | "parentExecutionId" | "requestedBy" | "source">
-  > = {},
+  overrides: Partial<Pick<CreateExecutionInput, "correlationId" | "requestedBy" | "source">> = {},
   kind: TrustedPrimitiveKind = "action"
 ): CreateExecutionInput {
   const runId = `run-${id}`

--- a/packages/core/src/testing/workflow-execution.ts
+++ b/packages/core/src/testing/workflow-execution.ts
@@ -39,7 +39,6 @@ export async function createTestWorkflowExecution(
     source: { type: "execution", executionId: parentExecutionId },
     ...(input.requestedBy === undefined ? {} : { requestedBy: structuredClone(input.requestedBy) }),
     correlationId: `test_correlation:${input.runId}`,
-    parentExecutionId,
     authorizationRef: { type: "trustedPrimitive", primitive },
   })
 

--- a/packages/core/src/workflows/run-dispatch.ts
+++ b/packages/core/src/workflows/run-dispatch.ts
@@ -346,7 +346,6 @@ async function assertAutomaticExecutionIdentity(
     execution.source.type !== input.source.type ||
     execution.source.eventId !== input.source.eventId ||
     execution.correlationId !== input.correlationId ||
-    execution.parentExecutionId !== undefined ||
     execution.requestedBy !== undefined
   ) {
     throw new WorkflowValidationError(

--- a/packages/core/tests/actions.test.ts
+++ b/packages/core/tests/actions.test.ts
@@ -700,7 +700,6 @@ describe("requestAction", () => {
       executor: { type: "primitive", kind: "action", runId: result.runId },
       source: { type: "execution", executionId: sixb.execution.id },
       correlationId: sixb.execution.correlationId,
-      parentExecutionId: sixb.execution.id,
       authorizationRef: {
         type: "trustedPrimitive",
         primitive: { kind: "action", id: "counted", runId: result.runId },

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -178,7 +178,6 @@ describe("execution scope factories", () => {
       source: { type: "queue", queue: "actions", jobId: "job-1" },
       requestedBy: { type: "user", id: "user-1" },
       correlationId: "correlation-1",
-      parentExecutionId: "execution-parent",
     })
 
     expect(scope.execution).toMatchObject({
@@ -191,7 +190,6 @@ describe("execution scope factories", () => {
       source: { type: "queue", queue: "actions", jobId: "job-1" },
       requestedBy: { type: "user", id: "user-1" },
       correlationId: "correlation-1",
-      parentExecutionId: "execution-parent",
     })
     expect(getAuthorizationRef(scope.authorization)).toEqual({
       type: "trustedPrimitive",
@@ -223,7 +221,6 @@ describe("execution scope factories", () => {
       source: { type: "execution", executionId: parent.execution.id },
       requestedBy: { type: "user", id: "user-1" },
       correlationId: parent.execution.correlationId,
-      parentExecutionId: parent.execution.id,
     })
 
     expect(scope.execution.executor).toEqual({
@@ -232,7 +229,10 @@ describe("execution scope factories", () => {
       runId: "agent-run-1",
     })
     expect(scope.execution.requestedBy).toEqual({ type: "user", id: "user-1" })
-    expect(scope.execution.parentExecutionId).toBe(parent.execution.id)
+    expect(scope.execution.source).toEqual({
+      type: "execution",
+      executionId: parent.execution.id,
+    })
     expect(scope.execution.correlationId).toBe(parent.execution.correlationId)
     expect(getAuthorizationRef(scope.authorization)).toEqual({
       type: "principal",
@@ -276,7 +276,7 @@ describe("execution scope factories", () => {
     })
   })
 
-  test("rejects incomplete or contradictory nested provenance", () => {
+  test("requires nested scopes to preserve a parent correlation id", () => {
     const primitive = { kind: "workflow", id: "onboarding", runId: "workflow-run-1" } as const
 
     expect(() =>
@@ -284,26 +284,15 @@ describe("execution scope factories", () => {
         projectId: "project-1",
         primitive,
         source: { type: "execution", executionId: "execution-parent" },
-        correlationId: "correlation-1",
       })
-    ).toThrow("Execution source must match the direct parent execution id")
-    expect(() =>
-      createTrustedPrimitiveScope({
-        projectId: "project-1",
-        primitive,
-        source: { type: "execution", executionId: "execution-other" },
-        correlationId: "correlation-1",
-        parentExecutionId: "execution-parent",
-      })
-    ).toThrow("Execution source must match the direct parent execution id")
-    expect(() =>
+    ).toThrow("Nested execution must preserve its parent correlation id")
+    expect(
       createTrustedPrimitiveScope({
         projectId: "project-1",
         primitive,
         source: { type: "queue", queue: "workflows", jobId: "job-1" },
-        parentExecutionId: "execution-parent",
       })
-    ).toThrow("Nested execution must preserve its parent correlation id")
+    ).toMatchObject({ execution: { source: { type: "queue", jobId: "job-1" } } })
   })
 })
 

--- a/packages/core/tests/execution-storage-contract.test.ts
+++ b/packages/core/tests/execution-storage-contract.test.ts
@@ -1,6 +1,40 @@
-import { InMemoryStorage } from "@sixb/core"
+import { describe, expect, test } from "bun:test"
+import { type ExecutionRecord, InMemoryStorage } from "@sixb/core"
+import { ExecutionStorageError } from "../src/storage/executions"
+import {
+  executionRecordFromStorageRow,
+  executionRecordToStorageRow,
+} from "../src/storage/executions/provider"
 import { runExecutionStorageContractSuite } from "../src/testing"
 
 runExecutionStorageContractSuite("InMemoryStorage execution ledger", {
   createStorage: () => new InMemoryStorage(),
+})
+
+describe("execution SQL mapping", () => {
+  test("rejects a parent column that contradicts the durable source", () => {
+    const execution: ExecutionRecord = {
+      id: "child",
+      projectId: "project-1",
+      executor: { type: "primitive", kind: "workflow", runId: "run-1" },
+      source: { type: "execution", executionId: "parent" },
+      correlationId: "correlation-1",
+      authorizationRef: {
+        type: "trustedPrimitive",
+        primitive: { kind: "workflow", id: "workflow-1", runId: "run-1" },
+      },
+      createdAt: new Date("2026-08-21T12:00:00.000Z"),
+    }
+    const row = executionRecordToStorageRow(execution)
+
+    let thrown: unknown
+    try {
+      executionRecordFromStorageRow({ ...row, parentExecutionId: "other-parent" })
+    } catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(ExecutionStorageError)
+    expect(thrown).toMatchObject({ code: "invalid_parent_execution" })
+  })
 })

--- a/packages/core/tests/workflow-request.test.ts
+++ b/packages/core/tests/workflow-request.test.ts
@@ -92,7 +92,6 @@ describe("sixb.workflows.request", () => {
     expect(execution).toMatchObject({
       executor: { type: "primitive", kind: "workflow", runId: result.runId },
       source: { type: "execution", executionId: sixb.execution.id },
-      parentExecutionId: sixb.execution.id,
       authorizationRef: {
         type: "trustedPrimitive",
         primitive: { kind: "workflow", id: "draft-invoice", runId: result.runId },
@@ -394,7 +393,6 @@ describe("automatic workflow dispatch", () => {
         primitive: { kind: "workflow", id: draftInvoice.id, runId: result.runId },
       },
     })
-    expect(execution?.parentExecutionId).toBeUndefined()
     expect(execution?.requestedBy).toBeUndefined()
 
     const [claimed] = await claimAll(host)

--- a/packages/core/tests/workflow-runs.test.ts
+++ b/packages/core/tests/workflow-runs.test.ts
@@ -836,7 +836,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       agentId: "resolver",
       runId: "wf-run-agent:node:0",
       executionId: "test_agent_execution:wrong-parent",
-      parentExecutionId: "unrelated-workflow-execution",
+      sourceExecutionId: "unrelated-workflow-execution",
     })
     await expect(
       storage.agentNodes.create({
@@ -851,7 +851,7 @@ describe("InMemoryWorkflowRunStorage", () => {
       projectId: "my-app",
       agentId: "resolver",
       runId: "wf-run-agent:node:0",
-      parentExecutionId: workflowRun.executionId,
+      sourceExecutionId: workflowRun.executionId,
     })
     const execution = await storage.agentNodes.create({
       projectId: "my-app",

--- a/packages/server/tests/agent-api-gateway.test.ts
+++ b/packages/server/tests/agent-api-gateway.test.ts
@@ -503,7 +503,7 @@ async function createGatewayRuntime(
       projectId: PROJECT_ID,
       agentId: "assistant",
       runId,
-      parentExecutionId: parentWorkflowExecutionId,
+      sourceExecutionId: parentWorkflowExecutionId,
     })
     await storage.workflowRuns.agentNodes.create({
       projectId: PROJECT_ID,

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -1966,7 +1966,7 @@ describe("SixbServer HTTP contract", () => {
           projectId: sixb.id,
           agentId: "device-resolver",
           runId: nodeRunId,
-          parentExecutionId: workflowExecutionId,
+          sourceExecutionId: workflowExecutionId,
         })
         executionIds.push(executionId)
         await runs.agentNodes.create({
@@ -2056,7 +2056,7 @@ describe("SixbServer HTTP contract", () => {
         projectId: sixb.id,
         agentId: "device-resolver",
         runId: nodeRunId,
-        parentExecutionId: workflowExecutionId,
+        sourceExecutionId: workflowExecutionId,
       })
       await runs.agentNodes.create({
         projectId: sixb.id,

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -2413,8 +2413,7 @@ describe("SixbServer HTTP contract", () => {
       expect(durableSyncRun).toMatchObject({ status: "queued", startedAt: undefined })
       expect(durableSyncExecution).toMatchObject({
         executor: { type: "primitive", kind: "sync", runId: requestSyncRunBody.runId },
-        source: { type: "execution" },
-        parentExecutionId: expect.any(String),
+        source: { type: "execution", executionId: expect.any(String) },
         authorizationRef: {
           type: "trustedPrimitive",
           primitive: {
@@ -2458,8 +2457,7 @@ describe("SixbServer HTTP contract", () => {
       expect(durablePipelineRun).toMatchObject({ status: "queued", startedAt: undefined })
       expect(durablePipelineExecution).toMatchObject({
         executor: { type: "primitive", kind: "pipeline", runId: requestPipelineRunBody.runId },
-        source: { type: "execution" },
-        parentExecutionId: expect.any(String),
+        source: { type: "execution", executionId: expect.any(String) },
         authorizationRef: {
           type: "trustedPrimitive",
           primitive: {

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -1514,7 +1514,6 @@ describe("runWorkflowJob", () => {
       expect(actionExecution).toMatchObject({
         executor: { type: "primitive", kind: "action", runId: "wfrun_action:action:1" },
         source: { type: "execution", executionId: result.run.executionId },
-        parentExecutionId: result.run.executionId,
         correlationId: workflowExecution?.correlationId,
         authorizationRef: {
           type: "trustedPrimitive",

--- a/storage/pg/src/pg-workflow-run-storage.ts
+++ b/storage/pg/src/pg-workflow-run-storage.ts
@@ -408,7 +408,7 @@ export class PgWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRunStorag
       executionId: input.executionId,
       nodeRunId: input.nodeRunId,
       agentId: input.agentId,
-      parentExecutionId: parent.execution_id,
+      workflowExecutionId: parent.execution_id,
     })
 
     try {

--- a/storage/pg/tests/pg-workflow-run-storage.e2e.ts
+++ b/storage/pg/tests/pg-workflow-run-storage.e2e.ts
@@ -657,7 +657,7 @@ describe("PgWorkflowRunStorage", () => {
       agentId: "resolver-agent",
       runId: "wf-run-agent:node:0",
       executionId: "test_agent_execution:wrong-parent",
-      parentExecutionId: "unrelated-workflow-execution",
+      sourceExecutionId: "unrelated-workflow-execution",
     })
     await expect(
       storage.workflowRuns.agentNodes.create({
@@ -672,7 +672,7 @@ describe("PgWorkflowRunStorage", () => {
       projectId: "my-app",
       agentId: "resolver-agent",
       runId: "wf-run-agent:node:0",
-      parentExecutionId: workflowRun.executionId,
+      sourceExecutionId: workflowRun.executionId,
     })
     await storage.workflowRuns.agentNodes.create({
       projectId: "my-app",

--- a/storage/sqlite/src/workflow-run-storage.ts
+++ b/storage/sqlite/src/workflow-run-storage.ts
@@ -492,7 +492,7 @@ export class SqliteWorkflowAgentNodeRunStorage implements WorkflowAgentNodeRunSt
       executionId: input.executionId,
       nodeRunId: input.nodeRunId,
       agentId: input.agentId,
-      parentExecutionId: parent.execution_id,
+      workflowExecutionId: parent.execution_id,
     })
 
     try {

--- a/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-workflow-run-storage.test.ts
@@ -611,7 +611,7 @@ describe("SqliteWorkflowRunStorage", () => {
       agentId: "resolver-agent",
       runId: "wf-run-agent:node:0",
       executionId: "test_agent_execution:wrong-parent",
-      parentExecutionId: "unrelated-workflow-execution",
+      sourceExecutionId: "unrelated-workflow-execution",
     })
     await expect(
       storage.agentNodes.create({
@@ -626,7 +626,7 @@ describe("SqliteWorkflowRunStorage", () => {
       projectId: "my-app",
       agentId: "resolver-agent",
       runId: "wf-run-agent:node:0",
-      parentExecutionId: workflowRun.executionId,
+      sourceExecutionId: workflowRun.executionId,
     })
     await storage.agentNodes.create({
       projectId: "my-app",


### PR DESCRIPTION
## Why

A child execution stored the same identifier twice:

```ts
source: { type: "execution", executionId: "exec_parent" }
parentExecutionId: "exec_parent"
```

Core and the providers already required these values to be identical. This duplication therefore
made it possible to construct contradictory inputs without providing any additional information.

## What changes

```text
Before                             After
source.executionId ─┐              source.executionId
                    ├─ parent             │
parentExecutionId ──┘                     └─ single logical parent
```

- `source.executionId` becomes the sole parent in `ExecutionContext` and `ExecutionRecord`.
- `parentExecutionId` is removed from Core contracts and creation inputs.
- Correlation and `requestedBy` validation load the parent from the source.
- Workflow/Agent links also validate this single source.
- Provider contracts verify that returned records no longer expose the duplicated field.

## SQL integrity preserved

The PostgreSQL and SQLite providers continue to derive their internal `parent_execution_id` column
from `source.executionId`:

```text
source.executionId
  ├─ source_id
  └─ parent_execution_id → FK executions(project_id, id)
```

The foreign key and existing constraints therefore remain in place. No schema changes or
migrations are required.

## Out of scope

- No changes to authorization or correlation propagation.
- No changes to the run lifecycle.
- No Projection changes: this normalization prepares the next slice.

## Stack

```text
#397 Sync + Pipeline execution linkage
  └─ this PR: provenance normalization
       └─ next PR: Projection execution linkage
```

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run build`
- `bun run test:ci` — 3,768 tests passed, 7 infrastructure tests skipped

Part of #183.
