### PR TITLE
example: demonstrate generated image tools

### DIFF
--- a/examples/northline/agents/operations-assistant.ts
+++ b/examples/northline/agents/operations-assistant.ts
@@ -1,5 +1,33 @@
-import { defineAgent, defineAgentTool, stringEnum } from "@sixb/core"
-import { gateway } from "ai"
+import { type AgentToolResult, defineAgent, defineAgentTool, stringEnum } from "@sixb/core"
+import { gateway, generateImage } from "ai"
+
+const IMAGE_MODEL = "xai/grok-imagine-image-2.0"
+
+export const generateImageTool = defineAgentTool("generate_image")
+  .description("Generate an image from a text prompt and return it as an attachment.")
+  .input({ prompt: "string" })
+  .run(async ({ input, artifacts, signal }) => {
+    // Temporary example integration: AI Gateway observes this image call, but Sixb's current usage
+    // ledger records only the worker-owned language-model calls that drive the agent loop.
+    const { image } = await generateImage({
+      model: gateway.image(IMAGE_MODEL),
+      prompt: input.prompt,
+      abortSignal: signal,
+    })
+    const { fileRef } = await artifacts.put({
+      body: image.uint8Array,
+      fileName: `generated-image.${imageFileExtension(image.mediaType)}`,
+      mediaType: image.mediaType,
+    })
+    const result: AgentToolResult = {
+      kind: "agentToolResult",
+      content: [
+        { type: "text", text: "Generated an image." },
+        { type: "file", fileRef },
+      ],
+    }
+    return result
+  })
 
 export const lookupResponsePolicy = defineAgentTool("lookup_response_policy")
   .description(
@@ -32,6 +60,7 @@ export const operationsAssistant = defineAgent("operations-assistant", {
   name: "Operations Assistant",
   description: "A demo agent showing how to add an AI assistant to a Sixb app.",
   model: gateway("deepseek/deepseek-v4-flash-vision-exp"),
+  reasoning: "medium",
   instructions: [
     "This is a demo agent for the Northline example.",
     "Help users understand and work with the business information available in this example.",
@@ -43,7 +72,15 @@ export const operationsAssistant = defineAgent("operations-assistant", {
       "`bun --filter @sixb/example-northline dev`.",
     "Only when a user asks how to customize the agent, explain that they can edit this file, " +
       "change the model passed to gateway(), and replace these instructions with their own prompt.",
+    "When the user asks you to create an image, call generate_image with a detailed prompt.",
   ].join("\n"),
-  tools: [lookupResponsePolicy],
+  tools: [lookupResponsePolicy, generateImageTool],
   loop: { stopWhen: { maxSteps: 12 } },
 })
+
+function imageFileExtension(mediaType: string): string {
+  if (mediaType === "image/jpeg") return "jpg"
+  if (mediaType === "image/webp") return "webp"
+  if (mediaType === "image/gif") return "gif"
+  return "png"
+}


### PR DESCRIPTION
Stack: 4 of 4. Depends on #440.

## Problem

The framework now supports tool-created files, but the example app did not show authors how to use the complete path from generation to attachment.

## Changes

- add a Northline image-generation tool
- publish generated bytes with `artifacts.put`
- return the durable image as a file-aware tool result
- use a vision-capable chat model so the example can inspect generated images

## Verification

- `bun --filter @sixb/example-northline typecheck`
- `bun --filter @sixb/example-northline build`
