### PR TITLE
scheduler: keep long delays and unschedulable expressions from stopping the scheduler

### DIFF
--- a/packages/core/src/scheduler/runtime.ts
+++ b/packages/core/src/scheduler/runtime.ts
@@ -6,6 +6,15 @@ import { SchedulerValidationError } from "./errors"
 /** Matches the `onError` flush budget: long enough for a healthy broker, short enough to shut down. */
 const DEFAULT_EMIT_DRAIN_TIMEOUT_MS = 5_000
 
+/**
+ * Largest delay `setTimeout` accepts before it overflows its 32-bit counter.
+ *
+ * Node coerces anything larger to `1`, so an unclamped monthly or yearly occurrence would fire
+ * immediately, find nothing due, and re-arm on the next tick -- spinning the event loop and
+ * emitting a `TimeoutOverflowWarning` for every re-arm until the occurrence came into range.
+ */
+const MAX_TIMER_DELAY_MS = 2_147_483_647
+
 export interface SchedulerRuntimeOptions {
   schedules: readonly ScheduleDefinition[]
   events: DomainEventLog
@@ -46,8 +55,19 @@ export class SchedulerRuntime implements SchedulerController {
 
     const now = this.now()
     for (const schedule of this.schedules) {
-      const next = nextCronOccurrence(schedule.trigger.expression, now, schedule.trigger.timezone)
-      this.nextOccurrences.set(schedule.id, next)
+      // Syntactically valid expressions can still have no reachable occurrence -- `0 0 30 2 *`
+      // parses but never matches. `tick()` already tolerates that per schedule; start-up must
+      // agree, or one unschedulable expression stops every other schedule in the project and
+      // crash-loops the scheduler role.
+      try {
+        const next = nextCronOccurrence(schedule.trigger.expression, now, schedule.trigger.timezone)
+        this.nextOccurrences.set(schedule.id, next)
+      } catch (error) {
+        console.error(
+          `[Sixb] Scheduler failed to compute next occurrence for '${schedule.id}':`,
+          error
+        )
+      }
     }
 
     this.armTimer()
@@ -107,7 +127,12 @@ export class SchedulerRuntime implements SchedulerController {
 
     if (earliest === null) return
 
-    const delayMs = Math.max(0, earliest.getTime() - this.now().getTime())
+    // Waking early is harmless: `tick()` re-arms from the same occurrence map, so a clamped delay
+    // just becomes several sleeps instead of one.
+    const delayMs = Math.min(
+      Math.max(0, earliest.getTime() - this.now().getTime()),
+      MAX_TIMER_DELAY_MS
+    )
     this.timer = setTimeout(() => this.tick(), delayMs)
   }
 

--- a/packages/core/tests/scheduler-runtime.test.ts
+++ b/packages/core/tests/scheduler-runtime.test.ts
@@ -335,4 +335,86 @@ describe("SchedulerRuntime", () => {
       console.error = originalError
     }
   })
+
+  // Guards the `MAX_TIMER_DELAY_MS` clamp in `armTimer`. To prove it still guards, drop the
+  // `Math.min(..., MAX_TIMER_DELAY_MS)` and this test fails: Node coerces the oversized delay to
+  // 1ms, so the timer fires immediately, finds nothing due, and re-arms forever.
+  test("clamps an occurrence beyond the setTimeout ceiling instead of spinning", async () => {
+    const eventsRuntime = createEvents()
+    const clock = createTestClock(new Date("2026-01-02T00:00:00Z"))
+    // Next 1 January is ~364 days out, far beyond the 24.8-day timer ceiling.
+    const schedule = defineSchedule("yearly").cron("0 0 1 1 *")
+
+    const delays: number[] = []
+    const originalSetTimeout = globalThis.setTimeout
+    globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...rest: unknown[]) => {
+      if (typeof timeout === "number") delays.push(timeout)
+      return (originalSetTimeout as (...args: unknown[]) => ReturnType<typeof setTimeout>)(
+        handler,
+        timeout,
+        ...rest
+      )
+    }) as unknown as typeof globalThis.setTimeout
+
+    try {
+      const runtime = new SchedulerRuntime({
+        schedules: [schedule],
+        events: eventsRuntime,
+        now: clock.now,
+      })
+      await runtime.start()
+
+      // A whole second of wall clock must not wake the scheduler even once.
+      clock.advance(1_000)
+      jest.advanceTimersByTime(1_000)
+
+      expect(delays).toHaveLength(1)
+      expect(delays[0]).toBe(2_147_483_647)
+      expect(await eventsRuntime.read({ types: ["schedule.triggered"] })).toHaveLength(0)
+
+      await runtime.stop()
+    } finally {
+      globalThis.setTimeout = originalSetTimeout
+    }
+  })
+
+  // Guards the try/catch added to `start()`. To prove it, remove that try/catch: `start()` throws,
+  // which the CLI turns into `process.exit(1)`, so one bad expression stops every schedule.
+  test("starts the remaining schedules when one expression has no reachable occurrence", async () => {
+    const eventsRuntime = createEvents()
+    const clock = createTestClock(new Date("2026-01-01T10:30:00Z"))
+
+    // `0 0 30 2 *` is syntactically valid and passes definition validation, but 30 February
+    // never occurs, so computing its next occurrence throws.
+    const unreachable = defineSchedule("feb-30").cron("0 0 30 2 *")
+    const healthy = defineSchedule("hourly").cron("0 * * * *")
+
+    const originalError = console.error
+    const errors: unknown[][] = []
+    console.error = (...args: unknown[]) => {
+      errors.push(args)
+    }
+
+    try {
+      const runtime = new SchedulerRuntime({
+        schedules: [unreachable, healthy],
+        events: eventsRuntime,
+        now: clock.now,
+      })
+
+      await runtime.start()
+
+      clock.advance(30 * MINUTE)
+      jest.advanceTimersByTime(30 * MINUTE)
+
+      const events = await eventsRuntime.read({ types: ["schedule.triggered"] })
+      expect(events).toHaveLength(1)
+      expect((events[0] as StoredScheduleTriggeredEvent).payload.scheduleId).toBe("hourly")
+      expect(errors.some((args) => String(args[0]).includes("feb-30"))).toBe(true)
+
+      await runtime.stop()
+    } finally {
+      console.error = originalError
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Two independent ways the scheduler could stop doing its job. Both are in
`SchedulerRuntime`; neither is reachable through a config error the validator catches.

**`armTimer` passed a raw delay to `setTimeout`.** Node coerces anything above 2147483647ms to
`1`, so any occurrence more than ~24.8 days out — every monthly and yearly cron — armed a timer
that fired immediately, found nothing due, re-armed, and repeated. That spins the event loop and
emits a `TimeoutOverflowWarning` per re-arm for the whole wait: roughly five days for a monthly
schedule, eleven months for a yearly one. `nextCronOccurrence` searches up to four years ahead, so
the returned instant can be ~58x over the ceiling.

Clamping is safe because `tick()` re-arms unconditionally from the same occurrence map: a clamped
delay just becomes several sleeps instead of one, and an early wake finds nothing due and does
nothing. Roughly fifteen extra wakes a year for a yearly cron.

**`start()` called `nextCronOccurrence` unguarded.** A syntactically valid expression can still
have no reachable occurrence — `0 0 30 2 *` parses, passes `validateSchedulesAtStartup`, and then
throws "No matching occurrence found within 4 years". That escaped `start()`, which
`runScheduler` turns into `process.exit(1)`, so one typo stopped every other schedule in the
project and crash-looped the scheduler role.

`tick()` already tolerates exactly this error per schedule; start-up now agrees with it. Making
start-up and steady state disagree on the same error seemed worse than either policy alone.

## Linked issue

None — found while reading the scheduler.

## Scope

`packages/core/src/scheduler/runtime.ts` and its test file. Deliberately not included:

- Making an unreachable expression a **startup** error. Arguably the better home for loudness is
  `validateSchedulesAtStartup`, which already calls `createCronMatcher` — but a reachability probe
  there would newly reject leap-day expressions sitting on the four-year boundary, so it wants its
  own discussion.
- Persisting a last-fired watermark. Occurrences during downtime are dropped today; that is a
  design question, not a bug.

While in here I also noticed two DST issues in `next-occurrence.ts` (a spring-forward skip and a
fall-back double-fire for timezone'd schedules) and that `N/step` silently drops the step. Happy to
open those separately — they seemed too unrelated to bundle.

## Validation

`bun run check`, `bun run typecheck`, `bun run build`, `bun run test:publish`, and the full unit
suite (3884 pass; the only failures are four `create-sixb`/`sixb init` tests that reproduce
identically on a clean `main` under Bun 1.4.0). `generate:client` is unaffected — no routes or
schemas change.

Both fixes are covered by tests that fail when their guard is removed:

- clamp reverted → the timer records 1001 wakes in one simulated second instead of 1
- `try/catch` reverted → `CronValidationError` escapes `start()`
