### PR TITLE
atlas: align UI styling with Sixb

### DIFF
--- a/packages/atlas/src/assets.ts
+++ b/packages/atlas/src/assets.ts
@@ -170,8 +170,8 @@ export function renderBuiltInUiShell(config: BuiltInUiShellConfig): string {
     <base href="/" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#f6f7fb" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)" />
     <title>Sixb Atlas</title>
     <style data-sixb-loading-shell>
       .sixb-loading-shell{position:fixed;inset:0;display:grid;place-items:center;background:#f6f7fb;color:#71717a}

--- a/packages/atlas/src/components/SettingsAccessGate.tsx
+++ b/packages/atlas/src/components/SettingsAccessGate.tsx
@@ -1,0 +1,43 @@
+import { getAuthSessionOptions } from "@sixb/client/hooks"
+import { useQuery } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import { AccessErrorState, LoadingSpinner } from "./SettingsAccessControls"
+import { SettingsTabs } from "./SettingsTabs"
+
+export function SettingsAccessGate({ children }: { readonly children: ReactNode }) {
+  const sessionQuery = useQuery({ ...getAuthSessionOptions(), retry: false })
+
+  if (sessionQuery.isLoading) {
+    return (
+      <div className="flex min-h-90 items-center justify-center">
+        <LoadingSpinner text="Checking your session…" />
+      </div>
+    )
+  }
+
+  if (sessionQuery.isError) {
+    return (
+      <div className="mx-auto w-full max-w-5xl space-y-4">
+        <SettingsTabs />
+        <AccessErrorState
+          title="Settings unavailable"
+          description="We could not verify your session. Try again shortly."
+        />
+      </div>
+    )
+  }
+
+  if (sessionQuery.data?.authenticated !== true) {
+    return (
+      <div className="mx-auto w-full max-w-5xl space-y-4">
+        <SettingsTabs />
+        <AccessErrorState
+          title="Sign in to manage project access"
+          description="Members, service accounts, tokens, and sessions are available after you sign in."
+        />
+      </div>
+    )
+  }
+
+  return children
+}

--- a/packages/atlas/src/components/common.tsx
+++ b/packages/atlas/src/components/common.tsx
@@ -81,6 +81,8 @@ export function PageFrame({
   eyebrow,
   title,
   description,
+  headerVariant = "standard",
+  headerDivider = true,
   backTo,
   backLabel,
   actions,
@@ -90,15 +92,25 @@ export function PageFrame({
   eyebrow?: string
   title: ReactNode
   description?: ReactNode
+  headerVariant?: "standard" | "collection"
+  headerDivider?: boolean
   backTo?: string
   backLabel?: string
   actions?: ReactNode
   contentClassName?: string
   children: ReactNode
 }) {
+  const collectionHeader = headerVariant === "collection"
+
   return (
     <div className="mx-auto flex w-full max-w-7xl flex-col p-3 sm:p-4 lg:p-6">
-      <div className={cn("mx-auto flex w-full max-w-5xl flex-col gap-4", contentClassName)}>
+      <div
+        className={cn(
+          "mx-auto flex w-full max-w-5xl flex-col",
+          collectionHeader ? "gap-2" : "gap-4",
+          contentClassName
+        )}
+      >
         {backTo && backLabel ? (
           <Button
             variant="ghost"
@@ -109,21 +121,38 @@ export function PageFrame({
             <Link to={backTo}>{backLabel}</Link>
           </Button>
         ) : null}
-        <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0 space-y-1">
+        <header
+          className={cn(
+            "flex gap-3 sm:flex-row sm:justify-between",
+            collectionHeader
+              ? "items-center"
+              : cn("flex-col sm:items-start", headerDivider && "atlas-page-header")
+          )}
+        >
+          <div className={cn("min-w-0", !collectionHeader && "space-y-1")}>
             {eyebrow ? (
-              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <p className="atlas-eyebrow text-[11px] font-semibold uppercase">
+                <span aria-hidden="true" className="atlas-signal-dot" />
                 {eyebrow}
               </p>
             ) : null}
-            <h1 className="break-words text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+            <h1
+              className={cn(
+                "break-words",
+                collectionHeader
+                  ? "text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+                  : "text-2xl font-medium tracking-[-0.025em] text-foreground sm:text-3xl"
+              )}
+            >
               {title}
             </h1>
             {description ? (
               <div className="max-w-3xl text-sm text-muted-foreground">{description}</div>
             ) : null}
           </div>
-          {actions ? <div className="shrink-0 sm:pt-1">{actions}</div> : null}
+          {actions ? (
+            <div className={cn("shrink-0", !collectionHeader && "sm:pt-1")}>{actions}</div>
+          ) : null}
         </header>
         {children}
       </div>

--- a/packages/atlas/src/components/layout/AppShell.tsx
+++ b/packages/atlas/src/components/layout/AppShell.tsx
@@ -9,15 +9,18 @@ interface AppShellProps {
 
 export function AppShell({ sidebar, children, currentProjectName }: AppShellProps) {
   return (
-    <SidebarProvider className="h-dvh overflow-hidden">
+    <SidebarProvider className="atlas-shell h-dvh overflow-hidden">
       {sidebar}
       <SidebarInset className="min-h-0 overflow-hidden">
         {/* Mobile-only header: gives users a way to open the sheet. */}
-        <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border bg-background px-3 md:hidden">
+        <header className="atlas-mobile-header flex h-[54px] shrink-0 items-center gap-3 border-b border-border px-3 md:hidden">
           <SidebarTrigger className="-ml-1" />
-          <p className="truncate text-sm font-medium text-foreground">
-            {currentProjectName ?? "Sixb"}
-          </p>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-foreground">Sixb Atlas</p>
+            {currentProjectName ? (
+              <p className="truncate text-[11px] text-muted-foreground">{currentProjectName}</p>
+            ) : null}
+          </div>
         </header>
         <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">{children}</main>
       </SidebarInset>

--- a/packages/atlas/src/components/layout/Sidebar.tsx
+++ b/packages/atlas/src/components/layout/Sidebar.tsx
@@ -23,7 +23,6 @@ import {
   Cable,
   Database,
   GitBranch,
-  Globe,
   Layers,
   LayoutGrid,
   ListChecks,
@@ -69,6 +68,23 @@ const projectNavItems: NavItem[] = [
   { id: "rules", label: "Rules", Icon: ListChecks },
   { id: "settings", label: "Settings", Icon: Settings },
 ]
+
+function SixbMark({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 480 394"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5.42 162.63 39.47 392.44 342.17 296.69 472.14 104.34 183.6 1.82C120.12 59.31 59.11 114.33 5.42 162.63Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
 
 function apiDocsUrl(): string {
   return new URL("/docs", client.getConfig().baseUrl ?? window.location.origin).toString()
@@ -178,14 +194,17 @@ export function Sidebar({
 
 export function AtlasSidebarHeader({ selectedProject }: { selectedProject: ProjectInfo | null }) {
   return (
-    <SidebarHeader className="border-b border-sidebar-border">
-      <div className="flex items-center gap-3 px-2 py-2 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:justify-center">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-accent text-sidebar-accent-foreground">
-          <Globe className="h-4 w-4" />
+    <SidebarHeader className="h-[54px] justify-center border-b border-sidebar-border">
+      <div className="flex items-center gap-3 px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+        {/* Sixb's orbit mark anchors Atlas to the website identity. */}
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center text-sidebar-accent-foreground">
+          <SixbMark className="h-[18px] w-[22px]" />
         </div>
         <div className="min-w-0 flex-1 group-data-[collapsible=icon]:hidden">
-          <p className="truncate text-sm font-semibold text-sidebar-foreground">Atlas</p>
-          <p className="truncate text-xs text-sidebar-foreground">
+          <p className="truncate text-[14px] font-semibold tracking-[-0.02em] text-sidebar-accent-foreground">
+            Sixb Atlas
+          </p>
+          <p className="truncate text-[11px] text-sidebar-foreground">
             {selectedProject ? selectedProject.name : "Loading project"}
           </p>
         </div>

--- a/packages/atlas/src/favicon.svg
+++ b/packages/atlas/src/favicon.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <circle cx="16" cy="16" r="12" fill="#000000" />
+  <path d="M4 12.5 6.25 27 22.75 21 29 8.75 13 4 4 12.5Z" fill="#000" />
 </svg>

--- a/packages/atlas/src/index.css
+++ b/packages/atlas/src/index.css
@@ -8,12 +8,122 @@
 @source "./pages/**/*.{ts,tsx}";
 
 :root {
+  /* Atlas follows the Sixb website's paper, ink, ledger-line, and signal-blue palette. */
+  --background: #fafafa;
+  --foreground: #17181c;
+  --card: #ffffff;
+  --card-foreground: #17181c;
+  --popover: #ffffff;
+  --popover-foreground: #17181c;
+  --primary: #17181c;
+  --primary-foreground: #ffffff;
+  --secondary: #f3f3f3;
+  --secondary-foreground: #17181c;
+  --accent: #f3f3f3;
+  --accent-foreground: #17181c;
+  --muted: #f5f5f5;
+  --muted-foreground: #63666d;
+  --border: #e1e1e1;
+  --input: #d6d6d6;
+  --ring: #007aff;
+  --info: #007aff;
+  --chart-1: #007aff;
+  --chart-2: #17181c;
+  --chart-3: #5799df;
+  --chart-4: #9ec3ee;
+  --chart-5: #d4e6ff;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #63666d;
+  --sidebar-primary: #17181c;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f3f3f3;
+  --sidebar-accent-foreground: #17181c;
+  --sidebar-border: #e1e1e1;
+  --sidebar-ring: #007aff;
+  --font-sans: "ABC Diatype", "SF Pro Text", "SF Pro Display", "Segoe UI Variable Text",
+    "Segoe UI", system-ui, sans-serif;
+  --radius: 0.25rem;
+  --shadow-2xs: none;
+  --shadow-xs: none;
+  --shadow-sm: none;
+  --shadow: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+  --shadow-xl: none;
+  --shadow-2xl: none;
+  --atlas-blue: #007aff;
+  --atlas-blue-deep: #0061cc;
+  --atlas-blue-soft: #9ec3ee;
+  --atlas-blue-line: #d4e6ff;
+  --atlas-blue-fill: #eef4ff;
+  --atlas-rail: #ffffff;
+  --atlas-sidebar-active: #17181c;
+  --atlas-sidebar-active-foreground: #ffffff;
+  --atlas-sidebar-count: #f1f1f1;
+  --atlas-surface-hover: #fafafa;
+  --atlas-row-hover: #f7f7f7;
+  --atlas-border-hover: #c6c6c6;
+
   font-family: var(--font-sans);
   line-height: 1.5;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+}
+
+.dark {
+  --background: #0b0b0b;
+  --foreground: #f5f5f5;
+  --card: #101010;
+  --card-foreground: #f5f5f5;
+  --popover: #151515;
+  --popover-foreground: #f5f5f5;
+  --primary: #f5f5f5;
+  --primary-foreground: #0b0b0b;
+  --secondary: #1a1a1a;
+  --secondary-foreground: #f5f5f5;
+  --accent: #202020;
+  --accent-foreground: #f5f5f5;
+  --muted: #181818;
+  --muted-foreground: #a1a1a1;
+  --border: #2b2b2b;
+  --input: #363636;
+  --ring: #007aff;
+  --info: #007aff;
+  --chart-1: #007aff;
+  --chart-2: #f5f5f5;
+  --chart-3: #68aef8;
+  --chart-4: #3f7fbd;
+  --chart-5: #23527f;
+  --sidebar: #0f0f0f;
+  --sidebar-foreground: #a1a1a1;
+  --sidebar-primary: #f5f5f5;
+  --sidebar-primary-foreground: #0b0b0b;
+  --sidebar-accent: #202020;
+  --sidebar-accent-foreground: #f5f5f5;
+  --sidebar-border: #2b2b2b;
+  --sidebar-ring: #007aff;
+  --atlas-blue: #007aff;
+  --atlas-blue-deep: #68aef8;
+  --atlas-blue-soft: #3f7fbd;
+  --atlas-blue-line: #23527f;
+  --atlas-blue-fill: #151515;
+  --atlas-rail: #0f0f0f;
+  --atlas-sidebar-active: #f5f5f5;
+  --atlas-sidebar-active-foreground: #0b0b0b;
+  --atlas-sidebar-count: #1c1c1c;
+  --atlas-surface-hover: #171717;
+  --atlas-row-hover: #151515;
+  --atlas-border-hover: #484848;
+  --shadow-2xs: none;
+  --shadow-xs: none;
+  --shadow-sm: none;
+  --shadow: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+  --shadow-xl: none;
+  --shadow-2xl: none;
 }
 
 html,
@@ -28,6 +138,12 @@ body {
   margin: 0;
 }
 
+h1,
+h2,
+h3 {
+  letter-spacing: -0.02em;
+}
+
 #root {
   height: 100%;
 }
@@ -38,10 +154,116 @@ a {
     transform 0.15s ease;
 }
 
+button:not(:disabled),
+a[href],
+[role="button"]:not([aria-disabled="true"]) {
+  cursor: pointer;
+}
+
 button:focus-visible,
 a:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 2px;
+}
+
+/* The application shell uses the website's pure paper surface and crisp dividing rules. */
+.atlas-shell {
+  background: var(--background);
+}
+
+.atlas-mobile-header {
+  background: var(--background);
+}
+
+[data-slot="sidebar-inner"] {
+  background-color: var(--sidebar);
+  background-image: none;
+}
+
+[data-sidebar="menu-button"] {
+  position: relative;
+  border-radius: 2px;
+  font-weight: 500;
+}
+
+[data-sidebar="menu-button"][data-active="true"] {
+  background: var(--atlas-sidebar-active);
+  color: var(--atlas-sidebar-active-foreground);
+}
+
+[data-sidebar="menu-button"][data-active="true"]:hover {
+  background: var(--atlas-sidebar-active);
+  color: var(--atlas-sidebar-active-foreground);
+}
+
+[data-sidebar="menu-badge"] {
+  min-width: 1.25rem;
+  border-radius: 2px;
+  background: var(--atlas-sidebar-count);
+  font-size: 0.6875rem;
+}
+
+[data-sidebar="menu-button"][data-active="true"] + [data-sidebar="menu-badge"] {
+  background: rgb(255 255 255 / 14%);
+  color: var(--atlas-sidebar-active-foreground);
+}
+
+/* Shared primitives get a restrained product treatment without changing @sixb/ui globally. */
+[data-slot="card"] {
+  border-color: var(--border);
+  border-radius: var(--radius);
+  box-shadow: none;
+}
+
+[data-slot="card"][role="button"]:hover {
+  border-color: var(--atlas-border-hover);
+  background: var(--atlas-surface-hover);
+}
+
+[data-slot="badge"][data-variant="secondary"] {
+  border-color: var(--border);
+  background: var(--secondary);
+  color: var(--foreground);
+}
+
+[data-slot="tabs-list"][data-variant="line"] [data-slot="tabs-trigger"][data-state="active"]::after {
+  background: var(--foreground);
+}
+
+[data-slot="table-header"] {
+  background: var(--background);
+}
+
+[data-slot="table-row"]:hover {
+  background: var(--atlas-row-hover);
+}
+
+[data-slot="button"],
+[data-slot="input"],
+[data-slot="select-trigger"],
+[data-slot="toggle-group"],
+[data-slot="tabs-list"]:not([data-variant="line"]) {
+  box-shadow: none;
+}
+
+.atlas-page-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 1.25rem;
+}
+
+.atlas-eyebrow {
+  color: var(--muted-foreground);
+  letter-spacing: 0.12em;
+}
+
+.atlas-signal-dot {
+  display: inline-block;
+  width: 0.35rem;
+  height: 0.35rem;
+  margin-right: 0.45rem;
+  border-radius: 999px;
+  background: var(--atlas-blue);
+  vertical-align: 0.08rem;
 }
 
 .scrollbar-auto-hide::-webkit-scrollbar {
@@ -60,6 +282,14 @@ a:focus-visible {
 
 .scrollbar-auto-hide::-webkit-scrollbar-track {
   background: transparent;
+}
+
+.atlas-tabs-scroll {
+  scrollbar-width: none;
+}
+
+.atlas-tabs-scroll::-webkit-scrollbar {
+  display: none;
 }
 
 /* React Flow theming — wire xyflow CSS vars to our design tokens. */

--- a/packages/atlas/src/index.html
+++ b/packages/atlas/src/index.html
@@ -5,8 +5,8 @@
     <base href="/" />
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#f6f7fb" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#101216" media="(prefers-color-scheme: dark)" />
     <title>Sixb Atlas</title>
   </head>
   <body>

--- a/packages/atlas/src/pages/ActionsPage.tsx
+++ b/packages/atlas/src/pages/ActionsPage.tsx
@@ -106,11 +106,7 @@ export function ActionsPage() {
   }
 
   return (
-    <PageFrame
-      eyebrow="Atlas"
-      title="Actions"
-      description="Request ontology actions and inspect their durable execution history."
-    >
+    <PageFrame title="Actions" headerDivider={false}>
       <Tabs value={activeTab} onValueChange={handleTabChange} className="gap-4">
         <TabsList variant="line" className="border-b border-border">
           <TabsTrigger value="actions">Actions</TabsTrigger>

--- a/packages/atlas/src/pages/LogsPage.tsx
+++ b/packages/atlas/src/pages/LogsPage.tsx
@@ -67,11 +67,7 @@ export function LogsPage() {
   }, [kind, level])
 
   return (
-    <PageFrame
-      title="Logs"
-      description="Live run output across syncs, pipelines, workflows, and actions."
-      contentClassName="max-w-6xl"
-    >
+    <PageFrame title="Logs" headerVariant="collection" contentClassName="max-w-6xl">
       <LogConsole
         builder={builder}
         showKind

--- a/packages/atlas/src/pages/ObjectTypeDetail.tsx
+++ b/packages/atlas/src/pages/ObjectTypeDetail.tsx
@@ -124,12 +124,9 @@ export function ObjectTypeDetail() {
         <div className="flex items-start gap-4">
           <LetterAvatar label={displayTitle} size="md" />
           <div className="min-w-0 flex-1 space-y-1">
-            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <h1 className="text-2xl font-semibold tracking-tight text-foreground">
-                {displayTitle}
-              </h1>
-              <code className="font-mono text-xs text-muted-foreground">{objectType.id}</code>
-            </div>
+            <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+              {displayTitle}
+            </h1>
             {objectType.description ? (
               <p className="text-sm leading-6 text-muted-foreground">{objectType.description}</p>
             ) : null}
@@ -181,26 +178,34 @@ export function ObjectTypeDetail() {
 
       {/* Tabs */}
       <Tabs value={resolvedTab} onValueChange={setActiveTab}>
-        <TabsList variant="line">
-          <TabsTrigger value="properties">
-            Properties
-            <Count value={objectType.properties.length} />
-          </TabsTrigger>
-          <TabsTrigger value="links">
-            Links
-            <Count value={objectType.links.length} />
-          </TabsTrigger>
-          <TabsTrigger value="actions">
-            Actions
-            <Count value={objectType.actions.length} />
-          </TabsTrigger>
-          {projectionCount > 0 ? (
-            <TabsTrigger value="projections">
-              Projections
-              <Count value={projectionCount} />
-            </TabsTrigger>
-          ) : null}
-        </TabsList>
+        <div className="relative">
+          <div className="atlas-tabs-scroll overflow-x-auto overscroll-x-contain pr-8 sm:pr-0">
+            <TabsList variant="line" className="min-w-max">
+              <TabsTrigger value="properties">
+                Properties
+                <Count value={objectType.properties.length} />
+              </TabsTrigger>
+              <TabsTrigger value="links">
+                Links
+                <Count value={objectType.links.length} />
+              </TabsTrigger>
+              <TabsTrigger value="actions">
+                Actions
+                <Count value={objectType.actions.length} />
+              </TabsTrigger>
+              {projectionCount > 0 ? (
+                <TabsTrigger value="projections">
+                  Projections
+                  <Count value={projectionCount} />
+                </TabsTrigger>
+              ) : null}
+            </TabsList>
+          </div>
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent sm:hidden"
+          />
+        </div>
 
         {/* Properties */}
         <TabsContent value="properties" className="space-y-6 pt-4">

--- a/packages/atlas/src/pages/OntologyExplorer.tsx
+++ b/packages/atlas/src/pages/OntologyExplorer.tsx
@@ -1,6 +1,6 @@
 import type { ListObjectTypesResponse } from "@sixb/client"
 import { listObjectTypesOptions } from "@sixb/client/hooks"
-import { Badge, Input } from "@sixb/ui/components"
+import { CollectionHeader, Input } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { useQuery } from "@tanstack/react-query"
 import { CornerDownRight, Link2, Rows3, Search, Zap } from "lucide-react"
@@ -41,26 +41,22 @@ export function OntologyExplorer({ onSelectType }: OntologyExplorerProps) {
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-4">
-      {/* Header */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <h1 className="text-lg font-semibold text-foreground">Ontology</h1>
-          <Badge variant="outline" className="text-xs">
-            {objectTypes.length} {objectTypes.length === 1 ? "type" : "types"}
-          </Badge>
-        </div>
-
-        <div className="relative w-full sm:w-64">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="text"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search types..."
-            className="pl-9"
-          />
-        </div>
-      </div>
+      <CollectionHeader
+        title="Ontology"
+        count={objectTypes.length}
+        actions={
+          <div className="relative w-full sm:w-64">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              type="text"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search types..."
+              className="pl-9"
+            />
+          </div>
+        }
+      />
 
       {/* List */}
       {objectTypes.length === 0 ? (

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -39,6 +39,7 @@ import {
 } from "react-router-dom"
 import { SidebarDataContext } from "../components/layout/sidebarData"
 import { KNOWN_VIEWS } from "../components/layout/viewMode"
+import { SettingsAccessGate } from "../components/SettingsAccessGate"
 import {
   getObjectSortPreference,
   type ObjectSortPreference,
@@ -403,10 +404,38 @@ export function ProjectWorkspace() {
               <Route path="rules" element={<RulesPage />} />
               <Route path="rules/:ruleId" element={<RuleDetailPage />} />
               <Route path="settings" element={<Navigate to="/settings/members" replace />} />
-              <Route path="settings/tokens" element={<SettingsTokensPage />} />
-              <Route path="settings/members" element={<SettingsMembersPage />} />
-              <Route path="settings/service-accounts" element={<SettingsServiceAccountsPage />} />
-              <Route path="settings/sessions" element={<SettingsSessionsPage />} />
+              <Route
+                path="settings/tokens"
+                element={
+                  <SettingsAccessGate>
+                    <SettingsTokensPage />
+                  </SettingsAccessGate>
+                }
+              />
+              <Route
+                path="settings/members"
+                element={
+                  <SettingsAccessGate>
+                    <SettingsMembersPage />
+                  </SettingsAccessGate>
+                }
+              />
+              <Route
+                path="settings/service-accounts"
+                element={
+                  <SettingsAccessGate>
+                    <SettingsServiceAccountsPage />
+                  </SettingsAccessGate>
+                }
+              />
+              <Route
+                path="settings/sessions"
+                element={
+                  <SettingsAccessGate>
+                    <SettingsSessionsPage />
+                  </SettingsAccessGate>
+                }
+              />
               <Route
                 path="ontology"
                 element={

--- a/packages/atlas/src/pages/WorkflowsPage.tsx
+++ b/packages/atlas/src/pages/WorkflowsPage.tsx
@@ -25,11 +25,7 @@ export function WorkflowsPage() {
   }
 
   return (
-    <PageFrame
-      eyebrow="Atlas"
-      title="Workflows"
-      description="Browse workflow definitions, trigger runs, and inspect execution history."
-    >
+    <PageFrame title="Workflows" headerDivider={false}>
       <Tabs value={activeTab} onValueChange={handleTabChange} className="gap-4">
         <TabsList variant="line" className="border-b border-border">
           <TabsTrigger value="workflows">Workflows</TabsTrigger>


### PR DESCRIPTION
## Summary

- refresh Atlas with the sharper Sixb light and dark visual language
- simplify sidebar branding, page headers, favicon, and surface hierarchy
- add a calm signed-out Settings access state
- improve mobile ontology tab scrolling and clean up object type details

## Screenshots
<img width="279" height="572" alt="Screenshot 2026-08-23 at 4 58 06 PM" src="https://github.com/user-attachments/assets/92ca4496-f943-4aeb-9eae-f6479fabfeb0" />

