### PR TITLE
stripe: add billing connector

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -294,6 +294,21 @@
         "@sixb/core": "workspace:^",
       },
     },
+    "connectors/stripe": {
+      "name": "@sixb/connector-stripe",
+      "version": "0.1.0",
+      "dependencies": {
+        "stripe": "^22.5.0",
+      },
+      "devDependencies": {
+        "@sixb/core": "workspace:*",
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+      "peerDependencies": {
+        "@sixb/core": "workspace:^",
+      },
+    },
     "connectors/teamleader": {
       "name": "@sixb/connector-teamleader",
       "version": "0.1.1",
@@ -1396,6 +1411,8 @@
 
     "@sixb/connector-sql": ["@sixb/connector-sql@workspace:connectors/sql"],
 
+    "@sixb/connector-stripe": ["@sixb/connector-stripe@workspace:connectors/stripe"],
+
     "@sixb/connector-teamleader": ["@sixb/connector-teamleader@workspace:connectors/teamleader"],
 
     "@sixb/connector-unipile": ["@sixb/connector-unipile@workspace:connectors/unipile"],
@@ -2263,6 +2280,8 @@
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "stripe": ["stripe@22.5.0", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-QVwMwriC0bbySx6R4dpsvJ0W//GojC1kwWVS6rPSoVqDUIZX4Hy3TaUrd2AZeXEAaKbfWIjQjvo3vKAReHZ0vQ=="],
 
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 

--- a/connectors/stripe/LICENSE
+++ b/connectors/stripe/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sixb contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/connectors/stripe/README.md
+++ b/connectors/stripe/README.md
@@ -1,0 +1,245 @@
+# @sixb/connector-stripe
+
+Typed Stripe Billing connector for Sixb. It covers Customers, Subscriptions, Invoices, Refunds,
+and v1 snapshot Events, with optional verified webhook delivery. Each resource lives in an
+independent module so another Stripe surface can be added without growing a monolithic client.
+
+The connector delegates wire-level behavior to Stripe's official SDK: generated request and
+response types, form encoding, API-version headers, structured errors, request ids, automatic
+network retries, idempotency keys, cursor pagination, and webhook signature verification all
+follow Stripe's implementation.
+
+## Register
+
+Create a restricted or secret API key in Stripe Workbench, then define the connector in your
+project's `connectors/` directory:
+
+```ts
+import { stripe } from "@sixb/connector-stripe"
+import { defineConnector } from "@sixb/core"
+
+export const stripeConnector = defineConnector(
+  "stripe",
+  stripe({
+    apiKey: process.env.STRIPE_SECRET_KEY!,
+  })
+)
+```
+
+`createSixb()` discovers the definition automatically. Resolve the typed client with:
+
+```ts
+const billing = await sixb.connector(stripeConnector)
+```
+
+Never put a secret key in browser code. This package is a server-side connector.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `apiKey` | Required secret key, or async resolver evaluated when Sixb connects the adapter. |
+| `maxNetworkRetries` | Retries after the initial request. Defaults to `1` in Stripe's SDK. |
+| `timeoutMs` | Per-request timeout. Defaults to 80 seconds in Stripe's SDK. |
+| `telemetry` | Set `false` to disable Stripe's request-latency telemetry. |
+| `stripeContext` | Account context applied to every request, including Stripe Connect calls. |
+| `onEvent` | Handler for inbound v1 snapshot-event webhooks. Registers the `events` route. |
+| `webhookSecret` | Endpoint signing secret beginning with `whsec_`. |
+| `webhookToleranceMs` | Maximum signature age. Defaults to 5 minutes. |
+| `webhooks` | Extra inbound webhooks to register alongside the built-in route. |
+
+For per-request Connect context, API-key rotation, API-version selection, timeout, retry count, or
+idempotency, pass `StripeRequestOptions` as the last argument to a resource method:
+
+```ts
+await billing.refunds.create(
+  { payment_intent: "pi_123", amount: 2_500 },
+  {
+    idempotencyKey: "refund:order-123:v1",
+    stripeContext: "acct_123",
+    timeout: 15_000,
+  }
+)
+```
+
+Stripe accepts idempotency keys on every v1 `POST`. The SDK also creates keys when it retries an
+eligible write after a network failure. Supply your own stable key when an operation can be
+retried by application code or a job runner.
+
+## API version and types
+
+The connector uses the API version bundled with the installed `stripe` SDK. The lockfile currently
+resolves `stripe` 22.5.0, whose generated types target `2026-07-29.dahlia`. Upgrade the SDK and
+review Stripe's API changelog together: response types intentionally describe the SDK's current API
+version, not every historical account version.
+
+Every parameter and object type used by the client is re-exported from this package. Successful
+single-object calls return `StripeResponse<T>`, so the object also carries Stripe's response
+metadata:
+
+```ts
+const customer = await billing.customers.get("cus_123")
+
+console.log(customer.email)
+console.log(customer.lastResponse.requestId)
+console.log(customer.lastResponse.statusCode)
+```
+
+Stripe errors are preserved as the official structured error classes, including `statusCode`,
+`requestId`, `code`, `param`, and the raw provider error.
+
+## Pagination
+
+Every collection exposes both the SDK's awaitable page request and an explicit async iterator:
+
+```ts
+const firstPage = await billing.invoices.list({ customer: "cus_123", limit: 100 })
+
+for await (const invoice of billing.invoices.listAll({ customer: "cus_123", limit: 100 })) {
+  // Map the invoice into a dataset or object.
+}
+```
+
+`listAll` follows Stripe's `starting_after` cursor. It preserves every initial filter and stops when
+`has_more` is false. `starting_after` and `ending_before` are rejected together, and page limits are
+validated as integers from 1 to 100 before a request is sent.
+
+Customer, Subscription, and Invoice search methods also expose `searchAll`. Stripe Search is
+eventually consistent: don't use it for read-after-write flows. Stripe documents normal propagation
+under one minute, possible delays up to one hour during outages, and no Search API availability for
+merchants in India.
+
+## Customers
+
+| Client method | Stripe endpoint |
+| --- | --- |
+| `billing.customers.create(params?, options?)` | `POST /v1/customers` |
+| `billing.customers.update(id, params?, options?)` | `POST /v1/customers/:id` |
+| `billing.customers.get(id, params?, options?)` | `GET /v1/customers/:id` |
+| `billing.customers.list(params?, options?)` | `GET /v1/customers` |
+| `billing.customers.listAll(params?, options?)` | Auto-pagination over the list endpoint |
+| `billing.customers.delete(id, params?, options?)` | `DELETE /v1/customers/:id` |
+| `billing.customers.search(params, options?)` | `GET /v1/customers/search` |
+| `billing.customers.searchAll(params, options?)` | Auto-pagination over the search endpoint |
+
+Deleting a customer is permanent and immediately cancels that customer's active subscriptions.
+Retrieving an already deleted customer returns Stripe's reduced `StripeDeletedCustomer` shape.
+
+## Subscriptions
+
+| Client method | Stripe endpoint |
+| --- | --- |
+| `billing.subscriptions.create(params, options?)` | `POST /v1/subscriptions` |
+| `billing.subscriptions.update(id, params?, options?)` | `POST /v1/subscriptions/:id` |
+| `billing.subscriptions.get(id, params?, options?)` | `GET /v1/subscriptions/:id` |
+| `billing.subscriptions.list(params?, options?)` | `GET /v1/subscriptions` |
+| `billing.subscriptions.listAll(params?, options?)` | Auto-pagination over the list endpoint |
+| `billing.subscriptions.cancel(id, params?, options?)` | `DELETE /v1/subscriptions/:id` |
+| `billing.subscriptions.migrate(id, params, options?)` | `POST /v1/subscriptions/:id/migrate` |
+| `billing.subscriptions.resume(id, params?, options?)` | `POST /v1/subscriptions/:id/resume` |
+| `billing.subscriptions.search(params, options?)` | `GET /v1/subscriptions/search` |
+| `billing.subscriptions.searchAll(params, options?)` | Auto-pagination over the search endpoint |
+
+`cancel` ends a subscription immediately. To schedule cancellation at the period end, use
+`update(id, { cancel_at_period_end: true })` instead.
+
+## Invoices
+
+| Client method | Stripe endpoint |
+| --- | --- |
+| `billing.invoices.create(params?, options?)` | `POST /v1/invoices` |
+| `billing.invoices.createPreview(params?, options?)` | `POST /v1/invoices/create_preview` |
+| `billing.invoices.update(id, params?, options?)` | `POST /v1/invoices/:id` |
+| `billing.invoices.get(id, params?, options?)` | `GET /v1/invoices/:id` |
+| `billing.invoices.list(params?, options?)` | `GET /v1/invoices` |
+| `billing.invoices.listAll(params?, options?)` | Auto-pagination over the list endpoint |
+| `billing.invoices.delete(id, params?, options?)` | `DELETE /v1/invoices/:id` |
+| `billing.invoices.attachPayment(id, params?, options?)` | `POST /v1/invoices/:id/attach_payment` |
+| `billing.invoices.finalize(id, params?, options?)` | `POST /v1/invoices/:id/finalize` |
+| `billing.invoices.markUncollectible(id, params?, options?)` | `POST /v1/invoices/:id/mark_uncollectible` |
+| `billing.invoices.pay(id, params?, options?)` | `POST /v1/invoices/:id/pay` |
+| `billing.invoices.send(id, params?, options?)` | `POST /v1/invoices/:id/send` |
+| `billing.invoices.void(id, params?, options?)` | `POST /v1/invoices/:id/void` |
+| `billing.invoices.search(params, options?)` | `GET /v1/invoices/search` |
+| `billing.invoices.searchAll(params, options?)` | Auto-pagination over the search endpoint |
+
+`delete` applies only to eligible draft invoices. Use `void` for a finalized invoice; voiding is
+irreversible and preserves the accounting record. A preview is ephemeral and does not appear in
+invoice lists.
+
+## Refunds
+
+| Client method | Stripe endpoint |
+| --- | --- |
+| `billing.refunds.create(params, options?)` | `POST /v1/refunds` |
+| `billing.refunds.update(id, params?, options?)` | `POST /v1/refunds/:id` |
+| `billing.refunds.get(id, params?, options?)` | `GET /v1/refunds/:id` |
+| `billing.refunds.list(params?, options?)` | `GET /v1/refunds` |
+| `billing.refunds.listAll(params?, options?)` | Auto-pagination over the list endpoint |
+| `billing.refunds.cancel(id, params?, options?)` | `POST /v1/refunds/:id/cancel` |
+
+Create a refund against a Charge or PaymentIntent. Stripe allows partial refunds up to the remaining
+unrefunded amount. `update` currently changes metadata only. `cancel` only applies to refunds in
+`requires_action`; refunds in other states cannot be canceled.
+
+## Events and webhooks
+
+The Events API supports polling and backfills for the previous 30 days:
+
+| Client method | Stripe endpoint |
+| --- | --- |
+| `billing.events.get(id, params?, options?)` | `GET /v1/events/:id` |
+| `billing.events.list(params?, options?)` | `GET /v1/events` |
+| `billing.events.listAll(params?, options?)` | Auto-pagination over the list endpoint |
+
+An event's `data.object` is rendered with the API version recorded in `event.api_version`, not the
+version used by the current request.
+
+For real-time delivery, configure a v1 snapshot event destination in Stripe Workbench and point it
+at Sixb's connector webhook route:
+
+```text
+POST /api/webhooks/stripe/events
+```
+
+Then configure the signing secret and handler:
+
+```ts
+export const stripeConnector = defineConnector(
+  "stripe",
+  stripe({
+    apiKey: process.env.STRIPE_SECRET_KEY!,
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET!,
+    onEvent: async ({ event, logger, client }) => {
+      logger.info(`[Stripe] ${event.type}`, event.id)
+
+      if (event.type === "invoice.paid") {
+        const stripe = await client()
+        const invoice = await stripe.invoices.get(event.data.object.id)
+        // Reconcile the current invoice state.
+      }
+    },
+  })
+)
+```
+
+The route verifies `Stripe-Signature` against the exact raw request bytes with Stripe's official
+SDK and rejects stale signatures outside the replay window. The event id is used as Sixb's delivery
+idempotency key because Stripe retries webhook deliveries. Missing secrets fail startup unless
+`webhookAllowUnverified: true` is explicitly set.
+
+This route handles v1 snapshot events. Stripe v2 thin events have a different payload and retrieval
+model and are intentionally outside this connector's current Events resource.
+
+## Cancellation limitation
+
+The Stripe 22.5.0 SDK does not expose `AbortSignal` in its request options. Sixb therefore refuses a
+new connection when its lifecycle signal is already aborted, but it cannot interrupt an individual
+Stripe request already in flight. Keep `timeoutMs` bounded; the SDK default is 80 seconds. Native
+`AbortSignal` support in Stripe's SDK would remove this limitation.
+
+## Test mode and sandboxes
+
+Use `sk_test_...` keys for test mode or a secret key created inside a Stripe Sandbox. Stripe uses the
+same API host for live mode, test mode, and Sandboxes; the key selects the environment. Test webhook
+signing secrets and live signing secrets are different, even when the endpoint URL is identical.

--- a/connectors/stripe/package.json
+++ b/connectors/stripe/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@sixb/connector-stripe",
+  "version": "0.1.0",
+  "description": "Stripe Billing API connector for Sixb",
+  "keywords": [
+    "sixb",
+    "bun",
+    "connector",
+    "integration",
+    "stripe"
+  ],
+  "homepage": "https://sixb.ai",
+  "bugs": {
+    "url": "https://github.com/sixb-ai/sixb/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sixb-ai/sixb.git",
+    "directory": "connectors/stripe"
+  },
+  "author": "Sixb contributors",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun ../../scripts/build-package.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "prepack": "bun run build"
+  },
+  "dependencies": {
+    "stripe": "^22.5.0"
+  },
+  "peerDependencies": {
+    "@sixb/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@sixb/core": "workspace:*",
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "engines": {
+    "bun": ">=1.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/connectors/stripe/src/client.ts
+++ b/connectors/stripe/src/client.ts
@@ -1,0 +1,25 @@
+import type Stripe from "stripe"
+import { type CustomersResource, createCustomersResource } from "./resources/customers"
+import { createEventsResource, type EventsResource } from "./resources/events"
+import { createInvoicesResource, type InvoicesResource } from "./resources/invoices"
+import { createRefundsResource, type RefundsResource } from "./resources/refunds"
+import { createSubscriptionsResource, type SubscriptionsResource } from "./resources/subscriptions"
+
+export interface StripeClient {
+  readonly customers: CustomersResource
+  readonly subscriptions: SubscriptionsResource
+  readonly invoices: InvoicesResource
+  readonly refunds: RefundsResource
+  /** Snapshot events available from Stripe for 30 days. */
+  readonly events: EventsResource
+}
+
+export function createStripeClient(sdk: Stripe): StripeClient {
+  return {
+    customers: createCustomersResource(sdk),
+    subscriptions: createSubscriptionsResource(sdk),
+    invoices: createInvoicesResource(sdk),
+    refunds: createRefundsResource(sdk),
+    events: createEventsResource(sdk),
+  }
+}

--- a/connectors/stripe/src/index.ts
+++ b/connectors/stripe/src/index.ts
@@ -1,0 +1,75 @@
+export { createStripeClient, type StripeClient } from "./client"
+export type {
+  CustomersResource,
+  StripeCustomer,
+  StripeCustomerCreateParams,
+  StripeCustomerDeleteParams,
+  StripeCustomerListParams,
+  StripeCustomerRetrieveParams,
+  StripeCustomerSearchParams,
+  StripeCustomerUpdateParams,
+  StripeDeletedCustomer,
+} from "./resources/customers"
+export type {
+  EventsResource,
+  StripeEvent,
+  StripeEventListParams,
+  StripeEventRetrieveParams,
+} from "./resources/events"
+export type {
+  InvoicesResource,
+  StripeDeletedInvoice,
+  StripeInvoice,
+  StripeInvoiceAttachPaymentParams,
+  StripeInvoiceCreateParams,
+  StripeInvoiceCreatePreviewParams,
+  StripeInvoiceDeleteParams,
+  StripeInvoiceFinalizeParams,
+  StripeInvoiceListParams,
+  StripeInvoiceMarkUncollectibleParams,
+  StripeInvoicePayParams,
+  StripeInvoiceRetrieveParams,
+  StripeInvoiceSearchParams,
+  StripeInvoiceSendParams,
+  StripeInvoiceUpdateParams,
+  StripeInvoiceVoidParams,
+} from "./resources/invoices"
+export type {
+  RefundsResource,
+  StripeRefund,
+  StripeRefundCancelParams,
+  StripeRefundCreateParams,
+  StripeRefundListParams,
+  StripeRefundRetrieveParams,
+  StripeRefundUpdateParams,
+} from "./resources/refunds"
+export type {
+  StripeSubscription,
+  StripeSubscriptionCancelParams,
+  StripeSubscriptionCreateParams,
+  StripeSubscriptionListParams,
+  StripeSubscriptionMigrateParams,
+  StripeSubscriptionResumeParams,
+  StripeSubscriptionRetrieveParams,
+  StripeSubscriptionSearchParams,
+  StripeSubscriptionUpdateParams,
+  SubscriptionsResource,
+} from "./resources/subscriptions"
+export type { StripeConnector } from "./stripe"
+export { stripe } from "./stripe"
+export type {
+  StripeApiKeyResolver,
+  StripeConnectorOptions,
+  StripeListPromise,
+  StripePage,
+  StripeRequestOptions,
+  StripeResponse,
+  StripeSearchPage,
+  StripeSearchPromise,
+} from "./types"
+export type {
+  StripeEventContext,
+  StripeEventHandler,
+  StripeEventsWebhookOptions,
+} from "./webhooks"
+export { stripeEventsWebhook } from "./webhooks"

--- a/connectors/stripe/src/resources/customers.ts
+++ b/connectors/stripe/src/resources/customers.ts
@@ -1,0 +1,96 @@
+import type Stripe from "stripe"
+import type {
+  StripeListPromise,
+  StripeRequestOptions,
+  StripeResponse,
+  StripeSearchPromise,
+} from "../types"
+import { assertCursorOptions, assertPageLimit, stripeId } from "../validation"
+
+export type StripeCustomer = Stripe.Customer
+export type StripeDeletedCustomer = Stripe.DeletedCustomer
+export type StripeCustomerCreateParams = Stripe.CustomerCreateParams
+export type StripeCustomerUpdateParams = Stripe.CustomerUpdateParams
+export type StripeCustomerRetrieveParams = Stripe.CustomerRetrieveParams
+export type StripeCustomerListParams = Stripe.CustomerListParams
+export type StripeCustomerDeleteParams = Stripe.CustomerDeleteParams
+export type StripeCustomerSearchParams = Stripe.CustomerSearchParams
+
+export interface CustomersResource {
+  /** `POST /v1/customers` */
+  create(
+    params?: StripeCustomerCreateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeCustomer>>
+  /** `POST /v1/customers/{id}` */
+  update(
+    id: string,
+    params?: StripeCustomerUpdateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeCustomer>>
+  /** `GET /v1/customers/{id}` */
+  get(
+    id: string,
+    params?: StripeCustomerRetrieveParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeCustomer | StripeDeletedCustomer>>
+  /** `GET /v1/customers` */
+  list(
+    params?: StripeCustomerListParams,
+    options?: StripeRequestOptions
+  ): StripeListPromise<StripeCustomer>
+  /** Auto-paginated iterator over `GET /v1/customers`. */
+  listAll(
+    params?: StripeCustomerListParams,
+    options?: StripeRequestOptions
+  ): AsyncIterable<StripeCustomer>
+  /** `DELETE /v1/customers/{id}` — permanent and also cancels active subscriptions. */
+  delete(
+    id: string,
+    params?: StripeCustomerDeleteParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeDeletedCustomer>>
+  /** `GET /v1/customers/search` — eventually consistent and unavailable in India. */
+  search(
+    params: StripeCustomerSearchParams,
+    options?: StripeRequestOptions
+  ): StripeSearchPromise<StripeCustomer>
+  /** Auto-paginated iterator over `GET /v1/customers/search`. */
+  searchAll(
+    params: StripeCustomerSearchParams,
+    options?: StripeRequestOptions
+  ): AsyncIterable<StripeCustomer>
+}
+
+export function createCustomersResource(sdk: Stripe): CustomersResource {
+  return {
+    create(params, options) {
+      return sdk.customers.create(params, options)
+    },
+    update(id, params, options) {
+      return sdk.customers.update(stripeId(id, "customer id"), params, options)
+    },
+    get(id, params, options) {
+      return sdk.customers.retrieve(stripeId(id, "customer id"), params, options)
+    },
+    list(params, options) {
+      assertCursorOptions(params)
+      return sdk.customers.list(params, options)
+    },
+    listAll(params, options) {
+      assertCursorOptions(params)
+      return sdk.customers.list(params, options)
+    },
+    delete(id, params, options) {
+      return sdk.customers.del(stripeId(id, "customer id"), params, options)
+    },
+    search(params, options) {
+      assertPageLimit(params.limit)
+      return sdk.customers.search(params, options)
+    },
+    searchAll(params, options) {
+      assertPageLimit(params.limit)
+      return sdk.customers.search(params, options)
+    },
+  }
+}

--- a/connectors/stripe/src/resources/events.ts
+++ b/connectors/stripe/src/resources/events.ts
@@ -1,0 +1,52 @@
+import type Stripe from "stripe"
+import type { StripeListPromise, StripeRequestOptions, StripeResponse } from "../types"
+import { assertCursorOptions, stripeId } from "../validation"
+
+export type StripeEvent = Stripe.Event
+export type StripeEventRetrieveParams = Stripe.EventRetrieveParams
+export type StripeEventListParams = Stripe.EventListParams
+
+export interface EventsResource {
+  /** `GET /v1/events/{id}` — Stripe guarantees retrieval for 30 days. */
+  get(
+    id: string,
+    params?: StripeEventRetrieveParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeEvent>>
+  /** `GET /v1/events` — Stripe exposes up to 30 days of events. */
+  list(
+    params?: StripeEventListParams,
+    options?: StripeRequestOptions
+  ): StripeListPromise<StripeEvent>
+  /** Auto-paginated iterator over `GET /v1/events`. */
+  listAll(
+    params?: StripeEventListParams,
+    options?: StripeRequestOptions
+  ): AsyncIterable<StripeEvent>
+}
+
+export function createEventsResource(sdk: Stripe): EventsResource {
+  return {
+    get(id, params, options) {
+      return sdk.events.retrieve(stripeId(id, "event id"), params, options)
+    },
+    list(params, options) {
+      assertEventListParams(params)
+      return sdk.events.list(params, options)
+    },
+    listAll(params, options) {
+      assertEventListParams(params)
+      return sdk.events.list(params, options)
+    },
+  }
+}
+
+function assertEventListParams(params: StripeEventListParams | undefined): void {
+  assertCursorOptions(params)
+  if (params?.type && params.types?.length) {
+    throw new Error("[SixbStripe] events.list accepts type or types, but not both.")
+  }
+  if (params?.types && params.types.length > 20) {
+    throw new Error("[SixbStripe] events.list accepts at most 20 event types.")
+  }
+}

--- a/connectors/stripe/src/resources/invoices.ts
+++ b/connectors/stripe/src/resources/invoices.ts
@@ -1,0 +1,165 @@
+import type Stripe from "stripe"
+import type {
+  StripeListPromise,
+  StripeRequestOptions,
+  StripeResponse,
+  StripeSearchPromise,
+} from "../types"
+import { assertCursorOptions, assertPageLimit, stripeId } from "../validation"
+
+export type StripeInvoice = Stripe.Invoice
+export type StripeDeletedInvoice = Stripe.DeletedInvoice
+export type StripeInvoiceCreateParams = Stripe.InvoiceCreateParams
+export type StripeInvoiceCreatePreviewParams = Stripe.InvoiceCreatePreviewParams
+export type StripeInvoiceUpdateParams = Stripe.InvoiceUpdateParams
+export type StripeInvoiceRetrieveParams = Stripe.InvoiceRetrieveParams
+export type StripeInvoiceListParams = Stripe.InvoiceListParams
+export type StripeInvoiceDeleteParams = Stripe.InvoiceDeleteParams
+export type StripeInvoiceSearchParams = Stripe.InvoiceSearchParams
+export type StripeInvoiceAttachPaymentParams = Stripe.InvoiceAttachPaymentParams
+export type StripeInvoiceFinalizeParams = Stripe.InvoiceFinalizeInvoiceParams
+export type StripeInvoiceMarkUncollectibleParams = Stripe.InvoiceMarkUncollectibleParams
+export type StripeInvoicePayParams = Stripe.InvoicePayParams
+export type StripeInvoiceSendParams = Stripe.InvoiceSendInvoiceParams
+export type StripeInvoiceVoidParams = Stripe.InvoiceVoidInvoiceParams
+
+export interface InvoicesResource {
+  /** `POST /v1/invoices` — creates a draft invoice. */
+  create(
+    params?: StripeInvoiceCreateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `POST /v1/invoices/create_preview` — returns an ephemeral invoice preview. */
+  createPreview(
+    params?: StripeInvoiceCreatePreviewParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `POST /v1/invoices/{id}` */
+  update(
+    id: string,
+    params?: StripeInvoiceUpdateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `GET /v1/invoices/{id}` */
+  get(
+    id: string,
+    params?: StripeInvoiceRetrieveParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `GET /v1/invoices` */
+  list(
+    params?: StripeInvoiceListParams,
+    options?: StripeRequestOptions
+  ): StripeListPromise<StripeInvoice>
+  /** Auto-paginated iterator over `GET /v1/invoices`. */
+  listAll(
+    params?: StripeInvoiceListParams,
+    options?: StripeRequestOptions
+  ): AsyncIterable<StripeInvoice>
+  /** `DELETE /v1/invoices/{id}` — draft one-off invoices only. */
+  delete(
+    id: string,
+    params?: StripeInvoiceDeleteParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeDeletedInvoice>>
+  /** `POST /v1/invoices/{id}/attach_payment` */
+  attachPayment(
+    id: string,
+    params?: StripeInvoiceAttachPaymentParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `POST /v1/invoices/{id}/finalize` */
+  finalize(
+    id: string,
+    params?: StripeInvoiceFinalizeParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `POST /v1/invoices/{id}/mark_uncollectible` */
+  markUncollectible(
+    id: string,
+    params?: StripeInvoiceMarkUncollectibleParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `POST /v1/invoices/{id}/pay` */
+  pay(
+    id: string,
+    params?: StripeInvoicePayParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `POST /v1/invoices/{id}/send` */
+  send(
+    id: string,
+    params?: StripeInvoiceSendParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `POST /v1/invoices/{id}/void` — irreversible. */
+  void(
+    id: string,
+    params?: StripeInvoiceVoidParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeInvoice>>
+  /** `GET /v1/invoices/search` — eventually consistent and unavailable in India. */
+  search(
+    params: StripeInvoiceSearchParams,
+    options?: StripeRequestOptions
+  ): StripeSearchPromise<StripeInvoice>
+  /** Auto-paginated iterator over `GET /v1/invoices/search`. */
+  searchAll(
+    params: StripeInvoiceSearchParams,
+    options?: StripeRequestOptions
+  ): AsyncIterable<StripeInvoice>
+}
+
+export function createInvoicesResource(sdk: Stripe): InvoicesResource {
+  return {
+    create(params, options) {
+      return sdk.invoices.create(params, options)
+    },
+    createPreview(params, options) {
+      return sdk.invoices.createPreview(params, options)
+    },
+    update(id, params, options) {
+      return sdk.invoices.update(stripeId(id, "invoice id"), params, options)
+    },
+    get(id, params, options) {
+      return sdk.invoices.retrieve(stripeId(id, "invoice id"), params, options)
+    },
+    list(params, options) {
+      assertCursorOptions(params)
+      return sdk.invoices.list(params, options)
+    },
+    listAll(params, options) {
+      assertCursorOptions(params)
+      return sdk.invoices.list(params, options)
+    },
+    delete(id, params, options) {
+      return sdk.invoices.del(stripeId(id, "invoice id"), params, options)
+    },
+    attachPayment(id, params, options) {
+      return sdk.invoices.attachPayment(stripeId(id, "invoice id"), params, options)
+    },
+    finalize(id, params, options) {
+      return sdk.invoices.finalizeInvoice(stripeId(id, "invoice id"), params, options)
+    },
+    markUncollectible(id, params, options) {
+      return sdk.invoices.markUncollectible(stripeId(id, "invoice id"), params, options)
+    },
+    pay(id, params, options) {
+      return sdk.invoices.pay(stripeId(id, "invoice id"), params, options)
+    },
+    send(id, params, options) {
+      return sdk.invoices.sendInvoice(stripeId(id, "invoice id"), params, options)
+    },
+    void(id, params, options) {
+      return sdk.invoices.voidInvoice(stripeId(id, "invoice id"), params, options)
+    },
+    search(params, options) {
+      assertPageLimit(params.limit)
+      return sdk.invoices.search(params, options)
+    },
+    searchAll(params, options) {
+      assertPageLimit(params.limit)
+      return sdk.invoices.search(params, options)
+    },
+  }
+}

--- a/connectors/stripe/src/resources/refunds.ts
+++ b/connectors/stripe/src/resources/refunds.ts
@@ -1,0 +1,71 @@
+import type Stripe from "stripe"
+import type { StripeListPromise, StripeRequestOptions, StripeResponse } from "../types"
+import { assertCursorOptions, stripeId } from "../validation"
+
+export type StripeRefund = Stripe.Refund
+export type StripeRefundCreateParams = Stripe.RefundCreateParams
+export type StripeRefundUpdateParams = Stripe.RefundUpdateParams
+export type StripeRefundRetrieveParams = Stripe.RefundRetrieveParams
+export type StripeRefundListParams = Stripe.RefundListParams
+export type StripeRefundCancelParams = Stripe.RefundCancelParams
+
+export interface RefundsResource {
+  /** `POST /v1/refunds` — requires a Charge or PaymentIntent. */
+  create(
+    params: StripeRefundCreateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeRefund>>
+  /** `POST /v1/refunds/{id}` — Stripe currently accepts metadata only. */
+  update(
+    id: string,
+    params?: StripeRefundUpdateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeRefund>>
+  /** `GET /v1/refunds/{id}` */
+  get(
+    id: string,
+    params?: StripeRefundRetrieveParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeRefund>>
+  /** `GET /v1/refunds` */
+  list(
+    params?: StripeRefundListParams,
+    options?: StripeRequestOptions
+  ): StripeListPromise<StripeRefund>
+  /** Auto-paginated iterator over `GET /v1/refunds`. */
+  listAll(
+    params?: StripeRefundListParams,
+    options?: StripeRequestOptions
+  ): AsyncIterable<StripeRefund>
+  /** `POST /v1/refunds/{id}/cancel` — only refunds in `requires_action`. */
+  cancel(
+    id: string,
+    params?: StripeRefundCancelParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeRefund>>
+}
+
+export function createRefundsResource(sdk: Stripe): RefundsResource {
+  return {
+    create(params, options) {
+      return sdk.refunds.create(params, options)
+    },
+    update(id, params, options) {
+      return sdk.refunds.update(stripeId(id, "refund id"), params, options)
+    },
+    get(id, params, options) {
+      return sdk.refunds.retrieve(stripeId(id, "refund id"), params, options)
+    },
+    list(params, options) {
+      assertCursorOptions(params)
+      return sdk.refunds.list(params, options)
+    },
+    listAll(params, options) {
+      assertCursorOptions(params)
+      return sdk.refunds.list(params, options)
+    },
+    cancel(id, params, options) {
+      return sdk.refunds.cancel(stripeId(id, "refund id"), params, options)
+    },
+  }
+}

--- a/connectors/stripe/src/resources/subscriptions.ts
+++ b/connectors/stripe/src/resources/subscriptions.ts
@@ -1,0 +1,115 @@
+import type Stripe from "stripe"
+import type {
+  StripeListPromise,
+  StripeRequestOptions,
+  StripeResponse,
+  StripeSearchPromise,
+} from "../types"
+import { assertCursorOptions, assertPageLimit, stripeId } from "../validation"
+
+export type StripeSubscription = Stripe.Subscription
+export type StripeSubscriptionCreateParams = Stripe.SubscriptionCreateParams
+export type StripeSubscriptionUpdateParams = Stripe.SubscriptionUpdateParams
+export type StripeSubscriptionRetrieveParams = Stripe.SubscriptionRetrieveParams
+export type StripeSubscriptionListParams = Stripe.SubscriptionListParams
+export type StripeSubscriptionCancelParams = Stripe.SubscriptionCancelParams
+export type StripeSubscriptionSearchParams = Stripe.SubscriptionSearchParams
+export type StripeSubscriptionMigrateParams = Stripe.SubscriptionMigrateParams
+export type StripeSubscriptionResumeParams = Stripe.SubscriptionResumeParams
+
+export interface SubscriptionsResource {
+  /** `POST /v1/subscriptions` */
+  create(
+    params: StripeSubscriptionCreateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeSubscription>>
+  /** `POST /v1/subscriptions/{id}` */
+  update(
+    id: string,
+    params?: StripeSubscriptionUpdateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeSubscription>>
+  /** `GET /v1/subscriptions/{id}` */
+  get(
+    id: string,
+    params?: StripeSubscriptionRetrieveParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeSubscription>>
+  /** `GET /v1/subscriptions` */
+  list(
+    params?: StripeSubscriptionListParams,
+    options?: StripeRequestOptions
+  ): StripeListPromise<StripeSubscription>
+  /** Auto-paginated iterator over `GET /v1/subscriptions`. */
+  listAll(
+    params?: StripeSubscriptionListParams,
+    options?: StripeRequestOptions
+  ): AsyncIterable<StripeSubscription>
+  /** `DELETE /v1/subscriptions/{id}` — immediate cancellation. */
+  cancel(
+    id: string,
+    params?: StripeSubscriptionCancelParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeSubscription>>
+  /** `POST /v1/subscriptions/{id}/migrate` — upgrades the subscription billing mode. */
+  migrate(
+    id: string,
+    params: StripeSubscriptionMigrateParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeSubscription>>
+  /** `POST /v1/subscriptions/{id}/resume` */
+  resume(
+    id: string,
+    params?: StripeSubscriptionResumeParams,
+    options?: StripeRequestOptions
+  ): Promise<StripeResponse<StripeSubscription>>
+  /** `GET /v1/subscriptions/search` — eventually consistent and unavailable in India. */
+  search(
+    params: StripeSubscriptionSearchParams,
+    options?: StripeRequestOptions
+  ): StripeSearchPromise<StripeSubscription>
+  /** Auto-paginated iterator over `GET /v1/subscriptions/search`. */
+  searchAll(
+    params: StripeSubscriptionSearchParams,
+    options?: StripeRequestOptions
+  ): AsyncIterable<StripeSubscription>
+}
+
+export function createSubscriptionsResource(sdk: Stripe): SubscriptionsResource {
+  return {
+    create(params, options) {
+      return sdk.subscriptions.create(params, options)
+    },
+    update(id, params, options) {
+      return sdk.subscriptions.update(stripeId(id, "subscription id"), params, options)
+    },
+    get(id, params, options) {
+      return sdk.subscriptions.retrieve(stripeId(id, "subscription id"), params, options)
+    },
+    list(params, options) {
+      assertCursorOptions(params)
+      return sdk.subscriptions.list(params, options)
+    },
+    listAll(params, options) {
+      assertCursorOptions(params)
+      return sdk.subscriptions.list(params, options)
+    },
+    cancel(id, params, options) {
+      return sdk.subscriptions.cancel(stripeId(id, "subscription id"), params, options)
+    },
+    migrate(id, params, options) {
+      return sdk.subscriptions.migrate(stripeId(id, "subscription id"), params, options)
+    },
+    resume(id, params, options) {
+      return sdk.subscriptions.resume(stripeId(id, "subscription id"), params, options)
+    },
+    search(params, options) {
+      assertPageLimit(params.limit)
+      return sdk.subscriptions.search(params, options)
+    },
+    searchAll(params, options) {
+      assertPageLimit(params.limit)
+      return sdk.subscriptions.search(params, options)
+    },
+  }
+}

--- a/connectors/stripe/src/stripe.ts
+++ b/connectors/stripe/src/stripe.ts
@@ -1,0 +1,110 @@
+import type { ConnectorAdapter, WebhookDefinition } from "@sixb/core"
+import { resolveWebhookVerification } from "@sixb/core"
+import Stripe from "stripe"
+import { createStripeClient, type StripeClient } from "./client"
+import type { StripeApiKeyResolver, StripeConnectorOptions } from "./types"
+import {
+  createStripeEventsWebhook,
+  STRIPE_CONNECTOR_WEBHOOK,
+  type StripeEventsWebhookOptions,
+} from "./webhooks"
+
+export type StripeConnector = ConnectorAdapter<"stripe", StripeClient>
+
+/**
+ * Stripe Billing connector backed by Stripe's official Node SDK.
+ *
+ * The connected client exposes only the five supported resource groups: customers,
+ * subscriptions, invoices, refunds, and snapshot events.
+ */
+export function stripe(options: StripeConnectorOptions): StripeConnector {
+  assertApiKeyResolver(options.apiKey)
+  assertOptions(options)
+
+  return {
+    type: "stripe",
+    webhooks: collectWebhooks(options),
+    async connect(context) {
+      context.signal.throwIfAborted()
+      const apiKey = await resolveApiKey(options.apiKey)
+      context.signal.throwIfAborted()
+
+      const sdk = new Stripe(apiKey, {
+        appInfo: {
+          name: "@sixb/connector-stripe",
+          url: "https://github.com/sixb-ai/sixb/tree/main/connectors/stripe",
+        },
+        typescript: true,
+        maxNetworkRetries: options.maxNetworkRetries,
+        timeout: options.timeoutMs,
+        telemetry: options.telemetry,
+        stripeContext: options.stripeContext,
+      })
+
+      return createStripeClient(sdk)
+    },
+  }
+}
+
+function collectWebhooks(
+  options: StripeConnectorOptions
+): readonly WebhookDefinition<unknown, StripeClient>[] | undefined {
+  const webhooks: WebhookDefinition<unknown, StripeClient>[] = []
+
+  if (options.onEvent) {
+    webhooks.push(
+      createStripeEventsWebhook(
+        {
+          onEvent: options.onEvent,
+          ...resolveWebhookVerification(STRIPE_CONNECTOR_WEBHOOK, {
+            credential: options.webhookSecret,
+            allowUnverified: options.webhookAllowUnverified,
+          }),
+          toleranceMs: options.webhookToleranceMs,
+        } satisfies StripeEventsWebhookOptions,
+        STRIPE_CONNECTOR_WEBHOOK
+      ) as WebhookDefinition<unknown, StripeClient>
+    )
+  }
+
+  if (options.webhooks) webhooks.push(...options.webhooks)
+  return webhooks.length > 0 ? webhooks : undefined
+}
+
+function assertApiKeyResolver(apiKey: StripeApiKeyResolver): void {
+  if (typeof apiKey === "string" && !apiKey.trim()) {
+    throw new Error("[SixbStripe] apiKey must not be empty.")
+  }
+  if (typeof apiKey !== "string" && typeof apiKey !== "function") {
+    throw new Error("[SixbStripe] apiKey must be a string or a function.")
+  }
+}
+
+async function resolveApiKey(apiKey: StripeApiKeyResolver): Promise<string> {
+  const value = typeof apiKey === "function" ? await apiKey() : apiKey
+  if (!value.trim()) {
+    throw new Error("[SixbStripe] apiKey must not be empty.")
+  }
+  return value
+}
+
+function assertOptions(options: StripeConnectorOptions): void {
+  if (
+    options.maxNetworkRetries !== undefined &&
+    (!Number.isInteger(options.maxNetworkRetries) || options.maxNetworkRetries < 0)
+  ) {
+    throw new Error("[SixbStripe] maxNetworkRetries must be a non-negative integer.")
+  }
+  if (
+    options.timeoutMs !== undefined &&
+    (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)
+  ) {
+    throw new Error("[SixbStripe] timeoutMs must be a positive finite number.")
+  }
+  if (options.stripeContext !== undefined && !options.stripeContext.trim()) {
+    throw new Error("[SixbStripe] stripeContext must not be empty.")
+  }
+  if (options.webhookSecret !== undefined && !options.webhookSecret.trim()) {
+    throw new Error("[SixbStripe] webhookSecret must not be empty.")
+  }
+}

--- a/connectors/stripe/src/types.ts
+++ b/connectors/stripe/src/types.ts
@@ -1,0 +1,50 @@
+import type { WebhookDefinition } from "@sixb/core"
+import type Stripe from "stripe"
+import type { StripeClient } from "./client"
+import type { StripeEventHandler } from "./webhooks"
+
+export type StripeApiKeyResolver = string | (() => string | Promise<string>)
+
+/** Per-request options supported by the official Stripe SDK. */
+export type StripeRequestOptions = Stripe.RequestOptions
+
+/** Stripe object enriched with response metadata such as `requestId` and `statusCode`. */
+export type StripeResponse<T> = Stripe.Response<T>
+
+/** One cursor-paginated Stripe list response. */
+export type StripePage<T> = Stripe.ApiList<T>
+
+/** A Stripe list request, which is both awaitable and auto-paginatable. */
+export type StripeListPromise<T> = Stripe.ApiListPromise<T>
+
+/** One page returned by Stripe's Search API. */
+export type StripeSearchPage<T> = Stripe.ApiSearchResult<T>
+
+/** A Stripe search request, which is both awaitable and auto-paginatable. */
+export type StripeSearchPromise<T> = Stripe.ApiSearchResultPromise<T>
+
+export interface StripeConnectorOptions {
+  /** Secret API key, or an async resolver evaluated whenever Sixb connects the adapter. */
+  readonly apiKey: StripeApiKeyResolver
+  /** Automatic retries after the initial request. Defaults to 1 in the Stripe SDK. */
+  readonly maxNetworkRetries?: number
+  /** Per-request timeout in milliseconds. Defaults to 80 seconds in the Stripe SDK. */
+  readonly timeoutMs?: number
+  /** Disable to stop sending request latency telemetry to Stripe. Defaults to true upstream. */
+  readonly telemetry?: boolean
+  /** Account context used for every request, including requests made for Stripe Connect. */
+  readonly stripeContext?: string
+  /**
+   * Handler for inbound snapshot-event webhook deliveries. Providing it registers the connector's
+   * `events` route; omit it and the connector exposes no built-in inbound HTTP surface.
+   */
+  readonly onEvent?: StripeEventHandler
+  /** Signing secret beginning with `whsec_`, used to verify the raw webhook request body. */
+  readonly webhookSecret?: string
+  /** Explicitly register an inbound webhook without signature verification. */
+  readonly webhookAllowUnverified?: boolean
+  /** Maximum accepted webhook signature age. Defaults to 5 minutes. */
+  readonly webhookToleranceMs?: number
+  /** Extra inbound webhooks to register alongside the built-in `events` route. */
+  readonly webhooks?: readonly WebhookDefinition<unknown, StripeClient>[]
+}

--- a/connectors/stripe/src/validation.ts
+++ b/connectors/stripe/src/validation.ts
@@ -1,0 +1,25 @@
+interface StripeCursorOptions {
+  readonly ending_before?: string
+  readonly limit?: number
+  readonly starting_after?: string
+}
+
+export function stripeId(value: string, label: string): string {
+  if (!value.trim()) {
+    throw new Error(`[SixbStripe] ${label} must not be empty.`)
+  }
+  return value
+}
+
+export function assertCursorOptions(options: StripeCursorOptions | undefined): void {
+  if (options?.starting_after && options.ending_before) {
+    throw new Error("[SixbStripe] starting_after and ending_before are mutually exclusive.")
+  }
+  assertPageLimit(options?.limit)
+}
+
+export function assertPageLimit(limit: number | undefined): void {
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > 100)) {
+    throw new Error("[SixbStripe] limit must be an integer between 1 and 100.")
+  }
+}

--- a/connectors/stripe/src/webhooks.ts
+++ b/connectors/stripe/src/webhooks.ts
@@ -1,0 +1,112 @@
+import type { Logger, OntologySource, Sixb } from "@sixb/core"
+import {
+  defineWebhook,
+  resolveWebhookVerification,
+  type WebhookDefinition,
+  type WebhookVerification,
+  type WebhookVerificationSubject,
+  warnUnverifiedWebhook,
+} from "@sixb/core"
+import Stripe from "stripe"
+import type { StripeClient } from "./client"
+import type { StripeEvent } from "./resources/events"
+
+const DEFAULT_TOLERANCE_MS = 5 * 60 * 1000
+
+export const STRIPE_WEBHOOK: WebhookVerificationSubject = {
+  connector: "SixbStripe",
+  verifies: "the Stripe-Signature HMAC",
+  credentialOption: "`credential` on `stripeEventsWebhook()`",
+  allowOption: "`allowUnverified: true`",
+}
+
+export const STRIPE_CONNECTOR_WEBHOOK: WebhookVerificationSubject = {
+  ...STRIPE_WEBHOOK,
+  credentialOption: "`webhookSecret` on `stripe()`",
+  allowOption: "`webhookAllowUnverified: true`",
+}
+
+export interface StripeEventContext {
+  readonly event: StripeEvent
+  readonly request: Request
+  readonly sixb: Sixb<readonly OntologySource[]>
+  readonly logger: Logger
+  /** Resolves the Stripe client lazily, only if the handler needs to read current state. */
+  client(): Promise<StripeClient>
+}
+
+export type StripeEventHandler = (context: StripeEventContext) => Promise<void> | void
+
+export type StripeEventsWebhookOptions = WebhookVerification & {
+  readonly onEvent: StripeEventHandler
+  /** Maximum accepted signature age. Defaults to 5 minutes. */
+  readonly toleranceMs?: number
+}
+
+/**
+ * Verified inbound webhook for Stripe v1 snapshot events.
+ *
+ * The raw bytes are checked with the official Stripe SDK before JSON parsing. The event id is
+ * reported as the delivery idempotency key because Stripe retries webhook deliveries.
+ */
+export function stripeEventsWebhook(
+  options: StripeEventsWebhookOptions
+): WebhookDefinition<StripeEvent, StripeClient> {
+  return createStripeEventsWebhook(options, STRIPE_WEBHOOK)
+}
+
+export function createStripeEventsWebhook(
+  options: StripeEventsWebhookOptions,
+  subject: WebhookVerificationSubject
+): WebhookDefinition<StripeEvent, StripeClient> {
+  const toleranceMs = options.toleranceMs ?? DEFAULT_TOLERANCE_MS
+  assertToleranceMs(toleranceMs)
+
+  const verification = resolveWebhookVerification(subject, options)
+  warnUnverifiedWebhook(subject, verification)
+
+  return defineWebhook("events")
+    .post()
+    .json({ parse: parseStripeEvent })
+    .verify(async ({ request, rawBody }) => {
+      if (!verification.credential) return
+
+      const signature = request.headers.get("stripe-signature")
+      if (!signature) {
+        throw new Error("[SixbStripe] Missing Stripe-Signature header.")
+      }
+
+      await Stripe.webhooks.constructEventAsync(
+        rawBody,
+        signature,
+        verification.credential,
+        toleranceMs / 1000
+      )
+    })
+    .idempotencyKey(({ body }) => body.id)
+    .handle<StripeClient>(async ({ body, request, sixb, logger, client }) => {
+      await options.onEvent({ event: body, request, sixb, logger, client })
+      return { status: 200 }
+    })
+}
+
+function parseStripeEvent(value: unknown): StripeEvent {
+  if (!isRecord(value) || value.object !== "event" || typeof value.id !== "string") {
+    throw new Error("[SixbStripe] Unexpected webhook payload.")
+  }
+  if (typeof value.type !== "string" || !isRecord(value.data)) {
+    throw new Error("[SixbStripe] Webhook event is missing type or data.")
+  }
+
+  return Stripe.webhooks.constructEventWithoutVerification(JSON.stringify(value))
+}
+
+function assertToleranceMs(toleranceMs: number): void {
+  if (!Number.isFinite(toleranceMs) || toleranceMs <= 0) {
+    throw new Error("[SixbStripe] webhookToleranceMs must be a positive finite number.")
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/connectors/stripe/tests/helpers.ts
+++ b/connectors/stripe/tests/helpers.ts
@@ -1,0 +1,75 @@
+import type { StripeConnectorOptions } from "../src"
+import { stripe } from "../src"
+
+export const CONTEXT = {
+  projectId: "demo",
+  connectorId: "stripe",
+  signal: new AbortController().signal,
+}
+
+export const API_KEY = "sk_test_sixb"
+
+export interface RecordedRequest {
+  readonly url: string
+  readonly method: string
+  readonly headers: Headers
+  readonly body?: string
+}
+
+export function mockFetch(
+  implementation: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = implementation as typeof fetch
+}
+
+export function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      "request-id": "req_test",
+      "stripe-version": "2026-03-25.dahlia",
+      ...(init?.headers ?? {}),
+    },
+  })
+}
+
+export function recorder(
+  responses: readonly Response[] | ((request: RecordedRequest) => Response)
+): RecordedRequest[] {
+  const calls: RecordedRequest[] = []
+  let index = 0
+
+  mockFetch(async (input, init) => {
+    const call: RecordedRequest = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === "string" ? init.body : undefined,
+    }
+    calls.push(call)
+
+    if (typeof responses === "function") return responses(call)
+
+    const response = responses[index++]
+    if (!response) throw new Error(`Unexpected request: ${call.method} ${call.url}`)
+    return response
+  })
+
+  return calls
+}
+
+export function createTestClient(options: Partial<StripeConnectorOptions> = {}) {
+  return stripe({
+    apiKey: API_KEY,
+    maxNetworkRetries: 0,
+    telemetry: false,
+    ...options,
+  }).connect(CONTEXT)
+}
+
+export async function collect<T>(items: AsyncIterable<T>): Promise<T[]> {
+  const collected: T[] = []
+  for await (const item of items) collected.push(item)
+  return collected
+}

--- a/connectors/stripe/tests/stripe.test.ts
+++ b/connectors/stripe/tests/stripe.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import Stripe from "stripe"
+import { stripe } from "../src"
+import { API_KEY, CONTEXT, collect, createTestClient, json, mockFetch, recorder } from "./helpers"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe("stripe connector", () => {
+  test("exposes only the five supported resource groups", async () => {
+    mockFetch(async () => json({}))
+    const client = await createTestClient()
+
+    expect(Object.keys(client)).toEqual([
+      "customers",
+      "subscriptions",
+      "invoices",
+      "refunds",
+      "events",
+    ])
+  })
+
+  test("resolves an async API key when Sixb connects the adapter", async () => {
+    let resolutions = 0
+    mockFetch(async () => json({ object: "list", data: [], has_more: false, url: "/v1/events" }))
+    const client = await stripe({
+      apiKey: async () => {
+        resolutions += 1
+        return API_KEY
+      },
+      maxNetworkRetries: 0,
+    }).connect(CONTEXT)
+
+    await client.events.list()
+
+    expect(resolutions).toBe(1)
+  })
+
+  test("does not connect after the Sixb lifecycle signal has been aborted", async () => {
+    const controller = new AbortController()
+    controller.abort(new DOMException("stopped", "AbortError"))
+
+    await expect(
+      stripe({ apiKey: API_KEY }).connect({ ...CONTEXT, signal: controller.signal })
+    ).rejects.toThrow("stopped")
+  })
+
+  test("validates connector options before constructing the SDK", () => {
+    expect(() => stripe({ apiKey: " " })).toThrow("apiKey must not be empty")
+    expect(() => stripe({ apiKey: 42 as unknown as string })).toThrow(
+      "apiKey must be a string or a function"
+    )
+    expect(() => stripe({ apiKey: API_KEY, maxNetworkRetries: -1 })).toThrow(
+      "maxNetworkRetries must be a non-negative integer"
+    )
+    expect(() => stripe({ apiKey: API_KEY, timeoutMs: 0 })).toThrow(
+      "timeoutMs must be a positive finite number"
+    )
+    expect(() => stripe({ apiKey: API_KEY, stripeContext: " " })).toThrow(
+      "stripeContext must not be empty"
+    )
+  })
+})
+
+describe("customers", () => {
+  test("uses Stripe form encoding, auth, response metadata, and an explicit idempotency key", async () => {
+    const calls = recorder([
+      json({ id: "cus_1", object: "customer", email: "ada@example.com", metadata: {} }),
+    ])
+    const client = await createTestClient()
+
+    const customer = await client.customers.create(
+      { email: "ada@example.com", metadata: { source: "sixb" } },
+      { idempotencyKey: "customer:ada" }
+    )
+
+    expect(customer.id).toBe("cus_1")
+    expect(customer.lastResponse.requestId).toBe("req_test")
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe("https://api.stripe.com/v1/customers")
+    expect(calls[0]?.method).toBe("POST")
+    expect(calls[0]?.headers.get("authorization")).toBe(`Bearer ${API_KEY}`)
+    expect(calls[0]?.headers.get("idempotency-key")).toBe("customer:ada")
+    expect(calls[0]?.headers.get("content-type")).toStartWith("application/x-www-form-urlencoded")
+    const body = new URLSearchParams(calls[0]?.body)
+    expect(body.get("email")).toBe("ada@example.com")
+    expect(body.get("metadata[source]")).toBe("sixb")
+  })
+
+  test("maps get, update, delete, list, and search to the documented endpoints", async () => {
+    const calls = recorder([
+      json({ id: "cus_1", object: "customer", metadata: {} }),
+      json({ id: "cus_1", object: "customer", metadata: {} }),
+      json({ id: "cus_1", object: "customer", deleted: true }),
+      json({ object: "list", data: [], has_more: false, url: "/v1/customers" }),
+      json({
+        object: "search_result",
+        data: [],
+        has_more: false,
+        next_page: null,
+        url: "/v1/customers/search",
+      }),
+    ])
+    const client = await createTestClient()
+
+    await client.customers.get("cus_1")
+    await client.customers.update("cus_1", { description: "Primary" })
+    await client.customers.delete("cus_1")
+    await client.customers.list({ email: "ada@example.com", limit: 25 })
+    await client.customers.search({ query: "email:'ada@example.com'", limit: 10 })
+
+    expect(calls.map(({ method, url }) => [method, new URL(url).pathname])).toEqual([
+      ["GET", "/v1/customers/cus_1"],
+      ["POST", "/v1/customers/cus_1"],
+      ["DELETE", "/v1/customers/cus_1"],
+      ["GET", "/v1/customers"],
+      ["GET", "/v1/customers/search"],
+    ])
+    expect(new URL(calls[3]?.url ?? "").searchParams.get("email")).toBe("ada@example.com")
+    expect(new URL(calls[4]?.url ?? "").searchParams.get("query")).toBe("email:'ada@example.com'")
+  })
+
+  test("listAll follows Stripe's starting_after cursor", async () => {
+    const calls = recorder((request) => {
+      const startingAfter = new URL(request.url).searchParams.get("starting_after")
+      return startingAfter
+        ? json({
+            object: "list",
+            data: [{ id: "cus_2", object: "customer", metadata: {} }],
+            has_more: false,
+            url: "/v1/customers",
+          })
+        : json({
+            object: "list",
+            data: [{ id: "cus_1", object: "customer", metadata: {} }],
+            has_more: true,
+            url: "/v1/customers",
+          })
+    })
+    const client = await createTestClient()
+
+    const customers = await collect(client.customers.listAll({ limit: 1 }))
+
+    expect(customers.map(({ id }) => id)).toEqual(["cus_1", "cus_2"])
+    expect(new URL(calls[1]?.url ?? "").searchParams.get("starting_after")).toBe("cus_1")
+  })
+
+  test("rejects invalid cursors, limits, and ids before issuing a request", async () => {
+    const calls = recorder([])
+    const client = await createTestClient()
+
+    expect(() =>
+      client.customers.list({ starting_after: "cus_1", ending_before: "cus_2" })
+    ).toThrow("mutually exclusive")
+    expect(() => client.customers.list({ limit: 101 })).toThrow("between 1 and 100")
+    expect(() => client.customers.get(" ")).toThrow("customer id must not be empty")
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe("subscriptions, invoices, refunds, and events", () => {
+  test("maps representative writes and reads for every resource", async () => {
+    const calls = recorder([
+      json({ id: "sub_1", object: "subscription" }),
+      json({ id: "sub_1", object: "subscription" }),
+      json({ id: "in_1", object: "invoice" }),
+      json({ id: "in_1", object: "invoice" }),
+      json({ id: "re_1", object: "refund" }),
+      json({ id: "re_1", object: "refund" }),
+      json({ id: "evt_1", object: "event", type: "invoice.paid", data: {} }),
+    ])
+    const client = await createTestClient()
+
+    await client.subscriptions.create({ customer: "cus_1" })
+    await client.subscriptions.cancel("sub_1", { invoice_now: true })
+    await client.invoices.create({ customer: "cus_1" })
+    await client.invoices.finalize("in_1", { auto_advance: false })
+    await client.refunds.create({ payment_intent: "pi_1", amount: 500 })
+    await client.refunds.cancel("re_1")
+    await client.events.get("evt_1")
+
+    expect(calls.map(({ method, url }) => [method, new URL(url).pathname])).toEqual([
+      ["POST", "/v1/subscriptions"],
+      ["DELETE", "/v1/subscriptions/sub_1"],
+      ["POST", "/v1/invoices"],
+      ["POST", "/v1/invoices/in_1/finalize"],
+      ["POST", "/v1/refunds"],
+      ["POST", "/v1/refunds/re_1/cancel"],
+      ["GET", "/v1/events/evt_1"],
+    ])
+  })
+
+  test("validates the event type filters documented by Stripe", async () => {
+    const calls = recorder([])
+    const client = await createTestClient()
+
+    expect(() => client.events.list({ type: "invoice.paid", types: ["customer.created"] })).toThrow(
+      "type or types"
+    )
+    expect(() =>
+      client.events.list({ types: Array.from({ length: 21 }, () => "invoice.paid") })
+    ).toThrow("at most 20")
+    expect(calls).toHaveLength(0)
+  })
+
+  test("surfaces Stripe's structured API errors without losing request metadata", async () => {
+    recorder([
+      json(
+        {
+          error: {
+            type: "invalid_request_error",
+            code: "resource_missing",
+            message: "No such customer: 'cus_missing'",
+            param: "id",
+          },
+        },
+        { status: 404, headers: { "request-id": "req_missing" } }
+      ),
+    ])
+    const client = await createTestClient()
+
+    const caught: unknown = await client.customers.get("cus_missing").catch((error) => error)
+
+    expect(caught).toBeInstanceOf(Stripe.errors.StripeInvalidRequestError)
+    if (!(caught instanceof Stripe.errors.StripeInvalidRequestError)) throw caught
+
+    expect(caught.statusCode).toBe(404)
+    expect(caught.requestId).toBe("req_missing")
+    expect(caught.code).toBe("resource_missing")
+    expect(caught.param).toBe("id")
+  })
+})

--- a/connectors/stripe/tests/webhooks.test.ts
+++ b/connectors/stripe/tests/webhooks.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { noopLogger } from "@sixb/core"
+import Stripe from "stripe"
+import type { StripeEvent, StripeEventContext } from "../src"
+import { stripe, stripeEventsWebhook } from "../src"
+import { API_KEY } from "./helpers"
+
+type VerifyContext = Parameters<NonNullable<ReturnType<typeof stripeEventsWebhook>["verify"]>>[0]
+type HandleContext = Parameters<ReturnType<typeof stripeEventsWebhook>["handle"]>[0]
+type IdempotencyContext = Parameters<
+  NonNullable<ReturnType<typeof stripeEventsWebhook>["idempotencyKey"]>
+>[0]
+
+const SECRET = "whsec_sixb_test"
+
+const EVENT: StripeEvent = {
+  id: "evt_1",
+  object: "event",
+  api_version: "2026-03-25.dahlia",
+  created: 1_788_000_000,
+  data: {
+    object: {
+      id: "cus_1",
+      object: "customer",
+      balance: 0,
+      created: 1_788_000_000,
+      default_source: null,
+      description: null,
+      email: "ada@example.com",
+      invoice_settings: {
+        custom_fields: null,
+        default_payment_method: null,
+        footer: null,
+        rendering_options: null,
+      },
+      livemode: false,
+      metadata: {},
+      shipping: null,
+    },
+  },
+  livemode: false,
+  pending_webhooks: 0,
+  request: { id: "req_1", idempotency_key: null },
+  type: "customer.created",
+}
+
+function verifyContext(body: string, signature: string | null): VerifyContext {
+  return {
+    request: new Request("https://app.example/api/webhooks/stripe/events", {
+      method: "POST",
+      headers: signature ? { "stripe-signature": signature } : {},
+    }),
+    rawBody: new TextEncoder().encode(body),
+  } as unknown as VerifyContext
+}
+
+describe("stripe events webhook", () => {
+  test("registers only when onEvent is configured", () => {
+    expect(stripe({ apiKey: API_KEY }).webhooks).toBeUndefined()
+    expect(
+      stripe({ apiKey: API_KEY, webhookAllowUnverified: true, onEvent: () => {} }).webhooks
+    ).toHaveLength(1)
+  })
+
+  test("verifies the raw payload with Stripe's SDK and dispatches the parsed event", async () => {
+    const received: StripeEventContext[] = []
+    const webhook = stripeEventsWebhook({
+      credential: SECRET,
+      onEvent: (context) => {
+        received.push(context)
+      },
+    })
+    const body = JSON.stringify(EVENT)
+    const signature = await Stripe.webhooks.generateTestHeaderStringAsync({
+      payload: body,
+      secret: SECRET,
+    })
+    const client = () => Promise.resolve({} as never)
+
+    await webhook.verify?.(verifyContext(body, signature))
+    const result = await webhook.handle({
+      request: new Request("https://app.example/hook", { method: "POST" }),
+      body: webhook.body.parse(JSON.parse(body)),
+      sixb: { id: "demo" },
+      logger: noopLogger,
+      client,
+    } as unknown as HandleContext)
+
+    expect(result).toEqual({ status: 200 })
+    expect(received).toHaveLength(1)
+    expect(received[0]?.event.id).toBe("evt_1")
+    expect(received[0]?.event.type).toBe("customer.created")
+    expect(received[0]?.client).toBe(client)
+  })
+
+  test("rejects tampered, stale, and unsigned deliveries", async () => {
+    const webhook = stripeEventsWebhook({ credential: SECRET, onEvent: () => {} })
+    const body = JSON.stringify(EVENT)
+    const signature = await Stripe.webhooks.generateTestHeaderStringAsync({
+      payload: body,
+      secret: SECRET,
+    })
+    const staleSignature = await Stripe.webhooks.generateTestHeaderStringAsync({
+      payload: body,
+      secret: SECRET,
+      timestamp: Math.floor(Date.now() / 1000) - 6 * 60,
+    })
+
+    await expect(
+      webhook.verify?.(verifyContext(JSON.stringify({ ...EVENT, id: "evt_tampered" }), signature))
+    ).rejects.toThrow("signature")
+    await expect(webhook.verify?.(verifyContext(body, staleSignature))).rejects.toThrow("tolerance")
+    await expect(webhook.verify?.(verifyContext(body, null))).rejects.toThrow(
+      "Missing Stripe-Signature"
+    )
+  })
+
+  test("reports the event id as the delivery idempotency key", () => {
+    const webhook = stripeEventsWebhook({ allowUnverified: true, onEvent: () => {} })
+
+    expect(webhook.idempotencyKey?.({ body: EVENT } as unknown as IdempotencyContext)).toBe("evt_1")
+  })
+
+  test("rejects malformed event payloads", () => {
+    const webhook = stripeEventsWebhook({ allowUnverified: true, onEvent: () => {} })
+
+    expect(() => webhook.body.parse({})).toThrow("Unexpected webhook payload")
+    expect(() => webhook.body.parse({ id: "evt_1", object: "event" })).toThrow(
+      "missing type or data"
+    )
+  })
+
+  test("requires a secret or an explicit unverified opt-in", () => {
+    // @ts-expect-error - neither `credential` nor `allowUnverified`
+    const missing: Parameters<typeof stripeEventsWebhook>[0] = { onEvent: () => {} }
+
+    expect(() => stripeEventsWebhook(missing)).toThrow(/Stripe-Signature/)
+  })
+
+  test("validates the webhook tolerance", () => {
+    expect(() =>
+      stripeEventsWebhook({ allowUnverified: true, onEvent: () => {}, toleranceMs: 0 })
+    ).toThrow("webhookToleranceMs must be a positive finite number")
+  })
+})

--- a/connectors/stripe/tsconfig.build.json
+++ b/connectors/stripe/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../packages/core/tsconfig.build.json"
+    }
+  ]
+}

--- a/connectors/stripe/tsconfig.json
+++ b/connectors/stripe/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "incremental": true,
+    "tsBuildInfoFile": "./.tsbuild/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/data/connectors.md
+++ b/docs/data/connectors.md
@@ -199,6 +199,7 @@ to `defineConnector`, and most ship a matching webhook helper for the [Webhooks]
 | `@sixb/connector-google` | `googleAds(...)` | Google Ads manager-account reporting | — |
 | `@sixb/connector-meta` | `meta(...)` | Meta Graph API (Facebook/Instagram) | — |
 | `@sixb/connector-pipedrive` | `pipedrive(...)` | Pipedrive CRM | `pipedriveEventsWebhook` |
+| `@sixb/connector-stripe` | `stripe(...)` | Stripe customers, subscriptions, invoices, refunds, events | `stripeEventsWebhook` |
 | `@sixb/connector-teamleader` | `teamleader(...)` | Teamleader CRM, invoicing, quotations | `defineTeamleaderWebhook` |
 | `@sixb/connector-pandadoc` | `pandadoc(...)` | PandaDoc documents and e-signatures | `pandaDocEventsWebhook` |
 | `@sixb/connector-companycam` | `companycam(...)` | CompanyCam jobsite photos | `companyCamEventsWebhook` |

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -56,6 +56,9 @@
       "path": "connectors/sql/tsconfig.build.json"
     },
     {
+      "path": "connectors/stripe/tsconfig.build.json"
+    },
+    {
       "path": "connectors/teamleader/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
       "@sixb/connector-rest": ["./connectors/rest/src/index.ts"],
       "@sixb/connector-sftp": ["./connectors/sftp/src/index.ts"],
       "@sixb/connector-sql": ["./connectors/sql/src/index.ts"],
+      "@sixb/connector-stripe": ["./connectors/stripe/src/index.ts"],
       "@sixb/connector-teamleader": ["./connectors/teamleader/src/index.ts"],
       "@sixb/connector-unipile": ["./connectors/unipile/src/index.ts"],
       "@sixb/core": ["./packages/core/src/index.ts"],


### PR DESCRIPTION
## Scope

| Resource | Coverage |
| --- | --- |
| Customers | CRUD, list, auto-pagination, search |
| Subscriptions | Lifecycle, list, auto-pagination, search |
| Invoices | Lifecycle, payment actions, list, auto-pagination, search |
| Refunds | Lifecycle, list, auto-pagination |
| Events | v1 snapshot reads, list, auto-pagination, verified webhooks |

## What

- Adds `@sixb/connector-stripe`, backed by Stripe's official typed SDK.
- Exposes generated Stripe wire types, Connect request options, idempotency keys, retries, bounded timeouts, and request IDs.
- Validates identifiers, cursor combinations, limits, event filters, and webhook configuration before requests are sent.
- Documents setup, every resource group, pagination, errors, Stripe Connect, and webhook handling.

## Why

- Gives syncs and workflows one typed server-side integration for Stripe billing data.
- Keeps transport, authentication, error metadata, and signature verification consistent across resources.
- Isolates each resource behind a small factory so later additions stay focused and reviewable.

## Key choices

| Choice | Reason |
| --- | --- |
| Official Stripe SDK | Reuses generated types plus Stripe's encoding, retry, idempotency, error, and signature behavior. |
| Explicit `listAll` / `searchAll` | Matches existing connector ergonomics while using Stripe cursor pagination. |
| v1 snapshot Events | Matches the requested Events API; v2 thin events use a different retrieval model. |
| Verified raw-body webhooks | Preserves Stripe's signature guarantees; unverified handling requires an explicit unsafe opt-in. |

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run test:ci` — 4,051 passed, 7 skipped
- `bun run build:js`
- `bun run test:publish` — 50 packages verified

## Known limitation

- `stripe@22.5.0` does not expose `AbortSignal` in request options; `timeoutMs` keeps network requests bounded.
