### PR TITLE
agents: let models inspect sandbox files

### DIFF
--- a/docs/agents/tools-and-gateway.md
+++ b/docs/agents/tools-and-gateway.md
@@ -126,6 +126,18 @@ promoted to normal assistant file attachments, with duplicate sandbox outputs re
 digest. Follow-up turns reconstruct files from the durable `FileRef` and materialize them into the
 new run sandbox.
 
+### Inspecting sandbox files
+
+The built-in `view_file` tool accepts a path inside the current run workspace. Current user images
+use normal user file input; historical attachments stay as metadata and sandbox files until the
+model calls `view_file`. Viewed images use the same provider-safe user-message bridge as selected
+tool results. Known attachment and tool-artifact paths reuse their existing `FileRef`. A previously
+unknown file created by `bash` is read within the same 25 MB limit, MIME-sniffed, published through
+the artifact path, and then returned as rich file content. Arbitrary bash paths are reread on each
+invocation so later edits remain visible; framework-owned attachment and artifact paths reuse their
+durable snapshots. Image decoding uses the same resize, base64, and pixel-count limits as direct
+attachments. Symbolic links and paths outside the workspace are rejected.
+
 `$SIXB_OUTPUT_DIR` remains the compatibility path for files produced directly by sandbox work.
 Complete files moved there are collected as final assistant attachments; it is not used as the live
 tool-result transport.
@@ -136,8 +148,9 @@ Tool definitions are not auto-discovered. Grant them through the agent definitio
 tools: [searchKnowledge]
 ```
 
-Names must be unique within one agent, and `read` and `bash` are reserved. Conversation, workflow,
-and CLI-managed agent runs use the same selected tools.
+Names must be unique within one agent. `bash`, `read`, and `view_file` are reserved for the
+framework's built-in sandbox tools. Conversation, workflow, and CLI-managed agent runs use the same
+selected tools.
 
 ### Exa web tools
 

--- a/packages/agent-worker/src/agent-skills.ts
+++ b/packages/agent-worker/src/agent-skills.ts
@@ -71,7 +71,7 @@ export function renderAgentSkillCatalog(
     executionGuidance,
     "Sixb API access is available from the sandboxed bash tool through a per-run gateway URL.",
     "Agent Skills are installed under $SIXB_SKILLS_DIR.",
-    "Message attachments, when present, are listed in $SIXB_ATTACHMENTS and materialized under $SIXB_ATTACHMENT_DIR when size limits allow.",
+    "Message attachments, when present, are listed in $SIXB_ATTACHMENTS and materialized under $SIXB_ATTACHMENT_DIR when size limits allow. Current attachments are provided directly; use view_file with a listed sandbox path to inspect historical files on demand.",
     "Prepare user-facing files under $SIXB_OUTPUT_STAGING_DIR, then atomically publish each complete file or directory with mv into $SIXB_OUTPUT_DIR. Only files under $SIXB_OUTPUT_DIR are attached to the final chat message when size limits allow.",
     "Never write a file directly in $SIXB_OUTPUT_DIR and never modify it after publication; publish only complete outputs.",
     "Use environment variables with bash. With read, use relative paths from this catalog or sandboxPath values.",

--- a/packages/agent-worker/src/attachments.ts
+++ b/packages/agent-worker/src/attachments.ts
@@ -217,6 +217,7 @@ export async function prepareAgentToolFileProjection(input: {
 
 function fileWorkItems(messages: readonly AgentMessageRecord[]): AttachmentWorkItem[] {
   const items: AttachmentWorkItem[] = []
+  const currentUserMessageId = latestUserMessageId(messages)
   for (const message of messages) {
     message.parts.forEach((part, partIndex) => {
       if (part.type === "file") {
@@ -227,7 +228,7 @@ function fileWorkItems(messages: readonly AgentMessageRecord[]): AttachmentWorkI
           key: attachmentKey(message.id, partIndex),
           contentPath: `/parts/${partIndex}/fileRef`,
           sandboxName: String(partIndex),
-          inlineContent: message.role !== "assistant",
+          inlineContent: message.role === "user" && message.id === currentUserMessageId,
           origin: "message-file",
         })
       } else if (
@@ -272,6 +273,14 @@ function fileWorkItems(messages: readonly AgentMessageRecord[]): AttachmentWorkI
   return deduplicated.filter(
     (item) => item.message.role !== "assistant" || retainedAssistantKeys.has(item.key)
   )
+}
+
+function latestUserMessageId(messages: readonly AgentMessageRecord[]): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.role === "user") return message.id
+  }
+  return undefined
 }
 
 function messageFileIdentity(messageId: string, fileRef: FileRef): string {
@@ -419,8 +428,8 @@ async function prepareOneAttachment(input: {
 
     if (inlineDisposition === "metadata-only" && notes.length === 0) {
       notes.push(
-        item.message.role === "assistant"
-          ? "[Generated file kept as metadata: use the sandbox path or content URL when its contents are needed.]"
+        !item.inlineContent
+          ? "[Historical file kept as metadata: use view_file with the sandbox path when its contents are needed.]"
           : remainingTextBytes === 0 && shouldAttemptTextInline(mediaType, fileName, stat.sizeBytes)
             ? "[File not inlined: the attachment text budget is exhausted; use the sandbox path or content URL.]"
             : "[File not inlined: available through the sandbox path or content URL.]"

--- a/packages/agent-worker/src/run-environment.ts
+++ b/packages/agent-worker/src/run-environment.ts
@@ -17,6 +17,7 @@ import { AgentSandboxFileRegistry } from "./sandbox-file-registry"
 import { AgentToolArtifactBudget, createAgentToolArtifacts } from "./tool-artifacts"
 import { AgentToolResultMediaBridge } from "./tool-result-media"
 import type { AgentExecutionContext, AgentTurnContext, AgentWorkerContext } from "./types"
+import { createViewFileTool } from "./view-file-tool"
 import { prepareWorkflowInputAttachments } from "./workflow-input-attachments"
 
 export interface AgentExecutionEnvironment {
@@ -184,6 +185,14 @@ function startAgentEnvironment(input: AgentEnvironmentSetup): AgentExecutionEnvi
   })
 
   let sandboxWasUsed = false
+  tools.view_file = createViewFileTool({
+    resolveSandbox: () => ready,
+    attachments: attachmentContext,
+    registry: fileRegistry,
+    artifactsForToolCall: ({ toolCallId, signal }) =>
+      artifactsForToolCall({ toolName: "view_file", toolCallId, signal }),
+    toolResultToModelOutput: (output) => mediaBridge.toModelOutput(output),
+  })
   const resolveSandbox = () => {
     sandboxWasUsed = true
     return ready

--- a/packages/agent-worker/src/view-file-tool.ts
+++ b/packages/agent-worker/src/view-file-tool.ts
@@ -1,0 +1,210 @@
+import { posix } from "node:path"
+import type { AgentToolArtifacts, FileRef, JsonValue } from "@sixb/core"
+import { AgentToolPublicError } from "@sixb/core"
+import { jsonSchema, type Tool, tool } from "ai"
+import { NEVER_ABORTED_SIGNAL } from "./abort"
+import type { PreparedAgentAttachmentContext } from "./attachments"
+import type { BashSandboxHandle } from "./bash-tool"
+import type { AgentSandboxFileRegistry } from "./sandbox-file-registry"
+import { inferAgentFileMediaType } from "./tool-artifacts"
+import type { AgentToolModelOutput } from "./tool-result-output"
+
+const VIEW_FILE_MAX_BYTES = 25 * 1024 * 1024
+const VIEW_FILE_TIMEOUT_MS = 30_000
+
+interface ViewFileInput {
+  readonly path: string
+}
+
+export function createViewFileTool(input: {
+  readonly resolveSandbox: () => Promise<BashSandboxHandle>
+  readonly attachments: PreparedAgentAttachmentContext
+  readonly registry: AgentSandboxFileRegistry
+  readonly artifactsForToolCall: (options: {
+    readonly toolCallId: string
+    readonly signal: AbortSignal
+  }) => AgentToolArtifacts
+  readonly toolResultToModelOutput: (input: {
+    readonly output: JsonValue
+    readonly signal: AbortSignal
+    readonly toolCallId: string
+  }) => AgentToolModelOutput | PromiseLike<AgentToolModelOutput>
+}): Tool<ViewFileInput, JsonValue> {
+  const signalsByToolCallId = new Map<string, AbortSignal>()
+  return tool({
+    description:
+      "Inspect a file in the current run sandbox. Use this for historical attachments and files created by bash. Paths must stay inside the sandbox working directory. Images are prepared for visual input when supported; other formats return bounded text or metadata.",
+    inputSchema: jsonSchema<ViewFileInput>({
+      type: "object",
+      properties: { path: { type: "string", minLength: 1 } },
+      required: ["path"],
+      additionalProperties: false,
+    }),
+    async execute({ path }, { abortSignal, toolCallId }): Promise<JsonValue> {
+      const signal = abortSignal ?? NEVER_ABORTED_SIGNAL
+      signalsByToolCallId.set(toolCallId, signal)
+      try {
+        signal.throwIfAborted()
+        const handle = await input.resolveSandbox()
+        const absolutePath = resolveSafeSandboxPath(handle.sandbox.workingDirectory, path)
+        const knownFileRef =
+          input.registry.get(absolutePath) ??
+          preparedFileRefAtPath(input.attachments, handle.sandbox.workingDirectory, absolutePath)
+
+        let fileRef: FileRef
+        if (knownFileRef) {
+          fileRef = knownFileRef
+        } else {
+          const bytes = await readSandboxFile({ handle, absolutePath, signal })
+          const fileName = safePublishedFileName(posix.basename(absolutePath))
+          const artifact = await input.artifactsForToolCall({ toolCallId, signal }).put({
+            body: bytes,
+            fileName,
+            mediaType: inferAgentFileMediaType(bytes, fileName),
+          })
+          fileRef = artifact.fileRef
+        }
+
+        // Prepared attachments and framework artifacts are immutable snapshots and can be reused.
+        // Arbitrary bash paths stay mutable, so do not cache their published snapshot at the source
+        // path; a later view_file call must read the path again.
+        if (knownFileRef) input.registry.register(absolutePath, fileRef)
+        return richViewFileResult(fileRef)
+      } catch (error) {
+        signalsByToolCallId.delete(toolCallId)
+        throw error
+      }
+    },
+    async toModelOutput({ output, toolCallId }) {
+      const signal = signalsByToolCallId.get(toolCallId) ?? NEVER_ABORTED_SIGNAL
+      try {
+        return await input.toolResultToModelOutput({ output, toolCallId, signal })
+      } finally {
+        signalsByToolCallId.delete(toolCallId)
+      }
+    },
+  })
+}
+
+function preparedFileRefAtPath(
+  attachments: PreparedAgentAttachmentContext,
+  workingDirectory: string,
+  absolutePath: string
+): FileRef | undefined {
+  for (const file of attachments.sandboxFiles) {
+    if (posix.resolve(workingDirectory, file.path) === absolutePath) {
+      return file.fileRef
+    }
+  }
+  return undefined
+}
+
+function resolveSafeSandboxPath(workingDirectory: string, requestedPath: string): string {
+  if (
+    typeof requestedPath !== "string" ||
+    requestedPath.length === 0 ||
+    requestedPath.includes("\0")
+  ) {
+    throw viewFileError("path must be a non-empty sandbox file path")
+  }
+  const root = posix.normalize(workingDirectory)
+  const absolutePath = posix.resolve(root, requestedPath)
+  if (absolutePath === root || !absolutePath.startsWith(`${root}/`)) {
+    throw viewFileError("path must stay inside the sandbox working directory")
+  }
+  return absolutePath
+}
+
+async function readSandboxFile(input: {
+  readonly handle: BashSandboxHandle
+  readonly absolutePath: string
+  readonly signal: AbortSignal
+}): Promise<Uint8Array> {
+  const result = await input.handle.sandbox.runCommand("bash", ["-lc", READ_VIEW_FILE_SCRIPT], {
+    env: {
+      ...(input.handle.env ?? {}),
+      SIXB_VIEW_FILE_PATH_B64: Buffer.from(input.absolutePath, "utf-8").toString("base64"),
+      SIXB_VIEW_FILE_ROOT: input.handle.sandbox.workingDirectory,
+      SIXB_VIEW_FILE_MAX_BYTES: String(VIEW_FILE_MAX_BYTES),
+    },
+    timeout: VIEW_FILE_TIMEOUT_MS,
+    signal: input.signal,
+  })
+  input.signal.throwIfAborted()
+
+  if (result.exitCode === 2) {
+    throw viewFileError("file does not exist, is not a regular file, or is a symbolic link")
+  }
+  if (result.exitCode === 3) {
+    throw viewFileError(`file exceeds the ${VIEW_FILE_MAX_BYTES}-byte inspection limit`)
+  }
+  if (result.exitCode === 4) {
+    throw viewFileError("resolved path escapes the sandbox working directory")
+  }
+  if (result.exitCode !== 0) {
+    throw viewFileError("file could not be read")
+  }
+
+  const separator = result.stdout.indexOf("\n")
+  const sizeBytes = Number(result.stdout.slice(0, separator))
+  const bytes = Buffer.from(
+    separator < 0 ? "" : result.stdout.slice(separator + 1).trim(),
+    "base64"
+  )
+  if (!Number.isInteger(sizeBytes) || sizeBytes < 0 || bytes.byteLength !== sizeBytes) {
+    throw viewFileError("file changed while it was being read")
+  }
+  return new Uint8Array(bytes)
+}
+
+function richViewFileResult(fileRef: FileRef): JsonValue {
+  const mediaType = fileRef.mediaType ?? "application/octet-stream"
+  const fileName = fileRef.fileName ?? "file"
+  const description = mediaType.startsWith("image/")
+    ? `Prepared image '${fileName}' for inspection.`
+    : `Prepared file '${fileName}' (${mediaType}) for inspection.`
+  return {
+    kind: "agentToolResult",
+    content: [
+      {
+        type: "text",
+        text: `${description} Size: ${fileRef.sizeBytes} bytes.`,
+      },
+      { type: "file", fileRef: { ...fileRef } },
+    ],
+  }
+}
+
+function safePublishedFileName(value: string): string {
+  const safe = value
+    .normalize("NFKC")
+    .replace(/[\u0000-\u001f\u007f]/g, "_")
+    .replace(/[\\/]/g, "_")
+    .slice(0, 120)
+  return safe && safe !== "." && safe !== ".." ? safe : "viewed-file.bin"
+}
+
+function viewFileError(message: string): AgentToolPublicError {
+  return new AgentToolPublicError(`[SixbAgentWorker] view_file ${message}.`)
+}
+
+const READ_VIEW_FILE_SCRIPT = `# sixb-read-view-file
+set -euo pipefail
+requested="$(printf '%s' "\${SIXB_VIEW_FILE_PATH_B64:?}" | base64 -d)"
+root="\${SIXB_VIEW_FILE_ROOT:?}"
+max_bytes="\${SIXB_VIEW_FILE_MAX_BYTES:?}"
+if [ ! -f "$requested" ] || [ -L "$requested" ]; then
+  exit 2
+fi
+parent="$(cd -P -- "$(dirname -- "$requested")" && pwd)"
+resolved="$parent/$(basename -- "$requested")"
+case "$resolved" in
+  "$root"/*) ;;
+  *) exit 4 ;;
+esac
+size="$(wc -c < "$resolved" | tr -d ' ')"
+if [ "$size" -gt "$max_bytes" ]; then
+  exit 3
+fi
+printf '%s\n' "$size"
+head -c "$max_bytes" "$resolved" | base64 | tr -d '\n'`

--- a/packages/agent-worker/tests/view-file-tool.test.ts
+++ b/packages/agent-worker/tests/view-file-tool.test.ts
@@ -9,8 +9,8 @@ import type {
 import { InMemoryBlobStorage } from "@sixb/core"
 import type { Tool } from "ai"
 import type { PreparedAgentAttachmentContext } from "../src/attachments"
-import { createAgentToolArtifacts } from "../src/tool-artifacts"
 import { AgentSandboxFileRegistry } from "../src/sandbox-file-registry"
+import { createAgentToolArtifacts } from "../src/tool-artifacts"
 import { createViewFileTool } from "../src/view-file-tool"
 
 const PNG_BYTES = Uint8Array.from(

--- a/packages/agent-worker/tests/view-file-tool.test.ts
+++ b/packages/agent-worker/tests/view-file-tool.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, test } from "bun:test"
+import type {
+  CommandResult,
+  JsonValue,
+  RunCommandOptions,
+  Sandbox,
+  SandboxFileRecord,
+} from "@sixb/core"
+import { InMemoryBlobStorage } from "@sixb/core"
+import type { Tool } from "ai"
+import type { PreparedAgentAttachmentContext } from "../src/attachments"
+import { createAgentToolArtifacts } from "../src/tool-artifacts"
+import { AgentSandboxFileRegistry } from "../src/sandbox-file-registry"
+import { createViewFileTool } from "../src/view-file-tool"
+
+const PNG_BYTES = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+    "base64"
+  )
+)
+
+describe("view_file tool", () => {
+  test("reuses a FileRef registered by another tool without republishing it", async () => {
+    const blobStorage = new InMemoryBlobStorage()
+    const fileRef = await blobStorage.put({
+      body: PNG_BYTES,
+      fileName: "generated.png",
+      mediaType: "image/png",
+    })
+    const sandbox = new ViewFileSandbox()
+    const registry = new AgentSandboxFileRegistry()
+    const artifactPath = `${sandbox.workingDirectory}/.sixb/agent/artifacts/generated.png`
+    registry.register(artifactPath, fileRef)
+    let publications = 0
+    const viewFile = executableViewFileTool(
+      createViewFileTool({
+        resolveSandbox: async () => ({ sandbox }),
+        attachments: emptyAttachments(),
+        registry,
+        artifactsForToolCall: () => {
+          publications += 1
+          throw new Error("Known files must not be republished.")
+        },
+        toolResultToModelOutput: unusedToolResultProjection,
+      })
+    )
+
+    const output = await viewFile.execute({ path: artifactPath })
+
+    expect(output).toMatchObject({
+      kind: "agentToolResult",
+      content: [
+        { type: "text", text: expect.stringContaining("Prepared image") },
+        { type: "file", fileRef },
+      ],
+    })
+    expect(JSON.stringify(output)).not.toContain(artifactPath)
+    expect(publications).toBe(0)
+    expect(sandbox.commands).toHaveLength(0)
+  })
+
+  test("rereads and republishes a mutable bash-created image", async () => {
+    const blobStorage = new InMemoryBlobStorage()
+    const sandbox = new ViewFileSandbox()
+    sandbox.files.set(`${sandbox.workingDirectory}/scratch/bash-image.bin`, PNG_BYTES)
+    const registry = new AgentSandboxFileRegistry()
+    let publications = 0
+    const viewFile = executableViewFileTool(
+      createViewFileTool({
+        resolveSandbox: async () => ({ sandbox }),
+        attachments: emptyAttachments(),
+        registry,
+        artifactsForToolCall: ({ toolCallId, signal }) => {
+          publications += 1
+          return createAgentToolArtifacts({
+            toolName: "view_file",
+            toolCallId,
+            signal,
+            blobStorage,
+            resolveSandbox: async () => ({ sandbox }),
+          })
+        },
+        toolResultToModelOutput: unusedToolResultProjection,
+      })
+    )
+
+    const first = await viewFile.execute({ path: "scratch/bash-image.bin" })
+    const updatedBytes = Uint8Array.from([...PNG_BYTES, 0])
+    sandbox.files.set(`${sandbox.workingDirectory}/scratch/bash-image.bin`, updatedBytes)
+    const second = await viewFile.execute({ path: "scratch/bash-image.bin" })
+
+    expect(first).toMatchObject({
+      kind: "agentToolResult",
+      content: [
+        { type: "text" },
+        { type: "file", fileRef: { fileName: "bash-image.bin", mediaType: "image/png" } },
+      ],
+    })
+    expect(second).toMatchObject({
+      kind: "agentToolResult",
+      content: [
+        { type: "text" },
+        {
+          type: "file",
+          fileRef: {
+            fileName: "bash-image.bin",
+            mediaType: "image/png",
+            sizeBytes: updatedBytes.byteLength,
+          },
+        },
+      ],
+    })
+    expect(second).not.toEqual(first)
+    expect(publications).toBe(2)
+    expect(sandbox.commands).toHaveLength(2)
+    expect(sandbox.writtenFiles.some((file) => file.path.includes(".sixb/agent/artifacts/"))).toBe(
+      true
+    )
+  })
+
+  test("returns clear metadata for formats that cannot be rendered as images", async () => {
+    const blobStorage = new InMemoryBlobStorage()
+    const fileRef = await blobStorage.put({
+      body: new TextEncoder().encode("%PDF-1.7\n"),
+      fileName: "report.pdf",
+      mediaType: "application/pdf",
+    })
+    const sandbox = new ViewFileSandbox()
+    const registry = new AgentSandboxFileRegistry()
+    const path = `${sandbox.workingDirectory}/report.pdf`
+    registry.register(path, fileRef)
+    const viewFile = executableViewFileTool(
+      createViewFileTool({
+        resolveSandbox: async () => ({ sandbox }),
+        attachments: emptyAttachments(),
+        registry,
+        artifactsForToolCall: () => {
+          throw new Error("unused")
+        },
+        toolResultToModelOutput: unusedToolResultProjection,
+      })
+    )
+
+    const output = await viewFile.execute({ path })
+
+    expect(JSON.stringify(output)).toContain("application/pdf")
+    expect(JSON.stringify(output)).toContain("Prepared file")
+    expect(JSON.stringify(output)).not.toContain(path)
+  })
+
+  test("registers a current sandbox path when reusing a prepared attachment", async () => {
+    const blobStorage = new InMemoryBlobStorage()
+    const fileRef = await blobStorage.put({
+      body: PNG_BYTES,
+      fileName: "historical.png",
+      mediaType: "image/png",
+    })
+    const sandbox = new ViewFileSandbox()
+    const relativePath = ".sixb/agent/attachments/message-1/0-historical.png"
+    const absolutePath = `${sandbox.workingDirectory}/${relativePath}`
+    const attachments: PreparedAgentAttachmentContext = {
+      ...emptyAttachments(),
+      sandboxFiles: [{ key: "file", path: relativePath, bytes: PNG_BYTES, fileRef }],
+    }
+    const registry = new AgentSandboxFileRegistry()
+    const viewFile = executableViewFileTool(
+      createViewFileTool({
+        resolveSandbox: async () => ({ sandbox }),
+        attachments,
+        registry,
+        artifactsForToolCall: () => {
+          throw new Error("Prepared files must not be republished.")
+        },
+        toolResultToModelOutput: unusedToolResultProjection,
+      })
+    )
+
+    await viewFile.execute({ path: relativePath })
+
+    expect(registry.pathFor(fileRef)).toBe(absolutePath)
+    expect(sandbox.commands).toHaveLength(0)
+  })
+
+  test("keeps distinct paths for references with identical bytes and different metadata", () => {
+    const registry = new AgentSandboxFileRegistry()
+    const digest = `sha256:${"a".repeat(64)}` as const
+    const blobId = `blob_${"a".repeat(64)}`
+    const first = { blobId, digest, sizeBytes: 1, fileName: "first.png", mediaType: "image/png" }
+    const second = { blobId, digest, sizeBytes: 1, fileName: "second.png", mediaType: "image/png" }
+
+    registry.register("/workspace/first.png", first)
+    registry.register("/workspace/second.png", second)
+
+    expect(registry.pathFor(first)).toBe("/workspace/first.png")
+    expect(registry.pathFor(second)).toBe("/workspace/second.png")
+  })
+
+  test("rejects paths outside the sandbox before reading them", async () => {
+    const sandbox = new ViewFileSandbox()
+    const viewFile = executableViewFileTool(
+      createViewFileTool({
+        resolveSandbox: async () => ({ sandbox }),
+        attachments: emptyAttachments(),
+        registry: new AgentSandboxFileRegistry(),
+        artifactsForToolCall: () => {
+          throw new Error("unused")
+        },
+        toolResultToModelOutput: unusedToolResultProjection,
+      })
+    )
+
+    await expect(viewFile.execute({ path: "../../etc/passwd" })).rejects.toThrow(
+      "path must stay inside the sandbox working directory"
+    )
+    expect(sandbox.commands).toHaveLength(0)
+  })
+})
+
+function unusedToolResultProjection(): { readonly type: "text"; readonly value: string } {
+  return { type: "text", value: "unused" }
+}
+
+function executableViewFileTool(definition: Tool<{ readonly path: string }, JsonValue>): {
+  execute(input: { readonly path: string }): Promise<JsonValue>
+} {
+  if (typeof definition.execute !== "function") throw new Error("Expected executable view_file.")
+  const execute = definition.execute as unknown as (
+    input: { readonly path: string },
+    options: { readonly toolCallId: string; readonly abortSignal: AbortSignal }
+  ) => Promise<JsonValue>
+  return {
+    execute: (input) =>
+      execute(input, {
+        toolCallId: "view-call-1",
+        abortSignal: new AbortController().signal,
+      }),
+  }
+}
+
+function emptyAttachments(): PreparedAgentAttachmentContext {
+  return {
+    entries: [],
+    promptTextByPartKey: new Map(),
+    modelFileDataByPartKey: new Map(),
+    sandboxFiles: [],
+    manifestJson: JSON.stringify({ attachments: [] }),
+  }
+}
+
+class ViewFileSandbox implements Sandbox {
+  readonly id = "view-file-sandbox"
+  readonly provider = "test"
+  readonly status = "running"
+  readonly workingDirectory = "/workspace"
+  readonly files = new Map<string, Uint8Array>()
+  readonly commands: Array<{ readonly command: string; readonly args: readonly string[] }> = []
+  readonly writtenFiles: SandboxFileRecord[] = []
+
+  async writeFiles(files: readonly SandboxFileRecord[]): Promise<void> {
+    this.writtenFiles.push(...files)
+    for (const file of files) {
+      const path = file.path.startsWith("/") ? file.path : `${this.workingDirectory}/${file.path}`
+      this.files.set(
+        path,
+        typeof file.contents === "string"
+          ? new TextEncoder().encode(file.contents)
+          : new Uint8Array(file.contents)
+      )
+    }
+  }
+
+  async runCommand(
+    command: string,
+    args: readonly string[] = [],
+    options: RunCommandOptions = {}
+  ): Promise<CommandResult> {
+    this.commands.push({ command, args })
+    const encodedPath = options.env?.SIXB_VIEW_FILE_PATH_B64
+    const path = encodedPath ? Buffer.from(encodedPath, "base64").toString("utf-8") : ""
+    const bytes = this.files.get(path)
+    if (!bytes) {
+      return { exitCode: 2, stdout: "", stderr: "missing", durationMs: 1 }
+    }
+    return {
+      exitCode: 0,
+      stdout: `${bytes.byteLength}\n${Buffer.from(bytes).toString("base64")}`,
+      stderr: "",
+      durationMs: 1,
+    }
+  }
+
+  async stop(): Promise<void> {}
+  async destroy(): Promise<void> {}
+}

--- a/packages/agent-worker/tests/worker.test.ts
+++ b/packages/agent-worker/tests/worker.test.ts
@@ -14,7 +14,9 @@ import {
   type AgentReasoningLevel,
   AgentRequestError,
   type AgentsRuntime,
+  type AgentToolArtifact,
   type AgentToolDefinition,
+  type AgentToolResult,
   type BlobStorage,
   type Broker,
   type CommandResult,
@@ -53,6 +55,7 @@ import { attachSixbErrorReporter } from "@sixb/core/internal/error-reporting"
 import { createSixbError } from "@sixb/core/internal/errors"
 import type { AgentQueueJob, ClaimedQueueJob } from "@sixb/core/queues"
 import {
+  type AgentMessageRecord,
   type AgentStorage,
   AgentStorageError,
   type AiUsageStorage,
@@ -70,7 +73,7 @@ import { convertArrayToReadableStream, MockLanguageModelV4 } from "ai/test"
 import { AgentWorker, type AgentWorkerOptions } from "../src"
 import { loadAgentSkills } from "../src/agent-skills"
 import { normalizeApiBaseUrl } from "../src/api-url"
-import { prepareAgentAttachments } from "../src/attachments"
+import { prepareAgentAttachments, toolResultAttachmentKey } from "../src/attachments"
 import { AgentExecutionLostError, AgentFinalizationError } from "../src/errors"
 import { finishRunOrThrow } from "../src/finalize"
 import { enqueueAiModelCallRecovery } from "../src/model-call-recovery"
@@ -90,6 +93,12 @@ const TEST_AGENT_API_BASE_URL = "http://localhost:3002/api/"
 const REQUESTER = { type: "user", id: "usr_requester" } as const
 const AGENT_PRINCIPAL = { type: "serviceAccount", id: "svc_agent_assistant" } as const
 const AGENT_RUNTIME_GROUP = defineGroup("agent-runtime", { label: "Agent runtime" })
+const TEST_PNG_BYTES = Uint8Array.from(
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+    "base64"
+  )
+)
 
 const USAGE: LanguageModelV4Usage = {
   inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
@@ -137,6 +146,103 @@ function toolThenAnswerModel(captureReplay?: (prompt: string) => void): MockLang
         { type: "reasoning-end", id: "r" },
         { type: "text-start", id: "t" },
         { type: "text-delta", id: "t", delta: "Echoed hi" },
+        { type: "text-end", id: "t" },
+        finish("stop"),
+      ])
+    },
+  })
+}
+
+function artifactToolThenAnswerModel(
+  capture: {
+    readonly live?: (prompt: unknown) => void
+    readonly replay?: (prompt: unknown) => void
+    readonly viewed?: (prompt: unknown) => void
+  } = {}
+): MockLanguageModelV4 {
+  let call = 0
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    supportedUrls: { "image/*": [/^data:/] },
+    doStream: async (options) => {
+      call += 1
+      if (call === 1) {
+        return stream([
+          { type: "stream-start", warnings: [] },
+          {
+            type: "tool-call",
+            toolCallId: "image-call-1",
+            toolName: "create_image",
+            input: JSON.stringify({}),
+          },
+          finish("tool-calls"),
+        ])
+      }
+      if (call === 2) capture.live?.(options.prompt)
+      if (call === 3) {
+        capture.replay?.(options.prompt)
+        const promptJson = JSON.stringify(options.prompt)
+        const sandboxPath = promptJson.match(/sandboxPath=\\"([^"]+generated\.png)\\"/)?.[1]
+        if (!sandboxPath) throw new Error("Expected replay attachment sandbox path.")
+        return stream([
+          { type: "stream-start", warnings: [] },
+          {
+            type: "tool-call",
+            toolCallId: "view-image-call-1",
+            toolName: "view_file",
+            input: JSON.stringify({ path: sandboxPath }),
+          },
+          finish("tool-calls"),
+        ])
+      }
+      if (call === 4) capture.viewed?.(options.prompt)
+      return stream([
+        { type: "stream-start", warnings: [] },
+        { type: "text-start", id: "t" },
+        { type: "text-delta", id: "t", delta: "Created the image" },
+        { type: "text-end", id: "t" },
+        finish("stop"),
+      ])
+    },
+  })
+}
+
+function bashImageThenViewModel(captureViewed: (prompt: unknown) => void): MockLanguageModelV4 {
+  let call = 0
+  return new MockLanguageModelV4({
+    modelId: "mock-model",
+    supportedUrls: { "image/*": [/^data:/] },
+    doStream: async (options) => {
+      call += 1
+      if (call === 1) {
+        return stream([
+          { type: "stream-start", warnings: [] },
+          {
+            type: "tool-call",
+            toolCallId: "bash-image-call-1",
+            toolName: "bash",
+            input: JSON.stringify({ command: "create-view-image" }),
+          },
+          finish("tool-calls"),
+        ])
+      }
+      if (call === 2) {
+        return stream([
+          { type: "stream-start", warnings: [] },
+          {
+            type: "tool-call",
+            toolCallId: "view-bash-image-call-1",
+            toolName: "view_file",
+            input: JSON.stringify({ path: "scratch/bash-image.png" }),
+          },
+          finish("tool-calls"),
+        ])
+      }
+      captureViewed(options.prompt)
+      return stream([
+        { type: "stream-start", warnings: [] },
+        { type: "text-start", id: "t" },
+        { type: "text-delta", id: "t", delta: "Viewed the bash image" },
         { type: "text-end", id: "t" },
         finish("stop"),
       ])
@@ -751,6 +857,7 @@ class RecordingSandbox implements Sandbox {
   status: "running" | "stopped" | "failed" = "running"
   readonly commands: RecordedCommand[] = []
   readonly writtenFiles: SandboxFileRecord[] = []
+  readonly files = new Map<string, Uint8Array>()
   readonly outputFiles = new Map<string, Uint8Array>()
   readonly outputListedSizeOverrides = new Map<string, number>()
   destroyed = false
@@ -773,6 +880,15 @@ class RecordingSandbox implements Sandbox {
 
   async writeFiles(files: readonly SandboxFileRecord[]): Promise<void> {
     this.writtenFiles.push(...files)
+    for (const file of files) {
+      const path = file.path.startsWith("/") ? file.path : join(this.workingDirectory, file.path)
+      this.files.set(
+        path,
+        typeof file.contents === "string"
+          ? new TextEncoder().encode(file.contents)
+          : new Uint8Array(file.contents)
+      )
+    }
   }
 
   writeOutputFile(relativePath: string, contents: string | Uint8Array): void {
@@ -790,6 +906,15 @@ class RecordingSandbox implements Sandbox {
       return {
         exitCode: 0,
         stdout: "created report.txt",
+        stderr: "",
+        durationMs: 1,
+      }
+    }
+    if (command === "bash" && script === "create-view-image") {
+      this.files.set(join(this.workingDirectory, "scratch", "bash-image.png"), TEST_PNG_BYTES)
+      return {
+        exitCode: 0,
+        stdout: "created scratch/bash-image.png",
         stderr: "",
         durationMs: 1,
       }
@@ -835,6 +960,28 @@ class RecordingSandbox implements Sandbox {
             exitCode: 2,
             stdout: "",
             stderr: "output file not found",
+            durationMs: 1,
+          }
+    }
+    if (
+      command === "bash" &&
+      typeof script === "string" &&
+      script.includes("sixb-read-view-file")
+    ) {
+      const encoded = options.env?.SIXB_VIEW_FILE_PATH_B64
+      const path = encoded ? Buffer.from(encoded, "base64").toString("utf-8") : ""
+      const bytes = this.files.get(path)
+      return bytes
+        ? {
+            exitCode: 0,
+            stdout: `${bytes.byteLength}\n${Buffer.from(bytes).toString("base64")}`,
+            stderr: "",
+            durationMs: 1,
+          }
+        : {
+            exitCode: 2,
+            stdout: "",
+            stderr: "file not found",
             durationMs: 1,
           }
     }
@@ -2844,12 +2991,117 @@ describe("AgentWorker", () => {
     expect(prepared.entries).toHaveLength(50)
     expect(prepared.promptTextByPartKey.has("assistant-0:0")).toBe(false)
     expect(prepared.promptTextByPartKey.get("assistant-50:0")).toContain(
-      "Generated file kept as metadata"
+      "Historical file kept as metadata"
     )
     expect(JSON.stringify([...prepared.promptTextByPartKey.values()])).not.toContain(
       "sensitive generated contents"
     )
     expect(prepared.modelFileDataByPartKey.size).toBe(0)
+  })
+
+  test("inlines only the current user image and defers historical images to view_file", async () => {
+    const blobStorage = new InMemoryBlobStorage()
+    const fileRef = await blobStorage.put({
+      body: TEST_PNG_BYTES,
+      fileName: "uploaded.png",
+      mediaType: "image/png",
+    })
+    const messages: AgentMessageRecord[] = [
+      {
+        id: "user-old",
+        projectId: PROJECT_ID,
+        threadId: "thread-1",
+        runId: "run-old",
+        role: "user",
+        seq: 1,
+        parts: [{ type: "file", fileRef }],
+        contentVersion: 1,
+        createdAt: new Date(2026, 0, 1),
+      },
+      {
+        id: "user-current",
+        projectId: PROJECT_ID,
+        threadId: "thread-1",
+        runId: "run-current",
+        role: "user",
+        seq: 2,
+        parts: [{ type: "file", fileRef }],
+        contentVersion: 1,
+        createdAt: new Date(2026, 0, 2),
+      },
+    ]
+
+    const prepared = await prepareAgentAttachments({
+      projectId: PROJECT_ID,
+      threadId: "thread-1",
+      messages,
+      blobStorage,
+      apiBaseUrl: TEST_AGENT_API_BASE_URL,
+      inlineImages: true,
+    })
+
+    expect(prepared.promptTextByPartKey.get("user-old:0")).toContain(
+      "Historical file kept as metadata"
+    )
+    expect(prepared.promptTextByPartKey.get("user-old:0")).toContain("view_file")
+    if (typeof Bun.Image === "function") {
+      expect(prepared.modelFileDataByPartKey.has("user-old:0")).toBe(false)
+      expect(prepared.modelFileDataByPartKey.get("user-current:0")?.data.href).toStartWith(
+        "data:image/png;base64,"
+      )
+    }
+  })
+
+  test("prepares nested rich tool-result files for replay and the next sandbox", async () => {
+    const blobStorage = new InMemoryBlobStorage()
+    const fileRef = await blobStorage.put({
+      body: TEST_PNG_BYTES,
+      fileName: "generated.png",
+      mediaType: "image/png",
+    })
+    const message: AgentMessageRecord = {
+      id: "assistant-rich",
+      projectId: PROJECT_ID,
+      threadId: "thread-1",
+      runId: "run-rich",
+      role: "assistant" as const,
+      seq: 1,
+      parts: [
+        {
+          type: "tool-call" as const,
+          toolCallId: "image-call-1",
+          toolName: "create_image",
+          input: {},
+          state: "output-available" as const,
+          output: {
+            kind: "agentToolResult",
+            content: [{ type: "file", fileRef: { ...fileRef } }],
+          },
+        },
+        { type: "file" as const, fileRef },
+      ],
+      contentVersion: 1,
+      createdAt: new Date(2026, 0, 1),
+    }
+
+    const prepared = await prepareAgentAttachments({
+      projectId: PROJECT_ID,
+      threadId: "thread-1",
+      messages: [message],
+      blobStorage,
+      apiBaseUrl: TEST_AGENT_API_BASE_URL,
+      inlineImages: true,
+    })
+    const key = toolResultAttachmentKey(message.id, 0, 0)
+
+    expect(prepared.entries).toHaveLength(1)
+    expect(prepared.entries[0]?.contentPath).toBe("/parts/0/output/content/0/fileRef")
+    expect(prepared.promptTextByPartKey.get(key)).toContain("generated.png")
+    expect(prepared.sandboxFiles).toHaveLength(1)
+    expect(prepared.sandboxFiles[0]?.path).toContain("tool-0-0-generated.png")
+    expect(prepared.sandboxFiles[0]?.bytes).toEqual(TEST_PNG_BYTES)
+    expect(prepared.modelFileDataByPartKey.has(key)).toBe(false)
+    expect(prepared.promptTextByPartKey.get(key)).toContain("Historical file kept as metadata")
   })
 
   test("provisions the sandbox concurrently without blocking turn start", async () => {
@@ -3187,6 +3439,224 @@ describe("AgentWorker", () => {
         },
         context: { run: { kind: "agent", id: selectedRequest.run.id } },
       })
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("publishes a selected tool artifact to blob storage and the run sandbox", async () => {
+    let published: AgentToolArtifact | undefined
+    let receivedToolCallId: string | undefined
+    let livePrompt: unknown
+    let replayPrompt: unknown
+    let viewedPrompt: unknown
+    const createImage = defineAgentTool("create_image")
+      .description("Create a test image.")
+      .input({})
+      .run(async ({ artifacts, toolCallId }) => {
+        receivedToolCallId = toolCallId
+        published = await artifacts.put({
+          body: TEST_PNG_BYTES,
+          fileName: "generated.png",
+          mediaType: "image/png",
+        })
+        return {
+          kind: "agentToolResult",
+          content: [
+            { type: "text", text: "Created an image." },
+            { type: "file", fileRef: published.fileRef },
+          ],
+        } satisfies AgentToolResult
+      })
+    const sandboxes = new RecordingSandboxFactory()
+    const sixb = buildSixb(
+      artifactToolThenAnswerModel({
+        live: (prompt) => {
+          livePrompt = prompt
+        },
+        replay: (prompt) => {
+          replayPrompt = prompt
+        },
+        viewed: (prompt) => {
+          viewedPrompt = prompt
+        },
+      }),
+      new InMemoryBroker(),
+      sandboxes,
+      { agentTools: [createImage] }
+    )
+    const storage = agentStorageOf(sixb)
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const request = await requestAgent(sixb, {
+        agentId: "assistant",
+        text: "create an image",
+      })
+      const run = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({ projectId: PROJECT_ID, id: request.run.id })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "tool artifact run terminal" }
+      )
+
+      expect(run.status).toBe("succeeded")
+      expect(receivedToolCallId).toBe("image-call-1")
+      expect(published).toBeDefined()
+      if (!published) throw new Error("Expected the selected tool to publish an artifact.")
+
+      expect(
+        new Uint8Array(
+          await new Response(await sixb.blobStorage.open(published.fileRef.blobId)).arrayBuffer()
+        )
+      ).toEqual(TEST_PNG_BYTES)
+      const sandboxFile = sandboxes.sandboxes[0]?.writtenFiles.find((file) =>
+        file.path.includes(".sixb/agent/artifacts/")
+      )
+      expect(sandboxFile?.contents).toEqual(TEST_PNG_BYTES)
+      expect(published.sandboxPath).toEndWith("-generated.png")
+
+      const messages = await listMessages(storage, request.run.threadId)
+      const firstAssistant = messages.find(
+        (message) =>
+          message.role === "assistant" &&
+          message.parts.some(
+            (part) => part.type === "tool-call" && part.toolName === createImage.name
+          )
+      )
+      expect(
+        firstAssistant?.parts.find(
+          (part) => part.type === "tool-call" && part.toolName === createImage.name
+        )
+      ).toMatchObject({
+        state: "output-available",
+        output: {
+          kind: "agentToolResult",
+          content: [{ type: "text" }, { type: "file", fileRef: published.fileRef }],
+        },
+      })
+      expect(firstAssistant?.parts.filter((part) => part.type === "file")).toEqual([
+        { type: "file", fileRef: published.fileRef },
+      ])
+      const richToolPartIndex = firstAssistant?.parts.findIndex(
+        (part) => part.type === "tool-call" && part.toolName === createImage.name
+      )
+      expect(richToolPartIndex).toBeGreaterThanOrEqual(0)
+      const durableJson = JSON.stringify(messages)
+      expect(durableJson).not.toContain("data:image")
+      expect(durableJson).not.toContain("iVBORw0KGgo")
+      expect(durableJson).not.toContain(published.sandboxPath)
+
+      const livePromptJson = JSON.stringify(livePrompt)
+      expect(livePromptJson).toContain("generated.png")
+      expect(livePromptJson).toContain("<tool_file")
+      expect(livePromptJson).toContain("<sixb_tool_files")
+      const livePromptMessages = Array.isArray(livePrompt) ? livePrompt : []
+      const liveToolResults = livePromptMessages.flatMap((message) => {
+        if (
+          typeof message !== "object" ||
+          message === null ||
+          !("role" in message) ||
+          message.role !== "tool" ||
+          !("content" in message) ||
+          !Array.isArray(message.content)
+        ) {
+          return []
+        }
+        return message.content.filter(
+          (part: unknown) =>
+            typeof part === "object" &&
+            part !== null &&
+            "type" in part &&
+            part.type === "tool-result"
+        )
+      })
+      expect(JSON.stringify(liveToolResults)).not.toContain('"type":"file"')
+      if (typeof Bun.Image === "function") {
+        expect(
+          livePromptMessages.some(
+            (message) =>
+              typeof message === "object" &&
+              message !== null &&
+              "role" in message &&
+              message.role === "user" &&
+              "content" in message &&
+              Array.isArray(message.content) &&
+              message.content.some(
+                (part: unknown) =>
+                  typeof part === "object" &&
+                  part !== null &&
+                  "type" in part &&
+                  part.type === "file"
+              )
+          )
+        ).toBe(true)
+        expect(livePromptJson).toContain(Buffer.from(TEST_PNG_BYTES).toString("base64"))
+      }
+
+      const followup = await requestAgent(sixb, {
+        agentId: "assistant",
+        threadId: request.run.threadId,
+        text: "inspect it again",
+      })
+      const replayRun = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({
+            projectId: PROJECT_ID,
+            id: followup.run.id,
+          })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "tool artifact replay run terminal" }
+      )
+      expect(replayRun.status).toBe("succeeded")
+
+      const replayPromptJson = JSON.stringify(replayPrompt)
+      expect(replayPromptJson).toContain("generated.png")
+      expect(replayPromptJson).toContain(
+        encodeURIComponent(`/parts/${richToolPartIndex}/output/content/1/fileRef`)
+      )
+      if (typeof Bun.Image === "function") {
+        expect(replayPromptJson).not.toContain(Buffer.from(TEST_PNG_BYTES).toString("base64"))
+      }
+      expect(
+        sandboxes.sandboxes[1]?.writtenFiles.some(
+          (file) =>
+            file.path.includes(".sixb/agent/attachments/") &&
+            file.path.endsWith(`tool-${richToolPartIndex}-1-generated.png`) &&
+            Buffer.from(file.contents).equals(Buffer.from(TEST_PNG_BYTES))
+        )
+      ).toBe(true)
+
+      const viewedPromptJson = JSON.stringify(viewedPrompt)
+      expect(viewedPromptJson).toContain("view_file")
+      if (typeof Bun.Image === "function") {
+        expect(viewedPromptJson).toContain(Buffer.from(TEST_PNG_BYTES).toString("base64"))
+      }
+      const replayMessages = await listMessages(storage, request.run.threadId)
+      const replayAssistant = replayMessages.find(
+        (message) =>
+          message.runId === followup.run.id &&
+          message.parts.some((part) => part.type === "tool-call" && part.toolName === "view_file")
+      )
+      expect(
+        replayAssistant?.parts.find(
+          (part) => part.type === "tool-call" && part.toolName === "view_file"
+        )
+      ).toMatchObject({
+        state: "output-available",
+        output: {
+          kind: "agentToolResult",
+          content: [{ type: "text" }, { type: "file", fileRef: published.fileRef }],
+        },
+      })
+      expect(
+        sandboxes.sandboxes[1]?.writtenFiles.filter((file) =>
+          file.path.includes(".sixb/agent/artifacts/")
+        )
+      ).toHaveLength(0)
     } finally {
       await worker.stop()
     }
@@ -4156,6 +4626,79 @@ describe("AgentWorker", () => {
       expect(parts.some((part) => part.type === "text" && part.text.includes("Bash ran"))).toBe(
         true
       )
+    } finally {
+      await worker.stop()
+    }
+  })
+
+  test("views and publishes an image created by bash", async () => {
+    let viewedPrompt: unknown
+    const sandboxes = new RecordingSandboxFactory()
+    const sixb = buildSixb(
+      bashImageThenViewModel((prompt) => {
+        viewedPrompt = prompt
+      }),
+      new InMemoryBroker(),
+      sandboxes
+    )
+    const storage = agentStorageOf(sixb)
+    const worker = new AgentWorker(sixb, workerOptions({ skillsDir: false }))
+
+    await worker.start()
+    try {
+      const request = await requestAgent(sixb, {
+        agentId: "assistant",
+        text: "create and inspect an image",
+      })
+      const run = await waitFor(
+        async () => {
+          const record = await storage.runs.getById({ projectId: PROJECT_ID, id: request.run.id })
+          return record && record.status !== "queued" && record.status !== "running" ? record : null
+        },
+        { label: "bash view_file run terminal" }
+      )
+
+      expect(run.status).toBe("succeeded")
+      const assistant = (await listMessages(storage, request.run.threadId)).find(
+        (message) => message.role === "assistant"
+      )
+      const viewCall = assistant?.parts.find(
+        (part) => part.type === "tool-call" && part.toolName === "view_file"
+      )
+      expect(viewCall).toMatchObject({
+        state: "output-available",
+        output: {
+          kind: "agentToolResult",
+          content: [
+            { type: "text", text: expect.stringContaining("Prepared image") },
+            {
+              type: "file",
+              fileRef: { fileName: "bash-image.png", mediaType: "image/png" },
+            },
+          ],
+        },
+      })
+      const filePart = assistant?.parts.find((part) => part.type === "file")
+      expect(filePart).toMatchObject({
+        type: "file",
+        fileRef: { fileName: "bash-image.png", mediaType: "image/png" },
+      })
+      if (!filePart || filePart.type !== "file") throw new Error("Expected viewed image file.")
+      expect(
+        new Uint8Array(
+          await new Response(await sixb.blobStorage.open(filePart.fileRef.blobId)).arrayBuffer()
+        )
+      ).toEqual(TEST_PNG_BYTES)
+      expect(
+        sandboxes.sandboxes[0]?.writtenFiles.some((file) =>
+          file.path.includes(".sixb/agent/artifacts/")
+        )
+      ).toBe(true)
+      if (typeof Bun.Image === "function") {
+        expect(JSON.stringify(viewedPrompt)).toContain(
+          Buffer.from(TEST_PNG_BYTES).toString("base64")
+        )
+      }
     } finally {
       await worker.stop()
     }

--- a/packages/core/src/agents/validation.ts
+++ b/packages/core/src/agents/validation.ts
@@ -31,7 +31,7 @@ const AGENT_TOOL_PRIMITIVE_SCHEMAS = new Set([
   "fileRef",
 ])
 
-export const AGENT_RESERVED_TOOL_NAMES = ["bash", "read"] as const
+export const AGENT_RESERVED_TOOL_NAMES = ["bash", "read", "view_file"] as const
 
 export function assertNonEmpty(value: string, field: string): void {
   if (!value.trim()) {

--- a/packages/core/tests/agents.test.ts
+++ b/packages/core/tests/agents.test.ts
@@ -227,7 +227,7 @@ describe("defineAgentTool", () => {
     for (const name of ["", "1search", "search knowledge", "a".repeat(65)]) {
       expect(() => validateName(name)).toThrow(AgentDefinitionError)
     }
-    for (const name of ["bash", "read"]) {
+    for (const name of ["bash", "read", "view_file"]) {
       expect(() => validateName(name)).toThrow("reserved by the framework")
     }
   })


### PR DESCRIPTION
Stack: 3 of 4. Depends on #439.

## Problem

Saving a file and placing it in the sandbox is not enough: the model still needs a safe way to inspect it. Historical attachments and files created by `bash` were available as paths, but the agent could not reliably view their contents during a turn.

## Changes

- add the built-in `view_file` tool for files inside the run workspace
- reuse existing `FileRef` values for known attachments and artifacts
- publish previously unknown sandbox files through the artifact path
- provide bounded image content through the provider-safe model bridge
- reject symlinks, escaping paths, oversized files, and reserved-name conflicts

## Verification

- 77 agent-worker and `view_file` tests
- core agent tests
- core and agent-worker typechecks
