### PR TITLE
core: centralize definition discovery

### DIFF
--- a/packages/core/src/bootstrap/discovery.ts
+++ b/packages/core/src/bootstrap/discovery.ts
@@ -10,30 +10,19 @@ import { readdir } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { pathToFileURL } from "node:url"
 import { isActionDefinition } from "../actions"
-import type { ActionDefinition } from "../actions/types"
-import type { AgentDefinition } from "../agents"
 import { isAgentDefinition } from "../agents"
 import { isConnectorDefinition } from "../connectors"
-import type { ConnectorDefinition } from "../connectors/types"
 import { isDatasetDefinition } from "../datasets"
-import type { DatasetDefinition } from "../datasets/types"
 import type { OntologyDocumentInput, OntologySource } from "../ontology/registry"
 import type { ObjectTypeWithPropertyTokens } from "../ontology/tokens"
 import type { ValueType } from "../ontology/types"
 import { isPipelineDefinition } from "../pipelines"
-import type { PipelineDefinition } from "../pipelines/types"
 import { isProjectionDefinition } from "../projections/builders"
-import type { ProjectionDefinition } from "../projections/types"
 import { isRuleDefinition } from "../rules"
-import type { RuleDefinition } from "../rules/types"
 import { RuntimeError } from "../runtime/errors"
-import type { ScheduleDefinition } from "../schedules"
 import { isScheduleDefinition } from "../schedules"
-import type { GroupDefinition, MembershipPolicyDefinition, RoleDefinition } from "../security"
 import { isGroupDefinition, isMembershipPolicyDefinition, isRoleDefinition } from "../security"
-import type { SyncDefinition } from "../syncs"
 import { isSyncDefinition } from "../syncs"
-import type { WorkflowDefinition } from "../workflows"
 import { isWorkflowDefinition } from "../workflows"
 
 const moduleExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"])
@@ -82,265 +71,112 @@ export async function discoverOntologySources(
   return discoveredSources
 }
 
-export async function discoverActions(projectRoot: string): Promise<readonly ActionDefinition[]> {
-  const actionsDir = join(projectRoot, "actions")
-  const modulePaths = await listModuleFiles(actionsDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
-    kind: "action",
-  })
+type DiscoveryModuleKind =
+  | "action"
+  | "agent"
+  | "connector"
+  | "dataset"
+  | "group"
+  | "membershipPolicy"
+  | "ontology"
+  | "pipeline"
+  | "projection"
+  | "role"
+  | "rule"
+  | "schedule"
+  | "sync"
+  | "workflow"
 
-  const actions: ActionDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isActionDefinition(candidate)) {
-      actions.push(candidate)
-    }
-  }
-
-  return actions
+interface DefinitionDiscoveryFamily<TDefinition> {
+  readonly directory: readonly string[]
+  readonly kind: Exclude<DiscoveryModuleKind, "ontology">
+  readonly isDefinition: (value: unknown) => value is TDefinition
 }
 
-export async function discoverDatasets(projectRoot: string): Promise<readonly DatasetDefinition[]> {
-  const datasetsDir = join(projectRoot, "datasets")
-  const modulePaths = await listModuleFiles(datasetsDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
-    kind: "dataset",
-  })
-
-  const datasets: DatasetDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isDatasetDefinition(candidate)) {
-      datasets.push(candidate)
-    }
-  }
-
-  return datasets
-}
-
-export async function discoverSyncs(projectRoot: string): Promise<readonly SyncDefinition[]> {
-  const syncsDir = join(projectRoot, "syncs")
-  const modulePaths = await listModuleFiles(syncsDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
-    kind: "sync",
-  })
-
-  const syncs: SyncDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isSyncDefinition(candidate)) {
-      syncs.push(candidate)
-    }
-  }
-
-  return syncs
-}
-
-export async function discoverProjections(
-  projectRoot: string
-): Promise<readonly ProjectionDefinition[]> {
-  const projectionsDir = join(projectRoot, "projections")
-  const modulePaths = await listModuleFiles(projectionsDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
+const definitionDiscoveryRegistry = {
+  actions: { directory: ["actions"], kind: "action", isDefinition: isActionDefinition },
+  projections: {
+    directory: ["projections"],
     kind: "projection",
-  })
-
-  const projections: ProjectionDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isProjectionDefinition(candidate)) {
-      projections.push(candidate)
-    }
-  }
-
-  return projections
-}
-
-export async function discoverConnectors(
-  projectRoot: string
-): Promise<readonly ConnectorDefinition[]> {
-  const connectorsDir = join(projectRoot, "connectors")
-  const modulePaths = await listModuleFiles(connectorsDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
-    kind: "connector",
-  })
-
-  const connectors: ConnectorDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isConnectorDefinition(candidate)) {
-      connectors.push(candidate)
-    }
-  }
-
-  return connectors
-}
-
-export async function discoverSchedules(
-  projectRoot: string
-): Promise<readonly ScheduleDefinition[]> {
-  const schedulesDir = join(projectRoot, "schedules")
-  const modulePaths = await listModuleFiles(schedulesDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
+    isDefinition: isProjectionDefinition,
+  },
+  schedules: {
+    directory: ["schedules"],
     kind: "schedule",
-  })
-
-  const schedules: ScheduleDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isScheduleDefinition(candidate)) {
-      schedules.push(candidate)
-    }
-  }
-
-  return schedules
-}
-
-export async function discoverPipelines(
-  projectRoot: string
-): Promise<readonly PipelineDefinition[]> {
-  const pipelinesDir = join(projectRoot, "pipelines")
-  const modulePaths = await listModuleFiles(pipelinesDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
+    isDefinition: isScheduleDefinition,
+  },
+  syncs: { directory: ["syncs"], kind: "sync", isDefinition: isSyncDefinition },
+  connectors: {
+    directory: ["connectors"],
+    kind: "connector",
+    isDefinition: isConnectorDefinition,
+  },
+  pipelines: {
+    directory: ["pipelines"],
     kind: "pipeline",
-  })
-
-  const pipelines: PipelineDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isPipelineDefinition(candidate)) {
-      pipelines.push(candidate)
-    }
-  }
-
-  return pipelines
-}
-
-export async function discoverRules(projectRoot: string): Promise<readonly RuleDefinition[]> {
-  // Rules follow the same convention-based discovery model as syncs and workflows:
-  // any exported rule definition, or arrays containing them, is collected.
-  const rulesDir = join(projectRoot, "rules")
-  const modulePaths = await listModuleFiles(rulesDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
-    kind: "rule",
-  })
-
-  const rules: RuleDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isRuleDefinition(candidate)) {
-      rules.push(candidate)
-    }
-  }
-
-  return rules
-}
-
-export async function discoverGroups(projectRoot: string): Promise<readonly GroupDefinition[]> {
-  const groupsDir = join(projectRoot, "security", "groups")
-  const modulePaths = await listModuleFiles(groupsDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
-    kind: "group",
-  })
-
-  const groups: GroupDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isGroupDefinition(candidate)) {
-      groups.push(candidate)
-    }
-  }
-
-  return groups
-}
-
-export async function discoverRoles(projectRoot: string): Promise<readonly RoleDefinition[]> {
-  const rolesDir = join(projectRoot, "security", "roles")
-  const modulePaths = await listModuleFiles(rolesDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
-    kind: "role",
-  })
-
-  const roles: RoleDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isRoleDefinition(candidate)) {
-      roles.push(candidate)
-    }
-  }
-
-  return roles
-}
-
-export async function discoverMembershipPolicies(
-  projectRoot: string
-): Promise<readonly MembershipPolicyDefinition[]> {
-  const policiesDir = join(projectRoot, "security", "policies")
-  const modulePaths = await listModuleFiles(policiesDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
-    kind: "membershipPolicy",
-  })
-
-  const membershipPolicies: MembershipPolicyDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isMembershipPolicyDefinition(candidate)) {
-      membershipPolicies.push(candidate)
-    }
-  }
-
-  return membershipPolicies
-}
-
-export async function discoverWorkflows(
-  projectRoot: string
-): Promise<readonly WorkflowDefinition[]> {
-  const workflowsDir = join(projectRoot, "workflows")
-  const modulePaths = await listModuleFiles(workflowsDir)
-  const exportedCandidates = await loadModuleExports({
-    modulePaths,
-    projectRoot,
+    isDefinition: isPipelineDefinition,
+  },
+  datasets: { directory: ["datasets"], kind: "dataset", isDefinition: isDatasetDefinition },
+  rules: { directory: ["rules"], kind: "rule", isDefinition: isRuleDefinition },
+  workflows: {
+    directory: ["workflows"],
     kind: "workflow",
-  })
+    isDefinition: isWorkflowDefinition,
+  },
+  groups: {
+    directory: ["security", "groups"],
+    kind: "group",
+    isDefinition: isGroupDefinition,
+  },
+  roles: {
+    directory: ["security", "roles"],
+    kind: "role",
+    isDefinition: isRoleDefinition,
+  },
+  membershipPolicies: {
+    directory: ["security", "policies"],
+    kind: "membershipPolicy",
+    isDefinition: isMembershipPolicyDefinition,
+  },
+  agents: { directory: ["agents"], kind: "agent", isDefinition: isAgentDefinition },
+} as const satisfies Record<string, DefinitionDiscoveryFamily<unknown>>
 
-  const workflows: WorkflowDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isWorkflowDefinition(candidate)) {
-      workflows.push(candidate)
-    }
-  }
+type DefinitionFromFamily<TFamily> =
+  TFamily extends DefinitionDiscoveryFamily<infer TDefinition> ? TDefinition : never
 
-  return workflows
+export type DiscoveredProjectDefinitions = {
+  readonly [TKey in keyof typeof definitionDiscoveryRegistry]: readonly DefinitionFromFamily<
+    (typeof definitionDiscoveryRegistry)[TKey]
+  >[]
 }
 
-export async function discoverAgents(projectRoot: string): Promise<readonly AgentDefinition[]> {
-  const agentsDir = join(projectRoot, "agents")
-  const modulePaths = await listModuleFiles(agentsDir)
+export async function discoverProjectDefinitions(
+  projectRoot: string
+): Promise<DiscoveredProjectDefinitions> {
+  const entries = await Promise.all(
+    Object.entries(definitionDiscoveryRegistry).map(async ([key, family]) => {
+      const definitions = await discoverDefinitionFamily(projectRoot, family)
+      return [key, definitions] as const
+    })
+  )
+
+  // Object.fromEntries erases literal keys. Every entry above comes from the exact registry and its
+  // definitions have passed that entry's type guard, so restoring the mapped result type is safe.
+  return Object.fromEntries(entries) as DiscoveredProjectDefinitions
+}
+
+async function discoverDefinitionFamily(
+  projectRoot: string,
+  family: DefinitionDiscoveryFamily<unknown>
+): Promise<readonly unknown[]> {
+  const modulePaths = await listModuleFiles(join(projectRoot, ...family.directory))
   const exportedCandidates = await loadModuleExports({
     modulePaths,
     projectRoot,
-    kind: "agent",
+    kind: family.kind,
   })
 
-  const agents: AgentDefinition[] = []
-  for (const candidate of exportedCandidates) {
-    if (isAgentDefinition(candidate)) {
-      agents.push(candidate)
-    }
-  }
-
-  return agents
+  return exportedCandidates.filter(family.isDefinition)
 }
 
 // ── Internal helpers ────────────────────────────────────────
@@ -348,23 +184,7 @@ export async function discoverAgents(projectRoot: string): Promise<readonly Agen
 async function loadModuleExports(options: {
   modulePaths: readonly string[]
   projectRoot: string
-  kind:
-    | "action"
-    | "agent"
-    | "ontology"
-    | "dataset"
-    | "function"
-    | "connector"
-    | "sync"
-    | "projection"
-    | "schedule"
-    | "pipeline"
-    | "rule"
-    | "trigger"
-    | "group"
-    | "role"
-    | "membershipPolicy"
-    | "workflow"
+  kind: DiscoveryModuleKind
 }): Promise<unknown[]> {
   const exportedCandidates: unknown[] = []
   const seen = new Set<unknown>()

--- a/packages/core/src/bootstrap/index.ts
+++ b/packages/core/src/bootstrap/index.ts
@@ -1,18 +1,7 @@
+export type { DiscoveredProjectDefinitions } from "./discovery"
 export {
-  discoverActions,
-  discoverAgents,
-  discoverConnectors,
-  discoverDatasets,
-  discoverGroups,
-  discoverMembershipPolicies,
   discoverOntologySources,
-  discoverPipelines,
-  discoverProjections,
-  discoverRoles,
-  discoverRules,
-  discoverSchedules,
-  discoverSyncs,
-  discoverWorkflows,
+  discoverProjectDefinitions,
 } from "./discovery"
 export type {
   GenerateOntologyTypeManifestOptions,

--- a/packages/core/src/runtime/create.ts
+++ b/packages/core/src/runtime/create.ts
@@ -3,22 +3,7 @@ import type { ActionDefinition } from "../actions"
 import type { AgentDefinition } from "../agents"
 import type { SixbAuthConfig } from "../auth"
 import type { BlobStorage } from "../blob-storage"
-import {
-  discoverActions,
-  discoverAgents,
-  discoverConnectors,
-  discoverDatasets,
-  discoverGroups,
-  discoverMembershipPolicies,
-  discoverOntologySources,
-  discoverPipelines,
-  discoverProjections,
-  discoverRoles,
-  discoverRules,
-  discoverSchedules,
-  discoverSyncs,
-  discoverWorkflows,
-} from "../bootstrap"
+import { discoverOntologySources, discoverProjectDefinitions } from "../bootstrap"
 import type { Broker } from "../broker"
 import type { ConnectorDefinition } from "../connectors/types"
 import type { DatasetDefinition } from "../datasets"
@@ -89,8 +74,8 @@ export async function createSixb(
 ): Promise<SixbHost<readonly OntologySource[]>> {
   const projectRoot = resolve(options.projectRoot ?? process.cwd())
 
-  const discovered = await discoverOntologySources(projectRoot)
-  const allSources = [...(options.ontologies ?? []), ...discovered]
+  const discoveredOntology = await discoverOntologySources(projectRoot)
+  const allSources = [...(options.ontologies ?? []), ...discoveredOntology]
 
   if (allSources.length === 0) {
     throw new RuntimeError(
@@ -98,35 +83,7 @@ export async function createSixb(
     )
   }
 
-  const [
-    actions,
-    projections,
-    schedules,
-    syncs,
-    connectors,
-    pipelines,
-    datasets,
-    rules,
-    workflows,
-    groups,
-    roles,
-    membershipPolicies,
-    agents,
-  ] = await Promise.all([
-    discoverActions(projectRoot),
-    discoverProjections(projectRoot),
-    discoverSchedules(projectRoot),
-    discoverSyncs(projectRoot),
-    discoverConnectors(projectRoot),
-    discoverPipelines(projectRoot),
-    discoverDatasets(projectRoot),
-    discoverRules(projectRoot),
-    discoverWorkflows(projectRoot),
-    discoverGroups(projectRoot),
-    discoverRoles(projectRoot),
-    discoverMembershipPolicies(projectRoot),
-    discoverAgents(projectRoot),
-  ])
+  const definitions = await discoverProjectDefinitions(projectRoot)
 
   // Explicit definitions come first so local setup can override ordering while duplicate ids are
   // still rejected by the SixbHost constructor. Every family merges — `actions` and `projections`
@@ -145,19 +102,19 @@ export async function createSixb(
     onError: options.onError,
     ontologyMaintenance: options.ontologyMaintenance,
     projectRoot,
-    actions: [...(options.actions ?? []), ...actions],
-    datasets: [...(options.datasets ?? []), ...datasets],
-    connectors: [...(options.connectors ?? []), ...connectors],
-    schedules: [...(options.schedules ?? []), ...schedules],
-    syncs: [...(options.syncs ?? []), ...syncs],
-    pipelines: [...(options.pipelines ?? []), ...pipelines],
-    projections: [...(options.projections ?? []), ...projections],
-    rules: [...(options.rules ?? []), ...rules],
-    workflows: [...(options.workflows ?? []), ...workflows],
-    groups: [...(options.groups ?? []), ...groups],
-    roles: [...(options.roles ?? []), ...roles],
-    membershipPolicies: [...(options.membershipPolicies ?? []), ...membershipPolicies],
-    agents: [...(options.agents ?? []), ...agents],
+    actions: [...(options.actions ?? []), ...definitions.actions],
+    datasets: [...(options.datasets ?? []), ...definitions.datasets],
+    connectors: [...(options.connectors ?? []), ...definitions.connectors],
+    schedules: [...(options.schedules ?? []), ...definitions.schedules],
+    syncs: [...(options.syncs ?? []), ...definitions.syncs],
+    pipelines: [...(options.pipelines ?? []), ...definitions.pipelines],
+    projections: [...(options.projections ?? []), ...definitions.projections],
+    rules: [...(options.rules ?? []), ...definitions.rules],
+    workflows: [...(options.workflows ?? []), ...definitions.workflows],
+    groups: [...(options.groups ?? []), ...definitions.groups],
+    roles: [...(options.roles ?? []), ...definitions.roles],
+    membershipPolicies: [...(options.membershipPolicies ?? []), ...definitions.membershipPolicies],
+    agents: [...(options.agents ?? []), ...definitions.agents],
     auth: options.auth,
   })
 }


### PR DESCRIPTION
## Summary

- replace 13 repetitive definition-discovery functions with one typed registry
- derive the aggregate discovery result from each registry type guard
- keep ontology discovery separate while preserving definition ordering, filtering, concurrency, and explicit-definition merging
- reduce the core implementation by 234 net lines

## Validation

- bun run typecheck
- bun run check
- bun run build
- bun run test:publish
- bun run test:ci (3,803 passed, 2 skipped, 0 failed)