### PR TITLE
meta: add batch reads and quota-aware retries

### DIFF
--- a/connectors/meta/README.md
+++ b/connectors/meta/README.md
@@ -7,6 +7,7 @@ Business/Creator accounts — one method per node/edge, nothing more.
 - **Pages** — list Facebook Pages and their linked Instagram accounts (`/me/accounts`)
 - **Instagram** — read the user profile, list media and stories, read account- and media-level insights
 - **Facebook** — read the Page profile, list published Page posts, read Page-level insights
+- **Batch** — combine up to 50 independent Graph reads, with an optional token per sub-request
 
 The connector stays metric-agnostic and returns Graph responses faithfully: it does
 not flatten attachments, coerce timestamps, reorder insights, or bake in a metric
@@ -33,7 +34,9 @@ export const metaConnector = defineConnector(
 | `accessToken`  | **Required.** Long-lived User or System-User access token.                        |
 | `graphVersion` | Graph API version segment. Defaults to `v23.0`.                                   |
 | `baseUrl`      | Full base URL override (takes precedence over `graphVersion`). Mainly for tests.  |
-| `maxRetries`   | Retries on 429/5xx responses. Defaults to `2`.                                    |
+| `retry`        | Retry policy for transient HTTP and Meta throttling errors. Defaults to 2 retries. |
+| `maxRetries`   | Deprecated shorthand for `retry.maxRetries`.                                      |
+| `onResponse`   | Observe response headers and parsed quota usage without wrapping returned objects. |
 | `timeoutMs`    | Per-request timeout in milliseconds.                                              |
 
 **Tokens.** The `accessToken` authorizes Page discovery (`/me/accounts`) and Instagram
@@ -60,6 +63,7 @@ The client mirrors the Graph API graph:
 | `meta.facebook(id, { accessToken }).get()`           | `GET /{page-id}`                     |
 | `meta.facebook(id, { accessToken }).posts.list()` / `.listAll()` | `GET /{page-id}/published_posts` |
 | `meta.facebook(id, { accessToken }).insights.get()`  | `GET /{page-id}/insights`            |
+| `meta.batch.get()` / `.execute()`                    | Graph API Batch endpoint              |
 
 > **Why `pages`, not `accounts`?** Meta's `/me/accounts` edge is a historical name —
 > it returns the Facebook **Pages** the token manages (`MetaFacebookPage`), each with
@@ -119,6 +123,39 @@ do {
 } while (after)
 ```
 
+Instagram's `/media` edge supports cursor pagination, not time-based pagination. Meta's
+[official Instagram API collection](https://www.postman.com/meta/instagram/documentation/6yqw8pt/instagram-api)
+documents the User Insights edge as the only Instagram edge with time-based pagination for
+Facebook Login. The connector therefore does not send undocumented `since` or `until` parameters
+to `/media`.
+
+### Batch reads
+
+The Graph Batch endpoint uses an outer `POST`, but this connector only constructs `GET`
+sub-requests. Each result is independent and keeps its status, raw body, headers, parsed body,
+quota usage, and structured Graph error when present:
+
+```ts
+type MediaEnvelope = { readonly data: readonly MetaInstagramMedia[] }
+
+const [page, media] = await meta.batch.execute([
+  meta.batch.get<MetaFacebookPageProfile>(`${pageId}?fields=id,name`, {
+    accessToken: pageAccessToken,
+  }),
+  meta.batch.get<MediaEnvelope>(`${igUserId}/media?fields=id,timestamp&limit=100`),
+] as const)
+
+if (media.ok) {
+  // media.body.data is typed; media.rawBody preserves Meta's original response body.
+} else {
+  // media.error is the structured Graph error for this sub-request only.
+}
+```
+
+Absolute URLs, empty batches, and batches above Meta's 50-request limit are rejected locally.
+Batching reduces network round trips, but every sub-request still counts separately toward Meta's
+usage limits. Throttled sub-requests are retried without replaying successful siblings.
+
 ## Insights & metric deprecations
 
 The connector is **metric-agnostic**: it passes `metrics`, `period`, `metricType`,
@@ -136,12 +173,38 @@ Meta's valid metric set changes frequently. Notable recent changes:
 
 Validate metric names against the live Graph API for your `graphVersion`.
 
+## Throttling and usage
+
+In addition to network failures, HTTP `429`, and `5xx`, the default policy retries Graph throttling
+codes `4`, `17`, `32`, and `613`, including when Meta returns them with HTTP `400`. Retries remain
+bounded by `retry.maxRetries`; customize `shouldRetry` or `delayMs` when a project needs a different
+backoff policy.
+
+`MetaApiError` exposes the parsed Graph error and body, `rawBody`, response headers, and parsed usage.
+Successful responses can be observed through `onResponse`, including `X-App-Usage` and
+`X-Business-Use-Case-Usage`:
+
+```ts
+meta({
+  accessToken,
+  onResponse({ path, usage }) {
+    console.log(path, usage.app, usage.businessUseCase)
+  },
+})
+```
+
+The connector reports quota signals but does not choose account pacing, persistence, or circuit
+breaker policy for the project.
+
 ## Notes
 
-- **Read-only.** This connector issues `GET` requests only.
+- **Read-only.** Every Graph operation is a read. Batch execution uses Meta's required outer
+  `POST`, but the connector only accepts `GET` sub-requests.
 - **Faithful responses.** Attachments are returned as a full array, timestamps as raw
   API strings, and insights in API order. Flatten or normalize in your project layer.
 - **No account orchestration.** Deduping Pages/accounts and filtering to a specific
   Page or Instagram account is project policy — build it on top of `pages.listAll()`.
+- **No media time window.** Meta does not officially support time-based pagination on the
+  Instagram `/media` edge; filter cursor-paginated results in the project layer.
 - **Webhooks** are out of scope (this is a sync/read use case). They can be added later
   via `defineWebhook` from `@sixb/core`.

--- a/connectors/meta/src/client.ts
+++ b/connectors/meta/src/client.ts
@@ -1,13 +1,13 @@
-import type { RestClient } from "@sixb/connector-rest"
 import type { MetaHttpContext } from "./http"
+import { createBatchApi } from "./resources/batch"
 import { createFacebookPageApi } from "./resources/facebook"
 import { createInstagramMediaApi, createInstagramUserApi } from "./resources/instagram"
 import { createPagesApi } from "./resources/pages"
 import type { MetaClient } from "./types/client"
 
-export function createMetaClient(http: RestClient): MetaClient {
-  const context: MetaHttpContext = { http }
+export function createMetaClient(context: MetaHttpContext): MetaClient {
   return {
+    batch: createBatchApi(context),
     pages: createPagesApi(context),
     instagram: (igUserId) => createInstagramUserApi(context, igUserId),
     instagramMedia: (mediaId) => createInstagramMediaApi(context, mediaId),

--- a/connectors/meta/src/http.ts
+++ b/connectors/meta/src/http.ts
@@ -1,18 +1,182 @@
-import type { RestClient } from "@sixb/connector-rest"
-import type { InsightsQuery, MetaInsight, MetaPage } from "./types/common"
+import {
+  parseRetryAfter,
+  type RestClient,
+  type RestRequestInit,
+  type RestRequestOptions,
+  readResponseBody,
+} from "@sixb/connector-rest"
+import type {
+  InsightsQuery,
+  MetaAppUsage,
+  MetaBusinessUseCaseUsage,
+  MetaBusinessUseCaseUsageEntry,
+  MetaGraphError,
+  MetaHeader,
+  MetaInsight,
+  MetaPage,
+  MetaResponseMetadata,
+  MetaRetryContext,
+  MetaRetryPolicy,
+  MetaUsage,
+} from "./types/common"
+
+const THROTTLING_ERROR_CODES = new Set([4, 17, 32, 613])
 
 export interface MetaHttpContext {
   readonly http: RestClient
+  readonly retry: MetaRetryController
+  readonly observe: MetaResponseObserver
+  readonly signal: AbortSignal
 }
 
 /** Raised when the Graph API returns a non-2xx response. The raw error body is preserved. */
 export class MetaApiError extends Error {
+  readonly name = "MetaApiError"
+  readonly headers: readonly MetaHeader[]
+  readonly usage: MetaUsage
+  readonly graphError?: MetaGraphError
+  readonly rawBody: string
+
   constructor(
     readonly status: number,
-    readonly body: string
+    readonly body: unknown,
+    headers: HeadersInit = {},
+    rawBody?: string
   ) {
-    super(`[SixbMeta] Graph API request failed with ${status}: ${body || "(empty body)"}`)
-    this.name = "MetaApiError"
+    const graphError = parseMetaGraphError(body)
+    super(formatMetaApiError(status, body, graphError))
+    const responseHeaders = new Headers(headers)
+    this.headers = toMetaHeaders(responseHeaders)
+    this.usage = parseMetaUsage(responseHeaders)
+    this.graphError = graphError
+    this.rawBody = rawBody ?? serializeBody(body)
+  }
+}
+
+export interface MetaRetryController {
+  readonly maxRetries: number
+  shouldRetry(context: MetaRetryContext): Promise<boolean>
+  delayMs(context: MetaRetryContext): Promise<number>
+}
+
+export interface MetaResponseObserver {
+  observeHttp(response: Response, path: string, method: "GET" | "POST"): Promise<void>
+  observeBatch(
+    path: string,
+    status: number,
+    headers: readonly MetaHeader[],
+    batchIndex: number
+  ): Promise<void>
+}
+
+export function createMetaRetryController(
+  policy: MetaRetryPolicy | undefined,
+  legacyMaxRetries: number | undefined
+): MetaRetryController {
+  const maxRetries = policy?.maxRetries ?? legacyMaxRetries ?? 2
+  if (!Number.isInteger(maxRetries) || maxRetries < 0) {
+    throw new Error("[SixbMeta] retry.maxRetries must be a non-negative integer.")
+  }
+
+  return {
+    maxRetries,
+    async shouldRetry(context) {
+      if (policy?.shouldRetry) return policy.shouldRetry(context)
+      if (isAbortError(context.error)) return false
+      if (context.error) return true
+      if (context.graphError?.code && THROTTLING_ERROR_CODES.has(context.graphError.code)) {
+        return true
+      }
+      const status = context.response?.status
+      return status === 429 || (status !== undefined && status >= 500)
+    },
+    async delayMs(context) {
+      if (policy?.delayMs) return policy.delayMs(context)
+      return (
+        parseRetryAfter(context.response?.headers.get("retry-after") ?? null) ??
+        Math.min(1000 * 2 ** context.attempt, 30_000)
+      )
+    },
+  }
+}
+
+export async function createMetaRetryContext(
+  response: Response | null,
+  error: unknown,
+  attempt: number,
+  request: {
+    readonly path: string
+    readonly method: "GET" | "POST"
+    readonly batchIndex?: number
+  }
+): Promise<MetaRetryContext> {
+  const body = response && !response.ok ? await readResponseBody(response.clone()) : undefined
+  return {
+    attempt,
+    path: request.path,
+    method: request.method,
+    response,
+    error,
+    graphError: parseMetaGraphError(body),
+    usage: response ? parseMetaUsage(response.headers) : {},
+    batchIndex: request.batchIndex,
+  }
+}
+
+export function createMetaResponseObserver(
+  handler: ((metadata: MetaResponseMetadata) => Promise<void> | void) | undefined
+): MetaResponseObserver {
+  const observed = new WeakSet<Response>()
+
+  return {
+    async observeHttp(response, path, method) {
+      if (!handler || observed.has(response)) return
+      observed.add(response)
+      const headers = toMetaHeaders(response.headers)
+      await handler({
+        path,
+        method,
+        status: response.status,
+        headers,
+        usage: parseMetaUsage(response.headers),
+      })
+    },
+    async observeBatch(path, status, headers, batchIndex) {
+      if (!handler) return
+      await handler({
+        path,
+        method: "GET",
+        status,
+        headers,
+        usage: parseMetaUsage(headers),
+        batchIndex,
+      })
+    },
+  }
+}
+
+export function observeMetaResponses(http: RestClient, observer: MetaResponseObserver): RestClient {
+  async function observed(
+    response: Promise<Response>,
+    path: string,
+    method: "GET" | "POST"
+  ): Promise<Response> {
+    const resolved = await response
+    await observer.observeHttp(resolved, path, method)
+    return resolved
+  }
+
+  return {
+    request(path: string, init?: RestRequestInit, options?: RestRequestOptions) {
+      const method = init?.method?.toUpperCase() === "POST" ? "POST" : "GET"
+      return observed(http.request(path, init, options), path, method)
+    },
+    get(path: string, init?: RestRequestInit, options?: RestRequestOptions) {
+      return observed(http.get(path, init, options), path, "GET")
+    },
+    post(path: string, body?: unknown, init?: RestRequestInit, options?: RestRequestOptions) {
+      return observed(http.post(path, body, init, options), path, "POST")
+    },
   }
 }
 
@@ -27,10 +191,12 @@ interface MetaListResponse<T> {
 }
 
 export async function readJson<T>(response: Response): Promise<T> {
+  const rawBody = response.status === 204 ? "" : await response.text()
+  const body = parseMetaBody(rawBody)
   if (!response.ok) {
-    throw new MetaApiError(response.status, await response.text().catch(() => ""))
+    throw new MetaApiError(response.status, body, response.headers, rawBody)
   }
-  return (await response.json()) as T
+  return body as T
 }
 
 /** Read a Graph list envelope into a `MetaPage`, mapping each raw item to a domain type. */
@@ -126,6 +292,143 @@ export function assertNonEmpty(value: string, field: string): void {
 export function nodePath(value: string, field: string): string {
   assertNonEmpty(value, field)
   return encodeURIComponent(value)
+}
+
+export function parseMetaBody(body: string): unknown {
+  if (!body) return undefined
+  try {
+    return JSON.parse(body)
+  } catch {
+    return body
+  }
+}
+
+export function parseMetaGraphError(body: unknown): MetaGraphError | undefined {
+  if (!isRecord(body) || !isRecord(body.error)) {
+    return undefined
+  }
+
+  const error = body.error
+  const message = error.message
+  if (typeof message !== "string") return undefined
+  return {
+    message,
+    type: optionalString(error.type),
+    code: optionalNumber(error.code),
+    error_subcode: optionalNumber(error.error_subcode),
+    is_transient: optionalBoolean(error.is_transient),
+    error_user_title: optionalString(error.error_user_title),
+    error_user_msg: optionalString(error.error_user_msg),
+    error_data: error.error_data,
+    fbtrace_id: optionalString(error.fbtrace_id),
+  }
+}
+
+export function toMetaHeaders(headers: Headers): readonly MetaHeader[] {
+  const result: MetaHeader[] = []
+  for (const [name, value] of headers) {
+    result.push({ name, value })
+  }
+  return result
+}
+
+export function parseMetaUsage(input: Headers | readonly MetaHeader[]): MetaUsage {
+  const headers =
+    input instanceof Headers
+      ? input
+      : new Headers(input.map(({ name, value }): [string, string] => [name, value]))
+  const app = parseAppUsage(headers.get("x-app-usage"))
+  const businessUseCase = parseBusinessUseCaseUsage(headers.get("x-business-use-case-usage"))
+  return {
+    app,
+    businessUseCase,
+  }
+}
+
+function parseAppUsage(value: string | null): MetaAppUsage | undefined {
+  const parsed = parseHeaderJson(value)
+  if (!isRecord(parsed)) return undefined
+  return {
+    call_count: optionalNumber(parsed.call_count),
+    total_cputime: optionalNumber(parsed.total_cputime),
+    total_time: optionalNumber(parsed.total_time),
+  }
+}
+
+function parseBusinessUseCaseUsage(value: string | null): MetaBusinessUseCaseUsage | undefined {
+  const parsed = parseHeaderJson(value)
+  if (!isRecord(parsed)) return undefined
+
+  const result: Record<string, readonly MetaBusinessUseCaseUsageEntry[]> = {}
+  for (const [businessId, rawEntries] of Object.entries(parsed)) {
+    if (!Array.isArray(rawEntries)) continue
+    result[businessId] = rawEntries.filter(isRecord).map((entry) => ({
+      type: optionalString(entry.type),
+      call_count: optionalNumber(entry.call_count),
+      total_cputime: optionalNumber(entry.total_cputime),
+      total_time: optionalNumber(entry.total_time),
+      estimated_time_to_regain_access: optionalNumber(entry.estimated_time_to_regain_access),
+    }))
+  }
+  return result
+}
+
+function parseHeaderJson(value: string | null): unknown {
+  if (!value) return undefined
+  try {
+    return JSON.parse(value)
+  } catch {
+    return undefined
+  }
+}
+
+function formatMetaApiError(
+  status: number,
+  body: unknown,
+  graphError: MetaGraphError | undefined
+): string {
+  const detail = graphError?.message ?? formatBody(body)
+  return `[SixbMeta] Graph API request failed with ${status}: ${detail}`
+}
+
+function formatBody(body: unknown): string {
+  if (typeof body === "string") return body || "(empty body)"
+  if (body === undefined) return "(empty body)"
+  try {
+    return JSON.stringify(body)
+  } catch {
+    return String(body)
+  }
+}
+
+function serializeBody(body: unknown): string {
+  if (body === undefined) return ""
+  if (typeof body === "string") return body
+  try {
+    return JSON.stringify(body)
+  } catch {
+    return String(body)
+  }
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError"
 }
 
 interface RawInsight {

--- a/connectors/meta/src/meta.ts
+++ b/connectors/meta/src/meta.ts
@@ -1,8 +1,15 @@
 import { rest } from "@sixb/connector-rest"
 import type { ConnectorAdapter } from "@sixb/core"
 import { createMetaClient } from "./client"
-import { assertNonEmpty } from "./http"
+import {
+  assertNonEmpty,
+  createMetaResponseObserver,
+  createMetaRetryContext,
+  createMetaRetryController,
+  observeMetaResponses,
+} from "./http"
 import type { MetaClient } from "./types/client"
+import type { MetaRetryContext } from "./types/common"
 import type { MetaConnectorOptions } from "./types/options"
 
 const GRAPH_API_HOST = "https://graph.facebook.com"
@@ -31,6 +38,24 @@ export function meta(options: MetaConnectorOptions): MetaConnector {
 
   const version = options.graphVersion ?? DEFAULT_GRAPH_VERSION
   const baseUrl = options.baseUrl ?? `${GRAPH_API_HOST}/${version}/`
+  const retry = createMetaRetryController(options.retry, options.maxRetries)
+  const observe = createMetaResponseObserver(options.onResponse)
+  const retryContexts = new WeakMap<Response, Promise<MetaRetryContext>>()
+
+  function resolveRetryContext(
+    response: Response | null,
+    error: unknown,
+    attempt: number,
+    path: string,
+    method: "GET" | "POST"
+  ): Promise<MetaRetryContext> {
+    if (!response) return createMetaRetryContext(response, error, attempt, { path, method })
+    const existing = retryContexts.get(response)
+    if (existing) return existing
+    const created = createMetaRetryContext(response, error, attempt, { path, method })
+    retryContexts.set(response, created)
+    return created
+  }
 
   const http = rest({
     baseUrl,
@@ -38,14 +63,49 @@ export function meta(options: MetaConnectorOptions): MetaConnector {
       Accept: "application/json",
       Authorization: `Bearer ${options.accessToken}`,
     },
-    retry: { maxRetries: options.maxRetries ?? 2 },
+    retry: {
+      maxRetries: retry.maxRetries,
+      async shouldRetry(context) {
+        const method = context.method === "POST" ? "POST" : "GET"
+        if (context.response) {
+          await observe.observeHttp(context.response, context.path, method)
+        }
+        return retry.shouldRetry(
+          await resolveRetryContext(
+            context.response,
+            context.error,
+            context.attempt,
+            context.path,
+            method
+          )
+        )
+      },
+      async delayMs(context) {
+        const method = context.method === "POST" ? "POST" : "GET"
+        return retry.delayMs(
+          await resolveRetryContext(
+            context.response,
+            context.error,
+            context.attempt,
+            context.path,
+            method
+          )
+        )
+      },
+    },
     timeoutMs: options.timeoutMs,
   })
 
   return {
     type: "meta",
     async connect(context) {
-      return createMetaClient(await http.connect(context))
+      const connectedHttp = observeMetaResponses(await http.connect(context), observe)
+      return createMetaClient({
+        http: connectedHttp,
+        retry,
+        observe,
+        signal: context.signal,
+      })
     },
   }
 }

--- a/connectors/meta/src/resources/batch.ts
+++ b/connectors/meta/src/resources/batch.ts
@@ -1,0 +1,228 @@
+import {
+  assertNonEmpty,
+  createMetaRetryContext,
+  type MetaHttpContext,
+  parseMetaBody,
+  parseMetaGraphError,
+  parseMetaUsage,
+  readJson,
+} from "../http"
+import type {
+  MetaBatchApi,
+  MetaBatchGetRequest,
+  MetaBatchResult,
+  MetaBatchResults,
+} from "../types/batch"
+import type { MetaHeader, MetaRetryContext } from "../types/common"
+
+const MAX_BATCH_SIZE = 50
+
+export function createBatchApi(context: MetaHttpContext): MetaBatchApi {
+  return {
+    get<TBody = unknown>(
+      relativeUrl: string,
+      options?: { readonly accessToken?: string }
+    ): MetaBatchGetRequest<TBody> {
+      assertNonEmpty(relativeUrl, "batch relativeUrl")
+      if (options?.accessToken !== undefined) {
+        assertNonEmpty(options.accessToken, "batch accessToken")
+      }
+      return { relativeUrl, accessToken: options?.accessToken }
+    },
+    execute: <const TRequests extends readonly MetaBatchGetRequest[]>(requests: TRequests) =>
+      executeBatch(context, requests),
+  }
+}
+
+async function executeBatch<const TRequests extends readonly MetaBatchGetRequest[]>(
+  context: MetaHttpContext,
+  requests: TRequests
+): Promise<MetaBatchResults<TRequests>> {
+  assertBatchSize(requests.length)
+  const prepared = requests.map((request, index) => ({
+    index,
+    request,
+    relativeUrl: prepareRelativeUrl(request),
+  }))
+  const results: MetaBatchResult[] = new Array(requests.length)
+  let pending = prepared
+  let attempt = 0
+
+  while (pending.length > 0) {
+    const rawResults = await sendBatch(
+      context,
+      pending.map(({ relativeUrl }) => relativeUrl)
+    )
+    if (rawResults.length !== pending.length) {
+      throw new Error(
+        `[SixbMeta] Graph batch returned ${rawResults.length} responses for ${pending.length} requests.`
+      )
+    }
+
+    const retryable: Array<{
+      readonly item: (typeof pending)[number]
+      readonly retryContext: MetaRetryContext
+    }> = []
+
+    for (const [pendingIndex, item] of pending.entries()) {
+      const raw = rawResults[pendingIndex]
+      if (!raw) {
+        throw new Error(`[SixbMeta] Graph batch response ${pendingIndex} is missing.`)
+      }
+      const result = readBatchResult(raw)
+      await context.observe.observeBatch(
+        item.request.relativeUrl,
+        result.status,
+        result.headers,
+        item.index
+      )
+
+      if (!result.ok && attempt < context.retry.maxRetries) {
+        const retryContext = await createMetaRetryContext(
+          batchResultResponse(result),
+          null,
+          attempt,
+          {
+            path: item.request.relativeUrl,
+            method: "GET",
+            batchIndex: item.index,
+          }
+        )
+        if (await context.retry.shouldRetry(retryContext)) {
+          retryable.push({ item, retryContext })
+          continue
+        }
+      }
+
+      results[item.index] = result
+    }
+
+    if (retryable.length === 0) break
+
+    const delays = await Promise.all(
+      retryable.map(({ retryContext }) => context.retry.delayMs(retryContext))
+    )
+    await sleep(Math.max(0, ...delays), context.signal)
+    pending = retryable.map(({ item }) => item)
+    attempt += 1
+  }
+
+  return results as MetaBatchResults<TRequests>
+}
+
+async function sendBatch(
+  context: MetaHttpContext,
+  relativeUrls: readonly string[]
+): Promise<readonly RawBatchResult[]> {
+  const batch = relativeUrls.map((relativeUrl) => ({
+    method: "GET",
+    relative_url: relativeUrl,
+  }))
+  const body = new URLSearchParams({ batch: JSON.stringify(batch) })
+  const response = await context.http.post("", body, undefined, { idempotent: true })
+  const parsed = await readJson<unknown>(response)
+  if (!Array.isArray(parsed)) {
+    throw new Error("[SixbMeta] Graph batch response must be an array.")
+  }
+  return parsed as readonly RawBatchResult[]
+}
+
+function readBatchResult(raw: RawBatchResult): MetaBatchResult {
+  if (!Number.isInteger(raw.code) || raw.code < 100 || raw.code > 599) {
+    throw new Error("[SixbMeta] Graph batch response is missing a valid status code.")
+  }
+  const status = raw.code
+  const rawBody = typeof raw.body === "string" ? raw.body : ""
+  const body = parseMetaBody(rawBody)
+  const headers = readBatchHeaders(raw.headers)
+  const usage = parseMetaUsage(headers)
+
+  return status >= 200 && status < 300
+    ? { ok: true, status, body, rawBody, headers, usage }
+    : {
+        ok: false,
+        status,
+        body,
+        rawBody,
+        headers,
+        usage,
+        error: parseMetaGraphError(body),
+      }
+}
+
+function readBatchHeaders(value: unknown): readonly MetaHeader[] {
+  if (!Array.isArray(value)) return []
+  const headers: MetaHeader[] = []
+  for (const entry of value) {
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      "name" in entry &&
+      "value" in entry &&
+      typeof entry.name === "string" &&
+      typeof entry.value === "string"
+    ) {
+      headers.push({ name: entry.name, value: entry.value })
+    }
+  }
+  return headers
+}
+
+function batchResultResponse(result: MetaBatchResult): Response {
+  const headers = new Headers()
+  for (const { name, value } of result.headers) {
+    headers.append(name, value)
+  }
+  return new Response(result.rawBody || null, { status: result.status, headers })
+}
+
+function prepareRelativeUrl(request: MetaBatchGetRequest): string {
+  const relativeUrl = request.relativeUrl.trim()
+  if (/^[a-z][a-z\d+.-]*:/i.test(relativeUrl) || relativeUrl.startsWith("//")) {
+    throw new Error("[SixbMeta] batch relativeUrl must not be absolute.")
+  }
+  if (relativeUrl.includes("#")) {
+    throw new Error("[SixbMeta] batch relativeUrl must not contain a fragment.")
+  }
+
+  const normalized = relativeUrl.replace(/^\/+/, "")
+  if (!request.accessToken) return normalized
+
+  const url = new URL(normalized, "https://graph.facebook.com/")
+  url.searchParams.set("access_token", request.accessToken)
+  return `${url.pathname.slice(1)}${url.search}`
+}
+
+function assertBatchSize(size: number): void {
+  if (size < 1 || size > MAX_BATCH_SIZE) {
+    throw new Error(`[SixbMeta] Graph batch must contain between 1 and ${MAX_BATCH_SIZE} requests.`)
+  }
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(abortReason(signal))
+  if (ms <= 0) return Promise.resolve()
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      signal.removeEventListener("abort", onAbort)
+      reject(abortReason(signal))
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("The operation was aborted.", "AbortError")
+}
+
+interface RawBatchResult {
+  readonly code: number
+  readonly headers?: unknown
+  readonly body?: string
+}

--- a/connectors/meta/src/types/batch.ts
+++ b/connectors/meta/src/types/batch.ts
@@ -1,0 +1,50 @@
+import type { MetaGraphError, MetaHeader, MetaUsage } from "./common"
+
+declare const metaBatchBody: unique symbol
+
+/** A read-only Graph API sub-request prepared for batch execution. */
+export interface MetaBatchGetRequest<TBody = unknown> {
+  readonly relativeUrl: string
+  readonly accessToken?: string
+  readonly [metaBatchBody]?: TBody
+}
+
+export interface MetaBatchSuccess<TBody> {
+  readonly ok: true
+  readonly status: number
+  readonly body: TBody
+  readonly rawBody: string
+  readonly headers: readonly MetaHeader[]
+  readonly usage: MetaUsage
+}
+
+export interface MetaBatchFailure {
+  readonly ok: false
+  readonly status: number
+  readonly body: unknown
+  readonly rawBody: string
+  readonly headers: readonly MetaHeader[]
+  readonly usage: MetaUsage
+  readonly error?: MetaGraphError
+}
+
+export type MetaBatchResult<TBody = unknown> = MetaBatchSuccess<TBody> | MetaBatchFailure
+
+export type MetaBatchResults<TRequests extends readonly MetaBatchGetRequest[]> = {
+  readonly [Index in keyof TRequests]: TRequests[Index] extends MetaBatchGetRequest<infer TBody>
+    ? MetaBatchResult<TBody>
+    : never
+}
+
+export interface MetaBatchApi {
+  /** Prepare a `GET` sub-request. Absolute URLs are rejected during execution. */
+  get<TBody = unknown>(
+    relativeUrl: string,
+    options?: { readonly accessToken?: string }
+  ): MetaBatchGetRequest<TBody>
+
+  /** Execute between 1 and 50 independent Graph reads and preserve their input order. */
+  execute<const TRequests extends readonly MetaBatchGetRequest[]>(
+    requests: TRequests
+  ): Promise<MetaBatchResults<TRequests>>
+}

--- a/connectors/meta/src/types/client.ts
+++ b/connectors/meta/src/types/client.ts
@@ -1,8 +1,12 @@
+import type { MetaBatchApi } from "./batch"
 import type { FacebookPageApi } from "./facebook"
 import type { InstagramMediaApi, InstagramUserApi } from "./instagram"
 import type { PagesApi } from "./pages"
 
 export interface MetaClient {
+  /** Read-only Graph API batch requests. */
+  readonly batch: MetaBatchApi
+
   /** `GET /me/accounts` — Facebook Pages and their linked Instagram accounts. */
   readonly pages: PagesApi
 

--- a/connectors/meta/src/types/common.ts
+++ b/connectors/meta/src/types/common.ts
@@ -15,6 +15,79 @@ export interface MetaPaginationOptions {
   readonly after?: string
 }
 
+/** A response header returned by Graph API, preserving Meta's batch representation. */
+export interface MetaHeader {
+  readonly name: string
+  readonly value: string
+}
+
+/** The structured `error` object returned by Graph API. */
+export interface MetaGraphError {
+  readonly message: string
+  readonly type?: string
+  readonly code?: number
+  readonly error_subcode?: number
+  readonly is_transient?: boolean
+  readonly error_user_title?: string
+  readonly error_user_msg?: string
+  readonly error_data?: unknown
+  readonly fbtrace_id?: string
+}
+
+/** Percentage-based application usage from `X-App-Usage`. */
+export interface MetaAppUsage {
+  readonly call_count?: number
+  readonly total_cputime?: number
+  readonly total_time?: number
+}
+
+/** One business-use-case usage entry from `X-Business-Use-Case-Usage`. */
+export interface MetaBusinessUseCaseUsageEntry extends MetaAppUsage {
+  readonly type?: string
+  /** Meta reports this duration in minutes. */
+  readonly estimated_time_to_regain_access?: number
+}
+
+/** Business object id to its reported business-use-case usage entries. */
+export type MetaBusinessUseCaseUsage = Readonly<
+  Record<string, readonly MetaBusinessUseCaseUsageEntry[]>
+>
+
+/** Parsed quota metadata. Missing or malformed headers are omitted. */
+export interface MetaUsage {
+  readonly app?: MetaAppUsage
+  readonly businessUseCase?: MetaBusinessUseCaseUsage
+}
+
+/** Metadata emitted for a Graph API response without changing resource return values. */
+export interface MetaResponseMetadata {
+  readonly path: string
+  readonly method: "GET" | "POST"
+  readonly status: number
+  readonly headers: readonly MetaHeader[]
+  readonly usage: MetaUsage
+  /** Present when the response belongs to a sub-request inside a Graph batch. */
+  readonly batchIndex?: number
+}
+
+/** Context supplied to a connector-level retry policy. */
+export interface MetaRetryContext {
+  readonly attempt: number
+  readonly path: string
+  readonly method: "GET" | "POST"
+  readonly response: Response | null
+  readonly error: unknown
+  readonly graphError?: MetaGraphError
+  readonly usage: MetaUsage
+  readonly batchIndex?: number
+}
+
+export interface MetaRetryPolicy {
+  readonly maxRetries?: number
+  shouldRetry?(context: MetaRetryContext): boolean | Promise<boolean>
+  delayMs?(context: MetaRetryContext): number | Promise<number>
+}
+
 /**
  * A measured Graph API metric, returned by an `/insights` edge.
  *

--- a/connectors/meta/src/types/index.ts
+++ b/connectors/meta/src/types/index.ts
@@ -1,10 +1,27 @@
+export type {
+  MetaBatchApi,
+  MetaBatchFailure,
+  MetaBatchGetRequest,
+  MetaBatchResult,
+  MetaBatchResults,
+  MetaBatchSuccess,
+} from "./batch"
 export type { MetaClient } from "./client"
 export type {
   InsightsQuery,
+  MetaAppUsage,
+  MetaBusinessUseCaseUsage,
+  MetaBusinessUseCaseUsageEntry,
+  MetaGraphError,
+  MetaHeader,
   MetaInsight,
   MetaInsightValue,
   MetaPage,
   MetaPaginationOptions,
+  MetaResponseMetadata,
+  MetaRetryContext,
+  MetaRetryPolicy,
+  MetaUsage,
 } from "./common"
 export type {
   FacebookPageApi,

--- a/connectors/meta/src/types/options.ts
+++ b/connectors/meta/src/types/options.ts
@@ -1,3 +1,5 @@
+import type { MetaResponseMetadata, MetaRetryPolicy } from "./common"
+
 export interface MetaConnectorOptions {
   /** Long-lived User or System-User access token. Required. */
   readonly accessToken: string
@@ -5,8 +7,12 @@ export interface MetaConnectorOptions {
   readonly graphVersion?: string
   /** Full base URL override (takes precedence over `graphVersion`). Mainly for tests. */
   readonly baseUrl?: string
-  /** Max retries on 429/5xx responses. Defaults to 2. */
+  /** @deprecated Prefer `retry.maxRetries`. */
   readonly maxRetries?: number
+  /** Retry policy for transient HTTP failures and Meta throttling errors. */
+  readonly retry?: MetaRetryPolicy
+  /** Observe response headers and parsed quota usage without wrapping resource return values. */
+  readonly onResponse?: (metadata: MetaResponseMetadata) => Promise<void> | void
   /** Per-request timeout in milliseconds. */
   readonly timeoutMs?: number
 }

--- a/connectors/meta/tests/batch.test.ts
+++ b/connectors/meta/tests/batch.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import type { MetaResponseMetadata } from "../src"
+import { meta } from "../src"
+
+const CONTEXT = {
+  projectId: "demo",
+  connectorId: "meta",
+  signal: new AbortController().signal,
+}
+
+function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as unknown as typeof fetch
+}
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
+  })
+}
+
+function readBatchBody(init: RequestInit | undefined): readonly {
+  readonly method: string
+  readonly relative_url: string
+}[] {
+  const form = new URLSearchParams(String(init?.body))
+  return JSON.parse(form.get("batch") ?? "[]")
+}
+
+describe("meta connector — batch", () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test("executes GET-only reads with per-request tokens and independent results", async () => {
+    let method = ""
+    let authorization = ""
+    let submitted: ReturnType<typeof readBatchBody> = []
+    const observed: MetaResponseMetadata[] = []
+    mockFetch((_input, init) => {
+      method = init?.method ?? ""
+      authorization = new Headers(init?.headers).get("authorization") ?? ""
+      submitted = readBatchBody(init)
+      return Promise.resolve(
+        json(
+          [
+            {
+              code: 200,
+              headers: [
+                {
+                  name: "X-Business-Use-Case-Usage",
+                  value: JSON.stringify({
+                    "page-1": [{ type: "pages", call_count: 12, total_time: 3 }],
+                  }),
+                },
+              ],
+              body: JSON.stringify({ id: "page-1" }),
+            },
+            {
+              code: 400,
+              body: JSON.stringify({
+                error: { message: "Invalid token", type: "OAuthException", code: 190 },
+              }),
+            },
+          ],
+          {
+            headers: {
+              "X-App-Usage": JSON.stringify({ call_count: 7, total_cputime: 2, total_time: 4 }),
+            },
+          }
+        )
+      )
+    })
+
+    const client = await meta({
+      accessToken: "user-token",
+      onResponse(metadata) {
+        observed.push(metadata)
+      },
+    }).connect(CONTEXT)
+    const [page, failure] = await client.batch.execute([
+      client.batch.get<{ readonly id: string }>("page-1?fields=id", {
+        accessToken: "page-token",
+      }),
+      client.batch.get("ig-1?fields=id"),
+    ] as const)
+
+    expect(method).toBe("POST")
+    expect(authorization).toBe("Bearer user-token")
+    expect(submitted).toEqual([
+      { method: "GET", relative_url: "page-1?fields=id&access_token=page-token" },
+      { method: "GET", relative_url: "ig-1?fields=id" },
+    ])
+    expect(page.ok).toBe(true)
+    if (page.ok) expect(page.body.id).toBe("page-1")
+    expect(failure.ok).toBe(false)
+    if (!failure.ok) expect(failure.error?.code).toBe(190)
+    expect(observed.find((entry) => entry.batchIndex === undefined)?.usage.app?.call_count).toBe(7)
+    expect(
+      observed.find((entry) => entry.batchIndex === 0)?.usage.businessUseCase?.["page-1"]?.[0]?.type
+    ).toBe("pages")
+  })
+
+  test("retries only throttled sub-requests and preserves input order", async () => {
+    const submitted: ReturnType<typeof readBatchBody>[] = []
+    mockFetch((_input, init) => {
+      submitted.push(readBatchBody(init))
+      return Promise.resolve(
+        submitted.length === 1
+          ? json([
+              { code: 200, body: JSON.stringify({ id: "first" }) },
+              {
+                code: 400,
+                headers: [{ name: "Retry-After", value: "0" }],
+                body: JSON.stringify({ error: { message: "Rate limited", code: 4 } }),
+              },
+            ])
+          : json([{ code: 200, body: JSON.stringify({ id: "second" }) }])
+      )
+    })
+
+    const client = await meta({
+      accessToken: "token",
+      retry: { maxRetries: 1, delayMs: () => 0 },
+    }).connect(CONTEXT)
+    const results = await client.batch.execute([
+      client.batch.get<{ readonly id: string }>("first?fields=id"),
+      client.batch.get<{ readonly id: string }>("second?fields=id"),
+    ] as const)
+
+    expect(submitted).toHaveLength(2)
+    expect(submitted[1]).toEqual([{ method: "GET", relative_url: "second?fields=id" }])
+    expect(results.map((result) => (result.ok ? result.body.id : "error"))).toEqual([
+      "first",
+      "second",
+    ])
+  })
+
+  test("marks the outer POST as replayable because every sub-request is a GET", async () => {
+    let attempts = 0
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(
+        attempts === 1
+          ? json({ error: { message: "Unavailable" } }, { status: 503 })
+          : json([{ code: 200, body: JSON.stringify({ id: "ok" }) }])
+      )
+    })
+
+    const client = await meta({
+      accessToken: "token",
+      retry: { maxRetries: 1, delayMs: () => 0 },
+    }).connect(CONTEXT)
+    const [result] = await client.batch.execute([client.batch.get("node?fields=id")] as const)
+
+    expect(attempts).toBe(2)
+    expect(result.ok).toBe(true)
+  })
+
+  test("rejects empty, oversized, and absolute batches before requesting", async () => {
+    let called = false
+    mockFetch(() => {
+      called = true
+      return Promise.resolve(json([]))
+    })
+    const client = await meta({ accessToken: "token" }).connect(CONTEXT)
+
+    await expect(client.batch.execute([])).rejects.toThrow("between 1 and 50")
+    await expect(
+      client.batch.execute(Array.from({ length: 51 }, (_, index) => client.batch.get(`${index}`)))
+    ).rejects.toThrow("between 1 and 50")
+    await expect(
+      client.batch.execute([client.batch.get("https://example.com/node")])
+    ).rejects.toThrow("must not be absolute")
+    expect(called).toBe(false)
+  })
+})

--- a/connectors/meta/tests/insights.test.ts
+++ b/connectors/meta/tests/insights.test.ts
@@ -126,7 +126,25 @@ describe("meta connector — insights", () => {
 
   test("throws MetaApiError on a non-2xx response", async () => {
     mockFetch(() =>
-      Promise.resolve(json({ error: { message: "Invalid metric" } }, { status: 400 }))
+      Promise.resolve(
+        json(
+          {
+            error: {
+              message: "Invalid metric",
+              type: "OAuthException",
+              code: 100,
+              error_subcode: 33,
+              fbtrace_id: "trace-1",
+            },
+          },
+          {
+            status: 400,
+            headers: {
+              "X-App-Usage": JSON.stringify({ call_count: 18, total_cputime: 2, total_time: 4 }),
+            },
+          }
+        )
+      )
     )
 
     const client = await meta({ accessToken: "t" }).connect(CONTEXT)
@@ -134,6 +152,72 @@ describe("meta connector — insights", () => {
 
     await expect(promise).rejects.toBeInstanceOf(MetaApiError)
     await expect(promise).rejects.toThrow("400")
+    const error = (await promise.catch((caught: unknown) => caught)) as MetaApiError
+    expect(error.graphError).toEqual({
+      message: "Invalid metric",
+      type: "OAuthException",
+      code: 100,
+      error_subcode: 33,
+      is_transient: undefined,
+      error_user_title: undefined,
+      error_user_msg: undefined,
+      error_data: undefined,
+      fbtrace_id: "trace-1",
+    })
+    expect(error.usage.app?.call_count).toBe(18)
+    expect(error.body).toEqual({
+      error: {
+        message: "Invalid metric",
+        type: "OAuthException",
+        code: 100,
+        error_subcode: 33,
+        fbtrace_id: "trace-1",
+      },
+    })
+    expect(JSON.parse(error.rawBody)).toEqual(error.body)
+  })
+
+  test("retries Meta throttling codes returned with HTTP 400", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls += 1
+      return Promise.resolve(
+        calls === 1
+          ? json(
+              { error: { message: "Application request limit reached", code: 4 } },
+              { status: 400 }
+            )
+          : json({ data: [{ name: "reach" }] })
+      )
+    })
+
+    const client = await meta({
+      accessToken: "t",
+      retry: { maxRetries: 1, delayMs: () => 0 },
+    }).connect(CONTEXT)
+    const insights = await client.instagram("ig-1").insights.get({ metrics: ["reach"] })
+
+    expect(calls).toBe(2)
+    expect(insights[0]?.name).toBe("reach")
+  })
+
+  test("does not retry non-throttling Graph errors", async () => {
+    let calls = 0
+    mockFetch(() => {
+      calls += 1
+      return Promise.resolve(
+        json({ error: { message: "Invalid token", code: 190 } }, { status: 400 })
+      )
+    })
+
+    const client = await meta({
+      accessToken: "t",
+      retry: { maxRetries: 2, delayMs: () => 0 },
+    }).connect(CONTEXT)
+    const promise = client.instagram("ig-1").insights.get({ metrics: ["reach"] })
+
+    await expect(promise).rejects.toBeInstanceOf(MetaApiError)
+    expect(calls).toBe(1)
   })
 
   test("retries 429 responses honoring Retry-After", async () => {

--- a/connectors/rest/src/rest.ts
+++ b/connectors/rest/src/rest.ts
@@ -110,12 +110,19 @@ function createRestClient(options: RestConnectorOptions, context: ConnectorConte
         bodyReplayable &&
         !isAbortError(error) &&
         retryAttempt < maxRetries &&
-        shouldRetry(retryContext)
+        (await shouldRetry(retryContext))
 
       if (canRetry) {
         retryAttempt += 1
+        let retryDelayMs: number
+        try {
+          retryDelayMs = await delayMs(retryContext)
+        } catch (delayError) {
+          await cancelResponseBody(response)
+          throw delayError
+        }
         await cancelResponseBody(response)
-        await sleep(delayMs(retryContext), requestSignal)
+        await sleep(retryDelayMs, requestSignal)
         continue
       }
 

--- a/connectors/rest/src/types.ts
+++ b/connectors/rest/src/types.ts
@@ -24,8 +24,8 @@ export interface RestRetryContext extends RestRequestContext {
 
 export interface RestRetryPolicy {
   readonly maxRetries?: number
-  shouldRetry?(context: RestRetryContext): boolean
-  delayMs?(context: RestRetryContext): number
+  shouldRetry?(context: RestRetryContext): boolean | Promise<boolean>
+  delayMs?(context: RestRetryContext): number | Promise<number>
 }
 
 export interface RestConnectorOptions {

--- a/connectors/rest/tests/rest.test.ts
+++ b/connectors/rest/tests/rest.test.ts
@@ -446,6 +446,44 @@ describe("rest reliability contract", () => {
     ])
   })
 
+  test("async retry policies can inspect a cloned response body", async () => {
+    let attempts = 0
+    let delayBody: unknown
+    mockFetch(() => {
+      attempts += 1
+      return Promise.resolve(
+        attempts === 1
+          ? Response.json({ retry: true }, { status: 400 })
+          : Response.json({ ok: true })
+      )
+    })
+    const client = await rest({
+      baseUrl: "https://api.example.com",
+      retry: {
+        maxRetries: 1,
+        async shouldRetry({ response }) {
+          if (!response) return false
+          const body = (await response.clone().json()) as { retry?: boolean }
+          return body.retry === true
+        },
+        async delayMs({ response }) {
+          delayBody = await response?.clone().json()
+          return 0
+        },
+      },
+    }).connect({
+      projectId: "demo",
+      connectorId: "contract",
+      signal: new AbortController().signal,
+    })
+
+    const response = await client.get("/async-retry")
+
+    expect(attempts).toBe(2)
+    expect(delayBody).toEqual({ retry: true })
+    expect(await response.json()).toEqual({ ok: true })
+  })
+
   test("a hard retry gate wins over a custom policy", async () => {
     let attempts = 0
     let decisions = 0


### PR DESCRIPTION
## What this PR adds

- Typed Graph Batch requests, limited to 50 `GET` subrequests.
- A distinct token and independent result or error for each subrequest.
- Targeted retries for throttled items only, while preserving result order.
- Support for Graph error codes `4`, `17`, `32`, and `613`, including HTTP `400` responses.
- Structured exposure of `X-App-Usage` and `X-Business-Use-Case-Usage`.
- Async retry policies in `@sixb/connector-rest` to inspect Graph error responses.

## Why

- Reduce network round trips during multi-Page and multi-account synchronizations.
- Centralize quota handling instead of adding HTTP logic to each project.
- Keep the client generic, typed, and faithful to Meta responses.

## Design choices

| Choice | Rationale |
| --- | --- |
| Outer `POST`, `GET` subrequests only | Matches Graph Batch while keeping the API functionally read-only. |
| Retry throttled failures only | Avoids repeating successful calls and consuming unnecessary quota. |
| No `since` / `until` on Instagram `/media` | Meta does not officially document these bounds for this endpoint; the limitation is documented in the README. |
| Raw bodies and headers preserved | Keeps the connector faithful to Graph API without imposing business-specific mapping. |

## Verification

- `bun run typecheck`
- `bun run check`
- `bun run test:ci` — 4,009 passed, 7 skipped
- REST and Meta connector builds
- Publish verification — 49 packages validated
