### PR TITLE
materializer: bind writes to durable executions

### DIFF
--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -55,7 +55,7 @@ event's `type`, `topic`, `partitionKey`, `payload`, and a broker `cursor`.
 | `schemaVersion` | `1` | Envelope schema version |
 | `projectId` | `string` | Owning project |
 | `occurredAt` | `string` | ISO timestamp |
-| `correlationId` | `string?` | Groups related events |
+| `correlationId` | `string?` | Groups related events. Required on ontology facts and copied from their execution |
 | `causationId` | `string?` | The event that caused this one |
 | `idempotencyKey` | `string?` | De-duplicates appends |
 | `actor` | `{ type, id }?` | Who made the write: `user`, `serviceAccount`, or `system`. Absent for trusted internal or explicitly auth-disabled executions |
@@ -73,7 +73,7 @@ consumer that may see an event twice can de-duplicate on it.
 
 | `origin.kind` | `actor` | The write was |
 | --- | --- | --- |
-| `action` | the requester | governed — validated, and recorded as a run |
+| `action` | absent | governed by a trusted Action execution; the original requester remains on that execution |
 | `runtime` | the principal | a direct write through `edit:object` or `append:telemetry` |
 | `runtime` | absent | system code: a worker, a sync, startup |
 | `projection` | absent | derived from a dataset |

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -323,7 +323,7 @@ describe("runActionJob", () => {
     }
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: { id: "act_finalize", actionId: "complete" },
     })
 

--- a/packages/action-worker/tests/run-action-job.test.ts
+++ b/packages/action-worker/tests/run-action-job.test.ts
@@ -71,22 +71,24 @@ function createSixb(
   return { host, sixb: createTestSixb(host) }
 }
 
-function createContext(host: ActionWorkerHost): ActionWorkerContext {
+async function createContext(
+  host: ActionWorkerHost,
+  run: ActionRunRecord
+): Promise<ActionWorkerContext> {
+  const durableExecution = await host.storage.executions.getById({
+    projectId: host.id,
+    id: run.executionId,
+  })
+  if (!durableExecution) {
+    throw new Error(`Action run '${run.id}' references missing execution '${run.executionId}'.`)
+  }
   const primitive = {
     kind: "action" as const,
-    id: host.definitions.actions.list()[0]?.id ?? "test-action",
-    runId: "direct-action-job-test",
+    id: run.actionId,
+    runId: run.id,
   }
   const execution = bindDurablePrimitiveExecution(host, {
-    execution: {
-      id: "direct-action-execution-test",
-      projectId: host.id,
-      executor: { type: "primitive", kind: primitive.kind, runId: primitive.runId },
-      source: { type: "event", eventId: "direct-action-event-test" },
-      correlationId: "direct-action-correlation-test",
-      authorizationRef: { type: "trustedPrimitive", primitive },
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-    },
+    execution: durableExecution,
     primitive,
   })
   return {
@@ -126,16 +128,17 @@ async function queueActionRun(
 }
 
 async function runStoredActionJob(
-  input: Omit<RunActionJobInput, "run">
+  input: Omit<RunActionJobInput, "run" | "runtime"> & { readonly host: ActionWorkerHost }
 ): ReturnType<typeof runActionJob> {
-  const run = await input.runtime.actionRunsStorage.getById({
-    projectId: input.runtime.id,
+  const run = await input.host.storage.actionRuns?.getById({
+    projectId: input.host.id,
     id: input.job.id,
   })
   if (!run) {
     throw new Error(`[Test] Action run '${input.job.id}' was not queued.`)
   }
-  return runActionJob({ ...input, run })
+  const { host, ...jobInput } = input
+  return runActionJob({ ...jobInput, runtime: await createContext(host, run), run })
 }
 
 describe("runActionJob", () => {
@@ -153,7 +156,7 @@ describe("runActionJob", () => {
 
     await expect(
       runActionJob({
-        runtime: createContext(host),
+        runtime: await createContext(host, run),
         job: {
           id: "act_other",
           actionId: "count",
@@ -191,7 +194,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: { id: "act_nullable", actionId: "captureNullable" },
     })
 
@@ -221,7 +224,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "setStatus",
@@ -271,7 +274,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "failWriteback",
@@ -360,7 +363,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_blob",
         actionId: "persistPayload",
@@ -399,7 +402,6 @@ describe("runActionJob", () => {
       id: "device-1",
       name: "Device 1",
     })
-    const context = createContext(host)
     await queueActionRun(host, {
       id: "act_1",
       actionId: "count",
@@ -408,7 +410,7 @@ describe("runActionJob", () => {
     })
 
     await runStoredActionJob({
-      runtime: context,
+      host,
       job: {
         id: "act_1",
         actionId: "count",
@@ -416,7 +418,7 @@ describe("runActionJob", () => {
     })
 
     const duplicate = await runStoredActionJob({
-      runtime: context,
+      host,
       job: {
         id: "act_1",
         actionId: "count",
@@ -447,7 +449,7 @@ describe("runActionJob", () => {
       params: { id: "device-1" },
     })
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "createDevice",
@@ -485,7 +487,7 @@ describe("runActionJob", () => {
       params: { id: "device-1", name: "Device 1" },
     })
     const created = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: { id: "act_create", actionId: "createDevice" },
     })
 
@@ -496,7 +498,7 @@ describe("runActionJob", () => {
       params: { id: "device-1", name: "Renamed Device" },
     })
     const updated = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: { id: "act_rename", actionId: "renameDevice" },
     })
 
@@ -588,7 +590,7 @@ describe("runActionJob", () => {
     expect(
       (
         await runStoredActionJob({
-          runtime: createContext(host),
+          host,
           job: { id: "act_assign_sensor", actionId: "assignSensor" },
         })
       ).status
@@ -619,7 +621,7 @@ describe("runActionJob", () => {
     expect(
       (
         await runStoredActionJob({
-          runtime: createContext(host),
+          host,
           job: { id: "act_clear_sensor", actionId: "clearSensor" },
         })
       ).status
@@ -685,7 +687,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "detachSensor",
@@ -751,7 +753,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "captureSensorName",
@@ -812,7 +814,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: { id: "act_1", actionId: "captureSensorName" },
     })
 
@@ -831,7 +833,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "missingAction",
@@ -877,7 +879,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "count",
@@ -898,7 +900,7 @@ describe("runActionJob", () => {
     expect(run?.finishedAt).toBeInstanceOf(Date)
 
     const redelivered = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: { id: "act_1", actionId: "count" },
       attempt: 2,
     })
@@ -940,7 +942,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "setStatus",
@@ -962,14 +964,15 @@ describe("runActionJob", () => {
       })
     const { host, sixb } = createSixb([deleteDevice])
     await sixb.objects.upsert("Device", { id: "device-1", name: "Device 1" })
-    await queueActionRun(host, {
+    const queuedRun = await queueActionRun(host, {
       id: "act_delete",
       actionId: "deleteDevice",
       subject: { kind: "object", objectTypeId: "Device", primaryId: "device-1" },
       params: {},
     })
     await host.storage.actionRuns!.start({ projectId: host.id, id: "act_delete" })
-    await createContext(host).ontologyMutations.commitEdits({
+    const context = await createContext(host, queuedRun)
+    await context.ontologyMutations.commitEdits({
       mode: "atomic",
       source: { kind: "action", actionId: "deleteDevice", runId: "act_delete" },
       operations: [
@@ -985,7 +988,7 @@ describe("runActionJob", () => {
     })
 
     const resumed = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: { id: "act_delete", actionId: "deleteDevice" },
       attempt: 2,
     })
@@ -1023,7 +1026,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "setStatus",
@@ -1088,7 +1091,7 @@ describe("runActionJob", () => {
     const controller = new AbortController()
 
     const execution = runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: { id: "act_cancelled", actionId: "waitForCancel" },
       signal: controller.signal,
       attempt: 1,
@@ -1136,7 +1139,7 @@ describe("runActionJob", () => {
     })
 
     const result = await runStoredActionJob({
-      runtime: createContext(host),
+      host,
       job: {
         id: "act_1",
         actionId: "setStatus",

--- a/packages/core/src/actions/commit-edits.ts
+++ b/packages/core/src/actions/commit-edits.ts
@@ -1,6 +1,5 @@
 import type { EditBatch } from "../edits"
 import { lowerEditBatch } from "../edits"
-import type { EventActor } from "../events/envelope"
 import type {
   EditCommitResult,
   EffectiveLinkChange,
@@ -30,7 +29,6 @@ export interface CommitActionEditsInput {
   readonly actionId: string
   readonly batch: EditBatch
   readonly dependencies?: ActionReadDependencies
-  readonly actor?: EventActor
 }
 
 /** The authoritative ontology commit an Action run produced. */
@@ -71,7 +69,6 @@ export async function commitActionEdits(
     expectedObjects: dependencies.objects,
     expectedLinks: dependencies.links,
     expectedLinkScopes: dependencies.linkScopes,
-    ...(input.actor !== undefined ? { actor: input.actor } : {}),
   })
   return toActionEditCommitResult(commit)
 }

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -1,6 +1,7 @@
 import type { Principal } from "../auth"
 import { emptyGrantSets, GRANT_KIND_KEYS } from "../authorization/grant-kinds"
 import type { AuthorizationContext, GrantIndex } from "../authorization/types"
+import { createSixbError } from "../errors/internal"
 import {
   type AuthorizablePrincipal,
   type AuthorizationRef,
@@ -150,18 +151,38 @@ export function getAuthorizationRef(authorization: RuntimeAuthorization): Author
 export function assertExecutionScopeProject(projectId: string, scope: ExecutionScope): void {
   assertNonEmpty(projectId, "Project id")
   if (scope.execution.projectId !== projectId) {
-    throw new Error(
-      `[Sixb] Execution scope belongs to project '${scope.execution.projectId}', not '${projectId}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[Sixb] Execution scope belongs to project '${scope.execution.projectId}', not '${projectId}'.`,
+      {
+        details: {
+          executionId: scope.execution.id,
+          expectedProjectId: projectId,
+          scopeProjectId: scope.execution.projectId,
+        },
+      }
     )
   }
 
   const resolved = resolveRuntimeAuthorization(scope.authorization)
   if (resolved.type === "denied") {
-    throw new Error("[Sixb] Execution scope carries unregistered runtime authorization.")
+    throw createSixbError(
+      "internal.unexpected",
+      "[Sixb] Execution scope carries unregistered runtime authorization.",
+      { details: { executionId: scope.execution.id, projectId } }
+    )
   }
   if (resolved.projectId !== projectId) {
-    throw new Error(
-      `[Sixb] Execution authorization belongs to project '${resolved.projectId}', not '${projectId}'.`
+    throw createSixbError(
+      "internal.unexpected",
+      `[Sixb] Execution authorization belongs to project '${resolved.projectId}', not '${projectId}'.`,
+      {
+        details: {
+          authorizationProjectId: resolved.projectId,
+          executionId: scope.execution.id,
+          expectedProjectId: projectId,
+        },
+      }
     )
   }
 }
@@ -174,7 +195,11 @@ export function resolveExecutionScopeAuthorization(
   assertExecutionScopeProject(projectId, scope)
   const resolved = resolveRuntimeAuthorization(scope.authorization)
   if (resolved.type === "denied") {
-    throw new Error("[Sixb] Execution scope carries unregistered runtime authorization.")
+    throw createSixbError(
+      "internal.unexpected",
+      "[Sixb] Execution scope carries unregistered runtime authorization.",
+      { details: { executionId: scope.execution.id, projectId } }
+    )
   }
 
   const { execution } = scope
@@ -261,8 +286,10 @@ function principalsEqual(
 }
 
 function invalidExecutionAuthority(executionId: string, reason: string): Error {
-  return new Error(
-    `[Sixb] Execution '${executionId}' is incompatible with its authority: ${reason}.`
+  return createSixbError(
+    "internal.unexpected",
+    `[Sixb] Execution '${executionId}' is incompatible with its authority: ${reason}.`,
+    { details: { executionId, reason } }
   )
 }
 

--- a/packages/core/src/execution/authorization.ts
+++ b/packages/core/src/execution/authorization.ts
@@ -166,6 +166,106 @@ export function assertExecutionScopeProject(projectId: string, scope: ExecutionS
   }
 }
 
+/** Validate that one registered authority belongs to the exact execution it accompanies. */
+export function resolveExecutionScopeAuthorization(
+  projectId: string,
+  scope: ExecutionScope
+): RegisteredRuntimeAuthorization {
+  assertExecutionScopeProject(projectId, scope)
+  const resolved = resolveRuntimeAuthorization(scope.authorization)
+  if (resolved.type === "denied") {
+    throw new Error("[Sixb] Execution scope carries unregistered runtime authorization.")
+  }
+
+  const { execution } = scope
+  switch (execution.executor.type) {
+    case "request":
+      if (
+        execution.source.type !== "http" ||
+        execution.source.requestId !== execution.executor.requestId
+      ) {
+        throw invalidExecutionAuthority(execution.id, "request source does not match its executor")
+      }
+      if (resolved.ref.type === "principal") {
+        if (
+          resolved.type !== "principal" ||
+          resolved.executionBinding !== undefined ||
+          !principalsEqual(execution.requestedBy, resolved.ref.principal)
+        ) {
+          throw invalidExecutionAuthority(
+            execution.id,
+            "request authority does not match its requested-by principal"
+          )
+        }
+        return resolved
+      }
+      if (resolved.ref.type === "disabled" && execution.requestedBy === undefined) return resolved
+      throw invalidExecutionAuthority(
+        execution.id,
+        "request execution requires principal or explicitly disabled authority"
+      )
+
+    case "primitive":
+      if (
+        resolved.ref.type !== "trustedPrimitive" ||
+        resolved.ref.primitive.kind !== execution.executor.kind ||
+        resolved.ref.primitive.id !== execution.executor.id ||
+        resolved.ref.primitive.runId !== execution.executor.runId
+      ) {
+        throw invalidExecutionAuthority(
+          execution.id,
+          "trusted primitive authority does not match its executor"
+        )
+      }
+      return resolved
+
+    case "agent":
+      if (
+        resolved.type !== "principal" ||
+        resolved.ref.type !== "principal" ||
+        resolved.ref.principal.type !== "serviceAccount" ||
+        resolved.ref.credential !== undefined ||
+        resolved.executionBinding?.type !== "agent" ||
+        resolved.executionBinding.executionId !== execution.id ||
+        resolved.executionBinding.agentId !== execution.executor.agentId ||
+        resolved.executionBinding.runId !== execution.executor.runId
+      ) {
+        throw invalidExecutionAuthority(
+          execution.id,
+          "agent authority does not match its execution binding"
+        )
+      }
+      return resolved
+
+    case "kernel":
+      if (
+        resolved.ref.type !== "kernel" ||
+        execution.requestedBy !== undefined ||
+        resolved.ref.operation.type !== execution.executor.operation.type ||
+        resolved.ref.operation.recoveryId !== execution.executor.operation.recoveryId
+      ) {
+        throw invalidExecutionAuthority(
+          execution.id,
+          "kernel authority does not match its executor"
+        )
+      }
+      return resolved
+  }
+}
+
+function principalsEqual(
+  left: AuthorizablePrincipal | undefined,
+  right: AuthorizablePrincipal | undefined
+): boolean {
+  return left?.type === right?.type && left?.id === right?.id
+}
+
+function invalidExecutionAuthority(executionId: string, reason: string): Error {
+  return new Error(
+    `[Sixb] Execution '${executionId}' is incompatible with its authority: ${reason}.`
+  )
+}
+
 function register(input: RegisteredRuntimeAuthorization): RuntimeAuthorization {
   assertNonEmpty(input.projectId, "Authorization project id")
   const authorization = createRuntimeAuthorizationCapability()

--- a/packages/core/src/execution/primitive.ts
+++ b/packages/core/src/execution/primitive.ts
@@ -1,4 +1,3 @@
-import { assertPrivileged } from "../authorization"
 import type { OntologySource } from "../ontology"
 import type { OntologyMutationRuntime } from "../runtime/ontology-mutations"
 import { getOntologyMutationRuntime } from "../runtime/ontology-mutations"
@@ -43,37 +42,8 @@ function bindPrimitiveScope(
   const bound: BoundPrimitiveExecution = {
     sixb,
     get ontologyMutations() {
-      ontologyMutations ??= createBoundOntologyMutations(host, scope)
+      ontologyMutations ??= getOntologyMutationRuntime(sixb)
       return ontologyMutations
-    },
-  }
-  return Object.freeze(bound)
-}
-
-function createBoundOntologyMutations(
-  host: object,
-  scope: ExecutionScope
-): OntologyMutationRuntime {
-  const mutations = getOntologyMutationRuntime(host)
-  const assertMutationAccess = () =>
-    assertPrivileged({ runtimeAuthorization: scope.authorization }, "ontology.mutate")
-
-  const bound: OntologyMutationRuntime = {
-    commitEdits: (command) => {
-      assertMutationAccess()
-      return mutations.commitEdits(command)
-    },
-    replaceProjection: (command) => {
-      assertMutationAccess()
-      return mutations.replaceProjection(command)
-    },
-    finishProjection: (command) => {
-      assertMutationAccess()
-      return mutations.finishProjection(command)
-    },
-    appendTelemetry: (command) => {
-      assertMutationAccess()
-      return mutations.appendTelemetry(command)
     },
   }
   return Object.freeze(bound)

--- a/packages/core/src/materialization/events.ts
+++ b/packages/core/src/materialization/events.ts
@@ -13,6 +13,7 @@ interface OntologyMaterializationEventBase {
   readonly schemaVersion: 1
   readonly projectId: string
   readonly occurredAt: string
+  readonly correlationId: string
   readonly actor?: EventActor
   readonly origin: OntologyMaterializationOrigin
   readonly commitId: string

--- a/packages/core/src/materialization/model.ts
+++ b/packages/core/src/materialization/model.ts
@@ -1,5 +1,5 @@
 import type { SixbFailure } from "../errors/types"
-import type { EventActor, EventOrigin } from "../events/envelope"
+import type { EventOrigin } from "../events/envelope"
 import type { PropertyChange, PropertyChangeMap } from "../events/property-changes"
 import type { JsonValue } from "../json"
 import type { ProjectionProtocolIdentity, ProjectionRunFailureCode } from "../projections/types"
@@ -116,7 +116,6 @@ export type OntologyEditOperation =
     }
 
 interface BaseOntologyEditCommit {
-  readonly actor?: EventActor
   readonly operations: readonly OntologyEditOperation[]
 }
 
@@ -237,7 +236,6 @@ export interface TelemetryAppend {
         /** True when this batch consumed the final row of the immutable dataset version. */
         readonly inputExhausted: boolean
       }
-  readonly actor?: EventActor
   readonly points: readonly TelemetryPointWrite[]
 }
 
@@ -367,19 +365,6 @@ export interface TelemetryCommitResult extends BaseCommitResult {
   readonly pointsUpdated: number
   readonly pointsUnchanged: number
   readonly latestObjectsChanged: number
-}
-
-export interface OntologyMaterializer {
-  readonly edits: {
-    commit(input: OntologyEditCommit): Promise<EditCommitResult>
-  }
-  readonly projections: {
-    replace(input: ProjectionSourceReplacement): Promise<ProjectionCommitResult>
-    finishRun(input: ProjectionRunFinishInput): Promise<void>
-  }
-  readonly telemetry: {
-    append(input: TelemetryAppend): Promise<TelemetryCommitResult>
-  }
 }
 
 export type ObjectOverride =

--- a/packages/core/src/materializer/README.md
+++ b/packages/core/src/materializer/README.md
@@ -13,11 +13,7 @@ runtime object/link     -> edits.commit  (mode: "atomic" | "continue", origin: r
 runtime telemetry       -> telemetry.append (origin: telemetry/runtime)
 ```
 
-`Sixb` constructs one Materializer and threads it through its internal runtime context, so the typed
-`objects(...)` SDK, the dynamic `Sixb` methods, and the Action worker all commit through the same
-engine. Runtime single calls are atomic; runtime batches use `continue` mode and map per-item
-outcomes back to caller positions. No ingress appends domain events or writes object, link, or
-timeseries providers directly.
+`SixbHost` owns one unbound Materializer. `withScope(...)` closes its mutation port over one validated execution before the typed `objects(...)` SDK or a trusted worker can use it. The host never exposes a raw mutation port. Runtime single calls are atomic; runtime batches use `continue` mode and map per-item outcomes back to caller positions. No ingress appends domain events or writes object, link, or timeseries providers directly.
 
 Committed facts are published from the transactional outbox after the commit resolves.
 `OntologyOutboxDispatcher` owns that protocol: ingresses call `notify()` for prompt, non-blocking
@@ -29,7 +25,9 @@ best effort — delivery may lag, but a committed fact is never lost.
 ```text
 normalize + validate intent
   -> derive deterministic identity
-  -> verify execution when run-backed and check replay
+  -> validate the execution/authority binding
+  -> persist or verify the durable execution
+  -> verify run ownership when run-backed and check replay
   -> begin serializable materialization session
   -> resolve effective state
   -> diff against committed state
@@ -51,9 +49,9 @@ ontology storage  -> sources, effective state, telemetry, commits, and outbox
 Materializer      -> semantic planning and cross-store transaction orchestration
 ```
 
-Ontology commit `origin` is the canonical correlation to an Action or projection run. Run records
-do not duplicate ontology commit ids or semantic commit history. Replacement projections need no
-resume checkpoint; projection telemetry stores only its next batch/row checkpoint on the run.
+Every ontology commit references its immutable execution through `executionId`. Storage providers enforce that reference. `origin` remains the semantic idempotency and run-correlation key: it says which runtime request, Action, projection replacement, or telemetry batch the commit represents; the execution says under which durable authority it ran. Neither field duplicates the other.
+
+Run records do not duplicate ontology commit ids or semantic commit history. Replacement projections need no resume checkpoint; projection telemetry stores only its next batch/row checkpoint on the run.
 
 Logical origins are unique in the ontology ledger: one commit per Action run, one per replacement
 run, and one per telemetry run/batch ordinal. Exact origin lookup is used for correctness; commit
@@ -94,9 +92,7 @@ its mutable overrides let operation N+1 observe operation N. In `continue` mode,
 operation rolls back only its working override; provider and infrastructure failures abort the
 whole transaction.
 
-Action-backed edits verify the matching running Action before work and again inside the commit
-transaction. Their semantic result lives only in the ontology commit, correlated by Action origin;
-the Action run is not a second commit ledger.
+Action-backed edits validate the trusted Action execution, the run's immutable `executionId`, and the running-state fence inside the commit transaction before new work. Exact replay remains valid after the run becomes terminal. Their semantic result lives only in the ontology commit, correlated by Action origin; the Action run is not a second commit ledger.
 
 ## Telemetry append
 

--- a/packages/core/src/materializer/edits/commit.ts
+++ b/packages/core/src/materializer/edits/commit.ts
@@ -1,4 +1,7 @@
-import { MaterializationValidationError } from "../../materialization/errors"
+import {
+  MaterializationConflictError,
+  MaterializationValidationError,
+} from "../../materialization/errors"
 import type {
   EditCommitResult,
   OntologyEditCommit,
@@ -10,7 +13,16 @@ import type { Storage } from "../../storage"
 import type { MaterializationSession, OntologyCommitWrite } from "../../storage/ontology"
 import type { MaterializerContext, MaterializerStorage } from "../context"
 import { replayCommit, withSerializationRetry } from "../execution/commit-lifecycle"
+import {
+  assertMaterializerRunExecution,
+  assertRuntimeMutationExecution,
+  assertTrustedPrimitiveMutationExecution,
+  ensureMaterializerExecution,
+  type MaterializerExecution,
+  prepareMaterializerExecution,
+} from "../execution/scope"
 import { drainStagedEvents, drainStagedWork } from "../execution/work-executor"
+import type { MaterializerCommand } from "../materializer"
 import {
   createActionIdempotencyKey,
   createRuntimeIdempotencyKey,
@@ -30,24 +42,22 @@ interface PreparedEditCommit {
   readonly input: NormalizedEditCommit
   readonly identity: TimedCommitIdentity
   readonly origin: OntologyMaterializationOrigin
+  readonly execution: MaterializerExecution
 }
 
 export async function commitEdits(
   context: MaterializerContext,
-  raw: OntologyEditCommit
+  raw: MaterializerCommand<OntologyEditCommit>
 ): Promise<EditCommitResult> {
   const command = prepareEditCommit(context, raw)
-  const replay = await replayEditCommit(context, command)
-  if (replay) return replay
-
   return executeEditCommit(context, command)
 }
 
 function prepareEditCommit(
   context: Pick<MaterializerContext, "projectId" | "clock">,
-  raw: OntologyEditCommit
+  raw: MaterializerCommand<OntologyEditCommit>
 ): PreparedEditCommit {
-  const input = normalizeOntologyEditCommit(raw)
+  const input = normalizeOntologyEditCommit(raw.input)
   const idempotencyKey = editIdempotencyKey(input)
   const identity = createTimedCommitIdentity({
     projectId: context.projectId,
@@ -55,7 +65,12 @@ function prepareEditCommit(
     normalizedCallerIntent: input,
     now: context.clock(),
   })
-  return { input, identity, origin: input.source }
+  return {
+    input,
+    identity,
+    origin: input.source,
+    execution: prepareMaterializerExecution(context.projectId, raw.scope),
+  }
 }
 
 function editIdempotencyKey(input: NormalizedEditCommit): string {
@@ -68,7 +83,8 @@ function editIdempotencyKey(input: NormalizedEditCommit): string {
 async function lockActionRunForMaterialization(
   storage: Storage,
   projectId: string,
-  input: NormalizedEditCommit
+  input: NormalizedEditCommit,
+  execution: MaterializerExecution
 ): Promise<void> {
   if (input.source.kind !== "action") return
   if (!storage.actionRuns) {
@@ -76,18 +92,45 @@ async function lockActionRunForMaterialization(
       "Storage does not provide Action run capabilities required by this commit."
     )
   }
-  await storage.actionRuns.lockForMaterialization({
+  const run = await storage.actionRuns.lockForMaterialization({
     projectId,
     actionId: input.source.actionId,
     runId: input.source.runId,
   })
+  assertMaterializerRunExecution(execution, run.executionId, `Action run '${run.id}'`)
 }
 
-function replayEditCommit(
-  context: MaterializerContext,
-  command: PreparedEditCommit
-): Promise<EditCommitResult | null> {
-  return replayCommit<EditCommitResult>(context, command.identity)
+async function validateMutationExecution(
+  storage: Storage,
+  projectId: string,
+  input: NormalizedEditCommit,
+  execution: MaterializerExecution
+): Promise<void> {
+  if (input.source.kind !== "action") {
+    assertRuntimeMutationExecution(execution)
+    return
+  }
+  assertTrustedPrimitiveMutationExecution(execution, {
+    kind: "action",
+    id: input.source.actionId,
+    runId: input.source.runId,
+  })
+  if (!storage.actionRuns) {
+    throw new MaterializationValidationError(
+      "Storage does not provide Action run capabilities required by this commit."
+    )
+  }
+  const run = await storage.actionRuns.getById({ projectId, id: input.source.runId })
+  if (!run) {
+    throw new MaterializationValidationError(`Action run '${input.source.runId}' was not found.`)
+  }
+  if (run.actionId !== input.source.actionId) {
+    throw new MaterializationConflictError(
+      "run-correlation",
+      `Action run '${run.id}' does not belong to action '${input.source.actionId}'.`
+    )
+  }
+  assertMaterializerRunExecution(execution, run.executionId, `Action run '${run.id}'`)
 }
 
 async function executeEditCommit(
@@ -106,10 +149,23 @@ async function executeEditTransaction(
   storage: MaterializerStorage,
   command: PreparedEditCommit
 ): Promise<EditCommitResult> {
-  await lockActionRunForMaterialization(storage, context.projectId, command.input)
+  await ensureMaterializerExecution(storage.executions, command.execution)
+  await validateMutationExecution(storage, context.projectId, command.input, command.execution)
 
-  const replay = await replayCommit<EditCommitResult>(context, command.identity, storage)
+  const replay = await replayCommit<EditCommitResult>(
+    context,
+    command.identity,
+    command.execution.executionId,
+    storage
+  )
   if (replay) return replay
+
+  await lockActionRunForMaterialization(
+    storage,
+    context.projectId,
+    command.input,
+    command.execution
+  )
 
   const session = await beginEditMaterialization(context, storage, command)
   const workingState = await loadEditWorkingState(
@@ -171,6 +227,7 @@ function buildEditCommit(
     id: command.identity.commitId,
     idempotencyKey: command.identity.idempotencyKey,
     requestHash: command.identity.requestHash,
+    executionId: command.execution.executionId,
     origin: command.origin,
     ontologyRevision: context.projectionRegistry.ontologyRevision,
     intent: {
@@ -180,8 +237,8 @@ function buildEditCommit(
     },
     committedAt: command.identity.committedAt,
   }
-  if (command.input.actor === undefined) return commit
-  return { ...commit, actor: command.input.actor }
+  if (command.execution.actor === undefined) return commit
+  return { ...commit, actor: command.execution.actor }
 }
 
 function editExpectations(input: NormalizedEditCommit) {
@@ -289,9 +346,13 @@ function isRecoverableEditValidation(
 }
 
 function editPlanContext(command: PreparedEditCommit) {
-  const context = { identity: command.identity, origin: command.origin }
-  if (command.input.actor === undefined) return context
-  return { ...context, actor: command.input.actor }
+  const context = {
+    identity: command.identity,
+    origin: command.origin,
+    correlationId: command.execution.correlationId,
+  }
+  if (command.execution.actor === undefined) return context
+  return { ...context, actor: command.execution.actor }
 }
 
 async function finalizeEditMaterialization(

--- a/packages/core/src/materializer/edits/plan.ts
+++ b/packages/core/src/materializer/edits/plan.ts
@@ -58,6 +58,7 @@ export interface EditPlanChanges {
 interface EditPlanContext {
   readonly identity: TimedCommitIdentity
   readonly origin: OntologyMaterializationOrigin
+  readonly correlationId: string
   readonly actor?: EventActor
 }
 
@@ -241,6 +242,7 @@ function materializationEventContext(
     commitId: planContext.identity.commitId,
     committedAt: planContext.identity.committedAt,
     origin: planContext.origin,
+    correlationId: planContext.correlationId,
   }
   if (planContext.actor === undefined) return base
   return { ...base, actor: planContext.actor }

--- a/packages/core/src/materializer/effective/build-events.ts
+++ b/packages/core/src/materializer/effective/build-events.ts
@@ -22,6 +22,7 @@ export interface MaterializationEventDraftContext {
   readonly projectId: string
   readonly commitId: string
   readonly committedAt: string
+  readonly correlationId: string
   readonly origin: OntologyMaterializationOrigin
   readonly actor?: EventActor
 }
@@ -165,6 +166,7 @@ function eventDraftBase(context: MaterializationEventDraftContext) {
     schemaVersion: 1 as const,
     projectId: context.projectId,
     occurredAt: context.committedAt,
+    correlationId: context.correlationId,
     origin: context.origin,
     commitId: context.commitId,
   }

--- a/packages/core/src/materializer/execution/commit-lifecycle.ts
+++ b/packages/core/src/materializer/execution/commit-lifecycle.ts
@@ -12,6 +12,7 @@ import type { CommitIdentity } from "../shared/identity"
 export async function replayCommitRecord(
   context: Pick<MaterializerContext, "projectId" | "storage">,
   identity: CommitIdentity,
+  executionId: string,
   storage: MaterializerStorage = context.storage
 ): Promise<OntologyCommitRecord | null> {
   const existing = await storage.ontology.commits.getByIdempotencyKey({
@@ -25,6 +26,12 @@ export async function replayCommitRecord(
       `Idempotency key '${identity.idempotencyKey}' was reused with different intent.`
     )
   }
+  if (existing.executionId !== executionId) {
+    throw new MaterializationConflictError(
+      "idempotency",
+      `Idempotency key '${identity.idempotencyKey}' belongs to execution '${existing.executionId}', not '${executionId}'.`
+    )
+  }
   return existing
 }
 
@@ -33,9 +40,10 @@ export async function replayCommit<
 >(
   context: Pick<MaterializerContext, "projectId" | "storage">,
   identity: CommitIdentity,
+  executionId: string,
   storage: MaterializerStorage = context.storage
 ): Promise<TResult | null> {
-  const existing = await replayCommitRecord(context, identity, storage)
+  const existing = await replayCommitRecord(context, identity, executionId, storage)
   if (!existing) return null
   return { ...structuredClone(existing.result), created: false } as TResult
 }

--- a/packages/core/src/materializer/execution/scope.ts
+++ b/packages/core/src/materializer/execution/scope.ts
@@ -1,0 +1,105 @@
+import type { EventActor } from "../../events/envelope"
+import {
+  type ResolvedRuntimeAuthorization,
+  resolveExecutionScopeAuthorization,
+} from "../../execution/authorization"
+import { ensureExecutionRecord, executionRecordInputFromRuntime } from "../../execution/durable"
+import type { ExecutionScope, TrustedPrimitiveKind } from "../../execution/types"
+import {
+  MaterializationConflictError,
+  MaterializationValidationError,
+} from "../../materialization/errors"
+import type {
+  CreateExecutionInput,
+  ExecutionRecord,
+  ExecutionStorage,
+} from "../../storage/executions"
+
+/** Immutable execution metadata attached to one prepared Materializer command. */
+export interface MaterializerExecution {
+  readonly scope: ExecutionScope
+  readonly record: CreateExecutionInput
+  readonly executionId: string
+  readonly correlationId: string
+  readonly actor?: EventActor
+}
+
+/** Validate the process-local scope before any Materializer read or write is attempted. */
+export function prepareMaterializerExecution(
+  projectId: string,
+  scope: ExecutionScope
+): MaterializerExecution {
+  let authorization: Exclude<ResolvedRuntimeAuthorization, { readonly type: "denied" }>
+  try {
+    authorization = resolveExecutionScopeAuthorization(projectId, scope)
+  } catch (error) {
+    throw new MaterializationValidationError(
+      error instanceof Error ? error.message : "Materializer execution scope is invalid."
+    )
+  }
+
+  const base = {
+    scope,
+    record: executionRecordInputFromRuntime({
+      execution: scope.execution,
+      runtimeAuthorization: scope.authorization,
+    }),
+    executionId: scope.execution.id,
+    correlationId: scope.execution.correlationId,
+  }
+  if (authorization.type !== "principal") return base
+  return { ...base, actor: authorization.context.principal }
+}
+
+/** Persist a direct request lazily, or prove that a durable worker restored the exact record. */
+export function ensureMaterializerExecution(
+  executions: ExecutionStorage,
+  execution: MaterializerExecution
+): Promise<ExecutionRecord> {
+  return ensureExecutionRecord(executions, execution.record)
+}
+
+/** Runtime mutations may come from any domain SDK execution except an internal kernel operation. */
+export function assertRuntimeMutationExecution(execution: MaterializerExecution): void {
+  if (execution.scope.execution.executor.type !== "kernel") return
+  throw new MaterializationValidationError(
+    `Kernel execution '${execution.executionId}' cannot enter the runtime mutation boundary.`
+  )
+}
+
+/** Require one internal mutation ingress to belong to its exact trusted primitive run. */
+export function assertTrustedPrimitiveMutationExecution(
+  execution: MaterializerExecution,
+  primitive: {
+    readonly kind: TrustedPrimitiveKind
+    readonly id: string
+    readonly runId: string
+  }
+): void {
+  const executor = execution.scope.execution.executor
+  if (
+    executor.type === "primitive" &&
+    executor.kind === primitive.kind &&
+    executor.id === primitive.id &&
+    executor.runId === primitive.runId
+  ) {
+    return
+  }
+  throw new MaterializationConflictError(
+    "run-correlation",
+    `Execution '${execution.executionId}' does not own ${primitive.kind} run '${primitive.runId}'.`
+  )
+}
+
+/** Require the provider-validated run to reference the same immutable execution as the command. */
+export function assertMaterializerRunExecution(
+  execution: MaterializerExecution,
+  runExecutionId: string,
+  label: string
+): void {
+  if (runExecutionId === execution.executionId) return
+  throw new MaterializationConflictError(
+    "run-correlation",
+    `${label} belongs to execution '${runExecutionId}', not '${execution.executionId}'.`
+  )
+}

--- a/packages/core/src/materializer/execution/scope.ts
+++ b/packages/core/src/materializer/execution/scope.ts
@@ -1,8 +1,5 @@
 import type { EventActor } from "../../events/envelope"
-import {
-  type ResolvedRuntimeAuthorization,
-  resolveExecutionScopeAuthorization,
-} from "../../execution/authorization"
+import { resolveExecutionScopeAuthorization } from "../../execution/authorization"
 import { ensureExecutionRecord, executionRecordInputFromRuntime } from "../../execution/durable"
 import type { ExecutionScope, TrustedPrimitiveKind } from "../../execution/types"
 import {
@@ -29,14 +26,7 @@ export function prepareMaterializerExecution(
   projectId: string,
   scope: ExecutionScope
 ): MaterializerExecution {
-  let authorization: Exclude<ResolvedRuntimeAuthorization, { readonly type: "denied" }>
-  try {
-    authorization = resolveExecutionScopeAuthorization(projectId, scope)
-  } catch (error) {
-    throw new MaterializationValidationError(
-      error instanceof Error ? error.message : "Materializer execution scope is invalid."
-    )
-  }
+  const authorization = resolveExecutionScopeAuthorization(projectId, scope)
 
   const base = {
     scope,

--- a/packages/core/src/materializer/index.ts
+++ b/packages/core/src/materializer/index.ts
@@ -77,7 +77,13 @@ export {
   computeProjectionRevision,
 } from "../projections/revision"
 export type { ProjectionOwnership, ResolvedProjection } from "../projections/types"
-export type { MaterializerStorage, OntologyMaterializerDependencies } from "./materializer"
+export type {
+  BoundOntologyMaterializer,
+  MaterializerCommand,
+  MaterializerStorage,
+  OntologyMaterializerContract,
+  OntologyMaterializerDependencies,
+} from "./materializer"
 export { createOntologyMaterializer, OntologyMaterializer } from "./materializer"
 export type {
   CommitIdentity,

--- a/packages/core/src/materializer/materializer.ts
+++ b/packages/core/src/materializer/materializer.ts
@@ -1,9 +1,12 @@
+import type { ExecutionScope } from "../execution"
 import type {
+  EditCommitResult,
   OntologyEditCommit,
-  OntologyMaterializer as OntologyMaterializerContract,
+  ProjectionCommitResult,
   ProjectionRunFinishInput,
   ProjectionSourceReplacement,
   TelemetryAppend,
+  TelemetryCommitResult,
 } from "../materialization/model"
 import type { OntologyRegistry } from "../ontology"
 import type { ProjectionRegistry } from "../projections/registry"
@@ -20,13 +23,72 @@ import { appendTelemetry } from "./telemetry/append"
 
 export type { MaterializerStorage, OntologyMaterializerDependencies } from "./context"
 
-export class OntologyMaterializer implements OntologyMaterializerContract {
-  readonly edits = { commit: (input: OntologyEditCommit) => commitEdits(this.context, input) }
-  readonly projections = {
-    replace: (input: ProjectionSourceReplacement) => replaceProjection(this.context, input),
-    finishRun: (input: ProjectionRunFinishInput) => finishProjectionRun(this.context, input),
+export interface MaterializerCommand<TInput> {
+  readonly scope: ExecutionScope
+  readonly input: TInput
+}
+
+export interface OntologyMaterializerContract {
+  withScope(scope: ExecutionScope): BoundOntologyMaterializer
+  readonly edits: {
+    commit(input: MaterializerCommand<OntologyEditCommit>): Promise<EditCommitResult>
   }
-  readonly telemetry = { append: (input: TelemetryAppend) => appendTelemetry(this.context, input) }
+  readonly projections: {
+    replace(
+      input: MaterializerCommand<ProjectionSourceReplacement>
+    ): Promise<ProjectionCommitResult>
+    finishRun(input: MaterializerCommand<ProjectionRunFinishInput>): Promise<void>
+  }
+  readonly telemetry: {
+    append(input: MaterializerCommand<TelemetryAppend>): Promise<TelemetryCommitResult>
+  }
+}
+
+/** Materializer facade closed over one explicit execution scope. */
+export interface BoundOntologyMaterializer {
+  readonly edits: {
+    commit(input: OntologyEditCommit): Promise<EditCommitResult>
+  }
+  readonly projections: {
+    replace(input: ProjectionSourceReplacement): Promise<ProjectionCommitResult>
+    finishRun(input: ProjectionRunFinishInput): Promise<void>
+  }
+  readonly telemetry: {
+    append(input: TelemetryAppend): Promise<TelemetryCommitResult>
+  }
+}
+
+export class OntologyMaterializer implements OntologyMaterializerContract {
+  readonly edits = {
+    commit: (command: MaterializerCommand<OntologyEditCommit>) =>
+      commitEdits(this.context, command),
+  }
+  readonly projections = {
+    replace: (command: MaterializerCommand<ProjectionSourceReplacement>) =>
+      replaceProjection(this.context, command),
+    finishRun: (command: MaterializerCommand<ProjectionRunFinishInput>) =>
+      finishProjectionRun(this.context, command),
+  }
+  readonly telemetry = {
+    append: (command: MaterializerCommand<TelemetryAppend>) =>
+      appendTelemetry(this.context, command),
+  }
+
+  withScope(scope: ExecutionScope): BoundOntologyMaterializer {
+    return Object.freeze({
+      edits: Object.freeze({
+        commit: (input: OntologyEditCommit) => this.edits.commit({ scope, input }),
+      }),
+      projections: Object.freeze({
+        replace: (input: ProjectionSourceReplacement) => this.projections.replace({ scope, input }),
+        finishRun: (input: ProjectionRunFinishInput) =>
+          this.projections.finishRun({ scope, input }),
+      }),
+      telemetry: Object.freeze({
+        append: (input: TelemetryAppend) => this.telemetry.append({ scope, input }),
+      }),
+    })
+  }
 
   private readonly context: MaterializerContext
 

--- a/packages/core/src/materializer/projections/finish-run.ts
+++ b/packages/core/src/materializer/projections/finish-run.ts
@@ -14,6 +14,14 @@ import type { MaterializerContext, MaterializerStorage } from "../context"
 import { withSerializationRetry } from "../execution/commit-lifecycle"
 import { lockProjectionRunForMaterialization } from "../execution/run-correlation"
 import {
+  assertMaterializerRunExecution,
+  assertTrustedPrimitiveMutationExecution,
+  ensureMaterializerExecution,
+  type MaterializerExecution,
+  prepareMaterializerExecution,
+} from "../execution/scope"
+import type { MaterializerCommand } from "../materializer"
+import {
   normalizePinnedDatasetVersion,
   normalizeProjectionExecution,
   normalizeProjectionSourceRef,
@@ -26,11 +34,12 @@ interface PreparedProjectionRunFinish {
   readonly identity: ProjectionMaterializationIdentity
   readonly resolved: ResolvedProjection<ProjectionDefinition>
   readonly finishedAt: Date
+  readonly execution: MaterializerExecution
 }
 
 export async function finishProjectionRun(
   context: MaterializerContext,
-  raw: ProjectionRunFinishInput
+  raw: MaterializerCommand<ProjectionRunFinishInput>
 ): Promise<void> {
   const command = prepareProjectionRunFinish(context, raw)
   await withSerializationRetry(context, () =>
@@ -42,14 +51,14 @@ export async function finishProjectionRun(
 
 function prepareProjectionRunFinish(
   context: Pick<MaterializerContext, "projectId" | "projectionRegistry" | "clock">,
-  raw: ProjectionRunFinishInput
+  raw: MaterializerCommand<ProjectionRunFinishInput>
 ): PreparedProjectionRunFinish {
-  assertValidTerminalDecision(raw)
-  const source = normalizeProjectionSourceRef(raw.source)
-  const datasetVersion = normalizePinnedDatasetVersion(raw.datasetVersion)
-  const execution = normalizeProjectionExecution(raw.execution)
+  assertValidTerminalDecision(raw.input)
+  const source = normalizeProjectionSourceRef(raw.input.source)
+  const datasetVersion = normalizePinnedDatasetVersion(raw.input.datasetVersion)
+  const projectionExecution = normalizeProjectionExecution(raw.input.execution)
   const resolved =
-    raw.protocol === "replacement"
+    raw.input.protocol === "replacement"
       ? context.projectionRegistry.resolveSource(source.projectionId)
       : context.projectionRegistry.resolveTelemetry(source.projectionId)
   if (resolved.datasetId !== datasetVersion.datasetId) {
@@ -64,10 +73,11 @@ function prepareProjectionRunFinish(
   })
   return {
     projectId: context.projectId,
-    input: { ...raw, source, datasetVersion, execution },
+    input: { ...raw.input, source, datasetVersion, execution: projectionExecution },
     identity,
     resolved,
-    finishedAt: new Date(raw.finishedAt ?? context.clock()),
+    finishedAt: new Date(raw.input.finishedAt ?? context.clock()),
+    execution: prepareMaterializerExecution(context.projectId, raw.scope),
   }
 }
 
@@ -75,13 +85,20 @@ async function finishProjectionRunTransaction(
   storage: MaterializerStorage,
   command: PreparedProjectionRunFinish
 ): Promise<void> {
-  const { projectionRuns } = await lockProjectionRunForMaterialization(storage, {
+  await ensureMaterializerExecution(storage.executions, command.execution)
+  assertTrustedPrimitiveMutationExecution(command.execution, {
+    kind: "projection",
+    id: command.input.source.projectionId,
+    runId: command.input.execution.projectionRunId,
+  })
+  const { projectionRuns, run } = await lockProjectionRunForMaterialization(storage, {
     projectId: command.projectId,
     projectionRunId: command.input.execution.projectionRunId,
     executionToken: command.input.execution.executionToken,
     identity: command.identity,
     resolved: command.resolved,
   })
+  assertMaterializerRunExecution(command.execution, run.executionId, `Projection run '${run.id}'`)
 
   if (command.input.protocol === "replacement") {
     await assertReplacementTerminalDecision(storage, command)
@@ -168,6 +185,7 @@ function assertReplacementCommitCorrelation(
   const { input, identity } = command
   if (
     commit.origin.kind !== "projection" ||
+    commit.executionId !== command.execution.executionId ||
     commit.intent.kind !== "projection" ||
     commit.result.kind !== "projection" ||
     commit.origin.projectionRunId !== input.execution.projectionRunId ||

--- a/packages/core/src/materializer/projections/replace.ts
+++ b/packages/core/src/materializer/projections/replace.ts
@@ -24,7 +24,15 @@ import type {
 import type { MaterializerContext, MaterializerStorage } from "../context"
 import { replayCommitRecord, withSerializationRetry } from "../execution/commit-lifecycle"
 import { lockProjectionRunForMaterialization } from "../execution/run-correlation"
+import {
+  assertMaterializerRunExecution,
+  assertTrustedPrimitiveMutationExecution,
+  ensureMaterializerExecution,
+  type MaterializerExecution,
+  prepareMaterializerExecution,
+} from "../execution/scope"
 import { drainStagedEvents, drainStagedWork } from "../execution/work-executor"
+import type { MaterializerCommand } from "../materializer"
 import { throwIfAborted } from "../shared/abort"
 import {
   type CommitIdentity,
@@ -58,6 +66,7 @@ interface PreparedProjectionReplacement {
   readonly projectionKind: "object" | "link"
   readonly runIdentity: ProjectionMaterializationIdentity
   readonly identity: CommitIdentity
+  readonly scopeExecution: MaterializerExecution
 }
 
 interface ProjectionCandidate {
@@ -77,15 +86,10 @@ interface ReadyProjectionReplacement extends ProjectionCandidate {
 
 export async function replaceProjection(
   context: MaterializerContext,
-  raw: ProjectionSourceReplacement
+  raw: MaterializerCommand<ProjectionSourceReplacement>
 ): Promise<ProjectionCommitResult> {
   const command = prepareProjectionReplacement(context, raw)
-  await assertProjectionExecution(context.storage, context.projectId, command, {
-    capabilityErrorMessage:
-      "Storage does not provide projection run capabilities required by source replacement.",
-  })
-
-  const replay = await replayProjectionCommit(context, command)
+  const replay = await admitProjectionExecution(context, command)
   if (replay) return replay
 
   const candidate = await prepareProjectionCandidate(context, command)
@@ -100,11 +104,11 @@ export async function replaceProjection(
 
 function prepareProjectionReplacement(
   context: Pick<MaterializerContext, "projectId" | "projectionRegistry">,
-  raw: ProjectionSourceReplacement
+  raw: MaterializerCommand<ProjectionSourceReplacement>
 ): PreparedProjectionReplacement {
-  const source = normalizeProjectionSourceRef(raw.source)
-  const datasetVersion = normalizePinnedDatasetVersion(raw.datasetVersion)
-  const execution = normalizeProjectionExecution(raw.execution)
+  const source = normalizeProjectionSourceRef(raw.input.source)
+  const datasetVersion = normalizePinnedDatasetVersion(raw.input.datasetVersion)
+  const execution = normalizeProjectionExecution(raw.input.execution)
   const resolved = context.projectionRegistry.resolveSource(source.projectionId)
   validateProjectionDataset(resolved, datasetVersion)
 
@@ -123,14 +127,15 @@ function prepareProjectionReplacement(
     source,
     datasetVersion,
     execution,
-    entries: raw.entries,
+    entries: raw.input.entries,
     resolved,
     projectionKind,
     runIdentity,
     identity,
+    scopeExecution: prepareMaterializerExecution(context.projectId, raw.scope),
   }
-  if (raw.signal === undefined) return command
-  return { ...command, signal: raw.signal }
+  if (raw.input.signal === undefined) return command
+  return { ...command, signal: raw.input.signal }
 }
 
 function validateProjectionDataset(
@@ -154,7 +159,12 @@ async function assertProjectionExecution(
   command: PreparedProjectionReplacement,
   options: { readonly capabilityErrorMessage?: string } = {}
 ): Promise<void> {
-  await lockProjectionRunForMaterialization(storage, {
+  assertTrustedPrimitiveMutationExecution(command.scopeExecution, {
+    kind: "projection",
+    id: command.source.projectionId,
+    runId: command.execution.projectionRunId,
+  })
+  const locked = await lockProjectionRunForMaterialization(storage, {
     projectId,
     projectionRunId: command.execution.projectionRunId,
     executionToken: command.execution.executionToken,
@@ -162,19 +172,31 @@ async function assertProjectionExecution(
     resolved: command.resolved,
     ...options,
   })
+  assertMaterializerRunExecution(
+    command.scopeExecution,
+    locked.run.executionId,
+    `Projection run '${locked.run.id}'`
+  )
 }
 
-async function replayProjectionCommit(
+async function admitProjectionExecution(
   context: MaterializerContext,
   command: PreparedProjectionReplacement
 ): Promise<ProjectionCommitResult | null> {
-  const existing = await replayCommitRecord(context, command.identity)
-  if (!existing) return null
   return withSerializationRetry(context, () =>
     context.storage.transaction(
       async (storage) => {
-        await assertProjectionExecution(storage, context.projectId, command)
-        const commit = await replayCommitRecord(context, command.identity, storage)
+        await ensureMaterializerExecution(storage.executions, command.scopeExecution)
+        await assertProjectionExecution(storage, context.projectId, command, {
+          capabilityErrorMessage:
+            "Storage does not provide projection run capabilities required by source replacement.",
+        })
+        const commit = await replayCommitRecord(
+          context,
+          command.identity,
+          command.scopeExecution.executionId,
+          storage
+        )
         return commit ? projectionReplayResult(commit, command) : null
       },
       { isolation: "serializable" }
@@ -280,8 +302,14 @@ async function executeProjectionTransaction(
   command: PreparedProjectionReplacement,
   ready: ReadyProjectionReplacement
 ): Promise<ProjectionCommitResult> {
+  await ensureMaterializerExecution(storage.executions, command.scopeExecution)
   await assertProjectionExecution(storage, context.projectId, command)
-  const replay = await replayCommitRecord(context, command.identity, storage)
+  const replay = await replayCommitRecord(
+    context,
+    command.identity,
+    command.scopeExecution.executionId,
+    storage
+  )
   if (replay) return projectionReplayResult(replay, command)
 
   const origin = projectionOrigin(command)
@@ -362,6 +390,7 @@ function projectionCommit(
     id: identity.commitId,
     idempotencyKey: identity.idempotencyKey,
     requestHash: identity.requestHash,
+    executionId: command.scopeExecution.executionId,
     origin,
     ontologyRevision: command.runIdentity.ontologyRevision,
     projectionRevision: command.runIdentity.projectionRevision,
@@ -385,6 +414,7 @@ async function planReadyProjection(
     projectionKind: command.projectionKind,
     identity: ready.identity,
     origin,
+    correlationId: command.scopeExecution.correlationId,
   }
   if (command.signal === undefined) {
     return planProjectionReplacement(context, storage, session, input)
@@ -435,7 +465,10 @@ async function abandonFailedCandidate(
 function shouldAbandonCandidate(error: unknown): boolean {
   if (error instanceof MaterializationValidationError) return true
   if (error instanceof MaterializationCancellationError) return true
-  return error instanceof MaterializationConflictError && error.kind === "run-correlation"
+  return (
+    error instanceof MaterializationConflictError &&
+    (error.kind === "run-correlation" || error.kind === "idempotency")
+  )
 }
 
 function validateProjectionWatermark(

--- a/packages/core/src/materializer/projections/replacement-plan.ts
+++ b/packages/core/src/materializer/projections/replacement-plan.ts
@@ -53,6 +53,7 @@ export interface ProjectionReplacementPlanInput {
   readonly projectionKind: "object" | "link"
   readonly identity: TimedCommitIdentity
   readonly origin: OntologyMaterializationOrigin
+  readonly correlationId: string
   readonly signal?: AbortSignal
 }
 
@@ -160,6 +161,7 @@ function appendObjectChangeWork(
         commitId: input.identity.commitId,
         committedAt: input.identity.committedAt,
         origin: input.origin,
+        correlationId: input.correlationId,
         change,
       })
     )
@@ -356,6 +358,7 @@ function appendLinkChangeWork(
         commitId: input.identity.commitId,
         committedAt: input.identity.committedAt,
         origin: input.origin,
+        correlationId: input.correlationId,
         change,
       })
     )

--- a/packages/core/src/materializer/shared/normalize.ts
+++ b/packages/core/src/materializer/shared/normalize.ts
@@ -1,4 +1,3 @@
-import type { EventActor } from "../../events/envelope"
 import { assertJsonValue, cloneJsonValue, compareStrings, stableJsonStringify } from "../../json"
 import { MaterializationValidationError } from "../../materialization/errors"
 import type {
@@ -58,21 +57,6 @@ function normalizeNonblank(value: string, label: string): string {
     throw new MaterializationValidationError(`${label} must be a nonblank string.`)
   }
   return value
-}
-
-function normalizeEventActor(actor: EventActor): EventActor {
-  if (typeof actor !== "object" || actor === null || Array.isArray(actor)) {
-    throw new MaterializationValidationError("Event actor must be an object.")
-  }
-  if (actor.type !== "user" && actor.type !== "serviceAccount" && actor.type !== "system") {
-    throw new MaterializationValidationError(
-      "Event actor type must be 'user', 'serviceAccount', or 'system'."
-    )
-  }
-  return Object.freeze({
-    type: actor.type,
-    id: normalizeNonblank(actor.id, "Event actor id"),
-  })
 }
 
 function normalizeTimestamp(value: string, label: string): string {
@@ -280,7 +264,6 @@ export function normalizeOntologyEditCommit(input: OntologyEditCommit): Ontology
         kind: "runtime",
         requestId: normalizeNonblank(input.source.requestId, "Runtime request id"),
       }),
-      ...(input.actor !== undefined ? { actor: normalizeEventActor(input.actor) } : {}),
       operations: Object.freeze(operations),
       ...(input.operationGroups !== undefined
         ? { operationGroups: normalizeOperationGroups(input.operationGroups, operationIds) }
@@ -306,7 +289,6 @@ export function normalizeOntologyEditCommit(input: OntologyEditCommit): Ontology
   return Object.freeze({
     mode: "atomic",
     source,
-    ...(input.actor !== undefined ? { actor: normalizeEventActor(input.actor) } : {}),
     operations: Object.freeze(operations),
     expectedObjects: deduplicateExpectations(
       expectedObjects,
@@ -521,7 +503,6 @@ export function normalizeTelemetryAppend(input: TelemetryAppend): TelemetryAppen
   }
   return Object.freeze({
     source,
-    ...(input.actor !== undefined ? { actor: normalizeEventActor(input.actor) } : {}),
     points: Object.freeze(points),
   })
 }

--- a/packages/core/src/materializer/telemetry/append.ts
+++ b/packages/core/src/materializer/telemetry/append.ts
@@ -19,16 +19,21 @@ import type {
 } from "../../storage/ontology"
 import type { MaterializerContext, MaterializerStorage } from "../context"
 import { validateTelemetryPoint } from "../effective/validate"
-import {
-  replayCommit,
-  replayCommitRecord,
-  withSerializationRetry,
-} from "../execution/commit-lifecycle"
+import { replayCommitRecord, withSerializationRetry } from "../execution/commit-lifecycle"
 import {
   type LockedProjectionExecution,
   lockProjectionRunForMaterialization,
 } from "../execution/run-correlation"
+import {
+  assertMaterializerRunExecution,
+  assertRuntimeMutationExecution,
+  assertTrustedPrimitiveMutationExecution,
+  ensureMaterializerExecution,
+  type MaterializerExecution,
+  prepareMaterializerExecution,
+} from "../execution/scope"
 import { drainStagedEvents, drainStagedWork } from "../execution/work-executor"
+import type { MaterializerCommand } from "../materializer"
 import {
   createProjectionTelemetryIdempotencyKey,
   createRuntimeTelemetryIdempotencyKey,
@@ -50,6 +55,7 @@ interface PreparedTelemetryBase {
   readonly inputPointCount: number
   readonly ontologyRevision: string
   readonly identity: TimedCommitIdentity
+  readonly execution: MaterializerExecution
 }
 
 interface PreparedRuntimeTelemetry extends PreparedTelemetryBase {
@@ -68,34 +74,36 @@ type PreparedTelemetryAppend = PreparedRuntimeTelemetry | PreparedProjectionTele
 
 export async function appendTelemetry(
   context: MaterializerContext,
-  raw: TelemetryAppend
+  raw: MaterializerCommand<TelemetryAppend>
 ): Promise<TelemetryCommitResult> {
   const command = prepareTelemetryAppend(context, raw)
-  if (command.kind === "runtime") {
-    const replay = await replayCommit<TelemetryCommitResult>(context, command.identity)
-    if (replay) return replay
-  }
-
   return executeTelemetryCommit(context, command)
 }
 
 function prepareTelemetryAppend(
   context: Pick<MaterializerContext, "projectId" | "ontology" | "projectionRegistry" | "clock">,
-  raw: TelemetryAppend
+  raw: MaterializerCommand<TelemetryAppend>
 ): PreparedTelemetryAppend {
-  const rawInputPointCount = raw.points.length
+  const rawInputPointCount = raw.input.points.length
   const input = normalizeTelemetryAppend({
-    ...raw,
-    points: raw.points.map((point) => validateTelemetryPoint(context.ontology, point)),
+    ...raw.input,
+    points: raw.input.points.map((point) => validateTelemetryPoint(context.ontology, point)),
   })
   const inputPointCount = telemetryInputPointCount(input, rawInputPointCount)
   validateTelemetryBatch(input, inputPointCount)
 
   const ontologyRevision = context.projectionRegistry.ontologyRevision
+  const execution = prepareMaterializerExecution(context.projectId, raw.scope)
   if (input.source.kind === "runtime") {
-    return prepareRuntimeTelemetry(context, input, input.source, inputPointCount, ontologyRevision)
+    return {
+      ...prepareRuntimeTelemetry(context, input, input.source, inputPointCount, ontologyRevision),
+      execution,
+    }
   }
-  return prepareProjectionTelemetry(context, input, input.source, inputPointCount, ontologyRevision)
+  return {
+    ...prepareProjectionTelemetry(context, input, input.source, inputPointCount, ontologyRevision),
+    execution,
+  }
 }
 
 function telemetryInputPointCount(
@@ -127,7 +135,7 @@ function prepareRuntimeTelemetry(
   source: RuntimeTelemetrySource,
   inputPointCount: number,
   ontologyRevision: string
-): PreparedRuntimeTelemetry {
+): Omit<PreparedRuntimeTelemetry, "execution"> {
   const identity = createTimedCommitIdentity({
     projectId: context.projectId,
     idempotencyKey: createRuntimeTelemetryIdempotencyKey(source.requestId),
@@ -143,7 +151,7 @@ function prepareProjectionTelemetry(
   source: ProjectionTelemetrySource,
   inputPointCount: number,
   ontologyRevision: string
-): PreparedProjectionTelemetry {
+): Omit<PreparedProjectionTelemetry, "execution"> {
   const resolvedProjection = context.projectionRegistry.resolveTelemetry(
     source.projection.projectionId
   )
@@ -220,8 +228,7 @@ function projectionTelemetryCallerIntent(
     inputPointCount,
     points: input.points,
   }
-  if (input.actor === undefined) return intent
-  return { ...intent, actor: input.actor }
+  return intent
 }
 
 async function assertTelemetryExecution(
@@ -229,7 +236,15 @@ async function assertTelemetryExecution(
   projectId: string,
   command: PreparedTelemetryAppend
 ): Promise<LockedProjectionExecution | null> {
-  if (command.kind === "runtime") return null
+  if (command.kind === "runtime") {
+    assertRuntimeMutationExecution(command.execution)
+    return null
+  }
+  assertTrustedPrimitiveMutationExecution(command.execution, {
+    kind: "projection",
+    id: command.source.projection.projectionId,
+    runId: command.source.execution.projectionRunId,
+  })
   const execution = await lockProjectionRunForMaterialization(storage, {
     projectId,
     projectionRunId: command.source.execution.projectionRunId,
@@ -239,6 +254,11 @@ async function assertTelemetryExecution(
     capabilityErrorMessage:
       "Storage does not provide projection run capabilities required by telemetry projection.",
   })
+  assertMaterializerRunExecution(
+    command.execution,
+    execution.run.executionId,
+    `Projection run '${execution.run.id}'`
+  )
   assertTelemetryBatchPosition(
     execution.run,
     command.source.batchOrdinal,
@@ -327,8 +347,14 @@ async function executeTelemetryTransaction(
   storage: MaterializerStorage,
   command: PreparedTelemetryAppend
 ): Promise<TelemetryCommitResult> {
+  await ensureMaterializerExecution(storage.executions, command.execution)
   const execution = await assertTelemetryExecution(storage, context.projectId, command)
-  const replay = await replayCommitRecord(context, command.identity, storage)
+  const replay = await replayCommitRecord(
+    context,
+    command.identity,
+    command.execution.executionId,
+    storage
+  )
   if (replay) {
     if (command.kind === "projection" && execution) {
       assertTelemetryReplayCheckpoint(execution.run, command.source.batchOrdinal)
@@ -355,7 +381,11 @@ async function executeTelemetryTransaction(
     session,
     command.input,
     command.identity,
-    origin
+    origin,
+    {
+      correlationId: command.execution.correlationId,
+      ...(command.execution.actor === undefined ? {} : { actor: command.execution.actor }),
+    }
   )
   await drainStagedWork(context, storage.ontology.materializations, session)
   const eventCount = await drainStagedEvents(
@@ -426,6 +456,7 @@ function telemetryCommit(
     id: command.identity.commitId,
     idempotencyKey: command.identity.idempotencyKey,
     requestHash: command.identity.requestHash,
+    executionId: command.execution.executionId,
     origin,
     ontologyRevision: command.ontologyRevision,
     intent: telemetryCommitIntent(command),
@@ -444,8 +475,8 @@ function telemetryCommitActor(
   commit: OntologyCommitWrite,
   command: PreparedTelemetryAppend
 ): OntologyCommitWrite {
-  if (command.input.actor === undefined) return commit
-  return { ...commit, actor: command.input.actor }
+  if (command.execution.actor === undefined) return commit
+  return { ...commit, actor: command.execution.actor }
 }
 
 function telemetryCommitIntent(command: PreparedTelemetryAppend): TelemetryOntologyCommitIntent {

--- a/packages/core/src/materializer/telemetry/plan.ts
+++ b/packages/core/src/materializer/telemetry/plan.ts
@@ -1,3 +1,4 @@
+import type { EventActor } from "../../events/envelope"
 import { stableJsonStringify } from "../../json"
 import { MaterializationObjectNotFoundError } from "../../materialization/errors"
 import type {
@@ -62,6 +63,12 @@ interface TelemetryPlanContext {
   readonly input: TelemetryAppend
   readonly identity: TimedCommitIdentity
   readonly origin: OntologyMaterializationOrigin
+  readonly event: TelemetryEventContext
+}
+
+interface TelemetryEventContext {
+  readonly correlationId: string
+  readonly actor?: EventActor
 }
 
 export async function planTelemetryAppend(
@@ -70,10 +77,11 @@ export async function planTelemetryAppend(
   session: MaterializationSession,
   input: TelemetryAppend,
   identity: TimedCommitIdentity,
-  origin: OntologyMaterializationOrigin
+  origin: OntologyMaterializationOrigin,
+  event: TelemetryEventContext
 ): Promise<TelemetryPlanCounts> {
   const counts = emptyTelemetryCounts()
-  const planContext = { input, identity, origin }
+  const planContext = { input, identity, origin, event }
   const objects = await loadTelemetryObjects(context, storage, session, input.points)
   const existingPoints = await loadExistingPoints(context, storage, session, input.points)
   for (const group of telemetryObjectGroups(input.points)) {
@@ -348,9 +356,10 @@ function telemetryEventContext(
     commitId: planContext.identity.commitId,
     committedAt: planContext.identity.committedAt,
     origin: planContext.origin,
+    correlationId: planContext.event.correlationId,
   }
-  if (planContext.input.actor === undefined) return eventContext
-  return { ...eventContext, actor: planContext.input.actor }
+  if (planContext.event.actor === undefined) return eventContext
+  return { ...eventContext, actor: planContext.event.actor }
 }
 
 function emptyTelemetryCounts(): MutableTelemetryPlanCounts {

--- a/packages/core/src/objects/materializer-adapter.ts
+++ b/packages/core/src/objects/materializer-adapter.ts
@@ -8,7 +8,6 @@
  */
 
 import { randomUUID } from "node:crypto"
-import type { EventActor } from "../events/envelope"
 import type { JsonValue } from "../json"
 import type {
   EditCommitResult,
@@ -37,12 +36,7 @@ import type { ObjectRow } from "../storage"
 import { ObjectError } from "./errors"
 
 /** The runtime pieces one commit needs. */
-// `authorization` is here only so a commit can name its actor. Trusted primitive and explicitly
-// auth-disabled executions have registered authority without a principal context.
-export type RuntimeMaterializerContext = Pick<
-  SixbRuntimeContext,
-  "projectId" | "storage" | "authorization"
->
+export type RuntimeMaterializerContext = Pick<SixbRuntimeContext, "projectId" | "storage">
 
 /** One caller-supplied batch item, lowered to the operations it contributes. */
 export interface RuntimeBatchGroup {
@@ -55,21 +49,6 @@ export interface RuntimeBatchCommit {
   readonly commit: EditCommitResult | null
   /** Outcomes per input position, in the order the item's operations were submitted. */
   readonly outcomes: ReadonlyMap<number, readonly OntologyOperationOutcome[]>
-}
-
-/**
- * The principal behind a runtime write, when there is one.
- *
- * `origin: { kind: "runtime" }` already says a write bypassed an Action; this says who made it.
- * Absent on a trusted primitive or explicitly auth-disabled execution, which makes the field's
- * absence meaningful rather than merely unset: an event with no actor was written by the system
- * itself.
- *
- * A `Principal` is an `EventActor` — same literals, no translation.
- */
-function runtimeActor(ctx: RuntimeMaterializerContext): { readonly actor?: EventActor } {
-  const principal = ctx.authorization?.principal
-  return principal === undefined ? {} : { actor: principal }
 }
 
 /**
@@ -86,7 +65,6 @@ export async function commitRuntimeOperations(
   const commit = await mutations.commitEdits({
     mode: "atomic",
     source: { kind: "runtime", requestId: randomUUID() },
-    ...runtimeActor(ctx),
     operations,
     expectedObjects: [],
     expectedLinks: [],
@@ -121,7 +99,6 @@ export async function commitRuntimeBatch(
   const commit = await mutations.commitEdits({
     mode: "continue",
     source: { kind: "runtime", requestId: randomUUID() },
-    ...runtimeActor(ctx),
     operations,
     ...(operationGroups.length > 0 ? { operationGroups } : {}),
   })

--- a/packages/core/src/objects/telemetry/write-batch.ts
+++ b/packages/core/src/objects/telemetry/write-batch.ts
@@ -34,8 +34,6 @@ export async function writeTelemetryBatch(
   try {
     commit = await getOntologyMutationRuntime(ctx).appendTelemetry({
       source: { kind: "runtime", requestId: randomUUID() },
-      // A `Principal` is an `EventActor` — same literals, no translation.
-      ...(ctx.authorization === undefined ? {} : { actor: ctx.authorization.principal }),
       points,
     })
   } catch (error) {

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -29,10 +29,7 @@ import {
   type DomainEventService,
   OntologyOutboxDispatcher,
 } from "../events"
-import {
-  assertExecutionScopeProject,
-  resolveRuntimeAuthorization,
-} from "../execution/authorization"
+import { resolveExecutionScopeAuthorization } from "../execution/authorization"
 import type { ExecutionScope } from "../execution/types"
 import type { LakeStorage } from "../lake-storage"
 import { type LoggerProvider, LoggingService, type ObservabilityOptions } from "../logging"
@@ -43,7 +40,7 @@ import {
   type OntologyOperationalStatus,
   type SixbReadiness,
 } from "../maintenance"
-import { createOntologyMaterializer } from "../materializer"
+import { createOntologyMaterializer, type OntologyMaterializerContract } from "../materializer"
 import type { PipelineDefinition } from "../pipelines/types"
 import { registerProjectionRegistry } from "../projections/internal"
 import type { ProjectionDefinition } from "../projections/types"
@@ -119,6 +116,7 @@ export class SixbHost<
   private readonly ontologyMaintenance: OntologyMaintenance
   private readonly storageReadiness: StorageReadiness
   private readonly connectorService: ConnectorService
+  private readonly materializer: OntologyMaterializerContract
   readonly definitions: SixbDefinitions
   readonly broker: Broker
   readonly events: DomainEventLog
@@ -172,7 +170,7 @@ export class SixbHost<
     assertWebhookRunStorage(connectors, this.storage)
     this.webhookRegistry = new WebhookRegistry({ connectors })
 
-    const materializer = createOntologyMaterializer({
+    this.materializer = createOntologyMaterializer({
       projectId: this.projectId,
       ontology: definitions.ontology,
       projections: definitions.projections,
@@ -204,12 +202,6 @@ export class SixbHost<
       queues: this.queues,
     }
     registerProjectionRegistry(this.hostContext, definitions.projections)
-    const ontologyMutations = createOntologyMutationRuntime({
-      materializer,
-      notifyCommittedFacts: () => this.committedFacts.notify(),
-    })
-    registerOntologyMutationRuntime(this, ontologyMutations)
-    registerOntologyMutationRuntime(this.hostContext, ontologyMutations)
     shareSixbErrorReporter(this, this.hostContext)
     this.scheduler = new SchedulerRuntime({
       schedules: definitions.schedules.list(),
@@ -219,11 +211,7 @@ export class SixbHost<
 
   /** Bind an existing opaque scope. This method never creates or escalates authority. */
   withScope(scope: ExecutionScope): Sixb<TOntologySources> {
-    assertExecutionScopeProject(this.projectId, scope)
-    const authorization = resolveRuntimeAuthorization(scope.authorization)
-    if (authorization.type === "denied") {
-      throw new Error("[Sixb] Execution scope carries unregistered runtime authorization.")
-    }
+    const authorization = resolveExecutionScopeAuthorization(this.projectId, scope)
     if (authorization.ref.type === "kernel") {
       throw new Error("[Sixb] Kernel authority cannot be bound to the domain SDK.")
     }
@@ -233,6 +221,13 @@ export class SixbHost<
       runtimeAuthorization: scope.authorization,
       ...(authorization.type === "principal" ? { authorization: authorization.context } : {}),
     }
+    registerOntologyMutationRuntime(
+      runtime,
+      createOntologyMutationRuntime({
+        materializer: this.materializer.withScope(scope),
+        notifyCommittedFacts: () => this.committedFacts.notify(),
+      })
+    )
     return createBoundSixb<TOntologySources>(runtime, this.sixbDependencies(), scope.execution)
   }
 

--- a/packages/core/src/runtime/ontology-mutations.ts
+++ b/packages/core/src/runtime/ontology-mutations.ts
@@ -1,13 +1,13 @@
 import type {
   EditCommitResult,
   OntologyEditCommit,
-  OntologyMaterializer,
   ProjectionCommitResult,
   ProjectionRunFinishInput,
   ProjectionSourceReplacement,
   TelemetryAppend,
   TelemetryCommitResult,
 } from "../materialization/model"
+import type { BoundOntologyMaterializer } from "../materializer"
 
 export interface OntologyMutationRuntime {
   commitEdits(input: OntologyEditCommit): Promise<EditCommitResult>
@@ -49,11 +49,12 @@ export function shareOntologyMutationRuntime(source: object, target: object): vo
   registerOntologyMutationRuntime(target, getOntologyMutationRuntime(source))
 }
 
+/** Adapt an already-bound Materializer to the internal ontology mutation runtime. */
 export function createOntologyMutationRuntime(input: {
-  readonly materializer: OntologyMaterializer
+  readonly materializer: BoundOntologyMaterializer
   readonly notifyCommittedFacts: () => void
 }): OntologyMutationRuntime {
-  return {
+  const runtime: OntologyMutationRuntime = {
     commitEdits: (command) =>
       commitAndNotify(() => input.materializer.edits.commit(command), input.notifyCommittedFacts),
     replaceProjection: (command) =>
@@ -68,6 +69,7 @@ export function createOntologyMutationRuntime(input: {
         input.notifyCommittedFacts
       ),
   }
+  return Object.freeze(runtime)
 }
 
 async function commitAndNotify<TResult extends { readonly eventCount: number }>(

--- a/packages/core/src/runtime/sixb.ts
+++ b/packages/core/src/runtime/sixb.ts
@@ -17,6 +17,7 @@ import { createSchedulesRuntime, type SchedulesRuntime } from "../schedules/exec
 import { createSyncsRuntime, type SyncsRuntime } from "../syncs/execution"
 import { createWorkflowsRuntime, type WorkflowsRuntime } from "../workflows/execution"
 import type { SixbDefinitions } from "./definitions"
+import { shareOntologyMutationRuntime } from "./ontology-mutations"
 import type { OntologySource, SixbRuntimeContext } from "./types"
 
 /** Domain SDK bound to one immutable execution and one registered runtime authority. */
@@ -58,6 +59,7 @@ export function createBoundSixb<TOntologySources extends readonly OntologySource
     execution,
     ...createExecutionFacades<TOntologySources>(runtime, execution, dependencies),
   }
+  shareOntologyMutationRuntime(runtime, sixb)
   boundSixbInstances.add(sixb)
   return sixb
 }

--- a/packages/core/src/storage/in-memory/index.ts
+++ b/packages/core/src/storage/in-memory/index.ts
@@ -110,6 +110,8 @@ export class InMemoryStorage implements Storage {
       getMaterializationLifecycle: () => this.getActiveMaterializationLifecycle(),
       assertSourceMaterializationExecution: (input) =>
         this.projectionRunStorage.assertSourceMaterializationExecutionUnlocked(input),
+      executionExists: async (projectId, executionId) =>
+        (await this.executionStorage.getById({ projectId, id: executionId })) !== null,
     })
     this.ontology = createOntologyOperationScope(this.ontologyStorage, scope)
     this.ontologyStorage.registerTestingAlias(this.ontology)

--- a/packages/core/src/storage/ontology/commits.ts
+++ b/packages/core/src/storage/ontology/commits.ts
@@ -55,6 +55,7 @@ interface OntologyCommitFields {
   readonly id: string
   readonly idempotencyKey: string
   readonly requestHash: string
+  readonly executionId: string
   readonly origin: OntologyMaterializationOrigin
   readonly actor?: EventActor
   readonly ontologyRevision: string

--- a/packages/core/src/storage/ontology/in-memory/index.ts
+++ b/packages/core/src/storage/ontology/in-memory/index.ts
@@ -26,6 +26,7 @@ interface InMemoryOntologyStorageOptions {
   readonly getTransactionToken: () => object | null
   readonly getMaterializationLifecycle: () => ProviderMaterializationTransactionLifecycle | null
   readonly assertSourceMaterializationExecution: AssertSourceMaterializationExecution
+  readonly executionExists: (projectId: string, executionId: string) => Promise<boolean>
 }
 
 export class InMemoryOntologyStorage implements OntologyStorage {
@@ -58,6 +59,7 @@ export class InMemoryOntologyStorage implements OntologyStorage {
       timeseries,
       options.getTransactionToken,
       options.getMaterializationLifecycle,
+      options.executionExists,
       {
         beforeRead: (boundary) => this.testHooks.beforeRead?.(boundary),
         beforeWrite: (boundary, ordinal) => this.testHooks.beforeWrite?.(boundary, ordinal),

--- a/packages/core/src/storage/ontology/in-memory/materializations.ts
+++ b/packages/core/src/storage/ontology/in-memory/materializations.ts
@@ -184,6 +184,7 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
     private readonly timeseries: InMemoryTimeseriesStorage,
     private readonly getTransactionToken: () => object | null,
     private readonly getMaterializationLifecycle: () => ProviderMaterializationTransactionLifecycle | null,
+    private readonly executionExists: (projectId: string, executionId: string) => Promise<boolean>,
     private readonly hooks: InMemoryOntologyStorageTestHooks = {}
   ) {}
 
@@ -196,6 +197,11 @@ export class InMemoryOntologyMaterializationStorage implements OntologyMateriali
       )
     }
     assertMaterializationHeader(input)
+    if (!(await this.executionExists(input.commit.projectId, input.commit.executionId))) {
+      throw new MaterializationValidationError(
+        `Ontology commit execution '${input.commit.executionId}' does not exist in project '${input.commit.projectId}'.`
+      )
+    }
     this.assertCommitAbsent(input)
     for (const expected of input.expected.sources)
       this.assertSource(expected, input.commit.projectId)

--- a/packages/core/src/storage/ontology/provider-header-validation.ts
+++ b/packages/core/src/storage/ontology/provider-header-validation.ts
@@ -35,6 +35,7 @@ function assertCommitEnvelope(commit: OntologyCommitWrite): void {
   assertNonblank(commit.id, "Materialization commit id")
   assertNonblank(commit.idempotencyKey, "Materialization idempotency key")
   assertNonblank(commit.requestHash, "Materialization request hash")
+  assertNonblank(commit.executionId, "Materialization execution id")
   assertNonblank(commit.ontologyRevision, "Materialization ontology revision")
   assertTimestamp(commit.committedAt, "Materialization commit time")
 }

--- a/packages/core/src/testing/materializer-fixture.ts
+++ b/packages/core/src/testing/materializer-fixture.ts
@@ -1,3 +1,4 @@
+import { createTestingScope } from "../execution/scopes"
 import type { JsonValue } from "../json"
 import type {
   EditCommitResult,
@@ -8,8 +9,8 @@ import type {
   TelemetryPointWrite,
 } from "../materialization/model"
 import {
+  type BoundOntologyMaterializer,
   createOntologyMaterializer,
-  type OntologyMaterializer,
   type OntologyMaterializerDependencies,
 } from "../materializer/materializer"
 import type { OntologyRegistry } from "../ontology"
@@ -33,7 +34,7 @@ export interface MaterializerFixtureSeed {
 }
 
 export interface MaterializerTestFixture {
-  readonly materializer: OntologyMaterializer
+  readonly materializer: BoundOntologyMaterializer
   commit(operations: readonly OntologyEditOperation[]): Promise<EditCommitResult>
   appendTelemetry(points: readonly TelemetryPointWrite[]): Promise<TelemetryCommitResult>
   seed(input: MaterializerFixtureSeed): Promise<void>
@@ -60,7 +61,14 @@ export function createMaterializerTestFixture(input: {
     projections,
     storage: input.storage,
     dependencies: input.dependencies,
-  })
+  }).withScope(
+    createTestingScope({
+      projectId: input.projectId,
+      executionId: `materializer_fixture_execution:${input.projectId}`,
+      requestId: `materializer_fixture_request:${input.projectId}`,
+      correlationId: `materializer_fixture_correlation:${input.projectId}`,
+    })
+  )
   let requestOrdinal = 0
 
   function nextRequestId(kind: "edit" | "telemetry"): string {

--- a/packages/core/src/testing/materializer-storage-contract.ts
+++ b/packages/core/src/testing/materializer-storage-contract.ts
@@ -10,6 +10,10 @@ import {
   prop,
   type Storage,
 } from ".."
+import type { TrustedPrimitiveRef } from "../execution"
+import { restoreTrustedPrimitiveExecutionScope } from "../execution/durable"
+import { createTestingScope } from "../execution/scopes"
+import type { OntologyMaterializer } from "../materializer"
 import {
   createOntologyMaterializer,
   type OntologyEditOperation,
@@ -17,8 +21,8 @@ import {
   type ProjectionSourceEntry,
 } from "../materializer"
 import type { ActionRunStorage, ProjectionRunStorage } from "../storage"
-import { queueTestActionRun } from "./action-execution"
-import { startTestProjectionRun } from "./projection-execution"
+import { createTestActionExecution, queueTestActionRun } from "./action-execution"
+import { createTestProjectionExecution, startTestProjectionRun } from "./projection-execution"
 
 export interface MaterializerStorageContractProvider<TStorage extends Storage> {
   readonly createStorage: () => TStorage | Promise<TStorage>
@@ -97,7 +101,6 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         materializationId: () => `storage-contract-candidate-${++materializationOrdinal}`,
       },
     })
-
     try {
       const firstVersion = {
         datasetId: devices.id,
@@ -110,7 +113,13 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         protocol: "replacement",
         datasetVersion: firstVersion,
       })
-      const first = await materializer.projections.replace({
+      const firstMaterializer = await projectionMaterializer(
+        materializer,
+        storage,
+        deviceProjection.id,
+        "replacement-v1"
+      )
+      const first = await firstMaterializer.projections.replace({
         source: { projectionId: deviceProjection.id },
         datasetVersion: firstVersion,
         execution: firstExecution,
@@ -136,7 +145,13 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         protocol: "replacement",
         datasetVersion: secondVersion,
       })
-      const second = await materializer.projections.replace({
+      const secondMaterializer = await projectionMaterializer(
+        materializer,
+        storage,
+        deviceProjection.id,
+        "replacement-v2"
+      )
+      const second = await secondMaterializer.projections.replace({
         source: { projectionId: deviceProjection.id },
         datasetVersion: secondVersion,
         execution: secondExecution,
@@ -155,8 +170,18 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         })
       ).toBeNull()
 
+      await createTestActionExecution(storage.executions, {
+        projectId: "materializer-storage-contract",
+        actionId: "renameDevice",
+        runId: "missing-action-run",
+      })
+      const missingActionMaterializer = await primitiveMaterializer(materializer, storage, {
+        kind: "action",
+        id: "renameDevice",
+        runId: "missing-action-run",
+      })
       await expect(
-        materializer.edits.commit({
+        missingActionMaterializer.edits.commit({
           mode: "atomic",
           source: { kind: "action", actionId: "renameDevice", runId: "missing-action-run" },
           operations: [
@@ -187,7 +212,12 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         id: "action-run",
         projectId: "materializer-storage-contract",
       })
-      const actionCommit = await materializer.edits.commit({
+      const actionMaterializer = await primitiveMaterializer(materializer, storage, {
+        kind: "action",
+        id: "renameDevice",
+        runId: "action-run",
+      })
+      const actionCommit = await actionMaterializer.edits.commit({
         mode: "atomic",
         source: { kind: "action", actionId: "renameDevice", runId: "action-run" },
         operations: [
@@ -216,8 +246,20 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         versionId: "readings-v1",
         createdAt: "2026-01-03T00:00:00.000Z",
       }
+      await createTestProjectionExecution(storage.executions, {
+        projectId: "materializer-storage-contract",
+        projectionId: temperatureProjection.id,
+        runId: "missing-telemetry-run",
+        datasetId: readings.id,
+        datasetVersionId: "missing-readings-run",
+      })
+      const missingTelemetryMaterializer = await primitiveMaterializer(materializer, storage, {
+        kind: "projection",
+        id: temperatureProjection.id,
+        runId: "missing-telemetry-run",
+      })
       await expect(
-        materializer.telemetry.append({
+        missingTelemetryMaterializer.telemetry.append({
           source: {
             kind: "projection",
             projection: { projectionId: temperatureProjection.id },
@@ -255,7 +297,13 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         datasetVersion: telemetryVersion,
         fixedBatchSize: 1,
       })
-      const telemetry = await materializer.telemetry.append({
+      const telemetryMaterializer = await projectionMaterializer(
+        materializer,
+        storage,
+        temperatureProjection.id,
+        "telemetry-v1"
+      )
+      const telemetry = await telemetryMaterializer.telemetry.append({
         source: {
           kind: "projection",
           projection: { projectionId: temperatureProjection.id },
@@ -306,6 +354,7 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         materializationId: () => `scope-contract-candidate-${++materializationOrdinal}`,
       },
     })
+    const runtimeMaterializer = materializer.withScope(runtimeScope())
     const linkRef = (targetId: string) => ({
       source: { objectTypeId: Device.id, primaryId: "document" },
       linkId: "parent",
@@ -323,7 +372,13 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
         protocol: "replacement",
         datasetVersion,
       })
-      await materializer.projections.replace({
+      const projectionMaterializerForRun = await projectionMaterializer(
+        materializer,
+        storage,
+        deviceProjection.id,
+        `scope-${versionId}`
+      )
+      await projectionMaterializerForRun.projections.replace({
         source: { projectionId: deviceProjection.id },
         datasetVersion,
         execution,
@@ -335,7 +390,7 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
       })
     }
     const edit = (requestId: string, operation: OntologyEditOperation) =>
-      materializer.edits.commit({
+      runtimeMaterializer.edits.commit({
         mode: "atomic",
         source: { kind: "runtime", requestId },
         operations: [operation],
@@ -388,6 +443,52 @@ export function runMaterializerStorageContractSuite<TStorage extends Storage>(
       await provider.cleanup?.(createdStorage)
     }
   })
+}
+
+function runtimeScope() {
+  return createTestingScope({
+    projectId: "materializer-storage-contract",
+    executionId: "materializer-storage-contract-runtime-execution",
+    requestId: "materializer-storage-contract-runtime-request",
+    correlationId: "materializer-storage-contract-runtime-correlation",
+  })
+}
+
+async function projectionMaterializer(
+  materializer: OntologyMaterializer,
+  storage: ContractStorage,
+  projectionId: string,
+  runId: string
+) {
+  return primitiveMaterializer(materializer, storage, {
+    kind: "projection",
+    id: projectionId,
+    runId,
+  })
+}
+
+async function primitiveMaterializer(
+  materializer: OntologyMaterializer,
+  storage: ContractStorage,
+  primitive: TrustedPrimitiveRef
+) {
+  const run =
+    primitive.kind === "action"
+      ? await storage.actionRuns.getById({
+          projectId: "materializer-storage-contract",
+          id: primitive.runId,
+        })
+      : await storage.projectionRuns.getById({
+          projectId: "materializer-storage-contract",
+          id: primitive.runId,
+        })
+  const executionId = run?.executionId ?? `test_${primitive.kind}_execution:${primitive.runId}`
+  const execution = await storage.executions.getById({
+    projectId: "materializer-storage-contract",
+    id: executionId,
+  })
+  if (!execution) throw new Error(`Test execution '${executionId}' is missing.`)
+  return materializer.withScope(restoreTrustedPrimitiveExecutionScope({ execution, primitive }))
 }
 
 function requireContractStorage(storage: Storage): ContractStorage {

--- a/packages/core/src/testing/ontology-contract-fixture.ts
+++ b/packages/core/src/testing/ontology-contract-fixture.ts
@@ -36,6 +36,7 @@ export function contractEditHeader(id: string): MaterializationPlanHeader {
       id,
       idempotencyKey: `runtime:${id}`,
       requestHash: `hash:${id}`,
+      executionId: `contract-execution:${id}`,
       origin: { kind: "runtime", requestId: id },
       ontologyRevision: "ontology-contract-revision",
       intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -67,7 +68,9 @@ export function contractEditResult(commitId: string, eventCount = 0) {
 
 export async function commitEmptyEdit(storage: OntologyContractStorage, id: string): Promise<void> {
   await storage.transaction(async (tx) => {
-    const session = await tx.ontology.materializations.begin(contractEditHeader(id))
+    const header = contractEditHeader(id)
+    await ensureContractExecution(tx, header)
+    const session = await tx.ontology.materializations.begin(header)
     await tx.ontology.materializations.finalize({
       session,
       finalization: { sourceActivations: [], result: contractEditResult(id) },
@@ -104,6 +107,7 @@ export async function commitExactObject(
     schemaVersion: 1 as const,
     projectId: header.commit.projectId,
     occurredAt: header.commit.committedAt,
+    correlationId: `contract-correlation:${id}`,
     origin: header.commit.origin,
     commitId: id,
     type: "object.created" as const,
@@ -140,6 +144,7 @@ export async function commitExactObject(
   ]
 
   await storage.transaction(async (tx) => {
+    await ensureContractExecution(tx, header)
     const materializations = tx.ontology.materializations
     const session = await materializations.begin(header)
     await materializations.stageWork({ session, records: work })
@@ -195,4 +200,26 @@ export async function commitExactObject(
   })
 
   return { eventId }
+}
+
+export async function ensureContractExecution(
+  storage: Pick<Storage, "executions">,
+  header: MaterializationPlanHeader
+): Promise<void> {
+  if (
+    await storage.executions.getById({
+      projectId: header.commit.projectId,
+      id: header.commit.executionId,
+    })
+  ) {
+    return
+  }
+  await storage.executions.create({
+    id: header.commit.executionId,
+    projectId: header.commit.projectId,
+    executor: { type: "request", requestId: `contract-request:${header.commit.id}` },
+    source: { type: "http", requestId: `contract-request:${header.commit.id}` },
+    correlationId: `contract-correlation:${header.commit.id}`,
+    authorizationRef: { type: "disabled" },
+  })
 }

--- a/packages/core/src/testing/ontology-storage-contract.ts
+++ b/packages/core/src/testing/ontology-storage-contract.ts
@@ -16,6 +16,7 @@ import {
   commitExactObject,
   contractEditHeader,
   contractEditResult,
+  ensureContractExecution,
   type OntologyContractStorage,
 } from "./ontology-contract-fixture"
 import { startTestProjectionRun } from "./projection-execution"
@@ -71,6 +72,7 @@ interface ReadyCandidate {
   readonly execution: ProjectionExecution
   readonly materializationId: string
   readonly source: { readonly projectionId: string }
+  readonly executionId: string
 }
 
 function ontologyOutboxFailure(message: string): OntologyOutboxFailure {
@@ -131,6 +133,7 @@ export function runOntologyStorageContractSuite<TStorage extends OntologyStorage
         ;(divergent.commit as { requestHash: string }).requestHash = "different-hash"
         await expect(
           storage.transaction(async (tx) => {
+            await ensureContractExecution(tx, divergent)
             await tx.ontology.materializations.begin(divergent)
           })
         ).rejects.toMatchObject({ kind: "idempotency" })
@@ -142,6 +145,30 @@ export function runOntologyStorageContractSuite<TStorage extends OntologyStorage
         })
         expect(list).toMatchObject({ total: 1, hasMore: false })
         expect(list.commits.map((commit) => commit.id)).toEqual(["commit-one"])
+      })
+    })
+
+    test("rejects an ontology commit whose execution does not exist", async () => {
+      await withStorage(async (storage) => {
+        const header = contractEditHeader("missing-execution")
+        await expect(
+          storage.transaction(async (tx) => {
+            const session = await tx.ontology.materializations.begin(header)
+            await tx.ontology.materializations.finalize({
+              session,
+              finalization: {
+                sourceActivations: [],
+                result: contractEditResult(header.commit.id),
+              },
+            })
+          })
+        ).rejects.toThrow()
+        await expect(
+          storage.ontology.commits.getById({
+            projectId: header.commit.projectId,
+            id: header.commit.id,
+          })
+        ).resolves.toBeNull()
       })
     })
 
@@ -181,9 +208,9 @@ export function runOntologyStorageContractSuite<TStorage extends OntologyStorage
         let leakedSession: MaterializationSession | undefined
         await expect(
           storage.transaction(async (tx) => {
-            leakedSession = await tx.ontology.materializations.begin(
-              contractEditHeader("leaked-session")
-            )
+            const leakedHeader = contractEditHeader("leaked-session")
+            await ensureContractExecution(tx, leakedHeader)
+            leakedSession = await tx.ontology.materializations.begin(leakedHeader)
           })
         ).rejects.toThrow("unfinished materialization session")
         if (!leakedSession) throw new Error("Expected an unfinished session handle")
@@ -715,7 +742,7 @@ export function runOntologyStorageContractSuite<TStorage extends OntologyStorage
             if (!tx.projectionRuns) {
               throw new Error("Contract transaction omitted required storage facades.")
             }
-            const header = telemetryHeader(identity, run.run.id)
+            const header = telemetryHeader(identity, run.run.id, run.run.executionId)
             const session = await tx.ontology.materializations.begin(header)
             await tx.ontology.materializations.finalize({
               session,
@@ -815,7 +842,7 @@ async function createReadyEmptyCandidate(
     assertionCount: 0,
     readyAt: new Date(Date.parse(identity.datasetVersion.createdAt) + 1_000).toISOString(),
   })
-  return { identity, execution, materializationId, source }
+  return { identity, execution, materializationId, source, executionId: run.run.executionId }
 }
 
 async function activateEmptyCandidate(
@@ -836,6 +863,7 @@ async function activateEmptyCandidate(
       id: commitId,
       idempotencyKey: `projection:${commitId}`,
       requestHash: `hash:${commitId}`,
+      executionId: candidate.executionId,
       origin: {
         kind: "projection",
         projectionId: candidate.source.projectionId,
@@ -909,7 +937,8 @@ async function activateEmptyCandidate(
 
 function telemetryHeader(
   identity: ProjectionMaterializationIdentity,
-  projectionRunId: string
+  projectionRunId: string,
+  executionId: string
 ): MaterializationPlanHeader {
   if (identity.protocol !== "telemetry") throw new Error("Expected telemetry identity")
   return {
@@ -918,6 +947,7 @@ function telemetryHeader(
       id: "telemetry-commit",
       idempotencyKey: "telemetry:telemetry-run:0",
       requestHash: "hash:telemetry-run:0",
+      executionId,
       origin: {
         kind: "telemetry",
         source: {

--- a/packages/core/tests/authorization-decision.test.ts
+++ b/packages/core/tests/authorization-decision.test.ts
@@ -270,6 +270,7 @@ const envelope = {
   schemaVersion: 1 as const,
   projectId: "p1",
   occurredAt: "2026-01-01T00:00:00.000Z",
+  correlationId: "correlation-1",
   cursor: "c1",
   origin: { kind: "runtime" as const, requestId: "request-1" },
   commitId: "commit-1",

--- a/packages/core/tests/edits.test.ts
+++ b/packages/core/tests/edits.test.ts
@@ -16,8 +16,8 @@ import {
 import { recordEdits } from "../src/actions/worker"
 import type { EditBatch } from "../src/edits"
 import { lowerEditBatch } from "../src/edits"
+import { bindDurablePrimitiveExecution } from "../src/execution/primitive"
 import { createLinkScopeFingerprint } from "../src/materializer"
-import { getOntologyMutationRuntime } from "../src/runtime/internal"
 import type { ObjectRow, Storage } from "../src/storage"
 import { StorageTransactionError } from "../src/storage"
 import { createTestSixb, queueTestActionRun } from "../src/testing"
@@ -86,7 +86,7 @@ async function startActionRun(host: EditsHost, runId: string, actionId = "markPa
   await actionRuns.start({ projectId: host.id, id: runId })
 }
 
-function commit(
+async function commit(
   host: EditsHost,
   input: {
     readonly runId: string
@@ -95,8 +95,20 @@ function commit(
     readonly dependencies?: Parameters<typeof commitActionEdits>[0]["dependencies"]
   }
 ) {
+  const run = await host.storage.actionRuns?.getById({ projectId: host.id, id: input.runId })
+  if (!run) throw new Error(`Expected Action run '${input.runId}'.`)
+  const execution = await host.storage.executions.getById({
+    projectId: host.id,
+    id: run.executionId,
+  })
+  if (!execution) throw new Error(`Expected Action execution '${run.executionId}'.`)
+  const primitive = {
+    kind: "action" as const,
+    id: input.actionId ?? "markPaid",
+    runId: input.runId,
+  }
   return commitActionEdits({
-    mutations: getOntologyMutationRuntime(host),
+    mutations: bindDurablePrimitiveExecution(host, { execution, primitive }).ontologyMutations,
     projectId: host.id,
     runId: input.runId,
     actionId: input.actionId ?? "markPaid",

--- a/packages/core/tests/event-schedules.test.ts
+++ b/packages/core/tests/event-schedules.test.ts
@@ -112,6 +112,7 @@ function objectUpdatedFact(
     schemaVersion: 1,
     projectId: "test",
     occurredAt: "2026-01-01T00:00:00.000Z",
+    correlationId: `correlation-${id}`,
     origin: { kind: "runtime", requestId: id },
     commitId: `commit-${id}`,
     commitOrdinal: 0,

--- a/packages/core/tests/events-outbox-dispatcher.test.ts
+++ b/packages/core/tests/events-outbox-dispatcher.test.ts
@@ -525,6 +525,7 @@ function objectCreatedEnvelope(id: string): OntologyMaterializationEvent {
     schemaVersion: 1,
     projectId: "project",
     occurredAt: NOW.toISOString(),
+    correlationId: "correlation-1",
     origin: { kind: "runtime", requestId: "request-1" },
     commitId: "commit-1",
     commitOrdinal: 0,

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -8,6 +8,7 @@ import {
   createPrincipalRuntimeAuthorization,
   createTrustedPrimitiveRuntimeAuthorization,
   getAuthorizationRef,
+  resolveExecutionScopeAuthorization,
   resolveRuntimeAuthorization,
 } from "../src/execution/authorization"
 import {
@@ -125,6 +126,22 @@ describe("runtime authorization capabilities", () => {
 })
 
 describe("execution scopes", () => {
+  test("rejects mixing an execution with authority from another scope", () => {
+    const principalScope = createTestingScope({
+      projectId: "project-1",
+      context: authorizationContext({ type: "user", id: "user-1" }),
+    })
+    const disabledScope = createTestingScope({ projectId: "project-1" })
+
+    expect(() => resolveExecutionScopeAuthorization("project-1", principalScope)).not.toThrow()
+    expect(() =>
+      resolveExecutionScopeAuthorization("project-1", {
+        execution: principalScope.execution,
+        authorization: disabledScope.authorization,
+      })
+    ).toThrow("incompatible with its authority")
+  })
+
   test("creates a principal request scope with explicit request provenance", () => {
     const scope = createPrincipalRequestScope({
       projectId: "project-1",

--- a/packages/core/tests/execution-authorization.test.ts
+++ b/packages/core/tests/execution-authorization.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { agentServiceAccountId } from "../src/agents/authority"
 import type { Principal } from "../src/auth"
 import { type AuthorizationContext, emptyGrantIndex } from "../src/authorization"
+import { isSixbError } from "../src/errors/internal"
 import { restoreAgentExecutionScope } from "../src/execution/agent"
 import {
   assertExecutionScopeProject,
@@ -134,12 +135,21 @@ describe("execution scopes", () => {
     const disabledScope = createTestingScope({ projectId: "project-1" })
 
     expect(() => resolveExecutionScopeAuthorization("project-1", principalScope)).not.toThrow()
-    expect(() =>
+    let error: unknown
+    try {
       resolveExecutionScopeAuthorization("project-1", {
         execution: principalScope.execution,
         authorization: disabledScope.authorization,
       })
-    ).toThrow("incompatible with its authority")
+    } catch (cause) {
+      error = cause
+    }
+    expect(isSixbError(error)).toBe(true)
+    expect(error).toMatchObject({ code: "internal.unexpected" })
+    expect(error).toHaveProperty(
+      "message",
+      expect.stringContaining("incompatible with its authority")
+    )
   })
 
   test("creates a principal request scope with explicit request provenance", () => {

--- a/packages/core/tests/materializer-contracts.test.ts
+++ b/packages/core/tests/materializer-contracts.test.ts
@@ -287,36 +287,6 @@ describe("materializer canonical contracts", () => {
     ).toThrow("exactly its matching link assertion")
   })
 
-  test("normalizes actors to the exact persisted shape", () => {
-    const normalized = normalizeOntologyEditCommit({
-      mode: "continue",
-      source: { kind: "runtime", requestId: "request-1" },
-      actor: { type: "serviceAccount", id: "service-1", ignored: true },
-      operations: [],
-    } as Parameters<typeof normalizeOntologyEditCommit>[0] & {
-      actor: { type: "serviceAccount"; id: string; ignored: boolean }
-    })
-    expect(normalized.actor).toEqual({ type: "serviceAccount", id: "service-1" })
-    expect(Object.keys(normalized.actor ?? {})).toEqual(["type", "id"])
-
-    expect(() =>
-      normalizeOntologyEditCommit({
-        mode: "continue",
-        source: { kind: "runtime", requestId: "request-1" },
-        actor: { type: "robot", id: "service-1" },
-        operations: [],
-      } as unknown as Parameters<typeof normalizeOntologyEditCommit>[0])
-    ).toThrow("Event actor type")
-    expect(() =>
-      normalizeOntologyEditCommit({
-        mode: "continue",
-        source: { kind: "runtime", requestId: "request-1" },
-        actor: { type: "system", id: "  " },
-        operations: [],
-      })
-    ).toThrow("Event actor id must be a nonblank string")
-  })
-
   test("collapses equal telemetry duplicates and rejects conflicting points", () => {
     const point = {
       series: { object: leftObject, propertyId: "temperature" },
@@ -404,6 +374,7 @@ describe("materializer canonical contracts", () => {
         id: "commit-1",
         idempotencyKey: "runtime:request-1",
         requestHash: "request-hash",
+        executionId: "execution-1",
         origin: { kind: "runtime", requestId: "request-1" },
         ontologyRevision: "ontology-revision",
         intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -446,6 +417,7 @@ describe("materializer canonical contracts", () => {
       id: "commit-1",
       idempotencyKey: "runtime:request-1",
       requestHash: "request-hash",
+      executionId: "execution-1",
       origin: { kind: "runtime", requestId: "request-1" },
       ontologyRevision: "ontology-revision",
       intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -491,6 +463,7 @@ describe("materializer canonical contracts", () => {
       schemaVersion: 1,
       projectId: "project",
       occurredAt: "2026-01-02T03:04:05.000Z",
+      correlationId: "correlation-1",
       origin: { kind: "runtime", requestId: "request-1" },
       commitId: "commit-1",
       commitOrdinal: 0,
@@ -542,11 +515,12 @@ describe("materializer canonical contracts", () => {
   })
 
   test("freezes persisted event ordering, origin, and commit ordinal", () => {
-    const event: OntologyMaterializationEvent = {
+    const event = {
       id: "event-1",
       schemaVersion: 1,
       projectId: "project",
       occurredAt: "2026-01-02T03:04:05.000Z",
+      correlationId: "correlation-1",
       origin: { kind: "runtime", requestId: "request-1" },
       commitId: "commit-1",
       commitOrdinal: 0,
@@ -561,7 +535,7 @@ describe("materializer canonical contracts", () => {
           obsolete: { operation: "cleared", before: "old", after: null },
         },
       },
-    }
+    } satisfies OntologyMaterializationEvent
 
     expect(event.payload.propertyChanges.obsolete?.operation).toBe("cleared")
     expect(ONTOLOGY_MATERIALIZATION_EVENT_KIND_ORDER).toEqual([

--- a/packages/core/tests/materializer-edits.test.ts
+++ b/packages/core/tests/materializer-edits.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import { emptyGrantIndex } from "../src"
+import { createTestingScope } from "../src/execution/scopes"
 import { createEventId, MaterializationConflictError } from "../src/materializer"
 import { InMemoryStorage, type Storage, type StoredLinkSlotOverride } from "../src/storage"
 import { getInMemoryOntologyStorageTestingAdapter } from "../src/storage/ontology/in-memory/testing"
@@ -15,6 +17,81 @@ import {
 const ref = (primaryId: string) => ({ objectTypeId: "Device", primaryId })
 
 describe("ontology materializer edits", () => {
+  test("derives durable provenance and event actor from the bound principal scope", async () => {
+    const storage = new InMemoryStorage()
+    await storage.auth.users.create({
+      projectId: "project",
+      id: "user-1",
+      email: "user-1@example.com",
+    })
+    const scope = createTestingScope({
+      projectId: "project",
+      executionId: "principal-execution",
+      requestId: "principal-request",
+      correlationId: "principal-correlation",
+      context: {
+        principal: { type: "user", id: "user-1" },
+        groupIds: [],
+        roleIds: [],
+        grants: emptyGrantIndex(),
+      },
+    })
+    const { materializer } = createMaterializerFixture({ storage, scope })
+
+    const result = await materializer.edits.commit(
+      atomic("principal-write", [
+        {
+          id: "create",
+          kind: "object.create",
+          ref: ref("principal-object"),
+          properties: { name: "Principal object" },
+        },
+      ])
+    )
+    await expect(
+      storage.executions.getById({ projectId: "project", id: scope.execution.id })
+    ).resolves.toMatchObject({
+      requestedBy: { type: "user", id: "user-1" },
+      authorizationRef: { type: "principal", principal: { type: "user", id: "user-1" } },
+    })
+    await expect(
+      storage.ontology.commits.getById({ projectId: "project", id: result.commitId })
+    ).resolves.toMatchObject({
+      executionId: "principal-execution",
+      actor: { type: "user", id: "user-1" },
+    })
+    const [event] = await storage.ontology.outbox.claim({
+      projectId: "project",
+      now: "2027-01-01T00:00:00.000Z",
+      limit: 10,
+      leaseId: "principal-events",
+      leaseExpiresAt: "2027-01-01T01:00:00.000Z",
+    })
+    expect(event.envelope).toMatchObject({
+      correlationId: "principal-correlation",
+      actor: { type: "user", id: "user-1" },
+    })
+  })
+
+  test("rejects replaying one request id from a different execution", async () => {
+    const storage = new InMemoryStorage()
+    const materializerFor = (executionId: string) =>
+      createMaterializerFixture({
+        storage,
+        scope: createTestingScope({
+          projectId: "project",
+          executionId,
+          requestId: "shared-request",
+          correlationId: `correlation:${executionId}`,
+        }),
+      }).materializer
+
+    await materializerFor("execution-1").edits.commit(atomic("shared-request", []))
+    await expect(
+      materializerFor("execution-2").edits.commit(atomic("shared-request", []))
+    ).rejects.toThrow("belongs to execution 'execution-1', not 'execution-2'")
+  })
+
   test("rejects an Action commit before mutation when strict run capabilities are absent", async () => {
     class StorageWithoutActionFence extends InMemoryStorage {
       private readonly missingActionRuns: Storage["actionRuns"] = undefined
@@ -46,7 +123,12 @@ describe("ontology materializer edits", () => {
   test("rejects invalid Action runs before ontology reads, staging, or mutation", async () => {
     const scenarios = [
       { kind: "absent", storedActionId: null, start: false, error: "not found" },
-      { kind: "wrong-action", storedActionId: "other", start: true, error: "does not belong" },
+      {
+        kind: "wrong-action",
+        storedActionId: "other",
+        start: true,
+        error: "does not authorize",
+      },
       { kind: "not-running", storedActionId: "approve", start: false, error: "status 'queued'" },
     ] as const
 

--- a/packages/core/tests/materializer-fixture.ts
+++ b/packages/core/tests/materializer-fixture.ts
@@ -9,6 +9,9 @@ import {
   OntologyRegistry,
   prop,
 } from "../src"
+import { restoreTrustedPrimitiveExecutionScope } from "../src/execution/durable"
+import { createTestingScope } from "../src/execution/scopes"
+import type { ExecutionScope } from "../src/execution/types"
 import {
   createOntologyMaterializer,
   type OntologyMaterializerDependencies,
@@ -19,7 +22,7 @@ import {
   type ProjectionSourceReplacement,
   type TelemetryAppend,
 } from "../src/materializer"
-import { claimTestProjectionRun } from "../src/testing"
+import { claimTestProjectionRun, createTestActionExecution } from "../src/testing"
 
 export const Device = defineObjectType({
   id: "Device",
@@ -62,6 +65,7 @@ export function createMaterializerFixture(
   input: {
     readonly dependencies?: OntologyMaterializerDependencies
     readonly storage?: InMemoryStorage
+    readonly scope?: ExecutionScope
   } = {}
 ) {
   const ontology = new OntologyRegistry({ sources: [Device] })
@@ -85,8 +89,23 @@ export function createMaterializerFixture(
       ...input.dependencies,
     },
   })
+  const runtimeMaterializer = baseMaterializer.withScope(
+    input.scope ??
+      createTestingScope({
+        projectId: "project",
+        executionId: "materializer-fixture-runtime-execution",
+        requestId: "materializer-fixture-runtime-request",
+        correlationId: "materializer-fixture-runtime-correlation",
+      })
+  )
   const materializer = {
-    edits: baseMaterializer.edits,
+    edits: {
+      async commit(request: Parameters<typeof runtimeMaterializer.edits.commit>[0]) {
+        if (request.source.kind !== "action") return runtimeMaterializer.edits.commit(request)
+        const scope = await actionScope(storage, request.source.actionId, request.source.runId)
+        return baseMaterializer.withScope(scope).edits.commit(request)
+      },
+    },
     projections: {
       async replace(request: ProjectionSourceReplacement) {
         const execution = await resolveFixtureExecution(storage, projections, request.execution, {
@@ -94,17 +113,34 @@ export function createMaterializerFixture(
           protocol: "replacement",
           datasetVersion: request.datasetVersion,
         })
-        return baseMaterializer.projections.replace({ ...request, execution })
+        const scope = await projectionScope(storage, {
+          projectId: "project",
+          projectionId: request.source.projectionId,
+          runId: execution.projectionRunId,
+        })
+        return baseMaterializer.withScope(scope).projections.replace({ ...request, execution })
       },
-      finishRun: baseMaterializer.projections.finishRun,
+      async finishRun(request: Parameters<typeof runtimeMaterializer.projections.finishRun>[0]) {
+        const scope = await projectionScope(storage, {
+          projectId: "project",
+          projectionId: request.source.projectionId,
+          runId: request.execution.projectionRunId,
+        })
+        return baseMaterializer.withScope(scope).projections.finishRun(request)
+      },
     },
     telemetry: {
       async append(request: TelemetryAppend) {
-        if (
-          request.source.kind !== "projection" ||
-          request.source.execution.executionToken !== FIXTURE_EXECUTION_TOKEN
-        ) {
-          return baseMaterializer.telemetry.append(request)
+        if (request.source.kind !== "projection") {
+          return runtimeMaterializer.telemetry.append(request)
+        }
+        if (request.source.execution.executionToken !== FIXTURE_EXECUTION_TOKEN) {
+          const scope = await projectionScope(storage, {
+            projectId: "project",
+            projectionId: request.source.projection.projectionId,
+            runId: request.source.execution.projectionRunId,
+          })
+          return baseMaterializer.withScope(scope).telemetry.append(request)
         }
         const execution = await claimProjectionExecution(storage, projections, {
           runId: request.source.execution.projectionRunId,
@@ -113,7 +149,12 @@ export function createMaterializerFixture(
           datasetVersion: request.source.datasetVersion,
           fixedBatchSize: request.source.sourceRowCount,
         })
-        return baseMaterializer.telemetry.append({
+        const scope = await projectionScope(storage, {
+          projectId: "project",
+          projectionId: request.source.projection.projectionId,
+          runId: execution.projectionRunId,
+        })
+        return baseMaterializer.withScope(scope).telemetry.append({
           ...request,
           source: { ...request.source, execution },
         })
@@ -121,6 +162,51 @@ export function createMaterializerFixture(
     },
   }
   return { materializer, storage, ontology, projections }
+}
+
+async function actionScope(
+  storage: InMemoryStorage,
+  actionId: string,
+  runId: string
+): Promise<ExecutionScope> {
+  const run = await storage.actionRuns?.getById({ projectId: "project", id: runId })
+  const executionId =
+    run?.executionId ??
+    (await createTestActionExecution(storage.executions, {
+      projectId: "project",
+      actionId,
+      runId,
+    }))
+  const execution = await storage.executions.getById({ projectId: "project", id: executionId })
+  if (!execution) throw new Error(`Action execution '${executionId}' is missing.`)
+  return restoreTrustedPrimitiveExecutionScope({
+    execution,
+    primitive: { kind: "action", id: actionId, runId },
+  })
+}
+
+export async function projectionScope(
+  storage: InMemoryStorage,
+  input: {
+    readonly projectId: string
+    readonly projectionId: string
+    readonly runId: string
+  }
+): Promise<ExecutionScope> {
+  const run = await storage.projectionRuns?.getById({
+    projectId: input.projectId,
+    id: input.runId,
+  })
+  if (!run) throw new Error(`Projection run '${input.runId}' is not available in the fixture.`)
+  const execution = await storage.executions.getById({
+    projectId: input.projectId,
+    id: run.executionId,
+  })
+  if (!execution) throw new Error(`Projection execution '${run.executionId}' is missing.`)
+  return restoreTrustedPrimitiveExecutionScope({
+    execution,
+    primitive: { kind: "projection", id: input.projectionId, runId: input.runId },
+  })
 }
 
 export function sourceEntry(id: string, name: string, note?: string | null): ProjectionSourceEntry {

--- a/packages/core/tests/materializer-projections.test.ts
+++ b/packages/core/tests/materializer-projections.test.ts
@@ -8,6 +8,7 @@ import {
   OntologyRegistry,
   prop,
 } from "../src"
+import { createTestingScope } from "../src/execution/scopes"
 import {
   createEventId,
   createOntologyMaterializer,
@@ -30,6 +31,7 @@ import {
   Device,
   entries,
   pendingProjectionExecution,
+  projectionScope,
   replacement,
   sourceEntry,
   sourceEntryWithParent,
@@ -579,7 +581,7 @@ describe("ontology materializer projection replacement", () => {
     })
     resume()
 
-    await expect(losing).rejects.toMatchObject({ kind: "run-correlation" })
+    await expect(losing).rejects.toMatchObject({ kind: "idempotency" })
     const loser = [
       ...getInMemoryOntologyStorageTestingAdapter(storage.ontology)
         .snapshot()
@@ -1289,22 +1291,31 @@ describe("ontology materializer projection replacement", () => {
         materializationId: () => "standalone-link-materialization",
       },
     })
-    await materializer.edits.commit(
-      atomic("standalone-link-endpoints", [
-        {
-          id: "one",
-          kind: "object.create",
-          ref: ref("one"),
-          properties: { name: "one" },
-        },
-        {
-          id: "two",
-          kind: "object.create",
-          ref: ref("two"),
-          properties: { name: "two" },
-        },
-      ])
-    )
+    await materializer
+      .withScope(
+        createTestingScope({
+          projectId: "project",
+          executionId: "standalone-link-request-execution",
+          requestId: "standalone-link-request",
+          correlationId: "standalone-link-correlation",
+        })
+      )
+      .edits.commit(
+        atomic("standalone-link-endpoints", [
+          {
+            id: "one",
+            kind: "object.create",
+            ref: ref("one"),
+            properties: { name: "one" },
+          },
+          {
+            id: "two",
+            kind: "object.create",
+            ref: ref("two"),
+            properties: { name: "two" },
+          },
+        ])
+      )
     const linkRef = { source: ref("one"), linkId: "peers", target: ref("two") }
     const datasetVersion = {
       datasetId: "device-peers",
@@ -1317,17 +1328,25 @@ describe("ontology materializer projection replacement", () => {
       protocol: "replacement",
       datasetVersion,
     })
-    const result = await materializer.projections.replace({
-      source: { projectionId: "device-peers" },
-      datasetVersion,
-      execution,
-      entries: entries([
-        {
-          root: { kind: "link", ref: linkRef },
-          assertions: [{ kind: "link", ref: linkRef }],
-        },
-      ]),
-    })
+    const result = await materializer
+      .withScope(
+        await projectionScope(storage, {
+          projectId: "project",
+          projectionId: "device-peers",
+          runId: execution.projectionRunId,
+        })
+      )
+      .projections.replace({
+        source: { projectionId: "device-peers" },
+        datasetVersion,
+        execution,
+        entries: entries([
+          {
+            root: { kind: "link", ref: linkRef },
+            assertions: [{ kind: "link", ref: linkRef }],
+          },
+        ]),
+      })
     expect(result.counts).toMatchObject({ linksCreated: 1 })
     expect(streamedLanes).toEqual(["source-replacement.link"])
     expect(
@@ -1384,23 +1403,31 @@ describe("ontology materializer projection replacement", () => {
       datasetVersion,
     })
     await expect(
-      materializer.projections.replace({
-        source: { projectionId: "owned" },
-        datasetVersion,
-        execution,
-        entries: entries([
-          {
-            root: { kind: "object", ref: { objectTypeId: "Owned", primaryId: "one" } },
-            assertions: [
-              {
-                kind: "object",
-                ref: { objectTypeId: "Owned", primaryId: "one" },
-                properties: { owned: "yes", unowned: "no" },
-              },
-            ],
-          },
-        ]),
-      })
+      materializer
+        .withScope(
+          await projectionScope(storage, {
+            projectId: "project",
+            projectionId: "owned",
+            runId: execution.projectionRunId,
+          })
+        )
+        .projections.replace({
+          source: { projectionId: "owned" },
+          datasetVersion,
+          execution,
+          entries: entries([
+            {
+              root: { kind: "object", ref: { objectTypeId: "Owned", primaryId: "one" } },
+              assertions: [
+                {
+                  kind: "object",
+                  ref: { objectTypeId: "Owned", primaryId: "one" },
+                  properties: { owned: "yes", unowned: "no" },
+                },
+              ],
+            },
+          ]),
+        })
     ).rejects.toThrow("unowned property")
 
     const { materializer: fixtureMaterializer } = createMaterializerFixture()

--- a/packages/core/tests/materializer-telemetry.test.ts
+++ b/packages/core/tests/materializer-telemetry.test.ts
@@ -463,7 +463,7 @@ describe("ontology materializer telemetry", () => {
     ).toHaveLength(2)
   })
 
-  test("uses one fenced transaction per projection batch and keeps runtime replay cheap", async () => {
+  test("uses one fenced transaction for projection batches and durable runtime replay", async () => {
     class TransactionCountingStorage extends InMemoryStorage {
       transactions: (StorageTransactionOptions | undefined)[] = []
 
@@ -533,7 +533,7 @@ describe("ontology materializer telemetry", () => {
     await expect(materializer.telemetry.append(runtimeAppend)).resolves.toMatchObject({
       created: false,
     })
-    expect(storage.transactions).toEqual([])
+    expect(storage.transactions).toEqual([{ isolation: "serializable" }])
   })
 
   test("uses physical input size for telemetry batch continuation after equal deduplication", async () => {

--- a/packages/core/tests/ontology-materialization-sealing.test.ts
+++ b/packages/core/tests/ontology-materialization-sealing.test.ts
@@ -11,6 +11,7 @@ import type {
   MaterializationStatePage,
   OntologyMaterializationStorage,
   ProjectionRunClaim,
+  Storage,
 } from "../src/storage"
 import { startTestProjectionRun } from "../src/testing"
 import { createMaterializerFixture } from "./materializer-fixture"
@@ -27,6 +28,7 @@ interface CandidateFixture {
   readonly materializationId: string
   readonly projectionKind: ReplacementKind
   readonly execution: { readonly projectionRunId: string; readonly executionToken: string }
+  readonly executionId: string
   readonly datasetVersion: {
     readonly datasetId: string
     readonly versionId: string
@@ -114,6 +116,7 @@ async function prepareEmptyCandidate(
     materializationId: input.materializationId,
     projectionKind: input.projectionKind,
     execution,
+    executionId: run.run.executionId,
     datasetVersion,
     readyAt: input.readyAt,
   }
@@ -131,6 +134,7 @@ function replacementHeader(
       id: commitId,
       idempotencyKey: `projection:${commitId}`,
       requestHash: commitId,
+      executionId: candidate.executionId,
       origin: {
         kind: "projection",
         projectionId: candidate.source.projectionId,
@@ -241,6 +245,7 @@ function emptyEditHeader(commitId: string): MaterializationPlanHeader {
       id: commitId,
       idempotencyKey: `runtime:${commitId}`,
       requestHash: commitId,
+      executionId: `execution:${commitId}`,
       origin: { kind: "runtime", requestId: commitId },
       ontologyRevision,
       intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -320,6 +325,28 @@ function objectUpsertChunk(
   }
 }
 
+async function beginMaterialization(
+  storage: Pick<Storage, "executions" | "ontology">,
+  header: MaterializationPlanHeader
+): Promise<MaterializationSession> {
+  if (!storage.ontology) throw new Error("missing ontology")
+  const execution = await storage.executions.getById({
+    projectId: header.commit.projectId,
+    id: header.commit.executionId,
+  })
+  if (!execution) {
+    await storage.executions.create({
+      id: header.commit.executionId,
+      projectId: header.commit.projectId,
+      executor: { type: "request", requestId: `request:${header.commit.id}` },
+      source: { type: "http", requestId: `request:${header.commit.id}` },
+      correlationId: `correlation:${header.commit.id}`,
+      authorizationRef: { type: "disabled" },
+    })
+  }
+  return storage.ontology.materializations.begin(header)
+}
+
 describe("in-memory ontology materialization finalization", () => {
   test("rejects ontology sessions inherited from a completed transaction", async () => {
     const storage = new InMemoryStorage()
@@ -331,7 +358,7 @@ describe("in-memory ontology materialization finalization", () => {
 
     await storage.transaction(() => {
       inheritedBegin = gate.then(() =>
-        storage.ontology.materializations.begin(emptyEditHeader("stale-transaction-context"))
+        beginMaterialization(storage, emptyEditHeader("stale-transaction-context"))
       )
     })
     release()
@@ -347,7 +374,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(emptyEditHeader("leaked-stream"))
+        const session = await beginMaterialization(tx, emptyEditHeader("leaked-stream"))
         const requests = (async function* () {
           yield {
             objects: [
@@ -387,7 +414,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(header)
+        const session = await beginMaterialization(tx, header)
         for await (const _page of tx.ontology.materializations.streamSourceReplacementState({
           session,
           source: candidate.source,
@@ -420,7 +447,7 @@ describe("in-memory ontology materialization finalization", () => {
     const header = replacementHeader(candidate, "empty-link-commit", "2026-01-03T00:00:00.000Z")
     await storage.transaction(async (tx) => {
       if (!tx.ontology) throw new Error("missing ontology")
-      const session = await tx.ontology.materializations.begin(header)
+      const session = await beginMaterialization(tx, header)
       await drainReplacementState(tx.ontology.materializations, session, candidate)
       await tx.ontology.materializations.finalize({
         session,
@@ -452,7 +479,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(header)
+        const session = await beginMaterialization(tx, header)
         await drainReplacementState(tx.ontology.materializations, session, candidate)
         await tx.ontology.materializations.stageWork({
           session,
@@ -478,6 +505,7 @@ describe("in-memory ontology materialization finalization", () => {
         id: "telemetry-classification",
         idempotencyKey: "runtime:telemetry-classification",
         requestHash: "telemetry-classification",
+        executionId: "execution:telemetry-classification",
         origin: {
           kind: "telemetry",
           source: { kind: "runtime", requestId: "telemetry-classification" },
@@ -496,7 +524,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(telemetryHeader)
+        const session = await beginMaterialization(tx, telemetryHeader)
         await tx.ontology.materializations.finalize({
           session,
           finalization: {
@@ -524,7 +552,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(planHeader)
+        const session = await beginMaterialization(tx, planHeader)
         await tx.ontology.materializations.stageWork({
           session,
           records: [
@@ -571,7 +599,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(eventHeader)
+        const session = await beginMaterialization(tx, eventHeader)
         await tx.ontology.materializations.stageWork({
           session,
           records: [
@@ -584,6 +612,7 @@ describe("in-memory ontology materialization finalization", () => {
                 schemaVersion: 1,
                 projectId,
                 occurredAt: eventHeader.commit.committedAt,
+                correlationId: `correlation:${eventHeader.commit.id}`,
                 origin: eventHeader.commit.origin,
                 commitId: eventHeader.commit.id,
                 type: "object.created",
@@ -623,7 +652,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(header)
+        const session = await beginMaterialization(tx, header)
         await tx.ontology.materializations.stageWork({ session, records: [first, second] })
 
         await expect(
@@ -691,7 +720,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(header)
+        const session = await beginMaterialization(tx, header)
         await tx.ontology.materializations.stageWork({ session, records })
         for await (const _page of tx.ontology.materializations.streamWork({
           session,
@@ -743,7 +772,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(header)
+        const session = await beginMaterialization(tx, header)
         await tx.ontology.materializations.stageWork({
           session,
           records: [
@@ -803,7 +832,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(header)
+        const session = await beginMaterialization(tx, header)
         await drainReplacementState(tx.ontology.materializations, session, opened)
         await tx.ontology.materializations.finalize({
           session,
@@ -833,7 +862,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(tooEarlyHeader)
+        const session = await beginMaterialization(tx, tooEarlyHeader)
         await drainReplacementState(tx.ontology.materializations, session, first)
         await tx.ontology.materializations.finalize({
           session,
@@ -845,7 +874,7 @@ describe("in-memory ontology materialization finalization", () => {
     const firstHeader = replacementHeader(first, "first-commit", "2026-01-03T00:00:00.000Z")
     await storage.transaction(async (tx) => {
       if (!tx.ontology) throw new Error("missing ontology")
-      const session = await tx.ontology.materializations.begin(firstHeader)
+      const session = await beginMaterialization(tx, firstHeader)
       await drainReplacementState(tx.ontology.materializations, session, first)
       await tx.ontology.materializations.finalize({
         session,
@@ -872,7 +901,7 @@ describe("in-memory ontology materialization finalization", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(secondHeader)
+        const session = await beginMaterialization(tx, secondHeader)
         await drainReplacementState(tx.ontology.materializations, session, second)
         await tx.ontology.materializations.finalize({
           session,
@@ -901,7 +930,7 @@ describe("in-memory ontology materialization finalization", () => {
     )
     await storage.transaction(async (tx) => {
       if (!tx.ontology) throw new Error("missing ontology")
-      const session = await tx.ontology.materializations.begin(activeHeader)
+      const session = await beginMaterialization(tx, activeHeader)
       await drainReplacementState(tx.ontology.materializations, session, active)
       await tx.ontology.materializations.finalize({
         session,
@@ -954,7 +983,7 @@ describe("in-memory ontology materialization finalization", () => {
       await expect(
         storage.transaction(async (tx) => {
           if (!tx.ontology) throw new Error("missing ontology")
-          const session = await tx.ontology.materializations.begin(header)
+          const session = await beginMaterialization(tx, header)
           await drainReplacementState(tx.ontology.materializations, session, candidate)
           await tx.ontology.materializations.finalize({
             session,

--- a/packages/core/tests/ontology-mutation-runtime.test.ts
+++ b/packages/core/tests/ontology-mutation-runtime.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, spyOn, test } from "bun:test"
+import type { BoundOntologyMaterializer } from "../src/materializer"
 import { createOntologyMutationRuntime } from "../src/runtime/internal"
 
-type Materializer = Parameters<typeof createOntologyMutationRuntime>[0]["materializer"]
-
-function materializerWithEventCount(eventCount: number): Materializer {
+function materializerWithEventCount(eventCount: number): BoundOntologyMaterializer {
   const result = { eventCount } as never
   return {
     edits: { commit: async () => result },
@@ -18,8 +17,9 @@ function materializerWithEventCount(eventCount: number): Materializer {
 describe("ontology mutation runtime", () => {
   test("wakes the outbox once after each commit that created facts", async () => {
     let wakes = 0
+    const bound = materializerWithEventCount(2)
     const runtime = createOntologyMutationRuntime({
-      materializer: materializerWithEventCount(2),
+      materializer: bound,
       notifyCommittedFacts: () => {
         wakes += 1
       },
@@ -35,8 +35,9 @@ describe("ontology mutation runtime", () => {
 
   test("does not wake for an empty commit or let wake-up failure reject a durable commit", async () => {
     let wakes = 0
+    const emptyBound = materializerWithEventCount(0)
     const empty = createOntologyMutationRuntime({
-      materializer: materializerWithEventCount(0),
+      materializer: emptyBound,
       notifyCommittedFacts: () => {
         wakes += 1
       },
@@ -44,8 +45,9 @@ describe("ontology mutation runtime", () => {
     await empty.commitEdits({} as never)
     expect(wakes).toBe(0)
 
+    const committedBound = materializerWithEventCount(1)
     const committed = createOntologyMutationRuntime({
-      materializer: materializerWithEventCount(1),
+      materializer: committedBound,
       notifyCommittedFacts: () => {
         throw new Error("wake failed")
       },

--- a/packages/core/tests/ontology-storage-in-memory.test.ts
+++ b/packages/core/tests/ontology-storage-in-memory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { defineObjectType, InMemoryStorage, link, OntologyRegistry, prop } from "../src"
+import { createTestingScope } from "../src/execution/scopes"
 import {
   createEventId,
   createLinkScopeFingerprint,
@@ -12,9 +13,11 @@ import {
   type MaterializationPlanFinalization,
   type MaterializationPlanHeader,
   type MaterializationPlanWorkItem,
+  type MaterializationSession,
   type OntologyCommitRecord,
   type OntologyCommitWrite,
   type OntologyOutboxFailure,
+  type Storage,
   StorageTransactionError,
 } from "../src/storage"
 import { getInMemoryStorageTestingAdapter } from "../src/storage/in-memory/testing"
@@ -24,6 +27,7 @@ import {
   atomic,
   createMaterializerFixture,
   pendingProjectionExecution,
+  projectionScope,
   replacement,
   sourceEntry,
 } from "./materializer-fixture"
@@ -136,7 +140,15 @@ describe("in-memory ontology storage", () => {
       runId: otherReplacement.execution.projectionRunId,
       datasetVersion: otherReplacement.datasetVersion,
     })
-    await other.projections.replace({ ...otherReplacement, execution: otherExecution })
+    await other
+      .withScope(
+        await projectionScope(storage, {
+          projectId: "other-project",
+          projectionId: "devices",
+          runId: otherExecution.projectionRunId,
+        })
+      )
+      .projections.replace({ ...otherReplacement, execution: otherExecution })
     expect(
       (
         await storage.ontology.sources.getActive({
@@ -154,31 +166,40 @@ describe("in-memory ontology storage", () => {
       )?.datasetVersion.versionId
     ).toBe("other-v1")
 
-    await other.edits.commit(
-      atomic("other-incident-authority", [
-        {
-          id: "hub",
-          kind: "object.create",
-          ref: { objectTypeId: "Device", primaryId: "hub" },
-          properties: { name: "other hub" },
-        },
-        {
-          id: "target",
-          kind: "object.create",
-          ref: { objectTypeId: "Device", primaryId: "other-target" },
-          properties: { name: "other target" },
-        },
-        {
-          id: "link",
-          kind: "link.upsert",
-          ref: {
-            source: { objectTypeId: "Device", primaryId: "hub" },
-            linkId: "parent",
-            target: { objectTypeId: "Device", primaryId: "other-target" },
+    await other
+      .withScope(
+        createTestingScope({
+          projectId: "other-project",
+          executionId: "other-incident-execution",
+          requestId: "other-incident-authority",
+          correlationId: "other-incident-correlation",
+        })
+      )
+      .edits.commit(
+        atomic("other-incident-authority", [
+          {
+            id: "hub",
+            kind: "object.create",
+            ref: { objectTypeId: "Device", primaryId: "hub" },
+            properties: { name: "other hub" },
           },
-        },
-      ])
-    )
+          {
+            id: "target",
+            kind: "object.create",
+            ref: { objectTypeId: "Device", primaryId: "other-target" },
+            properties: { name: "other target" },
+          },
+          {
+            id: "link",
+            kind: "link.upsert",
+            ref: {
+              source: { objectTypeId: "Device", primaryId: "hub" },
+              linkId: "parent",
+              target: { objectTypeId: "Device", primaryId: "other-target" },
+            },
+          },
+        ])
+      )
     const removed = await materializer.projections.replace(
       replacement("project-v2", "2026-01-02T00:00:00Z", [])
     )
@@ -409,6 +430,7 @@ describe("in-memory ontology storage", () => {
         id: "commit",
         idempotencyKey: "runtime:empty",
         requestHash: "hash",
+        executionId: "execution:empty",
         origin: { kind: "runtime", requestId: "empty" },
         ontologyRevision: "revision",
         intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -424,7 +446,7 @@ describe("in-memory ontology storage", () => {
     } satisfies MaterializationPlanHeader
     await storage.transaction(async (tx) => {
       if (!tx.ontology) throw new Error("missing ontology")
-      const session = await tx.ontology.materializations.begin(header)
+      const session = await beginMaterialization(tx, header)
       await tx.ontology.materializations.finalize({
         session,
         finalization: {
@@ -525,6 +547,7 @@ describe("in-memory ontology storage", () => {
         id: "session-lifecycle",
         idempotencyKey: "runtime:session-lifecycle",
         requestHash: "hash",
+        executionId: "execution:session-lifecycle",
         origin: { kind: "runtime", requestId: "session-lifecycle" },
         ontologyRevision: "revision",
         intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -538,7 +561,7 @@ describe("in-memory ontology storage", () => {
         points: [],
       },
     } satisfies MaterializationPlanHeader
-    await expect(storage.ontology.materializations.begin(header)).rejects.toThrow(
+    await expect(beginMaterialization(storage, header)).rejects.toThrow(
       "require an active storage transaction"
     )
 
@@ -547,7 +570,7 @@ describe("in-memory ontology storage", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        unfinished = await tx.ontology.materializations.begin(header)
+        unfinished = await beginMaterialization(tx, header)
       })
     ).rejects.toThrow("unfinished materialization session")
     await expect(
@@ -647,6 +670,7 @@ describe("in-memory ontology storage", () => {
         id: "work-commit",
         idempotencyKey: "runtime:work",
         requestHash: "work-hash",
+        executionId: "execution:work",
         origin: { kind: "runtime", requestId: "work" },
         ontologyRevision: "revision",
         intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -665,7 +689,7 @@ describe("in-memory ontology storage", () => {
     await storage.transaction(async (tx) => {
       if (!tx.ontology) throw new Error("missing ontology")
       const materializations = tx.ontology.materializations
-      const session = await materializations.begin(header)
+      const session = await beginMaterialization(tx, header)
       closedSession = session
       const classification = {
         kind: "classification" as const,
@@ -745,6 +769,7 @@ describe("in-memory ontology storage", () => {
               schemaVersion: 1,
               projectId: "project",
               occurredAt: "2026-01-01T00:00:00.000Z",
+              correlationId: "correlation:work",
               origin: { kind: "runtime", requestId: "work" },
               commitId: "work-commit",
               type: "object.updated",
@@ -767,6 +792,7 @@ describe("in-memory ontology storage", () => {
               schemaVersion: 1,
               projectId: "project",
               occurredAt: "2026-01-01T00:00:00.000Z",
+              correlationId: "correlation:work",
               origin: { kind: "runtime", requestId: "work" },
               commitId: "work-commit",
               type: "object.created",
@@ -917,12 +943,13 @@ describe("in-memory ontology storage", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        leakedSession = await tx.ontology.materializations.begin({
+        leakedSession = await beginMaterialization(tx, {
           commit: {
             projectId: "project",
             id: "rolled-back-session",
             idempotencyKey: "runtime:rolled-back-session",
             requestHash: "hash",
+            executionId: "execution:rolled-back-session",
             origin: { kind: "runtime", requestId: "rolled-back-session" },
             ontologyRevision: "revision",
             intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -1268,6 +1295,7 @@ describe("in-memory ontology storage", () => {
         id,
         idempotencyKey: `runtime:${id}`,
         requestHash: id,
+        executionId: `execution:${id}`,
         origin: { kind: "runtime", requestId: id },
         ontologyRevision: projections.ontologyRevision,
         intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -1284,7 +1312,7 @@ describe("in-memory ontology storage", () => {
     const expectBeginConflict = async (header: MaterializationPlanHeader, message: string) => {
       await storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        await expect(tx.ontology.materializations.begin(header)).rejects.toThrow(message)
+        await expect(beginMaterialization(tx, header)).rejects.toThrow(message)
       })
     }
     await expectBeginConflict(
@@ -1401,7 +1429,7 @@ describe("in-memory ontology storage", () => {
 
     await storage.transaction(async (tx) => {
       if (!tx.ontology) throw new Error("missing ontology")
-      const session = await tx.ontology.materializations.begin({
+      const session = await beginMaterialization(tx, {
         ...baseHeader("valid-cas"),
         expected: {
           ...baseHeader("valid-cas").expected,
@@ -1485,26 +1513,35 @@ describe("in-memory ontology storage", () => {
       dependencies: { clock: () => new Date("2026-01-01T00:00:00Z") },
     })
     const object = (primaryId: string) => ({ objectTypeId: "UnicodeNode", primaryId })
-    await materializer.edits.commit({
-      mode: "atomic",
-      source: { kind: "runtime", requestId: "unicode-links" },
-      operations: [
-        ...["source", "\uE000", "😀"].map((primaryId) => ({
-          id: `object-${primaryId}`,
-          kind: "object.create" as const,
-          ref: object(primaryId),
-          properties: { name: primaryId },
-        })),
-        ...["\uE000", "😀"].map((primaryId) => ({
-          id: `link-${primaryId}`,
-          kind: "link.upsert" as const,
-          ref: { source: object("source"), linkId: "neighbors", target: object(primaryId) },
-        })),
-      ],
-      expectedObjects: [],
-      expectedLinks: [],
-      expectedLinkScopes: [],
-    })
+    await materializer
+      .withScope(
+        createTestingScope({
+          projectId: "unicode-project",
+          executionId: "unicode-links-execution",
+          requestId: "unicode-links",
+          correlationId: "unicode-links-correlation",
+        })
+      )
+      .edits.commit({
+        mode: "atomic",
+        source: { kind: "runtime", requestId: "unicode-links" },
+        operations: [
+          ...["source", "\uE000", "😀"].map((primaryId) => ({
+            id: `object-${primaryId}`,
+            kind: "object.create" as const,
+            ref: object(primaryId),
+            properties: { name: primaryId },
+          })),
+          ...["\uE000", "😀"].map((primaryId) => ({
+            id: `link-${primaryId}`,
+            kind: "link.upsert" as const,
+            ref: { source: object("source"), linkId: "neighbors", target: object(primaryId) },
+          })),
+        ],
+        expectedObjects: [],
+        expectedLinks: [],
+        expectedLinkScopes: [],
+      })
     const rows = await storage.objects.listLinks({
       projectId: "unicode-project",
       objectTypeId: "UnicodeNode",
@@ -1525,12 +1562,13 @@ describe("in-memory ontology storage", () => {
     )
     await storage.transaction(async (tx) => {
       if (!tx.ontology) throw new Error("missing ontology")
-      const session = await tx.ontology.materializations.begin({
+      const session = await beginMaterialization(tx, {
         commit: {
           projectId: "unicode-project",
           id: "unicode-cas",
           idempotencyKey: "runtime:unicode-cas",
           requestHash: "unicode-cas",
+          executionId: "execution:unicode-cas",
           origin: { kind: "runtime", requestId: "unicode-cas" },
           ontologyRevision: projections.ontologyRevision,
           intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -1821,6 +1859,7 @@ describe("in-memory ontology storage", () => {
               schemaVersion: 1,
               projectId: "other-project",
               occurredAt: committedAt,
+              correlationId: `correlation:${commitId}`,
               origin: { kind: "runtime", requestId: commitId },
               commitId,
               commitOrdinal: 0,
@@ -1849,12 +1888,13 @@ describe("in-memory ontology storage", () => {
       await expect(
         storage.transaction(async (tx) => {
           if (!tx.ontology) throw new Error("missing ontology")
-          const session = await tx.ontology.materializations.begin({
+          const session = await beginMaterialization(tx, {
             commit: {
               projectId: "project",
               id: commitId,
               idempotencyKey: `runtime:${commitId}`,
               requestHash: commitId,
+              executionId: `execution:${commitId}`,
               origin: { kind: "runtime", requestId: commitId },
               ontologyRevision: "revision",
               intent: { kind: "edit", mode: "atomic", operationCount: 0 },
@@ -1907,6 +1947,7 @@ describe("in-memory ontology storage", () => {
         id,
         idempotencyKey: `action:${id}:edits`,
         requestHash: id,
+        executionId: `execution:${id}`,
         origin: { kind: "action", actionId: "action", runId: "run" },
         ontologyRevision: "revision",
         intent: { kind: "edit", mode: "atomic", operationCount },
@@ -1924,7 +1965,7 @@ describe("in-memory ontology storage", () => {
     await expect(
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(header("ordinal-gap"))
+        const session = await beginMaterialization(tx, header("ordinal-gap"))
         await tx.ontology.materializations.stageWork({
           session,
           records: [
@@ -1937,6 +1978,7 @@ describe("in-memory ontology storage", () => {
                 schemaVersion: 1,
                 projectId: "project",
                 occurredAt: committedAt,
+                correlationId: "correlation:ordinal-gap",
                 origin: { kind: "action", actionId: "action", runId: "run" },
                 commitId: "ordinal-gap",
                 partitionKey: "Device:one",
@@ -1983,6 +2025,7 @@ describe("in-memory ontology storage", () => {
                   schemaVersion: 1,
                   projectId: "project",
                   occurredAt: committedAt,
+                  correlationId: "correlation:ordinal-gap",
                   origin: { kind: "action", actionId: "action", runId: "run" },
                   commitId: "ordinal-gap",
                   commitOrdinal: 1,
@@ -2092,6 +2135,7 @@ describe("in-memory ontology storage", () => {
         id: "sealed-commit",
         idempotencyKey: "projection:sealed",
         requestHash: "sealed",
+        executionId: "execution:sealed",
         origin: {
           kind: "projection",
           projectionId: "devices",
@@ -2142,7 +2186,7 @@ describe("in-memory ontology storage", () => {
     const finalizeWithoutSemanticWork = (streamReplacement: boolean) =>
       storage.transaction(async (tx) => {
         if (!tx.ontology) throw new Error("missing ontology")
-        const session = await tx.ontology.materializations.begin(header)
+        const session = await beginMaterialization(tx, header)
         if (streamReplacement) {
           for (const entityKind of ["object", "link"] as const) {
             for await (const _page of tx.ontology.materializations.streamSourceReplacementState({
@@ -2310,6 +2354,7 @@ describe("in-memory ontology storage", () => {
           id: `correlation-${testCase.name}`,
           idempotencyKey: `projection:correlation:${testCase.name}`,
           requestHash: testCase.name,
+          executionId: `execution:correlation:${testCase.name}`,
           origin: {
             kind: "projection",
             projectionId: "devices",
@@ -2372,7 +2417,7 @@ describe("in-memory ontology storage", () => {
       await expect(
         storage.transaction(async (tx) => {
           if (!tx.ontology) throw new Error("missing ontology")
-          const session = await tx.ontology.materializations.begin(header)
+          const session = await beginMaterialization(tx, header)
           await tx.ontology.materializations.finalize({ session, finalization })
         })
       ).rejects.toThrow(testCase.message)
@@ -2428,6 +2473,28 @@ describe("in-memory ontology storage", () => {
   })
 })
 
+async function beginMaterialization(
+  storage: Pick<Storage, "executions" | "ontology">,
+  header: MaterializationPlanHeader
+): Promise<MaterializationSession> {
+  if (!storage.ontology) throw new Error("missing ontology")
+  const execution = await storage.executions.getById({
+    projectId: header.commit.projectId,
+    id: header.commit.executionId,
+  })
+  if (!execution) {
+    await storage.executions.create({
+      id: header.commit.executionId,
+      projectId: header.commit.projectId,
+      executor: { type: "request", requestId: `request:${header.commit.id}` },
+      source: { type: "http", requestId: `request:${header.commit.id}` },
+      correlationId: `correlation:${header.commit.id}`,
+      authorizationRef: { type: "disabled" },
+    })
+  }
+  return storage.ontology.materializations.begin(header)
+}
+
 async function expectLogicalOriginDuplicateRejected(
   storage: InMemoryStorage,
   commit: OntologyCommitRecord | null
@@ -2444,7 +2511,7 @@ async function expectLogicalOriginDuplicateRejected(
   await expect(
     storage.transaction(async (tx) => {
       if (!tx.ontology) throw new Error("missing ontology")
-      await tx.ontology.materializations.begin({
+      await beginMaterialization(tx, {
         commit: duplicate,
         expected: { sources: [], objects: [], links: [], linkScopes: [], points: [] },
       })

--- a/packages/core/tests/provider-header-validation.test.ts
+++ b/packages/core/tests/provider-header-validation.test.ts
@@ -23,6 +23,7 @@ function projectionHeader(originProjectionId = "devices"): MaterializationPlanHe
       id: "projection-commit",
       idempotencyKey: "projection:run",
       requestHash: "projection-request",
+      executionId: "projection-execution",
       origin: {
         kind: "projection",
         projectionId: originProjectionId,
@@ -59,6 +60,7 @@ function telemetryHeader(input?: {
       id: "telemetry-commit",
       idempotencyKey: "projection:run:batch:0",
       requestHash: "telemetry-request",
+      executionId: "projection-execution",
       origin: {
         kind: "telemetry",
         source: {

--- a/packages/core/tests/runtime-materializer-adapter.test.ts
+++ b/packages/core/tests/runtime-materializer-adapter.test.ts
@@ -51,7 +51,12 @@ const ONTOLOGY = [Room, Sensor] as const
 function createRuntime() {
   const deps = createTestRuntimeDeps()
   const host = new SixbHost({ id: "runtime-adapter-tests", ontology: ONTOLOGY, ...deps })
-  return { deps, host, sixb: createTestSixb(host) }
+  const sixb = createTestSixb(host, {
+    executionId: "runtime-adapter-execution",
+    requestId: "runtime-adapter-request",
+    correlationId: "runtime-adapter-correlation",
+  })
+  return { deps, host, sixb }
 }
 
 type AdapterRuntime = ReturnType<typeof createRuntime>["sixb"]
@@ -72,6 +77,11 @@ async function listSensorLinks(host: AdapterHost, linkId: string) {
 }
 
 describe("runtime object writes", () => {
+  test("does not expose an unbound ontology mutation port on the host", () => {
+    const { host } = createRuntime()
+    expect(() => getOntologyMutationRuntime(host)).toThrow("not registered")
+  })
+
   test("typed and dynamic mutations all commit through the materializer as runtime origins", async () => {
     const { host, sixb } = createRuntime()
 
@@ -96,6 +106,23 @@ describe("runtime object writes", () => {
     })
 
     expect(await commitOrigins(host)).toEqual(new Array(6).fill("runtime"))
+    const { commits } = await host.storage.ontology.commits.list({ projectId: host.id })
+    expect(commits.every((commit) => commit.executionId === sixb.execution.id)).toBe(true)
+    await expect(
+      host.storage.executions.getById({ projectId: host.id, id: sixb.execution.id })
+    ).resolves.toMatchObject({
+      id: "runtime-adapter-execution",
+      correlationId: "runtime-adapter-correlation",
+      authorizationRef: { type: "disabled" },
+    })
+    await waitFor(() => sixb.events.read().then((events) => events.length > 0))
+    const events = await sixb.events.read()
+    expect(events.length).toBeGreaterThan(0)
+    expect(
+      events.every(
+        (event) => event.correlationId === sixb.execution.correlationId && event.actor === undefined
+      )
+    ).toBe(true)
   })
 
   test("upserts an absent identity as a create and an existing one as a patch", async () => {
@@ -321,16 +348,24 @@ describe("runtime object batches", () => {
   })
 
   test("propagates a commit failure instead of turning it into item errors", async () => {
-    const { deps, host, sixb } = createRuntime()
-    getOntologyMutationRuntime(host).commitEdits = () =>
-      Promise.reject(new Error("provider exploded"))
+    const { deps, sixb } = createRuntime()
+    const adapter = getInMemoryOntologyStorageTestingAdapter(deps.storage.ontology)
+    adapter.setTestHooks({
+      beforeWrite() {
+        throw new Error("provider exploded")
+      },
+    })
 
-    await expect(
-      sixb.objects.upsertBatch("room", [
-        { properties: { id: "r1", name: "Kitchen" } },
-        { properties: { id: "r2", name: "Bedroom" } },
-      ])
-    ).rejects.toThrow("provider exploded")
+    try {
+      await expect(
+        sixb.objects.upsertBatch("room", [
+          { properties: { id: "r1", name: "Kitchen" } },
+          { properties: { id: "r2", name: "Bedroom" } },
+        ])
+      ).rejects.toThrow("provider exploded")
+    } finally {
+      adapter.setTestHooks({})
+    }
 
     const rows = await deps.storage.objects.list({
       projectId: sixb.execution.projectId,

--- a/packages/core/tests/scoped-sixb.test.ts
+++ b/packages/core/tests/scoped-sixb.test.ts
@@ -302,6 +302,19 @@ async function seedRequesterMemberships(
   }
 }
 
+async function seedServiceAccount(
+  host: TestExecutionHost & { readonly storage: Pick<Storage, "auth"> },
+  id: string
+): Promise<void> {
+  const auth = host.storage.auth
+  if (!auth) throw new Error("Test runtime requires auth storage.")
+  await auth.serviceAccounts.create({
+    projectId: host.id,
+    id,
+    name: "Test service account",
+  })
+}
+
 describe("bound Sixb object reads", () => {
   test("granted types support get, list, byId.get, and query", async () => {
     const host = createRuntime()
@@ -803,6 +816,7 @@ describe("bound Sixb object writes", () => {
 
   test("view plus edit writes, and the write is readable back", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const _sixb = createTestSixb(host)
     const scoped = bindPrincipal(host, contextFor(host, ["editors"]))
 
@@ -822,6 +836,7 @@ describe("bound Sixb object writes", () => {
 
   test("delete and restore ride on the same edit grant", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const sixb = createTestSixb(host)
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
 
@@ -858,6 +873,7 @@ describe("bound Sixb object writes", () => {
 describe("bound Sixb link writes", () => {
   test("edit on the source and view on the target links", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const sixb = createTestSixb(host)
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
     await sixb.objects(Invoice).upsert({ properties: { id: "i1" } })
@@ -936,6 +952,7 @@ describe("bound Sixb telemetry appends", () => {
 
   test("append works without view — the write-only ingest principal", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const sixb = createTestSixb(host)
     await sixb.objects(Contract).upsert({ properties: { id: "c1" } })
     const scoped = bindPrincipal(host, contextFor(host, ["ingest"]))
@@ -996,6 +1013,7 @@ describe("direct writes are attributable", () => {
 
   test("a principal write names its actor, an auth-disabled one names nobody", async () => {
     const host = createRuntime()
+    await seedPrincipal(host)
     const sixb = createTestSixb(host)
 
     // Auth-disabled execution: no authorization context, so no actor. The absence is the signal —
@@ -1016,6 +1034,7 @@ describe("direct writes are attributable", () => {
 
   test("a service account is recorded as a service actor", async () => {
     const host = createRuntime()
+    await seedServiceAccount(host, "svc_ingest")
     const sixb = createTestSixb(host)
     const serviceContext = resolveAuthorizationContext({
       principal: { type: "serviceAccount", id: "svc_ingest" },
@@ -1097,21 +1116,22 @@ describe("bound Sixb fails closed on ungranted surfaces", () => {
     expect(await agentSixb.blobs.stat(file.blobId)).not.toBeNull()
     expect(await agentSixb.connector(sourceConnector)).toEqual({})
 
-    const mismatchedRun = host.withScope({
-      authorization: scope.authorization,
-      execution: {
-        ...scope.execution,
-        executor: { type: "agent", agentId: "contract-agent", runId: "agent-run-2" },
-      },
-    })
-    expect(() => mismatchedRun.blobs.stat(file.blobId)).toThrow(AuthorizationError)
-    expect(() => mismatchedRun.connector(sourceConnector)).toThrow(AuthorizationError)
+    expect(() =>
+      host.withScope({
+        authorization: scope.authorization,
+        execution: {
+          ...scope.execution,
+          executor: { type: "agent", agentId: "contract-agent", runId: "agent-run-2" },
+        },
+      })
+    ).toThrow("agent authority does not match its execution binding")
 
-    const forgedProvenance = host.withScope({
-      authorization: scope.authorization,
-      execution: { ...scope.execution, id: "exec_forged" },
-    })
-    expect(() => forgedProvenance.blobs.stat(file.blobId)).toThrow(AuthorizationError)
+    expect(() =>
+      host.withScope({
+        authorization: scope.authorization,
+        execution: { ...scope.execution, id: "exec_forged" },
+      })
+    ).toThrow("agent authority does not match its execution binding")
   })
 })
 

--- a/packages/core/tests/sixb-runtime.test.ts
+++ b/packages/core/tests/sixb-runtime.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../src"
 import type { ObjectStorage, QueryObjectsInput, QueryObjectsResult } from "../src/storage"
 import { createTestSixb } from "../src/testing"
-import { createTestRuntimeDeps } from "./test-runtime-deps"
+import { createTestRuntimeDeps, waitFor } from "./test-runtime-deps"
 
 const Room = defineObjectType({
   id: "Room",
@@ -638,15 +638,18 @@ describe("SixbHost runtime", () => {
     ).rejects.toThrow("does not define link properties")
 
     // Latest telemetry is part of effective object state, so appending a point also updates the
-    // object it belongs to. Facts of one commit are claimed in commit-ordinal order, so a link
-    // never arrives before the object it references.
-    const stream = await sixb.events.read()
-    expect([...stream].map((event) => event.type)).toEqual([
+    // object it belongs to. The outbox is eventually dispatched and does not promise ordering
+    // between independent commits, so this assertion waits for and compares the complete fact set.
+    const stream = await waitFor(
+      () => sixb.events.read(),
+      (events) => events.length === 5
+    )
+    expect([...stream].map((event) => event.type).sort()).toEqual([
+      "link.created",
+      "object.created",
       "object.created",
       "object.updated",
       "telemetry.appended",
-      "object.created",
-      "link.created",
     ])
     expect(Object.fromEntries(stream.map((event) => [event.type, event.topic]))).toEqual({
       "object.created": "objects",
@@ -990,9 +993,10 @@ describe("SixbHost runtime", () => {
     expect(linksAfter).toHaveLength(0)
 
     // Verify link.deleted event was emitted
-    const events = await sixb.events.read({
-      types: ["link.deleted"],
-    })
+    const events = await waitFor(
+      () => sixb.events.read({ types: ["link.deleted"] }),
+      (published) => published.length === 1
+    )
     expect(events).toHaveLength(1)
   })
 

--- a/packages/orchestrator/tests/route-key.test.ts
+++ b/packages/orchestrator/tests/route-key.test.ts
@@ -166,6 +166,7 @@ describe("routeKeysForEvent", () => {
 
 function materializationCorrelation(id: string) {
   return {
+    correlationId: `correlation-${id}`,
     origin: { kind: "runtime" as const, requestId: `request-${id}` },
     commitId: `commit-${id}`,
     commitOrdinal: 0,

--- a/packages/orchestrator/tests/worker.test.ts
+++ b/packages/orchestrator/tests/worker.test.ts
@@ -105,6 +105,7 @@ function makeInvoiceUpdatedEvent(
     schemaVersion: 1,
     projectId,
     occurredAt: "2026-04-18T02:00:00.000Z",
+    correlationId: `correlation-${amountBefore}-${amountAfter}`,
     origin: { kind: "runtime", requestId: `request-${amountBefore}-${amountAfter}` },
     commitId: `commit-${amountBefore}-${amountAfter}`,
     commitOrdinal: 0,
@@ -377,7 +378,7 @@ describe("OrchestratorWorker", () => {
         input: {},
         scheduleId: daily.id,
         source: { type: "schedule", eventId: sourceEvent!.id },
-        correlationId: sourceEvent!.id,
+        correlationId: sourceEvent!.correlationId ?? sourceEvent!.id,
       }),
     ])
   })
@@ -415,7 +416,7 @@ describe("OrchestratorWorker", () => {
           input: { invoiceId: "inv-1", amount: 700 },
           scheduleId: highValueInvoice.id,
           source: { type: "event", eventId: sourceEvent!.id },
-          correlationId: sourceEvent!.id,
+          correlationId: sourceEvent!.correlationId ?? sourceEvent!.id,
         }),
       ])
       return true

--- a/packages/projection-worker/tests/run-projection-job.test.ts
+++ b/packages/projection-worker/tests/run-projection-job.test.ts
@@ -48,6 +48,7 @@ import type {
 import type {
   AbandonSourceMaterializationCandidateInput,
   OntologySourceRecord,
+  ProjectionRunRecord,
   ProjectionRunStorage,
   ReclaimSourceMaterializationInput,
 } from "@sixb/core/storage"
@@ -298,10 +299,6 @@ interface TestProjectionWorkerContext extends ProjectionWorkerContext {
 
 function createRuntime(
   host: ProjectionWorkerHost,
-  primitive: { readonly id: string; readonly runId: string } = {
-    id: host.definitions.projections.list()[0]?.id ?? "direct-projection-test",
-    runId: "direct-projection-job-test",
-  },
   catalogs: Partial<Pick<ProjectionWorkerContext, "datasets" | "projections">> = {}
 ): TestProjectionWorkerContext {
   const runtime = {
@@ -313,26 +310,34 @@ function createRuntime(
     datasets: catalogs.datasets ?? host.definitions.datasets,
     projections: catalogs.projections ?? host.definitions.projections,
   } satisfies TestProjectionWorkerContext
-  const trustedPrimitive = { kind: "projection" as const, ...primitive }
-  const execution = bindDurablePrimitiveExecution(host, {
-    execution: {
-      id: `direct-projection-execution-test:${primitive.runId}`,
-      projectId: host.id,
-      executor: {
-        type: "primitive",
-        kind: trustedPrimitive.kind,
-        runId: trustedPrimitive.runId,
-      },
-      source: { type: "event", eventId: `direct-projection-event-test:${primitive.runId}` },
-      correlationId: `direct-projection-correlation-test:${primitive.runId}`,
-      authorizationRef: { type: "trustedPrimitive", primitive: trustedPrimitive },
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-    },
-    primitive: trustedPrimitive,
-  })
-  registerOntologyMutationRuntime(runtime, execution.ontologyMutations)
   shareProjectionRegistry(host, runtime)
   return runtime
+}
+
+async function bindRuntimeToRun(
+  runtime: TestProjectionWorkerContext,
+  run: ProjectionRunRecord
+): Promise<TestProjectionWorkerContext> {
+  const durableExecution = await runtime.host.storage.executions.getById({
+    projectId: runtime.projectId,
+    id: run.executionId,
+  })
+  if (!durableExecution) {
+    throw new Error(`Projection run '${run.id}' references missing execution '${run.executionId}'.`)
+  }
+  const trustedPrimitive = {
+    kind: "projection" as const,
+    id: run.identity.projectionId,
+    runId: run.id,
+  }
+  const execution = bindDurablePrimitiveExecution(runtime.host, {
+    execution: durableExecution,
+    primitive: trustedPrimitive,
+  })
+  const bound = { ...runtime }
+  registerOntologyMutationRuntime(bound, execution.ontologyMutations)
+  shareProjectionRegistry(runtime.host, bound)
+  return bound
 }
 
 interface LegacyTestProjectionJob {
@@ -352,17 +357,7 @@ async function runProjectionJob(
     readonly batchSize?: number
   }
 ): Promise<ProjectionJobResult> {
-  const runtime = createRuntime(
-    input.runtime.host,
-    {
-      id: input.job.projectionId,
-      runId: input.job.id,
-    },
-    {
-      datasets: input.runtime.datasets,
-      projections: input.runtime.projections,
-    }
-  )
+  const runtime = input.runtime
   const registry = getProjectionRegistry(runtime)
   const version = await runtime.lakeStorage.getVersion(input.job.datasetId, input.job.versionId)
   let descriptor: ProjectionDispatchDescriptor
@@ -416,9 +411,11 @@ async function runProjectionJob(
       await queueTestProjectionRun(runtime.host.storage, { ...common, identity, target })
     }
   }
+  const run = await runtime.projectionRunsStorage.getById({ projectId: runtime.projectId, id })
+  if (!run) throw new Error(`Projection run '${id}' was not queued.`)
   return runCanonicalProjectionJob({
     ...canonicalInput,
-    runtime,
+    runtime: await bindRuntimeToRun(runtime, run),
     job: { id, ...identity },
     ...(batchSize === undefined ? {} : { telemetryBatchSize: batchSize }),
   })
@@ -955,14 +952,20 @@ describe("runProjectionJob", () => {
       identity,
       target: { objectTypeId: Room.id },
     })
-    await runCanonicalProjectionJob({ runtime, job })
+    const run = await runtime.projectionRunsStorage.getById({
+      projectId: runtime.projectId,
+      id: job.id,
+    })
+    if (!run) throw new Error(`Projection run '${job.id}' was not queued.`)
+    const boundRuntime = await bindRuntimeToRun(runtime, run)
+    await runCanonicalProjectionJob({ runtime: boundRuntime, job })
 
     const unavailable = () => {
       throw new Error("terminal replay accessed current configuration or lake state")
     }
     const replayRuntime: ProjectionWorkerContext = {
-      ...runtime,
-      lakeStorage: new Proxy(runtime.lakeStorage, { get: unavailable }),
+      ...boundRuntime,
+      lakeStorage: new Proxy(boundRuntime.lakeStorage, { get: unavailable }),
       datasets: { getById: unavailable },
       projections: { getById: unavailable },
     }
@@ -2928,7 +2931,7 @@ describe("runProjectionJob", () => {
     const version = await commitDatasetVersion(deps.lakeStorage, roomsDataset, [
       { room_id: "r1", room_name: "Kitchen", building_ref: null },
     ])
-    const runtime = createRuntime(sixb, undefined, {
+    const runtime = createRuntime(sixb, {
       datasets: {
         getById: () => null,
       },

--- a/packages/rules-worker/tests/evaluate-rule-event.test.ts
+++ b/packages/rules-worker/tests/evaluate-rule-event.test.ts
@@ -611,6 +611,7 @@ function materializerFixture(storage: Storage): MaterializerTestFixture {
 
 function materializationCorrelation(cursor: string) {
   return {
+    correlationId: `correlation-${cursor}`,
     origin: { kind: "runtime" as const, requestId: `request-${cursor}` },
     commitId: `commit-${cursor}`,
     commitOrdinal: 0,

--- a/packages/rules-worker/tests/worker.test.ts
+++ b/packages/rules-worker/tests/worker.test.ts
@@ -594,6 +594,7 @@ function objectUpdatedEvent(
     schemaVersion: 1,
     projectId,
     occurredAt: "2026-05-07T10:00:00.000Z",
+    correlationId: `correlation-${primaryId}-${status}`,
     origin: { kind: "runtime", requestId: `request-${primaryId}-${status}` },
     commitId: `commit-${primaryId}-${status}`,
     commitOrdinal: 0,

--- a/packages/server/tests/unifiedServer.test.ts
+++ b/packages/server/tests/unifiedServer.test.ts
@@ -115,6 +115,7 @@ describe("SixbServer API serving", () => {
         id: "telemetry-fan-1-rpm",
         schemaVersion: 1,
         projectId: sixb.id,
+        correlationId: "correlation-fan-1-rpm",
         origin: { kind: "runtime", requestId: "seed-fan-1-rpm" },
         commitId: "commit-fan-1-rpm",
         commitOrdinal: 0,

--- a/packages/server/tests/wsSubscribe.test.ts
+++ b/packages/server/tests/wsSubscribe.test.ts
@@ -510,6 +510,7 @@ function telemetryEnvelope(
     schemaVersion: 1,
     projectId,
     occurredAt: at,
+    correlationId: `correlation-${objectId}-${at}`,
     origin: { kind: "runtime", requestId: `seed-${objectId}-${at}` },
     commitId: `commit-${objectId}-${at}`,
     commitOrdinal: 0,

--- a/storage/pg/src/migrations.ts
+++ b/storage/pg/src/migrations.ts
@@ -60,6 +60,9 @@ import projectionExecutionsSql from "./migrations/022-projection-executions.sql"
   type: "text",
 }
 import webhookExecutionsSql from "./migrations/023-webhook-executions.sql" with { type: "text" }
+import ontologyCommitExecutionsSql from "./migrations/024-ontology-commit-executions.sql" with {
+  type: "text",
+}
 import type { SQL, SQLClient } from "./pg-client"
 
 export interface PostgresMigrationContext {
@@ -336,6 +339,7 @@ export const postgresStorageMigrations = defineMigrations<PostgresMigrationConte
     pgSql("021-sync-pipeline-executions", syncPipelineExecutionsSql),
     pgSql("022-projection-executions", projectionExecutionsSql),
     pgSql("023-webhook-executions", webhookExecutionsSql),
+    pgSql("024-ontology-commit-executions", ontologyCommitExecutionsSql),
   ],
 })
 

--- a/storage/pg/src/migrations/024-ontology-commit-executions.sql
+++ b/storage/pg/src/migrations/024-ontology-commit-executions.sql
@@ -1,0 +1,12 @@
+-- Existing commits cannot be assigned honest execution authority retroactively.
+SELECT 1 / CASE WHEN EXISTS (SELECT 1 FROM ontology_commits) THEN 0 ELSE 1 END;
+
+ALTER TABLE ontology_commits
+  ADD COLUMN execution_id TEXT NOT NULL,
+  ADD CONSTRAINT fk_ontology_commits_execution
+    FOREIGN KEY (project_id, execution_id)
+    REFERENCES executions (project_id, id)
+    ON DELETE RESTRICT;
+
+CREATE INDEX idx_ontology_commits_execution
+  ON ontology_commits (project_id, execution_id);

--- a/storage/pg/src/ontology-storage/materializations.ts
+++ b/storage/pg/src/ontology-storage/materializations.ts
@@ -837,12 +837,13 @@ export class PgOntologyMaterializationStorage implements OntologyMaterialization
     const actor = commit.actor === undefined ? null : jsonParameter(this.sql, commit.actor)
     const rows = await this.sql<PgOntologyCommitRow[]>`
       INSERT INTO ontology_commits (
-        project_id, id, idempotency_key, request_hash,
+        project_id, id, idempotency_key, request_hash, execution_id,
         origin_kind, origin_run_id, origin_batch_ordinal, origin, actor,
         ontology_revision, projection_revision, ownership_hash,
         intent, result, committed_at
       ) VALUES (
         ${commit.projectId}, ${commit.id}, ${commit.idempotencyKey}, ${commit.requestHash},
+        ${commit.executionId},
         ${origin.kind}, ${origin.runId}, ${origin.batchOrdinal},
         ${jsonParameter(this.sql, commit.origin)}, ${actor}, ${commit.ontologyRevision},
         ${commit.projectionRevision ?? null}, ${commit.ownershipHash ?? null},

--- a/storage/pg/src/ontology-storage/shared.ts
+++ b/storage/pg/src/ontology-storage/shared.ts
@@ -34,6 +34,7 @@ export interface PgOntologyCommitRow {
   readonly id: string
   readonly idempotency_key: string
   readonly request_hash: string
+  readonly execution_id: string
   readonly origin_kind: string
   readonly origin_run_id: string | null
   readonly origin_batch_ordinal: number | string | null
@@ -174,6 +175,7 @@ export function commitRecord(row: PgOntologyCommitRow): OntologyCommitRecord {
     id: row.id,
     idempotencyKey: row.idempotency_key,
     requestHash: row.request_hash,
+    executionId: row.execution_id,
     origin: structuredClone(row.origin) as OntologyCommitWrite["origin"],
     ...(row.actor === null
       ? {}

--- a/storage/pg/tests/pg-storage-migrations.e2e.ts
+++ b/storage/pg/tests/pg-storage-migrations.e2e.ts
@@ -75,6 +75,7 @@ describe("Postgres storage migrations", () => {
             "021-sync-pipeline-executions",
             "022-projection-executions",
             "023-webhook-executions",
+            "024-ontology-commit-executions",
           ],
         },
       ])
@@ -239,6 +240,13 @@ describe("Postgres storage migrations", () => {
           id: "023-webhook-executions",
           status: "applied",
           version: 23,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "024-ontology-commit-executions",
+          status: "applied",
+          version: 24,
         },
       ])
     })
@@ -699,6 +707,7 @@ describe("Postgres storage migrations", () => {
       expect(await readTableColumns(schemaName, "objects")).toContain("last_commit_id")
       expect(await readTableColumns(schemaName, "links")).toContain("last_commit_id")
       expect(await readTableColumns(schemaName, "timeseries")).toContain("last_commit_id")
+      expect(await readTableColumns(schemaName, "ontology_commits")).toContain("execution_id")
       expect(await readTableColumns(schemaName, "objects")).not.toContain("source_event_id")
       expect(await readTableColumns(schemaName, "links")).not.toContain("source_event_id")
       expect(await readTableColumns(schemaName, "timeseries")).not.toContain("source_event_id")
@@ -708,6 +717,9 @@ describe("Postgres storage migrations", () => {
       await expect(readColumnNullable(schemaName, "timeseries", "last_commit_id")).resolves.toBe(
         "NO"
       )
+      await expect(
+        readColumnNullable(schemaName, "ontology_commits", "execution_id")
+      ).resolves.toBe("NO")
       expect(await readTableColumns(schemaName, "timeseries_latest")).toEqual(
         expect.arrayContaining([
           "object_type_id",
@@ -1091,6 +1103,47 @@ describe("Postgres storage migrations", () => {
         }
       })
     }
+  })
+
+  test("rejects legacy ontology commits instead of inventing execution authority", async () => {
+    const schemaName = `sixb_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    await withSql(async (sql) => {
+      const schema = quoteIdent(schemaName)
+      const context = { exec: (sqlText: string) => sql.unsafe(sqlText).then(() => undefined) }
+
+      try {
+        await sql.unsafe(`CREATE SCHEMA ${schema}`)
+        await sql.unsafe(`SET search_path TO ${schema}`)
+        const migrationIndex = postgresStorageMigrations.steps.findIndex(
+          (migration) => migration.id === "024-ontology-commit-executions"
+        )
+        const migration = postgresStorageMigrations.steps[migrationIndex]
+        if (!migration) {
+          throw new Error("PostgreSQL ontology-commit execution migration is missing.")
+        }
+        for (const previous of postgresStorageMigrations.steps.slice(0, migrationIndex)) {
+          await previous.up(context)
+        }
+        await sql.unsafe(`
+          INSERT INTO ontology_commits (
+            project_id, id, idempotency_key, request_hash, origin_kind, origin,
+            ontology_revision, intent, result, committed_at
+          ) VALUES (
+            'project-a', 'legacy-commit', 'runtime:legacy-commit', 'legacy-hash', 'runtime',
+            '{"kind":"runtime","requestId":"legacy-request"}', 'ontology-1',
+            '{"kind":"edit","mode":"atomic","operationCount":0}',
+            '{"kind":"edit","commitId":"legacy-commit","created":true,"eventCount":0,"committedAt":"2026-01-01T00:00:00.000Z","outcomes":[],"changes":{"objects":[],"links":[]}}',
+            '2026-01-01T00:00:00.000Z'
+          )
+        `)
+
+        await expect(migration.up(context)).rejects.toThrow()
+        expect(await readTableColumns(schemaName, "ontology_commits")).not.toContain("execution_id")
+      } finally {
+        await sql.unsafe("RESET search_path")
+        await sql.unsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+      }
+    })
   })
 
   test("untracked existing schema collides and rolls back without conversion", async () => {
@@ -1546,6 +1599,13 @@ describe("Postgres storage migrations", () => {
           id: "023-webhook-executions",
           status: "applied",
           version: 23,
+        },
+        {
+          adapter_id: POSTGRES_STORAGE_ADAPTER_ID,
+          checksum_length: 64,
+          id: "024-ontology-commit-executions",
+          status: "applied",
+          version: 24,
         },
       ])
     } finally {

--- a/storage/sqlite/src/migrations.ts
+++ b/storage/sqlite/src/migrations.ts
@@ -63,6 +63,9 @@ import projectionExecutionsSql from "./migrations/022-projection-executions.sql"
   type: "text",
 }
 import webhookExecutionsSql from "./migrations/023-webhook-executions.sql" with { type: "text" }
+import ontologyCommitExecutionsSql from "./migrations/024-ontology-commit-executions.sql" with {
+  type: "text",
+}
 
 const MIGRATIONS_TABLE_SQL = `
   CREATE TABLE IF NOT EXISTS sixb_migrations (
@@ -129,6 +132,18 @@ export const sqliteStorageMigrations = defineMigrations({
         db.run(webhookExecutionsSql)
       },
       { checksum: checksum(webhookExecutionsSql) }
+    ),
+    sqliteStep(
+      "024-ontology-commit-executions",
+      (db) => {
+        if (db.query("SELECT 1 FROM ontology_commits LIMIT 1").get()) {
+          throw new Error(
+            "[SixbSqliteStorage] Ontology commit execution migration cannot preserve commits with unknown authority."
+          )
+        }
+        db.run(ontologyCommitExecutionsSql)
+      },
+      { checksum: checksum(ontologyCommitExecutionsSql) }
     ),
   ],
 })

--- a/storage/sqlite/src/migrations/024-ontology-commit-executions.sql
+++ b/storage/sqlite/src/migrations/024-ontology-commit-executions.sql
@@ -1,0 +1,58 @@
+DROP INDEX idx_ontology_commits_action_origin;
+DROP INDEX idx_ontology_commits_projection_origin;
+DROP INDEX idx_ontology_commits_telemetry_origin;
+DROP INDEX idx_ontology_commits_history;
+DROP INDEX idx_ontology_commits_origin;
+
+CREATE TABLE ontology_commits_v2 (
+  project_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  execution_id TEXT NOT NULL,
+  origin_kind TEXT NOT NULL CHECK (origin_kind IN ('action', 'runtime', 'projection', 'telemetry')),
+  origin_run_id TEXT,
+  origin_batch_ordinal INTEGER CHECK (
+    origin_batch_ordinal IS NULL OR origin_batch_ordinal >= 0
+  ),
+  origin TEXT NOT NULL CHECK (json_valid(origin)),
+  actor TEXT CHECK (actor IS NULL OR json_valid(actor)),
+  ontology_revision TEXT NOT NULL,
+  projection_revision TEXT,
+  ownership_hash TEXT,
+  intent TEXT NOT NULL CHECK (json_valid(intent)),
+  result TEXT NOT NULL CHECK (json_valid(result)),
+  committed_at TEXT NOT NULL,
+  PRIMARY KEY (project_id, id),
+  UNIQUE (project_id, idempotency_key),
+  FOREIGN KEY (project_id, execution_id)
+    REFERENCES executions (project_id, id)
+    ON DELETE RESTRICT,
+  CHECK (
+    (origin_kind IN ('action', 'projection') AND origin_run_id IS NOT NULL AND origin_batch_ordinal IS NULL)
+    OR (origin_kind = 'telemetry' AND (
+      (origin_run_id IS NULL AND origin_batch_ordinal IS NULL)
+      OR (origin_run_id IS NOT NULL AND origin_batch_ordinal IS NOT NULL)
+    ))
+    OR (origin_kind = 'runtime' AND origin_run_id IS NULL AND origin_batch_ordinal IS NULL)
+  )
+);
+
+DROP TABLE ontology_commits;
+ALTER TABLE ontology_commits_v2 RENAME TO ontology_commits;
+
+CREATE UNIQUE INDEX idx_ontology_commits_action_origin
+  ON ontology_commits(project_id, origin_run_id)
+  WHERE origin_kind = 'action';
+CREATE UNIQUE INDEX idx_ontology_commits_projection_origin
+  ON ontology_commits(project_id, origin_run_id)
+  WHERE origin_kind = 'projection';
+CREATE UNIQUE INDEX idx_ontology_commits_telemetry_origin
+  ON ontology_commits(project_id, origin_run_id, origin_batch_ordinal)
+  WHERE origin_kind = 'telemetry' AND origin_run_id IS NOT NULL;
+CREATE INDEX idx_ontology_commits_history
+  ON ontology_commits(project_id, committed_at, id);
+CREATE INDEX idx_ontology_commits_origin
+  ON ontology_commits(project_id, origin_kind, origin_run_id, origin_batch_ordinal);
+CREATE INDEX idx_ontology_commits_execution
+  ON ontology_commits(project_id, execution_id);

--- a/storage/sqlite/src/ontology-storage/materializations.ts
+++ b/storage/sqlite/src/ontology-storage/materializations.ts
@@ -700,11 +700,11 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
         .query(
           `
             INSERT INTO ontology_commits (
-              project_id, id, idempotency_key, request_hash,
+              project_id, id, idempotency_key, request_hash, execution_id,
               origin_kind, origin_run_id, origin_batch_ordinal, origin, actor,
               ontology_revision, projection_revision, ownership_hash,
               intent, result, committed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, json(?), json(?), ?, ?, ?, json(?), json(?), ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, json(?), json(?), ?, ?, ?, json(?), json(?), ?)
           `
         )
         .run(
@@ -712,6 +712,7 @@ export class SqliteOntologyMaterializationStorage implements OntologyMaterializa
           commit.id,
           commit.idempotencyKey,
           commit.requestHash,
+          commit.executionId,
           origin.kind,
           origin.runId,
           origin.batchOrdinal,

--- a/storage/sqlite/src/ontology-storage/shared.ts
+++ b/storage/sqlite/src/ontology-storage/shared.ts
@@ -32,6 +32,7 @@ export interface SqliteOntologyCommitRow {
   readonly id: string
   readonly idempotency_key: string
   readonly request_hash: string
+  readonly execution_id: string
   readonly origin_kind: string
   readonly origin_run_id: string | null
   readonly origin_batch_ordinal: number | null
@@ -149,6 +150,7 @@ export function commitRecord(row: SqliteOntologyCommitRow): OntologyCommitRecord
     id: row.id,
     idempotencyKey: row.idempotency_key,
     requestHash: row.request_hash,
+    executionId: row.execution_id,
     origin: parseJson<OntologyCommitWrite["origin"]>(row.origin),
     ...(row.actor === null
       ? {}

--- a/storage/sqlite/tests/sqlite-ontology-storage.test.ts
+++ b/storage/sqlite/tests/sqlite-ontology-storage.test.ts
@@ -27,6 +27,14 @@ test("SQLite work staging rolls back a partial batch after a later record confli
   const pending = classificationWork("pending")
   try {
     await storage.transaction(async (tx) => {
+      await tx.executions.create({
+        id: header.commit.executionId,
+        projectId: header.commit.projectId,
+        executor: { type: "request", requestId: "atomic-work-stage" },
+        source: { type: "http", requestId: "atomic-work-stage" },
+        correlationId: "contract-correlation:atomic-work-stage",
+        authorizationRef: { type: "disabled" },
+      })
       const materializations = tx.ontology.materializations
       const session = await materializations.begin(header)
       await materializations.stageWork({ session, records: [first] })
@@ -132,6 +140,7 @@ function atomicStageHeader(): MaterializationPlanHeader {
       id: "atomic-work-stage",
       idempotencyKey: "runtime:atomic-work-stage",
       requestHash: "hash:atomic-work-stage",
+      executionId: "contract-execution:atomic-work-stage",
       origin: { kind: "runtime", requestId: "atomic-work-stage" },
       ontologyRevision: "ontology-contract-revision",
       intent: { kind: "edit", mode: "atomic", operationCount: 0 },

--- a/storage/sqlite/tests/sqlite-storage-migrations.test.ts
+++ b/storage/sqlite/tests/sqlite-storage-migrations.test.ts
@@ -189,6 +189,13 @@ const expectedStorageMigrationRows = [
     status: "applied",
     version: 23,
   },
+  {
+    adapter_id: SQLITE_STORAGE_ADAPTER_ID,
+    checksum_length: 64,
+    id: "024-ontology-commit-executions",
+    status: "applied",
+    version: 24,
+  },
 ]
 
 afterEach(async () => {
@@ -1502,6 +1509,65 @@ describe("SQLite storage migrations", () => {
           ["project_id", "connector_id", "webhook_id", "idempotency_key"],
         ])
       )
+    } finally {
+      db.close()
+    }
+  })
+
+  test("rejects legacy ontology commits instead of inventing execution authority", () => {
+    const db = new Database(":memory:")
+    try {
+      const migrationIndex = sqliteStorageMigrations.steps.findIndex(
+        (migration) => migration.id === "024-ontology-commit-executions"
+      )
+      const migration = sqliteStorageMigrations.steps[migrationIndex]
+      if (!migration) throw new Error("SQLite ontology-commit execution migration is missing.")
+      for (const previous of sqliteStorageMigrations.steps.slice(0, migrationIndex)) {
+        previous.up(db)
+      }
+      db.query(`
+        INSERT INTO ontology_commits (
+          project_id, id, idempotency_key, request_hash, origin_kind, origin,
+          ontology_revision, intent, result, committed_at
+        ) VALUES (?, ?, ?, ?, 'runtime', json(?), ?, json(?), json(?), ?)
+      `).run(
+        "project-a",
+        "legacy-commit",
+        "runtime:legacy-commit",
+        "legacy-hash",
+        JSON.stringify({ kind: "runtime", requestId: "legacy-request" }),
+        "ontology-1",
+        JSON.stringify({ kind: "edit", mode: "atomic", operationCount: 0 }),
+        JSON.stringify({
+          kind: "edit",
+          commitId: "legacy-commit",
+          created: true,
+          eventCount: 0,
+          committedAt: "2026-01-01T00:00:00.000Z",
+          outcomes: [],
+          changes: { objects: [], links: [] },
+        }),
+        "2026-01-01T00:00:00.000Z"
+      )
+
+      expect(() => db.transaction(() => migration.up(db))()).toThrow("unknown authority")
+      expect(readMemoryTableColumns(db, "ontology_commits")).not.toContain("execution_id")
+    } finally {
+      db.close()
+    }
+  })
+
+  test("requires every ontology commit to reference a durable execution", () => {
+    const db = new Database(":memory:")
+    try {
+      for (const migration of sqliteStorageMigrations.steps) migration.up(db)
+
+      expect(readMemoryColumn(db, "ontology_commits", "execution_id")?.notnull).toBe(1)
+      expect(readMemoryForeignKeyTables(db, "ontology_commits")).toContain("executions")
+      expect(readMemoryIndexColumns(db, "idx_ontology_commits_execution")).toEqual([
+        "project_id",
+        "execution_id",
+      ])
     } finally {
       db.close()
     }


### PR DESCRIPTION
Part of #183.

## Why

Durable runs already restore their execution authority, but authoritative ontology writes did not persist or enforce that execution identity.

This slice closes that gap without mixing execution identity with semantic idempotency.

## Flow

```text
ExecutionScope
  → scoped Materializer
  → ontology mutation
  → commit + executionId
  → domain events
```

## What changes

- bind the Materializer to one validated `ExecutionScope`
- derive actor and correlation metadata from that scope
- persist and validate the execution before authoritative writes
- require `executionId` on ontology commits
- enforce execution references in memory, SQLite, and PostgreSQL
- prevent an idempotent replay from being reused by another execution
- bind Action and projection worker mutations to their durable run execution

## Error contract

- invalid or forged execution scopes remain coded as `internal.unexpected`
- Materializer validation and conflict classes remain internal control-flow signals
- outbox delivery keeps the canonical durable `event.delivery_failed` failure
- raw provider or Materializer diagnostics are never persisted as public failures

## Migration behavior

Legacy ontology commits cannot be assigned an honest authority retroactively.

Migration `023-ontology-commit-executions` rejects non-empty legacy commit histories instead of inventing an `executionId`. This is an intentional breaking change.

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run check`
- `bun run test:publish`
- `bun run generate:client`
- `bun run test:ci` — 3,901 passed, 7 skipped
- focused execution/materializer/provider tests — 341 passed

PostgreSQL e2e remains delegated to CI because Docker was not running locally.
