### PR TITLE
atlas: add immersive ontology graph explorer

### DIFF
--- a/packages/atlas/src/lib/ontologyGraphLayout.ts
+++ b/packages/atlas/src/lib/ontologyGraphLayout.ts
@@ -64,6 +64,8 @@ interface EdgeHandles {
   target: GraphHandleLayout
 }
 
+type GraphRoutingMode = "focus" | "overview"
+
 const PORT_MIN = 18
 const PORT_MAX = 82
 const ROUTE_GAP = 14
@@ -74,7 +76,7 @@ export function layoutOntologyGraph(
   nodes: GraphNodeInput[],
   edges: GraphEdgeInput[],
   focusId: string,
-  { nodeWidth, nodeHeight, columnGap = 260, rowGap = 70 }: GraphLayoutOptions
+  { nodeWidth, nodeHeight, columnGap = 400, rowGap = 120 }: GraphLayoutOptions
 ): { nodes: GraphNodeLayout[]; edges: GraphEdgeLayout[]; bounds: Rect } {
   const columns = partitionNodes(nodes, edges, focusId)
   orderColumns(columns, edges)
@@ -99,7 +101,38 @@ export function layoutOntologyGraph(
     focusId,
     { nodeWidth, nodeHeight },
     positions,
-    columnById
+    columnById,
+    "focus"
+  )
+}
+
+export function layoutOntologyOverviewGraph(
+  nodes: GraphNodeInput[],
+  edges: GraphEdgeInput[],
+  { nodeWidth, nodeHeight, columnGap = 240, rowGap = 140 }: GraphLayoutOptions
+): { nodes: GraphNodeLayout[]; edges: GraphEdgeLayout[]; bounds: Rect } {
+  const columns = partitionOverviewNodes(nodes, edges)
+  orderOverviewColumns(columns, edges)
+
+  const positions = new Map<string, GraphPoint>()
+  const columnById = new Map<string, number>()
+  const columnPitch = nodeWidth + columnGap
+  const rowPitch = nodeHeight + rowGap
+  columns.forEach((column, columnIndex) => {
+    column.forEach((nodeId, rowIndex) => {
+      positions.set(nodeId, { x: columnIndex * columnPitch, y: rowIndex * rowPitch })
+      columnById.set(nodeId, columnIndex)
+    })
+  })
+
+  return routePositionedGraph(
+    nodes,
+    edges,
+    null,
+    { nodeWidth, nodeHeight },
+    positions,
+    columnById,
+    "overview"
   )
 }
 
@@ -128,26 +161,51 @@ export function routeOntologyGraph(
     focusId,
     { nodeWidth, nodeHeight },
     positions,
-    columnById
+    columnById,
+    "focus"
+  )
+}
+
+export function routeOntologyOverviewGraph(
+  nodes: GraphPositionedNodeInput[],
+  edges: GraphEdgeInput[],
+  { nodeWidth, nodeHeight }: GraphLayoutOptions
+): { nodes: GraphNodeLayout[]; edges: GraphEdgeLayout[]; bounds: Rect } {
+  const positions = new Map(nodes.map((node) => [node.id, node.position]))
+  const orderedColumns = [...new Set(nodes.map((node) => node.position.x))].sort(
+    (left, right) => left - right
+  )
+  const columnByX = new Map(orderedColumns.map((x, index) => [x, index]))
+  const columnById = new Map(nodes.map((node) => [node.id, columnByX.get(node.position.x) ?? 0]))
+
+  return routePositionedGraph(
+    nodes,
+    edges,
+    null,
+    { nodeWidth, nodeHeight },
+    positions,
+    columnById,
+    "overview"
   )
 }
 
 function routePositionedGraph(
   nodes: GraphNodeInput[],
   edges: GraphEdgeInput[],
-  focusId: string,
+  focusId: string | null,
   { nodeWidth, nodeHeight }: Pick<GraphLayoutOptions, "nodeWidth" | "nodeHeight">,
   positions: ReadonlyMap<string, GraphPoint>,
-  columnById: ReadonlyMap<string, number>
+  columnById: ReadonlyMap<string, number>,
+  mode: GraphRoutingMode
 ): { nodes: GraphNodeLayout[]; edges: GraphEdgeLayout[]; bounds: Rect } {
-  const handles = assignHandles(edges, positions, columnById, focusId)
+  const handles = assignHandles(edges, positions, columnById, focusId, mode)
   const nodeRects = new Map(
     nodes.map((node) => [
       node.id,
       { ...positions.get(node.id)!, width: nodeWidth, height: nodeHeight },
     ])
   )
-  const routed = routeEdges(edges, handles, nodeRects, columnById, focusId)
+  const routed = routeEdges(edges, handles, nodeRects, columnById, focusId, mode)
   const labelWidths = new Map(edges.map((edge) => [edge.id, edge.labelWidth]))
   const bounds = layoutBounds([...nodeRects.values()], routed, labelWidths)
 
@@ -240,6 +298,87 @@ function partitionNodes(
   )
 }
 
+function partitionOverviewNodes(nodes: GraphNodeInput[], edges: GraphEdgeInput[]): string[][] {
+  if (nodes.length === 0) return []
+  const nodeIds = new Set(nodes.map((node) => node.id))
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const orderedNodes = [...nodes].sort((left, right) => left.label.localeCompare(right.label))
+  const graphEdges = edges.filter(
+    (edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target) && edge.source !== edge.target
+  )
+  if (graphEdges.length === 0) {
+    const columnCount = Math.max(1, Math.ceil(Math.sqrt(nodes.length)))
+    const columns = Array.from({ length: columnCount }, () => [] as string[])
+    orderedNodes.forEach((node, index) => {
+      columns[index % columnCount]!.push(node.id)
+    })
+    return columns
+  }
+
+  const outgoing = new Map(nodes.map((node) => [node.id, [] as GraphEdgeInput[]]))
+  const indegree = new Map(nodes.map((node) => [node.id, 0]))
+  for (const edge of graphEdges) {
+    outgoing.get(edge.source)!.push(edge)
+    indegree.set(edge.target, (indegree.get(edge.target) ?? 0) + 1)
+  }
+
+  const ranks = new Map<string, number>()
+  const queue = orderedNodes.filter((node) => indegree.get(node.id) === 0)
+  for (const node of queue) ranks.set(node.id, 0)
+  while (queue.length > 0) {
+    const node = queue.shift()!
+    const rank = ranks.get(node.id) ?? 0
+    for (const edge of outgoing.get(node.id) ?? []) {
+      ranks.set(edge.target, Math.max(ranks.get(edge.target) ?? 0, rank + 1))
+      indegree.set(edge.target, (indegree.get(edge.target) ?? 1) - 1)
+      if (indegree.get(edge.target) === 0) {
+        queue.push(nodeById.get(edge.target)!)
+        queue.sort((left, right) => left.label.localeCompare(right.label))
+      }
+    }
+  }
+
+  for (const node of orderedNodes) {
+    if (ranks.has(node.id)) continue
+    const incomingRanks = graphEdges
+      .filter((edge) => edge.target === node.id)
+      .map((edge) => ranks.get(edge.source))
+      .filter((rank): rank is number => rank !== undefined)
+    ranks.set(node.id, incomingRanks.length > 0 ? Math.max(...incomingRanks) + 1 : 0)
+  }
+
+  const maxRank = Math.max(...ranks.values(), 0)
+  const desiredColumns = Math.min(5, Math.max(2, Math.ceil(Math.sqrt(nodes.length))))
+  const columnCount = Math.min(desiredColumns, maxRank + 1)
+  const columns = Array.from({ length: Math.max(columnCount, 1) }, () => [] as string[])
+  const rankedNodes = [...orderedNodes].sort(
+    (left, right) =>
+      (ranks.get(left.id) ?? 0) - (ranks.get(right.id) ?? 0) ||
+      left.label.localeCompare(right.label)
+  )
+  rankedNodes.forEach((node) => {
+    const rank = ranks.get(node.id) ?? 0
+    const column = maxRank === 0 ? 0 : Math.round((rank * (columns.length - 1)) / maxRank)
+    columns[column]!.push(node.id)
+  })
+  return columns.filter((column) => column.length > 0)
+}
+
+function orderOverviewColumns(columns: string[][], edges: GraphEdgeInput[]): void {
+  for (let pass = 0; pass < 10; pass += 1) {
+    let improved = false
+    for (const column of columns) {
+      for (let index = 0; index < column.length - 1; index += 1) {
+        const before = orderScore(columns, edges)
+        ;[column[index], column[index + 1]] = [column[index + 1]!, column[index]!]
+        if (orderScore(columns, edges) < before) improved = true
+        else [column[index], column[index + 1]] = [column[index + 1]!, column[index]!]
+      }
+    }
+    if (!improved) break
+  }
+}
+
 function orderColumns(columns: string[][], edges: GraphEdgeInput[]): void {
   for (let pass = 0; pass < 8; pass += 1) {
     let improved = false
@@ -298,7 +437,8 @@ function assignHandles(
   edges: GraphEdgeInput[],
   positions: ReadonlyMap<string, GraphPoint>,
   columns: ReadonlyMap<string, number>,
-  focusId: string
+  focusId: string | null,
+  mode: GraphRoutingMode
 ): Map<string, EdgeHandles> {
   const sides = new Map<string, { source: GraphHandleSide; target: GraphHandleSide }>()
   for (const edge of edges) {
@@ -306,7 +446,15 @@ function assignHandles(
     const targetColumn = columns.get(edge.target) ?? 0
     if (sourceColumn < targetColumn) sides.set(edge.id, { source: "right", target: "left" })
     else if (sourceColumn > targetColumn) sides.set(edge.id, { source: "left", target: "right" })
-    else {
+    else if (mode === "overview") {
+      const source = positions.get(edge.source)
+      const target = positions.get(edge.target)
+      const sourceAbove = (source?.y ?? 0) <= (target?.y ?? 0)
+      sides.set(edge.id, {
+        source: sourceAbove ? "bottom" : "top",
+        target: sourceAbove ? "top" : "bottom",
+      })
+    } else {
       const outside = sourceColumn === 2 ? "right" : "left"
       sides.set(edge.id, { source: outside, target: outside })
     }
@@ -330,7 +478,7 @@ function assignHandles(
       return (leftOther?.y ?? 0) - (rightOther?.y ?? 0) || left.edge.id.localeCompare(right.edge.id)
     })
     const nodeId = group[0]?.edge[group[0].role]
-    const spreadFocus = nodeId === focusId && group.length >= 3
+    const spreadFocus = focusId !== null && nodeId === focusId && group.length >= 3
     const min = spreadFocus ? 10 : PORT_MIN
     const max = spreadFocus ? 90 : PORT_MAX
     group.forEach(({ edge, role }, index) => {
@@ -349,18 +497,31 @@ function routeEdges(
   handles: ReadonlyMap<string, EdgeHandles>,
   nodes: ReadonlyMap<string, Rect>,
   columns: ReadonlyMap<string, number>,
-  focusId: string
+  focusId: string | null,
+  mode: GraphRoutingMode
 ): GraphEdgeLayout[] {
   const allRects = [...nodes.values()]
   const bounds = graphBounds(allRects)
-  const focusRect = nodes.get(focusId)
-  const focusLanes = assignFocusLanes(edges, nodes, columns, focusId)
+  const focusRect = focusId ? nodes.get(focusId) : undefined
+  const focusLanes = focusId ? assignFocusLanes(edges, nodes, columns, focusId) : new Map()
+  const overviewLanes = mode === "overview" ? horizontalOverviewLanes(allRects, bounds) : []
   const usedSegments: Segment[] = []
   const usedLabels: Rect[] = []
   const groupIndex = new Map<string, number>()
 
   return [...edges]
     .sort((left, right) => {
+      if (mode === "overview") {
+        const leftSpan = Math.abs((columns.get(left.source) ?? 0) - (columns.get(left.target) ?? 0))
+        const rightSpan = Math.abs(
+          (columns.get(right.source) ?? 0) - (columns.get(right.target) ?? 0)
+        )
+        return (
+          rightSpan - leftSpan ||
+          right.labelWidth - left.labelWidth ||
+          left.id.localeCompare(right.id)
+        )
+      }
       const leftFocus = left.source === focusId || left.target === focusId ? 0 : 1
       const rightFocus = right.source === focusId || right.target === focusId ? 0 : 1
       return (
@@ -370,7 +531,7 @@ function routeEdges(
       )
     })
     .map((edge) => {
-      const focused = edge.source === focusId || edge.target === focusId
+      const focused = focusId !== null && (edge.source === focusId || edge.target === focusId)
       const edgeHandles = handles.get(edge.id)!
       const sourceRect = nodes.get(edge.source)!
       const targetRect = nodes.get(edge.target)!
@@ -393,16 +554,27 @@ function routeEdges(
         focusRect,
         edge.labelWidth,
         focused,
-        focusLanes.get(edge.id)
+        focusLanes.get(edge.id),
+        mode,
+        overviewLanes
       )
       const obstacles = allRects.filter((rect) => rect !== sourceRect && rect !== targetRect)
-      const points = candidates
+      const selected = candidates
         .map(simplifyRoute)
-        .map((route) => ({ route, score: routeScore(route, obstacles, usedSegments) }))
-        .sort((left, right) => left.score - right.score)[0]?.route ?? [start, end]
+        .map((route) => {
+          const segments = routeSegments(route)
+          const labelPosition = findLabelPosition(segments, edge.labelWidth, allRects, usedLabels)
+          return {
+            route,
+            labelPosition,
+            score: routeScore(route, obstacles, usedSegments) + (labelPosition ? 0 : 100_000),
+          }
+        })
+        .sort((left, right) => left.score - right.score)[0]
+      const points = selected?.route ?? [start, end]
       const segments = routeSegments(points)
       usedSegments.push(...segments)
-      const labelPosition = placeLabel(segments, edge.labelWidth, allRects, usedLabels)
+      const labelPosition = selected?.labelPosition ?? fallbackLabelPosition(segments)
       usedLabels.push({
         x: labelPosition.x - edge.labelWidth / 2,
         y: labelPosition.y - 11,
@@ -433,11 +605,41 @@ function routeCandidates(
   focus: Rect | undefined,
   labelWidth: number,
   focused: boolean,
-  preferredLane?: number
+  preferredLane: number | undefined,
+  mode: GraphRoutingMode,
+  overviewLanes: number[]
 ): GraphPoint[][] {
   const gap = focused ? FOCUS_ROUTE_GAP : ROUTE_GAP
-  const track = (points: GraphPoint[]) => (focused ? points : trackEndpoints(points, index))
+  const track = (points: GraphPoint[]) =>
+    focused || mode === "overview" ? points : trackEndpoints(points, index)
   if (sourceColumn === targetColumn) {
+    if (mode === "overview") {
+      const direction = Math.sign(end.y - start.y) || 1
+      const upper = direction > 0 ? source : target
+      const lower = direction > 0 ? target : source
+      const middle = (upper.y + upper.height + lower.y) / 2
+      const direct = Array.from({ length: 7 }, (_, lane) => {
+        const y = middle + (lane - 3) * ROUTE_GAP
+        return [start, { x: start.x, y }, { x: end.x, y }, end]
+      })
+      const startStubY = start.y + direction * 22
+      const endStubY = end.y - direction * 22
+      const sideRoutes = [-1, 1].flatMap((side) =>
+        Array.from({ length: 5 }, (_, lane) => {
+          const x =
+            source.x + (side < 0 ? -(32 + lane * ROUTE_GAP) : source.width + 32 + lane * ROUTE_GAP)
+          return [
+            start,
+            { x: start.x, y: startStubY },
+            { x, y: startStubY },
+            { x, y: endStubY },
+            { x: end.x, y: endStubY },
+            end,
+          ]
+        })
+      )
+      return [...direct, ...sideRoutes]
+    }
     const direction = sourceColumn === 2 ? 1 : -1
     const labelClearance = Math.max(72, labelWidth / 2 + 22)
     return Array.from({ length: 5 }, (_, lane) => {
@@ -459,6 +661,27 @@ function routeCandidates(
       : [preferredLane, ...fallbackLanes.filter((lane) => Math.abs(lane - preferredLane) > 1)]
   const adjacent = Math.abs(sourceColumn - targetColumn) === 1
   const direct = lanes.map((x) => track([start, { x, y: start.y }, { x, y: end.y }, end]))
+  if (mode === "overview") {
+    const direction = sourceColumn < targetColumn ? 1 : -1
+    const sourceTrack = Math.round(((start.y - source.y) / source.height) * 10)
+    const targetTrack = Math.round(((end.y - target.y) / target.height) * 10)
+    const startLane = start.x + direction * (22 + sourceTrack * 5)
+    const endLane = end.x - direction * (22 + targetTrack * 5)
+    const channels = overviewLanes.flatMap((center) =>
+      [-28, -14, 0, 14, 28].map((offset) => {
+        const y = center + offset
+        return [
+          start,
+          { x: startLane, y: start.y },
+          { x: startLane, y },
+          { x: endLane, y },
+          { x: endLane, y: end.y },
+          end,
+        ]
+      })
+    )
+    return [...direct, ...channels]
+  }
   if (adjacent) {
     if (focused) return direct
     const direction = sourceColumn < targetColumn ? 1 : -1
@@ -508,6 +731,20 @@ function routeCandidates(
   )
 }
 
+function horizontalOverviewLanes(nodes: Rect[], bounds: Rect): number[] {
+  const rows = [...new Set(nodes.map((node) => node.y))].sort((left, right) => left - right)
+  const lanes = [bounds.y - 48, bounds.y + bounds.height + 48]
+  for (let index = 0; index < rows.length - 1; index += 1) {
+    const upper = rows[index]!
+    const lower = rows[index + 1]!
+    const upperBottom = Math.max(
+      ...nodes.filter((node) => node.y === upper).map((node) => node.y + node.height)
+    )
+    if (lower - upperBottom >= 44) lanes.push((upperBottom + lower) / 2)
+  }
+  return lanes
+}
+
 function assignFocusLanes(
   edges: GraphEdgeInput[],
   nodes: ReadonlyMap<string, Rect>,
@@ -548,10 +785,25 @@ function assignFocusLanes(
     const right = side === 0 ? focus.x : Math.min(...otherRects.map((node) => node.x))
     const available = right - left - NODE_CLEARANCE * 2
     if (available <= 0) continue
-    const step = group.length === 1 ? 0 : Math.min(FOCUS_ROUTE_GAP, available / (group.length - 1))
+    const labelStep = Math.max(...group.map(({ labelWidth }) => labelWidth / 2 + 8))
+    const step =
+      group.length === 1
+        ? 0
+        : Math.min(Math.max(FOCUS_ROUTE_GAP, labelStep), available / (group.length - 1))
     const center = (left + right) / 2
-    group.forEach((edge, index) => {
-      lanes.set(edge.id, center + ((group.length - 1) / 2 - index) * step)
+    const slots = group.map((_, index) => center + (index - (group.length - 1) / 2) * step)
+    const focusCenter = focus.y + focus.height / 2
+    const upper = group.filter((edge) => {
+      const otherId = edge.source === focusId ? edge.target : edge.source
+      const other = nodes.get(otherId)!
+      return other.y + other.height / 2 <= focusCenter
+    })
+    const lower = group.filter((edge) => !upper.includes(edge))
+    upper.forEach((edge, index) => {
+      lanes.set(edge.id, slots[side === 0 ? group.length - 1 - index : index]!)
+    })
+    lower.forEach((edge, index) => {
+      lanes.set(edge.id, slots[side === 0 ? index : group.length - 1 - index]!)
     })
   }
   return lanes
@@ -591,22 +843,25 @@ function routeScore(candidate: GraphPoint[], obstacles: Rect[], used: Segment[])
     )
   )
     return Number.POSITIVE_INFINITY
-  if (segments.some((segment) => used.some((existing) => segmentsOverlap(segment, existing))))
-    return Number.POSITIVE_INFINITY
+  const overlaps = segments.reduce(
+    (total, segment) =>
+      total + used.filter((existing) => segmentsOverlap(segment, existing)).length,
+    0
+  )
   const length = segments.reduce((total, segment) => total + segmentLength(segment), 0)
   const crossings = segments.reduce(
     (total, segment) => total + used.filter((existing) => segmentsCross(segment, existing)).length,
     0
   )
-  return length + Math.max(0, segments.length - 1) * 48 + crossings * 420
+  return length + Math.max(0, segments.length - 1) * 48 + crossings * 420 + overlaps * 10_000
 }
 
-function placeLabel(
+function findLabelPosition(
   segments: Segment[],
   width: number,
   obstacles: Rect[],
   usedLabels: Rect[]
-): GraphPoint {
+): GraphPoint | undefined {
   for (const segment of [...segments].sort(
     (left, right) => segmentLength(right) - segmentLength(left)
   )) {
@@ -634,6 +889,10 @@ function placeLabel(
       return point
     }
   }
+  return undefined
+}
+
+function fallbackLabelPosition(segments: Segment[]): GraphPoint {
   const longest = [...segments].sort((left, right) => segmentLength(right) - segmentLength(left))[0]
   return longest
     ? { x: (longest.a.x + longest.b.x) / 2, y: (longest.a.y + longest.b.y) / 2 }

--- a/packages/atlas/src/pages/ObjectTypeDetail.tsx
+++ b/packages/atlas/src/pages/ObjectTypeDetail.tsx
@@ -20,7 +20,7 @@ import {
 } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { useQuery } from "@tanstack/react-query"
-import { ChevronRight } from "lucide-react"
+import { ChevronRight, Network } from "lucide-react"
 import { Fragment, type ReactNode, useMemo } from "react"
 import { useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { BackNav, LetterAvatar, LoadingState } from "../components/common"
@@ -34,10 +34,29 @@ function isTabValue(value: string | null): value is TabValue {
   return value !== null && (TAB_VALUES as readonly string[]).includes(value)
 }
 
-export function ObjectTypeDetail() {
-  const { typeId } = useParams<{ typeId: string }>()
+interface ObjectTypeDetailProps {
+  objectTypeId?: string
+  embedded?: boolean
+  onSelectType?: (typeId: string) => void
+}
+
+export function ObjectTypeDetail({
+  objectTypeId,
+  embedded = false,
+  onSelectType,
+}: ObjectTypeDetailProps = {}) {
+  const { typeId: routeTypeId } = useParams<{ typeId: string }>()
+  const typeId = objectTypeId ?? routeTypeId
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
+
+  const selectType = (nextTypeId: string) => {
+    if (onSelectType) {
+      onSelectType(nextTypeId)
+    } else {
+      navigate(`/ontology/${nextTypeId}`)
+    }
+  }
 
   const tabParam = searchParams.get("tab")
   const activeTab: TabValue = isTabValue(tabParam) ? tabParam : DEFAULT_TAB
@@ -117,7 +136,18 @@ export function ObjectTypeDetail() {
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6">
-      <BackNav to="/ontology" label="Ontology" />
+      {!embedded ? (
+        <div className="flex items-center justify-between gap-3">
+          <BackNav to="/ontology" label="Ontology" />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => navigate(`/ontology?type=${encodeURIComponent(objectType.id)}`)}
+          >
+            <Network /> Show in graph
+          </Button>
+        </div>
+      ) : null}
 
       {/* Header */}
       <header className="space-y-4">
@@ -143,7 +173,7 @@ export function ObjectTypeDetail() {
                   <Button
                     variant="link"
                     className="h-auto p-0 text-xs"
-                    onClick={() => navigate(`/ontology/${ancestor.id}`)}
+                    onClick={() => selectType(ancestor.id)}
                   >
                     {humanizeIdentifier(ancestor.name || ancestor.id)}
                   </Button>
@@ -166,7 +196,7 @@ export function ObjectTypeDetail() {
                   key={subtype.id}
                   variant="link"
                   className="h-auto p-0 text-xs"
-                  onClick={() => navigate(`/ontology/${subtype.id}`)}
+                  onClick={() => selectType(subtype.id)}
                 >
                   {humanizeIdentifier(subtype.name || subtype.id)}
                 </Button>
@@ -262,7 +292,7 @@ export function ObjectTypeDetail() {
                                   key={targetId}
                                   variant="link"
                                   className="h-auto p-0 font-mono text-xs"
-                                  onClick={() => navigate(`/ontology/${targetId}`)}
+                                  onClick={() => selectType(targetId)}
                                 >
                                   {targetId}
                                 </Button>
@@ -357,10 +387,7 @@ export function ObjectTypeDetail() {
                     <Card key={proj.id} className="space-y-4 p-4">
                       <ProjectionHeader id={proj.id} datasetId={proj.datasetId} />
                       <PropertyMappings entries={Object.entries(proj.properties)} />
-                      <ForeignKeys
-                        links={proj.links}
-                        onSelectType={(id) => navigate(`/ontology/${id}`)}
-                      />
+                      <ForeignKeys links={proj.links} onSelectType={selectType} />
                     </Card>
                   ))}
                 </div>
@@ -383,7 +410,7 @@ export function ObjectTypeDetail() {
                           <Button
                             variant="link"
                             className="h-auto p-0 font-mono text-xs"
-                            onClick={() => navigate(`/ontology/${proj.sourceObjectTypeId}`)}
+                            onClick={() => selectType(proj.sourceObjectTypeId)}
                           >
                             {proj.sourceObjectTypeId}
                           </Button>
@@ -394,7 +421,7 @@ export function ObjectTypeDetail() {
                           <Button
                             variant="link"
                             className="h-auto p-0 font-mono text-xs"
-                            onClick={() => navigate(`/ontology/${proj.targetObjectTypeId}`)}
+                            onClick={() => selectType(proj.targetObjectTypeId)}
                           >
                             {proj.targetObjectTypeId}
                           </Button>

--- a/packages/atlas/src/pages/OntologyExplorer.tsx
+++ b/packages/atlas/src/pages/OntologyExplorer.tsx
@@ -1,30 +1,132 @@
 import type { ListObjectTypesResponse } from "@sixb/client"
 import { listObjectTypesOptions } from "@sixb/client/hooks"
-import { CollectionHeader, Input } from "@sixb/ui/components"
+import { Badge, Button, CollectionViewToggle, Input, ScrollArea } from "@sixb/ui/components"
 import { cn } from "@sixb/ui/lib/utils"
 import { useQuery } from "@tanstack/react-query"
-import { CornerDownRight, Link2, Rows3, Search, Zap } from "lucide-react"
-import { useMemo, useState } from "react"
+import {
+  Background,
+  BackgroundVariant,
+  BaseEdge,
+  Controls,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  type EdgeTypes,
+  getSmoothStepPath,
+  Handle,
+  MarkerType,
+  type Node,
+  type NodeProps,
+  type NodeTypes,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+  useReactFlow,
+  type Edge as XYEdge,
+} from "@xyflow/react"
+import { CornerDownRight, Link2, Rows3, Search, X, Zap } from "lucide-react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { LetterAvatar } from "../components/common"
 import { humanizeIdentifier } from "../lib/labels"
+import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
+import { ObjectTypeDetail } from "./ObjectTypeDetail"
 
 type ObjectTypeSummary = ListObjectTypesResponse[number]
 type PropertySummary = ObjectTypeSummary["properties"][number]
+type LinkCardinality = NonNullable<ObjectTypeSummary["links"][number]["cardinality"]>
+type OntologyCollectionView = "graph" | "list"
+type OntologyView = OntologyCollectionView | "details"
 
 interface OntologyExplorerProps {
-  onSelectType: (typeId: string) => void
+  objectTypeCounts: ReadonlyMap<string, number>
+  selectedTypeId: string | null
+  detailsOpen: boolean
+  onSelectedTypeChange: (typeId: string | null) => void
+  onOpenType: (typeId: string) => void
+  onViewObjects: (typeId: string) => void
+}
+
+interface OntologyNodeData extends Record<string, unknown> {
+  label: string
+  objectCount: number
+  propertyCount: number
+  linkCount: number
+  sourcePorts: OntologyPort[]
+  targetPorts: OntologyPort[]
+  searchMatch: boolean
+  relationshipState: "overview" | "selected" | "connected" | "unrelated"
+}
+
+type OntologyNode = Node<OntologyNodeData, "ontology">
+
+interface OntologyEdgeData extends Record<string, unknown> {
+  relationshipLabel: string
+  cardinality?: LinkCardinality
+  dashed: boolean
+  stepPosition?: number
+}
+
+type OntologyEdge = XYEdge<OntologyEdgeData>
+
+interface OntologyGraphViewport {
+  x: number
+  y: number
+  zoom: number
+}
+
+type OntologyNodePositions = Record<string, { x: number; y: number }>
+
+interface OntologyPort {
+  id: string
+  side: "bottom" | "left" | "right" | "top"
+  offset: number
+}
+
+interface InspectorRelationship {
+  typeId: string
+  typeName: string
+  label: string
+  direction: "incoming" | "outgoing"
+  cardinality?: ObjectTypeSummary["links"][number]["cardinality"]
 }
 
 const PROPERTY_PREVIEW_LIMIT = 4
+const GRAPH_COLUMN_SPACING = 400
+const GRAPH_ROW_SPACING = 144
+const GRAPH_LAYOUT_DURATION = 280
+const GRAPH_PORT_MIN_OFFSET = 22
+const GRAPH_PORT_MAX_OFFSET = 78
+const GRAPH_EDGE_LANE_MIN = 0.28
+const GRAPH_EDGE_LANE_MAX = 0.72
+const ontologyCollectionViewOptions = [
+  { value: "graph", label: "Graph" },
+  { value: "list", label: "List" },
+] as const
+const ontologySelectedViewOptions = [
+  ...ontologyCollectionViewOptions,
+  { value: "details", label: "Details" },
+] as const
 
-export function OntologyExplorer({ onSelectType }: OntologyExplorerProps) {
+export function OntologyExplorer({
+  objectTypeCounts,
+  selectedTypeId,
+  detailsOpen,
+  onSelectedTypeChange,
+  onOpenType,
+  onViewObjects,
+}: OntologyExplorerProps) {
   const [search, setSearch] = useState("")
-
+  const [collectionView, setCollectionView] = useState<OntologyCollectionView>(() =>
+    getCollectionViewStyle("ontology", ["graph", "list"], "graph")
+  )
+  const [graphViewport, setGraphViewport] = useState<OntologyGraphViewport | null>(null)
+  const [graphNodePositions, setGraphNodePositions] = useState<OntologyNodePositions>({})
   const { data: objectTypes = [] } = useQuery(listObjectTypesOptions())
 
   const byId = useMemo(() => {
     const map = new Map<string, ObjectTypeSummary>()
-    for (const t of objectTypes) map.set(t.id, t)
+    for (const type of objectTypes) map.set(type.id, type)
     return map
   }, [objectTypes])
 
@@ -36,53 +138,1166 @@ export function OntologyExplorer({ onSelectType }: OntologyExplorerProps) {
   const filtered = useMemo(() => {
     const query = search.trim().toLowerCase()
     if (!query) return sorted
-    return sorted.filter((t) => matchesType(t, query))
-  }, [sorted, search])
+    return sorted.filter((type) => matchesType(type, query))
+  }, [search, sorted])
+
+  useEffect(() => {
+    if (!selectedTypeId || objectTypes.length === 0 || byId.has(selectedTypeId)) return
+    onSelectedTypeChange(null)
+  }, [byId, objectTypes, onSelectedTypeChange, selectedTypeId])
+
+  useEffect(() => {
+    if (!selectedTypeId || detailsOpen || collectionView !== "graph") return
+    const clearSelection = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onSelectedTypeChange(null)
+    }
+    window.addEventListener("keydown", clearSelection)
+    return () => window.removeEventListener("keydown", clearSelection)
+  }, [collectionView, detailsOpen, onSelectedTypeChange, selectedTypeId])
+
+  const selectedType = selectedTypeId ? (byId.get(selectedTypeId) ?? null) : null
+  const view: OntologyView = detailsOpen && selectedType ? "details" : collectionView
 
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-4">
-      <CollectionHeader
-        title="Ontology"
-        count={objectTypes.length}
-        actions={
-          <div className="relative w-full sm:w-64">
-            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              type="text"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search types..."
-              className="pl-9"
-            />
-          </div>
-        }
-      />
-
-      {/* List */}
-      {objectTypes.length === 0 ? (
-        <div className="rounded-lg border border-border bg-card py-12 text-center text-sm text-muted-foreground">
-          No object types defined.
-        </div>
-      ) : filtered.length === 0 ? (
-        <div className="rounded-lg border border-border bg-card py-12 text-center text-sm text-muted-foreground">
-          No types matching "{search}".
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-lg border border-border bg-card">
-          <ul className="divide-y divide-border">
-            {filtered.map((type) => (
-              <li key={type.id}>
-                <TypeRow
-                  type={type}
-                  parent={type.extends ? (byId.get(type.extends) ?? null) : null}
-                  onSelect={() => onSelectType(type.id)}
-                  onSelectType={onSelectType}
-                />
-              </li>
-            ))}
-          </ul>
-        </div>
+    <div
+      className={cn(
+        "h-[calc(100dvh-3rem)] min-h-0 w-full bg-background md:h-dvh",
+        view === "graph" && selectedType
+          ? "flex flex-col overflow-y-auto min-[900px]:flex-row min-[900px]:overflow-hidden"
+          : "flex flex-col overflow-y-auto lg:overflow-hidden"
       )}
+    >
+      <div
+        className="isolate grid h-full min-h-[680px] min-w-0 flex-1 overflow-hidden lg:min-h-0"
+        style={{ gridTemplateRows: "auto minmax(0, 1fr)" }}
+      >
+        <header className="flex min-w-0 shrink-0 flex-col gap-3 overflow-hidden bg-background px-3 py-3 sm:px-4 lg:px-6 xl:h-16 xl:flex-row xl:items-center xl:justify-between xl:py-0">
+          <div className="flex shrink-0 items-center gap-3">
+            <h1 className="text-lg font-semibold text-foreground">Ontology</h1>
+            <Badge variant="outline" className="text-xs">
+              {objectTypes.length} {objectTypes.length === 1 ? "type" : "types"}
+            </Badge>
+          </div>
+
+          <div className="flex min-w-0 w-full items-center gap-2 xl:w-auto">
+            <CollectionViewToggle
+              value={view}
+              options={selectedType ? ontologySelectedViewOptions : ontologyCollectionViewOptions}
+              onChange={(next) => {
+                if (next === "details") {
+                  if (selectedType) onOpenType(selectedType.id)
+                  return
+                }
+                setCollectionView(next)
+                setCollectionViewStyle("ontology", next)
+                if (detailsOpen && selectedType) onSelectedTypeChange(selectedType.id)
+              }}
+            />
+            {view !== "details" ? (
+              <div className="relative min-w-0 flex-1 xl:w-64 xl:flex-none">
+                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  type="text"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search types, fields, or links..."
+                  className="pl-9"
+                />
+              </div>
+            ) : null}
+          </div>
+        </header>
+
+        {objectTypes.length === 0 ? (
+          <EmptyOntology />
+        ) : (
+          <div className="relative min-h-0 overflow-hidden bg-background">
+            {view === "graph" ? (
+              <ReactFlowProvider>
+                <OntologyGraph
+                  objectTypes={objectTypes}
+                  objectTypeCounts={objectTypeCounts}
+                  search={search}
+                  selectedTypeId={selectedTypeId}
+                  onSelectType={onSelectedTypeChange}
+                  savedViewport={graphViewport}
+                  savedNodePositions={graphNodePositions}
+                  onViewportChange={setGraphViewport}
+                  onNodePositionChange={(nodeId, position) => {
+                    setGraphNodePositions((current) => ({ ...current, [nodeId]: position }))
+                  }}
+                />
+              </ReactFlowProvider>
+            ) : null}
+
+            {view === "list" ? (
+              <div className="absolute inset-0 z-10 overflow-y-auto bg-background p-3 motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150 sm:p-4 lg:p-6">
+                <OntologyList
+                  filtered={filtered}
+                  search={search}
+                  byId={byId}
+                  onSelectType={onOpenType}
+                />
+              </div>
+            ) : null}
+
+            {view === "details" && selectedType ? (
+              <div className="absolute inset-0 z-10 overflow-y-auto bg-background p-3 motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150 sm:p-4 lg:p-6">
+                <ObjectTypeDetail
+                  objectTypeId={selectedType.id}
+                  embedded
+                  onSelectType={onOpenType}
+                />
+              </div>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      {view === "graph" && selectedType ? (
+        <OntologyInspector
+          type={selectedType}
+          objectTypes={objectTypes}
+          objectCount={objectTypeCounts.get(selectedType.id) ?? 0}
+          onClose={() => onSelectedTypeChange(null)}
+          onOpenType={onOpenType}
+          onViewObjects={onViewObjects}
+          onSelectType={onSelectedTypeChange}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function EmptyOntology() {
+  return (
+    <div className="flex min-h-72 flex-1 items-center justify-center text-sm text-muted-foreground">
+      No object types defined.
+    </div>
+  )
+}
+
+function OntologyList({
+  filtered,
+  search,
+  byId,
+  onSelectType,
+}: {
+  filtered: ObjectTypeSummary[]
+  search: string
+  byId: ReadonlyMap<string, ObjectTypeSummary>
+  onSelectType: (typeId: string) => void
+}) {
+  if (filtered.length === 0) {
+    return (
+      <div className="py-12 text-center text-sm text-muted-foreground">
+        No types matching "{search}".
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl overflow-hidden border border-border bg-card">
+      <ul className="divide-y divide-border">
+        {filtered.map((type) => (
+          <li key={type.id}>
+            <TypeRow
+              type={type}
+              parent={type.extends ? (byId.get(type.extends) ?? null) : null}
+              onSelect={() => onSelectType(type.id)}
+              onSelectType={onSelectType}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function OntologyGraph({
+  objectTypes,
+  objectTypeCounts,
+  search,
+  selectedTypeId,
+  onSelectType,
+  savedViewport,
+  savedNodePositions,
+  onViewportChange,
+  onNodePositionChange,
+}: {
+  objectTypes: ObjectTypeSummary[]
+  objectTypeCounts: ReadonlyMap<string, number>
+  search: string
+  selectedTypeId: string | null
+  onSelectType: (typeId: string | null) => void
+  savedViewport: OntologyGraphViewport | null
+  savedNodePositions: OntologyNodePositions
+  onViewportChange: (viewport: OntologyGraphViewport) => void
+  onNodePositionChange: (nodeId: string, position: { x: number; y: number }) => void
+}) {
+  const topology = useMemo(
+    () => buildOntologyTopology(objectTypes, objectTypeCounts),
+    [objectTypeCounts, objectTypes]
+  )
+  const initialGraph = useMemo(() => {
+    const positions = resolveOntologyPositions(topology, selectedTypeId, savedNodePositions)
+    const nodes = topology.nodes.map((node) => ({
+      ...node,
+      position: positions.get(node.id) ?? node.position,
+    }))
+    const edges = topology.edges.map((edge) => orientOntologyEdge(edge, positions))
+    return assignOntologyPorts(nodes, edges, positions, selectedTypeId)
+  }, [savedNodePositions, selectedTypeId, topology])
+  const [nodes, setNodes, onNodesChange] = useNodesState<OntologyNode>(initialGraph.nodes)
+  const [edges, setEdges, onEdgesChange] = useEdgesState<OntologyEdge>(initialGraph.edges)
+  const { fitView, getNodes } = useReactFlow()
+  const nodesRef = useRef(nodes)
+  const layoutFrame = useRef<number | null>(null)
+  const previousLayoutSelection = useRef<string | null>(selectedTypeId)
+  const previousFitSelection = useRef<string | null>(selectedTypeId)
+
+  useEffect(() => {
+    nodesRef.current = nodes
+  }, [nodes])
+
+  useEffect(() => {
+    if (previousFitSelection.current === selectedTypeId) return
+    previousFitSelection.current = selectedTypeId
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const timer = window.setTimeout(
+      () => {
+        void fitView({
+          nodes: getNodes(),
+          padding: 0.14,
+          maxZoom: 1.1,
+          duration: reduceMotion ? 0 : 240,
+        })
+      },
+      reduceMotion ? 0 : GRAPH_LAYOUT_DURATION + 40
+    )
+    return () => window.clearTimeout(timer)
+  }, [fitView, getNodes, selectedTypeId])
+
+  useEffect(() => {
+    const query = search.trim().toLowerCase()
+    const relatedTypeIds = selectedTypeId
+      ? collectRelatedTypeIds(topology.edges, selectedTypeId)
+      : new Set<string>()
+    const searchMatches = new Set(
+      objectTypes.filter((type) => !query || matchesType(type, query)).map((type) => type.id)
+    )
+    const targetPositions = resolveOntologyPositions(topology, selectedTypeId, savedNodePositions)
+    const targetNodesWithoutPorts: OntologyNode[] = topology.nodes.map((node) => {
+      const relationshipState: OntologyNodeData["relationshipState"] = !selectedTypeId
+        ? "overview"
+        : node.id === selectedTypeId
+          ? "selected"
+          : relatedTypeIds.has(node.id)
+            ? "connected"
+            : "unrelated"
+
+      return {
+        ...node,
+        position: targetPositions.get(node.id) ?? node.position,
+        draggable: selectedTypeId === null,
+        selected: relationshipState === "selected",
+        data: {
+          ...node.data,
+          searchMatch: searchMatches.has(node.id),
+          relationshipState,
+        },
+      }
+    })
+    const orientedEdges = topology.edges.map((edge) => orientOntologyEdge(edge, targetPositions))
+    const { nodes: targetNodes, edges: portedEdges } = assignOntologyPorts(
+      targetNodesWithoutPorts,
+      orientedEdges,
+      targetPositions,
+      selectedTypeId
+    )
+    setEdges(
+      portedEdges.map((edge) =>
+        presentOntologyEdge(edge, selectedTypeId, query ? searchMatches : null)
+      )
+    )
+
+    const selectionChanged = previousLayoutSelection.current !== selectedTypeId
+    previousLayoutSelection.current = selectedTypeId
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    if (!selectionChanged || reduceMotion) {
+      nodesRef.current = targetNodes
+      setNodes(targetNodes)
+      return
+    }
+
+    if (layoutFrame.current !== null) window.cancelAnimationFrame(layoutFrame.current)
+    const currentById = new Map(nodesRef.current.map((node) => [node.id, node]))
+    const startPositions = new Map(
+      targetNodes.map((node) => [node.id, currentById.get(node.id)?.position ?? node.position])
+    )
+    const startedAt = window.performance.now()
+
+    const animateLayout = (timestamp: number) => {
+      const progress = Math.min((timestamp - startedAt) / GRAPH_LAYOUT_DURATION, 1)
+      const eased = easeInOutCubic(progress)
+      const nextNodes = targetNodes.map((node) => {
+        const start = startPositions.get(node.id) ?? node.position
+        return {
+          ...node,
+          position: {
+            x: start.x + (node.position.x - start.x) * eased,
+            y: start.y + (node.position.y - start.y) * eased,
+          },
+        }
+      })
+      nodesRef.current = nextNodes
+      setNodes(nextNodes)
+      if (progress < 1) layoutFrame.current = window.requestAnimationFrame(animateLayout)
+      else layoutFrame.current = null
+    }
+
+    layoutFrame.current = window.requestAnimationFrame(animateLayout)
+    return () => {
+      if (layoutFrame.current !== null) window.cancelAnimationFrame(layoutFrame.current)
+      layoutFrame.current = null
+    }
+  }, [objectTypes, savedNodePositions, search, selectedTypeId, setEdges, setNodes, topology])
+
+  return (
+    <div
+      className="relative min-h-[520px] border-b border-border bg-background lg:min-h-0 lg:border-b-0"
+      style={{ width: "100%", height: "100%" }}
+    >
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onInit={(instance) => {
+          if (savedViewport !== null || selectedTypeId === null) return
+          window.setTimeout(() => {
+            const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+            void instance.fitView({
+              nodes: instance.getNodes(),
+              padding: 0.14,
+              maxZoom: 1.1,
+              duration: reduceMotion ? 0 : 240,
+            })
+          }, 120)
+        }}
+        onNodeDragStop={(_event, node) => onNodePositionChange(node.id, node.position)}
+        onMoveEnd={(_event, viewport) => onViewportChange(viewport)}
+        nodeTypes={ontologyNodeTypes}
+        edgeTypes={ontologyEdgeTypes}
+        onNodeClick={(_event, node) => onSelectType(node.id === selectedTypeId ? null : node.id)}
+        onPaneClick={() => onSelectType(null)}
+        defaultViewport={savedViewport ?? undefined}
+        fitView={savedViewport === null && selectedTypeId === null}
+        fitViewOptions={{ padding: 0.1, maxZoom: 1.1 }}
+        minZoom={0.25}
+        maxZoom={1.5}
+        nodesConnectable={false}
+        panOnScroll
+        zoomOnPinch
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background variant={BackgroundVariant.Dots} gap={22} size={1} />
+        <Controls position="bottom-left" showInteractive={false} />
+      </ReactFlow>
+    </div>
+  )
+}
+
+function buildOntologyTopology(
+  objectTypes: ObjectTypeSummary[],
+  objectTypeCounts: ReadonlyMap<string, number>
+): { nodes: OntologyNode[]; edges: OntologyEdge[] } {
+  const typeIds = new Set(objectTypes.map((type) => type.id))
+  const anchorType = mostConnectedType(objectTypes)
+  const anchorTypeId = anchorType?.id ?? objectTypes[0]?.id
+  const leftIds = new Set(
+    anchorType?.links.flatMap((link) =>
+      Array.isArray(link.targetObjectTypeId) ? link.targetObjectTypeId : [link.targetObjectTypeId]
+    ) ?? []
+  )
+  leftIds.delete(anchorTypeId ?? "")
+  const byName = (left: ObjectTypeSummary, right: ObjectTypeSummary) =>
+    displayName(left).localeCompare(displayName(right))
+  const leftTypes = objectTypes.filter((type) => leftIds.has(type.id)).sort(byName)
+  let rightTypes = objectTypes
+    .filter((type) => type.id !== anchorTypeId && !leftIds.has(type.id))
+    .sort(byName)
+  if (leftTypes.length === 0) {
+    const split = Math.floor(rightTypes.length / 2)
+    for (const type of rightTypes.slice(0, split)) leftIds.add(type.id)
+    rightTypes = rightTypes.slice(split)
+  }
+  const resolvedLeftTypes = objectTypes.filter((type) => leftIds.has(type.id)).sort(byName)
+  const rowCount = Math.max(resolvedLeftTypes.length, rightTypes.length, 1)
+  const centerY = ((rowCount - 1) * GRAPH_ROW_SPACING) / 2
+  const positions = new Map<string, { x: number; y: number }>()
+  if (anchorTypeId) positions.set(anchorTypeId, { x: 0, y: centerY })
+  resolvedLeftTypes.forEach((type, index) => {
+    positions.set(type.id, { x: -GRAPH_COLUMN_SPACING, y: index * GRAPH_ROW_SPACING })
+  })
+  rightTypes.forEach((type, index) => {
+    positions.set(type.id, { x: GRAPH_COLUMN_SPACING, y: index * GRAPH_ROW_SPACING })
+  })
+
+  const nodes: OntologyNode[] = objectTypes.map((type) => ({
+    id: type.id,
+    type: "ontology",
+    position: positions.get(type.id) ?? { x: 0, y: 0 },
+    width: 216,
+    height: 82,
+    draggable: true,
+    selected: false,
+    data: {
+      label: displayName(type),
+      objectCount: objectTypeCounts.get(type.id) ?? 0,
+      propertyCount: type.properties.length,
+      linkCount: type.links.length,
+      sourcePorts: [],
+      targetPorts: [],
+      searchMatch: true,
+      relationshipState: "overview",
+    },
+  }))
+
+  const edges: OntologyEdge[] = []
+  for (const type of objectTypes) {
+    if (type.extends && typeIds.has(type.extends)) {
+      edges.push(
+        createOntologyEdge({
+          id: `extends:${type.id}:${type.extends}`,
+          source: type.id,
+          target: type.extends,
+          label: "extends",
+          dashed: true,
+          positions,
+        })
+      )
+    }
+    for (const link of type.links) {
+      const targets = Array.isArray(link.targetObjectTypeId)
+        ? link.targetObjectTypeId
+        : [link.targetObjectTypeId]
+      for (const target of targets) {
+        if (!typeIds.has(target)) continue
+        edges.push(
+          createOntologyEdge({
+            id: `link:${type.id}:${link.id}:${target}`,
+            source: type.id,
+            target,
+            label: humanizeIdentifier(link.name || link.id),
+            cardinality: link.cardinality ?? "many",
+            positions,
+          })
+        )
+      }
+    }
+  }
+  return { nodes, edges }
+}
+
+function resolveOntologyPositions(
+  topology: { nodes: OntologyNode[]; edges: OntologyEdge[] },
+  selectedTypeId: string | null,
+  savedNodePositions: OntologyNodePositions
+): Map<string, { x: number; y: number }> {
+  const overview = new Map(
+    topology.nodes.map((node) => [node.id, savedNodePositions[node.id] ?? node.position])
+  )
+  if (!selectedTypeId) return overview
+
+  const outgoing = new Set<string>()
+  const incoming = new Set<string>()
+  for (const edge of topology.edges) {
+    if (edge.source === selectedTypeId && edge.target !== selectedTypeId) outgoing.add(edge.target)
+    if (edge.target === selectedTypeId && edge.source !== selectedTypeId) incoming.add(edge.source)
+  }
+  for (const typeId of outgoing) incoming.delete(typeId)
+
+  const labels = new Map(topology.nodes.map((node) => [node.id, node.data.label]))
+  const byLabel = (left: string, right: string) =>
+    (labels.get(left) ?? left).localeCompare(labels.get(right) ?? right)
+  const incomingIds = [...incoming].sort(byLabel)
+  const outgoingIds = [...outgoing].sort(byLabel)
+  const unrelatedIds = topology.nodes
+    .map((node) => node.id)
+    .filter((typeId) => typeId !== selectedTypeId && !incoming.has(typeId) && !outgoing.has(typeId))
+    .sort(byLabel)
+  const leftUnrelated: string[] = []
+  const rightUnrelated: string[] = []
+  for (const typeId of unrelatedIds) {
+    const leftCount = incomingIds.length + leftUnrelated.length
+    const rightCount = outgoingIds.length + rightUnrelated.length
+    if (leftCount < rightCount) {
+      leftUnrelated.push(typeId)
+    } else if (rightCount < leftCount) {
+      rightUnrelated.push(typeId)
+    } else if ((overview.get(typeId)?.x ?? 0) < 0) {
+      leftUnrelated.push(typeId)
+    } else {
+      rightUnrelated.push(typeId)
+    }
+  }
+
+  const rowCount = Math.max(
+    incomingIds.length + leftUnrelated.length,
+    outgoingIds.length + rightUnrelated.length,
+    1
+  )
+  const centerY = ((rowCount - 1) * GRAPH_ROW_SPACING) / 2
+  const focused = new Map(overview)
+  focused.set(selectedTypeId, { x: 0, y: centerY })
+
+  const placeColumn = (directIds: string[], mutedIds: string[], x: number) => {
+    const directStart = Math.floor((rowCount - directIds.length) / 2)
+    const occupied = new Set<number>()
+    directIds.forEach((typeId, index) => {
+      const row = directStart + index
+      occupied.add(row)
+      focused.set(typeId, { x, y: row * GRAPH_ROW_SPACING })
+    })
+    const availableRows = Array.from({ length: rowCount }, (_, index) => index).filter(
+      (index) => !occupied.has(index)
+    )
+    mutedIds.forEach((typeId, index) => {
+      focused.set(typeId, { x, y: (availableRows[index] ?? index) * GRAPH_ROW_SPACING })
+    })
+  }
+
+  placeColumn(incomingIds, leftUnrelated, -GRAPH_COLUMN_SPACING)
+  placeColumn(outgoingIds, rightUnrelated, GRAPH_COLUMN_SPACING)
+  return focused
+}
+
+function orientOntologyEdge(
+  edge: OntologyEdge,
+  positions: ReadonlyMap<string, { x: number; y: number }>
+): OntologyEdge {
+  const sourceOnLeft = (positions.get(edge.target)?.x ?? 0) < (positions.get(edge.source)?.x ?? 0)
+  return {
+    ...edge,
+    sourceHandle: sourceOnLeft ? "source-left" : "source-right",
+    targetHandle: sourceOnLeft ? "target-right" : "target-left",
+  }
+}
+
+function assignOntologyPorts(
+  nodes: OntologyNode[],
+  edges: OntologyEdge[],
+  positions: ReadonlyMap<string, { x: number; y: number }>,
+  selectedTypeId: string | null
+): { nodes: OntologyNode[]; edges: OntologyEdge[] } {
+  const edgeGroups = new Map<string, OntologyEdge[]>()
+  for (const edge of edges) {
+    const side = edge.targetHandle === "target-right" ? "right" : "left"
+    const key = `${edge.target}:${side}`
+    const group = edgeGroups.get(key) ?? []
+    group.push(edge)
+    edgeGroups.set(key, group)
+  }
+
+  const targetPortsByNode = new Map<string, OntologyPort[]>()
+  const targetPortedEdges = new Map<string, OntologyEdge>()
+  for (const group of edgeGroups.values()) {
+    group.sort((left, right) => {
+      const verticalDifference =
+        (positions.get(left.source)?.y ?? 0) - (positions.get(right.source)?.y ?? 0)
+      return verticalDifference || left.id.localeCompare(right.id)
+    })
+    const baseSide: OntologyPort["side"] =
+      group[0]?.targetHandle === "target-right" ? "right" : "left"
+    const perimeterCount =
+      group[0]?.target === selectedTypeId && group.length >= 3
+        ? Math.floor((group.length + 1) / 3)
+        : 0
+    const edgesBySide = new Map<OntologyPort["side"], OntologyEdge[]>()
+    group.forEach((edge, index) => {
+      const side: OntologyPort["side"] =
+        index < perimeterCount
+          ? "top"
+          : index >= group.length - perimeterCount
+            ? "bottom"
+            : baseSide
+      const sideEdges = edgesBySide.get(side) ?? []
+      sideEdges.push(edge)
+      edgesBySide.set(side, sideEdges)
+    })
+
+    for (const [side, sideEdges] of edgesBySide) {
+      sideEdges.forEach((edge, index) => {
+        const offset = ontologyPortOffset(side, baseSide, index, sideEdges.length)
+        const id = `target-${side}-${baseSide}-${index}`
+        const ports = targetPortsByNode.get(edge.target) ?? []
+        ports.push({ id, side, offset })
+        targetPortsByNode.set(edge.target, ports)
+
+        const stepPosition =
+          sideEdges.length === 1
+            ? 0.5
+            : GRAPH_EDGE_LANE_MIN +
+              ((GRAPH_EDGE_LANE_MAX - GRAPH_EDGE_LANE_MIN) * index) / (sideEdges.length - 1)
+        targetPortedEdges.set(edge.id, {
+          ...edge,
+          targetHandle: id,
+          data: edge.data ? { ...edge.data, stepPosition } : undefined,
+        })
+      })
+    }
+  }
+
+  const edgesWithTargetPorts = edges.map((edge) => targetPortedEdges.get(edge.id) ?? edge)
+  const sourcePortsByNode = new Map<string, OntologyPort[]>()
+  const sourcePortedEdges = new Map<string, OntologyEdge>()
+  const selectedOutgoingEdges = selectedTypeId
+    ? edgesWithTargetPorts
+        .filter((edge) => edge.source === selectedTypeId && edge.target !== selectedTypeId)
+        .sort((left, right) => {
+          const verticalDifference =
+            (positions.get(left.target)?.y ?? 0) - (positions.get(right.target)?.y ?? 0)
+          return verticalDifference || left.id.localeCompare(right.id)
+        })
+    : []
+
+  if (selectedTypeId && selectedOutgoingEdges.length > 1) {
+    const baseSide: OntologyPort["side"] =
+      selectedOutgoingEdges[0]?.sourceHandle === "source-left" ? "left" : "right"
+    const perimeterCount =
+      selectedOutgoingEdges.length >= 3 ? Math.floor((selectedOutgoingEdges.length + 1) / 3) : 0
+    const edgesBySide = new Map<OntologyPort["side"], OntologyEdge[]>()
+    selectedOutgoingEdges.forEach((edge, index) => {
+      const side: OntologyPort["side"] =
+        index < perimeterCount
+          ? "top"
+          : index >= selectedOutgoingEdges.length - perimeterCount
+            ? "bottom"
+            : baseSide
+      const sideEdges = edgesBySide.get(side) ?? []
+      sideEdges.push(edge)
+      edgesBySide.set(side, sideEdges)
+    })
+
+    for (const [side, sideEdges] of edgesBySide) {
+      sideEdges.forEach((edge, index) => {
+        const offset = ontologyPortOffset(side, baseSide, index, sideEdges.length)
+        const id = `source-${side}-${baseSide}-${index}`
+        const ports = sourcePortsByNode.get(edge.source) ?? []
+        ports.push({ id, side, offset })
+        sourcePortsByNode.set(edge.source, ports)
+
+        const stepPosition =
+          sideEdges.length === 1
+            ? 0.5
+            : GRAPH_EDGE_LANE_MIN +
+              ((GRAPH_EDGE_LANE_MAX - GRAPH_EDGE_LANE_MIN) * index) / (sideEdges.length - 1)
+        sourcePortedEdges.set(edge.id, {
+          ...edge,
+          sourceHandle: id,
+          data: edge.data ? { ...edge.data, stepPosition } : undefined,
+        })
+      })
+    }
+  }
+
+  return {
+    nodes: nodes.map((node) => ({
+      ...node,
+      data: {
+        ...node.data,
+        sourcePorts: sourcePortsByNode.get(node.id) ?? [],
+        targetPorts: targetPortsByNode.get(node.id) ?? [],
+      },
+    })),
+    edges: edgesWithTargetPorts.map((edge) => sourcePortedEdges.get(edge.id) ?? edge),
+  }
+}
+
+function ontologyPortOffset(
+  side: OntologyPort["side"],
+  baseSide: OntologyPort["side"],
+  index: number,
+  count: number
+): number {
+  if (count === 1) return 50
+  const reverse =
+    (side === "top" && baseSide === "left") || (side === "bottom" && baseSide === "right")
+  const orderedIndex = reverse ? count - 1 - index : index
+  return (
+    GRAPH_PORT_MIN_OFFSET +
+    ((GRAPH_PORT_MAX_OFFSET - GRAPH_PORT_MIN_OFFSET) * orderedIndex) / (count - 1)
+  )
+}
+
+function easeInOutCubic(value: number): number {
+  return value < 0.5 ? 4 * value * value * value : 1 - (-2 * value + 2) ** 3 / 2
+}
+
+function createOntologyEdge({
+  id,
+  source,
+  target,
+  label,
+  cardinality,
+  positions,
+  dashed = false,
+}: {
+  id: string
+  source: string
+  target: string
+  label: string
+  cardinality?: LinkCardinality
+  positions: ReadonlyMap<string, { x: number; y: number }>
+  dashed?: boolean
+}): OntologyEdge {
+  const sourceOnLeft = (positions.get(target)?.x ?? 0) < (positions.get(source)?.x ?? 0)
+  return {
+    id,
+    source,
+    target,
+    sourceHandle: sourceOnLeft ? "source-left" : "source-right",
+    targetHandle: sourceOnLeft ? "target-right" : "target-left",
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 14,
+      height: 14,
+      color: "var(--border)",
+    },
+    type: "ontology",
+    style: {
+      stroke: "var(--border)",
+      strokeWidth: 1,
+      strokeDasharray: dashed ? "5 4" : undefined,
+      opacity: 0.8,
+    },
+    data: { relationshipLabel: label, cardinality, dashed },
+  }
+}
+
+function collectRelatedTypeIds(edges: OntologyEdge[], selectedTypeId: string): Set<string> {
+  const related = new Set<string>()
+  for (const edge of edges) {
+    if (edge.source === selectedTypeId) related.add(edge.target)
+    if (edge.target === selectedTypeId) related.add(edge.source)
+  }
+  return related
+}
+
+function relationshipLabel(data: OntologyEdgeData): string {
+  if (!data.cardinality) return data.relationshipLabel
+  const cardinality = data.cardinality === "one" ? "1" : "many"
+  return `${data.relationshipLabel} · ${cardinality}`
+}
+
+function presentOntologyEdge(
+  edge: OntologyEdge,
+  selectedTypeId: string | null,
+  searchMatches: ReadonlySet<string> | null
+): OntologyEdge {
+  const active = selectedTypeId === edge.source || selectedTypeId === edge.target
+  const matchesSearch =
+    !searchMatches || searchMatches.has(edge.source) || searchMatches.has(edge.target)
+  const emphasized = active && matchesSearch
+
+  return {
+    ...edge,
+    label: active && edge.data ? relationshipLabel(edge.data) : undefined,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 14,
+      height: 14,
+      color: emphasized ? "var(--foreground)" : "var(--border)",
+    },
+    style: {
+      ...edge.style,
+      stroke: emphasized ? "var(--foreground)" : "var(--border)",
+      strokeWidth: emphasized ? 1.4 : 1,
+      opacity: !matchesSearch ? 0.08 : selectedTypeId && !active ? 0.1 : 0.8,
+    },
+  }
+}
+
+function OntologyRelationshipEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  label,
+  data,
+}: EdgeProps<OntologyEdge>) {
+  const [path, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    borderRadius: 8,
+    stepPosition: data?.stepPosition,
+  })
+
+  return (
+    <>
+      <BaseEdge id={id} path={path} markerEnd={markerEnd} style={style} interactionWidth={16} />
+      {label ? (
+        <EdgeLabelRenderer>
+          <div
+            className="pointer-events-none absolute whitespace-nowrap rounded-md border border-border/70 bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-700"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      ) : null}
+    </>
+  )
+}
+
+const ontologyEdgeTypes = { ontology: OntologyRelationshipEdge } as unknown as EdgeTypes
+
+function OntologyGraphCard({ data, selected }: NodeProps<OntologyNode>) {
+  return (
+    <div
+      className={cn(
+        "flex h-[82px] w-[216px] cursor-pointer flex-col justify-center rounded-xl bg-card px-3.5 shadow-sm transition-[transform,border-color,box-shadow,opacity] duration-200 hover:-translate-y-0.5 hover:border-foreground/30 hover:shadow-md",
+        selected ? "border-2 border-foreground shadow-md" : "border border-border",
+        data.relationshipState === "connected" && !selected && "border-foreground/20",
+        data.relationshipState === "unrelated" && "opacity-30 hover:opacity-70",
+        !data.searchMatch && "opacity-20 hover:opacity-55"
+      )}
+    >
+      <OntologyHandles ports={data.targetPorts} type="target" />
+      <OntologyHandles ports={data.sourcePorts} type="source" />
+      <Handle
+        type="source"
+        position={Position.Left}
+        id="source-left"
+        className="!size-2 !border-0 !bg-transparent !opacity-0"
+      />
+      <div className="flex min-w-0 items-start gap-2.5">
+        <LetterAvatar label={data.label} size="sm" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-[13px] font-semibold text-foreground">{data.label}</p>
+          <p className="mt-0.5 text-[10px] tabular-nums text-muted-foreground">
+            {countLabel(data.objectCount, "object")}
+          </p>
+          <p className="mt-1 text-[10px] tabular-nums text-muted-foreground">
+            {countLabel(data.propertyCount, "property", "properties")}
+            <span aria-hidden="true" className="px-1.5 text-border">
+              ·
+            </span>
+            {countLabel(data.linkCount, "link")}
+          </p>
+        </div>
+      </div>
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="source-right"
+        className="!size-2 !border-0 !bg-transparent !opacity-0"
+      />
+    </div>
+  )
+}
+
+function OntologyHandles({ ports, type }: { ports: OntologyPort[]; type: "source" | "target" }) {
+  return ports.map((port) => {
+    const position =
+      port.side === "top"
+        ? Position.Top
+        : port.side === "bottom"
+          ? Position.Bottom
+          : port.side === "right"
+            ? Position.Right
+            : Position.Left
+    const style =
+      port.side === "top" || port.side === "bottom"
+        ? { left: `${port.offset}%` }
+        : { top: `${port.offset}%` }
+    return (
+      <Handle
+        key={port.id}
+        type={type}
+        position={position}
+        id={port.id}
+        style={style}
+        className="!size-2 !border-0 !bg-transparent !opacity-0"
+      />
+    )
+  })
+}
+
+const ontologyNodeTypes = { ontology: OntologyGraphCard } as unknown as NodeTypes
+
+function OntologyInspector({
+  type,
+  objectTypes,
+  objectCount,
+  onClose,
+  onOpenType,
+  onViewObjects,
+  onSelectType,
+}: {
+  type: ObjectTypeSummary
+  objectTypes: ObjectTypeSummary[]
+  objectCount: number
+  onClose: () => void
+  onOpenType: (typeId: string) => void
+  onViewObjects: (typeId: string) => void
+  onSelectType: (typeId: string | null) => void
+}) {
+  const byId = new Map(objectTypes.map((candidate) => [candidate.id, candidate]))
+  const outgoing: InspectorRelationship[] = type.links.flatMap((link) => {
+    const targets = Array.isArray(link.targetObjectTypeId)
+      ? link.targetObjectTypeId
+      : [link.targetObjectTypeId]
+    return targets.map((target) => ({
+      typeId: target,
+      typeName: byId.has(target) ? displayName(byId.get(target)!) : humanizeIdentifier(target),
+      label: humanizeIdentifier(link.name || link.id),
+      direction: "outgoing" as const,
+      cardinality: link.cardinality,
+    }))
+  })
+  const incoming: InspectorRelationship[] = objectTypes.flatMap((candidate) =>
+    candidate.links.flatMap((link) => {
+      const targets = Array.isArray(link.targetObjectTypeId)
+        ? link.targetObjectTypeId
+        : [link.targetObjectTypeId]
+      return targets.includes(type.id)
+        ? [
+            {
+              typeId: candidate.id,
+              typeName: displayName(candidate),
+              label: humanizeIdentifier(link.name || link.id),
+              direction: "incoming" as const,
+              cardinality: link.cardinality,
+            },
+          ]
+        : []
+    })
+  )
+  const inheritance: InspectorRelationship[] = []
+  if (type.extends) {
+    const parent = byId.get(type.extends)
+    inheritance.push({
+      typeId: type.extends,
+      typeName: parent ? displayName(parent) : humanizeIdentifier(type.extends),
+      label: "Extends",
+      direction: "outgoing",
+    })
+  }
+  for (const subtype of objectTypes.filter((candidate) => candidate.extends === type.id)) {
+    inheritance.push({
+      typeId: subtype.id,
+      typeName: displayName(subtype),
+      label: "Extended by",
+      direction: "incoming",
+    })
+  }
+  return (
+    <aside className="relative z-20 flex h-full min-h-0 w-full flex-col overflow-hidden border-t border-sidebar-border bg-white dark:bg-sidebar min-[900px]:w-[360px] min-[900px]:shrink-0 min-[900px]:border-l min-[900px]:border-t-0">
+      <ScrollArea className="min-h-0 flex-1 bg-white dark:bg-sidebar">
+        <div className="p-4 lg:p-5">
+          <div className="border-b border-border pb-5">
+            <div className="flex items-start gap-3">
+              <h2 className="min-w-0 flex-1 truncate text-xl font-semibold tracking-tight text-foreground">
+                {displayName(type)}
+              </h2>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={onClose}
+                aria-label="Close object type details"
+                className="-mr-1 -mt-1 shrink-0 text-muted-foreground"
+              >
+                <X />
+              </Button>
+            </div>
+            {type.description ? (
+              <p className="mt-3 text-xs leading-5 text-muted-foreground">{type.description}</p>
+            ) : null}
+          </div>
+
+          <div className="space-y-6 pt-6">
+            <InspectorSection title="Properties" count={type.properties.length}>
+              {type.properties.length > 0 ? (
+                <div className="divide-y divide-border/60">
+                  {type.properties.map((property) => (
+                    <div
+                      key={property.id}
+                      title={property.description ?? undefined}
+                      className="flex min-w-0 items-center gap-2 py-2.5 first:pt-0"
+                    >
+                      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                        <span className="flex min-w-0 items-center">
+                          <code className="min-w-0 truncate font-mono text-[11px] font-medium text-foreground">
+                            {property.id}
+                          </code>
+                          {property.required ? (
+                            <span
+                              aria-label="Required"
+                              title="Required"
+                              className="ml-0.5 shrink-0 text-xs font-semibold leading-none text-destructive"
+                            >
+                              *
+                            </span>
+                          ) : null}
+                        </span>
+                        {property.primary ? (
+                          <Badge
+                            variant="outline"
+                            className="h-4 shrink-0 rounded px-1 py-0 text-[8px] font-semibold"
+                          >
+                            ID
+                          </Badge>
+                        ) : null}
+                        {property.mode === "telemetry" ? (
+                          <Badge
+                            variant="secondary"
+                            className="h-4 shrink-0 rounded px-1 py-0 text-[8px]"
+                          >
+                            Telemetry
+                          </Badge>
+                        ) : null}
+                        {property.nullable ? (
+                          <span className="shrink-0 text-[9px] text-muted-foreground">
+                            Nullable
+                          </span>
+                        ) : null}
+                      </div>
+                      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                        {schemaTypeLabel(property)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground/70">No properties</p>
+              )}
+            </InspectorSection>
+
+            <InspectorSection title="Connected to" count={outgoing.length}>
+              <RelationshipList
+                items={outgoing}
+                emptyLabel="No outgoing links"
+                onSelect={onSelectType}
+              />
+            </InspectorSection>
+
+            <InspectorSection title="Linked from" count={incoming.length}>
+              <RelationshipList
+                items={incoming}
+                emptyLabel="No incoming links"
+                onSelect={onSelectType}
+              />
+            </InspectorSection>
+
+            {inheritance.length > 0 ? (
+              <InspectorSection title="Inheritance" count={inheritance.length}>
+                <RelationshipList items={inheritance} onSelect={onSelectType} />
+              </InspectorSection>
+            ) : null}
+
+            <InspectorSection title="Actions" count={type.actions.length}>
+              {type.actions.length > 0 ? (
+                <div className="divide-y divide-border/60">
+                  {type.actions.map((action) => (
+                    <div key={action.id} className="py-2 text-xs first:pt-0">
+                      {humanizeIdentifier(action.name || action.id)}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground/70">No actions</p>
+              )}
+            </InspectorSection>
+          </div>
+        </div>
+      </ScrollArea>
+
+      <div className="shrink-0 space-y-2 border-t border-sidebar-border bg-white p-4 dark:bg-sidebar lg:p-5">
+        <Button className="w-full" size="sm" onClick={() => onViewObjects(type.id)}>
+          View {countLabel(objectCount, "object")}
+        </Button>
+        <Button
+          variant="outline"
+          className="w-full bg-white dark:bg-sidebar"
+          size="sm"
+          onClick={() => onOpenType(type.id)}
+        >
+          Open details
+        </Button>
+      </div>
+    </aside>
+  )
+}
+
+function InspectorSection({
+  title,
+  count,
+  children,
+}: {
+  title: string
+  count: number
+  children: React.ReactNode
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        <span className="text-xs tabular-nums text-muted-foreground">{count}</span>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function RelationshipList({
+  items,
+  emptyLabel = "No relationships",
+  onSelect,
+}: {
+  items: InspectorRelationship[]
+  emptyLabel?: string
+  onSelect: (typeId: string) => void
+}) {
+  if (items.length === 0) {
+    return <p className="text-xs text-muted-foreground/70">{emptyLabel}</p>
+  }
+  return (
+    <div className="divide-y divide-border/60">
+      {items.map((item, index) => (
+        <button
+          key={`${item.direction}:${item.typeId}:${item.label}:${index}`}
+          type="button"
+          onClick={() => onSelect(item.typeId)}
+          className="group -mx-2 block w-[calc(100%+1rem)] rounded-md px-2 py-2.5 text-left transition-colors first:pt-0 hover:bg-muted focus-visible:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        >
+          <span className="flex min-w-0 items-baseline gap-2">
+            <span className="min-w-0 flex-1 truncate text-xs font-medium leading-4 text-foreground">
+              {item.label}
+            </span>
+            {item.cardinality ? (
+              <span className="shrink-0 font-mono text-[9px] text-muted-foreground">
+                {item.cardinality}
+              </span>
+            ) : null}
+          </span>
+          <span className="mt-0.5 block text-[10px] leading-4 text-muted-foreground">
+            {item.typeName}
+          </span>
+        </button>
+      ))}
     </div>
   )
 }
@@ -116,9 +1331,7 @@ function TypeRow({ type, parent, onSelect, onSelectType }: TypeRowProps) {
       <div className="pt-0.5">
         <LetterAvatar label={name} size="sm" />
       </div>
-
       <div className="flex min-w-0 flex-1 flex-col gap-1">
-        {/* Title line */}
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
           <span className="text-sm font-medium text-foreground">{name}</span>
           {showId ? (
@@ -138,19 +1351,17 @@ function TypeRow({ type, parent, onSelect, onSelectType }: TypeRowProps) {
             </button>
           ) : null}
         </div>
-
-        {/* Description — single line, slightly more present than property preview */}
         {type.description ? (
           <p className="line-clamp-1 text-xs leading-5 text-foreground/75">{type.description}</p>
         ) : null}
-
-        {/* Property preview — primary first, rendered in foreground; rest muted */}
         {preview.length > 0 ? (
           <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 font-mono text-[11px]">
-            {preview.map((prop, index) => (
-              <span key={prop.id} className="flex items-center gap-1.5">
-                <span className={cn(prop.primary ? "text-foreground" : "text-muted-foreground")}>
-                  {prop.id}
+            {preview.map((property, index) => (
+              <span key={property.id} className="flex items-center gap-1.5">
+                <span
+                  className={cn(property.primary ? "text-foreground" : "text-muted-foreground")}
+                >
+                  {property.id}
                 </span>
                 {index < preview.length - 1 ? (
                   <span aria-hidden="true" className="text-border">
@@ -165,8 +1376,6 @@ function TypeRow({ type, parent, onSelect, onSelectType }: TypeRowProps) {
           </div>
         ) : null}
       </div>
-
-      {/* Counts — small icons + numbers, right-aligned baseline */}
       <div className="hidden shrink-0 items-center gap-4 pt-1 text-[11px] tabular-nums text-muted-foreground sm:flex">
         <Metric
           icon={<Rows3 className="size-3.5" />}
@@ -193,15 +1402,35 @@ function Metric({ icon, value, label }: { icon: React.ReactNode; value: number; 
   )
 }
 
-function previewProperties(props: PropertySummary[], limit: number): PropertySummary[] {
-  const primary = props.find((p) => p.primary)
-  const rest = props.filter((p) => p.id !== primary?.id)
-  const ordered = primary ? [primary, ...rest] : rest
-  return ordered.slice(0, limit)
+function previewProperties(properties: PropertySummary[], limit: number): PropertySummary[] {
+  const primary = properties.find((property) => property.primary)
+  const rest = properties.filter((property) => property.id !== primary?.id)
+  return (primary ? [primary, ...rest] : rest).slice(0, limit)
 }
 
-function displayName(t: ObjectTypeSummary): string {
-  return humanizeIdentifier(t.name || t.id)
+function countLabel(value: number, singular: string, plural = `${singular}s`): string {
+  return `${value} ${value === 1 ? singular : plural}`
+}
+
+function schemaTypeLabel(property: PropertySummary): string {
+  return schemaValueLabel(property.schema, property.semanticType)
+}
+
+function schemaValueLabel(schema: unknown, fallback = "unknown"): string {
+  if (typeof schema === "string") return schema
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return fallback
+  }
+  const schemaRecord = schema as Record<string, unknown>
+  if (schemaRecord.type === "valueTypeRef" && typeof schemaRecord.valueTypeId === "string") {
+    return schemaRecord.valueTypeId
+  }
+  if (typeof schemaRecord.type === "string") return schemaRecord.type
+  return fallback
+}
+
+function displayName(type: ObjectTypeSummary): string {
+  return humanizeIdentifier(type.name || type.id)
 }
 
 function isRedundantId(name: string, id: string): boolean {
@@ -212,15 +1441,50 @@ function normalize(value: string): string {
   return value.toLowerCase().replace(/[\s_.-]+/g, "")
 }
 
-function matchesType(t: ObjectTypeSummary, query: string): boolean {
+function matchesType(type: ObjectTypeSummary, query: string): boolean {
   if (
-    t.id.toLowerCase().includes(query) ||
-    t.name.toLowerCase().includes(query) ||
-    (t.description?.toLowerCase().includes(query) ?? false)
+    type.id.toLowerCase().includes(query) ||
+    type.name.toLowerCase().includes(query) ||
+    (type.description?.toLowerCase().includes(query) ?? false)
   ) {
     return true
   }
-  return t.properties.some(
-    (p) => p.id.toLowerCase().includes(query) || p.name.toLowerCase().includes(query)
+  return (
+    type.properties.some(
+      (property) =>
+        property.id.toLowerCase().includes(query) || property.name.toLowerCase().includes(query)
+    ) ||
+    type.links.some((link) =>
+      [
+        link.id,
+        link.name,
+        ...(Array.isArray(link.targetObjectTypeId) ? link.targetObjectTypeId : []),
+      ]
+        .join(" ")
+        .toLowerCase()
+        .includes(query)
+    ) ||
+    type.actions.some(
+      (action) =>
+        action.id.toLowerCase().includes(query) || action.name.toLowerCase().includes(query)
+    )
   )
+}
+
+function mostConnectedType(objectTypes: ObjectTypeSummary[]): ObjectTypeSummary | undefined {
+  const incoming = new Map<string, number>()
+  for (const type of objectTypes) {
+    for (const link of type.links) {
+      const targets = Array.isArray(link.targetObjectTypeId)
+        ? link.targetObjectTypeId
+        : [link.targetObjectTypeId]
+      for (const target of targets) incoming.set(target, (incoming.get(target) ?? 0) + 1)
+    }
+  }
+  return [...objectTypes].sort(
+    (left, right) =>
+      right.links.length +
+      (incoming.get(right.id) ?? 0) -
+      (left.links.length + (incoming.get(left.id) ?? 0))
+  )[0]
 }

--- a/packages/atlas/src/pages/OntologyExplorer.tsx
+++ b/packages/atlas/src/pages/OntologyExplorer.tsx
@@ -29,14 +29,16 @@ import { CornerDownRight, Link2, Rows3, Search, X, Zap } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { LetterAvatar } from "../components/common"
 import { humanizeIdentifier } from "../lib/labels"
-import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
-import { ObjectTypeDetail } from "./ObjectTypeDetail"
 import {
   type GraphHandleLayout,
   type GraphPoint,
   layoutOntologyGraph,
+  layoutOntologyOverviewGraph,
   routeOntologyGraph,
-} from "./ontologyGraphLayout"
+  routeOntologyOverviewGraph,
+} from "../lib/ontologyGraphLayout"
+import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
+import { ObjectTypeDetail } from "./ObjectTypeDetail"
 
 type ObjectTypeSummary = ListObjectTypesResponse[number]
 type PropertySummary = ObjectTypeSummary["properties"][number]
@@ -335,24 +337,32 @@ function OntologyGraph({
     () => buildOntologyTopology(objectTypes, objectTypeCounts),
     [objectTypeCounts, objectTypes]
   )
-  const layout = useMemo(
-    () => layoutOntology(topology, selectedTypeId ?? mostConnectedNodeId(topology) ?? ""),
-    [selectedTypeId, topology]
-  )
+  const layout = useMemo(() => layoutOntology(topology, selectedTypeId), [selectedTypeId, topology])
+  const [hoveredTypeId, setHoveredTypeId] = useState<string | null>(null)
   const [nodes, setNodes, onNodesChange] = useNodesState<OntologyNode>(layout.nodes)
   const [edges, setEdges, onEdgesChange] = useEdgesState<OntologyEdge>(layout.edges)
-  const { fitBounds, getNodes, getZoom, setCenter } = useReactFlow<OntologyNode, OntologyEdge>()
+  const { fitBounds, getNodes } = useReactFlow<OntologyNode, OntologyEdge>()
   const initialSavedViewport = useRef(savedViewport)
   const nodesRef = useRef(nodes)
   const edgesRef = useRef(edges)
   const layoutFrame = useRef<number | null>(null)
   const previousLayoutSelection = useRef<string | null | undefined>(undefined)
   const previousSelection = useRef<string | null | undefined>(undefined)
+  const draggingRef = useRef(false)
+  const presentationRef = useRef({ objectTypes, search, selectedTypeId, hoveredTypeId })
   nodesRef.current = nodes
   edgesRef.current = edges
+  presentationRef.current = { objectTypes, search, selectedTypeId, hoveredTypeId }
 
   useEffect(() => {
-    const target = presentOntologyLayout(layout, objectTypes, search, selectedTypeId)
+    const presentation = presentationRef.current
+    const target = presentOntologyLayout(
+      layout,
+      presentation.objectTypes,
+      presentation.search,
+      presentation.selectedTypeId,
+      presentation.hoveredTypeId
+    )
     const selectionChanged =
       previousLayoutSelection.current !== undefined &&
       previousLayoutSelection.current !== selectedTypeId
@@ -361,6 +371,8 @@ function OntologyGraph({
 
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     if (!selectionChanged || reduceMotion) {
+      nodesRef.current = target.nodes
+      edgesRef.current = target.edges
       setNodes(target.nodes)
       setEdges(target.edges)
       return
@@ -396,7 +408,22 @@ function OntologyGraph({
       if (layoutFrame.current !== null) window.cancelAnimationFrame(layoutFrame.current)
       layoutFrame.current = null
     }
-  }, [layout, objectTypes, search, selectedTypeId, setEdges, setNodes])
+  }, [layout, selectedTypeId, setEdges, setNodes])
+
+  useEffect(() => {
+    const currentLayout = { ...layout, nodes: nodesRef.current, edges: edgesRef.current }
+    const presented = presentOntologyLayout(
+      currentLayout,
+      objectTypes,
+      search,
+      selectedTypeId,
+      hoveredTypeId
+    )
+    nodesRef.current = presented.nodes
+    edgesRef.current = presented.edges
+    setNodes(presented.nodes)
+    setEdges(presented.edges)
+  }, [hoveredTypeId, layout, objectTypes, search, selectedTypeId, setEdges, setNodes])
 
   useEffect(() => {
     const initialView = previousSelection.current === undefined
@@ -409,23 +436,19 @@ function OntologyGraph({
         ? layout.nodes.find((node) => node.id === selectedTypeId)
         : undefined
       if (selectedNode) {
-        void setCenter(
-          selectedNode.position.x + GRAPH_NODE_WIDTH / 2,
-          selectedNode.position.y + GRAPH_NODE_HEIGHT / 2,
-          {
-            zoom: Math.max(getZoom(), 0.95),
-            duration: reduceMotion ? 0 : GRAPH_LAYOUT_DURATION,
-          }
-        )
+        void fitBounds(focusNeighborhoodBounds(layout, selectedNode.id), {
+          padding: 0.14,
+          duration: reduceMotion ? 0 : GRAPH_LAYOUT_DURATION,
+        })
       } else {
         void fitBounds(layout.bounds, {
-          padding: 0.06,
+          padding: 0.08,
           duration: reduceMotion ? 0 : GRAPH_LAYOUT_DURATION,
         })
       }
     }, 80)
     return () => window.clearTimeout(timer)
-  }, [fitBounds, getZoom, layout, selectedTypeId, setCenter])
+  }, [fitBounds, layout, selectedTypeId])
 
   return (
     <div
@@ -438,6 +461,8 @@ function OntologyGraph({
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onNodeDragStart={(_event, node) => {
+          draggingRef.current = true
+          setHoveredTypeId(null)
           setEdges((current) =>
             current.map((edge) =>
               edge.source === node.id || edge.target === node.id
@@ -450,21 +475,32 @@ function OntologyGraph({
           )
         }}
         onNodeDragStop={(_event, node) => {
+          draggingRef.current = false
           const currentNodes = getNodes().map((current) =>
             current.id === node.id ? { ...current, position: node.position } : current
           )
-          const rerouted = routeOntologyAtPositions(
-            topology,
-            currentNodes,
-            selectedTypeId ?? mostConnectedNodeId(topology) ?? ""
+          const rerouted = routeOntologyAtPositions(topology, currentNodes, selectedTypeId)
+          const presented = presentOntologyLayout(
+            rerouted,
+            objectTypes,
+            search,
+            selectedTypeId,
+            hoveredTypeId
           )
-          const presented = presentOntologyLayout(rerouted, objectTypes, search, selectedTypeId)
+          nodesRef.current = presented.nodes
+          edgesRef.current = presented.edges
           setNodes(presented.nodes)
           setEdges(presented.edges)
         }}
         onMoveEnd={(_event, viewport) => onViewportChange(viewport)}
         nodeTypes={ontologyNodeTypes}
         edgeTypes={ontologyEdgeTypes}
+        onNodeMouseEnter={(_event, node) => {
+          if (!selectedTypeId && !draggingRef.current) setHoveredTypeId(node.id)
+        }}
+        onNodeMouseLeave={() => {
+          if (!draggingRef.current) setHoveredTypeId(null)
+        }}
         onNodeClick={(_event, node) => onSelectType(node.id === selectedTypeId ? null : node.id)}
         onPaneClick={() => onSelectType(null)}
         defaultViewport={savedViewport ?? undefined}
@@ -488,53 +524,80 @@ function layoutOntology(
     nodes: OntologyNode[]
     edges: OntologyEdge[]
   },
-  focusId: string
+  focusId: string | null
 ): {
   nodes: OntologyNode[]
   edges: OntologyEdge[]
   bounds: { x: number; y: number; width: number; height: number }
 } {
-  const routed = layoutOntologyGraph(
-    topology.nodes.map((node) => ({ id: node.id, label: node.data.label })),
-    topology.edges.map((edge) => {
-      const label = edge.data ? relationshipLabel(edge.data) : ""
-      return {
-        id: edge.id,
-        source: edge.source,
-        target: edge.target,
-        labelWidth: Math.max(48, label.length * 6.2 + 16),
-      }
-    }),
-    focusId,
-    { nodeWidth: GRAPH_NODE_WIDTH, nodeHeight: GRAPH_NODE_HEIGHT }
-  )
+  const graphNodes = topology.nodes.map((node) => ({ id: node.id, label: node.data.label }))
+  const graphEdges = topology.edges.map((edge) => {
+    const label = edge.data ? relationshipLabel(edge.data) : ""
+    return {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      labelWidth: Math.max(48, label.length * 6.2 + 16),
+    }
+  })
+  const routed = focusId
+    ? layoutOntologyGraph(graphNodes, graphEdges, focusId, {
+        nodeWidth: GRAPH_NODE_WIDTH,
+        nodeHeight: GRAPH_NODE_HEIGHT,
+      })
+    : layoutOntologyOverviewGraph(graphNodes, graphEdges, {
+        nodeWidth: GRAPH_NODE_WIDTH,
+        nodeHeight: GRAPH_NODE_HEIGHT,
+      })
   return applyOntologyRouting(topology, routed)
+}
+
+function focusNeighborhoodBounds(
+  layout: ReturnType<typeof layoutOntology>,
+  focusId: string
+): { x: number; y: number; width: number; height: number } {
+  const visibleIds = new Set([focusId])
+  for (const edge of layout.edges) {
+    if (edge.source === focusId) visibleIds.add(edge.target)
+    if (edge.target === focusId) visibleIds.add(edge.source)
+  }
+  const visibleNodes = layout.nodes.filter((node) => visibleIds.has(node.id))
+  const x = Math.min(...visibleNodes.map((node) => node.position.x))
+  const y = Math.min(...visibleNodes.map((node) => node.position.y))
+  const right = Math.max(...visibleNodes.map((node) => node.position.x + GRAPH_NODE_WIDTH))
+  const bottom = Math.max(...visibleNodes.map((node) => node.position.y + GRAPH_NODE_HEIGHT))
+  return { x, y, width: right - x, height: bottom - y }
 }
 
 function routeOntologyAtPositions(
   topology: { nodes: OntologyNode[]; edges: OntologyEdge[] },
   nodes: OntologyNode[],
-  focusId: string
+  focusId: string | null
 ): ReturnType<typeof layoutOntology> {
   const positions = new Map(nodes.map((node) => [node.id, node.position]))
-  const routed = routeOntologyGraph(
-    topology.nodes.map((node) => ({
-      id: node.id,
-      label: node.data.label,
-      position: positions.get(node.id) ?? node.position,
-    })),
-    topology.edges.map((edge) => {
-      const label = edge.data ? relationshipLabel(edge.data) : ""
-      return {
-        id: edge.id,
-        source: edge.source,
-        target: edge.target,
-        labelWidth: Math.max(48, label.length * 6.2 + 16),
-      }
-    }),
-    focusId,
-    { nodeWidth: GRAPH_NODE_WIDTH, nodeHeight: GRAPH_NODE_HEIGHT }
-  )
+  const graphNodes = topology.nodes.map((node) => ({
+    id: node.id,
+    label: node.data.label,
+    position: positions.get(node.id) ?? node.position,
+  }))
+  const graphEdges = topology.edges.map((edge) => {
+    const label = edge.data ? relationshipLabel(edge.data) : ""
+    return {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      labelWidth: Math.max(48, label.length * 6.2 + 16),
+    }
+  })
+  const routed = focusId
+    ? routeOntologyGraph(graphNodes, graphEdges, focusId, {
+        nodeWidth: GRAPH_NODE_WIDTH,
+        nodeHeight: GRAPH_NODE_HEIGHT,
+      })
+    : routeOntologyOverviewGraph(graphNodes, graphEdges, {
+        nodeWidth: GRAPH_NODE_WIDTH,
+        nodeHeight: GRAPH_NODE_HEIGHT,
+      })
   return applyOntologyRouting(topology, routed)
 }
 
@@ -594,25 +657,29 @@ function presentOntologyLayout(
   layout: ReturnType<typeof layoutOntology>,
   objectTypes: ObjectTypeSummary[],
   search: string,
-  selectedTypeId: string | null
+  selectedTypeId: string | null,
+  hoveredTypeId: string | null = null
 ): { nodes: OntologyNode[]; edges: OntologyEdge[] } {
   const query = search.trim().toLowerCase()
   const searchMatches = new Set(
     objectTypes.filter((type) => !query || matchesType(type, query)).map((type) => type.id)
   )
   const connected = new Set<string>()
-  if (selectedTypeId) {
+  const activeTypeId = selectedTypeId ?? hoveredTypeId
+  if (activeTypeId) {
     for (const edge of layout.edges) {
-      if (edge.source === selectedTypeId) connected.add(edge.target)
-      if (edge.target === selectedTypeId) connected.add(edge.source)
+      if (edge.source === activeTypeId) connected.add(edge.target)
+      if (edge.target === activeTypeId) connected.add(edge.source)
     }
   }
   return {
     nodes: layout.nodes.map((node) => {
-      const relationshipState: OntologyNodeData["relationshipState"] = !selectedTypeId
+      const relationshipState: OntologyNodeData["relationshipState"] = !activeTypeId
         ? "overview"
-        : node.id === selectedTypeId
-          ? "selected"
+        : node.id === activeTypeId
+          ? selectedTypeId
+            ? "selected"
+            : "connected"
           : connected.has(node.id)
             ? "connected"
             : "unrelated"
@@ -627,29 +694,13 @@ function presentOntologyLayout(
       }
     }),
     edges: layout.edges
-      .map((edge) => presentOntologyEdge(edge, selectedTypeId, query ? searchMatches : null))
+      .map((edge) => presentOntologyEdge(edge, activeTypeId, query ? searchMatches : null))
       .sort(
         (left, right) =>
           Number(left.data?.emphasized) - Number(right.data?.emphasized) ||
           left.id.localeCompare(right.id)
       ),
   }
-}
-
-function mostConnectedNodeId(topology: {
-  nodes: OntologyNode[]
-  edges: OntologyEdge[]
-}): string | undefined {
-  const degree = new Map(topology.nodes.map((node) => [node.id, 0]))
-  for (const edge of topology.edges) {
-    degree.set(edge.source, (degree.get(edge.source) ?? 0) + 1)
-    degree.set(edge.target, (degree.get(edge.target) ?? 0) + 1)
-  }
-  return [...topology.nodes].sort(
-    (left, right) =>
-      (degree.get(right.id) ?? 0) - (degree.get(left.id) ?? 0) ||
-      left.data.label.localeCompare(right.data.label)
-  )[0]?.id
 }
 
 function buildOntologyTopology(

--- a/packages/atlas/src/pages/OntologyExplorer.tsx
+++ b/packages/atlas/src/pages/OntologyExplorer.tsx
@@ -31,6 +31,12 @@ import { LetterAvatar } from "../components/common"
 import { humanizeIdentifier } from "../lib/labels"
 import { getCollectionViewStyle, setCollectionViewStyle } from "../lib/userPreferences"
 import { ObjectTypeDetail } from "./ObjectTypeDetail"
+import {
+  type GraphHandleLayout,
+  type GraphPoint,
+  layoutOntologyGraph,
+  routeOntologyGraph,
+} from "./ontologyGraphLayout"
 
 type ObjectTypeSummary = ListObjectTypesResponse[number]
 type PropertySummary = ObjectTypeSummary["properties"][number]
@@ -52,10 +58,10 @@ interface OntologyNodeData extends Record<string, unknown> {
   objectCount: number
   propertyCount: number
   linkCount: number
-  sourcePorts: OntologyPort[]
-  targetPorts: OntologyPort[]
+  sourceHandles: GraphHandleLayout[]
+  targetHandles: GraphHandleLayout[]
   searchMatch: boolean
-  relationshipState: "overview" | "selected" | "connected" | "unrelated"
+  relationshipState: "connected" | "overview" | "selected" | "unrelated"
 }
 
 type OntologyNode = Node<OntologyNodeData, "ontology">
@@ -64,7 +70,12 @@ interface OntologyEdgeData extends Record<string, unknown> {
   relationshipLabel: string
   cardinality?: LinkCardinality
   dashed: boolean
-  stepPosition?: number
+  sections: OntologyEdgeSection[]
+  labelPosition?: { x: number; y: number }
+  emphasized: boolean
+  contextual: boolean
+  muted: boolean
+  preview: boolean
 }
 
 type OntologyEdge = XYEdge<OntologyEdgeData>
@@ -75,12 +86,10 @@ interface OntologyGraphViewport {
   zoom: number
 }
 
-type OntologyNodePositions = Record<string, { x: number; y: number }>
-
-interface OntologyPort {
-  id: string
-  side: "bottom" | "left" | "right" | "top"
-  offset: number
+interface OntologyEdgeSection {
+  startPoint: GraphPoint
+  bendPoints: GraphPoint[]
+  endPoint: GraphPoint
 }
 
 interface InspectorRelationship {
@@ -92,13 +101,9 @@ interface InspectorRelationship {
 }
 
 const PROPERTY_PREVIEW_LIMIT = 4
-const GRAPH_COLUMN_SPACING = 400
-const GRAPH_ROW_SPACING = 144
+const GRAPH_NODE_WIDTH = 216
+const GRAPH_NODE_HEIGHT = 82
 const GRAPH_LAYOUT_DURATION = 280
-const GRAPH_PORT_MIN_OFFSET = 22
-const GRAPH_PORT_MAX_OFFSET = 78
-const GRAPH_EDGE_LANE_MIN = 0.28
-const GRAPH_EDGE_LANE_MAX = 0.72
 const ontologyCollectionViewOptions = [
   { value: "graph", label: "Graph" },
   { value: "list", label: "List" },
@@ -121,7 +126,6 @@ export function OntologyExplorer({
     getCollectionViewStyle("ontology", ["graph", "list"], "graph")
   )
   const [graphViewport, setGraphViewport] = useState<OntologyGraphViewport | null>(null)
-  const [graphNodePositions, setGraphNodePositions] = useState<OntologyNodePositions>({})
   const { data: objectTypes = [] } = useQuery(listObjectTypesOptions())
 
   const byId = useMemo(() => {
@@ -221,11 +225,7 @@ export function OntologyExplorer({
                   selectedTypeId={selectedTypeId}
                   onSelectType={onSelectedTypeChange}
                   savedViewport={graphViewport}
-                  savedNodePositions={graphNodePositions}
                   onViewportChange={setGraphViewport}
-                  onNodePositionChange={(nodeId, position) => {
-                    setGraphNodePositions((current) => ({ ...current, [nodeId]: position }))
-                  }}
                 />
               </ReactFlowProvider>
             ) : null}
@@ -321,9 +321,7 @@ function OntologyGraph({
   selectedTypeId,
   onSelectType,
   savedViewport,
-  savedNodePositions,
   onViewportChange,
-  onNodePositionChange,
 }: {
   objectTypes: ObjectTypeSummary[]
   objectTypeCounts: ReadonlyMap<string, number>
@@ -331,137 +329,103 @@ function OntologyGraph({
   selectedTypeId: string | null
   onSelectType: (typeId: string | null) => void
   savedViewport: OntologyGraphViewport | null
-  savedNodePositions: OntologyNodePositions
   onViewportChange: (viewport: OntologyGraphViewport) => void
-  onNodePositionChange: (nodeId: string, position: { x: number; y: number }) => void
 }) {
   const topology = useMemo(
     () => buildOntologyTopology(objectTypes, objectTypeCounts),
     [objectTypeCounts, objectTypes]
   )
-  const initialGraph = useMemo(() => {
-    const positions = resolveOntologyPositions(topology, selectedTypeId, savedNodePositions)
-    const nodes = topology.nodes.map((node) => ({
-      ...node,
-      position: positions.get(node.id) ?? node.position,
-    }))
-    const edges = topology.edges.map((edge) => orientOntologyEdge(edge, positions))
-    return assignOntologyPorts(nodes, edges, positions, selectedTypeId)
-  }, [savedNodePositions, selectedTypeId, topology])
-  const [nodes, setNodes, onNodesChange] = useNodesState<OntologyNode>(initialGraph.nodes)
-  const [edges, setEdges, onEdgesChange] = useEdgesState<OntologyEdge>(initialGraph.edges)
-  const { fitView, getNodes } = useReactFlow()
+  const layout = useMemo(
+    () => layoutOntology(topology, selectedTypeId ?? mostConnectedNodeId(topology) ?? ""),
+    [selectedTypeId, topology]
+  )
+  const [nodes, setNodes, onNodesChange] = useNodesState<OntologyNode>(layout.nodes)
+  const [edges, setEdges, onEdgesChange] = useEdgesState<OntologyEdge>(layout.edges)
+  const { fitBounds, getNodes, getZoom, setCenter } = useReactFlow<OntologyNode, OntologyEdge>()
+  const initialSavedViewport = useRef(savedViewport)
   const nodesRef = useRef(nodes)
+  const edgesRef = useRef(edges)
   const layoutFrame = useRef<number | null>(null)
-  const previousLayoutSelection = useRef<string | null>(selectedTypeId)
-  const previousFitSelection = useRef<string | null>(selectedTypeId)
+  const previousLayoutSelection = useRef<string | null | undefined>(undefined)
+  const previousSelection = useRef<string | null | undefined>(undefined)
+  nodesRef.current = nodes
+  edgesRef.current = edges
 
   useEffect(() => {
-    nodesRef.current = nodes
-  }, [nodes])
-
-  useEffect(() => {
-    if (previousFitSelection.current === selectedTypeId) return
-    previousFitSelection.current = selectedTypeId
-    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
-    const timer = window.setTimeout(
-      () => {
-        void fitView({
-          nodes: getNodes(),
-          padding: 0.14,
-          maxZoom: 1.1,
-          duration: reduceMotion ? 0 : 240,
-        })
-      },
-      reduceMotion ? 0 : GRAPH_LAYOUT_DURATION + 40
-    )
-    return () => window.clearTimeout(timer)
-  }, [fitView, getNodes, selectedTypeId])
-
-  useEffect(() => {
-    const query = search.trim().toLowerCase()
-    const relatedTypeIds = selectedTypeId
-      ? collectRelatedTypeIds(topology.edges, selectedTypeId)
-      : new Set<string>()
-    const searchMatches = new Set(
-      objectTypes.filter((type) => !query || matchesType(type, query)).map((type) => type.id)
-    )
-    const targetPositions = resolveOntologyPositions(topology, selectedTypeId, savedNodePositions)
-    const targetNodesWithoutPorts: OntologyNode[] = topology.nodes.map((node) => {
-      const relationshipState: OntologyNodeData["relationshipState"] = !selectedTypeId
-        ? "overview"
-        : node.id === selectedTypeId
-          ? "selected"
-          : relatedTypeIds.has(node.id)
-            ? "connected"
-            : "unrelated"
-
-      return {
-        ...node,
-        position: targetPositions.get(node.id) ?? node.position,
-        draggable: selectedTypeId === null,
-        selected: relationshipState === "selected",
-        data: {
-          ...node.data,
-          searchMatch: searchMatches.has(node.id),
-          relationshipState,
-        },
-      }
-    })
-    const orientedEdges = topology.edges.map((edge) => orientOntologyEdge(edge, targetPositions))
-    const { nodes: targetNodes, edges: portedEdges } = assignOntologyPorts(
-      targetNodesWithoutPorts,
-      orientedEdges,
-      targetPositions,
-      selectedTypeId
-    )
-    setEdges(
-      portedEdges.map((edge) =>
-        presentOntologyEdge(edge, selectedTypeId, query ? searchMatches : null)
-      )
-    )
-
-    const selectionChanged = previousLayoutSelection.current !== selectedTypeId
+    const target = presentOntologyLayout(layout, objectTypes, search, selectedTypeId)
+    const selectionChanged =
+      previousLayoutSelection.current !== undefined &&
+      previousLayoutSelection.current !== selectedTypeId
     previousLayoutSelection.current = selectedTypeId
+    if (layoutFrame.current !== null) window.cancelAnimationFrame(layoutFrame.current)
+
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
     if (!selectionChanged || reduceMotion) {
-      nodesRef.current = targetNodes
-      setNodes(targetNodes)
+      setNodes(target.nodes)
+      setEdges(target.edges)
       return
     }
 
-    if (layoutFrame.current !== null) window.cancelAnimationFrame(layoutFrame.current)
-    const currentById = new Map(nodesRef.current.map((node) => [node.id, node]))
-    const startPositions = new Map(
-      targetNodes.map((node) => [node.id, currentById.get(node.id)?.position ?? node.position])
-    )
+    const sourceNodes = new Map(nodesRef.current.map((node) => [node.id, node]))
+    const sourceEdges = new Map(edgesRef.current.map((edge) => [edge.id, edge]))
     const startedAt = window.performance.now()
-
-    const animateLayout = (timestamp: number) => {
+    const animate = (timestamp: number) => {
       const progress = Math.min((timestamp - startedAt) / GRAPH_LAYOUT_DURATION, 1)
       const eased = easeInOutCubic(progress)
-      const nextNodes = targetNodes.map((node) => {
-        const start = startPositions.get(node.id) ?? node.position
-        return {
-          ...node,
-          position: {
-            x: start.x + (node.position.x - start.x) * eased,
-            y: start.y + (node.position.y - start.y) * eased,
-          },
-        }
+      const nextNodes = target.nodes.map((node) => {
+        const source = sourceNodes.get(node.id)
+        return source
+          ? {
+              ...node,
+              position: interpolatePoint(source.position, node.position, eased),
+            }
+          : node
       })
+      const nextEdges = target.edges.map((edge) =>
+        interpolateOntologyEdge(sourceEdges.get(edge.id), edge, eased)
+      )
       nodesRef.current = nextNodes
+      edgesRef.current = nextEdges
       setNodes(nextNodes)
-      if (progress < 1) layoutFrame.current = window.requestAnimationFrame(animateLayout)
+      setEdges(nextEdges)
+      if (progress < 1) layoutFrame.current = window.requestAnimationFrame(animate)
       else layoutFrame.current = null
     }
-
-    layoutFrame.current = window.requestAnimationFrame(animateLayout)
+    layoutFrame.current = window.requestAnimationFrame(animate)
     return () => {
       if (layoutFrame.current !== null) window.cancelAnimationFrame(layoutFrame.current)
       layoutFrame.current = null
     }
-  }, [objectTypes, savedNodePositions, search, selectedTypeId, setEdges, setNodes, topology])
+  }, [layout, objectTypes, search, selectedTypeId, setEdges, setNodes])
+
+  useEffect(() => {
+    const initialView = previousSelection.current === undefined
+    previousSelection.current = selectedTypeId
+    if (initialView && initialSavedViewport.current) return
+
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    const timer = window.setTimeout(() => {
+      const selectedNode = selectedTypeId
+        ? layout.nodes.find((node) => node.id === selectedTypeId)
+        : undefined
+      if (selectedNode) {
+        void setCenter(
+          selectedNode.position.x + GRAPH_NODE_WIDTH / 2,
+          selectedNode.position.y + GRAPH_NODE_HEIGHT / 2,
+          {
+            zoom: Math.max(getZoom(), 0.95),
+            duration: reduceMotion ? 0 : GRAPH_LAYOUT_DURATION,
+          }
+        )
+      } else {
+        void fitBounds(layout.bounds, {
+          padding: 0.06,
+          duration: reduceMotion ? 0 : GRAPH_LAYOUT_DURATION,
+        })
+      }
+    }, 80)
+    return () => window.clearTimeout(timer)
+  }, [fitBounds, getZoom, layout, selectedTypeId, setCenter])
 
   return (
     <div
@@ -473,30 +437,41 @@ function OntologyGraph({
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
-        onInit={(instance) => {
-          if (savedViewport !== null || selectedTypeId === null) return
-          window.setTimeout(() => {
-            const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
-            void instance.fitView({
-              nodes: instance.getNodes(),
-              padding: 0.14,
-              maxZoom: 1.1,
-              duration: reduceMotion ? 0 : 240,
-            })
-          }, 120)
+        onNodeDragStart={(_event, node) => {
+          setEdges((current) =>
+            current.map((edge) =>
+              edge.source === node.id || edge.target === node.id
+                ? {
+                    ...edge,
+                    data: edge.data ? { ...edge.data, preview: true } : undefined,
+                  }
+                : edge
+            )
+          )
         }}
-        onNodeDragStop={(_event, node) => onNodePositionChange(node.id, node.position)}
+        onNodeDragStop={(_event, node) => {
+          const currentNodes = getNodes().map((current) =>
+            current.id === node.id ? { ...current, position: node.position } : current
+          )
+          const rerouted = routeOntologyAtPositions(
+            topology,
+            currentNodes,
+            selectedTypeId ?? mostConnectedNodeId(topology) ?? ""
+          )
+          const presented = presentOntologyLayout(rerouted, objectTypes, search, selectedTypeId)
+          setNodes(presented.nodes)
+          setEdges(presented.edges)
+        }}
         onMoveEnd={(_event, viewport) => onViewportChange(viewport)}
         nodeTypes={ontologyNodeTypes}
         edgeTypes={ontologyEdgeTypes}
         onNodeClick={(_event, node) => onSelectType(node.id === selectedTypeId ? null : node.id)}
         onPaneClick={() => onSelectType(null)}
         defaultViewport={savedViewport ?? undefined}
-        fitView={savedViewport === null && selectedTypeId === null}
-        fitViewOptions={{ padding: 0.1, maxZoom: 1.1 }}
         minZoom={0.25}
         maxZoom={1.5}
         nodesConnectable={false}
+        panOnDrag
         panOnScroll
         zoomOnPinch
         proOptions={{ hideAttribution: true }}
@@ -508,57 +483,195 @@ function OntologyGraph({
   )
 }
 
+function layoutOntology(
+  topology: {
+    nodes: OntologyNode[]
+    edges: OntologyEdge[]
+  },
+  focusId: string
+): {
+  nodes: OntologyNode[]
+  edges: OntologyEdge[]
+  bounds: { x: number; y: number; width: number; height: number }
+} {
+  const routed = layoutOntologyGraph(
+    topology.nodes.map((node) => ({ id: node.id, label: node.data.label })),
+    topology.edges.map((edge) => {
+      const label = edge.data ? relationshipLabel(edge.data) : ""
+      return {
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        labelWidth: Math.max(48, label.length * 6.2 + 16),
+      }
+    }),
+    focusId,
+    { nodeWidth: GRAPH_NODE_WIDTH, nodeHeight: GRAPH_NODE_HEIGHT }
+  )
+  return applyOntologyRouting(topology, routed)
+}
+
+function routeOntologyAtPositions(
+  topology: { nodes: OntologyNode[]; edges: OntologyEdge[] },
+  nodes: OntologyNode[],
+  focusId: string
+): ReturnType<typeof layoutOntology> {
+  const positions = new Map(nodes.map((node) => [node.id, node.position]))
+  const routed = routeOntologyGraph(
+    topology.nodes.map((node) => ({
+      id: node.id,
+      label: node.data.label,
+      position: positions.get(node.id) ?? node.position,
+    })),
+    topology.edges.map((edge) => {
+      const label = edge.data ? relationshipLabel(edge.data) : ""
+      return {
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        labelWidth: Math.max(48, label.length * 6.2 + 16),
+      }
+    }),
+    focusId,
+    { nodeWidth: GRAPH_NODE_WIDTH, nodeHeight: GRAPH_NODE_HEIGHT }
+  )
+  return applyOntologyRouting(topology, routed)
+}
+
+function applyOntologyRouting(
+  topology: { nodes: OntologyNode[]; edges: OntologyEdge[] },
+  routed: ReturnType<typeof layoutOntologyGraph>
+): {
+  nodes: OntologyNode[]
+  edges: OntologyEdge[]
+  bounds: { x: number; y: number; width: number; height: number }
+} {
+  const nodeLayout = new Map(routed.nodes.map((node) => [node.id, node]))
+  const edgeLayout = new Map(routed.edges.map((edge) => [edge.id, edge]))
+
+  return {
+    nodes: topology.nodes.map((node) => {
+      const positioned = nodeLayout.get(node.id)
+      return {
+        ...node,
+        position: positioned?.position ?? node.position,
+        data: {
+          ...node.data,
+          sourceHandles: positioned?.sourceHandles ?? [],
+          targetHandles: positioned?.targetHandles ?? [],
+        },
+      }
+    }),
+    edges: topology.edges.map((edge) => {
+      const routed = edgeLayout.get(edge.id)
+      return {
+        ...edge,
+        sourceHandle: routed?.sourceHandle,
+        targetHandle: routed?.targetHandle,
+        data: edge.data
+          ? {
+              ...edge.data,
+              sections: routed
+                ? [
+                    {
+                      startPoint: routed.points[0]!,
+                      bendPoints: routed.points.slice(1, -1),
+                      endPoint: routed.points.at(-1)!,
+                    },
+                  ]
+                : [],
+              labelPosition: routed?.labelPosition,
+              preview: false,
+            }
+          : undefined,
+      }
+    }),
+    bounds: routed.bounds,
+  }
+}
+
+function presentOntologyLayout(
+  layout: ReturnType<typeof layoutOntology>,
+  objectTypes: ObjectTypeSummary[],
+  search: string,
+  selectedTypeId: string | null
+): { nodes: OntologyNode[]; edges: OntologyEdge[] } {
+  const query = search.trim().toLowerCase()
+  const searchMatches = new Set(
+    objectTypes.filter((type) => !query || matchesType(type, query)).map((type) => type.id)
+  )
+  const connected = new Set<string>()
+  if (selectedTypeId) {
+    for (const edge of layout.edges) {
+      if (edge.source === selectedTypeId) connected.add(edge.target)
+      if (edge.target === selectedTypeId) connected.add(edge.source)
+    }
+  }
+  return {
+    nodes: layout.nodes.map((node) => {
+      const relationshipState: OntologyNodeData["relationshipState"] = !selectedTypeId
+        ? "overview"
+        : node.id === selectedTypeId
+          ? "selected"
+          : connected.has(node.id)
+            ? "connected"
+            : "unrelated"
+      return {
+        ...node,
+        selected: node.id === selectedTypeId,
+        data: {
+          ...node.data,
+          searchMatch: searchMatches.has(node.id),
+          relationshipState,
+        },
+      }
+    }),
+    edges: layout.edges
+      .map((edge) => presentOntologyEdge(edge, selectedTypeId, query ? searchMatches : null))
+      .sort(
+        (left, right) =>
+          Number(left.data?.emphasized) - Number(right.data?.emphasized) ||
+          left.id.localeCompare(right.id)
+      ),
+  }
+}
+
+function mostConnectedNodeId(topology: {
+  nodes: OntologyNode[]
+  edges: OntologyEdge[]
+}): string | undefined {
+  const degree = new Map(topology.nodes.map((node) => [node.id, 0]))
+  for (const edge of topology.edges) {
+    degree.set(edge.source, (degree.get(edge.source) ?? 0) + 1)
+    degree.set(edge.target, (degree.get(edge.target) ?? 0) + 1)
+  }
+  return [...topology.nodes].sort(
+    (left, right) =>
+      (degree.get(right.id) ?? 0) - (degree.get(left.id) ?? 0) ||
+      left.data.label.localeCompare(right.data.label)
+  )[0]?.id
+}
+
 function buildOntologyTopology(
   objectTypes: ObjectTypeSummary[],
   objectTypeCounts: ReadonlyMap<string, number>
 ): { nodes: OntologyNode[]; edges: OntologyEdge[] } {
   const typeIds = new Set(objectTypes.map((type) => type.id))
-  const anchorType = mostConnectedType(objectTypes)
-  const anchorTypeId = anchorType?.id ?? objectTypes[0]?.id
-  const leftIds = new Set(
-    anchorType?.links.flatMap((link) =>
-      Array.isArray(link.targetObjectTypeId) ? link.targetObjectTypeId : [link.targetObjectTypeId]
-    ) ?? []
-  )
-  leftIds.delete(anchorTypeId ?? "")
-  const byName = (left: ObjectTypeSummary, right: ObjectTypeSummary) =>
-    displayName(left).localeCompare(displayName(right))
-  const leftTypes = objectTypes.filter((type) => leftIds.has(type.id)).sort(byName)
-  let rightTypes = objectTypes
-    .filter((type) => type.id !== anchorTypeId && !leftIds.has(type.id))
-    .sort(byName)
-  if (leftTypes.length === 0) {
-    const split = Math.floor(rightTypes.length / 2)
-    for (const type of rightTypes.slice(0, split)) leftIds.add(type.id)
-    rightTypes = rightTypes.slice(split)
-  }
-  const resolvedLeftTypes = objectTypes.filter((type) => leftIds.has(type.id)).sort(byName)
-  const rowCount = Math.max(resolvedLeftTypes.length, rightTypes.length, 1)
-  const centerY = ((rowCount - 1) * GRAPH_ROW_SPACING) / 2
-  const positions = new Map<string, { x: number; y: number }>()
-  if (anchorTypeId) positions.set(anchorTypeId, { x: 0, y: centerY })
-  resolvedLeftTypes.forEach((type, index) => {
-    positions.set(type.id, { x: -GRAPH_COLUMN_SPACING, y: index * GRAPH_ROW_SPACING })
-  })
-  rightTypes.forEach((type, index) => {
-    positions.set(type.id, { x: GRAPH_COLUMN_SPACING, y: index * GRAPH_ROW_SPACING })
-  })
 
   const nodes: OntologyNode[] = objectTypes.map((type) => ({
     id: type.id,
     type: "ontology",
-    position: positions.get(type.id) ?? { x: 0, y: 0 },
-    width: 216,
-    height: 82,
-    draggable: true,
+    position: { x: 0, y: 0 },
+    width: GRAPH_NODE_WIDTH,
+    height: GRAPH_NODE_HEIGHT,
     selected: false,
     data: {
       label: displayName(type),
       objectCount: objectTypeCounts.get(type.id) ?? 0,
       propertyCount: type.properties.length,
       linkCount: type.links.length,
-      sourcePorts: [],
-      targetPorts: [],
+      sourceHandles: [],
+      targetHandles: [],
       searchMatch: true,
       relationshipState: "overview",
     },
@@ -574,7 +687,6 @@ function buildOntologyTopology(
           target: type.extends,
           label: "extends",
           dashed: true,
-          positions,
         })
       )
     }
@@ -591,7 +703,6 @@ function buildOntologyTopology(
             target,
             label: humanizeIdentifier(link.name || link.id),
             cardinality: link.cardinality ?? "many",
-            positions,
           })
         )
       }
@@ -600,248 +711,12 @@ function buildOntologyTopology(
   return { nodes, edges }
 }
 
-function resolveOntologyPositions(
-  topology: { nodes: OntologyNode[]; edges: OntologyEdge[] },
-  selectedTypeId: string | null,
-  savedNodePositions: OntologyNodePositions
-): Map<string, { x: number; y: number }> {
-  const overview = new Map(
-    topology.nodes.map((node) => [node.id, savedNodePositions[node.id] ?? node.position])
-  )
-  if (!selectedTypeId) return overview
-
-  const outgoing = new Set<string>()
-  const incoming = new Set<string>()
-  for (const edge of topology.edges) {
-    if (edge.source === selectedTypeId && edge.target !== selectedTypeId) outgoing.add(edge.target)
-    if (edge.target === selectedTypeId && edge.source !== selectedTypeId) incoming.add(edge.source)
-  }
-  for (const typeId of outgoing) incoming.delete(typeId)
-
-  const labels = new Map(topology.nodes.map((node) => [node.id, node.data.label]))
-  const byLabel = (left: string, right: string) =>
-    (labels.get(left) ?? left).localeCompare(labels.get(right) ?? right)
-  const incomingIds = [...incoming].sort(byLabel)
-  const outgoingIds = [...outgoing].sort(byLabel)
-  const unrelatedIds = topology.nodes
-    .map((node) => node.id)
-    .filter((typeId) => typeId !== selectedTypeId && !incoming.has(typeId) && !outgoing.has(typeId))
-    .sort(byLabel)
-  const leftUnrelated: string[] = []
-  const rightUnrelated: string[] = []
-  for (const typeId of unrelatedIds) {
-    const leftCount = incomingIds.length + leftUnrelated.length
-    const rightCount = outgoingIds.length + rightUnrelated.length
-    if (leftCount < rightCount) {
-      leftUnrelated.push(typeId)
-    } else if (rightCount < leftCount) {
-      rightUnrelated.push(typeId)
-    } else if ((overview.get(typeId)?.x ?? 0) < 0) {
-      leftUnrelated.push(typeId)
-    } else {
-      rightUnrelated.push(typeId)
-    }
-  }
-
-  const rowCount = Math.max(
-    incomingIds.length + leftUnrelated.length,
-    outgoingIds.length + rightUnrelated.length,
-    1
-  )
-  const centerY = ((rowCount - 1) * GRAPH_ROW_SPACING) / 2
-  const focused = new Map(overview)
-  focused.set(selectedTypeId, { x: 0, y: centerY })
-
-  const placeColumn = (directIds: string[], mutedIds: string[], x: number) => {
-    const directStart = Math.floor((rowCount - directIds.length) / 2)
-    const occupied = new Set<number>()
-    directIds.forEach((typeId, index) => {
-      const row = directStart + index
-      occupied.add(row)
-      focused.set(typeId, { x, y: row * GRAPH_ROW_SPACING })
-    })
-    const availableRows = Array.from({ length: rowCount }, (_, index) => index).filter(
-      (index) => !occupied.has(index)
-    )
-    mutedIds.forEach((typeId, index) => {
-      focused.set(typeId, { x, y: (availableRows[index] ?? index) * GRAPH_ROW_SPACING })
-    })
-  }
-
-  placeColumn(incomingIds, leftUnrelated, -GRAPH_COLUMN_SPACING)
-  placeColumn(outgoingIds, rightUnrelated, GRAPH_COLUMN_SPACING)
-  return focused
-}
-
-function orientOntologyEdge(
-  edge: OntologyEdge,
-  positions: ReadonlyMap<string, { x: number; y: number }>
-): OntologyEdge {
-  const sourceOnLeft = (positions.get(edge.target)?.x ?? 0) < (positions.get(edge.source)?.x ?? 0)
-  return {
-    ...edge,
-    sourceHandle: sourceOnLeft ? "source-left" : "source-right",
-    targetHandle: sourceOnLeft ? "target-right" : "target-left",
-  }
-}
-
-function assignOntologyPorts(
-  nodes: OntologyNode[],
-  edges: OntologyEdge[],
-  positions: ReadonlyMap<string, { x: number; y: number }>,
-  selectedTypeId: string | null
-): { nodes: OntologyNode[]; edges: OntologyEdge[] } {
-  const edgeGroups = new Map<string, OntologyEdge[]>()
-  for (const edge of edges) {
-    const side = edge.targetHandle === "target-right" ? "right" : "left"
-    const key = `${edge.target}:${side}`
-    const group = edgeGroups.get(key) ?? []
-    group.push(edge)
-    edgeGroups.set(key, group)
-  }
-
-  const targetPortsByNode = new Map<string, OntologyPort[]>()
-  const targetPortedEdges = new Map<string, OntologyEdge>()
-  for (const group of edgeGroups.values()) {
-    group.sort((left, right) => {
-      const verticalDifference =
-        (positions.get(left.source)?.y ?? 0) - (positions.get(right.source)?.y ?? 0)
-      return verticalDifference || left.id.localeCompare(right.id)
-    })
-    const baseSide: OntologyPort["side"] =
-      group[0]?.targetHandle === "target-right" ? "right" : "left"
-    const perimeterCount =
-      group[0]?.target === selectedTypeId && group.length >= 3
-        ? Math.floor((group.length + 1) / 3)
-        : 0
-    const edgesBySide = new Map<OntologyPort["side"], OntologyEdge[]>()
-    group.forEach((edge, index) => {
-      const side: OntologyPort["side"] =
-        index < perimeterCount
-          ? "top"
-          : index >= group.length - perimeterCount
-            ? "bottom"
-            : baseSide
-      const sideEdges = edgesBySide.get(side) ?? []
-      sideEdges.push(edge)
-      edgesBySide.set(side, sideEdges)
-    })
-
-    for (const [side, sideEdges] of edgesBySide) {
-      sideEdges.forEach((edge, index) => {
-        const offset = ontologyPortOffset(side, baseSide, index, sideEdges.length)
-        const id = `target-${side}-${baseSide}-${index}`
-        const ports = targetPortsByNode.get(edge.target) ?? []
-        ports.push({ id, side, offset })
-        targetPortsByNode.set(edge.target, ports)
-
-        const stepPosition =
-          sideEdges.length === 1
-            ? 0.5
-            : GRAPH_EDGE_LANE_MIN +
-              ((GRAPH_EDGE_LANE_MAX - GRAPH_EDGE_LANE_MIN) * index) / (sideEdges.length - 1)
-        targetPortedEdges.set(edge.id, {
-          ...edge,
-          targetHandle: id,
-          data: edge.data ? { ...edge.data, stepPosition } : undefined,
-        })
-      })
-    }
-  }
-
-  const edgesWithTargetPorts = edges.map((edge) => targetPortedEdges.get(edge.id) ?? edge)
-  const sourcePortsByNode = new Map<string, OntologyPort[]>()
-  const sourcePortedEdges = new Map<string, OntologyEdge>()
-  const selectedOutgoingEdges = selectedTypeId
-    ? edgesWithTargetPorts
-        .filter((edge) => edge.source === selectedTypeId && edge.target !== selectedTypeId)
-        .sort((left, right) => {
-          const verticalDifference =
-            (positions.get(left.target)?.y ?? 0) - (positions.get(right.target)?.y ?? 0)
-          return verticalDifference || left.id.localeCompare(right.id)
-        })
-    : []
-
-  if (selectedTypeId && selectedOutgoingEdges.length > 1) {
-    const baseSide: OntologyPort["side"] =
-      selectedOutgoingEdges[0]?.sourceHandle === "source-left" ? "left" : "right"
-    const perimeterCount =
-      selectedOutgoingEdges.length >= 3 ? Math.floor((selectedOutgoingEdges.length + 1) / 3) : 0
-    const edgesBySide = new Map<OntologyPort["side"], OntologyEdge[]>()
-    selectedOutgoingEdges.forEach((edge, index) => {
-      const side: OntologyPort["side"] =
-        index < perimeterCount
-          ? "top"
-          : index >= selectedOutgoingEdges.length - perimeterCount
-            ? "bottom"
-            : baseSide
-      const sideEdges = edgesBySide.get(side) ?? []
-      sideEdges.push(edge)
-      edgesBySide.set(side, sideEdges)
-    })
-
-    for (const [side, sideEdges] of edgesBySide) {
-      sideEdges.forEach((edge, index) => {
-        const offset = ontologyPortOffset(side, baseSide, index, sideEdges.length)
-        const id = `source-${side}-${baseSide}-${index}`
-        const ports = sourcePortsByNode.get(edge.source) ?? []
-        ports.push({ id, side, offset })
-        sourcePortsByNode.set(edge.source, ports)
-
-        const stepPosition =
-          sideEdges.length === 1
-            ? 0.5
-            : GRAPH_EDGE_LANE_MIN +
-              ((GRAPH_EDGE_LANE_MAX - GRAPH_EDGE_LANE_MIN) * index) / (sideEdges.length - 1)
-        sourcePortedEdges.set(edge.id, {
-          ...edge,
-          sourceHandle: id,
-          data: edge.data ? { ...edge.data, stepPosition } : undefined,
-        })
-      })
-    }
-  }
-
-  return {
-    nodes: nodes.map((node) => ({
-      ...node,
-      data: {
-        ...node.data,
-        sourcePorts: sourcePortsByNode.get(node.id) ?? [],
-        targetPorts: targetPortsByNode.get(node.id) ?? [],
-      },
-    })),
-    edges: edgesWithTargetPorts.map((edge) => sourcePortedEdges.get(edge.id) ?? edge),
-  }
-}
-
-function ontologyPortOffset(
-  side: OntologyPort["side"],
-  baseSide: OntologyPort["side"],
-  index: number,
-  count: number
-): number {
-  if (count === 1) return 50
-  const reverse =
-    (side === "top" && baseSide === "left") || (side === "bottom" && baseSide === "right")
-  const orderedIndex = reverse ? count - 1 - index : index
-  return (
-    GRAPH_PORT_MIN_OFFSET +
-    ((GRAPH_PORT_MAX_OFFSET - GRAPH_PORT_MIN_OFFSET) * orderedIndex) / (count - 1)
-  )
-}
-
-function easeInOutCubic(value: number): number {
-  return value < 0.5 ? 4 * value * value * value : 1 - (-2 * value + 2) ** 3 / 2
-}
-
 function createOntologyEdge({
   id,
   source,
   target,
   label,
   cardinality,
-  positions,
   dashed = false,
 }: {
   id: string
@@ -849,16 +724,12 @@ function createOntologyEdge({
   target: string
   label: string
   cardinality?: LinkCardinality
-  positions: ReadonlyMap<string, { x: number; y: number }>
   dashed?: boolean
 }): OntologyEdge {
-  const sourceOnLeft = (positions.get(target)?.x ?? 0) < (positions.get(source)?.x ?? 0)
   return {
     id,
     source,
     target,
-    sourceHandle: sourceOnLeft ? "source-left" : "source-right",
-    targetHandle: sourceOnLeft ? "target-right" : "target-left",
     markerEnd: {
       type: MarkerType.ArrowClosed,
       width: 14,
@@ -872,17 +743,17 @@ function createOntologyEdge({
       strokeDasharray: dashed ? "5 4" : undefined,
       opacity: 0.8,
     },
-    data: { relationshipLabel: label, cardinality, dashed },
+    data: {
+      relationshipLabel: label,
+      cardinality,
+      dashed,
+      sections: [],
+      emphasized: false,
+      contextual: false,
+      muted: false,
+      preview: false,
+    },
   }
-}
-
-function collectRelatedTypeIds(edges: OntologyEdge[], selectedTypeId: string): Set<string> {
-  const related = new Set<string>()
-  for (const edge of edges) {
-    if (edge.source === selectedTypeId) related.add(edge.target)
-    if (edge.target === selectedTypeId) related.add(edge.source)
-  }
-  return related
 }
 
 function relationshipLabel(data: OntologyEdgeData): string {
@@ -900,21 +771,24 @@ function presentOntologyEdge(
   const matchesSearch =
     !searchMatches || searchMatches.has(edge.source) || searchMatches.has(edge.target)
   const emphasized = active && matchesSearch
+  const contextual = Boolean(selectedTypeId && !active && matchesSearch)
 
   return {
     ...edge,
-    label: active && edge.data ? relationshipLabel(edge.data) : undefined,
+    label: edge.data ? relationshipLabel(edge.data) : undefined,
+    data: edge.data ? { ...edge.data, emphasized, contextual, muted: !matchesSearch } : undefined,
     markerEnd: {
       type: MarkerType.ArrowClosed,
       width: 14,
       height: 14,
-      color: emphasized ? "var(--foreground)" : "var(--border)",
+      color: emphasized ? "var(--foreground)" : "var(--muted-foreground)",
     },
     style: {
       ...edge.style,
-      stroke: emphasized ? "var(--foreground)" : "var(--border)",
-      strokeWidth: emphasized ? 1.4 : 1,
-      opacity: !matchesSearch ? 0.08 : selectedTypeId && !active ? 0.1 : 0.8,
+      stroke: emphasized ? "var(--foreground)" : "var(--muted-foreground)",
+      strokeWidth: emphasized ? 1.5 : 1.1,
+      opacity: !matchesSearch ? 0.08 : contextual ? 0.3 : 0.78,
+      transition: "opacity 180ms ease, stroke 180ms ease, stroke-width 180ms ease",
     },
   }
 }
@@ -932,25 +806,51 @@ function OntologyRelationshipEdge({
   label,
   data,
 }: EdgeProps<OntologyEdge>) {
-  const [path, labelX, labelY] = getSmoothStepPath({
+  const [previewPath, previewLabelX, previewLabelY] = getSmoothStepPath({
     sourceX,
     sourceY,
+    sourcePosition,
     targetX,
     targetY,
-    sourcePosition,
     targetPosition,
     borderRadius: 8,
-    stepPosition: data?.stepPosition,
+    offset: 18,
   })
+  const path = data?.preview
+    ? previewPath
+    : data?.sections.length
+      ? data.sections.map((section) => roundedOrthogonalPath(section)).join(" ")
+      : `M ${sourceX} ${sourceY} L ${targetX} ${targetY}`
+  const labelX = data?.preview ? previewLabelX : (data?.labelPosition?.x ?? (sourceX + targetX) / 2)
+  const labelY = data?.preview ? previewLabelY : (data?.labelPosition?.y ?? (sourceY + targetY) / 2)
 
   return (
     <>
+      {data?.emphasized ? (
+        <BaseEdge
+          id={`${id}-casing`}
+          path={path}
+          style={{
+            stroke: "var(--background)",
+            strokeWidth: 6,
+            strokeDasharray: undefined,
+            opacity: 0.96,
+          }}
+          interactionWidth={0}
+        />
+      ) : null}
       <BaseEdge id={id} path={path} markerEnd={markerEnd} style={style} interactionWidth={16} />
       {label ? (
         <EdgeLabelRenderer>
           <div
-            className="pointer-events-none absolute whitespace-nowrap rounded-md border border-border/70 bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-700"
+            className={cn(
+              "pointer-events-none absolute whitespace-nowrap rounded-md border bg-white px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-opacity",
+              data?.emphasized ? "border-neutral-400" : "border-neutral-200",
+              data?.contextual && "opacity-35",
+              data?.muted && "opacity-10"
+            )}
             style={{
+              zIndex: 20,
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
             }}
           >
@@ -962,6 +862,116 @@ function OntologyRelationshipEdge({
   )
 }
 
+function interpolateOntologyEdge(
+  source: OntologyEdge | undefined,
+  target: OntologyEdge,
+  progress: number
+): OntologyEdge {
+  const sourceSection = source?.data?.sections[0]
+  const targetSection = target.data?.sections[0]
+  if (!sourceSection || !targetSection || !target.data) return target
+
+  const sourcePoints = [
+    sourceSection.startPoint,
+    ...sourceSection.bendPoints,
+    sourceSection.endPoint,
+  ]
+  const targetPoints = [
+    targetSection.startPoint,
+    ...targetSection.bendPoints,
+    targetSection.endPoint,
+  ]
+  const pointCount = Math.max(sourcePoints.length, targetPoints.length)
+  const from = resamplePolyline(sourcePoints, pointCount)
+  const to = resamplePolyline(targetPoints, pointCount)
+  const points = from.map((point, index) => interpolatePoint(point, to[index]!, progress))
+  const sourceLabel = source?.data?.labelPosition ?? target.data.labelPosition
+  const targetLabel = target.data.labelPosition
+
+  return {
+    ...target,
+    data: {
+      ...target.data,
+      sections: [
+        {
+          startPoint: points[0]!,
+          bendPoints: points.slice(1, -1),
+          endPoint: points.at(-1)!,
+        },
+      ],
+      labelPosition:
+        sourceLabel && targetLabel
+          ? interpolatePoint(sourceLabel, targetLabel, progress)
+          : targetLabel,
+    },
+  }
+}
+
+function resamplePolyline(points: GraphPoint[], count: number): GraphPoint[] {
+  if (points.length === count) return points
+  const lengths = points
+    .slice(1)
+    .map((point, index) => Math.hypot(point.x - points[index]!.x, point.y - points[index]!.y))
+  const total = lengths.reduce((sum, length) => sum + length, 0)
+  if (total === 0) return Array.from({ length: count }, () => points[0]!)
+
+  return Array.from({ length: count }, (_, index) => {
+    const distance = (total * index) / (count - 1)
+    let traversed = 0
+    for (let segment = 0; segment < lengths.length; segment += 1) {
+      const length = lengths[segment]!
+      if (traversed + length < distance) {
+        traversed += length
+        continue
+      }
+      const progress = length === 0 ? 0 : (distance - traversed) / length
+      return interpolatePoint(points[segment]!, points[segment + 1]!, progress)
+    }
+    return points.at(-1)!
+  })
+}
+
+function interpolatePoint(from: GraphPoint, to: GraphPoint, progress: number): GraphPoint {
+  return {
+    x: from.x + (to.x - from.x) * progress,
+    y: from.y + (to.y - from.y) * progress,
+  }
+}
+
+function easeInOutCubic(value: number): number {
+  return value < 0.5 ? 4 * value ** 3 : 1 - (-2 * value + 2) ** 3 / 2
+}
+
+function roundedOrthogonalPath(section: OntologyEdgeSection): string {
+  const points = [section.startPoint, ...section.bendPoints, section.endPoint]
+  if (points.length < 3) {
+    return `M ${points[0]?.x ?? 0} ${points[0]?.y ?? 0} L ${points[1]?.x ?? 0} ${points[1]?.y ?? 0}`
+  }
+
+  let path = `M ${points[0]!.x} ${points[0]!.y}`
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const previous = points[index - 1]!
+    const corner = points[index]!
+    const next = points[index + 1]!
+    const incoming = Math.hypot(corner.x - previous.x, corner.y - previous.y)
+    const outgoing = Math.hypot(next.x - corner.x, next.y - corner.y)
+    const radius = Math.min(8, incoming / 2, outgoing / 2)
+    const before = moveToward(corner, previous, radius)
+    const after = moveToward(corner, next, radius)
+    path += ` L ${before.x} ${before.y} Q ${corner.x} ${corner.y} ${after.x} ${after.y}`
+  }
+  const end = points.at(-1)!
+  return `${path} L ${end.x} ${end.y}`
+}
+
+function moveToward(from: GraphPoint, to: GraphPoint, distance: number): GraphPoint {
+  const length = Math.hypot(to.x - from.x, to.y - from.y) || 1
+  return {
+    x: from.x + ((to.x - from.x) / length) * distance,
+    y: from.y + ((to.y - from.y) / length) * distance,
+  }
+}
+
 const ontologyEdgeTypes = { ontology: OntologyRelationshipEdge } as unknown as EdgeTypes
 
 function OntologyGraphCard({ data, selected }: NodeProps<OntologyNode>) {
@@ -970,19 +980,12 @@ function OntologyGraphCard({ data, selected }: NodeProps<OntologyNode>) {
       className={cn(
         "flex h-[82px] w-[216px] cursor-pointer flex-col justify-center rounded-xl bg-card px-3.5 shadow-sm transition-[transform,border-color,box-shadow,opacity] duration-200 hover:-translate-y-0.5 hover:border-foreground/30 hover:shadow-md",
         selected ? "border-2 border-foreground shadow-md" : "border border-border",
-        data.relationshipState === "connected" && !selected && "border-foreground/20",
-        data.relationshipState === "unrelated" && "opacity-30 hover:opacity-70",
+        data.relationshipState === "unrelated" && "opacity-55 hover:opacity-85",
         !data.searchMatch && "opacity-20 hover:opacity-55"
       )}
     >
-      <OntologyHandles ports={data.targetPorts} type="target" />
-      <OntologyHandles ports={data.sourcePorts} type="source" />
-      <Handle
-        type="source"
-        position={Position.Left}
-        id="source-left"
-        className="!size-2 !border-0 !bg-transparent !opacity-0"
-      />
+      <OntologyHandles handles={data.targetHandles} type="target" />
+      <OntologyHandles handles={data.sourceHandles} type="source" />
       <div className="flex min-w-0 items-start gap-2.5">
         <LetterAvatar label={data.label} size="sm" />
         <div className="min-w-0 flex-1">
@@ -999,37 +1002,34 @@ function OntologyGraphCard({ data, selected }: NodeProps<OntologyNode>) {
           </p>
         </div>
       </div>
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="source-right"
-        className="!size-2 !border-0 !bg-transparent !opacity-0"
-      />
     </div>
   )
 }
 
-function OntologyHandles({ ports, type }: { ports: OntologyPort[]; type: "source" | "target" }) {
-  return ports.map((port) => {
+function OntologyHandles({
+  handles,
+  type,
+}: {
+  handles: GraphHandleLayout[]
+  type: "source" | "target"
+}) {
+  return handles.map((handle) => {
     const position =
-      port.side === "top"
+      handle.side === "top"
         ? Position.Top
-        : port.side === "bottom"
+        : handle.side === "bottom"
           ? Position.Bottom
-          : port.side === "right"
+          : handle.side === "right"
             ? Position.Right
             : Position.Left
-    const style =
-      port.side === "top" || port.side === "bottom"
-        ? { left: `${port.offset}%` }
-        : { top: `${port.offset}%` }
+    const vertical = handle.side === "left" || handle.side === "right"
     return (
       <Handle
-        key={port.id}
+        key={handle.id}
         type={type}
         position={position}
-        id={port.id}
-        style={style}
+        id={handle.id}
+        style={vertical ? { top: `${handle.offset}%` } : { left: `${handle.offset}%` }}
         className="!size-2 !border-0 !bg-transparent !opacity-0"
       />
     )
@@ -1469,22 +1469,4 @@ function matchesType(type: ObjectTypeSummary, query: string): boolean {
         action.id.toLowerCase().includes(query) || action.name.toLowerCase().includes(query)
     )
   )
-}
-
-function mostConnectedType(objectTypes: ObjectTypeSummary[]): ObjectTypeSummary | undefined {
-  const incoming = new Map<string, number>()
-  for (const type of objectTypes) {
-    for (const link of type.links) {
-      const targets = Array.isArray(link.targetObjectTypeId)
-        ? link.targetObjectTypeId
-        : [link.targetObjectTypeId]
-      for (const target of targets) incoming.set(target, (incoming.get(target) ?? 0) + 1)
-    }
-  }
-  return [...objectTypes].sort(
-    (left, right) =>
-      right.links.length +
-      (incoming.get(right.id) ?? 0) -
-      (left.links.length + (incoming.get(left.id) ?? 0))
-  )[0]
 }

--- a/packages/atlas/src/pages/ProjectWorkspace.tsx
+++ b/packages/atlas/src/pages/ProjectWorkspace.tsx
@@ -55,7 +55,6 @@ import {
   DatasetsPage,
   LogsPage,
   ObjectDetailPage,
-  ObjectTypeDetail,
   OntologyExplorer,
   PipelineDetailPage,
   PipelinesPage,
@@ -88,6 +87,45 @@ export function ProjectWorkspace() {
   const [objectSortBy, setObjectSortBy] = useState<ObjectSortPreference>(getObjectSortPreference)
   const [searchParams, setSearchParams] = useSearchParams()
   const classFilter = searchParams.get("class") || null
+  const selectedOntologyTypeId = location.pathname === "/ontology" ? searchParams.get("type") : null
+  const ontologyDetailsOpen =
+    location.pathname === "/ontology" &&
+    selectedOntologyTypeId !== null &&
+    searchParams.get("view") === "details"
+
+  const setOntologyState = useCallback(
+    (typeId: string | null, details: boolean, options?: { replace?: boolean }) => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev)
+          if (typeId) {
+            params.set("type", typeId)
+          } else {
+            params.delete("type")
+          }
+          if (typeId && details) {
+            params.set("view", "details")
+          } else {
+            params.delete("view")
+          }
+          if (!typeId) params.delete("tab")
+          return params
+        },
+        { replace: options?.replace ?? true }
+      )
+    },
+    [setSearchParams]
+  )
+
+  const setSelectedOntologyTypeId = useCallback(
+    (typeId: string | null) => setOntologyState(typeId, false),
+    [setOntologyState]
+  )
+
+  const openOntologyTypeDetails = useCallback(
+    (typeId: string) => setOntologyState(typeId, true, { replace: false }),
+    [setOntologyState]
+  )
 
   const setClassFilter = useCallback(
     (next: string | null, options?: { replace?: boolean }) => {
@@ -348,8 +386,17 @@ export function ProjectWorkspace() {
     )
   }
 
+  const ontologyWorkspace = location.pathname === "/ontology"
   const constrained = (children: ReactNode) => (
-    <div className={cn("mx-auto w-full max-w-7xl min-w-0 p-3 sm:p-4 lg:p-6")}>{children}</div>
+    <div
+      className={cn(
+        ontologyWorkspace
+          ? "h-full min-h-0 w-full"
+          : "mx-auto w-full max-w-7xl min-w-0 p-3 sm:p-4 lg:p-6"
+      )}
+    >
+      {children}
+    </div>
   )
 
   // BrowserRouter transitions keep the current route visible while an intent-preloaded chunk
@@ -440,11 +487,18 @@ export function ProjectWorkspace() {
                 path="ontology"
                 element={
                   <OntologyExplorer
-                    onSelectType={(typeId) => navigate(toProjectPath(`ontology/${typeId}`))}
+                    objectTypeCounts={objectTypeCounts}
+                    selectedTypeId={selectedOntologyTypeId}
+                    detailsOpen={ontologyDetailsOpen}
+                    onSelectedTypeChange={setSelectedOntologyTypeId}
+                    onOpenType={openOntologyTypeDetails}
+                    onViewObjects={(typeId) => {
+                      navigate(toProjectPath(`?class=${encodeURIComponent(typeId)}`))
+                    }}
                   />
                 }
               />
-              <Route path="ontology/:typeId" element={<ObjectTypeDetail />} />
+              <Route path="ontology/:typeId" element={<OntologyTypeRedirect />} />
               <Route
                 path=":objectId"
                 element={
@@ -458,6 +512,13 @@ export function ProjectWorkspace() {
       </Routes>
     </Suspense>
   )
+}
+
+function OntologyTypeRedirect() {
+  const { typeId } = useParams<{ typeId: string }>()
+  if (!typeId) return <Navigate to="/ontology" replace />
+  const params = new URLSearchParams({ type: typeId, view: "details" })
+  return <Navigate to={`/ontology?${params.toString()}`} replace />
 }
 
 function RunsTabRedirect() {

--- a/packages/atlas/src/pages/ontologyGraphLayout.ts
+++ b/packages/atlas/src/pages/ontologyGraphLayout.ts
@@ -1,0 +1,745 @@
+export interface GraphPoint {
+  x: number
+  y: number
+}
+
+export interface GraphNodeInput {
+  id: string
+  label: string
+}
+
+export interface GraphPositionedNodeInput extends GraphNodeInput {
+  position: GraphPoint
+}
+
+export interface GraphEdgeInput {
+  id: string
+  source: string
+  target: string
+  labelWidth: number
+}
+
+export type GraphHandleSide = "bottom" | "left" | "right" | "top"
+
+export interface GraphHandleLayout {
+  id: string
+  offset: number
+  side: GraphHandleSide
+}
+
+export interface GraphNodeLayout {
+  id: string
+  position: GraphPoint
+  sourceHandles: GraphHandleLayout[]
+  targetHandles: GraphHandleLayout[]
+}
+
+export interface GraphEdgeLayout {
+  id: string
+  sourceHandle: string
+  targetHandle: string
+  points: GraphPoint[]
+  labelPosition: GraphPoint
+}
+
+interface GraphLayoutOptions {
+  nodeWidth: number
+  nodeHeight: number
+  columnGap?: number
+  rowGap?: number
+}
+
+interface Rect extends GraphPoint {
+  width: number
+  height: number
+}
+
+interface Segment {
+  a: GraphPoint
+  b: GraphPoint
+}
+
+interface EdgeHandles {
+  source: GraphHandleLayout
+  target: GraphHandleLayout
+}
+
+const PORT_MIN = 18
+const PORT_MAX = 82
+const ROUTE_GAP = 14
+const FOCUS_ROUTE_GAP = 32
+const NODE_CLEARANCE = 14
+
+export function layoutOntologyGraph(
+  nodes: GraphNodeInput[],
+  edges: GraphEdgeInput[],
+  focusId: string,
+  { nodeWidth, nodeHeight, columnGap = 260, rowGap = 70 }: GraphLayoutOptions
+): { nodes: GraphNodeLayout[]; edges: GraphEdgeLayout[]; bounds: Rect } {
+  const columns = partitionNodes(nodes, edges, focusId)
+  orderColumns(columns, edges)
+
+  const rowPitch = nodeHeight + rowGap
+  const columnPitch = nodeWidth + columnGap
+  const rowCount = Math.max(...columns.map((column) => column.length), 1)
+  const positions = new Map<string, GraphPoint>()
+  const columnById = new Map<string, number>()
+
+  columns.forEach((column, columnIndex) => {
+    const start = ((rowCount - column.length) * rowPitch) / 2
+    column.forEach((nodeId, rowIndex) => {
+      positions.set(nodeId, { x: columnIndex * columnPitch, y: start + rowIndex * rowPitch })
+      columnById.set(nodeId, columnIndex)
+    })
+  })
+
+  return routePositionedGraph(
+    nodes,
+    edges,
+    focusId,
+    { nodeWidth, nodeHeight },
+    positions,
+    columnById
+  )
+}
+
+export function routeOntologyGraph(
+  nodes: GraphPositionedNodeInput[],
+  edges: GraphEdgeInput[],
+  focusId: string,
+  { nodeWidth, nodeHeight }: GraphLayoutOptions
+): { nodes: GraphNodeLayout[]; edges: GraphEdgeLayout[]; bounds: Rect } {
+  const positions = new Map(nodes.map((node) => [node.id, node.position]))
+  const focus = positions.get(focusId) ?? nodes[0]?.position ?? { x: 0, y: 0 }
+  const focusCenter = focus.x + nodeWidth / 2
+  const columnById = new Map(
+    nodes.map((node) => {
+      const center = node.position.x + nodeWidth / 2
+      const column =
+        center < focusCenter - nodeWidth / 2 ? 0 : center > focusCenter + nodeWidth / 2 ? 2 : 1
+      return [node.id, column]
+    })
+  )
+  columnById.set(focusId, 1)
+
+  return routePositionedGraph(
+    nodes,
+    edges,
+    focusId,
+    { nodeWidth, nodeHeight },
+    positions,
+    columnById
+  )
+}
+
+function routePositionedGraph(
+  nodes: GraphNodeInput[],
+  edges: GraphEdgeInput[],
+  focusId: string,
+  { nodeWidth, nodeHeight }: Pick<GraphLayoutOptions, "nodeWidth" | "nodeHeight">,
+  positions: ReadonlyMap<string, GraphPoint>,
+  columnById: ReadonlyMap<string, number>
+): { nodes: GraphNodeLayout[]; edges: GraphEdgeLayout[]; bounds: Rect } {
+  const handles = assignHandles(edges, positions, columnById, focusId)
+  const nodeRects = new Map(
+    nodes.map((node) => [
+      node.id,
+      { ...positions.get(node.id)!, width: nodeWidth, height: nodeHeight },
+    ])
+  )
+  const routed = routeEdges(edges, handles, nodeRects, columnById, focusId)
+  const labelWidths = new Map(edges.map((edge) => [edge.id, edge.labelWidth]))
+  const bounds = layoutBounds([...nodeRects.values()], routed, labelWidths)
+
+  return {
+    nodes: nodes.map((node) => ({
+      id: node.id,
+      position: positions.get(node.id)!,
+      sourceHandles: edges
+        .filter((edge) => edge.source === node.id)
+        .map((edge) => handles.get(edge.id)!.source),
+      targetHandles: edges
+        .filter((edge) => edge.target === node.id)
+        .map((edge) => handles.get(edge.id)!.target),
+    })),
+    edges: routed,
+    bounds,
+  }
+}
+
+function layoutBounds(
+  nodes: Rect[],
+  edges: GraphEdgeLayout[],
+  labelWidths: ReadonlyMap<string, number>
+): Rect {
+  const left = Math.min(
+    ...nodes.map((node) => node.x),
+    ...edges.flatMap((edge) => edge.points.map((point) => point.x)),
+    ...edges.map((edge) => edge.labelPosition.x - (labelWidths.get(edge.id) ?? 0) / 2)
+  )
+  const top = Math.min(
+    ...nodes.map((node) => node.y),
+    ...edges.flatMap((edge) => edge.points.map((point) => point.y)),
+    ...edges.map((edge) => edge.labelPosition.y - 11)
+  )
+  const right = Math.max(
+    ...nodes.map((node) => node.x + node.width),
+    ...edges.flatMap((edge) => edge.points.map((point) => point.x)),
+    ...edges.map((edge) => edge.labelPosition.x + (labelWidths.get(edge.id) ?? 0) / 2)
+  )
+  const bottom = Math.max(
+    ...nodes.map((node) => node.y + node.height),
+    ...edges.flatMap((edge) => edge.points.map((point) => point.y)),
+    ...edges.map((edge) => edge.labelPosition.y + 11)
+  )
+  return { x: left, y: top, width: right - left, height: bottom - top }
+}
+
+function partitionNodes(
+  nodes: GraphNodeInput[],
+  edges: GraphEdgeInput[],
+  focusId: string
+): string[][] {
+  const side = new Map<string, number>([[focusId, 1]])
+  for (const edge of edges) {
+    if (edge.target === focusId && edge.source !== focusId) side.set(edge.source, 0)
+    if (edge.source === focusId && edge.target !== focusId) side.set(edge.target, 2)
+  }
+
+  const unresolved = new Set(nodes.map((node) => node.id).filter((id) => !side.has(id)))
+  while (unresolved.size > 0) {
+    let progressed = false
+    for (const id of [...unresolved].sort()) {
+      const neighbors = edges.flatMap((edge) =>
+        edge.source === id ? [edge.target] : edge.target === id ? [edge.source] : []
+      )
+      const votes = neighbors
+        .map((neighbor) => side.get(neighbor))
+        .filter((value): value is number => value === 0 || value === 2)
+      if (votes.length === 0) continue
+      side.set(id, votes.reduce((total, value) => total + value, 0) < votes.length ? 0 : 2)
+      unresolved.delete(id)
+      progressed = true
+    }
+    if (progressed) continue
+
+    const counts = [0, 2].map((value) => [...side.values()].filter((side) => side === value).length)
+    for (const id of [...unresolved].sort()) {
+      const value = counts[0]! <= counts[1]! ? 0 : 2
+      side.set(id, value)
+      counts[value === 0 ? 0 : 1]! += 1
+      unresolved.delete(id)
+    }
+  }
+
+  return [0, 1, 2].map((column) =>
+    nodes
+      .filter((node) => side.get(node.id) === column)
+      .sort((left, right) => left.label.localeCompare(right.label))
+      .map((node) => node.id)
+  )
+}
+
+function orderColumns(columns: string[][], edges: GraphEdgeInput[]): void {
+  for (let pass = 0; pass < 8; pass += 1) {
+    let improved = false
+    for (const column of [columns[0]!, columns[2]!]) {
+      for (let index = 0; index < column.length - 1; index += 1) {
+        const before = orderScore(columns, edges)
+        ;[column[index], column[index + 1]] = [column[index + 1]!, column[index]!]
+        if (orderScore(columns, edges) < before) improved = true
+        else [column[index], column[index + 1]] = [column[index + 1]!, column[index]!]
+      }
+    }
+    if (!improved) break
+  }
+}
+
+function orderScore(columns: string[][], edges: GraphEdgeInput[]): number {
+  const location = new Map<string, { column: number; row: number }>()
+  columns.forEach((column, columnIndex) => {
+    column.forEach((id, row) => {
+      location.set(id, { column: columnIndex, row })
+    })
+  })
+  let score = 0
+  for (const edge of edges) {
+    const source = location.get(edge.source)
+    const target = location.get(edge.target)
+    if (!source || !target) continue
+    score += Math.abs(source.row - target.row) * (source.column === target.column ? 5 : 1)
+  }
+  for (let left = 0; left < edges.length; left += 1) {
+    const firstSource = location.get(edges[left]!.source)
+    const firstTarget = location.get(edges[left]!.target)
+    if (!firstSource || !firstTarget || firstSource.column === firstTarget.column) continue
+    for (let right = left + 1; right < edges.length; right += 1) {
+      const secondSource = location.get(edges[right]!.source)
+      const secondTarget = location.get(edges[right]!.target)
+      if (!secondSource || !secondTarget) continue
+      const firstPair = [firstSource.column, firstTarget.column].sort().join(":")
+      const secondPair = [secondSource.column, secondTarget.column].sort().join(":")
+      if (firstPair !== secondPair) continue
+      const firstRows =
+        firstSource.column < firstTarget.column
+          ? [firstSource.row, firstTarget.row]
+          : [firstTarget.row, firstSource.row]
+      const secondRows =
+        secondSource.column < secondTarget.column
+          ? [secondSource.row, secondTarget.row]
+          : [secondTarget.row, secondSource.row]
+      if ((firstRows[0]! - secondRows[0]!) * (firstRows[1]! - secondRows[1]!) < 0) score += 40
+    }
+  }
+  return score
+}
+
+function assignHandles(
+  edges: GraphEdgeInput[],
+  positions: ReadonlyMap<string, GraphPoint>,
+  columns: ReadonlyMap<string, number>,
+  focusId: string
+): Map<string, EdgeHandles> {
+  const sides = new Map<string, { source: GraphHandleSide; target: GraphHandleSide }>()
+  for (const edge of edges) {
+    const sourceColumn = columns.get(edge.source) ?? 0
+    const targetColumn = columns.get(edge.target) ?? 0
+    if (sourceColumn < targetColumn) sides.set(edge.id, { source: "right", target: "left" })
+    else if (sourceColumn > targetColumn) sides.set(edge.id, { source: "left", target: "right" })
+    else {
+      const outside = sourceColumn === 2 ? "right" : "left"
+      sides.set(edge.id, { source: outside, target: outside })
+    }
+  }
+
+  const grouped = new Map<string, { edge: GraphEdgeInput; role: "source" | "target" }[]>()
+  for (const edge of edges) {
+    for (const role of ["source", "target"] as const) {
+      const nodeId = edge[role]
+      const side = sides.get(edge.id)![role]
+      const key = `${nodeId}:${side}`
+      grouped.set(key, [...(grouped.get(key) ?? []), { edge, role }])
+    }
+  }
+
+  const handles = new Map<string, Partial<EdgeHandles>>()
+  for (const group of grouped.values()) {
+    group.sort((left, right) => {
+      const leftOther = positions.get(left.edge[left.role === "source" ? "target" : "source"])
+      const rightOther = positions.get(right.edge[right.role === "source" ? "target" : "source"])
+      return (leftOther?.y ?? 0) - (rightOther?.y ?? 0) || left.edge.id.localeCompare(right.edge.id)
+    })
+    const nodeId = group[0]?.edge[group[0].role]
+    const spreadFocus = nodeId === focusId && group.length >= 3
+    const min = spreadFocus ? 10 : PORT_MIN
+    const max = spreadFocus ? 90 : PORT_MAX
+    group.forEach(({ edge, role }, index) => {
+      const side = sides.get(edge.id)![role]
+      const offset = group.length === 1 ? 50 : min + ((max - min) * index) / (group.length - 1)
+      const handle = { id: `${edge.id}:${role}`, side, offset }
+      handles.set(edge.id, { ...handles.get(edge.id), [role]: handle })
+    })
+  }
+
+  return new Map([...handles].map(([id, value]) => [id, value as EdgeHandles]))
+}
+
+function routeEdges(
+  edges: GraphEdgeInput[],
+  handles: ReadonlyMap<string, EdgeHandles>,
+  nodes: ReadonlyMap<string, Rect>,
+  columns: ReadonlyMap<string, number>,
+  focusId: string
+): GraphEdgeLayout[] {
+  const allRects = [...nodes.values()]
+  const bounds = graphBounds(allRects)
+  const focusRect = nodes.get(focusId)
+  const focusLanes = assignFocusLanes(edges, nodes, columns, focusId)
+  const usedSegments: Segment[] = []
+  const usedLabels: Rect[] = []
+  const groupIndex = new Map<string, number>()
+
+  return [...edges]
+    .sort((left, right) => {
+      const leftFocus = left.source === focusId || left.target === focusId ? 0 : 1
+      const rightFocus = right.source === focusId || right.target === focusId ? 0 : 1
+      return (
+        leftFocus - rightFocus ||
+        (leftFocus === 0 ? right.labelWidth - left.labelWidth : 0) ||
+        left.id.localeCompare(right.id)
+      )
+    })
+    .map((edge) => {
+      const focused = edge.source === focusId || edge.target === focusId
+      const edgeHandles = handles.get(edge.id)!
+      const sourceRect = nodes.get(edge.source)!
+      const targetRect = nodes.get(edge.target)!
+      const start = handlePoint(sourceRect, edgeHandles.source)
+      const end = handlePoint(targetRect, edgeHandles.target)
+      const sourceColumn = columns.get(edge.source) ?? 0
+      const targetColumn = columns.get(edge.target) ?? 0
+      const pair = [sourceColumn, targetColumn].sort().join(":")
+      const index = groupIndex.get(pair) ?? 0
+      groupIndex.set(pair, index + 1)
+      const candidates = routeCandidates(
+        start,
+        end,
+        sourceColumn,
+        targetColumn,
+        index,
+        bounds,
+        sourceRect,
+        targetRect,
+        focusRect,
+        edge.labelWidth,
+        focused,
+        focusLanes.get(edge.id)
+      )
+      const obstacles = allRects.filter((rect) => rect !== sourceRect && rect !== targetRect)
+      const points = candidates
+        .map(simplifyRoute)
+        .map((route) => ({ route, score: routeScore(route, obstacles, usedSegments) }))
+        .sort((left, right) => left.score - right.score)[0]?.route ?? [start, end]
+      const segments = routeSegments(points)
+      usedSegments.push(...segments)
+      const labelPosition = placeLabel(segments, edge.labelWidth, allRects, usedLabels)
+      usedLabels.push({
+        x: labelPosition.x - edge.labelWidth / 2,
+        y: labelPosition.y - 11,
+        width: edge.labelWidth,
+        height: 22,
+      })
+
+      return {
+        id: edge.id,
+        sourceHandle: edgeHandles.source.id,
+        targetHandle: edgeHandles.target.id,
+        points,
+        labelPosition,
+      }
+    })
+    .sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function routeCandidates(
+  start: GraphPoint,
+  end: GraphPoint,
+  sourceColumn: number,
+  targetColumn: number,
+  index: number,
+  bounds: Rect,
+  source: Rect,
+  target: Rect,
+  focus: Rect | undefined,
+  labelWidth: number,
+  focused: boolean,
+  preferredLane?: number
+): GraphPoint[][] {
+  const gap = focused ? FOCUS_ROUTE_GAP : ROUTE_GAP
+  const track = (points: GraphPoint[]) => (focused ? points : trackEndpoints(points, index))
+  if (sourceColumn === targetColumn) {
+    const direction = sourceColumn === 2 ? 1 : -1
+    const labelClearance = Math.max(72, labelWidth / 2 + 22)
+    return Array.from({ length: 5 }, (_, lane) => {
+      const x =
+        direction < 0
+          ? bounds.x - labelClearance - (index + lane) * ROUTE_GAP
+          : bounds.x + bounds.width + labelClearance + (index + lane) * ROUTE_GAP
+      return track([start, { x, y: start.y }, { x, y: end.y }, end])
+    })
+  }
+
+  const left = sourceColumn < targetColumn ? source : target
+  const right = sourceColumn < targetColumn ? target : source
+  const laneCenter = (left.x + left.width + right.x) / 2
+  const fallbackLanes = Array.from({ length: 7 }, (_, lane) => laneCenter + (lane - 3) * gap)
+  const lanes =
+    preferredLane === undefined
+      ? fallbackLanes
+      : [preferredLane, ...fallbackLanes.filter((lane) => Math.abs(lane - preferredLane) > 1)]
+  const adjacent = Math.abs(sourceColumn - targetColumn) === 1
+  const direct = lanes.map((x) => track([start, { x, y: start.y }, { x, y: end.y }, end]))
+  if (adjacent) {
+    if (focused) return direct
+    const direction = sourceColumn < targetColumn ? 1 : -1
+    const startLane = start.x + direction * (26 + (index % 4) * ROUTE_GAP)
+    const endLane = end.x - direction * (26 + (index % 4) * ROUTE_GAP)
+    const detours = [
+      bounds.y - 34 - index * ROUTE_GAP,
+      bounds.y + bounds.height + 34 + index * ROUTE_GAP,
+    ].map((y) =>
+      track([
+        start,
+        { x: startLane, y: start.y },
+        { x: startLane, y },
+        { x: endLane, y },
+        { x: endLane, y: end.y },
+        end,
+      ])
+    )
+    return [...direct, ...detours]
+  }
+
+  const baseLeftLane = bounds.x + source.width + 52 + (index % 5) * ROUTE_GAP
+  const baseRightLane = bounds.x + bounds.width - target.width - 52 - (index % 5) * ROUTE_GAP
+  const leftLane = focus ? Math.min(baseLeftLane, focus.x - NODE_CLEARANCE) : baseLeftLane
+  const rightLane = focus
+    ? Math.max(baseRightLane, focus.x + focus.width + NODE_CLEARANCE)
+    : baseRightLane
+  const outside = focus
+    ? [
+        focus.y - 28 - index * ROUTE_GAP,
+        focus.y + focus.height + 28 + index * ROUTE_GAP,
+        bounds.y - 38 - index * ROUTE_GAP,
+        bounds.y + bounds.height + 38 + index * ROUTE_GAP,
+      ]
+    : [bounds.y - 38 - index * ROUTE_GAP, bounds.y + bounds.height + 38 + index * ROUTE_GAP]
+  const startLane = sourceColumn < targetColumn ? leftLane : rightLane
+  const endLane = sourceColumn < targetColumn ? rightLane : leftLane
+  return outside.map((y) =>
+    track([
+      start,
+      { x: startLane, y: start.y },
+      { x: startLane, y },
+      { x: endLane, y },
+      { x: endLane, y: end.y },
+      end,
+    ])
+  )
+}
+
+function assignFocusLanes(
+  edges: GraphEdgeInput[],
+  nodes: ReadonlyMap<string, Rect>,
+  columns: ReadonlyMap<string, number>,
+  focusId: string
+): Map<string, number> {
+  const focus = nodes.get(focusId)
+  if (!focus) return new Map()
+
+  const lanes = new Map<string, number>()
+  for (const side of [0, 2]) {
+    const group = edges
+      .filter((edge) => {
+        if (edge.source !== focusId && edge.target !== focusId) return false
+        const otherId = edge.source === focusId ? edge.target : edge.source
+        return columns.get(otherId) === side
+      })
+      .sort((left, right) => {
+        const leftId = left.source === focusId ? left.target : left.source
+        const rightId = right.source === focusId ? right.target : right.source
+        const leftNode = nodes.get(leftId)
+        const rightNode = nodes.get(rightId)
+        return (
+          (leftNode?.y ?? 0) +
+            (leftNode?.height ?? 0) / 2 -
+            ((rightNode?.y ?? 0) + (rightNode?.height ?? 0) / 2) || left.id.localeCompare(right.id)
+        )
+      })
+    if (group.length === 0) continue
+
+    const otherRects = group.map(
+      (edge) => nodes.get(edge.source === focusId ? edge.target : edge.source)!
+    )
+    const left =
+      side === 0
+        ? Math.max(...otherRects.map((node) => node.x + node.width))
+        : focus.x + focus.width
+    const right = side === 0 ? focus.x : Math.min(...otherRects.map((node) => node.x))
+    const available = right - left - NODE_CLEARANCE * 2
+    if (available <= 0) continue
+    const step = group.length === 1 ? 0 : Math.min(FOCUS_ROUTE_GAP, available / (group.length - 1))
+    const center = (left + right) / 2
+    group.forEach((edge, index) => {
+      lanes.set(edge.id, center + ((group.length - 1) / 2 - index) * step)
+    })
+  }
+  return lanes
+}
+
+function trackEndpoints(points: GraphPoint[], index: number): GraphPoint[] {
+  const start = points[0]!
+  const end = points.at(-1)!
+  const firstLane = points[1]!
+  const lastLane = points.at(-2)!
+  const offset = (Math.floor(index / 2) + 1) * 4 * (index % 2 === 0 ? 1 : -1)
+  const startY = start.y + offset
+  const endY = end.y + offset
+  const stubDistance = 10 + (index + 1) * 2
+  const startStub = start.x + Math.sign(firstLane.x - start.x) * stubDistance
+  const endStub = end.x + Math.sign(lastLane.x - end.x) * stubDistance
+  const middle = points.slice(1, -1).map((point, middleIndex, values) => ({
+    x: point.x,
+    y: middleIndex === 0 ? startY : middleIndex === values.length - 1 ? endY : point.y,
+  }))
+  return [
+    start,
+    { x: startStub, y: start.y },
+    { x: startStub, y: startY },
+    ...middle,
+    { x: endStub, y: endY },
+    { x: endStub, y: end.y },
+    end,
+  ]
+}
+
+function routeScore(candidate: GraphPoint[], obstacles: Rect[], used: Segment[]): number {
+  const segments = routeSegments(candidate)
+  if (
+    segments.some((segment) =>
+      obstacles.some((rect) => segmentHitsRect(segment, expandRect(rect, NODE_CLEARANCE)))
+    )
+  )
+    return Number.POSITIVE_INFINITY
+  if (segments.some((segment) => used.some((existing) => segmentsOverlap(segment, existing))))
+    return Number.POSITIVE_INFINITY
+  const length = segments.reduce((total, segment) => total + segmentLength(segment), 0)
+  const crossings = segments.reduce(
+    (total, segment) => total + used.filter((existing) => segmentsCross(segment, existing)).length,
+    0
+  )
+  return length + Math.max(0, segments.length - 1) * 48 + crossings * 420
+}
+
+function placeLabel(
+  segments: Segment[],
+  width: number,
+  obstacles: Rect[],
+  usedLabels: Rect[]
+): GraphPoint {
+  for (const segment of [...segments].sort(
+    (left, right) => segmentLength(right) - segmentLength(left)
+  )) {
+    const horizontal = segment.a.y === segment.b.y
+    const length = segmentLength(segment)
+    const steps = Math.max(2, Math.floor(length / 12))
+    const samples = Array.from({ length: steps - 1 }, (_, index) => (index + 1) / steps).sort(
+      (left, right) => Math.abs(left - 0.5) - Math.abs(right - 0.5)
+    )
+    for (const fraction of samples) {
+      const point = {
+        x: segment.a.x + (segment.b.x - segment.a.x) * fraction,
+        y: segment.a.y + (segment.b.y - segment.a.y) * fraction,
+      }
+      const label = { x: point.x - width / 2, y: point.y - 11, width, height: 22 }
+      if (
+        (horizontal
+          ? Math.min(Math.abs(point.x - segment.a.x), Math.abs(point.x - segment.b.x)) <
+            width / 2 + 9
+          : Math.min(Math.abs(point.y - segment.a.y), Math.abs(point.y - segment.b.y)) < 13) ||
+        obstacles.some((rect) => rectsOverlap(label, expandRect(rect, 6))) ||
+        usedLabels.some((rect) => rectsOverlap(label, rect))
+      )
+        continue
+      return point
+    }
+  }
+  const longest = [...segments].sort((left, right) => segmentLength(right) - segmentLength(left))[0]
+  return longest
+    ? { x: (longest.a.x + longest.b.x) / 2, y: (longest.a.y + longest.b.y) / 2 }
+    : { x: 0, y: 0 }
+}
+
+function handlePoint(rect: Rect, handle: GraphHandleLayout): GraphPoint {
+  const ratio = handle.offset / 100
+  if (handle.side === "left") return { x: rect.x, y: rect.y + rect.height * ratio }
+  if (handle.side === "right") return { x: rect.x + rect.width, y: rect.y + rect.height * ratio }
+  if (handle.side === "top") return { x: rect.x + rect.width * ratio, y: rect.y }
+  return { x: rect.x + rect.width * ratio, y: rect.y + rect.height }
+}
+
+function graphBounds(rects: Rect[]): Rect {
+  const x = Math.min(...rects.map((rect) => rect.x))
+  const y = Math.min(...rects.map((rect) => rect.y))
+  const right = Math.max(...rects.map((rect) => rect.x + rect.width))
+  const bottom = Math.max(...rects.map((rect) => rect.y + rect.height))
+  return { x, y, width: right - x, height: bottom - y }
+}
+
+function simplifyRoute(points: GraphPoint[]): GraphPoint[] {
+  return points.filter((point, index) => {
+    if (index === 0 || index === points.length - 1) return true
+    const previous = points[index - 1]!
+    const next = points[index + 1]!
+    return !(
+      (previous.x === point.x && point.x === next.x) ||
+      (previous.y === point.y && point.y === next.y)
+    )
+  })
+}
+
+function routeSegments(points: GraphPoint[]): Segment[] {
+  return points.slice(1).map((point, index) => ({ a: points[index]!, b: point }))
+}
+
+function segmentLength(segment: Segment): number {
+  return Math.abs(segment.a.x - segment.b.x) + Math.abs(segment.a.y - segment.b.y)
+}
+
+function expandRect(rect: Rect, amount: number): Rect {
+  return {
+    x: rect.x - amount,
+    y: rect.y - amount,
+    width: rect.width + amount * 2,
+    height: rect.height + amount * 2,
+  }
+}
+
+function segmentHitsRect(segment: Segment, rect: Rect): boolean {
+  if (segment.a.x === segment.b.x) {
+    return (
+      segment.a.x > rect.x &&
+      segment.a.x < rect.x + rect.width &&
+      rangesOverlap(segment.a.y, segment.b.y, rect.y, rect.y + rect.height)
+    )
+  }
+  return (
+    segment.a.y > rect.y &&
+    segment.a.y < rect.y + rect.height &&
+    rangesOverlap(segment.a.x, segment.b.x, rect.x, rect.x + rect.width)
+  )
+}
+
+function segmentsOverlap(left: Segment, right: Segment): boolean {
+  if (left.a.x === left.b.x && right.a.x === right.b.x && left.a.x === right.a.x) {
+    return overlapLength(left.a.y, left.b.y, right.a.y, right.b.y) > 1
+  }
+  if (left.a.y === left.b.y && right.a.y === right.b.y && left.a.y === right.a.y) {
+    return overlapLength(left.a.x, left.b.x, right.a.x, right.b.x) > 1
+  }
+  return false
+}
+
+function segmentsCross(left: Segment, right: Segment): boolean {
+  const horizontal = left.a.y === left.b.y ? left : right.a.y === right.b.y ? right : null
+  const vertical = left.a.x === left.b.x ? left : right.a.x === right.b.x ? right : null
+  if (!horizontal || !vertical) return false
+  return (
+    between(vertical.a.x, horizontal.a.x, horizontal.b.x) &&
+    between(horizontal.a.y, vertical.a.y, vertical.b.y)
+  )
+}
+
+function rectsOverlap(left: Rect, right: Rect): boolean {
+  return (
+    left.x < right.x + right.width &&
+    left.x + left.width > right.x &&
+    left.y < right.y + right.height &&
+    left.y + left.height > right.y
+  )
+}
+
+function rangesOverlap(a: number, b: number, c: number, d: number): boolean {
+  return Math.max(Math.min(a, b), Math.min(c, d)) < Math.min(Math.max(a, b), Math.max(c, d))
+}
+
+function overlapLength(a: number, b: number, c: number, d: number): number {
+  return Math.max(
+    0,
+    Math.min(Math.max(a, b), Math.max(c, d)) - Math.max(Math.min(a, b), Math.min(c, d))
+  )
+}
+
+function between(value: number, a: number, b: number): boolean {
+  return value > Math.min(a, b) && value < Math.max(a, b)
+}

--- a/packages/atlas/tests/ontology-graph-layout.test.ts
+++ b/packages/atlas/tests/ontology-graph-layout.test.ts
@@ -3,8 +3,10 @@ import {
   type GraphEdgeInput,
   type GraphPoint,
   layoutOntologyGraph,
+  layoutOntologyOverviewGraph,
   routeOntologyGraph,
-} from "../src/pages/ontologyGraphLayout"
+  routeOntologyOverviewGraph,
+} from "../src/lib/ontologyGraphLayout"
 
 const NODE_WIDTH = 216
 const NODE_HEIGHT = 82
@@ -54,6 +56,57 @@ const edges: GraphEdgeInput[] = relationships.map(([source, target, label], inde
 }))
 
 describe("ontology graph layout", () => {
+  test("lays out the overview in a compact forward-reading graph", () => {
+    const layout = layoutOntologyOverviewGraph(nodes, edges, {
+      nodeWidth: NODE_WIDTH,
+      nodeHeight: NODE_HEIGHT,
+    })
+    const positions = new Map(layout.nodes.map((node) => [node.id, node.position]))
+    const columns = new Set(layout.nodes.map((node) => node.position.x))
+    const backwardEdges = edges.filter(
+      (edge) => positions.get(edge.source)!.x > positions.get(edge.target)!.x
+    )
+    const nodeBounds = boundsForNodes(layout.nodes)
+
+    expect(columns.size).toBeGreaterThanOrEqual(3)
+    expect(columns.size).toBeLessThanOrEqual(5)
+    expect(backwardEdges).toEqual([])
+    expect(layout.bounds.x).toBeGreaterThanOrEqual(nodeBounds.x - 90)
+    expect(layout.bounds.y).toBeGreaterThanOrEqual(nodeBounds.y - 90)
+    expect(layout.bounds.x + layout.bounds.width).toBeLessThanOrEqual(
+      nodeBounds.x + nodeBounds.width + 90
+    )
+    expect(layout.bounds.y + layout.bounds.height).toBeLessThanOrEqual(
+      nodeBounds.y + nodeBounds.height + 90
+    )
+    expectColumnSpacing(layout, 240, 140)
+    expectReadable(layout)
+  })
+
+  test("reroutes the overview after manual node movement", () => {
+    const canonical = layoutOntologyOverviewGraph(nodes, edges, {
+      nodeWidth: NODE_WIDTH,
+      nodeHeight: NODE_HEIGHT,
+    })
+    const movedNodes = nodes.map((node) => {
+      const position = canonical.nodes.find((candidate) => candidate.id === node.id)!.position
+      return {
+        ...node,
+        position:
+          node.id === "service-case" ? { x: position.x + 38, y: position.y + 52 } : position,
+      }
+    })
+    const rerouted = routeOntologyOverviewGraph(movedNodes, edges, {
+      nodeWidth: NODE_WIDTH,
+      nodeHeight: NODE_HEIGHT,
+    })
+
+    expect(rerouted.nodes.find((node) => node.id === "service-case")?.position).toEqual(
+      movedNodes.find((node) => node.id === "service-case")?.position
+    )
+    expectReadable(rerouted)
+  })
+
   test("leaves room between rows for relationship badges", () => {
     const layout = layoutOntologyGraph(nodes, edges, "equipment", {
       nodeWidth: NODE_WIDTH,
@@ -69,7 +122,7 @@ describe("ontology graph layout", () => {
     for (const column of columns.values()) {
       const rows = column.sort((left, right) => left - right)
       for (let index = 1; index < rows.length; index += 1) {
-        expect(rows[index]! - rows[index - 1]!).toBeGreaterThanOrEqual(NODE_HEIGHT + 70)
+        expect(rows[index]! - rows[index - 1]!).toBeGreaterThanOrEqual(NODE_HEIGHT + 120)
       }
     }
   })
@@ -83,7 +136,8 @@ describe("ontology graph layout", () => {
 
       expect(layout.nodes).toHaveLength(nodes.length)
       expect(layout.edges).toHaveLength(edges.length)
-      expect(layout.nodes.find((node) => node.id === focusId)?.position.x).toBe(NODE_WIDTH + 260)
+      expect(layout.nodes.find((node) => node.id === focusId)?.position.x).toBe(NODE_WIDTH + 400)
+      expectColumnSpacing(layout, 400, 120)
       for (const edge of layout.edges) {
         const input = edges.find((candidate) => candidate.id === edge.id)!
         if (input.source === focusId || input.target === focusId) {
@@ -174,7 +228,98 @@ describe("ontology graph layout", () => {
 
     expect(crossings).toEqual([])
   })
+
+  for (const focusId of nodes
+    .map((node) => node.id)
+    .filter((nodeId) => edges.filter((edge) => edge.source === nodeId).length >= 2)) {
+    test(`keeps ${focusId} output routes and badges separate`, () => {
+      const layout = layoutOntologyGraph(nodes, edges, focusId, {
+        nodeWidth: NODE_WIDTH,
+        nodeHeight: NODE_HEIGHT,
+      })
+      const outgoingIds = edges.filter((edge) => edge.source === focusId).map((edge) => edge.id)
+
+      expect(routeConflicts(layout, outgoingIds)).toEqual([])
+    })
+  }
 })
+
+function boundsForNodes(layoutNodes: ReturnType<typeof layoutOntologyGraph>["nodes"]): {
+  x: number
+  y: number
+  width: number
+  height: number
+} {
+  const x = Math.min(...layoutNodes.map((node) => node.position.x))
+  const y = Math.min(...layoutNodes.map((node) => node.position.y))
+  const right = Math.max(...layoutNodes.map((node) => node.position.x + NODE_WIDTH))
+  const bottom = Math.max(...layoutNodes.map((node) => node.position.y + NODE_HEIGHT))
+  return { x, y, width: right - x, height: bottom - y }
+}
+
+function expectColumnSpacing(
+  layout: ReturnType<typeof layoutOntologyGraph>,
+  columnGap: number,
+  rowGap: number
+): void {
+  const columns = new Map<number, number[]>()
+  for (const node of layout.nodes) {
+    columns.set(node.position.x, [...(columns.get(node.position.x) ?? []), node.position.y])
+  }
+  const xPositions = [...columns.keys()].sort((left, right) => left - right)
+  for (let index = 1; index < xPositions.length; index += 1) {
+    expect(xPositions[index]! - xPositions[index - 1]!).toBeGreaterThanOrEqual(
+      NODE_WIDTH + columnGap
+    )
+  }
+  for (const yPositions of columns.values()) {
+    yPositions.sort((left, right) => left - right)
+    for (let index = 1; index < yPositions.length; index += 1) {
+      expect(yPositions[index]! - yPositions[index - 1]!).toBeGreaterThanOrEqual(
+        NODE_HEIGHT + rowGap
+      )
+    }
+  }
+}
+
+function routeConflicts(
+  layout: ReturnType<typeof layoutOntologyGraph>,
+  edgeIds: string[]
+): string[] {
+  const routed = edgeIds.map((edgeId) => layout.edges.find((edge) => edge.id === edgeId)!)
+  const conflicts: string[] = []
+  for (let left = 0; left < routed.length; left += 1) {
+    for (let right = left + 1; right < routed.length; right += 1) {
+      const leftSegments = segments(routed[left]!.points)
+      const rightSegments = segments(routed[right]!.points)
+      if (
+        leftSegments.some((first) =>
+          rightSegments.some((second) => crosses(first, second) || overlaps(first, second))
+        )
+      ) {
+        conflicts.push(`${routed[left]!.id}:${routed[right]!.id}`)
+      }
+    }
+  }
+
+  for (let labelIndex = 0; labelIndex < routed.length; labelIndex += 1) {
+    const labeled = routed[labelIndex]!
+    const width = edges.find((edge) => edge.id === labeled.id)!.labelWidth
+    const label = {
+      x: labeled.labelPosition.x - width / 2,
+      y: labeled.labelPosition.y - 11,
+      width,
+      height: 22,
+    }
+    for (let routeIndex = 0; routeIndex < routed.length; routeIndex += 1) {
+      if (labelIndex === routeIndex) continue
+      if (segments(routed[routeIndex]!.points).some((segment) => hitsRect(segment, label))) {
+        conflicts.push(`${labeled.id}:${routed[routeIndex]!.id}`)
+      }
+    }
+  }
+  return conflicts
+}
 
 function expectReadable(layout: ReturnType<typeof layoutOntologyGraph>): void {
   const nodeRects = new Map(

--- a/packages/atlas/tests/ontology-graph-layout.test.ts
+++ b/packages/atlas/tests/ontology-graph-layout.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, test } from "bun:test"
+import {
+  type GraphEdgeInput,
+  type GraphPoint,
+  layoutOntologyGraph,
+  routeOntologyGraph,
+} from "../src/pages/ontologyGraphLayout"
+
+const NODE_WIDTH = 216
+const NODE_HEIGHT = 82
+const nodes = [
+  "building-alarm",
+  "customer-account",
+  "equipment",
+  "facility",
+  "field-note",
+  "quote",
+  "service-case",
+  "service-contract",
+  "service-visit",
+  "technician",
+  "work-order",
+].map((id) => ({ id, label: id }))
+
+const relationships: Array<[string, string, string]> = [
+  ["building-alarm", "equipment", "Equipment · 1"],
+  ["equipment", "facility", "Facility · 1"],
+  ["facility", "customer-account", "Customer · 1"],
+  ["field-note", "service-visit", "Visit · 1"],
+  ["field-note", "equipment", "Equipment · 1"],
+  ["field-note", "technician", "Author · 1"],
+  ["quote", "customer-account", "Customer · 1"],
+  ["quote", "facility", "Facility · 1"],
+  ["quote", "service-case", "Service Case · 1"],
+  ["quote", "service-visit", "Originating Visit · 1"],
+  ["service-case", "customer-account", "Customer · 1"],
+  ["service-case", "facility", "Facility · 1"],
+  ["service-case", "equipment", "Equipment · 1"],
+  ["service-case", "service-contract", "Applied Contract · 1"],
+  ["service-case", "building-alarm", "Originating Alarms · many"],
+  ["service-contract", "customer-account", "Customer · 1"],
+  ["service-contract", "facility", "Covered Facilities · many"],
+  ["service-visit", "work-order", "Work Order · 1"],
+  ["service-visit", "technician", "Technician · 1"],
+  ["work-order", "service-case", "Service Case · 1"],
+  ["work-order", "equipment", "Equipment · 1"],
+  ["work-order", "technician", "Assignee · 1"],
+]
+const edges: GraphEdgeInput[] = relationships.map(([source, target, label], index) => ({
+  id: `edge-${index}`,
+  source,
+  target,
+  labelWidth: Math.max(48, label.length * 6.2 + 16),
+}))
+
+describe("ontology graph layout", () => {
+  test("leaves room between rows for relationship badges", () => {
+    const layout = layoutOntologyGraph(nodes, edges, "equipment", {
+      nodeWidth: NODE_WIDTH,
+      nodeHeight: NODE_HEIGHT,
+    })
+    const columns = new Map<number, number[]>()
+    for (const node of layout.nodes) {
+      const column = columns.get(node.position.x) ?? []
+      column.push(node.position.y)
+      columns.set(node.position.x, column)
+    }
+
+    for (const column of columns.values()) {
+      const rows = column.sort((left, right) => left - right)
+      for (let index = 1; index < rows.length; index += 1) {
+        expect(rows[index]! - rows[index - 1]!).toBeGreaterThanOrEqual(NODE_HEIGHT + 70)
+      }
+    }
+  })
+
+  for (const { id: focusId } of nodes) {
+    test(`keeps the complete ${focusId} view readable`, () => {
+      const layout = layoutOntologyGraph(nodes, edges, focusId, {
+        nodeWidth: NODE_WIDTH,
+        nodeHeight: NODE_HEIGHT,
+      })
+
+      expect(layout.nodes).toHaveLength(nodes.length)
+      expect(layout.edges).toHaveLength(edges.length)
+      expect(layout.nodes.find((node) => node.id === focusId)?.position.x).toBe(NODE_WIDTH + 260)
+      for (const edge of layout.edges) {
+        const input = edges.find((candidate) => candidate.id === edge.id)!
+        if (input.source === focusId || input.target === focusId) {
+          expect(edge.points.length).toBeLessThanOrEqual(4)
+        }
+      }
+      expectReadable(layout)
+    })
+  }
+
+  test("globally reroutes after nodes are moved without restoring their positions", () => {
+    const focusId = "service-case"
+    const canonical = layoutOntologyGraph(nodes, edges, focusId, {
+      nodeWidth: NODE_WIDTH,
+      nodeHeight: NODE_HEIGHT,
+    })
+    const movedPositions = new Map(
+      canonical.nodes.map((node) => [
+        node.id,
+        node.id === focusId
+          ? { x: node.position.x + 72, y: node.position.y + 34 }
+          : node.id === "quote"
+            ? { x: node.position.x - 48, y: node.position.y - 42 }
+            : node.position,
+      ])
+    )
+    const rerouted = routeOntologyGraph(
+      nodes.map((node) => ({ ...node, position: movedPositions.get(node.id)! })),
+      edges,
+      focusId,
+      { nodeWidth: NODE_WIDTH, nodeHeight: NODE_HEIGHT }
+    )
+
+    expect(rerouted.nodes.find((node) => node.id === focusId)?.position).toEqual(
+      movedPositions.get(focusId)
+    )
+    expect(rerouted.nodes.find((node) => node.id === "quote")?.position).toEqual(
+      movedPositions.get("quote")
+    )
+    expectReadable(rerouted)
+  })
+
+  test("fans dense focus handles across the selected node", () => {
+    for (const focusId of ["service-case", "equipment"]) {
+      const layout = layoutOntologyGraph(nodes, edges, focusId, {
+        nodeWidth: NODE_WIDTH,
+        nodeHeight: NODE_HEIGHT,
+      })
+      const focus = layout.nodes.find((node) => node.id === focusId)!
+      const offsets = [...focus.sourceHandles, ...focus.targetHandles].map(
+        (handle) => handle.offset
+      )
+
+      expect(Math.min(...offsets)).toBe(10)
+      expect(Math.max(...offsets)).toBe(90)
+    }
+  })
+
+  test("keeps Quote and Work Order on separate incoming tracks", () => {
+    const layout = layoutOntologyGraph(nodes, edges, "service-case", {
+      nodeWidth: NODE_WIDTH,
+      nodeHeight: NODE_HEIGHT,
+    })
+    const tracks = ["edge-8", "edge-19"].map((edgeId) => {
+      const route = layout.edges.find((edge) => edge.id === edgeId)!
+      return segments(route.points).find((segment) => segment.a.x === segment.b.x)!.a.x
+    })
+
+    expect(Math.abs(tracks[0]! - tracks[1]!)).toBeGreaterThanOrEqual(32)
+  })
+
+  test("keeps Facility incoming relationships from crossing", () => {
+    const layout = layoutOntologyGraph(nodes, edges, "facility", {
+      nodeWidth: NODE_WIDTH,
+      nodeHeight: NODE_HEIGHT,
+    })
+    const incoming = ["edge-1", "edge-7", "edge-11", "edge-16"].map((edgeId) =>
+      segments(layout.edges.find((edge) => edge.id === edgeId)!.points)
+    )
+    const crossings: string[] = []
+    for (let left = 0; left < incoming.length; left += 1) {
+      for (let right = left + 1; right < incoming.length; right += 1) {
+        if (incoming[left]!.some((a) => incoming[right]!.some((b) => crosses(a, b)))) {
+          crossings.push(`${left}:${right}`)
+        }
+      }
+    }
+
+    expect(crossings).toEqual([])
+  })
+})
+
+function expectReadable(layout: ReturnType<typeof layoutOntologyGraph>): void {
+  const nodeRects = new Map(
+    layout.nodes.map((node) => [
+      node.id,
+      { ...node.position, width: NODE_WIDTH, height: NODE_HEIGHT },
+    ])
+  )
+  const edgeById = new Map(edges.map((edge) => [edge.id, edge]))
+  const routedSegments = layout.edges.map((edge) => ({
+    edge,
+    segments: segments(edge.points),
+  }))
+
+  const blockedEdges: string[] = []
+  for (const { edge, segments: path } of routedSegments) {
+    const input = edgeById.get(edge.id)!
+    for (const [nodeId, rect] of nodeRects) {
+      if (nodeId === input.source || nodeId === input.target) continue
+      if (path.some((segment) => hitsRect(segment, expand(rect, 13)))) {
+        blockedEdges.push(`${edge.id}:${nodeId}`)
+      }
+    }
+  }
+  expect(blockedEdges).toEqual([])
+
+  const overlappingEdges: string[] = []
+  for (let left = 0; left < routedSegments.length; left += 1) {
+    for (let right = left + 1; right < routedSegments.length; right += 1) {
+      if (
+        routedSegments[left]!.segments.some((first) =>
+          routedSegments[right]!.segments.some((second) => overlaps(first, second))
+        )
+      ) {
+        overlappingEdges.push(`${routedSegments[left]!.edge.id}:${routedSegments[right]!.edge.id}`)
+      }
+    }
+  }
+  expect(overlappingEdges).toEqual([])
+
+  const labels = layout.edges.map((edge) => {
+    const width = edgeById.get(edge.id)!.labelWidth
+    return {
+      id: edge.id,
+      x: edge.labelPosition.x - width / 2,
+      y: edge.labelPosition.y - 11,
+      width,
+      height: 22,
+    }
+  })
+  const blockedLabels = labels.flatMap((label) =>
+    [...nodeRects]
+      .filter(([, node]) => rectsOverlap(label, node))
+      .map(([nodeId]) => `${label.id}:${nodeId}`)
+  )
+  expect(blockedLabels).toEqual([])
+  const overlappingLabels: string[] = []
+  for (let left = 0; left < labels.length; left += 1) {
+    for (let right = left + 1; right < labels.length; right += 1) {
+      if (rectsOverlap(labels[left]!, labels[right]!)) {
+        overlappingLabels.push(`${labels[left]!.id}:${labels[right]!.id}`)
+      }
+    }
+  }
+  expect(overlappingLabels).toEqual([])
+}
+
+interface Rect extends GraphPoint {
+  width: number
+  height: number
+}
+
+interface Segment {
+  a: GraphPoint
+  b: GraphPoint
+}
+
+function segments(points: GraphPoint[]): Segment[] {
+  return points.slice(1).map((point, index) => ({ a: points[index]!, b: point }))
+}
+
+function hitsRect(segment: Segment, rect: Rect): boolean {
+  if (segment.a.x === segment.b.x) {
+    return (
+      segment.a.x > rect.x &&
+      segment.a.x < rect.x + rect.width &&
+      rangesOverlap(segment.a.y, segment.b.y, rect.y, rect.y + rect.height)
+    )
+  }
+  return (
+    segment.a.y > rect.y &&
+    segment.a.y < rect.y + rect.height &&
+    rangesOverlap(segment.a.x, segment.b.x, rect.x, rect.x + rect.width)
+  )
+}
+
+function overlaps(left: Segment, right: Segment): boolean {
+  if (left.a.x === left.b.x && right.a.x === right.b.x && left.a.x === right.a.x) {
+    return overlapLength(left.a.y, left.b.y, right.a.y, right.b.y) > 1
+  }
+  if (left.a.y === left.b.y && right.a.y === right.b.y && left.a.y === right.a.y) {
+    return overlapLength(left.a.x, left.b.x, right.a.x, right.b.x) > 1
+  }
+  return false
+}
+
+function crosses(left: Segment, right: Segment): boolean {
+  const horizontal = left.a.y === left.b.y ? left : right.a.y === right.b.y ? right : null
+  const vertical = left.a.x === left.b.x ? left : right.a.x === right.b.x ? right : null
+  if (!horizontal || !vertical) return false
+  return (
+    between(vertical.a.x, horizontal.a.x, horizontal.b.x) &&
+    between(horizontal.a.y, vertical.a.y, vertical.b.y)
+  )
+}
+
+function expand(rect: Rect, amount: number): Rect {
+  return {
+    x: rect.x - amount,
+    y: rect.y - amount,
+    width: rect.width + amount * 2,
+    height: rect.height + amount * 2,
+  }
+}
+
+function rectsOverlap(left: Rect, right: Rect): boolean {
+  return (
+    left.x < right.x + right.width &&
+    left.x + left.width > right.x &&
+    left.y < right.y + right.height &&
+    left.y + left.height > right.y
+  )
+}
+
+function rangesOverlap(a: number, b: number, c: number, d: number): boolean {
+  return Math.max(Math.min(a, b), Math.min(c, d)) < Math.min(Math.max(a, b), Math.max(c, d))
+}
+
+function overlapLength(a: number, b: number, c: number, d: number): number {
+  return Math.max(
+    0,
+    Math.min(Math.max(a, b), Math.max(c, d)) - Math.max(Math.min(a, b), Math.min(c, d))
+  )
+}
+
+function between(value: number, a: number, b: number): boolean {
+  return value > Math.min(a, b) && value < Math.max(a, b)
+}


### PR DESCRIPTION
## Summary

- replace the flat ontology landing page with an immersive, full-canvas graph explorer
- add selected-type framing, relationship-aware side-panel details, smooth transitions, search, list, and detail navigation
- add deterministic graph layout and routing for complete and focused ontology views, including cardinality badges and draggable nodes
- keep direct incoming and outgoing relationships in view while reducing emphasis on the remaining ontology
- add focused layout coverage for spacing, crossings, badges, handles, and manual node movement

## Screenshots
<img width="1517" height="1151" alt="Screenshot 2026-08-23 at 7 36 09 PM" src="https://github.com/user-attachments/assets/b214265c-773e-4d27-bca4-23090af3d70e" />


 
<img width="1530" height="1310" alt="Screenshot 2026-08-23 at 7 36 17 PM" src="https://github.com/user-attachments/assets/c21bcd79-2c7e-4ae8-b70a-60404f9abdaa" />
