### PR TITLE
connectors: centralize REST reliability

### DIFF
--- a/connectors/ace-iot/src/ace-iot.ts
+++ b/connectors/ace-iot/src/ace-iot.ts
@@ -1,11 +1,24 @@
-import { rest } from "@sixb/connector-rest"
+import {
+  type RestRetryContext,
+  type RestRetryPolicy,
+  rest,
+  shouldRetryRestRequest,
+} from "@sixb/connector-rest"
 import type { ConnectorAdapter } from "@sixb/core"
 import { createAceIotClient } from "./client"
 import { AceIotConfigurationError } from "./errors"
 import { createAceIotHttp } from "./http"
-import type { AceIotApiKeyResolver, AceIotClient, AceIotConnectorOptions } from "./types"
+import type {
+  AceIotApiKeyResolver,
+  AceIotClient,
+  AceIotConnectorOptions,
+  AceIotRequestMethod,
+  AceIotRetryContext,
+  AceIotRetryPolicy,
+} from "./types"
 
 const DEFAULT_BASE_URL = "https://flightdeck.aceiot.cloud/api/"
+const DEFAULT_MAX_RETRIES = 2
 
 export type AceIotConnector = ConnectorAdapter<"ace-iot", AceIotClient>
 
@@ -21,22 +34,59 @@ export function aceIot(options: AceIotConnectorOptions): AceIotConnector {
       Accept: "application/json",
     }),
     timeoutMs: options.timeoutMs,
-    // Retries are method-aware in the ACE HTTP layer.
-    retry: { maxRetries: 0 },
+    minDelayMs: options.minDelayMs,
+    retry: toRestRetryPolicy(options.retry),
   })
 
   return {
     type: "ace-iot",
     async connect(context) {
+      assertReliabilityOptions(options)
       const restClient = await restAdapter.connect(context)
-      return createAceIotClient(
-        createAceIotHttp(restClient, {
-          minDelayMs: options.minDelayMs,
-          retry: options.retry,
-          signal: context.signal,
-        })
+      return createAceIotClient(createAceIotHttp(restClient))
+    },
+  }
+}
+
+function toRestRetryPolicy(policy: AceIotRetryPolicy | undefined): RestRetryPolicy {
+  return {
+    maxRetries: policy?.maxRetries ?? DEFAULT_MAX_RETRIES,
+    shouldRetry(context) {
+      const aceContext = toAceIotRetryContext(context)
+      return (
+        policy?.shouldRetry?.(aceContext) ??
+        (!(context.error instanceof AceIotConfigurationError) && shouldRetryRestRequest(context))
       )
     },
+    ...(policy?.delayMs
+      ? {
+          delayMs: (context: RestRetryContext) =>
+            policy.delayMs?.(toAceIotRetryContext(context)) ?? 0,
+        }
+      : {}),
+  }
+}
+
+function toAceIotRetryContext(context: RestRetryContext): AceIotRetryContext {
+  return {
+    attempt: context.attempt,
+    method: context.method as AceIotRequestMethod,
+    idempotent: context.idempotent,
+    response: context.response,
+    error: context.error,
+  }
+}
+
+function assertReliabilityOptions(options: AceIotConnectorOptions): void {
+  const maxRetries = options.retry?.maxRetries ?? DEFAULT_MAX_RETRIES
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error("[SixbAceIot] retry.maxRetries must be a non-negative integer.")
+  }
+  if (
+    options.minDelayMs !== undefined &&
+    (!Number.isFinite(options.minDelayMs) || options.minDelayMs < 0)
+  ) {
+    throw new Error("[SixbAceIot] minDelayMs must be a non-negative finite number.")
   }
 }
 

--- a/connectors/ace-iot/src/errors.ts
+++ b/connectors/ace-iot/src/errors.ts
@@ -1,3 +1,5 @@
+import { parseRetryAfter } from "@sixb/connector-rest"
+
 /**
  * A problem with how the connector was configured, raised before or instead of a request.
  *
@@ -88,20 +90,6 @@ function extractMessage(value: unknown): string | null {
 
   const message = value.message
   return typeof message === "string" && message.trim() ? message : null
-}
-
-function parseRetryAfter(value: string | null): number | null {
-  if (!value) {
-    return null
-  }
-
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) {
-    return Math.max(seconds, 0) * 1000
-  }
-
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/connectors/ace-iot/src/http.ts
+++ b/connectors/ace-iot/src/http.ts
@@ -1,16 +1,10 @@
-import type { RestClient } from "@sixb/connector-rest"
-import { AceIotApiError, AceIotConfigurationError } from "./errors"
-import type {
-  AceIotRequestMethod,
-  AceIotRetryContext,
-  AceIotRetryPolicy,
-  QueryParams,
-  QueryValue,
-} from "./types"
+import { type RestClient, readResponseBody, withQuery } from "@sixb/connector-rest"
+import { AceIotApiError } from "./errors"
+import type { AceIotRequestMethod, QueryParams } from "./types"
 
 export interface AceIotRequestOptions {
   /**
-   * Mark a write that cannot change server state, so the default policy may replay it.
+   * Mark a write that cannot change server state, so the shared transport may replay it.
    * `POST /points/get_timeseries` is the one such route: it is a read that takes a body.
    */
   readonly idempotent?: boolean
@@ -30,20 +24,7 @@ export interface AceIotHttp {
   download(path: string, query?: QueryParams): Promise<Response>
 }
 
-export interface AceIotHttpOptions {
-  readonly minDelayMs?: number
-  readonly retry?: AceIotRetryPolicy
-  readonly signal?: AbortSignal
-}
-
-const DEFAULT_MAX_RETRIES = 2
-
-export function createAceIotHttp(rest: RestClient, options: AceIotHttpOptions = {}): AceIotHttp {
-  const retryPolicy = options.retry ?? {}
-  const maxRetries = retryPolicy.maxRetries ?? DEFAULT_MAX_RETRIES
-  assertMaxRetries(maxRetries)
-  const schedule = createRequestScheduler(options.minDelayMs ?? 0)
-
+export function createAceIotHttp(rest: RestClient): AceIotHttp {
   async function send(
     method: AceIotRequestMethod,
     path: string,
@@ -51,38 +32,11 @@ export function createAceIotHttp(rest: RestClient, options: AceIotHttpOptions = 
     query: QueryParams | undefined,
     idempotent: boolean
   ): Promise<Response> {
-    const requestPath = withQuery(path, query)
-
-    for (let attempt = 0; ; attempt++) {
-      let response: Response | null = null
-      let error: unknown = null
-
-      try {
-        await schedule()
-        response = await rest.request(requestPath, createRequestInit(method, body, options.signal))
-      } catch (caughtError) {
-        error = caughtError
-      }
-
-      const context: AceIotRetryContext = { attempt, method, idempotent, response, error }
-      const shouldRetry =
-        attempt < maxRetries &&
-        (retryPolicy.shouldRetry?.(context) ?? shouldRetryByDefault(context))
-
-      if (shouldRetry) {
-        if (response?.body) {
-          await response.body.cancel().catch(() => undefined)
-        }
-        await sleep(retryPolicy.delayMs?.(context) ?? defaultRetryDelayMs(context))
-        continue
-      }
-
-      if (error) {
-        throw error
-      }
-
-      return response as Response
-    }
+    return rest.request(
+      withQuery(path, query, { omitEmptyString: true }),
+      { method, body },
+      { idempotent }
+    )
   }
 
   async function request<T>(
@@ -128,59 +82,6 @@ export function createAceIotHttp(rest: RestClient, options: AceIotHttpOptions = 
   }
 }
 
-export function withQuery(path: string, query?: QueryParams): string {
-  const normalizedPath = path.startsWith("/") ? path.slice(1) : path
-  if (!query) {
-    return normalizedPath
-  }
-
-  const params = new URLSearchParams()
-  for (const [key, value] of Object.entries(query)) {
-    appendQueryParam(params, key, value)
-  }
-
-  const queryString = params.toString()
-  return queryString ? `${normalizedPath}?${queryString}` : normalizedPath
-}
-
-function createRequestInit(
-  method: AceIotRequestMethod,
-  body: unknown,
-  signal: AbortSignal | undefined
-): RequestInit {
-  const headers = new Headers()
-  const init: RequestInit = { method, headers, signal }
-  const serializedBody = serializeBody(body, headers)
-
-  if (serializedBody !== undefined) {
-    init.body = serializedBody
-  }
-
-  return init
-}
-
-function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
-  if (body === undefined) {
-    return undefined
-  }
-
-  // FormData must keep the boundary fetch generates, so no content-type is set for it here.
-  if (
-    typeof body === "string" ||
-    body instanceof Blob ||
-    body instanceof ArrayBuffer ||
-    ArrayBuffer.isView(body) ||
-    body instanceof FormData ||
-    body instanceof URLSearchParams ||
-    body instanceof ReadableStream
-  ) {
-    return body as BodyInit
-  }
-
-  headers.set("content-type", "application/json")
-  return JSON.stringify(body)
-}
-
 async function readJson<T>(response: Response): Promise<T> {
   const responseBody = await readResponseBody(response)
   if (!response.ok) {
@@ -188,107 +89,4 @@ async function readJson<T>(response: Response): Promise<T> {
   }
 
   return responseBody as T
-}
-
-async function readResponseBody(response: Response): Promise<unknown> {
-  if (response.status === 204) {
-    return undefined
-  }
-
-  const text = await response.text()
-  if (!text) {
-    return undefined
-  }
-
-  try {
-    return JSON.parse(text)
-  } catch {
-    return text
-  }
-}
-
-/**
- * Replay reads only. Every ACE write changes state — `POST /points/` and `PUT /points/{name}` merge
- * tags, and `POST /gateways/{name}/token` mints a credential — so a write is retried only when the
- * caller marks it idempotent or supplies its own policy.
- */
-function shouldRetryByDefault(context: AceIotRetryContext): boolean {
-  if (!(context.method === "GET" || context.idempotent) || isAbortError(context.error)) {
-    return false
-  }
-
-  // A misconfigured connector fails the same way on every attempt.
-  if (context.error instanceof AceIotConfigurationError) {
-    return false
-  }
-
-  if (context.error) {
-    return true
-  }
-
-  const status = context.response?.status
-  return status === 429 || (status !== undefined && status >= 500)
-}
-
-function defaultRetryDelayMs(context: AceIotRetryContext): number {
-  const retryAfter = parseRetryAfter(context.response?.headers.get("retry-after") ?? null)
-  return retryAfter ?? Math.min(1000 * 2 ** context.attempt, 30_000)
-}
-
-function parseRetryAfter(value: string | null): number | null {
-  if (!value) {
-    return null
-  }
-
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) {
-    return Math.max(seconds, 0) * 1000
-  }
-
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError"
-}
-
-function appendQueryParam(params: URLSearchParams, key: string, value: QueryValue): void {
-  if (value === undefined || value === "") {
-    return
-  }
-
-  params.set(key, String(value))
-}
-
-function assertMaxRetries(maxRetries: number): void {
-  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
-    throw new Error("[SixbAceIot] retry.maxRetries must be a non-negative integer.")
-  }
-}
-
-function createRequestScheduler(minDelayMs: number): () => Promise<void> {
-  if (!Number.isFinite(minDelayMs) || minDelayMs < 0) {
-    throw new Error("[SixbAceIot] minDelayMs must be a non-negative finite number.")
-  }
-
-  if (minDelayMs === 0) {
-    return () => Promise.resolve()
-  }
-
-  let nextAvailableAt = 0
-  let queue = Promise.resolve()
-
-  return () => {
-    const scheduled = queue.then(async () => {
-      await sleep(Math.max(nextAvailableAt - Date.now(), 0))
-      nextAvailableAt = Date.now() + minDelayMs
-    })
-    queue = scheduled.catch(() => undefined)
-    return scheduled
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
 }

--- a/connectors/google/src/http.ts
+++ b/connectors/google/src/http.ts
@@ -100,20 +100,15 @@ export function createGoogleHttp(clients: GoogleHttpClients): GoogleHttp {
     const retryable =
       options?.retryable ??
       (method === "GET" || (surface !== "analyticsAdmin" && surface !== "analyticsData"))
+    const requestOptions = { idempotent: retryable, retryable }
     // `post` serializes a JSON body and sets content-type under any verb;
     // `request` covers the bodiless verbs (GET/DELETE) without one.
     const response =
       method === "GET"
-        ? await client.get(url, { retry: retryable })
+        ? await client.get(url, undefined, requestOptions)
         : method === "DELETE"
-          ? await client.request(url, {
-              method: "DELETE",
-              retry: retryable,
-            })
-          : await client.post(url, options?.body, {
-              method,
-              retry: retryable,
-            })
+          ? await client.request(url, { method: "DELETE" }, requestOptions)
+          : await client.post(url, options?.body, { method }, requestOptions)
     return readJson<T>(response)
   }
 

--- a/connectors/mercury/src/errors.ts
+++ b/connectors/mercury/src/errors.ts
@@ -1,3 +1,5 @@
+import { parseRetryAfter } from "@sixb/connector-rest"
+
 export class MercuryApiError extends Error {
   readonly name = "MercuryApiError"
   readonly headers: Headers
@@ -47,20 +49,6 @@ function extractMessage(value: unknown): string | null {
   }
 
   return null
-}
-
-function parseRetryAfter(value: string | null): number | null {
-  if (!value) {
-    return null
-  }
-
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) {
-    return Math.max(seconds, 0) * 1000
-  }
-
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/connectors/mercury/src/http.ts
+++ b/connectors/mercury/src/http.ts
@@ -1,12 +1,6 @@
-import type { RestClient } from "@sixb/connector-rest"
+import { type RestClient, readResponseBody, withQuery } from "@sixb/connector-rest"
 import { MercuryApiError } from "./errors"
-import type {
-  MercuryRequestMethod,
-  MercuryRetryContext,
-  MercuryRetryPolicy,
-  QueryParams,
-  QueryValue,
-} from "./types"
+import type { MercuryRequestMethod, QueryParams } from "./types"
 
 export interface MercuryHttp {
   get<T>(path: string, query?: QueryParams): Promise<T>
@@ -15,58 +9,23 @@ export interface MercuryHttp {
   delete<T>(path: string, query?: QueryParams): Promise<T>
 }
 
-export interface MercuryHttpOptions {
-  readonly minDelayMs?: number
-  readonly retry?: MercuryRetryPolicy
-  readonly signal?: AbortSignal
-}
-
-const DEFAULT_MAX_RETRIES = 2
-
-export function createMercuryHttp(rest: RestClient, options: MercuryHttpOptions = {}): MercuryHttp {
-  const retryPolicy = options.retry ?? {}
-  const maxRetries = retryPolicy.maxRetries ?? DEFAULT_MAX_RETRIES
-  assertMaxRetries(maxRetries)
-  const schedule = createRequestScheduler(options.minDelayMs ?? 0)
-
+export function createMercuryHttp(rest: RestClient): MercuryHttp {
   async function request<T>(
     method: MercuryRequestMethod,
     path: string,
     body?: unknown,
     query?: QueryParams
   ): Promise<T> {
-    const requestPath = withQuery(path, query)
-
-    for (let attempt = 0; ; attempt++) {
-      let response: Response | null = null
-      let error: unknown = null
-
-      try {
-        await schedule()
-        response = await rest.request(requestPath, createRequestInit(method, body, options.signal))
-      } catch (caughtError) {
-        error = caughtError
-      }
-
-      const context: MercuryRetryContext = { attempt, method, response, error }
-      const shouldRetry =
-        attempt < maxRetries &&
-        (retryPolicy.shouldRetry?.(context) ?? shouldRetryByDefault(context))
-
-      if (shouldRetry) {
-        if (response?.body) {
-          await response.body.cancel().catch(() => undefined)
-        }
-        await sleep(retryPolicy.delayMs?.(context) ?? defaultRetryDelayMs(context))
-        continue
-      }
-
-      if (error) {
-        throw error
-      }
-
-      return readJson<T>(response as Response)
+    const response = await rest.request(withQuery(path, query, { omitEmptyString: true }), {
+      method,
+      body,
+    })
+    const responseBody = await readResponseBody(response)
+    if (!response.ok) {
+      throw new MercuryApiError(response.status, responseBody, response.headers)
     }
+
+    return responseBody as T
   }
 
   return {
@@ -83,168 +42,4 @@ export function createMercuryHttp(rest: RestClient, options: MercuryHttpOptions 
       return request<T>("DELETE", path, undefined, query)
     },
   }
-}
-
-export function withQuery(path: string, query?: QueryParams): string {
-  const normalizedPath = path.startsWith("/") ? path.slice(1) : path
-  if (!query) {
-    return normalizedPath
-  }
-
-  const params = new URLSearchParams()
-  for (const [key, value] of Object.entries(query)) {
-    appendQueryParam(params, key, value)
-  }
-
-  const queryString = params.toString()
-  return queryString ? `${normalizedPath}?${queryString}` : normalizedPath
-}
-
-function createRequestInit(
-  method: MercuryRequestMethod,
-  body: unknown,
-  signal: AbortSignal | undefined
-): RequestInit {
-  const headers = new Headers()
-  const init: RequestInit = { method, headers, signal }
-  const serializedBody = serializeBody(body, headers)
-
-  if (serializedBody !== undefined) {
-    init.body = serializedBody
-  }
-
-  return init
-}
-
-function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
-  if (body === undefined) {
-    return undefined
-  }
-
-  if (
-    typeof body === "string" ||
-    body instanceof Blob ||
-    body instanceof ArrayBuffer ||
-    ArrayBuffer.isView(body) ||
-    body instanceof FormData ||
-    body instanceof URLSearchParams ||
-    body instanceof ReadableStream
-  ) {
-    return body as BodyInit
-  }
-
-  headers.set("content-type", "application/json")
-  return JSON.stringify(body)
-}
-
-async function readJson<T>(response: Response): Promise<T> {
-  const responseBody = await readResponseBody(response)
-  if (!response.ok) {
-    throw new MercuryApiError(response.status, responseBody, response.headers)
-  }
-
-  return responseBody as T
-}
-
-async function readResponseBody(response: Response): Promise<unknown> {
-  if (response.status === 204) {
-    return undefined
-  }
-
-  const text = await response.text()
-  if (!text) {
-    return undefined
-  }
-
-  try {
-    return JSON.parse(text)
-  } catch {
-    return text
-  }
-}
-
-function shouldRetryByDefault(context: MercuryRetryContext): boolean {
-  // Mercury uses POST for category, customer, and invoice updates and PATCH for transaction
-  // metadata, so no write is safe to replay — only reads are retried.
-  if (context.method !== "GET" || isAbortError(context.error)) {
-    return false
-  }
-
-  if (context.error) {
-    return true
-  }
-
-  const status = context.response?.status
-  return status === 429 || (status !== undefined && status >= 500)
-}
-
-function defaultRetryDelayMs(context: MercuryRetryContext): number {
-  const retryAfter = parseRetryAfter(context.response?.headers.get("retry-after") ?? null)
-  return retryAfter ?? Math.min(1000 * 2 ** context.attempt, 30_000)
-}
-
-function parseRetryAfter(value: string | null): number | null {
-  if (!value) {
-    return null
-  }
-
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) {
-    return Math.max(seconds, 0) * 1000
-  }
-
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError"
-}
-
-/**
- * Mercury repeats a parameter to express a list — `?status=pending&status=sent` — so arrays are
- * appended rather than joined.
- */
-function appendQueryParam(params: URLSearchParams, key: string, value: QueryValue): void {
-  if (value === undefined || value === "") {
-    return
-  }
-
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      params.append(key, String(entry))
-    }
-    return
-  }
-
-  params.set(key, String(value))
-}
-
-function assertMaxRetries(maxRetries: number): void {
-  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
-    throw new Error("[SixbMercury] retry.maxRetries must be a non-negative integer.")
-  }
-}
-
-function createRequestScheduler(minDelayMs: number): () => Promise<void> {
-  if (!Number.isFinite(minDelayMs) || minDelayMs < 0) {
-    throw new Error("[SixbMercury] minDelayMs must be a non-negative finite number.")
-  }
-
-  let nextAvailableAt = 0
-  let queue = Promise.resolve()
-
-  return () => {
-    const scheduled = queue.then(async () => {
-      const waitMs = Math.max(nextAvailableAt - Date.now(), 0)
-      await sleep(waitMs)
-      nextAvailableAt = Date.now() + minDelayMs
-    })
-    queue = scheduled.catch(() => undefined)
-    return scheduled
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
 }

--- a/connectors/mercury/src/mercury.ts
+++ b/connectors/mercury/src/mercury.ts
@@ -1,4 +1,4 @@
-import { rest } from "@sixb/connector-rest"
+import { type RestRetryContext, type RestRetryPolicy, rest } from "@sixb/connector-rest"
 import {
   type ConnectorAdapter,
   resolveWebhookVerification,
@@ -6,10 +6,18 @@ import {
 } from "@sixb/core"
 import { createMercuryClient } from "./client"
 import { createMercuryHttp } from "./http"
-import type { MercuryAccessTokenResolver, MercuryClient, MercuryConnectorOptions } from "./types"
+import type {
+  MercuryAccessTokenResolver,
+  MercuryClient,
+  MercuryConnectorOptions,
+  MercuryRequestMethod,
+  MercuryRetryContext,
+  MercuryRetryPolicy,
+} from "./types"
 import { createMercuryEventsWebhook, MERCURY_CONNECTOR_WEBHOOK } from "./webhooks"
 
 const DEFAULT_BASE_URL = "https://api.mercury.com/api/v1/"
+const DEFAULT_MAX_RETRIES = 2
 
 export type MercuryConnector = ConnectorAdapter<"mercury", MercuryClient>
 
@@ -36,23 +44,58 @@ export function mercury(options: MercuryConnectorOptions): MercuryConnector {
       Accept: "application/json",
     }),
     timeoutMs: options.timeoutMs,
-    // Retries are method-aware in the Mercury HTTP layer.
-    retry: { maxRetries: 0 },
+    minDelayMs: options.minDelayMs,
+    retry: toRestRetryPolicy(options.retry),
   })
 
   return {
     type: "mercury",
     webhooks: collectWebhooks(options),
     async connect(context) {
+      assertReliabilityOptions(options)
       const restClient = await restAdapter.connect(context)
-      return createMercuryClient(
-        createMercuryHttp(restClient, {
-          minDelayMs: options.minDelayMs,
-          retry: options.retry,
-          signal: context.signal,
-        })
-      )
+      return createMercuryClient(createMercuryHttp(restClient))
     },
+  }
+}
+
+function toRestRetryPolicy(policy: MercuryRetryPolicy | undefined): RestRetryPolicy {
+  return {
+    maxRetries: policy?.maxRetries ?? DEFAULT_MAX_RETRIES,
+    ...(policy?.shouldRetry
+      ? {
+          shouldRetry: (context: RestRetryContext) =>
+            policy.shouldRetry?.(toMercuryRetryContext(context)) ?? false,
+        }
+      : {}),
+    ...(policy?.delayMs
+      ? {
+          delayMs: (context: RestRetryContext) =>
+            policy.delayMs?.(toMercuryRetryContext(context)) ?? 0,
+        }
+      : {}),
+  }
+}
+
+function toMercuryRetryContext(context: RestRetryContext): MercuryRetryContext {
+  return {
+    attempt: context.attempt,
+    method: context.method as MercuryRequestMethod,
+    response: context.response,
+    error: context.error,
+  }
+}
+
+function assertReliabilityOptions(options: MercuryConnectorOptions): void {
+  const maxRetries = options.retry?.maxRetries ?? DEFAULT_MAX_RETRIES
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error("[SixbMercury] retry.maxRetries must be a non-negative integer.")
+  }
+  if (
+    options.minDelayMs !== undefined &&
+    (!Number.isFinite(options.minDelayMs) || options.minDelayMs < 0)
+  ) {
+    throw new Error("[SixbMercury] minDelayMs must be a non-negative finite number.")
   }
 }
 

--- a/connectors/pennylane/src/errors.ts
+++ b/connectors/pennylane/src/errors.ts
@@ -1,3 +1,5 @@
+import { parseRetryAfter } from "@sixb/connector-rest"
+
 export class PennylaneApiError extends Error {
   readonly name = "PennylaneApiError"
   readonly headers: Headers
@@ -46,20 +48,6 @@ function extractMessage(value: unknown): string | null {
   }
 
   return null
-}
-
-function parseRetryAfter(value: string | null): number | null {
-  if (!value) {
-    return null
-  }
-
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) {
-    return Math.max(seconds, 0) * 1000
-  }
-
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/connectors/pennylane/src/http.ts
+++ b/connectors/pennylane/src/http.ts
@@ -1,12 +1,6 @@
-import type { RestClient } from "@sixb/connector-rest"
+import { type RestClient, readResponseBody, withQuery } from "@sixb/connector-rest"
 import { PennylaneApiError } from "./errors"
-import type {
-  PennylaneRequestMethod,
-  PennylaneRetryContext,
-  PennylaneRetryPolicy,
-  QueryParams,
-  QueryValue,
-} from "./types"
+import type { PennylaneRequestMethod, QueryParams } from "./types"
 
 export interface PennylaneHttp {
   get<T>(path: string, query?: QueryParams): Promise<T>
@@ -14,61 +8,23 @@ export interface PennylaneHttp {
   put<T>(path: string, body?: unknown, query?: QueryParams): Promise<T>
 }
 
-export interface PennylaneHttpOptions {
-  readonly minDelayMs?: number
-  readonly retry?: PennylaneRetryPolicy
-  readonly signal?: AbortSignal
-}
-
-const DEFAULT_MAX_RETRIES = 2
-
-export function createPennylaneHttp(
-  rest: RestClient,
-  options: PennylaneHttpOptions = {}
-): PennylaneHttp {
-  const retryPolicy = options.retry ?? {}
-  const maxRetries = retryPolicy.maxRetries ?? DEFAULT_MAX_RETRIES
-  assertMaxRetries(maxRetries)
-  const schedule = createRequestScheduler(options.minDelayMs ?? 0)
-
+export function createPennylaneHttp(rest: RestClient): PennylaneHttp {
   async function request<T>(
     method: PennylaneRequestMethod,
     path: string,
     body?: unknown,
     query?: QueryParams
   ): Promise<T> {
-    const requestPath = withQuery(path, query)
-
-    for (let attempt = 0; ; attempt++) {
-      let response: Response | null = null
-      let error: unknown = null
-
-      try {
-        await schedule()
-        response = await rest.request(requestPath, createRequestInit(method, body, options.signal))
-      } catch (caughtError) {
-        error = caughtError
-      }
-
-      const context: PennylaneRetryContext = { attempt, method, response, error }
-      const shouldRetry =
-        attempt < maxRetries &&
-        (retryPolicy.shouldRetry?.(context) ?? shouldRetryByDefault(context))
-
-      if (shouldRetry) {
-        if (response?.body) {
-          await response.body.cancel().catch(() => undefined)
-        }
-        await sleep(retryPolicy.delayMs?.(context) ?? defaultRetryDelayMs(context))
-        continue
-      }
-
-      if (error) {
-        throw error
-      }
-
-      return readJson<T>(response as Response)
+    const response = await rest.request(withQuery(path, query, { omitEmptyString: true }), {
+      method,
+      body,
+    })
+    const responseBody = await readResponseBody(response)
+    if (!response.ok) {
+      throw new PennylaneApiError(response.status, responseBody, response.headers)
     }
+
+    return responseBody as T
   }
 
   return {
@@ -82,156 +38,4 @@ export function createPennylaneHttp(
       return request<T>("PUT", path, body, query)
     },
   }
-}
-
-export function withQuery(path: string, query?: QueryParams): string {
-  const normalizedPath = path.startsWith("/") ? path.slice(1) : path
-  if (!query) {
-    return normalizedPath
-  }
-
-  const params = new URLSearchParams()
-  for (const [key, value] of Object.entries(query)) {
-    appendQueryParam(params, key, value)
-  }
-
-  const queryString = params.toString()
-  return queryString ? `${normalizedPath}?${queryString}` : normalizedPath
-}
-
-function createRequestInit(
-  method: PennylaneRequestMethod,
-  body: unknown,
-  signal: AbortSignal | undefined
-): RequestInit {
-  const headers = new Headers()
-  const init: RequestInit = { method, headers, signal }
-  const serializedBody = serializeBody(body, headers)
-
-  if (serializedBody !== undefined) {
-    init.body = serializedBody
-  }
-
-  return init
-}
-
-function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
-  if (body === undefined) {
-    return undefined
-  }
-
-  if (
-    typeof body === "string" ||
-    body instanceof Blob ||
-    body instanceof ArrayBuffer ||
-    ArrayBuffer.isView(body) ||
-    body instanceof FormData ||
-    body instanceof URLSearchParams ||
-    body instanceof ReadableStream
-  ) {
-    return body as BodyInit
-  }
-
-  headers.set("content-type", "application/json")
-  return JSON.stringify(body)
-}
-
-async function readJson<T>(response: Response): Promise<T> {
-  const responseBody = await readResponseBody(response)
-  if (!response.ok) {
-    throw new PennylaneApiError(response.status, responseBody, response.headers)
-  }
-
-  return responseBody as T
-}
-
-async function readResponseBody(response: Response): Promise<unknown> {
-  if (response.status === 204) {
-    return undefined
-  }
-
-  const text = await response.text()
-  if (!text) {
-    return undefined
-  }
-
-  try {
-    return JSON.parse(text)
-  } catch {
-    return text
-  }
-}
-
-function shouldRetryByDefault(context: PennylaneRetryContext): boolean {
-  // Quote updates can contain invoice_lines.create operations, so even PUT is not always safe.
-  if (context.method !== "GET" || isAbortError(context.error)) {
-    return false
-  }
-
-  if (context.error) {
-    return true
-  }
-
-  const status = context.response?.status
-  return status === 429 || (status !== undefined && status >= 500)
-}
-
-function defaultRetryDelayMs(context: PennylaneRetryContext): number {
-  const retryAfter = parseRetryAfter(context.response?.headers.get("retry-after") ?? null)
-  return retryAfter ?? Math.min(1000 * 2 ** context.attempt, 30_000)
-}
-
-function parseRetryAfter(value: string | null): number | null {
-  if (!value) {
-    return null
-  }
-
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) {
-    return Math.max(seconds, 0) * 1000
-  }
-
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError"
-}
-
-function appendQueryParam(params: URLSearchParams, key: string, value: QueryValue): void {
-  if (value === undefined || value === "") {
-    return
-  }
-
-  params.set(key, String(value))
-}
-
-function assertMaxRetries(maxRetries: number): void {
-  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
-    throw new Error("[SixbPennylane] retry.maxRetries must be a non-negative integer.")
-  }
-}
-
-function createRequestScheduler(minDelayMs: number): () => Promise<void> {
-  if (!Number.isFinite(minDelayMs) || minDelayMs < 0) {
-    throw new Error("[SixbPennylane] minDelayMs must be a non-negative finite number.")
-  }
-
-  let nextAvailableAt = 0
-  let queue = Promise.resolve()
-
-  return () => {
-    const scheduled = queue.then(async () => {
-      const waitMs = Math.max(nextAvailableAt - Date.now(), 0)
-      await sleep(waitMs)
-      nextAvailableAt = Date.now() + minDelayMs
-    })
-    queue = scheduled.catch(() => undefined)
-    return scheduled
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
 }

--- a/connectors/pennylane/src/pennylane.ts
+++ b/connectors/pennylane/src/pennylane.ts
@@ -1,4 +1,4 @@
-import { rest } from "@sixb/connector-rest"
+import { type RestRetryContext, type RestRetryPolicy, rest } from "@sixb/connector-rest"
 import type { ConnectorAdapter } from "@sixb/core"
 import { createPennylaneClient } from "./client"
 import { createPennylaneHttp } from "./http"
@@ -6,10 +6,14 @@ import type {
   PennylaneAccessTokenResolver,
   PennylaneClient,
   PennylaneConnectorOptions,
+  PennylaneRequestMethod,
+  PennylaneRetryContext,
+  PennylaneRetryPolicy,
 } from "./types"
 
 const DEFAULT_BASE_URL = "https://app.pennylane.com/api/external/v2/"
 const DEFAULT_MIN_DELAY_MS = 200
+const DEFAULT_MAX_RETRIES = 2
 
 export type PennylaneConnector = ConnectorAdapter<"pennylane", PennylaneClient>
 
@@ -23,22 +27,55 @@ export function pennylane(options: PennylaneConnectorOptions): PennylaneConnecto
       Accept: "application/json",
     }),
     timeoutMs: options.timeoutMs,
-    // Retries are method-aware in the Pennylane HTTP layer.
-    retry: { maxRetries: 0 },
+    minDelayMs: options.minDelayMs ?? DEFAULT_MIN_DELAY_MS,
+    retry: toRestRetryPolicy(options.retry),
   })
 
   return {
     type: "pennylane",
     async connect(context) {
+      assertReliabilityOptions(options)
       const restClient = await restAdapter.connect(context)
-      return createPennylaneClient(
-        createPennylaneHttp(restClient, {
-          minDelayMs: options.minDelayMs ?? DEFAULT_MIN_DELAY_MS,
-          retry: options.retry,
-          signal: context.signal,
-        })
-      )
+      return createPennylaneClient(createPennylaneHttp(restClient))
     },
+  }
+}
+
+function toRestRetryPolicy(policy: PennylaneRetryPolicy | undefined): RestRetryPolicy {
+  return {
+    maxRetries: policy?.maxRetries ?? DEFAULT_MAX_RETRIES,
+    ...(policy?.shouldRetry
+      ? {
+          shouldRetry: (context: RestRetryContext) =>
+            policy.shouldRetry?.(toPennylaneRetryContext(context)) ?? false,
+        }
+      : {}),
+    ...(policy?.delayMs
+      ? {
+          delayMs: (context: RestRetryContext) =>
+            policy.delayMs?.(toPennylaneRetryContext(context)) ?? 0,
+        }
+      : {}),
+  }
+}
+
+function toPennylaneRetryContext(context: RestRetryContext): PennylaneRetryContext {
+  return {
+    attempt: context.attempt,
+    method: context.method as PennylaneRequestMethod,
+    response: context.response,
+    error: context.error,
+  }
+}
+
+function assertReliabilityOptions(options: PennylaneConnectorOptions): void {
+  const maxRetries = options.retry?.maxRetries ?? DEFAULT_MAX_RETRIES
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error("[SixbPennylane] retry.maxRetries must be a non-negative integer.")
+  }
+  const minDelayMs = options.minDelayMs ?? DEFAULT_MIN_DELAY_MS
+  if (!Number.isFinite(minDelayMs) || minDelayMs < 0) {
+    throw new Error("[SixbPennylane] minDelayMs must be a non-negative finite number.")
   }
 }
 

--- a/connectors/rest/README.md
+++ b/connectors/rest/README.md
@@ -44,6 +44,23 @@ how to read the body.
 `headers` being a resolver rather than a value is the part worth remembering: it is what lets a
 connector hold a short-lived credential without reconstructing the connector.
 
-Retry is enabled per request by default when the connector has a retry policy. Pass
-`{ retry: false }` in `request`, `get`, or `post` options for non-idempotent mutations that must not
-be replayed. This local option is stripped before the native `fetch` call.
+## Reliability contract
+
+The default retry policy only replays idempotent methods (`GET`, `HEAD`, and `OPTIONS`) after a
+network error, 429, or 5xx response. A request body must also be mechanically replayable: stream
+bodies are never retried. Caller aborts stop both queued pacing and retry backoff immediately.
+
+Mark a semantically read-only write explicitly, or disable retries even when a custom policy is
+configured:
+
+```ts
+await client.post("reports/query", query, undefined, { idempotent: true })
+await client.get("volatile-snapshot", undefined, { retryable: false })
+```
+
+For compatibility, `{ retry: false }` in the request init remains an alias for
+`{ retryable: false }` and is stripped before the native `fetch` call.
+
+`onUnauthorized` follows the same rules: only an idempotent request with a replayable body is sent
+again after credentials are refreshed. The helpers `withQuery`, `readResponseBody`, and
+`parseRetryAfter` are exported for typed vendor connectors built on this transport.

--- a/connectors/rest/src/helpers.ts
+++ b/connectors/rest/src/helpers.ts
@@ -1,0 +1,87 @@
+import type { RestQueryOptions, RestQueryParams, RestQueryValue, RestRetryContext } from "./types"
+
+/** Add typed query parameters while keeping a relative path relative to the configured base URL. */
+export function withQuery(
+  path: string,
+  query?: RestQueryParams,
+  options: RestQueryOptions = {}
+): string {
+  const normalizedPath = path.startsWith("/") ? path.slice(1) : path
+  if (!query) return normalizedPath
+
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    appendQueryValue(params, key, value, options)
+  }
+
+  const queryString = params.toString()
+  return queryString ? `${normalizedPath}?${queryString}` : normalizedPath
+}
+
+/** Read an empty, JSON, or text response body without losing provider error detail. */
+export async function readResponseBody(response: Response): Promise<unknown> {
+  if (response.status === 204) return undefined
+
+  const text = await response.text()
+  if (!text) return undefined
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+/** Parse both delta-seconds and HTTP-date forms of Retry-After. */
+export function parseRetryAfter(value: string | null, now = Date.now()): number | null {
+  if (!value) return null
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) {
+    return Math.max(seconds, 0) * 1000
+  }
+
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? null : Math.max(timestamp - now, 0)
+}
+
+/** Conservative default: retry only idempotent transient failures, never caller aborts. */
+export function shouldRetryRestRequest(context: RestRetryContext): boolean {
+  if (!context.idempotent || isAbortError(context.error)) return false
+  if (context.error) return true
+
+  const status = context.response?.status
+  return status === 429 || (status !== undefined && status >= 500)
+}
+
+/** Retry-After when available, otherwise capped exponential backoff. */
+export function restRetryDelayMs(context: RestRetryContext): number {
+  return (
+    parseRetryAfter(context.response?.headers.get("retry-after") ?? null) ??
+    Math.min(1000 * 2 ** context.attempt, 30_000)
+  )
+}
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError"
+}
+
+function appendQueryValue(
+  params: URLSearchParams,
+  key: string,
+  value: RestQueryValue,
+  options: RestQueryOptions
+): void {
+  if (value === undefined || value === null || (options.omitEmptyString && value === "")) return
+
+  if (Array.isArray(value)) {
+    if (options.arrayFormat === "comma") {
+      params.set(key, value.map(String).join(","))
+      return
+    }
+    for (const entry of value) params.append(key, String(entry))
+    return
+  }
+
+  params.set(key, String(value))
+}

--- a/connectors/rest/src/index.ts
+++ b/connectors/rest/src/index.ts
@@ -1,11 +1,22 @@
+export {
+  parseRetryAfter,
+  readResponseBody,
+  shouldRetryRestRequest,
+  withQuery,
+} from "./helpers"
 export { rest } from "./rest"
 export type {
   RestClient,
   RestConnector,
   RestConnectorOptions,
   RestHeadersResolver,
+  RestQueryOptions,
+  RestQueryParams,
+  RestQueryScalar,
+  RestQueryValue,
   RestRequestContext,
   RestRequestInit,
+  RestRequestOptions,
   RestRetryContext,
   RestRetryPolicy,
 } from "./types"

--- a/connectors/rest/src/rest.ts
+++ b/connectors/rest/src/rest.ts
@@ -1,4 +1,5 @@
 import type { ConnectorContext } from "@sixb/core"
+import { isAbortError, restRetryDelayMs, shouldRetryRestRequest } from "./helpers"
 import type {
   RestClient,
   RestConnector,
@@ -6,43 +7,18 @@ import type {
   RestHeadersResolver,
   RestRequestContext,
   RestRequestInit,
+  RestRequestOptions,
   RestRetryContext,
-  RestRetryPolicy,
 } from "./types"
 
-const defaultRetryPolicy: Required<Pick<RestRetryPolicy, "maxRetries">> &
-  Pick<RestRetryPolicy, "shouldRetry" | "delayMs"> = {
-  maxRetries: 0,
-  shouldRetry(context) {
-    if (context.error) {
-      return true
-    }
-
-    if (!context.response) {
-      return false
-    }
-
-    return context.response.status === 429 || context.response.status >= 500
-  },
-  delayMs(context) {
-    const retryAfter = context.response?.headers.get("Retry-After")
-    if (retryAfter) {
-      const seconds = Number.parseInt(retryAfter, 10)
-      if (Number.isFinite(seconds)) {
-        return Math.max(seconds, 0) * 1000
-      }
-    }
-
-    return Math.min(1000 * 2 ** context.attempt, 30_000)
-  },
-}
+const safeMethods = new Set(["GET", "HEAD", "OPTIONS"])
 
 /**
  * Create a REST connector backed by the platform `fetch` implementation.
  *
- * The connected client stays close to native fetch while handling a few runtime
- * concerns centrally: base URL resolution, async headers, optional throttling,
- * timeout, retry, and one-time 401 refresh.
+ * The connected client stays close to native fetch while handling runtime concerns centrally:
+ * base URL resolution, async headers, serialized pacing, timeout, method-aware retry, response
+ * cleanup, body replay safety, and one-time 401 refresh.
  */
 export function rest(options: RestConnectorOptions): RestConnector {
   assertNonEmpty(options.baseUrl, "baseUrl")
@@ -57,107 +33,130 @@ export function rest(options: RestConnectorOptions): RestConnector {
 }
 
 function createRestClient(options: RestConnectorOptions, context: ConnectorContext): RestClient {
-  const retryPolicy = {
-    ...defaultRetryPolicy,
-    ...options.retry,
-  }
-  let lastRequestAt = 0
+  const maxRetries = options.retry?.maxRetries ?? 0
+  assertMaxRetries(maxRetries)
+  const shouldRetry = options.retry?.shouldRetry ?? shouldRetryRestRequest
+  const delayMs = options.retry?.delayMs ?? restRetryDelayMs
+  const schedule = createRequestScheduler(options.minDelayMs ?? 0)
 
-  const request = async (path: string, init: RestRequestInit = {}): Promise<Response> => {
-    const { retry = true, ...fetchInit } = init
+  const request = async (
+    path: string,
+    init: RestRequestInit = {},
+    requestOptions: RestRequestOptions = {}
+  ): Promise<Response> => {
+    const { retry, ...requestInit } = init
+    const preparedInit = prepareRequestInit(requestInit)
+    const method = (preparedInit.method ?? "GET").toUpperCase()
+    const idempotent = requestOptions.idempotent ?? safeMethods.has(method)
+    const retryable = requestOptions.retryable ?? retry ?? true
+    const bodyReplayable = !(preparedInit.body instanceof ReadableStream)
+    const requestSignal = combineSignals(context.signal, preparedInit.signal)
     const baseRequestContext: RestRequestContext = {
       projectId: context.projectId,
       connectorId: context.connectorId,
       path,
-      init: fetchInit,
+      init: { ...preparedInit, signal: requestSignal },
+      method,
+      idempotent,
+      bodyReplayable,
     }
 
     let unauthorizedRetried = false
-    // A stream body is consumed by the first attempt and can never be replayed,
-    // so neither the 401 refresh nor the retry policy may re-send this request —
-    // retrying would only mask the real failure behind a "stream already used" error.
-    const replayable = !(fetchInit.body instanceof ReadableStream)
-
     let retryAttempt = 0
+
     for (;;) {
-      // Apply the same pacing to retries as the initial request.
-      await applyMinDelay(
-        options.minDelayMs,
-        () => lastRequestAt,
-        (value) => {
-          lastRequestAt = value
-        },
-        fetchInit.signal
-      )
-
-      const resolvedInit = await resolveRequestInit(
-        fetchInit,
-        options.headers,
-        options.timeoutMs,
-        baseRequestContext
-      )
-
       let response: Response | null = null
       let error: unknown = null
 
       try {
+        // The queue reserves a distinct start slot for every initial request and retry.
+        await schedule(requestSignal)
+        const resolvedInit = await resolveRequestInit(
+          baseRequestContext.init,
+          options.headers,
+          options.timeoutMs,
+          baseRequestContext
+        )
         response = await fetch(new URL(path, options.baseUrl), resolvedInit)
       } catch (caughtError) {
         error = caughtError
       }
 
-      // Refresh auth at most once per request to avoid retry loops on bad credentials.
+      const retryContext: RestRetryContext = {
+        ...baseRequestContext,
+        attempt: retryAttempt,
+        response,
+        error,
+      }
+
+      // Authentication refresh is also a replay, so it follows the same semantic and mechanical
+      // safety gates as an ordinary retry. Refresh at most once to avoid bad-credential loops.
       if (
         response?.status === 401 &&
         !unauthorizedRetried &&
         options.onUnauthorized &&
-        replayable
+        retryable &&
+        idempotent &&
+        bodyReplayable
       ) {
         unauthorizedRetried = true
+        await cancelResponseBody(response)
         await options.onUnauthorized(baseRequestContext)
         continue
       }
 
-      const retryContext: RestRetryContext = { attempt: retryAttempt, response, error }
       const canRetry =
-        retry &&
-        replayable &&
-        retryAttempt < retryPolicy.maxRetries &&
-        retryPolicy.shouldRetry?.(retryContext) === true
+        retryable &&
+        bodyReplayable &&
+        !isAbortError(error) &&
+        retryAttempt < maxRetries &&
+        shouldRetry(retryContext)
 
       if (canRetry) {
         retryAttempt += 1
-        await sleep(retryPolicy.delayMs?.(retryContext) ?? 0, fetchInit.signal)
+        await cancelResponseBody(response)
+        await sleep(delayMs(retryContext), requestSignal)
         continue
       }
 
-      if (error) {
-        throw error
-      }
-
+      if (error) throw error
       return response as Response
     }
   }
 
   return {
     request,
-    get(path, init) {
-      return request(path, {
-        ...init,
-        method: init?.method ?? "GET",
-      })
+    get(path, init, requestOptions) {
+      return request(
+        path,
+        {
+          ...init,
+          method: init?.method ?? "GET",
+        },
+        requestOptions
+      )
     },
-    post(path, body, init) {
-      const headers = new Headers(init?.headers)
-      const requestBody = serializeBody(body, headers)
+    post(path, body, init, requestOptions) {
+      return request(
+        path,
+        {
+          ...init,
+          method: init?.method ?? "POST",
+          body,
+        },
+        requestOptions
+      )
+    },
+  }
+}
 
-      return request(path, {
-        ...init,
-        method: init?.method ?? "POST",
-        headers,
-        body: requestBody,
-      })
-    },
+function prepareRequestInit(init: RestRequestInit): RequestInit {
+  const headers = new Headers(init.headers)
+  const body = serializeBody(init.body, headers)
+  return {
+    ...init,
+    headers,
+    body,
   }
 }
 
@@ -191,41 +190,15 @@ async function resolveHeaders(
   headersResolver: RestHeadersResolver | undefined,
   context: RestRequestContext
 ): Promise<HeadersInit | undefined> {
-  if (!headersResolver) {
-    return undefined
-  }
-
+  if (!headersResolver) return undefined
   return typeof headersResolver === "function" ? headersResolver(context) : headersResolver
 }
 
-async function applyMinDelay(
-  minDelayMs: number | undefined,
-  getLastRequestAt: () => number,
-  setLastRequestAt: (value: number) => void,
-  signal: AbortSignal | null | undefined
-): Promise<void> {
-  if (!minDelayMs || minDelayMs <= 0) {
-    setLastRequestAt(Date.now())
-    return
-  }
-
-  const now = Date.now()
-  // Reserve the next start time synchronously so concurrent callers cannot all claim
-  // the same slot and burst together after one shared delay.
-  const scheduledAt = Math.max(now, getLastRequestAt() + minDelayMs)
-  setLastRequestAt(scheduledAt)
-  await sleep(scheduledAt - now, signal)
-}
-
 function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
-  if (body === undefined) {
-    return undefined
-  }
+  if (body === undefined) return undefined
 
   if (body === null) {
-    if (!headers.has("content-type")) {
-      headers.set("content-type", "application/json")
-    }
+    setJsonContentType(headers)
     return JSON.stringify(body)
   }
 
@@ -241,45 +214,102 @@ function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
     return body as BodyInit
   }
 
-  // Default plain values to JSON while leaving native fetch body types alone.
-  if (!headers.has("content-type")) {
-    headers.set("content-type", "application/json")
+  setJsonContentType(headers)
+  return JSON.stringify(body)
+}
+
+function setJsonContentType(headers: Headers): void {
+  if (!headers.has("content-type")) headers.set("content-type", "application/json")
+}
+
+function combineSignals(
+  contextSignal: AbortSignal,
+  requestSignal: AbortSignal | null | undefined
+): AbortSignal {
+  if (!requestSignal || requestSignal === contextSignal) return contextSignal
+  return AbortSignal.any([contextSignal, requestSignal])
+}
+
+function createRequestScheduler(minDelayMs: number): (signal: AbortSignal) => Promise<void> {
+  assertMinDelay(minDelayMs)
+  if (minDelayMs === 0) {
+    return (signal) => (signal.aborted ? Promise.reject(abortReason(signal)) : Promise.resolve())
   }
 
-  return JSON.stringify(body)
+  let nextAvailableAt = 0
+  let queue = Promise.resolve()
+
+  return (signal) => {
+    const scheduled = queue.then(async () => {
+      await sleep(Math.max(nextAvailableAt - Date.now(), 0), signal)
+      nextAvailableAt = Date.now() + minDelayMs
+    })
+    queue = scheduled.catch(() => undefined)
+    // A request can sit behind another request's pacing slot. Reject its caller immediately when
+    // aborted; the queued task will later observe the same signal and release the queue cleanly.
+    return abortable(scheduled, signal)
+  }
+}
+
+async function cancelResponseBody(response: Response | null): Promise<void> {
+  if (response?.body) await response.body.cancel().catch(() => undefined)
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortReason(signal))
+  if (ms <= 0) return Promise.resolve()
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener("abort", onAbort)
+      reject(abortReason(signal as AbortSignal))
+    }
+    signal?.addEventListener("abort", onAbort, { once: true })
+  })
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(abortReason(signal))
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(abortReason(signal))
+    signal.addEventListener("abort", onAbort, { once: true })
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort)
+        resolve(value)
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort)
+        reject(error)
+      }
+    )
+  })
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted.", "AbortError")
+}
+
+function assertMaxRetries(maxRetries: number): void {
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error("[SixbRest] retry.maxRetries must be a non-negative integer.")
+  }
+}
+
+function assertMinDelay(minDelayMs: number): void {
+  if (!Number.isFinite(minDelayMs) || minDelayMs < 0) {
+    throw new Error("[SixbRest] minDelayMs must be a non-negative finite number.")
+  }
 }
 
 function assertNonEmpty(value: string, field: string): void {
   if (!value.trim()) {
     throw new Error(`[SixbRest] ${field} must not be empty.`)
   }
-}
-
-function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
-  if (signal?.aborted) {
-    return Promise.reject(abortReason(signal))
-  }
-  if (ms <= 0) {
-    return Promise.resolve()
-  }
-  if (!signal) {
-    return new Promise((resolve) => setTimeout(resolve, ms))
-  }
-
-  return new Promise((resolve, reject) => {
-    const onAbort = () => {
-      clearTimeout(timer)
-      signal.removeEventListener("abort", onAbort)
-      reject(abortReason(signal))
-    }
-    const timer = setTimeout(() => {
-      signal.removeEventListener("abort", onAbort)
-      resolve()
-    }, ms)
-    signal.addEventListener("abort", onAbort, { once: true })
-  })
-}
-
-function abortReason(signal: AbortSignal): unknown {
-  return signal.reason ?? new DOMException("The operation was aborted.", "AbortError")
 }

--- a/connectors/rest/src/types.ts
+++ b/connectors/rest/src/types.ts
@@ -5,13 +5,18 @@ export interface RestRequestContext {
   readonly connectorId: ConnectorContext["connectorId"]
   readonly path: string
   readonly init: RequestInit
+  readonly method: string
+  /** Whether replaying this request is safe from an API-semantics perspective. */
+  readonly idempotent: boolean
+  /** Whether the serialized request body can mechanically be sent more than once. */
+  readonly bodyReplayable: boolean
 }
 
 export type RestHeadersResolver =
   | HeadersInit
   | ((context: RestRequestContext) => HeadersInit | Promise<HeadersInit>)
 
-export interface RestRetryContext {
+export interface RestRetryContext extends RestRequestContext {
   readonly attempt: number
   readonly response: Response | null
   readonly error: unknown
@@ -33,15 +38,39 @@ export interface RestConnectorOptions {
   readonly webhooks?: readonly WebhookDefinition<unknown, RestClient>[]
 }
 
-/** Native fetch options plus a local retry gate that is never sent over the wire. */
-export interface RestRequestInit extends RequestInit {
+export interface RestRequestOptions {
+  /** Override the method-derived idempotency used by the default retry policy. */
+  readonly idempotent?: boolean
+  /** Hard retry gate. False prevents custom policies and 401 refreshes from replaying the request. */
+  readonly retryable?: boolean
+}
+
+export type RestRequestInit = Omit<RequestInit, "body"> & {
+  readonly body?: unknown
+  /** @deprecated Pass `retryable` through RestRequestOptions instead. */
   readonly retry?: boolean
 }
 
+export type RestQueryScalar = string | number | boolean
+export type RestQueryValue = RestQueryScalar | readonly RestQueryScalar[] | null | undefined
+export type RestQueryParams = Readonly<Record<string, RestQueryValue>>
+
+export interface RestQueryOptions {
+  /** How array values are represented. Defaults to repeated query parameters. */
+  readonly arrayFormat?: "repeat" | "comma"
+  /** Whether empty string values are omitted. Defaults to false. */
+  readonly omitEmptyString?: boolean
+}
+
 export interface RestClient {
-  request(path: string, init?: RestRequestInit): Promise<Response>
-  get(path: string, init?: RestRequestInit): Promise<Response>
-  post(path: string, body?: unknown, init?: RestRequestInit): Promise<Response>
+  request(path: string, init?: RestRequestInit, options?: RestRequestOptions): Promise<Response>
+  get(path: string, init?: RestRequestInit, options?: RestRequestOptions): Promise<Response>
+  post(
+    path: string,
+    body?: unknown,
+    init?: RestRequestInit,
+    options?: RestRequestOptions
+  ): Promise<Response>
 }
 
 export type RestConnector = ConnectorAdapter<"rest", RestClient>

--- a/connectors/rest/tests/rest.test.ts
+++ b/connectors/rest/tests/rest.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { defineWebhook } from "@sixb/core"
-import { rest } from "../src"
+import { parseRetryAfter, readResponseBody, rest, withQuery } from "../src"
 
 function mockFetch(
   implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
@@ -192,7 +192,7 @@ describe("rest connector", () => {
       signal: new AbortController().signal,
     })
 
-    const response = await client.post("/mutation", {}, { retry: false })
+    const response = await client.get("/read", { retry: false })
 
     expect(response.status).toBe(503)
     expect(attempts).toBe(1)
@@ -346,5 +346,306 @@ describe("rest connector", () => {
     expect(response.status).toBe(201)
     expect(requestBody).toBe(JSON.stringify({ name: "Alice" }))
     expect(contentType).toBe("application/json")
+  })
+})
+
+describe("rest reliability contract", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("does not retry an unsafe method by default", async () => {
+    let attempts = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(new Response("busy", { status: 503 }))
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      retry: { maxRetries: 2, delayMs: () => 0 },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    const response = await client.post("/commands", { action: "run" })
+
+    expect(response.status).toBe(503)
+    expect(attempts).toBe(1)
+  })
+
+  test("does not refresh and replay an unsafe method after a 401", async () => {
+    let attempts = 0
+    let refreshes = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(new Response("unauthorized", { status: 401 }))
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      onUnauthorized() {
+        refreshes += 1
+      },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    const response = await client.post("/commands", { action: "run" })
+
+    expect(response.status).toBe(401)
+    expect(attempts).toBe(1)
+    expect(refreshes).toBe(0)
+  })
+
+  test("retries an explicitly idempotent post with a replayable body", async () => {
+    const bodies: string[] = []
+    const contexts: Array<{
+      method: string
+      path: string
+      idempotent: boolean
+      bodyReplayable: boolean
+    }> = []
+    mockFetch((_input, init) => {
+      bodies.push(String(init?.body))
+      return Promise.resolve(
+        bodies.length === 1 ? new Response("busy", { status: 503 }) : Response.json({ ok: true })
+      )
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      retry: {
+        maxRetries: 1,
+        shouldRetry(context) {
+          contexts.push({
+            method: context.method,
+            path: context.path,
+            idempotent: context.idempotent,
+            bodyReplayable: context.bodyReplayable,
+          })
+          return context.response?.status === 503
+        },
+        delayMs: () => 0,
+      },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    const response = await client.post("/query", { ids: ["one"] }, undefined, { idempotent: true })
+
+    expect(await response.json()).toEqual({ ok: true })
+    expect(bodies).toEqual(['{"ids":["one"]}', '{"ids":["one"]}'])
+    expect(contexts).toEqual([
+      { method: "POST", path: "/query", idempotent: true, bodyReplayable: true },
+    ])
+  })
+
+  test("a hard retry gate wins over a custom policy", async () => {
+    let attempts = 0
+    let decisions = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(new Response("busy", { status: 503 }))
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      retry: {
+        maxRetries: 2,
+        shouldRetry() {
+          decisions += 1
+          return true
+        },
+        delayMs: () => 0,
+      },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    await client.get("/unsafe-read", undefined, { retryable: false })
+
+    expect(attempts).toBe(1)
+    expect(decisions).toBe(0)
+  })
+
+  test("never retries an abort", async () => {
+    let attempts = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.reject(new DOMException("aborted", "AbortError"))
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      retry: { maxRetries: 2, shouldRetry: () => true, delayMs: () => 0 },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    await expect(client.get("/items")).rejects.toThrow("aborted")
+    expect(attempts).toBe(1)
+  })
+
+  test("an abort interrupts retry backoff", async () => {
+    const controller = new AbortController()
+    let attempts = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(new Response("busy", { status: 503 }))
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      retry: { maxRetries: 2, delayMs: () => 5_000 },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: controller.signal,
+    })
+
+    const request = client.get("/items")
+    setTimeout(() => controller.abort(new DOMException("cancelled", "AbortError")), 10)
+
+    await expect(request).rejects.toThrow("cancelled")
+    expect(attempts).toBe(1)
+  })
+
+  test("serializes concurrent request starts", async () => {
+    const starts: number[] = []
+    mockFetch(() => {
+      starts.push(Date.now())
+      return Promise.resolve(new Response("ok"))
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      minDelayMs: 20,
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    await Promise.all([client.get("/one"), client.get("/two"), client.get("/three")])
+
+    expect(starts).toHaveLength(3)
+    expect((starts[1] ?? 0) - (starts[0] ?? 0)).toBeGreaterThanOrEqual(15)
+    expect((starts[2] ?? 0) - (starts[1] ?? 0)).toBeGreaterThanOrEqual(15)
+  })
+
+  test("rejects an aborted request while it is queued behind another pacing slot", async () => {
+    const controller = new AbortController()
+    let attempts = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(new Response("ok"))
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      minDelayMs: 200,
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    await client.get("/one")
+    const blocker = client.get("/two")
+    const startedAt = Date.now()
+    const queued = client.get("/three", { signal: controller.signal })
+    setTimeout(() => controller.abort(new DOMException("cancelled", "AbortError")), 10)
+
+    await expect(queued).rejects.toThrow("cancelled")
+    expect(Date.now() - startedAt).toBeLessThan(100)
+    await blocker
+    expect(attempts).toBe(2)
+  })
+
+  test("resolves dynamic headers for every attempt", async () => {
+    const authorizations: string[] = []
+    let token = 0
+    mockFetch((_input, init) => {
+      authorizations.push(new Headers(init?.headers).get("authorization") ?? "")
+      return Promise.resolve(
+        authorizations.length === 1 ? new Response("busy", { status: 503 }) : new Response("ok")
+      )
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      headers: () => ({ Authorization: `Bearer ${++token}` }),
+      retry: { maxRetries: 1, delayMs: () => 0 },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    await client.get("/items")
+
+    expect(authorizations).toEqual(["Bearer 1", "Bearer 2"])
+  })
+
+  test("stops after maxRetries and returns the final response", async () => {
+    let attempts = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(new Response(`busy ${attempts}`, { status: 503 }))
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      retry: { maxRetries: 2, delayMs: () => 0 },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    const response = await client.get("/items")
+
+    expect(response.status).toBe(503)
+    expect(await response.text()).toBe("busy 3")
+    expect(attempts).toBe(3)
+  })
+
+  test("parses Retry-After, query encodings, and response bodies centrally", async () => {
+    const now = Date.parse("2026-08-20T12:00:00Z")
+    expect(parseRetryAfter("2", now)).toBe(2_000)
+    expect(parseRetryAfter("Thu, 20 Aug 2026 12:00:05 GMT", now)).toBe(5_000)
+    expect(parseRetryAfter("invalid", now)).toBeNull()
+
+    expect(
+      withQuery(
+        "/items",
+        { status: ["pending", "sent"], empty: "", missing: undefined },
+        { omitEmptyString: true }
+      )
+    ).toBe("items?status=pending&status=sent")
+    expect(withQuery("items", { status: ["pending", "sent"] }, { arrayFormat: "comma" })).toBe(
+      "items?status=pending%2Csent"
+    )
+
+    expect(await readResponseBody(Response.json({ ok: true }))).toEqual({ ok: true })
+    expect(await readResponseBody(new Response("plain text"))).toBe("plain text")
+    expect(await readResponseBody(new Response(null, { status: 204 }))).toBeUndefined()
+  })
+
+  test("rejects invalid reliability options when connecting", () => {
+    const context = {
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    }
+    expect(() =>
+      rest({ baseUrl: "https://api.example.com", retry: { maxRetries: -1 } }).connect(context)
+    ).toThrow("retry.maxRetries must be a non-negative integer")
+    expect(() =>
+      rest({ baseUrl: "https://api.example.com", minDelayMs: Number.NaN }).connect(context)
+    ).toThrow("minDelayMs must be a non-negative finite number")
   })
 })

--- a/connectors/unipile/src/errors.ts
+++ b/connectors/unipile/src/errors.ts
@@ -1,3 +1,5 @@
+import { parseRetryAfter } from "@sixb/connector-rest"
+
 export class UnipileApiError extends Error {
   readonly name = "UnipileApiError"
   readonly headers: Headers
@@ -49,20 +51,6 @@ function extractMessage(value: unknown): string | null {
   }
 
   return null
-}
-
-function parseRetryAfter(value: string | null): number | null {
-  if (!value) {
-    return null
-  }
-
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) {
-    return Math.max(seconds, 0) * 1000
-  }
-
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/connectors/unipile/src/http.ts
+++ b/connectors/unipile/src/http.ts
@@ -1,12 +1,6 @@
-import type { RestClient } from "@sixb/connector-rest"
+import { type RestClient, readResponseBody, withQuery } from "@sixb/connector-rest"
 import { UnipileApiError } from "./errors"
-import type {
-  QueryParams,
-  QueryValue,
-  UnipileRequestMethod,
-  UnipileRetryContext,
-  UnipileRetryPolicy,
-} from "./types"
+import type { QueryParams, UnipileRequestMethod } from "./types"
 
 export interface UnipileHttp {
   get<T>(path: string, query?: QueryParams, retryable?: boolean): Promise<T>
@@ -14,20 +8,7 @@ export interface UnipileHttp {
   delete<T>(path: string, query?: QueryParams): Promise<T>
 }
 
-export interface UnipileHttpOptions {
-  readonly minDelayMs?: number
-  readonly retry?: UnipileRetryPolicy
-  readonly signal?: AbortSignal
-}
-
-const DEFAULT_MAX_RETRIES = 2
-
-export function createUnipileHttp(rest: RestClient, options: UnipileHttpOptions = {}): UnipileHttp {
-  const retryPolicy = options.retry ?? {}
-  const maxRetries = retryPolicy.maxRetries ?? DEFAULT_MAX_RETRIES
-  assertMaxRetries(maxRetries)
-  const schedule = createRequestScheduler(options.minDelayMs ?? 0)
-
+export function createUnipileHttp(rest: RestClient): UnipileHttp {
   async function request<T>(
     method: UnipileRequestMethod,
     path: string,
@@ -35,40 +16,17 @@ export function createUnipileHttp(rest: RestClient, options: UnipileHttpOptions 
     query?: QueryParams,
     retryable = false
   ): Promise<T> {
-    const requestPath = withQuery(path, query)
-
-    for (let attempt = 0; ; attempt++) {
-      let response: Response | null = null
-      let error: unknown = null
-
-      try {
-        await schedule()
-        response = await rest.request(requestPath, createRequestInit(method, body, options.signal))
-      } catch (caughtError) {
-        error = caughtError
-      }
-
-      const context: UnipileRetryContext = { attempt, method, path, response, error }
-      const shouldRetry =
-        retryable &&
-        !isAbortError(error) &&
-        attempt < maxRetries &&
-        (retryPolicy.shouldRetry?.(context) ?? shouldRetryByDefault(context))
-
-      if (shouldRetry) {
-        if (response?.body) {
-          await response.body.cancel().catch(() => undefined)
-        }
-        await sleep(retryPolicy.delayMs?.(context) ?? defaultRetryDelayMs(context))
-        continue
-      }
-
-      if (error) {
-        throw error
-      }
-
-      return readResponse<T>(response as Response)
+    const response = await rest.request(
+      withQuery(path, query, { arrayFormat: "comma" }),
+      { method, body },
+      { retryable }
+    )
+    const responseBody = await readResponseBody(response)
+    if (!response.ok) {
+      throw new UnipileApiError(response.status, responseBody, response.headers)
     }
+
+    return responseBody as T
   }
 
   return {
@@ -76,153 +34,10 @@ export function createUnipileHttp(rest: RestClient, options: UnipileHttpOptions 
       return request<T>("GET", path, undefined, query, retryable)
     },
     post<T>(path: string, body?: unknown, query?: QueryParams) {
-      return request<T>("POST", path, body, query)
+      return request<T>("POST", path, body, query, false)
     },
     delete<T>(path: string, query?: QueryParams) {
-      return request<T>("DELETE", path, undefined, query)
+      return request<T>("DELETE", path, undefined, query, false)
     },
   }
-}
-
-export function withQuery(path: string, query?: QueryParams): string {
-  const normalizedPath = path.startsWith("/") ? path.slice(1) : path
-  if (!query) {
-    return normalizedPath
-  }
-
-  const params = new URLSearchParams()
-  for (const [key, value] of Object.entries(query)) {
-    appendQueryParam(params, key, value)
-  }
-  const queryString = params.toString()
-  return queryString ? `${normalizedPath}?${queryString}` : normalizedPath
-}
-
-function createRequestInit(
-  method: UnipileRequestMethod,
-  body: unknown,
-  signal: AbortSignal | undefined
-): RequestInit {
-  const headers = new Headers()
-  const init: RequestInit = { method, headers, signal }
-  const serializedBody = serializeBody(body, headers)
-  if (serializedBody !== undefined) {
-    init.body = serializedBody
-  }
-  return init
-}
-
-function serializeBody(body: unknown, headers: Headers): BodyInit | undefined {
-  if (body === undefined) {
-    return undefined
-  }
-  if (
-    typeof body === "string" ||
-    body instanceof Blob ||
-    body instanceof ArrayBuffer ||
-    ArrayBuffer.isView(body) ||
-    body instanceof FormData ||
-    body instanceof URLSearchParams ||
-    body instanceof ReadableStream
-  ) {
-    return body as BodyInit
-  }
-
-  headers.set("content-type", "application/json")
-  return JSON.stringify(body)
-}
-
-async function readResponse<T>(response: Response): Promise<T> {
-  const body = await readResponseBody(response)
-  if (!response.ok) {
-    throw new UnipileApiError(response.status, body, response.headers)
-  }
-  return body as T
-}
-
-async function readResponseBody(response: Response): Promise<unknown> {
-  if (response.status === 204) {
-    return undefined
-  }
-  const text = await response.text()
-  if (!text) {
-    return undefined
-  }
-  try {
-    return JSON.parse(text)
-  } catch {
-    return text
-  }
-}
-
-function shouldRetryByDefault(context: UnipileRetryContext): boolean {
-  if (context.error) {
-    // Native fetch reports transport failures as TypeError. Do not replay configuration,
-    // credential-resolver, or caller errors merely because they happened before a response.
-    return context.error instanceof TypeError
-  }
-  const status = context.response?.status
-  return status === 429 || (status !== undefined && status >= 500)
-}
-
-function defaultRetryDelayMs(context: UnipileRetryContext): number {
-  const retryAfter = parseRetryAfter(context.response?.headers.get("retry-after") ?? null)
-  return retryAfter ?? Math.min(1000 * 2 ** context.attempt, 30_000)
-}
-
-function parseRetryAfter(value: string | null): number | null {
-  if (!value) {
-    return null
-  }
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) {
-    return Math.max(seconds, 0) * 1000
-  }
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? null : Math.max(timestamp - Date.now(), 0)
-}
-
-function appendQueryParam(params: URLSearchParams, key: string, value: QueryValue): void {
-  if (value === undefined) {
-    return
-  }
-  if (Array.isArray(value)) {
-    // Unipile models multi-value query filters as one comma-separated string, not repeated keys.
-    params.set(key, value.map(String).join(","))
-    return
-  }
-  params.set(key, String(value))
-}
-
-function assertMaxRetries(maxRetries: number): void {
-  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
-    throw new Error("[SixbUnipile] retry.maxRetries must be a non-negative integer.")
-  }
-}
-
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError"
-}
-
-function createRequestScheduler(minDelayMs: number): () => Promise<void> {
-  if (!Number.isFinite(minDelayMs) || minDelayMs < 0) {
-    throw new Error("[SixbUnipile] minDelayMs must be a non-negative finite number.")
-  }
-
-  let nextAvailableAt = 0
-  let queue = Promise.resolve()
-
-  return () => {
-    const scheduled = queue.then(async () => {
-      const waitMs = Math.max(nextAvailableAt - Date.now(), 0)
-      await sleep(waitMs)
-      nextAvailableAt = Date.now() + minDelayMs
-    })
-    queue = scheduled.catch(() => undefined)
-    return scheduled
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
 }

--- a/connectors/unipile/src/unipile.ts
+++ b/connectors/unipile/src/unipile.ts
@@ -1,4 +1,4 @@
-import { rest } from "@sixb/connector-rest"
+import { type RestRetryContext, type RestRetryPolicy, rest } from "@sixb/connector-rest"
 import {
   type ConnectorAdapter,
   resolveWebhookVerification,
@@ -6,10 +6,19 @@ import {
 } from "@sixb/core"
 import { createUnipileClient } from "./client"
 import { createUnipileHttp } from "./http"
-import type { UnipileAccessTokenResolver, UnipileClient, UnipileConnectorOptions } from "./types"
+import type {
+  UnipileAccessTokenResolver,
+  UnipileClient,
+  UnipileConnectorOptions,
+  UnipileRequestMethod,
+  UnipileRetryContext,
+  UnipileRetryPolicy,
+} from "./types"
 import { createUnipileEventsWebhook, UNIPILE_CONNECTOR_WEBHOOK } from "./webhooks"
 
 export type UnipileConnector = ConnectorAdapter<"unipile", UnipileClient>
+
+const DEFAULT_MAX_RETRIES = 2
 
 /** Unipile v1 connector for messaging and LinkedIn outreach. */
 export function unipile(options: UnipileConnectorOptions): UnipileConnector {
@@ -28,24 +37,64 @@ export function unipile(options: UnipileConnectorOptions): UnipileConnector {
       Accept: "application/json",
     }),
     timeoutMs: options.timeoutMs,
-    // Retry decisions and concurrent request pacing are handled in the Unipile HTTP layer.
-    retry: { maxRetries: 0 },
+    minDelayMs: options.minDelayMs,
+    retry: toRestRetryPolicy(options.retry),
   })
 
   return {
     type: "unipile",
     webhooks: collectWebhooks(options),
     async connect(context) {
+      assertRetryPolicy(options.retry)
       const restClient = await restAdapter.connect(context)
-      return createUnipileClient(
-        createUnipileHttp(restClient, {
-          minDelayMs: options.minDelayMs,
-          retry: options.retry,
-          signal: context.signal,
-        }),
-        { dsn, webhookSecret: options.webhookSecret }
-      )
+      return createUnipileClient(createUnipileHttp(restClient), {
+        dsn,
+        webhookSecret: options.webhookSecret,
+      })
     },
+  }
+}
+
+function toRestRetryPolicy(policy: UnipileRetryPolicy | undefined): RestRetryPolicy {
+  return {
+    maxRetries: policy?.maxRetries ?? DEFAULT_MAX_RETRIES,
+    shouldRetry(context) {
+      const unipileContext = toUnipileRetryContext(context)
+      return policy?.shouldRetry?.(unipileContext) ?? shouldRetryByDefault(unipileContext)
+    },
+    ...(policy?.delayMs
+      ? {
+          delayMs: (context: RestRetryContext) =>
+            policy.delayMs?.(toUnipileRetryContext(context)) ?? 0,
+        }
+      : {}),
+  }
+}
+
+function toUnipileRetryContext(context: RestRetryContext): UnipileRetryContext {
+  return {
+    attempt: context.attempt,
+    method: context.method as UnipileRequestMethod,
+    path: context.path.split("?", 1)[0] ?? context.path,
+    response: context.response,
+    error: context.error,
+  }
+}
+
+function shouldRetryByDefault(context: UnipileRetryContext): boolean {
+  if (context.error) {
+    // Native fetch reports transport failures as TypeError. Credential-resolver and caller errors
+    // keep their original diagnostics and are not replayed.
+    return context.error instanceof TypeError
+  }
+  const status = context.response?.status
+  return status === 429 || (status !== undefined && status >= 500)
+}
+
+function assertRetryPolicy(policy: UnipileRetryPolicy | undefined): void {
+  const maxRetries = policy?.maxRetries ?? DEFAULT_MAX_RETRIES
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error("[SixbUnipile] retry.maxRetries must be a non-negative integer.")
   }
 }
 


### PR DESCRIPTION
## What

Centralize retry, pacing, body/query handling, response parsing, and safe 401 refresh in `connector-rest`.

ACE IoT proved the shared contract first; Mercury, Pennylane, and Unipile then migrated. Their HTTP wrappers now contain only provider-specific behavior.

## Why

The four wrappers duplicated 1,009 lines of reliability logic. One shared implementation prevents behavior drift and unsafe request replays while making future connectors smaller.

## Metrics

| Area | Added | Deleted | Net |
| --- | ---: | ---: | ---: |
| Production source | 593 | 1,065 | **-472** |
| Tests | 302 | 1 | +301 |
| Documentation | 18 | 0 | +18 |
| **Total** | **913** | **1,066** | **-153** |

Provider HTTP wrappers: **1,009 → 221 lines (-788)**.

## Safety and validation

- Unsafe writes, streams, and aborted requests are not replayed.
- Read-only POSTs require an explicit `idempotent` override.
- **265 focused connector tests passed.**
- Check, typecheck, build, and all 49 package smoke tests passed.
- Full suite: 3,812 passed and 2 skipped; two unrelated parallel CLI timeouts passed in isolation.

Provider APIs remain intact. Direct retry-enabled `connector-rest` consumers now receive conservative method-aware defaults.