### PR TITLE
connectors: add headless connection experience

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -595,9 +595,13 @@
       "devDependencies": {
         "@hey-api/openapi-ts": "0.90.10",
         "@tanstack/react-query": "^5.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/bun": "latest",
         "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "happy-dom": "^20.11.6",
         "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "typescript": "^5.7.0",
       },
       "peerDependencies": {
@@ -980,6 +984,10 @@
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.36", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -1523,9 +1531,15 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -1583,6 +1597,10 @@
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
@@ -1613,6 +1631,8 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
     "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
 
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
@@ -1638,6 +1658,8 @@
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
@@ -1777,6 +1799,8 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
@@ -1846,6 +1870,8 @@
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.11.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
@@ -1968,6 +1994,8 @@
     "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -2144,6 +2172,8 @@
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
@@ -2361,6 +2391,8 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
@@ -2565,6 +2597,8 @@
 
     "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
+    "@sixb/client/@types/react-dom": ["@types/react-dom@19.2.5", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg=="],
+
     "@sixb/ui/recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
 
     "@tailwindcss/cli/tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
@@ -2595,6 +2629,8 @@
 
     "bullmq/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
+    "happy-dom/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "imapflow/pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -2604,6 +2640,12 @@
     "nypm/citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -230,7 +230,7 @@ export function SocialConnection() {
 
   return (
     <>
-      <button onClick={social.connect} disabled={social.isPending}>
+      <button onClick={social.connect} disabled={!social.canConnect}>
         {social.connection?.account.label ?? "Connect social account"}
       </button>
 
@@ -262,7 +262,7 @@ exposes `disconnect()`, `revoke()`, and `needs_reauthorization`; Sixb imposes th
 visual representation.
 
 Selecting an account for an occupied slot returns a replacement conflict. Detect it with
-`isConnectorReplacementConflict(connection.error?.cause)`, ask for confirmation in the
+`isConnectorReplacementRequired(connection.error?.cause)`, ask for confirmation in the
 application, then retry with `selectAccount(accountId, { replace: true })`.
 
 To expose another account from the same OAuth grant, start a selection run from an existing

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -216,27 +216,38 @@ restart.
 
 ## Connect an OAuth account from an app
 
-Sixb owns the OAuth callback, state and PKCE exchange. The app starts the connection and redirects
-the browser to the provider:
+Sixb owns the OAuth callback, state, PKCE exchange, durable run, and lifecycle transitions. The
+application keeps control of its interface through one headless hook:
 
 ```tsx
-import { useConnectConnector } from "@sixb/client/hooks"
+import { useConnectorConnection } from "@sixb/client/hooks"
 
-export function ConnectSocialButton() {
-  const connect = useConnectConnector({
+export function SocialConnection() {
+  const social = useConnectorConnection({
     connectorId: "social",
     slot: "organic-marketing",
-    returnTo: "/settings/connectors",
-    onSuccess: ({ authorizationUrl }) => window.location.assign(authorizationUrl),
   })
 
-  return <button onClick={() => connect.mutate()}>Connect social account</button>
+  return (
+    <>
+      <button onClick={social.connect} disabled={social.isPending}>
+        {social.connection?.account.label ?? "Connect social account"}
+      </button>
+
+      {social.status === "selecting_account" &&
+        social.accounts.map((account) => (
+          <button key={account.id} onClick={() => social.selectAccount(account.id)}>
+            {account.label}
+          </button>
+        ))}
+    </>
+  )
 }
 ```
 
 `slot` is the stable application role filled by the connection, not the provider account id. For
 example, `organic-marketing`, `customer-support`, or `brand-france` can each resolve a different
-account later through `sixb.connector(...)`.
+account later through `sixb.connector(...)`. Project ownership is implicit in V1.
 
 Register this server-owned callback URL with the OAuth provider:
 
@@ -244,33 +255,15 @@ Register this server-owned callback URL with the OAuth provider:
 https://<sixb-api-origin>/auth/connectors/callback
 ```
 
-After OAuth, Sixb redirects to `returnTo` with `connectionRunId`. Read the run and select the account
-that should fill the slot:
+By default, OAuth returns to the current page while preserving unrelated query parameters and the
+URL hash. Keep the hook mounted there: it resumes the run from the non-secret callback identity and
+exposes `selecting_account` when the application must present provider accounts. The hook also
+exposes `disconnect()`, `revoke()`, and `needs_reauthorization`; Sixb imposes the protocol, not its
+visual representation.
 
-```tsx
-import { useConnectorConnectionRun, useSelectConnectorAccount } from "@sixb/client/hooks"
-
-export function SocialConnectionResult() {
-  const runId = new URLSearchParams(window.location.search).get("connectionRunId")
-  return runId ? <SocialConnectionRun runId={runId} /> : null
-}
-
-function SocialConnectionRun({ runId }: { runId: string }) {
-  const run = useConnectorConnectionRun({ connectorId: "social", runId })
-  const selectAccount = useSelectConnectorAccount({
-    connectorId: "social",
-    runId,
-  })
-
-  if (run.data?.status !== "waiting" || run.data.waitingFor !== "account_selection") return null
-
-  return run.data.accounts.map((account) => (
-    <button key={account.id} onClick={() => selectAccount.mutate({ accountId: account.id })}>
-      {account.label}
-    </button>
-  ))
-}
-```
+Selecting an account for an occupied slot returns a replacement conflict. Detect it with
+`isConnectorReplacementConflict(connection.error?.cause)`, ask for confirmation in the
+application, then retry with `selectAccount(accountId, { replace: true })`.
 
 To expose another account from the same OAuth grant, start a selection run from an existing
 connection. The provider authorization is not repeated:
@@ -287,7 +280,8 @@ const addAccount = useAddConnectorConnection({
 addAccount.mutate()
 ```
 
-The returned run is already waiting for `account_selection` and uses the same selection UI.
+The returned run is already waiting for `account_selection`. Use `useConnectorConnectionRun` and
+`useSelectConnectorAccount` when building this advanced multi-slot flow.
 
 A connection run records the interactive execution: `waiting`, `running`, then a terminal status.
 Its terminal record is secret-free and retained without automatic cleanup in V1.

--- a/docs/runtime/error-codes.md
+++ b/docs/runtime/error-codes.md
@@ -94,6 +94,7 @@ Additional rules:
 | `connector.operation_in_progress` | Yes | Another process is safely mutating the same authorization credentials. | Retry after the current credential operation finishes. |
 | `connector.provider_failed` | No | A provider operation failed or ended with an ambiguous outcome. | Inspect the native cause; restart authorization when Sixb failed closed. |
 | `connector.provider_unavailable` | Yes | The adapter guaranteed that a failed provider operation produced no external change. | Retry the unchanged operation later. |
+| `connector.replacement_required` | No | Account selection would replace the connection currently assigned to the slot. | Confirm replacement, then retry selection with `replace: true`, or choose another slot. |
 | `connector.revocation_pending` | Yes | Local access is disconnected, but provider revocation has not been durably confirmed. | Retry revocation; the operation is idempotent and local access remains closed. |
 | `dataset.not_found` | No | Dataset is unavailable to the caller. | Check its ID and access policy. |
 | `dataset.version_incompatible` | No | Version does not match the required dataset or schema. | Materialize a compatible version. |

--- a/packages/client/openapi.json
+++ b/packages/client/openapi.json
@@ -5247,6 +5247,7 @@
                         "connector.authorization_required",
                         "connector.operation_conflict",
                         "connector.operation_in_progress",
+                        "connector.replacement_required",
                         "connector.revocation_pending"
                       ],
                       "description": "Stable machine-readable failure code for programmatic handling."
@@ -5462,6 +5463,7 @@
                         "connector.authorization_required",
                         "connector.operation_conflict",
                         "connector.operation_in_progress",
+                        "connector.replacement_required",
                         "connector.revocation_pending"
                       ],
                       "description": "Stable machine-readable failure code for programmatic handling."
@@ -5778,6 +5780,7 @@
                         "connector.authorization_required",
                         "connector.operation_conflict",
                         "connector.operation_in_progress",
+                        "connector.replacement_required",
                         "connector.revocation_pending"
                       ],
                       "description": "Stable machine-readable failure code for programmatic handling."
@@ -7127,6 +7130,7 @@
                         "connector.authorization_required",
                         "connector.operation_conflict",
                         "connector.operation_in_progress",
+                        "connector.replacement_required",
                         "connector.revocation_pending"
                       ],
                       "description": "Stable machine-readable failure code for programmatic handling."
@@ -7825,6 +7829,7 @@
                         "connector.authorization_required",
                         "connector.operation_conflict",
                         "connector.operation_in_progress",
+                        "connector.replacement_required",
                         "connector.revocation_pending"
                       ],
                       "description": "Stable machine-readable failure code for programmatic handling."
@@ -8091,6 +8096,7 @@
                         "connector.authorization_required",
                         "connector.operation_conflict",
                         "connector.operation_in_progress",
+                        "connector.replacement_required",
                         "connector.revocation_pending"
                       ],
                       "description": "Stable machine-readable failure code for programmatic handling."

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -84,9 +84,13 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "0.90.10",
     "@tanstack/react-query": "^5.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/bun": "latest",
     "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "happy-dom": "^20.11.6",
     "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "typescript": "^5.7.0"
   },
   "license": "MIT",

--- a/packages/client/src/connectors/connection.ts
+++ b/packages/client/src/connectors/connection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { isSixbApiError } from "../api"
 import {
   useConnectConnector,
@@ -63,6 +63,8 @@ export interface UseConnectorConnectionResult {
   readonly connection: ConnectorConnection | undefined
   readonly accounts: readonly ConnectorAccount[]
   readonly error: ConnectorConnectionFailure | null
+  /** Whether a new authorization or reauthorization can start from the current state. */
+  readonly canConnect: boolean
   readonly isPending: boolean
   readonly selectedAccountId: string | undefined
   connect(): Promise<void>
@@ -86,6 +88,7 @@ export function useConnectorConnection({
   returnTo,
 }: UseConnectorConnectionOptions): UseConnectorConnectionResult {
   const [callback, setCallback] = useState(readConnectorConnectionCallback)
+  const connectInFlightRef = useRef<Promise<void> | null>(null)
   const callbackRunId = callback?.connectorId === connectorId ? callback.runId : null
   const connectionsQuery = useConnectorConnections({ connectorId })
   const connection = useMemo(
@@ -119,32 +122,54 @@ export function useConnectorConnection({
     connectionId: connection?.id ?? "",
   })
 
+  const refreshConnectionsAndConsumeCallback = useCallback(
+    async (
+      expectedCallback?: ConnectorConnectionCallback,
+      canConsume: () => boolean = () => true
+    ): Promise<void> => {
+      const result = await connectionsQuery.refetch()
+      if (result.error || !expectedCallback || !canConsume()) return
+      if (!result.data?.some((candidate) => candidate.slot === slot)) return
+
+      clearConnectorConnectionCallback(expectedCallback)
+      setCallback((current) =>
+        sameConnectorConnectionCallback(current, expectedCallback) ? null : current
+      )
+    },
+    [connectionsQuery.refetch, slot]
+  )
+
   const completedRunId = resumedRun?.status === "succeeded" ? resumedRun.id : null
   useEffect(() => {
     if (!completedRunId || !callback) return
     let active = true
 
-    void connectionsQuery.refetch().then((result) => {
-      if (!active || result.error) return
-      if (!result.data?.some((candidate) => candidate.slot === slot)) return
-      clearConnectorConnectionCallback(callback)
-      setCallback(null)
-    })
+    void refreshConnectionsAndConsumeCallback(callback, () => active)
 
     return () => {
       active = false
     }
-  }, [callback, completedRunId, connectionsQuery.refetch, slot])
+  }, [callback, completedRunId, refreshConnectionsAndConsumeCallback])
 
-  async function connect(): Promise<void> {
+  function connect(): Promise<void> {
+    if (connectInFlightRef.current) return connectInFlightRef.current
+    if (!canConnect) return Promise.resolve()
+
     resetError()
-    if (connection?.status === "connected" && resumedRun?.kind !== "reauthorize") return
+    const operation = (async () => {
+      const started =
+        resumedRun?.kind === "reauthorize" || connection?.status === "needs_reauthorization"
+          ? await reauthorizeMutation.mutateAsync()
+          : await connectMutation.mutateAsync()
+      redirectToAuthorization(started.authorizationUrl)
+    })()
+    connectInFlightRef.current = operation
+    operation.then(clearConnectInFlight, clearConnectInFlight)
+    return operation
 
-    const started =
-      resumedRun?.kind === "reauthorize" || connection?.status === "needs_reauthorization"
-        ? await reauthorizeMutation.mutateAsync()
-        : await connectMutation.mutateAsync()
-    redirectToAuthorization(started.authorizationUrl)
+    function clearConnectInFlight(): void {
+      if (connectInFlightRef.current === operation) connectInFlightRef.current = null
+    }
   }
 
   async function selectAccount(
@@ -172,10 +197,22 @@ export function useConnectorConnection({
   }
 
   async function refresh(): Promise<void> {
-    await Promise.all([
-      connectionsQuery.refetch(),
-      ...(callbackRunId === null ? [] : [runQuery.refetch()]),
-    ])
+    let completedCallback: ConnectorConnectionCallback | undefined
+    if (callbackRunId !== null) {
+      const runResult = await runQuery.refetch()
+      if (
+        !runResult.error &&
+        runResult.data?.slot === slot &&
+        runResult.data.status === "succeeded" &&
+        sameConnectorConnectionCallback(callback, {
+          connectorId,
+          runId: runResult.data.id,
+        })
+      ) {
+        completedCallback = callback ?? undefined
+      }
+    }
+    await refreshConnectionsAndConsumeCallback(completedCallback)
   }
 
   function dismiss(): void {
@@ -202,6 +239,20 @@ export function useConnectorConnection({
     run: resumedRun,
     connection,
   })
+  const mutationPending =
+    connectMutation.isPending ||
+    reauthorizeMutation.isPending ||
+    selectMutation.isPending ||
+    disconnectMutation.isPending ||
+    revokeMutation.isPending
+  const canConnect = connectorCanConnect({
+    status,
+    connectionsError: connectionsQuery.error,
+    runError: runQuery.error,
+    run: resumedRun,
+    connection,
+    mutationPending,
+  })
 
   return {
     status,
@@ -215,14 +266,8 @@ export function useConnectorConnection({
       mutationFailure("revoke", revokeMutation.error) ??
       runFailure(callbackRunId, resumedRun, runQuery.error) ??
       mutationFailure("load", connectionsQuery.error),
-    isPending:
-      status === "loading" ||
-      status === "authorizing" ||
-      connectMutation.isPending ||
-      reauthorizeMutation.isPending ||
-      selectMutation.isPending ||
-      disconnectMutation.isPending ||
-      revokeMutation.isPending,
+    canConnect,
+    isPending: status === "loading" || status === "authorizing" || mutationPending,
     selectedAccountId: selectMutation.variables?.accountId,
     connect,
     selectAccount,
@@ -234,14 +279,30 @@ export function useConnectorConnection({
   }
 }
 
-export function isConnectorReplacementConflict(error: unknown): boolean {
-  if (isSixbApiError(error)) return error.code === "connector.operation_conflict"
+export function isConnectorReplacementRequired(error: unknown): boolean {
+  if (isSixbApiError(error)) return error.code === "connector.replacement_required"
   return (
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
-    error.code === "connector.operation_conflict"
+    error.code === "connector.replacement_required"
   )
+}
+
+function connectorCanConnect(input: {
+  readonly status: ConnectorConnectionStatus
+  readonly connectionsError: Error | null
+  readonly runError: Error | null
+  readonly run: ConnectorConnectionRun | undefined
+  readonly connection: ConnectorConnection | undefined
+  readonly mutationPending: boolean
+}): boolean {
+  if (input.mutationPending || input.connectionsError || input.runError) return false
+  if (input.status === "disconnected" || input.status === "needs_reauthorization") return true
+  const run = input.run
+  if (input.status !== "error" || !run || !isRunTerminal(run)) return false
+  if (run.kind === "reauthorize") return input.connection !== undefined
+  return input.connection?.status !== "connected"
 }
 
 function connectionStatus(input: {
@@ -322,6 +383,17 @@ function isRunInProgress(run: ConnectorConnectionRun | undefined): boolean {
     run?.status === "running" ||
     (run?.status === "waiting" && run.waitingFor === "provider_authorization")
   )
+}
+
+function isRunTerminal(run: ConnectorConnectionRun | undefined): boolean {
+  return run?.status === "failed" || run?.status === "cancelled" || run?.status === "expired"
+}
+
+function sameConnectorConnectionCallback(
+  left: ConnectorConnectionCallback | null,
+  right: ConnectorConnectionCallback
+): boolean {
+  return left?.connectorId === right.connectorId && left.runId === right.runId
 }
 
 export function readConnectorConnectionCallback(

--- a/packages/client/src/connectors/connection.ts
+++ b/packages/client/src/connectors/connection.ts
@@ -1,0 +1,371 @@
+import { useEffect, useMemo, useState } from "react"
+import { isSixbApiError } from "../api"
+import {
+  useConnectConnector,
+  useDisconnectConnector,
+  useReauthorizeConnector,
+  useRevokeConnector,
+  useSelectConnectorAccount,
+} from "./mutations"
+import {
+  type ConnectorAccount,
+  type ConnectorConnection,
+  type ConnectorConnectionRun,
+  useConnectorConnectionRun,
+  useConnectorConnections,
+} from "./queries"
+
+const CONNECTOR_CALLBACK_CONNECTOR_PARAM = "connectionConnectorId"
+const CONNECTOR_CALLBACK_RUN_PARAM = "connectionRunId"
+const RUN_POLL_INTERVAL_MS = 1_000
+
+interface ConnectorConnectionCallback {
+  readonly connectorId: string
+  readonly runId: string
+}
+
+export interface UseConnectorConnectionOptions {
+  readonly connectorId: string
+  /** Stable application-defined role filled by this connection, for example `organic` or `ads`. */
+  readonly slot: string
+  /** Defaults to the current page while preserving unrelated query parameters and the hash. */
+  readonly returnTo?: string
+}
+
+export type ConnectorConnectionStatus =
+  | "loading"
+  | "disconnected"
+  | "authorizing"
+  | "selecting_account"
+  | "connected"
+  | "needs_reauthorization"
+  | "error"
+
+export type ConnectorConnectionOperation =
+  | "load"
+  | "resume"
+  | "connect"
+  | "select_account"
+  | "disconnect"
+  | "revoke"
+
+export interface ConnectorConnectionFailure {
+  readonly operation: ConnectorConnectionOperation
+  readonly cause: unknown
+}
+
+export interface ConnectorAccountSelectionOptions {
+  readonly replace?: boolean
+}
+
+export interface UseConnectorConnectionResult {
+  readonly status: ConnectorConnectionStatus
+  readonly connection: ConnectorConnection | undefined
+  readonly accounts: readonly ConnectorAccount[]
+  readonly error: ConnectorConnectionFailure | null
+  readonly isPending: boolean
+  readonly selectedAccountId: string | undefined
+  connect(): Promise<void>
+  selectAccount(accountId: string, options?: ConnectorAccountSelectionOptions): Promise<void>
+  disconnect(): Promise<void>
+  revoke(): Promise<void>
+  refresh(): Promise<void>
+  dismiss(): void
+  resetError(): void
+}
+
+/**
+ * Headless OAuth connection flow for one application-defined connector slot.
+ *
+ * The hook owns browser redirection, durable run resumption and cache convergence. The application
+ * owns presentation, including account selection and replacement confirmation.
+ */
+export function useConnectorConnection({
+  connectorId,
+  slot,
+  returnTo,
+}: UseConnectorConnectionOptions): UseConnectorConnectionResult {
+  const [callback, setCallback] = useState(readConnectorConnectionCallback)
+  const callbackRunId = callback?.connectorId === connectorId ? callback.runId : null
+  const connectionsQuery = useConnectorConnections({ connectorId })
+  const connection = useMemo(
+    () => connectionsQuery.data?.find((candidate) => candidate.slot === slot),
+    [connectionsQuery.data, slot]
+  )
+  const runQuery = useConnectorConnectionRun({
+    connectorId,
+    runId: callbackRunId,
+    refetchInterval: (query) => (isRunInProgress(query.state.data) ? RUN_POLL_INTERVAL_MS : false),
+  })
+  const resumedRun = runQuery.data?.slot === slot ? runQuery.data : undefined
+  const resolvedReturnTo = returnTo ?? connectorConnectionReturnTo()
+
+  const connectMutation = useConnectConnector({ connectorId, slot, returnTo: resolvedReturnTo })
+  const reauthorizeMutation = useReauthorizeConnector({
+    connectorId,
+    connectionId: connection?.id ?? "",
+    returnTo: resolvedReturnTo,
+  })
+  const selectMutation = useSelectConnectorAccount({
+    connectorId,
+    runId: resumedRun?.id ?? "",
+  })
+  const disconnectMutation = useDisconnectConnector({
+    connectorId,
+    connectionId: connection?.id ?? "",
+  })
+  const revokeMutation = useRevokeConnector({
+    connectorId,
+    connectionId: connection?.id ?? "",
+  })
+
+  const completedRunId = resumedRun?.status === "succeeded" ? resumedRun.id : null
+  useEffect(() => {
+    if (!completedRunId || !callback) return
+    let active = true
+
+    void connectionsQuery.refetch().then((result) => {
+      if (!active || result.error) return
+      if (!result.data?.some((candidate) => candidate.slot === slot)) return
+      clearConnectorConnectionCallback(callback)
+      setCallback(null)
+    })
+
+    return () => {
+      active = false
+    }
+  }, [callback, completedRunId, connectionsQuery.refetch, slot])
+
+  async function connect(): Promise<void> {
+    resetError()
+    if (connection?.status === "connected" && resumedRun?.kind !== "reauthorize") return
+
+    const started =
+      resumedRun?.kind === "reauthorize" || connection?.status === "needs_reauthorization"
+        ? await reauthorizeMutation.mutateAsync()
+        : await connectMutation.mutateAsync()
+    redirectToAuthorization(started.authorizationUrl)
+  }
+
+  async function selectAccount(
+    accountId: string,
+    options: ConnectorAccountSelectionOptions = {}
+  ): Promise<void> {
+    if (resumedRun?.status !== "waiting" || resumedRun.waitingFor !== "account_selection") {
+      throw new Error("[SixbClient] No connector account selection is currently pending.")
+    }
+    await selectMutation.mutateAsync({ accountId, replace: options.replace })
+  }
+
+  async function disconnect(): Promise<void> {
+    if (!connection) {
+      throw new Error("[SixbClient] Connector connection is unavailable.")
+    }
+    await disconnectMutation.mutateAsync()
+  }
+
+  async function revoke(): Promise<void> {
+    if (!connection) {
+      throw new Error("[SixbClient] Connector connection is unavailable.")
+    }
+    await revokeMutation.mutateAsync()
+  }
+
+  async function refresh(): Promise<void> {
+    await Promise.all([
+      connectionsQuery.refetch(),
+      ...(callbackRunId === null ? [] : [runQuery.refetch()]),
+    ])
+  }
+
+  function dismiss(): void {
+    if (!callback) return
+    clearConnectorConnectionCallback(callback)
+    setCallback(null)
+    resetError()
+  }
+
+  function resetError(): void {
+    connectMutation.reset()
+    reauthorizeMutation.reset()
+    selectMutation.reset()
+    disconnectMutation.reset()
+    revokeMutation.reset()
+  }
+
+  const status = connectionStatus({
+    callbackRunId,
+    connectionsPending: connectionsQuery.isPending,
+    connectionsError: connectionsQuery.error,
+    runPending: runQuery.isPending,
+    runError: runQuery.error,
+    run: resumedRun,
+    connection,
+  })
+
+  return {
+    status,
+    connection,
+    accounts: accountSelection(resumedRun),
+    error:
+      mutationFailure("connect", connectMutation.error) ??
+      mutationFailure("connect", reauthorizeMutation.error) ??
+      mutationFailure("select_account", selectMutation.error) ??
+      mutationFailure("disconnect", disconnectMutation.error) ??
+      mutationFailure("revoke", revokeMutation.error) ??
+      runFailure(callbackRunId, resumedRun, runQuery.error) ??
+      mutationFailure("load", connectionsQuery.error),
+    isPending:
+      status === "loading" ||
+      status === "authorizing" ||
+      connectMutation.isPending ||
+      reauthorizeMutation.isPending ||
+      selectMutation.isPending ||
+      disconnectMutation.isPending ||
+      revokeMutation.isPending,
+    selectedAccountId: selectMutation.variables?.accountId,
+    connect,
+    selectAccount,
+    disconnect,
+    revoke,
+    refresh,
+    dismiss,
+    resetError,
+  }
+}
+
+export function isConnectorReplacementConflict(error: unknown): boolean {
+  if (isSixbApiError(error)) return error.code === "connector.operation_conflict"
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "connector.operation_conflict"
+  )
+}
+
+function connectionStatus(input: {
+  readonly callbackRunId: string | null
+  readonly connectionsPending: boolean
+  readonly connectionsError: Error | null
+  readonly runPending: boolean
+  readonly runError: Error | null
+  readonly run: ConnectorConnectionRun | undefined
+  readonly connection: ConnectorConnection | undefined
+}): ConnectorConnectionStatus {
+  const { run } = input
+  if (run?.status === "waiting" && run.waitingFor === "account_selection") {
+    return "selecting_account"
+  }
+  if (input.callbackRunId !== null) {
+    if (
+      input.runError ||
+      run?.status === "failed" ||
+      run?.status === "cancelled" ||
+      run?.status === "expired"
+    ) {
+      return "error"
+    }
+    if (
+      input.runPending ||
+      run?.status === "waiting" ||
+      run?.status === "running" ||
+      run?.status === "succeeded"
+    ) {
+      return "authorizing"
+    }
+  }
+  if (input.connectionsError) return "error"
+  if (input.connectionsPending) return "loading"
+  if (input.connection?.status === "connected") return "connected"
+  if (input.connection?.status === "needs_reauthorization") return "needs_reauthorization"
+  return "disconnected"
+}
+
+function accountSelection(run: ConnectorConnectionRun | undefined): readonly ConnectorAccount[] {
+  if (run?.status !== "waiting" || run.waitingFor !== "account_selection") return []
+  return run.accounts
+}
+
+function mutationFailure(
+  operation: ConnectorConnectionOperation,
+  cause: unknown
+): ConnectorConnectionFailure | null {
+  return cause ? { operation, cause } : null
+}
+
+function runFailure(
+  callbackRunId: string | null,
+  run: ConnectorConnectionRun | undefined,
+  queryError: Error | null
+): ConnectorConnectionFailure | null {
+  if (callbackRunId === null) return null
+  if (queryError) return { operation: "resume", cause: queryError }
+  if (run?.status === "failed") return { operation: "resume", cause: run.error }
+  if (run?.status === "cancelled") {
+    return {
+      operation: "resume",
+      cause: new Error("[SixbClient] Connector authorization was cancelled."),
+    }
+  }
+  if (run?.status === "expired") {
+    return {
+      operation: "resume",
+      cause: new Error("[SixbClient] Connector authorization expired before completion."),
+    }
+  }
+  return null
+}
+
+function isRunInProgress(run: ConnectorConnectionRun | undefined): boolean {
+  return (
+    run?.status === "running" ||
+    (run?.status === "waiting" && run.waitingFor === "provider_authorization")
+  )
+}
+
+export function readConnectorConnectionCallback(
+  href: string | undefined = globalThis.location?.href
+): ConnectorConnectionCallback | null {
+  if (!href) return null
+  const url = new URL(href)
+  const connectorId = url.searchParams.get(CONNECTOR_CALLBACK_CONNECTOR_PARAM)?.trim()
+  const runId = url.searchParams.get(CONNECTOR_CALLBACK_RUN_PARAM)?.trim()
+  return connectorId && runId ? { connectorId, runId } : null
+}
+
+export function connectorConnectionReturnTo(
+  href: string | undefined = globalThis.location?.href
+): string {
+  if (!href) return ""
+  return withoutConnectorConnectionCallback(href).toString()
+}
+
+function clearConnectorConnectionCallback(expected: ConnectorConnectionCallback): void {
+  const href = globalThis.location?.href
+  if (!href || !globalThis.history) return
+  const current = readConnectorConnectionCallback(href)
+  if (current?.connectorId !== expected.connectorId || current.runId !== expected.runId) {
+    return
+  }
+  const url = withoutConnectorConnectionCallback(href)
+  globalThis.history.replaceState(
+    globalThis.history.state,
+    "",
+    `${url.pathname}${url.search}${url.hash}`
+  )
+}
+
+function withoutConnectorConnectionCallback(href: string): URL {
+  const url = new URL(href)
+  url.searchParams.delete(CONNECTOR_CALLBACK_CONNECTOR_PARAM)
+  url.searchParams.delete(CONNECTOR_CALLBACK_RUN_PARAM)
+  return url
+}
+
+function redirectToAuthorization(authorizationUrl: string): void {
+  if (!globalThis.location) {
+    throw new Error("[SixbClient] Connector authorization requires a browser.")
+  }
+  globalThis.location.assign(authorizationUrl)
+}

--- a/packages/client/src/connectors/index.ts
+++ b/packages/client/src/connectors/index.ts
@@ -1,0 +1,12 @@
+export {
+  type ConnectorAccountSelectionOptions,
+  type ConnectorConnectionFailure,
+  type ConnectorConnectionOperation,
+  type ConnectorConnectionStatus,
+  isConnectorReplacementConflict,
+  type UseConnectorConnectionOptions,
+  type UseConnectorConnectionResult,
+  useConnectorConnection,
+} from "./connection"
+export * from "./mutations"
+export * from "./queries"

--- a/packages/client/src/connectors/index.ts
+++ b/packages/client/src/connectors/index.ts
@@ -3,7 +3,7 @@ export {
   type ConnectorConnectionFailure,
   type ConnectorConnectionOperation,
   type ConnectorConnectionStatus,
-  isConnectorReplacementConflict,
+  isConnectorReplacementRequired,
   type UseConnectorConnectionOptions,
   type UseConnectorConnectionResult,
   useConnectorConnection,

--- a/packages/client/src/connectors/mutations.ts
+++ b/packages/client/src/connectors/mutations.ts
@@ -1,32 +1,32 @@
 import {
   type QueryClient,
-  queryOptions,
   type UseMutationOptions,
   type UseMutationResult,
-  type UseQueryOptions,
-  type UseQueryResult,
   useMutation,
-  useQuery,
   useQueryClient,
 } from "@tanstack/react-query"
-import { useSixbProviderClient } from "./client-provider"
+import { useSixbProviderClient } from "../client-provider"
 import {
   getConnectorConnectionRunQueryKey,
   listConnectorConnectionsQueryKey,
-} from "./generated/@tanstack/react-query.gen"
-import type { Client } from "./generated/client"
+} from "../generated/@tanstack/react-query.gen"
+import type { Client } from "../generated/client"
 import {
   addConnectorConnection,
-  getConnectorConnectionRun,
+  disconnectConnectorConnection,
+  reauthorizeConnectorConnection,
+  revokeConnectorConnection,
   selectConnectorConnectionRunAccount,
   startConnectorConnectionRun,
-} from "./generated/sdk.gen"
+} from "../generated/sdk.gen"
 import type {
   AddConnectorConnectionResponse,
-  GetConnectorConnectionRunResponse,
+  DisconnectConnectorConnectionResponse,
+  ReauthorizeConnectorConnectionResponse,
+  RevokeConnectorConnectionResponse,
   SelectConnectorConnectionRunAccountResponse,
   StartConnectorConnectionRunResponse,
-} from "./generated/types.gen"
+} from "../generated/types.gen"
 
 export interface AddConnectorConnectionOptions<TContext = unknown>
   extends Omit<
@@ -145,70 +145,6 @@ export function useConnectConnector<TContext = unknown>(
   )
 }
 
-export type ConnectorConnectionRunQueryKey = ReturnType<typeof getConnectorConnectionRunQueryKey>
-
-export interface ConnectorConnectionRunOptions
-  extends Omit<
-    UseQueryOptions<
-      GetConnectorConnectionRunResponse,
-      Error,
-      GetConnectorConnectionRunResponse,
-      ConnectorConnectionRunQueryKey
-    >,
-    "queryKey" | "queryFn"
-  > {
-  readonly connectorId: string
-  /** A missing callback query parameter disables the query. */
-  readonly runId: string | null | undefined
-  /** hey-api client override. Defaults to the nearest SixbProvider client, then the global client. */
-  readonly client?: Client
-}
-
-export function connectorConnectionRunQueryOptions(options: ConnectorConnectionRunOptions) {
-  const { connectorId, runId, client, ...queryOptionsInput } = options
-  const normalizedRunId = optionalNonblank(runId, "runId")
-  const path = {
-    connectorId: nonblank(connectorId, "connectorId"),
-    runId: normalizedRunId ?? "",
-  }
-  const queryKey = getConnectorConnectionRunQueryKey({ path })
-
-  return queryOptions<
-    GetConnectorConnectionRunResponse,
-    Error,
-    GetConnectorConnectionRunResponse,
-    ConnectorConnectionRunQueryKey
-  >({
-    ...queryOptionsInput,
-    enabled: normalizedRunId === undefined ? false : queryOptionsInput.enabled,
-    queryKey,
-    queryFn: async ({ signal }) => {
-      if (normalizedRunId === undefined) {
-        throw new Error("[SixbClient] runId is required to read a connector connection run.")
-      }
-      const { data } = await getConnectorConnectionRun<true>({
-        client,
-        path,
-        signal,
-        throwOnError: true,
-      })
-      return data
-    },
-  })
-}
-
-export function useConnectorConnectionRun(
-  options: ConnectorConnectionRunOptions
-): UseQueryResult<GetConnectorConnectionRunResponse, Error> {
-  const providerClient = useSixbProviderClient()
-  return useQuery(
-    connectorConnectionRunQueryOptions({
-      ...options,
-      client: options.client ?? providerClient,
-    })
-  )
-}
-
 export interface SelectConnectorAccountInput {
   readonly accountId: string
   readonly replace?: boolean
@@ -241,17 +177,19 @@ export function selectConnectorAccountMutationOptions<TContext = unknown>(
   TContext
 > {
   const { connectorId, runId, client, queryClient, onSuccess, ...mutationOptions } = options
-  const path = {
-    connectorId: nonblank(connectorId, "connectorId"),
+  const normalizedConnectorId = nonblank(connectorId, "connectorId")
+  const path = () => ({
+    connectorId: normalizedConnectorId,
     runId: nonblank(runId, "runId"),
-  }
+  })
 
   return {
     ...mutationOptions,
     mutationFn: async ({ accountId, replace }) => {
+      const resolvedPath = path()
       const { data } = await selectConnectorConnectionRunAccount<true>({
         client,
-        path,
+        path: resolvedPath,
         body: {
           accountId: nonblank(accountId, "accountId"),
           ...(replace === undefined ? {} : { replace }),
@@ -261,14 +199,9 @@ export function selectConnectorAccountMutationOptions<TContext = unknown>(
       return data
     },
     onSuccess: async (run, variables, context, mutation) => {
-      if (queryClient) {
-        queryClient.setQueryData(getConnectorConnectionRunQueryKey({ path }), run)
-        await queryClient.invalidateQueries({
-          queryKey: listConnectorConnectionsQueryKey({
-            path: { connectorId: path.connectorId },
-          }),
-        })
-      }
+      const resolvedPath = path()
+      queryClient?.setQueryData(getConnectorConnectionRunQueryKey({ path: resolvedPath }), run)
+      await invalidateConnectorConnections(queryClient, resolvedPath.connectorId)
       await onSuccess?.(run, variables, context, mutation)
     },
   }
@@ -293,17 +226,163 @@ export function useSelectConnectorAccount<TContext = unknown>(
   )
 }
 
+interface ConnectorConnectionMutationOptions<TResponse, TContext>
+  extends Omit<UseMutationOptions<TResponse, Error, void, TContext>, "mutationFn"> {
+  readonly connectorId: string
+  readonly connectionId: string
+  /** hey-api client override. Defaults to the nearest SixbProvider client, then the global client. */
+  readonly client?: Client
+  /** Override used by tests and non-hook option factory consumers. */
+  readonly queryClient?: QueryClient
+}
+
+export type DisconnectConnectorOptions<TContext = unknown> = ConnectorConnectionMutationOptions<
+  DisconnectConnectorConnectionResponse,
+  TContext
+>
+
+export function disconnectConnectorMutationOptions<TContext = unknown>(
+  options: DisconnectConnectorOptions<TContext>
+): UseMutationOptions<DisconnectConnectorConnectionResponse, Error, void, TContext> {
+  const { connectorId, connectionId, client, queryClient, onSuccess, ...mutationOptions } = options
+  const normalizedConnectorId = nonblank(connectorId, "connectorId")
+  const path = () => ({
+    connectorId: normalizedConnectorId,
+    connectionId: nonblank(connectionId, "connectionId"),
+  })
+
+  return {
+    ...mutationOptions,
+    mutationFn: async () => {
+      const resolvedPath = path()
+      const { data } = await disconnectConnectorConnection<true>({
+        client,
+        path: resolvedPath,
+        throwOnError: true,
+      })
+      return data
+    },
+    onSuccess: async (result, variables, context, mutation) => {
+      await invalidateConnectorConnections(queryClient, normalizedConnectorId)
+      await onSuccess?.(result, variables, context, mutation)
+    },
+  }
+}
+
+export function useDisconnectConnector<TContext = unknown>(
+  options: DisconnectConnectorOptions<TContext>
+): UseMutationResult<DisconnectConnectorConnectionResponse, Error, void, TContext> {
+  const providerClient = useSixbProviderClient()
+  const queryClient = useQueryClient()
+  return useMutation(
+    disconnectConnectorMutationOptions({
+      ...options,
+      client: options.client ?? providerClient,
+      queryClient: options.queryClient ?? queryClient,
+    })
+  )
+}
+
+export type RevokeConnectorOptions<TContext = unknown> = ConnectorConnectionMutationOptions<
+  RevokeConnectorConnectionResponse,
+  TContext
+>
+
+export function revokeConnectorMutationOptions<TContext = unknown>(
+  options: RevokeConnectorOptions<TContext>
+): UseMutationOptions<RevokeConnectorConnectionResponse, Error, void, TContext> {
+  const { connectorId, connectionId, client, queryClient, onSuccess, ...mutationOptions } = options
+  const normalizedConnectorId = nonblank(connectorId, "connectorId")
+  const path = () => ({
+    connectorId: normalizedConnectorId,
+    connectionId: nonblank(connectionId, "connectionId"),
+  })
+
+  return {
+    ...mutationOptions,
+    mutationFn: async () => {
+      const resolvedPath = path()
+      const { data } = await revokeConnectorConnection<true>({
+        client,
+        path: resolvedPath,
+        throwOnError: true,
+      })
+      return data
+    },
+    onSuccess: async (result, variables, context, mutation) => {
+      await invalidateConnectorConnections(queryClient, normalizedConnectorId)
+      await onSuccess?.(result, variables, context, mutation)
+    },
+  }
+}
+
+export function useRevokeConnector<TContext = unknown>(
+  options: RevokeConnectorOptions<TContext>
+): UseMutationResult<RevokeConnectorConnectionResponse, Error, void, TContext> {
+  const providerClient = useSixbProviderClient()
+  const queryClient = useQueryClient()
+  return useMutation(
+    revokeConnectorMutationOptions({
+      ...options,
+      client: options.client ?? providerClient,
+      queryClient: options.queryClient ?? queryClient,
+    })
+  )
+}
+
+export interface ReauthorizeConnectorOptions<TContext = unknown>
+  extends Omit<
+    UseMutationOptions<ReauthorizeConnectorConnectionResponse, Error, void, TContext>,
+    "mutationFn"
+  > {
+  readonly connectorId: string
+  readonly connectionId: string
+  readonly returnTo: string
+  /** hey-api client override. Defaults to the nearest SixbProvider client, then the global client. */
+  readonly client?: Client
+}
+
+export function reauthorizeConnectorMutationOptions<TContext = unknown>(
+  options: ReauthorizeConnectorOptions<TContext>
+): UseMutationOptions<ReauthorizeConnectorConnectionResponse, Error, void, TContext> {
+  const { connectorId, connectionId, returnTo, client, ...mutationOptions } = options
+  const normalizedConnectorId = nonblank(connectorId, "connectorId")
+
+  return {
+    ...mutationOptions,
+    mutationFn: async () => {
+      const { data } = await reauthorizeConnectorConnection<true>({
+        client,
+        path: {
+          connectorId: normalizedConnectorId,
+          connectionId: nonblank(connectionId, "connectionId"),
+        },
+        body: { returnTo: resolveReturnTo(returnTo) },
+        throwOnError: true,
+      })
+      return data
+    },
+  }
+}
+
+export function useReauthorizeConnector<TContext = unknown>(
+  options: ReauthorizeConnectorOptions<TContext>
+): UseMutationResult<ReauthorizeConnectorConnectionResponse, Error, void, TContext> {
+  const providerClient = useSixbProviderClient()
+  return useMutation(
+    reauthorizeConnectorMutationOptions({
+      ...options,
+      client: options.client ?? providerClient,
+    })
+  )
+}
+
 function nonblank(value: string, field: string): string {
   const normalized = value.trim()
   if (!normalized) {
     throw new Error(`[SixbClient] ${field} must be a non-empty string.`)
   }
   return normalized
-}
-
-function optionalNonblank(value: string | null | undefined, field: string): string | undefined {
-  if (value === null || value === undefined) return undefined
-  return nonblank(value, field)
 }
 
 function resolveReturnTo(value: string): string {
@@ -325,4 +404,14 @@ function resolveReturnTo(value: string): string {
       throw new Error("[SixbClient] Connector returnTo must be a valid URL.", { cause: error })
     }
   }
+}
+
+async function invalidateConnectorConnections(
+  queryClient: QueryClient | undefined,
+  connectorId: string
+): Promise<void> {
+  if (!queryClient) return
+  await queryClient.invalidateQueries({
+    queryKey: listConnectorConnectionsQueryKey({ path: { connectorId } }),
+  })
 }

--- a/packages/client/src/connectors/queries.ts
+++ b/packages/client/src/connectors/queries.ts
@@ -1,0 +1,150 @@
+import {
+  queryOptions,
+  type UseQueryOptions,
+  type UseQueryResult,
+  useQuery,
+} from "@tanstack/react-query"
+import { useSixbProviderClient } from "../client-provider"
+import {
+  getConnectorConnectionRunQueryKey,
+  listConnectorConnectionsQueryKey,
+} from "../generated/@tanstack/react-query.gen"
+import type { Client } from "../generated/client"
+import { getConnectorConnectionRun, listConnectorConnections } from "../generated/sdk.gen"
+import type {
+  GetConnectorConnectionRunResponse,
+  ListConnectorConnectionsResponse,
+} from "../generated/types.gen"
+
+export type ConnectorConnection = ListConnectorConnectionsResponse[number]
+export type ConnectorAccount = ConnectorConnection["account"]
+export type ConnectorConnectionRun = GetConnectorConnectionRunResponse
+
+export type ConnectorConnectionsQueryKey = ReturnType<typeof listConnectorConnectionsQueryKey>
+
+export interface ConnectorConnectionsOptions
+  extends Omit<
+    UseQueryOptions<
+      ListConnectorConnectionsResponse,
+      Error,
+      ListConnectorConnectionsResponse,
+      ConnectorConnectionsQueryKey
+    >,
+    "queryKey" | "queryFn"
+  > {
+  readonly connectorId: string
+  /** hey-api client override. Defaults to the nearest SixbProvider client, then the global client. */
+  readonly client?: Client
+}
+
+export function connectorConnectionsQueryOptions(options: ConnectorConnectionsOptions) {
+  const { connectorId, client, ...queryOptionsInput } = options
+  const path = { connectorId: nonblank(connectorId, "connectorId") }
+
+  return queryOptions<
+    ListConnectorConnectionsResponse,
+    Error,
+    ListConnectorConnectionsResponse,
+    ConnectorConnectionsQueryKey
+  >({
+    ...queryOptionsInput,
+    queryKey: listConnectorConnectionsQueryKey({ path }),
+    queryFn: async ({ signal }) => {
+      const { data } = await listConnectorConnections<true>({
+        client,
+        path,
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+  })
+}
+
+export function useConnectorConnections(
+  options: ConnectorConnectionsOptions
+): UseQueryResult<ListConnectorConnectionsResponse, Error> {
+  const providerClient = useSixbProviderClient()
+  return useQuery(
+    connectorConnectionsQueryOptions({
+      ...options,
+      client: options.client ?? providerClient,
+    })
+  )
+}
+
+export type ConnectorConnectionRunQueryKey = ReturnType<typeof getConnectorConnectionRunQueryKey>
+
+export interface ConnectorConnectionRunOptions
+  extends Omit<
+    UseQueryOptions<
+      GetConnectorConnectionRunResponse,
+      Error,
+      GetConnectorConnectionRunResponse,
+      ConnectorConnectionRunQueryKey
+    >,
+    "queryKey" | "queryFn"
+  > {
+  readonly connectorId: string
+  /** A missing callback query parameter disables the query. */
+  readonly runId: string | null | undefined
+  /** hey-api client override. Defaults to the nearest SixbProvider client, then the global client. */
+  readonly client?: Client
+}
+
+export function connectorConnectionRunQueryOptions(options: ConnectorConnectionRunOptions) {
+  const { connectorId, runId, client, ...queryOptionsInput } = options
+  const normalizedRunId = optionalNonblank(runId, "runId")
+  const path = {
+    connectorId: nonblank(connectorId, "connectorId"),
+    runId: normalizedRunId ?? "",
+  }
+
+  return queryOptions<
+    GetConnectorConnectionRunResponse,
+    Error,
+    GetConnectorConnectionRunResponse,
+    ConnectorConnectionRunQueryKey
+  >({
+    ...queryOptionsInput,
+    enabled: normalizedRunId === undefined ? false : queryOptionsInput.enabled,
+    queryKey: getConnectorConnectionRunQueryKey({ path }),
+    queryFn: async ({ signal }) => {
+      if (normalizedRunId === undefined) {
+        throw new Error("[SixbClient] runId is required to read a connector connection run.")
+      }
+      const { data } = await getConnectorConnectionRun<true>({
+        client,
+        path,
+        signal,
+        throwOnError: true,
+      })
+      return data
+    },
+  })
+}
+
+export function useConnectorConnectionRun(
+  options: ConnectorConnectionRunOptions
+): UseQueryResult<GetConnectorConnectionRunResponse, Error> {
+  const providerClient = useSixbProviderClient()
+  return useQuery(
+    connectorConnectionRunQueryOptions({
+      ...options,
+      client: options.client ?? providerClient,
+    })
+  )
+}
+
+function nonblank(value: string, field: string): string {
+  const normalized = value.trim()
+  if (!normalized) {
+    throw new Error(`[SixbClient] ${field} must be a non-empty string.`)
+  }
+  return normalized
+}
+
+function optionalNonblank(value: string | null | undefined, field: string): string | undefined {
+  if (value === null || value === undefined) return undefined
+  return nonblank(value, field)
+}

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -1844,6 +1844,7 @@ export type DisconnectConnectorConnectionErrors = {
       | "connector.authorization_required"
       | "connector.operation_conflict"
       | "connector.operation_in_progress"
+      | "connector.replacement_required"
       | "connector.revocation_pending"
   }
   /**
@@ -1922,6 +1923,7 @@ export type RevokeConnectorConnectionErrors = {
       | "connector.authorization_required"
       | "connector.operation_conflict"
       | "connector.operation_in_progress"
+      | "connector.replacement_required"
       | "connector.revocation_pending"
   }
   /**
@@ -2036,6 +2038,7 @@ export type StartConnectorConnectionRunErrors = {
       | "connector.authorization_required"
       | "connector.operation_conflict"
       | "connector.operation_in_progress"
+      | "connector.replacement_required"
       | "connector.revocation_pending"
   }
   /**
@@ -2343,6 +2346,7 @@ export type AddConnectorConnectionErrors = {
       | "connector.authorization_required"
       | "connector.operation_conflict"
       | "connector.operation_in_progress"
+      | "connector.replacement_required"
       | "connector.revocation_pending"
   }
   /**
@@ -2551,6 +2555,7 @@ export type SelectConnectorConnectionRunAccountErrors = {
       | "connector.authorization_required"
       | "connector.operation_conflict"
       | "connector.operation_in_progress"
+      | "connector.replacement_required"
       | "connector.revocation_pending"
   }
   /**
@@ -2758,6 +2763,7 @@ export type ReauthorizeConnectorConnectionErrors = {
       | "connector.authorization_required"
       | "connector.operation_conflict"
       | "connector.operation_in_progress"
+      | "connector.replacement_required"
       | "connector.revocation_pending"
   }
   /**

--- a/packages/client/src/hooks.ts
+++ b/packages/client/src/hooks.ts
@@ -19,7 +19,7 @@ import {
 } from "./models"
 
 export * from "./agent-streams"
-export * from "./connector-hooks"
+export * from "./connectors"
 export * from "./events"
 export * from "./events-hooks"
 export * from "./events-provider"

--- a/packages/client/tests/connector-connection.test.tsx
+++ b/packages/client/tests/connector-connection.test.tsx
@@ -1,0 +1,278 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { Window } from "happy-dom"
+import type { PropsWithChildren } from "react"
+import { SixbProvider } from "../src/client-provider"
+import {
+  isConnectorReplacementRequired,
+  useConnectorConnection,
+} from "../src/connectors/connection"
+import {
+  getConnectorConnectionRunQueryKey,
+  listConnectorConnectionsQueryKey,
+} from "../src/generated/@tanstack/react-query.gen"
+import { type Client, createClient, createConfig } from "../src/generated/client"
+import type {
+  GetConnectorConnectionRunResponse,
+  ListConnectorConnectionsResponse,
+} from "../src/generated/types.gen"
+
+const browserWindow = new Window({ url: "https://app.sixb.test/settings" })
+const installedBrowserGlobals = [
+  "window",
+  "self",
+  "document",
+  "location",
+  "history",
+  "navigator",
+  "Node",
+  "Element",
+  "HTMLElement",
+  "Event",
+  "EventTarget",
+  "MutationObserver",
+  "getComputedStyle",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const
+const previousBrowserGlobals = new Map<string, PropertyDescriptor | undefined>()
+
+const connection = {
+  id: "ccn_1",
+  connectorId: "github",
+  owner: { type: "project" },
+  slot: "default",
+  account: { id: "octocat", label: "Octocat" },
+  status: "connected",
+} as const
+
+const succeededRun: GetConnectorConnectionRunResponse = {
+  id: "ccr_1",
+  connectorId: "github",
+  kind: "connect",
+  owner: { type: "project" },
+  slot: "default",
+  createdAt: "2026-08-24T12:00:00.000Z",
+  updatedAt: "2026-08-24T12:02:00.000Z",
+  status: "succeeded",
+  connections: [connection],
+  finishedAt: "2026-08-24T12:02:00.000Z",
+}
+
+const waitingRun: GetConnectorConnectionRunResponse = {
+  id: "ccr_1",
+  connectorId: "github",
+  kind: "connect",
+  owner: { type: "project" },
+  slot: "default",
+  createdAt: "2026-08-24T12:00:00.000Z",
+  updatedAt: "2026-08-24T12:01:00.000Z",
+  status: "waiting",
+  waitingFor: "account_selection",
+  accounts: [{ id: "octocat", label: "Octocat" }],
+  expiresAt: "2026-08-24T12:10:00.000Z",
+}
+
+beforeAll(() => {
+  const values = browserWindow as unknown as Record<string, unknown>
+  for (const key of installedBrowserGlobals) {
+    previousBrowserGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    const value =
+      key === "window" || key === "self"
+        ? browserWindow
+        : key === "IS_REACT_ACT_ENVIRONMENT"
+          ? true
+          : values[key]
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
+  }
+})
+
+beforeEach(() => {
+  browserWindow.history.replaceState({}, "", "/settings")
+  browserWindow.document.body.replaceChildren()
+})
+
+afterEach(async () => {
+  cleanup()
+  await Bun.sleep(0)
+})
+
+afterAll(async () => {
+  await Bun.sleep(0)
+  for (const key of installedBrowserGlobals) {
+    const previous = previousBrowserGlobals.get(key)
+    if (previous) Object.defineProperty(globalThis, key, previous)
+    else Reflect.deleteProperty(globalThis, key)
+  }
+  browserWindow.close()
+})
+
+describe("useConnectorConnection", () => {
+  test("consumes a completed callback after refresh recovers from a connection read failure", async () => {
+    browserWindow.history.replaceState(
+      {},
+      "",
+      "/settings?tab=connectors&connectionConnectorId=github&connectionRunId=ccr_1#oauth"
+    )
+    let connectionReads = 0
+    const { client } = createHookClient(async (request) => {
+      const url = new URL(request.url)
+      if (request.method === "GET" && url.pathname.endsWith("/connections")) {
+        connectionReads += 1
+        if (connectionReads === 1) {
+          return Response.json({ error: "Temporary outage" }, { status: 503 })
+        }
+        return Response.json([connection])
+      }
+      if (request.method === "GET" && url.pathname.endsWith("/connection-runs/ccr_1")) {
+        return Response.json(succeededRun)
+      }
+      return Response.json({ error: "Unexpected request" }, { status: 500 })
+    })
+    const queryClient = connectorQueryClient()
+    seedConnectorQueries(queryClient, succeededRun, [])
+    const rendered = renderHook(
+      () => useConnectorConnection({ connectorId: "github", slot: "default" }),
+      { wrapper: connectorWrapper(client, queryClient) }
+    )
+
+    await waitFor(() => expect(connectionReads).toBe(1))
+    expect(rendered.result.current.status).toBe("authorizing")
+    expect(browserWindow.location.search).toContain("connectionRunId=ccr_1")
+
+    await act(async () => rendered.result.current.refresh())
+
+    await waitFor(() => expect(rendered.result.current.status).toBe("connected"))
+    expect(connectionReads).toBe(2)
+    expect(browserWindow.location.href).toBe("https://app.sixb.test/settings?tab=connectors#oauth")
+  })
+
+  test("does not start another authorization while account selection is pending", async () => {
+    browserWindow.history.replaceState(
+      {},
+      "",
+      "/settings?connectionConnectorId=github&connectionRunId=ccr_1"
+    )
+    const { client, requests } = createHookClient(async () =>
+      Response.json({ error: "Unexpected request" }, { status: 500 })
+    )
+    const queryClient = connectorQueryClient()
+    seedConnectorQueries(queryClient, waitingRun, [])
+    const rendered = renderHook(
+      () => useConnectorConnection({ connectorId: "github", slot: "default" }),
+      { wrapper: connectorWrapper(client, queryClient) }
+    )
+
+    expect(rendered.result.current.status).toBe("selecting_account")
+    expect(rendered.result.current.canConnect).toBe(false)
+    await act(async () => rendered.result.current.connect())
+
+    expect(requests).toEqual([])
+    expect(rendered.result.current.status).toBe("selecting_account")
+  })
+
+  test("coalesces concurrent connect calls into one authorization request", async () => {
+    let releaseRequest: (response: Response) => void = () => undefined
+    const providerResponse = new Promise<Response>((resolve) => {
+      releaseRequest = resolve
+    })
+    let markRequestStarted: () => void = () => undefined
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve
+    })
+    const { client, requests } = createHookClient(async () => {
+      markRequestStarted()
+      return providerResponse
+    })
+    const queryClient = connectorQueryClient()
+    queryClient.setQueryData(
+      listConnectorConnectionsQueryKey({ path: { connectorId: "github" } }),
+      []
+    )
+    const rendered = renderHook(
+      () => useConnectorConnection({ connectorId: "github", slot: "default" }),
+      { wrapper: connectorWrapper(client, queryClient) }
+    )
+
+    expect(rendered.result.current.canConnect).toBe(true)
+    let first!: Promise<void>
+    let second!: Promise<void>
+    await act(async () => {
+      first = rendered.result.current.connect()
+      second = rendered.result.current.connect()
+      await requestStarted
+      await Bun.sleep(0)
+    })
+
+    try {
+      expect(first).toBe(second)
+      expect(requests).toHaveLength(1)
+    } finally {
+      await act(async () => {
+        releaseRequest(Response.json({ error: "Temporary outage" }, { status: 503 }))
+        await Promise.allSettled([first, second])
+        await Bun.sleep(0)
+      })
+    }
+    expect(requests).toHaveLength(1)
+  })
+})
+
+describe("connector replacement errors", () => {
+  test("distinguishes replacement from unrelated operation conflicts", () => {
+    expect(isConnectorReplacementRequired({ code: "connector.replacement_required" })).toBe(true)
+    expect(isConnectorReplacementRequired({ code: "connector.operation_conflict" })).toBe(false)
+  })
+})
+
+function connectorQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function seedConnectorQueries(
+  queryClient: QueryClient,
+  run: GetConnectorConnectionRunResponse,
+  connections: ListConnectorConnectionsResponse
+): void {
+  queryClient.setQueryData(
+    getConnectorConnectionRunQueryKey({
+      path: { connectorId: "github", runId: "ccr_1" },
+    }),
+    run
+  )
+  queryClient.setQueryData(
+    listConnectorConnectionsQueryKey({ path: { connectorId: "github" } }),
+    connections
+  )
+}
+
+function connectorWrapper(client: Client, queryClient: QueryClient) {
+  return function ConnectorWrapper({ children }: PropsWithChildren) {
+    return (
+      <SixbProvider client={client}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </SixbProvider>
+    )
+  }
+}
+
+function createHookClient(handler: (request: Request) => Promise<Response>) {
+  const requests: Request[] = []
+  const client = createClient(
+    createConfig({
+      baseUrl: "https://api.sixb.test",
+      fetch: (async (request: Request) => {
+        requests.push(request)
+        return handler(request)
+      }) as unknown as typeof fetch,
+    })
+  )
+  return { client, requests }
+}

--- a/packages/client/tests/connector-hooks.test.ts
+++ b/packages/client/tests/connector-hooks.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test"
 import { QueryClient } from "@tanstack/react-query"
 import {
+  connectorConnectionReturnTo,
+  readConnectorConnectionCallback,
+} from "../src/connectors/connection"
+import {
   getConnectorConnectionRunQueryKey,
   listConnectorConnectionsQueryKey,
 } from "../src/generated/@tanstack/react-query.gen"
@@ -8,6 +12,9 @@ import { createClient, createConfig } from "../src/generated/client"
 import type {
   AddConnectorConnectionResponse,
   GetConnectorConnectionRunResponse,
+  ListConnectorConnectionsResponse,
+  ReauthorizeConnectorConnectionResponse,
+  RevokeConnectorConnectionResponse,
   SelectConnectorConnectionRunAccountResponse,
   StartConnectorConnectionRunResponse,
 } from "../src/generated/types.gen"
@@ -15,6 +22,10 @@ import {
   addConnectorConnectionMutationOptions,
   connectConnectorMutationOptions,
   connectorConnectionRunQueryOptions,
+  connectorConnectionsQueryOptions,
+  disconnectConnectorMutationOptions,
+  reauthorizeConnectorMutationOptions,
+  revokeConnectorMutationOptions,
   selectConnectorAccountMutationOptions,
 } from "../src/hooks"
 
@@ -66,6 +77,21 @@ const succeededRun: SelectConnectorConnectionRunAccountResponse = {
   finishedAt: "2026-08-24T12:02:00.000Z",
 }
 
+const connections: ListConnectorConnectionsResponse = succeededRun.connections
+
+const reauthorization: ReauthorizeConnectorConnectionResponse = {
+  runId: "ccr_3",
+  authorizationUrl: "https://github.com/login/oauth/authorize?state=reauthorize",
+  affectedConnections: connections,
+}
+
+const revoked: RevokeConnectorConnectionResponse = {
+  affectedConnections: connections.map((connection) => ({
+    ...connection,
+    status: "disconnected",
+  })),
+}
+
 function createConnectorTestClient() {
   const requests: Array<{ method: string; path: string; body?: unknown }> = []
   const client = createClient(
@@ -73,7 +99,8 @@ function createConnectorTestClient() {
       baseUrl: "http://sixb.test",
       fetch: (async (request: Request) => {
         const url = new URL(request.url)
-        const body = request.method === "POST" ? await request.json() : undefined
+        const requestBody = request.method === "POST" ? await request.text() : ""
+        const body = requestBody ? JSON.parse(requestBody) : undefined
         requests.push({ method: request.method, path: url.pathname, body })
 
         if (
@@ -99,6 +126,27 @@ function createConnectorTestClient() {
           url.pathname === "/api/connectors/github/connection-runs/ccr_1/selection"
         ) {
           return Response.json(succeededRun)
+        }
+        if (request.method === "GET" && url.pathname === "/api/connectors/github/connections") {
+          return Response.json(connections)
+        }
+        if (
+          request.method === "DELETE" &&
+          url.pathname === "/api/connectors/github/connections/ccn_1"
+        ) {
+          return Response.json({ success: true })
+        }
+        if (
+          request.method === "POST" &&
+          url.pathname === "/api/connectors/github/connections/ccn_1/revoke"
+        ) {
+          return Response.json(revoked)
+        }
+        if (
+          request.method === "POST" &&
+          url.pathname === "/api/connectors/github/connections/ccn_1/reauthorize"
+        ) {
+          return Response.json(reauthorization, { status: 201 })
         }
         return Response.json({ error: "Unexpected request" }, { status: 500 })
       }) as unknown as typeof fetch,
@@ -190,6 +238,87 @@ describe("connector connection hooks", () => {
     ).toEqual(additionalConnectionRun)
   })
 
+  test("lists connector connections through a connector-scoped query", async () => {
+    const { client, requests } = createConnectorTestClient()
+    const options = connectorConnectionsQueryOptions({ client, connectorId: "github" })
+    const queryFn = options.queryFn as unknown as (context: {
+      signal?: AbortSignal
+    }) => Promise<ListConnectorConnectionsResponse>
+
+    expect(await queryFn({})).toEqual(connections)
+    expect(requests).toEqual([
+      {
+        method: "GET",
+        path: "/api/connectors/github/connections",
+        body: undefined,
+      },
+    ])
+  })
+
+  test("disconnects and revokes through concise intents that invalidate connection state", async () => {
+    const { client, requests } = createConnectorTestClient()
+    const queryClient = new QueryClient()
+    const queryKey = listConnectorConnectionsQueryKey({ path: { connectorId: "github" } })
+    queryClient.setQueryData(queryKey, connections)
+
+    const disconnectOptions = disconnectConnectorMutationOptions({
+      client,
+      queryClient,
+      connectorId: "github",
+      connectionId: "ccn_1",
+    })
+    const disconnect = disconnectOptions.mutationFn as () => Promise<{ success: boolean }>
+    const disconnected = await disconnect()
+    await disconnectOptions.onSuccess?.(disconnected, undefined, undefined, {} as never)
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true)
+
+    queryClient.setQueryData(queryKey, connections)
+    const revokeOptions = revokeConnectorMutationOptions({
+      client,
+      queryClient,
+      connectorId: "github",
+      connectionId: "ccn_1",
+    })
+    const revoke = revokeOptions.mutationFn as () => Promise<RevokeConnectorConnectionResponse>
+    const revokedResult = await revoke()
+    await revokeOptions.onSuccess?.(revokedResult, undefined, undefined, {} as never)
+
+    expect(revokedResult).toEqual(revoked)
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true)
+    expect(requests.slice(-2)).toEqual([
+      {
+        method: "DELETE",
+        path: "/api/connectors/github/connections/ccn_1",
+        body: undefined,
+      },
+      {
+        method: "POST",
+        path: "/api/connectors/github/connections/ccn_1/revoke",
+        body: undefined,
+      },
+    ])
+  })
+
+  test("starts reauthorization without exposing the generated request shape", async () => {
+    const { client, requests } = createConnectorTestClient()
+    const options = reauthorizeConnectorMutationOptions({
+      client,
+      connectorId: "github",
+      connectionId: "ccn_1",
+      returnTo: "https://app.sixb.test/settings/connectors",
+    })
+    const mutationFn = options.mutationFn as () => Promise<ReauthorizeConnectorConnectionResponse>
+
+    expect(await mutationFn()).toEqual(reauthorization)
+    expect(requests).toEqual([
+      {
+        method: "POST",
+        path: "/api/connectors/github/connections/ccn_1/reauthorize",
+        body: { returnTo: "https://app.sixb.test/settings/connectors" },
+      },
+    ])
+  })
+
   test("reads the resumed run through the generated cache key", async () => {
     const { client, requests } = createConnectorTestClient()
     const options = connectorConnectionRunQueryOptions({
@@ -264,5 +393,29 @@ describe("connector connection hooks", () => {
       queryClient.getQueryData<SelectConnectorConnectionRunAccountResponse>(runQueryKey)
     ).toEqual(succeededRun)
     expect(queryClient.getQueryState(connectionsQueryKey)?.isInvalidated).toBe(true)
+  })
+})
+
+describe("connector connection callback", () => {
+  test("reads the namespaced connector and run identity", () => {
+    expect(
+      readConnectorConnectionCallback(
+        "https://app.sixb.test/settings?connectionConnectorId=tiktok&connectionRunId=ccr_123"
+      )
+    ).toEqual({ connectorId: "tiktok", runId: "ccr_123" })
+  })
+
+  test("ignores an incomplete callback identity", () => {
+    expect(
+      readConnectorConnectionCallback("https://app.sixb.test/settings?connectionRunId=ccr_123")
+    ).toBeNull()
+  })
+
+  test("preserves application URL state while removing callback parameters", () => {
+    expect(
+      connectorConnectionReturnTo(
+        "https://app.sixb.test/settings?tab=connectors&connectionConnectorId=tiktok&connectionRunId=ccr_123#oauth"
+      )
+    ).toBe("https://app.sixb.test/settings?tab=connectors#oauth")
   })
 })

--- a/packages/core/src/connectors/connections/contracts.ts
+++ b/packages/core/src/connectors/connections/contracts.ts
@@ -64,6 +64,7 @@ export type CompleteConnectorConnectionRunInput =
 
 export interface CompleteConnectorConnectionRunResult {
   readonly runId: string
+  readonly connectorId: string
   readonly returnTo: string
 }
 

--- a/packages/core/src/connectors/connections/runs.ts
+++ b/packages/core/src/connectors/connections/runs.ts
@@ -318,7 +318,7 @@ export class ConnectorConnectionRunService {
       }
       if (isConnectorStorageError(error, "connection_conflict")) {
         throw createConnectorCodedError(
-          "connector.operation_conflict",
+          "connector.replacement_required",
           "Connector slot is already occupied; explicit replacement is required.",
           { cause: error }
         )

--- a/packages/core/src/connectors/connections/runs.ts
+++ b/packages/core/src/connectors/connections/runs.ts
@@ -183,7 +183,11 @@ export class ConnectorConnectionRunService {
     )
     const claimed = await this.claimCallback(state, callbackBinding, redirectUri)
     if (claimed.type === "expired") {
-      return { runId: claimed.run.id, returnTo: claimed.returnTo }
+      return {
+        runId: claimed.run.id,
+        connectorId: claimed.run.connectorId,
+        returnTo: claimed.returnTo,
+      }
     }
 
     const { run, attempt, principal, returnTo } = claimed
@@ -193,7 +197,7 @@ export class ConnectorConnectionRunService {
         input.error === "access_denied"
           ? await this.cancelRun(run)
           : await this.failRun(run, providerCallbackError(input.error))
-      return { runId: finished.id, returnTo }
+      return { runId: finished.id, connectorId: finished.connectorId, returnTo }
     }
 
     let authorizationId = run.authorizationId
@@ -227,10 +231,10 @@ export class ConnectorConnectionRunService {
         },
       })
       const finished = await this.finalizeCompletedRun(run, authorization)
-      return { runId: finished.id, returnTo }
+      return { runId: finished.id, connectorId: finished.connectorId, returnTo }
     } catch (error) {
       const failed = await this.failRun(run, error, authorizationId)
-      return { runId: failed.id, returnTo }
+      return { runId: failed.id, connectorId: failed.connectorId, returnTo }
     }
   }
 

--- a/packages/core/src/errors/catalog.ts
+++ b/packages/core/src/errors/catalog.ts
@@ -58,6 +58,10 @@ export const SIXB_ERROR_DEFINITIONS = {
     publicMessage: "Connector provider is temporarily unavailable.",
     retryable: true,
   },
+  "connector.replacement_required": {
+    publicMessage: "Connector selection requires explicit replacement.",
+    retryable: false,
+  },
   "connector.revocation_pending": {
     publicMessage: "Connector revocation is pending.",
     retryable: true,

--- a/packages/core/tests/connector-connection-runs.test.ts
+++ b/packages/core/tests/connector-connection-runs.test.ts
@@ -4,6 +4,7 @@ import {
   authorize,
   callbackUrl,
   createHarness,
+  expectSixbError,
   managementCommand,
   projectOwner,
   rejectionOf,
@@ -169,6 +170,53 @@ describe("connector connection runs", () => {
         authorizationId: completed.authorizationId,
       })
     ).resolves.toHaveLength(2)
+  })
+
+  test("distinguishes an occupied slot from other run conflicts", async () => {
+    const harness = createHarness()
+    const command = managementCommand()
+    const existingAuthorization = await authorize(harness)
+    await harness.process.selectAccount(command, harness.connector.id, {
+      authorizationId: existingAuthorization.authorizationId,
+      accountId: "account-a",
+      owner: projectOwner,
+      slot: "social",
+    })
+
+    const started = await harness.process.startConnectionRun(command, harness.connector.id, {
+      owner: projectOwner,
+      slot: "social",
+      redirectUri: callbackUrl,
+      returnTo,
+    })
+    const state = new URL(started.authorizationUrl).searchParams.get("state")!
+    await harness.process.callbackProcess.completeConnectionRun({
+      state,
+      code: "authorization-code",
+      redirectUri: callbackUrl,
+      callbackBinding: started.callbackBinding.secret,
+    })
+
+    const replacementRequired = await rejectionOf(
+      harness.process.selectConnectionRunAccount(command, harness.connector.id, {
+        runId: started.runId,
+        accountId: "account-b",
+      })
+    )
+    expectSixbError(replacementRequired, "connector.replacement_required")
+
+    await harness.process.selectConnectionRunAccount(command, harness.connector.id, {
+      runId: started.runId,
+      accountId: "account-b",
+      replace: true,
+    })
+    const terminalConflict = await rejectionOf(
+      harness.process.selectConnectionRunAccount(command, harness.connector.id, {
+        runId: started.runId,
+        accountId: "account-b",
+      })
+    )
+    expectSixbError(terminalConflict, "connector.operation_conflict")
   })
 
   test("automatically revokes an abandoned account-selection run", async () => {

--- a/packages/core/tests/connector-connection-runs.test.ts
+++ b/packages/core/tests/connector-connection-runs.test.ts
@@ -50,7 +50,7 @@ describe("connector connection runs", () => {
       redirectUri: callbackUrl,
       callbackBinding: started.callbackBinding.secret,
     })
-    expect(completed).toEqual({ runId: started.runId, returnTo })
+    expect(completed).toEqual({ runId: started.runId, connectorId: harness.connector.id, returnTo })
 
     const waiting = await harness.process.getConnectionRun(
       command,
@@ -120,7 +120,11 @@ describe("connector connection runs", () => {
         redirectUri: callbackUrl,
         callbackBinding: started.callbackBinding.secret,
       })
-    ).resolves.toEqual({ runId: started.runId, returnTo })
+    ).resolves.toEqual({
+      runId: started.runId,
+      connectorId: harness.connector.id,
+      returnTo,
+    })
     await expect(
       harness.process.getConnectionRun(command, harness.connector.id, started.runId)
     ).resolves.toMatchObject({ status: "cancelled" })

--- a/packages/server/src/routes/connector-connection-runs.ts
+++ b/packages/server/src/routes/connector-connection-runs.ts
@@ -295,6 +295,7 @@ export function registerConnectorConnectionRunRoutes(
           })
           return connectorCallbackRedirect(
             result.returnTo,
+            result.connectorId,
             result.runId,
             clearConnectorCallbackCookie(request, callbackCookie.name)
           )
@@ -313,8 +314,14 @@ export function registerConnectorConnectionRunRoutes(
     )
 }
 
-function connectorCallbackRedirect(returnTo: string, runId: string, clearCookie: string): Response {
+function connectorCallbackRedirect(
+  returnTo: string,
+  connectorId: string,
+  runId: string,
+  clearCookie: string
+): Response {
   const destination = new URL(returnTo)
+  destination.searchParams.set("connectionConnectorId", connectorId)
   destination.searchParams.set("connectionRunId", runId)
   return new Response(null, {
     status: 302,

--- a/packages/server/src/schemas/connectors.ts
+++ b/packages/server/src/schemas/connectors.ts
@@ -17,6 +17,7 @@ export const CONNECTOR_HTTP_ERROR_CODES = [
   "connector.operation_in_progress",
   "connector.provider_failed",
   "connector.provider_unavailable",
+  "connector.replacement_required",
   "connector.revocation_pending",
 ] as const
 export type ConnectorHttpErrorCode = (typeof CONNECTOR_HTTP_ERROR_CODES)[number]
@@ -32,6 +33,7 @@ export const ConnectorConflictResponseSchema = connectorRouteErrorResponseSchema
   "connector.authorization_required",
   "connector.operation_conflict",
   "connector.operation_in_progress",
+  "connector.replacement_required",
   "connector.revocation_pending",
 ])
 export const ConnectorInternalErrorResponseSchema = connectorRouteErrorResponseSchema([

--- a/packages/server/src/utils/http.ts
+++ b/packages/server/src/utils/http.ts
@@ -24,6 +24,7 @@ const HTTP_STATUS_BY_ERROR_CODE: Partial<Record<SixbErrorCode, number>> = {
   "connector.operation_in_progress": 409,
   "connector.provider_failed": 502,
   "connector.provider_unavailable": 503,
+  "connector.replacement_required": 409,
   "connector.revocation_pending": 409,
   "dataset.not_found": 404,
   "dataset.version_not_found": 404,

--- a/packages/server/tests/connector-connections-routes.test.ts
+++ b/packages/server/tests/connector-connections-routes.test.ts
@@ -320,6 +320,7 @@ describe("connector connection Headless API", () => {
     expect(destination.origin).toBe("http://atlas.localhost")
     expect(destination.pathname).toBe("/settings/connectors")
     expect(destination.searchParams.get("tab")).toBe("crm")
+    expect(destination.searchParams.get("connectionConnectorId")).toBe("crm")
     expect(destination.searchParams.get("connectionRunId")).toBe(started.runId)
 
     const claimed = await harness.storage.connectorConnections.getConnectionRun({

--- a/packages/server/tests/connector-connections-routes.test.ts
+++ b/packages/server/tests/connector-connections-routes.test.ts
@@ -711,6 +711,30 @@ describe("connector connection Headless API", () => {
     )
   })
 
+  test("returns a dedicated conflict when account selection requires replacement", async () => {
+    const harness = await createHarness()
+    await connectAccount(harness, "social", "account-a")
+    const started = await startRun(harness, "social")
+    const callback = await completeRunAtProvider(harness, started.state, started.callbackCookie)
+    expect(callback.status).toBe(302)
+
+    const selection = await harness.app.handle(
+      new Request(
+        `http://api.localhost/api/connectors/crm/connection-runs/${started.runId}/selection`,
+        {
+          method: "POST",
+          headers: harness.session.mutationHeaders,
+          body: JSON.stringify({ accountId: "account-b" }),
+        }
+      )
+    )
+
+    expect(selection.status).toBe(409)
+    expect(await selection.json()).toMatchObject({
+      code: "connector.replacement_required",
+    })
+  })
+
   test("retains a durable cleanup handle when replacement revocation must be retried", async () => {
     const harness = await createHarness()
     const connected = await connectAccount(harness, "social", "account-a")


### PR DESCRIPTION
Part of #384. Stacked on #433.

## What

Adds the headless React experience for managed connector connections:

```tsx
const tiktok = useConnectorConnection({
  connectorId: "tiktok",
  slot: "organic",
})

<button onClick={tiktok.connect} disabled={tiktok.isPending}>
  {tiktok.connection?.account.label ?? "Connect TikTok"}
</button>
```

- resumes the durable connection run after the OAuth callback;
- exposes typed status, account selection, disconnect, revoke, refresh, and errors;
- adds concise low-level queries and mutations for advanced flows;
- documents slot semantics and replacement confirmation;
- keeps the callback payload secret-free with namespaced connector/run identifiers.

## Why

- applications keep full control of their UI;
- Sixb owns OAuth navigation, run resumption, lifecycle invariants, and cache convergence;
- Connector behavior lives in `@sixb/client/hooks`; no Connector UI is added to `@sixb/app`;
- client code is split by responsibility: `connection`, `queries`, and `mutations`.

```text
connect() → provider OAuth → callback → resume run → select account → connected
```

## Validation

- 4,042 tests passed; 7 external integration tests skipped;
- typecheck, lint, build, and client generation passed;
- 49 publishable packages verified.
