### PR TITLE
brokers: reject a subscribe cursor that predates the retained range

### DIFF
--- a/broker/nats/src/nats-broker.ts
+++ b/broker/nats/src/nats-broker.ts
@@ -310,6 +310,15 @@ export class NatsBroker implements Broker {
 
     let stopped = false
     const streamName = await this.requireStreamName(params.projectId, params.streamId)
+
+    // A cursor JetStream has already discarded would silently start the consumer at the oldest
+    // retained message, so a resuming subscriber would skip the gap without noticing. `read` and
+    // `tail` both reject it; this keeps `subscribe` consistent with them.
+    if (params.afterCursor !== undefined) {
+      const streamInfo = await this.fetchStreamInfo(streamName)
+      this.assertCursorInRetainedRange(streamInfo, params.streamId, params.afterCursor)
+    }
+
     const js = await this.getJetStream()
     const consumerOptions = this.consumerOptions({
       projectId: params.projectId,

--- a/docs/agents/running-and-streaming.md
+++ b/docs/agents/running-and-streaming.md
@@ -127,7 +127,10 @@ Each `record` frame carries an `AgentRunStreamEvent`:
 | `agent.run.finished` | The run ended. | `status`, `finishReason`, `error` |
 
 Records carry a **cursor**. Persist the last one you saw and pass it as `afterCursor` to resume
-where you left off — a client that reconnects mid-run replays the gap. `agent.ui.chunk` events are
+where you left off — a client that reconnects mid-run replays the gap. A cursor older than the
+stream's retention is rejected rather than quietly skipped, so a client that was away long enough
+for its resume point to be trimmed is resubscribed from the oldest retained record and told so by a
+`subscribed` frame carrying `afterCursor: null`. `agent.ui.chunk` events are
 live; the durable copy of the turn is the persisted assistant message, read back with
 `GET /api/agent-threads/:threadId/messages`.
 

--- a/packages/core/src/broker/in-memory.ts
+++ b/packages/core/src/broker/in-memory.ts
@@ -180,6 +180,14 @@ export class InMemoryBroker implements Broker {
     assertCursor(params.afterCursor)
     const storedStream = this.getEnsuredStream(params.projectId, params.streamId)
 
+    // Retention may have trimmed past the caller's cursor. Reject that here rather than let
+    // `readForward` skip silently to the oldest retained record: a resuming subscriber would be
+    // fast-forwarded over the gap and would believe it had seen everything. `read` and `tail`
+    // already reject it, and so does the Redis provider, so this keeps the three consistent.
+    // Checked before the subscription is registered so a throw cannot leave one behind.
+    this.applyRetention(storedStream)
+    this.assertCursorInRetainedRange(storedStream, params.afterCursor)
+
     const subscription: Subscription = {
       projectId: params.projectId,
       streamId: params.streamId,
@@ -191,7 +199,6 @@ export class InMemoryBroker implements Broker {
 
     const startMode = params.afterCursor !== undefined ? undefined : (params.from ?? "latest")
     if (params.afterCursor !== undefined || startMode === "earliest") {
-      this.applyRetention(storedStream)
       const initial = this.readForward(storedStream.records, {
         afterCursor: params.afterCursor,
         names: params.names,

--- a/packages/core/src/broker/types.ts
+++ b/packages/core/src/broker/types.ts
@@ -97,6 +97,11 @@ export interface Broker {
   /**
    * Subscribes to retained/live records. Defaults to `from: "latest"` unless
    * `afterCursor` is provided.
+   *
+   * Like `read`, providers must reject an `afterCursor` older than the retained
+   * range rather than silently advancing to the first retained record, so a
+   * resuming subscriber learns the gap exists instead of mistaking a truncated
+   * stream for a complete one.
    */
   subscribe(
     params: {

--- a/packages/core/src/testing/broker-contract.ts
+++ b/packages/core/src/testing/broker-contract.ts
@@ -707,7 +707,9 @@ export function runBrokerContractSuite<TBroker extends Broker>(
           ).rejects.toBeInstanceOf(BrokerError)
 
           // A resuming subscriber must be told the gap exists rather than silently fast-forwarded
-          // to the oldest retained record, which would look like a complete stream.
+          // to the oldest retained record, which would look like a complete stream. To prove this
+          // still guards, drop the `assertCursorInRetainedRange` call from `subscribe` in
+          // `broker/in-memory.ts` (or from `nats-broker.ts`) and only this expectation fails.
           await expect(
             broker.subscribe(
               {

--- a/packages/core/src/testing/broker-contract.ts
+++ b/packages/core/src/testing/broker-contract.ts
@@ -677,7 +677,7 @@ export function runBrokerContractSuite<TBroker extends Broker>(
         })
       })
 
-      test("rejects reads when the requested cursor predates the retained range", async () => {
+      test("rejects resuming from a cursor that predates the retained range", async () => {
         await withBroker(async (broker) => {
           const [first] = await appendRecords(broker, {
             projectId: "project-a",
@@ -704,6 +704,19 @@ export function runBrokerContractSuite<TBroker extends Broker>(
               streamId: retainedStream.id,
               beforeCursor: first?.cursor,
             })
+          ).rejects.toBeInstanceOf(BrokerError)
+
+          // A resuming subscriber must be told the gap exists rather than silently fast-forwarded
+          // to the oldest retained record, which would look like a complete stream.
+          await expect(
+            broker.subscribe(
+              {
+                projectId: "project-a",
+                streamId: retainedStream.id,
+                afterCursor: first?.cursor,
+              },
+              () => undefined
+            )
           ).rejects.toBeInstanceOf(BrokerError)
         })
       })

--- a/packages/server/src/routes/ws/agents.ts
+++ b/packages/server/src/routes/ws/agents.ts
@@ -1,6 +1,6 @@
 import type { OntologySource } from "@sixb/core"
 import { agentRunStreamDefinition, agentRunStreamId } from "@sixb/core/agents/streams"
-import type { BrokerRecord } from "@sixb/core/broker"
+import { BrokerCursorExpiredError, type BrokerRecord } from "@sixb/core/broker"
 import type { Sixb } from "@sixb/core/internal/request-execution"
 import type { Elysia } from "elysia"
 import { z } from "zod"
@@ -144,6 +144,17 @@ async function subscribeAgentStream(
 
   const buffered: BrokerRecord[] = []
   let live = false
+  const receive = (records: readonly BrokerRecord[]): void => {
+    if (!live) {
+      buffered.push(...records)
+      return
+    }
+    sendRecords(ws, records)
+  }
+
+  // Set when the requested cursor had already been trimmed, so the client learns its resume point
+  // is gone instead of silently receiving a stream that starts after the gap.
+  let resumedFromEarliest = false
   try {
     state.unsubscribe = await host.broker.subscribe(
       {
@@ -153,26 +164,39 @@ async function subscribeAgentStream(
           ? { from: "earliest" as const }
           : { afterCursor: message.afterCursor }),
       },
-      (records) => {
-        if (!live) {
-          buffered.push(...records)
-          return
-        }
-        sendRecords(ws, records)
-      }
+      receive
     )
     state.runId = message.runId
   } catch (error) {
-    state.unsubscribe = null
-    state.runId = null
-    safeSend(ws, { type: "error", message: errorMessage(error) })
-    return
+    // Retention can outrun a paused tab: an agent run stream keeps 5000 records and a streamed
+    // turn writes one per chunk. Replaying everything still retained beats leaving the socket
+    // open with a cursor the broker will reject forever.
+    if (error instanceof BrokerCursorExpiredError) {
+      try {
+        state.unsubscribe = await host.broker.subscribe(
+          { projectId: host.id, streamId, from: "earliest" },
+          receive
+        )
+        state.runId = message.runId
+        resumedFromEarliest = true
+      } catch (retryError) {
+        state.unsubscribe = null
+        state.runId = null
+        safeSend(ws, { type: "error", message: errorMessage(retryError) })
+        return
+      }
+    } else {
+      state.unsubscribe = null
+      state.runId = null
+      safeSend(ws, { type: "error", message: errorMessage(error) })
+      return
+    }
   }
 
   safeSend(ws, {
     type: "subscribed",
     runId: message.runId,
-    afterCursor: message.afterCursor ?? null,
+    afterCursor: resumedFromEarliest ? null : (message.afterCursor ?? null),
   })
   sendRecords(ws, buffered.splice(0))
   if (!(await sendRunSnapshot(sixb, ws, message.runId))) {


### PR DESCRIPTION
## Summary

`read` and `tail` both refuse an `afterCursor` older than what a stream still holds, because
silently advancing to the oldest retained record hands a caller a gap it cannot detect. `subscribe`
did not, in two of the three providers.

A subscriber resuming from a trimmed cursor was fast-forwarded to whatever survived retention and
delivered that as the continuation. Nothing reported the gap, so the caller saw a complete stream.

This is reachable from a client, not just in theory: `/ws/agents` passes a caller-supplied
`afterCursor` straight into `subscribe`, and agent run streams carry retention.

Redis already got this right, which is what made the divergence easy to miss. The in-memory
provider now checks before registering the subscription, so a rejected resume cannot leave one
behind; JetStream checks before building the consumer, and only when `afterCursor` is set, so
`from: "latest"` and `from: "earliest"` are unchanged.

**The second commit is the part I would not ship without.** Rejecting the cursor on its own turns a
silent gap into a dead socket: `/ws/agents` caught the error, dropped the subscription and sent
`{type:"error"}`, and the client handler only records the error — it does not close the socket,
does not reconnect, and does not clear its stored cursor. The socket stayed open holding a cursor
the broker would reject forever.

That is not a rare state. An agent run stream retains 5000 records and a streamed turn writes one
per chunk, so a long turn plus a backgrounded tab trims the resume point routinely. The websocket
now retries from the oldest retained record and reports `afterCursor: null` on the `subscribed`
frame, so the client learns its resume point is gone and replays what survives. `log-subscription-hub`
already does the equivalent with its `cursor_expired` reset.

## Linked issue

None — found while reading the broker providers.

## Scope

The contract suite covered `read` and `tail` but not `subscribe`, which is how two providers
drifted. It now covers all three, so every provider is held to the same rule — including a
third-party one. The rule itself also moved onto `subscribe`'s own contract docs; it lived only on
`read`'s, which is the other half of why this was easy to miss.

Not included: the pre-existing JetStream race where a stream can be trimmed between the info fetch
and consumer creation. `read` has the identical exposure and closing it needs an ack-time sequence
check.

## Validation

`bun run check`, `bun run typecheck`, `bun run build`, `bun run test:publish`, `generate:client`
(unchanged), and the full unit suite — 3884 pass, with only the four `create-sixb`/`sixb init`
failures that reproduce on a clean `main` under Bun 1.4.0.

Because this changes a shared contract, I ran the suite against real servers rather than in-memory
alone: **NATS 29/29** and **Redis 42/42** via each package's `docker-compose.yml`. The added case
fails against either changed provider with its guard removed, and the in-memory guard-removal check
is noted in the test.

I also traced every `broker.subscribe` call site for callers that pass `afterCursor`. `/ws/agents`
is the only non-test one; `ws/events`, `log-subscription-hub`, the orchestrator and the outbox
dispatcher all subscribe without a cursor and are unaffected.
