### PR TITLE
app: add isolated shared app runtime

### DIFF
--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -60,6 +60,43 @@ Routing rules:
   helpers, or routes you do not want mounted.
 - The route component is the page module's `default` export.
 
+### Shared pages
+
+A ShareType gets a public, grant-bound page through one explicit convention:
+
+```text
+app/shared/published-report/[grantId]/page.tsx
+app/shared/layout.tsx                              # optional shared-only layout
+```
+
+The directory name must match the ShareType ID. Other shapes below `app/shared/` fail the build so
+a page cannot cross the public boundary accidentally.
+
+```tsx
+import { useSharedAccess } from "@sixb/app/shared"
+
+export default function PublishedReportPage() {
+  const shared = useSharedAccess()
+
+  return (
+    <main>
+      <h1>{String(shared.resource.properties.title)}</h1>
+      <button
+        type="button"
+        onClick={() => shared.requestAction("acknowledge-report", { params: { note: "Reviewed" } })}
+      >
+        Acknowledge
+      </button>
+    </main>
+  )
+}
+```
+
+Sixb removes the URL fragment before loading page code, exchanges it, restores an existing shared
+session on reload, and loads the exact resource before rendering the page. The shared entry has no
+OIDC bootstrap or normal client; its client and TanStack Query cache are recreated per grant and
+cleared when access ends. Crossing between normal and shared pages always performs a full reload.
+
 Here's a projects listing page. It builds a typed query for active projects and
 renders each one as a card:
 

--- a/docs/apps/overview.md
+++ b/docs/apps/overview.md
@@ -69,8 +69,9 @@ app/shared/published-report/[grantId]/page.tsx
 app/shared/layout.tsx                              # optional shared-only layout
 ```
 
-The directory name must match the ShareType ID. Other shapes below `app/shared/` fail the build so
-a page cannot cross the public boundary accidentally.
+The directory name must match the ShareType ID. IDs are route-safe segments: they start with an
+ASCII letter or number and contain only letters, numbers, `.`, `_`, or `-`. Other shapes below
+`app/shared/` fail the build so a page cannot cross the public boundary accidentally.
 
 ```tsx
 import { useSharedAccess } from "@sixb/app/shared"
@@ -95,7 +96,9 @@ export default function PublishedReportPage() {
 Sixb removes the URL fragment before loading page code, exchanges it, restores an existing shared
 session on reload, and loads the exact resource before rendering the page. The shared entry has no
 OIDC bootstrap or normal client; its client and TanStack Query cache are recreated per grant and
-cleared when access ends. Crossing between normal and shared pages always performs a full reload.
+cleared when access ends. Temporary bootstrap failures offer a retry while retaining the link
+secret only in memory; the secret is discarded as soon as a session exists. Crossing between normal
+and shared pages always performs a full reload.
 
 Here's a projects listing page. It builds a typed query for active projects and
 renders each one as a card:

--- a/docs/auth/authorization.md
+++ b/docs/auth/authorization.md
@@ -121,6 +121,11 @@ Object or Action endpoints.
 same fixed object as their subject; callers can provide only the Action ID and its parameters. The
 request execution records `grantId` and `sessionId` as authority without inventing a user identity.
 
+Pages under `app/shared/<shareTypeId>/[grantId]/page.tsx` run in a separate browser entry point.
+The bootstrap removes the fragment before loading page code, exchanges it, validates that the grant
+matches the static ShareType page, and creates a client and query cache scoped to that grant. It
+never initializes OIDC, even when an application session already exists on the same origin.
+
 > **Only `can.view(Type)` reaches subtypes.** `can.edit` and `can.append` cover exactly the types
 > you name, so adding a type under one you granted never makes it writable on its own.
 

--- a/docs/client/overview.md
+++ b/docs/client/overview.md
@@ -55,6 +55,17 @@ const report = await shared.getResource()
 await shared.requestAction("acknowledge-report", { params: { note: "Reviewed" } })
 ```
 
+Inside `app/shared/<shareTypeId>/[grantId]/page.tsx`, the generated shared runtime owns that
+bootstrap and exposes the ready, exact-target handle:
+
+```ts
+import { useSharedAccess } from "@sixb/app/shared"
+
+const shared = useSharedAccess()
+shared.resource
+await shared.requestAction("acknowledge-report")
+```
+
 > `@sixb/client/hooks` re-exports the events layer and the typed-query hooks,
 > so a React app usually only imports from `/hooks`.
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -34,6 +34,14 @@ The generated entry also intercepts plain same-origin `<a href="/...">` clicks a
 
 If `app/layout.tsx` exists, it is used as a root layout wrapper. It can also export a `metadata` object (`title`, `description`, `favicon`, `themeColor`, and `backgroundColor`). Metadata is loaded during generation and written into the static HTML and manifest, so it is available before auth and client startup. The layout module must therefore be import-safe in Bun: do not access `window` or `document` at module scope. An `app/globals.css` file is imported automatically when present.
 
+### Shared Pages
+
+`app/shared/<shareTypeId>/[grantId]/page.tsx` creates a separate public entry point for an active
+shared grant. It never starts application auth, and `app/shared/layout.tsx` wraps only shared pages.
+Use `useSharedAccess()` from `@sixb/app/shared` to read the exact resource and request an allowed
+Action. The generated runtime owns fragment exchange, session restoration, and a grant-scoped
+client and query cache. Any other page shape below `app/shared/` fails generation.
+
 ### Built-in Agent Routes
 
 Custom apps automatically receive the shared Sixb agent chat UI at:
@@ -170,3 +178,4 @@ A file at `app/public/app.webmanifest` is ignored because the generated manifest
 | `AppMetadata` | Metadata shape exported by `app/layout.tsx` |
 | `createTailwindCssCompiler(options)` | Shared Tailwind v4 build pipeline (also used by Atlas) |
 | `@sixb/app/agents` | Full-page agent route plus `AgentPanel`, context provider/hooks, and helpers |
+| `@sixb/app/shared` | Grant-bound shared page runtime and `useSharedAccess()` hook |

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -40,7 +40,8 @@ If `app/layout.tsx` exists, it is used as a root layout wrapper. It can also exp
 shared grant. It never starts application auth, and `app/shared/layout.tsx` wraps only shared pages.
 Use `useSharedAccess()` from `@sixb/app/shared` to read the exact resource and request an allowed
 Action. The generated runtime owns fragment exchange, session restoration, and a grant-scoped
-client and query cache. Any other page shape below `app/shared/` fails generation.
+client and query cache. ShareType IDs must start with an ASCII letter or number and contain only
+letters, numbers, `.`, `_`, or `-`. Any other page shape below `app/shared/` fails generation.
 
 ### Built-in Agent Routes
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -33,6 +33,12 @@
       "bun": "./src/agents.ts",
       "import": "./dist/agents.js",
       "default": "./dist/agents.js"
+    },
+    "./shared": {
+      "types": "./dist/shared.d.ts",
+      "bun": "./src/shared.ts",
+      "import": "./dist/shared.js",
+      "default": "./dist/shared.js"
     }
   },
   "scripts": {
@@ -42,6 +48,7 @@
   },
   "dependencies": {
     "@sixb/agent-ui": "workspace:^",
+    "@sixb/client": "workspace:^",
     "@sixb/core": "workspace:^",
     "@sixb/ui": "workspace:^",
     "@tailwindcss/cli": "^4.2.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "build": "bun ../../scripts/build-package.ts",
     "typecheck": "tsc --noEmit",
+    "test:e2e": "bun ../../scripts/ci-guard.ts --stall 60 --max 240 bun test ./tests/shared-app.e2e.ts",
     "prepack": "bun run build"
   },
   "dependencies": {

--- a/packages/app/src/build.ts
+++ b/packages/app/src/build.ts
@@ -2,10 +2,13 @@ import { copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promis
 import { basename, dirname, join } from "node:path"
 
 const STATIC_ASSET_ORIGIN = "https://sixb-static.invalid"
+export const SHARED_APP_SHELL_FILE_NAME = "shared-index.html"
 
 export interface BuildAppOptions {
   /** Path to the generated index.html entry point */
   entryPath: string
+  /** Optional isolated shared-link HTML entry point. */
+  sharedEntryPath?: string
   /** Generated manifest copied to the stable `/app.webmanifest` output path. */
   manifestPath?: string
   /** Output directory, defaults to `.sixb/dist/app` */
@@ -29,38 +32,63 @@ export async function buildApp(options: BuildAppOptions): Promise<BuildAppResult
   await rm(outdir, { recursive: true, force: true })
   await mkdir(outdir, { recursive: true })
 
-  const bundleEntryPath = await prepareAppHtmlBundleEntry(options.entryPath)
-  let result: Awaited<ReturnType<typeof Bun.build>>
+  const entries = [
+    {
+      bundlePath: await prepareAppHtmlBundleEntry(options.entryPath),
+      outputName: "index.html",
+    },
+    ...(options.sharedEntryPath
+      ? [
+          {
+            bundlePath: await prepareAppHtmlBundleEntry(options.sharedEntryPath),
+            outputName: SHARED_APP_SHELL_FILE_NAME,
+          },
+        ]
+      : []),
+  ]
+  const failedLogs: string[] = []
+  let buildFailed = false
   try {
-    result = await Bun.build({
-      entrypoints: [bundleEntryPath],
-      outdir,
-      target: "browser",
-      conditions: ["bun"],
-      publicPath: "/",
-      minify: true,
-      // React is bundled into this browser output, so without pinning NODE_ENV the production build
-      // of a user's app ships React's development build: dev-only checks on every render, and the
-      // warnings that go with them. This is also the only knob that selects the production JSX
-      // runtime — an ambient NODE_ENV does not.
-      define: { "process.env.NODE_ENV": '"production"' },
-      sourcemap: "external",
-    })
+    // Build the two HTML entries independently. Bun currently mis-resolves some
+    // package-relative imports when separate HTML graphs share one build call;
+    // sequential builds still share content-hashed assets safely in one outdir.
+    for (const entry of entries) {
+      const result = await Bun.build({
+        entrypoints: [entry.bundlePath],
+        outdir,
+        target: "browser",
+        conditions: ["bun"],
+        publicPath: "/",
+        minify: true,
+        // React is bundled into this browser output, so without pinning NODE_ENV the production build
+        // of a user's app ships React's development build: dev-only checks on every render, and the
+        // warnings that go with them. This is also the only knob that selects the production JSX
+        // runtime — an ambient NODE_ENV does not.
+        define: { "process.env.NODE_ENV": '"production"' },
+        sourcemap: "external",
+      })
+      if (!result.success) {
+        buildFailed = true
+        failedLogs.push(...result.logs.map(String))
+        break
+      }
+      await rename(join(outdir, basename(entry.bundlePath)), join(outdir, entry.outputName))
+    }
   } finally {
-    await rm(bundleEntryPath, { force: true })
+    await Promise.all(entries.map((entry) => rm(entry.bundlePath, { force: true })))
   }
 
-  if (!result.success) {
+  if (buildFailed) {
     return {
       success: false,
       outdir,
-      logs: result.logs.map(String),
+      logs: failedLogs,
     }
   }
 
-  const bundleHtmlPath = join(outdir, basename(bundleEntryPath))
-  await rename(bundleHtmlPath, join(outdir, "index.html"))
-  await rewriteIndexAssetPaths(outdir)
+  for (const entry of entries) {
+    await rewriteHtmlAssetPaths(outdir, entry.outputName)
+  }
   if (options.manifestPath) {
     await copyFile(options.manifestPath, join(outdir, "app.webmanifest"))
   }
@@ -77,7 +105,8 @@ export async function prepareAppHtmlBundleEntry(entryPath: string): Promise<stri
     /(<link\s+rel=["'](?:manifest|icon|apple-touch-icon)["']\s+href=["'])(\/[^"']*)(["'][^>]*>)/g,
     `$1${STATIC_ASSET_ORIGIN}$2$3`
   )
-  const bundleEntryPath = join(dirname(entryPath), "index.sixb-bundle.html")
+  const entryName = basename(entryPath, ".html")
+  const bundleEntryPath = join(dirname(entryPath), `${entryName}.sixb-bundle.html`)
   await writeFile(bundleEntryPath, bundleHtml, "utf-8")
   return bundleEntryPath
 }
@@ -86,8 +115,8 @@ export function restoreAppStaticUrls(html: string): string {
   return html.replaceAll(STATIC_ASSET_ORIGIN, "")
 }
 
-async function rewriteIndexAssetPaths(outdir: string): Promise<void> {
-  const indexPath = join(outdir, "index.html")
+async function rewriteHtmlAssetPaths(outdir: string, fileName: string): Promise<void> {
+  const indexPath = join(outdir, fileName)
   const originalHtml = await readFile(indexPath, "utf-8")
   const html = restoreAppStaticUrls(originalHtml)
 

--- a/packages/app/src/codegen.ts
+++ b/packages/app/src/codegen.ts
@@ -809,11 +809,54 @@ if (import.meta.hot && (import.meta.hot.data as SharedAppHotData & { started?: b
 }
 
 let fragmentSecret = consumeFragmentSecret()
-void import("./shared-main").then(({ startSharedApp }) => {
-  const secret = fragmentSecret
-  fragmentSecret = null
-  startSharedApp(secret)
-})
+let importPending = false
+
+function showImportFailure(): void {
+  const root = document.getElementById("root")
+  if (!root) return
+
+  const main = document.createElement("main")
+  main.setAttribute("role", "alert")
+  main.style.cssText =
+    "min-height:100dvh;display:flex;flex-direction:column;align-items:center;" +
+    "justify-content:center;gap:.75rem;padding:2rem;text-align:center;" +
+    "font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+
+  const title = document.createElement("h1")
+  title.textContent = "Unable to open this link"
+  title.style.cssText = "margin:0;font-size:1.5rem"
+  const detail = document.createElement("p")
+  detail.textContent = "A temporary problem occurred. Please try again."
+  detail.style.cssText = "margin:0;max-width:32rem"
+  const retry = document.createElement("button")
+  retry.type = "button"
+  retry.textContent = "Try again"
+  retry.style.cssText =
+    "margin-top:.25rem;padding:.625rem 1rem;border:1px solid currentColor;" +
+    "border-radius:.375rem;background:transparent;color:inherit;cursor:pointer;font:inherit"
+  retry.addEventListener("click", () => void loadSharedApp())
+
+  main.append(title, detail, retry)
+  root.replaceChildren(main)
+}
+
+async function loadSharedApp(): Promise<void> {
+  if (importPending) return
+  importPending = true
+  try {
+    const { startSharedApp } = await import("./shared-main")
+    const secret = fragmentSecret
+    startSharedApp(secret)
+    fragmentSecret = null
+  } catch (error) {
+    console.error("[SixbSharedApp] Failed to load the shared app entry; retry is available.", error)
+    showImportFailure()
+  } finally {
+    importPending = false
+  }
+}
+
+void loadSharedApp()
 `
   const bootstrapPath = join(generatedDir, "shared-bootstrap.ts")
   await writeFileIfChanged(bootstrapPath, bootstrapContent)

--- a/packages/app/src/codegen.ts
+++ b/packages/app/src/codegen.ts
@@ -4,7 +4,7 @@ import type { AuthSessionAudience } from "@sixb/core"
 import { renderAppManifest } from "./manifest"
 import { resolveAppMetadata } from "./metadata"
 import { renderCustomAppRuntimeScript } from "./runtime"
-import type { PageRoute } from "./scanner"
+import type { PageRoute, SharedPageRoute } from "./scanner"
 
 export interface BuiltInRouteManifestEntry {
   readonly path: string
@@ -65,6 +65,37 @@ ${routeEntries}
 `
 
   const outPath = join(generatedDir, "routes.ts")
+  await writeFileIfChanged(outPath, content)
+  return outPath
+}
+
+/** Generates the isolated route table consumed only by the shared entry point. */
+export async function generateSharedRouteManifest(
+  routes: readonly SharedPageRoute[],
+  generatedDir: string
+): Promise<string> {
+  await mkdir(generatedDir, { recursive: true })
+
+  const imports = routes
+    .map(
+      (route, index) =>
+        `import SharedPage${index} from ${JSON.stringify(relativeTo(generatedDir, route.filePath))}`
+    )
+    .join("\n")
+  const entries = routes
+    .map(
+      (route, index) =>
+        `  { path: ${JSON.stringify(route.path)}, shareTypeId: ${JSON.stringify(route.shareTypeId)}, component: SharedPage${index} },`
+    )
+    .join("\n")
+  const content = `${imports}
+
+export const sharedRoutes = [
+${entries}
+]
+`
+
+  const outPath = join(generatedDir, "shared-routes.ts")
   await writeFileIfChanged(outPath, content)
   return outPath
 }
@@ -263,6 +294,20 @@ function InternalLinkInterceptor() {
   return null
 }
 
+// React Router links can bypass the plain-anchor interceptor. Crossing into the
+// shared boundary must still load its separate entry point and runtime.
+function SharedBoundaryReload() {
+  const location = useLocation()
+
+  React.useEffect(() => {
+    if (location.pathname === "/shared" || location.pathname.startsWith("/shared/")) {
+      window.location.reload()
+    }
+  }, [location.pathname])
+
+  return null
+}
+
 // Shared presentational fallback used by the not-found view and the error
 // boundary. Styled with @sixb/ui design tokens (var(--token)) so it adopts the
 // app's theme when those tokens are loaded, but every token has a hardcoded
@@ -451,6 +496,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <InternalLinkInterceptor />
+        <SharedBoundaryReload />
         <RoutedErrorBoundary>
           ${layoutWrapperStart}
             <Routes>
@@ -522,14 +568,295 @@ ${metadataHead}
   return { htmlPath, mainPath, manifestPath }
 }
 
-function renderMetadataHead(metadata: Awaited<ReturnType<typeof resolveAppMetadata>>): string {
+/**
+ * Generates a second browser entry for public shared links. It imports neither
+ * the application auth bootstrap nor the global client, and it uses its own
+ * layout and query cache through `SharedAccessBoundary`.
+ */
+export async function generateSharedAppEntry(
+  projectRoot: string,
+  generatedDir: string,
+  options: {
+    apiBaseUrl?: string
+    appDir?: string
+    publicDir?: string
+    stylesheetPath?: string | null
+  } = {}
+): Promise<{ htmlPath: string; mainPath: string }> {
+  await mkdir(generatedDir, { recursive: true })
+
+  const appDir = options.appDir ? resolve(projectRoot, options.appDir) : join(projectRoot, "app")
+  const publicDir = options.publicDir
+    ? resolve(projectRoot, options.publicDir)
+    : join(appDir, "public")
+  const globalsCssPath = join(appDir, "globals.css")
+  const applicationLayoutPath = join(appDir, "layout.tsx")
+  const sharedLayoutPath = join(appDir, "shared", "layout.tsx")
+  const metadata = await resolveAppMetadata({ layoutPath: applicationLayoutPath, publicDir })
+  const stylesheetPath =
+    options.stylesheetPath !== undefined
+      ? options.stylesheetPath
+      : (await fileExists(globalsCssPath))
+        ? globalsCssPath
+        : null
+  const stylesheetImport = stylesheetPath
+    ? `import ${JSON.stringify(relativeTo(generatedDir, stylesheetPath))}`
+    : ""
+  const hasLayout = await fileExists(sharedLayoutPath)
+  const layoutImport = hasLayout
+    ? `import SharedLayout from ${JSON.stringify(relativeTo(generatedDir, sharedLayoutPath))}\n`
+    : ""
+  const layoutWrapperStart = hasLayout ? "<SharedLayout>" : "<>"
+  const layoutWrapperEnd = hasLayout ? "</SharedLayout>" : "</>"
+  const runtimeConfigScript = options.apiBaseUrl
+    ? renderCustomAppRuntimeScript({
+        api: { baseUrl: options.apiBaseUrl },
+        // This value is documentary for the HTML payload. The shared entry does
+        // not import or initialize the application authentication runtime.
+        auth: { audience: "app", enabled: false },
+      })
+    : ""
+
+  const mainContent = `import React from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { BrowserRouter, Route, Routes, useLocation, useParams } from "react-router-dom"
+import {
+  readSharedAppRuntimeConfig,
+  SharedAccessBoundary,
+} from "@sixb/app/shared"
+import { sharedRoutes } from "./shared-routes"
+${stylesheetImport}
+${layoutImport}
+
+interface SharedAppHotData {
+  root?: Root
+}
+
+const runtimeConfig = readSharedAppRuntimeConfig()
+
+if (import.meta.hot) import.meta.hot.accept()
+
+function getRoot(): Root {
+  const element = document.getElementById("root")
+  if (!element) throw new Error("[SixbSharedApp] Could not find the root element.")
+
+  if (import.meta.hot) {
+    const data = import.meta.hot.data as SharedAppHotData
+    data.root ??= createRoot(element)
+    return data.root
+  }
+
+  return createRoot(element)
+}
+
+function ApplicationBoundaryReload() {
+  const location = useLocation()
+
+  React.useEffect(() => {
+    if (location.pathname !== "/shared" && !location.pathname.startsWith("/shared/")) {
+      window.location.reload()
+    }
+  }, [location.pathname])
+
+  return null
+}
+
+function SharedFallback({ title, detail }: { title: string; detail: string }) {
+  return (
+    <main
+      role="alert"
+      style={{
+        minHeight: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "0.75rem",
+        padding: "2rem",
+        textAlign: "center",
+        fontFamily:
+          "var(--font-sans, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif)",
+        background: "var(--background, #ffffff)",
+        color: "var(--foreground, #1f2933)",
+      }}
+    >
+      <h1 style={{ margin: 0, fontSize: "1.5rem" }}>{title}</h1>
+      <p style={{ margin: 0, maxWidth: "32rem", color: "var(--muted-foreground, #52606d)" }}>
+        {detail}
+      </p>
+    </main>
+  )
+}
+
+function SharedRoute({
+  route,
+  consumeFragmentSecret,
+}: {
+  route: (typeof sharedRoutes)[number]
+  consumeFragmentSecret: () => string | null
+}) {
+  const { grantId } = useParams<{ grantId: string }>()
+  if (!grantId) {
+    return <SharedFallback title="Link unavailable" detail="This shared link is invalid." />
+  }
+
+  return (
+    <SharedPageErrorBoundary resetKey={route.shareTypeId + ":" + grantId}>
+      <SharedAccessBoundary
+        key={route.shareTypeId + ":" + grantId}
+        apiBaseUrl={runtimeConfig.apiBaseUrl}
+        grantId={grantId}
+        shareTypeId={route.shareTypeId}
+        consumeFragmentSecret={consumeFragmentSecret}
+      >
+        ${layoutWrapperStart}
+          <route.component />
+        ${layoutWrapperEnd}
+      </SharedAccessBoundary>
+    </SharedPageErrorBoundary>
+  )
+}
+
+class SharedPageErrorBoundary extends React.Component<
+  { resetKey: string; children: React.ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("[SixbSharedApp] Uncaught shared page error:", error)
+  }
+
+  componentDidUpdate(previous: { resetKey: string }) {
+    if (this.state.failed && previous.resetKey !== this.props.resetKey) {
+      this.setState({ failed: false })
+    }
+  }
+
+  render() {
+    return this.state.failed ? (
+      <SharedFallback title="Something went wrong" detail="The shared page could not be displayed." />
+    ) : (
+      this.props.children
+    )
+  }
+}
+
+function SharedApp({
+  consumeFragmentSecret,
+}: {
+  consumeFragmentSecret: () => string | null
+}) {
+  return (
+    <BrowserRouter>
+      <ApplicationBoundaryReload />
+      <Routes>
+        {sharedRoutes.map((route) => (
+          <Route
+            key={route.path}
+            path={route.path}
+            element={
+              <SharedRoute route={route} consumeFragmentSecret={consumeFragmentSecret} />
+            }
+          />
+        ))}
+        <Route
+          path="*"
+          element={<SharedFallback title="Link unavailable" detail="This shared link is invalid." />}
+        />
+      </Routes>
+    </BrowserRouter>
+  )
+}
+
+export function startSharedApp(fragmentSecret: string | null) {
+  const consumeFragmentSecret = () => {
+    const value = fragmentSecret
+    fragmentSecret = null
+    return value
+  }
+  if (import.meta.hot) {
+    ;(import.meta.hot.data as SharedAppHotData & { started?: boolean }).started = true
+  }
+  getRoot().render(<SharedApp consumeFragmentSecret={consumeFragmentSecret} />)
+}
+
+if (import.meta.hot && (import.meta.hot.data as SharedAppHotData & { started?: boolean }).started) {
+  startSharedApp(null)
+}
+`
+
+  const mainPath = join(generatedDir, "shared-main.tsx")
+  await writeFileIfChanged(mainPath, mainContent)
+
+  // This bootstrap has no imports on purpose: it clears the bearer fragment
+  // before loading the authored page or any of its transitive dependencies.
+  const bootstrapContent = `function consumeFragmentSecret(): string | null {
+  const rawFragment = window.location.hash
+  if (!rawFragment) return null
+
+  const secret = rawFragment.startsWith("#") ? rawFragment.slice(1) : rawFragment
+  window.history.replaceState(
+    window.history.state,
+    "",
+    window.location.pathname + window.location.search
+  )
+  return secret || null
+}
+
+let fragmentSecret = consumeFragmentSecret()
+void import("./shared-main").then(({ startSharedApp }) => {
+  const secret = fragmentSecret
+  fragmentSecret = null
+  startSharedApp(secret)
+})
+`
+  const bootstrapPath = join(generatedDir, "shared-bootstrap.ts")
+  await writeFileIfChanged(bootstrapPath, bootstrapContent)
+
+  const metadataHead = renderMetadataHead(metadata, { manifest: false })
+  const htmlContent = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="robots" content="noindex, nofollow, noarchive" />
+    <meta name="referrer" content="no-referrer" />
+${metadataHead}
+    ${runtimeConfigScript}
+    <style>
+      * { box-sizing: border-box; }
+      html, body, #root { margin: 0; min-height: 100%; }
+      body, #root { min-height: 100vh; min-height: 100dvh; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./shared-bootstrap.ts"></script>
+  </body>
+</html>
+`
+
+  const htmlPath = join(generatedDir, "shared-index.html")
+  await writeFileIfChanged(htmlPath, htmlContent)
+  return { htmlPath, mainPath }
+}
+
+function renderMetadataHead(
+  metadata: Awaited<ReturnType<typeof resolveAppMetadata>>,
+  options: { readonly manifest?: boolean } = {}
+): string {
   const tags = [
     `    <title>${escapeHtmlText(metadata.title)}</title>`,
     ...(metadata.description
       ? [`    <meta name="description" content="${escapeHtmlAttribute(metadata.description)}" />`]
       : []),
     `    <meta name="theme-color" content="${escapeHtmlAttribute(metadata.themeColor)}" />`,
-    '    <link rel="manifest" href="/app.webmanifest" />',
+    ...(options.manifest === false ? [] : ['    <link rel="manifest" href="/app.webmanifest" />']),
     ...(metadata.favicon
       ? [`    <link rel="icon" href="${escapeHtmlAttribute(metadata.favicon)}" />`]
       : []),

--- a/packages/app/src/createCustomApp.ts
+++ b/packages/app/src/createCustomApp.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto"
 import { watch } from "node:fs"
 import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, join, normalize, relative, resolve } from "node:path"
@@ -8,10 +9,17 @@ import {
   buildApp,
   prepareAppHtmlBundleEntry,
   restoreAppStaticUrls,
+  SHARED_APP_SHELL_FILE_NAME,
 } from "./build"
-import { type BuiltInRouteManifestEntry, generateAppEntry, generateRouteManifest } from "./codegen"
+import {
+  type BuiltInRouteManifestEntry,
+  generateAppEntry,
+  generateRouteManifest,
+  generateSharedAppEntry,
+  generateSharedRouteManifest,
+} from "./codegen"
 import { renderCustomAppRuntimeScript } from "./runtime"
-import { type PageRoute, scanPages } from "./scanner"
+import { type PageRoute, partitionAppRoutes, scanPages } from "./scanner"
 import { type CustomAppStylesheet, resolveCustomAppStylesheet } from "./styles"
 import { createTailwindCssCompiler, type TailwindCssCompiler } from "./tailwind"
 
@@ -67,6 +75,7 @@ const builtInAgentRoutePaths = ["/agents", "/agents/new/:agentId", "/agents/:thr
 const builtInAgentRouteSourcePath = join(packageRoot, "src", "agents.ts")
 const customAppManifestRoute = "/app.webmanifest"
 const internalAppShellRoute = "/__sixb/generated/app-shell"
+const internalSharedAppShellRoute = "/__sixb/generated/shared-app-shell"
 
 export async function createCustomApp(options: CreateCustomAppOptions): Promise<CustomAppInstance> {
   const rootDir = resolve(options.rootDir)
@@ -214,6 +223,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
 
   async function prepareGeneratedApp(): Promise<{
     htmlPath: string
+    sharedHtmlPath: string | null
     manifestPath: string
     routes: PageRoute[]
   }> {
@@ -222,9 +232,13 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
       throw new Error(`[SixbCustomApp] No app routes found in ${appDir}`)
     }
 
-    const builtInRoutes = agentRoutesEnabled ? builtInAgentRoutesFor(routes) : []
+    const { applicationRoutes, sharedRoutes } = partitionAppRoutes(routes)
+    const builtInRoutes =
+      agentRoutesEnabled && applicationRoutes.length > 0
+        ? builtInAgentRoutesFor(applicationRoutes)
+        : []
     const stylesheets = await prepareStylesheets(builtInRoutes)
-    await generateRouteManifest(routes, generatedDir, { builtInRoutes })
+    await generateRouteManifest(applicationRoutes, generatedDir, { builtInRoutes })
     const { htmlPath, manifestPath } = await generateAppEntry(rootDir, generatedDir, {
       apiBaseUrl,
       audience,
@@ -234,7 +248,19 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
       frameworkStylesheetPaths: stylesheets.frameworkStylesheetPaths,
       stylesheetPath: stylesheets.stylesheetPath,
     })
-    return { htmlPath, manifestPath, routes }
+    let sharedHtmlPath: string | null = null
+    if (sharedRoutes.length > 0) {
+      await generateSharedRouteManifest(sharedRoutes, generatedDir)
+      sharedHtmlPath = (
+        await generateSharedAppEntry(rootDir, generatedDir, {
+          apiBaseUrl,
+          appDir,
+          publicDir,
+          stylesheetPath: stylesheets.stylesheetPath,
+        })
+      ).htmlPath
+    }
+    return { htmlPath, sharedHtmlPath, manifestPath, routes }
   }
 
   return {
@@ -250,12 +276,16 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
     async dev(devOptions: CustomAppDevOptions = {}) {
       const host = devOptions.host ?? "0.0.0.0"
       const port = devOptions.port ?? 3001
-      const { htmlPath, manifestPath } = await prepareGeneratedApp()
+      const { htmlPath, sharedHtmlPath, manifestPath } = await prepareGeneratedApp()
       let htmlImportVersion = 0
       let htmlBundle = await importHtmlBundle(htmlPath, htmlImportVersion)
+      let sharedHtmlBundle = sharedHtmlPath
+        ? await importHtmlBundle(sharedHtmlPath, htmlImportVersion)
+        : null
+      const privateSharedAppShellRoute = `${internalSharedAppShellRoute}-${randomBytes(18).toString("base64url")}`
       const publicRoutes = (await pathExists(publicDir)) ? await createPublicRoutes(publicDir) : {}
       let internalOrigin = ""
-      const serveOptions = (bundle: Bun.HTMLBundle) =>
+      const serveOptions = (bundle: Bun.HTMLBundle, sharedBundle: Bun.HTMLBundle | null) =>
         ({
           port,
           hostname: host,
@@ -265,11 +295,20 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
             ...reservedSixbRoutes(),
             [customAppManifestRoute]: manifestRoute(manifestPath),
             [internalAppShellRoute]: htmlBundleRoute(bundle),
+            ...(sharedBundle
+              ? { [privateSharedAppShellRoute]: htmlBundleRoute(sharedBundle) }
+              : {}),
+            ...sharedAppDevRoutes(
+              sharedBundle,
+              () => internalOrigin,
+              privateSharedAppShellRoute,
+              apiBaseUrl
+            ),
             "/": spaHtmlRoute(() => internalOrigin),
             "/*": spaHtmlRoute(() => internalOrigin),
           },
         }) as Parameters<typeof Bun.serve>[0]
-      const server = Bun.serve(serveOptions(htmlBundle))
+      const server = Bun.serve(serveOptions(htmlBundle, sharedHtmlBundle))
       internalOrigin = devServerInternalOrigin(host, server.port ?? port)
 
       // .ts/.tsx edits can change Tailwind's scanned classes and .css edits
@@ -280,10 +319,14 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
       const enqueueRebuild = () => {
         rebuildChain = rebuildChain
           .then(async () => {
-            const { htmlPath: nextHtmlPath } = await prepareGeneratedApp()
+            const { htmlPath: nextHtmlPath, sharedHtmlPath: nextSharedHtmlPath } =
+              await prepareGeneratedApp()
             htmlImportVersion++
             htmlBundle = await importHtmlBundle(nextHtmlPath, htmlImportVersion)
-            server.reload(serveOptions(htmlBundle))
+            sharedHtmlBundle = nextSharedHtmlPath
+              ? await importHtmlBundle(nextSharedHtmlPath, htmlImportVersion)
+              : null
+            server.reload(serveOptions(htmlBundle, sharedHtmlBundle))
           })
           .catch((error) => {
             // Keep serving the last good build, but tell the user why styles
@@ -338,18 +381,23 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
 
     async build(buildOptions: CustomAppBuildOptions = {}) {
       const outdir = resolve(rootDir, buildOptions.outdir ?? join(".sixb", "dist", "app"))
-      const { htmlPath, manifestPath } = await prepareGeneratedApp()
+      const { htmlPath, sharedHtmlPath, manifestPath } = await prepareGeneratedApp()
       const result = await buildApp({
         entryPath: htmlPath,
+        ...(sharedHtmlPath ? { sharedEntryPath: sharedHtmlPath } : {}),
         manifestPath,
         outdir,
       })
 
       if (result.success && (await pathExists(publicDir))) {
+        const reservedOutputPaths = new Set([
+          join(publicDir, "app.webmanifest"),
+          join(publicDir, SHARED_APP_SHELL_FILE_NAME),
+        ])
         await cp(publicDir, outdir, {
           recursive: true,
           force: true,
-          filter: (source) => resolve(source) !== join(publicDir, "app.webmanifest"),
+          filter: (source) => !reservedOutputPaths.has(resolve(source)),
         })
       }
 
@@ -361,6 +409,7 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
       const port = startOptions.port ?? 3001
       const outdir = resolve(rootDir, startOptions.outdir ?? join(".sixb", "dist", "app"))
       const indexPath = join(outdir, "index.html")
+      const sharedIndexPath = join(outdir, SHARED_APP_SHELL_FILE_NAME)
 
       if (!(await pathExists(indexPath))) {
         throw new Error(`[SixbCustomApp] No built app found in ${outdir}`)
@@ -371,6 +420,14 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
         audience: startOptions.audience ?? audience,
         authEnabled: startOptions.authEnabled ?? authEnabled,
       })
+      const sharedIndexHtml = (await pathExists(sharedIndexPath))
+        ? injectRuntimeConfig(await Bun.file(sharedIndexPath).text(), {
+            apiBaseUrl: startOptions.apiBaseUrl ?? apiBaseUrl,
+            audience: "app",
+            authEnabled: false,
+          })
+        : null
+      const runtimeApiBaseUrl = startOptions.apiBaseUrl ?? apiBaseUrl
       const server = Bun.serve({
         port,
         hostname: host,
@@ -381,8 +438,19 @@ export async function createCustomApp(options: CreateCustomAppOptions): Promise<
             return notFoundResponse()
           }
 
+          if (url.pathname === `/${SHARED_APP_SHELL_FILE_NAME}`) {
+            return notFoundResponse()
+          }
+
           if (req.method !== "GET" && req.method !== "HEAD") {
             return notFoundResponse()
+          }
+
+          if (isSharedAppRoute(url.pathname)) {
+            if (!sharedIndexHtml || isAssetRequest(url.pathname)) {
+              return notFoundResponse()
+            }
+            return sharedHtmlResponse(req, sharedIndexHtml, runtimeApiBaseUrl)
           }
 
           if (url.pathname === "/" || url.pathname === "") {
@@ -499,6 +567,7 @@ async function createPublicRoutes(publicDir: string): Promise<BunServeRoutes> {
 function reservedSixbRoutes(): BunServeRoutes {
   const handler = () => notFoundResponse()
   return {
+    [internalSharedAppShellRoute]: allMethodsRoute(handler),
     "/api": allMethodsRoute(handler),
     "/api/*": allMethodsRoute(handler),
     "/auth": allMethodsRoute(handler),
@@ -508,6 +577,34 @@ function reservedSixbRoutes(): BunServeRoutes {
     "/docs": allMethodsRoute(handler),
     "/docs/*": allMethodsRoute(handler),
   }
+}
+
+function sharedAppDevRoutes(
+  bundle: Bun.HTMLBundle | null,
+  internalOrigin: () => string,
+  shellRoute: string,
+  apiBaseUrl: string | undefined
+): BunServeRoutes {
+  if (!bundle) {
+    const handler = () => notFoundResponse()
+    return {
+      "/shared": allMethodsRoute(handler),
+      "/shared/*": allMethodsRoute(handler),
+    }
+  }
+
+  const handler = spaHtmlRoute(internalOrigin, {
+    shellRoute,
+    shared: { apiBaseUrl, development: true },
+  })
+  return {
+    "/shared": rejectMutations(handler),
+    "/shared/*": rejectMutations(handler),
+  }
+}
+
+function isSharedAppRoute(pathname: string): boolean {
+  return pathname === "/shared" || pathname.startsWith("/shared/")
 }
 
 function isReservedSixbRoute(pathname: string): boolean {
@@ -633,6 +730,65 @@ function htmlResponse(request: Request, html: string): Response {
   })
 }
 
+function sharedHtmlResponse(
+  request: Request,
+  html: string,
+  apiBaseUrl: string | undefined
+): Response {
+  const secured = secureSharedHtml(html, request, { apiBaseUrl, development: false })
+  return new Response(request.method === "HEAD" ? null : secured.html, {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      ...secured.headers,
+    },
+  })
+}
+
+function secureSharedHtml(
+  html: string,
+  request: Request,
+  options: { readonly apiBaseUrl?: string; readonly development: boolean }
+): { readonly html: string; readonly headers: Record<string, string> } {
+  const nonce = randomBytes(18).toString("base64url")
+  const requestOrigin = new URL(request.url).origin
+  let apiOrigin = requestOrigin
+  try {
+    apiOrigin = new URL(options.apiBaseUrl ?? requestOrigin, requestOrigin).origin
+  } catch {
+    // The client will surface the invalid runtime URL. Keep CSP fail-closed meanwhile.
+  }
+  const connectSources = ["'self'", ...(apiOrigin === requestOrigin ? [] : [apiOrigin])]
+  if (options.development) connectSources.push("ws:", "wss:")
+  const scriptSources = ["'self'", `'nonce-${nonce}'`]
+  if (options.development) scriptSources.push("'unsafe-eval'")
+  const contentSecurityPolicy = [
+    "default-src 'self'",
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'none'",
+    `script-src ${scriptSources.join(" ")}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data: https:",
+    `connect-src ${connectSources.join(" ")}`,
+    "manifest-src 'none'",
+  ].join("; ")
+
+  return {
+    html: html.replace(/<script(?![^>]*\snonce=)/g, `<script nonce="${nonce}"`),
+    headers: {
+      "cache-control": "no-store",
+      "content-security-policy": contentSecurityPolicy,
+      "permissions-policy": "camera=(), geolocation=(), microphone=()",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+      "x-frame-options": "DENY",
+      "x-robots-tag": "noindex, nofollow, noarchive",
+    },
+  }
+}
+
 // Bun.build emits content-hashed bundles named `chunk-<hash>.<ext>` (see buildApp).
 // Their contents can never change under the same URL, so they are safe to cache
 // forever — matching how Atlas serves its hashed assets. Files copied
@@ -695,6 +851,23 @@ function allMethodsRoute(handler: (request: Request) => Response): BunServeRoute
   } as unknown as BunServeRoute
 }
 
+function rejectMutations(route: BunServeRoute): BunServeRoute {
+  const reject = () => notFoundResponse()
+  const getHead = route as unknown as {
+    readonly GET: (request: Request) => Response | Promise<Response>
+    readonly HEAD: (request: Request) => Response | Promise<Response>
+  }
+  return {
+    GET: getHead.GET,
+    HEAD: getHead.HEAD,
+    POST: reject,
+    PUT: reject,
+    PATCH: reject,
+    DELETE: reject,
+    OPTIONS: reject,
+  } as unknown as BunServeRoute
+}
+
 async function importHtmlBundle(htmlPath: string, version: number): Promise<Bun.HTMLBundle> {
   const bundleEntryPath = await prepareAppHtmlBundleEntry(htmlPath)
   const url = pathToFileURL(bundleEntryPath)
@@ -728,14 +901,20 @@ function devServerInternalOrigin(host: string, port: number): string {
   return `http://${urlHost}:${port}`
 }
 
-function spaHtmlRoute(internalOrigin: () => string): BunServeRoute {
+function spaHtmlRoute(
+  internalOrigin: () => string,
+  options: {
+    readonly shellRoute?: string
+    readonly shared?: { readonly apiBaseUrl?: string; readonly development: boolean }
+  } = {}
+): BunServeRoute {
   return getHeadRoute(async (request) => {
     const publicUrl = new URL(request.url)
     if (publicUrl.pathname !== "/" && isAssetRequest(publicUrl.pathname)) {
       return notFoundResponse()
     }
 
-    const url = new URL(internalAppShellRoute, internalOrigin())
+    const url = new URL(options.shellRoute ?? internalAppShellRoute, internalOrigin())
     url.search = publicUrl.search
     const requestHeaders = new Headers(request.headers)
     for (const header of [
@@ -753,6 +932,18 @@ function spaHtmlRoute(internalOrigin: () => string): BunServeRoute {
     const responseHeaders = new Headers(bundleResponse.headers)
     responseHeaders.delete("content-length")
     responseHeaders.delete("etag")
+    let nonceSecuredHtml: string | null = null
+    if (options.shared) {
+      const secured = secureSharedHtml(
+        request.method === "HEAD" ? "" : restoreAppStaticUrls(await bundleResponse.text()),
+        request,
+        options.shared
+      )
+      nonceSecuredHtml = secured.html
+      for (const [name, value] of Object.entries(secured.headers)) {
+        responseHeaders.set(name, value)
+      }
+    }
     if (request.method === "HEAD") {
       return new Response(null, {
         status: bundleResponse.status,
@@ -761,7 +952,7 @@ function spaHtmlRoute(internalOrigin: () => string): BunServeRoute {
       })
     }
 
-    return new Response(restoreAppStaticUrls(await bundleResponse.text()), {
+    return new Response(nonceSecuredHtml ?? restoreAppStaticUrls(await bundleResponse.text()), {
       status: bundleResponse.status,
       statusText: bundleResponse.statusText,
       headers: responseHeaders,

--- a/packages/app/src/scanner.ts
+++ b/packages/app/src/scanner.ts
@@ -1,5 +1,6 @@
 import { readdir } from "node:fs/promises"
 import { join, relative } from "node:path"
+import { isRouteSafeShareTypeId, SHARE_TYPE_ID_REQUIREMENT } from "@sixb/core"
 
 export interface PageRoute {
   /** React Router path, e.g. "/" or "/remote/:id" */
@@ -41,12 +42,16 @@ export function partitionAppRoutes(routes: readonly PageRoute[]): PartitionedApp
     if (
       segments.length !== 4 ||
       !shareTypeId ||
-      shareTypeId.startsWith("[") ||
       segments[2] !== "[grantId]" ||
       (segments[3] !== "page.tsx" && segments[3] !== "page.ts")
     ) {
       throw new Error(
         `[SixbCustomApp] Shared pages must use app/shared/<shareTypeId>/[grantId]/page.tsx; found app/${route.relativePath.split("\\").join("/")}.`
+      )
+    }
+    if (!isRouteSafeShareTypeId(shareTypeId)) {
+      throw new Error(
+        `[SixbCustomApp] Shared page ShareType id '${shareTypeId}' ${SHARE_TYPE_ID_REQUIREMENT}.`
       )
     }
 

--- a/packages/app/src/scanner.ts
+++ b/packages/app/src/scanner.ts
@@ -10,6 +10,52 @@ export interface PageRoute {
   relativePath: string
 }
 
+export interface SharedPageRoute extends PageRoute {
+  /** ShareType selected by the static directory below `app/shared/`. */
+  shareTypeId: string
+}
+
+export interface PartitionedAppRoutes {
+  applicationRoutes: PageRoute[]
+  sharedRoutes: SharedPageRoute[]
+}
+
+/**
+ * Reserves `app/shared/` for the isolated shared-access entry point.
+ *
+ * Keeping one canonical shape makes public exposure explicit and lets the
+ * generated runtime bind the static ShareType to the grant returned by the API.
+ */
+export function partitionAppRoutes(routes: readonly PageRoute[]): PartitionedAppRoutes {
+  const applicationRoutes: PageRoute[] = []
+  const sharedRoutes: SharedPageRoute[] = []
+
+  for (const route of routes) {
+    const segments = route.relativePath.split(/[\\/]+/)
+    if (segments[0] !== "shared") {
+      applicationRoutes.push(route)
+      continue
+    }
+
+    const shareTypeId = segments[1]
+    if (
+      segments.length !== 4 ||
+      !shareTypeId ||
+      shareTypeId.startsWith("[") ||
+      segments[2] !== "[grantId]" ||
+      (segments[3] !== "page.tsx" && segments[3] !== "page.ts")
+    ) {
+      throw new Error(
+        `[SixbCustomApp] Shared pages must use app/shared/<shareTypeId>/[grantId]/page.tsx; found app/${route.relativePath.split("\\").join("/")}.`
+      )
+    }
+
+    sharedRoutes.push({ ...route, shareTypeId })
+  }
+
+  return { applicationRoutes, sharedRoutes }
+}
+
 /**
  * Recursively scans an `app/` directory for `page.tsx`/`page.ts` files and
  * converts them to React Router route paths.

--- a/packages/app/src/shared-runtime.ts
+++ b/packages/app/src/shared-runtime.ts
@@ -1,7 +1,9 @@
-import type {
-  SharedAccessClient,
-  SharedAccessContext,
-  SharedAccessResource,
+import {
+  isSixbApiError,
+  isValidSharedAccessSecret,
+  type SharedAccessClient,
+  type SharedAccessContext,
+  type SharedAccessResource,
 } from "@sixb/client/shared"
 
 export interface SharedAppBrowserLocation {
@@ -20,6 +22,8 @@ export interface BootstrapSharedAppAccessOptions {
   readonly grantId: string
   readonly fragmentSecret: string | null
   readonly client: SharedAccessClient
+  /** Called once the secret has been exchanged or an existing session validated. */
+  readonly onAccessEstablished?: () => void
 }
 
 export interface BootstrappedSharedAppAccess {
@@ -42,6 +46,10 @@ export class SharedAppUnavailableError extends Error {
 export async function bootstrapSharedAppAccess(
   options: BootstrapSharedAppAccessOptions
 ): Promise<BootstrappedSharedAppAccess> {
+  if (options.fragmentSecret !== null && !isValidSharedAccessSecret(options.fragmentSecret)) {
+    throw new SharedAppUnavailableError()
+  }
+
   const access = options.fragmentSecret
     ? await options.client.exchange(options.fragmentSecret)
     : await options.client.getSession()
@@ -53,6 +61,7 @@ export async function bootstrapSharedAppAccess(
   ) {
     throw new SharedAppUnavailableError()
   }
+  options.onAccessEstablished?.()
 
   const resource = await options.client.getResource()
   if (
@@ -63,6 +72,23 @@ export async function bootstrapSharedAppAccess(
   }
 
   return { access, resource }
+}
+
+export type SharedAppFailureKind = "terminal" | "retryable" | "unexpected"
+
+/** Keeps public failures generic while preserving enough signal for a safe retry. */
+export function classifySharedAppFailure(error: unknown): SharedAppFailureKind {
+  if (error instanceof SharedAppUnavailableError) return "terminal"
+
+  if (isSixbApiError(error)) {
+    if (error.status === 408 || error.status === 429 || error.status >= 500) {
+      return "retryable"
+    }
+    return "terminal"
+  }
+
+  if (error instanceof TypeError) return "retryable"
+  return "unexpected"
 }
 
 export function consumeSharedAppFragmentSecret(

--- a/packages/app/src/shared-runtime.ts
+++ b/packages/app/src/shared-runtime.ts
@@ -1,0 +1,79 @@
+import type {
+  SharedAccessClient,
+  SharedAccessContext,
+  SharedAccessResource,
+} from "@sixb/client/shared"
+
+export interface SharedAppBrowserLocation {
+  readonly hash: string
+  readonly pathname: string
+  readonly search: string
+}
+
+export interface SharedAppBrowserHistory {
+  readonly state: unknown
+  replaceState(data: unknown, unused: string, url?: string | URL | null): void
+}
+
+export interface BootstrapSharedAppAccessOptions {
+  readonly expectedShareTypeId: string
+  readonly grantId: string
+  readonly fragmentSecret: string | null
+  readonly client: SharedAccessClient
+}
+
+export interface BootstrappedSharedAppAccess {
+  readonly access: SharedAccessContext
+  readonly resource: SharedAccessResource
+}
+
+/** Generic by design: the public page must not reveal which boundary check failed. */
+export class SharedAppUnavailableError extends Error {
+  constructor() {
+    super("[SixbSharedApp] Shared access is unavailable.")
+    this.name = "SharedAppUnavailableError"
+  }
+}
+
+/**
+ * Establishes one shared page without consulting the normal application session.
+ * The fragment is removed before the long-lived link secret reaches the network.
+ */
+export async function bootstrapSharedAppAccess(
+  options: BootstrapSharedAppAccessOptions
+): Promise<BootstrappedSharedAppAccess> {
+  const access = options.fragmentSecret
+    ? await options.client.exchange(options.fragmentSecret)
+    : await options.client.getSession()
+
+  if (
+    !access.authenticated ||
+    access.grant.id !== options.grantId ||
+    access.grant.shareTypeId !== options.expectedShareTypeId
+  ) {
+    throw new SharedAppUnavailableError()
+  }
+
+  const resource = await options.client.getResource()
+  if (
+    resource.objectTypeId !== access.grant.target.objectTypeId ||
+    resource.primaryId !== access.grant.target.primaryId
+  ) {
+    throw new SharedAppUnavailableError()
+  }
+
+  return { access, resource }
+}
+
+export function consumeSharedAppFragmentSecret(
+  location: SharedAppBrowserLocation,
+  history: SharedAppBrowserHistory
+): string | null {
+  if (!location.hash) return null
+
+  const secret = location.hash.startsWith("#") ? location.hash.slice(1) : location.hash
+  // Clear the credential before exchange. If history replacement fails, abort rather
+  // than sending a reusable secret while it remains visible in the address bar.
+  history.replaceState(history.state, "", `${location.pathname}${location.search}`)
+  return secret || null
+}

--- a/packages/app/src/shared.ts
+++ b/packages/app/src/shared.ts
@@ -1,0 +1,263 @@
+import {
+  createSharedAccessClient,
+  type SharedAccessActionInput,
+  type SharedAccessActionResult,
+  type SharedAccessContext,
+  type SharedAccessResource,
+} from "@sixb/client/shared"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  createContext,
+  createElement,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+import { bootstrapSharedAppAccess, SharedAppUnavailableError } from "./shared-runtime"
+
+export interface SharedAppRuntimeConfig {
+  readonly apiBaseUrl: string
+}
+
+export interface SharedAccessValue {
+  readonly grantId: string
+  readonly shareTypeId: string
+  readonly grant: SharedAccessContext["grant"]
+  readonly session: SharedAccessContext["session"]
+  readonly resource: SharedAccessResource
+  requestAction(
+    actionId: string,
+    input?: SharedAccessActionInput
+  ): Promise<SharedAccessActionResult>
+  refreshResource(): Promise<SharedAccessResource>
+  signOut(): Promise<void>
+}
+
+export interface SharedAccessBoundaryProps {
+  readonly apiBaseUrl: string
+  readonly grantId: string
+  readonly shareTypeId: string
+  consumeFragmentSecret(): string | null
+  readonly children: ReactNode
+}
+
+type SharedAccessState =
+  | { readonly status: "loading" }
+  | { readonly status: "unavailable" }
+  | {
+      readonly status: "ready"
+      readonly access: SharedAccessContext
+      readonly resource: SharedAccessResource
+    }
+
+const SharedAccessContextValue = createContext<SharedAccessValue | null>(null)
+
+/** Reads only the API origin injected into the shared HTML entry. */
+export function readSharedAppRuntimeConfig(): SharedAppRuntimeConfig {
+  const runtime = (
+    window as Window & {
+      readonly __SIXB_RUNTIME__?: {
+        readonly api?: { readonly baseUrl?: unknown }
+      }
+    }
+  ).__SIXB_RUNTIME__
+  const configuredBaseUrl = runtime?.api?.baseUrl
+  return {
+    apiBaseUrl:
+      typeof configuredBaseUrl === "string" && configuredBaseUrl.trim()
+        ? configuredBaseUrl
+        : window.location.origin,
+  }
+}
+
+/** Returns the exact grant-bound authority prepared by the generated shared shell. */
+export function useSharedAccess(): SharedAccessValue {
+  const value = useContext(SharedAccessContextValue)
+  if (!value) {
+    throw new Error("[SixbSharedApp] useSharedAccess() must be used inside a shared page.")
+  }
+  return value
+}
+
+/** Framework-owned bootstrap boundary used by the generated shared entry point. */
+export function SharedAccessBoundary(props: SharedAccessBoundaryProps) {
+  const client = useMemo(
+    () => createSharedAccessClient({ grantId: props.grantId, baseUrl: props.apiBaseUrl }),
+    [props.apiBaseUrl, props.grantId]
+  )
+  const [queryClient] = useState(createSharedQueryClient)
+  const [state, setState] = useState<SharedAccessState>({ status: "loading" })
+
+  useEffect(() => {
+    let cancelled = false
+    setState({ status: "loading" })
+
+    void bootstrapSharedAppAccess({
+      expectedShareTypeId: props.shareTypeId,
+      grantId: props.grantId,
+      fragmentSecret: props.consumeFragmentSecret(),
+      client,
+    }).then(
+      (result) => {
+        if (!cancelled) setState({ status: "ready", ...result })
+      },
+      () => {
+        if (!cancelled) setState({ status: "unavailable" })
+      }
+    )
+
+    return () => {
+      cancelled = true
+    }
+  }, [client, props.consumeFragmentSecret, props.grantId, props.shareTypeId])
+
+  useEffect(() => {
+    return () => queryClient.clear()
+  }, [queryClient])
+
+  useEffect(() => {
+    if (state.status === "unavailable") queryClient.clear()
+  }, [queryClient, state.status])
+
+  useEffect(() => {
+    if (state.status !== "ready") return
+    const expiresAt = Math.min(
+      Date.parse(state.access.grant.expiresAt),
+      Date.parse(state.access.session.expiresAt)
+    )
+    if (!Number.isFinite(expiresAt)) {
+      setState({ status: "unavailable" })
+      return
+    }
+
+    const remaining = expiresAt - Date.now()
+    if (remaining <= 0) {
+      setState({ status: "unavailable" })
+      return
+    }
+
+    const timeout = window.setTimeout(
+      () => setState({ status: "unavailable" }),
+      Math.min(remaining, 2_147_483_647)
+    )
+    return () => window.clearTimeout(timeout)
+  }, [state])
+
+  const value = useMemo<SharedAccessValue | null>(() => {
+    if (state.status !== "ready") return null
+
+    return {
+      grantId: props.grantId,
+      shareTypeId: props.shareTypeId,
+      grant: state.access.grant,
+      session: state.access.session,
+      resource: state.resource,
+      async requestAction(actionId, input) {
+        try {
+          return await client.requestAction(actionId, input)
+        } catch (error) {
+          if (isUnavailableError(error)) setState({ status: "unavailable" })
+          throw error
+        }
+      },
+      async refreshResource() {
+        try {
+          const resource = await client.getResource()
+          assertExactResource(resource, state.access)
+          setState({ status: "ready", access: state.access, resource })
+          return resource
+        } catch (error) {
+          if (isUnavailableError(error)) setState({ status: "unavailable" })
+          throw error
+        }
+      },
+      async signOut() {
+        await client.signOut()
+        setState({ status: "unavailable" })
+      },
+    }
+  }, [client, props.grantId, props.shareTypeId, state])
+
+  const content =
+    state.status === "loading"
+      ? createElement(SharedAppFallback, {
+          role: "status",
+          title: "Opening shared access…",
+          detail: "Please wait while this link is verified.",
+        })
+      : state.status === "unavailable" || !value
+        ? createElement(SharedAppFallback, {
+            role: "alert",
+            title: "Link unavailable",
+            detail: "This shared link is invalid, expired, or no longer available.",
+          })
+        : createElement(SharedAccessContextValue.Provider, { value }, props.children)
+
+  return createElement(QueryClientProvider, { client: queryClient }, content)
+}
+
+function createSharedQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        retry: false,
+      },
+    },
+  })
+}
+
+function assertExactResource(resource: SharedAccessResource, access: SharedAccessContext): void {
+  if (
+    resource.objectTypeId !== access.grant.target.objectTypeId ||
+    resource.primaryId !== access.grant.target.primaryId
+  ) {
+    throw new SharedAppUnavailableError()
+  }
+}
+
+function isUnavailableError(error: unknown): boolean {
+  if (error instanceof SharedAppUnavailableError) return true
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    ((error as { readonly code?: unknown }).code === "share.access_unavailable" ||
+      (error as { readonly code?: unknown }).code === "share.resource_not_found")
+  )
+}
+
+function SharedAppFallback(props: {
+  readonly role: "alert" | "status"
+  readonly title: string
+  readonly detail: string
+}) {
+  return createElement(
+    "main",
+    {
+      role: props.role,
+      style: {
+        minHeight: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "0.75rem",
+        padding: "2rem",
+        textAlign: "center",
+        fontFamily:
+          "var(--font-sans, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif)",
+        background: "var(--background, #ffffff)",
+        color: "var(--foreground, #1f2933)",
+      },
+    },
+    createElement("h1", { style: { margin: 0, fontSize: "1.5rem" } }, props.title),
+    createElement(
+      "p",
+      { style: { margin: 0, maxWidth: "32rem", color: "var(--muted-foreground, #52606d)" } },
+      props.detail
+    )
+  )
+}

--- a/packages/app/src/shared.ts
+++ b/packages/app/src/shared.ts
@@ -1,5 +1,6 @@
 import {
   createSharedAccessClient,
+  isSixbApiError,
   type SharedAccessActionInput,
   type SharedAccessActionResult,
   type SharedAccessContext,
@@ -13,9 +14,14 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
-import { bootstrapSharedAppAccess, SharedAppUnavailableError } from "./shared-runtime"
+import {
+  bootstrapSharedAppAccess,
+  classifySharedAppFailure,
+  SharedAppUnavailableError,
+} from "./shared-runtime"
 
 export interface SharedAppRuntimeConfig {
   readonly apiBaseUrl: string
@@ -45,6 +51,7 @@ export interface SharedAccessBoundaryProps {
 
 type SharedAccessState =
   | { readonly status: "loading" }
+  | { readonly status: "retryable" }
   | { readonly status: "unavailable" }
   | {
       readonly status: "ready"
@@ -53,6 +60,8 @@ type SharedAccessState =
     }
 
 const SharedAccessContextValue = createContext<SharedAccessValue | null>(null)
+
+type SharedBootstrapOutcome = Exclude<SharedAccessState, { readonly status: "loading" }>
 
 /** Reads only the API origin injected into the shared HTML entry. */
 export function readSharedAppRuntimeConfig(): SharedAppRuntimeConfig {
@@ -89,29 +98,61 @@ export function SharedAccessBoundary(props: SharedAccessBoundaryProps) {
   )
   const [queryClient] = useState(createSharedQueryClient)
   const [state, setState] = useState<SharedAccessState>({ status: "loading" })
+  const [bootstrapAttempt, setBootstrapAttempt] = useState(0)
+  const fragmentSecret = useRef<string | null | undefined>(undefined)
+  const bootstrap = useRef<{
+    readonly attempt: number
+    readonly promise: Promise<SharedBootstrapOutcome>
+  } | null>(null)
 
   useEffect(() => {
     let cancelled = false
     setState({ status: "loading" })
 
-    void bootstrapSharedAppAccess({
-      expectedShareTypeId: props.shareTypeId,
-      grantId: props.grantId,
-      fragmentSecret: props.consumeFragmentSecret(),
-      client,
-    }).then(
-      (result) => {
-        if (!cancelled) setState({ status: "ready", ...result })
-      },
-      () => {
-        if (!cancelled) setState({ status: "unavailable" })
+    let current = bootstrap.current
+    if (!current || current.attempt !== bootstrapAttempt) {
+      if (fragmentSecret.current === undefined) {
+        fragmentSecret.current = props.consumeFragmentSecret()
       }
-    )
+
+      const promise = bootstrapSharedAppAccess({
+        expectedShareTypeId: props.shareTypeId,
+        grantId: props.grantId,
+        fragmentSecret: fragmentSecret.current,
+        client,
+        // Once exchange succeeds, the short-lived session is sufficient even
+        // if loading the resource fails and the user retries.
+        onAccessEstablished: () => {
+          fragmentSecret.current = null
+        },
+      }).then<SharedBootstrapOutcome, SharedBootstrapOutcome>(
+        (result) => {
+          fragmentSecret.current = null
+          return { status: "ready", ...result }
+        },
+        (error) => {
+          const kind = classifySharedAppFailure(error)
+          if (kind === "terminal") {
+            fragmentSecret.current = null
+            return { status: "unavailable" }
+          }
+
+          console.error("[SixbSharedApp] Could not open shared access; retry is available.", error)
+          return { status: "retryable" }
+        }
+      )
+      current = { attempt: bootstrapAttempt, promise }
+      bootstrap.current = current
+    }
+
+    void current.promise.then((result) => {
+      if (!cancelled) setState(result)
+    })
 
     return () => {
       cancelled = true
     }
-  }, [client, props.consumeFragmentSecret, props.grantId, props.shareTypeId])
+  }, [bootstrapAttempt, client, props.consumeFragmentSecret, props.grantId, props.shareTypeId])
 
   useEffect(() => {
     return () => queryClient.clear()
@@ -187,13 +228,20 @@ export function SharedAccessBoundary(props: SharedAccessBoundaryProps) {
           title: "Opening shared access…",
           detail: "Please wait while this link is verified.",
         })
-      : state.status === "unavailable" || !value
+      : state.status === "retryable"
         ? createElement(SharedAppFallback, {
             role: "alert",
-            title: "Link unavailable",
-            detail: "This shared link is invalid, expired, or no longer available.",
+            title: "Unable to open this link",
+            detail: "A temporary problem occurred. Please try again.",
+            onRetry: () => setBootstrapAttempt((attempt) => attempt + 1),
           })
-        : createElement(SharedAccessContextValue.Provider, { value }, props.children)
+        : state.status === "unavailable" || !value
+          ? createElement(SharedAppFallback, {
+              role: "alert",
+              title: "Link unavailable",
+              detail: "This shared link is invalid, expired, or no longer available.",
+            })
+          : createElement(SharedAccessContextValue.Provider, { value }, props.children)
 
   return createElement(QueryClientProvider, { client: queryClient }, content)
 }
@@ -221,11 +269,8 @@ function assertExactResource(resource: SharedAccessResource, access: SharedAcces
 function isUnavailableError(error: unknown): boolean {
   if (error instanceof SharedAppUnavailableError) return true
   return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    ((error as { readonly code?: unknown }).code === "share.access_unavailable" ||
-      (error as { readonly code?: unknown }).code === "share.resource_not_found")
+    isSixbApiError(error) &&
+    (error.code === "share.access_unavailable" || error.code === "share.resource_not_found")
   )
 }
 
@@ -233,6 +278,7 @@ function SharedAppFallback(props: {
   readonly role: "alert" | "status"
   readonly title: string
   readonly detail: string
+  readonly onRetry?: () => void
 }) {
   return createElement(
     "main",
@@ -258,6 +304,26 @@ function SharedAppFallback(props: {
       "p",
       { style: { margin: 0, maxWidth: "32rem", color: "var(--muted-foreground, #52606d)" } },
       props.detail
-    )
+    ),
+    props.onRetry
+      ? createElement(
+          "button",
+          {
+            type: "button",
+            onClick: props.onRetry,
+            style: {
+              marginTop: "0.25rem",
+              padding: "0.625rem 1rem",
+              border: "1px solid currentColor",
+              borderRadius: "0.375rem",
+              background: "transparent",
+              color: "inherit",
+              cursor: "pointer",
+              font: "inherit",
+            },
+          },
+          "Try again"
+        )
+      : null
   )
 }

--- a/packages/app/tests/helpers/shared-app-e2e-runner.ts
+++ b/packages/app/tests/helpers/shared-app-e2e-runner.ts
@@ -1,0 +1,237 @@
+import { mkdir, readFile, symlink, writeFile } from "node:fs/promises"
+import { createServer } from "node:net"
+import { dirname, join, resolve } from "node:path"
+import { buildApp } from "../../src/build"
+import { createCustomApp } from "../../src/createCustomApp"
+
+const scenario = process.argv[2]
+const root = process.argv[3]
+if (!scenario || !root) {
+  throw new Error("Expected a shared app e2e scenario and an isolated root directory.")
+}
+
+if (scenario === "dev-shells") {
+  await runDevShells(root)
+} else if (scenario === "production-shells") {
+  await runProductionShells(root)
+} else if (scenario === "html-entries") {
+  await runHtmlEntries(root)
+} else {
+  throw new Error(`Unknown shared app e2e scenario '${scenario}'.`)
+}
+
+async function runDevShells(projectRoot: string): Promise<void> {
+  await prepareSharedProject(projectRoot)
+  const port = await getFreePort()
+  const app = await createCustomApp({
+    rootDir: projectRoot,
+    apiBaseUrl: "https://api.example.com",
+    authEnabled: true,
+    agentRoutes: false,
+  })
+  const server = await app.dev({ host: "127.0.0.1", port })
+
+  try {
+    const application = await fetch(`http://127.0.0.1:${port}/`)
+    const shared = await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`)
+    const internalSharedShell = await fetch(
+      `http://127.0.0.1:${port}/__sixb/generated/shared-app-shell`
+    )
+    assertEqual(application.status, 200, "application shell status")
+    assertEqual(shared.status, 200, "shared shell status")
+    assertEqual(internalSharedShell.status, 404, "private shared shell status")
+
+    const applicationHtml = await application.text()
+    const sharedHtml = await shared.text()
+    const sharedCsp = shared.headers.get("content-security-policy") ?? ""
+    const scriptNonce = sharedHtml.match(/<script nonce="([^"]+)"/)?.[1]
+    assert(applicationHtml !== sharedHtml, "application and shared shells must differ")
+    assert(scriptNonce, "shared shell must contain a script nonce")
+    assertIncludes(sharedCsp, `'nonce-${scriptNonce}'`, "shared CSP nonce")
+    assertEqual(shared.headers.get("cache-control"), "no-store", "shared cache policy")
+    assertEqual(shared.headers.get("referrer-policy"), "no-referrer", "shared referrer policy")
+    assertEqual(
+      shared.headers.get("x-robots-tag"),
+      "noindex, nofollow, noarchive",
+      "shared robots policy"
+    )
+    assertIncludes(
+      sharedCsp,
+      "connect-src 'self' https://api.example.com",
+      "shared API connection policy"
+    )
+
+    const mutation = await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`, {
+      method: "POST",
+    })
+    assertEqual(mutation.status, 404, "shared shell mutation status")
+
+    const applicationRoutes = await readFile(
+      join(projectRoot, ".sixb", "generated", "routes.ts"),
+      "utf-8"
+    )
+    const sharedRoutes = await readFile(
+      join(projectRoot, ".sixb", "generated", "shared-routes.ts"),
+      "utf-8"
+    )
+    assert(
+      !applicationRoutes.includes("published-report"),
+      "normal routes must exclude shared page"
+    )
+    assert(sharedRoutes.includes("published-report"), "shared routes must include shared page")
+  } finally {
+    await server.stop()
+  }
+}
+
+async function runProductionShells(projectRoot: string): Promise<void> {
+  await prepareSharedProject(projectRoot)
+  const outdir = join(projectRoot, ".sixb", "dist", "app")
+  await mkdir(join(projectRoot, "app", "public"), { recursive: true })
+  await writeFile(
+    join(projectRoot, "app", "public", "shared-index.html"),
+    "<!doctype html><p>Public file must not replace the shared shell.</p>\n"
+  )
+
+  const app = await createCustomApp({
+    rootDir: projectRoot,
+    authEnabled: true,
+    agentRoutes: false,
+  })
+  const result = await app.build({ outdir })
+  assert(result.success, `shared app build failed: ${result.logs?.join("\n") ?? "unknown error"}`)
+  assert(
+    !(await readFile(join(outdir, "shared-index.html"), "utf-8")).includes(
+      "Public file must not replace"
+    ),
+    "public assets must not replace the framework shared shell"
+  )
+
+  const port = await getFreePort()
+  const server = await app.start({
+    host: "127.0.0.1",
+    port,
+    outdir,
+    apiBaseUrl: "https://api.example.com",
+    authEnabled: true,
+  })
+  try {
+    const application = await fetch(`http://127.0.0.1:${port}/`)
+    const shared = await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`)
+    const rawSharedShell = await fetch(`http://127.0.0.1:${port}/shared-index.html`)
+    assertEqual(application.status, 200, "production application shell status")
+    assertEqual(shared.status, 200, "production shared shell status")
+    assertEqual(rawSharedShell.status, 404, "raw shared shell status")
+    assert((await application.text()) !== (await shared.text()), "production shells must differ")
+    assertIncludes(
+      shared.headers.get("content-security-policy") ?? "",
+      "connect-src 'self' https://api.example.com",
+      "production shared CSP"
+    )
+  } finally {
+    await server.stop()
+  }
+}
+
+async function runHtmlEntries(projectRoot: string): Promise<void> {
+  const generatedDir = join(projectRoot, "generated")
+  const outdir = join(projectRoot, "dist")
+  await mkdir(generatedDir, { recursive: true })
+  await writeFile(join(generatedDir, "main.ts"), 'document.body.dataset.entry = "app"\n')
+  await writeFile(join(generatedDir, "shared-main.ts"), 'document.body.dataset.entry = "shared"\n')
+  await writeFile(
+    join(generatedDir, "index.html"),
+    '<!doctype html><body><script type="module" src="./main.ts"></script></body>\n'
+  )
+  await writeFile(
+    join(generatedDir, "shared-index.html"),
+    '<!doctype html><body><script type="module" src="./shared-main.ts"></script></body>\n'
+  )
+
+  const result = await buildApp({
+    entryPath: join(generatedDir, "index.html"),
+    sharedEntryPath: join(generatedDir, "shared-index.html"),
+    outdir,
+  })
+  assert(result.success, `HTML entry build failed: ${result.logs?.join("\n") ?? "unknown error"}`)
+
+  const applicationHtml = await readFile(join(outdir, "index.html"), "utf-8")
+  const sharedHtml = await readFile(join(outdir, "shared-index.html"), "utf-8")
+  assert(/src=["']\/[^"']+\.js["']/.test(applicationHtml), "normal assets must be root-relative")
+  assert(/src=["']\/[^"']+\.js["']/.test(sharedHtml), "shared assets must be root-relative")
+  assert(applicationHtml !== sharedHtml, "built HTML entries must differ")
+  assert(
+    !(await Bun.file(join(generatedDir, "index.sixb-bundle.html")).exists()),
+    "normal temporary bundle entry must be removed"
+  )
+  assert(
+    !(await Bun.file(join(generatedDir, "shared-index.sixb-bundle.html")).exists()),
+    "shared temporary bundle entry must be removed"
+  )
+}
+
+async function prepareSharedProject(projectRoot: string): Promise<void> {
+  await mkdir(join(projectRoot, "app", "shared", "published-report", "[grantId]"), {
+    recursive: true,
+  })
+  await writeFile(
+    join(projectRoot, "app", "page.tsx"),
+    "export default function AppPage() { return <main>Application shell</main> }\n"
+  )
+  await writeFile(
+    join(projectRoot, "app", "shared", "published-report", "[grantId]", "page.tsx"),
+    "export default function SharedPage() { return <main>Shared shell</main> }\n"
+  )
+  await linkSharedAppDependencies(projectRoot)
+}
+
+async function linkSharedAppDependencies(projectRoot: string): Promise<void> {
+  const appPackageRoot = resolve(import.meta.dir, "../..")
+  const targets = new Map<string, string>([
+    ["@sixb/app", appPackageRoot],
+    ["@sixb/client", resolve(appPackageRoot, "../client")],
+    ["@tanstack/react-query", join(appPackageRoot, "node_modules", "@tanstack/react-query")],
+    ["react", join(appPackageRoot, "node_modules", "react")],
+    ["react-dom", join(appPackageRoot, "node_modules", "react-dom")],
+    ["react-router-dom", join(appPackageRoot, "node_modules", "react-router-dom")],
+  ])
+
+  for (const [name, source] of targets) {
+    const target = join(projectRoot, "node_modules", ...name.split("/"))
+    await mkdir(dirname(target), { recursive: true })
+    await symlink(source, target, "dir")
+  }
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise<number>((resolvePort, reject) => {
+    const server = createServer()
+    server.on("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        reject(new Error("Could not resolve an open port"))
+        return
+      }
+      server.close((error) => (error ? reject(error) : resolvePort(address.port)))
+    })
+  })
+}
+
+function assert(value: unknown, message: string): asserts value {
+  if (!value) throw new Error(message)
+}
+
+function assertEqual(actual: unknown, expected: unknown, label: string): void {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${String(expected)}, received ${String(actual)}`)
+  }
+}
+
+function assertIncludes(actual: string, expected: string, label: string): void {
+  if (!actual.includes(expected)) {
+    throw new Error(
+      `${label}: expected ${JSON.stringify(actual)} to include ${JSON.stringify(expected)}`
+    )
+  }
+}

--- a/packages/app/tests/shared-app.e2e.ts
+++ b/packages/app/tests/shared-app.e2e.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+const repoRoot = resolve(import.meta.dir, "../../..")
+const runnerPath = join(import.meta.dir, "helpers", "shared-app-e2e-runner.ts")
+const workspaceTempDir = join(repoRoot, ".local", "test-tmp")
+const SCENARIO_BUDGET_MS = 60_000
+
+type SharedAppE2eScenario = "dev-shells" | "production-shells" | "html-entries"
+
+const scenarios: SharedAppE2eScenario[] = ["dev-shells", "production-shells", "html-entries"]
+
+test.each(scenarios)(
+  "runs the shared app %s bundling scenario in a bounded child process",
+  async (scenario) => {
+    await mkdir(workspaceTempDir, { recursive: true })
+    const scenarioRoot = await mkdtemp(join(workspaceTempDir, `sixb-shared-${scenario}-`))
+
+    try {
+      const result = await runScenario(scenario, scenarioRoot)
+      expect(result).toEqual({ exitCode: 0, output: "" })
+    } finally {
+      await rm(scenarioRoot, { recursive: true, force: true })
+    }
+  },
+  SCENARIO_BUDGET_MS + 10_000
+)
+
+/**
+ * The app runtime invokes Bun's HTML bundler. Running it inside this test process would make a
+ * native bundler deadlock survive the test timeout and wedge every later test. The child is
+ * killable, so the timeout below remains a real bound.
+ */
+async function runScenario(
+  scenario: (typeof scenarios)[number],
+  scenarioRoot: string
+): Promise<{ readonly exitCode: number; readonly output: string }> {
+  const proc = Bun.spawn([process.execPath, runnerPath, scenario, scenarioRoot], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const stdout = new Response(proc.stdout).text()
+  const stderr = new Response(proc.stderr).text()
+  let timedOut = false
+  const killTimer = setTimeout(() => {
+    timedOut = true
+    proc.kill()
+  }, SCENARIO_BUDGET_MS)
+
+  try {
+    const exitCode = await proc.exited
+    const output = `${await stdout}${await stderr}`.trim()
+    return {
+      exitCode,
+      output: timedOut
+        ? `Shared app ${scenario} bundling did not finish within ${SCENARIO_BUDGET_MS}ms and was killed.`
+        : exitCode === 0
+          ? ""
+          : output || `Shared app ${scenario} runner exited with code ${exitCode}.`,
+    }
+  } finally {
+    clearTimeout(killTimer)
+    await Promise.all([stdout.catch(() => ""), stderr.catch(() => "")])
+  }
+}

--- a/packages/app/tests/shared-app.test.ts
+++ b/packages/app/tests/shared-app.test.ts
@@ -1,15 +1,13 @@
 import { afterEach, describe, expect, mock, test } from "bun:test"
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
-import { createServer } from "node:net"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { join } from "node:path"
 import type { SharedAccessClient } from "@sixb/client/shared"
-import { buildApp } from "../src/build"
 import { generateSharedAppEntry, generateSharedRouteManifest } from "../src/codegen"
-import { createCustomApp } from "../src/createCustomApp"
 import { type PageRoute, partitionAppRoutes } from "../src/scanner"
 import {
   bootstrapSharedAppAccess,
+  classifySharedAppFailure,
   consumeSharedAppFragmentSecret,
   SharedAppUnavailableError,
 } from "../src/shared-runtime"
@@ -18,39 +16,6 @@ const publishedReportRoute: PageRoute = {
   path: "/shared/published-report/:grantId",
   filePath: "/project/app/shared/published-report/[grantId]/page.tsx",
   relativePath: "shared/published-report/[grantId]/page.tsx",
-}
-
-async function getFreePort(): Promise<number> {
-  return await new Promise<number>((resolvePort, reject) => {
-    const server = createServer()
-    server.on("error", reject)
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address()
-      if (!address || typeof address === "string") {
-        reject(new Error("Could not resolve an open port"))
-        return
-      }
-      server.close((error) => (error ? reject(error) : resolvePort(address.port)))
-    })
-  })
-}
-
-async function linkSharedAppDependencies(projectRoot: string): Promise<void> {
-  const appPackageRoot = resolve(import.meta.dir, "..")
-  const targets = new Map<string, string>([
-    ["@sixb/app", appPackageRoot],
-    ["@sixb/client", resolve(appPackageRoot, "../client")],
-    ["@tanstack/react-query", join(appPackageRoot, "node_modules", "@tanstack/react-query")],
-    ["react", join(appPackageRoot, "node_modules", "react")],
-    ["react-dom", join(appPackageRoot, "node_modules", "react-dom")],
-    ["react-router-dom", join(appPackageRoot, "node_modules", "react-router-dom")],
-  ])
-
-  for (const [name, source] of targets) {
-    const target = join(projectRoot, "node_modules", ...name.split("/"))
-    await mkdir(resolve(target, ".."), { recursive: true })
-    await symlink(source, target, "dir")
-  }
 }
 
 describe("shared app route boundary", () => {
@@ -71,7 +36,6 @@ describe("shared app route boundary", () => {
     "shared/page.tsx",
     "shared/published-report/page.tsx",
     "shared/published-report/[token]/page.tsx",
-    "shared/[shareTypeId]/[grantId]/page.tsx",
     "shared/published-report/[grantId]/details/page.tsx",
   ])("rejects malformed public shared route %s", (relativePath) => {
     expect(() =>
@@ -83,6 +47,23 @@ describe("shared app route boundary", () => {
         },
       ])
     ).toThrow("Shared pages must use app/shared/<shareTypeId>/[grantId]/page.tsx")
+  })
+
+  test.each([
+    ":report",
+    ".report",
+    "report name",
+    "[shareTypeId]",
+  ])("rejects route-unsafe ShareType id %s", (shareTypeId) => {
+    expect(() =>
+      partitionAppRoutes([
+        {
+          path: `/shared/${shareTypeId}/:grantId`,
+          filePath: `/project/app/shared/${shareTypeId}/[grantId]/page.tsx`,
+          relativePath: `shared/${shareTypeId}/[grantId]/page.tsx`,
+        },
+      ])
+    ).toThrow("ShareType id")
   })
 
   test("generates a manifest that binds each page to its declared ShareType", async () => {
@@ -211,6 +192,53 @@ describe("shared app bootstrap", () => {
       })
     ).rejects.toBeInstanceOf(SharedAppUnavailableError)
   })
+
+  test("rejects a malformed fragment without attempting an exchange", async () => {
+    const sharedClient = client()
+    await expect(
+      bootstrapSharedAppAccess({
+        expectedShareTypeId: "published-report",
+        grantId: "shr_1",
+        fragmentSecret: "not-a-secret",
+        client: sharedClient,
+      })
+    ).rejects.toBeInstanceOf(SharedAppUnavailableError)
+
+    expect(sharedClient.exchange).not.toHaveBeenCalled()
+  })
+
+  test("signals an established session before loading the resource", async () => {
+    const established: string[] = []
+    await expect(
+      bootstrapSharedAppAccess({
+        expectedShareTypeId: "published-report",
+        grantId: "shr_1",
+        fragmentSecret: "abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE",
+        client: client({
+          getResource: mock(async () => {
+            throw { name: "SixbApiError", status: 503 }
+          }),
+        }),
+        onAccessEstablished: () => established.push("established"),
+      })
+    ).rejects.toEqual({ name: "SixbApiError", status: 503 })
+
+    expect(established).toEqual(["established"])
+  })
+
+  test("separates terminal, retryable, and unexpected bootstrap failures", () => {
+    expect(classifySharedAppFailure(new SharedAppUnavailableError())).toBe("terminal")
+    expect(
+      classifySharedAppFailure({
+        name: "SixbApiError",
+        status: 401,
+        code: "share.access_unavailable",
+      })
+    ).toBe("terminal")
+    expect(classifySharedAppFailure({ name: "SixbApiError", status: 503 })).toBe("retryable")
+    expect(classifySharedAppFailure(new TypeError("fetch failed"))).toBe("retryable")
+    expect(classifySharedAppFailure(new Error("unexpected"))).toBe("unexpected")
+  })
 })
 
 describe("shared app entry", () => {
@@ -252,166 +280,10 @@ describe("shared app entry", () => {
     expect(bootstrap.indexOf("history.replaceState")).toBeLessThan(
       bootstrap.indexOf('import("./shared-main")')
     )
-    expect(bootstrap.indexOf("fragmentSecret = null")).toBeLessThan(
-      bootstrap.indexOf("startSharedApp(secret)")
+    expect(bootstrap.indexOf("startSharedApp(secret)")).toBeLessThan(
+      bootstrap.indexOf("fragmentSecret = null")
     )
-  })
-
-  test("serves separate dev shells and secures the public shared response", async () => {
-    const workspaceTempDir = resolve(import.meta.dir, "../../..", ".local", "test-tmp")
-    await mkdir(workspaceTempDir, { recursive: true })
-    root = await mkdtemp(join(workspaceTempDir, "sixb-shared-dev-"))
-    await mkdir(join(root, "app", "shared", "published-report", "[grantId]"), {
-      recursive: true,
-    })
-    await writeFile(
-      join(root, "app", "page.tsx"),
-      "export default function AppPage() { return <main>Application shell</main> }\n"
-    )
-    await writeFile(
-      join(root, "app", "shared", "published-report", "[grantId]", "page.tsx"),
-      "export default function SharedPage() { return <main>Shared shell</main> }\n"
-    )
-    await linkSharedAppDependencies(root)
-
-    const port = await getFreePort()
-    const app = await createCustomApp({
-      rootDir: root,
-      apiBaseUrl: "https://api.example.com",
-      authEnabled: true,
-      agentRoutes: false,
-    })
-    const server = await app.dev({ host: "127.0.0.1", port })
-
-    try {
-      const application = await fetch(`http://127.0.0.1:${port}/`)
-      const shared = await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`)
-      const internalSharedShell = await fetch(
-        `http://127.0.0.1:${port}/__sixb/generated/shared-app-shell`
-      )
-
-      expect(application.status).toBe(200)
-      expect(shared.status).toBe(200)
-      expect(internalSharedShell.status).toBe(404)
-      const applicationHtml = await application.text()
-      const sharedHtml = await shared.text()
-      const sharedCsp = shared.headers.get("content-security-policy") ?? ""
-      const scriptNonce = sharedHtml.match(/<script nonce="([^"]+)"/)?.[1]
-      expect(applicationHtml).not.toBe(sharedHtml)
-      expect(scriptNonce).toBeTruthy()
-      expect(sharedCsp).toContain(`'nonce-${scriptNonce}'`)
-      expect(shared.headers.get("cache-control")).toBe("no-store")
-      expect(shared.headers.get("referrer-policy")).toBe("no-referrer")
-      expect(shared.headers.get("x-robots-tag")).toBe("noindex, nofollow, noarchive")
-      expect(sharedCsp).toContain("connect-src 'self' https://api.example.com")
-      expect(
-        await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`, {
-          method: "POST",
-        })
-      ).toHaveProperty("status", 404)
-
-      const applicationRoutes = await readFile(
-        join(root, ".sixb", "generated", "routes.ts"),
-        "utf-8"
-      )
-      const sharedRoutes = await readFile(
-        join(root, ".sixb", "generated", "shared-routes.ts"),
-        "utf-8"
-      )
-      expect(applicationRoutes).not.toContain("published-report")
-      expect(sharedRoutes).toContain("published-report")
-    } finally {
-      await server.stop()
-    }
-  }, 30_000)
-
-  test("builds and serves the shared entry separately in production", async () => {
-    const workspaceTempDir = resolve(import.meta.dir, "../../..", ".local", "test-tmp")
-    await mkdir(workspaceTempDir, { recursive: true })
-    root = await mkdtemp(join(workspaceTempDir, "sixb-shared-build-"))
-    await mkdir(join(root, "app", "shared", "published-report", "[grantId]"), {
-      recursive: true,
-    })
-    await writeFile(
-      join(root, "app", "page.tsx"),
-      "export default function AppPage() { return <main>Application shell</main> }\n"
-    )
-    await writeFile(
-      join(root, "app", "shared", "published-report", "[grantId]", "page.tsx"),
-      "export default function SharedPage() { return <main>Shared shell</main> }\n"
-    )
-    await linkSharedAppDependencies(root)
-
-    const outdir = join(root, ".sixb", "dist", "app")
-    await mkdir(join(root, "app", "public"), { recursive: true })
-    await writeFile(
-      join(root, "app", "public", "shared-index.html"),
-      "<!doctype html><p>Public file must not replace the shared shell.</p>\n"
-    )
-
-    const app = await createCustomApp({ rootDir: root, authEnabled: true, agentRoutes: false })
-    const build = await app.build({ outdir })
-    expect(build.success).toBe(true)
-    expect(await readFile(join(outdir, "shared-index.html"), "utf-8")).not.toContain(
-      "Public file must not replace"
-    )
-
-    const port = await getFreePort()
-    const server = await app.start({
-      host: "127.0.0.1",
-      port,
-      outdir,
-      apiBaseUrl: "https://api.example.com",
-      authEnabled: true,
-    })
-    try {
-      const application = await fetch(`http://127.0.0.1:${port}/`)
-      const shared = await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`)
-      const rawSharedShell = await fetch(`http://127.0.0.1:${port}/shared-index.html`)
-      expect(application.status).toBe(200)
-      expect(shared.status).toBe(200)
-      expect(rawSharedShell.status).toBe(404)
-      expect(await application.text()).not.toBe(await shared.text())
-      expect(shared.headers.get("content-security-policy")).toContain(
-        "connect-src 'self' https://api.example.com"
-      )
-    } finally {
-      await server.stop()
-    }
-  }, 30_000)
-
-  test("builds both HTML entries with root-relative assets", async () => {
-    root = await mkdtemp(join(tmpdir(), "sixb-shared-build-entries-"))
-    const generatedDir = join(root, "generated")
-    const outdir = join(root, "dist")
-    await mkdir(generatedDir, { recursive: true })
-    await writeFile(join(generatedDir, "main.ts"), 'document.body.dataset.entry = "app"\n')
-    await writeFile(
-      join(generatedDir, "shared-main.ts"),
-      'document.body.dataset.entry = "shared"\n'
-    )
-    await writeFile(
-      join(generatedDir, "index.html"),
-      '<!doctype html><body><script type="module" src="./main.ts"></script></body>\n'
-    )
-    await writeFile(
-      join(generatedDir, "shared-index.html"),
-      '<!doctype html><body><script type="module" src="./shared-main.ts"></script></body>\n'
-    )
-
-    const result = await buildApp({
-      entryPath: join(generatedDir, "index.html"),
-      sharedEntryPath: join(generatedDir, "shared-index.html"),
-      outdir,
-    })
-
-    expect(result.success).toBe(true)
-    const applicationHtml = await readFile(join(outdir, "index.html"), "utf-8")
-    const sharedHtml = await readFile(join(outdir, "shared-index.html"), "utf-8")
-    expect(applicationHtml).toMatch(/src=["']\/[^"']+\.js["']/)
-    expect(sharedHtml).toMatch(/src=["']\/[^"']+\.js["']/)
-    expect(applicationHtml).not.toBe(sharedHtml)
-    expect(await Bun.file(join(generatedDir, "index.sixb-bundle.html")).exists()).toBe(false)
-    expect(await Bun.file(join(generatedDir, "shared-index.sixb-bundle.html")).exists()).toBe(false)
+    expect(bootstrap).toContain("Failed to load the shared app entry")
+    expect(bootstrap).toContain("Try again")
   })
 })

--- a/packages/app/tests/shared-app.test.ts
+++ b/packages/app/tests/shared-app.test.ts
@@ -1,0 +1,417 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { createServer } from "node:net"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import type { SharedAccessClient } from "@sixb/client/shared"
+import { buildApp } from "../src/build"
+import { generateSharedAppEntry, generateSharedRouteManifest } from "../src/codegen"
+import { createCustomApp } from "../src/createCustomApp"
+import { type PageRoute, partitionAppRoutes } from "../src/scanner"
+import {
+  bootstrapSharedAppAccess,
+  consumeSharedAppFragmentSecret,
+  SharedAppUnavailableError,
+} from "../src/shared-runtime"
+
+const publishedReportRoute: PageRoute = {
+  path: "/shared/published-report/:grantId",
+  filePath: "/project/app/shared/published-report/[grantId]/page.tsx",
+  relativePath: "shared/published-report/[grantId]/page.tsx",
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise<number>((resolvePort, reject) => {
+    const server = createServer()
+    server.on("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        reject(new Error("Could not resolve an open port"))
+        return
+      }
+      server.close((error) => (error ? reject(error) : resolvePort(address.port)))
+    })
+  })
+}
+
+async function linkSharedAppDependencies(projectRoot: string): Promise<void> {
+  const appPackageRoot = resolve(import.meta.dir, "..")
+  const targets = new Map<string, string>([
+    ["@sixb/app", appPackageRoot],
+    ["@sixb/client", resolve(appPackageRoot, "../client")],
+    ["@tanstack/react-query", join(appPackageRoot, "node_modules", "@tanstack/react-query")],
+    ["react", join(appPackageRoot, "node_modules", "react")],
+    ["react-dom", join(appPackageRoot, "node_modules", "react-dom")],
+    ["react-router-dom", join(appPackageRoot, "node_modules", "react-router-dom")],
+  ])
+
+  for (const [name, source] of targets) {
+    const target = join(projectRoot, "node_modules", ...name.split("/"))
+    await mkdir(resolve(target, ".."), { recursive: true })
+    await symlink(source, target, "dir")
+  }
+}
+
+describe("shared app route boundary", () => {
+  test("partitions only the canonical shared-page convention", () => {
+    const applicationRoute: PageRoute = {
+      path: "/reports",
+      filePath: "/project/app/reports/page.tsx",
+      relativePath: "reports/page.tsx",
+    }
+
+    expect(partitionAppRoutes([applicationRoute, publishedReportRoute])).toEqual({
+      applicationRoutes: [applicationRoute],
+      sharedRoutes: [{ ...publishedReportRoute, shareTypeId: "published-report" }],
+    })
+  })
+
+  test.each([
+    "shared/page.tsx",
+    "shared/published-report/page.tsx",
+    "shared/published-report/[token]/page.tsx",
+    "shared/[shareTypeId]/[grantId]/page.tsx",
+    "shared/published-report/[grantId]/details/page.tsx",
+  ])("rejects malformed public shared route %s", (relativePath) => {
+    expect(() =>
+      partitionAppRoutes([
+        {
+          path: `/${relativePath.replace(/\/page\.tsx$/, "")}`,
+          filePath: `/project/app/${relativePath}`,
+          relativePath,
+        },
+      ])
+    ).toThrow("Shared pages must use app/shared/<shareTypeId>/[grantId]/page.tsx")
+  })
+
+  test("generates a manifest that binds each page to its declared ShareType", async () => {
+    const root = await mkdtemp(join(tmpdir(), "sixb-shared-manifest-"))
+    try {
+      const manifestPath = await generateSharedRouteManifest(
+        [{ ...publishedReportRoute, shareTypeId: "published-report" }],
+        root
+      )
+      const manifest = await readFile(manifestPath, "utf-8")
+
+      expect(manifest).toContain('shareTypeId: "published-report"')
+      expect(manifest).toContain('path: "/shared/published-report/:grantId"')
+      expect(manifest).toContain("component: SharedPage0")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("shared app bootstrap", () => {
+  const context = {
+    authenticated: true as const,
+    csrfToken: "csrf",
+    grant: {
+      id: "shr_1",
+      shareTypeId: "published-report",
+      target: { objectTypeId: "PublishedReport", primaryId: "report-1" },
+      grants: [{ capability: "view" as const, objectTypeId: "PublishedReport" }],
+      expiresAt: "2026-09-01T12:00:00.000Z",
+    },
+    session: { expiresAt: "2026-08-22T12:15:00.000Z" },
+  }
+  const resource = {
+    primaryId: "report-1",
+    objectTypeId: "PublishedReport",
+    properties: { title: "Published report" },
+    createdAt: "2026-08-22T10:00:00.000Z",
+    updatedAt: "2026-08-22T10:00:00.000Z",
+  }
+
+  function client(overrides: Partial<SharedAccessClient> = {}): SharedAccessClient {
+    return {
+      exchange: mock(async () => context),
+      getSession: mock(async () => context),
+      getResource: mock(async () => resource),
+      requestAction: mock(async () => ({
+        runId: "run-1",
+        queuedAt: "2026-08-22T12:00:00.000Z",
+        created: true,
+      })),
+      signOut: mock(async () => ({ signedOut: true as const })),
+      ...overrides,
+    }
+  }
+
+  test("clears the fragment before exchanging it and loads the exact resource", async () => {
+    const calls: string[] = []
+    const sharedClient = client({
+      exchange: mock(async (secret: string) => {
+        calls.push(`exchange:${secret}`)
+        return context
+      }),
+    })
+    const history = {
+      state: { fixture: true },
+      replaceState: mock((_state: unknown, _unused: string, url?: string | URL | null) => {
+        calls.push(`replace:${String(url)}`)
+      }),
+    }
+
+    const fragmentSecret = consumeSharedAppFragmentSecret(
+      {
+        hash: "#abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE",
+        pathname: "/shared/published-report/shr_1",
+        search: "?source=email",
+      },
+      history
+    )
+    const result = await bootstrapSharedAppAccess({
+      expectedShareTypeId: "published-report",
+      grantId: "shr_1",
+      fragmentSecret,
+      client: sharedClient,
+    })
+
+    expect(calls[0]).toBe("replace:/shared/published-report/shr_1?source=email")
+    expect(calls[1]?.startsWith("exchange:")).toBe(true)
+    expect(sharedClient.getSession).not.toHaveBeenCalled()
+    expect(result).toEqual({ access: context, resource })
+  })
+
+  test("resumes an existing shared session when the URL has no fragment", async () => {
+    const sharedClient = client()
+    await bootstrapSharedAppAccess({
+      expectedShareTypeId: "published-report",
+      grantId: "shr_1",
+      fragmentSecret: null,
+      client: sharedClient,
+    })
+
+    expect(sharedClient.exchange).not.toHaveBeenCalled()
+    expect(sharedClient.getSession).toHaveBeenCalledTimes(1)
+  })
+
+  test("rejects a valid grant opened through another ShareType page", async () => {
+    expect(
+      bootstrapSharedAppAccess({
+        expectedShareTypeId: "proposal-approval",
+        grantId: "shr_1",
+        fragmentSecret: null,
+        client: client(),
+      })
+    ).rejects.toBeInstanceOf(SharedAppUnavailableError)
+  })
+
+  test("rejects a resource that does not match the grant target", async () => {
+    expect(
+      bootstrapSharedAppAccess({
+        expectedShareTypeId: "published-report",
+        grantId: "shr_1",
+        fragmentSecret: null,
+        client: client({
+          getResource: mock(async () => ({ ...resource, primaryId: "report-2" })),
+        }),
+      })
+    ).rejects.toBeInstanceOf(SharedAppUnavailableError)
+  })
+})
+
+describe("shared app entry", () => {
+  let root = ""
+
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true })
+  })
+
+  test("generates an isolated entry without application auth or the global client", async () => {
+    root = await mkdtemp(join(tmpdir(), "sixb-shared-entry-"))
+    const appDir = join(root, "app")
+    const generatedDir = join(root, ".sixb", "generated")
+    await mkdir(join(appDir, "shared"), { recursive: true })
+    await writeFile(
+      join(appDir, "shared", "layout.tsx"),
+      "export default function Layout({ children }) { return children }\n"
+    )
+
+    const { htmlPath, mainPath } = await generateSharedAppEntry(root, generatedDir, {
+      apiBaseUrl: "https://api.example.com",
+    })
+    const html = await readFile(htmlPath, "utf-8")
+    const main = await readFile(mainPath, "utf-8")
+    const bootstrap = await readFile(join(generatedDir, "shared-bootstrap.ts"), "utf-8")
+
+    expect(html).toContain('<meta name="robots" content="noindex, nofollow, noarchive" />')
+    expect(html).toContain('<meta name="referrer" content="no-referrer" />')
+    expect(html).not.toContain('rel="manifest"')
+    expect(main).toContain('from "@sixb/app/shared"')
+    expect(main).toContain('from "./shared-routes"')
+    expect(main).toContain('from "../../app/shared/layout.tsx"')
+    expect(main).toContain("<SharedAccessBoundary")
+    expect(main).toContain("consumeFragmentSecret={consumeFragmentSecret}")
+    expect(main).not.toContain("configureSixbBrowserClient")
+    expect(main).not.toContain("requireSixbBrowserAuthSession")
+    expect(main).not.toContain('from "@sixb/client"')
+    expect(bootstrap).not.toContain("import ")
+    expect(bootstrap.indexOf("history.replaceState")).toBeLessThan(
+      bootstrap.indexOf('import("./shared-main")')
+    )
+    expect(bootstrap.indexOf("fragmentSecret = null")).toBeLessThan(
+      bootstrap.indexOf("startSharedApp(secret)")
+    )
+  })
+
+  test("serves separate dev shells and secures the public shared response", async () => {
+    const workspaceTempDir = resolve(import.meta.dir, "../../..", ".local", "test-tmp")
+    await mkdir(workspaceTempDir, { recursive: true })
+    root = await mkdtemp(join(workspaceTempDir, "sixb-shared-dev-"))
+    await mkdir(join(root, "app", "shared", "published-report", "[grantId]"), {
+      recursive: true,
+    })
+    await writeFile(
+      join(root, "app", "page.tsx"),
+      "export default function AppPage() { return <main>Application shell</main> }\n"
+    )
+    await writeFile(
+      join(root, "app", "shared", "published-report", "[grantId]", "page.tsx"),
+      "export default function SharedPage() { return <main>Shared shell</main> }\n"
+    )
+    await linkSharedAppDependencies(root)
+
+    const port = await getFreePort()
+    const app = await createCustomApp({
+      rootDir: root,
+      apiBaseUrl: "https://api.example.com",
+      authEnabled: true,
+      agentRoutes: false,
+    })
+    const server = await app.dev({ host: "127.0.0.1", port })
+
+    try {
+      const application = await fetch(`http://127.0.0.1:${port}/`)
+      const shared = await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`)
+      const internalSharedShell = await fetch(
+        `http://127.0.0.1:${port}/__sixb/generated/shared-app-shell`
+      )
+
+      expect(application.status).toBe(200)
+      expect(shared.status).toBe(200)
+      expect(internalSharedShell.status).toBe(404)
+      const applicationHtml = await application.text()
+      const sharedHtml = await shared.text()
+      const sharedCsp = shared.headers.get("content-security-policy") ?? ""
+      const scriptNonce = sharedHtml.match(/<script nonce="([^"]+)"/)?.[1]
+      expect(applicationHtml).not.toBe(sharedHtml)
+      expect(scriptNonce).toBeTruthy()
+      expect(sharedCsp).toContain(`'nonce-${scriptNonce}'`)
+      expect(shared.headers.get("cache-control")).toBe("no-store")
+      expect(shared.headers.get("referrer-policy")).toBe("no-referrer")
+      expect(shared.headers.get("x-robots-tag")).toBe("noindex, nofollow, noarchive")
+      expect(sharedCsp).toContain("connect-src 'self' https://api.example.com")
+      expect(
+        await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`, {
+          method: "POST",
+        })
+      ).toHaveProperty("status", 404)
+
+      const applicationRoutes = await readFile(
+        join(root, ".sixb", "generated", "routes.ts"),
+        "utf-8"
+      )
+      const sharedRoutes = await readFile(
+        join(root, ".sixb", "generated", "shared-routes.ts"),
+        "utf-8"
+      )
+      expect(applicationRoutes).not.toContain("published-report")
+      expect(sharedRoutes).toContain("published-report")
+    } finally {
+      await server.stop()
+    }
+  }, 30_000)
+
+  test("builds and serves the shared entry separately in production", async () => {
+    const workspaceTempDir = resolve(import.meta.dir, "../../..", ".local", "test-tmp")
+    await mkdir(workspaceTempDir, { recursive: true })
+    root = await mkdtemp(join(workspaceTempDir, "sixb-shared-build-"))
+    await mkdir(join(root, "app", "shared", "published-report", "[grantId]"), {
+      recursive: true,
+    })
+    await writeFile(
+      join(root, "app", "page.tsx"),
+      "export default function AppPage() { return <main>Application shell</main> }\n"
+    )
+    await writeFile(
+      join(root, "app", "shared", "published-report", "[grantId]", "page.tsx"),
+      "export default function SharedPage() { return <main>Shared shell</main> }\n"
+    )
+    await linkSharedAppDependencies(root)
+
+    const outdir = join(root, ".sixb", "dist", "app")
+    await mkdir(join(root, "app", "public"), { recursive: true })
+    await writeFile(
+      join(root, "app", "public", "shared-index.html"),
+      "<!doctype html><p>Public file must not replace the shared shell.</p>\n"
+    )
+
+    const app = await createCustomApp({ rootDir: root, authEnabled: true, agentRoutes: false })
+    const build = await app.build({ outdir })
+    expect(build.success).toBe(true)
+    expect(await readFile(join(outdir, "shared-index.html"), "utf-8")).not.toContain(
+      "Public file must not replace"
+    )
+
+    const port = await getFreePort()
+    const server = await app.start({
+      host: "127.0.0.1",
+      port,
+      outdir,
+      apiBaseUrl: "https://api.example.com",
+      authEnabled: true,
+    })
+    try {
+      const application = await fetch(`http://127.0.0.1:${port}/`)
+      const shared = await fetch(`http://127.0.0.1:${port}/shared/published-report/shr_1`)
+      const rawSharedShell = await fetch(`http://127.0.0.1:${port}/shared-index.html`)
+      expect(application.status).toBe(200)
+      expect(shared.status).toBe(200)
+      expect(rawSharedShell.status).toBe(404)
+      expect(await application.text()).not.toBe(await shared.text())
+      expect(shared.headers.get("content-security-policy")).toContain(
+        "connect-src 'self' https://api.example.com"
+      )
+    } finally {
+      await server.stop()
+    }
+  }, 30_000)
+
+  test("builds both HTML entries with root-relative assets", async () => {
+    root = await mkdtemp(join(tmpdir(), "sixb-shared-build-entries-"))
+    const generatedDir = join(root, "generated")
+    const outdir = join(root, "dist")
+    await mkdir(generatedDir, { recursive: true })
+    await writeFile(join(generatedDir, "main.ts"), 'document.body.dataset.entry = "app"\n')
+    await writeFile(
+      join(generatedDir, "shared-main.ts"),
+      'document.body.dataset.entry = "shared"\n'
+    )
+    await writeFile(
+      join(generatedDir, "index.html"),
+      '<!doctype html><body><script type="module" src="./main.ts"></script></body>\n'
+    )
+    await writeFile(
+      join(generatedDir, "shared-index.html"),
+      '<!doctype html><body><script type="module" src="./shared-main.ts"></script></body>\n'
+    )
+
+    const result = await buildApp({
+      entryPath: join(generatedDir, "index.html"),
+      sharedEntryPath: join(generatedDir, "shared-index.html"),
+      outdir,
+    })
+
+    expect(result.success).toBe(true)
+    const applicationHtml = await readFile(join(outdir, "index.html"), "utf-8")
+    const sharedHtml = await readFile(join(outdir, "shared-index.html"), "utf-8")
+    expect(applicationHtml).toMatch(/src=["']\/[^"']+\.js["']/)
+    expect(sharedHtml).toMatch(/src=["']\/[^"']+\.js["']/)
+    expect(applicationHtml).not.toBe(sharedHtml)
+    expect(await Bun.file(join(generatedDir, "index.sixb-bundle.html")).exists()).toBe(false)
+    expect(await Bun.file(join(generatedDir, "shared-index.sixb-bundle.html")).exists()).toBe(false)
+  })
+})

--- a/packages/app/tsconfig.build.json
+++ b/packages/app/tsconfig.build.json
@@ -17,6 +17,9 @@
       "path": "../core/tsconfig.build.json"
     },
     {
+      "path": "../client/tsconfig.build.json"
+    },
+    {
       "path": "../agent-ui/tsconfig.build.json"
     }
   ]

--- a/packages/client/src/shared.ts
+++ b/packages/client/src/shared.ts
@@ -20,6 +20,7 @@ export type SharedAccessSession = GetSharedAccessSessionResponse
 export type SharedAccessResource = GetSharedAccessResourceResponse
 export type SharedAccessActionInput = RequestSharedAccessActionData["body"]
 export type SharedAccessActionResult = RequestSharedAccessActionResponse
+export { isSixbApiError } from "./api"
 
 export interface SharedAccessClientOptions {
   readonly grantId: string
@@ -39,6 +40,12 @@ export interface SharedAccessClient {
   signOut(): Promise<SignOutSharedAccessResponse>
 }
 
+const SHARED_ACCESS_SECRET_PATTERN = /^[A-Za-z0-9_-]{43}$/
+
+export function isValidSharedAccessSecret(value: unknown): value is string {
+  return typeof value === "string" && SHARED_ACCESS_SECRET_PATTERN.test(value)
+}
+
 /**
  * Creates an isolated client that can call only the shared protocol.
  *
@@ -56,7 +63,7 @@ export function createSharedAccessClient(options: SharedAccessClientOptions): Sh
 
   return {
     async exchange(secret) {
-      if (!/^[A-Za-z0-9_-]{43}$/.test(secret)) {
+      if (!isValidSharedAccessSecret(secret)) {
         throw new Error("[SixbClient] Shared access secret is invalid.")
       }
       const { data } = await exchangeSharedAccess({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -478,7 +478,13 @@ export type {
   ShareTypeGrant,
   ShareTypeReference,
 } from "./shares"
-export { defineShareType, isShareTypeDefinition, ShareError } from "./shares"
+export {
+  defineShareType,
+  isRouteSafeShareTypeId,
+  isShareTypeDefinition,
+  SHARE_TYPE_ID_REQUIREMENT,
+  ShareError,
+} from "./shares"
 
 // ── Storage ────────────────────────────────────────────────
 // Config contract + operator migration API + in-memory dev providers.

--- a/packages/core/src/shares/builders.ts
+++ b/packages/core/src/shares/builders.ts
@@ -1,14 +1,15 @@
 import type { ObjectTypeWithPropertyTokens } from "../ontology"
 import { assertGrantDefinition } from "../security/validation"
 import { ShareError } from "./errors"
+import { isRouteSafeShareTypeId, SHARE_TYPE_ID_REQUIREMENT } from "./id"
 import type { DefineShareTypeOptions, ShareTypeDefinition, ShareTypeGrant } from "./types"
 
 export function defineShareType<
   const TId extends string,
   const TTarget extends ObjectTypeWithPropertyTokens,
 >(options: DefineShareTypeOptions<TId, TTarget>): ShareTypeDefinition<TId, TTarget> {
-  if (typeof options.id !== "string" || !options.id.trim()) {
-    throw new ShareError("invalid_definition", "[Sixb] Share type id must not be empty.")
+  if (!isRouteSafeShareTypeId(options.id)) {
+    throw new ShareError("invalid_definition", `[Sixb] Share type id ${SHARE_TYPE_ID_REQUIREMENT}.`)
   }
   if (typeof options.target !== "object" || options.target === null || !options.target.id?.trim()) {
     throw new ShareError(

--- a/packages/core/src/shares/id.ts
+++ b/packages/core/src/shares/id.ts
@@ -1,0 +1,9 @@
+const SHARE_TYPE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/** ShareType IDs are embedded as one static shared-page route and filesystem segment. */
+export function isRouteSafeShareTypeId(value: unknown): value is string {
+  return typeof value === "string" && SHARE_TYPE_ID_PATTERN.test(value)
+}
+
+export const SHARE_TYPE_ID_REQUIREMENT =
+  "must be route-safe: start with an ASCII letter or number and contain only letters, numbers, '.', '_' or '-'"

--- a/packages/core/src/shares/index.ts
+++ b/packages/core/src/shares/index.ts
@@ -10,6 +10,7 @@ export type {
   ShareTypeReference,
 } from "./execution"
 export { createSharesRuntime } from "./execution"
+export { isRouteSafeShareTypeId, SHARE_TYPE_ID_REQUIREMENT } from "./id"
 export type {
   DefineShareTypeOptions,
   ShareTypeDefinition,

--- a/packages/core/src/shares/validation.ts
+++ b/packages/core/src/shares/validation.ts
@@ -3,6 +3,7 @@ import type { OntologyDefinitionCatalog } from "../ontology"
 import { assertGrantDefinition, type GrantDefinition } from "../security"
 import type { SharedAccessGrantRef } from "../storage/share-grants"
 import { ShareError } from "./errors"
+import { isRouteSafeShareTypeId, SHARE_TYPE_ID_REQUIREMENT } from "./id"
 import type { ShareTypeDefinition } from "./types"
 
 export function validateShareTypesAtStartup(input: {
@@ -16,8 +17,8 @@ export function validateShareTypesAtStartup(input: {
     if (share.kind !== "share") {
       throw invalid("Share type kind must be 'share'.")
     }
-    if (typeof share.id !== "string" || !share.id.trim()) {
-      throw invalid("Share type id must not be empty.")
+    if (!isRouteSafeShareTypeId(share.id)) {
+      throw invalid(`Share type id ${SHARE_TYPE_ID_REQUIREMENT}.`)
     }
     if (byId.has(share.id)) {
       throw invalid(`Duplicate share type id: ${share.id}`)

--- a/packages/core/tests/shares.test.ts
+++ b/packages/core/tests/shares.test.ts
@@ -72,6 +72,21 @@ function publisherContext(roles: readonly ResolvedRole[], principalId = "usr_pub
 }
 
 describe("shared access grants", () => {
+  test.each([
+    "sales/report",
+    ":report",
+    ".report",
+    "report name",
+  ])("rejects route-unsafe ShareType id %s", (id) => {
+    expect(() =>
+      defineShareType({
+        id,
+        target: Report,
+        grants: [can.view(Report)],
+      })
+    ).toThrow("route-safe")
+  })
+
   test("issues once, lists by exact target, and preserves the first revocation", async () => {
     const host = createHost()
     const setup = createTestSixb(host)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "@sixb/agent-worker": ["./packages/agent-worker/src/index.ts"],
       "@sixb/app": ["./packages/app/src/index.ts"],
       "@sixb/app/agents": ["./packages/app/src/agents.ts"],
+      "@sixb/app/shared": ["./packages/app/src/shared.ts"],
       "@sixb/atlas": ["./packages/atlas/src/index.ts"],
       "@sixb/auth-magic-link": ["./auth/magic-link/src/index.ts"],
       "@sixb/auth-oidc": ["./auth/oidc/src/index.ts"],


### PR DESCRIPTION
## What this adds

ShareTypes can expose a dedicated public page through one explicit convention:

```text
app/shared/<shareTypeId>/[grantId]/page.tsx
```

The page receives only:

- the exact Object targeted by the grant;
- the Actions still allowed by that ShareType;
- the lifecycle helpers for its own shared session.

```tsx
const shared = useSharedAccess()

shared.resource
await shared.requestAction("acknowledge-report", { params: { note: "Reviewed" } })
```

## Runtime flow

```text
shared URL + fragment secret
  → minimal bootstrap removes the fragment
  → exchange or restore the grant-bound session
  → load the exact target
  → render the matching ShareType page
```

## Isolation boundary

| | Normal app | Shared page |
|---|---|---|
| Entry point | `index.html` | `shared-index.html` |
| Identity | normal auth / OIDC | grant-bound shared session |
| Client and cache | application scope | isolated per grant |
| Data access | normal authorized APIs | exact target only |

The shared shell never starts the normal auth runtime. It is served with `no-store`, a nonce-based CSP, `no-referrer`, frame denial, and indexing disabled. Invalid shared route shapes fail during generation instead of silently crossing the public boundary.

## Scope

This deliberately keeps V1 narrow: no arbitrary Object queries, linked-object traversal, or ambient application authority. Shared Actions always execute against the fixed target recorded by the grant.

## Validation

- `bun test packages/app/tests/shared-app.test.ts` — 15 passing
- `bun run test:ci` — passing
- `bun run typecheck` — passing
- `bun run check` — passing
- `bun run build` — passing
- `bun run test:publish` — passing

Stacked on #416.

Closes #269
