### PR TITLE
executions: restore durable queue authority

### DIFF
--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -18,7 +18,7 @@ import {
 } from "@sixb/core"
 import { findActionEditCommit } from "@sixb/core/internal/actions"
 import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
-import { bindPrimitiveExecution } from "@sixb/core/internal/primitive-execution"
+import { bindDurablePrimitiveExecution } from "@sixb/core/internal/primitive-execution"
 import type { ActionRunParams, ActionRunRecord } from "@sixb/core/storage"
 import { createTestSixb, queueTestActionRun } from "@sixb/core/testing"
 import { runActionJob } from "../src/run-action-job"
@@ -72,13 +72,22 @@ function createSixb(
 }
 
 function createContext(host: ActionWorkerHost): ActionWorkerContext {
-  const execution = bindPrimitiveExecution(host, {
-    primitive: {
-      kind: "action",
-      id: host.definitions.actions.list()[0]?.id ?? "test-action",
-      runId: "direct-action-job-test",
+  const primitive = {
+    kind: "action" as const,
+    id: host.definitions.actions.list()[0]?.id ?? "test-action",
+    runId: "direct-action-job-test",
+  }
+  const execution = bindDurablePrimitiveExecution(host, {
+    execution: {
+      id: "direct-action-execution-test",
+      projectId: host.id,
+      executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+      source: { type: "event", eventId: "direct-action-event-test" },
+      correlationId: "direct-action-correlation-test",
+      authorizationRef: { type: "trustedPrimitive", primitive },
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
     },
-    source: { type: "queue", queue: "actions", jobId: "direct-action-job-test" },
+    primitive,
   })
   return {
     id: host.id,

--- a/packages/agent-worker/src/workflow-node-execution.ts
+++ b/packages/agent-worker/src/workflow-node-execution.ts
@@ -592,7 +592,7 @@ export async function enqueueWorkflowAgentNodeResume(
         type: "workflow.run.resume.requested",
         payload: {
           runId: node.workflowRunId,
-          resume: { kind: "agentNode", nodeRunId: node.id },
+          nodeRunId: node.id,
         },
       },
     ],

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1668,7 +1668,7 @@ describe("AgentWorker", () => {
         type: "workflow.run.resume.requested",
         payload: {
           runId,
-          resume: { kind: "agentNode", nodeRunId },
+          nodeRunId,
         },
       })
     } finally {

--- a/packages/core/src/execution/agent.ts
+++ b/packages/core/src/execution/agent.ts
@@ -69,7 +69,7 @@ export function restoreAgentExecutionScope(input: {
     projectId: input.execution.projectId,
     ...(input.execution.requestedBy === undefined
       ? {}
-      : { requestedBy: structuredClone(input.execution.requestedBy) }),
+      : { requestedBy: Object.freeze(structuredClone(input.execution.requestedBy)) }),
     executor: Object.freeze({ type: "agent", agentId: input.agentId, runId: input.runId }),
     source: Object.freeze(structuredClone(input.execution.source)),
     correlationId: input.execution.correlationId,

--- a/packages/core/src/execution/durable.ts
+++ b/packages/core/src/execution/durable.ts
@@ -26,7 +26,7 @@ export function executionRecordInputFromRuntime(input: {
       ? {}
       : { requestedBy: structuredClone(execution.requestedBy) }),
     executor: durableExecutor(execution),
-    source: durableSource(execution),
+    source: structuredClone(execution.source),
     correlationId: execution.correlationId,
     authorizationRef: getAuthorizationRef(input.runtimeAuthorization),
   }
@@ -127,7 +127,7 @@ export function restoreTrustedPrimitiveExecutionScope(input: {
     projectId: input.execution.projectId,
     ...(input.execution.requestedBy === undefined
       ? {}
-      : { requestedBy: structuredClone(input.execution.requestedBy) }),
+      : { requestedBy: Object.freeze(structuredClone(input.execution.requestedBy)) }),
     executor: Object.freeze({ type: "primitive", ...structuredClone(input.primitive) }),
     source: Object.freeze(structuredClone(input.execution.source)),
     correlationId: input.execution.correlationId,
@@ -156,16 +156,6 @@ function durableExecutor(execution: ExecutionContext): CreateExecutionInput["exe
     case "kernel":
       return { type: "kernel", operation: structuredClone(execution.executor.operation) }
   }
-}
-
-function durableSource(execution: ExecutionContext): CreateExecutionInput["source"] {
-  if (execution.source.type === "queue") {
-    throw new ExecutionStorageError(
-      "invalid_input",
-      `[Sixb] Execution '${execution.id}' has a transient queue source and cannot be persisted.`
-    )
-  }
-  return structuredClone(execution.source)
 }
 
 function assertExecutionRecordMatches(

--- a/packages/core/src/execution/primitive.ts
+++ b/packages/core/src/execution/primitive.ts
@@ -5,13 +5,7 @@ import { getOntologyMutationRuntime } from "../runtime/ontology-mutations"
 import { isBoundSixb, type Sixb } from "../runtime/sixb"
 import type { ExecutionRecord } from "../storage/executions"
 import { restoreTrustedPrimitiveExecutionScope } from "./durable"
-import { createTrustedPrimitiveScope } from "./scopes"
-import type {
-  AuthorizablePrincipal,
-  ExecutionScope,
-  ExecutionSource,
-  TrustedPrimitiveRef,
-} from "./types"
+import type { ExecutionScope, TrustedPrimitiveRef } from "./types"
 
 /** Minimal host boundary required by trusted primitive workers. */
 export interface PrimitiveExecutionHost {
@@ -23,28 +17,6 @@ export interface BoundPrimitiveExecution {
   readonly sixb: Sixb<readonly OntologySource[]>
   /** Internal mutation port guarded by the same runtime authority as `sixb`. */
   readonly ontologyMutations: OntologyMutationRuntime
-}
-
-export interface BindPrimitiveExecutionInput {
-  readonly primitive: TrustedPrimitiveRef
-  readonly source: ExecutionSource
-  readonly requestedBy?: AuthorizablePrincipal
-  readonly correlationId?: string
-}
-
-/** Bind the trusted authority of one claimed primitive run to the domain SDK. */
-export function bindPrimitiveExecution(
-  host: PrimitiveExecutionHost,
-  input: BindPrimitiveExecutionInput
-): BoundPrimitiveExecution {
-  const scope = createTrustedPrimitiveScope({
-    projectId: host.id,
-    primitive: input.primitive,
-    source: input.source,
-    ...(input.requestedBy === undefined ? {} : { requestedBy: input.requestedBy }),
-    ...(input.correlationId === undefined ? {} : { correlationId: input.correlationId }),
-  })
-  return bindPrimitiveScope(host, scope)
 }
 
 /** Bind a worker to the immutable execution already owned by its durable primitive run. */

--- a/packages/core/src/execution/scopes.ts
+++ b/packages/core/src/execution/scopes.ts
@@ -1,11 +1,9 @@
 import { randomUUID } from "node:crypto"
 import type { AuthorizationContext } from "../authorization"
 import {
-  createAgentRuntimeAuthorization,
   createDisabledRuntimeAuthorization,
   createKernelRuntimeAuthorization,
   createPrincipalRuntimeAuthorization,
-  createTrustedPrimitiveRuntimeAuthorization,
 } from "./authorization"
 import type {
   AuthorizablePrincipal,
@@ -14,7 +12,6 @@ import type {
   ExecutionScope,
   ExecutionSource,
   KernelOperation,
-  TrustedPrimitiveRef,
 } from "./types"
 
 export function createPrincipalRequestScope(input: {
@@ -52,67 +49,6 @@ export function createDisabledRequestScope(input: {
   })
 }
 
-export function createTrustedPrimitiveScope(input: {
-  readonly projectId: string
-  readonly primitive: TrustedPrimitiveRef
-  readonly source: ExecutionSource
-  readonly requestedBy?: AuthorizablePrincipal
-  readonly correlationId?: string
-}): ExecutionScope {
-  const execution = createInternalExecution({
-    projectId: input.projectId,
-    requestedBy: input.requestedBy,
-    executor: Object.freeze({
-      type: "primitive",
-      kind: input.primitive.kind,
-      id: input.primitive.id,
-      runId: input.primitive.runId,
-    }),
-    source: input.source,
-    correlationId: input.correlationId,
-  })
-  return Object.freeze({
-    execution,
-    authorization: createTrustedPrimitiveRuntimeAuthorization({
-      projectId: input.projectId,
-      primitive: input.primitive,
-    }),
-  })
-}
-
-export function createAgentScope(input: {
-  readonly projectId: string
-  readonly agentId: string
-  readonly runId: string
-  readonly context: AuthorizationContext
-  readonly source: ExecutionSource
-  readonly requestedBy?: AuthorizablePrincipal
-  readonly correlationId?: string
-}): ExecutionScope {
-  if (input.context.principal.type !== "serviceAccount") {
-    throw new Error("[Sixb] Agent execution authority must belong to a service account.")
-  }
-  assertNonEmpty(input.agentId, "Agent id")
-  assertNonEmpty(input.runId, "Agent run id")
-  const execution = createInternalExecution({
-    projectId: input.projectId,
-    requestedBy: input.requestedBy,
-    executor: Object.freeze({ type: "agent", agentId: input.agentId, runId: input.runId }),
-    source: input.source,
-    correlationId: input.correlationId,
-  })
-  return Object.freeze({
-    execution,
-    authorization: createAgentRuntimeAuthorization({
-      projectId: input.projectId,
-      context: input.context,
-      executionId: execution.id,
-      agentId: input.agentId,
-      runId: input.runId,
-    }),
-  })
-}
-
 export function createKernelScope(input: {
   readonly projectId: string
   readonly operation: KernelOperation
@@ -120,9 +56,9 @@ export function createKernelScope(input: {
   readonly correlationId?: string
 }): ExecutionScope {
   const operation = Object.freeze({ ...input.operation })
-  const execution = createInternalExecution({
+  const execution = createKernelExecution({
     projectId: input.projectId,
-    executor: Object.freeze({ type: "kernel", operation }),
+    operation,
     source: input.source,
     correlationId: input.correlationId,
   })
@@ -132,10 +68,9 @@ export function createKernelScope(input: {
   })
 }
 
-function createInternalExecution(input: {
+function createKernelExecution(input: {
   readonly projectId: string
-  readonly requestedBy?: AuthorizablePrincipal
-  readonly executor: Exclude<ExecutionContext["executor"], { readonly type: "request" }>
+  readonly operation: KernelOperation
   readonly source: ExecutionSource
   readonly correlationId?: string
 }): ExecutionContext {
@@ -144,10 +79,7 @@ function createInternalExecution(input: {
   return freezeExecution({
     id: `exec_${randomUUID()}`,
     projectId: input.projectId,
-    ...(input.requestedBy === undefined
-      ? {}
-      : { requestedBy: asAuthorizablePrincipal(input.requestedBy) }),
-    executor: input.executor,
+    executor: Object.freeze({ type: "kernel", operation: input.operation }),
     source,
     correlationId: input.correlationId ?? `corr_${randomUUID()}`,
   })
@@ -227,9 +159,6 @@ function snapshotExecutionSource(source: ExecutionSource): ExecutionSource {
   if (source.type === "datasetVersion") {
     assertNonEmpty(source.datasetId, "Execution source dataset id")
   }
-  if (source.type === "queue") {
-    assertNonEmpty(source.queue, "Execution source queue")
-  }
   return Object.freeze({ ...source })
 }
 
@@ -249,8 +178,6 @@ function sourceIdentifier(source: ExecutionSource): {
       return { label: "Execution source dataset version id", value: source.versionId }
     case "execution":
       return { label: "Execution source execution id", value: source.executionId }
-    case "queue":
-      return { label: "Execution source job id", value: source.jobId }
   }
 }
 

--- a/packages/core/src/execution/types.ts
+++ b/packages/core/src/execution/types.ts
@@ -40,7 +40,6 @@ export type ExecutionExecutor =
  * Occurrence that directly triggered an execution.
  *
  * An `execution` source is the single logical parent of a nested execution.
- * The `queue` source is transitional until workers restore durable execution authority.
  */
 export type ExecutionSource =
   | { readonly type: "http"; readonly requestId: string }
@@ -49,7 +48,6 @@ export type ExecutionSource =
   | { readonly type: "event"; readonly eventId: string }
   | { readonly type: "datasetVersion"; readonly datasetId: string; readonly versionId: string }
   | { readonly type: "execution"; readonly executionId: string }
-  | { readonly type: "queue"; readonly queue: string; readonly jobId: string }
 
 /** Immutable provenance for one request, primitive run, agent run, or kernel operation. */
 export interface ExecutionContext {

--- a/packages/core/src/queues/index.ts
+++ b/packages/core/src/queues/index.ts
@@ -26,6 +26,5 @@ export type {
   WorkflowQueueJob,
   WorkflowQueueJobFailureCode,
   WorkflowRunRequestedQueueJob,
-  WorkflowRunResumeCause,
   WorkflowRunResumeRequestedQueueJob,
 } from "./types"

--- a/packages/core/src/queues/types.ts
+++ b/packages/core/src/queues/types.ts
@@ -157,22 +157,13 @@ export interface WorkflowRunRequestedQueueJob
     }
   > {}
 
-export type WorkflowRunResumeCause =
-  | {
-      readonly kind: "intervention"
-      readonly interventionId: string
-    }
-  | {
-      readonly kind: "agentNode"
-      readonly nodeRunId: string
-    }
-
+/** Wake a durable wait edge; the worker resolves its type and current state from storage. */
 export interface WorkflowRunResumeRequestedQueueJob
   extends QueueJob<
     "workflow.run.resume.requested",
     {
       readonly runId: string
-      readonly resume: WorkflowRunResumeCause
+      readonly nodeRunId: string
     }
   > {}
 

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, test } from "bun:test"
+import { agentServiceAccountId } from "../src/agents/authority"
 import type { Principal } from "../src/auth"
 import { type AuthorizationContext, emptyGrantIndex } from "../src/authorization"
+import { restoreAgentExecutionScope } from "../src/execution/agent"
 import {
   assertExecutionScopeProject,
   createPrincipalRuntimeAuthorization,
+  createTrustedPrimitiveRuntimeAuthorization,
   getAuthorizationRef,
   resolveRuntimeAuthorization,
 } from "../src/execution/authorization"
 import {
-  createAgentScope,
+  createPrimitiveExecutionRecord,
+  restoreTrustedPrimitiveExecutionScope,
+} from "../src/execution/durable"
+import {
   createDisabledRequestScope,
   createKernelScope,
   createPrincipalRequestScope,
   createTestingScope,
-  createTrustedPrimitiveScope,
 } from "../src/execution/scopes"
 import {
   createRuntimeAuthorizationCapability,
@@ -119,7 +124,7 @@ describe("runtime authorization capabilities", () => {
   })
 })
 
-describe("execution scope factories", () => {
+describe("execution scopes", () => {
   test("creates a principal request scope with explicit request provenance", () => {
     const scope = createPrincipalRequestScope({
       projectId: "project-1",
@@ -172,12 +177,19 @@ describe("execution scope factories", () => {
   })
 
   test("creates an immutable trusted primitive scope", () => {
-    const scope = createTrustedPrimitiveScope({
-      projectId: "project-1",
-      primitive: { kind: "action", id: "send-email", runId: "action-run-1" },
-      source: { type: "queue", queue: "actions", jobId: "job-1" },
-      requestedBy: { type: "user", id: "user-1" },
-      correlationId: "correlation-1",
+    const primitive = { kind: "action", id: "send-email", runId: "action-run-1" } as const
+    const scope = restoreTrustedPrimitiveExecutionScope({
+      execution: {
+        id: "execution-action-1",
+        projectId: "project-1",
+        requestedBy: { type: "user", id: "user-1" },
+        executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
+        source: { type: "event", eventId: "event-1" },
+        correlationId: "correlation-1",
+        authorizationRef: { type: "trustedPrimitive", primitive },
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      primitive,
     })
 
     expect(scope.execution).toMatchObject({
@@ -187,7 +199,7 @@ describe("execution scope factories", () => {
         id: "send-email",
         runId: "action-run-1",
       },
-      source: { type: "queue", queue: "actions", jobId: "job-1" },
+      source: { type: "event", eventId: "event-1" },
       requestedBy: { type: "user", id: "user-1" },
       correlationId: "correlation-1",
     })
@@ -203,24 +215,21 @@ describe("execution scope factories", () => {
   })
 
   test("runs agents with service-account authority", () => {
-    const parent = createTestingScope({
-      projectId: "project-1",
-      context: authorizationContext({ type: "user", id: "user-1" }),
-      executionId: "execution-parent",
-      requestId: "request-parent",
-      correlationId: "correlation-1",
-    })
-    const scope = createAgentScope({
-      projectId: "project-1",
+    const principal = { type: "serviceAccount", id: agentServiceAccountId("research") } as const
+    const scope = restoreAgentExecutionScope({
       agentId: "research",
       runId: "agent-run-1",
-      context: authorizationContext({
-        type: "serviceAccount",
-        id: "agent-service-account",
-      }),
-      source: { type: "execution", executionId: parent.execution.id },
-      requestedBy: { type: "user", id: "user-1" },
-      correlationId: parent.execution.correlationId,
+      authorization: authorizationContext(principal),
+      execution: {
+        id: "execution-agent-1",
+        projectId: "project-1",
+        requestedBy: { type: "user", id: "user-1" },
+        executor: { type: "agent", runId: "agent-run-1" },
+        source: { type: "execution", executionId: "execution-parent" },
+        correlationId: "correlation-1",
+        authorizationRef: { type: "principal", principal },
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
     })
 
     expect(scope.execution.executor).toEqual({
@@ -231,30 +240,38 @@ describe("execution scope factories", () => {
     expect(scope.execution.requestedBy).toEqual({ type: "user", id: "user-1" })
     expect(scope.execution.source).toEqual({
       type: "execution",
-      executionId: parent.execution.id,
+      executionId: "execution-parent",
     })
-    expect(scope.execution.correlationId).toBe(parent.execution.correlationId)
+    expect(scope.execution.correlationId).toBe("correlation-1")
     expect(getAuthorizationRef(scope.authorization)).toEqual({
       type: "principal",
-      principal: { type: "serviceAccount", id: "agent-service-account" },
+      principal,
     })
+    expect(Object.isFrozen(scope.execution.requestedBy)).toBe(true)
   })
 
   test("rejects trusted authority for agents", () => {
+    const principal = { type: "serviceAccount", id: agentServiceAccountId("research") } as const
     expect(() =>
-      createAgentScope({
-        projectId: "project-1",
+      restoreAgentExecutionScope({
         agentId: "research",
         runId: "agent-run-2",
-        context: authorizationContext({ type: "user", id: "user-1" }),
-        source: { type: "queue", queue: "agents", jobId: "job-2" },
+        authorization: authorizationContext({ type: "user", id: "user-1" }),
+        execution: {
+          id: "execution-agent-2",
+          projectId: "project-1",
+          executor: { type: "agent", runId: "agent-run-2" },
+          source: { type: "execution", executionId: "execution-parent" },
+          correlationId: "correlation-1",
+          authorizationRef: { type: "principal", principal },
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
       })
-    ).toThrow("Agent execution authority must belong to a service account")
+    ).toThrow("does not authorize Agent run")
     expect(() =>
-      createTrustedPrimitiveScope({
+      createTrustedPrimitiveRuntimeAuthorization({
         projectId: "project-1",
         primitive: { kind: "agent", id: "research", runId: "agent-run-2" } as never,
-        source: { type: "queue", queue: "agents", jobId: "job-2" },
       })
     ).toThrow("Unknown trusted primitive kind 'agent'")
   })
@@ -276,23 +293,31 @@ describe("execution scope factories", () => {
     })
   })
 
-  test("requires nested scopes to preserve a parent correlation id", () => {
+  test("derives nested primitive provenance from its durable parent", () => {
     const primitive = { kind: "workflow", id: "onboarding", runId: "workflow-run-1" } as const
+    const execution = createPrimitiveExecutionRecord({
+      id: "workflow-execution-1",
+      primitive,
+      origin: {
+        type: "execution",
+        parent: {
+          id: "execution-parent",
+          projectId: "project-1",
+          requestedBy: { type: "user", id: "user-1" },
+          executor: { type: "request", requestId: "request-1" },
+          source: { type: "http", requestId: "request-1" },
+          correlationId: "correlation-1",
+          authorizationRef: { type: "disabled" },
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      },
+    })
 
-    expect(() =>
-      createTrustedPrimitiveScope({
-        projectId: "project-1",
-        primitive,
-        source: { type: "execution", executionId: "execution-parent" },
-      })
-    ).toThrow("Nested execution must preserve its parent correlation id")
-    expect(
-      createTrustedPrimitiveScope({
-        projectId: "project-1",
-        primitive,
-        source: { type: "queue", queue: "workflows", jobId: "job-1" },
-      })
-    ).toMatchObject({ execution: { source: { type: "queue", jobId: "job-1" } } })
+    expect(execution).toMatchObject({
+      source: { type: "execution", executionId: "execution-parent" },
+      correlationId: "correlation-1",
+      requestedBy: { type: "user", id: "user-1" },
+    })
   })
 })
 

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -30,7 +30,7 @@ import {
   type WorkflowDefinition,
 } from "../src"
 import { agentServiceAccountId, ensureAgentExecutionIdentity } from "../src/agents/authority"
-import { createAgentScope } from "../src/execution/scopes"
+import { restoreAgentExecutionScope } from "../src/execution/agent"
 import type { AuthStorage } from "../src/storage"
 import { createTestSixb, type TestExecutionHost } from "../src/testing"
 import { createTestRuntimeDeps, waitFor } from "./test-runtime-deps"
@@ -1068,17 +1068,28 @@ describe("bound Sixb fails closed on ungranted surfaces", () => {
 
   test("agent provider access is bound to the exact registered run", async () => {
     const host = createRuntime()
+    const principal = {
+      type: "serviceAccount" as const,
+      id: agentServiceAccountId("contract-agent"),
+    }
     const authorization = resolveAuthorizationContext({
-      principal: { type: "serviceAccount", id: "agent-service-account" },
+      principal,
       groupIds: [],
       roles: host.definitions.security.listResolvedRoles(),
     })
-    const scope = createAgentScope({
-      projectId: host.id,
+    const scope = restoreAgentExecutionScope({
       agentId: "contract-agent",
       runId: "agent-run-1",
-      context: authorization,
-      source: { type: "queue", queue: "agents", jobId: "job-1" },
+      authorization,
+      execution: {
+        id: "agent-execution-1",
+        projectId: host.id,
+        executor: { type: "agent", runId: "agent-run-1" },
+        source: { type: "execution", executionId: "request-execution-1" },
+        correlationId: "agent-correlation-1",
+        authorizationRef: { type: "principal", principal },
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
     })
     const agentSixb = host.withScope(scope)
 

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -29,7 +29,7 @@ import {
 } from "@sixb/core"
 import { createSixbError } from "@sixb/core/internal/errors"
 import type { DomainEventService } from "@sixb/core/internal/events"
-import { bindPrimitiveExecution } from "@sixb/core/internal/primitive-execution"
+import { bindDurablePrimitiveExecution } from "@sixb/core/internal/primitive-execution"
 import {
   createProjectionRunId,
   getProjectionRegistry,
@@ -313,9 +313,22 @@ function createRuntime(
     datasets: catalogs.datasets ?? host.definitions.datasets,
     projections: catalogs.projections ?? host.definitions.projections,
   } satisfies TestProjectionWorkerContext
-  const execution = bindPrimitiveExecution(host, {
-    primitive: { kind: "projection", ...primitive },
-    source: { type: "queue", queue: "projections", jobId: primitive.runId },
+  const trustedPrimitive = { kind: "projection" as const, ...primitive }
+  const execution = bindDurablePrimitiveExecution(host, {
+    execution: {
+      id: `direct-projection-execution-test:${primitive.runId}`,
+      projectId: host.id,
+      executor: {
+        type: "primitive",
+        kind: trustedPrimitive.kind,
+        runId: trustedPrimitive.runId,
+      },
+      source: { type: "event", eventId: `direct-projection-event-test:${primitive.runId}` },
+      correlationId: `direct-projection-correlation-test:${primitive.runId}`,
+      authorizationRef: { type: "trustedPrimitive", primitive: trustedPrimitive },
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    },
+    primitive: trustedPrimitive,
   })
   registerOntologyMutationRuntime(runtime, execution.ontologyMutations)
   shareProjectionRegistry(host, runtime)

--- a/packages/server/src/routes/workflows.ts
+++ b/packages/server/src/routes/workflows.ts
@@ -733,7 +733,7 @@ export function registerWorkflowRoutes(app: Elysia, host: SixbHostView) {
                 type: "workflow.run.resume.requested",
                 payload: {
                   runId: submitted.workflowRunId,
-                  resume: { kind: "intervention", interventionId: submitted.id },
+                  nodeRunId: submitted.nodeRunId,
                 },
               },
             ],

--- a/packages/server/tests/httpContract.test.ts
+++ b/packages/server/tests/httpContract.test.ts
@@ -1802,7 +1802,7 @@ describe("SixbServer HTTP contract", () => {
         type: "workflow.run.resume.requested",
         payload: {
           runId: pending.workflowRunId,
-          resume: { kind: "intervention", interventionId: pending.id },
+          nodeRunId: pending.nodeRunId,
         },
       })
 

--- a/packages/workflow-worker/README.md
+++ b/packages/workflow-worker/README.md
@@ -8,7 +8,7 @@ normal Sixb action path, and waits for terminal action events through `requestAc
 
 Workflows can pause at **intervention** nodes for human-in-the-loop decisions: the worker records a
 pending intervention, moves the run to `waiting`, and stops. When an app submits a response, a
-`workflow.run.resume.requested` job is enqueued and the worker resumes the run from where it paused.
+`workflow.run.resume.requested` job is enqueued with the durable run and node-run ids. The worker loads that wait edge from storage, validates that it belongs to the run, and derives whether it is resuming an intervention or an agent node before continuing from where the workflow paused.
 Each run ends with a final `workflow.run.finished` event. Workers that register intervention nodes
 require `storage.workflowInterventions`.
 

--- a/packages/workflow-worker/README.md
+++ b/packages/workflow-worker/README.md
@@ -8,7 +8,9 @@ normal Sixb action path, and waits for terminal action events through `requestAc
 
 Workflows can pause at **intervention** nodes for human-in-the-loop decisions: the worker records a
 pending intervention, moves the run to `waiting`, and stops. When an app submits a response, a
-`workflow.run.resume.requested` job is enqueued with the durable run and node-run ids. The worker loads that wait edge from storage, validates that it belongs to the run, and derives whether it is resuming an intervention or an agent node before continuing from where the workflow paused.
+`workflow.run.resume.requested` job is enqueued with the durable run and node-run ids. The worker
+loads that wait edge from storage, validates that it belongs to the run, and derives whether it is
+resuming an intervention or an agent node before continuing from where the workflow paused.
 Each run ends with a final `workflow.run.finished` event. Workers that register intervention nodes
 require `storage.workflowInterventions`.
 

--- a/packages/workflow-worker/src/execution/workflow-run-session.ts
+++ b/packages/workflow-worker/src/execution/workflow-run-session.ts
@@ -38,6 +38,14 @@ import type {
 import type { WorkflowExecutionState, WorkflowNodeExecutorRegistry } from "./node-executor"
 import { WorkflowNodeRunner } from "./workflow-node-runner"
 
+interface WorkflowResumeContext {
+  readonly signal: AbortSignal
+  readonly workflow: WorkflowDefinition
+  readonly valueTypesById: ReadonlyMap<string, ValueType>
+  readonly run: WorkflowRunRecord
+  readonly nodeRun: WorkflowNodeRunRecord
+}
+
 export class WorkflowRunSession {
   private sideEffectBoundaryPassed = false
 
@@ -213,157 +221,59 @@ export class WorkflowRunSession {
     const signal = input.signal ?? new AbortController().signal
     const workflow = requireWorkflow(runtime.sixb.workflows.getById(job.workflowId), job)
     const valueTypesById = runtime.ontology.getValueTypesById()
-    if (job.resume.kind === "agentNode") {
-      throwIfAborted(signal)
-      const run = await requireWorkflowRun({
-        workflowRuns: runtime.workflowRuns,
-        projectId: runtime.projectId,
-        workflowId: workflow.id,
-        id: job.id,
-      })
-      const completedNode = await requireWorkflowNodeRun({
-        workflowRuns: runtime.workflowRuns,
-        projectId: runtime.projectId,
-        workflowId: workflow.id,
-        workflowRunId: job.id,
-        id: job.resume.nodeRunId,
-      })
-      const execution = await runtime.workflowRuns.agentNodes.getByNodeRunId({
-        projectId: runtime.projectId,
-        nodeRunId: completedNode.id,
-      })
-      if (
-        completedNode.workflowRunId !== run.id ||
-        completedNode.workflowId !== workflow.id ||
-        completedNode.nodeType !== "agent" ||
-        !execution ||
-        execution.nodeRunId !== completedNode.id
-      ) {
-        throw createSixbError(
-          "internal.unexpected",
-          `[SixbWorkflowWorker] Agent node '${completedNode.id}' does not belong to workflow run '${run.id}'.`,
-          {
-            details: {
-              workflowId: workflow.id,
-              workflowRunId: run.id,
-              nodeId: completedNode.nodeId,
-              nodeRunId: completedNode.id,
-              ...(execution ? { agentId: execution.agentId } : {}),
-            },
-          }
-        )
-      }
-      if (run.status === "running") {
-        return WorkflowRunSession.recoverRunning(input, options)
-      }
-      const nodeRuns = await runtime.workflowRuns.nodes.list({
-        projectId: runtime.projectId,
-        workflowRunId: job.id,
-        order: "asc",
-      })
-      if (run.status === "succeeded") {
-        return {
-          id: job.id,
-          workflowId: workflow.id,
-          status: "succeeded",
-          run,
-          nodes: nodeRuns.nodes,
-          steps: reconstructWorkflowState({
-            workflow,
-            run,
-            nodeRuns: nodeRuns.nodes,
-            upToNodeIndex: workflow.nodes.length,
-            valueTypesById,
-          }).steps,
-        }
-      }
-      if (run.status !== "waiting" || completedNode.status !== "succeeded") {
-        throw createSixbError(
-          "internal.unexpected",
-          `[SixbWorkflowWorker] Workflow run '${job.id}' and agent node '${completedNode.id}' must be waiting/succeeded to resume.`,
-          {
-            details: {
-              agentId: execution.agentId,
-              workflowId: workflow.id,
-              workflowRunId: run.id,
-              nodeId: completedNode.nodeId,
-              nodeRunId: completedNode.id,
-            },
-          }
-        )
-      }
-      if (execution.status !== "succeeded" || !completedNode.output) {
-        throw createSixbError(
-          "internal.unexpected",
-          `[SixbWorkflowWorker] Agent execution '${completedNode.id}' must have a validated output to resume.`,
-          {
-            details: {
-              agentId: execution.agentId,
-              workflowId: workflow.id,
-              workflowRunId: run.id,
-              nodeId: completedNode.nodeId,
-              nodeRunId: completedNode.id,
-            },
-          }
-        )
-      }
-      const agentNode = requireAgentNode(workflow, completedNode)
-      const output = validateWorkflowAgentStepOutput({
-        workflowId: workflow.id,
-        agentStep: agentNode.agentStep,
-        value: completedNode.output,
-        valueTypesById,
-      })
-      const state = reconstructWorkflowState({
-        workflow,
-        run,
-        nodeRuns: nodeRuns.nodes,
-        upToNodeIndex: completedNode.nodeIndex,
-        valueTypesById,
-      })
-      const recorder = new WorkflowRunRecorder({
-        projectId: runtime.projectId,
-        workflow,
-        runId: job.id,
-        workflowRuns: runtime.workflowRuns,
-        observer: input.observer ?? noopWorkflowRunObserver,
-        initialCompletedNodes: nodeRuns.nodes.filter(
-          (nodeRun) =>
-            nodeRun.nodeIndex <= completedNode.nodeIndex && nodeRun.status === "succeeded"
-        ),
-        alreadyStarted: true,
-        execution: job.execution,
-      })
-      const logSession = resolveLoggingService(runtime.projectId, runtime.logging).startExecution({
-        kind: "workflow",
-        id: job.id,
-      })
-      const session = new WorkflowRunSession({
-        runtime,
-        job,
-        workflow,
+    throwIfAborted(signal)
+    const run = await requireWorkflowRun({
+      workflowRuns: runtime.workflowRuns,
+      projectId: runtime.projectId,
+      workflowId: workflow.id,
+      id: job.id,
+    })
+    const resumeNode = await requireWorkflowNodeRun({
+      workflowRuns: runtime.workflowRuns,
+      projectId: runtime.projectId,
+      workflowId: workflow.id,
+      workflowRunId: run.id,
+      id: job.nodeRunId,
+    })
+    if (resumeNode.nodeType === "intervention") {
+      return WorkflowRunSession.createForInterventionResume(input, options, {
         signal,
-        logSession,
+        workflow,
         valueTypesById,
-        workflowInputSnapshot: run.input,
-        state,
-        recorder,
-        runner: new WorkflowNodeRunner({ recorder, executors: options.executors }),
-        onRunFailed: input.onRunFailed,
+        run,
+        nodeRun: resumeNode,
       })
-      await runtime.workflowRuns.resume({
-        projectId: runtime.projectId,
-        id: job.id,
-        execution: job.execution,
-      })
-      session.markSideEffectBoundaryPassed()
-      const outputRecord: Record<string, unknown> = { ...output }
-      state.current = outputRecord
-      state.currentSnapshot = completedNode.output
-      state.steps[agentNode.key] = outputRecord
-      session.resumeFromIndex = completedNode.nodeIndex + 1
-      return session
     }
+    if (resumeNode.nodeType !== "agent") {
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow node '${resumeNode.id}' of type '${resumeNode.nodeType}' cannot resume a run.`,
+        {
+          details: {
+            workflowId: workflow.id,
+            workflowRunId: run.id,
+            nodeId: resumeNode.nodeId,
+            nodeRunId: resumeNode.id,
+          },
+        }
+      )
+    }
+    return WorkflowRunSession.createForAgentNodeResume(input, options, {
+      signal,
+      workflow,
+      valueTypesById,
+      run,
+      nodeRun: resumeNode,
+    })
+  }
+
+  private static async createForInterventionResume(
+    input: RunWorkflowResumeJobInput,
+    options: { readonly executors: WorkflowNodeExecutorRegistry },
+    context: WorkflowResumeContext
+  ): Promise<WorkflowRunSession | WorkflowRunResult> {
+    const { runtime, job } = input
+    const { workflow, valueTypesById, run, nodeRun: waitingNode } = context
     const workflowInterventions = runtime.storage.workflowInterventions
 
     if (!workflowInterventions) {
@@ -374,40 +284,26 @@ export class WorkflowRunSession {
           details: {
             workflowId: job.workflowId,
             workflowRunId: job.id,
-            interventionRecordId: job.resume.interventionId,
+            nodeId: waitingNode.nodeId,
+            nodeRunId: waitingNode.id,
           },
         }
       )
     }
 
-    throwIfAborted(signal)
-
-    const intervention = await requireInterventionRecord({
+    const intervention = await requireInterventionForNode({
       storage: workflowInterventions,
       projectId: runtime.projectId,
       workflowId: workflow.id,
       workflowRunId: job.id,
-      id: job.resume.interventionId,
+      nodeRunId: waitingNode.id,
     })
-    const run = await requireWorkflowRun({
-      workflowRuns: runtime.workflowRuns,
-      projectId: runtime.projectId,
-      workflowId: workflow.id,
-      id: job.id,
-    })
-    const waitingNode = await requireWorkflowNodeRun({
-      workflowRuns: runtime.workflowRuns,
-      projectId: runtime.projectId,
-      workflowId: workflow.id,
-      workflowRunId: job.id,
-      id: intervention.nodeRunId,
-    })
+
+    assertResumeMatchesRun({ workflow, job, run, intervention, waitingNode })
 
     if (run.status === "running") {
       return WorkflowRunSession.recoverRunning(input, options)
     }
-
-    assertResumeMatchesRun({ workflow, job, run, intervention, waitingNode })
 
     const nodeRuns = await runtime.workflowRuns.nodes.list({
       projectId: runtime.projectId,
@@ -416,20 +312,7 @@ export class WorkflowRunSession {
     })
 
     if (run.status === "succeeded" && waitingNode.status === "succeeded") {
-      return {
-        id: job.id,
-        workflowId: workflow.id,
-        status: "succeeded",
-        run,
-        nodes: nodeRuns.nodes,
-        steps: reconstructWorkflowState({
-          workflow,
-          run,
-          nodeRuns: nodeRuns.nodes,
-          upToNodeIndex: workflow.nodes.length,
-          valueTypesById,
-        }).steps,
-      }
+      return completedWorkflowResumeResult(context, nodeRuns.nodes)
     }
 
     if (run.status !== "waiting") {
@@ -515,33 +398,14 @@ export class WorkflowRunSession {
       alreadyStarted: true,
       execution: job.execution,
     })
-    const logSession = resolveLoggingService(runtime.projectId, runtime.logging).startExecution({
-      kind: "workflow",
-      id: job.id,
-    })
-    const session = new WorkflowRunSession({
-      runtime,
-      job,
-      workflow,
-      signal,
-      logSession,
-      valueTypesById,
-      workflowInputSnapshot: run.input,
+    const session = WorkflowRunSession.createResumedSession({
+      input,
+      options,
+      context,
       state,
       recorder,
-      runner: new WorkflowNodeRunner({
-        recorder,
-        executors: options.executors,
-      }),
-      onRunFailed: input.onRunFailed,
     })
-
-    await runtime.workflowRuns.resume({
-      projectId: runtime.projectId,
-      id: job.id,
-      execution: job.execution,
-    })
-
+    await resumeWorkflowRun(input)
     session.markSideEffectBoundaryPassed()
 
     try {
@@ -560,6 +424,152 @@ export class WorkflowRunSession {
     session.resumeFromIndex = intervention.nodeIndex + 1
 
     return session
+  }
+
+  private static async createForAgentNodeResume(
+    input: RunWorkflowResumeJobInput,
+    options: { readonly executors: WorkflowNodeExecutorRegistry },
+    context: WorkflowResumeContext
+  ): Promise<WorkflowRunSession | WorkflowRunResult> {
+    const { runtime, job } = input
+    const { workflow, valueTypesById, run, nodeRun } = context
+    const execution = await runtime.workflowRuns.agentNodes.getByNodeRunId({
+      projectId: runtime.projectId,
+      nodeRunId: nodeRun.id,
+    })
+    if (
+      nodeRun.workflowRunId !== run.id ||
+      nodeRun.workflowId !== workflow.id ||
+      !execution ||
+      execution.nodeRunId !== nodeRun.id
+    ) {
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Agent node '${nodeRun.id}' does not belong to workflow run '${run.id}'.`,
+        {
+          details: {
+            workflowId: workflow.id,
+            workflowRunId: run.id,
+            nodeId: nodeRun.nodeId,
+            nodeRunId: nodeRun.id,
+            ...(execution ? { agentId: execution.agentId } : {}),
+          },
+        }
+      )
+    }
+    if (run.status === "running") {
+      return WorkflowRunSession.recoverRunning(input, options)
+    }
+    const nodeRuns = await runtime.workflowRuns.nodes.list({
+      projectId: runtime.projectId,
+      workflowRunId: job.id,
+      order: "asc",
+    })
+    if (run.status === "succeeded") {
+      return completedWorkflowResumeResult(context, nodeRuns.nodes)
+    }
+    if (run.status !== "waiting" || nodeRun.status !== "succeeded") {
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Workflow run '${job.id}' and agent node '${nodeRun.id}' must be waiting/succeeded to resume.`,
+        {
+          details: {
+            agentId: execution.agentId,
+            workflowId: workflow.id,
+            workflowRunId: run.id,
+            nodeId: nodeRun.nodeId,
+            nodeRunId: nodeRun.id,
+          },
+        }
+      )
+    }
+    if (execution.status !== "succeeded" || !nodeRun.output) {
+      throw createSixbError(
+        "internal.unexpected",
+        `[SixbWorkflowWorker] Agent execution '${nodeRun.id}' must have a validated output to resume.`,
+        {
+          details: {
+            agentId: execution.agentId,
+            workflowId: workflow.id,
+            workflowRunId: run.id,
+            nodeId: nodeRun.nodeId,
+            nodeRunId: nodeRun.id,
+          },
+        }
+      )
+    }
+    const agentNode = requireAgentNode(workflow, nodeRun)
+    const output = validateWorkflowAgentStepOutput({
+      workflowId: workflow.id,
+      agentStep: agentNode.agentStep,
+      value: nodeRun.output,
+      valueTypesById,
+    })
+    const state = reconstructWorkflowState({
+      workflow,
+      run,
+      nodeRuns: nodeRuns.nodes,
+      upToNodeIndex: nodeRun.nodeIndex,
+      valueTypesById,
+    })
+    const recorder = new WorkflowRunRecorder({
+      projectId: runtime.projectId,
+      workflow,
+      runId: job.id,
+      workflowRuns: runtime.workflowRuns,
+      observer: input.observer ?? noopWorkflowRunObserver,
+      initialCompletedNodes: nodeRuns.nodes.filter(
+        (completed) => completed.nodeIndex <= nodeRun.nodeIndex && completed.status === "succeeded"
+      ),
+      alreadyStarted: true,
+      execution: job.execution,
+    })
+    const session = WorkflowRunSession.createResumedSession({
+      input,
+      options,
+      context,
+      state,
+      recorder,
+    })
+    await resumeWorkflowRun(input)
+    session.markSideEffectBoundaryPassed()
+    const outputRecord: Record<string, unknown> = { ...output }
+    state.current = outputRecord
+    state.currentSnapshot = nodeRun.output
+    state.steps[agentNode.key] = outputRecord
+    session.resumeFromIndex = nodeRun.nodeIndex + 1
+    return session
+  }
+
+  private static createResumedSession(input: {
+    readonly input: RunWorkflowResumeJobInput
+    readonly options: { readonly executors: WorkflowNodeExecutorRegistry }
+    readonly context: WorkflowResumeContext
+    readonly state: WorkflowExecutionState
+    readonly recorder: WorkflowRunRecorder
+  }): WorkflowRunSession {
+    const { runtime, job } = input.input
+    const { signal, workflow, valueTypesById, run } = input.context
+    const logSession = resolveLoggingService(runtime.projectId, runtime.logging).startExecution({
+      kind: "workflow",
+      id: job.id,
+    })
+    return new WorkflowRunSession({
+      runtime,
+      job,
+      workflow,
+      signal,
+      logSession,
+      valueTypesById,
+      workflowInputSnapshot: run.input,
+      state: input.state,
+      recorder: input.recorder,
+      runner: new WorkflowNodeRunner({
+        recorder: input.recorder,
+        executors: input.options.executors,
+      }),
+      onRunFailed: input.input.onRunFailed,
+    })
   }
 
   private resumeFromIndex = 0
@@ -718,6 +728,35 @@ export class WorkflowRunSession {
   }
 }
 
+function completedWorkflowResumeResult(
+  context: WorkflowResumeContext,
+  nodeRuns: readonly WorkflowNodeRunRecord[]
+): WorkflowRunResult {
+  const { workflow, run, valueTypesById } = context
+  return {
+    id: run.id,
+    workflowId: workflow.id,
+    status: "succeeded",
+    run,
+    nodes: nodeRuns,
+    steps: reconstructWorkflowState({
+      workflow,
+      run,
+      nodeRuns,
+      upToNodeIndex: workflow.nodes.length,
+      valueTypesById,
+    }).steps,
+  }
+}
+
+async function resumeWorkflowRun(input: RunWorkflowResumeJobInput): Promise<void> {
+  await input.runtime.workflowRuns.resume({
+    projectId: input.runtime.projectId,
+    id: input.job.id,
+    execution: input.job.execution,
+  })
+}
+
 function requireWorkflow(
   workflow: WorkflowDefinition | null,
   job: { readonly id: string; readonly workflowId: string }
@@ -733,32 +772,32 @@ function requireWorkflow(
   return workflow
 }
 
-async function requireInterventionRecord(input: {
+async function requireInterventionForNode(input: {
   readonly storage: WorkflowInterventionStorage
   readonly projectId: string
   readonly workflowId: string
   readonly workflowRunId: string
-  readonly id: string
+  readonly nodeRunId: string
 }): Promise<WorkflowInterventionRecord> {
-  const intervention = await input.storage.getById({
+  const result = await input.storage.list({
     projectId: input.projectId,
-    id: input.id,
+    nodeRunId: input.nodeRunId,
+    limit: 2,
   })
-
-  if (!intervention) {
+  const intervention = result.interventions[0]
+  if (!intervention || result.total !== 1) {
     throw createSixbError(
       "internal.unexpected",
-      `[SixbWorkflowWorker] Workflow intervention '${input.id}' not found.`,
+      `[SixbWorkflowWorker] Workflow node '${input.nodeRunId}' must reference exactly one intervention.`,
       {
         details: {
           workflowId: input.workflowId,
           workflowRunId: input.workflowRunId,
-          interventionRecordId: input.id,
+          nodeRunId: input.nodeRunId,
         },
       }
     )
   }
-
   return intervention
 }
 

--- a/packages/workflow-worker/src/types.ts
+++ b/packages/workflow-worker/src/types.ts
@@ -8,7 +8,6 @@ import type {
   WorkflowStepOutputs,
 } from "@sixb/core"
 import type { LoggingService } from "@sixb/core/internal/logging"
-import type { WorkflowRunResumeCause } from "@sixb/core/queues"
 import type {
   WorkflowInterventionRecord,
   WorkflowNodeRunRecord,
@@ -40,7 +39,7 @@ export interface WorkflowJob {
 export interface WorkflowResumeJob {
   readonly id: string
   readonly workflowId: string
-  readonly resume: WorkflowRunResumeCause
+  readonly nodeRunId: string
   readonly execution?: WorkflowRunExecution
 }
 

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -101,7 +101,7 @@ export class WorkflowWorker extends QueueWorker<
           job: {
             id: run.id,
             workflowId: run.workflowId,
-            resume: claimed.job.payload.resume,
+            nodeRunId: claimed.job.payload.nodeRunId,
             execution,
           },
           signal,

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -7,6 +7,7 @@ import type {
   Storage,
 } from "@sixb/core"
 import { reportRunFailure } from "@sixb/core/internal/error-reporting"
+import { isSixbError } from "@sixb/core/internal/errors"
 import type { LoggingService } from "@sixb/core/internal/logging"
 import {
   bindDurablePrimitiveExecution,
@@ -181,14 +182,23 @@ export class WorkflowWorker extends QueueWorker<
 
   protected override async onExecutionError(
     claimed: ClaimedQueueJob<WorkflowQueueJob>,
-    _error: unknown
-  ): Promise<QueueWorkerFailureDecision> {
+    error: unknown
+  ): Promise<QueueWorkerFailureDecision<(typeof WORKFLOW_RUN_FAILURE_CODES)[number]>> {
+    // A coded invariant failure is deterministic. Redelivery cannot repair a malformed durable
+    // identity edge, so honor the catalog policy before considering infrastructure retries.
+    if (isSixbError(error) && !error.retryable) {
+      return { kind: "fail" }
+    }
+
     const run = await this.workflowRuns
       .getById({
         projectId: this.host.id,
         id: claimed.job.payload.runId,
       })
       .catch(() => null)
+    if ((run?.status === "failed" || run?.status === "cancelled") && run.error) {
+      return { kind: "fail", failure: run.error }
+    }
     if (
       (!run || run.status === "queued" || run.status === "running") &&
       claimed.job.attempt < MAX_WORKFLOW_DELIVERY_ATTEMPTS

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -905,7 +905,7 @@ describe("runWorkflowJob", () => {
       job: {
         id: waiting.id,
         workflowId: workflow.id,
-        resume: { kind: "agentNode", nodeRunId: node!.id },
+        nodeRunId: node!.id,
       },
     })
     expect(resumed.status).toBe("succeeded")
@@ -995,10 +995,7 @@ describe("runWorkflowJob", () => {
       job: {
         id: "wfrun_resume",
         workflowId: workflow.id,
-        resume: {
-          kind: "intervention",
-          interventionId: "wfrun_resume:intervention:1",
-        },
+        nodeRunId: "wfrun_resume:node:1",
       },
       observer,
     })
@@ -1050,10 +1047,7 @@ describe("runWorkflowJob", () => {
       job: {
         id: "wfrun_resume",
         workflowId: workflow.id,
-        resume: {
-          kind: "intervention",
-          interventionId: "wfrun_resume:intervention:1",
-        },
+        nodeRunId: "wfrun_resume:node:1",
       },
       observer,
     })
@@ -1065,6 +1059,52 @@ describe("runWorkflowJob", () => {
 
     expect(duplicate.status).toBe("succeeded")
     expect(afterDuplicate.nodes.map((node) => node.id)).toEqual(nodes.nodes.map((node) => node.id))
+  })
+
+  test("rejects a foreign resume node before recovering a running delivery", async () => {
+    const workflow = defineWorkflow("intervention-resume-identity")
+      .input({
+        transaction: ref(Transaction),
+      })
+      .then(findBestInvoice)
+      .then(reviewBeforeAttach)
+    const sixb = createSixb({ workflows: [workflow] })
+    const runtime = createRuntime(sixb)
+
+    for (const id of ["wfrun_resume_owner", "wfrun_resume_other"]) {
+      await runWorkflowJob({
+        runtime,
+        job: {
+          id,
+          workflowId: workflow.id,
+          input: {
+            transaction: { objectTypeId: "Transaction", primaryId: "txn_1" },
+          },
+        },
+      })
+    }
+
+    await sixb.storage.workflowRuns!.resume({
+      projectId: sixb.id,
+      id: "wfrun_resume_owner",
+    })
+
+    await expect(
+      runWorkflowResumeJob({
+        runtime,
+        job: {
+          id: "wfrun_resume_owner",
+          workflowId: workflow.id,
+          nodeRunId: "wfrun_resume_other:node:1",
+        },
+      })
+    ).rejects.toThrow("does not match run 'wfrun_resume_owner'")
+
+    const run = await sixb.storage.workflowRuns!.getById({
+      projectId: sixb.id,
+      id: "wfrun_resume_owner",
+    })
+    expect(run?.status).toBe("running")
   })
 
   test("keeps runs waiting when submitted intervention responses are invalid", async () => {
@@ -1104,10 +1144,7 @@ describe("runWorkflowJob", () => {
         job: {
           id: "wfrun_invalid_resume_response",
           workflowId: workflow.id,
-          resume: {
-            kind: "intervention",
-            interventionId: "wfrun_invalid_resume_response:intervention:1",
-          },
+          nodeRunId: "wfrun_invalid_resume_response:node:1",
         },
       })
     ).rejects.toBeInstanceOf(WorkflowValidationError)

--- a/packages/workflow-worker/tests/run-workflow-job.test.ts
+++ b/packages/workflow-worker/tests/run-workflow-job.test.ts
@@ -1098,7 +1098,10 @@ describe("runWorkflowJob", () => {
           nodeRunId: "wfrun_resume_other:node:1",
         },
       })
-    ).rejects.toThrow("does not match run 'wfrun_resume_owner'")
+    ).rejects.toMatchObject({
+      code: "internal.unexpected",
+      message: expect.stringContaining("does not match run 'wfrun_resume_owner'"),
+    })
 
     const run = await sixb.storage.workflowRuns!.getById({
       projectId: sixb.id,

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -679,10 +679,7 @@ describe("WorkflowWorker", () => {
           type: "workflow.run.resume.requested",
           payload: {
             runId: "wfrun_worker_resume",
-            resume: {
-              kind: "intervention",
-              interventionId: "wfrun_worker_resume:intervention:1",
-            },
+            nodeRunId: "wfrun_worker_resume:node:1",
           },
         },
       ],
@@ -784,10 +781,7 @@ describe("WorkflowWorker", () => {
           type: "workflow.run.resume.requested",
           payload: {
             runId: "wfrun_worker_resume_failed",
-            resume: {
-              kind: "intervention",
-              interventionId: "wfrun_worker_resume_failed:intervention:1",
-            },
+            nodeRunId: "wfrun_worker_resume_failed:node:1",
           },
         },
       ],

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -17,7 +17,9 @@ import {
   SixbHost,
   type WorkflowDefinition,
 } from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
 import { LOGS_STREAM } from "@sixb/core/internal/logging"
+import type { ClaimedQueueJob, WorkflowQueueJob } from "@sixb/core/queues"
 import {
   createTestSixb,
   createTestWorkflowExecution,
@@ -88,6 +90,12 @@ const finalizeInvoice = defineWorkflowStep("finalize-invoice")
   }))
 
 const workers: WorkflowWorker[] = []
+
+class InspectableWorkflowWorker extends WorkflowWorker {
+  decideExecutionError(claimed: ClaimedQueueJob<WorkflowQueueJob>, error: unknown) {
+    return this.onExecutionError(claimed, error)
+  }
+}
 
 afterEach(async () => {
   for (const worker of workers) {
@@ -186,6 +194,45 @@ describe("WorkflowWorker", () => {
     expect(() => new WorkflowWorker(withoutWorkflowInterventions)).toThrow(
       "storage.workflowInterventions"
     )
+  })
+
+  test("does not retry deterministic coded delivery failures", async () => {
+    const workflow = defineWorkflow("deterministic-delivery-failure")
+      .input({ transaction: ref(Transaction) })
+      .then(findBestInvoice)
+    const sixb = createSixb({ workflows: [workflow] })
+    const worker = new InspectableWorkflowWorker(sixb)
+    const now = new Date().toISOString()
+    const claimed: ClaimedQueueJob<WorkflowQueueJob> = {
+      leaseId: "workflow-lease-1",
+      claimedAt: now,
+      leaseExpiresAt: now,
+      job: {
+        id: "workflow-job-1",
+        projectId: sixb.id,
+        createdAt: now,
+        availableAt: now,
+        attempt: 1,
+        type: "workflow.run.resume.requested",
+        payload: {
+          runId: "workflow-run-1",
+          nodeRunId: "workflow-run-1:node:0",
+        },
+      },
+    }
+
+    await expect(
+      worker.decideExecutionError(
+        claimed,
+        createSixbError(
+          "internal.unexpected",
+          "[SixbWorkflowWorker] Durable resume identity is invalid."
+        )
+      )
+    ).resolves.toEqual({ kind: "fail" })
+    await expect(
+      worker.decideExecutionError(claimed, new Error("storage unavailable"))
+    ).resolves.toMatchObject({ kind: "retry", availableAt: expect.any(String) })
   })
 
   test("streams a run-scoped log line to the broker", async () => {
@@ -379,7 +426,7 @@ describe("WorkflowWorker", () => {
       ],
     })
 
-    const worker = new WorkflowWorker(sixb)
+    const worker = new InspectableWorkflowWorker(sixb)
     workers.push(worker)
     await worker.start()
 
@@ -422,6 +469,27 @@ describe("WorkflowWorker", () => {
       failure: run?.error,
     })
     expect(reported[0]?.context.occurredAt).toBe(run?.error?.at ?? "")
+
+    const settledAt = new Date().toISOString()
+    await expect(
+      worker.decideExecutionError(
+        {
+          leaseId: "workflow-failed-lease",
+          claimedAt: settledAt,
+          leaseExpiresAt: settledAt,
+          job: {
+            id: "workflow-failed-job",
+            projectId: sixb.id,
+            createdAt: settledAt,
+            availableAt: settledAt,
+            attempt: 1,
+            type: "workflow.run.requested",
+            payload: { runId: "wfrun_worker_failed" },
+          },
+        },
+        workflowExplosion
+      )
+    ).resolves.toEqual({ kind: "fail", failure: run?.error })
 
     const events = await waitFor(
       () =>


### PR DESCRIPTION
Part of #183. Stacked on #401.

## Why

Every queued primitive now owns a durable run and execution, but two transitional paths remained:

- Workflow resume jobs carried a business cause chosen by the producer.
- Core could still create privileged in-memory scopes with a `queue` execution source.

This slice makes durable storage the only authority and resume-state source across queue boundaries.

## Flow

```text
queue payload { runId, nodeRunId }
  -> load durable run, wait node, and execution
  -> validate their relationship
  -> derive intervention or Agent resume state from storage
  -> restore RuntimeAuthorization
  -> bind the execution-scoped Sixb
```

## What changes

| Area | Change |
| --- | --- |
| Workflow resume | Payload becomes `{ runId, nodeRunId }`; no intervention or Agent cause crosses the queue |
| Validation | Foreign nodes and non-resumable node types are rejected before recovery |
| Execution model | Removes the transitional `queue` execution source |
| Privileged boundaries | Removes transient trusted/Agent scope factories and the non-durable primitive binder |
| Errors | Uses canonical coded failures for restoration invariants and honors their retry policy |
| Queue settlement | Reuses the exact failure already persisted on a terminal Workflow run |
| Tests | Direct worker tests restore explicit durable executions through the production boundary |

Automatic Sync, Pipeline, Projection, and Workflow admissions already use the orchestrator dispatcher registry. Workflow resume intentionally does not join that registry: it wakes an existing durable run instead of admitting a new one.

Queue leases and execution tokens remain attempt-ownership fences. They do not create or alter execution identity or authority.

## Invariants

- Queue contents identify work but cannot grant authority or choose its business state.
- Redelivery restores the same execution and only rotates attempt ownership.
- A coded non-retryable identity failure is not redelivered.
- A terminal Workflow run and its queue settlement expose the same `SixbFailure`.
- Internal transitional APIs are removed without compatibility aliases.

## Validation

- `bun run test:ci`: 3,894 passed, 7 skipped, 0 failed
- `bun run typecheck`
- `bun run build`
- `bun run test:publish`
- `bun run check`
- generated client verified with no diff
- targeted Workflow, Agent, Action, Projection, Core, and HTTP suites verified

## Next

Slice 5 will bind execution identity to authoritative Materializer commits.
