### PR TITLE
syncs: fan out managed connector connections

### DIFF
--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -174,8 +174,12 @@ can.manage(socialConnector)
 // or: can.manage(every.connector())
 ```
 
-> **Current scope.** OAuth-backed sync fan-out and webhook routing remain rejected until their
-> connection routing contracts are defined.
+Syncs automatically read every connected account for an OAuth connector. The handler receives
+non-secret connection metadata through `context.connection`; no connection selector is required
+in the Sync definition. See [OAuth connector fan-out](./syncs.md#oauth-connector-fan-out).
+
+> **Current scope.** OAuth-backed webhook routing remains rejected until its connection admission
+> contract is defined.
 
 ## Protect OAuth credentials
 

--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -46,6 +46,40 @@ The read handler receives the `client` returned by the connector's `connect()` a
 Snapshot and append handlers return rows; merge handlers return `change.upsert(...)` and
 `change.delete(...)` values. Each handler may return one value, an iterable, or an async iterable.
 
+## OAuth connector fan-out
+
+An OAuth connector may have several project connections. A Sync reads all currently connected
+accounts by default; its definition needs no selector:
+
+```ts
+export const syncSocialVideos = defineSync("sync-social-videos")
+  .from(socialConnector)
+  .read(async (social, { connection }) => {
+    const videos = await social.listVideos()
+    return videos.map((video) => ({
+      ...video,
+      sourceConnectionId: connection.id,
+      sourceAccountId: connection.account.id,
+    }))
+  })
+  .intoDataset(socialVideosDataset)
+```
+
+```text
+one Sync run
+  ├─ connection A → read
+  ├─ connection B → read
+  └─ one atomic dataset commit
+```
+
+Connections are read sequentially in stable order. If one source fails, the complete run fails and
+the previous dataset and checkpoints remain unchanged. Incremental checkpoints are isolated per
+connection and account; replacing an account starts that connection without the old cursor.
+
+For merge datasets, include connection or account identity in the primary key whenever provider
+record ids are not globally unique. With no connected account, the handler is not called and the
+run follows the normal empty-result semantics for its mode.
+
 ## Schedules
 
 Every sync declares when it runs with `.when(...)`. Call it more than once to add schedules; they
@@ -212,6 +246,7 @@ The read handler signature is `(client, context)`.
 | `context.syncId` | This sync's id |
 | `context.signal` | `AbortSignal` for cooperative cancellation |
 | `context.blobs` | Blob facade (`put`, `open`, `stat`) for file ingestion |
+| `context.connection` | Connection, slot and account metadata for OAuth-backed Syncs |
 | `context.checkpoint` | Last checkpoint value (only with `.checkpoint<T>()`) |
 | `context.setCheckpoint(next)` | Records the next checkpoint (only with `.checkpoint<T>()`) |
 

--- a/docs/data/syncs.md
+++ b/docs/data/syncs.md
@@ -76,6 +76,11 @@ Connections are read sequentially in stable order. If one source fails, the comp
 the previous dataset and checkpoints remain unchanged. Incremental checkpoints are isolated per
 connection and account; replacing an account starts that connection without the old cursor.
 
+The stored checkpoint is bound to the connector and its framework format. Changing the connector
+while keeping the same Sync id fails safely; use a new Sync id to start ingestion from scratch. The
+framework envelope is internal: `context.checkpoint` still contains only the value declared by the
+Sync.
+
 For merge datasets, include connection or account identity in the primary key whenever provider
 record ids are not globally unique. With no connected account, the handler is not called and the
 run follows the normal empty-result semantics for its mode.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,7 +26,7 @@ bun add @sixb/core
 
 **Connectors** -- Typed external system clients that you register with the runtime and resolve lazily with `sixb.connector(...)`.
 
-**Syncs** -- Declarative batch sync definitions that read from one connector and write into one raw dataset. V1 supports `snapshot`, `append`, and keyed `merge` modes with optional triggers and typed source checkpoints.
+**Syncs** -- Declarative batch sync definitions that read from one connector and write into one raw dataset. OAuth connectors fan out across their connected accounts with isolated checkpoints. V1 supports `snapshot`, `append`, and keyed `merge` modes with optional triggers and typed source checkpoints.
 
 **Queues** -- Typed durable work lanes for executable jobs such as sync runs, pipeline runs, and projection runs. App setup passes one `Queues` provider, while workers claim from lanes like `sixb.queues.syncRuns`.
 

--- a/packages/core/src/connectors/connections/contracts.ts
+++ b/packages/core/src/connectors/connections/contracts.ts
@@ -3,7 +3,11 @@ import type {
   ConnectorConnectionRunKind,
 } from "../../storage/connector-connections/types"
 import type { CreateExecutionInput } from "../../storage/executions/types"
-import type { ConnectorAccountCandidate, ConnectorConnectionSelector } from "../types"
+import type {
+  ConnectorAccountCandidate,
+  ConnectorConnectionMetadata,
+  ConnectorConnectionSelector,
+} from "../types"
 
 /** Durable, already-authorized request provenance carried into the process-owned OAuth service. */
 export interface ConnectorConnectionCommandContext {
@@ -85,10 +89,7 @@ export interface AddConnectorConnectionInput extends ConnectorConnectionSelector
   readonly fromConnectionId: string
 }
 
-export interface ConnectorConnectionView extends ConnectorConnectionSelector {
-  readonly id: string
-  readonly connectorId: string
-  readonly account: ConnectorAccountCandidate
+export interface ConnectorConnectionView extends ConnectorConnectionMetadata {
   readonly status: "connected" | "needs_reauthorization" | "disconnected"
 }
 

--- a/packages/core/src/connectors/connections/service.ts
+++ b/packages/core/src/connectors/connections/service.ts
@@ -49,10 +49,11 @@ import type {
   StartConnectorConnectionRunResult,
 } from "./contracts"
 import { connectorAuthorizationStatusError } from "./credential-mutations"
+import { runBoundedConnectorProviderOperation } from "./provider-operation"
 import { ConnectorAuthorizationRequestHandler } from "./request"
 import { ConnectorConnectionRunService } from "./runs"
 import { withConnectorStorageBoundary } from "./storage-boundary"
-import { nonblank } from "./validation"
+import { nonblank, positiveDuration } from "./validation"
 import { assertConnectorConnectionSelector, connectorConnectionView } from "./views"
 
 const DEFAULT_ATTEMPT_TTL_MS = 10 * 60_000
@@ -78,6 +79,7 @@ export class ConnectorConnectionService implements ConnectorConnectionProcess {
   private readonly definitionsById: ReadonlyMap<string, ConnectorDefinition>
   private abortController = new AbortController()
   private readonly connectionStorage: ConnectorConnectionStorage
+  private readonly providerOperationTimeoutMs: number
   private readonly authorizations: DefaultConnectorAuthorizationLifecycle
   private readonly requests: ConnectorAuthorizationRequestHandler
   private readonly runs: ConnectorConnectionRunService
@@ -96,8 +98,11 @@ export class ConnectorConnectionService implements ConnectorConnectionProcess {
     const hostSignal = () => this.abortController.signal
     const now = options.now ?? (() => new Date())
     const accountSelectionTtlMs = options.accountSelectionTtlMs ?? DEFAULT_SELECTION_TTL_MS
-    const providerOperationTimeoutMs =
-      options.providerOperationTimeoutMs ?? DEFAULT_PROVIDER_OPERATION_TIMEOUT_MS
+    const providerOperationTimeoutMs = positiveDuration(
+      options.providerOperationTimeoutMs ?? DEFAULT_PROVIDER_OPERATION_TIMEOUT_MS,
+      "provider operation timeout"
+    )
+    this.providerOperationTimeoutMs = providerOperationTimeoutMs
 
     this.authorizations = new DefaultConnectorAuthorizationLifecycle({
       projectId,
@@ -185,7 +190,8 @@ export class ConnectorConnectionService implements ConnectorConnectionProcess {
   /** Resolve a client from an immutable connection snapshot captured for one execution. */
   async connectExecutionConnection<TAdapter extends OAuthConnectorAdapter>(
     definition: ConnectorDefinition<string, TAdapter>,
-    connection: ConnectorConnectionRecord
+    connection: ConnectorConnectionRecord,
+    signal: AbortSignal = this.abortController.signal
   ): Promise<ConnectorClient<TAdapter>> {
     this.assertOAuthRegistered(definition)
     if (
@@ -203,16 +209,30 @@ export class ConnectorConnectionService implements ConnectorConnectionProcess {
       definition,
       connection.authorizationId
     )
+    const hostSignal = this.abortController.signal
+    const operationSignal =
+      signal === hostSignal ? hostSignal : AbortSignal.any([hostSignal, signal])
     try {
-      return (await definition.adapter.connect({
-        projectId: this.projectId,
-        connectorId: definition.id,
-        connectionId: connection.id,
-        account: connection.account,
-        tokenSource: this.authorizations.createTokenSource(definition, authorization.id),
-        signal: this.abortController.signal,
-      })) as ConnectorClient<TAdapter>
+      return (await runBoundedConnectorProviderOperation(
+        {
+          hostSignal: operationSignal,
+          timeoutMs: this.providerOperationTimeoutMs,
+        },
+        (providerSignal) => {
+          const clientSignal = AbortSignal.any([operationSignal, providerSignal])
+          return definition.adapter.connect({
+            projectId: this.projectId,
+            connectorId: definition.id,
+            connectionId: connection.id,
+            account: connection.account,
+            tokenSource: this.authorizations.createTokenSource(definition, authorization.id),
+            signal: clientSignal,
+          })
+        },
+        () => connectorClientInterruptionError(operationSignal)
+      )) as ConnectorClient<TAdapter>
     } catch (error) {
+      if (operationSignal.aborted) throw error
       throw providerBoundaryError(
         error,
         providerFailureCode(error),
@@ -572,6 +592,19 @@ export class ConnectorConnectionService implements ConnectorConnectionProcess {
       throw error
     }
   }
+}
+
+function connectorClientInterruptionError(signal: AbortSignal): Error {
+  if (signal.aborted) {
+    if (signal.reason instanceof Error) return signal.reason
+    const error = new Error("[Sixb] Connector client creation was cancelled.")
+    error.name = "AbortError"
+    return error
+  }
+  return createConnectorCodedError(
+    "connector.provider_unavailable",
+    "Connector client creation timed out."
+  )
 }
 
 function requireConnectionStorage(storage: Storage | undefined): {

--- a/packages/core/src/connectors/connections/service.ts
+++ b/packages/core/src/connectors/connections/service.ts
@@ -161,6 +161,44 @@ export class ConnectorConnectionService implements ConnectorConnectionProcess {
       )
     }
 
+    return this.connectExecutionConnection(definition, connection)
+  }
+
+  /** Snapshot the connected records that one trusted primitive execution may consume. */
+  async listExecutionConnections<TAdapter extends OAuthConnectorAdapter>(
+    definition: ConnectorDefinition<string, TAdapter>
+  ): Promise<readonly ConnectorConnectionRecord[]> {
+    this.assertOAuthRegistered(definition)
+    const connections = await withConnectorStorageBoundary(
+      "Connector connections could not be listed.",
+      () =>
+        this.connectionStorage.listConnections({
+          projectId: this.projectId,
+          connectorId: definition.id,
+        })
+    )
+    return connections
+      .filter((connection) => connection.status === "connected")
+      .sort((left, right) => left.id.localeCompare(right.id))
+  }
+
+  /** Resolve a client from an immutable connection snapshot captured for one execution. */
+  async connectExecutionConnection<TAdapter extends OAuthConnectorAdapter>(
+    definition: ConnectorDefinition<string, TAdapter>,
+    connection: ConnectorConnectionRecord
+  ): Promise<ConnectorClient<TAdapter>> {
+    this.assertOAuthRegistered(definition)
+    if (
+      connection.projectId !== this.projectId ||
+      connection.connectorId !== definition.id ||
+      connection.status !== "connected"
+    ) {
+      throw createConnectorCodedError(
+        "connector.not_found",
+        `Connector '${definition.id}' connection '${connection.id}' is not active in this project.`
+      )
+    }
+
     const authorization = await this.authorizations.requireStableActiveAuthorization(
       definition,
       connection.authorizationId

--- a/packages/core/src/connectors/execution.ts
+++ b/packages/core/src/connectors/execution.ts
@@ -6,10 +6,9 @@ import { createConnectorCodedError } from "./errors"
 import type { ConnectorService } from "./service"
 import type {
   AnyConnectorAdapter,
-  ConnectorAccountCandidate,
   ConnectorAdapter,
   ConnectorClient,
-  ConnectorConnectionOwner,
+  ConnectorConnectionMetadata,
   ConnectorConnectionSelector,
   ConnectorDefinition,
   OAuthConnectorAdapter,
@@ -30,14 +29,8 @@ export interface ConnectorRuntime {
 export interface ConnectorExecutionSource<
   TAdapter extends AnyConnectorAdapter = AnyConnectorAdapter,
 > {
-  readonly connection?: {
-    readonly id: string
-    readonly connectorId: string
-    readonly owner: ConnectorConnectionOwner
-    readonly slot: string
-    readonly account: ConnectorAccountCandidate
-  }
-  connect(): Promise<ConnectorClient<TAdapter>>
+  readonly connection?: ConnectorConnectionMetadata
+  connect(signal: AbortSignal): Promise<ConnectorClient<TAdapter>>
 }
 
 export interface ConnectorExecutionSourceResolver {
@@ -81,7 +74,7 @@ export function createConnectorRuntime(
       if (!isOAuthConnectorDefinition(definition)) {
         return [
           {
-            connect: () =>
+            connect: (_signal) =>
               connector(definition as ConnectorDefinition<string, ConnectorAdapter>) as Promise<
                 ConnectorClient<TAdapter>
               >,
@@ -99,8 +92,8 @@ export function createConnectorRuntime(
           slot: connection.slot,
           account: connection.account,
         },
-        connect: () =>
-          service.connectExecutionConnection(definition, connection) as Promise<
+        connect: (signal) =>
+          service.connectExecutionConnection(definition, connection, signal) as Promise<
             ConnectorClient<TAdapter>
           >,
       }))
@@ -138,7 +131,7 @@ export function getConnectorExecutionSourceResolver(
       }
       return [
         {
-          connect: () =>
+          connect: (_signal) =>
             connector(definition as ConnectorDefinition<string, ConnectorAdapter>) as Promise<
               ConnectorClient<TAdapter>
             >,

--- a/packages/core/src/connectors/execution.ts
+++ b/packages/core/src/connectors/execution.ts
@@ -5,8 +5,11 @@ import type { SixbRuntimeContext } from "../runtime/types"
 import { createConnectorCodedError } from "./errors"
 import type { ConnectorService } from "./service"
 import type {
+  AnyConnectorAdapter,
+  ConnectorAccountCandidate,
   ConnectorAdapter,
   ConnectorClient,
+  ConnectorConnectionOwner,
   ConnectorConnectionSelector,
   ConnectorDefinition,
   OAuthConnectorAdapter,
@@ -24,12 +27,33 @@ export interface ConnectorRuntime {
   ): Promise<ConnectorClient<TAdapter>>
 }
 
+export interface ConnectorExecutionSource<
+  TAdapter extends AnyConnectorAdapter = AnyConnectorAdapter,
+> {
+  readonly connection?: {
+    readonly id: string
+    readonly connectorId: string
+    readonly owner: ConnectorConnectionOwner
+    readonly slot: string
+    readonly account: ConnectorAccountCandidate
+  }
+  connect(): Promise<ConnectorClient<TAdapter>>
+}
+
+export interface ConnectorExecutionSourceResolver {
+  list<TAdapter extends AnyConnectorAdapter>(
+    definition: ConnectorDefinition<string, TAdapter>
+  ): Promise<readonly ConnectorExecutionSource<TAdapter>[]>
+}
+
+const sourceResolvers = new WeakMap<ConnectorRuntime, ConnectorExecutionSourceResolver>()
+
 export function createConnectorRuntime(
   runtime: SixbRuntimeContext,
   execution: ExecutionContext,
   service: ConnectorService
 ): ConnectorRuntime {
-  return ((definition: ConnectorDefinition, selector?: ConnectorConnectionSelector) => {
+  const connector = ((definition: ConnectorDefinition, selector?: ConnectorConnectionSelector) => {
     if (isOAuthConnectorDefinition(definition)) {
       assertConnectorConnectionAccess(runtime, execution)
       if (!selector) {
@@ -49,6 +73,79 @@ export function createConnectorRuntime(
     assertProviderAccess(runtime, execution, "connector.connect")
     return service.connect(definition as ConnectorDefinition<string, ConnectorAdapter>)
   }) as ConnectorRuntime
+
+  registerConnectorExecutionSourceResolver(connector, {
+    async list<TAdapter extends AnyConnectorAdapter>(
+      definition: ConnectorDefinition<string, TAdapter>
+    ): Promise<readonly ConnectorExecutionSource<TAdapter>[]> {
+      if (!isOAuthConnectorDefinition(definition)) {
+        return [
+          {
+            connect: () =>
+              connector(definition as ConnectorDefinition<string, ConnectorAdapter>) as Promise<
+                ConnectorClient<TAdapter>
+              >,
+          },
+        ]
+      }
+
+      assertConnectorConnectionAccess(runtime, execution)
+      const connections = await service.listExecutionConnections(definition)
+      return connections.map((connection) => ({
+        connection: {
+          id: connection.id,
+          connectorId: connection.connectorId,
+          owner: connection.owner,
+          slot: connection.slot,
+          account: connection.account,
+        },
+        connect: () =>
+          service.connectExecutionConnection(definition, connection) as Promise<
+            ConnectorClient<TAdapter>
+          >,
+      }))
+    },
+  })
+  return connector
+}
+
+function registerConnectorExecutionSourceResolver(
+  connector: ConnectorRuntime,
+  resolver: ConnectorExecutionSourceResolver
+): void {
+  const registered = sourceResolvers.get(connector)
+  if (registered && registered !== resolver) {
+    throw new Error("[Sixb] Connector source resolver is already registered for this execution.")
+  }
+  sourceResolvers.set(connector, resolver)
+}
+
+export function getConnectorExecutionSourceResolver(
+  connector: ConnectorRuntime
+): ConnectorExecutionSourceResolver {
+  const resolver = sourceResolvers.get(connector)
+  if (resolver) return resolver
+
+  return {
+    async list<TAdapter extends AnyConnectorAdapter>(
+      definition: ConnectorDefinition<string, TAdapter>
+    ): Promise<readonly ConnectorExecutionSource<TAdapter>[]> {
+      if (isOAuthConnectorDefinition(definition)) {
+        throw createConnectorCodedError(
+          "connector.configuration_invalid",
+          `[Sixb] OAuth connector '${definition.id}' cannot be resolved without the managed connection runtime.`
+        )
+      }
+      return [
+        {
+          connect: () =>
+            connector(definition as ConnectorDefinition<string, ConnectorAdapter>) as Promise<
+              ConnectorClient<TAdapter>
+            >,
+        },
+      ]
+    },
+  }
 }
 
 function assertConnectorConnectionAccess(

--- a/packages/core/src/connectors/index.ts
+++ b/packages/core/src/connectors/index.ts
@@ -9,6 +9,7 @@ export type {
   ConnectorAdapter,
   ConnectorClient,
   ConnectorConnectionClientContext,
+  ConnectorConnectionMetadata,
   ConnectorConnectionOptions,
   ConnectorConnectionOwner,
   ConnectorConnectionSelector,

--- a/packages/core/src/connectors/service.ts
+++ b/packages/core/src/connectors/service.ts
@@ -85,9 +85,10 @@ export class ConnectorService {
 
   connectExecutionConnection<TAdapter extends OAuthConnectorAdapter>(
     definition: ConnectorDefinition<string, TAdapter>,
-    connection: ConnectorConnectionRecord
+    connection: ConnectorConnectionRecord,
+    signal?: AbortSignal
   ): Promise<ConnectorClient<TAdapter>> {
-    return this.requireConnections().connectExecutionConnection(definition, connection)
+    return this.requireConnections().connectExecutionConnection(definition, connection, signal)
   }
 
   get connectionProcess(): ConnectorConnectionProcess | undefined {

--- a/packages/core/src/connectors/service.ts
+++ b/packages/core/src/connectors/service.ts
@@ -1,3 +1,4 @@
+import type { ConnectorConnectionRecord } from "../storage"
 import type { ConnectorConnectionProcess } from "./connections/contracts"
 import {
   ConnectorConnectionService,
@@ -74,6 +75,19 @@ export class ConnectorService {
     selector: ConnectorConnectionSelector
   ): Promise<ConnectorClient<TAdapter>> {
     return this.requireConnections().connectConnection(definition, selector)
+  }
+
+  listExecutionConnections<TAdapter extends OAuthConnectorAdapter>(
+    definition: ConnectorDefinition<string, TAdapter>
+  ): Promise<readonly ConnectorConnectionRecord[]> {
+    return this.requireConnections().listExecutionConnections(definition)
+  }
+
+  connectExecutionConnection<TAdapter extends OAuthConnectorAdapter>(
+    definition: ConnectorDefinition<string, TAdapter>,
+    connection: ConnectorConnectionRecord
+  ): Promise<ConnectorClient<TAdapter>> {
+    return this.requireConnections().connectExecutionConnection(definition, connection)
   }
 
   get connectionProcess(): ConnectorConnectionProcess | undefined {

--- a/packages/core/src/connectors/types.ts
+++ b/packages/core/src/connectors/types.ts
@@ -56,6 +56,13 @@ export interface ConnectorConnectionSelector {
   readonly slot: string
 }
 
+/** Stable, non-secret metadata shared by connector connection consumers. */
+export interface ConnectorConnectionMetadata extends ConnectorConnectionSelector {
+  readonly id: string
+  readonly connectorId: string
+  readonly account: ConnectorAccountCandidate
+}
+
 /** Credential protection required when an OAuth connector uses durable connection storage. */
 export interface ConnectorConnectionOptions {
   /** Canonical base64url encoding of exactly 32 random bytes, shared by storage replicas. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -604,6 +604,7 @@ export type {
   ConnectorAdapter,
   ConnectorClient,
   ConnectorConnectionClientContext,
+  ConnectorConnectionMetadata,
   ConnectorConnectionOptions,
   ConnectorConnectionOwner,
   ConnectorConnectionSelector,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -658,6 +658,7 @@ export type {
   DatasetSyncTarget,
   RequestSyncRunInput,
   SyncBuilder,
+  SyncConnectorConnection,
   SyncDefinition,
   SyncMode,
   SyncReadBuilder,

--- a/packages/core/src/runtime/host.ts
+++ b/packages/core/src/runtime/host.ts
@@ -175,7 +175,7 @@ export class SixbHost<
     })
     validateAuthStrategySecurityReferences(this.auth.getStrategy(), definitions.security)
     const connectors = definitions.connectors.list()
-    assertConnectorConnectionSurfaces(connectors, definitions.syncs.list())
+    assertConnectorConnectionSurfaces(connectors)
     const hasOAuthConnectors = connectors.some(isOAuthConnectorDefinition)
     const credentialProtector =
       hasOAuthConnectors && options.connectorConnections?.encryptionKey !== undefined
@@ -364,25 +364,13 @@ function assertWebhookRunStorage(
   }
 }
 
-function assertConnectorConnectionSurfaces(
-  connectors: readonly ConnectorDefinition[],
-  syncs: readonly SyncDefinition[]
-): void {
+function assertConnectorConnectionSurfaces(connectors: readonly ConnectorDefinition[]): void {
   for (const connector of connectors) {
     if (!isOAuthConnectorDefinition(connector)) continue
     if (connector.adapter.webhooks !== undefined) {
       throw createConnectorCodedError(
         "connector.configuration_invalid",
         `OAuth connector '${connector.id}' cannot register webhooks until connection routing is defined.`
-      )
-    }
-  }
-
-  for (const sync of syncs) {
-    if (isOAuthConnectorDefinition(sync.connector as ConnectorDefinition)) {
-      throw createConnectorCodedError(
-        "connector.configuration_invalid",
-        `Sync '${sync.id}' cannot use OAuth connector '${sync.connector.id}' until connection fan-out is defined.`
       )
     }
   }

--- a/packages/core/src/syncs/builders.ts
+++ b/packages/core/src/syncs/builders.ts
@@ -1,4 +1,4 @@
-import type { ConnectorAdapter, ConnectorDefinition } from "../connectors"
+import type { AnyConnectorAdapter, ConnectorDefinition } from "../connectors"
 import type { DatasetDefinition } from "../datasets"
 import type { ScheduleDefinition, ScheduleReference } from "../schedules"
 import { isScheduleDefinition } from "../schedules"
@@ -82,7 +82,7 @@ export function defineSync<TId extends string>(
       checkpoint<TNextCheckpoint>(): SyncBuilder<TId, TNextCheckpoint, SyncMode> {
         return createBuilder<TNextCheckpoint>()
       },
-      from<TConnector extends ConnectorDefinition<string, ConnectorAdapter>>(
+      from<TConnector extends ConnectorDefinition<string, AnyConnectorAdapter>>(
         connector: TConnector
       ): SyncReadBuilder<TId, TConnector, TCheckpoint, SyncMode> {
         return {

--- a/packages/core/src/syncs/index.ts
+++ b/packages/core/src/syncs/index.ts
@@ -13,12 +13,18 @@ export {
   type SyncRunDispatcherDependencies,
   type SyncRunDispatchPort,
 } from "./run-dispatch"
+export {
+  resolveSyncConnectorSources,
+  type SyncConnectorSource,
+  type SyncConnectorSourceResolver,
+} from "./sources"
 export type {
   BatchSyncConfig,
   BatchSyncDefinitionConfig,
   DatasetSyncTarget,
   SyncBlobContext,
   SyncBuilder,
+  SyncConnectorConnection,
   SyncDefinition,
   SyncMode,
   SyncReadBuilder,

--- a/packages/core/src/syncs/sources.ts
+++ b/packages/core/src/syncs/sources.ts
@@ -1,0 +1,20 @@
+import type { AnyConnectorAdapter, ConnectorDefinition, ConnectorRuntime } from "../connectors"
+import {
+  type ConnectorExecutionSource,
+  type ConnectorExecutionSourceResolver,
+  getConnectorExecutionSourceResolver,
+} from "../connectors/execution"
+
+/** One connector client invocation contributing values to a Sync run. */
+export type SyncConnectorSource<TAdapter extends AnyConnectorAdapter = AnyConnectorAdapter> =
+  ConnectorExecutionSource<TAdapter>
+
+export type SyncConnectorSourceResolver = ConnectorExecutionSourceResolver
+
+/** Resolve the source invocations owned by one connector definition for a Sync execution. */
+export function resolveSyncConnectorSources<TAdapter extends AnyConnectorAdapter>(
+  connector: ConnectorRuntime,
+  definition: ConnectorDefinition<string, TAdapter>
+): Promise<readonly SyncConnectorSource<TAdapter>[]> {
+  return getConnectorExecutionSourceResolver(connector).list(definition)
+}

--- a/packages/core/src/syncs/types.ts
+++ b/packages/core/src/syncs/types.ts
@@ -1,10 +1,9 @@
 import type { BlobStorage } from "../blob-storage"
 import {
   type AnyConnectorAdapter,
-  type ConnectorAccountCandidate,
   type ConnectorAdapter,
   type ConnectorClient,
-  type ConnectorConnectionOwner,
+  type ConnectorConnectionMetadata,
   type ConnectorDefinition,
   isConnectorDefinition,
   type OAuthConnectorAdapter,
@@ -19,13 +18,7 @@ import { isScheduleReference } from "../schedules"
 export type SyncBlobContext = Pick<BlobStorage, "put" | "open" | "stat">
 
 /** Non-secret connector connection metadata available to OAuth-backed Sync handlers. */
-export interface SyncConnectorConnection {
-  readonly id: string
-  readonly connectorId: string
-  readonly owner: ConnectorConnectionOwner
-  readonly slot: string
-  readonly account: ConnectorAccountCandidate
-}
+export type SyncConnectorConnection = ConnectorConnectionMetadata
 
 type SyncConnectionContext<TAdapter extends AnyConnectorAdapter> =
   TAdapter extends OAuthConnectorAdapter

--- a/packages/core/src/syncs/types.ts
+++ b/packages/core/src/syncs/types.ts
@@ -1,9 +1,13 @@
 import type { BlobStorage } from "../blob-storage"
 import {
+  type AnyConnectorAdapter,
+  type ConnectorAccountCandidate,
   type ConnectorAdapter,
   type ConnectorClient,
+  type ConnectorConnectionOwner,
   type ConnectorDefinition,
   isConnectorDefinition,
+  type OAuthConnectorAdapter,
 } from "../connectors"
 import type { DatasetDefinition, DatasetPrimaryKey, MergeChange } from "../datasets"
 import { isDatasetDefinition } from "../datasets"
@@ -14,8 +18,25 @@ import { isScheduleReference } from "../schedules"
 /** Blob operations available to sync read handlers. */
 export type SyncBlobContext = Pick<BlobStorage, "put" | "open" | "stat">
 
+/** Non-secret connector connection metadata available to OAuth-backed Sync handlers. */
+export interface SyncConnectorConnection {
+  readonly id: string
+  readonly connectorId: string
+  readonly owner: ConnectorConnectionOwner
+  readonly slot: string
+  readonly account: ConnectorAccountCandidate
+}
+
+type SyncConnectionContext<TAdapter extends AnyConnectorAdapter> =
+  TAdapter extends OAuthConnectorAdapter
+    ? { readonly connection: SyncConnectorConnection }
+    : { readonly connection?: undefined }
+
 /** Context passed to a sync read handler. */
-export type SyncReadContext<TCheckpoint = never> = {
+export type SyncReadContext<
+  TCheckpoint = never,
+  TAdapter extends AnyConnectorAdapter = ConnectorAdapter,
+> = {
   readonly projectId: string
   readonly syncId: string
   readonly signal: AbortSignal
@@ -26,7 +47,8 @@ export type SyncReadContext<TCheckpoint = never> = {
   : {
       readonly checkpoint?: TCheckpoint
       setCheckpoint(next: TCheckpoint): void
-    })
+    }) &
+  SyncConnectionContext<TAdapter>
 
 export type SyncMode = "snapshot" | "append" | "merge"
 
@@ -66,13 +88,13 @@ export interface DatasetSyncTarget {
  * they author a sync.
  */
 export type SyncReadHandler<
-  TAdapter extends ConnectorAdapter,
+  TAdapter extends AnyConnectorAdapter,
   TCheckpoint = never,
   TMode extends SyncMode = SyncMode,
 > = {
   bivarianceHack(
     client: ConnectorClient<TAdapter>,
-    context: SyncReadContext<TCheckpoint>
+    context: SyncReadContext<TCheckpoint, TAdapter>
   ): SyncReadResult<TMode> | Promise<SyncReadResult<TMode>>
 }["bivarianceHack"]
 
@@ -84,9 +106,9 @@ export type SyncReadHandler<
  */
 export interface SyncDefinition<
   TId extends string = string,
-  TConnector extends ConnectorDefinition<string, ConnectorAdapter> = ConnectorDefinition<
+  TConnector extends ConnectorDefinition<string, AnyConnectorAdapter> = ConnectorDefinition<
     string,
-    ConnectorAdapter
+    AnyConnectorAdapter
   >,
   TCheckpoint = unknown,
   TMode extends SyncMode = SyncMode,
@@ -102,9 +124,9 @@ export interface SyncDefinition<
 
 export interface SyncTargetBuilder<
   TId extends string = string,
-  TConnector extends ConnectorDefinition<string, ConnectorAdapter> = ConnectorDefinition<
+  TConnector extends ConnectorDefinition<string, AnyConnectorAdapter> = ConnectorDefinition<
     string,
-    ConnectorAdapter
+    AnyConnectorAdapter
   >,
   TCheckpoint = never,
   TMode extends SyncMode = SyncMode,
@@ -118,9 +140,9 @@ export interface SyncTargetBuilder<
 
 export interface SyncReadBuilder<
   TId extends string = string,
-  TConnector extends ConnectorDefinition<string, ConnectorAdapter> = ConnectorDefinition<
+  TConnector extends ConnectorDefinition<string, AnyConnectorAdapter> = ConnectorDefinition<
     string,
-    ConnectorAdapter
+    AnyConnectorAdapter
   >,
   TCheckpoint = never,
   TMode extends SyncMode = SyncMode,
@@ -137,7 +159,7 @@ export interface SyncBuilder<
 > {
   when(schedule: ScheduleDefinition): SyncBuilder<TId, TCheckpoint, TMode>
   checkpoint<TNextCheckpoint>(): SyncBuilder<TId, TNextCheckpoint, TMode>
-  from<TConnector extends ConnectorDefinition<string, ConnectorAdapter>>(
+  from<TConnector extends ConnectorDefinition<string, AnyConnectorAdapter>>(
     connector: TConnector
   ): SyncReadBuilder<TId, TConnector, TCheckpoint, TMode>
 }

--- a/packages/core/tests/connector-connection-execution.test.ts
+++ b/packages/core/tests/connector-connection-execution.test.ts
@@ -5,7 +5,8 @@ import { ConnectorService } from "../src/connectors/service"
 import { createTrustedPrimitiveRuntimeAuthorization } from "../src/execution/authorization"
 import { bindDurablePrimitiveExecution } from "../src/execution/primitive"
 import type { SixbRuntimeContext } from "../src/runtime/types"
-import { createTestActionExecution } from "../src/testing"
+import { resolveSyncConnectorSources } from "../src/syncs/sources"
+import { createTestActionExecution, createTestSyncExecution } from "../src/testing"
 import {
   callbackUrl,
   createHarness,
@@ -108,5 +109,76 @@ describe("connector connection execution boundary", () => {
     expect(() =>
       request.connector(harness.connector, { owner: projectOwner, slot: "social" })
     ).toThrow(AuthorizationError)
+  })
+
+  test("resolves every connected account for one trusted Sync execution", async () => {
+    const harness = createHarness()
+    const dependencies = createTestRuntimeDeps()
+    await seedConnectorActors(dependencies.storage, "default", new Date("2026-08-19T12:00:00.000Z"))
+    const management = requireConnectionProcess(
+      new ConnectorService("default", [harness.connector], {
+        storage: dependencies.storage,
+        credentialProtector: harness.protector,
+      })
+    )
+    const command = managementCommand("session-a", { projectId: "default" })
+
+    const started = await management.startAuthorization(command, harness.connector.id, {
+      owner: projectOwner,
+      slot: "brand-a",
+      redirectUri: callbackUrl,
+    })
+    const state = new URL(started.authorizationUrl).searchParams.get("state")!
+    const authorization = await management.completeAuthorization(command, harness.connector.id, {
+      state,
+      code: "authorization-code",
+      redirectUri: callbackUrl,
+    })
+    const first = await management.selectAccount(command, harness.connector.id, {
+      authorizationId: authorization.authorizationId,
+      accountId: "account-a",
+      owner: projectOwner,
+      slot: "brand-a",
+    })
+    const second = await management.selectAccount(command, harness.connector.id, {
+      authorizationId: authorization.authorizationId,
+      accountId: "account-b",
+      owner: projectOwner,
+      slot: "brand-b",
+    })
+    const host = new SixbHost({
+      ontology: [],
+      connectors: [harness.connector],
+      connectorConnections: { encryptionKey },
+      ...dependencies,
+    })
+    const primitive = { kind: "sync" as const, id: "sync-social", runId: "run-social" }
+    const executionId = await createTestSyncExecution(dependencies.storage.executions, {
+      projectId: "default",
+      syncId: primitive.id,
+      runId: primitive.runId,
+    })
+    const execution = await dependencies.storage.executions.getById({
+      projectId: "default",
+      id: executionId,
+    })
+    if (!execution) throw new Error("Expected the Sync execution fixture.")
+    const trusted = bindDurablePrimitiveExecution(host, { execution, primitive }).sixb
+
+    const sources = await resolveSyncConnectorSources(trusted.connector, harness.connector)
+    expect(sources.map((source) => source.connection?.id)).toEqual(
+      [first.id, second.id].sort((left, right) => left.localeCompare(right))
+    )
+    const clients = await Promise.all(sources.map((source) => source.connect()))
+    expect(clients.map((client) => client.accountId).sort()).toEqual(["account-a", "account-b"])
+
+    await management.disconnect(command, harness.connector.id, first.id)
+    const remaining = await resolveSyncConnectorSources(trusted.connector, harness.connector)
+    expect(remaining.map((source) => source.connection?.id)).toEqual([second.id])
+
+    const request = host.withScope(managementScope("session-a", { projectId: "default" }).scope)
+    await expect(resolveSyncConnectorSources(request.connector, harness.connector)).rejects.toThrow(
+      AuthorizationError
+    )
   })
 })

--- a/packages/core/tests/connector-connection-execution.test.ts
+++ b/packages/core/tests/connector-connection-execution.test.ts
@@ -8,12 +8,15 @@ import type { SixbRuntimeContext } from "../src/runtime/types"
 import { resolveSyncConnectorSources } from "../src/syncs/sources"
 import { createTestActionExecution, createTestSyncExecution } from "../src/testing"
 import {
+  authorize,
   callbackUrl,
   createHarness,
   encryptionKey,
+  expectSixbError,
   managementCommand,
   managementScope,
   projectOwner,
+  rejectionOf,
   requireConnectionProcess,
   seedConnectorActors,
 } from "./connector-connections.fixture"
@@ -169,7 +172,9 @@ describe("connector connection execution boundary", () => {
     expect(sources.map((source) => source.connection?.id)).toEqual(
       [first.id, second.id].sort((left, right) => left.localeCompare(right))
     )
-    const clients = await Promise.all(sources.map((source) => source.connect()))
+    const clients = await Promise.all(
+      sources.map((source) => source.connect(new AbortController().signal))
+    )
     expect(clients.map((client) => client.accountId).sort()).toEqual(["account-a", "account-b"])
 
     await management.disconnect(command, harness.connector.id, first.id)
@@ -181,4 +186,61 @@ describe("connector connection execution boundary", () => {
       AuthorizationError
     )
   })
+
+  test("cancels and bounds managed client creation", async () => {
+    const harness = createHarness({ providerOperationTimeoutMs: 20 })
+    const authorization = await authorize(harness)
+    await harness.process.selectAccount(managementCommand(), harness.connector.id, {
+      authorizationId: authorization.authorizationId,
+      accountId: "account-a",
+      owner: projectOwner,
+      slot: "social",
+    })
+    const primitive = { kind: "sync" as const, id: "sync-social", runId: "run-social" }
+    const execution = {
+      id: "execution-social",
+      projectId: "project",
+      executor: { type: "primitive" as const, ...primitive },
+      source: { type: "schedule" as const, eventId: "event-social" },
+      correlationId: "correlation-social",
+    }
+    const runtime = {
+      projectId: "project",
+      runtimeAuthorization: createTrustedPrimitiveRuntimeAuthorization({
+        projectId: "project",
+        primitive,
+      }),
+    } as SixbRuntimeContext
+    const connector = createConnectorRuntime(runtime, execution, harness.service)
+    const [source] = await resolveSyncConnectorSources(connector, harness.connector)
+    if (!source) throw new Error("Expected one managed connector source.")
+
+    harness.setConnectGate(new Promise(() => {}))
+    const runController = new AbortController()
+    const cancelled = source.connect(runController.signal)
+    await waitFor(() => harness.connectionSignals.length === 1)
+    runController.abort(new DOMException("cancelled by test", "AbortError"))
+    await expect(cancelled).rejects.toThrow("cancelled by test")
+    expect(harness.connectionSignals[0]?.aborted).toBe(true)
+
+    const timedOut = await rejectionOf(source.connect(new AbortController().signal))
+    expectSixbError(timedOut, "connector.provider_unavailable")
+    expect(harness.connectionSignals[1]?.aborted).toBe(true)
+
+    harness.setConnectGate(undefined)
+    const lifetimeController = new AbortController()
+    const client = await source.connect(lifetimeController.signal)
+    expect(client.aborted()).toBe(false)
+    lifetimeController.abort()
+    expect(client.aborted()).toBe(true)
+  })
 })
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await Bun.sleep(5)
+  }
+  throw new Error("Timed out waiting for connector client creation.")
+}

--- a/packages/core/tests/connector-connection-startup.test.ts
+++ b/packages/core/tests/connector-connection-startup.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import {
-  col,
-  defineConnector,
-  defineDataset,
-  defineSync,
-  SixbHost,
-  type SyncDefinition,
-} from "../src"
+import { col, defineConnector, defineDataset, defineSync, SixbHost } from "../src"
 import { ConnectorService } from "../src/connectors/service"
 import { InMemoryStorage } from "../src/storage/in-memory"
 import { createHarness, encryptionKey } from "./connector-connections.fixture"
@@ -65,20 +58,13 @@ describe("connector connection startup validation", () => {
     ).not.toThrow()
   })
 
-  test("rejects OAuth sync and webhook surfaces explicitly", () => {
+  test("accepts OAuth Syncs while rejecting unrouted webhook surfaces", () => {
     const harness = createHarness()
     const dataset = defineDataset("accounts", { schema: [col("id", "string")] })
-    const staticConnector = defineConnector("static", {
-      type: "static",
-      connect() {
-        return {}
-      },
-    })
     const sync = defineSync("accounts")
-      .from(staticConnector)
+      .from(harness.connector)
       .read(() => [])
       .intoDataset(dataset)
-    const oauthSync = { ...sync, connector: harness.connector } as unknown as SyncDefinition
 
     expect(
       () =>
@@ -86,11 +72,11 @@ describe("connector connection startup validation", () => {
           ontology: [],
           connectors: [harness.connector],
           datasets: [dataset],
-          syncs: [oauthSync],
+          syncs: [sync],
           connectorConnections: { encryptionKey },
           ...createTestRuntimeDeps(),
         })
-    ).toThrow("cannot use OAuth connector")
+    ).not.toThrow()
 
     Object.defineProperty(harness.connector.adapter, "webhooks", { value: [] })
     expect(

--- a/packages/core/tests/connector-connections.fixture.ts
+++ b/packages/core/tests/connector-connections.fixture.ts
@@ -65,9 +65,11 @@ export function createHarness(options: HarnessOptions = {}) {
   let discoverGate: Promise<void> | undefined
   let refreshGate: Promise<void> | undefined
   let revokeGate: Promise<void> | undefined
+  let connectGate: Promise<void> | undefined
   let providerRevoked = false
   const exchangedVerifiers: string[] = []
   const refreshInputs: ConnectorOAuthCredentials[] = []
+  const connectionSignals: AbortSignal[] = []
 
   const connector = defineConnector("social", {
     type: "fake-oauth",
@@ -128,7 +130,9 @@ export function createHarness(options: HarnessOptions = {}) {
         { id: "account-b", label: "Account B" },
       ]
     },
-    connect(context) {
+    async connect(context) {
+      connectionSignals.push(context.signal)
+      await connectGate
       let latestToken: Awaited<ReturnType<typeof context.tokenSource.get>> | undefined
       return {
         accountId: context.account.id,
@@ -203,10 +207,14 @@ export function createHarness(options: HarnessOptions = {}) {
     setRevokeGate(value: Promise<void> | undefined) {
       revokeGate = value
     },
+    setConnectGate(value: Promise<void> | undefined) {
+      connectGate = value
+    },
     now: () => new Date(now),
     counts: () => ({ exchangeCount, refreshCount, revokeCount }),
     exchangedVerifiers,
     refreshInputs,
+    connectionSignals,
   }
 }
 

--- a/packages/core/tests/syncs.types.ts
+++ b/packages/core/tests/syncs.types.ts
@@ -22,6 +22,30 @@ const erpDb = defineConnector("erpDb", {
   },
 })
 
+const social = defineConnector("social", {
+  type: "social-oauth",
+  authentication: {
+    type: "oauth2",
+    authorizationUrl() {
+      return "https://provider.test/oauth"
+    },
+    exchangeCode() {
+      return { accessToken: "access" }
+    },
+    refresh() {
+      return { accessToken: "refreshed" }
+    },
+  },
+  discoverAccounts() {
+    return [{ id: "account-a", label: "Account A" }]
+  },
+  connect(context) {
+    return {
+      accountId: context.account.id,
+    }
+  },
+})
+
 const rawOrdersDataset = defineDataset("raw.erp.orders", {
   schema: [col("id", "int64")],
 })
@@ -51,6 +75,7 @@ const syncOrders = defineSync("sync-orders")
     db.nonexistent()
 
     const _checkpoint: undefined = context.checkpoint
+    const _connection: undefined = context.connection
 
     // @ts-expect-error checkpoint setters are only exposed after .checkpoint<T>()
     context.setCheckpoint({ cursor: "next" })
@@ -79,6 +104,22 @@ const syncOrdersWithCheckpoint = defineSync("sync-orders-with-checkpoint")
     // @ts-expect-error checkpoint must match the type supplied to .checkpoint<T>()
     context.setCheckpoint({ page: 2 })
 
+    return [{ id: 1 }]
+  })
+  .intoDataset(rawOrdersDataset)
+
+const syncManagedAccounts = defineSync("sync-managed-accounts")
+  .checkpoint<{ cursor: string }>()
+  .from(social)
+  .read((client, context) => {
+    const _clientAccountId: string = client.accountId
+    const _connectionId: string = context.connection.id
+    const _connectorId: string = context.connection.connectorId
+    const _slot: string = context.connection.slot
+    const _accountId: string = context.connection.account.id
+    const _ownerType: "project" = context.connection.owner.type
+    const _checkpoint: { cursor: string } | undefined = context.checkpoint
+    context.setCheckpoint({ cursor: "next" })
     return [{ id: 1 }]
   })
   .intoDataset(rawOrdersDataset)
@@ -126,7 +167,12 @@ defineSync("invalid-merge-target", { mode: "merge" })
   // @ts-expect-error merge syncs require a dataset with a primary key
   .intoDataset(rawOrdersDataset)
 
-const _syncDefinitions: SyncDefinition[] = [syncOrders, syncOrdersWithCheckpoint, mergeOrders]
+const _syncDefinitions: SyncDefinition[] = [
+  syncOrders,
+  syncOrdersWithCheckpoint,
+  syncManagedAccounts,
+  mergeOrders,
+]
 const _connector = syncOrders.connector
 const _checkpointConnector = syncOrdersWithCheckpoint.connector
 

--- a/packages/sync-worker/src/checkpoints.ts
+++ b/packages/sync-worker/src/checkpoints.ts
@@ -1,0 +1,200 @@
+import {
+  assertJsonValue,
+  cloneJsonValue,
+  isJsonValue,
+  type JsonValue,
+  type SyncConnectorConnection,
+} from "@sixb/core"
+import { createSixbError } from "@sixb/core/internal/errors"
+
+const SYNC_CHECKPOINT_KIND = "sync_checkpoint"
+const SYNC_CHECKPOINT_VERSION = 1
+
+type SyncCheckpointStrategy = "single" | "connections"
+
+interface ConnectionCheckpointEntry {
+  readonly connectionId: string
+  readonly accountId: string
+  readonly checkpoint?: JsonValue
+}
+
+export interface SyncCheckpointCodec {
+  read(value: JsonValue | undefined): JsonValue | undefined
+  serialize(value: JsonValue): JsonValue
+}
+
+/** Bind opaque handler checkpoints to the framework source contract stored beside the run. */
+export function createSyncCheckpointCodec(options: {
+  readonly syncId: string
+  readonly connectorId: string
+  readonly strategy: SyncCheckpointStrategy
+}): SyncCheckpointCodec {
+  return {
+    read(value) {
+      if (value === undefined) return undefined
+      if (!isSyncCheckpoint(value)) {
+        // Static Sync checkpoints predate the framework envelope. Preserve them in place and
+        // migrate the next successful run; managed fan-out has no compatible legacy raw format.
+        if (options.strategy === "single") return cloneJsonValue(value)
+        throw incompatibleCheckpoint(options, "format")
+      }
+      if (value.version !== SYNC_CHECKPOINT_VERSION) {
+        throw incompatibleCheckpoint(options, "version")
+      }
+      if (value.connectorId !== options.connectorId) {
+        throw incompatibleCheckpoint(options, "connector")
+      }
+      if (value.strategy !== options.strategy) {
+        throw incompatibleCheckpoint(options, "strategy")
+      }
+      if (!("value" in value) || !isJsonValue(value.value)) {
+        throw invalidFrameworkCheckpoint(options.syncId)
+      }
+      return cloneJsonValue(value.value)
+    },
+    serialize(value) {
+      const envelope: unknown = {
+        kind: SYNC_CHECKPOINT_KIND,
+        version: SYNC_CHECKPOINT_VERSION,
+        connectorId: options.connectorId,
+        strategy: options.strategy,
+        value: cloneJsonValue(value),
+      }
+      assertJsonValue(envelope, "Sync checkpoint envelope")
+      return envelope
+    },
+  }
+}
+
+/** Per-connection cursor state carried inside a framework-managed checkpoint envelope. */
+export class ConnectionCheckpoints {
+  private readonly entries: Map<string, ConnectionCheckpointEntry>
+
+  private constructor(entries: Map<string, ConnectionCheckpointEntry>) {
+    this.entries = entries
+  }
+
+  static from(syncId: string, value: JsonValue | undefined): ConnectionCheckpoints {
+    if (value === undefined) return new ConnectionCheckpoints(new Map())
+    if (!isConnectionCheckpoint(value)) throw invalidConnectionCheckpoint(syncId)
+
+    const entries = new Map<string, ConnectionCheckpointEntry>()
+    for (const candidate of value.entries) {
+      if (
+        !isRecord(candidate) ||
+        typeof candidate.connectionId !== "string" ||
+        !candidate.connectionId.trim() ||
+        typeof candidate.accountId !== "string" ||
+        !candidate.accountId.trim() ||
+        entries.has(candidate.connectionId)
+      ) {
+        throw invalidConnectionCheckpoint(syncId)
+      }
+      if ("checkpoint" in candidate && !isJsonValue(candidate.checkpoint)) {
+        throw invalidConnectionCheckpoint(syncId)
+      }
+      entries.set(candidate.connectionId, {
+        connectionId: candidate.connectionId,
+        accountId: candidate.accountId,
+        ...(candidate.checkpoint === undefined
+          ? {}
+          : { checkpoint: cloneJsonValue(candidate.checkpoint as JsonValue) }),
+      })
+    }
+    return new ConnectionCheckpoints(entries)
+  }
+
+  reconcile(connections: readonly SyncConnectorConnection[]): void {
+    for (const connection of connections) {
+      const existing = this.entries.get(connection.id)
+      if (existing && existing.accountId !== connection.account.id) {
+        this.entries.delete(connection.id)
+      }
+    }
+  }
+
+  get(connection: SyncConnectorConnection): JsonValue | undefined {
+    const entry = this.entries.get(connection.id)
+    if (entry?.accountId !== connection.account.id || entry.checkpoint === undefined) {
+      return undefined
+    }
+    return cloneJsonValue(entry.checkpoint)
+  }
+
+  set(connection: SyncConnectorConnection, checkpoint: JsonValue): void {
+    this.entries.set(connection.id, {
+      connectionId: connection.id,
+      accountId: connection.account.id,
+      checkpoint: cloneJsonValue(checkpoint),
+    })
+  }
+
+  serialize(): JsonValue {
+    const value: unknown = {
+      entries: [...this.entries.values()]
+        .sort((left, right) => left.connectionId.localeCompare(right.connectionId))
+        .map((entry) => ({
+          connectionId: entry.connectionId,
+          accountId: entry.accountId,
+          ...(entry.checkpoint === undefined
+            ? {}
+            : { checkpoint: cloneJsonValue(entry.checkpoint) }),
+        })),
+    }
+    assertJsonValue(value, "Managed connector Sync checkpoint")
+    return value
+  }
+}
+
+function incompatibleCheckpoint(
+  options: { readonly syncId: string; readonly connectorId: string },
+  reason: "format" | "version" | "connector" | "strategy"
+): Error {
+  return createSixbError(
+    "sync.execution_failed",
+    `[SixbSyncWorker] Sync '${options.syncId}' has a checkpoint incompatible with connector '${options.connectorId}'. Use a new Sync id to reset its ingestion state.`,
+    {
+      details: {
+        syncId: options.syncId,
+        connectorId: options.connectorId,
+        reason: `checkpoint_${reason}`,
+      },
+    }
+  )
+}
+
+function invalidFrameworkCheckpoint(syncId: string): Error {
+  return createSixbError(
+    "internal.unexpected",
+    `[SixbSyncWorker] Sync '${syncId}' has an invalid checkpoint envelope.`,
+    { details: { syncId } }
+  )
+}
+
+function invalidConnectionCheckpoint(syncId: string): Error {
+  return createSixbError(
+    "internal.unexpected",
+    `[SixbSyncWorker] Sync '${syncId}' has an invalid managed connector checkpoint.`,
+    { details: { syncId } }
+  )
+}
+
+function isSyncCheckpoint(value: JsonValue): value is JsonValue & {
+  readonly kind: typeof SYNC_CHECKPOINT_KIND
+  readonly version?: JsonValue
+  readonly connectorId?: JsonValue
+  readonly strategy?: JsonValue
+  readonly value?: JsonValue
+} {
+  return isRecord(value) && value.kind === SYNC_CHECKPOINT_KIND
+}
+
+function isConnectionCheckpoint(value: JsonValue): value is JsonValue & {
+  readonly entries: JsonValue[]
+} {
+  return isRecord(value) && Array.isArray(value.entries)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/sync-worker/src/normalize.ts
+++ b/packages/sync-worker/src/normalize.ts
@@ -46,6 +46,28 @@ export function throwIfAborted(signal: AbortSignal): void {
   }
 }
 
+/** Stop awaiting user/provider work when the queue delivery is cancelled or loses its lease. */
+export async function runAbortable<T>(
+  signal: AbortSignal,
+  run: () => PromiseLike<T> | T
+): Promise<T> {
+  throwIfAborted(signal)
+  let rejectAborted: ((error: Error) => void) | undefined
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAborted = reject
+  })
+  const onAbort = () => rejectAborted?.(toAbortError(signal))
+  signal.addEventListener("abort", onAbort, { once: true })
+
+  const operation = Promise.resolve().then(run)
+  operation.catch(() => {})
+  try {
+    return await Promise.race([operation, aborted])
+  } finally {
+    signal.removeEventListener("abort", onAbort)
+  }
+}
+
 export function assertDatasetRow(value: unknown, syncId: string, itemIndex: number): DatasetRow {
   if (isPlainObject(value)) {
     return value
@@ -58,21 +80,41 @@ export function assertDatasetRow(value: unknown, syncId: string, itemIndex: numb
 
 export async function* normalizeReadResult(
   readResult: SyncReadResult,
-  syncId: string
+  syncId: string,
+  signal: AbortSignal
 ): AsyncIterable<unknown> {
   if (isAsyncIterable(readResult)) {
-    yield* readResult
+    const iterator = readResult[Symbol.asyncIterator]()
+    let completed = false
+    try {
+      while (true) {
+        const next = await runAbortable(signal, () => iterator.next())
+        if (next.done) {
+          completed = true
+          return
+        }
+        yield next.value
+      }
+    } finally {
+      if (!completed && iterator.return) {
+        const closing = Promise.resolve().then(() => iterator.return?.())
+        if (signal.aborted) closing.catch(() => {})
+        else await closing
+      }
+    }
     return
   }
 
   if (isIterable(readResult)) {
     for (const item of readResult) {
+      throwIfAborted(signal)
       yield item
     }
     return
   }
 
   if (isPlainObject(readResult)) {
+    throwIfAborted(signal)
     yield readResult
     return
   }

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -1,5 +1,4 @@
 import {
-  assertJsonValue,
   type BlobStorage,
   cloneJsonValue,
   type DatasetDefinition,
@@ -8,9 +7,7 @@ import {
   getDatasetRowValidationError,
   isFileRef,
   type JsonValue,
-  type Logger,
   type MergeChange,
-  type SyncDefinition,
 } from "@sixb/core"
 import {
   captureSixbFailure,
@@ -21,13 +18,9 @@ import {
 import { resolveLoggingService } from "@sixb/core/internal/logging"
 import { type DatasetVersion, getDatasetMergeChangeValidationError } from "@sixb/core/lake-storage"
 import { SYNC_RUN_FAILURE_CODES, type SyncRunRecord } from "@sixb/core/storage"
-import { assertDatasetRow, normalizeReadResult, throwIfAborted } from "./normalize"
-import type {
-  RunSyncJobInput,
-  SyncRunFinishedHandler,
-  SyncRunResult,
-  SyncWorkerContext,
-} from "./types"
+import { assertDatasetRow, throwIfAborted } from "./normalize"
+import { readSyncValues } from "./source-read"
+import type { RunSyncJobInput, SyncRunFinishedHandler, SyncRunResult } from "./types"
 
 export class SyncRunAlreadyStartedError extends Error {
   override readonly name = "SyncRunAlreadyStartedError"
@@ -83,7 +76,10 @@ function translateSyncExecutionError(
     readonly datasetId: string
   }
 ): unknown {
-  if (isSixbError(error) && error.code === "internal.unexpected") {
+  if (
+    isSixbError(error) &&
+    (error.code === "internal.unexpected" || error.code === "sync.execution_failed")
+  ) {
     return error
   }
 
@@ -169,31 +165,6 @@ function assertMergeChange(
     )
   }
   return value as MergeChange<DatasetRow, DatasetRow>
-}
-
-async function readSyncValues(options: {
-  runtime: SyncWorkerContext
-  sync: SyncDefinition
-  signal: AbortSignal
-  blobStorage: BlobStorage
-  logger: Logger
-  previousCheckpoint: JsonValue | undefined
-  setCheckpoint(next: unknown): void
-}): Promise<AsyncIterable<unknown>> {
-  const client = await options.runtime.connector(options.sync.connector)
-  const readResult = await options.sync.read(client, {
-    projectId: options.runtime.id,
-    syncId: options.sync.id,
-    signal: options.signal,
-    blobs: options.blobStorage,
-    logger: options.logger,
-    checkpoint:
-      options.previousCheckpoint !== undefined
-        ? cloneJsonValue(options.previousCheckpoint)
-        : undefined,
-    setCheckpoint: options.setCheckpoint,
-  })
-  return normalizeReadResult(readResult, options.sync.id)
 }
 
 async function* validatedDatasetRows(options: {
@@ -355,13 +326,14 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
       readSyncValues({
         runtime,
         sync,
+        runId: job.id,
+        datasetId: dataset.id,
         signal,
         blobStorage,
         logger,
         previousCheckpoint,
         setCheckpoint(next) {
-          assertJsonValue(next, `Sync '${sync.id}' checkpoint`)
-          nextCheckpoint = cloneJsonValue(next)
+          nextCheckpoint = next === undefined ? undefined : cloneJsonValue(next)
         },
       })
     const onRead = () => {

--- a/packages/sync-worker/src/run-sync-job.ts
+++ b/packages/sync-worker/src/run-sync-job.ts
@@ -19,7 +19,7 @@ import { resolveLoggingService } from "@sixb/core/internal/logging"
 import { type DatasetVersion, getDatasetMergeChangeValidationError } from "@sixb/core/lake-storage"
 import { SYNC_RUN_FAILURE_CODES, type SyncRunRecord } from "@sixb/core/storage"
 import { assertDatasetRow, throwIfAborted } from "./normalize"
-import { readSyncValues } from "./source-read"
+import { readSyncValues, type SyncSourceValue } from "./source-read"
 import type { RunSyncJobInput, SyncRunFinishedHandler, SyncRunResult } from "./types"
 
 export class SyncRunAlreadyStartedError extends Error {
@@ -168,67 +168,103 @@ function assertMergeChange(
 }
 
 async function* validatedDatasetRows(options: {
-  values: AsyncIterable<unknown>
+  values: AsyncIterable<SyncSourceValue>
   signal: AbortSignal
   blobStorage: BlobStorage
   syncId: string
+  runId: string
   dataset: DatasetDefinition
   onRead(): void
 }): AsyncIterable<DatasetRow> {
   let itemIndex = 0
-  for await (const value of options.values) {
+  for await (const sourceValue of options.values) {
     throwIfAborted(options.signal)
     itemIndex += 1
 
-    const row = assertDatasetRow(value, options.syncId, itemIndex)
-    // Validate before handing rows to lake storage so sync failures include
-    // the source item index; lake storage still re-validates as the final boundary.
-    const validationError = getDatasetRowValidationError(row, options.dataset)
-    if (validationError) {
-      throw new Error(
-        `[SixbSyncWorker] Sync '${options.syncId}' returned an invalid row at item ${itemIndex}. ${validationError}`
-      )
+    let row: DatasetRow
+    try {
+      row = assertDatasetRow(sourceValue.value, options.syncId, itemIndex)
+      // Validate before handing rows to lake storage so sync failures include
+      // the source item index; lake storage still re-validates as the final boundary.
+      const validationError = getDatasetRowValidationError(row, options.dataset)
+      if (validationError) {
+        throw new Error(
+          `[SixbSyncWorker] Sync '${options.syncId}' returned an invalid row at item ${itemIndex}. ${validationError}`
+        )
+      }
+
+      // Lake storage validates fileRef shape; the worker owns existence checks against blob storage.
+      await verifyRowFileRefs({
+        blobStorage: options.blobStorage,
+        syncId: options.syncId,
+        dataset: options.dataset,
+        row,
+        itemIndex,
+      })
+      options.onRead()
+    } catch (error) {
+      throw sourceValidationError(error, sourceValue, options, itemIndex)
     }
-
-    // Lake storage validates fileRef shape; the worker owns existence checks against blob storage.
-    await verifyRowFileRefs({
-      blobStorage: options.blobStorage,
-      syncId: options.syncId,
-      dataset: options.dataset,
-      row,
-      itemIndex,
-    })
-
-    options.onRead()
     yield row
   }
 }
 
 async function* validatedMergeChanges(options: {
-  values: AsyncIterable<unknown>
+  values: AsyncIterable<SyncSourceValue>
   signal: AbortSignal
   blobStorage: BlobStorage
   syncId: string
+  runId: string
   dataset: DatasetDefinition
   onRead(): void
 }): AsyncIterable<MergeChange<DatasetRow, DatasetRow>> {
   let itemIndex = 0
-  for await (const value of options.values) {
+  for await (const sourceValue of options.values) {
     throwIfAborted(options.signal)
     itemIndex += 1
-    const mergeChange = assertMergeChange(value, options.syncId, options.dataset, itemIndex)
-    if (mergeChange.kind === "upsert") {
-      await verifyRowFileRefs({
-        blobStorage: options.blobStorage,
-        syncId: options.syncId,
-        dataset: options.dataset,
-        row: mergeChange.row,
-        itemIndex,
-      })
+    let mergeChange: MergeChange<DatasetRow, DatasetRow>
+    try {
+      mergeChange = assertMergeChange(sourceValue.value, options.syncId, options.dataset, itemIndex)
+      if (mergeChange.kind === "upsert") {
+        await verifyRowFileRefs({
+          blobStorage: options.blobStorage,
+          syncId: options.syncId,
+          dataset: options.dataset,
+          row: mergeChange.row,
+          itemIndex,
+        })
+      }
+      options.onRead()
+    } catch (error) {
+      throw sourceValidationError(error, sourceValue, options, itemIndex)
     }
-    options.onRead()
     yield mergeChange
   }
+}
+
+function sourceValidationError(
+  error: unknown,
+  sourceValue: SyncSourceValue,
+  options: { readonly syncId: string; readonly runId: string; readonly dataset: DatasetDefinition },
+  itemIndex: number
+): unknown {
+  const connection = sourceValue.connection
+  if (!connection) return error
+  const code =
+    isSixbError(error) && error.code === "internal.unexpected"
+      ? "internal.unexpected"
+      : "sync.execution_failed"
+  return createSixbError(code, summarizeErrorMessage(error, "Sync source validation failed."), {
+    cause: error,
+    details: {
+      syncId: options.syncId,
+      runId: options.runId,
+      datasetId: options.dataset.id,
+      itemIndex,
+      connectionId: connection.id,
+      accountId: connection.account.id,
+    },
+  })
 }
 
 interface SyncCommitResult {
@@ -358,6 +394,7 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
           signal,
           blobStorage,
           syncId: sync.id,
+          runId: job.id,
           dataset,
           onRead,
         })
@@ -386,6 +423,7 @@ export async function runSyncJob(input: RunSyncJobInput): Promise<SyncRunResult>
           signal,
           blobStorage,
           syncId: sync.id,
+          runId: job.id,
           dataset,
           onRead,
         })

--- a/packages/sync-worker/src/source-read.ts
+++ b/packages/sync-worker/src/source-read.ts
@@ -2,7 +2,6 @@ import {
   assertJsonValue,
   type BlobStorage,
   cloneJsonValue,
-  isJsonValue,
   type JsonValue,
   type Logger,
   type SyncConnectorConnection,
@@ -11,15 +10,17 @@ import {
 import { isOAuthConnectorDefinition } from "@sixb/core/internal/connector-connections"
 import { createSixbError, summarizeErrorMessage } from "@sixb/core/internal/errors"
 import type { SyncConnectorSource } from "@sixb/core/internal/syncs"
-import { normalizeReadResult, throwIfAborted } from "./normalize"
+import {
+  ConnectionCheckpoints,
+  createSyncCheckpointCodec,
+  type SyncCheckpointCodec,
+} from "./checkpoints"
+import { normalizeReadResult, runAbortable, throwIfAborted } from "./normalize"
 import type { SyncWorkerContext } from "./types"
 
-const CONNECTION_CHECKPOINT_KIND = "connector_connections"
-
-interface ConnectionCheckpointEntry {
-  readonly connectionId: string
-  readonly accountId: string
-  readonly checkpoint?: JsonValue
+export interface SyncSourceValue {
+  readonly value: unknown
+  readonly connection?: SyncConnectorConnection
 }
 
 interface ReadSyncValuesInput {
@@ -37,13 +38,18 @@ interface ReadSyncValuesInput {
 /** Resolve and invoke every source contributing to one atomic Sync run. */
 export async function readSyncValues(
   options: ReadSyncValuesInput
-): Promise<AsyncIterable<unknown>> {
+): Promise<AsyncIterable<SyncSourceValue>> {
   const sources = await options.runtime.connectorSources.list(options.sync.connector)
   if (!isOAuthConnectorDefinition(options.sync.connector)) {
     if (sources.length !== 1 || sources[0]?.connection !== undefined) {
       throw sourceInvariant(options.sync.id, "Static connectors must resolve exactly one source.")
     }
-    return readStaticSource(options, sources[0])
+    const checkpointCodec = createSyncCheckpointCodec({
+      syncId: options.sync.id,
+      connectorId: options.sync.connector.id,
+      strategy: "single",
+    })
+    return readStaticSource(options, sources[0], checkpointCodec)
   }
 
   const connectionIds = new Set<string>()
@@ -67,66 +73,41 @@ export async function readSyncValues(
     connectionIds.add(connection.id)
     return {
       connection,
-      connect: () => source.connect(),
+      connect: (signal: AbortSignal) => source.connect(signal),
     }
   })
   managedSources.sort((left, right) => left.connection.id.localeCompare(right.connection.id))
-  const checkpoints = ConnectionCheckpoints.from(options.sync.id, options.previousCheckpoint)
+  const checkpointCodec = createSyncCheckpointCodec({
+    syncId: options.sync.id,
+    connectorId: options.sync.connector.id,
+    strategy: "connections",
+  })
+  const checkpoints = ConnectionCheckpoints.from(
+    options.sync.id,
+    checkpointCodec.read(options.previousCheckpoint)
+  )
   checkpoints.reconcile(managedSources.map((source) => source.connection))
-  options.setCheckpoint(checkpoints.serialize())
+  const storeCheckpoint = () =>
+    options.setCheckpoint(checkpointCodec.serialize(checkpoints.serialize()))
+  storeCheckpoint()
 
-  return readManagedSources(options, managedSources, checkpoints)
+  return readManagedSources(options, managedSources, checkpoints, storeCheckpoint)
 }
 
 async function readStaticSource(
   options: ReadSyncValuesInput,
-  source: SyncConnectorSource
-): Promise<AsyncIterable<unknown>> {
-  const client = await source.connect()
-  const readResult = await options.sync.read(
-    client as never,
-    {
-      projectId: options.runtime.id,
-      syncId: options.sync.id,
-      signal: options.signal,
-      blobs: options.blobStorage,
-      logger: options.logger,
-      checkpoint:
-        options.previousCheckpoint === undefined
-          ? undefined
-          : cloneJsonValue(options.previousCheckpoint),
-      setCheckpoint(next: unknown) {
-        assertJsonValue(next, `Sync '${options.sync.id}' checkpoint`)
-        options.setCheckpoint(cloneJsonValue(next))
-      },
-    } as never
-  )
-  return normalizeReadResult(readResult, options.sync.id)
-}
-
-async function* readManagedSources(
-  options: ReadSyncValuesInput,
-  sources: readonly (SyncConnectorSource & {
-    readonly connection: SyncConnectorConnection
-  })[],
-  checkpoints: ConnectionCheckpoints
-): AsyncIterable<unknown> {
-  for (const source of sources) {
-    yield* readManagedSource(options, source, checkpoints)
+  source: SyncConnectorSource,
+  checkpointCodec: SyncCheckpointCodec
+): Promise<AsyncIterable<SyncSourceValue>> {
+  const previousCheckpoint = checkpointCodec.read(options.previousCheckpoint)
+  if (previousCheckpoint !== undefined) {
+    // Migrate legacy raw checkpoints only after the complete run succeeds.
+    options.setCheckpoint(checkpointCodec.serialize(previousCheckpoint))
   }
-}
-
-async function* readManagedSource(
-  options: ReadSyncValuesInput,
-  source: SyncConnectorSource & { readonly connection: SyncConnectorConnection },
-  checkpoints: ConnectionCheckpoints
-): AsyncIterable<unknown> {
-  const { connection } = source
-  try {
-    throwIfAborted(options.signal)
-    const client = await source.connect()
-    const previous = checkpoints.get(connection)
-    const readResult = await options.sync.read(
+  const client = await runAbortable(options.signal, () => source.connect(options.signal))
+  throwIfAborted(options.signal)
+  const readResult = await runAbortable(options.signal, () =>
+    options.sync.read(
       client as never,
       {
         projectId: options.runtime.id,
@@ -134,19 +115,68 @@ async function* readManagedSource(
         signal: options.signal,
         blobs: options.blobStorage,
         logger: options.logger,
-        connection,
-        checkpoint: previous === undefined ? undefined : cloneJsonValue(previous),
+        checkpoint:
+          previousCheckpoint === undefined ? undefined : cloneJsonValue(previousCheckpoint),
         setCheckpoint(next: unknown) {
-          assertJsonValue(
-            next,
-            `Sync '${options.sync.id}' connection '${connection.id}' checkpoint`
-          )
-          checkpoints.set(connection, cloneJsonValue(next))
-          options.setCheckpoint(checkpoints.serialize())
+          assertJsonValue(next, `Sync '${options.sync.id}' checkpoint`)
+          options.setCheckpoint(checkpointCodec.serialize(cloneJsonValue(next)))
         },
       } as never
     )
-    yield* normalizeReadResult(readResult, options.sync.id)
+  )
+  return sourceValues(normalizeReadResult(readResult, options.sync.id, options.signal))
+}
+
+async function* readManagedSources(
+  options: ReadSyncValuesInput,
+  sources: readonly (SyncConnectorSource & {
+    readonly connection: SyncConnectorConnection
+  })[],
+  checkpoints: ConnectionCheckpoints,
+  storeCheckpoint: () => void
+): AsyncIterable<SyncSourceValue> {
+  for (const source of sources) {
+    yield* readManagedSource(options, source, checkpoints, storeCheckpoint)
+  }
+}
+
+async function* readManagedSource(
+  options: ReadSyncValuesInput,
+  source: SyncConnectorSource & { readonly connection: SyncConnectorConnection },
+  checkpoints: ConnectionCheckpoints,
+  storeCheckpoint: () => void
+): AsyncIterable<SyncSourceValue> {
+  const { connection } = source
+  try {
+    throwIfAborted(options.signal)
+    const client = await runAbortable(options.signal, () => source.connect(options.signal))
+    throwIfAborted(options.signal)
+    const previous = checkpoints.get(connection)
+    const readResult = await runAbortable(options.signal, () =>
+      options.sync.read(
+        client as never,
+        {
+          projectId: options.runtime.id,
+          syncId: options.sync.id,
+          signal: options.signal,
+          blobs: options.blobStorage,
+          logger: options.logger,
+          connection,
+          checkpoint: previous === undefined ? undefined : cloneJsonValue(previous),
+          setCheckpoint(next: unknown) {
+            assertJsonValue(
+              next,
+              `Sync '${options.sync.id}' connection '${connection.id}' checkpoint`
+            )
+            checkpoints.set(connection, cloneJsonValue(next))
+            storeCheckpoint()
+          },
+        } as never
+      )
+    )
+    for await (const value of normalizeReadResult(readResult, options.sync.id, options.signal)) {
+      yield { value, connection }
+    }
   } catch (error) {
     if (options.signal.aborted) throw error
     throw createSixbError(
@@ -166,112 +196,12 @@ async function* readManagedSource(
   }
 }
 
-class ConnectionCheckpoints {
-  private readonly entries: Map<string, ConnectionCheckpointEntry>
-
-  private constructor(entries: Map<string, ConnectionCheckpointEntry>) {
-    this.entries = entries
-  }
-
-  static from(syncId: string, value: JsonValue | undefined): ConnectionCheckpoints {
-    if (value === undefined || !isConnectionCheckpoint(value)) {
-      return new ConnectionCheckpoints(new Map())
-    }
-    if (!Array.isArray(value.entries)) {
-      throw invalidCheckpoint(syncId)
-    }
-
-    const entries = new Map<string, ConnectionCheckpointEntry>()
-    for (const candidate of value.entries) {
-      if (
-        !isRecord(candidate) ||
-        typeof candidate.connectionId !== "string" ||
-        !candidate.connectionId.trim() ||
-        typeof candidate.accountId !== "string" ||
-        !candidate.accountId.trim() ||
-        entries.has(candidate.connectionId)
-      ) {
-        throw invalidCheckpoint(syncId)
-      }
-      if ("checkpoint" in candidate && !isJsonValue(candidate.checkpoint)) {
-        throw invalidCheckpoint(syncId)
-      }
-      entries.set(candidate.connectionId, {
-        connectionId: candidate.connectionId,
-        accountId: candidate.accountId,
-        ...("checkpoint" in candidate
-          ? { checkpoint: cloneJsonValue(candidate.checkpoint as JsonValue) }
-          : {}),
-      })
-    }
-    return new ConnectionCheckpoints(entries)
-  }
-
-  reconcile(connections: readonly SyncConnectorConnection[]): void {
-    for (const connection of connections) {
-      const existing = this.entries.get(connection.id)
-      if (existing && existing.accountId !== connection.account.id) {
-        this.entries.delete(connection.id)
-      }
-    }
-  }
-
-  get(connection: SyncConnectorConnection): JsonValue | undefined {
-    const entry = this.entries.get(connection.id)
-    if (entry?.accountId !== connection.account.id || entry.checkpoint === undefined) {
-      return undefined
-    }
-    return cloneJsonValue(entry.checkpoint)
-  }
-
-  set(connection: SyncConnectorConnection, checkpoint: JsonValue): void {
-    this.entries.set(connection.id, {
-      connectionId: connection.id,
-      accountId: connection.account.id,
-      checkpoint: cloneJsonValue(checkpoint),
-    })
-  }
-
-  serialize(): JsonValue | undefined {
-    if (this.entries.size === 0) return undefined
-    const value: unknown = {
-      kind: CONNECTION_CHECKPOINT_KIND,
-      entries: [...this.entries.values()]
-        .sort((left, right) => left.connectionId.localeCompare(right.connectionId))
-        .map((entry) => ({
-          connectionId: entry.connectionId,
-          accountId: entry.accountId,
-          ...(entry.checkpoint === undefined
-            ? {}
-            : { checkpoint: cloneJsonValue(entry.checkpoint) }),
-        })),
-    }
-    assertJsonValue(value, "Managed connector Sync checkpoint")
-    return value
-  }
-}
-
-function isConnectionCheckpoint(value: JsonValue | undefined): value is JsonValue & {
-  readonly kind: typeof CONNECTION_CHECKPOINT_KIND
-  readonly entries?: JsonValue
-} {
-  return isRecord(value) && value.kind === CONNECTION_CHECKPOINT_KIND
-}
-
-function invalidCheckpoint(syncId: string): Error {
-  return createSixbError(
-    "internal.unexpected",
-    `[SixbSyncWorker] Sync '${syncId}' has an invalid managed connector checkpoint.`,
-    { details: { syncId } }
-  )
-}
-
 function sourceInvariant(syncId: string, message: string): Error {
   return createSixbError("internal.unexpected", `[SixbSyncWorker] ${message}`, {
     details: { syncId },
   })
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
+async function* sourceValues(values: AsyncIterable<unknown>): AsyncIterable<SyncSourceValue> {
+  for await (const value of values) yield { value }
 }

--- a/packages/sync-worker/src/source-read.ts
+++ b/packages/sync-worker/src/source-read.ts
@@ -1,0 +1,277 @@
+import {
+  assertJsonValue,
+  type BlobStorage,
+  cloneJsonValue,
+  isJsonValue,
+  type JsonValue,
+  type Logger,
+  type SyncConnectorConnection,
+  type SyncDefinition,
+} from "@sixb/core"
+import { isOAuthConnectorDefinition } from "@sixb/core/internal/connector-connections"
+import { createSixbError, summarizeErrorMessage } from "@sixb/core/internal/errors"
+import type { SyncConnectorSource } from "@sixb/core/internal/syncs"
+import { normalizeReadResult, throwIfAborted } from "./normalize"
+import type { SyncWorkerContext } from "./types"
+
+const CONNECTION_CHECKPOINT_KIND = "connector_connections"
+
+interface ConnectionCheckpointEntry {
+  readonly connectionId: string
+  readonly accountId: string
+  readonly checkpoint?: JsonValue
+}
+
+interface ReadSyncValuesInput {
+  readonly runtime: SyncWorkerContext
+  readonly sync: SyncDefinition
+  readonly runId: string
+  readonly datasetId: string
+  readonly signal: AbortSignal
+  readonly blobStorage: BlobStorage
+  readonly logger: Logger
+  readonly previousCheckpoint: JsonValue | undefined
+  setCheckpoint(next: JsonValue | undefined): void
+}
+
+/** Resolve and invoke every source contributing to one atomic Sync run. */
+export async function readSyncValues(
+  options: ReadSyncValuesInput
+): Promise<AsyncIterable<unknown>> {
+  const sources = await options.runtime.connectorSources.list(options.sync.connector)
+  if (!isOAuthConnectorDefinition(options.sync.connector)) {
+    if (sources.length !== 1 || sources[0]?.connection !== undefined) {
+      throw sourceInvariant(options.sync.id, "Static connectors must resolve exactly one source.")
+    }
+    return readStaticSource(options, sources[0])
+  }
+
+  const connectionIds = new Set<string>()
+  const managedSources = sources.map((source) => {
+    if (!source.connection) {
+      throw sourceInvariant(
+        options.sync.id,
+        "OAuth connector sources must include connection metadata."
+      )
+    }
+    const connection = source.connection
+    if (connection.connectorId !== options.sync.connector.id) {
+      throw sourceInvariant(
+        options.sync.id,
+        `Connection '${connection.id}' belongs to connector '${connection.connectorId}', not '${options.sync.connector.id}'.`
+      )
+    }
+    if (connectionIds.has(connection.id)) {
+      throw sourceInvariant(options.sync.id, `Connection '${connection.id}' was resolved twice.`)
+    }
+    connectionIds.add(connection.id)
+    return {
+      connection,
+      connect: () => source.connect(),
+    }
+  })
+  managedSources.sort((left, right) => left.connection.id.localeCompare(right.connection.id))
+  const checkpoints = ConnectionCheckpoints.from(options.sync.id, options.previousCheckpoint)
+  checkpoints.reconcile(managedSources.map((source) => source.connection))
+  options.setCheckpoint(checkpoints.serialize())
+
+  return readManagedSources(options, managedSources, checkpoints)
+}
+
+async function readStaticSource(
+  options: ReadSyncValuesInput,
+  source: SyncConnectorSource
+): Promise<AsyncIterable<unknown>> {
+  const client = await source.connect()
+  const readResult = await options.sync.read(
+    client as never,
+    {
+      projectId: options.runtime.id,
+      syncId: options.sync.id,
+      signal: options.signal,
+      blobs: options.blobStorage,
+      logger: options.logger,
+      checkpoint:
+        options.previousCheckpoint === undefined
+          ? undefined
+          : cloneJsonValue(options.previousCheckpoint),
+      setCheckpoint(next: unknown) {
+        assertJsonValue(next, `Sync '${options.sync.id}' checkpoint`)
+        options.setCheckpoint(cloneJsonValue(next))
+      },
+    } as never
+  )
+  return normalizeReadResult(readResult, options.sync.id)
+}
+
+async function* readManagedSources(
+  options: ReadSyncValuesInput,
+  sources: readonly (SyncConnectorSource & {
+    readonly connection: SyncConnectorConnection
+  })[],
+  checkpoints: ConnectionCheckpoints
+): AsyncIterable<unknown> {
+  for (const source of sources) {
+    yield* readManagedSource(options, source, checkpoints)
+  }
+}
+
+async function* readManagedSource(
+  options: ReadSyncValuesInput,
+  source: SyncConnectorSource & { readonly connection: SyncConnectorConnection },
+  checkpoints: ConnectionCheckpoints
+): AsyncIterable<unknown> {
+  const { connection } = source
+  try {
+    throwIfAborted(options.signal)
+    const client = await source.connect()
+    const previous = checkpoints.get(connection)
+    const readResult = await options.sync.read(
+      client as never,
+      {
+        projectId: options.runtime.id,
+        syncId: options.sync.id,
+        signal: options.signal,
+        blobs: options.blobStorage,
+        logger: options.logger,
+        connection,
+        checkpoint: previous === undefined ? undefined : cloneJsonValue(previous),
+        setCheckpoint(next: unknown) {
+          assertJsonValue(
+            next,
+            `Sync '${options.sync.id}' connection '${connection.id}' checkpoint`
+          )
+          checkpoints.set(connection, cloneJsonValue(next))
+          options.setCheckpoint(checkpoints.serialize())
+        },
+      } as never
+    )
+    yield* normalizeReadResult(readResult, options.sync.id)
+  } catch (error) {
+    if (options.signal.aborted) throw error
+    throw createSixbError(
+      "sync.execution_failed",
+      summarizeErrorMessage(error, "Managed connector Sync source failed."),
+      {
+        cause: error,
+        details: {
+          syncId: options.sync.id,
+          runId: options.runId,
+          datasetId: options.datasetId,
+          connectionId: connection.id,
+          accountId: connection.account.id,
+        },
+      }
+    )
+  }
+}
+
+class ConnectionCheckpoints {
+  private readonly entries: Map<string, ConnectionCheckpointEntry>
+
+  private constructor(entries: Map<string, ConnectionCheckpointEntry>) {
+    this.entries = entries
+  }
+
+  static from(syncId: string, value: JsonValue | undefined): ConnectionCheckpoints {
+    if (value === undefined || !isConnectionCheckpoint(value)) {
+      return new ConnectionCheckpoints(new Map())
+    }
+    if (!Array.isArray(value.entries)) {
+      throw invalidCheckpoint(syncId)
+    }
+
+    const entries = new Map<string, ConnectionCheckpointEntry>()
+    for (const candidate of value.entries) {
+      if (
+        !isRecord(candidate) ||
+        typeof candidate.connectionId !== "string" ||
+        !candidate.connectionId.trim() ||
+        typeof candidate.accountId !== "string" ||
+        !candidate.accountId.trim() ||
+        entries.has(candidate.connectionId)
+      ) {
+        throw invalidCheckpoint(syncId)
+      }
+      if ("checkpoint" in candidate && !isJsonValue(candidate.checkpoint)) {
+        throw invalidCheckpoint(syncId)
+      }
+      entries.set(candidate.connectionId, {
+        connectionId: candidate.connectionId,
+        accountId: candidate.accountId,
+        ...("checkpoint" in candidate
+          ? { checkpoint: cloneJsonValue(candidate.checkpoint as JsonValue) }
+          : {}),
+      })
+    }
+    return new ConnectionCheckpoints(entries)
+  }
+
+  reconcile(connections: readonly SyncConnectorConnection[]): void {
+    for (const connection of connections) {
+      const existing = this.entries.get(connection.id)
+      if (existing && existing.accountId !== connection.account.id) {
+        this.entries.delete(connection.id)
+      }
+    }
+  }
+
+  get(connection: SyncConnectorConnection): JsonValue | undefined {
+    const entry = this.entries.get(connection.id)
+    if (entry?.accountId !== connection.account.id || entry.checkpoint === undefined) {
+      return undefined
+    }
+    return cloneJsonValue(entry.checkpoint)
+  }
+
+  set(connection: SyncConnectorConnection, checkpoint: JsonValue): void {
+    this.entries.set(connection.id, {
+      connectionId: connection.id,
+      accountId: connection.account.id,
+      checkpoint: cloneJsonValue(checkpoint),
+    })
+  }
+
+  serialize(): JsonValue | undefined {
+    if (this.entries.size === 0) return undefined
+    const value: unknown = {
+      kind: CONNECTION_CHECKPOINT_KIND,
+      entries: [...this.entries.values()]
+        .sort((left, right) => left.connectionId.localeCompare(right.connectionId))
+        .map((entry) => ({
+          connectionId: entry.connectionId,
+          accountId: entry.accountId,
+          ...(entry.checkpoint === undefined
+            ? {}
+            : { checkpoint: cloneJsonValue(entry.checkpoint) }),
+        })),
+    }
+    assertJsonValue(value, "Managed connector Sync checkpoint")
+    return value
+  }
+}
+
+function isConnectionCheckpoint(value: JsonValue | undefined): value is JsonValue & {
+  readonly kind: typeof CONNECTION_CHECKPOINT_KIND
+  readonly entries?: JsonValue
+} {
+  return isRecord(value) && value.kind === CONNECTION_CHECKPOINT_KIND
+}
+
+function invalidCheckpoint(syncId: string): Error {
+  return createSixbError(
+    "internal.unexpected",
+    `[SixbSyncWorker] Sync '${syncId}' has an invalid managed connector checkpoint.`,
+    { details: { syncId } }
+  )
+}
+
+function sourceInvariant(syncId: string, message: string): Error {
+  return createSixbError("internal.unexpected", `[SixbSyncWorker] ${message}`, {
+    details: { syncId },
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -1,26 +1,20 @@
-import type {
-  BlobStorage,
-  ConnectorRuntime,
-  LakeStorage,
-  SixbDefinitions,
-  SixbFailure,
-  SyncMode,
-} from "@sixb/core"
+import type { BlobStorage, LakeStorage, SixbDefinitions, SixbFailure, SyncMode } from "@sixb/core"
 import type { LoggingService } from "@sixb/core/internal/logging"
+import type { SyncConnectorSourceResolver } from "@sixb/core/internal/syncs"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
 import type { SyncRunFailureCode, SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
 
-export interface SyncWorkerContext {
-  readonly id: string
-  readonly syncRunsStorage: SyncRunStorage
-  readonly lakeStorage: LakeStorage
-  readonly blobs: BlobStorage
-  readonly logging?: LoggingService
+  export interface SyncWorkerContext {
+    readonly id: string
+    readonly syncRunsStorage: SyncRunStorage
+    readonly lakeStorage: LakeStorage
+    readonly blobs: BlobStorage
+    readonly logging?: LoggingService
 
-  readonly datasets: Pick<SixbDefinitions["datasets"], "getById">
-  readonly syncs: Pick<SixbDefinitions["syncs"], "getById">
-  readonly connector: ConnectorRuntime
-}
+    readonly datasets: Pick<SixbDefinitions["datasets"], "getById">
+    readonly syncs: Pick<SixbDefinitions["syncs"], "getById">
+    readonly connectorSources: SyncConnectorSourceResolver
+  }
 
 export interface RunSyncJobInput {
   readonly runtime: SyncWorkerContext

--- a/packages/sync-worker/src/types.ts
+++ b/packages/sync-worker/src/types.ts
@@ -4,17 +4,17 @@ import type { SyncConnectorSourceResolver } from "@sixb/core/internal/syncs"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
 import type { SyncRunFailureCode, SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
 
-  export interface SyncWorkerContext {
-    readonly id: string
-    readonly syncRunsStorage: SyncRunStorage
-    readonly lakeStorage: LakeStorage
-    readonly blobs: BlobStorage
-    readonly logging?: LoggingService
+export interface SyncWorkerContext {
+  readonly id: string
+  readonly syncRunsStorage: SyncRunStorage
+  readonly lakeStorage: LakeStorage
+  readonly blobs: BlobStorage
+  readonly logging?: LoggingService
 
-    readonly datasets: Pick<SixbDefinitions["datasets"], "getById">
-    readonly syncs: Pick<SixbDefinitions["syncs"], "getById">
-    readonly connectorSources: SyncConnectorSourceResolver
-  }
+  readonly datasets: Pick<SixbDefinitions["datasets"], "getById">
+  readonly syncs: Pick<SixbDefinitions["syncs"], "getById">
+  readonly connectorSources: SyncConnectorSourceResolver
+}
 
 export interface RunSyncJobInput {
   readonly runtime: SyncWorkerContext

--- a/packages/sync-worker/src/worker.ts
+++ b/packages/sync-worker/src/worker.ts
@@ -5,6 +5,7 @@ import {
   bindDurablePrimitiveExecution,
   type PrimitiveExecutionHost,
 } from "@sixb/core/internal/primitive-execution"
+import { resolveSyncConnectorSources } from "@sixb/core/internal/syncs"
 import type { QueueWorkerFailureDecision } from "@sixb/core/internal/workers"
 import { QueueWorker } from "@sixb/core/internal/workers"
 import type { DatasetVersion } from "@sixb/core/lake-storage"
@@ -227,6 +228,8 @@ function buildSyncContext(
     logging: host.logging,
     syncs: host.definitions.syncs,
     datasets: host.definitions.datasets,
-    connector: sixb.connector,
+    connectorSources: {
+      list: (definition) => resolveSyncConnectorSources(sixb.connector, definition),
+    },
   }
 }

--- a/packages/sync-worker/tests/managed-connector-sync-safety.test.ts
+++ b/packages/sync-worker/tests/managed-connector-sync-safety.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, test } from "bun:test"
+import { change, col, defineConnector, defineDataset, defineSync, type JsonValue } from "@sixb/core"
+import { blobIdFromDigest } from "@sixb/core/blob-storage"
+import type { SyncConnectorSource } from "@sixb/core/internal/syncs"
+import type { SyncRunRecord } from "@sixb/core/storage"
+import {
+  createFixture,
+  run,
+  seedSuccessfulCheckpoint,
+  social,
+  socialRows,
+  source,
+  waitFor,
+} from "./managed-connector-sync.fixture"
+
+const socialFiles = defineDataset("raw.social.files", {
+  schema: [col("id", "string"), col("attachment", "fileRef", { nullable: true })],
+})
+
+const socialMerge = defineDataset("raw.social.merge", {
+  schema: [col("id", "string")],
+  primaryKey: "id",
+})
+
+const missingBlobDigest = `sha256:${"0".repeat(64)}` as const
+
+const staticSocial = defineConnector("social", {
+  type: "static-social",
+  connect() {
+    return {}
+  },
+})
+
+describe("managed connector Sync safety", () => {
+  test("fails closed when the durable checkpoint belongs to another source contract", async () => {
+    const sync = defineSync("sync-checkpoint-identity", { mode: "append" })
+      .checkpoint<{ cursor: string }>()
+      .from(social)
+      .read(() => [])
+      .intoDataset(socialRows)
+    const cases: readonly {
+      readonly name: string
+      readonly reason: string
+      readonly checkpoint: JsonValue
+    }[] = [
+      {
+        name: "legacy checkpoint",
+        reason: "checkpoint_format",
+        checkpoint: { cursor: "100" },
+      },
+      {
+        name: "unsupported envelope version",
+        reason: "checkpoint_version",
+        checkpoint: {
+          kind: "sync_checkpoint",
+          version: 2,
+          connectorId: social.id,
+          strategy: "connections",
+          value: { entries: [] },
+        },
+      },
+      {
+        name: "different connector",
+        reason: "checkpoint_connector",
+        checkpoint: {
+          kind: "sync_checkpoint",
+          version: 1,
+          connectorId: "another-connector",
+          strategy: "connections",
+          value: { entries: [] },
+        },
+      },
+      {
+        name: "different strategy",
+        reason: "checkpoint_strategy",
+        checkpoint: {
+          kind: "sync_checkpoint",
+          version: 1,
+          connectorId: social.id,
+          strategy: "single",
+          value: { cursor: "100" },
+        },
+      },
+    ]
+
+    for (const [index, candidate] of cases.entries()) {
+      const fixture = createFixture(sync, () => [source("connection-a", "account-a", "brand-a")])
+      await seedSuccessfulCheckpoint(
+        fixture,
+        sync.id,
+        `run-checkpoint-seed-${index}`,
+        candidate.checkpoint
+      )
+      const runId = `run-checkpoint-incompatible-${index}`
+
+      await expect(run(fixture, sync.id, runId)).rejects.toThrow("checkpoint incompatible")
+      const failed = await fixture.runtime.syncRunsStorage.getById({
+        projectId: fixture.runtime.id,
+        id: runId,
+      })
+      expect(failed).toMatchObject({
+        status: "failed",
+        error: {
+          code: "sync.execution_failed",
+          details: {
+            syncId: sync.id,
+            connectorId: social.id,
+            reason: candidate.reason,
+          },
+        },
+      })
+    }
+  })
+
+  test("also rejects a connection checkpoint after the source becomes static", async () => {
+    const sync = defineSync("sync-static-checkpoint-identity", { mode: "append" })
+      .checkpoint<{ cursor: string }>()
+      .from(staticSocial)
+      .read(() => [])
+      .intoDataset(socialRows)
+    const staticSource: SyncConnectorSource = {
+      async connect() {
+        return {}
+      },
+    }
+    const fixture = createFixture(sync, () => [staticSource])
+    await seedSuccessfulCheckpoint(fixture, sync.id, "run-static-seed", {
+      kind: "sync_checkpoint",
+      version: 1,
+      connectorId: staticSocial.id,
+      strategy: "connections",
+      value: { entries: [] },
+    })
+
+    await expect(run(fixture, sync.id, "run-static-incompatible")).rejects.toThrow(
+      "checkpoint incompatible"
+    )
+    const failed = await fixture.runtime.syncRunsStorage.getById({
+      projectId: fixture.runtime.id,
+      id: "run-static-incompatible",
+    })
+    expect(failed).toMatchObject({
+      status: "failed",
+      error: {
+        code: "sync.execution_failed",
+        details: {
+          connectorId: staticSocial.id,
+          reason: "checkpoint_strategy",
+        },
+      },
+    })
+  })
+
+  test("keeps connection provenance on dataset validation failures", async () => {
+    const sync = defineSync("sync-validation-provenance")
+      .from(social)
+      .read((_client, { connection }) => ({
+        id: connection.id === "connection-b" ? 42 : connection.id,
+      }))
+      .intoDataset(socialRows)
+    const fixture = createFixture(sync, () => [
+      source("connection-a", "account-a", "brand-a"),
+      source("connection-b", "account-b", "brand-b"),
+    ])
+
+    await expect(run(fixture, sync.id, "run-invalid-row")).rejects.toThrow("invalid row")
+    const failed = await fixture.runtime.syncRunsStorage.getById({
+      projectId: fixture.runtime.id,
+      id: "run-invalid-row",
+    })
+    expect(failed).toMatchObject({
+      status: "failed",
+      error: {
+        code: "sync.execution_failed",
+        details: {
+          connectionId: "connection-b",
+          accountId: "account-b",
+          itemIndex: 2,
+        },
+      },
+    })
+  })
+
+  test("keeps connection provenance on missing blob failures", async () => {
+    const sync = defineSync("sync-file-provenance")
+      .from(social)
+      .read((_client, { connection }) => ({
+        id: connection.id,
+        ...(connection.id === "connection-b"
+          ? {
+              attachment: {
+                blobId: blobIdFromDigest(missingBlobDigest),
+                digest: missingBlobDigest,
+                sizeBytes: 1,
+              },
+            }
+          : {}),
+      }))
+      .intoDataset(socialFiles)
+    const fixture = createFixture(sync, () => [
+      source("connection-a", "account-a", "brand-a"),
+      source("connection-b", "account-b", "brand-b"),
+    ])
+
+    await expect(run(fixture, sync.id, "run-missing-blob")).rejects.toThrow(
+      "referencing unknown blob"
+    )
+    const failed = await fixture.runtime.syncRunsStorage.getById({
+      projectId: fixture.runtime.id,
+      id: "run-missing-blob",
+    })
+    expect(failed).toMatchObject({
+      status: "failed",
+      error: {
+        code: "sync.execution_failed",
+        details: {
+          connectionId: "connection-b",
+          accountId: "account-b",
+          itemIndex: 2,
+        },
+      },
+    })
+  })
+
+  test("keeps connection provenance on merge validation failures", async () => {
+    const sync = defineSync("sync-merge-provenance", { mode: "merge" })
+      .from(social)
+      .read((_client, { connection }) =>
+        change.upsert({ id: connection.id === "connection-b" ? 42 : connection.id })
+      )
+      .intoDataset(socialMerge)
+    const fixture = createFixture(sync, () => [
+      source("connection-a", "account-a", "brand-a"),
+      source("connection-b", "account-b", "brand-b"),
+    ])
+
+    await expect(run(fixture, sync.id, "run-invalid-merge")).rejects.toThrow("invalid merge change")
+    const failed = await fixture.runtime.syncRunsStorage.getById({
+      projectId: fixture.runtime.id,
+      id: "run-invalid-merge",
+    })
+    expect(failed).toMatchObject({
+      status: "failed",
+      error: {
+        code: "sync.execution_failed",
+        details: {
+          connectionId: "connection-b",
+          accountId: "account-b",
+          itemIndex: 2,
+        },
+      },
+    })
+  })
+
+  test("cancels while a connector source is still connecting", async () => {
+    let sourceSignal: AbortSignal | undefined
+    const pendingSource: SyncConnectorSource = {
+      ...source("connection-a", "account-a", "brand-a"),
+      connect(signal) {
+        sourceSignal = signal
+        return new Promise(() => {})
+      },
+    }
+    const sync = defineSync("sync-cancel-connect")
+      .from(social)
+      .read(() => [])
+      .intoDataset(socialRows)
+    const fixture = createFixture(sync, () => [pendingSource])
+    const controller = new AbortController()
+    const running = run(fixture, sync.id, "run-cancel-connect", controller.signal)
+
+    await waitFor(() => sourceSignal !== undefined)
+    controller.abort(new DOMException("cancelled while connecting", "AbortError"))
+    await expectCancelled(fixture, "run-cancel-connect", running)
+    expect(sourceSignal?.aborted).toBe(true)
+  })
+
+  test("cancels while awaiting the read handler", async () => {
+    let handlerStarted = false
+    const sync = defineSync("sync-cancel-handler")
+      .from(social)
+      .read(() => {
+        handlerStarted = true
+        return new Promise<never>(() => {})
+      })
+      .intoDataset(socialRows)
+    const fixture = createFixture(sync, () => [source("connection-a", "account-a", "brand-a")])
+    const controller = new AbortController()
+    const running = run(fixture, sync.id, "run-cancel-handler", controller.signal)
+
+    await waitFor(() => handlerStarted)
+    controller.abort(new DOMException("cancelled while reading", "AbortError"))
+    await expectCancelled(fixture, "run-cancel-handler", running)
+  })
+
+  test("cancels while awaiting the next async source value", async () => {
+    let nextStarted = false
+    let iteratorClosed = false
+    const sync = defineSync("sync-cancel-iterator")
+      .from(social)
+      .read(
+        (): AsyncIterable<unknown> => ({
+          [Symbol.asyncIterator]() {
+            return {
+              next() {
+                nextStarted = true
+                return new Promise(() => {})
+              },
+              return() {
+                iteratorClosed = true
+                return Promise.resolve({ done: true, value: undefined })
+              },
+            }
+          },
+        })
+      )
+      .intoDataset(socialRows)
+    const fixture = createFixture(sync, () => [source("connection-a", "account-a", "brand-a")])
+    const controller = new AbortController()
+    const running = run(fixture, sync.id, "run-cancel-iterator", controller.signal)
+
+    await waitFor(() => nextStarted)
+    controller.abort(new DOMException("cancelled while iterating", "AbortError"))
+    await expectCancelled(fixture, "run-cancel-iterator", running)
+    await waitFor(() => iteratorClosed)
+  })
+})
+
+async function expectCancelled(
+  fixture: ReturnType<typeof createFixture>,
+  runId: string,
+  running: Promise<unknown>
+): Promise<void> {
+  let rejection: unknown
+  try {
+    await running
+  } catch (error) {
+    rejection = error
+  }
+  expect(rejection).toBeInstanceOf(Error)
+  expect((rejection as Error).name).toBe("AbortError")
+
+  const record: SyncRunRecord | null = await fixture.runtime.syncRunsStorage.getById({
+    projectId: fixture.runtime.id,
+    id: runId,
+  })
+  expect(record).toMatchObject({
+    status: "cancelled",
+    error: { code: "runtime.cancelled" },
+  })
+}

--- a/packages/sync-worker/tests/managed-connector-sync.fixture.ts
+++ b/packages/sync-worker/tests/managed-connector-sync.fixture.ts
@@ -1,0 +1,170 @@
+import type { DatasetRow, JsonValue, SyncDefinition } from "@sixb/core"
+import {
+  col,
+  defineConnector,
+  defineDataset,
+  InMemoryBlobStorage,
+  InMemoryLakeStorage,
+  InMemoryStorage,
+} from "@sixb/core"
+import type { SyncConnectorSource, SyncConnectorSourceResolver } from "@sixb/core/internal/syncs"
+import type { ExecutionStorage } from "@sixb/core/storage"
+import { runSyncJob as runSyncJobWithDurableRun } from "../src/run-sync-job"
+import type { SyncWorkerContext } from "../src/types"
+
+export const social = defineConnector("social", {
+  type: "social-oauth",
+  authentication: {
+    type: "oauth2",
+    authorizationUrl() {
+      return "https://provider.test/oauth"
+    },
+    exchangeCode() {
+      return { accessToken: "access" }
+    },
+    refresh() {
+      return { accessToken: "refreshed" }
+    },
+  },
+  discoverAccounts() {
+    return []
+  },
+  connect(context) {
+    return { accountId: context.account.id }
+  },
+})
+
+export const socialRows = defineDataset("raw.social.rows", {
+  schema: [col("id", "string"), col("accountId", "string", { nullable: true })],
+})
+
+export interface ManagedSyncFixture {
+  readonly runtime: SyncWorkerContext
+  readonly executions: ExecutionStorage
+  readonly lakeStorage: InMemoryLakeStorage
+}
+
+export function createFixture(
+  sync: SyncDefinition,
+  sources: () => readonly SyncConnectorSource[]
+): ManagedSyncFixture {
+  const storage = new InMemoryStorage()
+  const connectorSources: SyncConnectorSourceResolver = {
+    async list() {
+      return sources() as never
+    },
+  }
+  const lakeStorage = new InMemoryLakeStorage()
+  return {
+    executions: storage.executions,
+    lakeStorage,
+    runtime: {
+      id: "project-1",
+      syncRunsStorage: storage.syncRuns,
+      lakeStorage,
+      blobs: new InMemoryBlobStorage(),
+      datasets: {
+        getById(datasetId) {
+          return datasetId === sync.target.dataset.id ? sync.target.dataset : null
+        },
+      },
+      syncs: {
+        getById(syncId) {
+          return syncId === sync.id ? sync : null
+        },
+      },
+      connectorSources,
+    },
+  }
+}
+
+export function source(connectionId: string, accountId: string, slot: string): SyncConnectorSource {
+  return {
+    connection: {
+      id: connectionId,
+      connectorId: social.id,
+      owner: { type: "project" },
+      slot,
+      account: { id: accountId, label: accountId },
+    },
+    async connect() {
+      return { accountId }
+    },
+  }
+}
+
+export async function run(
+  fixture: ManagedSyncFixture,
+  syncId: string,
+  runId: string,
+  signal?: AbortSignal
+) {
+  const queued = await queueRun(fixture, syncId, runId)
+  return runSyncJobWithDurableRun({
+    runtime: fixture.runtime,
+    run: queued,
+    ...(signal === undefined ? {} : { signal }),
+  })
+}
+
+export async function seedSuccessfulCheckpoint(
+  fixture: ManagedSyncFixture,
+  syncId: string,
+  runId: string,
+  checkpoint: JsonValue
+): Promise<void> {
+  const queued = await queueRun(fixture, syncId, runId)
+  await fixture.runtime.syncRunsStorage.start({
+    projectId: fixture.runtime.id,
+    id: queued.id,
+  })
+  await fixture.runtime.syncRunsStorage.finish({
+    projectId: fixture.runtime.id,
+    id: queued.id,
+    status: "succeeded",
+    rowsRead: 0,
+    checkpoint,
+  })
+}
+
+export async function rows(storage: InMemoryLakeStorage): Promise<DatasetRow[]> {
+  const result: DatasetRow[] = []
+  for await (const row of storage.readRows({ datasetId: socialRows.id })) {
+    result.push(row)
+  }
+  return result
+}
+
+export async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await Bun.sleep(5)
+  }
+  throw new Error("Timed out waiting for managed Sync state.")
+}
+
+async function queueRun(fixture: ManagedSyncFixture, syncId: string, runId: string) {
+  const sync = fixture.runtime.syncs.getById(syncId)
+  if (!sync) throw new Error(`[Test] Unknown Sync '${syncId}'.`)
+  const executionId = `exec:${runId}`
+  await fixture.executions.create({
+    id: executionId,
+    projectId: fixture.runtime.id,
+    executor: { type: "primitive", kind: "sync", runId },
+    source: { type: "schedule", eventId: `event:${runId}` },
+    correlationId: `correlation:${runId}`,
+    authorizationRef: {
+      type: "trustedPrimitive",
+      primitive: { kind: "sync", id: sync.id, runId },
+    },
+  })
+  return fixture.runtime.syncRunsStorage.queue({
+    id: runId,
+    projectId: fixture.runtime.id,
+    executionId,
+    syncId: sync.id,
+    datasetId: sync.target.dataset.id,
+    mode: sync.config.mode,
+  })
+}

--- a/packages/sync-worker/tests/managed-connector-sync.test.ts
+++ b/packages/sync-worker/tests/managed-connector-sync.test.ts
@@ -1,134 +1,14 @@
 import { describe, expect, test } from "bun:test"
-import type { DatasetRow } from "@sixb/core"
+import { defineSync } from "@sixb/core"
+import type { SyncConnectorSource } from "@sixb/core/internal/syncs"
 import {
-  col,
-  defineConnector,
-  defineDataset,
-  defineSync,
-  InMemoryBlobStorage,
-  InMemoryLakeStorage,
-  InMemoryStorage,
-  type SyncDefinition,
-} from "@sixb/core"
-import type { SyncConnectorSource, SyncConnectorSourceResolver } from "@sixb/core/internal/syncs"
-import type { ExecutionStorage } from "@sixb/core/storage"
-import { runSyncJob as runSyncJobWithDurableRun } from "../src/run-sync-job"
-import type { SyncWorkerContext } from "../src/types"
-
-const social = defineConnector("social", {
-  type: "social-oauth",
-  authentication: {
-    type: "oauth2",
-    authorizationUrl() {
-      return "https://provider.test/oauth"
-    },
-    exchangeCode() {
-      return { accessToken: "access" }
-    },
-    refresh() {
-      return { accessToken: "refreshed" }
-    },
-  },
-  discoverAccounts() {
-    return []
-  },
-  connect(context) {
-    return { accountId: context.account.id }
-  },
-})
-
-const socialRows = defineDataset("raw.social.rows", {
-  schema: [col("id", "string"), col("accountId", "string", { nullable: true })],
-})
-
-interface ManagedSyncFixture {
-  readonly runtime: SyncWorkerContext
-  readonly executions: ExecutionStorage
-  readonly lakeStorage: InMemoryLakeStorage
-}
-
-function createFixture(
-  sync: SyncDefinition,
-  sources: () => readonly SyncConnectorSource[]
-): ManagedSyncFixture {
-  const storage = new InMemoryStorage()
-  const connectorSources: SyncConnectorSourceResolver = {
-    async list() {
-      return sources() as never
-    },
-  }
-  const lakeStorage = new InMemoryLakeStorage()
-  return {
-    executions: storage.executions,
-    lakeStorage,
-    runtime: {
-      id: "project-1",
-      syncRunsStorage: storage.syncRuns,
-      lakeStorage,
-      blobs: new InMemoryBlobStorage(),
-      datasets: {
-        getById(datasetId) {
-          return datasetId === sync.target.dataset.id ? sync.target.dataset : null
-        },
-      },
-      syncs: {
-        getById(syncId) {
-          return syncId === sync.id ? sync : null
-        },
-      },
-      connectorSources,
-    },
-  }
-}
-
-function source(connectionId: string, accountId: string, slot: string): SyncConnectorSource {
-  return {
-    connection: {
-      id: connectionId,
-      connectorId: social.id,
-      owner: { type: "project" },
-      slot,
-      account: { id: accountId, label: accountId },
-    },
-    async connect() {
-      return { accountId }
-    },
-  }
-}
-
-async function run(fixture: ManagedSyncFixture, syncId: string, runId: string) {
-  const sync = fixture.runtime.syncs.getById(syncId)
-  if (!sync) throw new Error(`[Test] Unknown Sync '${syncId}'.`)
-  const executionId = `exec:${runId}`
-  await fixture.executions.create({
-    id: executionId,
-    projectId: fixture.runtime.id,
-    executor: { type: "primitive", kind: "sync", runId },
-    source: { type: "schedule", eventId: `event:${runId}` },
-    correlationId: `correlation:${runId}`,
-    authorizationRef: {
-      type: "trustedPrimitive",
-      primitive: { kind: "sync", id: sync.id, runId },
-    },
-  })
-  const queued = await fixture.runtime.syncRunsStorage.queue({
-    id: runId,
-    projectId: fixture.runtime.id,
-    executionId,
-    syncId: sync.id,
-    datasetId: sync.target.dataset.id,
-    mode: sync.config.mode,
-  })
-  return runSyncJobWithDurableRun({ runtime: fixture.runtime, run: queued })
-}
-
-async function rows(storage: InMemoryLakeStorage): Promise<DatasetRow[]> {
-  const result: DatasetRow[] = []
-  for await (const row of storage.readRows({ datasetId: socialRows.id })) {
-    result.push(row)
-  }
-  return result
-}
+  createFixture,
+  rows,
+  run,
+  social,
+  socialRows,
+  source,
+} from "./managed-connector-sync.fixture"
 
 describe("managed connector Sync fan-out", () => {
   test("reads every connection into one snapshot and clears it when none remain", async () => {
@@ -194,6 +74,22 @@ describe("managed connector Sync fan-out", () => {
     nextCursor.set("connection-a", "a-1")
     nextCursor.set("connection-b", "b-1")
     await run(fixture, sync.id, "run-checkpoints-1")
+    const firstRun = await fixture.runtime.syncRunsStorage.getById({
+      projectId: fixture.runtime.id,
+      id: "run-checkpoints-1",
+    })
+    expect(firstRun?.checkpoint).toMatchObject({
+      kind: "sync_checkpoint",
+      version: 1,
+      connectorId: social.id,
+      strategy: "connections",
+      value: {
+        entries: [
+          { connectionId: "connection-a", accountId: "account-a", checkpoint: { cursor: "a-1" } },
+          { connectionId: "connection-b", accountId: "account-b", checkpoint: { cursor: "b-1" } },
+        ],
+      },
+    })
 
     sources = [source("connection-a", "account-a", "brand-a")]
     nextCursor.set("connection-a", "a-2")

--- a/packages/sync-worker/tests/managed-connector-sync.test.ts
+++ b/packages/sync-worker/tests/managed-connector-sync.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "bun:test"
+import type { DatasetRow } from "@sixb/core"
+import {
+  col,
+  defineConnector,
+  defineDataset,
+  defineSync,
+  InMemoryBlobStorage,
+  InMemoryLakeStorage,
+  InMemoryStorage,
+  type SyncDefinition,
+} from "@sixb/core"
+import type { SyncConnectorSource, SyncConnectorSourceResolver } from "@sixb/core/internal/syncs"
+import type { ExecutionStorage } from "@sixb/core/storage"
+import { runSyncJob as runSyncJobWithDurableRun } from "../src/run-sync-job"
+import type { SyncWorkerContext } from "../src/types"
+
+const social = defineConnector("social", {
+  type: "social-oauth",
+  authentication: {
+    type: "oauth2",
+    authorizationUrl() {
+      return "https://provider.test/oauth"
+    },
+    exchangeCode() {
+      return { accessToken: "access" }
+    },
+    refresh() {
+      return { accessToken: "refreshed" }
+    },
+  },
+  discoverAccounts() {
+    return []
+  },
+  connect(context) {
+    return { accountId: context.account.id }
+  },
+})
+
+const socialRows = defineDataset("raw.social.rows", {
+  schema: [col("id", "string"), col("accountId", "string", { nullable: true })],
+})
+
+interface ManagedSyncFixture {
+  readonly runtime: SyncWorkerContext
+  readonly executions: ExecutionStorage
+  readonly lakeStorage: InMemoryLakeStorage
+}
+
+function createFixture(
+  sync: SyncDefinition,
+  sources: () => readonly SyncConnectorSource[]
+): ManagedSyncFixture {
+  const storage = new InMemoryStorage()
+  const connectorSources: SyncConnectorSourceResolver = {
+    async list() {
+      return sources() as never
+    },
+  }
+  const lakeStorage = new InMemoryLakeStorage()
+  return {
+    executions: storage.executions,
+    lakeStorage,
+    runtime: {
+      id: "project-1",
+      syncRunsStorage: storage.syncRuns,
+      lakeStorage,
+      blobs: new InMemoryBlobStorage(),
+      datasets: {
+        getById(datasetId) {
+          return datasetId === sync.target.dataset.id ? sync.target.dataset : null
+        },
+      },
+      syncs: {
+        getById(syncId) {
+          return syncId === sync.id ? sync : null
+        },
+      },
+      connectorSources,
+    },
+  }
+}
+
+function source(connectionId: string, accountId: string, slot: string): SyncConnectorSource {
+  return {
+    connection: {
+      id: connectionId,
+      connectorId: social.id,
+      owner: { type: "project" },
+      slot,
+      account: { id: accountId, label: accountId },
+    },
+    async connect() {
+      return { accountId }
+    },
+  }
+}
+
+async function run(fixture: ManagedSyncFixture, syncId: string, runId: string) {
+  const sync = fixture.runtime.syncs.getById(syncId)
+  if (!sync) throw new Error(`[Test] Unknown Sync '${syncId}'.`)
+  const executionId = `exec:${runId}`
+  await fixture.executions.create({
+    id: executionId,
+    projectId: fixture.runtime.id,
+    executor: { type: "primitive", kind: "sync", runId },
+    source: { type: "schedule", eventId: `event:${runId}` },
+    correlationId: `correlation:${runId}`,
+    authorizationRef: {
+      type: "trustedPrimitive",
+      primitive: { kind: "sync", id: sync.id, runId },
+    },
+  })
+  const queued = await fixture.runtime.syncRunsStorage.queue({
+    id: runId,
+    projectId: fixture.runtime.id,
+    executionId,
+    syncId: sync.id,
+    datasetId: sync.target.dataset.id,
+    mode: sync.config.mode,
+  })
+  return runSyncJobWithDurableRun({ runtime: fixture.runtime, run: queued })
+}
+
+async function rows(storage: InMemoryLakeStorage): Promise<DatasetRow[]> {
+  const result: DatasetRow[] = []
+  for await (const row of storage.readRows({ datasetId: socialRows.id })) {
+    result.push(row)
+  }
+  return result
+}
+
+describe("managed connector Sync fan-out", () => {
+  test("reads every connection into one snapshot and clears it when none remain", async () => {
+    const seen: string[] = []
+    const sync = defineSync("sync-social-accounts")
+      .from(social)
+      .read((client, context) => {
+        seen.push(context.connection.id)
+        return {
+          id: `${context.connection.id}:row`,
+          accountId: client.accountId,
+        }
+      })
+      .intoDataset(socialRows)
+    let sources = [
+      source("connection-b", "account-b", "brand-b"),
+      source("connection-a", "account-a", "brand-a"),
+    ]
+    const fixture = createFixture(sync, () => sources)
+
+    const result = await run(fixture, sync.id, "run-managed")
+    expect(result.rowsRead).toBe(2)
+    expect(seen).toEqual(["connection-a", "connection-b"])
+    expect(await rows(fixture.lakeStorage)).toEqual([
+      { id: "connection-a:row", accountId: "account-a" },
+      { id: "connection-b:row", accountId: "account-b" },
+    ])
+
+    sources = []
+    const empty = await run(fixture, sync.id, "run-managed-empty")
+    expect(empty.rowsRead).toBe(0)
+    expect(await rows(fixture.lakeStorage)).toEqual([])
+  })
+
+  test("isolates checkpoints and resets only a replaced account", async () => {
+    const seen: {
+      connectionId: string
+      accountId: string
+      checkpoint: string | undefined
+    }[] = []
+    const nextCursor = new Map<string, string>()
+    const sync = defineSync("sync-social-checkpoints", { mode: "append" })
+      .checkpoint<{ cursor: string }>()
+      .from(social)
+      .read((client, context) => {
+        seen.push({
+          connectionId: context.connection.id,
+          accountId: client.accountId,
+          checkpoint: context.checkpoint?.cursor,
+        })
+        const cursor = nextCursor.get(context.connection.id)
+        if (!cursor) throw new Error("Missing test cursor.")
+        context.setCheckpoint({ cursor })
+        return { id: `${context.connection.id}:${cursor}` }
+      })
+      .intoDataset(socialRows)
+    let sources: readonly SyncConnectorSource[] = [
+      source("connection-a", "account-a", "brand-a"),
+      source("connection-b", "account-b", "brand-b"),
+    ]
+    const fixture = createFixture(sync, () => sources)
+
+    nextCursor.set("connection-a", "a-1")
+    nextCursor.set("connection-b", "b-1")
+    await run(fixture, sync.id, "run-checkpoints-1")
+
+    sources = [source("connection-a", "account-a", "brand-a")]
+    nextCursor.set("connection-a", "a-2")
+    await run(fixture, sync.id, "run-checkpoints-2")
+
+    sources = [
+      source("connection-a", "account-a", "brand-a"),
+      source("connection-b", "account-b", "brand-b"),
+    ]
+    nextCursor.set("connection-a", "a-3")
+    nextCursor.set("connection-b", "b-2")
+    await run(fixture, sync.id, "run-checkpoints-3")
+
+    sources = [
+      source("connection-a", "account-c", "brand-a"),
+      source("connection-b", "account-b", "brand-b"),
+    ]
+    nextCursor.set("connection-a", "c-1")
+    nextCursor.set("connection-b", "b-3")
+    await run(fixture, sync.id, "run-checkpoints-4")
+
+    expect(seen).toEqual([
+      { connectionId: "connection-a", accountId: "account-a", checkpoint: undefined },
+      { connectionId: "connection-b", accountId: "account-b", checkpoint: undefined },
+      { connectionId: "connection-a", accountId: "account-a", checkpoint: "a-1" },
+      { connectionId: "connection-a", accountId: "account-a", checkpoint: "a-2" },
+      { connectionId: "connection-b", accountId: "account-b", checkpoint: "b-1" },
+      { connectionId: "connection-a", accountId: "account-c", checkpoint: undefined },
+      { connectionId: "connection-b", accountId: "account-b", checkpoint: "b-2" },
+    ])
+  })
+
+  test("preserves the previous dataset and checkpoints when one source fails", async () => {
+    let generation = "initial"
+    let failConnectionB = false
+    const sync = defineSync("sync-social-atomic")
+      .checkpoint<{ cursor: string }>()
+      .from(social)
+      .read((client, context) => {
+        if (failConnectionB && context.connection.id === "connection-b") {
+          throw new Error("provider unavailable")
+        }
+        context.setCheckpoint({ cursor: `${client.accountId}:${generation}` })
+        return {
+          id: `${context.connection.id}:${generation}`,
+          accountId: client.accountId,
+        }
+      })
+      .intoDataset(socialRows)
+    const sources = [
+      source("connection-a", "account-a", "brand-a"),
+      source("connection-b", "account-b", "brand-b"),
+    ]
+    const fixture = createFixture(sync, () => sources)
+
+    await run(fixture, sync.id, "run-atomic-1")
+    const initialRows = await rows(fixture.lakeStorage)
+    const firstRun = await fixture.runtime.syncRunsStorage.getById({
+      projectId: fixture.runtime.id,
+      id: "run-atomic-1",
+    })
+
+    generation = "next"
+    failConnectionB = true
+    await expect(run(fixture, sync.id, "run-atomic-2")).rejects.toThrow("provider unavailable")
+
+    expect(await rows(fixture.lakeStorage)).toEqual(initialRows)
+    const failedRun = await fixture.runtime.syncRunsStorage.getById({
+      projectId: fixture.runtime.id,
+      id: "run-atomic-2",
+    })
+    expect(failedRun).toMatchObject({
+      status: "failed",
+      checkpoint: undefined,
+      error: {
+        code: "sync.execution_failed",
+        details: {
+          connectionId: "connection-b",
+          accountId: "account-b",
+        },
+      },
+    })
+    expect(firstRun?.checkpoint).toBeDefined()
+  })
+})

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -4,9 +4,6 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type {
   BlobStorage,
-  ConnectorAdapter,
-  ConnectorClient,
-  ConnectorDefinition,
   DatasetDefinition,
   DatasetRow,
   FileRef,
@@ -23,6 +20,7 @@ import {
   InMemoryLakeStorage,
   InMemoryStorage,
 } from "@sixb/core"
+import type { SyncConnectorSourceResolver } from "@sixb/core/internal/syncs"
 import type { BeginDatasetWriteInput, LakeWriteSession } from "@sixb/core/lake-storage"
 import type { ExecutionStorage, SyncRunRecord, SyncRunStorage } from "@sixb/core/storage"
 import { LocalLakeStorage } from "@sixb/lake-local"
@@ -99,6 +97,19 @@ function createRuntime(options: {
   const blobStorage = options.blobStorage ?? new InMemoryBlobStorage()
   const client = options.client ?? {}
 
+  const connectorSources: SyncConnectorSourceResolver = {
+    async list() {
+      return [
+        {
+          async connect() {
+            await options.onConnect?.()
+            return client
+          },
+        },
+      ] as never
+    },
+  }
+
   return {
     id: "project-1",
     syncRunsStorage,
@@ -114,12 +125,7 @@ function createRuntime(options: {
         return syncId === options.sync.id ? options.sync : null
       },
     },
-    async connector<TAdapter extends ConnectorAdapter>(
-      _definition: ConnectorDefinition<string, TAdapter>
-    ): Promise<ConnectorClient<TAdapter>> {
-      await options.onConnect?.()
-      return client as ConnectorClient<TAdapter>
-    },
+    connectorSources,
   }
 }
 

--- a/packages/sync-worker/tests/run-sync-job.test.ts
+++ b/packages/sync-worker/tests/run-sync-job.test.ts
@@ -7,6 +7,7 @@ import type {
   DatasetDefinition,
   DatasetRow,
   FileRef,
+  JsonValue,
   LakeStorage,
   SyncDefinition,
 } from "@sixb/core"
@@ -83,6 +84,16 @@ const keyedDocsDataset = defineDataset("raw.keyed-docs", {
   schema: rawDocsDataset.schema.columns,
   primaryKey: "id",
 })
+
+function storedErpCheckpoint(value: JsonValue): JsonValue {
+  return {
+    kind: "sync_checkpoint",
+    version: 1,
+    connectorId: erpDb.id,
+    strategy: "single",
+    value,
+  }
+}
 
 function createRuntime(options: {
   sync: SyncDefinition
@@ -484,7 +495,7 @@ describe("runSyncJob", () => {
       id: "run_1",
     })
     expect(seenCheckpoint).toEqual({ cursor: "cursor-1" })
-    expect(run?.checkpoint).toEqual({ cursor: "cursor-2" })
+    expect(run?.checkpoint).toEqual(storedErpCheckpoint({ cursor: "cursor-2" }))
   })
 
   test("streams ordered merge changes and stores the successful checkpoint", async () => {
@@ -525,7 +536,7 @@ describe("runSyncJob", () => {
       mode: "merge",
       status: "succeeded",
       rowsRead: 2,
-      checkpoint: { cursor: "event-2" },
+      checkpoint: storedErpCheckpoint({ cursor: "event-2" }),
     })
   })
 
@@ -604,7 +615,7 @@ describe("runSyncJob", () => {
     ).toMatchObject({
       status: "succeeded",
       rowsRead: 1,
-      checkpoint: { cursor: "event-1" },
+      checkpoint: storedErpCheckpoint({ cursor: "event-1" }),
       output: undefined,
     })
   })
@@ -770,7 +781,7 @@ describe("runSyncJob", () => {
     ).toMatchObject({
       status: "succeeded",
       rowsRead: 0,
-      checkpoint: { cursor: "cursor-1" },
+      checkpoint: storedErpCheckpoint({ cursor: "cursor-1" }),
     })
   })
 
@@ -904,7 +915,7 @@ describe("runSyncJob", () => {
       id: "run_succeeded",
     })
     expect(seenCheckpoints).toEqual([{ cursor: "cursor-1" }, { cursor: "cursor-1" }])
-    expect(succeededRun?.checkpoint).toEqual({ cursor: "cursor-2" })
+    expect(succeededRun?.checkpoint).toEqual(storedErpCheckpoint({ cursor: "cursor-2" }))
   })
 
   test("rejects non-JSON checkpoint values", async () => {

--- a/packages/sync-worker/tests/worker.test.ts
+++ b/packages/sync-worker/tests/worker.test.ts
@@ -34,6 +34,16 @@ const erpDb = defineConnector("erpDb", {
   },
 })
 
+function storedErpCheckpoint(cursor: string) {
+  return {
+    kind: "sync_checkpoint",
+    version: 1,
+    connectorId: erpDb.id,
+    strategy: "single",
+    value: { cursor },
+  }
+}
+
 function makeDataset(id: string) {
   return defineDataset(id, {
     schema: [col("orderId", "string"), col("customerName", "string", { nullable: true })],
@@ -504,8 +514,8 @@ describe("SyncWorker", () => {
     await Bun.sleep(50)
     await worker.stop()
 
-    expect(createdRun?.checkpoint).toEqual({ cursor: "cursor-1" })
-    expect(noOpRun?.checkpoint).toEqual({ cursor: "cursor-2" })
+    expect(createdRun?.checkpoint).toEqual(storedErpCheckpoint("cursor-1"))
+    expect(noOpRun?.checkpoint).toEqual(storedErpCheckpoint("cursor-2"))
     expect(noOpRun?.output?.versionId).toBe(createdRun?.output?.versionId)
 
     const events = await sixb.events.read({
@@ -581,7 +591,7 @@ describe("SyncWorker", () => {
     await worker.stop()
 
     expect(run?.output).toBeUndefined()
-    expect(run?.checkpoint).toEqual({ cursor: "cursor-1" })
+    expect(run?.checkpoint).toEqual(storedErpCheckpoint("cursor-1"))
     const events = await sixb.events.read({
       types: ["sync.run.started", "dataset.version.committed", "sync.run.finished"],
     })


### PR DESCRIPTION
Part of #384. Stacked on #430.

## Why

Managed connections can authorize several provider accounts, while Syncs could only resolve one
static client. This slice connects the managed OAuth lifecycle to ingestion without adding routing
configuration to Sync definitions.

## What changes

- OAuth-backed Syncs read every active connector connection by default.
- `context.connection` exposes non-secret connection, slot and account metadata.
- Static connector Syncs keep their existing behavior.
- The execution runtime resolves sources; the worker never accesses connection storage directly.

```ts
defineSync("sync-social-videos")
  .from(socialConnector)
  .read(async (social, { connection }) => {
    const videos = await social.listVideos()
    return videos.map((video) => ({
      ...video,
      sourceConnectionId: connection.id,
    }))
  })
  .intoDataset(socialVideos)
```

## Execution model

```text
one Sync run
  ├─ connection A → read + checkpoint A
  ├─ connection B → read + checkpoint B
  └─ one atomic dataset commit
```

| Choice | Reason |
| --- | --- |
| All active connections by default | Keeps authoring declarative and requires no selector DSL. |
| Sequential reads in V1 | Deterministic, provider-friendly foundation; bounded parallelism can be added later. |
| One atomic commit | A source failure cannot publish a partial dataset or advance checkpoints. |
| Checkpoint by connection + account | Replacing one account resets only its cursor; disconnected connections retain theirs. |

## Scope

- No connection filtering or parallel fan-out in this V1.
- Global Sync-run overlap fencing remains a separate Sync-wide change because it also affects
  static connectors.

## Validation

- 4,027 tests passed; 7 external integration tests skipped; 0 failed.
- Typecheck, Biome, build and publish-artifact checks passed.
