### PR TITLE
workers: configure per-process concurrency

### DIFF
--- a/docs/deployment/overview.md
+++ b/docs/deployment/overview.md
@@ -122,6 +122,28 @@ sixb worker agent --agent-turn-timeout 20m
 SIXB_AGENT_TURN_TIMEOUT=20m sixb worker-group
 ```
 
+Queue workers execute a bounded number of jobs in each process. Agent workers default to `4`;
+sync, pipeline, projection, workflow, and action workers default to `1`. Set a scalar count for a
+single worker process:
+
+```bash
+sixb worker agent --concurrency 8
+sixb worker sync --concurrency 2
+```
+
+For `sixb worker-group` and `sixb dev`, repeat `--concurrency <type>=<count>` so each lane keeps an
+independent resource budget:
+
+```bash
+sixb worker-group sync agent --concurrency sync=2 --concurrency agent=8
+sixb dev --concurrency agent=1
+```
+
+The flag wins over `SIXB_<TYPE>_WORKER_CONCURRENCY`, such as
+`SIXB_AGENT_WORKER_CONCURRENCY=8`. Action execution remains serial and rejects a concurrency
+override. Concurrency is jobs inside one process; use deployment replicas to run more worker
+processes.
+
 A role process is **idle**, not an error, when it has nothing to do — an
 orchestrator with no routes, a rules process with no rules, or a worker group
 with no registered worker types prints a warning and stays running.
@@ -316,6 +338,10 @@ orchestrator, scheduler, and rules roles must each run as a **single process**.
 | `sixb rules`                       | **one**  | reconciliation has no cross-process lease               |
 
 Running two of a single-process role does not corrupt data — it duplicates runs.
+
+Worker concurrency and replicas multiply. For example, three agent-worker replicas at concurrency
+`8` can run up to 24 agent jobs. Size that total for model-provider limits, sandbox capacity,
+connector quotas, and storage write contention.
 
 ## Related
 

--- a/packages/agent-worker/src/worker.ts
+++ b/packages/agent-worker/src/worker.ts
@@ -88,7 +88,7 @@ export class AgentWorker extends QueueWorker<AgentQueueJob, typeof AGENT_RUN_FAI
       queue: host.queues.agents,
       failureCodes: AGENT_RUN_FAILURE_CODES,
       workerId: `agent-worker-${host.id}`,
-      claimLimit: normalizeConcurrency(options.concurrency),
+      claimLimit: options.concurrency ?? DEFAULT_AGENT_CONCURRENCY,
       leaseMs,
       idlePollMs: options.idlePollMs,
     })
@@ -783,20 +783,6 @@ async function waitForAbort(ms: number, signal: AbortSignal): Promise<void> {
     signal.addEventListener("abort", finish, { once: true })
   })
 }
-
-function normalizeConcurrency(value: number | undefined): number {
-  if (value === undefined) {
-    return DEFAULT_AGENT_CONCURRENCY
-  }
-  if (!Number.isFinite(value) || value < 1) {
-    throw createSixbError(
-      "internal.unexpected",
-      "[SixbAgentWorker] Agent worker concurrency must be at least 1."
-    )
-  }
-  return Math.floor(value)
-}
-
 function normalizeTurnTimeoutMs(value: number | undefined): number {
   const timeoutMs = value ?? DEFAULT_TURN_TIMEOUT_MS
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_TIMER_DURATION_MS) {

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -1392,6 +1392,13 @@ function hangingModel(): MockLanguageModelV4 {
 }
 
 describe("AgentWorker", () => {
+  test("uses four concurrent jobs by default and accepts an explicit limit", () => {
+    const sixb = buildSixb(toolThenAnswerModel())
+
+    expect(new AgentWorker(sixb, workerOptions()).concurrency).toBe(4)
+    expect(new AgentWorker(sixb, workerOptions({ concurrency: 7 })).concurrency).toBe(7)
+  })
+
   test("requires an API base URL", () => {
     const sixb = buildSixb(toolThenAnswerModel())
 

--- a/packages/cli/src/commands/dev.tsx
+++ b/packages/cli/src/commands/dev.tsx
@@ -7,6 +7,7 @@ import { apiDocsUrl, apiEventsUrl, apiUrl, resolveBrowserTopology } from "../lib
 import { type LoadedSixbHost, loadSixbFromEntry } from "../lib/loadSixb"
 import { runUntilSignal, startSixbRuntime, stopQuietly } from "../lib/runtime"
 import { generateProjectTypes } from "../lib/typegen"
+import { resolveWorkerConcurrency } from "../lib/worker-concurrency"
 import { DevView, LoadingView, renderCliError, renderPersistent } from "../ui"
 
 export interface DevOptions {
@@ -19,12 +20,14 @@ export interface DevOptions {
   atlasPublicOrigin?: string
   appPublicOrigin?: string
   agentTurnTimeout?: string
+  concurrency?: readonly string[]
 }
 
 export async function runDev(options: DevOptions = {}) {
   process.env.NODE_ENV = "development"
 
   const agentTurnTimeoutMs = resolveAgentTurnTimeoutMs(options.agentTurnTimeout)
+  const workerConcurrency = resolveWorkerConcurrency(options.concurrency)
   const entry = resolve(options.entry ?? "sixb.config.ts")
 
   const app = renderPersistent(
@@ -61,6 +64,7 @@ export async function runDev(options: DevOptions = {}) {
       cohostWorkers: true,
       agentApiBaseUrl: topology.apiPublicOrigin,
       agentTurnTimeoutMs,
+      workerConcurrency,
     })
     const authEnabled = host.auth.isEnabled()
 
@@ -117,6 +121,16 @@ export async function runDev(options: DevOptions = {}) {
         wsUrl={apiEventsUrl(topology)}
         uiUrl={topology.atlasPublicOrigin}
         appUrl={appUrl}
+        workers={[
+          { type: "action", worker: runtime.actionWorker },
+          { type: "agent", worker: runtime.agentWorker },
+          { type: "projection", worker: runtime.projectionWorker },
+          { type: "pipeline", worker: runtime.pipelineWorker },
+          { type: "workflow", worker: runtime.workflowWorker },
+          { type: "sync", worker: runtime.syncWorker },
+        ].flatMap(({ type, worker }) =>
+          worker ? [{ type, concurrency: worker.concurrency }] : []
+        )}
         warnings={runtime.warnings}
       />
     )

--- a/packages/cli/src/commands/worker-group.tsx
+++ b/packages/cli/src/commands/worker-group.tsx
@@ -1,4 +1,3 @@
-import type { Worker } from "@sixb/core/internal/workers"
 import { resolveAgentTurnTimeoutMs } from "../lib/agent-turn-timeout"
 import { type LoadedSixbHost, loadSixbFromEntry } from "../lib/loadSixb"
 import { resolveRuntimeEntry } from "../lib/production"
@@ -10,9 +9,11 @@ import {
 } from "../lib/runtime"
 import { assertShareableProviders } from "../lib/shareable-providers"
 import { migrateStorageForRole } from "../lib/storage-migration"
+import { resolveWorkerConcurrency } from "../lib/worker-concurrency"
 import {
   assertWorkerInputs,
   createWorkerForType,
+  type QueueWorkerProcess,
   resolveRegisteredWorkerTypes,
   resolveWorkerTypeToStart,
 } from "../lib/worker-registry"
@@ -24,6 +25,7 @@ export interface WorkerGroupOptions {
   workerTypes?: readonly string[]
   apiPublicOrigin?: string
   agentTurnTimeout?: string
+  concurrency?: readonly string[]
 }
 
 export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
@@ -33,6 +35,7 @@ export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
   // fails fast, just like `sixb worker`.
   const requestedTypes = (options.workerTypes ?? []).map(resolveWorkerTypeToStart)
   const agentTurnTimeoutMs = resolveAgentTurnTimeoutMs(options.agentTurnTimeout)
+  const workerConcurrency = resolveWorkerConcurrency(options.concurrency)
   const entry = await resolveRuntimeEntry({ entry: options.entry })
 
   const app = renderPersistent(
@@ -40,7 +43,7 @@ export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
   )
 
   let sixb: LoadedSixbHost | null = null
-  let workers: Worker[] = []
+  let workers: QueueWorkerProcess[] = []
 
   async function stopWorkersAndProviders() {
     await Promise.all(workers.map((worker) => stopQuietly(() => worker.stop())))
@@ -89,6 +92,7 @@ export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
       createWorkerForType(host, workerType, {
         agentApiBaseUrl: options.apiPublicOrigin,
         agentTurnTimeoutMs,
+        workerConcurrency,
       })
     )
     await Promise.all(workers.map((worker) => worker.start()))
@@ -101,7 +105,10 @@ export async function runWorkerGroup(options: WorkerGroupOptions = {}) {
     app.rerender(
       <WorkerGroupView
         name={sixb.id}
-        workerTypes={workerTypes}
+        workers={workerTypes.map((workerType, index) => ({
+          type: workerType,
+          concurrency: workers[index]?.concurrency ?? 1,
+        }))}
         storage={migration.summary}
         warnings={warnings}
       />

--- a/packages/cli/src/commands/worker.tsx
+++ b/packages/cli/src/commands/worker.tsx
@@ -1,4 +1,3 @@
-import type { Worker } from "@sixb/core/internal/workers"
 import { resolveAgentTurnTimeoutMs } from "../lib/agent-turn-timeout"
 import { SixbCliError } from "../lib/errors"
 import { type LoadedSixbHost, loadSixbFromEntry } from "../lib/loadSixb"
@@ -11,8 +10,10 @@ import {
 } from "../lib/runtime"
 import { assertShareableProviders } from "../lib/shareable-providers"
 import { migrateStorageForRole } from "../lib/storage-migration"
+import { resolveSingleWorkerConcurrency } from "../lib/worker-concurrency"
 import {
   createWorkerForType,
+  type QueueWorkerProcess,
   resolveWorkerTypeToStart,
   unmetWorkerRequirement,
 } from "../lib/worker-registry"
@@ -24,6 +25,7 @@ export interface WorkerOptions {
   workerType?: string
   apiPublicOrigin?: string
   agentTurnTimeout?: string
+  concurrency?: string
 }
 
 export async function runWorker(options: WorkerOptions = {}) {
@@ -31,6 +33,7 @@ export async function runWorker(options: WorkerOptions = {}) {
 
   const workerType = resolveWorkerTypeToStart(options.workerType)
   const agentTurnTimeoutMs = resolveAgentTurnTimeoutMs(options.agentTurnTimeout)
+  const workerConcurrency = resolveSingleWorkerConcurrency(workerType, options.concurrency)
   const entry = await resolveRuntimeEntry({ entry: options.entry })
 
   const app = renderPersistent(
@@ -38,7 +41,7 @@ export async function runWorker(options: WorkerOptions = {}) {
   )
 
   let sixb: LoadedSixbHost | null = null
-  let worker: Worker | null = null
+  let worker: QueueWorkerProcess | null = null
 
   try {
     sixb = await loadSixbFromEntry(entry)
@@ -70,11 +73,19 @@ export async function runWorker(options: WorkerOptions = {}) {
     worker = createWorkerForType(sixb, workerType, {
       agentApiBaseUrl: options.apiPublicOrigin,
       agentTurnTimeoutMs,
+      workerConcurrency,
     })
     await worker.start()
 
     const workerId = `${workerType}-worker-${sixb.id}`
-    app.rerender(<WorkerView name={sixb.id} workerId={workerId} storage={migration.summary} />)
+    app.rerender(
+      <WorkerView
+        name={sixb.id}
+        workerId={workerId}
+        concurrency={worker.concurrency}
+        storage={migration.summary}
+      />
+    )
 
     await Promise.race([
       runUntilSignal(async () => {

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -61,7 +61,7 @@ async function readPackageVersion(): Promise<string> {
 
 function getFlag(name: string): string | undefined {
   const direct = args.find((arg) => arg.startsWith(`--${name}=`))
-  if (direct) return direct.split("=")[1]
+  if (direct) return direct.slice(name.length + 3)
 
   const idx = args.indexOf(`--${name}`)
   if (idx >= 0) return args[idx + 1]

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -69,7 +69,7 @@ function getFlag(name: string): string | undefined {
   return undefined
 }
 
-function getFlags(name: string): string[] {
+function getFlags(name: string, options: { readonly includeMissing?: boolean } = {}): string[] {
   const values: string[] = []
 
   for (let index = 0; index < args.length; index++) {
@@ -79,6 +79,8 @@ function getFlags(name: string): string[] {
       if (value && !value.startsWith("--")) {
         values.push(value)
         index++
+      } else if (options.includeMissing) {
+        values.push("")
       }
     } else if (arg?.startsWith(`--${name}=`)) {
       values.push(arg.slice(name.length + 3))
@@ -86,6 +88,11 @@ function getFlags(name: string): string[] {
   }
 
   return values
+}
+
+function getFlagRequiringValue(name: string): string | undefined {
+  const value = getFlag(name)
+  return value ?? (hasFlagValue(name) ? "" : undefined)
 }
 
 function hasFlag(name: string): boolean {
@@ -104,6 +111,7 @@ const flagsWithValues = new Set([
   "api-host",
   "api-public-origin",
   "agent-turn-timeout",
+  "concurrency",
   "atlas-public-origin",
   "app-public-origin",
   "outdir",
@@ -129,7 +137,8 @@ function getCommandPositionals(): string[] {
 
     if (arg.startsWith("--")) {
       const flagName = arg.slice(2).split("=")[0] ?? ""
-      if (!arg.includes("=") && flagsWithValues.has(flagName)) {
+      const next = args[index + 1]
+      if (!arg.includes("=") && flagsWithValues.has(flagName) && next && !next.startsWith("--")) {
         index++
       }
       continue
@@ -177,6 +186,7 @@ async function main(): Promise<void> {
         atlasPublicOrigin: getFlag("atlas-public-origin"),
         appPublicOrigin: getFlag("app-public-origin"),
         agentTurnTimeout: getFlag("agent-turn-timeout"),
+        concurrency: getFlags("concurrency", { includeMissing: true }),
       })
       break
     }
@@ -193,6 +203,7 @@ async function main(): Promise<void> {
         workerType: getCommandPositionals()[0],
         apiPublicOrigin: getFlag("api-public-origin"),
         agentTurnTimeout: getFlag("agent-turn-timeout"),
+        concurrency: getFlagRequiringValue("concurrency"),
       })
       break
     }
@@ -205,6 +216,7 @@ async function main(): Promise<void> {
         workerTypes: getCommandPositionals(),
         apiPublicOrigin: getFlag("api-public-origin"),
         agentTurnTimeout: getFlag("agent-turn-timeout"),
+        concurrency: getFlags("concurrency", { includeMissing: true }),
       })
       break
     }

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -23,6 +23,7 @@ import { RulesWorker } from "@sixb/rules-worker"
 import { SyncWorker } from "@sixb/sync-worker"
 import { WorkflowWorker } from "@sixb/workflow-worker"
 import type { LoadedSixbHost } from "./loadSixb"
+import type { WorkerConcurrency } from "./worker-registry"
 
 export function waitForWorkerFailure(worker: Worker | null | undefined): Promise<never> {
   return new Promise<never>((_resolve, reject) => {
@@ -57,6 +58,7 @@ export interface StartSixbRuntimeOptions {
   readonly cohostWorkers?: boolean
   readonly agentApiBaseUrl?: string
   readonly agentTurnTimeoutMs?: number
+  readonly workerConcurrency?: WorkerConcurrency
 }
 
 export interface RunningRulesRuntime {
@@ -244,6 +246,7 @@ export async function startSixbRuntime(
       if (sixb.definitions.agents.list().length > 0 && sixb.storage.agents) {
         agentWorker = new AgentWorker(sixb, {
           apiBaseUrl: requireAgentApiBaseUrl(options.agentApiBaseUrl),
+          concurrency: options.workerConcurrency?.agent,
           turnTimeoutMs: options.agentTurnTimeoutMs,
         })
         await agentWorker.start()
@@ -251,22 +254,28 @@ export async function startSixbRuntime(
 
       const projectionCount = sixb.definitions.projections.list().length
       if (projectionCount > 0) {
-        projectionWorker = new ProjectionWorker(sixb)
+        projectionWorker = new ProjectionWorker(sixb, {
+          concurrency: options.workerConcurrency?.projection,
+        })
         await projectionWorker.start()
       }
 
       if (sixb.definitions.pipelines.list().length > 0) {
-        pipelineWorker = new PipelineWorker(sixb)
+        pipelineWorker = new PipelineWorker(sixb, {
+          concurrency: options.workerConcurrency?.pipeline,
+        })
         await pipelineWorker.start()
       }
 
       if (sixb.definitions.workflows.list().length > 0) {
-        workflowWorker = new WorkflowWorker(sixb)
+        workflowWorker = new WorkflowWorker(sixb, {
+          concurrency: options.workerConcurrency?.workflow,
+        })
         await workflowWorker.start()
       }
 
       if (sixb.definitions.syncs.list().length > 0) {
-        syncWorker = new SyncWorker(sixb)
+        syncWorker = new SyncWorker(sixb, { concurrency: options.workerConcurrency?.sync })
         await syncWorker.start()
       }
 

--- a/packages/cli/src/lib/worker-concurrency.ts
+++ b/packages/cli/src/lib/worker-concurrency.ts
@@ -1,0 +1,128 @@
+import { WORKER_TYPES, type WorkerConcurrency, type WorkerType } from "./worker-registry"
+
+const CONFIGURABLE_WORKER_TYPES = [
+  "sync",
+  "agent",
+  "pipeline",
+  "projection",
+  "workflow",
+] as const satisfies readonly WorkerType[]
+
+type ConfigurableWorkerType = (typeof CONFIGURABLE_WORKER_TYPES)[number]
+
+const concurrencyEnvironmentVariables = {
+  sync: "SIXB_SYNC_WORKER_CONCURRENCY",
+  agent: "SIXB_AGENT_WORKER_CONCURRENCY",
+  pipeline: "SIXB_PIPELINE_WORKER_CONCURRENCY",
+  projection: "SIXB_PROJECTION_WORKER_CONCURRENCY",
+  workflow: "SIXB_WORKFLOW_WORKER_CONCURRENCY",
+} as const satisfies Record<ConfigurableWorkerType, string>
+
+/** Resolve the scalar concurrency accepted by `sixb worker <type>`. */
+export function resolveSingleWorkerConcurrency(
+  workerType: WorkerType,
+  value: string | undefined
+): WorkerConcurrency {
+  if (workerType === "action") {
+    if (value !== undefined || nonblank(process.env.SIXB_ACTION_WORKER_CONCURRENCY)) {
+      throw fixedActionConcurrency()
+    }
+    return {}
+  }
+
+  const environmentVariable = concurrencyEnvironmentVariables[workerType]
+  const configured = value?.trim() ?? nonblank(process.env[environmentVariable])
+  if (configured === undefined) return {}
+
+  return { [workerType]: parseConcurrency(configured, `--concurrency or ${environmentVariable}`) }
+}
+
+/**
+ * Resolve repeatable `<type>=<count>` values for co-hosted workers. Per-type CLI values override
+ * their environment variables; repeated CLI values use the last occurrence.
+ */
+export function resolveWorkerConcurrency(values: readonly string[] = []): WorkerConcurrency {
+  const resolved: Partial<Record<WorkerType, number>> = {}
+
+  for (const workerType of CONFIGURABLE_WORKER_TYPES) {
+    const environmentVariable = concurrencyEnvironmentVariables[workerType]
+    const configured = nonblank(process.env[environmentVariable])
+    if (configured !== undefined) {
+      resolved[workerType] = parseConcurrency(configured, environmentVariable)
+    }
+  }
+
+  if (nonblank(process.env.SIXB_ACTION_WORKER_CONCURRENCY)) {
+    throw fixedActionConcurrency()
+  }
+
+  for (const value of values) {
+    const entry = parseWorkerConcurrencyEntry(value)
+    resolved[entry.workerType] = entry.concurrency
+  }
+
+  return resolved
+}
+
+function parseWorkerConcurrencyEntry(value: string): {
+  readonly workerType: ConfigurableWorkerType
+  readonly concurrency: number
+} {
+  const separator = value.indexOf("=")
+  if (separator <= 0 || separator !== value.lastIndexOf("=")) {
+    throw invalidWorkerConcurrencyEntry(value)
+  }
+
+  const workerType = value.slice(0, separator).trim()
+  const configured = value.slice(separator + 1).trim()
+  if (!isWorkerType(workerType)) {
+    throw new Error(
+      `[SixbCLI] Unknown worker concurrency type '${workerType || value}'. Available: ${CONFIGURABLE_WORKER_TYPES.join(", ")}.`
+    )
+  }
+  if (workerType === "action") {
+    throw fixedActionConcurrency()
+  }
+
+  return {
+    workerType,
+    concurrency: parseConcurrency(configured, `--concurrency ${workerType}=<count>`),
+  }
+}
+
+function parseConcurrency(value: string, source: string): number {
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw invalidConcurrency(value, source)
+  }
+
+  const concurrency = Number(value)
+  if (!Number.isSafeInteger(concurrency)) {
+    throw invalidConcurrency(value, source)
+  }
+  return concurrency
+}
+
+function nonblank(value: string | undefined): string | undefined {
+  return value?.trim() || undefined
+}
+
+function isWorkerType(value: string): value is WorkerType {
+  return WORKER_TYPES.some((workerType) => workerType === value)
+}
+
+function invalidConcurrency(value: string, source: string): Error {
+  return new Error(
+    `[SixbCLI] Invalid worker concurrency '${value}'. Use a positive integer with ${source}.`
+  )
+}
+
+function invalidWorkerConcurrencyEntry(value: string): Error {
+  return new Error(
+    `[SixbCLI] Invalid worker concurrency '${value}'. Use a repeatable type=count value like ` +
+      "--concurrency agent=4 --concurrency sync=2."
+  )
+}
+
+function fixedActionConcurrency(): Error {
+  return new Error("[SixbCLI] Action worker concurrency is fixed at 1 and cannot be configured.")
+}

--- a/packages/cli/src/lib/worker-concurrency.ts
+++ b/packages/cli/src/lib/worker-concurrency.ts
@@ -1,36 +1,25 @@
-import { WORKER_TYPES, type WorkerConcurrency, type WorkerType } from "./worker-registry"
-
-const CONFIGURABLE_WORKER_TYPES = [
-  "sync",
-  "agent",
-  "pipeline",
-  "projection",
-  "workflow",
-] as const satisfies readonly WorkerType[]
-
-type ConfigurableWorkerType = (typeof CONFIGURABLE_WORKER_TYPES)[number]
-
-const concurrencyEnvironmentVariables = {
-  sync: "SIXB_SYNC_WORKER_CONCURRENCY",
-  agent: "SIXB_AGENT_WORKER_CONCURRENCY",
-  pipeline: "SIXB_PIPELINE_WORKER_CONCURRENCY",
-  projection: "SIXB_PROJECTION_WORKER_CONCURRENCY",
-  workflow: "SIXB_WORKFLOW_WORKER_CONCURRENCY",
-} as const satisfies Record<ConfigurableWorkerType, string>
+import {
+  type ConfigurableWorkerType,
+  WORKER_CONCURRENCY_CONFIG,
+  WORKER_TYPES,
+  type WorkerConcurrency,
+  type WorkerType,
+} from "./worker-registry"
 
 /** Resolve the scalar concurrency accepted by `sixb worker <type>`. */
 export function resolveSingleWorkerConcurrency(
   workerType: WorkerType,
   value: string | undefined
 ): WorkerConcurrency {
-  if (workerType === "action") {
-    if (value !== undefined || nonblank(process.env.SIXB_ACTION_WORKER_CONCURRENCY)) {
+  const definition = WORKER_CONCURRENCY_CONFIG[workerType]
+  if (!isConfigurableWorkerType(workerType)) {
+    if (value !== undefined || nonblank(process.env[definition.environmentVariable])) {
       throw fixedActionConcurrency()
     }
     return {}
   }
 
-  const environmentVariable = concurrencyEnvironmentVariables[workerType]
+  const environmentVariable = definition.environmentVariable
   const configured = value?.trim() ?? nonblank(process.env[environmentVariable])
   if (configured === undefined) return {}
 
@@ -42,22 +31,28 @@ export function resolveSingleWorkerConcurrency(
  * their environment variables; repeated CLI values use the last occurrence.
  */
 export function resolveWorkerConcurrency(values: readonly string[] = []): WorkerConcurrency {
-  const resolved: Partial<Record<WorkerType, number>> = {}
+  const overrides = values.map(parseWorkerConcurrencyEntry)
+  const overriddenWorkerTypes = new Set(overrides.map((entry) => entry.workerType))
+  const resolved: Partial<Record<ConfigurableWorkerType, number>> = {}
 
-  for (const workerType of CONFIGURABLE_WORKER_TYPES) {
-    const environmentVariable = concurrencyEnvironmentVariables[workerType]
+  for (const workerType of WORKER_TYPES) {
+    const definition = WORKER_CONCURRENCY_CONFIG[workerType]
+    if (!isConfigurableWorkerType(workerType)) {
+      if (nonblank(process.env[definition.environmentVariable])) {
+        throw fixedActionConcurrency()
+      }
+      continue
+    }
+    if (overriddenWorkerTypes.has(workerType)) continue
+
+    const environmentVariable = definition.environmentVariable
     const configured = nonblank(process.env[environmentVariable])
     if (configured !== undefined) {
       resolved[workerType] = parseConcurrency(configured, environmentVariable)
     }
   }
 
-  if (nonblank(process.env.SIXB_ACTION_WORKER_CONCURRENCY)) {
-    throw fixedActionConcurrency()
-  }
-
-  for (const value of values) {
-    const entry = parseWorkerConcurrencyEntry(value)
+  for (const entry of overrides) {
     resolved[entry.workerType] = entry.concurrency
   }
 
@@ -77,10 +72,10 @@ function parseWorkerConcurrencyEntry(value: string): {
   const configured = value.slice(separator + 1).trim()
   if (!isWorkerType(workerType)) {
     throw new Error(
-      `[SixbCLI] Unknown worker concurrency type '${workerType || value}'. Available: ${CONFIGURABLE_WORKER_TYPES.join(", ")}.`
+      `[SixbCLI] Unknown worker concurrency type '${workerType || value}'. Available: ${WORKER_TYPES.filter(isConfigurableWorkerType).join(", ")}.`
     )
   }
-  if (workerType === "action") {
+  if (!isConfigurableWorkerType(workerType)) {
     throw fixedActionConcurrency()
   }
 
@@ -108,6 +103,10 @@ function nonblank(value: string | undefined): string | undefined {
 
 function isWorkerType(value: string): value is WorkerType {
   return WORKER_TYPES.some((workerType) => workerType === value)
+}
+
+function isConfigurableWorkerType(value: WorkerType): value is ConfigurableWorkerType {
+  return WORKER_CONCURRENCY_CONFIG[value].configurable
 }
 
 function invalidConcurrency(value: string, source: string): Error {

--- a/packages/cli/src/lib/worker-registry.ts
+++ b/packages/cli/src/lib/worker-registry.ts
@@ -19,7 +19,26 @@ export const WORKER_TYPES = [
 ] as const
 
 export type WorkerType = (typeof WORKER_TYPES)[number]
-export type WorkerConcurrency = Readonly<Partial<Record<WorkerType, number>>>
+
+export const WORKER_CONCURRENCY_CONFIG = {
+  sync: { configurable: true, environmentVariable: "SIXB_SYNC_WORKER_CONCURRENCY" },
+  action: { configurable: false, environmentVariable: "SIXB_ACTION_WORKER_CONCURRENCY" },
+  agent: { configurable: true, environmentVariable: "SIXB_AGENT_WORKER_CONCURRENCY" },
+  pipeline: { configurable: true, environmentVariable: "SIXB_PIPELINE_WORKER_CONCURRENCY" },
+  projection: { configurable: true, environmentVariable: "SIXB_PROJECTION_WORKER_CONCURRENCY" },
+  workflow: { configurable: true, environmentVariable: "SIXB_WORKFLOW_WORKER_CONCURRENCY" },
+} as const satisfies Record<
+  WorkerType,
+  { readonly configurable: boolean; readonly environmentVariable: string }
+>
+
+export type ConfigurableWorkerType = {
+  [Type in WorkerType]: (typeof WORKER_CONCURRENCY_CONFIG)[Type]["configurable"] extends true
+    ? Type
+    : never
+}[WorkerType]
+
+export type WorkerConcurrency = Readonly<Partial<Record<ConfigurableWorkerType, number>>>
 export type QueueWorkerProcess = Worker & { readonly concurrency: number }
 
 export interface WorkerCreationOptions {

--- a/packages/cli/src/lib/worker-registry.ts
+++ b/packages/cli/src/lib/worker-registry.ts
@@ -9,13 +9,27 @@ import { SixbCliError } from "./errors"
 import type { LoadedSixbHost } from "./loadSixb"
 import { configuredOrigin } from "./public-origin"
 
+export const WORKER_TYPES = [
+  "sync",
+  "action",
+  "agent",
+  "pipeline",
+  "projection",
+  "workflow",
+] as const
+
+export type WorkerType = (typeof WORKER_TYPES)[number]
+export type WorkerConcurrency = Readonly<Partial<Record<WorkerType, number>>>
+export type QueueWorkerProcess = Worker & { readonly concurrency: number }
+
 export interface WorkerCreationOptions {
   readonly agentApiBaseUrl?: string
   readonly agentTurnTimeoutMs?: number
+  readonly workerConcurrency?: WorkerConcurrency
 }
 
 interface WorkerFactory {
-  readonly create: (sixb: LoadedSixbHost, options: WorkerCreationOptions) => Worker
+  readonly create: (sixb: LoadedSixbHost, options: WorkerCreationOptions) => QueueWorkerProcess
   /**
    * Why this worker cannot be constructed with the given options, or `null` when it can.
    * Asked before anything is constructed, so a group names every reason at once.
@@ -29,9 +43,10 @@ interface WorkerFactory {
 const AGENT_ORIGIN_REQUIRED =
   "requires --api-public-origin or SIXB_API_PUBLIC_ORIGIN (agent workers call the API)"
 
-const workerFactories: Record<string, WorkerFactory> = {
+const workerFactories: Record<WorkerType, WorkerFactory> = {
   sync: {
-    create: (sixb) => new SyncWorker(sixb),
+    create: (sixb, options) =>
+      new SyncWorker(sixb, { concurrency: options.workerConcurrency?.sync }),
   },
   action: {
     create: (sixb) => new ActionWorker(sixb),
@@ -40,19 +55,23 @@ const workerFactories: Record<string, WorkerFactory> = {
     create: (sixb, options) =>
       new AgentWorker(sixb, {
         apiBaseUrl: resolveAgentApiBaseUrl(options.agentApiBaseUrl),
+        concurrency: options.workerConcurrency?.agent,
         turnTimeoutMs: options.agentTurnTimeoutMs,
       }),
     unmetRequirement: (options) =>
       agentApiBaseUrl(options.agentApiBaseUrl) ? null : AGENT_ORIGIN_REQUIRED,
   },
   pipeline: {
-    create: (sixb) => new PipelineWorker(sixb),
+    create: (sixb, options) =>
+      new PipelineWorker(sixb, { concurrency: options.workerConcurrency?.pipeline }),
   },
   projection: {
-    create: (sixb) => new ProjectionWorker(sixb),
+    create: (sixb, options) =>
+      new ProjectionWorker(sixb, { concurrency: options.workerConcurrency?.projection }),
   },
   workflow: {
-    create: (sixb) => new WorkflowWorker(sixb),
+    create: (sixb, options) =>
+      new WorkflowWorker(sixb, { concurrency: options.workerConcurrency?.workflow }),
   },
 }
 
@@ -60,8 +79,8 @@ export function createWorkerForType(
   sixb: LoadedSixbHost,
   workerType: string,
   options: WorkerCreationOptions = {}
-): Worker {
-  const factory = workerFactories[workerType]
+): QueueWorkerProcess {
+  const factory = isWorkerType(workerType) ? workerFactories[workerType] : undefined
   if (!factory) {
     throw new Error(`[SixbWorker] Unknown worker '${workerType}'. Available: ${knownWorkers()}`)
   }
@@ -69,12 +88,12 @@ export function createWorkerForType(
   return factory.create(sixb, options)
 }
 
-export function resolveWorkerTypeToStart(requestedWorker?: string): string {
+export function resolveWorkerTypeToStart(requestedWorker?: string): WorkerType {
   if (!requestedWorker) {
     throw new Error(`[SixbWorker] Usage: sixb worker <${knownWorkers().replaceAll(", ", "|")}>`)
   }
 
-  if (!workerFactories[requestedWorker]) {
+  if (!isWorkerType(requestedWorker)) {
     throw new Error(
       `[SixbWorker] Unknown worker '${requestedWorker}'. Available: ${knownWorkers()}`
     )
@@ -91,7 +110,9 @@ export function unmetWorkerRequirement(
   workerType: string,
   options: WorkerCreationOptions
 ): string | null {
-  return workerFactories[workerType]?.unmetRequirement?.(options) ?? null
+  return isWorkerType(workerType)
+    ? (workerFactories[workerType].unmetRequirement?.(options) ?? null)
+    : null
 }
 
 export interface WorkerGroupInputs {
@@ -141,8 +162,8 @@ export function assertWorkerInputs(input: WorkerGroupInputs): void {
   })
 }
 
-export function resolveRegisteredWorkerTypes(sixb: LoadedSixbHost): readonly string[] {
-  const workerTypes: string[] = []
+export function resolveRegisteredWorkerTypes(sixb: LoadedSixbHost): readonly WorkerType[] {
+  const workerTypes: WorkerType[] = []
 
   if (sixb.definitions.syncs.list().length > 0) {
     workerTypes.push("sync")
@@ -172,7 +193,11 @@ export function resolveRegisteredWorkerTypes(sixb: LoadedSixbHost): readonly str
 }
 
 function knownWorkers(): string {
-  return Object.keys(workerFactories).join(", ")
+  return WORKER_TYPES.join(", ")
+}
+
+function isWorkerType(value: string): value is WorkerType {
+  return WORKER_TYPES.some((workerType) => workerType === value)
 }
 
 function agentApiBaseUrl(value: string | undefined): string | null {

--- a/packages/cli/src/ui/index.tsx
+++ b/packages/cli/src/ui/index.tsx
@@ -396,6 +396,10 @@ export function HelpView({ errorMessage }: { errorMessage?: string }) {
             label: "--agent-turn-timeout <duration>",
             value: "Agent turn wall-clock budget (default: 10m)",
           },
+          {
+            label: "--concurrency <value>",
+            value: "Concurrent jobs: count for worker; repeat type=count for dev/worker-group",
+          },
           { label: "--atlas-public-origin <origin>", value: "Public Atlas origin" },
           { label: "--app-public-origin <origin>", value: "Public custom app origin" },
           { label: "--api-url <url>", value: "API origin for auth/token commands" },
@@ -433,8 +437,8 @@ export function HelpView({ errorMessage }: { errorMessage?: string }) {
           "sixb orchestrator",
           "sixb rules",
           "sixb worker pipeline",
-          "sixb worker workflow",
-          "sixb worker-group sync pipeline projection",
+          "sixb worker agent --concurrency 8",
+          "sixb worker-group sync agent --concurrency sync=2 --concurrency agent=8",
           "sixb dev --entry examples/mac-os/sixb.config.ts --port 8080",
           "sixb check",
           "sixb typegen",
@@ -498,6 +502,7 @@ export function DevView({
   wsUrl,
   uiUrl,
   appUrl,
+  workers = [],
   warnings = [],
 }: {
   name: string
@@ -506,6 +511,7 @@ export function DevView({
   wsUrl: string
   uiUrl: string | null
   appUrl?: string | null
+  workers?: readonly { readonly type: string; readonly concurrency: number }[]
   warnings?: readonly string[]
 }) {
   const serverItems: KeyValueItem[] = [
@@ -529,6 +535,18 @@ export function DevView({
           <ServicePanel name="Custom app" items={[{ label: "URL", value: appUrl }]} />
         </>
       ) : null}
+      {workers.length > 0 ? (
+        <>
+          <Spacer />
+          <ServicePanel
+            name="Workers"
+            items={workers.map((worker) => ({
+              label: worker.type,
+              value: `running · concurrency ${worker.concurrency}`,
+            }))}
+          />
+        </>
+      ) : null}
       {warnings.length > 0 ? (
         <>
           <Spacer />
@@ -547,11 +565,13 @@ export function DevView({
 export function WorkerView({
   name,
   workerId,
+  concurrency,
   storage,
   warnings = [],
 }: {
   name: string
   workerId: string
+  concurrency: number
   storage?: string | null
   warnings?: readonly string[]
 }) {
@@ -562,7 +582,13 @@ export function WorkerView({
       </Text>
       <Text dimColor>{name}</Text>
       <Spacer />
-      <ServicePanel name="Worker" items={[{ label: "ID", value: workerId }]} />
+      <ServicePanel
+        name="Worker"
+        items={[
+          { label: "ID", value: workerId },
+          { label: "Concurrency", value: String(concurrency) },
+        ]}
+      />
       <StoragePanel summary={storage} />
       {warnings.length > 0 ? (
         <>
@@ -579,12 +605,12 @@ export function WorkerView({
 
 export function WorkerGroupView({
   name,
-  workerTypes,
+  workers,
   storage,
   warnings = [],
 }: {
   name: string
-  workerTypes: readonly string[]
+  workers: readonly { readonly type: string; readonly concurrency: number }[]
   storage?: string | null
   warnings?: readonly string[]
 }) {
@@ -597,7 +623,10 @@ export function WorkerGroupView({
       <Spacer />
       <ServicePanel
         name="Workers"
-        items={workerTypes.map((workerType) => ({ label: workerType, value: "running" }))}
+        items={workers.map((worker) => ({
+          label: worker.type,
+          value: `running · concurrency ${worker.concurrency}`,
+        }))}
       />
       <StoragePanel summary={storage} />
       {warnings.length > 0 ? (

--- a/packages/cli/tests/fixtures/worker-group/sixb.config.ts
+++ b/packages/cli/tests/fixtures/worker-group/sixb.config.ts
@@ -107,7 +107,8 @@ function claimLoggingQueue<T extends object>(queue: T, workerType: string): T {
         return (...args: unknown[]) => {
           if (!logged) {
             logged = true
-            logFixtureEvent({ type: "claim", workerType })
+            const params = args[0] as { readonly limit?: unknown } | undefined
+            logFixtureEvent({ type: "claim", workerType, limit: params?.limit })
           }
           return (value as (...a: unknown[]) => unknown).apply(target, args)
         }

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -346,9 +346,13 @@ describe("startSixbRuntime", () => {
       syncs: [sync],
     })
 
-    const runtime = await startSixbRuntime(sixb, { cohostWorkers: true })
+    const runtime = await startSixbRuntime(sixb, {
+      cohostWorkers: true,
+      workerConcurrency: { sync: 3 },
+    })
 
     expect(runtime.syncWorker).not.toBeNull()
+    expect(runtime.syncWorker?.concurrency).toBe(3)
 
     await new SyncRunDispatcher({
       id: sixb.id,

--- a/packages/cli/tests/worker-concurrency.test.ts
+++ b/packages/cli/tests/worker-concurrency.test.ts
@@ -44,6 +44,13 @@ describe("worker concurrency configuration", () => {
     expect(resolveSingleWorkerConcurrency("agent", "8")).toEqual({ agent: 8 })
   })
 
+  test("does not validate an environment value replaced by a typed CLI override", () => {
+    process.env.SIXB_AGENT_WORKER_CONCURRENCY = "invalid"
+
+    // Reverting to environment-first parsing makes this throw before the valid override is read.
+    expect(resolveWorkerConcurrency(["agent=8"])).toEqual({ agent: 8 })
+  })
+
   test("combines per-worker environments and repeatable typed overrides", () => {
     process.env.SIXB_AGENT_WORKER_CONCURRENCY = "3"
     process.env.SIXB_SYNC_WORKER_CONCURRENCY = "2"

--- a/packages/cli/tests/worker-concurrency.test.ts
+++ b/packages/cli/tests/worker-concurrency.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import {
+  resolveSingleWorkerConcurrency,
+  resolveWorkerConcurrency,
+} from "../src/lib/worker-concurrency"
+
+const environmentVariables = [
+  "SIXB_SYNC_WORKER_CONCURRENCY",
+  "SIXB_ACTION_WORKER_CONCURRENCY",
+  "SIXB_AGENT_WORKER_CONCURRENCY",
+  "SIXB_PIPELINE_WORKER_CONCURRENCY",
+  "SIXB_PROJECTION_WORKER_CONCURRENCY",
+  "SIXB_WORKFLOW_WORKER_CONCURRENCY",
+] as const
+
+const originalEnvironment = Object.fromEntries(
+  environmentVariables.map((name) => [name, process.env[name]])
+) as Record<(typeof environmentVariables)[number], string | undefined>
+
+describe("worker concurrency configuration", () => {
+  beforeEach(() => {
+    for (const name of environmentVariables) {
+      delete process.env[name]
+    }
+  })
+
+  afterEach(() => {
+    for (const name of environmentVariables) {
+      const original = originalEnvironment[name]
+      if (original === undefined) delete process.env[name]
+      else process.env[name] = original
+    }
+  })
+
+  test("leaves worker defaults in authority when nothing is configured", () => {
+    expect(resolveSingleWorkerConcurrency("agent", undefined)).toEqual({})
+    expect(resolveWorkerConcurrency()).toEqual({})
+  })
+
+  test("resolves a scalar for a single worker and lets the flag win over its environment", () => {
+    process.env.SIXB_AGENT_WORKER_CONCURRENCY = "3"
+
+    expect(resolveSingleWorkerConcurrency("agent", undefined)).toEqual({ agent: 3 })
+    expect(resolveSingleWorkerConcurrency("agent", "8")).toEqual({ agent: 8 })
+  })
+
+  test("combines per-worker environments and repeatable typed overrides", () => {
+    process.env.SIXB_AGENT_WORKER_CONCURRENCY = "3"
+    process.env.SIXB_SYNC_WORKER_CONCURRENCY = "2"
+    process.env.SIXB_WORKFLOW_WORKER_CONCURRENCY = "4"
+
+    expect(resolveWorkerConcurrency(["agent=8", "projection=5", "agent=10"])).toEqual({
+      agent: 10,
+      sync: 2,
+      projection: 5,
+      workflow: 4,
+    })
+  })
+
+  test("rejects malformed, zero, fractional, and unsafe concurrency values", () => {
+    for (const value of ["", "0", "-1", "1.5", "many", "9007199254740992"]) {
+      expect(() => resolveSingleWorkerConcurrency("sync", value)).toThrow(
+        "Invalid worker concurrency"
+      )
+    }
+  })
+
+  test("rejects malformed mappings and unknown worker types", () => {
+    expect(() => resolveWorkerConcurrency(["agent"])).toThrow("type=count")
+    expect(() => resolveWorkerConcurrency(["unknown=2"])).toThrow(
+      "Unknown worker concurrency type 'unknown'"
+    )
+  })
+
+  test("keeps the action worker's deliberate serial limit", () => {
+    expect(resolveSingleWorkerConcurrency("action", undefined)).toEqual({})
+    expect(() => resolveSingleWorkerConcurrency("action", "2")).toThrow(
+      "Action worker concurrency is fixed at 1"
+    )
+    expect(() => resolveWorkerConcurrency(["action=2"])).toThrow(
+      "Action worker concurrency is fixed at 1"
+    )
+  })
+})

--- a/packages/cli/tests/worker-group.e2e.ts
+++ b/packages/cli/tests/worker-group.e2e.ts
@@ -138,4 +138,19 @@ describe("sixb worker-group (e2e)", () => {
     },
     WORKER_GROUP_TIMEOUT_MS
   )
+
+  test(
+    "applies an independent concurrency limit to each selected worker",
+    async () => {
+      const { ready, logEntries } = await startThenStop(
+        ["worker-group", "sync", "agent", "--concurrency", "sync=2", "--concurrency", "agent=6"],
+        "worker-group"
+      )
+
+      expect(ready).toBe(true)
+      expect(logEntries).toContainEqual({ type: "claim", workerType: "sync", limit: 2 })
+      expect(logEntries).toContainEqual({ type: "claim", workerType: "agent", limit: 6 })
+    },
+    WORKER_GROUP_TIMEOUT_MS
+  )
 })

--- a/packages/cli/tests/worker-group.test.ts
+++ b/packages/cli/tests/worker-group.test.ts
@@ -80,6 +80,26 @@ describe("sixb worker-group", () => {
     expect(result.stdout).not.toContain("requires a queues provider")
   })
 
+  test("validates typed worker concurrency before loading providers", async () => {
+    const result = await runOnce(
+      ["worker-group", "sync", "--concurrency", "sync=0"],
+      "valid-project"
+    )
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain("Invalid worker concurrency '0'")
+    expect(result.stdout).not.toContain("requires a queues provider")
+  })
+
+  test("rejects a missing typed worker concurrency value", async () => {
+    const result = await runOnce(["worker-group", "sync", "--concurrency"], "valid-project")
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain("Invalid worker concurrency ''")
+    expect(result.stdout).not.toContain("Unknown worker")
+    expect(result.stdout).not.toContain("requires a queues provider")
+  })
+
   test("refuses without migrating, so a bad command leaves no schema behind", async () => {
     // The fixture registers agents, so auto-selection picks the `agent` worker, whose construction
     // needs an API origin. The refusal is right; running a schema change first was not.

--- a/packages/cli/tests/worker.test.ts
+++ b/packages/cli/tests/worker.test.ts
@@ -143,6 +143,24 @@ describe("sixb worker", () => {
     expect(result.stderr).toBe("")
   })
 
+  test("validates worker concurrency before loading providers", () => {
+    const result = runWorkerFixture("valid-project", ["sync", "--concurrency", "0"])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain("Invalid worker concurrency '0'")
+    expect(result.stdout).not.toContain("requires a queues provider")
+    expect(result.stderr).toBe("")
+  })
+
+  test("rejects a missing worker concurrency value", () => {
+    const result = runWorkerFixture("valid-project", ["sync", "--concurrency"])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain("Invalid worker concurrency ''")
+    expect(result.stdout).not.toContain("requires a queues provider")
+    expect(result.stderr).toBe("")
+  })
+
   test("refuses without migrating, so a bad command leaves no schema behind", async () => {
     // `sixb worker agent` cannot start without an API origin, and used to find that out after
     // bringing the schema up to date.
@@ -177,6 +195,7 @@ describe("sixb worker", () => {
 
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain("worker <type>")
+    expect(result.stdout).toContain("--concurrency <value>")
     expect(result.stdout).not.toContain("--type <type>")
     expect(result.stdout).not.toContain("--worker <type>")
     expect(result.stdout).toContain("sync, action, agent")

--- a/packages/cli/tests/worker.test.ts
+++ b/packages/cli/tests/worker.test.ts
@@ -161,6 +161,16 @@ describe("sixb worker", () => {
     expect(result.stderr).toBe("")
   })
 
+  test("preserves the complete equals-form concurrency value for validation", () => {
+    // Reverting getFlag() to split("=")[1] truncates this to 3 and lets startup continue.
+    const result = runWorkerFixture("valid-project", ["sync", "--concurrency=3=4"])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain("Invalid worker concurrency '3=4'")
+    expect(result.stdout).not.toContain("requires a queues provider")
+    expect(result.stderr).toBe("")
+  })
+
   test("refuses without migrating, so a bad command leaves no schema behind", async () => {
     // `sixb worker agent` cannot start without an API origin, and used to find that out after
     // bringing the schema up to date.

--- a/packages/core/src/workers/queue-worker.ts
+++ b/packages/core/src/workers/queue-worker.ts
@@ -66,9 +66,14 @@ export abstract class QueueWorker<
       failureCodes: config.failureCodes,
       workerId: config.workerId,
       leaseMs: config.leaseMs ?? DEFAULT_LEASE_MS,
-      claimLimit: config.claimLimit ?? DEFAULT_CLAIM_LIMIT,
+      claimLimit: normalizeClaimLimit(config.claimLimit),
       idlePollMs: config.idlePollMs ?? DEFAULT_IDLE_POLL_MS,
     }
+  }
+
+  /** Maximum jobs this worker process claims and executes at once. */
+  get concurrency(): number {
+    return this.config.claimLimit
   }
 
   protected async run(signal: AbortSignal): Promise<void> {
@@ -241,6 +246,14 @@ export abstract class QueueWorker<
       })
     await delivery.fail(failure)
   }
+}
+
+function normalizeClaimLimit(value: number | undefined): number {
+  const claimLimit = value ?? DEFAULT_CLAIM_LIMIT
+  if (!Number.isSafeInteger(claimLimit) || claimLimit < 1) {
+    throw new Error("[SixbQueueWorker] Worker concurrency must be a positive safe integer.")
+  }
+  return claimLimit
 }
 
 async function settleOrLog<TJob extends QueueJob, TFailureCode extends SixbErrorCode>(

--- a/packages/core/tests/queue-worker.test.ts
+++ b/packages/core/tests/queue-worker.test.ts
@@ -22,6 +22,31 @@ async function waitFor(fn: () => Promise<boolean> | boolean, timeoutMs = 1_000):
 }
 
 describe("QueueWorker", () => {
+  test("defaults to one concurrent job and rejects invalid claim limits", () => {
+    const queues = new InMemoryQueues()
+    class InspectableWorker extends QueueWorker<
+      SyncRunRequestedQueueJob,
+      typeof SYNC_RUN_FAILURE_CODES
+    > {
+      protected async execute(): Promise<void> {}
+    }
+
+    const defaults = {
+      projectId: PROJECT_ID,
+      queue: queues.syncRuns,
+      failureCodes: SYNC_RUN_FAILURE_CODES,
+      workerId: "w",
+    }
+    expect(new InspectableWorker(defaults).concurrency).toBe(1)
+    expect(new InspectableWorker({ ...defaults, claimLimit: 3 }).concurrency).toBe(3)
+
+    for (const claimLimit of [0, -1, 1.5, Number.POSITIVE_INFINITY]) {
+      expect(() => new InspectableWorker({ ...defaults, claimLimit })).toThrow(
+        "Worker concurrency must be a positive safe integer"
+      )
+    }
+  })
+
   test("processes claimed jobs and completes them", async () => {
     const queues = new InMemoryQueues()
     const processed: string[] = []

--- a/packages/pipeline-worker/src/index.ts
+++ b/packages/pipeline-worker/src/index.ts
@@ -1,2 +1,3 @@
 export type { PipelineWorkerHost } from "./types"
+export type { PipelineWorkerOptions } from "./worker"
 export { PipelineWorker } from "./worker"

--- a/packages/pipeline-worker/src/worker.ts
+++ b/packages/pipeline-worker/src/worker.ts
@@ -14,6 +14,11 @@ import {
 import { PipelineRunAlreadyStartedError, runPipelineJob } from "./run-pipeline-job"
 import type { PipelineJob, PipelineWorkerContext, PipelineWorkerHost } from "./types"
 
+export interface PipelineWorkerOptions {
+  /** Maximum pipeline run jobs this worker claims and executes at once. Defaults to 1. */
+  readonly concurrency?: number
+}
+
 export class PipelineWorker extends QueueWorker<
   PipelineRunRequestedQueueJob,
   typeof PIPELINE_RUN_FAILURE_CODES
@@ -21,7 +26,7 @@ export class PipelineWorker extends QueueWorker<
   private readonly context: PipelineWorkerContext
   private readonly host: PipelineWorkerHost
 
-  constructor(host: PipelineWorkerHost) {
+  constructor(host: PipelineWorkerHost, options: PipelineWorkerOptions = {}) {
     if (host.definitions.pipelines.list().length === 0) {
       throw new Error("[SixbPipelineWorker] No pipeline definitions are registered.")
     }
@@ -36,6 +41,7 @@ export class PipelineWorker extends QueueWorker<
       queue: host.queues.pipelines,
       failureCodes: PIPELINE_RUN_FAILURE_CODES,
       workerId: `pipeline-worker-${host.id}`,
+      claimLimit: options.concurrency,
     })
 
     this.context = buildPipelineContext(host, pipelineRunsStorage)

--- a/packages/pipeline-worker/tests/worker.test.ts
+++ b/packages/pipeline-worker/tests/worker.test.ts
@@ -148,6 +148,20 @@ async function seedDatasetVersion(
 }
 
 describe("PipelineWorker", () => {
+  test("defaults to one concurrent job and accepts an explicit limit", () => {
+    const cleanStep = definePipelineStep("concurrency-options")
+      .inputs({ rawCustomers: rawCustomersDataset })
+      .output(customersDataset)
+      .run(async () => {})
+    const sixb = createSixbForPipeline({
+      pipeline: definePipeline("concurrency-options").then(cleanStep),
+      datasets: [rawCustomersDataset, customersDataset],
+    })
+
+    expect(new PipelineWorker(sixb).concurrency).toBe(1)
+    expect(new PipelineWorker(sixb, { concurrency: 3 }).concurrency).toBe(3)
+  })
+
   test("requires registered pipelines and pipeline run storage", () => {
     const emptySixb = new SixbHost({
       id: "pipeline-worker-tests",

--- a/packages/projection-worker/src/index.ts
+++ b/packages/projection-worker/src/index.ts
@@ -1,2 +1,2 @@
-export type { ProjectionWorkerHost } from "./worker"
+export type { ProjectionWorkerHost, ProjectionWorkerOptions } from "./worker"
 export { ProjectionWorker } from "./worker"

--- a/packages/projection-worker/src/worker.ts
+++ b/packages/projection-worker/src/worker.ts
@@ -20,6 +20,11 @@ import { projectionRetryAvailableAt } from "./retry-backoff"
 import { isPermanentProjectionFailure, runProjectionJob } from "./run-projection-job"
 import type { ProjectionWorkerContext } from "./types"
 
+export interface ProjectionWorkerOptions {
+  /** Maximum projection run jobs this worker claims and executes at once. Defaults to 1. */
+  readonly concurrency?: number
+}
+
 export class ProjectionWorker extends QueueWorker<
   ProjectionRunRequestedQueueJob,
   typeof PROJECTION_RUN_FAILURE_CODES
@@ -27,7 +32,7 @@ export class ProjectionWorker extends QueueWorker<
   private readonly host: ProjectionWorkerHost
   private readonly projectionRunsStorage: ProjectionRunStorage
 
-  constructor(host: ProjectionWorkerHost) {
+  constructor(host: ProjectionWorkerHost, options: ProjectionWorkerOptions = {}) {
     const projectionCount = host.definitions.projections.list().length
     if (projectionCount === 0) {
       throw new Error("[SixbProjectionWorker] No projection definitions are registered.")
@@ -43,6 +48,7 @@ export class ProjectionWorker extends QueueWorker<
       queue: host.queues.projections,
       failureCodes: PROJECTION_RUN_FAILURE_CODES,
       workerId: `projection-worker-${host.id}`,
+      claimLimit: options.concurrency,
     })
     this.host = host
     this.projectionRunsStorage = projectionRunsStorage

--- a/packages/projection-worker/tests/worker.test.ts
+++ b/packages/projection-worker/tests/worker.test.ts
@@ -126,6 +126,13 @@ async function waitFor<T>(
 }
 
 describe("ProjectionWorker", () => {
+  test("defaults to one concurrent job and accepts an explicit limit", () => {
+    const sixb = createSixb({ datasets: [roomsDataset], projections: [roomProjection] })
+
+    expect(new ProjectionWorker(sixb).concurrency).toBe(1)
+    expect(new ProjectionWorker(sixb, { concurrency: 3 }).concurrency).toBe(3)
+  })
+
   test("processes queued projection jobs end-to-end", async () => {
     const sixb = createSixb({
       datasets: [roomsDataset],

--- a/packages/sync-worker/src/index.ts
+++ b/packages/sync-worker/src/index.ts
@@ -1,2 +1,2 @@
-export type { SyncWorkerHost } from "./worker"
+export type { SyncWorkerHost, SyncWorkerOptions } from "./worker"
 export { SyncWorker } from "./worker"

--- a/packages/sync-worker/src/worker.ts
+++ b/packages/sync-worker/src/worker.ts
@@ -25,13 +25,18 @@ export interface SyncWorkerHost extends PrimitiveExecutionHost {
   readonly definitions: Pick<SixbDefinitions, "syncs" | "datasets">
 }
 
+export interface SyncWorkerOptions {
+  /** Maximum sync run jobs this worker claims and executes at once. Defaults to 1. */
+  readonly concurrency?: number
+}
+
 export class SyncWorker extends QueueWorker<
   SyncRunRequestedQueueJob,
   typeof SYNC_RUN_FAILURE_CODES
 > {
   private readonly host: SyncWorkerHost
 
-  constructor(host: SyncWorkerHost) {
+  constructor(host: SyncWorkerHost, options: SyncWorkerOptions = {}) {
     if (host.definitions.syncs.list().length === 0) {
       throw new Error("[SixbSyncWorker] No sync definitions are registered.")
     }
@@ -41,6 +46,7 @@ export class SyncWorker extends QueueWorker<
       queue: host.queues.syncRuns,
       failureCodes: SYNC_RUN_FAILURE_CODES,
       workerId: `sync-worker-${host.id}`,
+      claimLimit: options.concurrency,
     })
 
     assertSyncStorage(host)

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -155,6 +155,18 @@ async function enqueueSyncRun(
 }
 
 describe("SyncWorker", () => {
+  test("defaults to one concurrent job and accepts an explicit limit", () => {
+    const dataset = makeDataset("raw.erp.concurrency-options")
+    const sync = defineSync("sync-concurrency-options")
+      .from(erpDb)
+      .read(() => [])
+      .intoDataset(dataset)
+    const sixb = createSixbForSync(sync)
+
+    expect(new SyncWorker(sixb).concurrency).toBe(1)
+    expect(new SyncWorker(sixb, { concurrency: 3 }).concurrency).toBe(3)
+  })
+
   test("processes queued sync jobs end-to-end", async () => {
     const rawOrdersDataset = makeDataset("raw.erp.orders")
     const sync = defineSync("sync-orders")

--- a/packages/workflow-worker/src/index.ts
+++ b/packages/workflow-worker/src/index.ts
@@ -1,2 +1,2 @@
-export type { WorkflowWorkerHost } from "./worker"
+export type { WorkflowWorkerHost, WorkflowWorkerOptions } from "./worker"
 export { WorkflowWorker } from "./worker"

--- a/packages/workflow-worker/src/worker.ts
+++ b/packages/workflow-worker/src/worker.ts
@@ -33,6 +33,11 @@ import type {
 const MAX_WORKFLOW_DELIVERY_ATTEMPTS = 5
 const WORKFLOW_RETRY_BACKOFF_MS = 1_000
 
+export interface WorkflowWorkerOptions {
+  /** Maximum workflow run jobs this worker claims and executes at once. Defaults to 1. */
+  readonly concurrency?: number
+}
+
 export class WorkflowWorker extends QueueWorker<
   WorkflowQueueJob,
   typeof WORKFLOW_RUN_FAILURE_CODES
@@ -41,7 +46,7 @@ export class WorkflowWorker extends QueueWorker<
   private readonly observer: WorkflowRunObserver
   private readonly workflowRuns: WorkflowRunStorage
 
-  constructor(host: WorkflowWorkerHost) {
+  constructor(host: WorkflowWorkerHost, options: WorkflowWorkerOptions = {}) {
     if (host.definitions.workflows.list().length === 0) {
       throw new Error("[SixbWorkflowWorker] No workflow definitions are registered.")
     }
@@ -62,6 +67,7 @@ export class WorkflowWorker extends QueueWorker<
       queue: host.queues.workflows,
       failureCodes: WORKFLOW_RUN_FAILURE_CODES,
       workerId: `workflow-worker-${host.id}`,
+      claimLimit: options.concurrency,
     })
 
     this.host = host

--- a/packages/workflow-worker/tests/worker.test.ts
+++ b/packages/workflow-worker/tests/worker.test.ts
@@ -152,6 +152,16 @@ async function waitFor<T>(
 }
 
 describe("WorkflowWorker", () => {
+  test("defaults to one concurrent job and accepts an explicit limit", () => {
+    const workflow = defineWorkflow("concurrency-options")
+      .input({ transaction: ref(Transaction) })
+      .then(findBestInvoice)
+    const sixb = createSixb({ workflows: [workflow] })
+
+    expect(new WorkflowWorker(sixb).concurrency).toBe(1)
+    expect(new WorkflowWorker(sixb, { concurrency: 3 }).concurrency).toBe(3)
+  })
+
   test("requires registered workflows and workflow storage", () => {
     expect(() => new WorkflowWorker(createSixb({}))).toThrow("No workflow definitions")
 


### PR DESCRIPTION
## Summary

Adds configurable concurrency for queue workers.

This PR is stacked on #427 and should merge after it.

## Usage

~~~bash
sixb worker agent --concurrency 8

sixb worker-group sync agent \
  --concurrency sync=2 \
  --concurrency agent=8

sixb dev --concurrency agent=8
~~~

Per-worker environment variables are also supported:

~~~bash
SIXB_AGENT_WORKER_CONCURRENCY=8 sixb worker agent
~~~

## Behavior

- Agent workers keep their default concurrency of 4.
- Sync, pipeline, projection, and workflow workers keep their default of 1.
- Action workers remain serial and reject overrides.
- Invalid values fail before providers start.
- CLI status panels show the effective concurrency.

Concurrency is per process and multiplies with deployment replicas.

## Validation

- bun run typecheck
- bun run check
- bun run build
- bun run test:publish
- bun run test:ci — 3,961 passed, 2 expected live-integration skips